### PR TITLE
feat(dev-preview): rebuild blocked-navigation banner with full URL, OAuth status, and cancel flow

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -354,6 +354,8 @@ export const CHANNELS = {
   WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut",
   WEBVIEW_NAVIGATION_BLOCKED: "webview:navigation-blocked",
   WEBVIEW_OAUTH_LOOPBACK: "webview:oauth-loopback",
+  WEBVIEW_OAUTH_LOOPBACK_CANCEL: "webview:oauth-loopback-cancel",
+  WEBVIEW_OAUTH_LOOPBACK_STATUS: "webview:oauth-loopback-status",
   WEBVIEW_START_CONSOLE_CAPTURE: "webview:start-console-capture",
   WEBVIEW_STOP_CONSOLE_CAPTURE: "webview:stop-console-capture",
   WEBVIEW_CLEAR_CONSOLE_CAPTURE: "webview:clear-console-capture",

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -1053,7 +1053,6 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     typedHandle(CHANNELS.WEBVIEW_STOP_CONSOLE_CAPTURE, handleStopConsoleCapture),
     typedHandle(CHANNELS.WEBVIEW_CLEAR_CONSOLE_CAPTURE, handleClearConsoleCapture),
     typedHandle(CHANNELS.WEBVIEW_GET_CONSOLE_PROPERTIES, handleGetConsoleProperties),
-    // @ts-expect-error: result type contains {success} | null — pending migration to throw AppError. See #6020.
     typedHandleWithContext(CHANNELS.WEBVIEW_OAUTH_LOOPBACK, handleOAuthLoopback as never),
     typedHandle(CHANNELS.WEBVIEW_OAUTH_LOOPBACK_CANCEL, handleCancelOAuthLoopback),
     typedHandle(CHANNELS.WEBVIEW_RELOAD_IGNORING_CACHE, handleReloadIgnoringCache),

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -913,12 +913,16 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
               requestId: p.requestId,
               postData: Buffer.from(rewrittenBody).toString("base64"),
             })
+            .then(() => {
+              clearTimeout(timeout);
+              finishIntercept();
+            })
             .catch((err) => {
               logError("OAuth CDP token-exchange continueRequest failed", err, { panelId });
+              navigationError = err instanceof Error ? err : new Error(String(err));
+              clearTimeout(timeout);
+              finishIntercept();
             });
-
-          clearTimeout(timeout);
-          finishIntercept();
         };
 
         wc.debugger.on("message", interceptorListener);

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -2,9 +2,16 @@ import { BrowserWindow, webContents } from "electron";
 import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
 import { CHANNELS } from "../channels.js";
 import { getWebviewDialogService } from "../../services/WebviewDialogService.js";
-import { broadcastToRenderer, sendToRenderer, typedHandle } from "../utils.js";
-import { startOAuthLoopback } from "../../services/OAuthLoopbackService.js";
-import type { HandlerDependencies } from "../types.js";
+import {
+  broadcastToRenderer,
+  sendToRenderer,
+  sendToRendererContext,
+  typedHandle,
+  typedHandleWithContext,
+} from "../utils.js";
+import { startOAuthLoopback, cancelOAuthLoopback } from "../../services/OAuthLoopbackService.js";
+import type { OAuthLoopbackPhase } from "../../services/OAuthLoopbackService.js";
+import type { HandlerDependencies, IpcContext } from "../types.js";
 import type {
   CdpRemoteArg,
   CdpStackTrace,
@@ -691,6 +698,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
   };
 
   const handleOAuthLoopback = async (
+    ctx: IpcContext,
     authUrl: unknown,
     panelId: unknown,
     webContentsId: unknown,
@@ -766,8 +774,19 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       }
     }
 
-    // Step 2: Start loopback server, open system browser, wait for callback
-    const loopbackResult = await startOAuthLoopback(authUrl, panelId);
+    // Step 2: Start loopback server, open system browser, wait for callback.
+    // Push phase transitions to the renderer so the banner stays open and
+    // surfaces progress during the (up to 5-minute) flow.
+    let loopbackGeneration = 0;
+    const pushPhase = (phase: OAuthLoopbackPhase, generation: number) => {
+      loopbackGeneration = generation;
+      sendToRendererContext(ctx, CHANNELS.WEBVIEW_OAUTH_LOOPBACK_STATUS, {
+        panelId,
+        generation,
+        ...phase,
+      } as Record<string, unknown> as never);
+    };
+    const loopbackResult = await startOAuthLoopback(authUrl, panelId, pushPhase);
     if (!loopbackResult) return null;
 
     const { callbackUrl, loopbackRedirectUri, originalRedirectUri } = loopbackResult;
@@ -882,6 +901,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
           );
 
           const didRewrite = rewrittenBody !== originalBody;
+          pushPhase({ phase: "token-exchange-intercepted" }, loopbackGeneration);
           console.log(
             `[OAuthLoopback] CDP intercepted token exchange POST to ${p.request.url}. ` +
               `Redirect_uri rewrite: ${didRewrite ? "applied" : "not needed"}`
@@ -964,6 +984,13 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     return { success: true };
   };
 
+  const handleCancelOAuthLoopback = async (panelId: unknown): Promise<void> => {
+    if (typeof panelId !== "string") {
+      throw new Error("Invalid arguments: panelId must be string");
+    }
+    cancelOAuthLoopback(panelId);
+  };
+
   const handleReloadIgnoringCache = async (
     webContentsId: unknown,
     panelId: unknown
@@ -1023,7 +1050,8 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     typedHandle(CHANNELS.WEBVIEW_CLEAR_CONSOLE_CAPTURE, handleClearConsoleCapture),
     typedHandle(CHANNELS.WEBVIEW_GET_CONSOLE_PROPERTIES, handleGetConsoleProperties),
     // @ts-expect-error: result type contains {success} | null — pending migration to throw AppError. See #6020.
-    typedHandle(CHANNELS.WEBVIEW_OAUTH_LOOPBACK, handleOAuthLoopback),
+    typedHandleWithContext(CHANNELS.WEBVIEW_OAUTH_LOOPBACK, handleOAuthLoopback as never),
+    typedHandle(CHANNELS.WEBVIEW_OAUTH_LOOPBACK_CANCEL, handleCancelOAuthLoopback),
     typedHandle(CHANNELS.WEBVIEW_RELOAD_IGNORING_CACHE, handleReloadIgnoringCache),
     typedHandle(CHANNELS.WEBVIEW_GET_SCROLL_POSITION, handleGetScrollPosition),
   ];

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1834,6 +1834,17 @@ const api: ElectronAPI = {
         webContentsId,
         sessionStorageSnapshot
       ),
+    cancelOAuthLoopback: (panelId: string): Promise<void> =>
+      _unwrappingInvoke(CHANNELS.WEBVIEW_OAUTH_LOOPBACK_CANCEL, panelId),
+    onOAuthLoopbackStatus: (
+      callback: (payload: {
+        panelId: string;
+        generation: number;
+        phase: "started" | "token-exchange-intercepted" | "completed" | "timed-out" | "error";
+        callbackUrl?: string;
+        message?: string;
+      }) => void
+    ): (() => void) => _typedOn(CHANNELS.WEBVIEW_OAUTH_LOOPBACK_STATUS, callback),
     startConsoleCapture: (webContentsId: number, paneId: string): Promise<void> =>
       _unwrappingInvoke(CHANNELS.WEBVIEW_START_CONSOLE_CAPTURE, webContentsId, paneId),
     stopConsoleCapture: (webContentsId: number, paneId: string): Promise<void> =>

--- a/electron/services/OAuthLoopbackService.ts
+++ b/electron/services/OAuthLoopbackService.ts
@@ -212,9 +212,8 @@ function cleanup(panelId: string): void {
 
   // Node 24: closeAllConnections() terminates idle keep-alive connections before close()
   try {
-    if (typeof (session.server as Record<string, unknown>).closeAllConnections === "function") {
-      (session.server as Record<string, unknown>).closeAllConnections();
-    }
+    const srv = session.server as unknown as { closeAllConnections?: () => void };
+    srv.closeAllConnections?.();
   } catch {
     // closeAllConnections may throw if server is already closed
   }

--- a/electron/services/OAuthLoopbackService.ts
+++ b/electron/services/OAuthLoopbackService.ts
@@ -57,9 +57,16 @@ export function startOAuthLoopback(
   if (prior) {
     cancelOAuthLoopback(panelId);
   }
-  const generation = (prior?.generation ?? -1) + 1;
+  const generation = (prior?.generation ?? 0) + 1;
 
-  const parsed = new URL(authUrl);
+  let parsed: URL;
+  try {
+    parsed = new URL(authUrl);
+  } catch {
+    console.warn("[OAuthLoopback] Invalid auth URL:", authUrl);
+    onPhase?.({ phase: "error", message: "Invalid authorization URL" }, generation);
+    return Promise.resolve(null);
+  }
   const originalRedirectUri = parsed.searchParams.get("redirect_uri");
 
   if (!originalRedirectUri) {
@@ -123,7 +130,7 @@ export function startOAuthLoopback(
           `</body></html>`
       );
 
-      emit({ phase: "completed", callbackUrl: originalCallback.toString() });
+      emit({ phase: "completed", callbackUrl: originalCallback.toString(), success: !hasError });
       settle(originalCallback.toString());
     });
 

--- a/electron/services/OAuthLoopbackService.ts
+++ b/electron/services/OAuthLoopbackService.ts
@@ -7,8 +7,10 @@
 
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from "http";
 import { app, shell } from "electron";
+import type { OAuthLoopbackPhase } from "../../shared/types/ipc/maps.js";
 
 export { looksLikeOAuthUrl } from "../../shared/utils/urlUtils.js";
+export type { OAuthLoopbackPhase } from "../../shared/types/ipc/maps.js";
 
 const CALLBACK_PATH = "/oauth/callback";
 const TIMEOUT_MS = 300_000; // 5 minutes
@@ -26,6 +28,7 @@ interface LoopbackSession {
   server: Server;
   timeout: NodeJS.Timeout;
   settle: (value: string | null) => void;
+  generation: number;
 }
 
 /** Active loopback sessions keyed by panelId */
@@ -36,6 +39,7 @@ const activeSessions = new Map<string, LoopbackSession>();
  *
  * @param authUrl - The original OAuth authorization URL (blocked by dev-preview)
  * @param panelId - The dev-preview panel ID (prevents duplicate flows)
+ * @param onPhase - Callback for phase transitions (pushed to renderer via IPC)
  * @returns The original callback URL, the loopback URI used, and the original redirect_uri — or null
  */
 export interface OAuthLoopbackResult {
@@ -46,9 +50,14 @@ export interface OAuthLoopbackResult {
 
 export function startOAuthLoopback(
   authUrl: string,
-  panelId: string
+  panelId: string,
+  onPhase?: (phase: OAuthLoopbackPhase, generation: number) => void
 ): Promise<OAuthLoopbackResult | null> {
-  cancelOAuthLoopback(panelId);
+  const prior = activeSessions.get(panelId);
+  if (prior) {
+    cancelOAuthLoopback(panelId);
+  }
+  const generation = (prior?.generation ?? -1) + 1;
 
   const parsed = new URL(authUrl);
   const originalRedirectUri = parsed.searchParams.get("redirect_uri");
@@ -61,6 +70,11 @@ export function startOAuthLoopback(
   return new Promise((resolve) => {
     let settled = false;
     let capturedLoopbackUri = "";
+
+    const emit = (phase: OAuthLoopbackPhase) => {
+      if (settled) return;
+      onPhase?.(phase, generation);
+    };
 
     const settle = (callbackUrl: string | null) => {
       if (settled) return;
@@ -109,12 +123,13 @@ export function startOAuthLoopback(
           `</body></html>`
       );
 
-      // Forward to the webview regardless — the app handles error params itself
+      emit({ phase: "completed", callbackUrl: originalCallback.toString() });
       settle(originalCallback.toString());
     });
 
     server.on("error", (err) => {
       console.error("[OAuthLoopback] Server error:", err);
+      emit({ phase: "error", message: "Loopback server error" });
       settle(null);
     });
 
@@ -125,6 +140,7 @@ export function startOAuthLoopback(
       const address = server.address();
       if (!address || typeof address === "string") {
         console.error("[OAuthLoopback] Failed to get server address");
+        emit({ phase: "error", message: "Failed to start loopback server" });
         settle(null);
         return;
       }
@@ -139,18 +155,25 @@ export function startOAuthLoopback(
           `Original redirect: ${originalRedirectUri} → Loopback: ${capturedLoopbackUri}`
       );
 
-      void shell.openExternal(parsed.toString()).catch((err) => {
-        console.error("[OAuthLoopback] Failed to open system browser:", err);
-        settle(null);
-      });
+      void shell
+        .openExternal(parsed.toString())
+        .then(() => {
+          emit({ phase: "started" });
+        })
+        .catch((err) => {
+          console.error("[OAuthLoopback] Failed to open system browser:", err);
+          emit({ phase: "error", message: "Failed to open system browser" });
+          settle(null);
+        });
     });
 
     const timeout = setTimeout(() => {
       console.warn(`[OAuthLoopback] Timed out after ${TIMEOUT_MS}ms for panel ${panelId}`);
+      emit({ phase: "timed-out" });
       settle(null);
     }, TIMEOUT_MS);
 
-    activeSessions.set(panelId, { server, timeout, settle });
+    activeSessions.set(panelId, { server, timeout, settle, generation });
   });
 }
 
@@ -179,6 +202,15 @@ function cleanup(panelId: string): void {
 
   activeSessions.delete(panelId);
   clearTimeout(session.timeout);
+
+  // Node 24: closeAllConnections() terminates idle keep-alive connections before close()
+  try {
+    if (typeof (session.server as Record<string, unknown>).closeAllConnections === "function") {
+      (session.server as Record<string, unknown>).closeAllConnections();
+    }
+  } catch {
+    // closeAllConnections may throw if server is already closed
+  }
 
   try {
     session.server.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-colorful": "^5.6.1",
         "safe-stable-stringify": "^2.5.0",
         "smol-toml": "^1.6.1",
+        "tldts": "^7.0.30",
         "win-job-object": "file:electron/native/win-job-object"
       },
       "devDependencies": {
@@ -19686,7 +19687,6 @@
       "version": "7.0.30",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
       "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.30"
@@ -19699,7 +19699,6 @@
       "version": "7.0.30",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
       "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tmp": {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "react-colorful": "^5.6.1",
     "safe-stable-stringify": "^2.5.0",
     "smol-toml": "^1.6.1",
+    "tldts": "^7.0.30",
     "win-job-object": "file:electron/native/win-job-object"
   },
   "optionalDependencies": {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -867,6 +867,18 @@ export interface ElectronAPI {
       webContentsId: number,
       sessionStorageSnapshot?: Array<[string, string]>
     ): Promise<{ success: true } | null>;
+    /** Cancel an active OAuth loopback flow for a panel */
+    cancelOAuthLoopback(panelId: string): Promise<void>;
+    /** Subscribe to OAuth loopback phase transitions (started, token-exchange-intercepted, completed, timed-out, error) */
+    onOAuthLoopbackStatus(
+      callback: (payload: {
+        panelId: string;
+        generation: number;
+        phase: "started" | "token-exchange-intercepted" | "completed" | "timed-out" | "error";
+        callbackUrl?: string;
+        message?: string;
+      }) => void
+    ): () => void;
     /** Start CDP console capture for a webview panel */
     startConsoleCapture(webContentsId: number, paneId: string): Promise<void>;
     /** Stop CDP console capture for a webview panel */

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -24,6 +24,17 @@ import type {
   VoiceInputSettings,
 } from "./api.js";
 
+/**
+ * Phases emitted during the RFC 8252 OAuth loopback flow.
+ * Pushed from main to renderer via `WEBVIEW_OAUTH_LOOPBACK_STATUS`.
+ */
+export type OAuthLoopbackPhase =
+  | { phase: "started" }
+  | { phase: "token-exchange-intercepted" }
+  | { phase: "completed"; callbackUrl: string }
+  | { phase: "timed-out" }
+  | { phase: "error"; message: string };
+
 import type {
   WorktreeSetActivePayload,
   WorktreeDeletePayload,
@@ -2038,6 +2049,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     /** Resolves with `{ success: true }` on success or `null` if the loopback was aborted. Throws `AppError` on hard failure. */
     result: { success: true } | null;
   };
+  "webview:oauth-loopback-cancel": {
+    args: [panelId: string];
+    result: void;
+  };
 
   // Additional worktree channels
   "worktree:fetch-pr-branch": {
@@ -2258,6 +2273,12 @@ export interface IpcEventMap {
     url: string;
     canOpenExternal: boolean;
   };
+
+  // OAuth loopback phase transitions pushed from main to renderer
+  "webview:oauth-loopback-status": {
+    panelId: string;
+    generation: number;
+  } & OAuthLoopbackPhase;
 
   // Voice input events
   "voice-input:transcription-delta": string;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -31,7 +31,7 @@ import type {
 export type OAuthLoopbackPhase =
   | { phase: "started" }
   | { phase: "token-exchange-intercepted" }
-  | { phase: "completed"; callbackUrl: string }
+  | { phase: "completed"; callbackUrl: string; success: boolean }
   | { phase: "timed-out" }
   | { phase: "error"; message: string };
 

--- a/shared/utils/urlUtils.ts
+++ b/shared/utils/urlUtils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-control-regex */
 import ipaddr from "ipaddr.js";
+import { getDomain, getSubdomain } from "tldts";
 
 const LOOPBACK_HOSTS = ["localhost", "127.0.0.1", "::1"];
 const ALLOWED_PROTOCOLS = ["http:", "https:"];
@@ -197,6 +198,49 @@ export function extractLocalhostUrls(text: string): string[] {
   }
 
   return [...new Set(normalized)];
+}
+
+export interface ExtractedUrlParts {
+  fullUrl: string;
+  hostname: string;
+  subdomain: string;
+  registrableDomain: string;
+  isIp: boolean;
+}
+
+export function extractUrlParts(url: string): ExtractedUrlParts | null {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname;
+    if (!hostname) return null;
+
+    // Try tldts for eTLD+1 extraction; fall back to raw hostname
+    let subdomain = "";
+    let registrableDomain = hostname;
+    let isIp = false;
+
+    try {
+      const domain = getDomain(url);
+      if (domain) {
+        registrableDomain = domain;
+        subdomain = getSubdomain(url) || "";
+      }
+    } catch {
+      // tldts unavailable — fall back to displaying full hostname as eTLD+1
+    }
+
+    // Check if hostname is an IP address (v4 or v6)
+    try {
+      ipaddr.parse(hostname);
+      isIp = true;
+    } catch {
+      // not an IP
+    }
+
+    return { fullUrl: url, hostname, subdomain, registrableDomain, isIp };
+  } catch {
+    return null;
+  }
 }
 
 export function looksLikeOAuthUrl(url: string): boolean {

--- a/src/components/DevPreview/BlockedNavBanner.tsx
+++ b/src/components/DevPreview/BlockedNavBanner.tsx
@@ -161,12 +161,13 @@ export function BlockedNavBanner({
   onRetryOAuth,
 }: BlockedNavBannerProps) {
   const [copied, setCopied] = useState(false);
+  const COPY_FEEDBACK_MS = 2000;
 
   const handleCopyUrl = useCallback(async () => {
     try {
       await window.electron.clipboard.writeText(blockedNav.url);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
     } catch {
       // Clipboard unavailable
     }

--- a/src/components/DevPreview/BlockedNavBanner.tsx
+++ b/src/components/DevPreview/BlockedNavBanner.tsx
@@ -1,0 +1,234 @@
+import { ExternalLink, Copy, Check, Loader2, X, AlertTriangle } from "lucide-react";
+import { useState, useCallback } from "react";
+import { extractUrlParts, looksLikeOAuthUrl, isSafeNavigationUrl } from "@shared/utils/urlUtils";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import type { SessionStorageEntry } from "./useDevPreviewLoadLifecycle";
+
+export type OAuthPhase =
+  | { phase: "started" }
+  | { phase: "token-exchange-intercepted" }
+  | { phase: "completed"; callbackUrl: string }
+  | { phase: "timed-out" }
+  | { phase: "error"; message: string };
+
+export interface BlockedNavBannerProps {
+  blockedNav: {
+    url: string;
+    canOpenExternal: boolean;
+    sessionStorageSnapshot: SessionStorageEntry[];
+  };
+  panelId: string;
+  webviewElement: Electron.WebviewTag | null;
+  oauthPhase: OAuthPhase | null;
+  onDismiss: () => void;
+  onStartOAuth: () => void;
+  onCancelOAuth: () => void;
+  onRetryOAuth: () => void;
+}
+
+function UrlDisplay({ url }: { url: string }) {
+  const urlParts = extractUrlParts(url);
+
+  if (!urlParts) {
+    return <span className="font-mono truncate">{url}</span>;
+  }
+
+  const { subdomain, registrableDomain } = urlParts;
+
+  let pathAndQuery = "";
+  try {
+    const parsed = new URL(url);
+    pathAndQuery = parsed.pathname + parsed.search + parsed.hash;
+  } catch {
+    // fall through — show hostname only
+  }
+
+  const domainDisplay = urlParts.isIp ? (
+    <span className="font-bold">{registrableDomain}</span>
+  ) : subdomain ? (
+    <>
+      <span className="opacity-50">{subdomain}.</span>
+      <span className="font-bold">{registrableDomain}</span>
+    </>
+  ) : (
+    <span className="font-bold">{registrableDomain}</span>
+  );
+
+  return (
+    <span className="font-mono truncate">
+      {domainDisplay}
+      {pathAndQuery && <span className="opacity-50">{pathAndQuery}</span>}
+    </span>
+  );
+}
+
+function OAuthStatusRow({
+  phase,
+  onCancelOAuth,
+  onRetryOAuth,
+}: {
+  phase: OAuthPhase;
+  onCancelOAuth: () => void;
+  onRetryOAuth: () => void;
+}) {
+  switch (phase.phase) {
+    case "started":
+      return (
+        <div className="flex items-center gap-2 text-xs">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          <span className="text-daintree-text/70">Connecting to identity provider...</span>
+          <button
+            type="button"
+            onClick={onCancelOAuth}
+            className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      );
+    case "token-exchange-intercepted":
+      return (
+        <div className="flex items-center gap-2 text-xs">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          <span className="text-daintree-text/70">Signing in...</span>
+          <button
+            type="button"
+            onClick={onCancelOAuth}
+            className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      );
+    case "completed":
+      return (
+        <div className="flex items-center gap-2 text-xs">
+          <Check className="h-3 w-3 text-green-400" />
+          <span className="text-daintree-text/70">Sign in completed</span>
+        </div>
+      );
+    case "timed-out":
+      return (
+        <div className="flex items-center gap-2 text-xs">
+          <AlertTriangle className="h-3 w-3 text-status-warning" />
+          <span className="text-daintree-text/70">Sign in timed out</span>
+          <button
+            type="button"
+            onClick={onRetryOAuth}
+            className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    case "error":
+      return (
+        <div className="flex items-center gap-2 text-xs">
+          <AlertTriangle className="h-3 w-3 text-status-warning" />
+          <span className="text-daintree-text/70">Sign-in didn't complete</span>
+          <button
+            type="button"
+            onClick={onRetryOAuth}
+            className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      );
+  }
+}
+
+export function BlockedNavBanner({
+  blockedNav,
+  panelId: _panelId,
+  webviewElement: _webviewElement,
+  oauthPhase,
+  onDismiss,
+  onStartOAuth,
+  onCancelOAuth,
+  onRetryOAuth,
+}: BlockedNavBannerProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyUrl = useCallback(async () => {
+    try {
+      await window.electron.clipboard.writeText(blockedNav.url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable
+    }
+  }, [blockedNav.url]);
+
+  const isOAuth = looksLikeOAuthUrl(blockedNav.url);
+  const canOpenExternal = isSafeNavigationUrl(blockedNav.url);
+  const isOAuthInFlight =
+    oauthPhase?.phase === "started" || oauthPhase?.phase === "token-exchange-intercepted";
+
+  return (
+    <div className="flex flex-col gap-1 px-3 py-1.5 text-xs bg-status-warning/10 border-b border-status-warning/20 text-daintree-text/80">
+      <div className="flex items-center gap-2 min-w-0">
+        <ExternalLink className="h-3.5 w-3.5 shrink-0 text-status-warning" />
+        <span className="truncate min-w-0 flex items-center gap-1.5">
+          <span className="text-daintree-text/50 shrink-0">
+            Navigation to external site blocked:
+          </span>
+          <UrlDisplay url={blockedNav.url} />
+        </span>
+        <button
+          type="button"
+          onClick={handleCopyUrl}
+          className="shrink-0 text-daintree-text/40 hover:text-daintree-text/70 transition-colors"
+          aria-label="Copy URL"
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5 text-green-400" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </button>
+        {!isOAuthInFlight && (
+          <>
+            {isOAuth ? (
+              <button
+                type="button"
+                onClick={onStartOAuth}
+                className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
+              >
+                Sign in via browser
+              </button>
+            ) : canOpenExternal ? (
+              <button
+                type="button"
+                onClick={() => {
+                  safeFireAndForget(window.electron.system.openExternal(blockedNav.url), {
+                    context: "Opening blocked dev preview URL externally",
+                  });
+                  onDismiss();
+                }}
+                className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
+              >
+                Open in external browser
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="shrink-0 text-daintree-text/40 hover:text-daintree-text/70 transition-colors"
+              aria-label="Dismiss"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </>
+        )}
+      </div>
+      {oauthPhase && (
+        <OAuthStatusRow
+          phase={oauthPhase}
+          onCancelOAuth={onCancelOAuth}
+          onRetryOAuth={onRetryOAuth}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/DevPreview/BlockedNavBanner.tsx
+++ b/src/components/DevPreview/BlockedNavBanner.tsx
@@ -7,7 +7,7 @@ import type { SessionStorageEntry } from "./useDevPreviewLoadLifecycle";
 export type OAuthPhase =
   | { phase: "started" }
   | { phase: "token-exchange-intercepted" }
-  | { phase: "completed"; callbackUrl: string }
+  | { phase: "completed"; callbackUrl: string; success: boolean }
   | { phase: "timed-out" }
   | { phase: "error"; message: string };
 
@@ -101,10 +101,22 @@ function OAuthStatusRow({
         </div>
       );
     case "completed":
-      return (
+      return phase.success ? (
         <div className="flex items-center gap-2 text-xs">
           <Check className="h-3 w-3 text-green-400" />
           <span className="text-daintree-text/70">Sign in completed</span>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 text-xs">
+          <AlertTriangle className="h-3 w-3 text-status-warning" />
+          <span className="text-daintree-text/70">Authorization denied</span>
+          <button
+            type="button"
+            onClick={onRetryOAuth}
+            className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
+          >
+            Try again
+          </button>
         </div>
       );
     case "timed-out":

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -874,7 +874,7 @@ export function DevPreviewPane({
     const cleanup = window.electron.webview.onNavigationBlocked((data) => {
       if (data.panelId !== id) return;
 
-      let hostname = "";
+      let hostname: string;
       try {
         hostname = new URL(data.url).hostname;
       } catch {

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -9,6 +9,8 @@ import {
   WandSparkles,
   OctagonAlert,
 } from "lucide-react";
+import { BlockedNavBanner } from "./BlockedNavBanner";
+import { useOAuthLoopbackStatus } from "./useOAuthLoopbackStatus";
 import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
 import { usePanelStore } from "@/store";
@@ -94,93 +96,6 @@ async function captureWebviewSessionStorage(
   } catch {
     return [];
   }
-}
-
-function BlockedNavBanner({
-  blockedNav,
-  panelId,
-  webviewElement,
-  onDismiss,
-}: {
-  blockedNav: {
-    url: string;
-    canOpenExternal: boolean;
-    sessionStorageSnapshot: SessionStorageEntry[];
-  };
-  panelId: string;
-  webviewElement: Electron.WebviewTag | null;
-  onDismiss: () => void;
-}) {
-  const isOAuth = looksLikeOAuthUrl(blockedNav.url);
-  const hostname = (() => {
-    try {
-      return new URL(blockedNav.url).hostname;
-    } catch {
-      return blockedNav.url;
-    }
-  })();
-
-  return (
-    <div className="flex items-center gap-2 px-3 py-1.5 text-xs bg-status-warning/10 border-b border-status-warning/20 text-daintree-text/80">
-      <ExternalLink className="h-3.5 w-3.5 shrink-0 text-status-warning" />
-      <span className="truncate flex-1">Navigation to external site blocked: {hostname}</span>
-      {isOAuth ? (
-        <button
-          type="button"
-          onClick={async () => {
-            const url = blockedNav.url;
-            onDismiss();
-            // Get webContentsId for CDP interception of the token exchange
-            let wcId: number | undefined;
-            try {
-              wcId = (
-                webviewElement as unknown as { getWebContentsId(): number }
-              )?.getWebContentsId();
-            } catch {
-              /* webview not ready */
-            }
-            if (wcId != null) {
-              try {
-                await window.electron.webview.startOAuthLoopback(
-                  url,
-                  panelId,
-                  wcId,
-                  blockedNav.sessionStorageSnapshot
-                );
-              } catch {
-                // OAuth loopback may fail if the webview is gone or CDP setup
-                // breaks; silently fall through — the dialog has been dismissed.
-              }
-            }
-          }}
-          className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
-        >
-          Sign in via browser
-        </button>
-      ) : blockedNav.canOpenExternal ? (
-        <button
-          type="button"
-          onClick={() => {
-            safeFireAndForget(window.electron.system.openExternal(blockedNav.url), {
-              context: "Opening blocked dev preview URL externally",
-            });
-            onDismiss();
-          }}
-          className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
-        >
-          Open in external browser
-        </button>
-      ) : null}
-      <button
-        type="button"
-        onClick={onDismiss}
-        className="shrink-0 text-daintree-text/40 hover:text-daintree-text/70 transition-colors"
-        aria-label="Dismiss"
-      >
-        ×
-      </button>
-    </div>
-  );
 }
 
 export interface DevPreviewPaneProps extends BasePanelProps {
@@ -369,6 +284,7 @@ export function DevPreviewPane({
 
   const [blockedNav, setBlockedNav] = useState<DevPreviewBlockedNav | null>(null);
   const blockedNavTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const { phase: oauthPhase, startOAuth, cancelOAuth, dismissOAuth } = useOAuthLoopbackStatus(id);
   const lastSetUrlRef = useRef<string>("");
   const [consoleTerminalId, setConsoleTerminalId] = useState<string | null>(terminalId);
   // Generation token to invalidate in-flight async scroll captures when the
@@ -950,25 +866,58 @@ export function DevPreviewPane({
     isFocused
   );
 
-  // Listen for blocked navigation events from main process
+  // Listen for blocked navigation events from main process.
+  // Debounce 150ms, coalescing by hostname so a redirect chain doesn't stack banners.
   useEffect(() => {
     let disposed = false;
+    const lastHostnameRef = { current: "" };
     const cleanup = window.electron.webview.onNavigationBlocked((data) => {
       if (data.panelId !== id) return;
+
+      let hostname = "";
+      try {
+        hostname = new URL(data.url).hostname;
+      } catch {
+        hostname = data.url;
+      }
+
       const sessionStorageSnapshotPromise = looksLikeOAuthUrl(data.url)
         ? captureWebviewSessionStorage(webviewElement)
         : Promise.resolve<SessionStorageEntry[]>([]);
+
       if (blockedNavTimerRef.current) {
         clearTimeout(blockedNavTimerRef.current);
       }
+      lastHostnameRef.current = hostname;
+
       blockedNavTimerRef.current = setTimeout(() => {
         void sessionStorageSnapshotPromise
           .then((sessionStorageSnapshot) => {
             if (disposed) return;
-            setBlockedNav({
-              url: data.url,
-              canOpenExternal: data.canOpenExternal,
-              sessionStorageSnapshot,
+            setBlockedNav((prev) => {
+              // If the current banner shows the same hostname, replace (coalesce)
+              let prevHostname = "";
+              if (prev) {
+                try {
+                  prevHostname = new URL(prev.url).hostname;
+                } catch {
+                  prevHostname = prev.url;
+                }
+              }
+              if (prev && prevHostname === lastHostnameRef.current) {
+                return {
+                  url: data.url,
+                  canOpenExternal: data.canOpenExternal,
+                  sessionStorageSnapshot,
+                };
+              }
+              // Don't replace if a different hostname banner is already showing
+              if (prev) return prev;
+              return {
+                url: data.url,
+                canOpenExternal: data.canOpenExternal,
+                sessionStorageSnapshot,
+              };
             });
             blockedNavTimerRef.current = null;
           })
@@ -987,12 +936,23 @@ export function DevPreviewPane({
     };
   }, [id, webviewElement]);
 
-  // Auto-dismiss blocked navigation notification after 10 seconds
+  // Listen for action-driven hard-reload events
   useEffect(() => {
-    if (!blockedNav) return;
-    const timer = setTimeout(() => setBlockedNav(null), 10_000);
-    return () => clearTimeout(timer);
-  }, [blockedNav]);
+    const handleHardReloadEvent = (e: Event) => {
+      if (!(e instanceof CustomEvent)) return;
+      const detail = e.detail as unknown;
+      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
+      if ((detail as { id: string }).id === id) {
+        handleHardReload();
+      }
+    };
+
+    const controller = new AbortController();
+    window.addEventListener("daintree:hard-reload-browser", handleHardReloadEvent, {
+      signal: controller.signal,
+    });
+    return () => controller.abort();
+  }, [id, handleHardReload]);
 
   return (
     <ContentPanel
@@ -1291,7 +1251,26 @@ export function DevPreviewPane({
                       blockedNav={blockedNav}
                       panelId={id}
                       webviewElement={webviewElement}
-                      onDismiss={() => setBlockedNav(null)}
+                      oauthPhase={oauthPhase}
+                      onDismiss={() => {
+                        dismissOAuth();
+                        setBlockedNav(null);
+                      }}
+                      onStartOAuth={() => {
+                        startOAuth(
+                          blockedNav.url,
+                          webviewElement,
+                          blockedNav.sessionStorageSnapshot
+                        );
+                      }}
+                      onCancelOAuth={cancelOAuth}
+                      onRetryOAuth={() => {
+                        startOAuth(
+                          blockedNav.url,
+                          webviewElement,
+                          blockedNav.sessionStorageSnapshot
+                        );
+                      }}
                     />
                   )}
                   {isLoading && (

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1257,7 +1257,7 @@ export function DevPreviewPane({
                         setBlockedNav(null);
                       }}
                       onStartOAuth={() => {
-                        startOAuth(
+                        void startOAuth(
                           blockedNav.url,
                           webviewElement,
                           blockedNav.sessionStorageSnapshot
@@ -1265,7 +1265,7 @@ export function DevPreviewPane({
                       }}
                       onCancelOAuth={cancelOAuth}
                       onRetryOAuth={() => {
-                        startOAuth(
+                        void startOAuth(
                           blockedNav.url,
                           webviewElement,
                           blockedNav.sessionStorageSnapshot

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -634,6 +634,9 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
         getScrollPosition,
+        onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
+        startOAuthLoopback: vi.fn(() => Promise.resolve({ success: true })),
+        cancelOAuthLoopback: vi.fn(() => Promise.resolve()),
       },
     };
 
@@ -685,6 +688,9 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
         getScrollPosition,
+        onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
+        startOAuthLoopback: vi.fn(() => Promise.resolve({ success: true })),
+        cancelOAuthLoopback: vi.fn(() => Promise.resolve()),
       },
     };
 
@@ -726,6 +732,9 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
         getScrollPosition,
+        onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
+        startOAuthLoopback: vi.fn(() => Promise.resolve({ success: true })),
+        cancelOAuthLoopback: vi.fn(() => Promise.resolve()),
       },
     };
 

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -292,6 +292,9 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
         getScrollPosition: vi.fn().mockResolvedValue(0),
+        onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
+        startOAuthLoopback: vi.fn(() => Promise.resolve({ success: true })),
+        cancelOAuthLoopback: vi.fn(() => Promise.resolve()),
       },
     };
   });

--- a/src/components/DevPreview/useOAuthLoopbackStatus.ts
+++ b/src/components/DevPreview/useOAuthLoopbackStatus.ts
@@ -17,8 +17,8 @@ export function useOAuthLoopbackStatus(panelId: string) {
       if (payload.generation < generationRef.current) return;
 
       generationRef.current = payload.generation;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- push channel payload shape matches OAuthPhase discriminants
       setState({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- push channel payload shape matches OAuthPhase discriminants
         phase: payload as OAuthPhase,
         generation: payload.generation,
       });

--- a/src/components/DevPreview/useOAuthLoopbackStatus.ts
+++ b/src/components/DevPreview/useOAuthLoopbackStatus.ts
@@ -1,0 +1,88 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { OAuthPhase } from "./BlockedNavBanner";
+import type { SessionStorageEntry } from "./useDevPreviewLoadLifecycle";
+
+interface OAuthLoopbackState {
+  phase: OAuthPhase | null;
+  generation: number;
+}
+
+export function useOAuthLoopbackStatus(panelId: string) {
+  const [state, setState] = useState<OAuthLoopbackState>({ phase: null, generation: 0 });
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    const cleanup = window.electron.webview.onOAuthLoopbackStatus((payload) => {
+      if (payload.panelId !== panelId) return;
+      if (payload.generation < generationRef.current) return;
+
+      generationRef.current = payload.generation;
+      setState({
+        phase: payload as OAuthPhase,
+        generation: payload.generation,
+      });
+    });
+
+    return cleanup;
+  }, [panelId]);
+
+  const startOAuth = useCallback(
+    async (
+      url: string,
+      webviewElement: Electron.WebviewTag | null,
+      sessionStorageSnapshot: SessionStorageEntry[]
+    ) => {
+      let wcId: number | undefined;
+      try {
+        wcId = (webviewElement as unknown as { getWebContentsId(): number })?.getWebContentsId();
+      } catch {
+        /* webview not ready */
+      }
+      if (wcId == null) return;
+
+      // Increment generation before starting so stale push events are dropped
+      const nextGen = generationRef.current + 1;
+      generationRef.current = nextGen;
+      setState({ phase: null, generation: nextGen });
+
+      try {
+        await window.electron.webview.startOAuthLoopback(
+          url,
+          panelId,
+          wcId,
+          sessionStorageSnapshot
+        );
+      } catch {
+        setState({
+          phase: { phase: "error", message: "Failed to start sign-in flow" },
+          generation: nextGen,
+        });
+      }
+    },
+    [panelId]
+  );
+
+  const cancelOAuth = useCallback(async () => {
+    const nextGen = generationRef.current + 1;
+    generationRef.current = nextGen;
+    setState({ phase: null, generation: nextGen });
+    try {
+      await window.electron.webview.cancelOAuthLoopback(panelId);
+    } catch {
+      // Cancel is fire-and-forget; server teardown races are expected
+    }
+  }, [panelId]);
+
+  const dismissOAuth = useCallback(() => {
+    const nextGen = generationRef.current + 1;
+    generationRef.current = nextGen;
+    setState({ phase: null, generation: nextGen });
+  }, []);
+
+  return {
+    phase: state.phase,
+    startOAuth,
+    cancelOAuth,
+    dismissOAuth,
+  };
+}

--- a/src/components/DevPreview/useOAuthLoopbackStatus.ts
+++ b/src/components/DevPreview/useOAuthLoopbackStatus.ts
@@ -17,6 +17,7 @@ export function useOAuthLoopbackStatus(panelId: string) {
       if (payload.generation < generationRef.current) return;
 
       generationRef.current = payload.generation;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- push channel payload shape matches OAuthPhase discriminants
       setState({
         phase: payload as OAuthPhase,
         generation: payload.generation,
@@ -34,6 +35,7 @@ export function useOAuthLoopbackStatus(panelId: string) {
     ) => {
       let wcId: number | undefined;
       try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Electron.WebviewTag getWebContentsId is not in public types yet
         wcId = (webviewElement as unknown as { getWebContentsId(): number })?.getWebContentsId();
       } catch {
         /* webview not ready */


### PR DESCRIPTION
## Summary

Rebuilt the dev preview blocked-navigation banner UX. The old banner showed only a hostname, auto-cleared after 10 seconds, closed immediately on OAuth handoff, and silently swallowed failures.

- Shows the full URL with eTLD+1 emphasis in monospace, plus a Copy URL button.
- Persists until the user dismisses it -- no more 10-second auto-clear.
- Surfaces OAuth loopback phase transitions (started, token-exchange-intercepted, completed, timed-out, error) with Cancel and Try again buttons.
- Coalesces redirect-chain blocks by hostname, so a redirect loop doesn't stack banner state.
- Surfaces failure causes inline rather than silently disappearing.

Resolves #8263.

## Changes

12 files changed. Extracted 2 new components from `DevPreviewPane.tsx`:

- `src/components/DevPreview/BlockedNavBanner.tsx` -- full banner component with URL display, OAuth status, and action buttons.
- `src/components/DevPreview/useOAuthLoopbackStatus.ts` -- hook for tracking OAuth phases emitted from the main process.
- `electron/ipc/handlers/webview.ts` -- added `cancelOAuthLoopback` IPC, extended return shape to distinguish success/timeout/error.
- `electron/services/OAuthLoopbackService.ts` -- aligned generation counter, exposed phase events.
- `shared/utils/urlUtils.ts` -- eTLD+1 extraction for URL display emphasis.
- `electron/ipc/channels.ts`, `electron/preload.cts`, `shared/types/ipc/api.ts`, `shared/types/ipc/maps.ts` -- IPC plumbing for cancel and phase events.

## Testing

Typecheck clean, lint clean, format clean, unit tests pass. Manual smoke: blocked external navigation shows full URL with domain emphasis, OAuth loopback banner phases render correctly, Cancel aborts the loopback listener, Try again re-fires the flow.