### PR TITLE
fix(mcp): bind Daintree Assistant context at provision time

### DIFF
--- a/electron/ipc/handlers/help.ts
+++ b/electron/ipc/handlers/help.ts
@@ -4,6 +4,7 @@ import type * as HelpServiceModule from "../../services/HelpService.js";
 import type * as HelpSessionServiceModule from "../../services/HelpSessionService.js";
 import { getAgentAvailabilityStore } from "../../services/AgentAvailabilityStore.js";
 import type { HelpAssistantTier } from "../../../shared/types/ipc/maps.js";
+import type { ActionContext } from "../../../shared/types/actions.js";
 
 let cachedHelpService: typeof HelpServiceModule | null = null;
 async function getHelpService(): Promise<typeof HelpServiceModule> {
@@ -36,7 +37,17 @@ function handleUnmarkTerminal(terminalId: string): void {
 
 async function handleProvisionSession(
   ctx: import("../types.js").IpcContext,
-  input: { projectId: string; projectPath: string; agentId: string }
+  input: {
+    projectId: string;
+    projectPath: string;
+    agentId: string;
+    /**
+     * Renderer `ActionContext` snapshot captured synchronously when the
+     * user launched the assistant. Bound to the MCP session so pinned tool
+     * dispatch targets the worktree/terminal focused at launch (#8317).
+     */
+    context?: ActionContext;
+  }
 ): Promise<{
   sessionId: string;
   sessionPath: string;
@@ -56,6 +67,7 @@ async function handleProvisionSession(
     agentId: input.agentId,
     windowId: ctx.senderWindow.id,
     projectViewWebContentsId: ctx.webContentsId,
+    actionContext: input.context,
   });
 }
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -15,6 +15,7 @@ import { isIpcEnvelope } from "../shared/types/ipc/errors.js";
 import { deserializeError } from "../shared/utils/ipcErrorSerialization.js";
 import type { AppErrorCode } from "../shared/types/appError.js";
 import type { McpRuntimeSnapshot } from "../shared/types/ipc/mcpServer.js";
+import type { ActionContext } from "../shared/types/actions.js";
 import type { PushProgressEvent } from "../shared/types/ipc/gitPush.js";
 import type { HelpAssistantTier } from "../shared/types/ipc/maps.js";
 import { CHANNELS } from "./ipc/channels.js";
@@ -2450,11 +2451,18 @@ const api: ElectronAPI = {
         actionId: string;
         args?: unknown;
         confirmed?: boolean;
+        context?: ActionContext;
       }) => void
     ) => {
       const handler = (
         _event: Electron.IpcRendererEvent,
-        payload: { requestId: string; actionId: string; args?: unknown; confirmed?: boolean }
+        payload: {
+          requestId: string;
+          actionId: string;
+          args?: unknown;
+          confirmed?: boolean;
+          context?: ActionContext;
+        }
       ) => callback(payload);
       ipcRenderer.on(CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST, handler);
       return () => ipcRenderer.removeListener(CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST, handler);

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -10,6 +10,7 @@ import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { probeMcpServer, probeMcpSseServer } from "./mcp-server/readinessProbe.js";
 import { getAssistantWiredAgentIds } from "../../shared/config/agentRegistry.js";
 import type { HelpAssistantTier } from "../../shared/types/ipc/maps.js";
+import type { ActionContext } from "../../shared/types/actions.js";
 import type { PtyClient } from "./PtyClient.js";
 import { ASSISTANT_SCRATCH_ENV_VAR, getScratchDirForSession } from "./AssistantScratchService.js";
 import type { PendingHelpHibernationStore } from "./PendingHelpHibernationStore.js";
@@ -52,6 +53,15 @@ interface ProvisionInput {
   agentId: string;
   windowId: number;
   projectViewWebContentsId: number;
+  /**
+   * Snapshot of the renderer's `ActionContext` captured synchronously when
+   * the user launched the assistant, before any `await`. Bound to the MCP
+   * session at handshake and replayed as `contextOverride` on every tool
+   * dispatch so a focus shift during the model's turn can't retarget the
+   * action onto the wrong worktree/terminal (#8317). Optional — older
+   * renderers / test fixtures omit it and fall back to live context.
+   */
+  actionContext?: ActionContext;
 }
 
 export interface ProvisionResult {
@@ -82,6 +92,13 @@ interface HelpSessionRecord {
   bypassPermissions: boolean;
   createdAt: number;
   revoked: boolean;
+  /**
+   * Renderer `ActionContext` snapshot bound at provision time. Returned by
+   * `getActionContextForToken` so the MCP handshake can pin every tool call
+   * to the worktree/terminal the user had focused when they launched the
+   * assistant (#8317). Undefined when the renderer didn't supply one.
+   */
+  actionContext?: ActionContext;
   /** Computed at provision for codex sessions; consumed by lifecycle.ts. */
   codexLaunchArgs?: string[];
   /** Computed at provision for gemini sessions; consumed by lifecycle.ts. */
@@ -316,6 +333,22 @@ export class HelpSessionService {
   }
 
   /**
+   * Looks up the renderer `ActionContext` snapshot bound to a help-session
+   * bearer at provision time. The MCP server uses this at handshake to pin
+   * every tool dispatch to the worktree/terminal the user had focused when
+   * the assistant launched, so a focus shift during the model's turn can't
+   * silently retarget the action (#8317). Returns null for unknown, revoked,
+   * or context-less tokens — the dispatch then falls back to live context,
+   * matching pre-#8317 behaviour.
+   */
+  getActionContextForToken(token: string): ActionContext | null {
+    if (!token) return null;
+    const record = this.sessionsByToken.get(token);
+    if (!record || record.revoked) return null;
+    return record.actionContext ?? null;
+  }
+
+  /**
    * Inverse of `terminalBySessionId` for the assistant-turn audit. Returns
    * the help-session id currently bound to a given terminal id, or null
    * when the terminal is not (or no longer) a help-session terminal. Linear
@@ -532,6 +565,7 @@ export class HelpSessionService {
       bypassPermissions: settings.bypassPermissions,
       createdAt: now,
       revoked: false,
+      actionContext: input.actionContext,
       codexLaunchArgs,
       geminiLaunchArgs,
       copilotLaunchArgs,
@@ -1108,6 +1142,9 @@ export class HelpSessionService {
     mcpServerService.setHelpTokenValidator((token) => this.validateToken(token));
     mcpServerService.setHelpSessionWebContentsResolver((token) =>
       this.getWebContentsIdForToken(token)
+    );
+    mcpServerService.setHelpSessionActionContextResolver((token) =>
+      this.getActionContextForToken(token)
     );
     mcpServerService.setSessionIdResolver((terminalId) => this.getSessionIdForTerminal(terminalId));
     if (!mcpServerService.isEnabled()) {

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -22,6 +22,7 @@ import type {
   DispatchEnvelope,
   HelpTokenValidator,
   HelpSessionWebContentsResolver,
+  HelpSessionActionContextResolver,
 } from "./mcp-server/shared.js";
 import type { ActionManifestEntry } from "../../shared/types/actions.js";
 import { events } from "./events.js";
@@ -122,8 +123,8 @@ export class McpServerService {
       dispatchAction: (actionId, args, confirmed) =>
         this.bridge.dispatchAction(actionId, args, confirmed),
       requestManifestForWebContents: (id) => this.bridge.requestManifestForWebContents(id),
-      dispatchActionForWebContents: (id, actionId, args, confirmed) =>
-        this.bridge.dispatchActionForWebContents(id, actionId, args, confirmed),
+      dispatchActionForWebContents: (id, actionId, args, confirmed, contextOverride) =>
+        this.bridge.dispatchActionForWebContents(id, actionId, args, confirmed, contextOverride),
       handleWaitUntilIdle: (rawArgs, signal) => handleWaitUntilIdle(rawArgs, signal),
       getCachedManifest: () => this.bridge.getCachedManifest(),
       clearCachedManifest: () => this.bridge.clearCache(),
@@ -169,6 +170,10 @@ export class McpServerService {
 
   setHelpSessionWebContentsResolver(resolver: HelpSessionWebContentsResolver | null): void {
     this.httpLifecycle.setHelpSessionWebContentsResolver(resolver);
+  }
+
+  setHelpSessionActionContextResolver(resolver: HelpSessionActionContextResolver | null): void {
+    this.httpLifecycle.setHelpSessionActionContextResolver(resolver);
   }
 
   private emitStatusChange(): void {

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -27,6 +27,7 @@ const {
     setEnabled: vi.fn().mockResolvedValue(undefined),
     setHelpTokenValidator: vi.fn(),
     setHelpSessionWebContentsResolver: vi.fn(),
+    setHelpSessionActionContextResolver: vi.fn(),
     setSessionIdResolver: vi.fn(),
     recordTurnOutcome: vi.fn(),
     getRuntimeState: vi.fn<
@@ -347,6 +348,34 @@ describe("HelpSessionService", () => {
 
     await service.revokeSession(result.sessionId);
     expect(service.getWebContentsIdForToken(result.token)).toBeNull();
+  });
+
+  it("getActionContextForToken returns the provision-time snapshot and null for unknown / revoked / context-less tokens (#8317)", async () => {
+    const withCtx = await service.provisionSession({
+      ...provisionInput(),
+      actionContext: { focusedWorktreeId: "wt-1", focusedTerminalId: "term-9" },
+    });
+    if (!withCtx) throw new Error("expected result");
+
+    expect(service.getActionContextForToken(withCtx.token)).toEqual({
+      focusedWorktreeId: "wt-1",
+      focusedTerminalId: "term-9",
+    });
+    expect(service.getActionContextForToken("not-a-real-token")).toBeNull();
+    expect(service.getActionContextForToken("")).toBeNull();
+
+    await service.revokeSession(withCtx.sessionId);
+    expect(service.getActionContextForToken(withCtx.token)).toBeNull();
+
+    // A session provisioned without a context snapshot falls back to null so
+    // pinned dispatch keeps live context (pre-#8317 behaviour).
+    const noCtx = await service.provisionSession({
+      ...provisionInput(),
+      projectId: "proj-noctx",
+      projectPath: "/tmp/proj-noctx",
+    });
+    if (!noCtx) throw new Error("expected result");
+    expect(service.getActionContextForToken(noCtx.token)).toBeNull();
   });
 
   it("getWebContentsIdForToken returns the per-session pin when two sessions are minted from different views", async () => {

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -48,6 +48,7 @@ function fakeDeps(overrides?: Partial<HttpLifecycleDeps>): HttpLifecycleDeps {
       httpSessions: new Map(),
       sessionTierMap: new Map(),
       sessionWebContentsMap: new Map(),
+      sessionContextMap: new Map(),
       resourceSubscriptions: new Map(),
       drain: vi.fn(),
       getTier: vi.fn(() => "workbench" as const),

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -157,6 +157,52 @@ describe("rendererBridge — per-session pinned dispatch (#7002)", () => {
     expect(wcB.send).not.toHaveBeenCalled();
   });
 
+  it("threads the bound ActionContext into the pinned dispatch IPC payload (#8317)", async () => {
+    const wc = makeWebContents(701);
+    mockWebContentsRegistry.set(701, wc);
+
+    let sentPayload: { requestId: string; context?: unknown } | undefined;
+    wc.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST) return;
+      sentPayload = payload as { requestId: string; context?: unknown };
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+          { sender: { id: 701 } },
+          { requestId: payload.requestId, result: { ok: true, result: "ok" } }
+        );
+      });
+    });
+
+    const boundContext = { focusedWorktreeId: "wt-1", focusedTerminalId: "term-9" };
+    await bridge.dispatchActionForWebContents(701, "terminal.inject", {}, false, boundContext);
+
+    expect(sentPayload?.context).toEqual(boundContext);
+  });
+
+  it("sends context: undefined when no override is supplied — unpinned path is untouched (#8317)", async () => {
+    const wc = makeWebContents(702);
+    mockWebContentsRegistry.set(702, wc);
+
+    let sentPayload: { requestId: string; context?: unknown } | undefined;
+    wc.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST) return;
+      sentPayload = payload as { requestId: string; context?: unknown };
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+          { sender: { id: 702 } },
+          { requestId: payload.requestId, result: { ok: true, result: "ok" } }
+        );
+      });
+    });
+
+    await bridge.dispatchActionForWebContents(702, "actions.list", {}, false);
+
+    expect(sentPayload).toBeDefined();
+    expect(sentPayload?.context).toBeUndefined();
+  });
+
   it("fails closed when the pinned view has been destroyed (#7002 — never silently re-routes)", async () => {
     // No entry for id=999 → webContents.fromId returns undefined.
     await expect(bridge.requestManifestForWebContents(999)).rejects.toThrow(

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -11,7 +11,12 @@ import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { summarizeMcpArgs } from "../../../shared/utils/mcpArgsSummary.js";
 import { scrubSecrets } from "../../utils/secretScrubber.js";
 import { sanitizePath } from "../../utils/pathScrubber.js";
-import type { HelpTokenValidator, HelpSessionWebContentsResolver, McpTier } from "./shared.js";
+import type {
+  HelpTokenValidator,
+  HelpSessionWebContentsResolver,
+  HelpSessionActionContextResolver,
+  McpTier,
+} from "./shared.js";
 import {
   extractBearerToken,
   isAuthorized,
@@ -53,7 +58,8 @@ export interface HttpLifecycleDeps {
     id: number,
     actionId: string,
     args: unknown,
-    confirmed?: boolean
+    confirmed?: boolean,
+    contextOverride?: import("../../../shared/types/actions.js").ActionContext
   ) => Promise<import("./shared.js").DispatchEnvelope>;
   handleWaitUntilIdle: (
     rawArgs: unknown,
@@ -88,6 +94,7 @@ export class HttpLifecycle {
   private stopPromise: Promise<void> | null = null;
   private helpTokenValidator: HelpTokenValidator | null = null;
   private helpSessionWebContentsResolver: HelpSessionWebContentsResolver | null = null;
+  private helpSessionActionContextResolver: HelpSessionActionContextResolver | null = null;
   private lastError: string | null = null;
   private intentionalStop = false;
   private restartAttempts = 0;
@@ -141,6 +148,10 @@ export class HttpLifecycle {
     this.helpSessionWebContentsResolver = resolver;
   }
 
+  setHelpSessionActionContextResolver(resolver: HelpSessionActionContextResolver | null): void {
+    this.helpSessionActionContextResolver = resolver;
+  }
+
   /**
    * Parses a Bearer header and asks the help-session resolver for the
    * pinned WebContents id. Returns null for non-help bearers (api-key /
@@ -152,6 +163,21 @@ export class HttpLifecycle {
     const token = extractBearerToken(authHeader);
     if (!token) return null;
     return this.helpSessionWebContentsResolver(token);
+  }
+
+  /**
+   * Parses a Bearer header and asks the help-session resolver for the
+   * `ActionContext` snapshot bound to it at provision time (#8317). Returns
+   * null for non-help bearers so external/api-key sessions keep their live
+   * focused-window context in `buildSessionServerDeps`.
+   */
+  private resolveActionContext(
+    authHeader: string
+  ): import("../../../shared/types/actions.js").ActionContext | null {
+    if (!this.helpSessionActionContextResolver) return null;
+    const token = extractBearerToken(authHeader);
+    if (!token) return null;
+    return this.helpSessionActionContextResolver(token);
   }
 
   private getConfig() {
@@ -493,6 +519,11 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionWebContentsMap.set(sessionId, pinnedWebContentsId);
       }
 
+      const boundActionContext = this.resolveActionContext(authHeader);
+      if (boundActionContext !== null) {
+        this.deps.sessionStore.sessionContextMap.set(sessionId, boundActionContext);
+      }
+
       const deps = this.buildSessionServerDeps(sessionId);
       const server = createSessionServer(sessionId, deps);
 
@@ -506,6 +537,7 @@ export class HttpLifecycle {
         }
         this.deps.sessionStore.sessionTierMap.delete(sessionId);
         this.deps.sessionStore.sessionWebContentsMap.delete(sessionId);
+        this.deps.sessionStore.sessionContextMap.delete(sessionId);
         cleanupResourceSubscriptions(sessionId, this.deps.sessionStore);
       };
 
@@ -516,6 +548,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessions.delete(sessionId);
         this.deps.sessionStore.sessionTierMap.delete(sessionId);
         this.deps.sessionStore.sessionWebContentsMap.delete(sessionId);
+        this.deps.sessionStore.sessionContextMap.delete(sessionId);
         transport.onclose = undefined;
         await transport.close().catch(() => {});
         throw err;
@@ -582,6 +615,11 @@ export class HttpLifecycle {
       this.deps.sessionStore.sessionWebContentsMap.set(newSessionId, pinnedWebContentsId);
     }
 
+    const boundActionContext = this.resolveActionContext(authHeader);
+    if (boundActionContext !== null) {
+      this.deps.sessionStore.sessionContextMap.set(newSessionId, boundActionContext);
+    }
+
     const deps = this.buildSessionServerDeps(newSessionId);
     const server = createSessionServer(newSessionId, deps);
     const allowedHosts = [`127.0.0.1:${this.port}`, `localhost:${this.port}`];
@@ -615,6 +653,7 @@ export class HttpLifecycle {
       }
       this.deps.sessionStore.sessionTierMap.delete(id);
       this.deps.sessionStore.sessionWebContentsMap.delete(id);
+      this.deps.sessionStore.sessionContextMap.delete(id);
       cleanupResourceSubscriptions(id, this.deps.sessionStore);
     };
 
@@ -632,10 +671,12 @@ export class HttpLifecycle {
         }
         this.deps.sessionStore.sessionTierMap.delete(id);
         this.deps.sessionStore.sessionWebContentsMap.delete(id);
+        this.deps.sessionStore.sessionContextMap.delete(id);
         cleanupResourceSubscriptions(id, this.deps.sessionStore);
       } else {
         this.deps.sessionStore.sessionTierMap.delete(newSessionId);
         this.deps.sessionStore.sessionWebContentsMap.delete(newSessionId);
+        this.deps.sessionStore.sessionContextMap.delete(newSessionId);
         cleanupResourceSubscriptions(newSessionId, this.deps.sessionStore);
       }
       await transport.close().catch(() => {});
@@ -676,7 +717,13 @@ export class HttpLifecycle {
     ) => {
       const id = this.deps.sessionStore.sessionWebContentsMap.get(sessionId);
       if (id !== undefined && pinnedDispatch) {
-        return pinnedDispatch(id, actionId, args, confirmed);
+        // Replay the provision-time context snapshot so the assistant's
+        // tool call targets the worktree/terminal the user had focused
+        // when they launched it — not wherever focus drifted to during
+        // the model's turn (#8317). Absent for context-less sessions, in
+        // which case pinned dispatch falls back to live renderer context.
+        const boundContext = this.deps.sessionStore.sessionContextMap.get(sessionId);
+        return pinnedDispatch(id, actionId, args, confirmed, boundContext);
       }
       return this.deps.dispatchAction(actionId, args, confirmed);
     };

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -2,7 +2,7 @@ import { ipcMain, webContents as electronWebContents } from "electron";
 import { randomUUID } from "node:crypto";
 import type { WindowRegistry } from "../../window/WindowRegistry.js";
 import { getProjectViewManager } from "../../window/windowRef.js";
-import type { ActionManifestEntry } from "../../../shared/types/actions.js";
+import type { ActionContext, ActionManifestEntry } from "../../../shared/types/actions.js";
 import { CHANNELS } from "../../ipc/channels.js";
 import type { PendingRequest, DispatchEnvelope } from "./shared.js";
 import { MCP_MANIFEST_REQUEST_TIMEOUT_MS, MCP_DISPATCH_TIMEOUT_MS } from "./shared.js";
@@ -117,7 +117,8 @@ export function createRendererBridge(
     resolveWebContents: () => Electron.WebContents,
     actionId: string,
     args: unknown,
-    confirmed: boolean
+    confirmed: boolean,
+    contextOverride?: ActionContext
   ): Promise<DispatchEnvelope> {
     return new Promise((resolve, reject) => {
       let webContents: Electron.WebContents;
@@ -167,6 +168,10 @@ export function createRendererBridge(
           actionId,
           args,
           confirmed,
+          // Only pinned help-session dispatch passes a contextOverride; the
+          // unpinned external/api-key path leaves this undefined so the
+          // renderer keeps its live focused-window context (#8317).
+          context: contextOverride,
         });
       } catch (err) {
         clearTimeout(timer);
@@ -220,9 +225,16 @@ export function createRendererBridge(
     id: number,
     actionId: string,
     args: unknown,
-    confirmed = false
+    confirmed = false,
+    contextOverride?: ActionContext
   ): Promise<DispatchEnvelope> {
-    return sendDispatchRequest(() => getPinnedWebContents(id), actionId, args, confirmed);
+    return sendDispatchRequest(
+      () => getPinnedWebContents(id),
+      actionId,
+      args,
+      confirmed,
+      contextOverride
+    );
   }
 
   const manifestHandler = (

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -1,3 +1,4 @@
+import type { ActionContext } from "../../../shared/types/actions.js";
 import type { McpTier, McpSseSession, McpHttpSession } from "./shared.js";
 import { MCP_SSE_IDLE_TIMEOUT_MS } from "./shared.js";
 import type { CallToolResultLike, DedupCacheEntry } from "./sessionDedup.js";
@@ -10,6 +11,12 @@ export class SessionStore {
   // for help-session bearers; api-key / pane-token sessions stay absent and
   // fall through to the focused-window dispatch path. See #7002.
   readonly sessionWebContentsMap = new Map<string, number>();
+  // sessionId → ActionContext snapshot captured in the renderer at provision
+  // time and bound at handshake. Populated only for help-session bearers, in
+  // exact lockstep with sessionWebContentsMap. Pinned dispatch passes this as
+  // `contextOverride` so a focus shift between the model's tool call and the
+  // dispatch can't retarget the action. See #8317.
+  readonly sessionContextMap = new Map<string, ActionContext>();
   readonly resourceSubscriptions = new Map<string, Map<string, () => void>>();
   // Per-session idempotency dedup state for the MCP creation-tool allowlist.
   // Two phases: in-flight singleflight (same-moment duplicates share the
@@ -36,6 +43,7 @@ export class SessionStore {
       this.sessions.delete(sessionId);
       this.sessionTierMap.delete(sessionId);
       this.sessionWebContentsMap.delete(sessionId);
+      this.sessionContextMap.delete(sessionId);
       this.clearDedupState(sessionId);
       this.cleanupResourceSubscriptionsFn(sessionId);
       session.transport.close().catch(() => {
@@ -60,6 +68,7 @@ export class SessionStore {
       this.httpSessions.delete(sessionId);
       this.sessionTierMap.delete(sessionId);
       this.sessionWebContentsMap.delete(sessionId);
+      this.sessionContextMap.delete(sessionId);
       this.clearDedupState(sessionId);
       this.cleanupResourceSubscriptionsFn(sessionId);
       session.transport.close().catch(() => {
@@ -113,6 +122,7 @@ export class SessionStore {
     this.httpSessions.clear();
     this.sessionTierMap.clear();
     this.sessionWebContentsMap.clear();
+    this.sessionContextMap.clear();
 
     for (const bucket of this.resourceSubscriptions.values()) {
       for (const unsub of bucket.values()) {

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -1,6 +1,10 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import type { ActionDispatchResult, BuiltInActionId } from "../../../shared/types/actions.js";
+import type {
+  ActionContext,
+  ActionDispatchResult,
+  BuiltInActionId,
+} from "../../../shared/types/actions.js";
 import type {
   McpAuditRecord,
   McpAuditResult,
@@ -44,6 +48,17 @@ export type HelpTokenValidator = (token: string) => HelpAssistantTier | false;
  * pane tokens), which keep the existing focused-window semantics.
  */
 export type HelpSessionWebContentsResolver = (token: string) => number | null;
+/**
+ * Resolver used at MCP transport handshake to bind a help-session bearer to
+ * the `ActionContext` snapshot captured in the renderer at provision time
+ * (#8317). Returning a non-null context causes `httpLifecycle` to record it
+ * in `sessionContextMap` so every tool call from that session dispatches
+ * against the worktree/terminal the user had focused when they launched the
+ * assistant — not whatever they happen to be looking at when the model's
+ * tool call lands. Returns null for non-help bearers (api-key / pane
+ * tokens), which intentionally keep the live focused-window context.
+ */
+export type HelpSessionActionContextResolver = (token: string) => ActionContext | null;
 export type { HelpAssistantTier };
 
 export const MCP_SERVER_KEY = "daintree";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1407,6 +1407,12 @@ export interface ElectronAPI {
         actionId: string;
         args?: unknown;
         confirmed?: boolean;
+        /**
+         * Provision-time `ActionContext` snapshot bound to pinned
+         * help-session dispatch (#8317). Undefined for unpinned
+         * external/api-key dispatch, which keeps live renderer context.
+         */
+        context?: ActionContext;
       }) => void
     ): () => void;
     /** Send action dispatch result to main process */
@@ -1473,7 +1479,12 @@ export interface ElectronAPI {
     getFolderPath(): Promise<string | null>;
     markTerminal(terminalId: string): Promise<void>;
     unmarkTerminal(terminalId: string): Promise<void>;
-    provisionSession(input: { projectId: string; projectPath: string; agentId: string }): Promise<{
+    provisionSession(input: {
+      projectId: string;
+      projectPath: string;
+      agentId: string;
+      context?: ActionContext;
+    }): Promise<{
       sessionId: string;
       sessionPath: string;
       token: string;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -189,7 +189,14 @@ export interface GeneratedIpcInvokeMap {
     result: void;
   };
   "help:provision-session": {
-    args: [input: { projectId: string; projectPath: string; agentId: string }];
+    args: [
+      input: {
+        projectId: string;
+        projectPath: string;
+        agentId: string;
+        context?: import("../actions.js").ActionContext | undefined;
+      },
+    ];
     result: {
       sessionId: string;
       sessionPath: string;

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -59,6 +59,7 @@ describe("useMcpBridge", () => {
         actionId: string;
         args?: unknown;
         confirmed?: boolean;
+        context?: Record<string, unknown>;
       }) => void | Promise<void>)
     | undefined;
   let cleanupManifest: ReturnType<typeof vi.fn>;
@@ -94,6 +95,7 @@ describe("useMcpBridge", () => {
               actionId: string;
               args?: unknown;
               confirmed?: boolean;
+              context?: Record<string, unknown>;
             }) => void | Promise<void>
           ) => {
             dispatchHandler = callback;
@@ -151,6 +153,46 @@ describe("useMcpBridge", () => {
       result: { ok: true, result: { ok: true } },
       confirmationDecision: undefined,
     });
+  });
+
+  it("forwards the bound provision-time context as contextOverride (#8317)", async () => {
+    mocks.get.mockReturnValue(safeManifestEntry());
+    mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+
+    renderHook(() => useMcpBridge());
+
+    const boundContext = { focusedWorktreeId: "wt-7", focusedTerminalId: "term-2" };
+    await dispatchHandler?.({
+      requestId: "req-ctx",
+      actionId: "terminal.inject",
+      args: { text: "ls" },
+      context: boundContext,
+    });
+
+    expect(mocks.dispatch).toHaveBeenCalledWith(
+      "terminal.inject",
+      { text: "ls" },
+      { source: "agent", confirmed: undefined, contextOverride: boundContext }
+    );
+  });
+
+  it("passes contextOverride: undefined for unpinned dispatch — live context preserved (#8317)", async () => {
+    mocks.get.mockReturnValue(safeManifestEntry());
+    mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+
+    renderHook(() => useMcpBridge());
+
+    await dispatchHandler?.({
+      requestId: "req-no-ctx",
+      actionId: "actions.list",
+      args: { limit: 3 },
+    });
+
+    expect(mocks.dispatch).toHaveBeenCalledWith(
+      "actions.list",
+      { limit: 3 },
+      { source: "agent", confirmed: undefined, contextOverride: undefined }
+    );
   });
 
   it("suppresses create-time panel focus while an MCP action dispatch is in flight", async () => {

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -253,6 +253,35 @@ describe("useMcpBridge", () => {
     });
   });
 
+  it("preserves the bound context across the confirmation wait (#8317)", async () => {
+    mocks.get.mockReturnValue(confirmManifestEntry());
+    mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+
+    renderHook(() => useMcpBridge());
+
+    const boundContext = { focusedWorktreeId: "wt-confirm" };
+    const dispatched = dispatchHandler?.({
+      requestId: "req-confirm-ctx",
+      actionId: "worktree.delete",
+      args: { worktreeId: "wt-1" },
+      context: boundContext,
+    });
+
+    await Promise.resolve();
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+
+    useMcpConfirmStore.getState().resolveCurrent("approved");
+    await dispatched;
+
+    // contextOverride must be the value captured in the handler closure,
+    // not re-read from live state after the modal await resolved.
+    expect(mocks.dispatch).toHaveBeenCalledWith(
+      "worktree.delete",
+      { worktreeId: "wt-1" },
+      { source: "agent", confirmed: true, contextOverride: boundContext }
+    );
+  });
+
   it("returns USER_REJECTED without ever calling actionService.dispatch when the user cancels", async () => {
     mocks.get.mockReturnValue(confirmManifestEntry());
     mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -85,7 +85,7 @@ export function useMcpBridge(): void {
     });
 
     const cleanupDispatch = window.electron.mcpBridge.onDispatchActionRequest(
-      async ({ requestId, actionId, args, confirmed }) => {
+      async ({ requestId, actionId, args, confirmed, context }) => {
         let confirmationDecision: McpConfirmationDecision | undefined;
         try {
           let effectiveConfirmed = confirmed;
@@ -134,6 +134,13 @@ export function useMcpBridge(): void {
             actionService.dispatch(actionId as ActionId, dispatchArgs, {
               source: "agent",
               confirmed: effectiveConfirmed,
+              // Pinned help-session dispatch carries the provision-time
+              // context snapshot; replay it so the action targets the
+              // worktree/terminal focused at launch, not wherever focus
+              // drifted during the model's turn (#8317). Undefined for
+              // unpinned external dispatch — ActionService then falls
+              // back to live renderer context, unchanged behaviour.
+              contextOverride: context,
             })
           );
           if (disposed) return;

--- a/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
+++ b/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
@@ -3,6 +3,7 @@ import type { CliAvailability } from "@shared/types";
 
 const {
   mockDispatch,
+  mockGetContext,
   mockNotify,
   mockGetAgentPrefsState,
   mockGetCliAvailabilityState,
@@ -11,6 +12,7 @@ const {
   mockLogError,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn().mockResolvedValue({ ok: true }),
+  mockGetContext: vi.fn(() => ({})),
   mockNotify: vi.fn().mockReturnValue(""),
   mockGetAgentPrefsState: vi.fn(),
   mockGetCliAvailabilityState: vi.fn(),
@@ -20,7 +22,7 @@ const {
 }));
 
 vi.mock("@/services/ActionService", () => ({
-  actionService: { dispatch: mockDispatch },
+  actionService: { dispatch: mockDispatch, getContext: mockGetContext },
 }));
 
 vi.mock("@/lib/notify", () => ({
@@ -301,6 +303,7 @@ describe("help.launchAgent", () => {
       projectId: "proj-1",
       projectPath: "/repo",
       agentId: "claude",
+      context: {},
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
@@ -315,6 +318,34 @@ describe("help.launchAgent", () => {
         },
       }),
       { source: "user" }
+    );
+  });
+
+  it("snapshots the action context synchronously before the getFolderPath await (#8317)", async () => {
+    // getContext returns the value captured at call time. Resolve
+    // getFolderPath only after we've mutated what getContext would return —
+    // proving the capture happened on the synchronous first line, not after
+    // the await (the stale-read race this fix closes; lesson #5087).
+    mockGetContext.mockReturnValue({ focusedWorktreeId: "wt-at-launch" });
+    let resolveFolder: (v: string) => void = () => {};
+    (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise<string>((r) => {
+        resolveFolder = r;
+      })
+    );
+    mockGetProjectState.mockReturnValue({
+      currentProject: { id: "proj-1", path: "/repo" },
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
+
+    const runPromise = action.run(undefined, stubCtx);
+    // Focus drifts while getFolderPath is still pending.
+    mockGetContext.mockReturnValue({ focusedWorktreeId: "wt-drifted" });
+    resolveFolder("/mock/help");
+    await runPromise;
+
+    expect(window.electron.help.provisionSession).toHaveBeenCalledWith(
+      expect.objectContaining({ context: { focusedWorktreeId: "wt-at-launch" } })
     );
   });
 

--- a/src/services/actions/definitions/helpActions.ts
+++ b/src/services/actions/definitions/helpActions.ts
@@ -53,6 +53,13 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
     keywords: ["assistant", "support", "docs", "guide"],
     argsSchema: z.object({ agentId: AgentIdSchema.optional() }).optional(),
     run: async (args?: unknown) => {
+      // Snapshot the renderer's action context BEFORE any await. This is
+      // bound to the MCP session at provision and replayed as the
+      // contextOverride on every assistant tool call, so a focus shift
+      // during the model's turn can't retarget actions onto the wrong
+      // worktree/terminal (#8317). Capturing after an await would
+      // reintroduce the exact stale-read race this fixes (lesson #5087).
+      const capturedContext = actionService.getContext();
       const folderPath = await window.electron.help.getFolderPath();
       if (!folderPath) {
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
@@ -97,6 +104,7 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
           projectId: project.id,
           projectPath: project.path,
           agentId,
+          context: capturedContext,
         });
       } catch (err) {
         logError("Failed to provision help session", err);

--- a/src/services/actions/definitions/helpActions.ts
+++ b/src/services/actions/definitions/helpActions.ts
@@ -59,7 +59,12 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
       // during the model's turn can't retarget actions onto the wrong
       // worktree/terminal (#8317). Capturing after an await would
       // reintroduce the exact stale-read race this fixes (lesson #5087).
+      // `currentProject` is captured in the same synchronous block so the
+      // session is provisioned with a project identity and context snapshot
+      // that are guaranteed consistent — a project switch during the
+      // `getFolderPath()` await can't split them (#8317).
       const capturedContext = actionService.getContext();
+      const project = useProjectStore.getState().currentProject;
       const folderPath = await window.electron.help.getFolderPath();
       if (!folderPath) {
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
@@ -87,7 +92,6 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
       const helpPrompt =
         "I need help with Daintree, an Electron-based IDE for orchestrating AI coding agents. Please briefly tell me how you can help.";
 
-      const project = useProjectStore.getState().currentProject;
       let session: Awaited<ReturnType<typeof window.electron.help.provisionSession>> | null = null;
       if (!project) {
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok


### PR DESCRIPTION
## Summary

- The `contextOverride` field in the Daintree Assistant MCP dispatch path was being ignored — context never made it through to the actual tool call.
- Fix captures an `ActionContext` snapshot synchronously at assistant launch, threads it through the `provisionSession` IPC call into `HelpSessionRecord`, stores it in `sessionContextMap`, and pins it through to `useMcpBridge` as `contextOverride`. Scoped to the pinned `help-session` path only.
- 320 tests pass; all 7 verify checks (typecheck, lint, format, build, ipc, channels, help) are green.

Resolves #8317

## Changes

- `helpActions.ts` — capture `ActionContext` snapshot at `launchDaintreeAssistant` time
- `help.ts` (IPC handler) — accept and store `actionContext` on `provisionSession`
- `HelpSessionService.ts` — extend `HelpSessionRecord` with `actionContext`; populate `sessionContextMap`
- `McpServerService.ts` — read context from `sessionContextMap` and forward to `rendererBridge`
- `httpLifecycle.ts` — propagate context through the pinned MCP dispatch path
- `rendererBridge.ts` — pass context as `contextOverride` to `useMcpBridge`
- `useMcpBridge.ts` — wire `contextOverride` through to dispatch
- `shared/types/ipc/api.ts` + `generated.ts` — extend `provisionSession` payload type
- Tests added for `HelpSessionService`, `rendererBridge`, `useMcpBridge`, and `helpLaunchAgent`

## Testing

Ran all 320 affected tests locally. All pass. Verified the full check suite (typecheck, lint, format, build, ipc, channels, help) — all green.