### PR TITLE
feat(forge): rename project GitHub tab to Code Forge, default to GitHub

### DIFF
--- a/src/components/Project/CodeForgeTab.tsx
+++ b/src/components/Project/CodeForgeTab.tsx
@@ -3,7 +3,7 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { RemoteInfo } from "@shared/types/ipc/github";
 import type { RegisteredForgeProvider } from "@shared/types/forge";
 
-interface ForgeProviderTabProps {
+interface CodeForgeTabProps {
   githubRemote: string | undefined;
   onGithubRemoteChange: (remote: string | undefined) => void;
   forgeProviderOverride: string | null;
@@ -11,13 +11,13 @@ interface ForgeProviderTabProps {
   projectPath: string | undefined;
 }
 
-export function ForgeProviderTab({
+export function CodeForgeTab({
   githubRemote,
   onGithubRemoteChange,
   forgeProviderOverride,
   onForgeProviderOverrideChange,
   projectPath,
-}: ForgeProviderTabProps) {
+}: CodeForgeTabProps) {
   const [remotes, setRemotes] = useState<RemoteInfo[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -87,9 +87,9 @@ export function ForgeProviderTab({
   return (
     <div className="space-y-6">
       <div>
-        <label className="block text-sm font-medium text-daintree-text mb-1">GitHub Remote</label>
+        <label className="block text-sm font-medium text-daintree-text mb-1">Forge Remote</label>
         <p className="text-xs text-daintree-text/60 mb-2">
-          Select which git remote to use for GitHub integration (issues, PRs, and pulse data).
+          Select which git remote to use for forge integration (issues, PRs, and pulse data).
         </p>
         {loading ? (
           <div className="text-sm text-daintree-text/60">Loading remotes...</div>
@@ -115,7 +115,7 @@ export function ForgeProviderTab({
       <div>
         <label className="block text-sm font-medium text-daintree-text mb-1">Forge provider</label>
         <p className="text-xs text-daintree-text/60 mb-2">
-          Pin this project to a specific forge provider, overriding hostname auto-detection.
+          Pin this project to a specific forge provider. Defaults to GitHub when no override is set.
         </p>
         {providersLoading ? (
           <div className="text-sm text-daintree-text/60">Loading providers...</div>
@@ -129,7 +129,7 @@ export function ForgeProviderTab({
             }
             className="w-full px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
           >
-            <option value="">Auto-detect</option>
+            <option value="">Default (GitHub)</option>
             {providers.map((p) => (
               <option key={`${p.pluginId}:${p.contribution.id}`} value={p.contribution.id}>
                 {p.contribution.name}

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1025,7 +1025,7 @@ function ProjectFormTabContent({
         />
       );
 
-    case "project:github":
+    case "project:code-forge":
       return (
         <LazyComp
           githubRemote={projectForm.githubRemote}

--- a/src/components/Settings/__tests__/SettingsDialog.rememberTab.test.ts
+++ b/src/components/Settings/__tests__/SettingsDialog.rememberTab.test.ts
@@ -26,7 +26,7 @@ const VALID_TABS: SettingsTab[] = [
   "project:recipes",
   "project:commands",
   "project:notifications",
-  "project:github",
+  "project:code-forge",
 ];
 
 /**

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -306,7 +306,7 @@ describe("SETTINGS_SEARCH_INDEX", () => {
       "project:recipes",
       "project:commands",
       "project:notifications",
-      "project:github",
+      "project:code-forge",
     ];
     for (const tab of expectedTabs) {
       expect(tabs.has(tab as never), `tab "${tab}" should be in index`).toBe(true);
@@ -367,7 +367,7 @@ describe("SETTINGS_SEARCH_INDEX", () => {
       "project:recipes": "Recipes",
       "project:commands": "Commands",
       "project:notifications": "Notifications",
-      "project:github": "GitHub",
+      "project:code-forge": "Code Forge",
     };
     for (const entry of SETTINGS_SEARCH_INDEX) {
       expect(
@@ -405,7 +405,7 @@ describe("SETTINGS_SEARCH_INDEX", () => {
       "project:recipes": "Recipes",
       "project:commands": "Commands",
       "project:notifications": "Notifications",
-      "project:github": "GitHub",
+      "project:code-forge": "Code Forge",
     };
     for (const tabKey of Object.keys(tabTitles)) {
       const navEntry = SETTINGS_SEARCH_INDEX.find((e) => e.id === `tab-nav-${tabKey}`);

--- a/src/components/Settings/__tests__/settingsTabRegistry.test.ts
+++ b/src/components/Settings/__tests__/settingsTabRegistry.test.ts
@@ -246,7 +246,7 @@ describe("getSettingsNavGroups", () => {
       "project:recipes",
       "project:commands",
       "project:notifications",
-      "project:github",
+      "project:code-forge",
     ];
     expect(groups[0]!.entries.map((e) => e.id)).toEqual(expectedOrder);
   });

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -106,7 +106,7 @@ const importProjectAutomationTab = () => import("@/components/Project/Automation
 const importProjectRecipesTab = () => import("@/components/Project/RecipesTab");
 const importProjectCommandsTab = () => import("./CommandOverridesTab");
 const importProjectNotificationsTab = () => import("@/components/Project/ProjectNotificationsTab");
-const importProjectForgeProviderTab = () => import("@/components/Project/ForgeProviderTab");
+const importProjectCodeForgeTab = () => import("@/components/Project/CodeForgeTab");
 
 // ── Lazy components (module-level — React requires stable lazy() refs) ──
 
@@ -182,8 +182,8 @@ const LazyProjectCommandsTab = lazy(() =>
 const LazyProjectNotificationsTab = lazy(() =>
   importProjectNotificationsTab().then((m) => ({ default: m.ProjectNotificationsTab }))
 );
-const LazyProjectForgeProviderTab = lazy(() =>
-  importProjectForgeProviderTab().then((m) => ({ default: m.ForgeProviderTab }))
+const LazyProjectCodeForgeTab = lazy(() =>
+  importProjectCodeForgeTab().then((m) => ({ default: m.CodeForgeTab }))
 );
 
 // ── Voice requiresEnabled gates (referenced repeatedly) ─────────────────
@@ -1521,14 +1521,14 @@ export const SETTINGS_REGISTRY = [
   } satisfies LazySettingsTabEntry,
 
   {
-    id: "project:github",
+    id: "project:code-forge",
     scope: "project",
     group: "Project",
-    label: "GitHub",
-    icon: <Github className="w-4 h-4" />,
+    label: "Code Forge",
+    icon: <GitBranch className="w-4 h-4" />,
     importKind: "lazy",
-    importer: importProjectForgeProviderTab,
-    LazyComponent: LazyProjectForgeProviderTab,
+    importer: importProjectCodeForgeTab,
+    LazyComponent: LazyProjectCodeForgeTab,
     needsProjectForm: true,
   } satisfies LazySettingsTabEntry,
 ] as const satisfies readonly AnySettingsTabEntry[];
@@ -1683,11 +1683,12 @@ export const PROJECT_SETTINGS_SECTIONS: Readonly<
     searchNavDescription: "Project-specific notification overrides",
     searchNavKeywords: ["project", "notifications", "alerts", "sounds", "overrides"],
   },
-  "project:github": {
-    tabLabel: "GitHub",
-    searchNavDescription: "Per-project GitHub remote configuration for issues, PRs, and pulse data",
+  "project:code-forge": {
+    tabLabel: "Code Forge",
+    searchNavDescription: "Per-project forge remote configuration for issues, PRs, and pulse data",
     searchNavKeywords: [
       "project",
+      "forge",
       "github",
       "remote",
       "origin",
@@ -1697,11 +1698,11 @@ export const PROJECT_SETTINGS_SECTIONS: Readonly<
     ],
     sections: [
       {
-        id: "project-github-remote",
-        section: "GitHub Remote",
-        title: "GitHub Remote",
-        description: "Select which git remote to use for GitHub integration",
-        keywords: ["github", "remote", "origin", "git", "repository", "fetch", "push"],
+        id: "project-code-forge-remote",
+        section: "Forge Remote",
+        title: "Forge Remote",
+        description: "Select which git remote to use for forge integration",
+        keywords: ["forge", "github", "remote", "origin", "git", "repository", "fetch", "push"],
       },
     ],
   },
@@ -1760,7 +1761,7 @@ export const projectTabIcons: Record<ProjectSettingsTab, ReactNode> = {
   "project:recipes": <Workflow className="w-5 h-5 text-text-secondary" />,
   "project:commands": <Command className="w-5 h-5 text-text-secondary" />,
   "project:notifications": <Bell className="w-5 h-5 text-text-secondary" />,
-  "project:github": <Github className="w-5 h-5 text-text-secondary" />,
+  "project:code-forge": <GitBranch className="w-5 h-5 text-text-secondary" />,
 };
 
 export function scopeForTab(tab: SettingsTab): SettingsScope {

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -42,7 +42,7 @@ export const SettingsTabSchema = z.enum([
   "project:recipes",
   "project:commands",
   "project:notifications",
-  "project:github",
+  "project:code-forge",
 ]);
 
 export const SettingsNavTargetSchema = z.object({


### PR DESCRIPTION
## Summary
- Renames the per-project GitHub settings tab to "Code Forge" so it can host settings for other forges going forward.
- Defaults the forge provider selector to GitHub instead of Auto-detect, since GitHub is the right starting point for most projects.
- Updates the tab icon from the GitHub mark to a `GitBranch` icon to match the broader scope.

Resolves #8330

## Changes
- Renamed `GitHubTab.tsx` to `CodeForgeTab.tsx` and updated all component references.
- Changed tab ID from `project:github` to `project:code-forge` in the settings registry, search index, tab schema, and tests.
- Updated labels: "GitHub Remote" to "Forge Remote", "Auto-detect" to "Default (GitHub)".
- Swapped icon from `Github` to `GitBranch`.

## Testing
- Existing settings registry, search, and remember-tab unit tests pass with updated tab IDs.