### PR TITLE
feat(dev-preview): add rotation, DPR, and zoom-to-fit viewport controls

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -147,6 +147,12 @@ export interface DevPreviewPanelOptions extends AddPanelOptionsBase {
   devPreviewConsoleOpen?: boolean;
   /** Active viewport preset for responsive emulation (undefined = fill) */
   viewportPreset?: ViewportPresetId;
+  /** Whether the active viewport preset is rotated to landscape */
+  viewportRotated?: boolean;
+  /** Device-pixel-ratio override for the active viewport preset */
+  viewportDpr?: 1 | 2 | 3;
+  /** Whether the viewport is scaled to fit the available pane */
+  viewportFit?: boolean;
   /** Last captured scroll position, paired with URL for stale-scroll prevention */
   devPreviewScrollPosition?: { url: string; scrollY: number };
 }

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -378,6 +378,12 @@ export interface DevPreviewPanelData extends BasePanelData {
   exitBehavior?: PanelExitBehavior;
   /** Active viewport preset (undefined = fill/full-width) */
   viewportPreset?: ViewportPresetId;
+  /** Whether the active viewport preset is rotated to landscape (width/height swapped) */
+  viewportRotated?: boolean;
+  /** Device-pixel-ratio override for the active viewport preset (visual change deferred to #8278) */
+  viewportDpr?: 1 | 2 | 3;
+  /** Whether the viewport is scaled down to fit the available pane (zoom-to-fit) */
+  viewportFit?: boolean;
   /** Last captured scroll position, paired with URL for stale-scroll prevention */
   devPreviewScrollPosition?: { url: string; scrollY: number };
 }
@@ -496,6 +502,12 @@ export interface TerminalInstance {
   devPreviewConsoleOpen?: boolean;
   /** Active viewport preset for dev-preview responsive emulation (undefined = fill) */
   viewportPreset?: ViewportPresetId;
+  /** Whether the active dev-preview viewport preset is rotated to landscape */
+  viewportRotated?: boolean;
+  /** Device-pixel-ratio override for the active dev-preview viewport preset */
+  viewportDpr?: 1 | 2 | 3;
+  /** Whether the dev-preview viewport is scaled to fit the available pane */
+  viewportFit?: boolean;
   /** Last captured dev-preview scroll position, paired with URL for stale-scroll prevention */
   devPreviewScrollPosition?: { url: string; scrollY: number };
   /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -93,6 +93,12 @@ export interface PanelSnapshot {
   devPreviewConsoleOpen?: boolean;
   /** Active viewport preset for dev-preview responsive emulation */
   viewportPreset?: ViewportPresetId;
+  /** Whether the active dev-preview viewport preset is rotated to landscape */
+  viewportRotated?: boolean;
+  /** Device-pixel-ratio override for the active dev-preview viewport preset */
+  viewportDpr?: 1 | 2 | 3;
+  /** Whether the dev-preview viewport is scaled to fit the available pane */
+  viewportFit?: boolean;
   /** Last captured dev-preview scroll position, paired with URL for stale-scroll prevention */
   devPreviewScrollPosition?: { url: string; scrollY: number };
   /** Behavior when terminal exits */

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -11,6 +11,7 @@ import {
   ZoomIn,
   ZoomOut,
   Camera,
+  Maximize2,
   SquareTerminal,
   Code,
   Smartphone,
@@ -48,6 +49,9 @@ interface BrowserToolbarProps {
   isConsoleOpen?: boolean;
   isWebviewReady?: boolean;
   viewportPreset?: ViewportPresetId;
+  viewportRotated?: boolean;
+  viewportDpr?: 1 | 2 | 3;
+  viewportFit?: boolean;
   onNavigate: (url: string) => void;
   onBack: () => void;
   onForward: () => void;
@@ -59,6 +63,9 @@ interface BrowserToolbarProps {
   onToggleConsole?: () => void;
   onToggleDevTools?: () => void;
   onViewportPresetChange?: (preset: ViewportPresetId | undefined) => void;
+  onViewportRotateToggle?: () => void;
+  onViewportDprChange?: (dpr: 1 | 2 | 3) => void;
+  onViewportFitToggle?: () => void;
 }
 
 export function BrowserToolbar({
@@ -72,6 +79,9 @@ export function BrowserToolbar({
   isConsoleOpen = false,
   isWebviewReady = false,
   viewportPreset,
+  viewportRotated = false,
+  viewportDpr = 1,
+  viewportFit = false,
   onNavigate,
   onBack,
   onForward,
@@ -83,6 +93,9 @@ export function BrowserToolbar({
   onToggleConsole,
   onToggleDevTools,
   onViewportPresetChange,
+  onViewportRotateToggle,
+  onViewportDprChange,
+  onViewportFitToggle,
 }: BrowserToolbarProps) {
   const [inputValue, setInputValue] = useState(getDisplayUrl(url));
   const [isEditing, setIsEditing] = useState(false);
@@ -538,6 +551,84 @@ export function BrowserToolbar({
                   </button>
                 );
               })}
+            </div>
+          )}
+          {viewportPreset && (
+            <div className="flex items-center ml-1 pl-1.5 border-l border-overlay">
+              {onViewportRotateToggle && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={onViewportRotateToggle}
+                      className={cn(
+                        buttonClass,
+                        viewportRotated && "bg-overlay-emphasis text-daintree-text"
+                      )}
+                      aria-label="Rotate viewport"
+                      aria-pressed={viewportRotated}
+                    >
+                      <RotateCw className="w-4 h-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {viewportRotated ? "Portrait" : "Landscape"}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+              {onViewportDprChange && (
+                <div
+                  role="radiogroup"
+                  aria-label="Device pixel ratio"
+                  className="flex items-center ml-0.5"
+                >
+                  {([1, 2, 3] as const).map((dpr) => {
+                    const isSelected = viewportDpr === dpr;
+                    return (
+                      <button
+                        key={dpr}
+                        type="button"
+                        role="radio"
+                        aria-checked={isSelected}
+                        aria-label={`Device pixel ratio ${dpr}x`}
+                        onClick={() => {
+                          if (!isSelected) onViewportDprChange(dpr);
+                        }}
+                        className={cn(
+                          "px-1.5 py-1 rounded text-[10px] font-medium transition-colors",
+                          "hover:bg-overlay-medium",
+                          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
+                          isSelected
+                            ? "bg-overlay-emphasis text-daintree-text"
+                            : "text-daintree-text/50"
+                        )}
+                      >
+                        {dpr}×
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+              {onViewportFitToggle && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={onViewportFitToggle}
+                      className={cn(
+                        buttonClass,
+                        "ml-0.5",
+                        viewportFit && "bg-overlay-emphasis text-daintree-text"
+                      )}
+                      aria-label="Zoom to fit"
+                      aria-pressed={viewportFit}
+                    >
+                      <Maximize2 className="w-4 h-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Zoom to fit</TooltipContent>
+                </Tooltip>
+              )}
             </div>
           )}
         </div>

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -114,6 +114,7 @@ export function BrowserToolbar({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const chipRowRef = useRef<HTMLDivElement>(null);
+  const dprRowRef = useRef<HTMLDivElement>(null);
   const lastViewportPresetRef = useRef<ViewportPresetId>("iphone");
   const [chipFocusedIndex, setChipFocusedIndex] = useState<number>(-1);
   const listboxId = useId();
@@ -192,6 +193,51 @@ export function BrowserToolbar({
     return () =>
       container.removeEventListener("keydown", handleKeyDown as unknown as EventListener);
   }, [onViewportPresetChange, viewportPreset]);
+
+  useEffect(() => {
+    const container = dprRowRef.current;
+    if (!container) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const buttons = Array.from(
+        container.querySelectorAll<HTMLButtonElement>("button[role='radio']:not(:disabled)")
+      );
+      if (buttons.length === 0) return;
+
+      const currentIndex = buttons.findIndex((b) => b === document.activeElement);
+      let nextIndex = currentIndex;
+
+      if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        nextIndex = currentIndex < buttons.length - 1 ? currentIndex + 1 : 0;
+      } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        nextIndex = currentIndex > 0 ? currentIndex - 1 : buttons.length - 1;
+      } else if (e.key === "Home") {
+        e.preventDefault();
+        nextIndex = 0;
+      } else if (e.key === "End") {
+        e.preventDefault();
+        nextIndex = buttons.length - 1;
+      } else {
+        return;
+      }
+
+      if (nextIndex !== currentIndex && nextIndex >= 0 && nextIndex < buttons.length) {
+        const nextButton = buttons[nextIndex];
+        nextButton?.focus();
+        // APG radiogroup contract: selection follows focus.
+        const dprValue = Number(nextButton?.getAttribute("data-dpr"));
+        if ((dprValue === 1 || dprValue === 2 || dprValue === 3) && onViewportDprChange) {
+          onViewportDprChange(dprValue);
+        }
+      }
+    };
+
+    container.addEventListener("keydown", handleKeyDown as unknown as EventListener);
+    return () =>
+      container.removeEventListener("keydown", handleKeyDown as unknown as EventListener);
+  }, [onViewportDprChange, viewportPreset, viewportDpr]);
 
   useEffect(() => {
     if (!isEditing) {
@@ -578,6 +624,7 @@ export function BrowserToolbar({
               )}
               {onViewportDprChange && (
                 <div
+                  ref={dprRowRef}
                   role="radiogroup"
                   aria-label="Device pixel ratio"
                   className="flex items-center ml-0.5"
@@ -591,6 +638,8 @@ export function BrowserToolbar({
                         role="radio"
                         aria-checked={isSelected}
                         aria-label={`Device pixel ratio ${dpr}x`}
+                        data-dpr={dpr}
+                        tabIndex={isSelected ? 0 : -1}
                         onClick={() => {
                           if (!isSelected) onViewportDprChange(dpr);
                         }}

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -205,7 +205,7 @@ export function BrowserToolbar({
       if (buttons.length === 0) return;
 
       const currentIndex = buttons.findIndex((b) => b === document.activeElement);
-      let nextIndex = currentIndex;
+      let nextIndex: number;
 
       if (e.key === "ArrowRight" || e.key === "ArrowDown") {
         e.preventDefault();

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -797,15 +797,18 @@ export function DevPreviewPane({
   // Measure the available preview area so zoom-to-fit can scale the device
   // frame down to fit both pane dimensions. A static scale would break on
   // pane resize, so this tracks the container via ResizeObserver.
-  const fitContainerRef = useRef<HTMLDivElement>(null);
+  // Callback ref (not useRef) so the observer effect re-runs when the
+  // fit-container div mounts for the first time — it lives in the webview
+  // branch, which only renders once the dev server reaches "running", long
+  // after viewportFit/viewportPreset may have been set.
+  const [fitContainerEl, setFitContainerEl] = useState<HTMLDivElement | null>(null);
   const [fitContainerSize, setFitContainerSize] = useState<{ w: number; h: number }>({
     w: 0,
     h: 0,
   });
   useEffect(() => {
-    if (!viewportFit || !viewportPreset) return;
-    const el = fitContainerRef.current;
-    if (!el) return;
+    if (!viewportFit || !viewportPreset || !fitContainerEl) return;
+    const el = fitContainerEl;
     const measure = () => {
       setFitContainerSize({ w: el.clientWidth, h: el.clientHeight });
     };
@@ -813,7 +816,7 @@ export function DevPreviewPane({
     const observer = new ResizeObserver(measure);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [viewportFit, viewportPreset]);
+  }, [viewportFit, viewportPreset, fitContainerEl]);
 
   const fitScale =
     viewportFit && effectiveViewport
@@ -1153,7 +1156,7 @@ export function DevPreviewPane({
             </div>
           ) : (
             <div
-              ref={fitContainerRef}
+              ref={setFitContainerEl}
               className={cn(
                 "h-full",
                 viewportPreset &&
@@ -1184,110 +1187,113 @@ export function DevPreviewPane({
                     : undefined
                 }
               >
-                <div
-                  className={
-                    viewportPreset && viewportFit
-                      ? "absolute top-0 left-0 origin-top-left"
-                      : "w-full h-full"
-                  }
-                  style={
-                    viewportPreset && viewportFit && effectiveViewport
-                      ? {
-                          width: effectiveViewport.width,
-                          height: effectiveViewport.height,
-                          transform: `scale(${fitScale})`,
-                        }
-                      : undefined
-                  }
-                >
-                  <>
-                    {webviewLoadError && (
-                      <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
-                        <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
-                        <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                          {webviewLoadError.startsWith("Load timed out") ||
-                          webviewLoadError.startsWith("Connection to")
-                            ? "Page Load Timed Out"
-                            : webviewLoadError.startsWith("Load cancelled")
-                              ? "Load Cancelled"
-                              : "Dev Server Unreachable"}
-                        </h3>
-                        <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
-                          {webviewLoadError}
-                        </p>
-                        <div className="flex items-center gap-1">
+                <>
+                  {webviewLoadError && (
+                    <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
+                      <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
+                      <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
+                        {webviewLoadError.startsWith("Load timed out") ||
+                        webviewLoadError.startsWith("Connection to")
+                          ? "Page Load Timed Out"
+                          : webviewLoadError.startsWith("Load cancelled")
+                            ? "Load Cancelled"
+                            : "Dev Server Unreachable"}
+                      </h3>
+                      <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
+                        {webviewLoadError}
+                      </p>
+                      <div className="flex items-center gap-1">
+                        <Button
+                          onClick={
+                            webviewLoadError.startsWith("Load cancelled") ||
+                            webviewLoadError.startsWith("Load timed out") ||
+                            webviewLoadError.startsWith("Connection to")
+                              ? handleRetryWebviewLoad
+                              : handleHardRestart
+                          }
+                          variant="ghost"
+                          size="sm"
+                          className="gap-1.5 px-2.5 py-1.5 group"
+                        >
+                          <RotateCw className="h-3.5 w-3.5" />
+                          <span className="text-xs">
+                            {webviewLoadError.startsWith("Load cancelled") ||
+                            webviewLoadError.startsWith("Load timed out") ||
+                            webviewLoadError.startsWith("Connection to")
+                              ? "Retry"
+                              : "Hard Restart"}
+                          </span>
+                        </Button>
+                        {currentUrl && (
                           <Button
-                            onClick={
-                              webviewLoadError.startsWith("Load cancelled") ||
-                              webviewLoadError.startsWith("Load timed out") ||
-                              webviewLoadError.startsWith("Connection to")
-                                ? handleRetryWebviewLoad
-                                : handleHardRestart
-                            }
+                            onClick={handleOpenExternal}
                             variant="ghost"
                             size="sm"
-                            className="gap-1.5 px-2.5 py-1.5 group"
+                            className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
                           >
-                            <RotateCw className="h-3.5 w-3.5" />
-                            <span className="text-xs">
-                              {webviewLoadError.startsWith("Load cancelled") ||
-                              webviewLoadError.startsWith("Load timed out") ||
-                              webviewLoadError.startsWith("Connection to")
-                                ? "Retry"
-                                : "Hard Restart"}
-                            </span>
+                            <ExternalLink className="h-3.5 w-3.5" />
+                            <span className="text-xs">Open external</span>
                           </Button>
-                          {currentUrl && (
-                            <Button
-                              onClick={handleOpenExternal}
-                              variant="ghost"
-                              size="sm"
-                              className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
-                            >
-                              <ExternalLink className="h-3.5 w-3.5" />
-                              <span className="text-xs">Open external</span>
-                            </Button>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                    {blockedNav && (
-                      <BlockedNavBanner
-                        blockedNav={blockedNav}
-                        panelId={id}
-                        webviewElement={webviewElement}
-                        onDismiss={() => setBlockedNav(null)}
-                      />
-                    )}
-                    {isLoading && (
-                      <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
-                        <Spinner size="2xl" className="text-status-info" />
-                        {isSlowLoad && (
-                          <>
-                            <p className="text-xs text-daintree-text/50">
-                              Taking longer than usual...
-                            </p>
-                            <Button
-                              onClick={handleCancelLoad}
-                              variant="ghost"
-                              size="sm"
-                              className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
-                            >
-                              <Square className="h-3.5 w-3.5" />
-                              <span className="text-xs">Cancel</span>
-                            </Button>
-                          </>
                         )}
                       </div>
-                    )}
-                    {showRecoverySpinner && !webviewLoadError && (
-                      <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
-                        <Spinner size="2xl" className="text-status-info" />
-                        <p className="text-xs text-daintree-text/50">Rehydrating preview...</p>
-                      </div>
-                    )}
-                    {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
-                    {findInPage.isOpen && <FindBar find={findInPage} />}
+                    </div>
+                  )}
+                  {blockedNav && (
+                    <BlockedNavBanner
+                      blockedNav={blockedNav}
+                      panelId={id}
+                      webviewElement={webviewElement}
+                      onDismiss={() => setBlockedNav(null)}
+                    />
+                  )}
+                  {isLoading && (
+                    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
+                      <Spinner size="2xl" className="text-status-info" />
+                      {isSlowLoad && (
+                        <>
+                          <p className="text-xs text-daintree-text/50">
+                            Taking longer than usual...
+                          </p>
+                          <Button
+                            onClick={handleCancelLoad}
+                            variant="ghost"
+                            size="sm"
+                            className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+                          >
+                            <Square className="h-3.5 w-3.5" />
+                            <span className="text-xs">Cancel</span>
+                          </Button>
+                        </>
+                      )}
+                    </div>
+                  )}
+                  {showRecoverySpinner && !webviewLoadError && (
+                    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
+                      <Spinner size="2xl" className="text-status-info" />
+                      <p className="text-xs text-daintree-text/50">Rehydrating preview...</p>
+                    </div>
+                  )}
+                  {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
+                  {findInPage.isOpen && <FindBar find={findInPage} />}
+                  {/* Only the webview is scaled by zoom-to-fit; overlays above
+                        stay at full size relative to the outer container so
+                        their action buttons remain readable and clickable. */}
+                  <div
+                    className={
+                      viewportPreset && viewportFit
+                        ? "absolute top-0 left-0 origin-top-left"
+                        : "w-full h-full"
+                    }
+                    style={
+                      viewportPreset && viewportFit && effectiveViewport
+                        ? {
+                            width: effectiveViewport.width,
+                            height: effectiveViewport.height,
+                            transform: `scale(${fitScale})`,
+                          }
+                        : undefined
+                    }
+                  >
                     <webview
                       ref={setWebviewNode}
                       src={currentUrl}
@@ -1299,9 +1305,9 @@ export function DevPreviewPane({
                         isDragging && "invisible pointer-events-none"
                       )}
                     />
-                    <WebviewDialog dialog={currentDialog} onRespond={handleDialogRespond} />
-                  </>
-                </div>
+                  </div>
+                  <WebviewDialog dialog={currentDialog} onRespond={handleDialogRespond} />
+                </>
               </div>
             </div>
           )}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -44,7 +44,11 @@ import { WebviewDialog } from "../Browser/WebviewDialog";
 import { FindBar } from "../Browser/FindBar";
 import { useFindInPage } from "@/hooks/useFindInPage";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
-import { getViewportPreset } from "@/panels/dev-preview/viewportPresets";
+import {
+  getViewportPreset,
+  getEffectiveViewportSize,
+  computeFitScale,
+} from "@/panels/dev-preview/viewportPresets";
 import type { ViewportPresetId } from "@shared/types/panel";
 import { logError } from "@/utils/logger";
 import { loadWebviewUrl } from "./loadWebviewUrl";
@@ -297,6 +301,9 @@ export function DevPreviewPane({
   const setBrowserZoom = usePanelStore((state) => state.setBrowserZoom);
   const setDevPreviewConsoleOpen = usePanelStore((state) => state.setDevPreviewConsoleOpen);
   const setViewportPreset = usePanelStore((state) => state.setViewportPreset);
+  const setViewportRotated = usePanelStore((state) => state.setViewportRotated);
+  const setViewportDpr = usePanelStore((state) => state.setViewportDpr);
+  const setViewportFit = usePanelStore((state) => state.setViewportFit);
   const setDevPreviewScrollPosition = usePanelStore((state) => state.setDevPreviewScrollPosition);
   const currentProjectId = useProjectStore((state) => state.currentProject?.id);
   const projectSettings = useProjectSettingsStore((state) => state.settings);
@@ -307,6 +314,12 @@ export function DevPreviewPane({
   const devCommand =
     terminal?.devCommand?.trim() || projectSettings?.devServerCommand?.trim() || "";
   const viewportPreset = terminal?.viewportPreset;
+  const viewportRotated = terminal?.viewportRotated ?? false;
+  const viewportDpr = terminal?.viewportDpr ?? 1;
+  const viewportFit = terminal?.viewportFit ?? false;
+  const effectiveViewport = viewportPreset
+    ? getEffectiveViewportSize(viewportPreset, viewportRotated)
+    : null;
 
   const { status, url, terminalId, error, start, restart, isRestarting, stuckTier } = useDevServer({
     panelId: id,
@@ -763,6 +776,55 @@ export function DevPreviewPane({
     [id, setViewportPreset]
   );
 
+  const handleViewportRotateToggle = useCallback(() => {
+    setViewportRotated(id, !viewportRotated);
+  }, [id, setViewportRotated, viewportRotated]);
+
+  const handleViewportDprChange = useCallback(
+    (dpr: 1 | 2 | 3) => {
+      setViewportDpr(id, dpr);
+      // TODO(#8278): once the enableDeviceEmulation IPC bridge lands, apply the
+      // deviceScaleFactor to the live webview here. Until then this only
+      // persists the preference so the toolbar shape is stable when #8278 ships.
+    },
+    [id, setViewportDpr]
+  );
+
+  const handleViewportFitToggle = useCallback(() => {
+    setViewportFit(id, !viewportFit);
+  }, [id, setViewportFit, viewportFit]);
+
+  // Measure the available preview area so zoom-to-fit can scale the device
+  // frame down to fit both pane dimensions. A static scale would break on
+  // pane resize, so this tracks the container via ResizeObserver.
+  const fitContainerRef = useRef<HTMLDivElement>(null);
+  const [fitContainerSize, setFitContainerSize] = useState<{ w: number; h: number }>({
+    w: 0,
+    h: 0,
+  });
+  useEffect(() => {
+    if (!viewportFit || !viewportPreset) return;
+    const el = fitContainerRef.current;
+    if (!el) return;
+    const measure = () => {
+      setFitContainerSize({ w: el.clientWidth, h: el.clientHeight });
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [viewportFit, viewportPreset]);
+
+  const fitScale =
+    viewportFit && effectiveViewport
+      ? computeFitScale(
+          fitContainerSize.w,
+          fitContainerSize.h,
+          effectiveViewport.width,
+          effectiveViewport.height
+        )
+      : 1;
+
   useEffect(() => {
     if (isWebviewReady && currentUrl && currentUrl !== lastSetUrlRef.current) {
       lastSetUrlRef.current = currentUrl;
@@ -937,6 +999,9 @@ export function DevPreviewPane({
           isWebviewReady={isWebviewReady}
           isConsoleOpen={isConsoleOpen}
           viewportPreset={viewportPreset}
+          viewportRotated={viewportRotated}
+          viewportDpr={viewportDpr}
+          viewportFit={viewportFit}
           onNavigate={handleNavigate}
           onBack={handleBack}
           onForward={handleForward}
@@ -948,6 +1013,9 @@ export function DevPreviewPane({
           onToggleDevTools={handleToggleDevTools}
           onToggleConsole={handleToggleConsole}
           onViewportPresetChange={handleViewportPresetChange}
+          onViewportRotateToggle={handleViewportRotateToggle}
+          onViewportDprChange={handleViewportDprChange}
+          onViewportFitToggle={handleViewportFitToggle}
         />
 
         {stuckTier >= 2 && (
@@ -960,11 +1028,17 @@ export function DevPreviewPane({
           />
         )}
 
-        <div className="relative flex-1 min-h-0 bg-surface-canvas overflow-auto">
-          {viewportPreset && (
+        <div
+          className={cn(
+            "relative flex-1 min-h-0 bg-surface-canvas",
+            viewportPreset && viewportFit ? "overflow-hidden" : "overflow-auto"
+          )}
+        >
+          {viewportPreset && effectiveViewport && (
             <div className="absolute top-1 left-1/2 -translate-x-1/2 z-10 px-1.5 py-0.5 rounded text-[10px] font-medium bg-surface/90 text-daintree-text/60 border border-overlay/50">
-              {getViewportPreset(viewportPreset).label} · {getViewportPreset(viewportPreset).width}×
-              {getViewportPreset(viewportPreset).height}
+              {getViewportPreset(viewportPreset).label} · {effectiveViewport.width}×
+              {effectiveViewport.height}
+              {viewportFit && fitScale < 1 && ` · ${Math.round(fitScale * 100)}%`}
             </div>
           )}
           {isRestarting || status === "starting" || status === "installing" ? (
@@ -1078,7 +1152,16 @@ export function DevPreviewPane({
               </p>
             </div>
           ) : (
-            <div className={cn("h-full", viewportPreset && "flex items-start justify-center pt-5")}>
+            <div
+              ref={fitContainerRef}
+              className={cn(
+                "h-full",
+                viewportPreset &&
+                  (viewportFit
+                    ? "flex items-center justify-center"
+                    : "flex items-start justify-center pt-5")
+              )}
+            >
               <div
                 className={cn(
                   "relative",
@@ -1087,116 +1170,138 @@ export function DevPreviewPane({
                     : "h-full"
                 )}
                 style={
-                  viewportPreset
-                    ? {
-                        maxWidth: getViewportPreset(viewportPreset).width,
-                        width: "100%",
-                        aspectRatio: `${getViewportPreset(viewportPreset).width} / ${getViewportPreset(viewportPreset).height}`,
-                      }
+                  viewportPreset && effectiveViewport
+                    ? viewportFit
+                      ? {
+                          width: effectiveViewport.width * fitScale,
+                          height: effectiveViewport.height * fitScale,
+                        }
+                      : {
+                          maxWidth: effectiveViewport.width,
+                          width: "100%",
+                          aspectRatio: `${effectiveViewport.width} / ${effectiveViewport.height}`,
+                        }
                     : undefined
                 }
               >
-                <>
-                  {webviewLoadError && (
-                    <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
-                      <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
-                      <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                        {webviewLoadError.startsWith("Load timed out") ||
-                        webviewLoadError.startsWith("Connection to")
-                          ? "Page Load Timed Out"
-                          : webviewLoadError.startsWith("Load cancelled")
-                            ? "Load Cancelled"
-                            : "Dev Server Unreachable"}
-                      </h3>
-                      <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
-                        {webviewLoadError}
-                      </p>
-                      <div className="flex items-center gap-1">
-                        <Button
-                          onClick={
-                            webviewLoadError.startsWith("Load cancelled") ||
-                            webviewLoadError.startsWith("Load timed out") ||
-                            webviewLoadError.startsWith("Connection to")
-                              ? handleRetryWebviewLoad
-                              : handleHardRestart
-                          }
-                          variant="ghost"
-                          size="sm"
-                          className="gap-1.5 px-2.5 py-1.5 group"
-                        >
-                          <RotateCw className="h-3.5 w-3.5" />
-                          <span className="text-xs">
-                            {webviewLoadError.startsWith("Load cancelled") ||
-                            webviewLoadError.startsWith("Load timed out") ||
-                            webviewLoadError.startsWith("Connection to")
-                              ? "Retry"
-                              : "Hard Restart"}
-                          </span>
-                        </Button>
-                        {currentUrl && (
+                <div
+                  className={
+                    viewportPreset && viewportFit
+                      ? "absolute top-0 left-0 origin-top-left"
+                      : "w-full h-full"
+                  }
+                  style={
+                    viewportPreset && viewportFit && effectiveViewport
+                      ? {
+                          width: effectiveViewport.width,
+                          height: effectiveViewport.height,
+                          transform: `scale(${fitScale})`,
+                        }
+                      : undefined
+                  }
+                >
+                  <>
+                    {webviewLoadError && (
+                      <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
+                        <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
+                        <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
+                          {webviewLoadError.startsWith("Load timed out") ||
+                          webviewLoadError.startsWith("Connection to")
+                            ? "Page Load Timed Out"
+                            : webviewLoadError.startsWith("Load cancelled")
+                              ? "Load Cancelled"
+                              : "Dev Server Unreachable"}
+                        </h3>
+                        <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
+                          {webviewLoadError}
+                        </p>
+                        <div className="flex items-center gap-1">
                           <Button
-                            onClick={handleOpenExternal}
+                            onClick={
+                              webviewLoadError.startsWith("Load cancelled") ||
+                              webviewLoadError.startsWith("Load timed out") ||
+                              webviewLoadError.startsWith("Connection to")
+                                ? handleRetryWebviewLoad
+                                : handleHardRestart
+                            }
                             variant="ghost"
                             size="sm"
-                            className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+                            className="gap-1.5 px-2.5 py-1.5 group"
                           >
-                            <ExternalLink className="h-3.5 w-3.5" />
-                            <span className="text-xs">Open external</span>
+                            <RotateCw className="h-3.5 w-3.5" />
+                            <span className="text-xs">
+                              {webviewLoadError.startsWith("Load cancelled") ||
+                              webviewLoadError.startsWith("Load timed out") ||
+                              webviewLoadError.startsWith("Connection to")
+                                ? "Retry"
+                                : "Hard Restart"}
+                            </span>
                           </Button>
+                          {currentUrl && (
+                            <Button
+                              onClick={handleOpenExternal}
+                              variant="ghost"
+                              size="sm"
+                              className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+                            >
+                              <ExternalLink className="h-3.5 w-3.5" />
+                              <span className="text-xs">Open external</span>
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                    {blockedNav && (
+                      <BlockedNavBanner
+                        blockedNav={blockedNav}
+                        panelId={id}
+                        webviewElement={webviewElement}
+                        onDismiss={() => setBlockedNav(null)}
+                      />
+                    )}
+                    {isLoading && (
+                      <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
+                        <Spinner size="2xl" className="text-status-info" />
+                        {isSlowLoad && (
+                          <>
+                            <p className="text-xs text-daintree-text/50">
+                              Taking longer than usual...
+                            </p>
+                            <Button
+                              onClick={handleCancelLoad}
+                              variant="ghost"
+                              size="sm"
+                              className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+                            >
+                              <Square className="h-3.5 w-3.5" />
+                              <span className="text-xs">Cancel</span>
+                            </Button>
+                          </>
                         )}
                       </div>
-                    </div>
-                  )}
-                  {blockedNav && (
-                    <BlockedNavBanner
-                      blockedNav={blockedNav}
-                      panelId={id}
-                      webviewElement={webviewElement}
-                      onDismiss={() => setBlockedNav(null)}
-                    />
-                  )}
-                  {isLoading && (
-                    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
-                      <Spinner size="2xl" className="text-status-info" />
-                      {isSlowLoad && (
-                        <>
-                          <p className="text-xs text-daintree-text/50">
-                            Taking longer than usual...
-                          </p>
-                          <Button
-                            onClick={handleCancelLoad}
-                            variant="ghost"
-                            size="sm"
-                            className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
-                          >
-                            <Square className="h-3.5 w-3.5" />
-                            <span className="text-xs">Cancel</span>
-                          </Button>
-                        </>
-                      )}
-                    </div>
-                  )}
-                  {showRecoverySpinner && !webviewLoadError && (
-                    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
-                      <Spinner size="2xl" className="text-status-info" />
-                      <p className="text-xs text-daintree-text/50">Rehydrating preview...</p>
-                    </div>
-                  )}
-                  {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
-                  {findInPage.isOpen && <FindBar find={findInPage} />}
-                  <webview
-                    ref={setWebviewNode}
-                    src={currentUrl}
-                    partition={webviewPartition}
-                    // @ts-expect-error React 19 requires "" to emit the attribute; boolean true is silently dropped
-                    allowpopups=""
-                    className={cn(
-                      "w-full h-full border-0",
-                      isDragging && "invisible pointer-events-none"
                     )}
-                  />
-                  <WebviewDialog dialog={currentDialog} onRespond={handleDialogRespond} />
-                </>
+                    {showRecoverySpinner && !webviewLoadError && (
+                      <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
+                        <Spinner size="2xl" className="text-status-info" />
+                        <p className="text-xs text-daintree-text/50">Rehydrating preview...</p>
+                      </div>
+                    )}
+                    {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
+                    {findInPage.isOpen && <FindBar find={findInPage} />}
+                    <webview
+                      ref={setWebviewNode}
+                      src={currentUrl}
+                      partition={webviewPartition}
+                      // @ts-expect-error React 19 requires "" to emit the attribute; boolean true is silently dropped
+                      allowpopups=""
+                      className={cn(
+                        "w-full h-full border-0",
+                        isDragging && "invisible pointer-events-none"
+                      )}
+                    />
+                    <WebviewDialog dialog={currentDialog} onRespond={handleDialogRespond} />
+                  </>
+                </div>
               </div>
             </div>
           )}

--- a/src/config/__tests__/panelKindSerialisers.test.ts
+++ b/src/config/__tests__/panelKindSerialisers.test.ts
@@ -46,6 +46,11 @@ describe("panelKindSerialisers", () => {
         devPreviewConsoleOpen: true,
         createdAt: 100,
         browserHistory: undefined,
+        viewportPreset: undefined,
+        viewportRotated: false,
+        viewportDpr: 1,
+        viewportFit: false,
+        devPreviewScrollPosition: undefined,
       });
     });
 
@@ -59,6 +64,36 @@ describe("panelKindSerialisers", () => {
       const deserialize = getDeserializer("dev-preview");
       const result = deserialize!({ id: "d1" });
       expect(result.devCommand).toBeUndefined();
+    });
+
+    it("keeps a known viewportPreset and round-trips emulation fields", () => {
+      const deserialize = getDeserializer("dev-preview");
+      const result = deserialize!({
+        id: "d1",
+        viewportPreset: "ipad",
+        viewportRotated: true,
+        viewportDpr: 2,
+        viewportFit: true,
+      });
+      expect(result.viewportPreset).toBe("ipad");
+      expect(result.viewportRotated).toBe(true);
+      expect(result.viewportDpr).toBe(2);
+      expect(result.viewportFit).toBe(true);
+    });
+
+    it("drops a stale/unknown viewportPreset id instead of resurrecting it", () => {
+      const deserialize = getDeserializer("dev-preview");
+      const result = deserialize!({ id: "d1", viewportPreset: "nokia" });
+      expect(result.viewportPreset).toBeUndefined();
+    });
+
+    it("clamps an out-of-range persisted viewportDpr to 1", () => {
+      const deserialize = getDeserializer("dev-preview");
+      const result = deserialize!({
+        id: "d1",
+        viewportDpr: 5 as unknown as 1 | 2 | 3,
+      });
+      expect(result.viewportDpr).toBe(1);
     });
   });
 

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -1,7 +1,13 @@
 import type { PanelKind, ViewportPresetId } from "@/types";
 import type { AddTerminalArgs, SavedTerminalData } from "@/utils/stateHydration/statePatcher";
+import { VIEWPORT_PRESETS } from "@/panels/dev-preview/viewportPresets";
 
 type PanelKindDeserializer = (saved: SavedTerminalData) => Partial<AddTerminalArgs>;
+
+/** Coerce a persisted viewport-preset string to a known id, dropping stale values. */
+function sanitizeViewportPreset(value: string | undefined): ViewportPresetId | undefined {
+  return value !== undefined && value in VIEWPORT_PRESETS ? (value as ViewportPresetId) : undefined;
+}
 
 const DESERIALIZERS: Record<string, PanelKindDeserializer> = {
   browser: (saved) => ({
@@ -20,7 +26,7 @@ const DESERIALIZERS: Record<string, PanelKindDeserializer> = {
       browserHistory: saved.browserHistory,
       browserZoom: saved.browserZoom,
       devPreviewConsoleOpen: saved.devPreviewConsoleOpen,
-      viewportPreset: saved.viewportPreset as ViewportPresetId | undefined,
+      viewportPreset: sanitizeViewportPreset(saved.viewportPreset),
       viewportRotated: saved.viewportRotated === true,
       viewportDpr: saved.viewportDpr === 2 || saved.viewportDpr === 3 ? saved.viewportDpr : 1,
       viewportFit: saved.viewportFit === true,

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -21,6 +21,9 @@ const DESERIALIZERS: Record<string, PanelKindDeserializer> = {
       browserZoom: saved.browserZoom,
       devPreviewConsoleOpen: saved.devPreviewConsoleOpen,
       viewportPreset: saved.viewportPreset as ViewportPresetId | undefined,
+      viewportRotated: saved.viewportRotated === true,
+      viewportDpr: saved.viewportDpr === 2 || saved.viewportDpr === 3 ? saved.viewportDpr : 1,
+      viewportFit: saved.viewportFit === true,
       devPreviewScrollPosition: saved.devPreviewScrollPosition,
       createdAt: saved.createdAt,
     };

--- a/src/panels/dev-preview/__tests__/serializer.test.ts
+++ b/src/panels/dev-preview/__tests__/serializer.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import type { DevPreviewPanelData } from "@shared/types/panel";
+
+import { serializeDevPreview } from "../serializer";
+
+function basePanel(overrides: Partial<DevPreviewPanelData> = {}): DevPreviewPanelData {
+  return {
+    id: "dp-1",
+    kind: "dev-preview",
+    title: "Dev Preview",
+    location: "grid",
+    cwd: "/tmp/project",
+    ...overrides,
+  } as DevPreviewPanelData;
+}
+
+describe("serializeDevPreview", () => {
+  it("omits viewport emulation fields when unset", () => {
+    const snapshot = serializeDevPreview(basePanel());
+    expect(snapshot).not.toHaveProperty("viewportRotated");
+    expect(snapshot).not.toHaveProperty("viewportDpr");
+    expect(snapshot).not.toHaveProperty("viewportFit");
+  });
+
+  it("round-trips rotation, dpr, and fit when set", () => {
+    const snapshot = serializeDevPreview(
+      basePanel({
+        viewportPreset: "ipad",
+        viewportRotated: true,
+        viewportDpr: 2,
+        viewportFit: true,
+      })
+    );
+    expect(snapshot).toMatchObject({
+      viewportPreset: "ipad",
+      viewportRotated: true,
+      viewportDpr: 2,
+      viewportFit: true,
+    });
+  });
+
+  it("persists explicit falsey defaults so a restored panel is not ambiguous", () => {
+    const snapshot = serializeDevPreview(
+      basePanel({ viewportRotated: false, viewportDpr: 1, viewportFit: false })
+    );
+    expect(snapshot.viewportRotated).toBe(false);
+    expect(snapshot.viewportDpr).toBe(1);
+    expect(snapshot.viewportFit).toBe(false);
+  });
+});

--- a/src/panels/dev-preview/__tests__/viewportPresets.test.ts
+++ b/src/panels/dev-preview/__tests__/viewportPresets.test.ts
@@ -89,6 +89,11 @@ describe("computeFitScale", () => {
     expect(computeFitScale(900, 800, 820, 1180)).toBeCloseTo(800 / 1180, 5);
   });
 
+  it("scales a wide viewport down when width is the constraint", () => {
+    // iPad landscape 1180×820 in a narrow 300×1200 pane — width is the constraint
+    expect(computeFitScale(300, 1200, 1180, 820)).toBeCloseTo(300 / 1180, 5);
+  });
+
   it("never upscales a small viewport (caps at 1)", () => {
     // Galaxy 360×780 in a huge 1920×1200 pane stays device-accurate
     expect(computeFitScale(1920, 1200, 360, 780)).toBe(1);

--- a/src/panels/dev-preview/__tests__/viewportPresets.test.ts
+++ b/src/panels/dev-preview/__tests__/viewportPresets.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import type { ViewportPresetId } from "@shared/types/panel";
 
-import { VIEWPORT_PRESET_LIST, VIEWPORT_PRESETS, getViewportPreset } from "../viewportPresets";
+import {
+  VIEWPORT_PRESET_LIST,
+  VIEWPORT_PRESETS,
+  getViewportPreset,
+  getEffectiveViewportSize,
+  computeFitScale,
+} from "../viewportPresets";
 
 describe("VIEWPORT_PRESETS", () => {
   it("renders smallest-to-largest in the chip row order", () => {
@@ -63,5 +69,32 @@ describe("getViewportPreset", () => {
   it("falls back to iphone when given a stale persisted id", () => {
     const stale = "nokia" as unknown as ViewportPresetId;
     expect(getViewportPreset(stale)).toBe(VIEWPORT_PRESETS.iphone);
+  });
+});
+
+describe("getEffectiveViewportSize", () => {
+  it("returns preset dimensions when not rotated", () => {
+    expect(getEffectiveViewportSize("ipad", false)).toEqual({ width: 820, height: 1180 });
+  });
+
+  it("swaps width and height when rotated to landscape", () => {
+    expect(getEffectiveViewportSize("ipad", true)).toEqual({ width: 1180, height: 820 });
+    expect(getEffectiveViewportSize("galaxy", true)).toEqual({ width: 780, height: 360 });
+  });
+});
+
+describe("computeFitScale", () => {
+  it("scales a tall viewport down to fit the limiting dimension", () => {
+    // iPad portrait 820×1180 in a 900×800 pane — height is the constraint
+    expect(computeFitScale(900, 800, 820, 1180)).toBeCloseTo(800 / 1180, 5);
+  });
+
+  it("never upscales a small viewport (caps at 1)", () => {
+    // Galaxy 360×780 in a huge 1920×1200 pane stays device-accurate
+    expect(computeFitScale(1920, 1200, 360, 780)).toBe(1);
+  });
+
+  it("returns 1 when the container has not been measured yet", () => {
+    expect(computeFitScale(0, 0, 820, 1180)).toBe(1);
   });
 });

--- a/src/panels/dev-preview/defaults.ts
+++ b/src/panels/dev-preview/defaults.ts
@@ -17,6 +17,9 @@ export function createDevPreviewDefaults(
     devPreviewConsoleOpen: options.devPreviewConsoleOpen,
     exitBehavior: options.exitBehavior,
     viewportPreset: options.viewportPreset,
+    viewportRotated: options.viewportRotated ?? false,
+    viewportDpr: options.viewportDpr ?? 1,
+    viewportFit: options.viewportFit ?? false,
     devPreviewScrollPosition: options.devPreviewScrollPosition,
   };
 }

--- a/src/panels/dev-preview/serializer.ts
+++ b/src/panels/dev-preview/serializer.ts
@@ -20,6 +20,9 @@ export function serializeDevPreview(t: DevPreviewSerializeInput): Partial<PanelS
       devPreviewConsoleOpen: t.devPreviewConsoleOpen,
     }),
     ...(t.viewportPreset !== undefined && { viewportPreset: t.viewportPreset }),
+    ...(t.viewportRotated !== undefined && { viewportRotated: t.viewportRotated }),
+    ...(t.viewportDpr !== undefined && { viewportDpr: t.viewportDpr }),
+    ...(t.viewportFit !== undefined && { viewportFit: t.viewportFit }),
     ...(t.devPreviewScrollPosition !== undefined && {
       devPreviewScrollPosition: t.devPreviewScrollPosition,
     }),

--- a/src/panels/dev-preview/viewportPresets.ts
+++ b/src/panels/dev-preview/viewportPresets.ts
@@ -48,3 +48,35 @@ export const VIEWPORT_PRESET_LIST: ViewportPreset[] = Object.values(VIEWPORT_PRE
 export function getViewportPreset(id: ViewportPresetId): ViewportPreset {
   return VIEWPORT_PRESETS[id] ?? VIEWPORT_PRESETS.iphone;
 }
+
+/**
+ * Effective viewport dimensions for a preset, with width/height swapped when
+ * the preset is rotated to landscape.
+ */
+export function getEffectiveViewportSize(
+  id: ViewportPresetId,
+  rotated: boolean
+): { width: number; height: number } {
+  const preset = getViewportPreset(id);
+  return rotated
+    ? { width: preset.height, height: preset.width }
+    : { width: preset.width, height: preset.height };
+}
+
+/**
+ * Scale factor that fits a viewport of `viewportW`×`viewportH` into a container
+ * of `containerW`×`containerH`. Never upscales (capped at 1) so small mobile
+ * viewports stay device-accurate instead of filling large panes. Returns 1 when
+ * the container has not been measured yet.
+ */
+export function computeFitScale(
+  containerW: number,
+  containerH: number,
+  viewportW: number,
+  viewportH: number
+): number {
+  if (containerW <= 0 || containerH <= 0 || viewportW <= 0 || viewportH <= 0) {
+    return 1;
+  }
+  return Math.min(containerW / viewportW, containerH / viewportH, 1);
+}

--- a/src/store/slices/panelRegistry/browser.ts
+++ b/src/store/slices/panelRegistry/browser.ts
@@ -23,6 +23,9 @@ export const createBrowserActions = (
   | "setBrowserConsoleOpen"
   | "setDevPreviewConsoleOpen"
   | "setViewportPreset"
+  | "setViewportRotated"
+  | "setViewportDpr"
+  | "setViewportFit"
   | "setDevPreviewScrollPosition"
   | "setDevServerState"
   | "setSpawnError"
@@ -111,6 +114,54 @@ export const createBrowserActions = (
       const newById = {
         ...state.panelsById,
         [id]: { ...terminal, viewportPreset: preset },
+      };
+      saveNormalized(newById, state.panelIds);
+      return { panelsById: newById };
+    });
+  },
+
+  setViewportRotated: (id, rotated) => {
+    set((state) => {
+      const terminal = state.panelsById[id];
+      if (!terminal) return state;
+      if (terminal.kind !== "dev-preview") return state;
+      if ((terminal.viewportRotated ?? false) === rotated) return state;
+
+      const newById = {
+        ...state.panelsById,
+        [id]: { ...terminal, viewportRotated: rotated },
+      };
+      saveNormalized(newById, state.panelIds);
+      return { panelsById: newById };
+    });
+  },
+
+  setViewportDpr: (id, dpr) => {
+    set((state) => {
+      const terminal = state.panelsById[id];
+      if (!terminal) return state;
+      if (terminal.kind !== "dev-preview") return state;
+      if ((terminal.viewportDpr ?? 1) === dpr) return state;
+
+      const newById = {
+        ...state.panelsById,
+        [id]: { ...terminal, viewportDpr: dpr },
+      };
+      saveNormalized(newById, state.panelIds);
+      return { panelsById: newById };
+    });
+  },
+
+  setViewportFit: (id, fit) => {
+    set((state) => {
+      const terminal = state.panelsById[id];
+      if (!terminal) return state;
+      if (terminal.kind !== "dev-preview") return state;
+      if ((terminal.viewportFit ?? false) === fit) return state;
+
+      const newById = {
+        ...state.panelsById,
+        [id]: { ...terminal, viewportFit: fit },
       };
       saveNormalized(newById, state.panelIds);
       return { panelsById: newById };

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -167,6 +167,9 @@ export interface PanelRegistrySlice {
     id: string,
     preset: import("@shared/types/panel.js").ViewportPresetId | undefined
   ) => void;
+  setViewportRotated: (id: string, rotated: boolean) => void;
+  setViewportDpr: (id: string, dpr: 1 | 2 | 3) => void;
+  setViewportFit: (id: string, fit: boolean) => void;
   setDevPreviewScrollPosition: (
     id: string,
     position: { url: string; scrollY: number } | undefined

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -37,6 +37,9 @@ export interface AddTerminalArgs extends AddPanelOptionsBase {
   devServerTerminalId?: string | null;
   devPreviewConsoleOpen?: boolean;
   viewportPreset?: string;
+  viewportRotated?: boolean;
+  viewportDpr?: 1 | 2 | 3;
+  viewportFit?: boolean;
   devPreviewScrollPosition?: { url: string; scrollY: number };
 }
 
@@ -62,6 +65,9 @@ export interface SavedTerminalData {
   devCommand?: string;
   devPreviewConsoleOpen?: boolean;
   viewportPreset?: string;
+  viewportRotated?: boolean;
+  viewportDpr?: 1 | 2 | 3;
+  viewportFit?: boolean;
   devPreviewScrollPosition?: { url: string; scrollY: number };
   exitBehavior?: PanelExitBehavior;
   agentSessionId?: string;


### PR DESCRIPTION
## Summary

- Adds three viewport controls to the Dev Preview toolbar: portrait/landscape rotation (swaps active preset width/height), a 1×/2×/3× DPR selector, and a zoom-to-fit toggle that scales large viewports down to fit the pane via CSS `transform: scale` with a `ResizeObserver`-driven refit (capped at 1, no upscaling)
- Converts the previously decorative canvas badge into a functional fit indicator showing effective/rotated dims and scale %
- New state (`viewportRotated`, `viewportDpr`, `viewportFit`) persists on `DevPreviewPanelData` and round-trips through the serializer with sanitization (stale preset ids dropped, DPR clamped)

Closes #8279 (partial — DPR visual effect tracked by #8278)

## Changes

- `DevPreviewPane.tsx` — rotation toggle, DPR chip group (APG roving-tabindex keyboard nav), zoom-to-fit toggle, `computeFitScale` helper, `getEffectiveViewportSize` helper, `ResizeObserver` refit loop, fit indicator badge
- `shared/types/panel.ts` — `viewportRotated`, `viewportDpr`, `viewportFit` on `DevPreviewPanelData`
- `src/panels/dev-preview/serializer.ts` + `defaults.ts` — round-trip + safe defaults
- `src/config/panelKindSerialisers.ts` — deserializer sanitization
- Toolbar controls follow chip-row density and `bg-overlay-emphasis` pressed state; no accent colour
- DPR persists as scaffolding with a `// TODO(#8278)` stub — `enableDeviceEmulation` isn't accessible from the Electron 41 sandbox, so the actual `deviceScaleFactor` wiring lands with #8278

## Testing

- `getEffectiveViewportSize` — rotation swap (portrait ↔ landscape)
- `computeFitScale` — limiting-dimension logic, cap-at-1, zero-guard
- Serializer round-trip for all three new fields
- Deserializer sanitization — stale preset id drop, DPR clamp
- Full `npm run check` passes; 23 662 unit tests green; build clean