### PR TITLE
fix(dev-preview): show inline banners for webview crashes and hangs

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -353,6 +353,8 @@ export const CHANNELS = {
   WEBVIEW_DIALOG_RESPONSE: "webview:dialog-response",
   WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut",
   WEBVIEW_NAVIGATION_BLOCKED: "webview:navigation-blocked",
+  WEBVIEW_UNRESPONSIVE: "webview:unresponsive",
+  WEBVIEW_RESPONSIVE: "webview:responsive",
   WEBVIEW_OAUTH_LOOPBACK: "webview:oauth-loopback",
   WEBVIEW_START_CONSOLE_CAPTURE: "webview:start-console-capture",
   WEBVIEW_STOP_CONSOLE_CAPTURE: "webview:stop-console-capture",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1821,6 +1821,10 @@ const api: ElectronAPI = {
     onNavigationBlocked: (
       callback: (payload: { panelId: string; url: string; canOpenExternal: boolean }) => void
     ): (() => void) => _typedOn(CHANNELS.WEBVIEW_NAVIGATION_BLOCKED, callback),
+    onUnresponsive: (callback: (payload: { panelId: string }) => void): (() => void) =>
+      _typedOn(CHANNELS.WEBVIEW_UNRESPONSIVE, callback),
+    onResponsive: (callback: (payload: { panelId: string }) => void): (() => void) =>
+      _typedOn(CHANNELS.WEBVIEW_RESPONSIVE, callback),
     startOAuthLoopback: (
       authUrl: string,
       panelId: string,

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -457,6 +457,31 @@ export function setupWebviewCSP(): void {
         }
       );
 
+      // Surface render-process hang to the renderer when the guest stops processing
+      // input events for >30s. Auto-clears when `responsive` fires.
+      const notifyUnresponsive = () => {
+        if (contents.isDestroyed()) return;
+        const panelId = getWebviewDialogService().getPanelId(contents.id);
+        if (!panelId) return;
+        const parentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
+        if (parentWindow && !parentWindow.isDestroyed()) {
+          getAppWebContents(parentWindow).send(CHANNELS.WEBVIEW_UNRESPONSIVE, { panelId });
+        }
+      };
+
+      const notifyResponsive = () => {
+        if (contents.isDestroyed()) return;
+        const panelId = getWebviewDialogService().getPanelId(contents.id);
+        if (!panelId) return;
+        const parentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
+        if (parentWindow && !parentWindow.isDestroyed()) {
+          getAppWebContents(parentWindow).send(CHANNELS.WEBVIEW_RESPONSIVE, { panelId });
+        }
+      };
+
+      contents.on("unresponsive", notifyUnresponsive);
+      contents.on("responsive", notifyResponsive);
+
       // Intercept find-in-page shortcuts (Cmd/Ctrl+F, Cmd/Ctrl+G, Escape) from webview guests
       contents.on("before-input-event", (event, input) => {
         if (input.type !== "keyDown") return;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -860,6 +860,10 @@ export interface ElectronAPI {
     onNavigationBlocked(
       callback: (payload: { panelId: string; url: string; canOpenExternal: boolean }) => void
     ): () => void;
+    /** Subscribe to unresponsive events from webview guest render processes */
+    onUnresponsive(callback: (payload: { panelId: string }) => void): () => void;
+    /** Subscribe to responsive (recovery) events from webview guest render processes */
+    onResponsive(callback: (payload: { panelId: string }) => void): () => void;
     /** Start OAuth loopback flow: system browser for IdP, ephemeral server for callback, CDP for token exchange */
     startOAuthLoopback(
       authUrl: string,

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2259,6 +2259,16 @@ export interface IpcEventMap {
     canOpenExternal: boolean;
   };
 
+  // Webview render process became unresponsive (>30s no input processing)
+  "webview:unresponsive": {
+    panelId: string;
+  };
+
+  // Webview render process recovered from unresponsive state
+  "webview:responsive": {
+    panelId: string;
+  };
+
   // Voice input events
   "voice-input:transcription-delta": string;
   "voice-input:transcription-complete": { text: string; willCorrect: boolean };

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -656,10 +656,7 @@ export function DevPreviewPane({
     }
   }, [currentUrl, setWebviewLoadError, setIsSlowLoad, setIsLoading]);
 
-  const handleHardReload = useCallback(() => {
-    setCrashState("none");
-    setCrashDetails(null);
-    crashTimestampsRef.current = [];
+  const performReload = useCallback(() => {
     const webview = webviewRef.current;
     if (!webview || !isWebviewReady) return;
     setWebviewLoadError(null);
@@ -707,11 +704,18 @@ export function DevPreviewPane({
     setDevPreviewConsoleOpen(id, !isConsoleOpen);
   }, [id, isConsoleOpen, setDevPreviewConsoleOpen]);
 
-  // Keep crashReloadRef in sync so onRenderProcessGone can call handleHardReload
+  const handleHardReload = useCallback(() => {
+    setCrashState("none");
+    setCrashDetails(null);
+    crashTimestampsRef.current = [];
+    performReload();
+  }, [performReload]);
+
+  // Keep crashReloadRef in sync so onRenderProcessGone can call performReload
   // before it exists in the lexical scope.
   useEffect(() => {
-    crashReloadRef.current = handleHardReload;
-  }, [handleHardReload]);
+    crashReloadRef.current = performReload;
+  }, [performReload]);
 
   const handleOpenExternal = useCallback(() => {
     if (currentUrl) {

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -8,6 +8,7 @@ import {
   Square,
   WandSparkles,
   OctagonAlert,
+  XCircle,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
@@ -368,6 +369,13 @@ export function DevPreviewPane({
   });
 
   const [blockedNav, setBlockedNav] = useState<DevPreviewBlockedNav | null>(null);
+  const [crashState, setCrashState] = useState<"none" | "crashed" | "unresponsive">("none");
+  const [crashDetails, setCrashDetails] = useState<{
+    reason: string;
+    exitCode: number;
+  } | null>(null);
+  const crashTimestampsRef = useRef<number[]>([]);
+  const crashReloadRef = useRef<() => void>(() => {});
   const blockedNavTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastSetUrlRef = useRef<string>("");
   const [consoleTerminalId, setConsoleTerminalId] = useState<string | null>(terminalId);
@@ -441,6 +449,20 @@ export function DevPreviewPane({
     };
   }, [isRecoveringFromEviction, webviewElement]);
 
+  const handleRenderProcessGone = useCallback((details: { reason: string; exitCode: number }) => {
+    const now = Date.now();
+    const timestamps = crashTimestampsRef.current.filter((ts) => now - ts < 60_000);
+    timestamps.push(now);
+    crashTimestampsRef.current = timestamps;
+
+    setCrashDetails(details);
+    setCrashState("crashed");
+
+    if (timestamps.length < 2) {
+      crashReloadRef.current();
+    }
+  }, []);
+
   const {
     isWebviewReady,
     setIsWebviewReady,
@@ -465,6 +487,7 @@ export function DevPreviewPane({
     originalUaRef,
     setHistory,
     setBlockedNav,
+    onRenderProcessGone: handleRenderProcessGone,
   });
 
   useEffect(() => {
@@ -634,6 +657,9 @@ export function DevPreviewPane({
   }, [currentUrl, setWebviewLoadError, setIsSlowLoad, setIsLoading]);
 
   const handleHardReload = useCallback(() => {
+    setCrashState("none");
+    setCrashDetails(null);
+    crashTimestampsRef.current = [];
     const webview = webviewRef.current;
     if (!webview || !isWebviewReady) return;
     setWebviewLoadError(null);
@@ -681,6 +707,12 @@ export function DevPreviewPane({
     setDevPreviewConsoleOpen(id, !isConsoleOpen);
   }, [id, isConsoleOpen, setDevPreviewConsoleOpen]);
 
+  // Keep crashReloadRef in sync so onRenderProcessGone can call handleHardReload
+  // before it exists in the lexical scope.
+  useEffect(() => {
+    crashReloadRef.current = handleHardReload;
+  }, [handleHardReload]);
+
   const handleOpenExternal = useCallback(() => {
     if (currentUrl) {
       safeFireAndForget(window.electron.system.openExternal(currentUrl), {
@@ -726,6 +758,9 @@ export function DevPreviewPane({
     setIsSlowLoad(false);
     setIsWebviewReady(false);
     setWebviewLoadError(null);
+    setCrashState("none");
+    setCrashDetails(null);
+    crashTimestampsRef.current = [];
     void restart();
   }, [
     id,
@@ -993,6 +1028,50 @@ export function DevPreviewPane({
     const timer = setTimeout(() => setBlockedNav(null), 10_000);
     return () => clearTimeout(timer);
   }, [blockedNav]);
+
+  // Listen for webview unresponsive/responsive events from the main process
+  useEffect(() => {
+    const cleanupUnresponsive = window.electron.webview.onUnresponsive((data) => {
+      if (data.panelId !== id) return;
+      setCrashState((prev) => (prev === "crashed" ? prev : "unresponsive"));
+    });
+    const cleanupResponsive = window.electron.webview.onResponsive((data) => {
+      if (data.panelId !== id) return;
+      setCrashState((prev) => (prev === "unresponsive" ? "none" : prev));
+    });
+    return () => {
+      cleanupUnresponsive();
+      cleanupResponsive();
+    };
+  }, [id]);
+
+  // Clear crash state on successful navigation
+  useEffect(() => {
+    if (crashState === "none") return;
+    if (currentUrl && currentUrl !== "about:blank") {
+      setCrashState("none");
+      setCrashDetails(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- clear on URL change only
+  }, [currentUrl]);
+
+  // Listen for action-driven hard-reload events
+  useEffect(() => {
+    const handleHardReloadEvent = (e: Event) => {
+      if (!(e instanceof CustomEvent)) return;
+      const detail = e.detail as unknown;
+      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
+      if ((detail as { id: string }).id === id) {
+        handleHardReload();
+      }
+    };
+
+    const controller = new AbortController();
+    window.addEventListener("daintree:hard-reload-browser", handleHardReloadEvent, {
+      signal: controller.signal,
+    });
+    return () => controller.abort();
+  }, [id, handleHardReload]);
 
   return (
     <ContentPanel
@@ -1292,6 +1371,62 @@ export function DevPreviewPane({
                       panelId={id}
                       webviewElement={webviewElement}
                       onDismiss={() => setBlockedNav(null)}
+                    />
+                  )}
+                  {crashState === "crashed" && (
+                    <InlineStatusBanner
+                      icon={XCircle}
+                      title="Preview process crashed"
+                      description={
+                        crashDetails
+                          ? `Reason: ${crashDetails.reason} (exit code ${crashDetails.exitCode})`
+                          : "The renderer process terminated unexpectedly."
+                      }
+                      severity="error"
+                      animated={false}
+                      actions={[
+                        {
+                          id: "reload",
+                          label: "Reload",
+                          icon: RotateCw,
+                          variant: "dangerFilled",
+                          onClick: handleHardReload,
+                          ariaLabel: "Reload preview page",
+                        },
+                        {
+                          id: "hard-restart",
+                          label: "Hard restart",
+                          icon: RotateCw,
+                          variant: "danger",
+                          onClick: handleHardRestart,
+                          ariaLabel: "Hard restart preview",
+                        },
+                      ]}
+                      onClose={() => {
+                        setCrashState("none");
+                        setCrashDetails(null);
+                        crashTimestampsRef.current = [];
+                      }}
+                    />
+                  )}
+                  {crashState === "unresponsive" && (
+                    <InlineStatusBanner
+                      icon={AlertTriangle}
+                      title="Preview is not responding"
+                      description="The page may be stuck in a long-running operation."
+                      severity="warning"
+                      animated={false}
+                      actions={[
+                        {
+                          id: "hard-restart",
+                          label: "Hard restart",
+                          icon: RotateCw,
+                          variant: "danger",
+                          onClick: handleHardRestart,
+                          ariaLabel: "Hard restart preview",
+                        },
+                      ]}
+                      onClose={() => setCrashState("none")}
                     />
                   )}
                   {isLoading && (

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1056,8 +1056,7 @@ export function DevPreviewPane({
       setCrashState("none");
       setCrashDetails(null);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- clear on URL change only
-  }, [currentUrl]);
+  }, [currentUrl, crashState]);
 
   // Listen for action-driven hard-reload events
   useEffect(() => {

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -292,6 +292,8 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
         getScrollPosition: vi.fn().mockResolvedValue(0),
+        onUnresponsive: vi.fn(() => vi.fn()),
+        onResponsive: vi.fn(() => vi.fn()),
       },
     };
   });
@@ -631,6 +633,8 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
         getScrollPosition,
+        onUnresponsive: vi.fn(() => vi.fn()),
+        onResponsive: vi.fn(() => vi.fn()),
       },
     };
 
@@ -682,6 +686,8 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
         getScrollPosition,
+        onUnresponsive: vi.fn(() => vi.fn()),
+        onResponsive: vi.fn(() => vi.fn()),
       },
     };
 
@@ -723,6 +729,8 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
         getScrollPosition,
+        onUnresponsive: vi.fn(() => vi.fn()),
+        onResponsive: vi.fn(() => vi.fn()),
       },
     };
 

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -42,6 +42,7 @@ interface UseDevPreviewLoadLifecycleParams {
   originalUaRef: React.MutableRefObject<string | null>;
   setHistory: React.Dispatch<React.SetStateAction<BrowserHistory>>;
   setBlockedNav: React.Dispatch<React.SetStateAction<DevPreviewBlockedNav | null>>;
+  onRenderProcessGone?: (details: { reason: string; exitCode: number }) => void;
 }
 
 interface UseDevPreviewLoadLifecycleResult {
@@ -70,6 +71,7 @@ export function useDevPreviewLoadLifecycle({
   originalUaRef,
   setHistory,
   setBlockedNav,
+  onRenderProcessGone,
 }: UseDevPreviewLoadLifecycleParams): UseDevPreviewLoadLifecycleResult {
   const [isWebviewReady, setIsWebviewReady] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -358,6 +360,15 @@ export function useDevPreviewLoadLifecycle({
       recordVisit(navigatedUrl);
     };
 
+    const handleRenderProcessGone = (e: Event) => {
+      const detail = (e as unknown as { detail?: { reason?: string; exitCode?: number } }).detail;
+      if (!detail || detail.reason === "clean-exit") return;
+      onRenderProcessGone?.({
+        reason: detail.reason ?? "unknown",
+        exitCode: detail.exitCode ?? -1,
+      });
+    };
+
     webview.addEventListener("did-start-loading", handleDidStartLoading);
     webview.addEventListener("did-stop-loading", handleDidStopLoading);
     webview.addEventListener("did-finish-load", handleDidFinishLoad);
@@ -368,6 +379,7 @@ export function useDevPreviewLoadLifecycle({
       handleDidNavigateInPage as unknown as EventListener
     );
     webview.addEventListener("page-title-updated", handlePageTitleUpdated);
+    webview.addEventListener("render-process-gone", handleRenderProcessGone);
 
     return () => {
       webview.removeEventListener("did-start-loading", handleDidStartLoading);
@@ -380,6 +392,7 @@ export function useDevPreviewLoadLifecycle({
         handleDidNavigateInPage as unknown as EventListener
       );
       webview.removeEventListener("page-title-updated", handlePageTitleUpdated);
+      webview.removeEventListener("render-process-gone", handleRenderProcessGone);
       if (failLoadRetryRef.current) {
         clearTimeout(failLoadRetryRef.current);
         failLoadRetryRef.current = null;
@@ -393,7 +406,15 @@ export function useDevPreviewLoadLifecycle({
         loadTimeoutRef.current = null;
       }
     };
-  }, [webviewElement, loadTimeoutMs, evictingRef, lastSetUrlRef, setHistory, setBlockedNav]);
+  }, [
+    webviewElement,
+    loadTimeoutMs,
+    evictingRef,
+    lastSetUrlRef,
+    setHistory,
+    setBlockedNav,
+    onRenderProcessGone,
+  ]);
 
   useEffect(() => {
     const webview = webviewElement;

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -362,11 +362,11 @@ export function useDevPreviewLoadLifecycle({
 
     const handleRenderProcessGone = (e: Event) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      const detail = (e as unknown as { detail?: { reason?: string; exitCode?: number } }).detail;
-      if (!detail || detail.reason === "clean-exit") return;
+      const details = (e as unknown as { details?: { reason?: string; exitCode?: number } }).details;
+      if (!details || details.reason === "clean-exit") return;
       onRenderProcessGone?.({
-        reason: detail.reason ?? "unknown",
-        exitCode: detail.exitCode ?? -1,
+        reason: details.reason ?? "unknown",
+        exitCode: details.exitCode ?? -1,
       });
     };
 

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -361,6 +361,7 @@ export function useDevPreviewLoadLifecycle({
     };
 
     const handleRenderProcessGone = (e: Event) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       const detail = (e as unknown as { detail?: { reason?: string; exitCode?: number } }).detail;
       if (!detail || detail.reason === "clean-exit") return;
       onRenderProcessGone?.({


### PR DESCRIPTION
## Summary
- The dev-preview canvas now surfaces render-process-gone and unresponsive webview events as inline banners with Reload and Hard restart actions. No more blank pane when the renderer dies.
- Crash-loop detection auto-reloads on the first crash, then shows a persistent banner for two or more crashes within 60 seconds. Prevents the reload-death-spiral.
- Clean-exit render-process-gone reasons are filtered out; everything else surfaces as an error banner.

Resolves #8270

## Changes
- `electron/ipc/channels.ts` -- new `WEBVIEW_UNRESPONSIVE` / `WEBVIEW_RESPONSIVE` IPC channels
- `electron/preload.cts` -- exposed `onUnresponsive` / `onResponsive` subscription wrappers
- `electron/setup/protocols.ts` -- wired `unresponsive` / `responsive` listeners on the `WebContents`
- `shared/types/ipc/api.ts` + `maps.ts` -- typed the new IPC channel payloads
- `src/components/DevPreview/DevPreviewPane.tsx` -- `InlineStatusBanner` rendering, crash-loop state, `performReload` extracted for reuse
- `src/components/DevPreview/useDevPreviewLoadLifecycle.ts` -- `render-process-gone` DOM listener with clean-exit filtering
- `src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx` -- test coverage for the new banner states

## Testing
- Verified that render-process-gone events fire inline banners with the correct actions
- Confirmed unresponsive/responsive IPC flow from main process to renderer
- Crash-loop detection gates tested: single crash auto-reloads, >=2 within 60s shows the persistent banner
- Clean-exit (reason "clean") does not trigger a banner