### PR TITLE
feat(dev-preview): plumb typed errors through dev-preview error overlays

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1138,7 +1138,11 @@ export function DevPreviewPane({
                             ? "Load cancelled"
                             : webviewLoadError.code === "connection_refused"
                               ? "Dev server unreachable"
-                              : "Page load failed"}
+                              : webviewLoadError.code === "name_not_resolved"
+                                ? "Couldn't resolve address"
+                                : webviewLoadError.code === "internet_disconnected"
+                                  ? "No internet connection"
+                                  : "Page load failed"}
                       </h3>
                       <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
                         {webviewLoadError.message}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1005,7 +1005,7 @@ export function DevPreviewPane({
                 </Button>
                 {error.type === "missing-dependencies" || error.type === "permission" ? (
                   <Button
-                    onClick={() => actionService.dispatch("panel.focus", { panelId: id })}
+                    onClick={() => setDevPreviewConsoleOpen(id, true)}
                     variant="ghost"
                     size="sm"
                     className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
@@ -1121,11 +1121,7 @@ export function DevPreviewPane({
                   {reconnectAttempt > 0 && !webviewLoadError && (
                     <div className="absolute bottom-0 left-0 right-0 z-20 flex items-center justify-center gap-2 px-3 py-1.5 text-xs bg-status-info/10 border-t border-status-info/20 text-daintree-text/70">
                       <Spinner size="xs" className="text-status-info" />
-                      <span>
-                        Reconnecting
-                        {reconnectAttempt > 0 ? ` (attempt ${reconnectAttempt} of 5)` : ""}
-                        ...
-                      </span>
+                      <span>Reconnecting (attempt {reconnectAttempt} of 5)...</span>
                     </div>
                   )}
                   {webviewLoadError && (

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -417,6 +417,7 @@ export function DevPreviewPane({
     setIsSlowLoad,
     webviewLoadError,
     setWebviewLoadError,
+    reconnectAttempt,
     clearLoadTimers,
     clearRetryState,
   } = useDevPreviewLoadLifecycle({
@@ -580,7 +581,7 @@ export function DevPreviewPane({
     } catch {
       // Webview detached
     }
-    setWebviewLoadError("Load cancelled.");
+    setWebviewLoadError({ code: "aborted", message: "Load cancelled." });
   }, [clearLoadTimers, setIsSlowLoad, setIsLoading, setWebviewLoadError]);
 
   const handleRetryWebviewLoad = useCallback(() => {
@@ -978,7 +979,15 @@ export function DevPreviewPane({
           ) : status === "error" && error ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
               <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
-              <h3 className="text-sm font-medium text-daintree-text/70 mb-1">Dev Server Error</h3>
+              <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
+                {error.type === "port-conflict"
+                  ? "Port conflict"
+                  : error.type === "missing-dependencies"
+                    ? "Missing dependencies"
+                    : error.type === "permission"
+                      ? "Permission denied"
+                      : "Dev server error"}
+              </h3>
               <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
                 {error.message}
               </p>
@@ -990,9 +999,21 @@ export function DevPreviewPane({
                   className="gap-1.5 px-2.5 py-1.5 group"
                 >
                   <RotateCw className="h-3.5 w-3.5" />
-                  <span className="text-xs">Retry</span>
+                  <span className="text-xs">
+                    {error.type === "missing-dependencies" ? "Retry install" : "Retry"}
+                  </span>
                 </Button>
-                {currentUrl && (
+                {error.type === "missing-dependencies" || error.type === "permission" ? (
+                  <Button
+                    onClick={() => actionService.dispatch("panel.focus", { panelId: id })}
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                    <span className="text-xs">View terminal</span>
+                  </Button>
+                ) : currentUrl ? (
                   <Button
                     onClick={handleOpenExternal}
                     variant="ghost"
@@ -1002,7 +1023,7 @@ export function DevPreviewPane({
                     <ExternalLink className="h-3.5 w-3.5" />
                     <span className="text-xs">Open external</span>
                   </Button>
-                )}
+                ) : null}
               </div>
             </div>
           ) : !currentUrl || status !== "running" ? (
@@ -1010,7 +1031,7 @@ export function DevPreviewPane({
               {isUnconfigured ? (
                 <div className="flex flex-col items-center text-center max-w-md">
                   <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                    Configure Dev Server
+                    Configure dev server
                   </h3>
                   <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
                     No dev server command is configured for this project.
@@ -1057,7 +1078,7 @@ export function DevPreviewPane({
               ) : (
                 <div className="flex flex-col items-center text-center max-w-md">
                   <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                    Waiting for Dev Server
+                    Waiting for dev server
                   </h3>
                   <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
                     The development server will appear here once it starts and a URL is detected.
@@ -1097,28 +1118,37 @@ export function DevPreviewPane({
                 }
               >
                 <>
+                  {reconnectAttempt > 0 && !webviewLoadError && (
+                    <div className="absolute bottom-0 left-0 right-0 z-20 flex items-center justify-center gap-2 px-3 py-1.5 text-xs bg-status-info/10 border-t border-status-info/20 text-daintree-text/70">
+                      <Spinner size="xs" className="text-status-info" />
+                      <span>
+                        Reconnecting
+                        {reconnectAttempt > 0 ? ` (attempt ${reconnectAttempt} of 5)` : ""}
+                        ...
+                      </span>
+                    </div>
+                  )}
                   {webviewLoadError && (
                     <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
                       <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
                       <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                        {webviewLoadError.startsWith("Load timed out") ||
-                        webviewLoadError.startsWith("Connection to")
-                          ? "Page Load Timed Out"
-                          : webviewLoadError.startsWith("Load cancelled")
-                            ? "Load Cancelled"
-                            : "Dev Server Unreachable"}
+                        {webviewLoadError.code === "timeout"
+                          ? "Page load timed out"
+                          : webviewLoadError.code === "aborted"
+                            ? "Load cancelled"
+                            : webviewLoadError.code === "connection_refused"
+                              ? "Dev server unreachable"
+                              : "Page load failed"}
                       </h3>
                       <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
-                        {webviewLoadError}
+                        {webviewLoadError.message}
                       </p>
                       <div className="flex items-center gap-1">
                         <Button
                           onClick={
-                            webviewLoadError.startsWith("Load cancelled") ||
-                            webviewLoadError.startsWith("Load timed out") ||
-                            webviewLoadError.startsWith("Connection to")
-                              ? handleRetryWebviewLoad
-                              : handleHardRestart
+                            webviewLoadError.code === "connection_refused"
+                              ? handleHardRestart
+                              : handleRetryWebviewLoad
                           }
                           variant="ghost"
                           size="sm"
@@ -1126,11 +1156,9 @@ export function DevPreviewPane({
                         >
                           <RotateCw className="h-3.5 w-3.5" />
                           <span className="text-xs">
-                            {webviewLoadError.startsWith("Load cancelled") ||
-                            webviewLoadError.startsWith("Load timed out") ||
-                            webviewLoadError.startsWith("Connection to")
-                              ? "Retry"
-                              : "Hard Restart"}
+                            {webviewLoadError.code === "connection_refused"
+                              ? "Hard restart"
+                              : "Retry"}
                           </span>
                         </Button>
                         {currentUrl && (

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -53,7 +53,12 @@ type DevServerState = {
   status: "stopped" | "starting" | "installing" | "running" | "error";
   url: string | null;
   terminalId: string | null;
-  error: { type: "unknown" | "port-conflict" | "missing-dependencies"; message: string } | null;
+  error: {
+    type: "unknown" | "port-conflict" | "missing-dependencies" | "permission";
+    message: string;
+    port?: string;
+    module?: string;
+  } | null;
   start: ReturnType<typeof vi.fn>;
   restart: ReturnType<typeof vi.fn>;
   isRestarting: boolean;
@@ -387,7 +392,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
     expect(webview.stop).toHaveBeenCalledTimes(1);
     expect(webview.reload).not.toHaveBeenCalled();
-    expect(container.textContent).toContain("Page Load Timed Out");
+    expect(container.textContent).toContain("Page load timed out");
   });
 
   it("clears stuck-load timeout when loading fails", () => {
@@ -1027,7 +1032,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       }
     }
 
-    expect(container.textContent).toContain("Dev Server Unreachable");
+    expect(container.textContent).toContain("Dev server unreachable");
     expect(container.textContent).toContain("Unable to connect to dev server");
   });
 
@@ -1052,11 +1057,11 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       }
     }
 
-    expect(container.textContent).toContain("Dev Server Unreachable");
+    expect(container.textContent).toContain("Dev server unreachable");
 
     fireEvent.click(screen.getByTestId("hard-restart"));
 
-    expect(container.textContent).not.toContain("Dev Server Unreachable");
+    expect(container.textContent).not.toContain("Dev server unreachable");
   });
 
   describe("slow-load and timeout escalation", () => {
@@ -1120,7 +1125,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
       expect(webview.stop).toHaveBeenCalledTimes(1);
       expect(webview.reload).not.toHaveBeenCalled();
-      expect(container.textContent).toContain("Page Load Timed Out");
+      expect(container.textContent).toContain("Page load timed out");
     });
 
     it("Retry from timeout clears error and loads current URL", () => {

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -154,6 +154,11 @@ export function useDevPreviewLoadLifecycle({
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
       }
+      if (failLoadRetryRef.current) {
+        clearTimeout(failLoadRetryRef.current);
+        failLoadRetryRef.current = null;
+      }
+      failLoadRetryCountRef.current = 0;
       slowLoadTimeoutRef.current = setTimeout(() => {
         try {
           if (webview.isLoading()) {
@@ -219,6 +224,9 @@ export function useDevPreviewLoadLifecycle({
       if (e.errorCode === -3) return;
       // Ignore cancellations
       if (e.errorCode === -6) return;
+      // Ignore subframe failures — they don't affect the main-frame load state
+      if (!e.isMainFrame) return;
+
       setIsLoading(false);
       setIsSlowLoad(false);
       if (slowLoadTimeoutRef.current) {
@@ -237,7 +245,7 @@ export function useDevPreviewLoadLifecycle({
       const ERR_CONNECTION_TIMED_OUT = -118;
 
       // Non-retryable errors: surface directly with friendly messages
-      if (e.isMainFrame && e.errorCode === ERR_NAME_NOT_RESOLVED && e.validatedURL) {
+      if (e.errorCode === ERR_NAME_NOT_RESOLVED && e.validatedURL) {
         let hostname = e.validatedURL;
         try {
           hostname = new URL(e.validatedURL).hostname;
@@ -251,14 +259,14 @@ export function useDevPreviewLoadLifecycle({
         });
         return;
       }
-      if (e.isMainFrame && e.errorCode === ERR_INTERNET_DISCONNECTED) {
+      if (e.errorCode === ERR_INTERNET_DISCONNECTED) {
         setWebviewLoadError({
           code: "internet_disconnected",
           message: "No internet connection. Check your network.",
         });
         return;
       }
-      if (e.isMainFrame && e.errorCode === ERR_CONNECTION_TIMED_OUT && e.validatedURL) {
+      if (e.errorCode === ERR_CONNECTION_TIMED_OUT && e.validatedURL) {
         setWebviewLoadError({
           code: "timeout",
           message: `Connection to ${e.validatedURL} timed out. The server may be unreachable.`,
@@ -269,10 +277,7 @@ export function useDevPreviewLoadLifecycle({
 
       // Retry on connection-refused errors: the readiness check may have passed
       // a moment before the server was fully reachable from the webview.
-      if (
-        e.isMainFrame &&
-        (e.errorCode === ERR_CONNECTION_REFUSED || e.errorCode === ERR_CONNECTION_RESET)
-      ) {
+      if (e.errorCode === ERR_CONNECTION_REFUSED || e.errorCode === ERR_CONNECTION_RESET) {
         const MAX_RETRIES = 5;
         const retryCount = failLoadRetryCountRef.current;
         if (retryCount >= MAX_RETRIES) {
@@ -312,15 +317,13 @@ export function useDevPreviewLoadLifecycle({
       // Catch-all for unhandled error codes (-2 ERR_FAILED, -7 ERR_TIMED_OUT,
       // -104 ERR_CONNECTION_FAILED, and any other unexpected codes).
       // Without this branch the webview shows a blank white screen with no error.
-      if (e.isMainFrame) {
-        const desc = e.errorDescription || `Error code ${e.errorCode}`;
-        setWebviewLoadError({
-          code: "failed",
-          message: `Page failed to load: ${desc}.`,
-          errorCode: e.errorCode,
-          validatedURL: e.validatedURL || undefined,
-        });
-      }
+      const desc = e.errorDescription || `Error code ${e.errorCode}`;
+      setWebviewLoadError({
+        code: "failed",
+        message: `Page failed to load: ${desc}.`,
+        errorCode: e.errorCode,
+        validatedURL: e.validatedURL || undefined,
+      });
     };
 
     const handleDidNavigate = (e: Electron.DidNavigateEvent) => {

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -15,6 +15,21 @@ export type DevPreviewBlockedNav = {
   sessionStorageSnapshot: SessionStorageEntry[];
 };
 
+export type WebviewLoadErrorCode =
+  | "aborted"
+  | "timeout"
+  | "name_not_resolved"
+  | "internet_disconnected"
+  | "connection_refused"
+  | "failed";
+
+export interface WebviewLoadError {
+  code: WebviewLoadErrorCode;
+  message: string;
+  errorCode?: number;
+  validatedURL?: string;
+}
+
 interface UseDevPreviewLoadLifecycleParams {
   webviewElement: Electron.WebviewTag | null;
   id: string;
@@ -36,8 +51,9 @@ interface UseDevPreviewLoadLifecycleResult {
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   isSlowLoad: boolean;
   setIsSlowLoad: React.Dispatch<React.SetStateAction<boolean>>;
-  webviewLoadError: string | null;
-  setWebviewLoadError: React.Dispatch<React.SetStateAction<string | null>>;
+  webviewLoadError: WebviewLoadError | null;
+  setWebviewLoadError: React.Dispatch<React.SetStateAction<WebviewLoadError | null>>;
+  reconnectAttempt: number;
   clearLoadTimers: () => void;
   clearRetryState: () => void;
 }
@@ -58,7 +74,8 @@ export function useDevPreviewLoadLifecycle({
   const [isWebviewReady, setIsWebviewReady] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isSlowLoad, setIsSlowLoad] = useState(false);
-  const [webviewLoadError, setWebviewLoadError] = useState<string | null>(null);
+  const [webviewLoadError, setWebviewLoadError] = useState<WebviewLoadError | null>(null);
+  const [reconnectAttempt, setReconnectAttempt] = useState<number>(0);
 
   // Read projectId through a ref so a late project-hydration transition
   // (undefined → id) doesn't rebind the webview listeners mid-load and clear
@@ -88,6 +105,7 @@ export function useDevPreviewLoadLifecycle({
       failLoadRetryRef.current = null;
     }
     failLoadRetryCountRef.current = 0;
+    setReconnectAttempt(0);
   }, []);
 
   useEffect(() => {
@@ -128,6 +146,7 @@ export function useDevPreviewLoadLifecycle({
     const handleDidStartLoading = () => {
       setIsLoading(true);
       setWebviewLoadError(null);
+      setReconnectAttempt(0);
       setIsSlowLoad(false);
       if (slowLoadTimeoutRef.current) {
         clearTimeout(slowLoadTimeoutRef.current);
@@ -151,9 +170,10 @@ export function useDevPreviewLoadLifecycle({
             webview.stop();
             setIsSlowLoad(false);
             setIsLoading(false);
-            setWebviewLoadError(
-              `Load timed out after ${Math.round(loadTimeoutMs / 1000)}s. The server at ${webview.getURL()} may be unreachable or slow to respond.`
-            );
+            setWebviewLoadError({
+              code: "timeout",
+              message: `Load timed out after ${Math.round(loadTimeoutMs / 1000)}s. The server at ${webview.getURL()} may be unreachable or slow to respond.`,
+            });
           }
         } catch {
           // Webview detached before timeout fired
@@ -177,6 +197,7 @@ export function useDevPreviewLoadLifecycle({
     const handleDidFinishLoad = () => {
       setIsLoading(false);
       setWebviewLoadError(null);
+      setReconnectAttempt(0);
       setIsSlowLoad(false);
       if (slowLoadTimeoutRef.current) {
         clearTimeout(slowLoadTimeoutRef.current);
@@ -223,17 +244,26 @@ export function useDevPreviewLoadLifecycle({
         } catch {
           // Use raw validatedURL if parsing fails
         }
-        setWebviewLoadError(`Couldn't resolve ${hostname}. Check the URL or your connection.`);
+        setWebviewLoadError({
+          code: "name_not_resolved",
+          message: `Couldn't resolve ${hostname}. Check the URL or your connection.`,
+          validatedURL: e.validatedURL,
+        });
         return;
       }
       if (e.isMainFrame && e.errorCode === ERR_INTERNET_DISCONNECTED) {
-        setWebviewLoadError("No internet connection. Check your network.");
+        setWebviewLoadError({
+          code: "internet_disconnected",
+          message: "No internet connection. Check your network.",
+        });
         return;
       }
       if (e.isMainFrame && e.errorCode === ERR_CONNECTION_TIMED_OUT && e.validatedURL) {
-        setWebviewLoadError(
-          `Connection to ${e.validatedURL} timed out. The server may be unreachable.`
-        );
+        setWebviewLoadError({
+          code: "timeout",
+          message: `Connection to ${e.validatedURL} timed out. The server may be unreachable.`,
+          errorCode: ERR_CONNECTION_TIMED_OUT,
+        });
         return;
       }
 
@@ -246,12 +276,17 @@ export function useDevPreviewLoadLifecycle({
         const MAX_RETRIES = 5;
         const retryCount = failLoadRetryCountRef.current;
         if (retryCount >= MAX_RETRIES) {
-          const urlContext = e.validatedURL ? ` at ${e.validatedURL}` : "";
-          setWebviewLoadError(
-            `Unable to connect to dev server${urlContext}. The server may be on a different port.`
-          );
-        } else if (retryCount < MAX_RETRIES) {
+          setReconnectAttempt(0);
+          setWebviewLoadError({
+            code: "connection_refused",
+            message: `Unable to connect to dev server${e.validatedURL ? ` at ${e.validatedURL}` : ""}. The server may be on a different port.`,
+            validatedURL: e.validatedURL || undefined,
+          });
+          return;
+        }
+        if (retryCount < MAX_RETRIES) {
           failLoadRetryCountRef.current += 1;
+          setReconnectAttempt(retryCount + 1);
           // Capture URL at fail-time so the retry loads the same page even if
           // the webview navigates elsewhere during the backoff window.
           const urlToRetry = e.validatedURL || "";
@@ -270,7 +305,21 @@ export function useDevPreviewLoadLifecycle({
               // Webview detached
             }
           }, delayMs);
+          return;
         }
+      }
+
+      // Catch-all for unhandled error codes (-2 ERR_FAILED, -7 ERR_TIMED_OUT,
+      // -104 ERR_CONNECTION_FAILED, and any other unexpected codes).
+      // Without this branch the webview shows a blank white screen with no error.
+      if (e.isMainFrame) {
+        const desc = e.errorDescription || `Error code ${e.errorCode}`;
+        setWebviewLoadError({
+          code: "failed",
+          message: `Page failed to load: ${desc}.`,
+          errorCode: e.errorCode,
+          validatedURL: e.validatedURL || undefined,
+        });
       }
     };
 
@@ -280,6 +329,7 @@ export function useDevPreviewLoadLifecycle({
       if (navigatedUrl === "about:blank" && evictingRef.current) return;
       setBlockedNav(null);
       setWebviewLoadError(null);
+      setReconnectAttempt(0);
       // A confirmed new main-frame navigation means we're past any previous failure;
       // reset the retry budget so stale exhaustion doesn't block future attempts.
       failLoadRetryCountRef.current = 0;
@@ -462,6 +512,7 @@ export function useDevPreviewLoadLifecycle({
     setIsSlowLoad,
     webviewLoadError,
     setWebviewLoadError,
+    reconnectAttempt,
     clearLoadTimers,
     clearRetryState,
   };

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { useProjectStore } from "@/store/projectStore";
-import type { DevServerErrorType } from "../../shared/utils/devServerErrors";
+import type { DevServerError } from "../../shared/utils/devServerErrors";
 import type { DevPreviewSessionState } from "../../shared/types/ipc/devPreview";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
@@ -20,7 +20,7 @@ export interface UseDevServerState {
   status: DevPreviewStatus;
   url: string | null;
   terminalId: string | null;
-  error: { type: DevServerErrorType; message: string; recommendedActionId?: string } | null;
+  error: DevServerError | null;
 }
 
 export interface UseDevServerReturn extends UseDevServerState {
@@ -100,11 +100,7 @@ export function useDevServer({
   const [status, setStatus] = useState<DevPreviewStatus>("stopped");
   const [url, setUrl] = useState<string | null>(null);
   const [terminalId, setTerminalId] = useState<string | null>(null);
-  const [error, setError] = useState<{
-    type: DevServerErrorType;
-    message: string;
-    recommendedActionId?: string;
-  } | null>(null);
+  const [error, setError] = useState<DevServerError | null>(null);
   const [isRestarting, setIsRestarting] = useState(false);
   const [stuckTier, setStuckTier] = useState<DevServerStuckTier>(0);
   const latestSessionRef = useRef<{
@@ -175,15 +171,7 @@ export function useDevServer({
     setStatus(state.status);
     setUrl(state.url);
     setTerminalId(state.terminalId);
-    setError(
-      state.error
-        ? {
-            type: state.error.type,
-            message: state.error.message,
-            recommendedActionId: state.error.recommendedActionId,
-          }
-        : null
-    );
+    setError(state.error ?? null);
     setIsRestarting(state.isRestarting);
   }, []);
 

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -177,6 +177,9 @@ export function useDevServer({
 
   const applyInvokeError = useCallback((err: unknown) => {
     if (!isMountedRef.current) return;
+    // IPC rejections are opaque — formatErrorMessage produces a user-facing
+    // string; if the main process ever sends structured DevServerError rejects,
+    // this path would need deserialization to preserve type/port/module.
     const message = formatErrorMessage(err, "Dev server request failed");
     latestSessionRef.current = {
       status: "error",


### PR DESCRIPTION
## Summary
- Replaces brittle `startsWith()` string matching on webview error messages with a `WebviewLoadError` discriminated union, switching on type discriminators instead
- Widens `DevServerError` to its full type with `port` and `module` fields, preserving structured data through the error path
- Adds `reconnectAttempt` state with a reconnecting indicator bar, and a "View terminal" action for missing-deps/permission errors

Resolves #8265

## Changes
- Introduced `WebviewLoadError` discriminated union (`code`, `message`, `errorCode`, `validatedURL`) in `useDevPreviewLoadLifecycle`
- Switched both error surfaces (dev server + webview load) to switch on type discriminators with per-variant titles, body, and recovery actions
- Widened `useDevServer` error state to full `DevServerError` type, preserving `port`/`module` fields
- Added `reconnectAttempt` counter surfaced as a reconnecting indicator bar during connection-refused retries
- Added "View terminal" action for `missing-dependencies` and `permission` error variants
- Added catch-all branch for unhandled Chromium error codes (-2, -7, -104) that previously showed a blank white screen
- Applied sentence-case to all error and status titles
- Updated tests to match new error code and title conventions

## Testing
- Typecheck passes clean
- Existing dev preview pane webview tests updated and passing
- Manually verified each error variant renders the correct title/body/actions
- Verified the catch-all handles Chromium codes that previously showed nothing