### PR TITLE
feat(dev-preview): polish eviction-recovery empty state and add recovery spinner

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -280,14 +280,14 @@ export function DevPreviewPane({
   const previousIsEvictedRef = useRef(false);
 
   useEffect(() => {
-    if (previousIsEvictedRef.current && !isEvicted) {
+    if (previousIsEvictedRef.current && !isEvicted && hasBeenVisible) {
       setIsRecoveringFromEviction(true);
     }
     if (isEvicted) {
       setIsRecoveringFromEviction(false);
     }
     previousIsEvictedRef.current = isEvicted;
-  }, [isEvicted]);
+  }, [isEvicted, hasBeenVisible]);
 
   const showRecoverySpinner = useDeferredLoading(isRecoveringFromEviction, UI_DOHERTY_THRESHOLD);
 
@@ -306,6 +306,15 @@ export function DevPreviewPane({
     };
 
     webview.addEventListener("did-finish-load", handleRecoveryFinishLoad);
+
+    try {
+      if (webview.getURL() !== "about:blank" && !webview.isLoading()) {
+        setIsRecoveringFromEviction(false);
+      }
+    } catch {
+      // Webview not ready
+    }
+
     return () => {
       webview.removeEventListener("did-finish-load", handleRecoveryFinishLoad);
     };
@@ -999,7 +1008,7 @@ export function DevPreviewPane({
                       )}
                     </div>
                   )}
-                  {showRecoverySpinner && !isLoading && !webviewLoadError && (
+                  {showRecoverySpinner && !webviewLoadError && (
                     <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
                       <Spinner size="2xl" className="text-status-info" />
                       <p className="text-xs text-daintree-text/50">Rehydrating preview...</p>

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -34,6 +34,8 @@ import { actionService } from "@/services/ActionService";
 import { useWebviewThrottle } from "@/hooks/useWebviewThrottle";
 import { useHasBeenVisible } from "@/hooks/useHasBeenVisible";
 import { useWebviewEviction } from "@/hooks/useWebviewEviction";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { useWebviewDialog } from "@/hooks/useWebviewDialog";
 import { WebviewDialog } from "../Browser/WebviewDialog";
 import { FindBar } from "../Browser/FindBar";
@@ -273,6 +275,41 @@ export function DevPreviewPane({
     Boolean(currentProjectId) && !isSettingsLoading && projectSettings !== null && !devCommand;
 
   const { isEvicted, evictingRef } = useWebviewEviction(id, location);
+
+  const [isRecoveringFromEviction, setIsRecoveringFromEviction] = useState(false);
+  const previousIsEvictedRef = useRef(false);
+
+  useEffect(() => {
+    if (previousIsEvictedRef.current && !isEvicted) {
+      setIsRecoveringFromEviction(true);
+    }
+    if (isEvicted) {
+      setIsRecoveringFromEviction(false);
+    }
+    previousIsEvictedRef.current = isEvicted;
+  }, [isEvicted]);
+
+  const showRecoverySpinner = useDeferredLoading(isRecoveringFromEviction, UI_DOHERTY_THRESHOLD);
+
+  useEffect(() => {
+    const webview = webviewElement;
+    if (!webview || !isRecoveringFromEviction) return;
+
+    const handleRecoveryFinishLoad = () => {
+      try {
+        if (webview.getURL() !== "about:blank") {
+          setIsRecoveringFromEviction(false);
+        }
+      } catch {
+        // Webview detached
+      }
+    };
+
+    webview.addEventListener("did-finish-load", handleRecoveryFinishLoad);
+    return () => {
+      webview.removeEventListener("did-finish-load", handleRecoveryFinishLoad);
+    };
+  }, [isRecoveringFromEviction, webviewElement]);
 
   const {
     isWebviewReady,
@@ -859,7 +896,9 @@ export function DevPreviewPane({
             </div>
           ) : isEvicted ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
-              <p className="text-xs text-daintree-text/50">Reclaimed for memory</p>
+              <p className="text-xs text-daintree-text/50">
+                Preview paused to save memory — will reload when opened
+              </p>
             </div>
           ) : (
             <div className={cn("h-full", viewportPreset && "flex items-start justify-center pt-5")}>
@@ -958,6 +997,12 @@ export function DevPreviewPane({
                           </Button>
                         </>
                       )}
+                    </div>
+                  )}
+                  {showRecoverySpinner && !isLoading && !webviewLoadError && (
+                    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
+                      <Spinner size="2xl" className="text-status-info" />
+                      <p className="text-xs text-daintree-text/50">Rehydrating preview...</p>
                     </div>
                   )}
                   {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -769,15 +769,15 @@ describe("GitHubResourceList wake-coordinator revalidation", () => {
     // Advance past debounce.
     await vi.advanceTimersByTimeAsync(400);
 
-    await waitFor(() => {
-      expect(mockListIssues.mock.calls.length).toBeGreaterThanOrEqual(1);
-    });
     // The list-query effect re-runs twice on search-clear (numberQuery flip,
     // then debouncedSearch flip after the debounce timer) — both calls are
     // pre-existing behavior. The wake epoch must NOT add a third call: the
     // consume-during-numeric-search fix guarantees the stale wake doesn't
-    // replay when numberQuery transitions back to null.
-    expect(mockListIssues).toHaveBeenCalledTimes(2);
+    // replay when numberQuery transitions back to null. waitFor on the exact
+    // count so CI doesn't race the second effect flush.
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(2);
+    });
   });
 
   it("clears the refreshing spinner when a wake revalidation is interrupted by a numeric search", async () => {


### PR DESCRIPTION
## Summary
I polished the eviction recovery flow in the dev-preview panel. The old copy — `Reclaimed for memory` — read like a terminal state, which doesn't match the actual behaviour since the panel auto-recovers when you switch back to it. The new copy makes that explicit, and I added a Doherty-gated spinner to bridge the reload silence window so it doesn't read as broken.

Resolves #8282.

## Changes
- Replaced "Reclaimed for memory" with "Preview paused to save memory — will reload when opened"
- Added `isRecoveringFromEviction` latch activated on eviction-to-visible transitions
- Wired a `useDeferredLoading(..., UI_DOHERTY_THRESHOLD)`-gated spinner so brief remounts stay silent and only loads exceeding 400ms surface a loading hint
- Added a `hasBeenVisible` gate so the spinner doesn't fire on first mount
- Added a race-condition guard that resets the latch on re-eviction

## Testing
- Verified the updated placeholder copy appears on evicted panels
- Confirmed the recovery spinner only renders after the 400ms Doherty threshold
- Confirmed `hasBeenVisible` gate prevents the spinner on initial panel mount
- Verified the latch resets correctly when a panel is re-evicted during recovery