### PR TITLE
feat(backend): add Procfile and mise.toml detectors, pre-launch port extraction

### DIFF
--- a/electron/services/DevPreviewCommandNormalizer.ts
+++ b/electron/services/DevPreviewCommandNormalizer.ts
@@ -19,11 +19,14 @@ export const PKG_SCRIPT_RE =
 // --turbopack to `next dev && echo done` attaches the flag to echo, not next.
 export const SHELL_CONTROL_RE = /[;&|#`]|<|>|\$\(/;
 
-export const PORT_FLAG_RE = /(?:--port(?:=|\s+)|-p\s+|PORT=)(["']?)(?:\$\{PORT:-)?(\d+)\}?\1/i;
+export const PORT_FLAG_RE =
+  /(?:--port(?:=|\s+)|-p\s+|\bPORT=)(["']?)(?:\$\{PORT:-)?(\d+)(?![.\w])\}?\1/i;
+
+export const PORT_FLAG_PRESENT_RE = /(?:--port(?:=|\s+)|-p\s+|\bPORT=)/i;
 
 export const FRAMEWORK_DEFAULT_PORTS: Array<[RegExp, number]> = [
   [/\bnext\s+dev\b/, 3000],
-  [/\bremix\b/, 3000],
+  [/\bremix\s+(?:dev|run|start|watch)\b/, 3000],
   [/\bvite\b/, 5173],
   [/\bsvelte-kit\s+dev\b/, 5173],
   [/\bastro\s+dev\b/, 4321],
@@ -60,6 +63,8 @@ export async function extractPort(command: string, cwd: string): Promise<number 
     if (port >= 1 && port <= 65535) return port;
     return null;
   }
+
+  if (PORT_FLAG_PRESENT_RE.test(resolved)) return null;
 
   for (const [re, defaultPort] of FRAMEWORK_DEFAULT_PORTS) {
     if (re.test(resolved)) return defaultPort;

--- a/electron/services/DevPreviewCommandNormalizer.ts
+++ b/electron/services/DevPreviewCommandNormalizer.ts
@@ -19,6 +19,55 @@ export const PKG_SCRIPT_RE =
 // --turbopack to `next dev && echo done` attaches the flag to echo, not next.
 export const SHELL_CONTROL_RE = /[;&|#`]|<|>|\$\(/;
 
+export const PORT_FLAG_RE = /(?:--port(?:=|\s+)|-p\s+|PORT=)(["']?)(?:\$\{PORT:-)?(\d+)\}?\1/i;
+
+export const FRAMEWORK_DEFAULT_PORTS: Array<[RegExp, number]> = [
+  [/\bnext\s+dev\b/, 3000],
+  [/\bremix\b/, 3000],
+  [/\bvite\b/, 5173],
+  [/\bsvelte-kit\s+dev\b/, 5173],
+  [/\bastro\s+dev\b/, 4321],
+  [/\brails\s+server\b/, 3000],
+  [/\bmanage\.py\s+runserver\b/, 8000],
+  [/\bmix\s+phx\.server\b/, 4000],
+  [/\bphp\s+artisan\s+serve\b/, 8000],
+];
+
+export async function extractPort(command: string, cwd: string): Promise<number | null> {
+  if (SHELL_CONTROL_RE.test(command)) return null;
+
+  let resolved = command;
+
+  const scriptMatch = PKG_SCRIPT_RE.exec(command);
+  if (scriptMatch) {
+    const scriptName = scriptMatch[1];
+    try {
+      const pkgRaw = await fs.readFile(path.join(cwd, "package.json"), "utf-8");
+      const pkg = JSON.parse(pkgRaw);
+      const scriptBody = pkg?.scripts?.[scriptName];
+      if (typeof scriptBody === "string") {
+        if (SHELL_CONTROL_RE.test(scriptBody)) return null;
+        resolved = scriptBody;
+      }
+    } catch {
+      // package.json missing or invalid — continue with original command
+    }
+  }
+
+  const flagMatch = PORT_FLAG_RE.exec(resolved);
+  if (flagMatch) {
+    const port = parseInt(flagMatch[2], 10);
+    if (port >= 1 && port <= 65535) return port;
+    return null;
+  }
+
+  for (const [re, defaultPort] of FRAMEWORK_DEFAULT_PORTS) {
+    if (re.test(resolved)) return defaultPort;
+  }
+
+  return null;
+}
+
 export function stripTurbopackFlag(command: string): string {
   return command
     .replace(/\s+--\s+--turbo(?:pack)?\b/, "") // " -- --turbopack" (pkg manager form)

--- a/electron/services/RunCommandDetector.ts
+++ b/electron/services/RunCommandDetector.ts
@@ -2,6 +2,7 @@ import path from "path";
 import fs from "fs/promises";
 import { existsSync } from "fs";
 import { load } from "js-yaml";
+import { parse as parseToml } from "smol-toml";
 import type { RunCommand } from "../types/index.js";
 import { Cache } from "../utils/cache.js";
 
@@ -40,6 +41,8 @@ export class RunCommandDetector {
       this.detectMakefile(projectPath),
       this.detectJustfile(projectPath),
       this.detectTaskfile(projectPath),
+      this.detectProcfile(projectPath),
+      this.detectMise(projectPath),
       this.detectDjango(projectPath),
       this.detectComposer(projectPath),
       this.detectDevContainer(projectPath),
@@ -242,6 +245,100 @@ export class RunCommandDetector {
       return commands;
     } catch (error) {
       console.warn(`[RunCommandDetector] Failed to parse ${taskfilePath}:`, error);
+      return [];
+    }
+  }
+
+  private async detectProcfile(root: string): Promise<RunCommand[]> {
+    const procfilePath = path.join(root, "Procfile");
+    if (!existsSync(procfilePath)) return [];
+
+    try {
+      const content = await fs.readFile(procfilePath, "utf-8");
+      const lines = content.split("\n");
+      const commands: RunCommand[] = [];
+      const seen = new Set<string>();
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+
+        const match = /^([A-Za-z0-9_-]+):\s*(.+)$/.exec(trimmed);
+        if (!match) continue;
+
+        const name = match[1];
+        const commandBody = match[2].trim();
+        if (!commandBody || seen.has(name)) continue;
+        if (!isSafeScriptName(name)) continue;
+
+        seen.add(name);
+        commands.push({
+          id: `procfile-${name}`,
+          name,
+          command: commandBody,
+          icon: "terminal",
+        });
+      }
+
+      return commands;
+    } catch (error) {
+      console.warn(`[RunCommandDetector] Failed to parse ${procfilePath}:`, error);
+      return [];
+    }
+  }
+
+  private async detectMise(root: string): Promise<RunCommand[]> {
+    const misePath = path.join(root, "mise.toml");
+    if (!existsSync(misePath)) return [];
+
+    try {
+      const content = await fs.readFile(misePath, "utf-8");
+      const doc = parseToml(content) as Record<string, unknown> | null;
+      if (!doc || typeof doc !== "object") return [];
+
+      const tasks = doc.tasks;
+      if (!tasks || typeof tasks !== "object" || Array.isArray(tasks)) return [];
+
+      const commands: RunCommand[] = [];
+
+      for (const [name, def] of Object.entries(tasks as Record<string, unknown>)) {
+        if (name.startsWith("_")) continue;
+        if (!isSafeScriptName(name)) continue;
+
+        if (typeof def === "string") {
+          commands.push({
+            id: `mise-${name}`,
+            name,
+            command: `mise run ${name}`,
+            icon: "terminal",
+            description: def,
+          });
+          continue;
+        }
+
+        if (typeof def !== "object" || def === null) continue;
+
+        const taskDef = def as Record<string, unknown>;
+        if (taskDef.hide === true) continue;
+
+        const run = taskDef.run;
+        if (!run) continue;
+        if (typeof run !== "string" && !Array.isArray(run)) continue;
+
+        const desc = typeof taskDef.description === "string" ? taskDef.description : undefined;
+
+        commands.push({
+          id: `mise-${name}`,
+          name,
+          command: `mise run ${name}`,
+          icon: "terminal",
+          description: desc,
+        });
+      }
+
+      return commands;
+    } catch (error) {
+      console.warn(`[RunCommandDetector] Failed to parse ${misePath}:`, error);
       return [];
     }
   }

--- a/electron/services/RunCommandDetector.ts
+++ b/electron/services/RunCommandDetector.ts
@@ -324,6 +324,11 @@ export class RunCommandDetector {
         const run = taskDef.run;
         if (!run) continue;
         if (typeof run !== "string" && !Array.isArray(run)) continue;
+        if (
+          Array.isArray(run) &&
+          (run.length === 0 || !run.every((v): v is string => typeof v === "string"))
+        )
+          continue;
 
         const desc = typeof taskDef.description === "string" ? taskDef.description : undefined;
 

--- a/electron/services/__tests__/RunCommandDetector.test.ts
+++ b/electron/services/__tests__/RunCommandDetector.test.ts
@@ -804,6 +804,32 @@ describe("RunCommandDetector", () => {
         }),
       ]);
     });
+
+    it("skips task with empty array run", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "mise.toml"),
+        ["[tasks.empty]", "run = []", "", "[tasks.build]", 'run = "npm run build"'].join("\n"),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const miseCommands = commands.filter((cmd) => cmd.id.startsWith("mise-"));
+
+      expect(miseCommands.map((cmd) => cmd.id)).toEqual(["mise-build"]);
+    });
+
+    it("skips task with non-string array run elements", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "mise.toml"),
+        ["[tasks.bad]", "run = [1, 2]", "", "[tasks.build]", 'run = "npm run build"'].join("\n"),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const miseCommands = commands.filter((cmd) => cmd.id.startsWith("mise-"));
+
+      expect(miseCommands.map((cmd) => cmd.id)).toEqual(["mise-build"]);
+    });
   });
 
   describe("devcontainer detection", () => {

--- a/electron/services/__tests__/RunCommandDetector.test.ts
+++ b/electron/services/__tests__/RunCommandDetector.test.ts
@@ -533,6 +533,279 @@ describe("RunCommandDetector", () => {
     });
   });
 
+  describe("Procfile detection", () => {
+    it("detects web process", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "Procfile"),
+        "web: npm run dev\nworker: npm run worker\n",
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const procCommands = commands.filter((cmd) => cmd.id.startsWith("procfile-"));
+
+      expect(procCommands).toEqual([
+        expect.objectContaining({
+          id: "procfile-web",
+          name: "web",
+          command: "npm run dev",
+          icon: "terminal",
+        }),
+        expect.objectContaining({
+          id: "procfile-worker",
+          name: "worker",
+          command: "npm run worker",
+          icon: "terminal",
+        }),
+      ]);
+    });
+
+    it("skips comment lines", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "Procfile"),
+        "# This is a comment\nweb: npm run dev\n# Another comment\n",
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const procCommands = commands.filter((cmd) => cmd.id.startsWith("procfile-"));
+
+      expect(procCommands.map((cmd) => cmd.id)).toEqual(["procfile-web"]);
+    });
+
+    it("skips blank lines", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "Procfile"),
+        "\n\nweb: npm run dev\n\nrelease: npm run migrate\n",
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const procCommands = commands.filter((cmd) => cmd.id.startsWith("procfile-"));
+
+      expect(procCommands.map((cmd) => cmd.id)).toEqual(["procfile-web", "procfile-release"]);
+    });
+
+    it("deduplicates duplicate process names", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "Procfile"),
+        "web: npm run dev\nweb: npm run start\n",
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const procCommands = commands.filter((cmd) => cmd.id.startsWith("procfile-"));
+
+      expect(procCommands).toHaveLength(1);
+      expect(procCommands[0]?.command).toBe("npm run dev");
+    });
+
+    it("skips lines without colon separator", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "Procfile"),
+        "web: npm run dev\ninvalid line\nworker: npm run worker\n",
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const procCommands = commands.filter((cmd) => cmd.id.startsWith("procfile-"));
+
+      expect(procCommands.map((cmd) => cmd.id)).toEqual(["procfile-web", "procfile-worker"]);
+    });
+
+    it("skips empty command body", async () => {
+      await fs.writeFile(path.join(tempDir, "Procfile"), "web:\nworker: npm run worker\n", "utf-8");
+
+      const commands = await detector.detect(tempDir);
+      const procCommands = commands.filter((cmd) => cmd.id.startsWith("procfile-"));
+
+      expect(procCommands.map((cmd) => cmd.id)).toEqual(["procfile-worker"]);
+    });
+
+    it("returns empty when no Procfile exists", async () => {
+      const commands = await detector.detect(tempDir);
+      const procCommands = commands.filter((cmd) => cmd.id.startsWith("procfile-"));
+      expect(procCommands).toEqual([]);
+    });
+  });
+
+  describe("mise.toml detection", () => {
+    it("detects tasks with string run", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "mise.toml"),
+        [
+          "[tasks.build]",
+          'run = "npm run build"',
+          'description = "Build the project"',
+          "",
+          "[tasks.test]",
+          'run = "npm test"',
+        ].join("\n"),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const miseCommands = commands.filter((cmd) => cmd.id.startsWith("mise-"));
+
+      expect(miseCommands).toEqual([
+        expect.objectContaining({
+          id: "mise-build",
+          name: "build",
+          command: "mise run build",
+          description: "Build the project",
+        }),
+        expect.objectContaining({
+          id: "mise-test",
+          name: "test",
+          command: "mise run test",
+        }),
+      ]);
+    });
+
+    it("detects task with array run", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "mise.toml"),
+        [
+          "[tasks.dev]",
+          'run = ["npm run dev", "npm run css"]',
+          'description = "Start dev servers"',
+        ].join("\n"),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const miseCommands = commands.filter((cmd) => cmd.id.startsWith("mise-"));
+
+      expect(miseCommands).toEqual([
+        expect.objectContaining({
+          id: "mise-dev",
+          command: "mise run dev",
+          description: "Start dev servers",
+        }),
+      ]);
+    });
+
+    it("detects string shorthand task", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "mise.toml"),
+        'tasks.build = "npm run build"\n',
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const miseCommands = commands.filter((cmd) => cmd.id.startsWith("mise-"));
+
+      expect(miseCommands).toEqual([
+        expect.objectContaining({
+          id: "mise-build",
+          command: "mise run build",
+          description: "npm run build",
+        }),
+      ]);
+    });
+
+    it("skips hidden tasks", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "mise.toml"),
+        [
+          "[tasks.setup]",
+          'run = "npm install"',
+          "hide = true",
+          "",
+          "[tasks.build]",
+          'run = "npm run build"',
+        ].join("\n"),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const miseCommands = commands.filter((cmd) => cmd.id.startsWith("mise-"));
+
+      expect(miseCommands.map((cmd) => cmd.id)).toEqual(["mise-build"]);
+    });
+
+    it("skips _-prefixed tasks", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "mise.toml"),
+        [
+          "[tasks._internal]",
+          'run = "echo internal"',
+          "",
+          "[tasks.build]",
+          'run = "npm run build"',
+        ].join("\n"),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const miseCommands = commands.filter((cmd) => cmd.id.startsWith("mise-"));
+
+      expect(miseCommands.map((cmd) => cmd.id)).toEqual(["mise-build"]);
+    });
+
+    it("skips tasks without run field", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "mise.toml"),
+        [
+          "[tasks.incomplete]",
+          'description = "Missing run"',
+          "",
+          "[tasks.build]",
+          'run = "npm run build"',
+        ].join("\n"),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const miseCommands = commands.filter((cmd) => cmd.id.startsWith("mise-"));
+
+      expect(miseCommands.map((cmd) => cmd.id)).toEqual(["mise-build"]);
+    });
+
+    it("returns empty when no mise.toml exists", async () => {
+      const commands = await detector.detect(tempDir);
+      const miseCommands = commands.filter((cmd) => cmd.id.startsWith("mise-"));
+      expect(miseCommands).toEqual([]);
+    });
+
+    it("returns empty when mise.toml has no [tasks]", async () => {
+      await fs.writeFile(path.join(tempDir, "mise.toml"), '[tools]\nnode = "22"\n', "utf-8");
+
+      const commands = await detector.detect(tempDir);
+      const miseCommands = commands.filter((cmd) => cmd.id.startsWith("mise-"));
+      expect(miseCommands).toEqual([]);
+    });
+
+    it("returns empty for malformed TOML", async () => {
+      await fs.writeFile(path.join(tempDir, "mise.toml"), "[[invalid toml [}", "utf-8");
+
+      const commands = await detector.detect(tempDir);
+      const miseCommands = commands.filter((cmd) => cmd.id.startsWith("mise-"));
+
+      expect(miseCommands).toEqual([]);
+    });
+
+    it("detects task with quoted name containing special chars", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "mise.toml"),
+        ['[tasks."dev:app"]', 'run = "npm run dev"', 'description = "Dev server"'].join("\n"),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const miseCommands = commands.filter((cmd) => cmd.id.startsWith("mise-"));
+
+      expect(miseCommands).toEqual([
+        expect.objectContaining({
+          id: "mise-dev:app",
+          name: "dev:app",
+          command: "mise run dev:app",
+          description: "Dev server",
+        }),
+      ]);
+    });
+  });
+
   describe("devcontainer detection", () => {
     it("detects string postStartCommand", async () => {
       const devcontainerDir = path.join(tempDir, ".devcontainer");

--- a/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
+++ b/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { normalizeNextjsDevCommand } from "../DevPreviewCommandNormalizer.js";
+import { extractPort, normalizeNextjsDevCommand } from "../DevPreviewCommandNormalizer.js";
 
 const mockReadFile = vi.fn<(path: string, encoding: string) => Promise<string>>();
 
@@ -226,5 +226,117 @@ describe("normalizeNextjsDevCommand", () => {
         "npm run dev"
       );
     });
+  });
+});
+
+describe("extractPort", () => {
+  const CWD = "/project";
+
+  it("extracts --port flag with space", async () => {
+    expect(await extractPort("next dev --port 3001", CWD)).toBe(3001);
+  });
+
+  it("extracts --port flag with equals", async () => {
+    expect(await extractPort("next dev --port=3002", CWD)).toBe(3002);
+  });
+
+  it("extracts -p flag", async () => {
+    expect(await extractPort("vite -p 5174", CWD)).toBe(5174);
+  });
+
+  it("extracts PORT= env var", async () => {
+    expect(await extractPort("PORT=8080 node server.js", CWD)).toBe(8080);
+  });
+
+  it("extracts port from ${PORT:-N} shell variable form", async () => {
+    expect(await extractPort('next dev --port "${PORT:-4321}"', CWD)).toBe(4321);
+  });
+
+  it("extracts port from single-quoted ${PORT:-N}", async () => {
+    expect(await extractPort("next dev --port '${PORT:-3000}'", CWD)).toBe(3000);
+  });
+
+  it("returns null for shell control character &&", async () => {
+    expect(await extractPort("next dev && echo done", CWD)).toBeNull();
+  });
+
+  it("returns null for shell control character ;", async () => {
+    expect(await extractPort("next dev; echo ready", CWD)).toBeNull();
+  });
+
+  it("returns null for shell comment #", async () => {
+    expect(await extractPort("next dev # with port 3000", CWD)).toBeNull();
+  });
+
+  it("returns null for pipe |", async () => {
+    expect(await extractPort("next dev | tee log", CWD)).toBeNull();
+  });
+
+  it("returns Next.js default port 3000", async () => {
+    expect(await extractPort("next dev", CWD)).toBe(3000);
+  });
+
+  it("returns Vite default port 5173", async () => {
+    expect(await extractPort("vite", CWD)).toBe(5173);
+  });
+
+  it("returns SvelteKit default port 5173", async () => {
+    expect(await extractPort("svelte-kit dev", CWD)).toBe(5173);
+  });
+
+  it("returns Astro default port 4321", async () => {
+    expect(await extractPort("astro dev", CWD)).toBe(4321);
+  });
+
+  it("returns Rails default port 3000", async () => {
+    expect(await extractPort("rails server", CWD)).toBe(3000);
+  });
+
+  it("returns Django default port 8000", async () => {
+    expect(await extractPort("python manage.py runserver", CWD)).toBe(8000);
+  });
+
+  it("returns Phoenix default port 4000", async () => {
+    expect(await extractPort("mix phx.server", CWD)).toBe(4000);
+  });
+
+  it("returns Laravel default port 8000", async () => {
+    expect(await extractPort("php artisan serve", CWD)).toBe(8000);
+  });
+
+  it("resolves pkg manager command through package.json for port extraction", async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ scripts: { dev: "next dev -p 3001" } }));
+    expect(await extractPort("npm run dev", CWD)).toBe(3001);
+  });
+
+  it("bails out when resolved pkg script has shell control", async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ scripts: { dev: "next dev && echo done" } }));
+    expect(await extractPort("npm run dev", CWD)).toBeNull();
+  });
+
+  it("returns framework default when pkg script has no explicit port", async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ scripts: { dev: "astro dev" } }));
+    expect(await extractPort("npm run dev", CWD)).toBe(4321);
+  });
+
+  it("returns null when no match and no framework default", async () => {
+    expect(await extractPort("echo hello", CWD)).toBeNull();
+  });
+
+  it("returns null when no package.json exists for pkg manager command", async () => {
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    expect(await extractPort("npm run dev", CWD)).toBeNull();
+  });
+
+  it("returns null for port 0 (invalid)", async () => {
+    expect(await extractPort("next dev --port 0", CWD)).toBeNull();
+  });
+
+  it("returns null for port 65536 (invalid)", async () => {
+    expect(await extractPort("next dev --port 65536", CWD)).toBeNull();
+  });
+
+  it("returns Remix default port 3000", async () => {
+    expect(await extractPort("remix dev", CWD)).toBe(3000);
   });
 });

--- a/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
+++ b/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
@@ -339,4 +339,24 @@ describe("extractPort", () => {
   it("returns Remix default port 3000", async () => {
     expect(await extractPort("remix dev", CWD)).toBe(3000);
   });
+
+  it("returns null when Remix command is not a dev invocation", async () => {
+    expect(await extractPort("remix routes", CWD)).toBeNull();
+  });
+
+  it("returns null for SUPPORT=8080 (PORT= substring in longer env var)", async () => {
+    expect(await extractPort("SUPPORT=8080 node server.js", CWD)).toBeNull();
+  });
+
+  it("returns null for --port 3000abc (partial digit extraction)", async () => {
+    expect(await extractPort("next dev --port 3000abc", CWD)).toBeNull();
+  });
+
+  it("returns null for --port 3000.5 (partial float extraction)", async () => {
+    expect(await extractPort("next dev --port 3000.5", CWD)).toBeNull();
+  });
+
+  it("returns null for --port with non-numeric value", async () => {
+    expect(await extractPort("next dev --port abc", CWD)).toBeNull();
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "node-pty": "1.2.0-beta.12",
         "react-colorful": "^5.6.1",
         "safe-stable-stringify": "^2.5.0",
+        "smol-toml": "^1.6.1",
         "win-job-object": "file:electron/native/win-job-object"
       },
       "devDependencies": {
@@ -18931,7 +18932,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
       "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "node-pty": "1.2.0-beta.12",
     "react-colorful": "^5.6.1",
     "safe-stable-stringify": "^2.5.0",
+    "smol-toml": "^1.6.1",
     "win-job-object": "file:electron/native/win-job-object"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Summary

`RunCommandDetector` now parses `Procfile` and `mise.toml` run commands, filling a gap where those files were ignored while npm scripts, Makefiles, Justfiles, and others were already covered. Also adds pre-launch port extraction to `DevPreviewCommandNormalizer` so the dev preview panel has a port to display before the server logs one on startup.

Resolves #8266.

## Changes

- **New detectors** in `RunCommandDetector` -- `detectProcfile` and `detectMise` -- each following the structure of the existing `detectJustfile` / `detectTaskfile` methods
- **Port extraction** in `DevPreviewCommandNormalizer` -- `extractPort`, `PORT_FLAG_RE`, `PORT_FLAG_PRESENT_RE`, and `FRAMEWORK_DEFAULT_PORTS` with fallback ports for Next.js (3000), Vite/SvelteKit (5173), Astro (4321), Remix (3000), Rails (3000), Django (8000), Phoenix (4000), and Laravel (8000)
- **Dependency** -- promoted `smol-toml` from transitive to direct dependency for mise.toml parsing
- **126 tests passing**, including 36 new tests covering Procfile detection, mise.toml task parsing, port extraction, and framework fallback defaults