### PR TITLE
feat(forge): Preferences → Forge Integrations section

### DIFF
--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type {
-  ForgeProviderEntry,
-  ResolvedForgeProvider,
-} from "../../../../shared/types/forge.js";
+import type { ForgeProviderEntry, ResolvedForgeProvider } from "../../../../shared/types/forge.js";
 
 const ipcMainMock = vi.hoisted(() => ({
   handle: vi.fn(),

--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -114,6 +114,27 @@ describe("registerForgeSettingsHandlers", () => {
     expect(storeMock.set).toHaveBeenCalledWith("forgeDefaultProviderId", null);
   });
 
+  it("setDefaultProvider treats whitespace-only strings as null", () => {
+    registerForgeSettingsHandlers();
+    const setDefault = findHandler("forge:set-default-provider");
+    expect(setDefault(null, "   ")).toEqual({ defaultProviderId: null });
+    expect(storeMock.set).toHaveBeenCalledWith("forgeDefaultProviderId", null);
+  });
+
+  it("setDefaultProvider trims surrounding whitespace from the persisted id", () => {
+    registerForgeSettingsHandlers();
+    const setDefault = findHandler("forge:set-default-provider");
+    expect(setDefault(null, "  acme.gitea  ")).toEqual({ defaultProviderId: "acme.gitea" });
+    expect(storeMock.set).toHaveBeenCalledWith("forgeDefaultProviderId", "acme.gitea");
+  });
+
+  it("getSettings treats whitespace-only stored values as null", () => {
+    storeMock._data["forgeDefaultProviderId"] = "   ";
+    registerForgeSettingsHandlers();
+    const getSettings = findHandler("forge:get-settings");
+    expect(getSettings(null)).toEqual({ defaultProviderId: null });
+  });
+
   it("getProviders returns the live registry contents", () => {
     const entries: ForgeProviderEntry[] = [
       {

--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ForgeProviderEntry } from "../../../../shared/types/forge.js";
+import type {
+  ForgeProviderEntry,
+  ResolvedForgeProvider,
+} from "../../../../shared/types/forge.js";
 
 const ipcMainMock = vi.hoisted(() => ({
   handle: vi.fn(),
@@ -28,9 +31,9 @@ const registryMock = vi.hoisted(() => ({
 vi.mock("../../../services/forgeProviderRegistry.js", () => registryMock);
 
 const resolverMock = vi.hoisted(() => ({
-  resolveForgeProvider: vi.fn<(projectId: string) => Promise<ForgeProviderEntry | null>>(
-    async () => null
-  ),
+  resolveForgeProvider: vi.fn<
+    (projectId: string, remoteUrl?: string) => Promise<ResolvedForgeProvider>
+  >(async () => ({ entry: null, resolvedVia: null })),
 }));
 
 vi.mock("../../../services/forgeProviderResolver.js", () => resolverMock);
@@ -142,19 +145,48 @@ describe("registerForgeSettingsHandlers", () => {
       pluginId: "builtin",
       contribution: { id: "github", name: "GitHub", matches: ["github.com"] },
     };
-    resolverMock.resolveForgeProvider.mockResolvedValueOnce(entry);
+    const resolved: ResolvedForgeProvider = { entry, resolvedVia: "hostname" };
+    resolverMock.resolveForgeProvider.mockResolvedValueOnce(resolved);
     registerForgeSettingsHandlers();
     const resolveProvider = findHandler("forge:resolve-provider");
-    await expect(resolveProvider(null, "project-1")).resolves.toEqual(entry);
-    expect(resolverMock.resolveForgeProvider).toHaveBeenCalledWith("project-1");
+    await expect(resolveProvider(null, "project-1")).resolves.toEqual(resolved);
+    expect(resolverMock.resolveForgeProvider).toHaveBeenCalledWith("project-1", undefined);
   });
 
-  it("resolveProvider returns null for invalid projectId payloads without calling the resolver", async () => {
+  it("resolveProvider forwards the optional remoteUrl when provided", async () => {
+    const entry: ForgeProviderEntry = {
+      pluginId: "acme.gitea",
+      contribution: { id: "gitea", name: "Gitea", matches: ["gitea.example.com"] },
+    };
+    const resolved: ResolvedForgeProvider = { entry, resolvedVia: "hostname" };
+    resolverMock.resolveForgeProvider.mockResolvedValueOnce(resolved);
     registerForgeSettingsHandlers();
     const resolveProvider = findHandler("forge:resolve-provider");
-    await expect(resolveProvider(null, "")).resolves.toBeNull();
-    await expect(resolveProvider(null, 42)).resolves.toBeNull();
-    await expect(resolveProvider(null, undefined)).resolves.toBeNull();
+    await expect(
+      resolveProvider(null, "project-1", "git@gitea.example.com:owner/repo.git")
+    ).resolves.toEqual(resolved);
+    expect(resolverMock.resolveForgeProvider).toHaveBeenCalledWith(
+      "project-1",
+      "git@gitea.example.com:owner/repo.git"
+    );
+  });
+
+  it("resolveProvider treats a non-string remoteUrl as undefined", async () => {
+    const resolved: ResolvedForgeProvider = { entry: null, resolvedVia: null };
+    resolverMock.resolveForgeProvider.mockResolvedValueOnce(resolved);
+    registerForgeSettingsHandlers();
+    const resolveProvider = findHandler("forge:resolve-provider");
+    await expect(resolveProvider(null, "project-1", 42)).resolves.toEqual(resolved);
+    expect(resolverMock.resolveForgeProvider).toHaveBeenCalledWith("project-1", undefined);
+  });
+
+  it("resolveProvider returns no-match for invalid projectId payloads without calling the resolver", async () => {
+    registerForgeSettingsHandlers();
+    const resolveProvider = findHandler("forge:resolve-provider");
+    const noMatch = { entry: null, resolvedVia: null };
+    await expect(resolveProvider(null, "")).resolves.toEqual(noMatch);
+    await expect(resolveProvider(null, 42)).resolves.toEqual(noMatch);
+    await expect(resolveProvider(null, undefined)).resolves.toEqual(noMatch);
     expect(resolverMock.resolveForgeProvider).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -37,17 +37,14 @@ export function registerForgeSettingsHandlers(): () => void {
   );
 
   cleanups.push(
-    typedHandle(
-      CHANNELS.FORGE_RESOLVE_PROVIDER,
-      async (projectId: unknown, remoteUrl: unknown) => {
-        if (typeof projectId !== "string" || projectId.length === 0) {
-          return { entry: null, resolvedVia: null };
-        }
-        const remoteUrlArg =
-          typeof remoteUrl === "string" && remoteUrl.length > 0 ? remoteUrl : undefined;
-        return resolveForgeProvider(projectId, remoteUrlArg);
+    typedHandle(CHANNELS.FORGE_RESOLVE_PROVIDER, async (projectId: unknown, remoteUrl: unknown) => {
+      if (typeof projectId !== "string" || projectId.length === 0) {
+        return { entry: null, resolvedVia: null };
       }
-    )
+      const remoteUrlArg =
+        typeof remoteUrl === "string" && remoteUrl.length > 0 ? remoteUrl : undefined;
+      return resolveForgeProvider(projectId, remoteUrlArg);
+    })
   );
 
   return () => cleanups.forEach((c) => c());

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -37,10 +37,17 @@ export function registerForgeSettingsHandlers(): () => void {
   );
 
   cleanups.push(
-    typedHandle(CHANNELS.FORGE_RESOLVE_PROVIDER, async (projectId: unknown) => {
-      if (typeof projectId !== "string" || projectId.length === 0) return null;
-      return resolveForgeProvider(projectId);
-    })
+    typedHandle(
+      CHANNELS.FORGE_RESOLVE_PROVIDER,
+      async (projectId: unknown, remoteUrl: unknown) => {
+        if (typeof projectId !== "string" || projectId.length === 0) {
+          return { entry: null, resolvedVia: null };
+        }
+        const remoteUrlArg =
+          typeof remoteUrl === "string" && remoteUrl.length > 0 ? remoteUrl : undefined;
+        return resolveForgeProvider(projectId, remoteUrlArg);
+      }
+    )
   );
 
   return () => cleanups.forEach((c) => c());

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -6,7 +6,9 @@ import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
 
 function readDefaultProviderId(): string | null {
   const value = store.get("forgeDefaultProviderId");
-  return typeof value === "string" && value.length > 0 ? value : null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 export function registerForgeSettingsHandlers(): () => void {
@@ -20,7 +22,11 @@ export function registerForgeSettingsHandlers(): () => void {
 
   cleanups.push(
     typedHandle(CHANNELS.FORGE_SET_DEFAULT_PROVIDER, (providerId: unknown) => {
-      const next = typeof providerId === "string" && providerId.length > 0 ? providerId : null;
+      let next: string | null = null;
+      if (typeof providerId === "string") {
+        const trimmed = providerId.trim();
+        if (trimmed.length > 0) next = trimmed;
+      }
       if (next === null) {
         store.set("forgeDefaultProviderId", null);
       } else {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2339,8 +2339,8 @@ const api: ElectronAPI = {
     setDefaultProvider: (providerId: string | null) =>
       _unwrappingInvoke(CHANNELS.FORGE_SET_DEFAULT_PROVIDER, providerId),
     getProviders: () => _unwrappingInvoke(CHANNELS.FORGE_GET_PROVIDERS),
-    resolveProvider: (projectId: string) =>
-      _unwrappingInvoke(CHANNELS.FORGE_RESOLVE_PROVIDER, projectId),
+    resolveProvider: (projectId: string, remoteUrl?: string) =>
+      _unwrappingInvoke(CHANNELS.FORGE_RESOLVE_PROVIDER, projectId, remoteUrl),
   },
 
   // Voice Input API

--- a/electron/services/__tests__/forgeProviderResolver.test.ts
+++ b/electron/services/__tests__/forgeProviderResolver.test.ts
@@ -69,14 +69,17 @@ beforeEach(() => {
 });
 
 describe("resolveForgeProvider", () => {
-  it("returns null when the project does not exist", async () => {
+  it("returns no-match when the project does not exist", async () => {
     projectStoreMock.getProjectById.mockReturnValue(null);
-    expect(await resolveForgeProvider("missing")).toBeNull();
+    expect(await resolveForgeProvider("missing")).toEqual({ entry: null, resolvedVia: null });
   });
 
-  it("returns null for empty or non-string projectId", async () => {
-    expect(await resolveForgeProvider("")).toBeNull();
-    expect(await resolveForgeProvider(undefined as unknown as string)).toBeNull();
+  it("returns no-match for empty or non-string projectId", async () => {
+    expect(await resolveForgeProvider("")).toEqual({ entry: null, resolvedVia: null });
+    expect(await resolveForgeProvider(undefined as unknown as string)).toEqual({
+      entry: null,
+      resolvedVia: null,
+    });
   });
 
   it("returns the override match when forgeProviderOverride names a registered provider", async () => {
@@ -89,7 +92,7 @@ describe("resolveForgeProvider", () => {
     });
 
     const result = await resolveForgeProvider("project-1");
-    expect(result).toEqual(gitea);
+    expect(result).toEqual({ entry: gitea, resolvedVia: "override" });
     // Override path bypasses hostname matching entirely.
     expect(registryMock.listMatchingProviders).not.toHaveBeenCalled();
   });
@@ -102,10 +105,13 @@ describe("resolveForgeProvider", () => {
       forgeProviderOverride: "acme.gitea.gitea",
     });
 
-    expect(await resolveForgeProvider("project-1")).toEqual(gitea);
+    expect(await resolveForgeProvider("project-1")).toEqual({
+      entry: gitea,
+      resolvedVia: "override",
+    });
   });
 
-  it("returns null when forgeProviderOverride names an unregistered provider (no fallthrough)", async () => {
+  it("returns no-match when forgeProviderOverride names an unregistered provider (no fallthrough)", async () => {
     const github = makeProvider("builtin", "github", ["github.com"]);
     registryMock.getRegisteredForgeProviders.mockReturnValue([github]);
     registryMock.listMatchingProviders.mockReturnValue([github]);
@@ -117,7 +123,7 @@ describe("resolveForgeProvider", () => {
       forgeProviderOverride: "gone.away",
     });
 
-    expect(await resolveForgeProvider("project-1")).toBeNull();
+    expect(await resolveForgeProvider("project-1")).toEqual({ entry: null, resolvedVia: null });
     expect(registryMock.listMatchingProviders).not.toHaveBeenCalled();
   });
 
@@ -129,7 +135,10 @@ describe("resolveForgeProvider", () => {
       forgeProviderOverride: null,
     });
 
-    expect(await resolveForgeProvider("project-1")).toEqual(github);
+    expect(await resolveForgeProvider("project-1")).toEqual({
+      entry: github,
+      resolvedVia: "hostname",
+    });
   });
 
   it("treats forgeProviderOverride absent as auto-detect (falls through)", async () => {
@@ -137,7 +146,10 @@ describe("resolveForgeProvider", () => {
     registryMock.listMatchingProviders.mockReturnValue([github]);
     projectStoreMock.getProjectSettings.mockResolvedValue({ runCommands: [] });
 
-    expect(await resolveForgeProvider("project-1")).toEqual(github);
+    expect(await resolveForgeProvider("project-1")).toEqual({
+      entry: github,
+      resolvedVia: "hostname",
+    });
   });
 
   it("returns the global default when it matches one of the remote candidates", async () => {
@@ -146,10 +158,13 @@ describe("resolveForgeProvider", () => {
     registryMock.listMatchingProviders.mockReturnValue([github, enterprise]);
     storeMock._data["forgeDefaultProviderId"] = "gh-enterprise";
 
-    expect(await resolveForgeProvider("project-1")).toEqual(enterprise);
+    expect(await resolveForgeProvider("project-1")).toEqual({
+      entry: enterprise,
+      resolvedVia: "default",
+    });
   });
 
-  it("returns null when the global default is not a hostname match for the remote", async () => {
+  it("returns no-match when the global default is not a hostname match for the remote", async () => {
     const github = makeProvider("builtin", "github", ["github.com"]);
     const gitea = makeProvider("acme.gitea", "gitea", ["gitea.example.com"]);
     // The default IS registered globally — but not for this remote's hostname.
@@ -158,7 +173,7 @@ describe("resolveForgeProvider", () => {
     registryMock.listMatchingProviders.mockReturnValue([github]);
     storeMock._data["forgeDefaultProviderId"] = "gitea";
 
-    expect(await resolveForgeProvider("project-1")).toBeNull();
+    expect(await resolveForgeProvider("project-1")).toEqual({ entry: null, resolvedVia: null });
   });
 
   it("accepts namespaced ids for the global default", async () => {
@@ -166,7 +181,10 @@ describe("resolveForgeProvider", () => {
     registryMock.listMatchingProviders.mockReturnValue([github]);
     storeMock._data["forgeDefaultProviderId"] = "builtin.github";
 
-    expect(await resolveForgeProvider("project-1")).toEqual(github);
+    expect(await resolveForgeProvider("project-1")).toEqual({
+      entry: github,
+      resolvedVia: "default",
+    });
   });
 
   it("returns the first hostname match when no override or default is set", async () => {
@@ -174,20 +192,23 @@ describe("resolveForgeProvider", () => {
     const other = makeProvider("acme.other", "other", ["github.com"]);
     registryMock.listMatchingProviders.mockReturnValue([github, other]);
 
-    expect(await resolveForgeProvider("project-1")).toEqual(github);
+    expect(await resolveForgeProvider("project-1")).toEqual({
+      entry: github,
+      resolvedVia: "hostname",
+    });
   });
 
-  it("returns null when there are no hostname matches", async () => {
+  it("returns no-match when there are no hostname matches", async () => {
     registryMock.listMatchingProviders.mockReturnValue([]);
-    expect(await resolveForgeProvider("project-1")).toBeNull();
+    expect(await resolveForgeProvider("project-1")).toEqual({ entry: null, resolvedVia: null });
   });
 
-  it("returns null when the remote URL cannot be read", async () => {
+  it("returns no-match when the remote URL cannot be read", async () => {
     gitServiceMock.getRemoteUrl.mockResolvedValue(null);
     const github = makeProvider("builtin", "github", ["github.com"]);
     registryMock.listMatchingProviders.mockReturnValue([github]);
 
-    expect(await resolveForgeProvider("project-1")).toBeNull();
+    expect(await resolveForgeProvider("project-1")).toEqual({ entry: null, resolvedVia: null });
     expect(registryMock.listMatchingProviders).not.toHaveBeenCalled();
   });
 
@@ -200,12 +221,15 @@ describe("resolveForgeProvider", () => {
       forgeProviderOverride: "gitea",
     });
 
-    expect(await resolveForgeProvider("project-1")).toEqual(gitea);
+    expect(await resolveForgeProvider("project-1")).toEqual({
+      entry: gitea,
+      resolvedVia: "override",
+    });
   });
 
-  it("returns null when getRemoteUrl rejects", async () => {
+  it("returns no-match when getRemoteUrl rejects", async () => {
     gitServiceMock.getRemoteUrl.mockRejectedValue(new Error("not a git repo"));
-    expect(await resolveForgeProvider("project-1")).toBeNull();
+    expect(await resolveForgeProvider("project-1")).toEqual({ entry: null, resolvedVia: null });
   });
 
   it("falls through to hostname match when getProjectSettings rejects", async () => {
@@ -216,7 +240,10 @@ describe("resolveForgeProvider", () => {
     const github = makeProvider("builtin", "github", ["github.com"]);
     registryMock.listMatchingProviders.mockReturnValue([github]);
 
-    expect(await resolveForgeProvider("project-1")).toEqual(github);
+    expect(await resolveForgeProvider("project-1")).toEqual({
+      entry: github,
+      resolvedVia: "hostname",
+    });
   });
 
   it("does not throw when a synchronous registry call throws", async () => {
@@ -224,7 +251,7 @@ describe("resolveForgeProvider", () => {
       throw new Error("boom");
     });
 
-    expect(await resolveForgeProvider("project-1")).toBeNull();
+    expect(await resolveForgeProvider("project-1")).toEqual({ entry: null, resolvedVia: null });
   });
 
   it("does no caching — settings, store, remote, and registry are re-read on each call", async () => {
@@ -238,5 +265,47 @@ describe("resolveForgeProvider", () => {
     expect(gitServiceMock.getRemoteUrl).toHaveBeenCalledTimes(2);
     expect(registryMock.listMatchingProviders).toHaveBeenCalledTimes(2);
     expect(storeMock.get).toHaveBeenCalledWith("forgeDefaultProviderId");
+  });
+
+  it("uses the supplied remoteUrl for hostname matching instead of origin", async () => {
+    const gitea = makeProvider("acme.gitea", "gitea", ["gitea.example.com"]);
+    registryMock.listMatchingProviders.mockReturnValue([gitea]);
+
+    const result = await resolveForgeProvider(
+      "project-1",
+      "git@gitea.example.com:owner/repo.git"
+    );
+
+    expect(result).toEqual({ entry: gitea, resolvedVia: "hostname" });
+    expect(gitServiceMock.getRemoteUrl).not.toHaveBeenCalled();
+    expect(registryMock.listMatchingProviders).toHaveBeenCalledWith(
+      "git@gitea.example.com:owner/repo.git"
+    );
+  });
+
+  it("ignores an empty supplied remoteUrl and falls back to origin", async () => {
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    registryMock.listMatchingProviders.mockReturnValue([github]);
+
+    const result = await resolveForgeProvider("project-1", "");
+
+    expect(result).toEqual({ entry: github, resolvedVia: "hostname" });
+    expect(gitServiceMock.getRemoteUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("override path ignores the supplied remoteUrl entirely", async () => {
+    const gitea = makeProvider("acme.gitea", "gitea", ["gitea.example.com"]);
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    registryMock.getRegisteredForgeProviders.mockReturnValue([github, gitea]);
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeProviderOverride: "gitea",
+    });
+
+    const result = await resolveForgeProvider("project-1", "https://github.com/owner/repo.git");
+
+    expect(result).toEqual({ entry: gitea, resolvedVia: "override" });
+    expect(registryMock.listMatchingProviders).not.toHaveBeenCalled();
+    expect(gitServiceMock.getRemoteUrl).not.toHaveBeenCalled();
   });
 });

--- a/electron/services/__tests__/forgeProviderResolver.test.ts
+++ b/electron/services/__tests__/forgeProviderResolver.test.ts
@@ -271,10 +271,7 @@ describe("resolveForgeProvider", () => {
     const gitea = makeProvider("acme.gitea", "gitea", ["gitea.example.com"]);
     registryMock.listMatchingProviders.mockReturnValue([gitea]);
 
-    const result = await resolveForgeProvider(
-      "project-1",
-      "git@gitea.example.com:owner/repo.git"
-    );
+    const result = await resolveForgeProvider("project-1", "git@gitea.example.com:owner/repo.git");
 
     expect(result).toEqual({ entry: gitea, resolvedVia: "hostname" });
     expect(gitServiceMock.getRemoteUrl).not.toHaveBeenCalled();

--- a/electron/services/forgeProviderResolver.ts
+++ b/electron/services/forgeProviderResolver.ts
@@ -1,8 +1,13 @@
-import type { RegisteredForgeProvider } from "../../shared/types/forge.js";
+import type {
+  RegisteredForgeProvider,
+  ResolvedForgeProvider,
+} from "../../shared/types/forge.js";
 import { getRegisteredForgeProviders, listMatchingProviders } from "./forgeProviderRegistry.js";
 import { projectStore } from "./ProjectStore.js";
 import { gitServiceCache } from "./GitServiceCache.js";
 import { store } from "../store.js";
+
+const NO_MATCH: ResolvedForgeProvider = { entry: null, resolvedVia: null };
 
 /**
  * Pick the single active forge provider for a project from the candidates the
@@ -14,10 +19,14 @@ import { store } from "../store.js";
  *      provider is one of the candidates for the project's remote.
  *   3. First hostname match from `listMatchingProviders(remoteUrl)`.
  *
- * Returns `null` when no rule resolves — override pointing at an uninstalled
- * plugin, default pointing at an unregistered ID, or no hostname match.
- * Consumers treat `null` the same as "no provider registered" (quiet linkage
- * absence, no toast, no log spam).
+ * Returns `{ entry: null, resolvedVia: null }` when no rule resolves — override
+ * pointing at an uninstalled plugin, default pointing at an unregistered ID, or
+ * no hostname match. Consumers treat `entry === null` the same as "no provider
+ * registered" (quiet linkage absence, no toast, no log spam).
+ *
+ * `resolvedVia` reports which precedence tier picked the entry so the
+ * Preferences UI can render an explanatory tooltip without re-implementing
+ * the chain. Issue #8064.
  *
  * Stateless and synchronous per the issue contract — no caching beyond
  * per-call. Settings changes re-resolve on the next call.
@@ -25,15 +34,21 @@ import { store } from "../store.js";
  * Override and global-default IDs may be stored either as the bare
  * `contribution.id` (e.g. `"github"`) or as the namespaced `{pluginId}.{id}`
  * form. The matcher accepts both.
+ *
+ * `remoteUrl`, when supplied, replaces the resolver's internal `getRemoteUrl`
+ * lookup for hostname matching. Per-remote resolution (Preferences →
+ * Forge Integrations) uses this; project-wide callers (PR linkage) omit it
+ * and fall back to the project's `origin` remote.
  */
 export async function resolveForgeProvider(
-  projectId: string
-): Promise<RegisteredForgeProvider | null> {
-  if (typeof projectId !== "string" || projectId.length === 0) return null;
+  projectId: string,
+  remoteUrl?: string
+): Promise<ResolvedForgeProvider> {
+  if (typeof projectId !== "string" || projectId.length === 0) return NO_MATCH;
 
   try {
     const project = projectStore.getProjectById(projectId);
-    if (!project) return null;
+    if (!project) return NO_MATCH;
 
     // 1. Per-project override — searches the full registry, not just remote
     //    candidates. A user who names a provider overrides hostname matching
@@ -45,26 +60,34 @@ export async function resolveForgeProvider(
     const override = settings?.forgeProviderOverride;
     if (typeof override === "string" && override.length > 0) {
       const all = getRegisteredForgeProviders();
-      return findById(all, override) ?? null;
+      const match = findById(all, override);
+      return match ? { entry: match, resolvedVia: "override" } : NO_MATCH;
     }
 
-    const gitService = gitServiceCache.getGitService(project.path);
-    const remoteUrl = await gitService.getRemoteUrl(project.path).catch(() => null);
-    if (!remoteUrl) return null;
-    const candidates = listMatchingProviders(remoteUrl);
+    let effectiveRemoteUrl: string | null;
+    if (typeof remoteUrl === "string" && remoteUrl.length > 0) {
+      effectiveRemoteUrl = remoteUrl;
+    } else {
+      const gitService = gitServiceCache.getGitService(project.path);
+      effectiveRemoteUrl = await gitService.getRemoteUrl(project.path).catch(() => null);
+    }
+    if (!effectiveRemoteUrl) return NO_MATCH;
+    const candidates = listMatchingProviders(effectiveRemoteUrl);
 
     // 2. Global default — must be one of the remote's candidates. A default
     //    that does not match this project's remote returns null (no fallthrough).
     const globalDefault = store.get("forgeDefaultProviderId");
     if (typeof globalDefault === "string" && globalDefault.length > 0) {
-      return findById(candidates, globalDefault) ?? null;
+      const match = findById(candidates, globalDefault);
+      return match ? { entry: match, resolvedVia: "default" } : NO_MATCH;
     }
 
     // 3. First hostname match (or null if there are no candidates).
-    return candidates[0] ?? null;
+    const first = candidates[0];
+    return first ? { entry: first, resolvedVia: "hostname" } : NO_MATCH;
   } catch (error) {
     console.warn(`[forgeProviderResolver] resolve failed for ${projectId}:`, error);
-    return null;
+    return NO_MATCH;
   }
 }
 

--- a/electron/services/forgeProviderResolver.ts
+++ b/electron/services/forgeProviderResolver.ts
@@ -1,7 +1,4 @@
-import type {
-  RegisteredForgeProvider,
-  ResolvedForgeProvider,
-} from "../../shared/types/forge.js";
+import type { RegisteredForgeProvider, ResolvedForgeProvider } from "../../shared/types/forge.js";
 import { getRegisteredForgeProviders, listMatchingProviders } from "./forgeProviderRegistry.js";
 import { projectStore } from "./ProjectStore.js";
 import { gitServiceCache } from "./GitServiceCache.js";

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -382,3 +382,26 @@ export interface ForgeProviderEntry {
   pluginId: string;
   contribution: ForgeProviderContribution;
 }
+
+/**
+ * Which precedence rule fired during a `resolveForgeProvider` call.
+ *
+ *   - `"override"` — per-project `forgeProviderOverride` named a registered provider.
+ *   - `"default"`  — global default (`forgeDefaultProviderId`) matched one of
+ *                    the project's remote candidates.
+ *   - `"hostname"` — first hostname match for the project's remote URL.
+ *
+ * `null` lives on the wrapper alongside `entry: null` when no rule resolved.
+ */
+export type ForgeProviderResolutionVia = "override" | "default" | "hostname";
+
+/**
+ * Resolver output: the chosen provider entry plus the precedence rule that
+ * picked it. The renderer renders an explanatory tooltip from `resolvedVia`
+ * without re-implementing the precedence chain. When `entry === null`,
+ * `resolvedVia === null` — no rule fired.
+ */
+export interface ResolvedForgeProvider {
+  entry: ForgeProviderEntry | null;
+  resolvedVia: ForgeProviderResolutionVia | null;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -538,5 +538,7 @@ export type {
   ForgeProviderContribution,
   ForgeProviderDescriptor,
   ForgeProviderEntry,
+  ForgeProviderResolutionVia,
   ForgeCapabilityHint,
+  ResolvedForgeProvider,
 } from "./forge.js";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -22,7 +22,7 @@ import type { AgentSettings, AgentSettingsEntry } from "../agentSettings.js";
 import type { AgentPreset } from "../../config/agentRegistry.js";
 import type { VoiceInputStatus } from "../voice.js";
 export type { VoiceInputStatus };
-import type { ForgeProviderEntry } from "../forge.js";
+import type { ForgeProviderEntry, ResolvedForgeProvider } from "../forge.js";
 import type { ResourceProfilePayload } from "../resourceProfile.js";
 import type {
   CreateWorktreeOptions,
@@ -1268,11 +1268,16 @@ export interface ElectronAPI {
     /**
      * Resolve the active forge provider for the given project, applying the
      * per-project override → global default → first hostname match precedence
-     * chain. Returns `null` when no rule resolves (override or default points
-     * at an unavailable provider, no hostname match). Consumers treat `null`
-     * the same as "no provider registered".
+     * chain. `entry` is `null` when no rule resolves (override or default
+     * points at an unavailable provider, no hostname match) and `resolvedVia`
+     * is `null` in lock-step. Consumers treat `entry === null` the same as
+     * "no provider registered".
+     *
+     * `remoteUrl`, when supplied, replaces the project's `origin` for the
+     * hostname-match step — used by per-remote routing UIs that need a
+     * resolution per remote rather than the project default.
      */
-    resolveProvider(projectId: string): Promise<ForgeProviderEntry | null>;
+    resolveProvider(projectId: string, remoteUrl?: string): Promise<ResolvedForgeProvider>;
   };
   voiceInput: {
     getSettings(): Promise<VoiceInputSettings>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -174,7 +174,7 @@ import type { CloneRepoOptions, CloneRepoResult } from "./gitClone.js";
 import type { AppAgentConfig } from "../appAgent.js";
 import type { AgentSessionRecord } from "./agentSessionHistory.js";
 import type { GeneratedIpcInvokeMap } from "./generated.js";
-import type { ForgeProviderEntry } from "../forge.js";
+import type { ForgeProviderEntry, ResolvedForgeProvider } from "../forge.js";
 
 export type ChecklistItemId =
   | "openedProject"
@@ -1611,8 +1611,8 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     result: ForgeProviderEntry[];
   };
   "forge:resolve-provider": {
-    args: [projectId: string];
-    result: ForgeProviderEntry | null;
+    args: [projectId: string, remoteUrl?: string];
+    result: ResolvedForgeProvider;
   };
 
   // Shortcut Hints

--- a/src/components/Settings/ForgeIntegrationsTab.tsx
+++ b/src/components/Settings/ForgeIntegrationsTab.tsx
@@ -58,9 +58,15 @@ export function ForgeIntegrationsTab() {
   const [remotes, setRemotes] = useState<RemoteRouting[]>([]);
   const [remotesLoading, setRemotesLoading] = useState(false);
   const [remotesError, setRemotesError] = useState<string | null>(null);
-  // Mirror `remotes` into a ref so `reresolveRemotes` can read the latest value
-  // without closing over the state (which would risk re-resolving stale remotes
-  // when the active project changes between the settings write and its reply).
+  // Mirror project id + remotes into refs so a `reresolveRemotes` call that was
+  // dispatched on project A doesn't run with A's id against B's remotes after
+  // an active-project switch lands between the settings write and its reply.
+  // `reresolveRemotes` reads both refs and is itself stable, so the callback
+  // captured by `handleChange` always picks up the current values.
+  const activeProjectIdRef = useRef<string | undefined>(activeProjectId);
+  useEffect(() => {
+    activeProjectIdRef.current = activeProjectId;
+  }, [activeProjectId]);
   const remotesRef = useRef<RemoteRouting[]>([]);
   useEffect(() => {
     remotesRef.current = remotes;
@@ -182,14 +188,19 @@ export function ForgeIntegrationsTab() {
   // global default can shift the `resolvedVia` badge for remotes whose origin
   // currently resolves via "hostname" — the default tier now wins.
   const reresolveRemotes = useCallback(async () => {
-    if (!activeProjectId) return;
+    const currentProjectId = activeProjectIdRef.current;
+    if (!currentProjectId) return;
     const currentRemotes = remotesRef.current.map((r) => r.remote);
     if (currentRemotes.length === 0) return;
     const resolutions = await Promise.allSettled(
       currentRemotes.map((remote) =>
-        window.electron.forge.resolveProvider(activeProjectId, remote.fetchUrl)
+        window.electron.forge.resolveProvider(currentProjectId, remote.fetchUrl)
       )
     );
+    // Bail if the active project switched mid-flight — the project-change
+    // effect already re-resolves remotes for the new project, so applying
+    // these results would overwrite the correct ones.
+    if (activeProjectIdRef.current !== currentProjectId) return;
     setRemotes(
       currentRemotes.map((remote, idx) => {
         const result = resolutions[idx];
@@ -199,7 +210,7 @@ export function ForgeIntegrationsTab() {
         return { remote, resolved: { entry: null, resolvedVia: null } };
       })
     );
-  }, [activeProjectId]);
+  }, []);
 
   const handleChange = useCallback(
     async (value: string) => {

--- a/src/components/Settings/ForgeIntegrationsTab.tsx
+++ b/src/components/Settings/ForgeIntegrationsTab.tsx
@@ -10,6 +10,8 @@ import { SettingsSection } from "./SettingsSection";
 import { SettingsSelect, type SettingsSelectOption } from "./SettingsSelect";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useProjectStore } from "@/store";
+import { useDeferredLoading } from "@/hooks";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
 
@@ -56,6 +58,16 @@ export function ForgeIntegrationsTab() {
   const [remotes, setRemotes] = useState<RemoteRouting[]>([]);
   const [remotesLoading, setRemotesLoading] = useState(false);
   const [remotesError, setRemotesError] = useState<string | null>(null);
+  // Mirror `remotes` into a ref so `reresolveRemotes` can read the latest value
+  // without closing over the state (which would risk re-resolving stale remotes
+  // when the active project changes between the settings write and its reply).
+  const remotesRef = useRef<RemoteRouting[]>([]);
+  useEffect(() => {
+    remotesRef.current = remotes;
+  }, [remotes]);
+  // Defer the "Loading remotes…" text past the Doherty threshold so fast IPC
+  // resolutions don't flash a loading state for sub-400ms work.
+  const showRemotesLoading = useDeferredLoading(remotesLoading, UI_DOHERTY_THRESHOLD);
 
   useEffect(() => {
     let cancelled = false;
@@ -171,7 +183,7 @@ export function ForgeIntegrationsTab() {
   // currently resolves via "hostname" — the default tier now wins.
   const reresolveRemotes = useCallback(async () => {
     if (!activeProjectId) return;
-    const currentRemotes = remotes.map((r) => r.remote);
+    const currentRemotes = remotesRef.current.map((r) => r.remote);
     if (currentRemotes.length === 0) return;
     const resolutions = await Promise.allSettled(
       currentRemotes.map((remote) =>
@@ -187,7 +199,7 @@ export function ForgeIntegrationsTab() {
         return { remote, resolved: { entry: null, resolvedVia: null } };
       })
     );
-  }, [activeProjectId, remotes]);
+  }, [activeProjectId]);
 
   const handleChange = useCallback(
     async (value: string) => {
@@ -253,7 +265,7 @@ export function ForgeIntegrationsTab() {
           activeProjectId={activeProjectId}
           providersInstalled={providers.length}
           remotes={remotes}
-          loading={remotesLoading}
+          loading={showRemotesLoading}
           error={remotesError}
         />
       </SettingsSection>
@@ -280,9 +292,7 @@ function ProjectRoutingPanel({
 }: ProjectRoutingPanelProps) {
   if (!activeProjectId) {
     return (
-      <p className="text-xs text-daintree-text/50">
-        Open a project to view its forge routing.
-      </p>
+      <p className="text-xs text-daintree-text/50">Open a project to view its forge routing.</p>
     );
   }
 

--- a/src/components/Settings/ForgeIntegrationsTab.tsx
+++ b/src/components/Settings/ForgeIntegrationsTab.tsx
@@ -1,8 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { GitBranch } from "lucide-react";
-import type { ForgeProviderEntry } from "@shared/types";
+import { GitBranch, Route } from "lucide-react";
+import type {
+  ForgeProviderEntry,
+  ForgeProviderResolutionVia,
+  ResolvedForgeProvider,
+} from "@shared/types";
+import type { RemoteInfo } from "@shared/types/ipc/github";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSelect, type SettingsSelectOption } from "./SettingsSelect";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useProjectStore } from "@/store";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
 
@@ -18,12 +25,37 @@ interface ForgeSettings {
 
 const DEFAULT_SETTINGS: ForgeSettings = { defaultProviderId: null };
 
+interface RemoteRouting {
+  remote: RemoteInfo;
+  resolved: ResolvedForgeProvider;
+}
+
+const TOOLTIP_COPY: Record<ForgeProviderResolutionVia, string> = {
+  override: "Resolved from this project's provider override.",
+  default: "Resolved by the global default provider.",
+  hostname: "Resolved by matching the remote hostname.",
+};
+
+const BADGE_LABEL: Record<ForgeProviderResolutionVia, string> = {
+  override: "Override",
+  default: "Default",
+  hostname: "Hostname",
+};
+
 export function ForgeIntegrationsTab() {
   const [settings, setSettings] = useState<ForgeSettings>(DEFAULT_SETTINGS);
   const [providers, setProviders] = useState<ForgeProviderEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const writeSeqRef = useRef(0);
+
+  const activeProject = useProjectStore((s) => s.currentProject);
+  const activeProjectId = activeProject?.id;
+  const activeProjectPath = activeProject?.path;
+
+  const [remotes, setRemotes] = useState<RemoteRouting[]>([]);
+  const [remotesLoading, setRemotesLoading] = useState(false);
+  const [remotesError, setRemotesError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -46,6 +78,58 @@ export function ForgeIntegrationsTab() {
       cancelled = true;
     };
   }, []);
+
+  // Load remotes + per-remote resolution whenever the active project changes.
+  // Single effect keyed on [activeProjectId, activeProjectPath] avoids the
+  // ordered-effects trap from #4958 where separate effects sharing a `cancelled`
+  // flag could fire out of expected order.
+  useEffect(() => {
+    if (!activeProjectId || !activeProjectPath) {
+      setRemotes([]);
+      setRemotesLoading(false);
+      setRemotesError(null);
+      return;
+    }
+    let cancelled = false;
+    setRemotesLoading(true);
+    setRemotesError(null);
+    setRemotes([]);
+
+    (async () => {
+      try {
+        const loadedRemotes = await window.electron.github.listRemotes(activeProjectPath);
+        if (cancelled) return;
+        if (loadedRemotes.length === 0) {
+          setRemotes([]);
+          return;
+        }
+        const resolutions = await Promise.allSettled(
+          loadedRemotes.map((remote) =>
+            window.electron.forge.resolveProvider(activeProjectId, remote.fetchUrl)
+          )
+        );
+        if (cancelled) return;
+        const next: RemoteRouting[] = loadedRemotes.map((remote, idx) => {
+          const result = resolutions[idx];
+          if (result?.status === "fulfilled") {
+            return { remote, resolved: result.value };
+          }
+          return { remote, resolved: { entry: null, resolvedVia: null } };
+        });
+        setRemotes(next);
+      } catch (err) {
+        if (cancelled) return;
+        setRemotesError(formatErrorMessage(err, "Couldn't read git remotes"));
+        logError("Failed to load forge routing for active project", err);
+      } finally {
+        if (!cancelled) setRemotesLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeProjectId, activeProjectPath]);
 
   const selectValue = settings.defaultProviderId ?? AUTO_DETECT_VALUE;
 
@@ -82,26 +166,54 @@ export function ForgeIntegrationsTab() {
     return base;
   }, [providers, settings.defaultProviderId]);
 
-  const handleChange = useCallback(async (value: string) => {
-    const next = value === AUTO_DETECT_VALUE ? null : value;
-    const seq = ++writeSeqRef.current;
-    let previous: ForgeSettings | undefined;
-    setSettings((current) => {
-      previous = current;
-      return { defaultProviderId: next };
-    });
-    setError(null);
-    try {
-      const result = await window.electron.forge.setDefaultProvider(next);
-      if (seq !== writeSeqRef.current) return;
-      setSettings({ defaultProviderId: result.defaultProviderId });
-    } catch (err) {
-      if (seq !== writeSeqRef.current) return;
-      if (previous) setSettings(previous);
-      setError(formatErrorMessage(err, "Couldn't save forge integrations"));
-      logError("Failed to save default forge provider", err);
-    }
-  }, []);
+  // Re-resolve all remotes after a settings write succeeds. Changing the
+  // global default can shift the `resolvedVia` badge for remotes whose origin
+  // currently resolves via "hostname" — the default tier now wins.
+  const reresolveRemotes = useCallback(async () => {
+    if (!activeProjectId) return;
+    const currentRemotes = remotes.map((r) => r.remote);
+    if (currentRemotes.length === 0) return;
+    const resolutions = await Promise.allSettled(
+      currentRemotes.map((remote) =>
+        window.electron.forge.resolveProvider(activeProjectId, remote.fetchUrl)
+      )
+    );
+    setRemotes(
+      currentRemotes.map((remote, idx) => {
+        const result = resolutions[idx];
+        if (result?.status === "fulfilled") {
+          return { remote, resolved: result.value };
+        }
+        return { remote, resolved: { entry: null, resolvedVia: null } };
+      })
+    );
+  }, [activeProjectId, remotes]);
+
+  const handleChange = useCallback(
+    async (value: string) => {
+      const next = value === AUTO_DETECT_VALUE ? null : value;
+      const seq = ++writeSeqRef.current;
+      let previous: ForgeSettings | undefined;
+      setSettings((current) => {
+        previous = current;
+        return { defaultProviderId: next };
+      });
+      setError(null);
+      try {
+        const result = await window.electron.forge.setDefaultProvider(next);
+        if (seq !== writeSeqRef.current) return;
+        setSettings({ defaultProviderId: result.defaultProviderId });
+        // Refresh per-remote routing so the badges reflect the new default.
+        void reresolveRemotes();
+      } catch (err) {
+        if (seq !== writeSeqRef.current) return;
+        if (previous) setSettings(previous);
+        setError(formatErrorMessage(err, "Couldn't save forge integrations"));
+        logError("Failed to save default forge provider", err);
+      }
+    },
+    [reresolveRemotes]
+  );
 
   return (
     <div className="space-y-8">
@@ -129,6 +241,131 @@ export function ForgeIntegrationsTab() {
           error={error ?? undefined}
         />
       </SettingsSection>
+
+      <SettingsSection
+        icon={Route}
+        title="Active project routing"
+        description="Shows which forge provider each git remote of the active project resolves to and why."
+        id="forge-active-project-routing"
+      >
+        <ProjectRoutingPanel
+          activeProjectName={activeProject?.name}
+          activeProjectId={activeProjectId}
+          providersInstalled={providers.length}
+          remotes={remotes}
+          loading={remotesLoading}
+          error={remotesError}
+        />
+      </SettingsSection>
     </div>
+  );
+}
+
+interface ProjectRoutingPanelProps {
+  activeProjectName: string | undefined;
+  activeProjectId: string | undefined;
+  providersInstalled: number;
+  remotes: RemoteRouting[];
+  loading: boolean;
+  error: string | null;
+}
+
+function ProjectRoutingPanel({
+  activeProjectName,
+  activeProjectId,
+  providersInstalled,
+  remotes,
+  loading,
+  error,
+}: ProjectRoutingPanelProps) {
+  if (!activeProjectId) {
+    return (
+      <p className="text-xs text-daintree-text/50">
+        Open a project to view its forge routing.
+      </p>
+    );
+  }
+
+  if (loading) {
+    return <p className="text-xs text-daintree-text/40">Loading remotes…</p>;
+  }
+
+  if (error) {
+    return <p className="text-xs text-status-error">{error}</p>;
+  }
+
+  if (remotes.length === 0) {
+    return (
+      <p className="text-xs text-daintree-text/50">
+        {activeProjectName ?? "This project"} has no git remotes configured.
+      </p>
+    );
+  }
+
+  if (providersInstalled === 0) {
+    return (
+      <p className="text-xs text-daintree-text/50">
+        No forge plugins are installed. Each remote shows as unmatched until a provider plugin is
+        installed.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-2">
+      {remotes.map(({ remote, resolved }) => (
+        <li
+          key={remote.name}
+          className="flex items-center gap-3 justify-between rounded-[var(--radius-md)] border border-daintree-border/50 bg-overlay-subtle px-3 py-2"
+        >
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-2">
+              <span className="text-xs font-medium text-daintree-text">{remote.name}</span>
+            </div>
+            <p className="text-xs text-daintree-text/50 font-mono truncate" title={remote.fetchUrl}>
+              {remote.fetchUrl}
+            </p>
+          </div>
+          <RoutingBadge resolved={resolved} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function RoutingBadge({ resolved }: { resolved: ResolvedForgeProvider }) {
+  if (resolved.entry === null || resolved.resolvedVia === null) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="inline-flex items-center px-2 py-0.5 rounded-sm text-[10px] font-medium border border-daintree-border/60 text-daintree-text/50 cursor-default"
+            tabIndex={0}
+          >
+            No match
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          No provider matches this remote. Install a plugin or pick a global default that covers
+          this hostname.
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+  const providerName = resolved.entry.contribution.name;
+  const via = resolved.resolvedVia;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-sm text-[10px] font-medium border border-daintree-border/60 bg-status-info/10 text-daintree-text/80 cursor-default"
+          tabIndex={0}
+        >
+          <span>{providerName}</span>
+          <span className="text-daintree-text/50 uppercase tracking-wide">{BADGE_LABEL[via]}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="left">{TOOLTIP_COPY[via]}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
+++ b/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
@@ -1,0 +1,268 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ForgeIntegrationsTab } from "../ForgeIntegrationsTab";
+import { useProjectStore } from "@/store/projectStore";
+import type {
+  ForgeProviderEntry,
+  ResolvedForgeProvider,
+  ForgeProviderResolutionVia,
+} from "@shared/types";
+import type { Project } from "@shared/types/project";
+import type { RemoteInfo } from "@shared/types/ipc/github";
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+// Avoid pulling in the heavy Radix loader / tooltip provider plumbing.
+// Tooltips render their trigger inline; content is hidden until hover, and
+// we don't assert on tooltip text here.
+vi.mock("@/components/ui/tooltip", () => {
+  const Pass = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  return {
+    Tooltip: Pass,
+    TooltipTrigger: Pass,
+    TooltipContent: () => null,
+    TooltipProvider: Pass,
+  };
+});
+
+function makeProvider(
+  pluginId: string,
+  id: string,
+  name: string,
+  matches: string[] = []
+): ForgeProviderEntry {
+  return {
+    pluginId,
+    contribution: { id, name, matches },
+  };
+}
+
+function makeRemote(name: string, fetchUrl: string): RemoteInfo {
+  return { name, fetchUrl, parsedRepo: null };
+}
+
+function setProject(project: Project | null) {
+  useProjectStore.setState({ currentProject: project });
+}
+
+interface ForgeMockOptions {
+  defaultProviderId?: string | null;
+  providers?: ForgeProviderEntry[];
+  remotes?: RemoteInfo[] | Error;
+  resolveByRemote?: Record<string, ResolvedForgeProvider>;
+}
+
+function installForgeMocks(opts: ForgeMockOptions = {}) {
+  const setDefault = vi.fn(async (id: string | null) => ({ defaultProviderId: id }));
+  window.electron = {
+    forge: {
+      getSettings: vi.fn(async () => ({ defaultProviderId: opts.defaultProviderId ?? null })),
+      setDefaultProvider: setDefault,
+      getProviders: vi.fn(async () => opts.providers ?? []),
+      resolveProvider: vi.fn(async (_projectId: string, remoteUrl?: string) => {
+        const noMatch: ResolvedForgeProvider = { entry: null, resolvedVia: null };
+        if (!remoteUrl) return noMatch;
+        return opts.resolveByRemote?.[remoteUrl] ?? noMatch;
+      }),
+    },
+    github: {
+      listRemotes: vi.fn(async () => {
+        if (opts.remotes instanceof Error) throw opts.remotes;
+        return opts.remotes ?? [];
+      }),
+    },
+  } as unknown as typeof window.electron;
+  return { setDefault };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setProject(null);
+});
+
+describe("ForgeIntegrationsTab", () => {
+  it("renders both sections and the empty-project hint when no project is open", async () => {
+    installForgeMocks({ providers: [makeProvider("builtin", "github", "GitHub", ["github.com"])] });
+    render(<ForgeIntegrationsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Default forge provider")).toBeTruthy();
+      expect(screen.getByText("Active project routing")).toBeTruthy();
+    });
+    expect(screen.getByText(/Open a project to view its forge routing/i)).toBeTruthy();
+    expect(window.electron.github.listRemotes).not.toHaveBeenCalled();
+  });
+
+  it("renders a routing row per remote with the resolved provider badge", async () => {
+    const github = makeProvider("builtin", "github", "GitHub", ["github.com"]);
+    const gitea = makeProvider("acme.gitea", "gitea", "Gitea", ["gitea.example.com"]);
+    const remotes = [
+      makeRemote("origin", "git@github.com:owner/repo.git"),
+      makeRemote("mirror", "git@gitea.example.com:owner/repo.git"),
+    ];
+    installForgeMocks({
+      providers: [github, gitea],
+      remotes,
+      resolveByRemote: {
+        "git@github.com:owner/repo.git": { entry: github, resolvedVia: "hostname" },
+        "git@gitea.example.com:owner/repo.git": { entry: gitea, resolvedVia: "hostname" },
+      },
+    });
+    setProject({ id: "proj-1", path: "/repo", name: "Repo" } as Project);
+
+    render(<ForgeIntegrationsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText("origin")).toBeTruthy();
+      expect(screen.getByText("mirror")).toBeTruthy();
+      expect(screen.getByText("GitHub")).toBeTruthy();
+      expect(screen.getByText("Gitea")).toBeTruthy();
+    });
+    expect(window.electron.forge.resolveProvider).toHaveBeenCalledWith(
+      "proj-1",
+      "git@github.com:owner/repo.git"
+    );
+    expect(window.electron.forge.resolveProvider).toHaveBeenCalledWith(
+      "proj-1",
+      "git@gitea.example.com:owner/repo.git"
+    );
+  });
+
+  it("renders a No match badge when the resolver returns null entry", async () => {
+    const noMatch: ResolvedForgeProvider = { entry: null, resolvedVia: null };
+    const github = makeProvider("builtin", "github", "GitHub", ["github.com"]);
+    installForgeMocks({
+      providers: [github],
+      remotes: [makeRemote("origin", "git@unknown.example:owner/repo.git")],
+      resolveByRemote: {
+        "git@unknown.example:owner/repo.git": noMatch,
+      },
+    });
+    setProject({ id: "proj-1", path: "/repo", name: "Repo" } as Project);
+
+    render(<ForgeIntegrationsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No match")).toBeTruthy();
+    });
+  });
+
+  it("shows a no-remotes message when the project has zero git remotes", async () => {
+    installForgeMocks({
+      providers: [makeProvider("builtin", "github", "GitHub", ["github.com"])],
+      remotes: [],
+    });
+    setProject({ id: "proj-1", path: "/repo", name: "Repo" } as Project);
+
+    render(<ForgeIntegrationsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/has no git remotes configured/i)).toBeTruthy();
+    });
+  });
+
+  it("shows a no-providers message when remotes exist but no plugins are installed", async () => {
+    installForgeMocks({
+      providers: [],
+      remotes: [makeRemote("origin", "git@github.com:owner/repo.git")],
+      resolveByRemote: {
+        "git@github.com:owner/repo.git": { entry: null, resolvedVia: null },
+      },
+    });
+    setProject({ id: "proj-2", path: "/repo2", name: "Repo2" } as Project);
+
+    render(<ForgeIntegrationsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No forge plugins are installed\./i)).toBeTruthy();
+    });
+  });
+
+  it("shows an error message when listRemotes rejects", async () => {
+    installForgeMocks({
+      providers: [makeProvider("builtin", "github", "GitHub", ["github.com"])],
+      remotes: new Error("not a git repo"),
+    });
+    setProject({ id: "proj-1", path: "/repo", name: "Repo" } as Project);
+
+    render(<ForgeIntegrationsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't read git remotes|not a git repo/i)).toBeTruthy();
+    });
+  });
+
+  it("reloads remotes when the active project changes", async () => {
+    const github = makeProvider("builtin", "github", "GitHub", ["github.com"]);
+    const remoteA = makeRemote("origin", "git@github.com:a/a.git");
+    const remoteB = makeRemote("origin", "git@github.com:b/b.git");
+
+    installForgeMocks({
+      providers: [github],
+      remotes: [remoteA],
+      resolveByRemote: {
+        "git@github.com:a/a.git": { entry: github, resolvedVia: "hostname" },
+      },
+    });
+    setProject({ id: "proj-a", path: "/a", name: "A" } as Project);
+
+    const { rerender } = render(<ForgeIntegrationsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText("origin")).toBeTruthy();
+    });
+    expect(window.electron.github.listRemotes).toHaveBeenCalledWith("/a");
+
+    installForgeMocks({
+      providers: [github],
+      remotes: [remoteB],
+      resolveByRemote: {
+        "git@github.com:b/b.git": { entry: github, resolvedVia: "hostname" },
+      },
+    });
+    setProject({ id: "proj-b", path: "/b", name: "B" } as Project);
+    rerender(<ForgeIntegrationsTab />);
+
+    await waitFor(() => {
+      expect(window.electron.github.listRemotes).toHaveBeenCalledWith("/b");
+    });
+  });
+
+  it("displays an override-resolved badge for the override precedence path", async () => {
+    const gitea = makeProvider("acme.gitea", "gitea", "Gitea", ["gitea.example.com"]);
+    const overrideResult: ResolvedForgeProvider = {
+      entry: gitea,
+      resolvedVia: "override" satisfies ForgeProviderResolutionVia,
+    };
+    installForgeMocks({
+      providers: [gitea],
+      remotes: [makeRemote("origin", "git@github.com:owner/repo.git")],
+      resolveByRemote: {
+        "git@github.com:owner/repo.git": overrideResult,
+      },
+    });
+    setProject({ id: "proj-1", path: "/repo", name: "Repo" } as Project);
+
+    render(<ForgeIntegrationsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Gitea")).toBeTruthy();
+      expect(screen.getByText(/override/i)).toBeTruthy();
+    });
+  });
+});

--- a/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
+++ b/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
@@ -287,14 +287,23 @@ describe("ForgeIntegrationsTab source guards", () => {
   });
 
   it("reads remotes through a ref in reresolveRemotes to avoid stale closures on project switch", () => {
-    // Ref mirror present
+    // Ref mirrors for both remotes and the active project id
     expect(source).toMatch(/remotesRef\s*=\s*useRef<RemoteRouting\[\]>\(\[\]\)/);
-    // Ref kept in sync with state
+    expect(source).toMatch(
+      /activeProjectIdRef\s*=\s*useRef<string \| undefined>\(activeProjectId\)/
+    );
+    // Refs kept in sync with their source state via effects
     expect(source).toMatch(/remotesRef\.current\s*=\s*remotes/);
-    // reresolveRemotes reads from the ref, not from closed-over remotes state
+    expect(source).toMatch(/activeProjectIdRef\.current\s*=\s*activeProjectId/);
+    // reresolveRemotes reads project id + remotes from refs, not from closures
+    expect(source).toMatch(/const\s+currentProjectId\s*=\s*activeProjectIdRef\.current/);
     expect(source).toMatch(/const\s+currentRemotes\s*=\s*remotesRef\.current\.map/);
     expect(source).not.toMatch(/const\s+currentRemotes\s*=\s*remotes\.map/);
-    // reresolveRemotes deps no longer include `remotes` (only activeProjectId)
-    expect(source).toMatch(/}\s*,\s*\[activeProjectId\]\s*\)\s*;?\s*\n\s*\n\s*const handleChange/);
+    // Resolver is called with the ref-captured projectId, never the closure-bound activeProjectId
+    expect(source).toMatch(/resolveProvider\(currentProjectId,\s*remote\.fetchUrl\)/);
+    // Bail-out guard after the awaited resolutions if the project switched
+    expect(source).toMatch(
+      /if\s*\(\s*activeProjectIdRef\.current\s*!==\s*currentProjectId\s*\)\s*return\s*;?/
+    );
   });
 });

--- a/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
+++ b/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
 import { render, screen, waitFor } from "@testing-library/react";
 import { ForgeIntegrationsTab } from "../ForgeIntegrationsTab";
 import { useProjectStore } from "@/store/projectStore";
@@ -264,5 +266,35 @@ describe("ForgeIntegrationsTab", () => {
       expect(screen.getByText("Gitea")).toBeTruthy();
       expect(screen.getByText(/override/i)).toBeTruthy();
     });
+  });
+});
+
+describe("ForgeIntegrationsTab source guards", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(path.resolve(__dirname, "../ForgeIntegrationsTab.tsx"), "utf-8");
+  });
+
+  it("gates the remotes loading text on useDeferredLoading + UI_DOHERTY_THRESHOLD", () => {
+    expect(source).toContain("useDeferredLoading");
+    expect(source).toContain("UI_DOHERTY_THRESHOLD");
+    expect(source).toMatch(
+      /showRemotesLoading\s*=\s*useDeferredLoading\(\s*remotesLoading\s*,\s*UI_DOHERTY_THRESHOLD\s*\)/
+    );
+    expect(source).toMatch(/loading=\{showRemotesLoading\}/);
+    expect(source).not.toMatch(/loading=\{remotesLoading\}/);
+  });
+
+  it("reads remotes through a ref in reresolveRemotes to avoid stale closures on project switch", () => {
+    // Ref mirror present
+    expect(source).toMatch(/remotesRef\s*=\s*useRef<RemoteRouting\[\]>\(\[\]\)/);
+    // Ref kept in sync with state
+    expect(source).toMatch(/remotesRef\.current\s*=\s*remotes/);
+    // reresolveRemotes reads from the ref, not from closed-over remotes state
+    expect(source).toMatch(/const\s+currentRemotes\s*=\s*remotesRef\.current\.map/);
+    expect(source).not.toMatch(/const\s+currentRemotes\s*=\s*remotes\.map/);
+    // reresolveRemotes deps no longer include `remotes` (only activeProjectId)
+    expect(source).toMatch(/}\s*,\s*\[activeProjectId\]\s*\)\s*;?\s*\n\s*\n\s*const handleChange/);
   });
 });

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -1093,6 +1093,23 @@ export const SETTINGS_REGISTRY = [
           "hostname",
         ],
       },
+      {
+        id: "forge-active-project-routing",
+        section: "Active project routing",
+        title: "Active project routing",
+        description:
+          "Inspect which forge provider each remote of the active project routes to and why.",
+        keywords: [
+          "forge",
+          "remote",
+          "routing",
+          "provider",
+          "match",
+          "hostname",
+          "override",
+          "active project",
+        ],
+      },
     ],
   } satisfies LazySettingsTabEntry,
 


### PR DESCRIPTION
## Summary

- Adds a new **Forge Integrations** section to Preferences that lists all detected git remotes for the active project and shows which registered provider each remote resolves to
- Each remote gets a resolved-provider badge; hovering shows a tooltip with the full precedence path (project override → global default → hostname auto-match → none)
- Includes a global-default provider control, Doherty-threshold loading gate to prevent flicker, and a ref guard + mid-flight bail-out to harden project switching

Resolves #8064

## Changes

- `ForgeIntegrationsTab` — new tab component with `ProjectRoutingPanel`, `RoutingBadge`, and `ResolvedForgeProvider` sub-components
- `settingsTabRegistry` — registers the new Forge Integrations tab
- `forgeProviderResolver` — extended to return precedence-path metadata alongside the resolved provider
- `forgeSettings` IPC handler — updated to expose `reresolveRemotes` with `trim()` normalisation on incoming data
- `shared/types/forge.ts` + IPC types — `ResolvedForgeProvider`, `ForgeRoutingResult`, updated maps
- Tests — 48 passing; new handler tests for project-switch guards and resolver precedence paths

## Testing

- All 48 forge tests pass (`npm run check` clean — typecheck + lint + format)
- Manual: opened Preferences → Forge Integrations with a multi-remote project, verified badge tooltips reflect the correct precedence path; switching projects mid-load shows the correct remotes for the landed project