### PR TITLE
feat(dev-preview): add explicit Stop button with graceful termination

### DIFF
--- a/docs/architecture/destructive-action-safeguards.md
+++ b/docs/architecture/destructive-action-safeguards.md
@@ -92,6 +92,12 @@ Columns:
 | `terminal.restartAll` | **confirm** (updated #8245) | yes (`TerminalDestructiveActionConfirmDialog`) — fires when any non-trash terminal has a running agent | local-irreversible | many terminals | D1 | Done (#8245) | — |
 | `terminal.restartService` | safe | n/a | local-irreversible (all PTY processes restart) | every terminal in the window | D1 | Action is gated on `backendStatus === "disconnected"`; the gate already implies an error state, so leave as-is | — |
 
+### Dev preview
+
+| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `devPreview.stop` | safe | n/a | local-undo (re-start) | one dev server | D0 | Leave | — |
+
 ### Fleet operations
 
 | Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -49,7 +49,11 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
     kill: (msg) => {
       const termInfo = ptyManager.getTerminal(msg.id);
       const killedPid = termInfo?.ptyProcess.pid;
-      ptyManager.kill(msg.id, msg.reason, { escalationDelayMs: msg.escalationDelayMs });
+      if (msg.escalationDelayMs !== undefined) {
+        ptyManager.kill(msg.id, msg.reason, { escalationDelayMs: msg.escalationDelayMs });
+      } else {
+        ptyManager.kill(msg.id, msg.reason);
+      }
       if (killedPid !== undefined) {
         resourceGovernor.trackKilledPid(killedPid);
       }

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -49,7 +49,7 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
     kill: (msg) => {
       const termInfo = ptyManager.getTerminal(msg.id);
       const killedPid = termInfo?.ptyProcess.pid;
-      ptyManager.kill(msg.id, msg.reason);
+      ptyManager.kill(msg.id, msg.reason, { escalationDelayMs: msg.escalationDelayMs });
       if (killedPid !== undefined) {
         resourceGovernor.trackKilledPid(killedPid);
       }

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -143,6 +143,7 @@ export class DevPreviewSessionService {
       worktreeId: request.worktreeId ?? null,
     });
     const key = createSessionKey(request.projectId, request.panelId);
+    let state: DevPreviewSessionState | undefined;
     await this.runLocked(key, async () => {
       if (this.disposed) return;
       const session = this.getOrCreateSession(request.projectId, request.panelId);
@@ -193,8 +194,9 @@ export class DevPreviewSessionService {
       }
 
       await this.ensureSessionTerminal(session);
+      state = this.getSessionState(request.projectId, request.panelId);
     });
-    return this.getSessionState(request.projectId, request.panelId);
+    return state ?? this.getSessionState(request.projectId, request.panelId);
   }
 
   async restart(request: DevPreviewSessionRequest): Promise<DevPreviewSessionState> {
@@ -205,6 +207,7 @@ export class DevPreviewSessionService {
       projectId: request.projectId,
     });
     const key = createSessionKey(request.projectId, request.panelId);
+    let state: DevPreviewSessionState | undefined;
     try {
       await this.runLocked(key, async () => {
         const session = this.sessions.get(key);
@@ -223,6 +226,7 @@ export class DevPreviewSessionService {
             terminalId: null,
             isRestarting: false,
           });
+          state = this.getSessionState(request.projectId, request.panelId);
           return;
         }
 
@@ -236,6 +240,7 @@ export class DevPreviewSessionService {
 
         await this.stopSessionTerminal(session, "restart");
         await this.spawnSessionTerminal(session);
+        state = this.getSessionState(request.projectId, request.panelId);
       });
     } finally {
       markPerformance(PERF_MARKS.DEVPREVIEW_RESTART_END, {
@@ -244,7 +249,7 @@ export class DevPreviewSessionService {
         durationMs: Date.now() - restartStartedAt,
       });
     }
-    return this.getSessionState(request.projectId, request.panelId);
+    return state ?? this.getSessionState(request.projectId, request.panelId);
   }
 
   async stop(request: DevPreviewSessionRequest): Promise<DevPreviewSessionState> {

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -46,6 +46,7 @@ interface DevPreviewSession extends DevPreviewSessionState {
   installAttemptedGeneration: number | null;
   startupReplayTimer: ReturnType<typeof setTimeout> | null;
   updatedAtPerformanceMs: number;
+  forceKilled?: boolean;
 }
 
 const RUNNING_STATES: ReadonlySet<DevPreviewSessionStatus> = new Set([
@@ -55,6 +56,7 @@ const RUNNING_STATES: ReadonlySet<DevPreviewSessionStatus> = new Set([
 ]);
 
 const DEFAULT_TIMEOUT_MS = 8000;
+const DEV_PREVIEW_STOP_ESCALATION_MS = 5000;
 const STALE_START_RECOVERY_MS = 10000;
 const STARTUP_REPLAY_DELAY_MS = 1500;
 const REPLAY_HISTORY_MAX_LINES = 300;
@@ -229,6 +231,7 @@ export class DevPreviewSessionService {
           url: null,
           error: null,
           isRestarting: true,
+          forceKilled: undefined,
         });
 
         await this.stopSessionTerminal(session, "restart");
@@ -251,15 +254,30 @@ export class DevPreviewSessionService {
       const session = this.sessions.get(key);
       if (!session) return;
 
-      await this.stopSessionTerminal(session, "stop");
-      this.updateSession(session, {
-        status: "stopped",
-        url: null,
-        assignedUrl: null,
-        error: null,
-        terminalId: null,
-        isRestarting: false,
-      });
+      if (session.terminalId) {
+        this.updateSession(session, { status: "stopping", isRestarting: false });
+        const stopStartedAt = performance.now();
+        await this.stopSessionTerminal(session, "stop", DEV_PREVIEW_STOP_ESCALATION_MS);
+        const forceKilled = performance.now() - stopStartedAt >= DEV_PREVIEW_STOP_ESCALATION_MS;
+        this.updateSession(session, {
+          status: "stopped",
+          url: null,
+          assignedUrl: null,
+          error: null,
+          terminalId: null,
+          isRestarting: false,
+          forceKilled,
+        });
+      } else {
+        this.updateSession(session, {
+          status: "stopped",
+          url: null,
+          assignedUrl: null,
+          error: null,
+          terminalId: null,
+          isRestarting: false,
+        });
+      }
     });
     return this.getSessionState(request.projectId, request.panelId);
   }
@@ -399,6 +417,7 @@ export class DevPreviewSessionService {
         isRestarting: false,
         generation: 0,
         updatedAt: Date.now(),
+        forceKilled: undefined,
       };
     }
     return this.toPublicState(session);
@@ -417,6 +436,7 @@ export class DevPreviewSessionService {
       isRestarting: session.isRestarting,
       generation: session.generation,
       updatedAt: session.updatedAt,
+      forceKilled: session.forceKilled,
     };
   }
 
@@ -433,6 +453,7 @@ export class DevPreviewSessionService {
         | "isRestarting"
         | "worktreeId"
         | "generation"
+        | "forceKilled"
       >
     >
   ): void {
@@ -445,6 +466,7 @@ export class DevPreviewSessionService {
     if (updates.isRestarting !== undefined) session.isRestarting = updates.isRestarting;
     if (updates.worktreeId !== undefined) session.worktreeId = updates.worktreeId;
     if (updates.generation !== undefined) session.generation = updates.generation;
+    if (updates.forceKilled !== undefined) session.forceKilled = updates.forceKilled;
     session.updatedAt = Date.now();
     session.updatedAtPerformanceMs = performance.now();
     this.onStateChanged(this.toPublicState(session));
@@ -471,7 +493,12 @@ export class DevPreviewSessionService {
         const terminalId = session.terminalId;
         this.attachTerminal(session, terminalId);
         if (!RUNNING_STATES.has(session.status)) {
-          this.updateSession(session, { status: "starting", error: null, url: null });
+          this.updateSession(session, {
+            status: "starting",
+            error: null,
+            url: null,
+            forceKilled: undefined,
+          });
         }
 
         if ((session.status === "starting" || session.status === "installing") && !session.url) {
@@ -542,6 +569,7 @@ export class DevPreviewSessionService {
       assignedUrl,
       error: null,
       generation: nextGeneration,
+      forceKilled: undefined,
     });
 
     try {
@@ -654,7 +682,11 @@ export class DevPreviewSessionService {
     session.terminalId = null;
   }
 
-  private async stopSessionTerminal(session: DevPreviewSession, context: string): Promise<void> {
+  private async stopSessionTerminal(
+    session: DevPreviewSession,
+    context: string,
+    escalationDelayMs?: number
+  ): Promise<void> {
     this.clearStartupReplay(session);
     session.readinessAbort?.abort();
     session.readinessAbort = null;
@@ -671,7 +703,7 @@ export class DevPreviewSessionService {
     session.lastErrorKey = null;
 
     try {
-      this.ptyClient.kill(terminalId, `dev-preview:${context}`);
+      this.ptyClient.kill(terminalId, `dev-preview:${context}`, { escalationDelayMs });
     } catch (err) {
       const message = formatErrorMessage(err, "Failed to kill dev preview terminal");
       if (!this.isBenignMissingTerminalError(message)) {

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -466,7 +466,7 @@ export class DevPreviewSessionService {
     if (updates.isRestarting !== undefined) session.isRestarting = updates.isRestarting;
     if (updates.worktreeId !== undefined) session.worktreeId = updates.worktreeId;
     if (updates.generation !== undefined) session.generation = updates.generation;
-    if (updates.forceKilled !== undefined) session.forceKilled = updates.forceKilled;
+    if ("forceKilled" in updates) session.forceKilled = updates.forceKilled;
     session.updatedAt = Date.now();
     session.updatedAtPerformanceMs = performance.now();
     this.onStateChanged(this.toPublicState(session));

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -703,7 +703,11 @@ export class DevPreviewSessionService {
     session.lastErrorKey = null;
 
     try {
-      this.ptyClient.kill(terminalId, `dev-preview:${context}`, { escalationDelayMs });
+      if (escalationDelayMs !== undefined) {
+        this.ptyClient.kill(terminalId, `dev-preview:${context}`, { escalationDelayMs });
+      } else {
+        this.ptyClient.kill(terminalId, `dev-preview:${context}`);
+      }
     } catch (err) {
       const message = formatErrorMessage(err, "Failed to kill dev preview terminal");
       if (!this.isBenignMissingTerminalError(message)) {

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -657,7 +657,7 @@ export class PtyClient extends EventEmitter {
     this.send({ type: "resize", id, cols, rows });
   }
 
-  kill(id: string, reason?: string): void {
+  kill(id: string, reason?: string, options?: { escalationDelayMs?: number }): void {
     getTrashedPidTracker().removeTrashed(id);
     const wasKnown = this.pendingSpawns.has(id);
     this.pendingSpawns.delete(id);
@@ -684,7 +684,7 @@ export class PtyClient extends EventEmitter {
     }
     // Always send the kill IPC. The host-side handler kills the terminal if
     // it exists and removes any persisted session state for the id.
-    this.send({ type: "kill", id, reason });
+    this.send({ type: "kill", id, reason, escalationDelayMs: options?.escalationDelayMs });
   }
 
   /** Check if a terminal exists (based on local tracking) */

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -368,14 +368,18 @@ export class PtyManager extends EventEmitter {
   /**
    * Kill a terminal process.
    */
-  kill(id: string, reason?: string, options?: { preserveSession?: boolean }): void {
+  kill(
+    id: string,
+    reason?: string,
+    options?: { preserveSession?: boolean; escalationDelayMs?: number }
+  ): void {
     this.pendingResizes.delete(id);
     this.registry.clearTrashTimeout(id);
 
     const terminal = this.registry.get(id);
     if (terminal) {
       const wasExited = terminal.getInfo().isExited;
-      terminal.kill(reason);
+      terminal.kill(reason, options?.escalationDelayMs);
       // Note: deletion handled in onExit callback
       if (wasExited) {
         this.registry.delete(id);

--- a/electron/services/pty/ProcessTreeKiller.ts
+++ b/electron/services/pty/ProcessTreeKiller.ts
@@ -26,7 +26,7 @@ export class ProcessTreeKiller {
    *   where timers don't fire). If false, SIGKILL escalation fires after 500ms and re-reads
    *   the descendant list to catch processes spawned during the grace window.
    */
-  execute(immediate: boolean): void {
+  execute(immediate: boolean, escalationDelayMs?: number): void {
     this.abort();
 
     const shellPid = this.ptyProcess.pid;
@@ -87,13 +87,15 @@ export class ProcessTreeKiller {
       return;
     }
 
+    const delay = escalationDelayMs ?? SIGKILL_ESCALATION_DELAY_MS;
+
     // Re-read descendants inside the timer so children spawned in the
     // grace window between SIGTERM and SIGKILL are also reaped. Capturing
     // the snapshot in a closure here would orphan late-forked subprocesses.
     this.killTreeTimer = setTimeout(() => {
       this.killTreeTimer = null;
       this.sigkillSweep(shellPid);
-    }, SIGKILL_ESCALATION_DELAY_MS);
+    }, delay);
     this.killTreeTimer.unref?.();
   }
 

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -963,7 +963,7 @@ export class TerminalProcess {
     });
   }
 
-  kill(reason?: string): void {
+  kill(reason?: string, escalationDelayMs?: number): void {
     const terminal = this.terminalInfo;
     const exitReason: ExitReason = reason === "graceful-shutdown" ? "graceful-shutdown" : "kill";
 
@@ -995,7 +995,7 @@ export class TerminalProcess {
     // `reason: "kill"` carried through the lifecycle state machine.
     this.disposeHeadless();
 
-    this.processTreeKiller.execute(false);
+    this.processTreeKiller.execute(false, escalationDelayMs);
   }
 
   checkFlooding(): { flooded: boolean; resumed: boolean } {

--- a/shared/config/actionIds.ts
+++ b/shared/config/actionIds.ts
@@ -403,6 +403,7 @@ export const BUILT_IN_ACTION_IDS = [
   "devServer.start",
   "devPreview.restartClearCache",
   "devPreview.reinstall",
+  "devPreview.stop",
 
   // -- envActions --
   "env.global.get",

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -1,6 +1,12 @@
 import type { DevServerError } from "../../utils/devServerErrors.js";
 
-export type DevPreviewSessionStatus = "stopped" | "starting" | "installing" | "running" | "error";
+export type DevPreviewSessionStatus =
+  | "stopped"
+  | "starting"
+  | "installing"
+  | "running"
+  | "stopping"
+  | "error";
 
 export interface DevPreviewEnsureRequest {
   panelId: string;
@@ -33,6 +39,7 @@ export interface DevPreviewSessionState {
   isRestarting: boolean;
   generation: number;
   updatedAt: number;
+  forceKilled?: boolean;
 }
 
 export interface DevPreviewStateChangedPayload {

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -68,7 +68,7 @@ export type PtyHostRequest =
   | { type: "broadcast-write"; ids: string[]; data: string }
   | { type: "submit"; id: string; text: string }
   | { type: "batch-double-escape"; ids: string[] }
-  | { type: "kill"; id: string; reason?: string }
+  | { type: "kill"; id: string; reason?: string; escalationDelayMs?: number }
   | { type: "trash"; id: string }
   | { type: "restore"; id: string }
   | { type: "set-activity-tier"; id: string; tier: PtyHostActivityTier }

--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useState, useCallback, useEffect } from "react";
-import { ChevronUp, RotateCw } from "lucide-react";
+import { ChevronUp, RotateCw, CircleStop } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -16,6 +16,7 @@ interface ConsoleDrawerProps {
   defaultOpen?: boolean;
   isRestarting?: boolean;
   onHardRestart?: () => void;
+  onStop?: () => void;
 }
 
 const STATUS_LABEL: Record<
@@ -42,6 +43,11 @@ const STATUS_LABEL: Record<
     textClass: "text-server-running",
     dotClass: "bg-server-running",
   },
+  stopping: {
+    label: "Stopping",
+    textClass: "text-server-starting",
+    dotClass: "bg-server-starting",
+  },
   error: {
     label: "Error",
     textClass: "text-server-error",
@@ -57,6 +63,7 @@ export function ConsoleDrawer({
   defaultOpen = false,
   isRestarting = false,
   onHardRestart,
+  onStop,
 }: ConsoleDrawerProps) {
   const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(defaultOpen);
   const isOpen = controlledIsOpen ?? uncontrolledIsOpen;
@@ -86,9 +93,16 @@ export function ConsoleDrawer({
     status === "installing"
       ? "Hard restart dev preview (may interrupt installation)"
       : "Hard restart dev preview";
+  const stopVisible =
+    onStop &&
+    (status === "starting" ||
+      status === "installing" ||
+      status === "running" ||
+      status === "stopping");
+  const stopDisabled = isRestarting || status === "stopping";
   const statusClass = cn(
     "inline-flex min-h-8 items-center px-3 text-[10px] font-semibold uppercase tracking-wide",
-    onHardRestart && "border-r border-overlay/70",
+    (onHardRestart || stopVisible) && "border-r border-overlay/70",
     statusLabel.textClass
   );
 
@@ -114,6 +128,29 @@ export function ConsoleDrawer({
           <span className={cn("mr-2 h-1.5 w-1.5 shrink-0 rounded-full", statusLabel.dotClass)} />
           {statusLabel.label}
         </div>
+
+        {stopVisible && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <button
+                  type="button"
+                  onClick={onStop}
+                  disabled={stopDisabled}
+                  className={cn(
+                    "p-1.5 rounded hover:bg-overlay-medium disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors",
+                    status === "stopping" && "animate-pulse-immediate"
+                  )}
+                  aria-label="Stop dev server"
+                  aria-busy={status === "stopping"}
+                >
+                  <CircleStop className="h-3.5 w-3.5" />
+                </button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Stop dev server</TooltipContent>
+          </Tooltip>
+        )}
 
         {onHardRestart && (
           <Tooltip>

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -7,6 +7,7 @@ import {
   Settings,
   Square,
   WandSparkles,
+  OctagonAlert,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
@@ -26,6 +27,7 @@ import {
 } from "../Browser/historyUtils";
 import { useDevServer, type UseDevServerReturn } from "@/hooks/useDevServer";
 import { ConsoleDrawer } from "./ConsoleDrawer";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
 import { computeDevServerUrl } from "./urlSync";
@@ -308,7 +310,18 @@ export function DevPreviewPane({
     terminal?.devCommand?.trim() || projectSettings?.devServerCommand?.trim() || "";
   const viewportPreset = terminal?.viewportPreset;
 
-  const { status, url, terminalId, error, start, restart, isRestarting, stuckTier } = useDevServer({
+  const {
+    status,
+    url,
+    terminalId,
+    error,
+    start,
+    stop,
+    restart,
+    isRestarting,
+    stuckTier,
+    forceKilled,
+  } = useDevServer({
     panelId: id,
     devCommand,
     cwd,
@@ -323,6 +336,14 @@ export function DevPreviewPane({
     const panelToken = sanitizePartitionToken(id);
     return `persist:dev-preview-${projectToken}-${worktreeToken}-${panelToken}`;
   }, [currentProjectId, worktreeId, id]);
+
+  const [forceKillBannerDismissed, setForceKillBannerDismissed] = useState(false);
+
+  useEffect(() => {
+    if (forceKilled) {
+      setForceKillBannerDismissed(false);
+    }
+  }, [forceKilled]);
 
   const [history, setHistory] = useState<BrowserHistory>(() => {
     const saved = terminal?.browserHistory;
@@ -1202,6 +1223,16 @@ export function DevPreviewPane({
           )}
         </div>
 
+        {forceKilled && status === "stopped" && !forceKillBannerDismissed && (
+          <InlineStatusBanner
+            icon={OctagonAlert}
+            title="Dev server was force-quit"
+            description="The server did not exit within 5 seconds and was terminated."
+            severity="warning"
+            onClose={() => setForceKillBannerDismissed(true)}
+            actions={[]}
+          />
+        )}
         {consoleTerminalId && (
           <ConsoleDrawer
             terminalId={consoleTerminalId}
@@ -1210,6 +1241,7 @@ export function DevPreviewPane({
             onOpenChange={(nextOpen) => setDevPreviewConsoleOpen(id, nextOpen)}
             isRestarting={isRestarting}
             onHardRestart={handleHardRestart}
+            onStop={stop}
           />
         )}
       </div>

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -27,7 +27,6 @@ import {
 } from "../Browser/historyUtils";
 import { useDevServer, type UseDevServerReturn } from "@/hooks/useDevServer";
 import { ConsoleDrawer } from "./ConsoleDrawer";
-import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
 import { computeDevServerUrl } from "./urlSync";

--- a/src/components/DevPreview/__tests__/DevPreviewPane.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.test.tsx
@@ -79,6 +79,7 @@ const statusConfig: Record<DevPreviewStatus, { label: string; color: string }> =
   starting: { label: "Starting", color: "text-blue-400" },
   installing: { label: "Installing", color: "text-yellow-400" },
   running: { label: "Running", color: "text-green-400" },
+  stopping: { label: "Stopping", color: "text-blue-400" },
   error: { label: "Error", color: "text-red-400" },
   stopped: { label: "Stopped", color: "text-gray-400" },
 };

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -5,7 +5,13 @@ import type { DevPreviewSessionState } from "../../shared/types/ipc/devPreview";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 
-export type DevPreviewStatus = "stopped" | "starting" | "installing" | "running" | "error";
+export type DevPreviewStatus =
+  | "stopped"
+  | "starting"
+  | "installing"
+  | "running"
+  | "stopping"
+  | "error";
 
 export interface UseDevServerOptions {
   panelId: string;
@@ -34,6 +40,7 @@ export interface UseDevServerReturn extends UseDevServerState {
    * Resets to 0 whenever status leaves `starting`.
    */
   stuckTier: DevServerStuckTier;
+  forceKilled?: boolean;
 }
 
 /**
@@ -107,6 +114,7 @@ export function useDevServer({
   } | null>(null);
   const [isRestarting, setIsRestarting] = useState(false);
   const [stuckTier, setStuckTier] = useState<DevServerStuckTier>(0);
+  const [forceKilled, setForceKilled] = useState<boolean | undefined>(undefined);
   const latestSessionRef = useRef<{
     status: DevPreviewStatus;
     url: string | null;
@@ -185,6 +193,7 @@ export function useDevServer({
         : null
     );
     setIsRestarting(state.isRestarting);
+    setForceKilled(state.forceKilled);
   }, []);
 
   const applyInvokeError = useCallback((err: unknown) => {
@@ -503,5 +512,6 @@ export function useDevServer({
     restart,
     isRestarting,
     stuckTier,
+    forceKilled,
   };
 }

--- a/src/services/actions/definitions/devServerActions.ts
+++ b/src/services/actions/definitions/devServerActions.ts
@@ -77,4 +77,29 @@ export function registerDevServerActions(
       await window.electron.devPreview.restart({ panelId, projectId });
     },
   }));
+
+  actions.set("devPreview.stop", () => ({
+    id: "devPreview.stop",
+    title: "Stop Dev Server",
+    description: "Stop the currently focused dev preview server",
+    category: "devServer",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async (_args: unknown, ctx: ActionContext) => {
+      if (!ctx.projectId) {
+        throw new Error("No project is currently open");
+      }
+
+      const panelId = ctx.focusedTerminalId;
+      if (!panelId) {
+        throw new Error("No dev preview panel is focused");
+      }
+
+      await window.electron.devPreview.stop({
+        panelId,
+        projectId: ctx.projectId,
+      });
+    },
+  }));
 }


### PR DESCRIPTION
## Summary
- Adds an explicit Stop button to the dev preview console drawer. Clicking sends SIGTERM first, waits 5 seconds, then escalates to SIGKILL if the server hasn't exited.
- Surfaces "stopping" status inline so the user knows termination is in progress, and shows a force-kill banner when escalation fires.
- Adds `devPreview.stop` action ID and definition, plus the audit table row for dev preview lifecycle.

Resolves #8277

## Changes
- `ConsoleDrawer.tsx` -- Stop button on drawer header; "stopping" status pill; force-kill escalation banner
- `DevPreviewSessionService.ts` -- 5s SIGTERM grace period with SIGKILL escalation in `stop()`
- `ProcessTreeKiller.ts`, `TerminalProcess.ts`, `PtyManager.ts`, `PtyClient.ts` -- configurable `escalationDelayMs` threaded through the kill chain
- `useDevServer.ts` -- "stopping" status wiring
- `devServerActions.ts` -- `devPreview.stop` action definition
- `actionIds.ts` -- new action ID
- `destructive-action-safeguards.md` -- audit row for dev preview lifecycle

## Testing
Manually verified the stop/grace/force-kill flow with a dev server that ignores SIGTERM. Confirmed the drawer updates reactively through each phase.