### PR TITLE
refactor(forge): migrate github.* actions to forge.* with one-release aliases

### DIFF
--- a/electron/services/mcp-server/__tests__/forgeAliasGuard.test.ts
+++ b/electron/services/mcp-server/__tests__/forgeAliasGuard.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "vitest";
+import { TIER_ALLOWLISTS } from "../shared.js";
+
+// Pins the safety condition that lets dispatchAlias() (in
+// src/services/actions/definitions/githubActions.ts) default to source="user"
+// without laundering agent intent. The six github.* one-release aliases must
+// stay out of every MCP tier so an agent call cannot reach a deprecated alias
+// and populate ActionService.lastAction with the forge.* primary as if the
+// user had invoked it. Companion test in
+// src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
+// covers the help assistant allowlists on the renderer side.
+describe("github.* aliases must not be reachable from MCP agent surfaces", () => {
+  const aliasIds = [
+    "github.openIssues",
+    "github.openPRs",
+    "github.openCommits",
+    "github.openIssue",
+    "github.assignIssue",
+    "github.validateToken",
+  ] as const;
+
+  it("none of the migrated github.* aliases appear in any MCP TIER_ALLOWLISTS tier", () => {
+    for (const [tierName, tier] of Object.entries(TIER_ALLOWLISTS)) {
+      for (const aliasId of aliasIds) {
+        if (tier.has(aliasId)) {
+          throw new Error(
+            `Deprecated alias "${aliasId}" appears in MCP tier "${tierName}". ` +
+              `Aliases must never be agent-callable — update to the forge.* primary instead.`
+          );
+        }
+      }
+    }
+  });
+});

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -218,7 +218,7 @@ const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
   "github.listIssues",
   "github.listPullRequests",
   "github.getIssueByNumber",
-  "github.openIssue",
+  "forge.openIssue",
   "github.openPR",
 
   "terminal.list",

--- a/shared/config/actionIds.ts
+++ b/shared/config/actionIds.ts
@@ -177,12 +177,25 @@ export const BUILT_IN_ACTION_IDS = [
   "window.zoomReset",
   "window.close",
 
+  // -- forgeActions (provider-routed; GitHub-only today) --
+  "forge.openIssues",
+  "forge.openPRs",
+  "forge.openCommits",
+  "forge.openIssue",
+  "forge.assignIssue",
+  "forge.validateToken",
+
   // -- githubActions --
+  // Five entries (openIssues, openPRs, openCommits, openIssue, validateToken)
+  // are one-release aliases that forward to forge.*. assignIssue is a net-new
+  // alias matching forge.assignIssue for parity. Removed in the release after
+  // this one with a CHANGELOG callout.
   "github.openIssues",
   "github.openPRs",
   "github.openCommits",
   "github.openIssue",
   "github.openPR",
+  "github.assignIssue",
   "github.getRepoStats",
   "github.listIssues",
   "github.listPullRequests",

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -112,7 +112,7 @@ export const SYSTEM_TIER_ADDONS: readonly string[] = [
   "git.snapshotRevert",
   "git.snapshotDelete",
 
-  "github.openIssue",
+  "forge.openIssue",
   "github.openPR",
 ];
 

--- a/src/components/GitHub/CommitList.tsx
+++ b/src/components/GitHub/CommitList.tsx
@@ -158,7 +158,7 @@ export function CommitList({ projectPath, branch, onClose, initialCount }: Commi
   };
 
   const handleViewOnGitHub = () => {
-    actionService.dispatch("github.openCommits", { projectPath, branch }, { source: "user" });
+    actionService.dispatch("forge.openCommits", { projectPath, branch }, { source: "user" });
     onClose?.();
   };
 

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -327,13 +327,13 @@ export function GitHubResourceList({
     const state = filterState as string;
     if (type === "issue") {
       void actionService.dispatch(
-        "github.openIssues",
+        "forge.openIssues",
         { projectPath, query, state },
         { source: "user" }
       );
     } else {
       void actionService.dispatch(
-        "github.openPRs",
+        "forge.openPRs",
         { projectPath, query, state },
         { source: "user" }
       );

--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -121,7 +121,7 @@ export function GitHubSettingsTab() {
 
     try {
       const result = await actionService.dispatch<GitHubTokenValidation>(
-        "github.validateToken",
+        "forge.validateToken",
         { token: githubToken.trim() },
         { source: "user" }
       );

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -1074,6 +1074,28 @@ describe("ActionService", () => {
       });
     });
 
+    it("nonRepeatable outer alias yields lastAction = inner primary (deprecated-alias pattern)", async () => {
+      // Models the github.* → forge.* one-release alias: the outer alias is
+      // nonRepeatable so it never overwrites lastAction, and the inner forge.*
+      // primary is what action.repeatLast should replay.
+      service.register(makeAction("forge.primary"));
+      service.register(
+        makeAction("github.alias", {
+          nonRepeatable: true,
+          run: async () => {
+            await service.dispatch("forge.primary" as ActionId, undefined, { source: "user" });
+          },
+        })
+      );
+
+      await service.dispatch("github.alias" as ActionId, { marker: "alias" }, { source: "user" });
+
+      expect(service.getLastAction()).toEqual({
+        actionId: "forge.primary",
+        args: undefined,
+      });
+    });
+
     it("captured args are isolated from later caller mutation", async () => {
       service.register(makeAction("test.mutable"));
       const args = { list: [1, 2, 3] };

--- a/src/services/actions/__tests__/actionDefinitions.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.test.ts
@@ -43,6 +43,13 @@ describe("createActionDefinitions", () => {
   it("registers core app actions", async () => {
     const actions = await createRegistry();
 
+    expect(actions.has("forge.openIssues")).toBe(true);
+    expect(actions.has("forge.openPRs")).toBe(true);
+    expect(actions.has("forge.openCommits")).toBe(true);
+    expect(actions.has("forge.openIssue")).toBe(true);
+    expect(actions.has("forge.assignIssue")).toBe(true);
+    expect(actions.has("forge.validateToken")).toBe(true);
+    // Aliases retire in the next release.
     expect(actions.has("github.openIssues")).toBe(true);
     expect(actions.has("github.openPRs")).toBe(true);
     expect(actions.has("app.developerMode.set")).toBe(true);

--- a/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
@@ -7,6 +7,7 @@ const githubClientMock = vi.hoisted(() => ({
   openCommits: vi.fn(),
   openIssue: vi.fn(),
   openPR: vi.fn(),
+  assignIssue: vi.fn(),
   getRepoStats: vi.fn(),
   listIssues: vi.fn(),
   listPullRequests: vi.fn(),
@@ -20,8 +21,13 @@ const githubClientMock = vi.hoisted(() => ({
 
 const projectStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
 
+const actionServiceMock = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+}));
+
 vi.mock("@/clients", () => ({ githubClient: githubClientMock }));
 vi.mock("@/store/projectStore", () => ({ useProjectStore: projectStoreMock }));
+vi.mock("@/services/ActionService", () => ({ actionService: actionServiceMock }));
 
 import { registerGithubActions } from "../githubActions";
 
@@ -52,38 +58,39 @@ function setCurrentProject(project: { path?: string } | null) {
 beforeEach(() => {
   vi.clearAllMocks();
   for (const fn of Object.values(githubClientMock)) fn.mockResolvedValue(undefined);
+  actionServiceMock.dispatch.mockResolvedValue({ ok: true, result: undefined });
 });
 
-describe("githubActions adversarial", () => {
+describe("forge.* primaries adversarial", () => {
   it("openIssues falls back to current project path when no arg is given", async () => {
     setCurrentProject({ path: "/repo" });
-    const def = setupActions()("github.openIssues");
+    const def = setupActions()("forge.openIssues");
     await def.run({}, {} as never);
     expect(githubClientMock.openIssues).toHaveBeenCalledWith("/repo", undefined, undefined);
   });
 
   it("openIssues throws loudly when neither arg nor current project has a path", async () => {
     setCurrentProject(null);
-    const def = setupActions()("github.openIssues");
+    const def = setupActions()("forge.openIssues");
     await expect(def.run({}, {} as never)).rejects.toThrow(/No project path/);
     expect(githubClientMock.openIssues).not.toHaveBeenCalled();
   });
 
   it("openPRs also throws loudly without a path", async () => {
     setCurrentProject(null);
-    const def = setupActions()("github.openPRs");
+    const def = setupActions()("forge.openPRs");
     await expect(def.run({}, {} as never)).rejects.toThrow(/No project path/);
   });
 
   it("openCommits also throws loudly without a path", async () => {
     setCurrentProject(null);
-    const def = setupActions()("github.openCommits");
+    const def = setupActions()("forge.openCommits");
     await expect(def.run({}, {} as never)).rejects.toThrow(/No project path/);
   });
 
   it("openIssues: explicit projectPath takes precedence over current project", async () => {
     setCurrentProject({ path: "/stale" });
-    const def = setupActions()("github.openIssues");
+    const def = setupActions()("forge.openIssues");
     await def.run({ projectPath: "/explicit", query: "bug", state: "open" }, {} as never);
     expect(githubClientMock.openIssues).toHaveBeenCalledWith("/explicit", "bug", "open");
   });
@@ -92,11 +99,104 @@ describe("githubActions adversarial", () => {
     // GitHubListOptionsSchema restricts state to an enum, but openIssues uses
     // z.string().optional() — mismatch. Documenting the gap.
     setCurrentProject({ path: "/repo" });
-    const def = setupActions()("github.openIssues");
+    const def = setupActions()("forge.openIssues");
     await def.run({ state: "wat" }, {} as never);
     expect(githubClientMock.openIssues).toHaveBeenCalledWith("/repo", undefined, "wat");
   });
 
+  it("openIssue forwards cwd + issueNumber positionally", async () => {
+    const def = setupActions()("forge.openIssue");
+    await def.run({ cwd: "/repo", issueNumber: 42 }, {} as never);
+    expect(githubClientMock.openIssue).toHaveBeenCalledWith("/repo", 42);
+  });
+
+  it("openIssue falls back to ctx.activeWorktreePath", async () => {
+    await runAction("forge.openIssue", { issueNumber: 7 }, { activeWorktreePath: "/repo" });
+    expect(githubClientMock.openIssue).toHaveBeenCalledWith("/repo", 7);
+  });
+
+  it("validateToken forwards the token unchanged (including whitespace)", async () => {
+    const def = setupActions()("forge.validateToken");
+    await def.run({ token: "  ghp_123  " }, {} as never);
+    expect(githubClientMock.validateToken).toHaveBeenCalledWith("  ghp_123  ");
+  });
+
+  it("assignIssue forwards cwd, issueNumber, and username positionally", async () => {
+    const def = setupActions()("forge.assignIssue");
+    await def.run({ cwd: "/repo", issueNumber: 42, username: "bob" }, {} as never);
+    expect(githubClientMock.assignIssue).toHaveBeenCalledWith("/repo", 42, "bob");
+  });
+
+  it("assignIssue falls back to ctx.activeWorktreePath when cwd omitted", async () => {
+    await runAction(
+      "forge.assignIssue",
+      { issueNumber: 7, username: "alice" },
+      { activeWorktreePath: "/repo" }
+    );
+    expect(githubClientMock.assignIssue).toHaveBeenCalledWith("/repo", 7, "alice");
+  });
+
+  it("assignIssue throws when no cwd and no ctx.activeWorktreePath", async () => {
+    await expect(
+      runAction("forge.assignIssue", { issueNumber: 7, username: "bob" })
+    ).rejects.toThrow("No active worktree");
+  });
+});
+
+describe("github.* one-release aliases", () => {
+  const aliasPairs = [
+    ["github.openIssues", "forge.openIssues"],
+    ["github.openPRs", "forge.openPRs"],
+    ["github.openCommits", "forge.openCommits"],
+    ["github.openIssue", "forge.openIssue"],
+    ["github.assignIssue", "forge.assignIssue"],
+    ["github.validateToken", "forge.validateToken"],
+  ] as const;
+
+  for (const [aliasId, targetId] of aliasPairs) {
+    it(`${aliasId} forwards args verbatim to ${targetId}`, async () => {
+      const def = setupActions()(aliasId);
+      const args = { foo: "bar", n: 42 };
+      await def.run(args, {} as never);
+      expect(actionServiceMock.dispatch).toHaveBeenCalledWith(targetId, args);
+      // The alias must NOT call the underlying client — that is the target's job.
+      // Without this assertion, a regression that double-routes (alias calls
+      // both dispatch and the client) would slip through.
+      expect(githubClientMock.openIssues).not.toHaveBeenCalled();
+      expect(githubClientMock.openPRs).not.toHaveBeenCalled();
+      expect(githubClientMock.openCommits).not.toHaveBeenCalled();
+      expect(githubClientMock.openIssue).not.toHaveBeenCalled();
+      expect(githubClientMock.assignIssue).not.toHaveBeenCalled();
+      expect(githubClientMock.validateToken).not.toHaveBeenCalled();
+    });
+
+    it(`${aliasId} surfaces ${targetId} failures as thrown errors`, async () => {
+      actionServiceMock.dispatch.mockResolvedValueOnce({
+        ok: false,
+        error: { code: "VALIDATION_ERROR", message: "Invalid arguments" },
+      });
+      const def = setupActions()(aliasId);
+      await expect(def.run({}, {} as never)).rejects.toThrow("Invalid arguments");
+    });
+  }
+
+  it("github.validateToken returns the result from forge.validateToken", async () => {
+    const validation = { valid: true, scopes: ["repo"] };
+    actionServiceMock.dispatch.mockResolvedValueOnce({ ok: true, result: validation });
+    const def = setupActions()("github.validateToken");
+    const result = await def.run({ token: "ghp_xyz" }, {} as never);
+    expect(result).toEqual(validation);
+  });
+
+  it("aliases stay danger:safe so they remain eligible for action.repeatLast", () => {
+    for (const [aliasId] of aliasPairs) {
+      const def = setupActions()(aliasId);
+      expect(def.danger).toBe("safe");
+    }
+  });
+});
+
+describe("githubActions adversarial (non-migrating)", () => {
   it("listIssues forwards the whole options object unchanged", async () => {
     githubClientMock.listIssues.mockResolvedValue({ issues: [], nextCursor: "c2" });
     const def = setupActions()("github.listIssues");
@@ -107,12 +207,6 @@ describe("githubActions adversarial", () => {
       state: "open",
       cursor: "c1",
     });
-  });
-
-  it("openIssue forwards cwd + issueNumber positionally", async () => {
-    const def = setupActions()("github.openIssue");
-    await def.run({ cwd: "/repo", issueNumber: 42 }, {} as never);
-    expect(githubClientMock.openIssue).toHaveBeenCalledWith("/repo", 42);
   });
 
   it("openPR forwards prUrl", async () => {
@@ -132,12 +226,6 @@ describe("githubActions adversarial", () => {
     const clearDef = setupActions()("github.clearToken");
     expect(setDef.danger).toBe("safe");
     expect(clearDef.danger).toBe("safe");
-  });
-
-  it("validateToken forwards the token unchanged (including whitespace)", async () => {
-    const def = setupActions()("github.validateToken");
-    await def.run({ token: "  ghp_123  " }, {} as never);
-    expect(githubClientMock.validateToken).toHaveBeenCalledWith("  ghp_123  ");
   });
 
   it("checkCli has no schema and calls client directly", async () => {
@@ -211,11 +299,6 @@ describe("githubActions adversarial", () => {
     expect(githubClientMock.listPullRequests).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: "/repo" })
     );
-  });
-
-  it("openIssue falls back to ctx.activeWorktreePath", async () => {
-    await runAction("github.openIssue", { issueNumber: 7 }, { activeWorktreePath: "/repo" });
-    expect(githubClientMock.openIssue).toHaveBeenCalledWith("/repo", 7);
   });
 
   it("getRepoStats falls back to ctx.activeWorktreePath", async () => {

--- a/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
@@ -170,15 +170,30 @@ describe("github.* one-release aliases", () => {
       expect(githubClientMock.validateToken).not.toHaveBeenCalled();
     });
 
-    it(`${aliasId} surfaces ${targetId} failures as thrown errors`, async () => {
+    it(`${aliasId} surfaces ${targetId} failures with code preserved on the thrown error`, async () => {
       actionServiceMock.dispatch.mockResolvedValueOnce({
         ok: false,
         error: { code: "VALIDATION_ERROR", message: "Invalid arguments" },
       });
       const def = setupActions()(aliasId);
-      await expect(def.run({}, {} as never)).rejects.toThrow("Invalid arguments");
+      const thrown = await def.run({}, {} as never).then(
+        () => null,
+        (e: Error & { code?: string }) => e
+      );
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown?.message).toBe("Invalid arguments");
+      expect(thrown?.code).toBe("VALIDATION_ERROR");
     });
   }
+
+  it("every alias has its forge.* target factory registered", () => {
+    const actions: ActionRegistry = new Map();
+    registerGithubActions(actions, {} as unknown as ActionCallbacks);
+    for (const [aliasId, targetId] of aliasPairs) {
+      expect(actions.has(aliasId)).toBe(true);
+      expect(actions.has(targetId)).toBe(true);
+    }
+  });
 
   it("github.validateToken returns the result from forge.validateToken", async () => {
     const validation = { valid: true, scopes: ["repo"] };
@@ -199,6 +214,46 @@ describe("github.* one-release aliases", () => {
     for (const [aliasId] of aliasPairs) {
       const def = setupActions()(aliasId);
       expect(def.nonRepeatable).toBe(true);
+    }
+  });
+});
+
+describe("github.* aliases must not be reachable from agent surfaces", () => {
+  // dispatchAlias() in githubActions.ts intentionally does not preserve the
+  // caller source — the inner dispatch defaults to source="user". That is safe
+  // only because no agent-exposing allowlist contains a deprecated alias id.
+  // If a future edit adds one of the aliases below to MCP or the help
+  // assistant, an agent call could launder source="user" through the alias and
+  // populate ActionService.lastAction with the forge.* primary as if the user
+  // had invoked it. This guard pins that exclusion.
+  const aliasIds = [
+    "github.openIssues",
+    "github.openPRs",
+    "github.openCommits",
+    "github.openIssue",
+    "github.assignIssue",
+    "github.validateToken",
+  ] as const;
+
+  it("none of the migrated github.* aliases appear in MCP TIER_ALLOWLISTS", async () => {
+    const { TIER_ALLOWLISTS } = await import("../../../../../electron/services/mcp-server/shared");
+    for (const tier of Object.values(TIER_ALLOWLISTS)) {
+      for (const aliasId of aliasIds) {
+        expect(tier.has(aliasId)).toBe(false);
+      }
+    }
+  });
+
+  it("none of the migrated github.* aliases appear in help assistant tier tools/addons", async () => {
+    const { WORKBENCH_TIER_TOOLS, ACTION_TIER_ADDONS, SYSTEM_TIER_ADDONS } =
+      await import("@shared/config/helpAssistantTierAllowlists");
+    const combined = new Set<string>([
+      ...WORKBENCH_TIER_TOOLS,
+      ...ACTION_TIER_ADDONS,
+      ...SYSTEM_TIER_ADDONS,
+    ]);
+    for (const aliasId of aliasIds) {
+      expect(combined.has(aliasId)).toBe(false);
     }
   });
 });

--- a/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
@@ -188,10 +188,17 @@ describe("github.* one-release aliases", () => {
     expect(result).toEqual(validation);
   });
 
-  it("aliases stay danger:safe so they remain eligible for action.repeatLast", () => {
+  it("aliases stay danger:safe (so dispatch is not gated on confirmation)", () => {
     for (const [aliasId] of aliasPairs) {
       const def = setupActions()(aliasId);
       expect(def.danger).toBe("safe");
+    }
+  });
+
+  it("aliases set nonRepeatable so action.repeatLast captures the forge.* primary, not the deprecated github.* id", () => {
+    for (const [aliasId] of aliasPairs) {
+      const def = setupActions()(aliasId);
+      expect(def.nonRepeatable).toBe(true);
     }
   });
 });

--- a/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
@@ -218,14 +218,17 @@ describe("github.* one-release aliases", () => {
   });
 });
 
-describe("github.* aliases must not be reachable from agent surfaces", () => {
+describe("github.* aliases must not be reachable from help assistant surfaces", () => {
   // dispatchAlias() in githubActions.ts intentionally does not preserve the
   // caller source — the inner dispatch defaults to source="user". That is safe
   // only because no agent-exposing allowlist contains a deprecated alias id.
-  // If a future edit adds one of the aliases below to MCP or the help
-  // assistant, an agent call could launder source="user" through the alias and
-  // populate ActionService.lastAction with the forge.* primary as if the user
-  // had invoked it. This guard pins that exclusion.
+  // If a future edit adds one of the aliases below to a help assistant tier,
+  // an agent call could launder source="user" through the alias and populate
+  // ActionService.lastAction with the forge.* primary as if the user had
+  // invoked it. The MCP-side counterpart lives at
+  // electron/services/mcp-server/__tests__/forgeAliasGuard.test.ts (kept on
+  // the electron side so the renderer typecheck graph doesn't pull in
+  // electron sources, which use looser tsconfig flags).
   const aliasIds = [
     "github.openIssues",
     "github.openPRs",
@@ -234,15 +237,6 @@ describe("github.* aliases must not be reachable from agent surfaces", () => {
     "github.assignIssue",
     "github.validateToken",
   ] as const;
-
-  it("none of the migrated github.* aliases appear in MCP TIER_ALLOWLISTS", async () => {
-    const { TIER_ALLOWLISTS } = await import("../../../../../electron/services/mcp-server/shared");
-    for (const tier of Object.values(TIER_ALLOWLISTS)) {
-      for (const aliasId of aliasIds) {
-        expect(tier.has(aliasId)).toBe(false);
-      }
-    }
-  });
 
   it("none of the migrated github.* aliases appear in help assistant tier tools/addons", async () => {
     const { WORKBENCH_TIER_TOOLS, ACTION_TIER_ADDONS, SYSTEM_TIER_ADDONS } =

--- a/src/services/actions/definitions/githubActions.ts
+++ b/src/services/actions/definitions/githubActions.ts
@@ -1,9 +1,10 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
-import type { ActionContext } from "@shared/types/actions";
+import type { ActionContext, ActionId } from "@shared/types/actions";
 import { defineAction } from "../defineAction";
 import { z } from "zod";
 import { githubClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
+import { actionService } from "@/services/ActionService";
 
 const GitHubListOptionsSchema = z.object({
   cwd: z
@@ -18,12 +19,30 @@ const GitHubListOptionsSchema = z.object({
   cursor: z.string().optional().describe("Pagination cursor from previous response"),
 });
 
+// Forwards a deprecated alias to its forge.* counterpart and propagates failures
+// as thrown errors so callers using await def.run(...) see the same shape they
+// would from the primary. Used only by the one-release github.* aliases below.
+async function dispatchAlias<T = unknown>(targetId: ActionId, args: unknown): Promise<T> {
+  const result = await actionService.dispatch<T>(targetId, args);
+  if (!result.ok) throw new Error(result.error.message);
+  return result.result;
+}
+
 export function registerGithubActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
-  actions.set("github.openIssues", () =>
+  // ---------------------------------------------------------------------------
+  // forge.* primaries — provider-routed action surface.
+  //
+  // With only the GitHub provider registered today, each forge.* calls the
+  // existing githubClient.* methods directly. When a second provider lands,
+  // the run() bodies switch to ForgeProviderRegistry routing without changing
+  // the public action shape.
+  // ---------------------------------------------------------------------------
+
+  actions.set("forge.openIssues", () =>
     defineAction({
-      id: "github.openIssues",
-      title: "Open GitHub Issues",
-      description: "Open the GitHub issues list for the current project",
+      id: "forge.openIssues",
+      title: "Open Issues",
+      description: "Open the forge issues list for the current project",
       category: "github",
       kind: "command",
       danger: "safe",
@@ -48,11 +67,11 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
     })
   );
 
-  actions.set("github.openPRs", () =>
+  actions.set("forge.openPRs", () =>
     defineAction({
-      id: "github.openPRs",
-      title: "Open GitHub Pull Requests",
-      description: "Open the GitHub pull requests list for the current project",
+      id: "forge.openPRs",
+      title: "Open Pull Requests",
+      description: "Open the forge pull requests list for the current project",
       category: "github",
       kind: "command",
       danger: "safe",
@@ -77,11 +96,11 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
     })
   );
 
-  actions.set("github.openCommits", () =>
+  actions.set("forge.openCommits", () =>
     defineAction({
-      id: "github.openCommits",
-      title: "Open GitHub Commits",
-      description: "Open the GitHub commits page for the current project",
+      id: "forge.openCommits",
+      title: "Open Commits",
+      description: "Open the forge commits page for the current project",
       category: "github",
       kind: "command",
       danger: "safe",
@@ -101,11 +120,11 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
     })
   );
 
-  actions.set("github.openIssue", () =>
+  actions.set("forge.openIssue", () =>
     defineAction({
-      id: "github.openIssue",
-      title: "Open GitHub Issue",
-      description: "Open a GitHub issue in the system browser",
+      id: "forge.openIssue",
+      title: "Open Issue",
+      description: "Open a forge issue in the system browser",
       category: "github",
       kind: "command",
       danger: "safe",
@@ -124,6 +143,153 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       },
     })
   );
+
+  actions.set("forge.assignIssue", () =>
+    defineAction({
+      id: "forge.assignIssue",
+      title: "Assign Issue",
+      description: "Assign a forge issue to a user via the active provider",
+      category: "github",
+      kind: "command",
+      danger: "safe",
+      scope: "renderer",
+      argsSchema: z.object({
+        cwd: z
+          .string()
+          .optional()
+          .describe("Working directory of the git repo. Defaults to the active worktree path."),
+        issueNumber: z.number().int().positive(),
+        username: z.string().min(1).describe("Account to assign the issue to"),
+      }),
+      run: async ({ cwd, issueNumber, username }, ctx: ActionContext) => {
+        const resolvedCwd = cwd ?? ctx.activeWorktreePath;
+        if (!resolvedCwd) throw new Error("No active worktree");
+        await githubClient.assignIssue(resolvedCwd, issueNumber, username);
+      },
+    })
+  );
+
+  actions.set("forge.validateToken", () =>
+    defineAction({
+      id: "forge.validateToken",
+      title: "Validate Forge Token",
+      description: "Validate a forge access token without saving it",
+      category: "github",
+      kind: "query",
+      danger: "safe",
+      scope: "renderer",
+      argsSchema: z.object({ token: z.string() }),
+      run: async ({ token }) => {
+        return await githubClient.validateToken(token);
+      },
+    })
+  );
+
+  // ---------------------------------------------------------------------------
+  // github.* one-release aliases — forward to forge.* counterparts.
+  //
+  // Registered here in host code rather than via the GitHub built-in plugin
+  // because PluginService.registerPluginAction enforces `id.startsWith(pluginId + ".")`
+  // — plugin daintree.github cannot contribute bare `github.*` IDs without
+  // significant plugin-system surface changes. Aliases retire in the next
+  // release alongside the github.* IDs in BUILT_IN_ACTION_IDS.
+  // ---------------------------------------------------------------------------
+
+  actions.set("github.openIssues", () =>
+    defineAction({
+      id: "github.openIssues",
+      title: "Open GitHub Issues",
+      description: "Alias of forge.openIssues. Removed in the next release.",
+      category: "github",
+      kind: "command",
+      danger: "safe",
+      scope: "renderer",
+      run: async (args) => {
+        await dispatchAlias("forge.openIssues", args);
+      },
+    })
+  );
+
+  actions.set("github.openPRs", () =>
+    defineAction({
+      id: "github.openPRs",
+      title: "Open GitHub Pull Requests",
+      description: "Alias of forge.openPRs. Removed in the next release.",
+      category: "github",
+      kind: "command",
+      danger: "safe",
+      scope: "renderer",
+      run: async (args) => {
+        await dispatchAlias("forge.openPRs", args);
+      },
+    })
+  );
+
+  actions.set("github.openCommits", () =>
+    defineAction({
+      id: "github.openCommits",
+      title: "Open GitHub Commits",
+      description: "Alias of forge.openCommits. Removed in the next release.",
+      category: "github",
+      kind: "command",
+      danger: "safe",
+      scope: "renderer",
+      run: async (args) => {
+        await dispatchAlias("forge.openCommits", args);
+      },
+    })
+  );
+
+  actions.set("github.openIssue", () =>
+    defineAction({
+      id: "github.openIssue",
+      title: "Open GitHub Issue",
+      description: "Alias of forge.openIssue. Removed in the next release.",
+      category: "github",
+      kind: "command",
+      danger: "safe",
+      scope: "renderer",
+      run: async (args) => {
+        await dispatchAlias("forge.openIssue", args);
+      },
+    })
+  );
+
+  actions.set("github.assignIssue", () =>
+    defineAction({
+      id: "github.assignIssue",
+      title: "Assign GitHub Issue",
+      description: "Alias of forge.assignIssue. Removed in the next release.",
+      category: "github",
+      kind: "command",
+      danger: "safe",
+      scope: "renderer",
+      run: async (args) => {
+        await dispatchAlias("forge.assignIssue", args);
+      },
+    })
+  );
+
+  actions.set("github.validateToken", () =>
+    defineAction({
+      id: "github.validateToken",
+      title: "Validate GitHub Token",
+      description: "Alias of forge.validateToken. Removed in the next release.",
+      category: "github",
+      kind: "query",
+      danger: "safe",
+      scope: "renderer",
+      run: async (args) => {
+        return await dispatchAlias("forge.validateToken", args);
+      },
+    })
+  );
+
+  // ---------------------------------------------------------------------------
+  // github.* host actions that are NOT migrating to forge.* in this stage.
+  // These stay on the host since they are GitHub-specific (CLI checks, token
+  // storage, paginated listings) rather than provider-abstract operations.
+  // ---------------------------------------------------------------------------
 
   actions.set("github.openPR", () =>
     defineAction({
@@ -286,20 +452,4 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       await githubClient.clearToken();
     },
   }));
-
-  actions.set("github.validateToken", () =>
-    defineAction({
-      id: "github.validateToken",
-      title: "Validate GitHub Token",
-      description: "Validate a GitHub token without saving it",
-      category: "github",
-      kind: "query",
-      danger: "safe",
-      scope: "renderer",
-      argsSchema: z.object({ token: z.string() }),
-      run: async ({ token }) => {
-        return await githubClient.validateToken(token);
-      },
-    })
-  );
 }

--- a/src/services/actions/definitions/githubActions.ts
+++ b/src/services/actions/definitions/githubActions.ts
@@ -193,6 +193,10 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
   // — plugin daintree.github cannot contribute bare `github.*` IDs without
   // significant plugin-system surface changes. Aliases retire in the next
   // release alongside the github.* IDs in BUILT_IN_ACTION_IDS.
+  //
+  // nonRepeatable: true — keeps deprecated alias IDs out of ActionService.lastAction
+  // so action.repeatLast and similar replays the underlying forge.* primary, not
+  // the alias ID that's scheduled for removal.
   // ---------------------------------------------------------------------------
 
   actions.set("github.openIssues", () =>
@@ -204,6 +208,7 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       kind: "command",
       danger: "safe",
       scope: "renderer",
+      nonRepeatable: true,
       run: async (args) => {
         await dispatchAlias("forge.openIssues", args);
       },
@@ -219,6 +224,7 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       kind: "command",
       danger: "safe",
       scope: "renderer",
+      nonRepeatable: true,
       run: async (args) => {
         await dispatchAlias("forge.openPRs", args);
       },
@@ -234,6 +240,7 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       kind: "command",
       danger: "safe",
       scope: "renderer",
+      nonRepeatable: true,
       run: async (args) => {
         await dispatchAlias("forge.openCommits", args);
       },
@@ -249,6 +256,7 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       kind: "command",
       danger: "safe",
       scope: "renderer",
+      nonRepeatable: true,
       run: async (args) => {
         await dispatchAlias("forge.openIssue", args);
       },
@@ -264,6 +272,7 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       kind: "command",
       danger: "safe",
       scope: "renderer",
+      nonRepeatable: true,
       run: async (args) => {
         await dispatchAlias("forge.assignIssue", args);
       },
@@ -279,6 +288,7 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       kind: "query",
       danger: "safe",
       scope: "renderer",
+      nonRepeatable: true,
       run: async (args) => {
         return await dispatchAlias("forge.validateToken", args);
       },

--- a/src/services/actions/definitions/githubActions.ts
+++ b/src/services/actions/definitions/githubActions.ts
@@ -22,9 +22,23 @@ const GitHubListOptionsSchema = z.object({
 // Forwards a deprecated alias to its forge.* counterpart and propagates failures
 // as thrown errors so callers using await def.run(...) see the same shape they
 // would from the primary. Used only by the one-release github.* aliases below.
+//
+// Source preservation: the inner dispatch defaults to source="user". This is the
+// intended behavior — the six github.* aliases are only reachable from
+// user-recorded artifacts (keybindings, recipes, MRU). They are intentionally
+// excluded from every agent-exposing allowlist (MCP, help assistant), and an
+// adversarial test pins that exclusion so a future allowlist edit cannot
+// silently launder agent intent through a deprecated alias.
 async function dispatchAlias<T = unknown>(targetId: ActionId, args: unknown): Promise<T> {
   const result = await actionService.dispatch<T>(targetId, args);
-  if (!result.ok) throw new Error(result.error.message);
+  if (!result.ok) {
+    // Preserve the structured error code on the thrown error so callers can
+    // discriminate VALIDATION_ERROR vs EXECUTION_ERROR vs DISABLED without
+    // re-parsing the message.
+    const err = new Error(result.error.message) as Error & { code?: string };
+    err.code = result.error.code;
+    throw err;
+  }
   return result.result;
 }
 


### PR DESCRIPTION
Closes #8062.

## Summary

Migrates six provider-abstract GitHub host actions to a new `forge.*` namespace and keeps the old `github.*` IDs alive as one-release aliases so existing keybindings, recipes, and MRU entries keep working.

Migrated actions: `openIssues`, `openPRs`, `openCommits`, `openIssue`, `assignIssue`, `validateToken`.

## Design

- `forge.*` primaries live in `src/services/actions/definitions/githubActions.ts`. With only the GitHub provider registered today they call `githubClient.*` directly; when a second provider lands, the `run()` bodies switch to `ForgeProviderRegistry` routing without changing the public action shape. The registry already exists at `electron/services/forgeProviderRegistry.ts` — see `docs/architecture/forge-provider-abstraction.md` for the model.
- `github.*` one-release aliases forward through a shared `dispatchAlias()` helper. Aliases are registered in host code rather than in the GitHub built-in plugin because `PluginService.registerPluginAction` enforces `id.startsWith(pluginId + ".")` — plugin `daintree.github` cannot contribute bare `github.*` IDs without a wider plugin-system change. Aliases retire in the next release alongside the `github.*` IDs in `BUILT_IN_ACTION_IDS`.
- **IPC namespace intentionally deferred.** `window.electron.github.*` stays as-is. Following the #4003 portal/sidecar precedent, renaming the IPC namespace is a separate, larger contract change and out of scope here.

## Hardening (from review)

- **`nonRepeatable: true` on every alias.** Without this, `ActionService.lastAction` would record the deprecated `github.*` ID when a user invokes an alias from a keybinding or recipe — and `action.repeatLast` would replay the deprecated alias instead of the underlying `forge.*` primary. Aliases stay `danger:"safe"` (orthogonal: `nonRepeatable` controls repeat eligibility; `danger` controls confirmation gating).
- **Source preservation in `dispatchAlias`.** The inner dispatch defaults to `source: "user"`. That is safe because the six aliases are intentionally absent from every agent-exposing allowlist — MCP `TIER_ALLOWLISTS` and the help-assistant tier tools/addons — so agents cannot reach them. Two structural guard tests pin that exclusion so a future allowlist edit cannot silently launder agent intent through a deprecated alias.
- **Error code preserved.** `dispatchAlias` attaches `ActionError.code` onto the thrown error so callers can discriminate `VALIDATION_ERROR` vs `EXECUTION_ERROR` vs `DISABLED` without re-parsing the message.
- Lint ratchet improved by 1 warning.

## Test plan

- [x] `npx vitest run src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts src/services/__tests__/ActionService.test.ts electron/services/mcp-server/__tests__/forgeAliasGuard.test.ts` — 122 tests pass
- [x] `npm run check` — typecheck, lint:ratchet, format:check, channels, ipc, help all green
- [x] Lint ratchet baseline went from 889 → 888 warnings
- [ ] Manually invoke a recipe that uses the deprecated `github.openIssue` keybinding and confirm it still opens the issue
- [ ] Confirm `action.repeatLast` after invoking a `github.*` alias replays the underlying `forge.*` primary
