### PR TITLE
fix(git): wire confirm dialogs at remaining destructive direct-IPC bypass sites

### DIFF
--- a/docs/architecture/destructive-action-safeguards.md
+++ b/docs/architecture/destructive-action-safeguards.md
@@ -48,14 +48,14 @@ Columns:
 | `git.stageFile` / `git.unstageFile` | safe | n/a | local-undo (inverse exists) | one file | D0 | Leave | — |
 | `git.stageAll` / `git.unstageAll` | safe | n/a | local-undo (inverse exists) | worktree | D0 | Leave | — |
 | `git.commit` (action) | safe | n/a (caller-supplied msg required) | local-undo (amend / reset until push) | one commit | D0 | Leave action; but every commit _submission_ call site must gate on authored, non-fallback message (see follow-ups) | — |
-| `git.push` (action) | **confirm** (updated #7881) | none in palette/keybinding path | shared-state (force-push to undo) | one branch on origin | D2 | Add commit-and-push confirmation when invoked outside ReviewHub | TBD |
-| `git.snapshotRevert` | confirm | none at `WorktreeCard.tsx:183` direct IPC call | local-irreversible (wipes working tree to snapshot) | one worktree | D1 | Wire `ConfirmDialog` at the WorktreeMenu call site | TBD |
+| `git.push` (action) | **confirm** (updated #7881) | yes — `GitPushConfirmDialog` (deferred-Promise gate via `gitPushConfirmStore`; the action `run()` awaits confirmation, dialog previews target branch + recent local commits, #8242) | shared-state (force-push to undo) | one branch on origin | D2 | Done (#8242) — palette/keybinding push gates on the same D2 preview | — |
+| `git.snapshotRevert` | confirm | yes — `ConfirmDialog` via `useWorktreeActions` / `WorktreeDialogs` (preview names the snapshot capture time; #8242) | local-irreversible (wipes working tree to snapshot) | one worktree | D1 | Done (#8242) — confirm wired at the WorktreeCard menu call site | — |
 | `git.snapshotDelete` | **confirm** (updated #7881) | none — call site not yet identified | local-irreversible (no recovery once deleted) | one worktree | D1 | Wire `ConfirmDialog` wherever the action is invoked | TBD |
 | `ReviewHubContent.tsx` `handleCommitAndPush(message)` | (bypass — chains `commit` + `runPush`) | yes (`CommitPanel` push confirm — every remote push gates on `ConfirmDialog` with branch pill + commit message preview + per-worktree opt-out, #8025) | shared-state | one branch on origin | D2 | Leave — wired model for bundled commit-and-push | — |
 | `ForcePushConfirmDialog.tsx` `forcePushWithLease` | (bypass, but **dialog already wired**) | yes (`ForcePushConfirmDialog`) | shared-state, recoverable only by lease check | one branch on origin | D2 | Leave — current implementation is the model for D2 confirms | — |
-| `ReviewHubContent.tsx:896` `pullRebase` | (bypass) | none | local-irreversible until pushed (rebase can clobber) | one worktree | D1 | Add confirm + show divergence preview before rebase | TBD |
+| `ReviewHubContent.tsx:896` `pullRebase` | (bypass, but **dialog now wired**) | yes — `ConfirmDialog` previews local-ahead vs incoming-behind divergence on the current branch before rebase (#8242); `git.pullRebase` action reclassified `safe`→`confirm` | local-irreversible until pushed (rebase can clobber) | one worktree | D1 | Done (#8242) — confirm + divergence preview wired at the ReviewHub call site | — |
 | `ReviewHubContent.tsx:733` `abortRepositoryOperation` | (bypass) | none | local-undo (abort is the recovery) | one worktree | D0 | Leave (abort _is_ the recovery path) | — |
-| `ReviewHubContent.tsx:778` `checkoutOursTheirs` | (bypass) | none | local-irreversible (overwrites conflict resolution) | one file | D1 | Add confirm for files with uncommitted work; otherwise inline button is acceptable | TBD |
+| `ReviewHubContent.tsx:778` `checkoutOursTheirs` | (bypass, but **dialog now wired**) | yes — `ConfirmDialog` in `ConflictPanel` previews the file path + side (rebase-aware) before overwriting the conflict buffer (#8242) | local-irreversible (overwrites conflict resolution) | one file | D1 | Done (#8242) — every conflict-buffer overwrite gates on a per-file confirm | — |
 
 ### Worktree operations
 
@@ -163,11 +163,11 @@ Direct `window.electron.*` IPC calls that skip `ActionService`. These are the hi
 
 | File | Operation | Has UI confirm? |
 | --- | --- | --- |
-| `src/components/Worktree/WorktreeCard.tsx` | `git.snapshotRevert` (context menu) | **No** — context menu invokes directly |
+| `src/components/Worktree/WorktreeCard.tsx` | `git.snapshotRevert` (context menu) | **Yes** — `ConfirmDialog` via `useWorktreeActions` / `WorktreeDialogs` (#8242) |
 | `src/components/Worktree/ReviewHub/ReviewHubContent.tsx` | `stageAll`, `unstageAll`, `stageFile`, `commit` block | Authored-message gate on commit; no top-level dialog |
 | `src/components/Worktree/ReviewHub/ReviewHubContent.tsx` | `handleCommitAndPush` (bundled `commit` + `push`) | **Yes** — `CommitPanel` push confirm with branch pill + commit message preview + per-worktree opt-out (#8025); only user-initiated remote push path |
-| `src/components/Worktree/ReviewHub/ReviewHubContent.tsx` | `pullRebase` | **No** |
-| `src/components/Worktree/ReviewHub/ReviewHubContent.tsx` | `checkoutOursTheirs` | **No** |
+| `src/components/Worktree/ReviewHub/ReviewHubContent.tsx` | `pullRebase` | **Yes** — `ConfirmDialog` with ahead/behind divergence preview (#8242) |
+| `src/components/Worktree/ReviewHub/ReviewHubContent.tsx` | `checkoutOursTheirs` | **Yes** — per-file `ConfirmDialog` in `ConflictPanel` (#8242) |
 | `src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx` | `forcePushWithLease` | **Yes** — model implementation |
 
 ## Maintenance

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -249,6 +249,13 @@ const LazyPanelLimitConfirmDialog = lazy(() =>
   preloadPanelLimitConfirmDialog().then((m) => ({ default: m.PanelLimitConfirmDialog }))
 );
 
+function preloadGitPushConfirmDialog() {
+  return import("./components/Git/GitPushConfirmDialog");
+}
+const LazyGitPushConfirmDialog = lazy(() =>
+  preloadGitPushConfirmDialog().then((m) => ({ default: m.GitPushConfirmDialog }))
+);
+
 import { Toaster } from "./components/ui/toaster";
 import { ShortcutHint } from "./components/ui/ShortcutHint";
 import { ReEntrySummary } from "./components/ui/ReEntrySummary";
@@ -1221,6 +1228,18 @@ function App() {
               >
                 <Suspense fallback={null}>
                   <LazyPanelLimitConfirmDialog />
+                </Suspense>
+              </ErrorBoundary>
+            )}
+
+            {isStateLoaded && (
+              <ErrorBoundary
+                variant="component"
+                componentName="GitPushConfirmDialog"
+                resetKeys={[Number(isStateLoaded)]}
+              >
+                <Suspense fallback={null}>
+                  <LazyGitPushConfirmDialog />
                 </Suspense>
               </ErrorBoundary>
             )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -256,6 +256,15 @@ const LazyGitPushConfirmDialog = lazy(() =>
   preloadGitPushConfirmDialog().then((m) => ({ default: m.GitPushConfirmDialog }))
 );
 
+function preloadGitPullRebaseConfirmDialog() {
+  return import("./components/Git/GitPullRebaseConfirmDialog");
+}
+const LazyGitPullRebaseConfirmDialog = lazy(() =>
+  preloadGitPullRebaseConfirmDialog().then((m) => ({
+    default: m.GitPullRebaseConfirmDialog,
+  }))
+);
+
 import { Toaster } from "./components/ui/toaster";
 import { ShortcutHint } from "./components/ui/ShortcutHint";
 import { ReEntrySummary } from "./components/ui/ReEntrySummary";
@@ -1240,6 +1249,18 @@ function App() {
               >
                 <Suspense fallback={null}>
                   <LazyGitPushConfirmDialog />
+                </Suspense>
+              </ErrorBoundary>
+            )}
+
+            {isStateLoaded && (
+              <ErrorBoundary
+                variant="component"
+                componentName="GitPullRebaseConfirmDialog"
+                resetKeys={[Number(isStateLoaded)]}
+              >
+                <Suspense fallback={null}>
+                  <LazyGitPullRebaseConfirmDialog />
                 </Suspense>
               </ErrorBoundary>
             )}

--- a/src/components/Git/GitPullRebaseConfirmDialog.tsx
+++ b/src/components/Git/GitPullRebaseConfirmDialog.tsx
@@ -6,31 +6,32 @@ import { AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
-import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
+import { useGitPullRebaseConfirmStore } from "@/store/gitPullRebaseConfirmStore";
 
 const COMMIT_LIMIT = 12;
 const SHORT_HASH_LEN = 7;
 
-interface PushPreviewCommit {
+interface RebasePreviewCommit {
   hash: string;
   message: string;
   author: string;
 }
 
 /**
- * D2 confirm for `git.push` dispatched from the action palette or a keybinding
- * (#8242). Reads the pending request from `gitPushConfirmStore`, previews the
- * target branch and the recent local commits, and resolves the deferred
- * Promise the action `run()` is awaiting.
+ * D1 confirm for the `git.pullRebase` action dispatched outside the ReviewHub
+ * (palette, keybinding, terminal push-error recovery banner) (#8242). Reads
+ * the pending request from `gitPullRebaseConfirmStore`, previews the local
+ * commits a rebase would replay, and resolves the deferred Promise the action
+ * `run()` is awaiting.
  */
-function GitPushConfirmDialogInner() {
-  const pendingConfirm = useGitPushConfirmStore((s) => s.pendingConfirm);
-  const resolveConfirmation = useGitPushConfirmStore((s) => s.resolveConfirmation);
+function GitPullRebaseConfirmDialogInner() {
+  const pendingConfirm = useGitPullRebaseConfirmStore((s) => s.pendingConfirm);
+  const resolveConfirmation = useGitPullRebaseConfirmStore((s) => s.resolveConfirmation);
 
   const cwd = pendingConfirm?.cwd ?? null;
 
   const [branch, setBranch] = useState<string | null>(null);
-  const [commits, setCommits] = useState<PushPreviewCommit[] | null>(null);
+  const [commits, setCommits] = useState<RebasePreviewCommit[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const requestIdRef = useRef(0);
@@ -61,13 +62,13 @@ function GitPushConfirmDialogInner() {
         })
         .catch((err: unknown) => {
           if (requestIdRef.current !== requestId) return;
-          setLoadError(formatErrorMessage(err, "Failed to load push preview"));
+          setLoadError(formatErrorMessage(err, "Failed to load rebase preview"));
         })
         .finally(() => {
           if (requestIdRef.current !== requestId) return;
           setIsLoading(false);
         }),
-      { context: "GitPushConfirmDialog: load push preview" }
+      { context: "GitPullRebaseConfirmDialog: load rebase preview" }
     );
   }, [cwd]);
 
@@ -85,8 +86,8 @@ function GitPushConfirmDialogInner() {
   // Resolve false on unmount to prevent a leaked awaited Promise.
   useEffect(() => {
     return () => {
-      if (useGitPushConfirmStore.getState().pendingConfirm) {
-        useGitPushConfirmStore.getState().resolveConfirmation(false);
+      if (useGitPullRebaseConfirmStore.getState().pendingConfirm) {
+        useGitPullRebaseConfirmStore.getState().resolveConfirmation(false);
       }
     };
   }, []);
@@ -99,14 +100,15 @@ function GitPushConfirmDialogInner() {
     <ConfirmDialog
       isOpen={true}
       onClose={() => resolveConfirmation(false)}
-      title={`Push '${branchLabel}'?`}
+      title={`Pull and rebase '${branchLabel}'?`}
       description={
         <span>
-          Pushes local commits on <span className="font-mono">{branchLabel}</span> to its remote
-          branch. If the remote has moved forward, the push is rejected until you pull and rebase.
+          Pulls the remote and replays your local commits on{" "}
+          <span className="font-mono">{branchLabel}</span> on top of it. Rebasing rewrites local
+          commit history and cannot be undone.
         </span>
       }
-      confirmLabel="Push"
+      confirmLabel="Pull and rebase"
       cancelLabel="Cancel"
       variant="destructive"
       isConfirmLoading={isLoading}
@@ -115,14 +117,14 @@ function GitPushConfirmDialogInner() {
       <div className="rounded border border-tint/[0.08] bg-tint/[0.04]">
         <div className="px-3 py-2 border-b border-tint/[0.08]">
           <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
-            Recent local commits
+            Local commits to replay
           </span>
         </div>
 
         {isLoading && (
           <div
             className="flex items-center justify-center py-6"
-            data-testid="git-push-commits-loading"
+            data-testid="git-pull-rebase-commits-loading"
           >
             <Spinner size="sm" className="text-daintree-text/40" />
           </div>
@@ -136,7 +138,7 @@ function GitPushConfirmDialogInner() {
               <button
                 type="button"
                 onClick={loadPreview}
-                data-testid="git-push-commits-retry"
+                data-testid="git-pull-rebase-commits-retry"
                 className={cn(
                   "mt-1 inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium transition-colors",
                   "bg-status-error/15 hover:bg-status-error/25 text-status-error",
@@ -161,7 +163,7 @@ function GitPushConfirmDialogInner() {
               <li
                 key={commit.hash}
                 className="flex items-baseline gap-2"
-                data-testid="git-push-commit-row"
+                data-testid="git-pull-rebase-commit-row"
               >
                 <span className="font-mono text-[10px] text-daintree-text/40 shrink-0 tabular-nums">
                   {commit.hash.slice(0, SHORT_HASH_LEN)}
@@ -179,10 +181,10 @@ function GitPushConfirmDialogInner() {
   );
 }
 
-export function GitPushConfirmDialog() {
+export function GitPullRebaseConfirmDialog() {
   return (
-    <ErrorBoundary variant="component" componentName="GitPushConfirmDialog">
-      <GitPushConfirmDialogInner />
+    <ErrorBoundary variant="component" componentName="GitPullRebaseConfirmDialog">
+      <GitPullRebaseConfirmDialogInner />
     </ErrorBoundary>
   );
 }

--- a/src/components/Git/GitPushConfirmDialog.tsx
+++ b/src/components/Git/GitPushConfirmDialog.tsx
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { Spinner } from "@/components/ui/Spinner";
+import { AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
+
+const COMMIT_LIMIT = 12;
+const SHORT_HASH_LEN = 7;
+
+interface PushPreviewCommit {
+  hash: string;
+  message: string;
+  author: string;
+}
+
+/**
+ * D2 confirm for `git.push` dispatched from the action palette or a keybinding
+ * (#8242). Reads the pending request from `gitPushConfirmStore`, previews the
+ * target branch and the recent local commits, and resolves the deferred
+ * Promise the action `run()` is awaiting.
+ */
+function GitPushConfirmDialogInner() {
+  const pendingConfirm = useGitPushConfirmStore((s) => s.pendingConfirm);
+  const resolveConfirmation = useGitPushConfirmStore((s) => s.resolveConfirmation);
+
+  const cwd = pendingConfirm?.cwd ?? null;
+
+  const [branch, setBranch] = useState<string | null>(null);
+  const [commits, setCommits] = useState<PushPreviewCommit[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const requestIdRef = useRef(0);
+
+  const loadPreview = useCallback(() => {
+    if (!cwd) return;
+    const requestId = ++requestIdRef.current;
+    setIsLoading(true);
+    setLoadError(null);
+    setBranch(null);
+    setCommits(null);
+
+    safeFireAndForget(
+      Promise.all([
+        window.electron.git.getStagingStatus(cwd),
+        window.electron.git.listCommits({ cwd, limit: COMMIT_LIMIT }),
+      ])
+        .then(([status, commitList]) => {
+          if (requestIdRef.current !== requestId) return;
+          setBranch(status.currentBranch);
+          setCommits(
+            commitList.items.map((c) => ({
+              hash: c.hash,
+              message: c.message,
+              author: c.author.name,
+            }))
+          );
+        })
+        .catch((err: unknown) => {
+          if (requestIdRef.current !== requestId) return;
+          setLoadError(formatErrorMessage(err, "Failed to load push preview"));
+        })
+        .finally(() => {
+          if (requestIdRef.current !== requestId) return;
+          setIsLoading(false);
+        }),
+      { context: "GitPushConfirmDialog: load push preview" }
+    );
+  }, [cwd]);
+
+  useEffect(() => {
+    if (!cwd) {
+      setBranch(null);
+      setCommits(null);
+      setLoadError(null);
+      setIsLoading(false);
+      return;
+    }
+    loadPreview();
+  }, [cwd, loadPreview]);
+
+  // Resolve false on unmount to prevent a leaked awaited Promise.
+  useEffect(() => {
+    return () => {
+      if (useGitPushConfirmStore.getState().pendingConfirm) {
+        useGitPushConfirmStore.getState().resolveConfirmation(false);
+      }
+    };
+  }, []);
+
+  if (!pendingConfirm) return null;
+
+  const branchLabel = branch ?? "current branch";
+
+  return (
+    <ConfirmDialog
+      isOpen={true}
+      onClose={() => resolveConfirmation(false)}
+      title={`Push '${branchLabel}'?`}
+      description={
+        <span>
+          Pushes local commits on <span className="font-mono">{branchLabel}</span> to its remote
+          branch. If the remote has moved forward, the push is rejected until you pull and rebase.
+        </span>
+      }
+      confirmLabel="Push"
+      cancelLabel="Cancel"
+      variant="destructive"
+      onConfirm={() => resolveConfirmation(true)}
+    >
+      <div className="rounded border border-tint/[0.08] bg-tint/[0.04]">
+        <div className="px-3 py-2 border-b border-tint/[0.08]">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+            Recent local commits
+          </span>
+        </div>
+
+        {isLoading && (
+          <div
+            className="flex items-center justify-center py-6"
+            data-testid="git-push-commits-loading"
+          >
+            <Spinner size="sm" className="text-daintree-text/40" />
+          </div>
+        )}
+
+        {!isLoading && loadError && (
+          <div className="px-3 py-3 text-status-error flex items-start gap-2">
+            <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+            <div className="flex-1 min-w-0">
+              <div>{loadError}</div>
+              <button
+                type="button"
+                onClick={loadPreview}
+                data-testid="git-push-commits-retry"
+                className={cn(
+                  "mt-1 inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium transition-colors",
+                  "bg-status-error/15 hover:bg-status-error/25 text-status-error",
+                  "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-status-error"
+                )}
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        )}
+
+        {!isLoading && !loadError && commits && commits.length === 0 && (
+          <div className="px-3 py-3 text-daintree-text/50">
+            No local commits found on this branch.
+          </div>
+        )}
+
+        {!isLoading && !loadError && commits && commits.length > 0 && (
+          <ul className="px-3 py-2 space-y-1.5 max-h-[180px] overflow-y-auto">
+            {commits.map((commit) => (
+              <li
+                key={commit.hash}
+                className="flex items-baseline gap-2"
+                data-testid="git-push-commit-row"
+              >
+                <span className="font-mono text-[10px] text-daintree-text/40 shrink-0 tabular-nums">
+                  {commit.hash.slice(0, SHORT_HASH_LEN)}
+                </span>
+                <span className="text-daintree-text/80 truncate min-w-0">{commit.message}</span>
+                <span className="text-[10px] text-daintree-text/40 shrink-0 ml-auto">
+                  {commit.author}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </ConfirmDialog>
+  );
+}
+
+export function GitPushConfirmDialog() {
+  return (
+    <ErrorBoundary variant="component" componentName="GitPushConfirmDialog">
+      <GitPushConfirmDialogInner />
+    </ErrorBoundary>
+  );
+}

--- a/src/components/Worktree/ReviewHub/ConflictPanel.tsx
+++ b/src/components/Worktree/ReviewHub/ConflictPanel.tsx
@@ -230,6 +230,10 @@ export function ConflictPanel({
   onContinue,
 }: ConflictPanelProps) {
   const [isAbortOpen, setIsAbortOpen] = useState(false);
+  const [pendingCheckout, setPendingCheckout] = useState<{
+    filePath: string;
+    side: "ours" | "theirs";
+  } | null>(null);
   const [isAborting, setIsAborting] = useState(false);
   const [isContinuing, setIsContinuing] = useState(false);
   const [busyFile, setBusyFile] = useState<string | null>(null);
@@ -529,7 +533,7 @@ export function ConflictPanel({
                       variant="ghost"
                       size="sm"
                       onClick={() => {
-                        handleCheckoutSide(file.path, "ours").catch(() => {});
+                        setPendingCheckout({ filePath: file.path, side: "ours" });
                       }}
                       disabled={isBusy}
                       className="h-5 px-1.5 text-[10px]"
@@ -542,7 +546,7 @@ export function ConflictPanel({
                       variant="ghost"
                       size="sm"
                       onClick={() => {
-                        handleCheckoutSide(file.path, "theirs").catch(() => {});
+                        setPendingCheckout({ filePath: file.path, side: "theirs" });
                       }}
                       disabled={isBusy}
                       className="h-5 px-1.5 text-[10px]"
@@ -675,6 +679,40 @@ export function ConflictPanel({
         onConfirm={() => void handleAbort()}
         isConfirmLoading={isAborting}
         variant="destructive"
+      />
+
+      <ConfirmDialog
+        isOpen={pendingCheckout !== null}
+        onClose={() => setPendingCheckout(null)}
+        title={
+          pendingCheckout ? `Take ${pendingCheckout.side} for '${pendingCheckout.filePath}'?` : ""
+        }
+        description={
+          pendingCheckout ? (
+            <span>
+              Overwrites the conflicted file with the{" "}
+              {pendingCheckout.side === "ours"
+                ? isRebase
+                  ? "destination branch"
+                  : "current branch"
+                : isRebase
+                  ? "incoming commit"
+                  : "incoming changes"}{" "}
+              version. Any manual conflict edits in this file are discarded and cannot be undone.
+            </span>
+          ) : (
+            ""
+          )
+        }
+        confirmLabel={pendingCheckout ? `Take ${pendingCheckout.side}` : "Confirm"}
+        cancelLabel="Cancel"
+        variant="destructive"
+        onConfirm={() => {
+          if (!pendingCheckout) return;
+          const { filePath, side } = pendingCheckout;
+          setPendingCheckout(null);
+          handleCheckoutSide(filePath, side).catch(() => {});
+        }}
       />
     </div>
   );

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -40,6 +40,7 @@ import { ConflictPanel } from "./ConflictPanel";
 import { FileDiffModal } from "../FileDiffModal";
 import { BaseBranchDiffModal } from "./BaseBranchDiffModal";
 import { ForcePushConfirmDialog } from "./ForcePushConfirmDialog";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -238,6 +239,7 @@ export function ReviewHubContent({
   const [viewedFiles, setViewedFiles] = useState<Set<string>>(() => new Set());
   const [diffMode, setDiffMode] = useState<DiffMode>("working-tree");
   const [forcePushDialogOpen, setForcePushDialogOpen] = useState(false);
+  const [pullRebaseConfirmOpen, setPullRebaseConfirmOpen] = useState(false);
   const [pullRebasing, setPullRebasing] = useState(false);
   const isPullRebasingRef = useRef(false);
   const [baseBranchFiles, setBaseBranchFiles] = useState<CrossWorktreeFile[] | null>(null);
@@ -391,6 +393,15 @@ export function ReviewHubContent({
     for (const wt of state.worktrees.values()) {
       if (wt.path === worktreePath) {
         return wt.behindCount;
+      }
+    }
+    return undefined;
+  });
+
+  const aheadCount = useWorktreeStore((state) => {
+    for (const wt of state.worktrees.values()) {
+      if (wt.path === worktreePath) {
+        return wt.aheadCount;
       }
     }
     return undefined;
@@ -1359,7 +1370,7 @@ export function ReviewHubContent({
                   void handleRetryPush();
                   return;
                 case "pull-rebase":
-                  void handlePullRebase();
+                  setPullRebaseConfirmOpen(true);
                   return;
                 case "force-push":
                   setForcePushDialogOpen(true);
@@ -2068,6 +2079,40 @@ export function ReviewHubContent({
           onError={handleForcePushError}
         />
       )}
+
+      <ConfirmDialog
+        isOpen={pullRebaseConfirmOpen}
+        onClose={() => setPullRebaseConfirmOpen(false)}
+        title={`Pull and rebase '${status?.currentBranch ?? "current branch"}'?`}
+        description={
+          <span>
+            Replays{" "}
+            {aheadCount != null ? (
+              <span className="font-medium text-daintree-text">
+                {aheadCount} local commit{aheadCount === 1 ? "" : "s"}
+              </span>
+            ) : (
+              "your local commits"
+            )}{" "}
+            on top of{" "}
+            {behindCount != null ? (
+              <span className="font-medium text-daintree-text">
+                {behindCount} incoming commit{behindCount === 1 ? "" : "s"}
+              </span>
+            ) : (
+              "the incoming commits"
+            )}{" "}
+            from the remote. Rebasing rewrites local commit history and cannot be undone.
+          </span>
+        }
+        confirmLabel="Pull and rebase"
+        cancelLabel="Cancel"
+        variant="destructive"
+        onConfirm={() => {
+          setPullRebaseConfirmOpen(false);
+          void handlePullRebase();
+        }}
+      />
     </>
   );
 }

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -1321,6 +1321,19 @@ describe("ReviewHub", () => {
       });
     });
 
+    it("does not call checkoutOursTheirs until the confirm dialog is accepted (#8242)", async () => {
+      getStagingStatusMock.mockResolvedValue(makeMergingStatus());
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByTestId("conflict-panel"));
+      fireEvent.click(screen.getByRole("button", { name: /Take ours for src\/app\.ts/i }));
+
+      // Dialog is open but unconfirmed — the IPC must not have fired.
+      await screen.findByRole("alertdialog");
+      expect(checkoutOursTheirsMock).not.toHaveBeenCalled();
+    });
+
     it("renders the Abort action inside the operation chrome, not the footer", async () => {
       getStagingStatusMock.mockResolvedValue(makeMergingStatus());
 
@@ -1767,6 +1780,29 @@ describe("ReviewHub", () => {
       // refresh() called: once on initial load + once after commit (in
       // handleCommitAndPush) + once after pull-rebase success.
       expect(getStagingStatusMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not call pullRebase until the confirm dialog is accepted (#8242)", async () => {
+      pushMock.mockRejectedValue(
+        Object.assign(new Error("! [rejected]"), {
+          name: "GitOperationError",
+          gitReason: "push-rejected-outdated",
+          leaseSha: "abc123",
+          branchName: "feature/x",
+        })
+      );
+
+      await triggerCommitAndPush();
+      await screen.findByTestId("review-hub-push-error");
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("review-hub-push-error-cta"));
+        await Promise.resolve();
+      });
+
+      // Dialog is open but unconfirmed — the rebase IPC must not have fired.
+      await screen.findByRole("alertdialog");
+      expect(pullRebaseMock).not.toHaveBeenCalled();
     });
 
     it("Pull-and-rebase failure surfaces conflict-unresolved through the banner", async () => {

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -296,6 +296,30 @@ const makeWorktreeState = (path = WORKTREE_PATH): WorktreeState =>
     lastActivityTimestamp: null,
   }) as unknown as WorktreeState;
 
+/**
+ * `checkoutOursTheirs` now gates on a per-file `ConfirmDialog` (#8242). The
+ * row button only opens the dialog; clicking its `Take ours` / `Take theirs`
+ * confirm button is what reaches the IPC.
+ */
+async function confirmCheckout(side: "ours" | "theirs"): Promise<void> {
+  const dialog = await screen.findByRole("alertdialog");
+  const confirmBtn = within(dialog).getByRole("button", {
+    name: side === "ours" ? "Take ours" : "Take theirs",
+  });
+  fireEvent.click(confirmBtn);
+}
+
+/**
+ * `pullRebase` now gates on a `ConfirmDialog` showing the divergence preview
+ * (#8242). The push-error CTA only opens the dialog; clicking its
+ * `Pull and rebase` confirm button is what reaches the IPC.
+ */
+async function confirmPullRebase(): Promise<void> {
+  const dialog = await screen.findByRole("alertdialog");
+  const confirmBtn = within(dialog).getByRole("button", { name: "Pull and rebase" });
+  fireEvent.click(confirmBtn);
+}
+
 describe("ReviewHub", () => {
   let capturedUpdateCallback: ((state: WorktreeState) => void) | null = null;
   const mockUnsubscribe = vi.fn();
@@ -1275,6 +1299,7 @@ describe("ReviewHub", () => {
       await waitFor(() => screen.getByTestId("conflict-panel"));
       const takeOurs = screen.getByRole("button", { name: /Take ours for src\/app\.ts/i });
       fireEvent.click(takeOurs);
+      await confirmCheckout("ours");
 
       await waitFor(() => {
         expect(checkoutOursTheirsMock).toHaveBeenCalledWith(WORKTREE_PATH, "src/app.ts", "ours");
@@ -1289,6 +1314,7 @@ describe("ReviewHub", () => {
       await waitFor(() => screen.getByTestId("conflict-panel"));
       const takeTheirs = screen.getByRole("button", { name: /Take theirs for src\/app\.ts/i });
       fireEvent.click(takeTheirs);
+      await confirmCheckout("theirs");
 
       await waitFor(() => {
         expect(checkoutOursTheirsMock).toHaveBeenCalledWith(WORKTREE_PATH, "src/app.ts", "theirs");
@@ -1380,6 +1406,7 @@ describe("ReviewHub", () => {
       await waitFor(() => screen.getByTestId("conflict-panel"));
       const takeOurs = screen.getByRole("button", { name: /Take ours for src\/app\.ts/i });
       fireEvent.click(takeOurs);
+      await confirmCheckout("ours");
 
       await waitFor(() => {
         // The row reappears after rollback — the Take ours button is still rendered.
@@ -1408,6 +1435,7 @@ describe("ReviewHub", () => {
       await waitFor(() => screen.getByTestId("conflict-panel"));
       const takeOurs = screen.getByRole("button", { name: /Take ours for src\/app\.ts/i });
       fireEvent.click(takeOurs);
+      await confirmCheckout("ours");
 
       // After the click, the optimistic row disappears for `src/app.ts` —
       // only `src/other.ts` remains conflicted. Continue must still be
@@ -1729,6 +1757,10 @@ describe("ReviewHub", () => {
         fireEvent.click(screen.getByTestId("review-hub-push-error-cta"));
         await Promise.resolve();
       });
+      await act(async () => {
+        await confirmPullRebase();
+        await Promise.resolve();
+      });
 
       await waitFor(() => expect(pullRebaseMock).toHaveBeenCalledWith(WORKTREE_PATH));
       await waitFor(() => expect(screen.queryByTestId("review-hub-push-error")).toBeNull());
@@ -1759,6 +1791,10 @@ describe("ReviewHub", () => {
 
       await act(async () => {
         fireEvent.click(screen.getByTestId("review-hub-push-error-cta"));
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await confirmPullRebase();
         await Promise.resolve();
       });
 

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -159,44 +159,6 @@ export function WorktreeCard({
     }
   };
 
-  const [hasSnapshot, setHasSnapshot] = useState(false);
-
-  // Check for snapshot availability — re-runs when agent activity changes
-  React.useEffect(() => {
-    let cancelled = false;
-    window.electron.git
-      .snapshotGet(worktree.id)
-      .then((info) => {
-        if (!cancelled) setHasSnapshot(info !== null && info.hasChanges);
-      })
-      .catch(() => {
-        // Ignore errors — snapshot check is best-effort
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [worktree.id, worktree.lastActivityTimestamp]);
-
-  const handleRevertAgentChanges = async () => {
-    try {
-      const result = await window.electron.git.snapshotRevert(worktree.id);
-      setHasSnapshot(false);
-      if (result.hasConflicts) {
-        // Notify about conflicts
-        void actionService.dispatch(
-          "app.showNotification",
-          {
-            type: "warning",
-            message: result.message,
-          },
-          { source: "user" }
-        );
-      }
-    } catch {
-      // Error handled by IPC layer
-    }
-  };
-
   const {
     counts: terminalCounts,
     terminals: worktreeTerminals,
@@ -328,6 +290,8 @@ export function WorktreeCard({
     handleCloseAll,
     handleTerminateAll,
     handleResourceTeardown,
+    hasSnapshot,
+    handleRevertAgentChanges,
   } = useWorktreeActions({
     worktree,
     onCopyTree,

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -83,7 +83,12 @@ export function useWorktreeActions({
         setSnapshotCreatedAt(available ? info.createdAt : null);
       })
       .catch(() => {
-        // Ignore errors — snapshot check is best-effort.
+        // Snapshot check is best-effort, but a failure after a prior success
+        // (host restart, snapshot deleted externally) must not leave the
+        // Revert button live against a snapshot that may no longer exist.
+        if (cancelled) return;
+        setHasSnapshot(false);
+        setSnapshotCreatedAt(null);
       });
     return () => {
       cancelled = true;

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -1,4 +1,4 @@
-import { createElement, useCallback, useState, type ReactNode } from "react";
+import { createElement, useCallback, useEffect, useState, type ReactNode } from "react";
 import type { WorktreeState } from "@/types";
 import { logError } from "@/utils/logger";
 import { actionService } from "@/services/ActionService";
@@ -40,6 +40,9 @@ export interface UseWorktreeActionsResult {
   handleCloseAll: () => void;
   handleTerminateAll: () => void;
   handleResourceTeardown: () => void;
+
+  hasSnapshot: boolean;
+  handleRevertAgentChanges: () => void;
 }
 
 export function useWorktreeActions({
@@ -64,6 +67,68 @@ export function useWorktreeActions({
   const closeConfirmDialog = useCallback(() => {
     setConfirmDialog({ isOpen: false });
   }, []);
+
+  const [hasSnapshot, setHasSnapshot] = useState(false);
+  const [snapshotCreatedAt, setSnapshotCreatedAt] = useState<number | null>(null);
+
+  // Check for snapshot availability — re-runs when agent activity changes.
+  useEffect(() => {
+    let cancelled = false;
+    window.electron.git
+      .snapshotGet(worktree.id)
+      .then((info) => {
+        if (cancelled) return;
+        const available = info !== null && info.hasChanges;
+        setHasSnapshot(available);
+        setSnapshotCreatedAt(available ? info.createdAt : null);
+      })
+      .catch(() => {
+        // Ignore errors — snapshot check is best-effort.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [worktree.id, worktree.lastActivityTimestamp]);
+
+  const handleRevertAgentChanges = useCallback(() => {
+    const label = worktree.issueTitle ?? worktree.branch ?? worktree.name;
+    const preview =
+      snapshotCreatedAt != null
+        ? createElement(
+            "p",
+            { className: "text-xs text-daintree-text/60" },
+            `Snapshot captured ${new Date(snapshotCreatedAt).toLocaleString()}.`
+          )
+        : undefined;
+    setConfirmDialog({
+      isOpen: true,
+      title: `Revert agent changes for '${label}'?`,
+      description:
+        "Reverting to the pre-agent snapshot permanently discards every working tree change made since the snapshot in this worktree. This cannot be undone.",
+      confirmLabel: "Revert agent changes",
+      variant: "destructive",
+      children: preview,
+      onConfirm: () => {
+        setConfirmDialog({ isOpen: false });
+        window.electron.git
+          .snapshotRevert(worktree.id)
+          .then((result) => {
+            setHasSnapshot(false);
+            setSnapshotCreatedAt(null);
+            if (result.hasConflicts) {
+              void actionService.dispatch(
+                "app.showNotification",
+                { type: "warning", message: result.message },
+                { source: "user" }
+              );
+            }
+          })
+          .catch((error) => {
+            logError("Failed to revert agent changes", error);
+          });
+      },
+    });
+  }, [worktree.id, worktree.issueTitle, worktree.branch, worktree.name, snapshotCreatedAt]);
 
   const handlePathClick = useCallback(() => {
     void actionService.dispatch("system.openPath", { path: worktree.path }, { source: "user" });
@@ -225,5 +290,7 @@ export function useWorktreeActions({
     handleSelectAllAgents,
     handleSelectWaitingAgents,
     handleSelectWorkingAgents,
+    hasSnapshot,
+    handleRevertAgentChanges,
   };
 }

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -234,6 +234,7 @@ describe("duplicate registrations", () => {
  */
 const EXPECTED_CONFIRM_DANGER: ReadonlyArray<ActionId> = [
   "git.push",
+  "git.pullRebase",
   "git.snapshotRevert",
   "git.snapshotDelete",
   "terminal.kill",

--- a/src/services/actions/definitions/__tests__/gitActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/gitActions.adversarial.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
 import { registerGitActions } from "../gitActions";
 import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
+import { useGitPullRebaseConfirmStore } from "@/store/gitPullRebaseConfirmStore";
 
 /**
  * `git.push` now awaits a deferred-Promise confirm gate (#8242). In a unit
@@ -15,6 +16,14 @@ async function resolvePushConfirm(ok: boolean): Promise<void> {
   useGitPushConfirmStore.getState().resolveConfirmation(ok);
 }
 
+/** Same deferred-Promise gate, for `git.pullRebase` (#8242). */
+async function resolvePullRebaseConfirm(ok: boolean): Promise<void> {
+  await vi.waitFor(() => {
+    expect(useGitPullRebaseConfirmStore.getState().pendingConfirm).not.toBeNull();
+  });
+  useGitPullRebaseConfirmStore.getState().resolveConfirmation(ok);
+}
+
 type GitStub = {
   [K in
     | "stageAll"
@@ -23,6 +32,7 @@ type GitStub = {
     | "unstageFile"
     | "commit"
     | "push"
+    | "pullRebase"
     | "getFileDiff"
     | "listCommits"
     | "getStagingStatus"
@@ -41,6 +51,7 @@ function makeGitStub(): GitStub {
     unstageFile: vi.fn().mockResolvedValue(undefined),
     commit: vi.fn().mockResolvedValue({ sha: "abc" }),
     push: vi.fn().mockResolvedValue({ ok: true }),
+    pullRebase: vi.fn().mockResolvedValue(undefined),
     getFileDiff: vi.fn().mockResolvedValue("diff"),
     listCommits: vi.fn().mockResolvedValue([]),
     getStagingStatus: vi.fn().mockResolvedValue({}),
@@ -139,6 +150,31 @@ describe("gitActions adversarial", () => {
     await resolvePushConfirm(false);
     await p;
     expect(git.push).not.toHaveBeenCalled();
+  });
+
+  it("git.pullRebase fires IPC only after the confirm gate is accepted", async () => {
+    const { run, git } = setupActions();
+    const p = run("git.pullRebase", { cwd: "/repo" });
+    expect(git.pullRebase).not.toHaveBeenCalled();
+    await resolvePullRebaseConfirm(true);
+    await p;
+    expect(git.pullRebase).toHaveBeenCalledWith("/repo");
+  });
+
+  it("git.pullRebase does not reach IPC when the confirm gate is declined", async () => {
+    const { run, git } = setupActions();
+    const p = run("git.pullRebase", { cwd: "/repo" });
+    await resolvePullRebaseConfirm(false);
+    await p;
+    expect(git.pullRebase).not.toHaveBeenCalled();
+  });
+
+  it("git.pullRebase falls back to ctx.activeWorktreePath when no cwd arg is given", async () => {
+    const { run, git } = setupActions();
+    const p = run("git.pullRebase", undefined, { activeWorktreePath: "/repo" });
+    await resolvePullRebaseConfirm(true);
+    await p;
+    expect(git.pullRebase).toHaveBeenCalledWith("/repo");
   });
 
   it("git.getFileDiff forwards cwd, filePath, and status positionally without mutation", async () => {

--- a/src/services/actions/definitions/__tests__/gitActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/gitActions.adversarial.test.ts
@@ -1,6 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
 import { registerGitActions } from "../gitActions";
+import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
+
+/**
+ * `git.push` now awaits a deferred-Promise confirm gate (#8242). In a unit
+ * context there is no mounted `GitPushConfirmDialog`, so resolve the pending
+ * request explicitly once `run()` has registered it.
+ */
+async function resolvePushConfirm(ok: boolean): Promise<void> {
+  await vi.waitFor(() => {
+    expect(useGitPushConfirmStore.getState().pendingConfirm).not.toBeNull();
+  });
+  useGitPushConfirmStore.getState().resolveConfirmation(ok);
+}
 
 type GitStub = {
   [K in
@@ -106,14 +119,26 @@ describe("gitActions adversarial", () => {
 
   it("git.push preserves explicit setUpstream:false (doesn't convert it to undefined)", async () => {
     const { run, git } = setupActions();
-    await run("git.push", { cwd: "/repo", setUpstream: false });
+    const p = run("git.push", { cwd: "/repo", setUpstream: false });
+    await resolvePushConfirm(true);
+    await p;
     expect(git.push).toHaveBeenCalledWith("/repo", false);
   });
 
   it("git.push preserves explicit setUpstream:true", async () => {
     const { run, git } = setupActions();
-    await run("git.push", { cwd: "/repo", setUpstream: true });
+    const p = run("git.push", { cwd: "/repo", setUpstream: true });
+    await resolvePushConfirm(true);
+    await p;
     expect(git.push).toHaveBeenCalledWith("/repo", true);
+  });
+
+  it("git.push does not reach IPC when the confirm gate is declined", async () => {
+    const { run, git } = setupActions();
+    const p = run("git.push", { cwd: "/repo" });
+    await resolvePushConfirm(false);
+    await p;
+    expect(git.push).not.toHaveBeenCalled();
   });
 
   it("git.getFileDiff forwards cwd, filePath, and status positionally without mutation", async () => {

--- a/src/services/actions/definitions/gitActions.ts
+++ b/src/services/actions/definitions/gitActions.ts
@@ -1,6 +1,7 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import type { ActionContext } from "@shared/types/actions";
 import { GitStatusSchema, PulseRangeDaysSchema } from "./schemas";
+import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
 import { z } from "zod";
 
 export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
@@ -217,6 +218,12 @@ export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCa
       const { cwd, setUpstream } = (args ?? {}) as { cwd?: string; setUpstream?: boolean };
       const resolvedCwd = cwd ?? ctx.activeWorktreePath;
       if (!resolvedCwd) throw new Error("No active worktree");
+      // Agent sources are gated by ActionService before run() is reached;
+      // palette/keybinding/user sources reach here directly, so enforce the
+      // D2 push preview here (#8242). The dialog shows the target branch and
+      // the commits that would be pushed before the IPC fires.
+      const confirmed = await useGitPushConfirmStore.getState().requestConfirmation(resolvedCwd);
+      if (!confirmed) return;
       return await window.electron.git.push(resolvedCwd, setUpstream);
     },
   }));
@@ -227,7 +234,7 @@ export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCa
     description: "Pull remote changes and rebase local commits",
     category: "git",
     kind: "command",
-    danger: "safe",
+    danger: "confirm",
     scope: "renderer",
     argsSchema: z.object({ cwd: z.string().optional() }).optional(),
     run: async (args: unknown, ctx: ActionContext) => {

--- a/src/services/actions/definitions/gitActions.ts
+++ b/src/services/actions/definitions/gitActions.ts
@@ -2,6 +2,7 @@ import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import type { ActionContext } from "@shared/types/actions";
 import { GitStatusSchema, PulseRangeDaysSchema } from "./schemas";
 import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
+import { useGitPullRebaseConfirmStore } from "@/store/gitPullRebaseConfirmStore";
 import { z } from "zod";
 
 export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
@@ -241,6 +242,15 @@ export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCa
       const { cwd } = (args ?? {}) as { cwd?: string };
       const resolvedCwd = cwd ?? ctx.activeWorktreePath;
       if (!resolvedCwd) throw new Error("No active worktree");
+      // Agent sources are gated by ActionService before run(); palette,
+      // keybinding, and the terminal push-error recovery banner reach here
+      // directly, so enforce the rebase confirm here (#8242). The ReviewHub
+      // CTA calls the IPC directly and is gated by its own in-component
+      // dialog, so it never goes through this action path.
+      const confirmed = await useGitPullRebaseConfirmStore
+        .getState()
+        .requestConfirmation(resolvedCwd);
+      if (!confirmed) return;
       await window.electron.git.pullRebase(resolvedCwd);
     },
   }));

--- a/src/store/__tests__/gitPullRebaseConfirmStore.test.ts
+++ b/src/store/__tests__/gitPullRebaseConfirmStore.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { useGitPullRebaseConfirmStore } from "../gitPullRebaseConfirmStore";
+
+afterEach(() => {
+  if (useGitPullRebaseConfirmStore.getState().pendingConfirm) {
+    useGitPullRebaseConfirmStore.getState().resolveConfirmation(false);
+  }
+});
+
+describe("gitPullRebaseConfirmStore", () => {
+  it("resolves the awaited Promise with the value passed to resolveConfirmation", async () => {
+    const pending = useGitPullRebaseConfirmStore.getState().requestConfirmation("/repo");
+    expect(useGitPullRebaseConfirmStore.getState().pendingConfirm?.cwd).toBe("/repo");
+
+    useGitPullRebaseConfirmStore.getState().resolveConfirmation(true);
+    await expect(pending).resolves.toBe(true);
+    expect(useGitPullRebaseConfirmStore.getState().pendingConfirm).toBeNull();
+  });
+
+  it("resolves with false when declined", async () => {
+    const pending = useGitPullRebaseConfirmStore.getState().requestConfirmation("/repo");
+    useGitPullRebaseConfirmStore.getState().resolveConfirmation(false);
+    await expect(pending).resolves.toBe(false);
+  });
+
+  it("cancels a prior pending request (resolves it false) when a new one arrives", async () => {
+    const first = useGitPullRebaseConfirmStore.getState().requestConfirmation("/repo-a");
+    const second = useGitPullRebaseConfirmStore.getState().requestConfirmation("/repo-b");
+
+    await expect(first).resolves.toBe(false);
+    expect(useGitPullRebaseConfirmStore.getState().pendingConfirm?.cwd).toBe("/repo-b");
+
+    useGitPullRebaseConfirmStore.getState().resolveConfirmation(true);
+    await expect(second).resolves.toBe(true);
+  });
+
+  it("resolveConfirmation is a no-op when nothing is pending", () => {
+    expect(() => useGitPullRebaseConfirmStore.getState().resolveConfirmation(true)).not.toThrow();
+    expect(useGitPullRebaseConfirmStore.getState().pendingConfirm).toBeNull();
+  });
+});

--- a/src/store/__tests__/gitPushConfirmStore.test.ts
+++ b/src/store/__tests__/gitPushConfirmStore.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { useGitPushConfirmStore } from "../gitPushConfirmStore";
+
+afterEach(() => {
+  // Resolve any leaked pending request so it can't bleed into the next test.
+  if (useGitPushConfirmStore.getState().pendingConfirm) {
+    useGitPushConfirmStore.getState().resolveConfirmation(false);
+  }
+});
+
+describe("gitPushConfirmStore", () => {
+  it("resolves the awaited Promise with the value passed to resolveConfirmation", async () => {
+    const { requestConfirmation } = useGitPushConfirmStore.getState();
+    const pending = requestConfirmation("/repo");
+
+    expect(useGitPushConfirmStore.getState().pendingConfirm?.cwd).toBe("/repo");
+
+    useGitPushConfirmStore.getState().resolveConfirmation(true);
+    await expect(pending).resolves.toBe(true);
+    expect(useGitPushConfirmStore.getState().pendingConfirm).toBeNull();
+  });
+
+  it("resolves with false when declined", async () => {
+    const pending = useGitPushConfirmStore.getState().requestConfirmation("/repo");
+    useGitPushConfirmStore.getState().resolveConfirmation(false);
+    await expect(pending).resolves.toBe(false);
+  });
+
+  it("cancels a prior pending request (resolves it false) when a new one arrives", async () => {
+    const first = useGitPushConfirmStore.getState().requestConfirmation("/repo-a");
+    const second = useGitPushConfirmStore.getState().requestConfirmation("/repo-b");
+
+    await expect(first).resolves.toBe(false);
+    expect(useGitPushConfirmStore.getState().pendingConfirm?.cwd).toBe("/repo-b");
+
+    useGitPushConfirmStore.getState().resolveConfirmation(true);
+    await expect(second).resolves.toBe(true);
+  });
+
+  it("resolveConfirmation is a no-op when nothing is pending", () => {
+    expect(() => useGitPushConfirmStore.getState().resolveConfirmation(true)).not.toThrow();
+    expect(useGitPushConfirmStore.getState().pendingConfirm).toBeNull();
+  });
+});

--- a/src/store/gitPullRebaseConfirmStore.ts
+++ b/src/store/gitPullRebaseConfirmStore.ts
@@ -1,0 +1,50 @@
+import { create } from "zustand";
+
+/**
+ * Deferred-Promise confirm gate for the `git.pullRebase` action when
+ * dispatched outside the ReviewHub component path — palette, keybinding, or
+ * the terminal push-error `ErrorBanner` recovery action
+ * (`shared/utils/gitOperationErrors.ts` maps `push-rejected-outdated` to
+ * `git.pullRebase`). `ActionService.dispatch` only blocks unconfirmed agent
+ * sources, so those interactive paths would otherwise rebase with no preview
+ * (#8242). The ReviewHub CTA calls `window.electron.git.pullRebase` directly
+ * and is gated by its own in-component `ConfirmDialog`, so it never reaches
+ * this store.
+ *
+ * Mirrors `gitPushConfirmStore` / `panelLimitStore`: a second request while
+ * one is pending cancels the first (resolves false).
+ */
+
+interface PendingPullRebaseConfirmation {
+  resolve: (ok: boolean) => void;
+  cwd: string;
+}
+
+interface GitPullRebaseConfirmState {
+  pendingConfirm: PendingPullRebaseConfirmation | null;
+  requestConfirmation: (cwd: string) => Promise<boolean>;
+  resolveConfirmation: (ok: boolean) => void;
+}
+
+export const useGitPullRebaseConfirmStore = create<GitPullRebaseConfirmState>()((set, get) => ({
+  pendingConfirm: null,
+
+  requestConfirmation: (cwd: string): Promise<boolean> => {
+    const existing = get().pendingConfirm;
+    if (existing) {
+      existing.resolve(false);
+    }
+
+    return new Promise<boolean>((resolve) => {
+      set({ pendingConfirm: { resolve, cwd } });
+    });
+  },
+
+  resolveConfirmation: (ok: boolean) => {
+    const pending = get().pendingConfirm;
+    if (pending) {
+      pending.resolve(ok);
+      set({ pendingConfirm: null });
+    }
+  },
+}));

--- a/src/store/gitPushConfirmStore.ts
+++ b/src/store/gitPushConfirmStore.ts
@@ -1,0 +1,47 @@
+import { create } from "zustand";
+
+/**
+ * Deferred-Promise confirm gate for `git.push` dispatched from the action
+ * palette or a keybinding. `ActionService.dispatch` only blocks destructive
+ * actions from `source === "agent"`, so palette/keybinding pushes would
+ * otherwise reach `window.electron.git.push` with no D2 preview (#8242).
+ *
+ * Mirrors the `panelLimitStore` request/resolve pattern: the action `run()`
+ * awaits `requestConfirmation`, the lazily-mounted `GitPushConfirmDialog`
+ * resolves it. A second request while one is pending cancels the first
+ * (resolves false) — same semantics as `panelLimitStore`.
+ */
+
+interface PendingPushConfirmation {
+  resolve: (ok: boolean) => void;
+  cwd: string;
+}
+
+interface GitPushConfirmState {
+  pendingConfirm: PendingPushConfirmation | null;
+  requestConfirmation: (cwd: string) => Promise<boolean>;
+  resolveConfirmation: (ok: boolean) => void;
+}
+
+export const useGitPushConfirmStore = create<GitPushConfirmState>()((set, get) => ({
+  pendingConfirm: null,
+
+  requestConfirmation: (cwd: string): Promise<boolean> => {
+    const existing = get().pendingConfirm;
+    if (existing) {
+      existing.resolve(false);
+    }
+
+    return new Promise<boolean>((resolve) => {
+      set({ pendingConfirm: { resolve, cwd } });
+    });
+  },
+
+  resolveConfirmation: (ok: boolean) => {
+    const pending = get().pendingConfirm;
+    if (pending) {
+      pending.resolve(ok);
+      set({ pendingConfirm: null });
+    }
+  },
+}));


### PR DESCRIPTION
## Summary

- Wires `ConfirmDialog` gates at the four remaining direct-IPC destructive bypass sites identified in the `docs/architecture/destructive-action-safeguards.md` audit.
- `git.pullRebase` reclassified from `safe` to `confirm` danger — the terminal `ErrorBanner` recovery path was silently rebasing without any user confirmation.
- All four TBD rows in the safeguards audit flipped to closed; `EXPECTED_CONFIRM_DANGER` test guard updated.

Resolves #8242

## Changes

**`git.push`** — new `gitPushConfirmStore` + lazy-mounted `GitPushConfirmDialog` in `App`. Previews target branch and recent local commits before any palette/keybinding push fires.

**`git.snapshotRevert`** — snapshot state/effect/handler migrated into `useWorktreeActions`, gated via the existing `WorktreeDialogs` `ConfirmDialog` path. No new dialog surface needed.

**`git.pullRebase`** — reclassified `danger: "safe"` → `danger: "confirm"`. `ReviewHub` CTA now shows ahead/behind divergence preview. New `gitPullRebaseConfirmStore` + `GitPullRebaseConfirmDialog` gates both the action dispatch path and the live terminal `ErrorBanner` recovery path so neither can fire without an explicit confirm.

**`checkoutOursTheirs`** — per-file rebase-aware `ConfirmDialog` added to `ConflictPanel`.

## Testing

- 255 targeted vitest pass (new store unit tests, adversarial gate tests, negative `ReviewHub` tests asserting IPC does not fire pre-confirm)
- `npm run check` fully green (lint warnings net -1)