### PR TITLE
feat(dev-preview): wire guest-page console capture into the drawer

### DIFF
--- a/e2e/full/panels/core-dev-preview.spec.ts
+++ b/e2e/full/panels/core-dev-preview.spec.ts
@@ -157,12 +157,12 @@ test.describe.serial("Core: Dev Preview", () => {
       }
 
       await consoleToggle.click();
-      await expect(window.locator('[aria-label="Hide Terminal"]')).toBeVisible({
+      await expect(consoleToggle).toHaveAttribute("aria-expanded", "true", {
         timeout: T_SHORT,
       });
 
-      await window.locator('[aria-label="Hide Terminal"]').click();
-      await expect(window.locator('[aria-label="Show Terminal"]')).toBeVisible({
+      await consoleToggle.click();
+      await expect(consoleToggle).toHaveAttribute("aria-expanded", "false", {
         timeout: T_SHORT,
       });
     });
@@ -253,14 +253,14 @@ server.listen(0, '127.0.0.1', () => {
       const { window } = ctx;
 
       // Open console drawer
-      const consoleToggle = window.locator('[aria-label="Show Terminal"]').first();
+      const consoleToggle = window.locator(SEL.devPreview.consoleToggle).first();
       if (!(await consoleToggle.isVisible({ timeout: T_SHORT }).catch(() => false))) {
         test.skip();
         return;
       }
       await consoleToggle.click();
 
-      await expect(window.locator('[aria-label="Hide Terminal"]')).toBeVisible({
+      await expect(consoleToggle).toHaveAttribute("aria-expanded", "true", {
         timeout: T_SHORT,
       });
 
@@ -285,8 +285,8 @@ server.listen(0, '127.0.0.1', () => {
         .toContain("localhost:");
 
       // Close the console drawer
-      await window.locator('[aria-label="Hide Terminal"]').click();
-      await expect(window.locator('[aria-label="Show Terminal"]').first()).toBeVisible({
+      await consoleToggle.click();
+      await expect(consoleToggle).toHaveAttribute("aria-expanded", "false", {
         timeout: T_SHORT,
       });
     });

--- a/e2e/full/panels/dev-preview-console-capture.spec.ts
+++ b/e2e/full/panels/dev-preview-console-capture.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/test";
+import { writeFileSync } from "fs";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { getGridPanelCount } from "../../helpers/panels";
+import { SEL } from "../../helpers/selectors";
+import { T_SHORT, T_MEDIUM, T_LONG } from "../../helpers/timeouts";
+
+const CAPTURE_MARKER = "e2e-console-capture-error";
+const PROJECT_NAME = "Dev Preview Console Capture";
+
+let ctx: AppContext;
+let fixtureRepoPath: string;
+let fixtureCleanup: (() => void) | undefined;
+
+test.describe.serial("Dev Preview: guest-page console capture", () => {
+  test.beforeAll(async () => {
+    const { dir, cleanup } = createFixtureRepo({ name: "dev-preview-console-capture" });
+    fixtureRepoPath = dir;
+    fixtureCleanup = cleanup;
+
+    // Dev server returns a page that logs an error on load. We also push a
+    // second error via executeJavaScript after attach to make capture
+    // deterministic regardless of CDP attach timing on initial load.
+    const serverScript = `
+const http = require('http');
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/html' });
+  res.end('<html><body><h1>Console Capture E2E</h1><script>console.error("${CAPTURE_MARKER}-initial")</script></body></html>');
+});
+server.listen(0, '127.0.0.1', () => {
+  console.log('http://localhost:' + server.address().port);
+});
+`;
+    writeFileSync(path.join(fixtureRepoPath, "dev-server.cjs"), serverScript);
+
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureRepoPath, PROJECT_NAME);
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("captures guest console errors into the Console tab", async () => {
+    const { window } = ctx;
+
+    const devBtn = window.locator(SEL.toolbar.openDevPreview);
+    if (!(await devBtn.isVisible().catch(() => false))) {
+      test.skip();
+      return;
+    }
+
+    const before = await getGridPanelCount(window);
+    await devBtn.click();
+    await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(before + 1);
+
+    await expect(window.locator("text=Configure Dev Server")).toBeVisible({
+      timeout: T_MEDIUM,
+    });
+
+    await window.evaluate(async () => {
+      const current = await window.electron.project.getCurrent();
+      if (!current?.id) return;
+      const settings = await window.electron.project.getSettings(current.id);
+      await window.electron.project.saveSettings(current.id, {
+        ...settings,
+        devServerCommand: "node dev-server.cjs",
+      });
+    });
+    await window.reload({ waitUntil: "domcontentloaded" });
+    await window.locator(SEL.toolbar.toggleSidebar).waitFor({
+      state: "visible",
+      timeout: T_LONG,
+    });
+
+    const consoleBar = window.locator('[aria-controls^="console-drawer-"]').locator("..");
+    const statusBadge = consoleBar.locator('[role="status"]');
+    await expect(statusBadge).toContainText("Running", { timeout: T_LONG });
+
+    const webview = window.locator("webview");
+    await expect(webview).toBeAttached({ timeout: T_MEDIUM });
+
+    // Open the drawer and switch to the Console tab.
+    const consoleToggle = window.locator(SEL.devPreview.consoleToggle).first();
+    await consoleToggle.click();
+    await expect(consoleToggle).toHaveAttribute("aria-expanded", "true", {
+      timeout: T_SHORT,
+    });
+    await window.locator(SEL.devPreview.consoleTab).click();
+
+    // Emit a deterministic error from the guest page after capture is active.
+    await expect
+      .poll(
+        async () => {
+          return window.evaluate(async (marker) => {
+            const wv = document.querySelector("webview") as Electron.WebviewTag | null;
+            if (!wv) return false;
+            try {
+              await wv.executeJavaScript(`console.error("${marker}-runtime")`);
+              return true;
+            } catch {
+              return false;
+            }
+          }, CAPTURE_MARKER);
+        },
+        { timeout: T_LONG }
+      )
+      .toBe(true);
+
+    // The captured row surfaces in the Console tab panel.
+    await expect(window.locator(`text=${CAPTURE_MARKER}-runtime`).first()).toBeVisible({
+      timeout: T_LONG,
+    });
+
+    // The Console tab carries an error-count badge once errors land.
+    const consoleTab = window.locator(SEL.devPreview.consoleTab);
+    await expect
+      .poll(
+        async () => {
+          const text = (await consoleTab.textContent()) ?? "";
+          const match = text.match(/\d+/);
+          return match ? Number(match[0]) : 0;
+        },
+        { timeout: T_LONG }
+      )
+      .toBeGreaterThanOrEqual(1);
+  });
+});

--- a/e2e/full/panels/nextjs-turbopack.spec.ts
+++ b/e2e/full/panels/nextjs-turbopack.spec.ts
@@ -144,10 +144,10 @@ server.listen(0, '127.0.0.1', () => {
 
     // --- Verify --turbopack was injected ---
 
-    const consoleToggle = window.locator('[aria-label="Show Terminal"]').first();
+    const consoleToggle = window.locator(SEL.devPreview.consoleToggle).first();
     if (await consoleToggle.isVisible({ timeout: T_SHORT }).catch(() => false)) {
       await consoleToggle.click();
-      await expect(window.locator('[aria-label="Hide Terminal"]')).toBeVisible({
+      await expect(consoleToggle).toHaveAttribute("aria-expanded", "true", {
         timeout: T_SHORT,
       });
 
@@ -169,7 +169,7 @@ server.listen(0, '127.0.0.1', () => {
         )
         .toContain("--turbopack");
 
-      await window.locator('[aria-label="Hide Terminal"]').click();
+      await consoleToggle.click();
     }
 
     // --- Verify webview renders styled content ---

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -124,7 +124,9 @@ export const SEL = {
     findClose: '[aria-label="Close find bar"]',
   },
   devPreview: {
-    consoleToggle: '[aria-label="Show Terminal"], [aria-label="Hide Terminal"]',
+    consoleToggle: '[aria-label="Toggle output drawer"]',
+    consoleTab: '[role="tab"][data-tab="console"]',
+    outputTab: '[role="tab"][data-tab="output"]',
   },
   projectSwitcher: {
     palette: '[data-testid="project-switcher-palette"]',

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -145,6 +145,8 @@ export interface DevPreviewPanelOptions extends AddPanelOptionsBase {
   devServerTerminalId?: string;
   /** Whether the dev-preview console drawer is open */
   devPreviewConsoleOpen?: boolean;
+  /** Active dev-preview console drawer tab ("output" = PTY, "console" = guest-page console) */
+  devPreviewConsoleTab?: "output" | "console";
   /** Active viewport preset for responsive emulation (undefined = fill) */
   viewportPreset?: ViewportPresetId;
   /** Whether the active viewport preset is rotated to landscape */

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -279,6 +279,8 @@ export interface PtyPanelData extends BasePanelData {
   devServerTerminalId?: string;
   /** Whether the dev-preview console drawer is open */
   devPreviewConsoleOpen?: boolean;
+  /** Active dev-preview console drawer tab ("output" = PTY, "console" = guest-page console) */
+  devPreviewConsoleTab?: "output" | "console";
   /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */
   exitBehavior?: PanelExitBehavior;
   /** Detected process icon ID for dynamic terminal icons (transient, not persisted) */
@@ -366,6 +368,8 @@ export interface DevPreviewPanelData extends BasePanelData {
   browserZoom?: number;
   /** Whether the console drawer is open */
   devPreviewConsoleOpen?: boolean;
+  /** Active dev-preview console drawer tab ("output" = PTY, "console" = guest-page console) */
+  devPreviewConsoleTab?: "output" | "console";
   /** Dev server status */
   devServerStatus?: "stopped" | "starting" | "installing" | "running" | "error";
   /** Dev server URL */
@@ -500,6 +504,8 @@ export interface TerminalInstance {
   devServerTerminalId?: string;
   /** Whether the dev-preview console drawer is open */
   devPreviewConsoleOpen?: boolean;
+  /** Active dev-preview console drawer tab ("output" = PTY, "console" = guest-page console) */
+  devPreviewConsoleTab?: "output" | "console";
   /** Active viewport preset for dev-preview responsive emulation (undefined = fill) */
   viewportPreset?: ViewportPresetId;
   /** Whether the active dev-preview viewport preset is rotated to landscape */

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -91,6 +91,8 @@ export interface PanelSnapshot {
   devServerTerminalId?: string;
   /** Whether the dev-preview console drawer is open */
   devPreviewConsoleOpen?: boolean;
+  /** Active dev-preview console drawer tab ("output" = PTY, "console" = guest-page console) */
+  devPreviewConsoleTab?: "output" | "console";
   /** Active viewport preset for dev-preview responsive emulation */
   viewportPreset?: ViewportPresetId;
   /** Whether the active dev-preview viewport preset is rotated to landscape */

--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState, useCallback, useEffect } from "react";
+import { Suspense, useState, useCallback, useEffect, useRef } from "react";
 import { ChevronUp, RotateCw, CircleStop } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -7,13 +7,23 @@ import { XtermAdapter } from "../Terminal/XtermAdapter";
 import { terminalInstanceService } from "../../services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import type { DevPreviewStatus } from "@/hooks/useDevServer";
+import { useConsoleCaptureStore, ZERO_COUNTS } from "@/store/consoleCaptureStore";
+import { ConsolePanel } from "./ConsolePanel";
+
+export type ConsoleDrawerTab = "output" | "console";
 
 interface ConsoleDrawerProps {
   terminalId: string;
+  /** Panel ID — keys the guest-page console-capture store. */
+  paneId: string;
+  /** webContentsId of the live guest webview, for lazy object inspection. */
+  webContentsId?: number;
   status?: DevPreviewStatus;
   isOpen?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
   defaultOpen?: boolean;
+  activeTab?: ConsoleDrawerTab;
+  onTabChange?: (tab: ConsoleDrawerTab) => void;
   isRestarting?: boolean;
   onHardRestart?: () => void;
   onStop?: () => void;
@@ -55,18 +65,78 @@ const STATUS_LABEL: Record<
   },
 };
 
+const DRAWER_HEIGHT = 300;
+
+interface DrawerTabButtonProps {
+  tab: ConsoleDrawerTab;
+  label: string;
+  isActive: boolean;
+  controlsId: string;
+  onSelect: () => void;
+  badge?: number;
+}
+
+function DrawerTabButton({
+  tab,
+  label,
+  isActive,
+  controlsId,
+  onSelect,
+  badge,
+}: DrawerTabButtonProps) {
+  return (
+    <button
+      type="button"
+      id={`${controlsId}-tab`}
+      data-tab={tab}
+      onClick={onSelect}
+      tabIndex={isActive ? 0 : -1}
+      role="tab"
+      aria-selected={isActive}
+      aria-controls={controlsId}
+      className={cn(
+        "relative px-3 py-1.5 text-xs font-medium rounded transition-colors",
+        "hover:text-daintree-text hover:bg-overlay-soft",
+        "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-status-info",
+        isActive ? "text-daintree-text" : "text-daintree-text/65"
+      )}
+    >
+      {label}
+      {badge !== undefined && badge > 0 && (
+        <span className="ml-1.5 px-1.5 py-0.5 text-xs tabular-nums bg-status-error/15 text-status-error rounded-full">
+          {badge}
+        </span>
+      )}
+      {isActive && <div className="absolute bottom-0 left-0 right-0 h-px bg-daintree-accent/70" />}
+    </button>
+  );
+}
+
 export function ConsoleDrawer({
   terminalId,
+  paneId,
+  webContentsId,
   status = "stopped",
   isOpen: controlledIsOpen,
   onOpenChange,
   defaultOpen = false,
+  activeTab: controlledActiveTab,
+  onTabChange,
   isRestarting = false,
   onHardRestart,
   onStop,
 }: ConsoleDrawerProps) {
   const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(defaultOpen);
   const isOpen = controlledIsOpen ?? uncontrolledIsOpen;
+
+  const [uncontrolledTab, setUncontrolledTab] = useState<ConsoleDrawerTab>("output");
+  const activeTab = controlledActiveTab ?? uncontrolledTab;
+
+  const tablistRef = useRef<HTMLDivElement>(null);
+
+  const errorCount = useConsoleCaptureStore(
+    (state) => (state.counters.get(paneId) ?? ZERO_COUNTS).errorCount
+  );
 
   const toggleDrawer = useCallback(() => {
     const nextIsOpen = !isOpen;
@@ -76,18 +146,66 @@ export function ConsoleDrawer({
     onOpenChange?.(nextIsOpen);
   }, [isOpen, controlledIsOpen, onOpenChange]);
 
+  const selectTab = useCallback(
+    (tab: ConsoleDrawerTab) => {
+      if (controlledActiveTab === undefined) {
+        setUncontrolledTab(tab);
+      }
+      onTabChange?.(tab);
+    },
+    [controlledActiveTab, onTabChange]
+  );
+
+  const handleTablistKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const container = tablistRef.current;
+      if (!container) return;
+
+      const tabButtons = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
+      const focusedIndex = tabButtons.indexOf(document.activeElement as HTMLButtonElement);
+      if (focusedIndex === -1) return;
+
+      let nextIndex: number | null = null;
+      switch (e.key) {
+        case "ArrowRight":
+          nextIndex = (focusedIndex + 1) % tabButtons.length;
+          break;
+        case "ArrowLeft":
+          nextIndex = (focusedIndex - 1 + tabButtons.length) % tabButtons.length;
+          break;
+        case "Home":
+          nextIndex = 0;
+          break;
+        case "End":
+          nextIndex = tabButtons.length - 1;
+          break;
+        default:
+          return;
+      }
+
+      e.preventDefault();
+      const nextTab = tabButtons[nextIndex];
+      if (!nextTab) return;
+      nextTab.focus();
+      const tabId = nextTab.dataset.tab as ConsoleDrawerTab | undefined;
+      if (tabId) selectTab(tabId);
+    },
+    [selectTab]
+  );
+
+  const isOutputVisible = isOpen && activeTab === "output";
+
   useEffect(() => {
-    terminalInstanceService.setVisible(terminalId, isOpen);
-  }, [terminalId, isOpen]);
+    terminalInstanceService.setVisible(terminalId, isOutputVisible);
+  }, [terminalId, isOutputVisible]);
 
   const getRefreshTier = useCallback(() => {
-    return isOpen ? TerminalRefreshTier.VISIBLE : TerminalRefreshTier.BACKGROUND;
-  }, [isOpen]);
+    return isOutputVisible ? TerminalRefreshTier.VISIBLE : TerminalRefreshTier.BACKGROUND;
+  }, [isOutputVisible]);
 
   const statusLabel = isRestarting
     ? { label: "Restarting", textClass: "text-server-starting", dotClass: "bg-server-starting" }
     : (STATUS_LABEL[status] ?? STATUS_LABEL.stopped);
-  const toggleLabel = isOpen ? "Hide Terminal" : "Show Terminal";
   const hardRestartDisabled = !onHardRestart || isRestarting || status === "starting";
   const restartTooltip =
     status === "installing"
@@ -106,6 +224,10 @@ export function ConsoleDrawer({
     statusLabel.textClass
   );
 
+  const drawerRegionId = `console-drawer-${terminalId}`;
+  const outputPanelId = `dev-preview-output-panel-${terminalId}`;
+  const consolePanelId = `dev-preview-console-panel-${terminalId}`;
+
   return (
     <div className="flex flex-col border-t border-overlay bg-surface">
       <div className="flex items-stretch bg-overlay-soft">
@@ -114,14 +236,14 @@ export function ConsoleDrawer({
           onClick={toggleDrawer}
           className="flex min-h-8 min-w-0 flex-1 items-center gap-2 border-r border-overlay/70 px-3 py-1.5 text-xs font-semibold text-daintree-text/80 transition-colors hover:bg-overlay-medium focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-status-info"
           aria-expanded={isOpen}
-          aria-controls={`console-drawer-${terminalId}`}
-          aria-label={toggleLabel}
+          aria-controls={drawerRegionId}
+          aria-label="Toggle output drawer"
         >
           <ChevronUp
             className={cn("h-4 w-4 shrink-0 transition-transform", isOpen && "rotate-180")}
             aria-hidden="true"
           />
-          <span className="truncate">{toggleLabel}</span>
+          <span className="truncate">Output drawer</span>
         </button>
 
         <div className={statusClass} role="status" aria-live="polite">
@@ -177,19 +299,64 @@ export function ConsoleDrawer({
       </div>
 
       <div
-        id={`console-drawer-${terminalId}`}
-        className={cn("overflow-hidden transition-[height]", isOpen ? "h-[300px]" : "h-0")}
+        id={drawerRegionId}
+        className="overflow-hidden transition-[height]"
+        style={{ height: isOpen ? DRAWER_HEIGHT : 0 }}
         aria-hidden={!isOpen}
       >
-        <div className="h-[300px] bg-surface-canvas">
-          <Suspense fallback={null}>
-            <XtermAdapter
-              terminalId={terminalId}
-              getRefreshTier={getRefreshTier}
-              restoreOnAttach={true}
-              className="!rounded-none !px-0 !pt-0 !pb-0"
+        <div className="flex h-full flex-col bg-surface-canvas">
+          <div
+            ref={tablistRef}
+            role="tablist"
+            aria-label="Dev preview console tabs"
+            onKeyDown={handleTablistKeyDown}
+            className="flex shrink-0 items-center gap-1 border-b border-overlay/70 bg-overlay-soft px-2"
+          >
+            <DrawerTabButton
+              tab="output"
+              label="Output"
+              isActive={activeTab === "output"}
+              controlsId={outputPanelId}
+              onSelect={() => selectTab("output")}
             />
-          </Suspense>
+            <DrawerTabButton
+              tab="console"
+              label="Console"
+              isActive={activeTab === "console"}
+              controlsId={consolePanelId}
+              onSelect={() => selectTab("console")}
+              badge={errorCount}
+            />
+          </div>
+
+          <div className="relative min-h-0 flex-1">
+            <div
+              id={outputPanelId}
+              role="tabpanel"
+              aria-labelledby={`${outputPanelId}-tab`}
+              hidden={activeTab !== "output"}
+              className="absolute inset-0"
+            >
+              <Suspense fallback={null}>
+                <XtermAdapter
+                  terminalId={terminalId}
+                  getRefreshTier={getRefreshTier}
+                  restoreOnAttach={true}
+                  className="!rounded-none !px-0 !pt-0 !pb-0"
+                />
+              </Suspense>
+            </div>
+            {activeTab === "console" && (
+              <div
+                id={consolePanelId}
+                role="tabpanel"
+                aria-labelledby={`${consolePanelId}-tab`}
+                className="absolute inset-0"
+              >
+                <ConsolePanel paneId={paneId} webContentsId={webContentsId} />
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -107,7 +107,7 @@ function DrawerTabButton({
           {badge}
         </span>
       )}
-      {isActive && <div className="absolute bottom-0 left-0 right-0 h-px bg-daintree-accent/70" />}
+      {isActive && <div className="absolute bottom-0 left-0 right-0 h-px bg-daintree-text/70" />}
     </button>
   );
 }

--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -162,10 +162,11 @@ export function ConsoleDrawer({
       if (!container) return;
 
       const tabButtons = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
-      const focusedIndex = tabButtons.indexOf(document.activeElement as HTMLButtonElement);
+      const active = document.activeElement;
+      const focusedIndex = active instanceof HTMLButtonElement ? tabButtons.indexOf(active) : -1;
       if (focusedIndex === -1) return;
 
-      let nextIndex: number | null = null;
+      let nextIndex: number;
       switch (e.key) {
         case "ArrowRight":
           nextIndex = (focusedIndex + 1) % tabButtons.length;
@@ -187,8 +188,8 @@ export function ConsoleDrawer({
       const nextTab = tabButtons[nextIndex];
       if (!nextTab) return;
       nextTab.focus();
-      const tabId = nextTab.dataset.tab as ConsoleDrawerTab | undefined;
-      if (tabId) selectTab(tabId);
+      const tabId = nextTab.dataset.tab;
+      if (tabId === "output" || tabId === "console") selectTab(tabId);
     },
     [selectTab]
   );

--- a/src/components/DevPreview/ConsolePanel.tsx
+++ b/src/components/DevPreview/ConsolePanel.tsx
@@ -9,6 +9,7 @@ import {
   ZERO_COUNTS,
 } from "@/store/consoleCaptureStore";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { ObjectInspector } from "./ObjectInspector";
 import { StackTrace } from "./StackTrace";
 
@@ -132,7 +133,9 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
     // long-lived sessions with heavy object logging don't leak main-process
     // memory. Best-effort: the renderer-side clear is the user-visible action.
     if (webContentsId != null) {
-      void window.electron.webview.clearConsoleCapture(webContentsId, paneId).catch(() => {});
+      safeFireAndForget(window.electron.webview.clearConsoleCapture(webContentsId, paneId), {
+        context: "Clearing dev-preview console capture",
+      });
     }
   }, [clearMessages, paneId, webContentsId]);
 

--- a/src/components/DevPreview/ConsolePanel.tsx
+++ b/src/components/DevPreview/ConsolePanel.tsx
@@ -126,6 +126,16 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
   const counts = useConsoleCaptureStore((state) => state.counters.get(paneId) ?? ZERO_COUNTS);
   const clearMessages = useConsoleCaptureStore((state) => state.clearMessages);
 
+  const handleClear = useCallback(() => {
+    clearMessages(paneId);
+    // Also release the CDP-retained remote object references for this pane so
+    // long-lived sessions with heavy object logging don't leak main-process
+    // memory. Best-effort: the renderer-side clear is the user-visible action.
+    if (webContentsId != null) {
+      void window.electron.webview.clearConsoleCapture(webContentsId, paneId).catch(() => {});
+    }
+  }, [clearMessages, paneId, webContentsId]);
+
   // Apply level and search filters, then handle group collapsing
   const filtered = useMemo(() => {
     const lowerSearch = search ? search.toLowerCase() : "";
@@ -333,7 +343,7 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
           <TooltipTrigger asChild>
             <button
               type="button"
-              onClick={() => clearMessages(paneId)}
+              onClick={handleClear}
               className="p-1 rounded hover:bg-overlay-medium text-daintree-text/50 hover:text-daintree-text transition-colors"
               aria-label="Clear console"
             >

--- a/src/components/DevPreview/ConsolePanel.tsx
+++ b/src/components/DevPreview/ConsolePanel.tsx
@@ -1,0 +1,371 @@
+import { memo, useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { Trash2, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  useConsoleCaptureStore,
+  type ConsoleLevel,
+  type ConsoleMessage,
+  EMPTY_MESSAGES,
+  ZERO_COUNTS,
+} from "@/store/consoleCaptureStore";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ObjectInspector } from "./ObjectInspector";
+import { StackTrace } from "./StackTrace";
+
+interface ConsolePanelProps {
+  paneId: string;
+  webContentsId?: number;
+}
+
+type LevelFilter = ConsoleLevel | "all";
+
+const LEVEL_STYLES: Record<ConsoleLevel, { row: string; badge: string; label: string }> = {
+  log: {
+    row: "text-daintree-text/80",
+    badge: "text-daintree-text/50 bg-daintree-text/10",
+    label: "LOG",
+  },
+  info: {
+    row: "text-status-info",
+    badge: "text-status-info bg-status-info/15",
+    label: "INF",
+  },
+  warning: {
+    row: "text-status-warning",
+    badge: "text-status-warning bg-status-warning/15",
+    label: "WRN",
+  },
+  error: {
+    row: "text-status-error",
+    badge: "text-status-error bg-status-error/15",
+    label: "ERR",
+  },
+};
+
+const FILTER_BUTTONS: { filter: LevelFilter; label: string }[] = [
+  { filter: "all", label: "All" },
+  { filter: "error", label: "Errors" },
+  { filter: "warning", label: "Warn" },
+  { filter: "log", label: "Log" },
+];
+
+const ConsoleRow = memo(function ConsoleRow({
+  msg,
+  webContentsId,
+  isGroupCollapsed,
+  onToggleGroup,
+}: {
+  msg: ConsoleMessage;
+  webContentsId?: number;
+  isGroupCollapsed?: boolean;
+  onToggleGroup?: (msgId: number) => void;
+}) {
+  const style = LEVEL_STYLES[msg.level];
+  const indentPx = msg.groupDepth * 12;
+  const handleToggle = useCallback(() => onToggleGroup?.(msg.id), [onToggleGroup, msg.id]);
+
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 px-2 py-0.5 border-b border-overlay/30 hover:bg-overlay-subtle",
+        style.row
+      )}
+      style={indentPx > 0 ? { paddingLeft: `${8 + indentPx}px` } : undefined}
+    >
+      <span className="shrink-0 text-daintree-text/30 select-none tabular-nums">
+        {msg.timeLabel}
+      </span>
+      <span
+        className={cn(
+          "shrink-0 text-[9px] font-bold tracking-wide px-1 py-0.5 rounded select-none",
+          style.badge
+        )}
+      >
+        {style.label}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="break-all whitespace-pre-wrap select-text">
+          {msg.isGroupHeader && onToggleGroup && (
+            <button
+              type="button"
+              onClick={handleToggle}
+              className="text-daintree-text/40 mr-1 select-none hover:text-daintree-text/60"
+            >
+              {isGroupCollapsed ? "▶" : "▼"}
+            </button>
+          )}
+          {msg.args.length > 0 ? (
+            msg.args.map((arg, i) => (
+              <span key={i}>
+                {i > 0 && <span className="mx-1" />}
+                <ObjectInspector arg={arg} webContentsId={webContentsId} isStale={msg.isStale} />
+              </span>
+            ))
+          ) : (
+            <span className="text-daintree-text/50">{msg.summaryText}</span>
+          )}
+        </div>
+        {msg.stackTrace && <StackTrace stackTrace={msg.stackTrace} />}
+      </div>
+    </div>
+  );
+});
+
+export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
+  const [levelFilter, setLevelFilter] = useState<LevelFilter>("all");
+  const [search, setSearch] = useState("");
+  const [isAtBottom, setIsAtBottom] = useState(true);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<number>>(new Set());
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const prevLastIdRef = useRef<number | null>(null);
+  const lastSeenTailIdRef = useRef<number | null>(null);
+
+  const allMessages = useConsoleCaptureStore(
+    (state) => state.messages.get(paneId) ?? EMPTY_MESSAGES
+  );
+  const counts = useConsoleCaptureStore((state) => state.counters.get(paneId) ?? ZERO_COUNTS);
+  const clearMessages = useConsoleCaptureStore((state) => state.clearMessages);
+
+  // Apply level and search filters, then handle group collapsing
+  const filtered = useMemo(() => {
+    const lowerSearch = search ? search.toLowerCase() : "";
+
+    // First pass: filter by level and search
+    let result = allMessages.filter((msg) => {
+      // Always show group headers regardless of level filter
+      if (msg.isGroupHeader) return true;
+
+      if (levelFilter !== "all") {
+        if (levelFilter === "warning" && msg.level !== "warning") return false;
+        if (levelFilter === "error" && msg.level !== "error") return false;
+        if (levelFilter === "log" && msg.level !== "log" && msg.level !== "info") return false;
+      }
+      if (lowerSearch) {
+        return msg.summaryText.toLowerCase().includes(lowerSearch);
+      }
+      return true;
+    });
+
+    // Second pass: hide children of collapsed groups
+    if (collapsedGroups.size > 0) {
+      let skipDepth: number | null = null;
+
+      result = result.filter((msg) => {
+        if (skipDepth !== null) {
+          if (msg.groupDepth > skipDepth) return false;
+          skipDepth = null;
+        }
+
+        if (msg.isGroupHeader && collapsedGroups.has(msg.id)) {
+          skipDepth = msg.groupDepth;
+          return true; // Show the header, hide children
+        }
+
+        return true;
+      });
+    }
+
+    return result;
+  }, [allMessages, levelFilter, search, collapsedGroups]);
+
+  // Reset auto-collapse tracking when the pane changes
+  useEffect(() => {
+    lastSeenTailIdRef.current = null;
+    setCollapsedGroups(new Set());
+  }, [paneId]);
+
+  // Auto-collapse startGroupCollapsed entries — scan only newly-arrived messages.
+  // Track the last-seen tail message id (not array index) so the cursor survives
+  // 500-cap eviction, where the array length stays the same but new ids land at the end.
+  useEffect(() => {
+    if (allMessages.length === 0) {
+      lastSeenTailIdRef.current = null;
+      // Drop any stale collapsed-group ids from the prior session
+      setCollapsedGroups((prev) => (prev.size === 0 ? prev : new Set()));
+      return;
+    }
+
+    const newTail = allMessages[allMessages.length - 1]!;
+    if (newTail.id === lastSeenTailIdRef.current) return;
+
+    const lastSeenTailId = lastSeenTailIdRef.current;
+    let firstNewIdx = allMessages.length;
+    if (lastSeenTailId === null) {
+      firstNewIdx = 0;
+    } else {
+      while (firstNewIdx > 0 && allMessages[firstNewIdx - 1]!.id > lastSeenTailId) {
+        firstNewIdx--;
+      }
+    }
+    lastSeenTailIdRef.current = newTail.id;
+
+    if (firstNewIdx >= allMessages.length) return;
+
+    let newIds: number[] | null = null;
+    for (let i = firstNewIdx; i < allMessages.length; i++) {
+      const msg = allMessages[i]!;
+      if (msg.cdpType === "startGroupCollapsed") {
+        (newIds ??= []).push(msg.id);
+      }
+    }
+
+    if (newIds === null) return;
+    const ids = newIds;
+    setCollapsedGroups((prev) => {
+      const merged = new Set(prev);
+      let changed = false;
+      for (const id of ids) {
+        if (!merged.has(id)) {
+          merged.add(id);
+          changed = true;
+        }
+      }
+      return changed ? merged : prev;
+    });
+  }, [allMessages]);
+
+  const { errorCount, warnCount } = counts;
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const threshold = 8;
+    setIsAtBottom(el.scrollTop + el.clientHeight >= el.scrollHeight - threshold);
+  }, []);
+
+  const lastVisibleId = filtered.length > 0 ? filtered[filtered.length - 1]!.id : null;
+  useEffect(() => {
+    if (lastVisibleId === prevLastIdRef.current) return;
+    prevLastIdRef.current = lastVisibleId;
+    if (isAtBottom) {
+      requestAnimationFrame(() => {
+        const el = scrollRef.current;
+        if (el) el.scrollTop = el.scrollHeight;
+      });
+    }
+  }, [lastVisibleId, isAtBottom]);
+
+  const handleScrollToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+      setIsAtBottom(true);
+    }
+  }, []);
+
+  const toggleGroup = useCallback((msgId: number) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(msgId)) {
+        next.delete(msgId);
+      } else {
+        next.add(msgId);
+      }
+      return next;
+    });
+  }, []);
+
+  const buttonClass =
+    "px-2 py-0.5 rounded text-[10px] font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent/50";
+
+  return (
+    <div className="flex h-full flex-col bg-daintree-bg">
+      {/* Toolbar */}
+      <div className="flex items-center gap-1.5 px-2 py-1 border-b border-overlay bg-surface shrink-0">
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-daintree-text/50 mr-1">
+          Console
+        </span>
+
+        {/* Level filters */}
+        <div className="flex items-center gap-0.5">
+          {FILTER_BUTTONS.map(({ filter, label }) => (
+            <button
+              key={filter}
+              type="button"
+              onClick={() => setLevelFilter(filter)}
+              className={cn(
+                buttonClass,
+                levelFilter === filter
+                  ? "bg-overlay-emphasis text-daintree-text"
+                  : "text-daintree-text/50 hover:bg-overlay-soft hover:text-daintree-text/70"
+              )}
+            >
+              {label}
+              {filter === "error" && errorCount > 0 && (
+                <span className="ml-1 tabular-nums text-status-error">{errorCount}</span>
+              )}
+              {filter === "warning" && warnCount > 0 && (
+                <span className="ml-1 tabular-nums text-status-warning">{warnCount}</span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        {/* Search */}
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Filter…"
+          className="flex-1 min-w-0 max-w-[160px] px-2 py-0.5 text-[11px] rounded bg-daintree-bg border border-overlay focus:outline-hidden focus:border-border-strong text-daintree-text placeholder:text-daintree-text/30"
+        />
+
+        <div className="flex-1" />
+
+        {/* Scroll to bottom */}
+        {!isAtBottom && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleScrollToBottom}
+                className="p-1 rounded hover:bg-overlay-medium text-daintree-text/50 hover:text-daintree-text transition-colors"
+              >
+                <ChevronDown className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Scroll to bottom</TooltipContent>
+          </Tooltip>
+        )}
+
+        {/* Clear */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => clearMessages(paneId)}
+              className="p-1 rounded hover:bg-overlay-medium text-daintree-text/50 hover:text-daintree-text transition-colors"
+              aria-label="Clear console"
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Clear console</TooltipContent>
+        </Tooltip>
+      </div>
+
+      {/* Message list */}
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto font-mono text-[11px] leading-relaxed"
+      >
+        {filtered.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-daintree-text/30 text-xs select-none">
+            {allMessages.length === 0 ? "No console output" : "No messages match filter"}
+          </div>
+        ) : (
+          filtered.map((msg) => (
+            <ConsoleRow
+              key={msg.id}
+              msg={msg}
+              webContentsId={webContentsId}
+              isGroupCollapsed={collapsedGroups.has(msg.id)}
+              onToggleGroup={msg.isGroupHeader ? toggleGroup : undefined}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -685,16 +685,6 @@ export function DevPreviewPane({
     setDevPreviewConsoleOpen(id, !isConsoleOpen);
   }, [id, isConsoleOpen, setDevPreviewConsoleOpen]);
 
-  const handleToggleDevTools = useCallback(() => {
-    const webview = webviewRef.current;
-    if (!webview || !isWebviewReady) return;
-    if (webview.isDevToolsOpened()) {
-      webview.closeDevTools();
-    } else {
-      webview.openDevTools();
-    }
-  }, [isWebviewReady]);
-
   const handleOpenExternal = useCallback(() => {
     if (currentUrl) {
       safeFireAndForget(window.electron.system.openExternal(currentUrl), {

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -27,6 +27,7 @@ import {
 } from "../Browser/historyUtils";
 import { useDevServer, type UseDevServerReturn } from "@/hooks/useDevServer";
 import { ConsoleDrawer } from "./ConsoleDrawer";
+import { useDevPreviewConsoleCapture } from "./useDevPreviewConsoleCapture";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
 import { computeDevServerUrl } from "./urlSync";
@@ -301,6 +302,7 @@ export function DevPreviewPane({
   const setBrowserHistory = usePanelStore((state) => state.setBrowserHistory);
   const setBrowserZoom = usePanelStore((state) => state.setBrowserZoom);
   const setDevPreviewConsoleOpen = usePanelStore((state) => state.setDevPreviewConsoleOpen);
+  const setDevPreviewConsoleTab = usePanelStore((state) => state.setDevPreviewConsoleTab);
   const setViewportPreset = usePanelStore((state) => state.setViewportPreset);
   const setViewportRotated = usePanelStore((state) => state.setViewportRotated);
   const setViewportDpr = usePanelStore((state) => state.setViewportDpr);
@@ -376,6 +378,8 @@ export function DevPreviewPane({
   // promise that resolves after the clear must NOT write the stale position back.
   const scrollCaptureGenerationRef = useRef<number>(0);
   const isConsoleOpen = terminal?.devPreviewConsoleOpen ?? false;
+  const activeConsoleTab = terminal?.devPreviewConsoleTab ?? "output";
+  const [guestWebContentsId, setGuestWebContentsId] = useState<number | undefined>(undefined);
   // Store the original guest UA so we can restore it when clearing a preset
   const originalUaRef = useRef<string | null>(null);
   const [isAutoDetecting, setIsAutoDetecting] = useState(false);
@@ -681,6 +685,16 @@ export function DevPreviewPane({
     setDevPreviewConsoleOpen(id, !isConsoleOpen);
   }, [id, isConsoleOpen, setDevPreviewConsoleOpen]);
 
+  const handleToggleDevTools = useCallback(() => {
+    const webview = webviewRef.current;
+    if (!webview || !isWebviewReady) return;
+    if (webview.isDevToolsOpened()) {
+      webview.closeDevTools();
+    } else {
+      webview.openDevTools();
+    }
+  }, [isWebviewReady]);
+
   const handleOpenExternal = useCallback(() => {
     if (currentUrl) {
       safeFireAndForget(window.electron.system.openExternal(currentUrl), {
@@ -866,6 +880,23 @@ export function DevPreviewPane({
       }
     }
   }, [currentUrl, isWebviewReady, webviewElement]);
+
+  // Wire the guest-page CDP console capture into the renderer store. The hook
+  // owns start/stop keyed on the ready/eviction lifecycle; here we only mirror
+  // the live webContentsId so lazy object inspection can reach the right guest.
+  useDevPreviewConsoleCapture(id, webviewRef, isWebviewReady, isEvicted);
+
+  useEffect(() => {
+    if (!isWebviewReady || isEvicted) {
+      setGuestWebContentsId(undefined);
+      return;
+    }
+    try {
+      setGuestWebContentsId(webviewRef.current?.getWebContentsId());
+    } catch {
+      setGuestWebContentsId(undefined);
+    }
+  }, [isWebviewReady, isEvicted]);
 
   // Blank the webview and clear timers before React unmounts it for faster memory reclamation
   useEffect(() => {
@@ -1374,9 +1405,13 @@ export function DevPreviewPane({
         {consoleTerminalId && (
           <ConsoleDrawer
             terminalId={consoleTerminalId}
+            paneId={id}
+            webContentsId={guestWebContentsId}
             status={status}
             isOpen={isConsoleOpen}
             onOpenChange={(nextOpen) => setDevPreviewConsoleOpen(id, nextOpen)}
+            activeTab={activeConsoleTab}
+            onTabChange={(tab) => setDevPreviewConsoleTab(id, tab)}
             isRestarting={isRestarting}
             onHardRestart={handleHardRestart}
             onStop={stop}

--- a/src/components/DevPreview/ObjectInspector.tsx
+++ b/src/components/DevPreview/ObjectInspector.tsx
@@ -1,0 +1,169 @@
+import { useState, useCallback } from "react";
+import type { CdpRemoteArg, CdpPropertyDescriptor } from "@shared/types/ipc/webviewConsole";
+import { cn } from "@/lib/utils";
+
+interface ObjectInspectorProps {
+  arg: CdpRemoteArg;
+  webContentsId?: number;
+  isStale?: boolean;
+  depth?: number;
+}
+
+const MAX_DEPTH = 5;
+
+function PrimitiveValue({ arg }: { arg: CdpRemoteArg & { type: "primitive" } }) {
+  switch (arg.kind) {
+    case "string":
+      return <span className="text-syntax-string">&quot;{String(arg.value)}&quot;</span>;
+    case "number":
+      return <span className="text-syntax-number">{String(arg.value)}</span>;
+    case "boolean":
+      return <span className="text-category-purple">{String(arg.value)}</span>;
+    case "null":
+      return <span className="text-daintree-text/40">null</span>;
+    case "undefined":
+      return <span className="text-daintree-text/40">undefined</span>;
+    case "symbol":
+      return <span className="text-syntax-keyword">{String(arg.value)}</span>;
+    case "bigint":
+      return <span className="text-syntax-number">{String(arg.value)}</span>;
+    default:
+      return <span>{String(arg.value)}</span>;
+  }
+}
+
+function PropertyTree({
+  properties,
+  webContentsId,
+  isStale,
+  depth,
+}: {
+  properties: CdpPropertyDescriptor[];
+  webContentsId?: number;
+  isStale?: boolean;
+  depth: number;
+}) {
+  // Filter out __proto__ and non-enumerable properties for cleaner display
+  const visibleProps = properties.filter((p) => p.enumerable !== false && p.name !== "__proto__");
+
+  return (
+    <div className="pl-3 border-l border-tint/10">
+      {visibleProps.map((prop) => (
+        <div key={prop.name} className="flex items-start gap-1">
+          <span className="text-text-secondary shrink-0">{prop.name}</span>
+          <span className="text-daintree-text/40 shrink-0">:</span>
+          {prop.value ? (
+            <ObjectInspector
+              arg={prop.value}
+              webContentsId={webContentsId}
+              isStale={isStale}
+              depth={depth + 1}
+            />
+          ) : (
+            <span className="text-daintree-text/40">undefined</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ObjectInspector({
+  arg,
+  webContentsId,
+  isStale = false,
+  depth = 0,
+}: ObjectInspectorProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [properties, setProperties] = useState<CdpPropertyDescriptor[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [fetchError, setFetchError] = useState(false);
+
+  const handleExpand = useCallback(async () => {
+    if (isExpanded) {
+      setIsExpanded(false);
+      return;
+    }
+
+    if (properties) {
+      setIsExpanded(true);
+      return;
+    }
+
+    if (
+      arg.type !== "object" ||
+      !arg.objectId ||
+      webContentsId == null ||
+      isStale ||
+      depth >= MAX_DEPTH
+    ) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const result = await window.electron.webview.getConsoleProperties(
+        webContentsId,
+        arg.objectId
+      );
+      setProperties(result.properties);
+      setIsExpanded(true);
+      setFetchError(false);
+    } catch {
+      setFetchError(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isExpanded, properties, arg, webContentsId, isStale, depth]);
+
+  if (arg.type === "primitive") {
+    return <PrimitiveValue arg={arg} />;
+  }
+
+  if (arg.type === "function") {
+    return <span className="text-category-cyan italic">ƒ {arg.description}</span>;
+  }
+
+  // Object type
+  const canExpand = !!arg.objectId && webContentsId != null && !isStale && depth < MAX_DEPTH;
+  const displayText = arg.preview ?? arg.description ?? arg.className ?? "Object";
+
+  if (isStale) {
+    return (
+      <span className="text-daintree-text/30 italic" title="Value unavailable after navigation">
+        {displayText}
+      </span>
+    );
+  }
+
+  if (!canExpand) {
+    return <span className="text-daintree-text/70">{displayText}</span>;
+  }
+
+  return (
+    <span className="inline">
+      <button
+        type="button"
+        onClick={() => void handleExpand()}
+        className={cn(
+          "inline text-left hover:bg-tint/5 rounded px-0.5 -mx-0.5 transition-colors",
+          isExpanded ? "text-daintree-text/90" : "text-daintree-text/70"
+        )}
+      >
+        <span className="text-daintree-text/40 mr-0.5 select-none">
+          {isLoading ? "⏳" : isExpanded ? "▼" : "▶"}
+        </span>
+        {displayText}
+      </button>
+      {fetchError && <span className="text-status-error text-[10px] ml-1">unavailable</span>}
+      {isExpanded && properties && (
+        <PropertyTree
+          properties={properties}
+          webContentsId={webContentsId}
+          isStale={isStale}
+          depth={depth}
+        />
+      )}
+    </span>
+  );
+}

--- a/src/components/DevPreview/StackTrace.tsx
+++ b/src/components/DevPreview/StackTrace.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import type { CdpStackTrace } from "@shared/types/ipc/webviewConsole";
+
+interface StackTraceProps {
+  stackTrace: CdpStackTrace;
+}
+
+export function StackTrace({ stackTrace }: StackTraceProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (stackTrace.callFrames.length === 0) return null;
+
+  return (
+    <div className="mt-0.5">
+      <button
+        type="button"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        className="text-[10px] text-daintree-text/40 hover:text-daintree-text/60 transition-colors select-none"
+      >
+        <span className="mr-0.5">{isExpanded ? "▼" : "▶"}</span>
+        stack trace
+      </button>
+      {isExpanded && (
+        <div className="pl-3 border-l border-tint/10 mt-0.5 select-text">
+          {stackTrace.callFrames.map((frame, i) => (
+            <div key={i} className="text-daintree-text/40 text-[10px] leading-relaxed">
+              <span className="text-daintree-text/50">{frame.functionName || "(anonymous)"}</span>
+              {frame.url && (
+                <span>
+                  {" "}
+                  ({frame.url}:{frame.lineNumber}:{frame.columnNumber})
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/DevPreview/__tests__/ConsoleDrawer.test.tsx
+++ b/src/components/DevPreview/__tests__/ConsoleDrawer.test.tsx
@@ -6,6 +6,8 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { ConsoleDrawer } from "../ConsoleDrawer";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
+import { useConsoleCaptureStore } from "@/store/consoleCaptureStore";
+import type { SerializedConsoleRow } from "@shared/types/ipc/webviewConsole";
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
@@ -32,12 +34,36 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+const mockTerminalId = "test-terminal-id";
+const mockPaneId = "test-pane-id";
+
+function renderDrawer(props: Partial<React.ComponentProps<typeof ConsoleDrawer>> = {}) {
+  return render(<ConsoleDrawer terminalId={mockTerminalId} paneId={mockPaneId} {...props} />);
+}
+
+function seedConsoleRow(overrides: Partial<SerializedConsoleRow> = {}): void {
+  const level = overrides.level ?? "error";
+  const row: SerializedConsoleRow = {
+    id: Math.floor(Math.random() * 1e9),
+    paneId: mockPaneId,
+    level,
+    cdpType: level,
+    args: [],
+    summaryText: "boom",
+    timestamp: Date.now(),
+    navigationGeneration: 0,
+    groupDepth: 0,
+    ...overrides,
+  };
+  useConsoleCaptureStore.getState().addStructuredMessage(row);
+}
+
 describe("ConsoleDrawer", () => {
-  const mockTerminalId = "test-terminal-id";
-  const getToggleButton = () => screen.getByRole("button", { name: /(?:show|hide) terminal/i });
+  const getToggleButton = () => screen.getByRole("button", { name: "Toggle output drawer" });
 
   beforeEach(() => {
     vi.clearAllMocks();
+    useConsoleCaptureStore.setState({ messages: new Map(), counters: new Map() });
   });
 
   afterEach(() => {
@@ -46,189 +72,183 @@ describe("ConsoleDrawer", () => {
 
   describe("XtermAdapter mounting", () => {
     it("renders XtermAdapter unconditionally even when closed", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      renderDrawer({ defaultOpen: false });
       const adapter = screen.getByTestId("xterm-adapter");
       expect(adapter).toBeTruthy();
       expect(adapter.getAttribute("data-terminal-id")).toBe(mockTerminalId);
     });
 
     it("keeps XtermAdapter mounted when drawer is open", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
+      renderDrawer({ defaultOpen: true });
       const adapter = screen.getByTestId("xterm-adapter");
       expect(adapter).toBeTruthy();
       expect(adapter.getAttribute("data-terminal-id")).toBe(mockTerminalId);
     });
 
     it("keeps XtermAdapter in DOM after toggling from open to closed", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
+      renderDrawer({ defaultOpen: true });
+      fireEvent.click(getToggleButton());
+      expect(screen.getByTestId("xterm-adapter")).toBeTruthy();
+    });
 
-      const button = getToggleButton();
-      fireEvent.click(button);
-
-      const adapter = screen.getByTestId("xterm-adapter");
-      expect(adapter).toBeTruthy();
+    it("keeps XtermAdapter mounted when the Console tab is active", () => {
+      renderDrawer({ defaultOpen: true });
+      fireEvent.click(screen.getByRole("tab", { name: /console/i }));
+      // Output (PTY) must stay mounted so scrollback survives a tab switch.
+      expect(screen.getByTestId("xterm-adapter")).toBeTruthy();
     });
 
     it("enables serialized restore on attach", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      renderDrawer({ defaultOpen: false });
       const adapter = screen.getByTestId("xterm-adapter");
       expect(adapter.getAttribute("data-restore-on-attach")).toBe("true");
     });
   });
 
   describe("drawer visibility", () => {
-    it("renders with h-0 class when closed by default", () => {
-      const { container } = render(
-        <ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />
-      );
-      const drawer = container.querySelector('[id^="console-drawer-"]');
-      expect(drawer?.className).toContain("h-0");
-      expect(drawer?.className).not.toContain("h-[300px]");
+    it("collapses to height 0 when closed by default", () => {
+      const { container } = renderDrawer({ defaultOpen: false });
+      const drawer = container.querySelector<HTMLElement>('[id^="console-drawer-"]');
+      expect(drawer?.style.height).toBe("0px");
     });
 
-    it("renders with h-[300px] class when open by default", () => {
-      const { container } = render(
-        <ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />
-      );
-      const drawer = container.querySelector('[id^="console-drawer-"]');
-      expect(drawer?.className).toContain("h-[300px]");
-      expect(drawer?.className).not.toContain("h-0");
+    it("expands to a fixed height when open by default", () => {
+      const { container } = renderDrawer({ defaultOpen: true });
+      const drawer = container.querySelector<HTMLElement>('[id^="console-drawer-"]');
+      expect(drawer?.style.height).toBe("300px");
     });
 
-    it("toggles height class when button is clicked", () => {
-      const { container } = render(
-        <ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />
-      );
-      const drawer = container.querySelector('[id^="console-drawer-"]');
+    it("toggles height when the button is clicked", () => {
+      const { container } = renderDrawer({ defaultOpen: false });
+      const drawer = container.querySelector<HTMLElement>('[id^="console-drawer-"]');
 
-      expect(drawer?.className).toContain("h-0");
-
-      const button = getToggleButton();
-      fireEvent.click(button);
-
-      expect(drawer?.className).toContain("h-[300px]");
-      expect(drawer?.className).not.toContain("h-0");
-    });
-
-    it("inner container always has h-[300px] class", () => {
-      const { container } = render(
-        <ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />
-      );
-      const innerContainer = container.querySelector(".h-\\[300px\\].bg-surface-canvas");
-      expect(innerContainer).toBeTruthy();
-      expect(innerContainer?.className).toContain("h-[300px]");
+      expect(drawer?.style.height).toBe("0px");
+      fireEvent.click(getToggleButton());
+      expect(drawer?.style.height).toBe("300px");
     });
   });
 
-  describe("button state", () => {
-    it("displays 'Show Terminal' when closed", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
-      expect(screen.getByText("Show Terminal")).toBeTruthy();
-    });
-
-    it("displays 'Hide Terminal' when open", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
-      expect(screen.getByText("Hide Terminal")).toBeTruthy();
+  describe("toggle button", () => {
+    it("uses a stable label that does not change with open state", () => {
+      const { rerender } = renderDrawer({ isOpen: false });
+      expect(screen.getByRole("button", { name: "Toggle output drawer" })).toBeTruthy();
+      rerender(<ConsoleDrawer terminalId={mockTerminalId} paneId={mockPaneId} isOpen={true} />);
+      // Same accessible name when open — state is conveyed by aria-expanded + icon.
+      expect(screen.getByRole("button", { name: "Toggle output drawer" })).toBeTruthy();
     });
 
     it("sets aria-expanded to false when closed", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
-      const button = getToggleButton();
-      expect(button.getAttribute("aria-expanded")).toBe("false");
+      renderDrawer({ defaultOpen: false });
+      expect(getToggleButton().getAttribute("aria-expanded")).toBe("false");
     });
 
     it("sets aria-expanded to true when open", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
-      const button = getToggleButton();
-      expect(button.getAttribute("aria-expanded")).toBe("true");
+      renderDrawer({ defaultOpen: true });
+      expect(getToggleButton().getAttribute("aria-expanded")).toBe("true");
     });
 
     it("toggles aria-expanded on click", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      renderDrawer({ defaultOpen: false });
       const button = getToggleButton();
 
       expect(button.getAttribute("aria-expanded")).toBe("false");
-
       fireEvent.click(button);
       expect(button.getAttribute("aria-expanded")).toBe("true");
-
       fireEvent.click(button);
       expect(button.getAttribute("aria-expanded")).toBe("false");
     });
 
-    it("uses an upward icon for 'Show Terminal' and rotates when open", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
-      const closedButton = getToggleButton();
-      const closedIcon = closedButton.querySelector("svg");
+    it("rotates the chevron icon when open", () => {
+      renderDrawer({ defaultOpen: false });
+      const closedIcon = getToggleButton().querySelector("svg");
       expect(closedIcon?.getAttribute("class")).not.toContain("rotate-180");
 
-      fireEvent.click(closedButton);
-      const openButton = getToggleButton();
-      const openIcon = openButton.querySelector("svg");
+      fireEvent.click(getToggleButton());
+      const openIcon = getToggleButton().querySelector("svg");
       expect(openIcon?.getAttribute("class")).toContain("rotate-180");
+    });
+  });
+
+  describe("tabs", () => {
+    it("defaults to the Output tab", () => {
+      renderDrawer({ defaultOpen: true });
+      const outputTab = screen.getByRole("tab", { name: /output/i });
+      expect(outputTab.getAttribute("aria-selected")).toBe("true");
+    });
+
+    it("activates the Console tab on click (uncontrolled)", () => {
+      renderDrawer({ defaultOpen: true });
+      const consoleTab = screen.getByRole("tab", { name: /console/i });
+      fireEvent.click(consoleTab);
+      expect(consoleTab.getAttribute("aria-selected")).toBe("true");
+    });
+
+    it("respects the controlled activeTab prop", () => {
+      renderDrawer({ defaultOpen: true, activeTab: "console" });
+      expect(screen.getByRole("tab", { name: /console/i }).getAttribute("aria-selected")).toBe(
+        "true"
+      );
+    });
+
+    it("calls onTabChange when a tab is selected", () => {
+      const onTabChange = vi.fn();
+      renderDrawer({ defaultOpen: true, activeTab: "output", onTabChange });
+      fireEvent.click(screen.getByRole("tab", { name: /console/i }));
+      expect(onTabChange).toHaveBeenCalledWith("console");
+    });
+
+    it("supports arrow-key navigation between tabs", () => {
+      renderDrawer({ defaultOpen: true });
+      const tablist = screen.getByRole("tablist");
+      const outputTab = screen.getByRole("tab", { name: /output/i });
+      outputTab.focus();
+      fireEvent.keyDown(tablist, { key: "ArrowRight" });
+      expect(screen.getByRole("tab", { name: /console/i }).getAttribute("aria-selected")).toBe(
+        "true"
+      );
+    });
+
+    it("shows an error-count badge on the Console tab", () => {
+      seedConsoleRow({ level: "error" });
+      seedConsoleRow({ level: "error" });
+      renderDrawer({ defaultOpen: true });
+      const consoleTab = screen.getByRole("tab", { name: /console/i });
+      expect(consoleTab.textContent).toContain("2");
+    });
+
+    it("does not show a badge when there are no errors", () => {
+      seedConsoleRow({ level: "warning" });
+      renderDrawer({ defaultOpen: true });
+      const consoleTab = screen.getByRole("tab", { name: /console/i });
+      expect(consoleTab.textContent).toBe("Console");
     });
   });
 
   describe("hard restart action", () => {
     it("does not render restart button without handler", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      renderDrawer({ defaultOpen: false });
       expect(screen.queryByRole("button", { name: "Hard restart dev preview" })).toBeNull();
     });
 
     it("renders restart button when handler is provided", () => {
-      render(
-        <ConsoleDrawer
-          terminalId={mockTerminalId}
-          defaultOpen={false}
-          onHardRestart={vi.fn()}
-          status="running"
-        />
-      );
+      renderDrawer({ defaultOpen: false, onHardRestart: vi.fn(), status: "running" });
       expect(screen.getByRole("button", { name: "Hard restart dev preview" })).toBeTruthy();
-    });
-
-    it("renders restart button as icon-only with no visible text", () => {
-      render(
-        <ConsoleDrawer
-          terminalId={mockTerminalId}
-          defaultOpen={false}
-          onHardRestart={vi.fn()}
-          status="running"
-        />
-      );
-      const restartButton = screen.getByRole("button", { name: "Hard restart dev preview" });
-      expect(restartButton.textContent).toBe("");
-      expect(restartButton.querySelector("svg")).toBeTruthy();
     });
 
     it("calls onHardRestart when restart button is clicked", () => {
       const onHardRestart = vi.fn();
-      render(
-        <ConsoleDrawer
-          terminalId={mockTerminalId}
-          defaultOpen={false}
-          onHardRestart={onHardRestart}
-          status="running"
-        />
-      );
-
-      const restartButton = screen.getByRole("button", { name: "Hard restart dev preview" });
-      fireEvent.click(restartButton);
-
+      renderDrawer({ defaultOpen: false, onHardRestart, status: "running" });
+      fireEvent.click(screen.getByRole("button", { name: "Hard restart dev preview" }));
       expect(onHardRestart).toHaveBeenCalledTimes(1);
     });
 
     it("disables restart button while restarting", () => {
-      render(
-        <ConsoleDrawer
-          terminalId={mockTerminalId}
-          defaultOpen={false}
-          onHardRestart={vi.fn()}
-          status="running"
-          isRestarting={true}
-        />
-      );
-
+      renderDrawer({
+        defaultOpen: false,
+        onHardRestart: vi.fn(),
+        status: "running",
+        isRestarting: true,
+      });
       const restartButton = screen.getByRole("button", { name: "Hard restart dev preview" });
       expect(restartButton.getAttribute("disabled")).not.toBeNull();
       expect(restartButton.getAttribute("aria-busy")).toBe("true");
@@ -236,200 +256,122 @@ describe("ConsoleDrawer", () => {
     });
 
     it("disables restart button while starting", () => {
-      render(
-        <ConsoleDrawer
-          terminalId={mockTerminalId}
-          defaultOpen={false}
-          onHardRestart={vi.fn()}
-          status="starting"
-        />
-      );
-
+      renderDrawer({ defaultOpen: false, onHardRestart: vi.fn(), status: "starting" });
       const restartButton = screen.getByRole("button", { name: "Hard restart dev preview" });
       expect(restartButton.getAttribute("disabled")).not.toBeNull();
     });
 
     it("enables restart button while installing with warning tooltip", () => {
-      render(
-        <ConsoleDrawer
-          terminalId={mockTerminalId}
-          defaultOpen={false}
-          onHardRestart={vi.fn()}
-          status="installing"
-        />
-      );
-
+      renderDrawer({ defaultOpen: false, onHardRestart: vi.fn(), status: "installing" });
       const restartButton = screen.getByRole("button", {
         name: "Hard restart dev preview (may interrupt installation)",
       });
       expect(restartButton.getAttribute("disabled")).toBeNull();
-      expect(restartButton.getAttribute("aria-label")).toBe(
-        "Hard restart dev preview (may interrupt installation)"
-      );
+    });
+  });
+
+  describe("dev-server status pill", () => {
+    it("renders the status pill independently of panel-state frame signal", () => {
+      renderDrawer({ defaultOpen: false, status: "running" });
+      expect(screen.getByText("Running")).toBeTruthy();
     });
   });
 
   describe("terminalInstanceService integration", () => {
     it("calls setVisible with false when initially closed", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      renderDrawer({ defaultOpen: false });
       expect(terminalInstanceService.setVisible).toHaveBeenCalledWith(mockTerminalId, false);
     });
 
-    it("calls setVisible with true when initially open", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
+    it("calls setVisible with true when open on the Output tab", () => {
+      renderDrawer({ defaultOpen: true });
       expect(terminalInstanceService.setVisible).toHaveBeenCalledWith(mockTerminalId, true);
     });
 
-    it("calls setVisible on toggle from closed to open", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
-
+    it("drops the terminal to background when the Console tab is active", () => {
+      renderDrawer({ defaultOpen: true });
       vi.clearAllMocks();
-
-      const button = getToggleButton();
-      fireEvent.click(button);
-
-      expect(terminalInstanceService.setVisible).toHaveBeenCalledTimes(1);
-      expect(terminalInstanceService.setVisible).toHaveBeenCalledWith(mockTerminalId, true);
-    });
-
-    it("calls setVisible bidirectionally (open -> closed -> open)", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
-
-      vi.clearAllMocks();
-
-      const button = getToggleButton();
-
-      fireEvent.click(button);
-      expect(terminalInstanceService.setVisible).toHaveBeenCalledWith(mockTerminalId, false);
-
-      fireEvent.click(button);
-      expect(terminalInstanceService.setVisible).toHaveBeenCalledWith(mockTerminalId, true);
-
-      expect(terminalInstanceService.setVisible).toHaveBeenCalledTimes(2);
-    });
-
-    it("handles terminalId change while closed", () => {
-      const { rerender } = render(<ConsoleDrawer terminalId="terminal-1" defaultOpen={false} />);
-
-      vi.clearAllMocks();
-
-      rerender(<ConsoleDrawer terminalId="terminal-2" defaultOpen={false} />);
-
-      expect(terminalInstanceService.setVisible).toHaveBeenCalledWith("terminal-2", false);
-    });
-
-    it("handles terminalId change while open", () => {
-      const { rerender } = render(<ConsoleDrawer terminalId="terminal-1" defaultOpen={true} />);
-
-      vi.clearAllMocks();
-
-      rerender(<ConsoleDrawer terminalId="terminal-2" defaultOpen={true} />);
-
-      expect(terminalInstanceService.setVisible).toHaveBeenCalledWith("terminal-2", true);
+      fireEvent.click(screen.getByRole("tab", { name: /console/i }));
+      expect(terminalInstanceService.setVisible).toHaveBeenLastCalledWith(mockTerminalId, false);
     });
 
     it("supports controlled open state", () => {
       const onOpenChange = vi.fn();
       const { rerender } = render(
-        <ConsoleDrawer terminalId={mockTerminalId} isOpen={false} onOpenChange={onOpenChange} />
+        <ConsoleDrawer
+          terminalId={mockTerminalId}
+          paneId={mockPaneId}
+          isOpen={false}
+          onOpenChange={onOpenChange}
+        />
       );
 
-      const button = getToggleButton();
-      fireEvent.click(button);
-
+      fireEvent.click(getToggleButton());
       expect(onOpenChange).toHaveBeenCalledWith(true);
       expect(terminalInstanceService.setVisible).toHaveBeenLastCalledWith(mockTerminalId, false);
 
       rerender(
-        <ConsoleDrawer terminalId={mockTerminalId} isOpen={true} onOpenChange={onOpenChange} />
+        <ConsoleDrawer
+          terminalId={mockTerminalId}
+          paneId={mockPaneId}
+          isOpen={true}
+          onOpenChange={onOpenChange}
+        />
       );
-
       expect(terminalInstanceService.setVisible).toHaveBeenLastCalledWith(mockTerminalId, true);
     });
   });
 
   describe("refresh tier management", () => {
-    it("provides VISIBLE refresh tier when drawer is open", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
-      const tierDisplay = screen.getByTestId("refresh-tier");
-      expect(tierDisplay.textContent).toBe(TerminalRefreshTier.VISIBLE.toString());
+    it("provides VISIBLE refresh tier when open on the Output tab", () => {
+      renderDrawer({ defaultOpen: true });
+      expect(screen.getByTestId("refresh-tier").textContent).toBe(
+        TerminalRefreshTier.VISIBLE.toString()
+      );
     });
 
     it("provides BACKGROUND refresh tier when drawer is closed", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
-      const tierDisplay = screen.getByTestId("refresh-tier");
-      expect(tierDisplay.textContent).toBe(TerminalRefreshTier.BACKGROUND.toString());
+      renderDrawer({ defaultOpen: false });
+      expect(screen.getByTestId("refresh-tier").textContent).toBe(
+        TerminalRefreshTier.BACKGROUND.toString()
+      );
     });
 
-    it("updates refresh tier bidirectionally (closed -> open -> closed)", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
-
-      let tierDisplay = screen.getByTestId("refresh-tier");
-      expect(tierDisplay.textContent).toBe(TerminalRefreshTier.BACKGROUND.toString());
-
-      const button = getToggleButton();
-      fireEvent.click(button);
-
-      tierDisplay = screen.getByTestId("refresh-tier");
-      expect(tierDisplay.textContent).toBe(TerminalRefreshTier.VISIBLE.toString());
-
-      fireEvent.click(button);
-
-      tierDisplay = screen.getByTestId("refresh-tier");
-      expect(tierDisplay.textContent).toBe(TerminalRefreshTier.BACKGROUND.toString());
+    it("drops to BACKGROUND tier when the Console tab is active", () => {
+      renderDrawer({ defaultOpen: true });
+      fireEvent.click(screen.getByRole("tab", { name: /console/i }));
+      expect(screen.getByTestId("refresh-tier").textContent).toBe(
+        TerminalRefreshTier.BACKGROUND.toString()
+      );
     });
   });
 
   describe("drawer container", () => {
     it("has overflow-hidden class to prevent content leak", () => {
-      const { container } = render(
-        <ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />
-      );
+      const { container } = renderDrawer({ defaultOpen: false });
       const drawer = container.querySelector('[id^="console-drawer-"]');
       expect(drawer?.className).toContain("overflow-hidden");
     });
 
     it("has transition-[height] for smooth animation", () => {
-      const { container } = render(
-        <ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />
-      );
+      const { container } = renderDrawer({ defaultOpen: false });
       const drawer = container.querySelector('[id^="console-drawer-"]');
       expect(drawer?.className).toContain("transition-[height]");
     });
 
     it("sets correct aria-controls id", () => {
-      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
-      const button = getToggleButton();
-      expect(button.getAttribute("aria-controls")).toBe(`console-drawer-${mockTerminalId}`);
-    });
-
-    it("sets aria-hidden to true when drawer is closed", () => {
-      const { container } = render(
-        <ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />
+      renderDrawer({ defaultOpen: false });
+      expect(getToggleButton().getAttribute("aria-controls")).toBe(
+        `console-drawer-${mockTerminalId}`
       );
-      const drawer = container.querySelector('[id^="console-drawer-"]');
-      expect(drawer?.getAttribute("aria-hidden")).toBe("true");
-    });
-
-    it("sets aria-hidden to false when drawer is open", () => {
-      const { container } = render(
-        <ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />
-      );
-      const drawer = container.querySelector('[id^="console-drawer-"]');
-      expect(drawer?.getAttribute("aria-hidden")).toBe("false");
     });
 
     it("toggles aria-hidden when drawer state changes", () => {
-      const { container } = render(
-        <ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />
-      );
+      const { container } = renderDrawer({ defaultOpen: false });
       const drawer = container.querySelector('[id^="console-drawer-"]');
 
       expect(drawer?.getAttribute("aria-hidden")).toBe("true");
-
-      const button = getToggleButton();
-      fireEvent.click(button);
-
+      fireEvent.click(getToggleButton());
       expect(drawer?.getAttribute("aria-hidden")).toBe("false");
     });
   });

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -79,6 +79,7 @@ const {
   };
   const terminalStoreState = {
     activeDockTerminalId: undefined as string | undefined,
+    panelsById: {} as Record<string, unknown>,
     getTerminal: vi.fn(),
     setBrowserUrl: vi.fn(),
     setBrowserHistory: vi.fn(),

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -84,6 +84,7 @@ const {
     setBrowserHistory: vi.fn(),
     setBrowserZoom: vi.fn(),
     setDevPreviewConsoleOpen: vi.fn(),
+    setDevPreviewConsoleTab: vi.fn(),
     setViewportPreset: vi.fn(),
     setDevPreviewScrollPosition: vi.fn(
       (_id: string, position: { url: string; scrollY: number } | undefined) => {
@@ -292,6 +293,10 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
         getScrollPosition: vi.fn().mockResolvedValue(0),
+        startConsoleCapture: vi.fn(() => Promise.resolve()),
+        stopConsoleCapture: vi.fn(() => Promise.resolve()),
+        onConsoleMessage: vi.fn(() => vi.fn()),
+        onConsoleContextCleared: vi.fn(() => vi.fn()),
       },
     };
   });

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -637,6 +637,10 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
         getScrollPosition,
+        startConsoleCapture: vi.fn(() => Promise.resolve()),
+        stopConsoleCapture: vi.fn(() => Promise.resolve()),
+        onConsoleMessage: vi.fn(() => vi.fn()),
+        onConsoleContextCleared: vi.fn(() => vi.fn()),
       },
     };
 
@@ -688,6 +692,10 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
         getScrollPosition,
+        startConsoleCapture: vi.fn(() => Promise.resolve()),
+        stopConsoleCapture: vi.fn(() => Promise.resolve()),
+        onConsoleMessage: vi.fn(() => vi.fn()),
+        onConsoleContextCleared: vi.fn(() => vi.fn()),
       },
     };
 
@@ -729,6 +737,10 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
         getScrollPosition,
+        startConsoleCapture: vi.fn(() => Promise.resolve()),
+        stopConsoleCapture: vi.fn(() => Promise.resolve()),
+        onConsoleMessage: vi.fn(() => vi.fn()),
+        onConsoleContextCleared: vi.fn(() => vi.fn()),
       },
     };
 

--- a/src/components/DevPreview/__tests__/useDevPreviewConsoleCapture.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewConsoleCapture.test.tsx
@@ -2,11 +2,13 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { createRef } from "react";
 import { useDevPreviewConsoleCapture } from "../useDevPreviewConsoleCapture";
 import { useConsoleCaptureStore } from "@/store/consoleCaptureStore";
+import { usePanelStore } from "@/store";
 import type { SerializedConsoleRow } from "@shared/types/ipc/webviewConsole";
+import type { TerminalInstance } from "@/types";
 
 const PANE_ID = "pane-1";
 const WC_ID = 42;
@@ -43,6 +45,8 @@ beforeEach(() => {
   clearedCb = undefined;
   vi.clearAllMocks();
   useConsoleCaptureStore.setState({ messages: new Map(), counters: new Map() });
+  // Default: panel is NOT registered (treated as a real teardown).
+  usePanelStore.setState({ panelsById: {} });
   (window as unknown as { electron: Record<string, unknown> }).electron = {
     webview: {
       startConsoleCapture,
@@ -98,17 +102,18 @@ describe("useDevPreviewConsoleCapture", () => {
     expect(startConsoleCapture).not.toHaveBeenCalled();
   });
 
-  it("stops capture and unsubscribes on unmount", () => {
+  it("stops capture and unsubscribes on unmount", async () => {
     const ref = makeWebviewRef();
     ref.current = { getWebContentsId: () => WC_ID } as unknown as Electron.WebviewTag;
     const { unmount } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, ref, true, false));
     unmount();
     expect(offMessage).toHaveBeenCalledTimes(1);
     expect(offCleared).toHaveBeenCalledTimes(1);
-    expect(stopConsoleCapture).toHaveBeenCalledWith(WC_ID, PANE_ID);
+    // stop is chained after the start promise settles (microtask).
+    await waitFor(() => expect(stopConsoleCapture).toHaveBeenCalledWith(WC_ID, PANE_ID));
   });
 
-  it("stops capture when the panel becomes evicted", () => {
+  it("stops capture when the panel becomes evicted", async () => {
     const ref = makeWebviewRef();
     ref.current = { getWebContentsId: () => WC_ID } as unknown as Electron.WebviewTag;
     const { rerender } = renderHook(
@@ -119,7 +124,7 @@ describe("useDevPreviewConsoleCapture", () => {
     expect(startConsoleCapture).toHaveBeenCalledTimes(1);
 
     rerender({ evicted: true });
-    expect(stopConsoleCapture).toHaveBeenCalledWith(WC_ID, PANE_ID);
+    await waitFor(() => expect(stopConsoleCapture).toHaveBeenCalledWith(WC_ID, PANE_ID));
   });
 
   it("routes only matching-pane console messages into the store", () => {
@@ -147,7 +152,7 @@ describe("useDevPreviewConsoleCapture", () => {
     expect(useConsoleCaptureStore.getState().getMessages(PANE_ID)[0]?.isStale).toBe(true);
   });
 
-  it("drops the pane's buffered rows when the panel unmounts", () => {
+  it("drops the pane's buffered rows when the panel is deleted (no longer registered)", () => {
     const ref = makeWebviewRef();
     ref.current = { getWebContentsId: () => WC_ID } as unknown as Electron.WebviewTag;
     const { unmount } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, ref, true, false));
@@ -156,5 +161,21 @@ describe("useDevPreviewConsoleCapture", () => {
 
     unmount();
     expect(useConsoleCaptureStore.getState().getMessages(PANE_ID)).toHaveLength(0);
+  });
+
+  it("keeps buffered rows when the panel only deactivates in a grid tab group", () => {
+    // Panel is still registered: unmount is a tab-switch deactivation, not a
+    // deletion, so captured rows must survive until the user switches back.
+    usePanelStore.setState({
+      panelsById: { [PANE_ID]: { id: PANE_ID } as unknown as TerminalInstance },
+    });
+    const ref = makeWebviewRef();
+    ref.current = { getWebContentsId: () => WC_ID } as unknown as Electron.WebviewTag;
+    const { unmount } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, ref, true, false));
+    messageCb?.(row({ paneId: PANE_ID }));
+    expect(useConsoleCaptureStore.getState().getMessages(PANE_ID)).toHaveLength(1);
+
+    unmount();
+    expect(useConsoleCaptureStore.getState().getMessages(PANE_ID)).toHaveLength(1);
   });
 });

--- a/src/components/DevPreview/__tests__/useDevPreviewConsoleCapture.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewConsoleCapture.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { createRef } from "react";
+import { useDevPreviewConsoleCapture } from "../useDevPreviewConsoleCapture";
+import { useConsoleCaptureStore } from "@/store/consoleCaptureStore";
+import type { SerializedConsoleRow } from "@shared/types/ipc/webviewConsole";
+
+const PANE_ID = "pane-1";
+const WC_ID = 42;
+
+let messageCb: ((row: SerializedConsoleRow) => void) | undefined;
+let clearedCb: ((p: { paneId: string; navigationGeneration: number }) => void) | undefined;
+const offMessage = vi.fn();
+const offCleared = vi.fn();
+
+const startConsoleCapture = vi.fn(() => Promise.resolve());
+const stopConsoleCapture = vi.fn(() => Promise.resolve());
+
+function makeWebviewRef(): React.RefObject<Electron.WebviewTag | null> {
+  return createRef<Electron.WebviewTag>();
+}
+
+function row(overrides: Partial<SerializedConsoleRow> = {}): SerializedConsoleRow {
+  return {
+    id: Math.floor(Math.random() * 1e9),
+    paneId: PANE_ID,
+    level: "error",
+    cdpType: "error",
+    args: [],
+    summaryText: "boom",
+    timestamp: Date.now(),
+    navigationGeneration: 1,
+    groupDepth: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  messageCb = undefined;
+  clearedCb = undefined;
+  vi.clearAllMocks();
+  useConsoleCaptureStore.setState({ messages: new Map(), counters: new Map() });
+  (window as unknown as { electron: Record<string, unknown> }).electron = {
+    webview: {
+      startConsoleCapture,
+      stopConsoleCapture,
+      onConsoleMessage: vi.fn((cb: (r: SerializedConsoleRow) => void) => {
+        messageCb = cb;
+        return offMessage;
+      }),
+      onConsoleContextCleared: vi.fn(
+        (cb: (p: { paneId: string; navigationGeneration: number }) => void) => {
+          clearedCb = cb;
+          return offCleared;
+        }
+      ),
+    },
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useDevPreviewConsoleCapture", () => {
+  it("starts capture when the webview is ready and not evicted", () => {
+    const ref = makeWebviewRef();
+    ref.current = { getWebContentsId: () => WC_ID } as unknown as Electron.WebviewTag;
+    renderHook(() => useDevPreviewConsoleCapture(PANE_ID, ref, true, false));
+    expect(startConsoleCapture).toHaveBeenCalledWith(WC_ID, PANE_ID);
+  });
+
+  it("does not start capture before the webview is ready", () => {
+    const ref = makeWebviewRef();
+    ref.current = { getWebContentsId: () => WC_ID } as unknown as Electron.WebviewTag;
+    renderHook(() => useDevPreviewConsoleCapture(PANE_ID, ref, false, false));
+    expect(startConsoleCapture).not.toHaveBeenCalled();
+  });
+
+  it("does not start capture while evicted", () => {
+    const ref = makeWebviewRef();
+    ref.current = { getWebContentsId: () => WC_ID } as unknown as Electron.WebviewTag;
+    renderHook(() => useDevPreviewConsoleCapture(PANE_ID, ref, true, true));
+    expect(startConsoleCapture).not.toHaveBeenCalled();
+  });
+
+  it("does not start capture when getWebContentsId throws", () => {
+    const ref = makeWebviewRef();
+    ref.current = {
+      getWebContentsId: () => {
+        throw new Error("not attached");
+      },
+    } as unknown as Electron.WebviewTag;
+    renderHook(() => useDevPreviewConsoleCapture(PANE_ID, ref, true, false));
+    expect(startConsoleCapture).not.toHaveBeenCalled();
+  });
+
+  it("stops capture and unsubscribes on unmount", () => {
+    const ref = makeWebviewRef();
+    ref.current = { getWebContentsId: () => WC_ID } as unknown as Electron.WebviewTag;
+    const { unmount } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, ref, true, false));
+    unmount();
+    expect(offMessage).toHaveBeenCalledTimes(1);
+    expect(offCleared).toHaveBeenCalledTimes(1);
+    expect(stopConsoleCapture).toHaveBeenCalledWith(WC_ID, PANE_ID);
+  });
+
+  it("stops capture when the panel becomes evicted", () => {
+    const ref = makeWebviewRef();
+    ref.current = { getWebContentsId: () => WC_ID } as unknown as Electron.WebviewTag;
+    const { rerender } = renderHook(
+      ({ evicted }: { evicted: boolean }) =>
+        useDevPreviewConsoleCapture(PANE_ID, ref, true, evicted),
+      { initialProps: { evicted: false } }
+    );
+    expect(startConsoleCapture).toHaveBeenCalledTimes(1);
+
+    rerender({ evicted: true });
+    expect(stopConsoleCapture).toHaveBeenCalledWith(WC_ID, PANE_ID);
+  });
+
+  it("routes only matching-pane console messages into the store", () => {
+    const ref = makeWebviewRef();
+    ref.current = { getWebContentsId: () => WC_ID } as unknown as Electron.WebviewTag;
+    renderHook(() => useDevPreviewConsoleCapture(PANE_ID, ref, true, false));
+
+    messageCb?.(row({ paneId: "other-pane" }));
+    expect(useConsoleCaptureStore.getState().getMessages(PANE_ID)).toHaveLength(0);
+
+    messageCb?.(row({ paneId: PANE_ID }));
+    expect(useConsoleCaptureStore.getState().getMessages(PANE_ID)).toHaveLength(1);
+  });
+
+  it("marks rows stale only for the matching pane on context-cleared", () => {
+    const ref = makeWebviewRef();
+    ref.current = { getWebContentsId: () => WC_ID } as unknown as Electron.WebviewTag;
+    renderHook(() => useDevPreviewConsoleCapture(PANE_ID, ref, true, false));
+
+    messageCb?.(row({ paneId: PANE_ID, navigationGeneration: 1 }));
+    clearedCb?.({ paneId: "other-pane", navigationGeneration: 2 });
+    expect(useConsoleCaptureStore.getState().getMessages(PANE_ID)[0]?.isStale).toBe(false);
+
+    clearedCb?.({ paneId: PANE_ID, navigationGeneration: 2 });
+    expect(useConsoleCaptureStore.getState().getMessages(PANE_ID)[0]?.isStale).toBe(true);
+  });
+
+  it("drops the pane's buffered rows when the panel unmounts", () => {
+    const ref = makeWebviewRef();
+    ref.current = { getWebContentsId: () => WC_ID } as unknown as Electron.WebviewTag;
+    const { unmount } = renderHook(() => useDevPreviewConsoleCapture(PANE_ID, ref, true, false));
+    messageCb?.(row({ paneId: PANE_ID }));
+    expect(useConsoleCaptureStore.getState().getMessages(PANE_ID)).toHaveLength(1);
+
+    unmount();
+    expect(useConsoleCaptureStore.getState().getMessages(PANE_ID)).toHaveLength(0);
+  });
+});

--- a/src/components/DevPreview/useDevPreviewConsoleCapture.ts
+++ b/src/components/DevPreview/useDevPreviewConsoleCapture.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useConsoleCaptureStore } from "@/store/consoleCaptureStore";
 import { usePanelStore } from "@/store";
-import { logError } from "@/utils/logger";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 
 /**
  * Wires the main-process CDP console-capture pipeline to the renderer
@@ -39,11 +39,8 @@ export function useDevPreviewConsoleCapture(
     // Chain stop after start settles so a fast ready→evict cycle can't let a
     // slow startConsoleCapture resolve after cleanup already fired, which
     // would leave a CDP session attached with nothing to detach it.
-    const started = window.electron.webview
-      .startConsoleCapture(webContentsId, paneId)
-      .catch((err) => {
-        logError("[DevPreviewConsoleCapture] startConsoleCapture failed", err);
-      });
+    const started = window.electron.webview.startConsoleCapture(webContentsId, paneId);
+    safeFireAndForget(started, { context: "Starting dev-preview console capture" });
 
     const store = useConsoleCaptureStore.getState();
 
@@ -62,11 +59,13 @@ export function useDevPreviewConsoleCapture(
     return () => {
       offMessage();
       offCleared();
-      void started.finally(() => {
-        void window.electron.webview.stopConsoleCapture(webContentsId, paneId).catch((err) => {
-          logError("[DevPreviewConsoleCapture] stopConsoleCapture failed", err);
-        });
-      });
+      const stopped = started
+        .catch(() => {
+          // Start failure is already reported above; swallow it here so the
+          // sequencing chain still reaches the stop call.
+        })
+        .then(() => window.electron.webview.stopConsoleCapture(webContentsId, paneId));
+      safeFireAndForget(stopped, { context: "Stopping dev-preview console capture" });
     };
   }, [paneId, webviewRef, isWebviewReady, isEvicted]);
 

--- a/src/components/DevPreview/useDevPreviewConsoleCapture.ts
+++ b/src/components/DevPreview/useDevPreviewConsoleCapture.ts
@@ -1,0 +1,71 @@
+import { useEffect } from "react";
+import { useConsoleCaptureStore } from "@/store/consoleCaptureStore";
+import { logError } from "@/utils/logger";
+
+/**
+ * Wires the main-process CDP console-capture pipeline to the renderer
+ * `consoleCaptureStore` for a single dev-preview panel.
+ *
+ * Capture starts only while the webview is mounted and ready
+ * (`isWebviewReady && !isEvicted`) and stops on unmount or eviction. The
+ * webview DOM node is unmounted while evicted, so the webContentsId is
+ * re-derived from the ref each time the effect re-runs rather than cached.
+ *
+ * Both IPC subscriptions filter by `paneId`: `onConsoleMessage` is a global
+ * stream keyed by `row.paneId`, so an unfiltered handler in multiple mounted
+ * panes would duplicate every row.
+ */
+export function useDevPreviewConsoleCapture(
+  paneId: string,
+  webviewRef: React.RefObject<Electron.WebviewTag | null>,
+  isWebviewReady: boolean,
+  isEvicted: boolean
+): void {
+  useEffect(() => {
+    if (!isWebviewReady || isEvicted) return;
+
+    const webview = webviewRef.current;
+    if (!webview) return;
+
+    let webContentsId: number;
+    try {
+      webContentsId = webview.getWebContentsId();
+    } catch {
+      // WebContents not attached yet — the next ready/evicted transition retries.
+      return;
+    }
+
+    void window.electron.webview.startConsoleCapture(webContentsId, paneId).catch((err) => {
+      logError("[DevPreviewConsoleCapture] startConsoleCapture failed", err);
+    });
+
+    const store = useConsoleCaptureStore.getState();
+
+    const offMessage = window.electron.webview.onConsoleMessage((row) => {
+      if (row.paneId !== paneId) return;
+      store.addStructuredMessage(row);
+    });
+
+    const offCleared = window.electron.webview.onConsoleContextCleared(
+      ({ paneId: clearedPaneId, navigationGeneration }) => {
+        if (clearedPaneId !== paneId) return;
+        store.markStale(paneId, navigationGeneration);
+      }
+    );
+
+    return () => {
+      offMessage();
+      offCleared();
+      void window.electron.webview.stopConsoleCapture(webContentsId, paneId).catch((err) => {
+        logError("[DevPreviewConsoleCapture] stopConsoleCapture failed", err);
+      });
+    };
+  }, [paneId, webviewRef, isWebviewReady, isEvicted]);
+
+  // Drop this pane's buffered rows + counts when the panel unmounts entirely.
+  useEffect(() => {
+    return () => {
+      useConsoleCaptureStore.getState().removePane(paneId);
+    };
+  }, [paneId]);
+}

--- a/src/components/DevPreview/useDevPreviewConsoleCapture.ts
+++ b/src/components/DevPreview/useDevPreviewConsoleCapture.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useConsoleCaptureStore } from "@/store/consoleCaptureStore";
+import { usePanelStore } from "@/store";
 import { logError } from "@/utils/logger";
 
 /**
@@ -35,9 +36,14 @@ export function useDevPreviewConsoleCapture(
       return;
     }
 
-    void window.electron.webview.startConsoleCapture(webContentsId, paneId).catch((err) => {
-      logError("[DevPreviewConsoleCapture] startConsoleCapture failed", err);
-    });
+    // Chain stop after start settles so a fast ready→evict cycle can't let a
+    // slow startConsoleCapture resolve after cleanup already fired, which
+    // would leave a CDP session attached with nothing to detach it.
+    const started = window.electron.webview
+      .startConsoleCapture(webContentsId, paneId)
+      .catch((err) => {
+        logError("[DevPreviewConsoleCapture] startConsoleCapture failed", err);
+      });
 
     const store = useConsoleCaptureStore.getState();
 
@@ -56,16 +62,25 @@ export function useDevPreviewConsoleCapture(
     return () => {
       offMessage();
       offCleared();
-      void window.electron.webview.stopConsoleCapture(webContentsId, paneId).catch((err) => {
-        logError("[DevPreviewConsoleCapture] stopConsoleCapture failed", err);
+      void started.finally(() => {
+        void window.electron.webview.stopConsoleCapture(webContentsId, paneId).catch((err) => {
+          logError("[DevPreviewConsoleCapture] stopConsoleCapture failed", err);
+        });
       });
     };
   }, [paneId, webviewRef, isWebviewReady, isEvicted]);
 
-  // Drop this pane's buffered rows + counts when the panel unmounts entirely.
+  // Drop this pane's buffered rows + counts only when the panel is gone for
+  // good. Unmount alone is not deletion: a DevPreview panel in a grid tab
+  // group fully unmounts when another tab is activated, and we must keep its
+  // captured rows so they survive a tab switch. By cleanup time a deleted
+  // panel is already absent from the panel registry, so its absence is the
+  // signal that this is a real teardown rather than a deactivation.
   useEffect(() => {
     return () => {
-      useConsoleCaptureStore.getState().removePane(paneId);
+      if (!usePanelStore.getState().panelsById?.[paneId]) {
+        useConsoleCaptureStore.getState().removePane(paneId);
+      }
     };
   }, [paneId]);
 }

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -26,6 +26,7 @@ const DESERIALIZERS: Record<string, PanelKindDeserializer> = {
       browserHistory: saved.browserHistory,
       browserZoom: saved.browserZoom,
       devPreviewConsoleOpen: saved.devPreviewConsoleOpen,
+      devPreviewConsoleTab: saved.devPreviewConsoleTab,
       viewportPreset: sanitizeViewportPreset(saved.viewportPreset),
       viewportRotated: saved.viewportRotated === true,
       viewportDpr: saved.viewportDpr === 2 || saved.viewportDpr === 3 ? saved.viewportDpr : 1,

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -63,6 +63,7 @@ const PERSISTED_DEV_PREVIEW_FIELDS = [
   "browserHistory",
   "browserZoom",
   "devPreviewConsoleOpen",
+  "devPreviewConsoleTab",
   "devPreviewScrollPosition",
   "exitBehavior",
 ] as const satisfies readonly (keyof DevPreviewData)[];
@@ -134,6 +135,7 @@ const devPreviewFixture: TerminalInstance = {
   browserHistory: browserHistoryFixture,
   browserZoom: 1,
   devPreviewConsoleOpen: false,
+  devPreviewConsoleTab: "console",
   devPreviewScrollPosition: { url: "http://localhost:3000", scrollY: 250 },
   exitBehavior: "keep",
 };
@@ -155,6 +157,7 @@ const savedDevPreview: SavedTerminalData = {
   browserHistory: browserHistoryFixture,
   browserZoom: 1,
   devPreviewConsoleOpen: false,
+  devPreviewConsoleTab: "console",
   devPreviewScrollPosition: { url: "http://localhost:3000", scrollY: 250 },
   exitBehavior: "keep",
   createdAt: 1_700_000_000_000,

--- a/src/panels/__tests__/registry.roundtrip.test.ts
+++ b/src/panels/__tests__/registry.roundtrip.test.ts
@@ -49,6 +49,7 @@ type PersistedDevPreviewFields =
   | "browserHistory"
   | "browserZoom"
   | "devPreviewConsoleOpen"
+  | "devPreviewConsoleTab"
   | "devPreviewScrollPosition"
   | "exitBehavior";
 
@@ -107,6 +108,9 @@ const devPreviewArbSpec = {
   browserHistory: fc.option(browserHistoryArb, { nil: undefined }),
   browserZoom: fc.option(zoomArb, { nil: undefined }),
   devPreviewConsoleOpen: fc.option(fc.boolean(), { nil: undefined }),
+  devPreviewConsoleTab: fc.option(fc.constantFrom("output" as const, "console" as const), {
+    nil: undefined,
+  }),
   devPreviewScrollPosition: fc.option(scrollPositionArb, { nil: undefined }),
   exitBehavior: fc.option(exitBehaviorArb, { nil: undefined }),
 } satisfies { [K in PersistedDevPreviewFields]-?: fc.Arbitrary<DevPreviewData[K]> };
@@ -210,6 +214,7 @@ describe("panel serializer round-trip (property tests)", () => {
         expect(restored.browserHistory).toEqual(fields.browserHistory);
         expect(restored.browserZoom).toBe(fields.browserZoom);
         expect(restored.devPreviewConsoleOpen).toBe(fields.devPreviewConsoleOpen);
+        expect(restored.devPreviewConsoleTab).toBe(fields.devPreviewConsoleTab);
         expect(restored.devPreviewScrollPosition).toEqual(fields.devPreviewScrollPosition);
 
         // exitBehavior is NOT returned by getDeserializer("dev-preview"); the real

--- a/src/panels/__tests__/registry.serialization.test.ts
+++ b/src/panels/__tests__/registry.serialization.test.ts
@@ -105,6 +105,7 @@ describe("panelKindRegistry serialize hooks (co-located)", () => {
           browserUrl: "http://localhost:5173",
           browserZoom: 1.0,
           devPreviewConsoleOpen: true,
+          devPreviewConsoleTab: "console",
           createdAt: 100,
           exitBehavior: "keep",
         })
@@ -115,6 +116,7 @@ describe("panelKindRegistry serialize hooks (co-located)", () => {
         browserUrl: "http://localhost:5173",
         browserZoom: 1.0,
         devPreviewConsoleOpen: true,
+        devPreviewConsoleTab: "console",
         createdAt: 100,
         exitBehavior: "keep",
       });

--- a/src/panels/dev-preview/__tests__/defaults.test.ts
+++ b/src/panels/dev-preview/__tests__/defaults.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { createDevPreviewDefaults } from "../defaults";
+import type { DevPreviewPanelOptions } from "@shared/types/addPanelOptions";
+
+function options(overrides: Partial<DevPreviewPanelOptions> = {}): DevPreviewPanelOptions {
+  return {
+    kind: "dev-preview",
+    cwd: "/project",
+    ...overrides,
+  } as DevPreviewPanelOptions;
+}
+
+describe("createDevPreviewDefaults", () => {
+  it("forwards devPreviewConsoleTab so the persisted tab survives restore", () => {
+    expect(createDevPreviewDefaults(options({ devPreviewConsoleTab: "console" }))).toMatchObject({
+      devPreviewConsoleTab: "console",
+    });
+  });
+
+  it("leaves devPreviewConsoleTab undefined when not persisted", () => {
+    expect(createDevPreviewDefaults(options()).devPreviewConsoleTab).toBeUndefined();
+  });
+
+  it("still forwards devPreviewConsoleOpen alongside the tab field", () => {
+    const result = createDevPreviewDefaults(
+      options({ devPreviewConsoleOpen: true, devPreviewConsoleTab: "console" })
+    );
+    expect(result.devPreviewConsoleOpen).toBe(true);
+    expect(result.devPreviewConsoleTab).toBe("console");
+  });
+});

--- a/src/panels/dev-preview/defaults.ts
+++ b/src/panels/dev-preview/defaults.ts
@@ -15,6 +15,7 @@ export function createDevPreviewDefaults(
     devServerError: options.devServerError,
     devServerTerminalId: options.devServerTerminalId,
     devPreviewConsoleOpen: options.devPreviewConsoleOpen,
+    devPreviewConsoleTab: options.devPreviewConsoleTab,
     exitBehavior: options.exitBehavior,
     viewportPreset: options.viewportPreset,
     viewportRotated: options.viewportRotated ?? false,

--- a/src/panels/dev-preview/serializer.ts
+++ b/src/panels/dev-preview/serializer.ts
@@ -19,6 +19,9 @@ export function serializeDevPreview(t: DevPreviewSerializeInput): Partial<PanelS
     ...(t.devPreviewConsoleOpen !== undefined && {
       devPreviewConsoleOpen: t.devPreviewConsoleOpen,
     }),
+    ...(t.devPreviewConsoleTab !== undefined && {
+      devPreviewConsoleTab: t.devPreviewConsoleTab,
+    }),
     ...(t.viewportPreset !== undefined && { viewportPreset: t.viewportPreset }),
     ...(t.viewportRotated !== undefined && { viewportRotated: t.viewportRotated }),
     ...(t.viewportDpr !== undefined && { viewportDpr: t.viewportDpr }),

--- a/src/store/slices/panelRegistry/browser.ts
+++ b/src/store/slices/panelRegistry/browser.ts
@@ -22,6 +22,7 @@ export const createBrowserActions = (
   | "setBrowserZoom"
   | "setBrowserConsoleOpen"
   | "setDevPreviewConsoleOpen"
+  | "setDevPreviewConsoleTab"
   | "setViewportPreset"
   | "setViewportRotated"
   | "setViewportDpr"
@@ -98,6 +99,22 @@ export const createBrowserActions = (
       const newById = {
         ...state.panelsById,
         [id]: { ...terminal, devPreviewConsoleOpen: isOpen },
+      };
+      saveNormalized(newById, state.panelIds);
+      return { panelsById: newById };
+    });
+  },
+
+  setDevPreviewConsoleTab: (id, tab) => {
+    set((state) => {
+      const terminal = state.panelsById[id];
+      if (!terminal) return state;
+      if (terminal.kind !== "dev-preview") return state;
+      if (terminal.devPreviewConsoleTab === tab) return state;
+
+      const newById = {
+        ...state.panelsById,
+        [id]: { ...terminal, devPreviewConsoleTab: tab },
       };
       saveNormalized(newById, state.panelIds);
       return { panelsById: newById };

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -163,6 +163,7 @@ export interface PanelRegistrySlice {
   setBrowserZoom: (id: string, zoom: number) => void;
   setBrowserConsoleOpen: (id: string, isOpen: boolean) => void;
   setDevPreviewConsoleOpen: (id: string, isOpen: boolean) => void;
+  setDevPreviewConsoleTab: (id: string, tab: "output" | "console") => void;
   setViewportPreset: (
     id: string,
     preset: import("@shared/types/panel.js").ViewportPresetId | undefined

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -36,6 +36,7 @@ export interface AddTerminalArgs extends AddPanelOptionsBase {
   devServerError?: { type: string; message: string } | null;
   devServerTerminalId?: string | null;
   devPreviewConsoleOpen?: boolean;
+  devPreviewConsoleTab?: "output" | "console";
   viewportPreset?: string;
   viewportRotated?: boolean;
   viewportDpr?: 1 | 2 | 3;
@@ -64,6 +65,7 @@ export interface SavedTerminalData {
   createdAt?: number;
   devCommand?: string;
   devPreviewConsoleOpen?: boolean;
+  devPreviewConsoleTab?: "output" | "console";
   viewportPreset?: string;
   viewportRotated?: boolean;
   viewportDpr?: 1 | 2 | 3;
@@ -223,6 +225,11 @@ export function buildArgsForBackendTerminal(
     browserHistory: isDevPreview ? saved.browserHistory : undefined,
     browserZoom: isDevPreview ? saved.browserZoom : undefined,
     devPreviewConsoleOpen: isDevPreview ? saved.devPreviewConsoleOpen : undefined,
+    devPreviewConsoleTab:
+      isDevPreview &&
+      (saved.devPreviewConsoleTab === "console" || saved.devPreviewConsoleTab === "output")
+        ? saved.devPreviewConsoleTab
+        : undefined,
     devPreviewScrollPosition: isDevPreview ? saved.devPreviewScrollPosition : undefined,
     exitBehavior: saved.exitBehavior,
     agentSessionId: backendTerminal.agentSessionId ?? saved.agentSessionId,
@@ -284,6 +291,11 @@ export function buildArgsForReconnectedFallback(
     browserHistory: isDevPreview ? saved.browserHistory : undefined,
     browserZoom: isDevPreview ? saved.browserZoom : undefined,
     devPreviewConsoleOpen: isDevPreview ? saved.devPreviewConsoleOpen : undefined,
+    devPreviewConsoleTab:
+      isDevPreview &&
+      (saved.devPreviewConsoleTab === "console" || saved.devPreviewConsoleTab === "output")
+        ? saved.devPreviewConsoleTab
+        : undefined,
     devPreviewScrollPosition: isDevPreview ? saved.devPreviewScrollPosition : undefined,
     exitBehavior: saved.exitBehavior,
     agentSessionId: reconnectedTerminal.agentSessionId ?? saved.agentSessionId,


### PR DESCRIPTION
## Summary

The CDP console-capture backend in the main process and the `consoleCaptureStore` in the renderer were already built — there just wasn't anything subscribing to them. This PR wires those two halves together and ships the actual UI.

- Recovered `ConsolePanel`, `ObjectInspector`, and `StackTrace` into `src/components/DevPreview/` and made `ConsolePanel` fill its container; the clear button now also releases CDP-retained object refs
- New `useDevPreviewConsoleCapture` hook: starts/stops CDP capture keyed on webview ready/eviction lifecycle, filters `onConsoleMessage`/`onConsoleContextCleared` by `paneId`, chains stop-then-start to close a ready→evict race, and only drops buffered rows on real panel deletion (survives grid-tab deactivation)
- `ConsoleDrawer` refactored into a two-tab Output/Console dock modelled on `DiagnosticsDock` (role=tablist, arrow-key nav, error-count badge)

Resolves #8268

## Changes

- `devPreviewConsoleTab` persisted field threaded through the full persistence chain: `panel.ts`, `project.ts`, `addPanelOptions.ts`, store slice, defaults, serializer, `panelKindSerialisers` deserializer, and `statePatcher` with literal validation
- DevTools toggle added to the dev-preview toolbar
- Toggle button uses a stable `aria-label` ("Toggle output drawer") with open/closed state conveyed by `aria-expanded` + chevron rotation only, per CLAUDE.md
- E2E selector sweep for the removed Show/Hide Terminal labels (`selectors.ts`, `core-dev-preview.spec.ts`, `nextjs-turbopack.spec.ts`) + new `dev-preview-console-capture.spec.ts`

## Testing

- Rewrote `ConsoleDrawer.test.tsx`, added `useDevPreviewConsoleCapture.test.tsx` and `dev-preview defaults.test.ts`
- Updated registry roundtrip, serialization, and fieldcoverage tests
- New E2E spec covers the full capture flow: open drawer, switch to Console tab, verify messages appear, clear, verify count badge updates