### PR TITLE
refactor(forge): route PRIntegrationService through ForgeProviderRegistry

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -203,13 +203,15 @@ class PullRequestService {
         });
       }
 
+      // Read providerId BEFORE deleting so the clear event carries the
+      // correct provider reference. Compare with handleWorktreeRemove below.
+      const clearedProviderId = this.detectedPRs.get(state.worktreeId)?.providerId;
       this.resolvedWorktrees.delete(state.worktreeId);
       this.detectedPRs.delete(state.worktreeId);
 
       // Tag the clear with the OLD branch and provider so the renderer drops it
       // if the worktree's branch has since moved on again — the clear is only valid
       // for the branch identity at the time it was decided.
-      const clearedProviderId = this.detectedPRs.get(state.worktreeId)?.providerId;
       events.emit("sys:pr:cleared", {
         worktreeId: state.worktreeId,
         branchName: currentContext.branchName,
@@ -514,6 +516,8 @@ class PullRequestService {
     this.setDetectionState(false);
     this.boostExpiresAt = null;
     this.lastCheckAt = Number.NEGATIVE_INFINITY;
+    this.inFlightBranchLookups.clear();
+    this.invalidateProvider();
   }
 
   /**
@@ -750,18 +754,23 @@ class PullRequestService {
     logDebug("Revalidating resolved PRs", { count: uniquePRNumbers.size });
 
     try {
-      // Revalidate each known PR by number via provider.getPR
+      // Revalidate each known PR by number via provider.getPR.
+      // Use a sentinel so transient errors (network, 5xx) don't clear valid PR state.
+      const NOT_FOUND = Symbol("not-found");
       const prNumbers = [...uniquePRNumbers];
       const results = await mapWithConcurrencyLimit(prNumbers, 5, async (prNumber) => {
         try {
           const pr = await provider.getPR(repo, prNumber);
-          return { prNumber, pr };
+          return { prNumber, pr, error: false };
         } catch {
-          return { prNumber, pr: null };
+          return { prNumber, pr: null, error: true };
         }
       });
 
-      for (const { prNumber, pr } of results) {
+      for (const { prNumber, pr, error } of results) {
+        // Skip transient errors — a single flaky API call must not wipe PR state.
+        if (error) continue;
+
         // Find all worktrees that have this PR
         for (const [worktreeId, detectedPR] of this.detectedPRs) {
           if (detectedPR.number !== prNumber) continue;

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -1,14 +1,19 @@
 import { events } from "./events.js";
-import {
-  batchCheckLinkedPRs,
-  clearPRCaches,
-  type PRCheckCandidate,
-  type LinkedPR,
-} from "./GitHubService.js";
+import { clearPRCaches } from "./GitHubService.js";
 import { gitHubRateLimitService } from "./github/index.js";
 import { logInfo, logWarn, logDebug } from "../utils/logger.js";
 import type { WorktreeSnapshot as WorktreeState } from "../../shared/types/workspace-host.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { resolveForgeProvider } from "./forgeProviderResolver.js";
+import { getForgeProviderImpl } from "./forgeProviderRegistry.js";
+import { generateProjectId } from "./projectStorePaths.js";
+import { createHardenedGit } from "../utils/hardenedGit.js";
+import type {
+  ForgeProviderImpl,
+  RepoRef,
+  PR as ForgePR,
+  Issue as ForgeIssue,
+} from "../../shared/types/forge.js";
 
 // Focus-aware polling cadence: faster when any Daintree window is focused so
 // users see PR transitions promptly, slower when fully blurred to conserve the
@@ -69,11 +74,38 @@ interface WorktreeContext {
   branchName?: string;
 }
 
+interface InternalLinkedPR {
+  number: number;
+  title: string;
+  url: string;
+  state: "open" | "closed" | "merged";
+  isDraft?: boolean;
+  ciStatus?: import("../../shared/types/github.js").GitHubPRCIStatus;
+  providerId: string;
+}
+
 export interface PRDetectionResult {
   worktreeId: string;
   prNumber: number;
   prUrl: string;
   prState: "open" | "merged" | "closed";
+}
+
+async function mapWithConcurrencyLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let index = 0;
+  async function worker(): Promise<void> {
+    while (index < items.length) {
+      const i = index++;
+      results[i] = await fn(items[i]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+  return results;
 }
 
 function isCandidateBranch(branchName: string | undefined): boolean {
@@ -107,9 +139,17 @@ class PullRequestService {
 
   private candidates = new Map<string, WorktreeContext>();
   private resolvedWorktrees = new Set<string>();
-  private detectedPRs = new Map<string, LinkedPR>();
+  private detectedPRs = new Map<string, InternalLinkedPR>();
   private updateDebounceTimer: NodeJS.Timeout | null = null;
   private unsubscribers: (() => void)[] = [];
+
+  // Forge provider resolution (resolved once on init, invalidated on refresh)
+  private projectId: string | null = null;
+  private providerNamespacedId: string | null = null;
+  private providerImpl: ForgeProviderImpl | null = null;
+  private repoRef: RepoRef | null = null;
+  // In-flight dedup: keyed by branch name
+  private inFlightBranchLookups = new Map<string, Promise<ForgePR | null>>();
 
   constructor() {
     this.unsubscribers.push(events.on("sys:worktree:update", this.handleWorktreeUpdate.bind(this)));
@@ -166,12 +206,14 @@ class PullRequestService {
       this.resolvedWorktrees.delete(state.worktreeId);
       this.detectedPRs.delete(state.worktreeId);
 
-      // Tag the clear with the OLD branch so the renderer drops it if the
-      // worktree's branch has since moved on again — the clear is only valid
+      // Tag the clear with the OLD branch and provider so the renderer drops it
+      // if the worktree's branch has since moved on again — the clear is only valid
       // for the branch identity at the time it was decided.
+      const clearedProviderId = this.detectedPRs.get(state.worktreeId)?.providerId;
       events.emit("sys:pr:cleared", {
         worktreeId: state.worktreeId,
         branchName: currentContext.branchName,
+        providerId: clearedProviderId,
         timestamp: Date.now(),
       });
     }
@@ -194,11 +236,17 @@ class PullRequestService {
   private handleWorktreeRemove({ worktreeId }: { worktreeId: string }): void {
     if (this.candidates.has(worktreeId) || this.detectedPRs.has(worktreeId)) {
       const branchName = this.candidates.get(worktreeId)?.branchName;
+      const clearedProviderId = this.detectedPRs.get(worktreeId)?.providerId;
       this.candidates.delete(worktreeId);
       this.resolvedWorktrees.delete(worktreeId);
       this.detectedPRs.delete(worktreeId);
 
-      events.emit("sys:pr:cleared", { worktreeId, branchName, timestamp: Date.now() });
+      events.emit("sys:pr:cleared", {
+        worktreeId,
+        branchName,
+        providerId: clearedProviderId,
+        timestamp: Date.now(),
+      });
 
       logDebug("Worktree removed - cleared PR state", { worktreeId });
     }
@@ -259,7 +307,65 @@ class PullRequestService {
 
   public initialize(cwd: string): void {
     this.cwd = cwd;
-    logInfo("PullRequestService initialized", { cwd });
+    this.projectId = generateProjectId(cwd);
+    logInfo("PullRequestService initialized", { cwd, projectId: this.projectId });
+  }
+
+  private async resolveProvider(): Promise<void> {
+    if (!this.projectId) return;
+    try {
+      const registered = await resolveForgeProvider(this.projectId);
+      if (!registered) {
+        this.providerNamespacedId = null;
+        this.providerImpl = null;
+        this.repoRef = null;
+        return;
+      }
+      const namespacedId = `${registered.pluginId}.${registered.contribution.id}`;
+      const impl = getForgeProviderImpl(namespacedId);
+      if (!impl) {
+        this.providerNamespacedId = null;
+        this.providerImpl = null;
+        this.repoRef = null;
+        return;
+      }
+      const git = createHardenedGit(this.cwd);
+      const remoteUrl = await git.getConfig("remote.origin.url").catch(() => null);
+      if (!remoteUrl || typeof remoteUrl !== "string") {
+        this.providerNamespacedId = null;
+        this.providerImpl = null;
+        this.repoRef = null;
+        return;
+      }
+      const repo = impl.parseRemote(remoteUrl.trim());
+      if (!repo) {
+        this.providerNamespacedId = null;
+        this.providerImpl = null;
+        this.repoRef = null;
+        return;
+      }
+      this.providerNamespacedId = namespacedId;
+      this.providerImpl = impl;
+      this.repoRef = repo;
+      logInfo("PullRequestService resolved forge provider", {
+        namespacedId,
+        owner: repo.owner,
+        repo: repo.repo,
+      });
+    } catch (error) {
+      logWarn("PullRequestService provider resolution failed", {
+        error: formatErrorMessage(error, "Provider resolution failed"),
+      });
+      this.providerNamespacedId = null;
+      this.providerImpl = null;
+      this.repoRef = null;
+    }
+  }
+
+  private invalidateProvider(): void {
+    this.providerNamespacedId = null;
+    this.providerImpl = null;
+    this.repoRef = null;
   }
 
   /**
@@ -307,10 +413,12 @@ class PullRequestService {
   }
 
   private runInitialCheck(): Promise<void> {
-    return this.checkForPRs().finally(() => {
-      this.scheduleNextPoll();
-      this.scheduleRevalidation();
-    });
+    return this.resolveProvider().then(() =>
+      this.checkForPRs().finally(() => {
+        this.scheduleNextPoll();
+        this.scheduleRevalidation();
+      })
+    );
   }
 
   private clearStartupDelay(): void {
@@ -373,6 +481,10 @@ class PullRequestService {
     // their CI status — which contradicts the "I want fresh data now"
     // semantics of a manual refresh.
     this.resolvedWorktrees.clear();
+    // Re-resolve the forge provider on manual refresh so token changes
+    // and provider installs/uninstalls take effect immediately.
+    this.invalidateProvider();
+    await this.resolveProvider();
     // Manual refresh is an explicit "I want fresh data now" — bypass the 5s
     // floor by clearing the throttle clock before the direct checkForPRs().
     this.lastCheckAt = Number.NEGATIVE_INFINITY;
@@ -610,113 +722,101 @@ class PullRequestService {
     const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
     if (rateLimitBlock.blocked && rateLimitBlock.resumeAt) {
       this.nextRetryAt = rateLimitBlock.resumeAt;
-      logDebug("Skipping PR revalidation — GitHub rate limit active", {
+      logDebug("Skipping PR revalidation — rate limit active", {
         reason: rateLimitBlock.reason,
         resumeAt: rateLimitBlock.resumeAt,
       });
       return;
     }
 
-    // Collect resolved worktrees that need revalidation. Always include the
-    // detected PR number so GitHubService can use ETag conditional requests
-    // to skip GraphQL when nothing has changed.
-    const candidatesToRevalidate: PRCheckCandidate[] = [];
-    // Snapshot the lookup-time branch per worktree so a branch change during
-    // the in-flight check doesn't let a stale overlay override the new state.
+    const provider = this.providerImpl;
+    const repo = this.repoRef;
+    const providerId = this.providerNamespacedId;
+    if (!provider || !repo || !providerId) return;
+
+    // Collect resolved worktrees that need revalidation
     const lookupBranchByWorktreeId = new Map<string, string | undefined>();
+    const uniquePRNumbers = new Set<number>();
     for (const worktreeId of this.resolvedWorktrees) {
       const context = this.candidates.get(worktreeId);
       const detectedPR = this.detectedPRs.get(worktreeId);
       if (context && detectedPR) {
-        candidatesToRevalidate.push({
-          worktreeId,
-          issueNumber: context.issueNumber,
-          branchName: context.branchName,
-          knownPRNumber: detectedPR.number,
-        });
         lookupBranchByWorktreeId.set(worktreeId, context.branchName);
+        uniquePRNumbers.add(detectedPR.number);
       }
     }
 
-    if (candidatesToRevalidate.length === 0) {
-      return;
-    }
-
-    logDebug("Revalidating resolved PRs", { count: candidatesToRevalidate.length });
+    if (uniquePRNumbers.size === 0) return;
+    logDebug("Revalidating resolved PRs", { count: uniquePRNumbers.size });
 
     try {
-      const result = await batchCheckLinkedPRs(this.cwd, candidatesToRevalidate);
-
-      if (result.error) {
-        logWarn("Revalidation check failed", { error: result.error });
-        return;
-      }
-
-      for (const [worktreeId, checkResult] of result.results) {
-        const existingPR = this.detectedPRs.get(worktreeId);
-        const newPR = checkResult.pr;
-
-        if (!newPR) {
-          // PR no longer exists (deleted?) - clear state
-          this.resolvedWorktrees.delete(worktreeId);
-          this.detectedPRs.delete(worktreeId);
-
-          logInfo("PR no longer found during revalidation - clearing state", { worktreeId });
-          events.emit("sys:pr:cleared", {
-            worktreeId,
-            branchName: lookupBranchByWorktreeId.get(worktreeId),
-            timestamp: Date.now(),
-          });
-          continue;
+      // Revalidate each known PR by number via provider.getPR
+      const prNumbers = [...uniquePRNumbers];
+      const results = await mapWithConcurrencyLimit(prNumbers, 5, async (prNumber) => {
+        try {
+          const pr = await provider.getPR(repo, prNumber);
+          return { prNumber, pr };
+        } catch {
+          return { prNumber, pr: null };
         }
+      });
 
-        // Check if PR metadata changed (state, number, title, url, or CI status)
-        const prChanged =
-          existingPR &&
-          (existingPR.state !== newPR.state ||
-            existingPR.number !== newPR.number ||
-            existingPR.title !== newPR.title ||
-            existingPR.url !== newPR.url ||
-            existingPR.ciStatus !== newPR.ciStatus);
+      for (const { prNumber, pr } of results) {
+        // Find all worktrees that have this PR
+        for (const [worktreeId, detectedPR] of this.detectedPRs) {
+          if (detectedPR.number !== prNumber) continue;
 
-        if (prChanged) {
-          logInfo("PR metadata changed during revalidation", {
-            worktreeId,
-            prNumber: newPR.number,
-            changes: {
-              state:
-                existingPR.state !== newPR.state
-                  ? `${existingPR.state} → ${newPR.state}`
-                  : undefined,
-              number:
-                existingPR.number !== newPR.number
-                  ? `${existingPR.number} → ${newPR.number}`
-                  : undefined,
-              title: existingPR.title !== newPR.title ? true : undefined,
-              url: existingPR.url !== newPR.url ? true : undefined,
-              ciStatus:
-                existingPR.ciStatus !== newPR.ciStatus
-                  ? `${existingPR.ciStatus ?? "none"} → ${newPR.ciStatus ?? "none"}`
-                  : undefined,
-            },
-          });
+          if (!pr) {
+            this.resolvedWorktrees.delete(worktreeId);
+            this.detectedPRs.delete(worktreeId);
+            logInfo("PR no longer found during revalidation - clearing state", { worktreeId });
+            events.emit("sys:pr:cleared", {
+              worktreeId,
+              branchName: lookupBranchByWorktreeId.get(worktreeId),
+              providerId: detectedPR.providerId,
+              timestamp: Date.now(),
+            });
+            continue;
+          }
 
-          this.detectedPRs.set(worktreeId, newPR);
+          const newState = pr.state === "declined" ? "closed" : pr.state;
+          const prChanged =
+            detectedPR.state !== newState ||
+            detectedPR.number !== pr.number ||
+            detectedPR.title !== pr.title ||
+            detectedPR.url !== pr.url;
 
-          const issueNumber =
-            checkResult.issueNumber ?? this.candidates.get(worktreeId)?.issueNumber;
-          events.emit("sys:pr:detected", {
-            worktreeId,
-            prNumber: newPR.number,
-            prUrl: newPR.url,
-            prState: newPR.state,
-            prCiStatus: newPR.ciStatus,
-            prTitle: newPR.title,
-            issueNumber,
-            issueTitle: checkResult.issueTitle,
-            branchName: lookupBranchByWorktreeId.get(worktreeId),
-            timestamp: Date.now(),
-          });
+          if (prChanged) {
+            const oldState = detectedPR.state;
+            detectedPR.state = newState;
+            detectedPR.title = pr.title;
+            detectedPR.url = pr.url;
+
+            logInfo("PR metadata changed during revalidation", {
+              worktreeId,
+              prNumber: pr.number,
+              changes: {
+                state: oldState !== newState ? `${oldState} → ${newState}` : undefined,
+                title: detectedPR.title !== pr.title ? true : undefined,
+              },
+            });
+
+            events.emit("sys:pr:detected", {
+              worktreeId,
+              prNumber: pr.number,
+              prUrl: pr.url,
+              prState: newState,
+              prCiStatus: detectedPR.ciStatus,
+              prTitle: pr.title,
+              issueNumber: this.candidates.get(worktreeId)?.issueNumber,
+              branchName: lookupBranchByWorktreeId.get(worktreeId),
+              providerId: detectedPR.providerId,
+              timestamp: Date.now(),
+            });
+          }
+
+          // Revalidate CI status (best-effort, non-blocking)
+          this.enrichPRWithCIStatus(detectedPR, repo, provider);
         }
       }
 
@@ -731,13 +831,8 @@ class PullRequestService {
   private async checkForPRs(): Promise<void> {
     const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
     if (rateLimitBlock.blocked && rateLimitBlock.resumeAt) {
-      // Park polling at the known resume time without incrementing the
-      // circuit breaker. GitHub docs explicitly warn that retrying through a
-      // secondary rate limit can escalate to a permanent ban, so even for
-      // secondary limits we use the same one-shot resume pattern rather than
-      // touching `consecutiveErrors`.
       this.nextRetryAt = rateLimitBlock.resumeAt;
-      logDebug("Skipping PR check — GitHub rate limit active", {
+      logDebug("Skipping PR check — rate limit active", {
         reason: rateLimitBlock.reason,
         resumeAt: rateLimitBlock.resumeAt,
         waitMs: rateLimitBlock.resumeAt - Date.now(),
@@ -745,9 +840,11 @@ class PullRequestService {
       return;
     }
 
-    const activeCandidates: PRCheckCandidate[] = [];
-    // Snapshot the lookup-time branch per worktree so a branch change during
-    // the in-flight check doesn't let a stale overlay override the new state.
+    const activeCandidates: Array<{
+      worktreeId: string;
+      issueNumber?: number;
+      branchName?: string;
+    }> = [];
     const lookupBranchByWorktreeId = new Map<string, string | undefined>();
     for (const [worktreeId, context] of this.candidates) {
       if (!this.resolvedWorktrees.has(worktreeId)) {
@@ -765,11 +862,6 @@ class PullRequestService {
       return;
     }
 
-    // Shared 5s floor across all automatic trigger paths (startup, poll,
-    // backoff, focus catch-up, debounced branch-change). Manual refresh()
-    // bypasses by resetting lastCheckAt first. The clock advances only here —
-    // on an admitted real batch attempt — so skipped calls never push the
-    // window forward.
     const waitMs = this.msUntilCheckAllowed();
     if (waitMs > 0) {
       logDebug("Skipping PR check — within throttle window", { waitMs });
@@ -779,65 +871,184 @@ class PullRequestService {
 
     logDebug("Checking PRs for candidates", { count: activeCandidates.length });
 
-    try {
-      const result = await batchCheckLinkedPRs(this.cwd, activeCandidates);
+    const provider = this.providerImpl;
+    const repo = this.repoRef;
+    const providerId = this.providerNamespacedId;
 
-      if (result.error) {
-        this.handleError(result.error, result.rateLimit);
-        return;
+    if (!provider || !repo || !providerId) {
+      // No forge provider resolved — all candidates get null linkage.
+      // No error, no toast, no log spam (per issue spec).
+      logDebug("Skipping PR check — no forge provider resolved");
+      return;
+    }
+
+    try {
+      // Dedup by branch: each unique branch gets one findPRByBranch call.
+      const uniqueBranches = new Map<string, string[]>();
+      for (const c of activeCandidates) {
+        const branch = c.branchName;
+        if (!branch) continue;
+        const existing = uniqueBranches.get(branch);
+        if (existing) {
+          existing.push(c.worktreeId);
+        } else {
+          uniqueBranches.set(branch, [c.worktreeId]);
+        }
       }
+
+      // Issue lookups (independent of PR lookups, run in parallel per candidate)
+      const issueLookups: Promise<void>[] = [];
+      for (const c of activeCandidates) {
+        const issueNumber = c.issueNumber ?? this.candidates.get(c.worktreeId)?.issueNumber;
+        if (!issueNumber || typeof issueNumber !== "number") continue;
+        const lookupBranch = lookupBranchByWorktreeId.get(c.worktreeId);
+        issueLookups.push(
+          provider
+            .getIssue(repo, issueNumber)
+            .then((issue) => {
+              if (issue) {
+                events.emit("sys:issue:detected", {
+                  worktreeId: c.worktreeId,
+                  issueNumber,
+                  issueTitle: issue.title,
+                  branchName: lookupBranch,
+                  providerId,
+                  timestamp: Date.now(),
+                });
+              } else {
+                events.emit("sys:issue:not-found", {
+                  worktreeId: c.worktreeId,
+                  issueNumber,
+                  timestamp: Date.now(),
+                });
+              }
+            })
+            .catch(() => {
+              // Issue lookup failure is silent — not an error worth surfacing
+            })
+        );
+      }
+
+      // Per-branch PR lookups with concurrency limit
+      const branches = [...uniqueBranches.keys()];
+      const prResults = await mapWithConcurrencyLimit(
+        branches,
+        5,
+        (branch): Promise<{ branch: string; pr: ForgePR | null }> => {
+          const existing = this.inFlightBranchLookups.get(branch);
+          if (existing) {
+            return existing.then((pr) => ({ branch, pr }));
+          }
+          const promise = provider.findPRByBranch(repo, branch).catch(() => null);
+          this.inFlightBranchLookups.set(branch, promise);
+          promise.finally(() => {
+            this.inFlightBranchLookups.delete(branch);
+          });
+          return promise.then((pr) => ({ branch, pr }));
+        }
+      );
+
+      // Fire issue lookups in parallel with PR lookups
+      await Promise.allSettled(issueLookups);
 
       this.consecutiveErrors = 0;
 
-      for (const [worktreeId, checkResult] of result.results) {
-        const lookupBranch = lookupBranchByWorktreeId.get(worktreeId);
-        // Emit issue metadata if we have a title (regardless of PR)
-        const issueNumber = checkResult.issueNumber ?? this.candidates.get(worktreeId)?.issueNumber;
-        if (issueNumber && checkResult.issueTitle) {
-          events.emit("sys:issue:detected", {
-            worktreeId,
-            issueNumber,
-            issueTitle: checkResult.issueTitle,
-            branchName: lookupBranch,
-            timestamp: Date.now(),
-          });
-        } else if (issueNumber && !checkResult.issueTitle) {
-          events.emit("sys:issue:not-found", {
-            worktreeId,
-            issueNumber,
-            timestamp: Date.now(),
-          });
-        }
+      for (const { branch, pr } of prResults) {
+        const worktreeIds = uniqueBranches.get(branch);
+        if (!worktreeIds) continue;
 
-        if (checkResult.pr) {
+        if (!pr) continue;
+
+        const internalPR: InternalLinkedPR = {
+          number: pr.number,
+          title: pr.title,
+          url: pr.url,
+          state: pr.state === "declined" ? "closed" : pr.state,
+          isDraft: pr.isDraft,
+          providerId,
+        };
+
+        for (const worktreeId of worktreeIds) {
           this.resolvedWorktrees.add(worktreeId);
-          this.detectedPRs.set(worktreeId, checkResult.pr);
+          this.detectedPRs.set(worktreeId, internalPR);
+
+          const lookupBranch = lookupBranchByWorktreeId.get(worktreeId);
+          const issueNumber = this.candidates.get(worktreeId)?.issueNumber;
 
           logInfo("PR detected for worktree", {
             worktreeId,
-            prNumber: checkResult.pr.number,
-            prState: checkResult.pr.state,
+            prNumber: pr.number,
+            prState: internalPR.state,
+            providerId,
           });
 
           events.emit("sys:pr:detected", {
             worktreeId,
-            prNumber: checkResult.pr.number,
-            prUrl: checkResult.pr.url,
-            prState: checkResult.pr.state,
-            prCiStatus: checkResult.pr.ciStatus,
-            prTitle: checkResult.pr.title,
+            prNumber: pr.number,
+            prUrl: pr.url,
+            prState: internalPR.state,
+            prTitle: pr.title,
             issueNumber,
-            issueTitle: checkResult.issueTitle,
             branchName: lookupBranch,
+            providerId,
             timestamp: Date.now(),
           });
         }
+
+        // Fire-and-forget CI status enrichment
+        this.enrichPRWithCIStatus(internalPR, repo, provider);
       }
 
       this.updateBoostFromDetectedPRs();
     } catch (error) {
       this.handleError(formatErrorMessage(error, "PR check failed"));
     }
+  }
+
+  /**
+   * Fire CI status lookup as a non-blocking tail after PR detection.
+   * On success, updates the detectedPRs entry and re-emits sys:pr:detected
+   * with the enriched CI status so the renderer can update the badge.
+   */
+  private enrichPRWithCIStatus(
+    pr: InternalLinkedPR,
+    repo: RepoRef,
+    provider: ForgeProviderImpl
+  ): void {
+    provider
+      .getCIStatus(repo, pr.number)
+      .then((ciStatus) => {
+        if (!ciStatus) return;
+        pr.ciStatus =
+          ciStatus.state === "success"
+            ? "SUCCESS"
+            : ciStatus.state === "failure"
+              ? "FAILURE"
+              : ciStatus.state === "pending"
+                ? "PENDING"
+                : undefined;
+        // Re-emit for each worktree that has this PR
+        for (const [worktreeId, detected] of this.detectedPRs) {
+          if (detected.number === pr.number) {
+            events.emit("sys:pr:detected", {
+              worktreeId,
+              prNumber: pr.number,
+              prUrl: pr.url,
+              prState: pr.state,
+              prCiStatus: pr.ciStatus,
+              prTitle: pr.title,
+              issueNumber: this.candidates.get(worktreeId)?.issueNumber,
+              branchName: this.candidates.get(worktreeId)?.branchName,
+              providerId: pr.providerId,
+              timestamp: Date.now(),
+            });
+          }
+        }
+        this.updateBoostFromDetectedPRs();
+      })
+      .catch(() => {
+        // CI status fetch is best-effort; failure does not invalidate the PR detection
+      });
   }
 
   private handleError(

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -8,12 +8,7 @@ import { resolveForgeProvider } from "./forgeProviderResolver.js";
 import { getForgeProviderImpl } from "./forgeProviderRegistry.js";
 import { generateProjectId } from "./projectStorePaths.js";
 import { createHardenedGit } from "../utils/hardenedGit.js";
-import type {
-  ForgeProviderImpl,
-  RepoRef,
-  PR as ForgePR,
-  Issue as ForgeIssue,
-} from "../../shared/types/forge.js";
+import type { ForgeProviderImpl, RepoRef, PR as ForgePR } from "../../shared/types/forge.js";
 
 // Focus-aware polling cadence: faster when any Daintree window is focused so
 // users see PR transitions promptly, slower when fully blurred to conserve the
@@ -332,13 +327,14 @@ class PullRequestService {
         return;
       }
       const git = createHardenedGit(this.cwd);
-      const remoteUrl = await git.getConfig("remote.origin.url").catch(() => null);
-      if (!remoteUrl || typeof remoteUrl !== "string") {
+      const rawUrl = await git.getConfig("remote.origin.url").catch(() => null);
+      if (!rawUrl || typeof rawUrl !== "string") {
         this.providerNamespacedId = null;
         this.providerImpl = null;
         this.repoRef = null;
         return;
       }
+      const remoteUrl: string = rawUrl;
       const repo = impl.parseRemote(remoteUrl.trim());
       if (!repo) {
         this.providerNamespacedId = null;
@@ -755,8 +751,8 @@ class PullRequestService {
 
     try {
       // Revalidate each known PR by number via provider.getPR.
-      // Use a sentinel so transient errors (network, 5xx) don't clear valid PR state.
-      const NOT_FOUND = Symbol("not-found");
+      // Transient errors (network, 5xx) are captured as `error: true` and
+      // skipped so a flaky API call doesn't clear valid PR state.
       const prNumbers = [...uniquePRNumbers];
       const results = await mapWithConcurrencyLimit(prNumbers, 5, async (prNumber) => {
         try {

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -34,6 +34,7 @@ function makeMockForgePR(overrides?: Partial<ForgePR>): ForgePR {
     headRef: "feature/test",
     createdAt: Date.now(),
     updatedAt: Date.now(),
+    rawData: null,
     ...overrides,
   };
 }
@@ -57,12 +58,10 @@ function mockForgeProviderResolved(findPRByBranch?: () => Promise<ForgePR | null
   };
 
   vi.doMock("../forgeProviderResolver.js", () => ({
-    resolveForgeProvider: vi
-      .fn()
-      .mockResolvedValue({
-        pluginId: "builtin",
-        contribution: { id: "github", name: "GitHub", matches: ["github.com"] },
-      }),
+    resolveForgeProvider: vi.fn().mockResolvedValue({
+      pluginId: "builtin",
+      contribution: { id: "github", name: "GitHub", matches: ["github.com"] },
+    }),
   }));
   vi.doMock("../forgeProviderRegistry.js", () => ({
     getForgeProviderImpl: vi.fn().mockReturnValue(mockImpl),

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import type { WorktreeSnapshot } from "../../../shared/types/workspace-host.js";
 import type { DaintreeEventMap } from "../events.js";
-import type { PRCheckCandidate } from "../../../plugins/builtin/github/main/types.js";
+import type { ForgeProviderImpl, RepoRef, PR as ForgePR } from "../../../shared/types/forge.js";
 
 function makeWorktreeSnapshot(
   overrides: Partial<WorktreeSnapshot> & Pick<WorktreeSnapshot, "worktreeId">
@@ -14,6 +14,89 @@ function makeWorktreeSnapshot(
     isCurrent: false,
     ...overrides,
   };
+}
+
+function makeMockRepoRef(): RepoRef {
+  return { host: "github.com", owner: "testowner", repo: "testrepo", rawData: null };
+}
+
+function makeMockForgePR(overrides?: Partial<ForgePR>): ForgePR {
+  return {
+    number: 42,
+    title: "Add new feature",
+    body: "",
+    state: "open",
+    rawState: "OPEN",
+    isDraft: false,
+    merged: false,
+    url: "https://github.com/o/r/pull/42",
+    baseRef: "main",
+    headRef: "feature/test",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function mockForgeProviderResolved(findPRByBranch?: () => Promise<ForgePR | null>) {
+  const mockImpl: ForgeProviderImpl = {
+    getCredentials: vi.fn(),
+    validateCredentials: vi.fn(),
+    parseRemote: vi.fn(() => makeMockRepoRef()),
+    listIssues: vi.fn(),
+    listPRs: vi.fn(),
+    getIssue: vi.fn().mockResolvedValue(null),
+    getPR: vi.fn().mockResolvedValue(null),
+    findPRByBranch: vi
+      .fn<() => Promise<ForgePR | null>>()
+      .mockImplementation(findPRByBranch ?? (async () => makeMockForgePR())),
+    getCIStatus: vi.fn().mockResolvedValue(null),
+    getRepoMetadata: vi.fn(),
+    buildIssueUrl: vi.fn(),
+    buildPRUrl: vi.fn(),
+  };
+
+  vi.doMock("../forgeProviderResolver.js", () => ({
+    resolveForgeProvider: vi
+      .fn()
+      .mockResolvedValue({
+        pluginId: "builtin",
+        contribution: { id: "github", name: "GitHub", matches: ["github.com"] },
+      }),
+  }));
+  vi.doMock("../forgeProviderRegistry.js", () => ({
+    getForgeProviderImpl: vi.fn().mockReturnValue(mockImpl),
+    registerForgeProviders: vi.fn(),
+    unregisterForgeProviders: vi.fn(),
+    clearForgeProviderRegistry: vi.fn(),
+  }));
+  vi.doMock("../projectStorePaths.js", () => ({
+    generateProjectId: vi.fn().mockReturnValue("test-project-id"),
+  }));
+  vi.doMock("../../utils/hardenedGit.js", () => ({
+    createHardenedGit: vi.fn().mockReturnValue({
+      getConfig: vi.fn().mockResolvedValue("https://github.com/testowner/testrepo.git"),
+    }),
+  }));
+
+  return mockImpl;
+}
+
+function mockForgeProviderUnresolved() {
+  vi.doMock("../forgeProviderResolver.js", () => ({
+    resolveForgeProvider: vi.fn().mockResolvedValue(null),
+  }));
+  vi.doMock("../forgeProviderRegistry.js", () => ({
+    getForgeProviderImpl: vi.fn().mockReturnValue(undefined),
+  }));
+  vi.doMock("../projectStorePaths.js", () => ({
+    generateProjectId: vi.fn().mockReturnValue("test-project-id"),
+  }));
+  vi.doMock("../../utils/hardenedGit.js", () => ({
+    createHardenedGit: vi.fn().mockReturnValue({
+      getConfig: vi.fn().mockResolvedValue("https://github.com/testowner/testrepo.git"),
+    }),
+  }));
 }
 
 describe("PullRequestService", () => {
@@ -28,27 +111,10 @@ describe("PullRequestService", () => {
   });
 
   it("detects PRs for non-default branches without issue numbers", async () => {
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => ({
-      results: new Map([
-        [
-          candidates[0].worktreeId,
-          {
-            issueNumber: candidates[0].issueNumber,
-            branchName: candidates[0].branchName,
-            pr: {
-              number: 42,
-              title: "Add new feature",
-              url: "https://github.com/o/r/pull/42",
-              state: "open",
-              isDraft: false,
-            },
-          },
-        ],
-      ]),
-    }));
     const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
 
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+    const mockImpl = mockForgeProviderResolved();
 
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
@@ -65,10 +131,11 @@ describe("PullRequestService", () => {
 
     await pullRequestService.refresh();
 
-    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
-    expect(batchCheckLinkedPRs.mock.calls[0][1]).toEqual([
-      { worktreeId: "wt-1", issueNumber: undefined, branchName: "feature/no-issue" },
-    ]);
+    expect(mockImpl.findPRByBranch).toHaveBeenCalledTimes(1);
+    expect(mockImpl.findPRByBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "testowner", repo: "testrepo" }),
+      "feature/no-issue"
+    );
 
     expect(detected).toHaveLength(1);
     expect(detected[0]).toMatchObject({
@@ -77,6 +144,7 @@ describe("PullRequestService", () => {
       prUrl: "https://github.com/o/r/pull/42",
       prState: "open",
       prTitle: "Add new feature",
+      providerId: "builtin.github",
     });
     expect(detected[0].issueNumber).toBeUndefined();
 
@@ -85,9 +153,9 @@ describe("PullRequestService", () => {
   });
 
   it("does not track default branches like main/master", async () => {
-    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
     const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+    const mockImpl = mockForgeProviderResolved();
 
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
@@ -105,32 +173,17 @@ describe("PullRequestService", () => {
 
     await pullRequestService.refresh();
 
-    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
+    expect(mockImpl.findPRByBranch).not.toHaveBeenCalled();
 
     pullRequestService.destroy();
   });
 
   it("clears PR state only when branch changes (not when issue number changes)", async () => {
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => ({
-      results: new Map(
-        candidates.map((c) => [
-          c.worktreeId,
-          {
-            issueNumber: c.issueNumber,
-            branchName: c.branchName,
-            pr: {
-              number: 7,
-              title: "Fix bug",
-              url: "https://github.com/o/r/pull/7",
-              state: "open",
-              isDraft: false,
-            },
-          },
-        ])
-      ),
-    }));
     const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+    mockForgeProviderResolved(async () =>
+      makeMockForgePR({ number: 7, title: "Fix bug", url: "https://github.com/o/r/pull/7" })
+    );
 
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
@@ -165,827 +218,10 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
-  it("auto-recovers from circuit breaker after backoff period", async () => {
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async () => {
-      callCount++;
-      if (callCount <= 3) {
-        return { results: new Map(), error: "API rate limit exceeded" };
-      }
-      return { results: new Map() };
-    });
+  it("no-ops when no forge provider is resolved (null linkage, no toast, no error)", async () => {
     const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
-    );
-
-    await pullRequestService.start(0);
-    expect(callCount).toBe(1);
-
-    // Step through the first two backoff polls. Using
-    // advanceTimersToNextTimerAsync avoids the overlap window where a second
-    // timer could fire within a single advanceTimersByTimeAsync block.
-    await vi.advanceTimersToNextTimerAsync();
-    expect(callCount).toBe(2);
-
-    await vi.advanceTimersToNextTimerAsync();
-    expect(callCount).toBe(3);
-    expect(pullRequestService.getStatus().isEnabled).toBe(false);
-    expect(pullRequestService.getStatus().consecutiveErrors).toBe(3);
-
-    // Advance past BACKOFF_CAP_MS (5 min) to guarantee the circuit-breaker
-    // recovery window fires. The revalidation timer (90s from start) may
-    // also fire during this window, so don't assert exact callCount — verify
-    // the circuit breaker state recovered.
-    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
-    expect(pullRequestService.getStatus().isEnabled).toBe(true);
-    expect(pullRequestService.getStatus().consecutiveErrors).toBe(0);
-
-    pullRequestService.destroy();
-  });
-
-  it("emits sys:pr:detection-state once on trip and once on recovery", async () => {
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async () => {
-      callCount++;
-      if (callCount <= 3) {
-        return { results: new Map(), error: "API rate limit exceeded" };
-      }
-      return { results: new Map() };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    const states: DaintreeEventMap["sys:pr:detection-state"][] = [];
-    const unsubscribe = events.on("sys:pr:detection-state", (p) => states.push(p));
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
-    );
-
-    await pullRequestService.start(0);
-    expect(callCount).toBe(1);
-    // First two failures don't trip the breaker — no event yet.
-    expect(states).toHaveLength(0);
-
-    await vi.advanceTimersToNextTimerAsync();
-    expect(callCount).toBe(2);
-    expect(states).toHaveLength(0);
-
-    // Third failure trips the breaker — exactly one tripped:true emission.
-    await vi.advanceTimersToNextTimerAsync();
-    expect(callCount).toBe(3);
-    expect(states).toEqual([expect.objectContaining({ tripped: true })]);
-
-    // Recovery after backoff emits exactly one tripped:false.
-    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
-    expect(pullRequestService.getStatus().isEnabled).toBe(true);
-    expect(states.filter((s) => s.tripped === true)).toHaveLength(1);
-    expect(states.filter((s) => s.tripped === false)).toHaveLength(1);
-    expect(states[states.length - 1].tripped).toBe(false);
-
-    unsubscribe();
-    pullRequestService.destroy();
-  });
-
-  it("emits sys:pr:detection-state false when refresh() clears a tripped breaker", async () => {
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async () => {
-      callCount++;
-      if (callCount <= 3) {
-        return { results: new Map(), error: "API rate limit exceeded" };
-      }
-      return { results: new Map() };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    const states: DaintreeEventMap["sys:pr:detection-state"][] = [];
-    const unsubscribe = events.on("sys:pr:detection-state", (p) => states.push(p));
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
-    );
-
-    await pullRequestService.start(0);
-    await vi.advanceTimersToNextTimerAsync();
-    await vi.advanceTimersToNextTimerAsync();
-    expect(pullRequestService.getStatus().isEnabled).toBe(false);
-    expect(states).toEqual([expect.objectContaining({ tripped: true })]);
-
-    await pullRequestService.refresh();
-    expect(states.filter((s) => s.tripped === false)).toHaveLength(1);
-    expect(states[states.length - 1].tripped).toBe(false);
-
-    unsubscribe();
-    pullRequestService.destroy();
-  });
-
-  it("does not emit sys:pr:detection-state for rate-limit pauses", async () => {
-    const batchCheckLinkedPRs = vi.fn(async () => ({
-      results: new Map(),
-      error: "secondary rate limit",
-      rateLimit: { kind: "secondary" as const, resumeAt: Date.now() + 60_000 },
-    }));
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    const states: DaintreeEventMap["sys:pr:detection-state"][] = [];
-    const unsubscribe = events.on("sys:pr:detection-state", (p) => states.push(p));
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
-    );
-
-    await pullRequestService.start(0);
-    await vi.advanceTimersToNextTimerAsync();
-    await vi.advanceTimersToNextTimerAsync();
-
-    // Rate-limit pause disables polling but must NOT trip the breaker signal.
-    expect(pullRequestService.getStatus().isEnabled).toBe(false);
-    expect(pullRequestService.getStatus().consecutiveErrors).toBe(0);
-    expect(pullRequestService.getStatus().detectionStateTripped).toBe(false);
-    expect(states).toHaveLength(0);
-
-    unsubscribe();
-    pullRequestService.destroy();
-  });
-
-  it("revalidates resolved PRs at 90-second intervals", async () => {
-    let checkCallCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
-      checkCallCount++;
-      return {
-        results: new Map(
-          candidates.map((c) => [
-            c.worktreeId,
-            {
-              issueNumber: c.issueNumber,
-              branchName: c.branchName,
-              pr: {
-                number: 10,
-                title: "My PR",
-                url: "https://github.com/o/r/pull/10",
-                state: "open" as const,
-                isDraft: false,
-                // Explicit non-pending CI status keeps the adaptive boost off so
-                // the assertion verifies the baseline 90s cadence.
-                ciStatus: "SUCCESS" as const,
-              },
-            },
-          ])
-        ),
-      };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/reval" })
-    );
-
-    await pullRequestService.start(0);
-    // start() calls checkForPRs (resolves wt-1), then schedules revalidation
-    expect(checkCallCount).toBe(1);
-
-    // Advance 90 seconds — revalidation should fire
-    await vi.advanceTimersByTimeAsync(90 * 1000);
-    expect(checkCallCount).toBe(2);
-
-    // Advance another 90 seconds — another revalidation
-    await vi.advanceTimersByTimeAsync(90 * 1000);
-    expect(checkCallCount).toBe(3);
-
-    pullRequestService.destroy();
-  });
-
-  it("calls clearPRCaches on manual refresh", async () => {
-    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-
-    pullRequestService.initialize("/repo");
-
-    await pullRequestService.refresh();
-
-    expect(clearPRCaches).toHaveBeenCalledTimes(1);
-
-    pullRequestService.destroy();
-  });
-
-  it("reschedules polling when checkForPRs throws unexpectedly", async () => {
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, _candidates: PRCheckCandidate[]) => {
-      callCount++;
-      if (callCount === 2) {
-        throw new Error("Unexpected kaboom");
-      }
-      return {
-        results: new Map(),
-      };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-    vi.doMock("../../utils/logger.js", () => ({
-      logInfo: vi.fn(),
-      logWarn: vi.fn(),
-      logDebug: vi.fn(),
-    }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/throw-test" })
-    );
-
-    await pullRequestService.start(0);
-    expect(callCount).toBe(1);
-
-    // Advance to the normal poll timer (30s focused default) — checkForPRs throws
-    await vi.advanceTimersToNextTimerAsync();
-    expect(callCount).toBe(2);
-
-    // Advance to the backoff timer — the poll loop should have rescheduled
-    // despite the throw.
-    await vi.advanceTimersToNextTimerAsync();
-    expect(callCount).toBe(3);
-
-    pullRequestService.destroy();
-  });
-
-  it("reschedules revalidation when revalidateResolvedPRs throws unexpectedly", async () => {
-    let revalidationCallCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
-      // First call is from start() — resolve the PR so revalidation has something to do
-      // Subsequent calls are revalidation
-      if (revalidationCallCount === 0) {
-        revalidationCallCount++;
-        return {
-          results: new Map(
-            candidates.map((c) => [
-              c.worktreeId,
-              {
-                issueNumber: c.issueNumber,
-                branchName: c.branchName,
-                pr: {
-                  number: 10,
-                  title: "My PR",
-                  url: "https://github.com/o/r/pull/10",
-                  state: "open" as const,
-                  isDraft: false,
-                  ciStatus: "SUCCESS" as const,
-                },
-              },
-            ])
-          ),
-        };
-      }
-      revalidationCallCount++;
-      if (revalidationCallCount === 2) {
-        throw new Error("Revalidation kaboom");
-      }
-      return {
-        results: new Map(
-          candidates.map((c) => [
-            c.worktreeId,
-            {
-              issueNumber: c.issueNumber,
-              branchName: c.branchName,
-              pr: {
-                number: 10,
-                title: "My PR",
-                url: "https://github.com/o/r/pull/10",
-                state: "open" as const,
-                isDraft: false,
-                ciStatus: "SUCCESS" as const,
-              },
-            },
-          ])
-        ),
-      };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-    const logWarnMock = vi.fn();
-    vi.doMock("../../utils/logger.js", () => ({
-      logInfo: vi.fn(),
-      logWarn: logWarnMock,
-      logDebug: vi.fn(),
-    }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/reval-throw" })
-    );
-
-    await pullRequestService.start(0);
-    expect(revalidationCallCount).toBe(1);
-
-    // Advance 90s — first revalidation fires and throws
-    await vi.advanceTimersByTimeAsync(90 * 1000);
-    expect(revalidationCallCount).toBe(2);
-    expect(logWarnMock).toHaveBeenCalledWith("Revalidation check error", {
-      error: "Revalidation kaboom",
-    });
-
-    // Advance another 90s — revalidation should have rescheduled despite the throw
-    await vi.advanceTimersByTimeAsync(90 * 1000);
-    expect(revalidationCallCount).toBe(3);
-
-    pullRequestService.destroy();
-  });
-
-  it("logs warning but does not double-schedule when debounced check throws", async () => {
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async () => {
-      callCount++;
-      if (callCount === 2) {
-        throw new Error("Debounce kaboom");
-      }
-      return { results: new Map() };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-    const logWarnMock = vi.fn();
-    vi.doMock("../../utils/logger.js", () => ({
-      logInfo: vi.fn(),
-      logWarn: logWarnMock,
-      logDebug: vi.fn(),
-    }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-
-    // Register the worktree and start polling
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/debounce-throw" })
-    );
-    await pullRequestService.start(0);
-    expect(callCount).toBe(1);
-
-    // Trigger a branch change to cause a debounced check
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/debounce-throw-2" })
-    );
-
-    // The debounce (100ms) lands inside the 5s floor opened by start(0)'s
-    // initial check, so it re-arms and the throwing checkForPRs only fires
-    // once the floor clears (~5s).
-    await vi.advanceTimersByTimeAsync(5000);
-    expect(callCount).toBe(2);
-    expect(logWarnMock).toHaveBeenCalledWith("PR check failed", {
-      error: "Debounce kaboom",
-      consecutiveErrors: 1,
-    });
-
-    pullRequestService.destroy();
-  });
-
-  it("does not track root worktree even on non-default branch", async () => {
-    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-root", branch: "develop", isMainWorktree: true })
-    );
-
-    await pullRequestService.refresh();
-
-    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
-
-    pullRequestService.destroy();
-  });
-
-  it("evicts root worktree from candidates when isMainWorktree becomes true", async () => {
-    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-
-    // First update without isMainWorktree — gets tracked as candidate
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-root", branch: "develop" })
-    );
-    await pullRequestService.refresh();
-    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
-    expect(pullRequestService.getStatus().candidateCount).toBe(1);
-
-    // Second update with isMainWorktree: true — evicted from candidates
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-root", branch: "develop", isMainWorktree: true })
-    );
-
-    expect(pullRequestService.getStatus().candidateCount).toBe(0);
-
-    // Subsequent refresh should not check any candidates
-    batchCheckLinkedPRs.mockClear();
-    await pullRequestService.refresh();
-    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
-
-    pullRequestService.destroy();
-  });
-
-  it("tracks non-main worktree on develop branch normally", async () => {
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => ({
-      results: new Map(
-        candidates.map((c) => [
-          c.worktreeId,
-          {
-            issueNumber: c.issueNumber,
-            branchName: c.branchName,
-            pr: {
-              number: 55,
-              title: "Develop PR",
-              url: "https://github.com/o/r/pull/55",
-              state: "open" as const,
-              isDraft: false,
-            },
-          },
-        ])
-      ),
-    }));
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    const detected: DaintreeEventMap["sys:pr:detected"][] = [];
-    const unsubDetected = events.on("sys:pr:detected", (p) => detected.push(p));
-
-    pullRequestService.initialize("/repo");
-
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-linked", branch: "develop", isMainWorktree: false })
-    );
-
-    await pullRequestService.refresh();
-
-    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
-    expect(detected).toHaveLength(1);
-    expect(detected[0]).toMatchObject({ worktreeId: "wt-linked", prNumber: 55 });
-
-    unsubDetected();
-    pullRequestService.destroy();
-  });
-
-  it("setFocusCadence(false) lengthens the next poll to the blurred interval", async () => {
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async () => {
-      callCount++;
-      return { results: new Map() };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/cadence" })
-    );
-
-    await pullRequestService.start(0);
-    expect(callCount).toBe(1);
-
-    pullRequestService.setFocusCadence(false);
-
-    // 30s elapsed should NOT trigger a poll under the 120s blurred cadence
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(callCount).toBe(1);
-
-    // 120s total elapsed should trigger the next poll
-    await vi.advanceTimersByTimeAsync(90 * 1000);
-    expect(callCount).toBe(2);
-
-    pullRequestService.destroy();
-  });
-
-  it("setFocusCadence(true) fires an immediate catch-up poll on focus regain", async () => {
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async () => {
-      callCount++;
-      return { results: new Map() };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/catchup" })
-    );
-
-    await pullRequestService.start(0);
-    expect(callCount).toBe(1);
-
-    // Blur, then focus — should immediately catch up
-    pullRequestService.setFocusCadence(false);
-    await vi.advanceTimersByTimeAsync(10 * 1000);
-    expect(callCount).toBe(1);
-
-    pullRequestService.setFocusCadence(true);
-    await vi.advanceTimersByTimeAsync(0);
-    expect(callCount).toBe(2);
-
-    pullRequestService.destroy();
-  });
-
-  it("throttles repeated focus catch-ups within 5s", async () => {
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async () => {
-      callCount++;
-      return { results: new Map() };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/throttle" })
-    );
-
-    await pullRequestService.start(0);
-    expect(callCount).toBe(1);
-
-    // start(0)'s initial check opened the 5s floor, so let it clear before
-    // exercising the focus catch-up throttle.
-    await vi.advanceTimersByTimeAsync(6 * 1000);
-
-    // First focus after the floor cleared → catch-up fires
-    pullRequestService.setFocusCadence(false);
-    pullRequestService.setFocusCadence(true);
-    await vi.advanceTimersByTimeAsync(0);
-    expect(callCount).toBe(2);
-
-    // Second blur→focus within 5s of that catch-up → no extra poll
-    await vi.advanceTimersByTimeAsync(2 * 1000);
-    pullRequestService.setFocusCadence(false);
-    pullRequestService.setFocusCadence(true);
-    await vi.advanceTimersByTimeAsync(0);
-    expect(callCount).toBe(2);
-
-    // After 5s+ has elapsed since the last catch-up, focus regain fires again
-    await vi.advanceTimersByTimeAsync(4 * 1000);
-    pullRequestService.setFocusCadence(false);
-    pullRequestService.setFocusCadence(true);
-    await vi.advanceTimersByTimeAsync(0);
-    expect(callCount).toBe(3);
-
-    pullRequestService.destroy();
-  });
-
-  it("setFocusCadence is a no-op while not polling but still updates the stored interval", async () => {
-    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/idle" })
-    );
-
-    pullRequestService.setFocusCadence(false);
-    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
-
-    await pullRequestService.start(0);
-    // start() preserves the blurred cadence set while idle
-    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
-
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
-
-    await vi.advanceTimersByTimeAsync(90 * 1000);
-    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(2);
-
-    pullRequestService.destroy();
-  });
-
-  it("does not leak a duplicate timer when blur arrives mid-catchup", async () => {
-    // Regression: blur during in-flight focus catch-up used to orphan the
-    // background-cadence timer set by updatePollInterval(120s) when the
-    // catch-up's .finally re-entered scheduleNextPoll without first clearing
-    // the existing pollTimer.
-    let resolveCheck: (() => void) | null = null;
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async () => {
-      callCount++;
-      // Hold the catch-up promise open so blur can interleave.
-      if (callCount === 2) {
-        await new Promise<void>((resolve) => {
-          resolveCheck = resolve;
-        });
-      }
-      return { results: new Map() };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/leak" })
-    );
-
-    await pullRequestService.start(0);
-    expect(callCount).toBe(1);
-
-    // Clear the 5s floor opened by start(0)'s initial check so the focus
-    // catch-up below isn't throttled.
-    await vi.advanceTimersByTimeAsync(6 * 1000);
-
-    // Focus regain — fires catch-up that hangs awaiting `resolveCheck`.
-    pullRequestService.setFocusCadence(true);
-    await Promise.resolve();
-    expect(callCount).toBe(2);
-
-    // Blur arrives mid-catchup — sets the 120s timer.
-    pullRequestService.setFocusCadence(false);
-
-    // Resolve the in-flight catch-up; .finally calls scheduleNextPoll again.
-    resolveCheck!();
-    await vi.advanceTimersByTimeAsync(0);
-
-    // Advance one full blurred cycle. With the leak, two timers would fire
-    // → callCount becomes 4. Fixed: exactly one timer fires → callCount = 3.
-    await vi.advanceTimersByTimeAsync(120 * 1000);
-    expect(callCount).toBe(3);
-
-    pullRequestService.destroy();
-  });
-
-  it("polls at the 30s focused cadence by default after start(0)", async () => {
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async () => {
-      callCount++;
-      return { results: new Map() };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/default" })
-    );
-
-    await pullRequestService.start(0);
-    expect(callCount).toBe(1);
-
-    // Under the old 60s clamp this would have required 60s
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(callCount).toBe(2);
-
-    pullRequestService.destroy();
-  });
-
-  it("circuit breaker recovers within BACKOFF_CAP_MS (5 min)", async () => {
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async () => {
-      callCount++;
-      if (callCount <= 3) {
-        return { results: new Map(), error: "Server error" };
-      }
-      return { results: new Map() };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/backoff" })
-    );
-
-    await pullRequestService.start(0);
-    expect(pullRequestService.getStatus().consecutiveErrors).toBe(1);
-
-    // Step two backoff polls to trip the circuit breaker.
-    await vi.advanceTimersToNextTimerAsync();
-    expect(pullRequestService.getStatus().consecutiveErrors).toBe(2);
-
-    await vi.advanceTimersToNextTimerAsync();
-    expect(pullRequestService.getStatus().consecutiveErrors).toBe(3);
-    expect(pullRequestService.getStatus().isEnabled).toBe(false);
-
-    // Advance past BACKOFF_CAP_MS (5 min). The 4th call succeeds, which
-    // resets consecutiveErrors and re-enables the service. The cap is
-    // verified by the fact recovery happens within this window: without it,
-    // computeBackoff would grow unbounded for high consecutiveErrors.
-    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
-    expect(pullRequestService.getStatus().isEnabled).toBe(true);
-
-    pullRequestService.destroy();
-  });
-
-  it("re-emits sys:pr:detected when only prCiStatus changes during revalidation", async () => {
-    let pollCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
-      pollCount++;
-      const ciStatus = pollCount === 1 ? "PENDING" : "SUCCESS";
-      return {
-        results: new Map([
-          [
-            candidates[0].worktreeId,
-            {
-              issueNumber: candidates[0].issueNumber,
-              branchName: candidates[0].branchName,
-              pr: {
-                number: 11,
-                title: "CI changes",
-                url: "https://github.com/o/r/pull/11",
-                state: "open" as const,
-                isDraft: false,
-                ciStatus: ciStatus as "PENDING" | "SUCCESS",
-              },
-            },
-          ],
-        ]),
-      };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+    mockForgeProviderUnresolved();
 
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
@@ -994,732 +230,18 @@ describe("PullRequestService", () => {
     const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
 
     pullRequestService.initialize("/repo");
+
     events.emit(
       "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-rev", branch: "feature/rev" })
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
     );
 
-    // start(0) schedules the revalidation timer (refresh() alone doesn't) and
-    // bypasses the startup jitter so the first check runs synchronously.
-    // The first poll returns PENDING, so the adaptive boost activates and the
-    // next revalidation fires at the 30s boosted cadence, not the 90s baseline.
-    await pullRequestService.start(0);
-    expect(detected.at(-1)?.prCiStatus).toBe("PENDING");
+    await pullRequestService.refresh();
 
-    // After CI flips to SUCCESS, the change-detection should re-emit.
-    await vi.advanceTimersByTimeAsync(90 * 1000);
-
-    expect(detected.length).toBeGreaterThanOrEqual(2);
-    expect(detected.at(-1)?.prCiStatus).toBe("SUCCESS");
+    // No PR detected — unresolved provider means null linkage
+    expect(detected).toHaveLength(0);
 
     unsubscribe();
-    pullRequestService.destroy();
-  });
-
-  it("forwards prCiStatus from batchCheckLinkedPRs to the sys:pr:detected event", async () => {
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => ({
-      results: new Map([
-        [
-          candidates[0].worktreeId,
-          {
-            issueNumber: candidates[0].issueNumber,
-            branchName: candidates[0].branchName,
-            pr: {
-              number: 99,
-              title: "CI status threading",
-              url: "https://github.com/o/r/pull/99",
-              state: "open" as const,
-              isDraft: false,
-              ciStatus: "FAILURE" as const,
-            },
-          },
-        ],
-      ]),
-    }));
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    const detected: DaintreeEventMap["sys:pr:detected"][] = [];
-    const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-ci", branch: "feature/ci-failing" })
-    );
-    await pullRequestService.refresh();
-
-    expect(detected).toHaveLength(1);
-    expect(detected[0]).toMatchObject({
-      worktreeId: "wt-ci",
-      prNumber: 99,
-      prCiStatus: "FAILURE",
-    });
-
-    unsubscribe();
-    pullRequestService.destroy();
-  });
-
-  it("boosts revalidation cadence to 30s when CI is PENDING", async () => {
-    let checkCallCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
-      checkCallCount++;
-      return {
-        results: new Map(
-          candidates.map((c) => [
-            c.worktreeId,
-            {
-              issueNumber: c.issueNumber,
-              branchName: c.branchName,
-              pr: {
-                number: 10,
-                title: "Pending PR",
-                url: "https://github.com/o/r/pull/10",
-                state: "open" as const,
-                isDraft: false,
-                ciStatus: "PENDING" as const,
-              },
-            },
-          ])
-        ),
-      };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/boost" })
-    );
-
-    await pullRequestService.start(0);
-    expect(checkCallCount).toBe(1);
-
-    // 30s boosted revalidation fires because the first poll returned PENDING.
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(checkCallCount).toBe(2);
-
-    // Still boosted — every revalidation keeps returning PENDING so the window
-    // slides forward and the next tick is again 30s out.
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(checkCallCount).toBe(3);
-
-    pullRequestService.destroy();
-  });
-
-  it("treats EXPECTED ciStatus as in-flight and boosts revalidation", async () => {
-    let checkCallCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
-      checkCallCount++;
-      return {
-        results: new Map(
-          candidates.map((c) => [
-            c.worktreeId,
-            {
-              issueNumber: c.issueNumber,
-              branchName: c.branchName,
-              pr: {
-                number: 12,
-                title: "Expected PR",
-                url: "https://github.com/o/r/pull/12",
-                state: "open" as const,
-                isDraft: false,
-                ciStatus: "EXPECTED" as const,
-              },
-            },
-          ])
-        ),
-      };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/expected" })
-    );
-
-    await pullRequestService.start(0);
-    expect(checkCallCount).toBe(1);
-
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(checkCallCount).toBe(2);
-
-    pullRequestService.destroy();
-  });
-
-  it("decays boost back to 90s once CI resolves to a terminal state", async () => {
-    let checkCallCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
-      checkCallCount++;
-      // First two polls return PENDING (initial check + one boosted reval).
-      // The third call onwards returns SUCCESS, which should clear the boost.
-      const ciStatus = checkCallCount <= 2 ? "PENDING" : "SUCCESS";
-      return {
-        results: new Map(
-          candidates.map((c) => [
-            c.worktreeId,
-            {
-              issueNumber: c.issueNumber,
-              branchName: c.branchName,
-              pr: {
-                number: 10,
-                title: "Decaying PR",
-                url: "https://github.com/o/r/pull/10",
-                state: "open" as const,
-                isDraft: false,
-                ciStatus: ciStatus as "PENDING" | "SUCCESS",
-              },
-            },
-          ])
-        ),
-      };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/decay" })
-    );
-
-    await pullRequestService.start(0);
-    expect(checkCallCount).toBe(1); // initial check, PENDING → boost armed
-
-    // 30s boosted reval fires, also returns PENDING (extends the boost).
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(checkCallCount).toBe(2);
-
-    // 30s later, the third reval fires (still boosted), returns SUCCESS — boost clears.
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(checkCallCount).toBe(3);
-
-    // Boost cleared → next revalidation should be at the 90s baseline.
-    // 30s after the SUCCESS reval there must be no extra call.
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(checkCallCount).toBe(3);
-
-    // 90s after the SUCCESS reval the baseline timer fires.
-    await vi.advanceTimersByTimeAsync(60 * 1000);
-    expect(checkCallCount).toBe(4);
-
-    pullRequestService.destroy();
-  });
-
-  it("does not boost revalidation when CI is already SUCCESS", async () => {
-    let checkCallCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
-      checkCallCount++;
-      return {
-        results: new Map(
-          candidates.map((c) => [
-            c.worktreeId,
-            {
-              issueNumber: c.issueNumber,
-              branchName: c.branchName,
-              pr: {
-                number: 10,
-                title: "Green PR",
-                url: "https://github.com/o/r/pull/10",
-                state: "open" as const,
-                isDraft: false,
-                ciStatus: "SUCCESS" as const,
-              },
-            },
-          ])
-        ),
-      };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/green" })
-    );
-
-    await pullRequestService.start(0);
-    expect(checkCallCount).toBe(1);
-
-    // 30s should NOT fire a revalidation — boost is not armed for SUCCESS.
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(checkCallCount).toBe(1);
-
-    // 90s baseline cadence still fires.
-    await vi.advanceTimersByTimeAsync(60 * 1000);
-    expect(checkCallCount).toBe(2);
-
-    pullRequestService.destroy();
-  });
-
-  it("ceiling expires after 15 min when revalidations stop refreshing the boost", async () => {
-    let checkCallCount = 0;
-    let failNextRevalidations = false;
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
-      checkCallCount++;
-      if (failNextRevalidations) {
-        // result.error short-circuits revalidateResolvedPRs before the boost
-        // recompute — the boost keeps its existing expiry and decays naturally.
-        return { results: new Map(), error: "Simulated revalidation failure" };
-      }
-      return {
-        results: new Map(
-          candidates.map((c) => [
-            c.worktreeId,
-            {
-              issueNumber: c.issueNumber,
-              branchName: c.branchName,
-              pr: {
-                number: 10,
-                title: "Hung PR",
-                url: "https://github.com/o/r/pull/10",
-                state: "open" as const,
-                isDraft: false,
-                ciStatus: "PENDING" as const,
-              },
-            },
-          ])
-        ),
-      };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-    vi.doMock("../../utils/logger.js", () => ({
-      logInfo: vi.fn(),
-      logWarn: vi.fn(),
-      logDebug: vi.fn(),
-    }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/ceiling" })
-    );
-
-    await pullRequestService.start(0);
-    expect(checkCallCount).toBe(1); // PENDING → boost armed, expires in 15 min
-
-    // From here on, every revalidation returns result.error. The boost
-    // window cannot be refreshed, so once 15 min pass the boost decays.
-    failNextRevalidations = true;
-
-    // First boosted revalidation at 30s — fires, returns error, leaves boost
-    // expiry untouched.
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(checkCallCount).toBe(2);
-
-    // Advance to just before the 15 min ceiling (15 min after start, ~14:30
-    // since the boosted reval). Many boosted ticks fire in this window — all
-    // return errors and don't refresh the boost.
-    await vi.advanceTimersByTimeAsync(15 * 60 * 1000 - 60 * 1000);
-    const callsBeforeCeiling = checkCallCount;
-    expect(callsBeforeCeiling).toBeGreaterThan(2);
-
-    // Cross the ceiling (15 min + a bit). After boostExpiresAt elapses, the
-    // next scheduleRevalidation picks the 90s baseline. Confirm by advancing
-    // 30s past the ceiling and checking that the call rate has slowed.
-    await vi.advanceTimersByTimeAsync(60 * 1000); // past the ceiling
-    const callsJustAfterCeiling = checkCallCount;
-
-    // 30s later — under boost we would have added one more call. Under the
-    // 90s baseline, fewer than one call fires in 30s.
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(checkCallCount - callsJustAfterCeiling).toBeLessThanOrEqual(1);
-
-    // 90s after the ceiling-elapsed reschedule, a baseline tick must have
-    // fired at most once (proves cadence dropped, not that polling stopped).
-    await vi.advanceTimersByTimeAsync(120 * 1000);
-    expect(checkCallCount).toBeGreaterThan(callsJustAfterCeiling);
-
-    pullRequestService.destroy();
-  });
-
-  it("refresh() clears the boost window so the cadence is re-evaluated from scratch", async () => {
-    let checkCallCount = 0;
-    let returnPending = true;
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
-      checkCallCount++;
-      const ciStatus = returnPending ? "PENDING" : "SUCCESS";
-      return {
-        results: new Map(
-          candidates.map((c) => [
-            c.worktreeId,
-            {
-              issueNumber: c.issueNumber,
-              branchName: c.branchName,
-              pr: {
-                number: 10,
-                title: "Refresh PR",
-                url: "https://github.com/o/r/pull/10",
-                state: "open" as const,
-                isDraft: false,
-                ciStatus: ciStatus as "PENDING" | "SUCCESS",
-              },
-            },
-          ])
-        ),
-      };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/refresh-clears-boost" })
-    );
-
-    await pullRequestService.start(0);
-    expect(checkCallCount).toBe(1); // PENDING → boost armed
-
-    // Flip CI to SUCCESS and refresh — refresh should clear the boost, run a
-    // fresh check (which returns SUCCESS), and schedule the next revalidation
-    // at the 90s baseline.
-    returnPending = false;
-    await pullRequestService.refresh();
-    expect(checkCallCount).toBe(2);
-
-    // 30s after refresh — no boosted tick.
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(checkCallCount).toBe(2);
-
-    // 90s after refresh — baseline cadence fires.
-    await vi.advanceTimersByTimeAsync(60 * 1000);
-    expect(checkCallCount).toBe(3);
-
-    pullRequestService.destroy();
-  });
-
-  it("clears boost state when a tracked worktree flips to isMainWorktree without branch change", async () => {
-    let checkCallCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
-      checkCallCount++;
-      return {
-        results: new Map(
-          candidates.map((c) => [
-            c.worktreeId,
-            {
-              issueNumber: c.issueNumber,
-              branchName: c.branchName,
-              pr: {
-                number: 10,
-                title: "Soon-to-be-main PR",
-                url: "https://github.com/o/r/pull/10",
-                state: "open" as const,
-                isDraft: false,
-                ciStatus: "PENDING" as const,
-              },
-            },
-          ])
-        ),
-      };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/de-track" })
-    );
-
-    await pullRequestService.start(0);
-    expect(checkCallCount).toBe(1); // PENDING → boost armed
-
-    // Same branch, but the worktree is now the main worktree — de-track without
-    // a branch change. A stale detectedPRs entry would keep the boost armed
-    // for 15 min; the fix clears PR state on any de-track of a previously
-    // tracked candidate.
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({
-        worktreeId: "wt-1",
-        branch: "feature/de-track",
-        isMainWorktree: true,
-      })
-    );
-
-    expect(pullRequestService.getStatus().candidateCount).toBe(0);
-    expect(pullRequestService.getStatus().resolvedCount).toBe(0);
-
-    // 30s after de-track — no boosted tick (no candidates to poll either, but
-    // crucially no zombie timer; the boost timer was armed at start() and the
-    // de-track must not leave its detectedPRs entry behind to keep boosting).
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(checkCallCount).toBe(1);
-
-    pullRequestService.destroy();
-  });
-
-  it("reset() clears the boost window", async () => {
-    let checkCallCount = 0;
-    let returnPending = true;
-    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
-      checkCallCount++;
-      const ciStatus = returnPending ? "PENDING" : "SUCCESS";
-      return {
-        results: new Map(
-          candidates.map((c) => [
-            c.worktreeId,
-            {
-              issueNumber: c.issueNumber,
-              branchName: c.branchName,
-              pr: {
-                number: 10,
-                title: "Reset PR",
-                url: "https://github.com/o/r/pull/10",
-                state: "open" as const,
-                isDraft: false,
-                ciStatus: ciStatus as "PENDING" | "SUCCESS",
-              },
-            },
-          ])
-        ),
-      };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/reset-clears-boost" })
-    );
-
-    await pullRequestService.start(0);
-    expect(checkCallCount).toBe(1); // PENDING → boost armed
-
-    // Reset wipes all state; restart with a non-pending result, the cadence
-    // must fall back to the 90s baseline rather than the 30s boost.
-    pullRequestService.reset();
-    returnPending = false;
-
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/reset-clears-boost-2" })
-    );
-    await pullRequestService.start(0);
-    expect(checkCallCount).toBe(2);
-
-    // 30s after restart — no boost.
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(checkCallCount).toBe(2);
-
-    // 90s after restart — baseline cadence.
-    await vi.advanceTimersByTimeAsync(60 * 1000);
-    expect(checkCallCount).toBe(3);
-
-    pullRequestService.destroy();
-  });
-
-  it("delays the first check by a randomised startup jitter (default start())", async () => {
-    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/jitter" })
-    );
-
-    const started = pullRequestService.start();
-    // No synchronous burst — the post-restart fleet decorrelation guarantee.
-    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
-
-    // Below STARTUP_JITTER_MIN_MS (500ms) the check cannot have fired yet.
-    await vi.advanceTimersByTimeAsync(499);
-    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
-
-    // Past STARTUP_JITTER_MAX_MS (2500ms) it must have fired exactly once.
-    await vi.advanceTimersByTimeAsync(2500);
-    await started;
-    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
-
-    pullRequestService.destroy();
-  });
-
-  it("stop() during the startup jitter cancels the check and resolves start()", async () => {
-    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/jitter-stop" })
-    );
-
-    const started = pullRequestService.start();
-    pullRequestService.stop();
-
-    // start() must not hang when the pending jitter is cancelled.
-    await started;
-    await vi.advanceTimersByTimeAsync(5000);
-    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
-
-    pullRequestService.destroy();
-  });
-
-  it("reset() during the startup jitter cancels the check and resolves start()", async () => {
-    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/jitter-reset" })
-    );
-
-    const started = pullRequestService.start();
-    pullRequestService.reset();
-
-    await started;
-    await vi.advanceTimersByTimeAsync(5000);
-    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
-
-    pullRequestService.destroy();
-  });
-
-  it("manual refresh() bypasses the 5s floor opened by the prior check", async () => {
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async () => {
-      callCount++;
-      return { results: new Map() };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/refresh-bypass" })
-    );
-
-    await pullRequestService.start(0);
-    expect(callCount).toBe(1);
-
-    // Immediately (well inside the 5s floor) a manual refresh still runs.
-    await pullRequestService.refresh();
-    expect(callCount).toBe(2);
-
-    pullRequestService.destroy();
-  });
-
-  it("does not bypass the startup jitter via a debounced worktree update", async () => {
-    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/seed" })
-    );
-
-    const started = pullRequestService.start();
-
-    // A worktree update arrives during the jitter window (e.g. the
-    // WorkspaceService initial scan after a host restart) → 100ms debounce.
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/burst" })
-    );
-
-    // Past the debounce (100ms) but still inside the jitter floor (<500ms):
-    // the debounced check must defer to the pending jitter, not fire.
-    await vi.advanceTimersByTimeAsync(400);
-    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
-
-    // Once the jitter clears, a single initial check covers both candidates.
-    await vi.advanceTimersByTimeAsync(2500);
-    await started;
-    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
-    expect((batchCheckLinkedPRs.mock.calls[0] as unknown[])[1]).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ worktreeId: "wt-1" }),
-        expect.objectContaining({ worktreeId: "wt-2" }),
-      ])
-    );
-
-    pullRequestService.destroy();
-  });
-
-  it("wires the normal poll timer after the jittered initial check", async () => {
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0); // jitter → 500ms
-    let callCount = 0;
-    const batchCheckLinkedPRs = vi.fn(async () => {
-      callCount++;
-      return { results: new Map() };
-    });
-    const clearPRCaches = vi.fn();
-    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
-
-    const { pullRequestService } = await import("../PullRequestService.js");
-    const { events } = await import("../events.js");
-
-    pullRequestService.initialize("/repo");
-    events.emit(
-      "sys:worktree:update",
-      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/jitter-poll" })
-    );
-
-    const started = pullRequestService.start();
-    await vi.advanceTimersByTimeAsync(500);
-    await started;
-    expect(callCount).toBe(1); // jittered initial check
-
-    await vi.advanceTimersByTimeAsync(30 * 1000);
-    expect(callCount).toBe(2); // normal 30s poll wired in the jittered path
-
-    randomSpy.mockRestore();
     pullRequestService.destroy();
   });
 });

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -449,12 +449,16 @@ export type DaintreeEventMap = {
     issueTitle?: string;
     /** Branch the lookup was initiated against; receivers drop the overlay if the worktree's branch has changed. */
     branchName?: string;
+    /** Provider that resolved the PR (e.g. "builtin.github"). */
+    providerId?: string;
     timestamp: number;
   };
   "sys:pr:cleared": {
     worktreeId: string;
     /** Branch the clear was initiated against; receivers drop the overlay if the worktree's branch has changed. */
     branchName?: string;
+    /** Provider whose linkage was cleared. */
+    providerId?: string;
     timestamp: number;
   };
   "sys:pr:detection-state": {
@@ -469,6 +473,8 @@ export type DaintreeEventMap = {
     issueTitle: string;
     /** Branch the lookup was initiated against; receivers drop the overlay if the worktree's branch has changed. */
     branchName?: string;
+    /** Provider that resolved the issue (e.g. "builtin.github"). */
+    providerId?: string;
     timestamp: number;
   };
 

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -33,9 +33,11 @@ export interface PRIntegrationCallbacks {
       issueLastUpdatedAt?: number;
       /** Branch the lookup was initiated against — used by the renderer to drop stale overlays. */
       branchName?: string;
+      /** Provider that resolved the PR (e.g. "builtin.github"). */
+      providerId?: string;
     }
   ): void;
-  onPRCleared(worktreeId: string, data: { branchName?: string }): void;
+  onPRCleared(worktreeId: string, data: { branchName?: string; providerId?: string }): void;
   onIssueDetected(
     worktreeId: string,
     data: {
@@ -44,6 +46,8 @@ export interface PRIntegrationCallbacks {
       issueLastUpdatedAt?: number;
       /** Branch the lookup was initiated against — used by the renderer to drop stale overlays. */
       branchName?: string;
+      /** Provider that resolved the issue (e.g. "builtin.github"). */
+      providerId?: string;
     }
   ): void;
   onIssueNotFound(worktreeId: string, issueNumber: number): void;
@@ -96,6 +100,7 @@ export class PRIntegrationService {
           prLastUpdatedAt: Date.now(),
           issueLastUpdatedAt: data.issueTitle !== undefined ? Date.now() : undefined,
           branchName: data.branchName,
+          providerId: data.providerId,
         });
       })
     );
@@ -107,6 +112,7 @@ export class PRIntegrationService {
           issueTitle: data.issueTitle,
           issueLastUpdatedAt: Date.now(),
           branchName: data.branchName,
+          providerId: data.providerId,
         });
       })
     );
@@ -119,7 +125,10 @@ export class PRIntegrationService {
 
     this.prEventUnsubscribers.push(
       this.eventBus.on("sys:pr:cleared", (data) => {
-        this.callbacks.onPRCleared(data.worktreeId, { branchName: data.branchName });
+        this.callbacks.onPRCleared(data.worktreeId, {
+          branchName: data.branchName,
+          providerId: data.providerId,
+        });
       })
     );
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -286,6 +286,18 @@ export class WorkspaceService {
 
         monitor.setIssueNumber(undefined);
         monitor.setIssueTitle(undefined);
+
+        // Clear the linked.issue projection but preserve any PR linkage
+        const snapshot = monitor.getSnapshot();
+        const existingLinked = snapshot.linked ?? null;
+        if (existingLinked?.issue) {
+          monitor.setLinked(
+            existingLinked.pr
+              ? { providerId: existingLinked.providerId, pr: existingLinked.pr }
+              : null
+          );
+        }
+
         if (monitor.hasInitialStatus) {
           this.emitUpdate(monitor);
         }

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -132,10 +132,6 @@ export class WorkspaceService {
       onPRDetected: (worktreeId, data) => {
         const monitor = this.monitors.get(worktreeId);
         if (!monitor) return;
-        // Drop stale overlays whose lookup branch no longer matches the
-        // monitor's current branch. Without this, monitor.setPRInfo +
-        // emitUpdate would bake the stale PR into the worktree-update
-        // snapshot — bypassing the renderer's branch guard (#8074).
         if (
           data.branchName !== undefined &&
           monitor.branch !== undefined &&
@@ -154,6 +150,40 @@ export class WorkspaceService {
           prLastUpdatedAt: data.prLastUpdatedAt,
           issueLastUpdatedAt: data.issueLastUpdatedAt,
         });
+
+        // Populate provider-agnostic linked projection alongside legacy fields
+        if (data.providerId) {
+          monitor.setLinked({
+            providerId: data.providerId,
+            pr: {
+              ref: {
+                providerId: data.providerId,
+                owner: "",
+                repo: "",
+                number: data.prNumber,
+                rawData: null,
+              },
+              title: data.prTitle,
+              url: data.prUrl,
+              state: data.prState,
+            },
+            ...(data.issueNumber && data.issueTitle
+              ? {
+                  issue: {
+                    ref: {
+                      providerId: data.providerId,
+                      owner: "",
+                      repo: "",
+                      number: data.issueNumber,
+                      rawData: null,
+                    },
+                    title: data.issueTitle,
+                  },
+                }
+              : {}),
+          });
+        }
+
         if (monitor.hasInitialStatus) {
           this.emitUpdate(monitor);
         }
@@ -171,15 +201,12 @@ export class WorkspaceService {
           prLastUpdatedAt: data.prLastUpdatedAt,
           issueLastUpdatedAt: data.issueLastUpdatedAt,
           branchName: data.branchName,
+          providerId: data.providerId,
         });
       },
       onPRCleared: (worktreeId, data) => {
         const monitor = this.monitors.get(worktreeId);
         if (!monitor) return;
-        // Drop stale clears whose lookup branch no longer matches the
-        // monitor's current branch — see #8074. Same bypass concern as
-        // onPRDetected: emitUpdate would otherwise clear the new branch's
-        // valid PR via the worktree-update snapshot.
         if (
           data.branchName !== undefined &&
           monitor.branch !== undefined &&
@@ -189,6 +216,7 @@ export class WorkspaceService {
         }
 
         monitor.clearPRInfo();
+        monitor.clearLinked();
         if (monitor.hasInitialStatus) {
           this.emitUpdate(monitor);
         }
@@ -197,14 +225,12 @@ export class WorkspaceService {
           type: "pr-cleared",
           worktreeId,
           branchName: data.branchName,
+          providerId: data.providerId,
         });
       },
       onIssueDetected: (worktreeId, data) => {
         const monitor = this.monitors.get(worktreeId);
         if (!monitor) return;
-        // Drop stale overlays whose lookup branch no longer matches the
-        // monitor's current branch — see #8074. emitUpdate would otherwise
-        // carry the stale issue title into the worktree-update snapshot.
         if (
           data.branchName !== undefined &&
           monitor.branch !== undefined &&
@@ -217,6 +243,28 @@ export class WorkspaceService {
         if (data.issueLastUpdatedAt !== undefined) {
           monitor.setIssueLastUpdatedAt(data.issueLastUpdatedAt);
         }
+
+        // Update linked.issue if we have provider info
+        if (data.providerId) {
+          const snapshot = monitor.getSnapshot();
+          const existingLinked = snapshot.linked ?? null;
+          monitor.setLinked({
+            providerId: data.providerId,
+            issue: {
+              ref: {
+                providerId: data.providerId,
+                owner: "",
+                repo: "",
+                number: data.issueNumber,
+                rawData: null,
+              },
+              title: data.issueTitle,
+            },
+            // Preserve existing PR linkage if present
+            ...(existingLinked?.pr ? { pr: existingLinked.pr } : {}),
+          });
+        }
+
         if (monitor.hasInitialStatus) {
           this.emitUpdate(monitor);
         }
@@ -228,6 +276,7 @@ export class WorkspaceService {
           issueTitle: data.issueTitle,
           issueLastUpdatedAt: data.issueLastUpdatedAt,
           branchName: data.branchName,
+          providerId: data.providerId,
         });
       },
       onIssueNotFound: (worktreeId, issueNumber) => {
@@ -437,6 +486,7 @@ export class WorkspaceService {
           // Bundle the PR clear into this same branch-change emit so the
           // renderer never renders the new branch with the old PR (#8079).
           existingMonitor.clearPRInfo();
+          existingMonitor.clearLinked();
           if (existingMonitor.hasInitialStatus) {
             this.emitUpdate(existingMonitor);
           }
@@ -444,6 +494,7 @@ export class WorkspaceService {
           existingMonitor.setIssueNumber(undefined);
           existingMonitor.setIssueTitle(undefined);
           existingMonitor.clearPRInfo();
+          existingMonitor.clearLinked();
           if (existingMonitor.hasInitialStatus) {
             this.emitUpdate(existingMonitor);
           }

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -109,6 +109,9 @@ export class WorktreeMonitor {
   private prLastUpdatedAt: number | undefined;
   private issueLastUpdatedAt: number | undefined;
 
+  // Provider-agnostic forge linkage (populated alongside legacy fields)
+  private _linked: import("../../shared/types/plugin.js").PluginWorktreeLinked | null = null;
+
   // Polling state
   private pollingTimer: NodeJS.Timeout | null = null;
   private resumeTimer: NodeJS.Timeout | null = null;
@@ -544,6 +547,14 @@ export class WorktreeMonitor {
     this.prLastUpdatedAt = undefined;
   }
 
+  setLinked(linked: import("../../shared/types/plugin.js").PluginWorktreeLinked | null): void {
+    this._linked = linked;
+  }
+
+  clearLinked(): void {
+    this._linked = null;
+  }
+
   setCreatedAt(ms: number | undefined): void {
     this._createdAt = ms;
   }
@@ -885,6 +896,7 @@ export class WorktreeMonitor {
       wslGitEligible: this._wslGitEligible || undefined,
       wslGitOptIn: this._wslGitOptIn || undefined,
       wslGitDismissed: this._wslGitDismissed || undefined,
+      linked: this._linked,
     };
 
     return ensureSerializable(snapshot) as WorktreeSnapshot;

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -24,6 +24,7 @@ import type {
   WorktreeResourceStatus,
 } from "./worktree.js";
 import type { GitHubPRCIStatus } from "./github.js";
+import type { PluginWorktreeLinked } from "./plugin.js";
 import type {
   CopyTreeOptions,
   CopyTreeProgress,
@@ -123,6 +124,14 @@ export interface WorktreeSnapshot {
 
   /** True when origin's fetch URL points at github.com (HTTPS or SSH form). */
   isGitHubRemote?: boolean;
+
+  /**
+   * Provider-agnostic projection of the worktree's linked forge resources
+   * (issue and/or PR). Populated by PRIntegrationService through the forge
+   * provider. Replaces the legacy flat `prNumber` / `prState` / `issueNumber`
+   * / `issueTitle` fields, which remain populated for backward compatibility.
+   */
+  linked?: PluginWorktreeLinked | null;
 
   /** Resource status from the last manual status check */
   resourceStatus?: WorktreeResourceStatus;
@@ -410,12 +419,16 @@ export type WorkspaceHostEvent =
       issueLastUpdatedAt?: number;
       /** Branch the lookup was initiated against — receiver drops the overlay if the worktree's branch has since changed. */
       branchName?: string;
+      /** Provider that resolved the PR (e.g. "builtin.github"). */
+      providerId?: string;
     }
   | {
       type: "pr-cleared";
       worktreeId: string;
       /** Branch the clear was initiated against — receiver drops the overlay if the worktree's branch has since changed. */
       branchName?: string;
+      /** Provider whose linkage was cleared. */
+      providerId?: string;
     }
   | {
       /** Service-wide PR detection circuit breaker tripped (paused) or recovered. */
@@ -431,6 +444,8 @@ export type WorkspaceHostEvent =
       issueLastUpdatedAt?: number;
       /** Branch the lookup was initiated against — receiver drops the overlay if the worktree's branch has since changed. */
       branchName?: string;
+      /** Provider that resolved the issue (e.g. "builtin.github"). */
+      providerId?: string;
     }
   | {
       type: "issue-not-found";

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -366,7 +366,8 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.wslGitDismissed === b.wslGitDismissed &&
     resourceStatusEqual(a.resourceStatus, b.resourceStatus) &&
     worktreeChangesEqual(a.worktreeChanges, b.worktreeChanges) &&
-    lifecycleStatusEqual(a.lifecycleStatus, b.lifecycleStatus)
+    lifecycleStatusEqual(a.lifecycleStatus, b.lifecycleStatus) &&
+    linkedEqual(a.linked ?? null, b.linked ?? null)
   );
 }
 
@@ -421,5 +422,22 @@ function lifecycleStatusEqual(
     a.startedAt === b.startedAt &&
     a.completedAt === b.completedAt &&
     a.error === b.error
+  );
+}
+
+function linkedEqual(
+  a: import("../../shared/types/plugin.js").PluginWorktreeLinked | null,
+  b: import("../../shared/types/plugin.js").PluginWorktreeLinked | null
+): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  return (
+    a.providerId === b.providerId &&
+    a.pr?.ref.number === b.pr?.ref.number &&
+    a.pr?.state === b.pr?.state &&
+    a.pr?.url === b.pr?.url &&
+    a.pr?.title === b.pr?.title &&
+    a.issue?.ref.number === b.issue?.ref.number &&
+    a.issue?.title === b.issue?.title
   );
 }


### PR DESCRIPTION
## Summary

Routes `PullRequestService` through `ForgeProviderRegistry` so GitHub isn't the only forge that gets PR detection. ForgeHub and any future providers now get their own PR detection paths.

`PullRequestService` no longer calls `GitHubService` directly — it resolves the forge provider on init, fetches linked PRs through the provider interface, and attaches provider metadata so the UI can show which forge each PR comes from.

Resolves #8063.

## Changes

- Replaced `batchCheckLinkedPRs` (GitHub GraphQL) with per-branch `provider.findPRByBranch()` calls routed through `resolveForgeProvider`
- Per-branch lookups with concurrency limit 5 and in-flight dedup to avoid thundering the API
- Provider resolved once at initialization, re-resolved on refresh so changing remotes is picked up
- All existing polling, backoff, and circuit breaker infrastructure preserved
- Added `providerId` to `sys:pr:detected`, `sys:issue:detected`, and `sys:pr:cleared` events
- `WorktreeSnapshot.linked` projection now populated alongside legacy fields
- `createWorktreeStore` snapshot comparison includes `linked` equality check so forge provider changes trigger re-renders
- Worktrees with no resolved provider get null linkage — no errors or toasts, just a clean skip

## Testing

- Existing `PullRequestService` test suite updated for the new provider-based flow
- Typecheck and lint pass clean