### PR TITLE
feat(dev-preview): phased skeleton replaces bare spinners

### DIFF
--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -62,6 +62,7 @@ export const AppStateTerminalEntrySchema = z
     browserUrl: z.string().optional(),
     devCommand: z.string().optional(),
     devServerStatus: z.enum(["stopped", "starting", "installing", "running", "error"]).optional(),
+    devServerPhaseLabel: z.string().nullable().optional(),
     devServerUrl: z.string().optional(),
     devServerError: z
       .object({
@@ -121,6 +122,7 @@ export const TerminalSnapshotSchema = z
     browserUrl: z.string().optional(),
     devCommand: z.string().optional(),
     devServerStatus: z.enum(["stopped", "starting", "installing", "running", "error"]).optional(),
+    devServerPhaseLabel: z.string().nullable().optional(),
     devServerUrl: z.string().optional(),
     devServerError: z
       .object({

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -247,6 +247,7 @@ export class DevPreviewSessionService {
           error: null,
           isRestarting: true,
           forceKilled: undefined,
+          phaseLabel: "Restarting",
         });
 
         await this.stopSessionTerminal(session, "restart");
@@ -537,6 +538,7 @@ export class DevPreviewSessionService {
       generation: 0,
       updatedAt: Date.now(),
       updatedAtPerformanceMs: performance.now(),
+      phaseLabel: null,
       cwd: "",
       devCommand: "",
       turbopackEnabled: true,
@@ -572,6 +574,7 @@ export class DevPreviewSessionService {
         generation: 0,
         updatedAt: Date.now(),
         forceKilled: undefined,
+        phaseLabel: null,
       };
     }
     return this.toPublicState(session);
@@ -591,6 +594,7 @@ export class DevPreviewSessionService {
       generation: session.generation,
       updatedAt: session.updatedAt,
       forceKilled: session.forceKilled,
+      phaseLabel: session.phaseLabel,
     };
   }
 
@@ -608,6 +612,7 @@ export class DevPreviewSessionService {
         | "worktreeId"
         | "generation"
         | "forceKilled"
+        | "phaseLabel"
       >
     >
   ): void {
@@ -621,6 +626,7 @@ export class DevPreviewSessionService {
     if (updates.worktreeId !== undefined) session.worktreeId = updates.worktreeId;
     if (updates.generation !== undefined) session.generation = updates.generation;
     if ("forceKilled" in updates) session.forceKilled = updates.forceKilled;
+    if (updates.phaseLabel !== undefined) session.phaseLabel = updates.phaseLabel;
     session.updatedAt = Date.now();
     session.updatedAtPerformanceMs = performance.now();
     this.onStateChanged(this.toPublicState(session));
@@ -724,6 +730,7 @@ export class DevPreviewSessionService {
       error: null,
       generation: nextGeneration,
       forceKilled: undefined,
+      phaseLabel: "Starting dev server",
     });
 
     try {
@@ -957,7 +964,12 @@ export class DevPreviewSessionService {
       this.pollServerReadiness(session, session.pendingUrl, abort.signal, session.generation);
     }
 
-    if (!result.error) return;
+    if (!result.error) {
+      if (session.status === "starting" && session.phaseLabel !== "Compiling") {
+        this.updateSession(session, { phaseLabel: "Compiling" });
+      }
+      return;
+    }
     const errorKey = `${result.error.type}:${result.error.message}`;
     if (errorKey === session.lastErrorKey) return;
     session.lastErrorKey = errorKey;
@@ -1076,6 +1088,7 @@ export class DevPreviewSessionService {
         type: "missing-dependencies",
         message: `Running ${installCommand}...`,
       },
+      phaseLabel: "Installing dependencies",
     });
 
     try {

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -422,6 +422,7 @@ export class DevPreviewSessionService {
           terminalId: null,
           isRestarting: false,
           forceKilled,
+          phaseLabel: null,
         });
       } else {
         this.updateSession(session, {
@@ -431,6 +432,7 @@ export class DevPreviewSessionService {
           error: null,
           terminalId: null,
           isRestarting: false,
+          phaseLabel: null,
         });
       }
     });
@@ -998,6 +1000,7 @@ export class DevPreviewSessionService {
       url: null,
       assignedUrl: null,
       isRestarting: false,
+      phaseLabel: null,
     });
   }
 
@@ -1034,6 +1037,7 @@ export class DevPreviewSessionService {
         },
         terminalId: null,
         isRestarting: false,
+        phaseLabel: null,
       });
       return;
     }
@@ -1057,6 +1061,7 @@ export class DevPreviewSessionService {
         error,
         terminalId: null,
         isRestarting: false,
+        phaseLabel: null,
       });
       return;
     }
@@ -1068,6 +1073,7 @@ export class DevPreviewSessionService {
       error: null,
       terminalId: null,
       isRestarting: false,
+      phaseLabel: null,
     });
   }
 
@@ -1158,6 +1164,7 @@ export class DevPreviewSessionService {
             url,
             error: null,
             isRestarting: false,
+            phaseLabel: null,
           });
           markPerformance(PERF_MARKS.DEVPREVIEW_RUNNING, {
             panelId: session.panelId,
@@ -1175,6 +1182,7 @@ export class DevPreviewSessionService {
               message: `Dev server at ${url} did not respond within ${READINESS_TIMEOUT_MS / 1000} seconds`,
             },
             isRestarting: false,
+            phaseLabel: null,
           });
         }
       })
@@ -1200,6 +1208,7 @@ export class DevPreviewSessionService {
             message: `Dev server readiness check failed: ${message}`,
           },
           isRestarting: false,
+          phaseLabel: null,
         });
       });
   }

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -40,6 +40,7 @@ export interface DevPreviewSessionState {
   generation: number;
   updatedAt: number;
   forceKilled?: boolean;
+  phaseLabel: string | null;
 }
 
 export interface DevPreviewStateChangedPayload {

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -271,6 +271,8 @@ export interface PtyPanelData extends BasePanelData {
   devCommand?: string;
   /** Dev server status for dev-preview panels */
   devServerStatus?: "stopped" | "starting" | "installing" | "running" | "error";
+  /** Dev server phase label for dev-preview panels */
+  devServerPhaseLabel?: string | null;
   /** Dev server URL for dev-preview panels */
   devServerUrl?: string;
   /** Dev server error for dev-preview panels */
@@ -368,6 +370,8 @@ export interface DevPreviewPanelData extends BasePanelData {
   devPreviewConsoleOpen?: boolean;
   /** Dev server status */
   devServerStatus?: "stopped" | "starting" | "installing" | "running" | "error";
+  /** Dev server phase label */
+  devServerPhaseLabel?: string | null;
   /** Dev server URL */
   devServerUrl?: string;
   /** Dev server error */
@@ -492,6 +496,8 @@ export interface TerminalInstance {
   devCommand?: string;
   /** Dev server status for dev-preview panels */
   devServerStatus?: "stopped" | "starting" | "installing" | "running" | "error";
+  /** Dev server phase label for dev-preview panels */
+  devServerPhaseLabel?: string | null;
   /** Dev server URL for dev-preview panels */
   devServerUrl?: string;
   /** Dev server error for dev-preview panels */

--- a/src/components/DevPreview/DevPreviewLoadingState.tsx
+++ b/src/components/DevPreview/DevPreviewLoadingState.tsx
@@ -1,0 +1,72 @@
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { SkeletonHint } from "@/components/ui/Skeleton";
+
+interface DevPreviewLoadingStateProps {
+  isPending: boolean;
+  phaseLabel: string | null;
+  variant: "full" | "overlay";
+  className?: string;
+}
+
+export function DevPreviewLoadingState({
+  isPending,
+  phaseLabel,
+  variant,
+  className,
+}: DevPreviewLoadingStateProps) {
+  const showLoader = useDeferredLoading(isPending, UI_DOHERTY_THRESHOLD);
+
+  if (!showLoader) return null;
+
+  if (variant === "overlay") {
+    return (
+      <div
+        className={`absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3 ${className ?? ""}`}
+        role="status"
+        aria-busy="true"
+      >
+        {phaseLabel && (
+          <p aria-live="polite" className="text-sm text-daintree-text/60">
+            {phaseLabel}
+          </p>
+        )}
+        <SkeletonHint className="pointer-events-auto" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`absolute inset-0 flex flex-col bg-daintree-bg ${className ?? ""}`}
+      role="status"
+      aria-busy="true"
+      aria-label={phaseLabel ?? "Loading dev preview"}
+    >
+      <span className="sr-only">{phaseLabel ?? "Loading dev preview"}</span>
+
+      {/* Content area skeleton — no header/toolbar (real toolbar renders above) */}
+      <div className="flex-1 min-h-0 p-3 space-y-3" aria-hidden="true">
+        <div className="animate-pulse-delayed h-4 w-3/4 bg-muted rounded" />
+        <div className="animate-pulse-delayed h-4 w-1/2 bg-muted rounded" />
+        <div className="animate-pulse-delayed h-4 w-5/6 bg-muted rounded" />
+        <div className="animate-pulse-delayed h-3 w-2/3 bg-muted rounded" />
+        <div className="animate-pulse-delayed h-32 w-full bg-muted rounded mt-4" />
+        <div className="animate-pulse-delayed h-3 w-1/3 bg-muted rounded" />
+        <div className="animate-pulse-delayed h-3 w-1/4 bg-muted rounded" />
+      </div>
+
+      {/* Phase label */}
+      {phaseLabel && (
+        <p
+          aria-live="polite"
+          className="absolute bottom-12 left-1/2 -translate-x-1/2 text-sm text-daintree-text/60"
+        >
+          {phaseLabel}
+        </p>
+      )}
+
+      <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
+    </div>
+  );
+}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -410,6 +410,21 @@ export function DevPreviewPane({
     };
   }, [phaseLabel]);
 
+  // Bypass debounce on deliberate transitions (e.g. restart) so the user sees
+  // the label even when the backend replaces it within the 600ms window.
+  useEffect(() => {
+    if (isRestarting) {
+      lastPhaseChangeAtRef.current = 0;
+      if (phaseDebounceTimerRef.current) {
+        clearTimeout(phaseDebounceTimerRef.current);
+        phaseDebounceTimerRef.current = null;
+      }
+      if (phaseLabel) {
+        setDebouncedPhaseLabel(phaseLabel);
+      }
+    }
+  }, [isRestarting]); // eslint-disable-line react-hooks/exhaustive-deps -- phaseLabel is read but not needed as dep; only restart transitions matter
+
   // Stall detection — auto-open console drawer on fatal error or 15s no-phase-progress
   const stallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasAutoOpenedConsoleRef = useRef(false);
@@ -433,6 +448,7 @@ export function DevPreviewPane({
     }
 
     if (status === "starting" || status === "installing") {
+      hasAutoOpenedConsoleRef.current = false;
       if (stallTimerRef.current) {
         clearTimeout(stallTimerRef.current);
       }

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1400,10 +1400,11 @@ export function DevPreviewPane({
                     </div>
                   )}
                   {showRecoverySpinner && !webviewLoadError && (
-                    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
-                      <Spinner size="2xl" className="text-status-info" />
-                      <p className="text-xs text-daintree-text/50">Rehydrating preview...</p>
-                    </div>
+                    <DevPreviewLoadingState
+                      variant="overlay"
+                      isPending={true}
+                      phaseLabel="Rehydrating preview"
+                    />
                   )}
                   {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
                   {findInPage.isOpen && <FindBar find={findInPage} />}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -9,7 +9,6 @@ import {
   WandSparkles,
   OctagonAlert,
 } from "lucide-react";
-import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
 import { usePanelStore } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
@@ -27,6 +26,7 @@ import {
 } from "../Browser/historyUtils";
 import { useDevServer, type UseDevServerReturn } from "@/hooks/useDevServer";
 import { ConsoleDrawer } from "./ConsoleDrawer";
+import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
 import { computeDevServerUrl } from "./urlSync";
@@ -327,6 +327,7 @@ export function DevPreviewPane({
     url,
     terminalId,
     error,
+    phaseLabel,
     start,
     stop,
     restart,
@@ -384,6 +385,73 @@ export function DevPreviewPane({
   const isSettingsLoading = useProjectSettingsStore((state) => state.isLoading);
   const isMountedRef = useRef(true);
   const prevStatusRef = useRef(status);
+
+  // Phase label debounce (600ms) — prevents three-label slot machine on warm-cache boots
+  const lastPhaseChangeAtRef = useRef<number>(0);
+  const phaseDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [debouncedPhaseLabel, setDebouncedPhaseLabel] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (phaseLabel === null) {
+      setDebouncedPhaseLabel(null);
+      return;
+    }
+    lastPhaseChangeAtRef.current = Date.now();
+    phaseDebounceTimerRef.current = setTimeout(() => {
+      if (Date.now() - lastPhaseChangeAtRef.current >= 600) {
+        setDebouncedPhaseLabel(phaseLabel);
+      }
+    }, 600);
+    return () => {
+      if (phaseDebounceTimerRef.current) {
+        clearTimeout(phaseDebounceTimerRef.current);
+        phaseDebounceTimerRef.current = null;
+      }
+    };
+  }, [phaseLabel]);
+
+  // Stall detection — auto-open console drawer on fatal error or 15s no-phase-progress
+  const stallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasAutoOpenedConsoleRef = useRef(false);
+
+  useEffect(() => {
+    if (status === "error" && error) {
+      if (!hasAutoOpenedConsoleRef.current && !isConsoleOpen) {
+        hasAutoOpenedConsoleRef.current = true;
+        setDevPreviewConsoleOpen(id, true);
+      }
+      return;
+    }
+
+    if (status === "running" || status === "stopped") {
+      hasAutoOpenedConsoleRef.current = false;
+      if (stallTimerRef.current) {
+        clearTimeout(stallTimerRef.current);
+        stallTimerRef.current = null;
+      }
+      return;
+    }
+
+    if (status === "starting" || status === "installing") {
+      if (stallTimerRef.current) {
+        clearTimeout(stallTimerRef.current);
+      }
+      stallTimerRef.current = setTimeout(() => {
+        if (!hasAutoOpenedConsoleRef.current && !isConsoleOpen) {
+          hasAutoOpenedConsoleRef.current = true;
+          setDevPreviewConsoleOpen(id, true);
+        }
+      }, 15000);
+    }
+
+    return () => {
+      if (stallTimerRef.current) {
+        clearTimeout(stallTimerRef.current);
+        stallTimerRef.current = null;
+      }
+    };
+  }, [status, phaseLabel, error, id, isConsoleOpen, setDevPreviewConsoleOpen]);
+
   const loadTimeoutMs =
     Math.min(Math.max(projectSettings?.devServerLoadTimeout ?? 30, 1), 120) * 1000;
 
@@ -1066,13 +1134,11 @@ export function DevPreviewPane({
             </div>
           )}
           {isRestarting || status === "starting" || status === "installing" ? (
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg">
-              <Spinner size="2xl" className="text-status-info mb-4" />
-              <p className="text-sm text-daintree-text/60">
-                {isRestarting ? "Restarting" : status === "installing" ? "Installing" : "Starting"}
-                ...
-              </p>
-            </div>
+            <DevPreviewLoadingState
+              variant="full"
+              isPending={true}
+              phaseLabel={debouncedPhaseLabel}
+            />
           ) : status === "error" && error ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
               <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
@@ -1295,24 +1361,23 @@ export function DevPreviewPane({
                     />
                   )}
                   {isLoading && (
-                    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
-                      <Spinner size="2xl" className="text-status-info" />
-                      {isSlowLoad && (
-                        <>
-                          <p className="text-xs text-daintree-text/50">
-                            Taking longer than usual...
-                          </p>
-                          <Button
-                            onClick={handleCancelLoad}
-                            variant="ghost"
-                            size="sm"
-                            className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
-                          >
-                            <Square className="h-3.5 w-3.5" />
-                            <span className="text-xs">Cancel</span>
-                          </Button>
-                        </>
-                      )}
+                    <DevPreviewLoadingState
+                      variant="overlay"
+                      isPending={true}
+                      phaseLabel={isSlowLoad ? "Taking longer than usual..." : "Loading preview"}
+                    />
+                  )}
+                  {isLoading && isSlowLoad && (
+                    <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-20">
+                      <Button
+                        onClick={handleCancelLoad}
+                        variant="ghost"
+                        size="sm"
+                        className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+                      >
+                        <Square className="h-3.5 w-3.5" />
+                        <span className="text-xs">Cancel</span>
+                      </Button>
                     </div>
                   )}
                   {showRecoverySpinner && !webviewLoadError && (

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -386,7 +386,10 @@ export function DevPreviewPane({
   const isMountedRef = useRef(true);
   const prevStatusRef = useRef(status);
 
-  // Phase label debounce (600ms) — prevents three-label slot machine on warm-cache boots
+  const PHASE_DEBOUNCE_MS = 600;
+  const STALL_DETECTION_MS = 15_000;
+
+  // Phase label debounce — prevents three-label slot machine on warm-cache boots
   const lastPhaseChangeAtRef = useRef<number>(0);
   const phaseDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [debouncedPhaseLabel, setDebouncedPhaseLabel] = useState<string | null>(null);
@@ -398,10 +401,10 @@ export function DevPreviewPane({
     }
     lastPhaseChangeAtRef.current = Date.now();
     phaseDebounceTimerRef.current = setTimeout(() => {
-      if (Date.now() - lastPhaseChangeAtRef.current >= 600) {
+      if (Date.now() - lastPhaseChangeAtRef.current >= PHASE_DEBOUNCE_MS) {
         setDebouncedPhaseLabel(phaseLabel);
       }
-    }, 600);
+    }, PHASE_DEBOUNCE_MS);
     return () => {
       if (phaseDebounceTimerRef.current) {
         clearTimeout(phaseDebounceTimerRef.current);
@@ -411,7 +414,7 @@ export function DevPreviewPane({
   }, [phaseLabel]);
 
   // Bypass debounce on deliberate transitions (e.g. restart) so the user sees
-  // the label even when the backend replaces it within the 600ms window.
+  // the label even when the backend replaces it within the debounce window.
   useEffect(() => {
     if (isRestarting) {
       lastPhaseChangeAtRef.current = 0;
@@ -457,7 +460,7 @@ export function DevPreviewPane({
           hasAutoOpenedConsoleRef.current = true;
           setDevPreviewConsoleOpen(id, true);
         }
-      }, 15000);
+      }, STALL_DETECTION_MS);
     }
 
     return () => {

--- a/src/hooks/__tests__/useDevServer.adversarial.test.tsx
+++ b/src/hooks/__tests__/useDevServer.adversarial.test.tsx
@@ -42,6 +42,7 @@ function buildState(overrides: Partial<DevPreviewSessionState>): DevPreviewSessi
     isRestarting: overrides.isRestarting ?? false,
     generation: overrides.generation ?? 0,
     updatedAt: overrides.updatedAt ?? Date.now(),
+    phaseLabel: overrides.phaseLabel ?? null,
   };
 }
 

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -27,6 +27,7 @@ export interface UseDevServerState {
   url: string | null;
   terminalId: string | null;
   error: DevServerError | null;
+  phaseLabel: string | null;
 }
 
 export interface UseDevServerReturn extends UseDevServerState {
@@ -108,6 +109,7 @@ export function useDevServer({
   const [url, setUrl] = useState<string | null>(null);
   const [terminalId, setTerminalId] = useState<string | null>(null);
   const [error, setError] = useState<DevServerError | null>(null);
+  const [phaseLabel, setPhaseLabel] = useState<string | null>(null);
   const [isRestarting, setIsRestarting] = useState(false);
   const [stuckTier, setStuckTier] = useState<DevServerStuckTier>(0);
   const [forceKilled, setForceKilled] = useState<boolean | undefined>(undefined);
@@ -182,6 +184,7 @@ export function useDevServer({
     setError(state.error ?? null);
     setIsRestarting(state.isRestarting);
     setForceKilled(state.forceKilled);
+    setPhaseLabel(state.phaseLabel);
   }, []);
 
   const applyInvokeError = useCallback((err: unknown) => {
@@ -199,6 +202,7 @@ export function useDevServer({
     setError({ type: "unknown", message });
     setTerminalId(null);
     setIsRestarting(false);
+    setPhaseLabel(null);
   }, []);
 
   const ensureLatestConfig = useCallback(
@@ -353,6 +357,7 @@ export function useDevServer({
       setTerminalId(null);
       setError(null);
       setIsRestarting(false);
+      setPhaseLabel(null);
       lastEnsureConfigRef.current = "";
       pendingEnsureConfigRef.current = null;
       persistedEnsureCache.delete(panelId);
@@ -498,6 +503,7 @@ export function useDevServer({
     url,
     terminalId,
     error,
+    phaseLabel,
     start,
     stop,
     restart,


### PR DESCRIPTION
## Summary
Replaces the bare `Spinner` loading states in `DevPreviewPane` with a phased, Doherty-gated skeleton. Users now see which phase the dev server is in (starting, installing, compiling, loading) instead of staring at an unlabeled spinner that could mean anything.

Tracks `phaseLabel` from the electron service through the renderer hook to the UI, infers a `Compiling` phase from post-install stdout, and auto-opens the `ConsoleDrawer` on fatal errors or 15s stalls so the user has a path to diagnose.

Fixes #8264

## Changes
- New `DevPreviewLoadingState` component with Doherty-gated skeleton and `aria-live` phase label
- `phaseLabel` field added across shared types, IPC schema, and electron service
- `Compiling` phase inferred from any post-install stdout that isn't a URL-detection event
- 600ms ref-based phase debounce prevents label slot-machine on fast boots
- Auto-opens `ConsoleDrawer` on fatal errors or 15s stalls with no recognized phase token
- Dropped `text-status-info` accent on both original spinner sites

## Testing
Manually tested across cold `npm install`, warm-cache reload, fatal error, and slow-boot scenarios. Phase labels track correctly through each transition. The 600ms debounce suppresses flicker on sub-second phase transitions.