### PR TITLE
fix(ui): anchor InlineStatusBanner dismiss button to top-right

### DIFF
--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -151,6 +151,22 @@ export function InlineStatusBanner({
 
   const hasDescription = description || contextLine || descriptionExtras;
 
+  const closeButton = onClose ? (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onClose();
+      }}
+      aria-label={closeAriaLabel}
+      className="p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0"
+    >
+      <X className="h-3.5 w-3.5" aria-hidden="true" />
+    </button>
+  ) : null;
+
+  const showControlsRow = !!trailingSlot || (!hasDescription && !!onClose) || actions.length > 0;
+
   return (
     <div
       className={cn(
@@ -186,12 +202,15 @@ export function InlineStatusBanner({
         />
         {hasDescription ? (
           <div className="flex-1 min-w-0">
-            <span
-              className={cn("text-sm font-medium", isNeutral && "text-daintree-text")}
-              style={isNeutral ? undefined : { color: `var(${colorVar})` }}
-            >
-              {title}
-            </span>
+            <div className="flex justify-between items-start gap-2">
+              <span
+                className={cn("text-sm font-medium", isNeutral && "text-daintree-text")}
+                style={isNeutral ? undefined : { color: `var(${colorVar})` }}
+              >
+                {title}
+              </span>
+              {closeButton}
+            </div>
             {description && (
               <p
                 className={cn("text-xs mt-0.5 break-words", isNeutral && "text-daintree-text/70")}
@@ -232,69 +251,61 @@ export function InlineStatusBanner({
         )}
       </div>
 
-      <div className={cn("flex items-center shrink-0", hasDescription ? "gap-2 ml-6" : "gap-1")}>
-        {trailingSlot}
-        {onClose && (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onClose();
-            }}
-            aria-label={closeAriaLabel}
-            className="p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
-          >
-            <X className="h-3.5 w-3.5" aria-hidden="true" />
-          </button>
-        )}
-        {actions.map((action) => {
-          const variant = action.variant ?? "primary";
-          const variantClasses = getButtonClasses(variant);
-          const variantStyle = colorVar ? getButtonStyle(variant, colorVar) : undefined;
-          const isDisabled = action.disabled || action.loading;
-          const iconClasses = action.iconOnly ? "w-3.5 h-3.5" : "w-3 h-3";
-          const spinnerSize = action.iconOnly ? "sm" : "xs";
-          const buttonEl = (
-            <button
-              key={action.id}
-              type="button"
-              disabled={isDisabled}
-              aria-busy={action.loading || undefined}
-              onClick={(e) => {
-                e.stopPropagation();
-                if (isDisabled) return;
-                action.onClick();
-              }}
-              className={cn(
-                action.iconOnly ? "p-1" : "flex items-center gap-1.5 px-2 py-1 text-xs font-medium",
-                "transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent",
-                variantClasses,
-                (variant === "danger" || variant === "dangerFilled") &&
-                  "hover:[color:var(--hover-color)] hover:[background:var(--hover-bg)]",
-                isDisabled && "cursor-not-allowed opacity-60 hover:bg-transparent"
-              )}
-              style={variantStyle}
-              aria-label={action.ariaLabel}
-            >
-              {action.loading ? (
-                <Spinner size={spinnerSize} />
-              ) : (
-                action.icon && <action.icon className={iconClasses} aria-hidden="true" />
-              )}
-              {!action.iconOnly && action.label}
-            </button>
-          );
+      {showControlsRow && (
+        <div className={cn("flex items-center shrink-0", hasDescription ? "gap-2 ml-6" : "gap-1")}>
+          {trailingSlot}
+          {!hasDescription && closeButton}
+          {actions.map((action) => {
+            const variant = action.variant ?? "primary";
+            const variantClasses = getButtonClasses(variant);
+            const variantStyle = colorVar ? getButtonStyle(variant, colorVar) : undefined;
+            const isDisabled = action.disabled || action.loading;
+            const iconClasses = action.iconOnly ? "w-3.5 h-3.5" : "w-3 h-3";
+            const spinnerSize = action.iconOnly ? "sm" : "xs";
+            const buttonEl = (
+              <button
+                key={action.id}
+                type="button"
+                disabled={isDisabled}
+                aria-busy={action.loading || undefined}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (isDisabled) return;
+                  action.onClick();
+                }}
+                className={cn(
+                  action.iconOnly
+                    ? "p-1"
+                    : "flex items-center gap-1.5 px-2 py-1 text-xs font-medium",
+                  "transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent",
+                  variantClasses,
+                  (variant === "danger" || variant === "dangerFilled") &&
+                    "hover:[color:var(--hover-color)] hover:[background:var(--hover-bg)]",
+                  isDisabled && "cursor-not-allowed opacity-60 hover:bg-transparent"
+                )}
+                style={variantStyle}
+                aria-label={action.ariaLabel}
+              >
+                {action.loading ? (
+                  <Spinner size={spinnerSize} />
+                ) : (
+                  action.icon && <action.icon className={iconClasses} aria-hidden="true" />
+                )}
+                {!action.iconOnly && action.label}
+              </button>
+            );
 
-          return action.title ? (
-            <Tooltip key={action.id}>
-              <TooltipTrigger asChild>{buttonEl}</TooltipTrigger>
-              <TooltipContent side="bottom">{action.title}</TooltipContent>
-            </Tooltip>
-          ) : (
-            <React.Fragment key={action.id}>{buttonEl}</React.Fragment>
-          );
-        })}
-      </div>
+            return action.title ? (
+              <Tooltip key={action.id}>
+                <TooltipTrigger asChild>{buttonEl}</TooltipTrigger>
+                <TooltipContent side="bottom">{action.title}</TooltipContent>
+              </Tooltip>
+            ) : (
+              <React.Fragment key={action.id}>{buttonEl}</React.Fragment>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -305,6 +305,136 @@ describe("InlineStatusBanner", () => {
     }
   });
 
+  describe("dismiss button layout", () => {
+    it("renders dismiss in the title row when hasDescription is true and actions is empty", () => {
+      const onClose = vi.fn();
+      render(
+        <InlineStatusBanner
+          icon={AlertTriangle}
+          title="25 panels open"
+          description="Consider closing idle panels."
+          severity="warning"
+          animated={false}
+          actions={[]}
+          onClose={onClose}
+        />
+      );
+      const title = screen.getByText("25 panels open");
+      const dismiss = screen.getByRole("button", { name: "Dismiss" });
+      // Dismiss shares a parent with the title text (the flex justify-between wrapper)
+      const titleParent = title.closest('[class*="flex"]');
+      const dismissParent = dismiss.closest('[class*="flex"]');
+      expect(titleParent).toBe(dismissParent);
+      // The parent is the justify-between wrapper, not the controls row
+      expect(titleParent?.className).toContain("justify-between");
+    });
+
+    it("fires onClose when the title-row dismiss is clicked", () => {
+      const onClose = vi.fn();
+      render(
+        <InlineStatusBanner
+          icon={AlertTriangle}
+          title="25 panels open"
+          description="Consider closing idle panels."
+          severity="warning"
+          animated={false}
+          actions={[]}
+          onClose={onClose}
+        />
+      );
+      screen.getByRole("button", { name: "Dismiss" }).click();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("moves dismiss out of the controls row when hasDescription is true", () => {
+      const { container } = render(
+        <InlineStatusBanner
+          icon={AlertTriangle}
+          title="Title"
+          description="Description"
+          severity="warning"
+          animated={false}
+          actions={[{ id: "retry", label: "Retry", onClick: () => {} }]}
+          onClose={() => {}}
+        />
+      );
+      const controlsRow = container.querySelector(".ml-6");
+      expect(controlsRow).toBeTruthy();
+      // Dismiss button is NOT inside the ml-6 controls row
+      expect(controlsRow?.querySelector('[aria-label="Dismiss"]')).toBeNull();
+    });
+
+    it("keeps dismiss in the controls row for single-line banners", () => {
+      const { container } = render(
+        <InlineStatusBanner
+          icon={Info}
+          title="Single line"
+          severity="info"
+          animated={false}
+          actions={[]}
+          onClose={() => {}}
+        />
+      );
+      // Single-line: no ml-6 wrapper, X is in the controls row (gap-1)
+      const controlsRow = container.querySelector('[class*="gap-1"]');
+      expect(controlsRow).toBeTruthy();
+      expect(controlsRow?.querySelector('[aria-label="Dismiss"]')).toBeTruthy();
+    });
+
+    it("renders dismiss in title row with descriptionExtras and no description prop", () => {
+      const onClose = vi.fn();
+      render(
+        <InlineStatusBanner
+          icon={AlertTriangle}
+          title="25 panels open"
+          descriptionExtras={<button type="button">Close completed</button>}
+          severity="warning"
+          animated={false}
+          actions={[]}
+          onClose={onClose}
+        />
+      );
+      const title = screen.getByText("25 panels open");
+      const dismiss = screen.getByRole("button", { name: "Dismiss" });
+      const titleParent = title.closest('[class*="justify-between"]');
+      expect(titleParent).toBeTruthy();
+      expect(titleParent!.contains(dismiss)).toBe(true);
+    });
+
+    it("does not render an empty controls row when hasDescription, no actions, and onClose is present", () => {
+      const { container } = render(
+        <InlineStatusBanner
+          icon={AlertTriangle}
+          title="25 panels open"
+          description="Consider closing idle panels."
+          severity="warning"
+          animated={false}
+          actions={[]}
+          onClose={() => {}}
+        />
+      );
+      // No ml-6 or gap-1 controls row should exist — dismiss is in the title row
+      const controlsRow = container.querySelector('[class*="ml-6"]');
+      expect(controlsRow).toBeNull();
+    });
+
+    it("does not render a controls row when hasDescription is true with no trailingSlot, no actions, and no onClose", () => {
+      const { container } = render(
+        <InlineStatusBanner
+          icon={AlertTriangle}
+          title="Recovering"
+          description="The host is restarting."
+          severity="warning"
+          animated={false}
+          actions={[]}
+        />
+      );
+      // HostCrashBanner case — no controls row at all
+      const controlsRow = container.querySelector('[class*="ml-6"]');
+      expect(controlsRow).toBeNull();
+    });
+  });
+
   it("uses the 250ms entrance duration class when animated", () => {
     const { container } = render(
       <InlineStatusBanner


### PR DESCRIPTION
Fixes #8291.

When `InlineStatusBanner` rendered across multiple lines, the dismiss button landed in its own indented row below the content, floating mid-banner. This was most visible on the `TerminalCountWarning` panel-count banner, but hit any consumer with a description and no action buttons.

The fix anchors the dismiss button to the top-right corner of the title row, so it sits naturally alongside the title text. The controls row now only renders when it has actual content, which means it disappears entirely when there's nothing left for it to show.

* `src/components/Terminal/InlineStatusBanner.tsx` -- extracted the close button, moved it into a `flex justify-between` wrapper in the title row when `hasDescription` is true, and gated the controls row to only render when `trailingSlot`, a non-description close button, or `actions` are present.
* `src/components/Terminal/__tests__/InlineStatusBanner.test.tsx` -- added tests covering dismiss-in-title-row layout, empty controls row suppression, single-line backward compat, `descriptionExtras` placement, and the no-controls edge case.