### PR TITLE
fix(keybinding): tighten actionId type and validate user overrides

### DIFF
--- a/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
+++ b/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
@@ -5,7 +5,7 @@ import { useOverlayState } from "@/hooks";
 import { Kbd, KbdChord } from "@/components/ui/Kbd";
 import { MODIFIER_SEARCH_MAP, isChordPrefix, normalizeQuery } from "@/lib/kbdShortcut";
 import { keybindingService } from "../../services/KeybindingService";
-import type { KeybindingConfig } from "../../services/KeybindingService";
+import type { RegisteredKeybindingConfig } from "../../services/KeybindingService";
 
 const CATEGORY_ORDER = [
   "Terminal",
@@ -23,7 +23,7 @@ interface ShortcutReferenceDialogProps {
   onClose: () => void;
 }
 
-interface ShortcutSearchItem extends KeybindingConfig {
+interface ShortcutSearchItem extends RegisteredKeybindingConfig {
   effectiveCombo: string;
   displayCombo: string;
   normalizedCombo: string;

--- a/src/components/KeyboardShortcuts/__tests__/ShortcutReferenceDialog.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/ShortcutReferenceDialog.test.tsx
@@ -2,7 +2,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { ShortcutReferenceDialog } from "../ShortcutReferenceDialog";
-import type { KeybindingConfig } from "@/services/KeybindingService";
+import type { RegisteredKeybindingConfig } from "@/services/KeybindingService";
 
 vi.stubGlobal(
   "ResizeObserver",
@@ -13,7 +13,7 @@ vi.stubGlobal(
   }
 );
 
-const mockBindings: Array<KeybindingConfig & { effectiveCombo: string }> = [
+const mockBindings: Array<RegisteredKeybindingConfig & { effectiveCombo: string }> = [
   {
     actionId: "terminal.stashInput",
     combo: "Cmd+K Cmd+S",
@@ -24,7 +24,7 @@ const mockBindings: Array<KeybindingConfig & { effectiveCombo: string }> = [
     effectiveCombo: "Cmd+K Cmd+S",
   },
   {
-    actionId: "app.toggleSidebar",
+    actionId: "nav.toggleSidebar",
     combo: "Cmd+B",
     scope: "global",
     priority: 0,
@@ -33,7 +33,7 @@ const mockBindings: Array<KeybindingConfig & { effectiveCombo: string }> = [
     effectiveCombo: "Cmd+B",
   },
   {
-    actionId: "terminal.newPanel",
+    actionId: "terminal.new",
     combo: "Cmd+T",
     scope: "global",
     priority: 0,
@@ -42,7 +42,7 @@ const mockBindings: Array<KeybindingConfig & { effectiveCombo: string }> = [
     effectiveCombo: "Cmd+T",
   },
   {
-    actionId: "app.openSettings",
+    actionId: "app.settings",
     combo: "Cmd+,",
     scope: "global",
     priority: 0,
@@ -51,7 +51,7 @@ const mockBindings: Array<KeybindingConfig & { effectiveCombo: string }> = [
     effectiveCombo: "Cmd+,",
   },
   {
-    actionId: "app.commandPalette",
+    actionId: "action.palette.open",
     combo: "Cmd+Shift+P",
     scope: "global",
     priority: 0,
@@ -60,7 +60,7 @@ const mockBindings: Array<KeybindingConfig & { effectiveCombo: string }> = [
     effectiveCombo: "Cmd+Shift+P",
   },
   {
-    actionId: "app.unboundAction",
+    actionId: "project.mruCycleNewer",
     combo: "",
     scope: "global",
     priority: 0,
@@ -72,11 +72,11 @@ const mockBindings: Array<KeybindingConfig & { effectiveCombo: string }> = [
 
 const mockDisplayCombos: Record<string, string> = {
   "terminal.stashInput": "⌘K ⌘S",
-  "app.toggleSidebar": "⌘B",
-  "terminal.newPanel": "⌘T",
-  "app.openSettings": "⌘,",
-  "app.commandPalette": "⌘⇧P",
-  "app.unboundAction": "",
+  "nav.toggleSidebar": "⌘B",
+  "terminal.new": "⌘T",
+  "app.settings": "⌘,",
+  "action.palette.open": "⌘⇧P",
+  "project.mruCycleNewer": "",
 };
 
 vi.mock("@/services/KeybindingService", () => {

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { Search, X, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { keybindingService, KeybindingConfig } from "@/services/KeybindingService";
+import { keybindingService, type RegisteredKeybindingConfig } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
@@ -9,7 +9,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { KeybindingProfileActions } from "./KeybindingProfileActions";
 import { SettingsShortcutCapture } from "@/components/KeyboardShortcuts";
 
-interface ShortcutBinding extends KeybindingConfig {
+interface ShortcutBinding extends RegisteredKeybindingConfig {
   effectiveCombo: string;
   isOverridden: boolean;
 }

--- a/src/components/__tests__/agentPinSync.integration.test.tsx
+++ b/src/components/__tests__/agentPinSync.integration.test.tsx
@@ -96,6 +96,7 @@ vi.mock("@shared/config/agentIds", () => {
   const set: ReadonlySet<string> = new Set<string>(BUILT_IN_AGENT_IDS);
   return {
     BUILT_IN_AGENT_IDS,
+    BUILT_IN_AGENT_KEY_ACTIONS: BUILT_IN_AGENT_IDS.map((id) => `agent.${id}`),
     isBuiltInAgentId: (value: unknown): boolean => typeof value === "string" && set.has(value),
   };
 });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -37,7 +37,11 @@ export {
 } from "./useKeybinding";
 export { useGlobalKeybindings, usePendingChord } from "./useGlobalKeybindings";
 export { keybindingService } from "../services/KeybindingService";
-export type { KeyScope, KeybindingConfig } from "../services/KeybindingService";
+export type {
+  KeyScope,
+  KeybindingConfig,
+  RegisteredKeybindingConfig,
+} from "../services/KeybindingService";
 
 export { useProjectSettings } from "./useProjectSettings";
 export { useProjectSettingsForm } from "./useProjectSettingsForm";

--- a/src/hooks/useGlobalKeybindings.ts
+++ b/src/hooks/useGlobalKeybindings.ts
@@ -145,13 +145,9 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
 
           // Dispatch through ActionService
           void actionService
-            .dispatch(
-              result.match.actionId as Parameters<typeof actionService.dispatch>[0],
-              undefined,
-              {
-                source: "keybinding",
-              }
-            )
+            .dispatch(result.match.actionId, undefined, {
+              source: "keybinding",
+            })
             .then((dispatchResult) => {
               if (!dispatchResult.ok) {
                 logError(

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -1,6 +1,6 @@
 import type {
   KeyScope,
-  KeybindingConfig,
+  RegisteredKeybindingConfig,
   KeybindingConflict,
   KeybindingResolutionResult,
 } from "./keybindingUtils";
@@ -12,6 +12,8 @@ import {
 } from "./keybindingUtils";
 import { DEFAULT_KEYBINDINGS } from "./defaultKeybindings";
 import { isMac } from "@/lib/platform";
+import { BUILT_IN_ACTION_IDS } from "@shared/config/actionIds";
+import { KEY_ACTION_VALUES } from "@shared/types/keymap";
 
 export * from "./keybindingUtils";
 export * from "./defaultKeybindings";
@@ -20,8 +22,13 @@ function scopesConflict(a: KeyScope, b: KeyScope): boolean {
   return a === b || a === "global" || b === "global";
 }
 
+const builtInActionIdSet: ReadonlySet<string> = new Set([
+  ...BUILT_IN_ACTION_IDS,
+  ...KEY_ACTION_VALUES,
+]);
+
 class KeybindingService {
-  private bindings: Map<string, KeybindingConfig[]> = new Map();
+  private bindings: Map<string, RegisteredKeybindingConfig[]> = new Map();
   private overrides: Map<string, string[]> = new Map();
   private scopeStack: KeyScope[] = ["global"];
   private currentScope: KeyScope = "global";
@@ -46,11 +53,16 @@ class KeybindingService {
       const overrides = await window.electron.keybinding.getOverrides();
       this.overrides.clear();
       if (overrides && typeof overrides === "object") {
-        Object.entries(overrides).forEach(([actionId, combos]) => {
-          if (Array.isArray(combos)) {
-            this.overrides.set(actionId, combos);
+        for (const [actionId, combos] of Object.entries(overrides)) {
+          if (!Array.isArray(combos)) continue;
+          if (!builtInActionIdSet.has(actionId) && !this.bindings.has(actionId)) {
+            console.warn(
+              `[KeybindingService] Dropping override for unknown action "${actionId}" — not a built-in or registered binding.`
+            );
+            continue;
           }
-        });
+          this.overrides.set(actionId, combos as string[]);
+        }
       }
       this.notifyListeners();
     }
@@ -213,14 +225,14 @@ class KeybindingService {
     return this.currentScope;
   }
 
-  getBinding(actionId: string): KeybindingConfig | undefined {
+  getBinding(actionId: string): RegisteredKeybindingConfig | undefined {
     const arr = this.bindings.get(actionId);
     if (!arr || arr.length === 0) return undefined;
     const scopeMatch = arr.find((b) => b.scope === this.currentScope);
     return scopeMatch ?? arr[0];
   }
 
-  getAllBindings(): KeybindingConfig[] {
+  getAllBindings(): RegisteredKeybindingConfig[] {
     return Array.from(this.bindings.values()).flat();
   }
 
@@ -340,14 +352,14 @@ class KeybindingService {
   }
 
   resolveKeybinding(event: KeyboardEvent): KeybindingResolutionResult {
-    let bestMatch: KeybindingConfig | undefined;
+    let bestMatch: RegisteredKeybindingConfig | undefined;
     let bestPriority = -Infinity;
     let foundChordPrefix = false;
 
     const currentCombo = this.eventToCombo(event);
 
     // When a chord is pending, prioritize chord completion over standalone shortcuts
-    let chordCompletionMatch: KeybindingConfig | undefined;
+    let chordCompletionMatch: RegisteredKeybindingConfig | undefined;
     let chordCompletionPriority = -Infinity;
 
     for (const arr of this.bindings.values()) {
@@ -441,12 +453,12 @@ class KeybindingService {
     return scope === "global" || scope === this.currentScope;
   }
 
-  findMatchingAction(event: KeyboardEvent): KeybindingConfig | undefined {
+  findMatchingAction(event: KeyboardEvent): RegisteredKeybindingConfig | undefined {
     const result = this.resolveKeybinding(event);
     return result.match;
   }
 
-  registerBinding(config: KeybindingConfig): void {
+  registerBinding(config: RegisteredKeybindingConfig): void {
     if (config.combo) {
       for (const arr of this.bindings.values()) {
         for (const existing of arr) {
@@ -504,7 +516,9 @@ class KeybindingService {
     return display;
   }
 
-  getAllBindingsWithEffectiveCombos(): Array<KeybindingConfig & { effectiveCombo: string }> {
+  getAllBindingsWithEffectiveCombos(): Array<
+    RegisteredKeybindingConfig & { effectiveCombo: string }
+  > {
     return Array.from(this.bindings.values())
       .flat()
       .map((binding) => {

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -4,7 +4,7 @@ import {
   KeybindingService,
   normalizeKey,
   normalizeKeyForBinding,
-  type KeybindingConfig,
+  type RegisteredKeybindingConfig,
 } from "../KeybindingService";
 
 function setPlatform(platform: string) {
@@ -494,7 +494,7 @@ describe("KeybindingService", () => {
 
     const all = service.getAllBindingsWithEffectiveCombos();
     const binding = all.find((entry) => entry.actionId === "terminal.duplicate") as
-      | (KeybindingConfig & { effectiveCombo: string })
+      | (RegisteredKeybindingConfig & { effectiveCombo: string })
       | undefined;
 
     expect(binding).toBeTruthy();
@@ -1628,6 +1628,113 @@ describe("KeybindingService", () => {
         createKeyboardEvent({ key: "+", code: "Equal", metaKey: true, shiftKey: true })
       );
       expect(match?.actionId).toBe("window.zoomIn");
+    });
+  });
+
+  describe("loadOverrides warn-and-drop — issue #8318", () => {
+    function mockElectronOverrides(overrides: Record<string, string[]>) {
+      vi.stubGlobal("window", {
+        electron: {
+          keybinding: {
+            getOverrides: vi.fn().mockResolvedValue(overrides),
+            setOverride: vi.fn().mockResolvedValue(undefined),
+            removeOverride: vi.fn().mockResolvedValue(undefined),
+            resetAll: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+      });
+    }
+
+    it("loads valid built-in override", async () => {
+      setPlatform("MacIntel");
+      mockElectronOverrides({ "terminal.close": ["Cmd+Shift+W"] });
+      const service = new KeybindingService();
+
+      await service.loadOverrides();
+      expect(service.getEffectiveCombo("terminal.close")).toBe("Cmd+Shift+W");
+    });
+
+    it("drops unknown actionId with warning", async () => {
+      setPlatform("MacIntel");
+      mockElectronOverrides({ "terminal.clearr": ["Cmd+X"] });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const service = new KeybindingService();
+
+      await service.loadOverrides();
+      expect(service.getOverride("terminal.clearr")).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Dropping override for unknown action "terminal.clearr"')
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("retains valid entries in mixed valid + invalid overrides", async () => {
+      setPlatform("MacIntel");
+      mockElectronOverrides({
+        "terminal.close": ["Cmd+Shift+W"],
+        "terminal.clearr": ["Cmd+X"],
+        "terminal.new": ["Cmd+Shift+N"],
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const service = new KeybindingService();
+
+      await service.loadOverrides();
+      expect(service.getEffectiveCombo("terminal.close")).toBe("Cmd+Shift+W");
+      expect(service.getEffectiveCombo("terminal.new")).toBe("Cmd+Shift+N");
+      expect(service.getOverride("terminal.clearr")).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      warnSpy.mockRestore();
+    });
+
+    it("empty overrides load without warning", async () => {
+      setPlatform("MacIntel");
+      mockElectronOverrides({});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const service = new KeybindingService();
+
+      await service.loadOverrides();
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it("calling loadOverrides twice does not resurrect stale invalid entries", async () => {
+      setPlatform("MacIntel");
+      mockElectronOverrides({ "terminal.clearr": ["Cmd+X"] });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const service = new KeybindingService();
+
+      await service.loadOverrides();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      warnSpy.mockClear();
+
+      await service.loadOverrides();
+      // Second load from same stub returns the same invalid entry, dropped again
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(service.getOverride("terminal.clearr")).toBeUndefined();
+
+      warnSpy.mockRestore();
+    });
+
+    it("preserves plugin-like binding registered before loadOverrides", async () => {
+      setPlatform("MacIntel");
+      mockElectronOverrides({ "plugin.foo": ["Cmd+P"] });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const service = new KeybindingService();
+      service.registerBinding({
+        actionId: "plugin.foo",
+        combo: "",
+        scope: "global",
+        priority: 0,
+      });
+
+      await service.loadOverrides();
+      expect(service.getEffectiveCombo("plugin.foo")).toBe("Cmd+P");
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
     });
   });
 

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -8,6 +8,7 @@ import { BUILT_IN_ACTION_IDS } from "@shared/config/actionIds";
 import type { ActionId } from "@shared/types/actions";
 import type { ActionRegistry, ActionCallbacks } from "../actionTypes";
 import { validateDefinitionInvariants } from "../../ActionService";
+import { DEFAULT_KEYBINDINGS } from "../../defaultKeybindings";
 
 /**
  * Action IDs that exist in BuiltInKeyAction but are intentionally NOT in the
@@ -165,6 +166,19 @@ describe("registry-vs-union drift", () => {
       }
     }
     expect(missing.sort()).toEqual([]);
+  });
+
+  it("every DEFAULT_KEYBINDINGS actionId has a registry entry (or is a key-only action)", async () => {
+    const { registry } = await createRegistryWithAudit();
+
+    const missing: Array<{ actionId: string; combo: string }> = [];
+    for (const binding of DEFAULT_KEYBINDINGS) {
+      const id = binding.actionId;
+      if (KEY_ONLY_ACTIONS.has(id)) continue;
+      if (registry.has(id as ActionId)) continue;
+      missing.push({ actionId: id, combo: binding.combo });
+    }
+    expect(missing).toEqual([]);
   });
 });
 

--- a/src/services/keybindingUtils.ts
+++ b/src/services/keybindingUtils.ts
@@ -1,9 +1,10 @@
+import type { BuiltInActionId, ActionId } from "@shared/types/actions";
 import { isMac } from "@/lib/platform";
 
 export type KeyScope = "global" | "terminal" | "modal" | "worktreeList" | "portal" | "worktreeGrid";
 
 export interface KeybindingConfig {
-  actionId: string;
+  actionId: BuiltInActionId;
   combo: string; // e.g., "Cmd+T", "Ctrl+Shift+P", "Escape", "Cmd+K Cmd+S" (chords)
   scope: KeyScope;
   priority: number; // Higher priority wins in conflicts (default 0)
@@ -11,15 +12,21 @@ export interface KeybindingConfig {
   category?: string; // Category for organization in UI (e.g., "Terminal", "Panels")
 }
 
+// Wide variant for internal storage, registerBinding, and return types — actionId
+// accepts plugin-defined IDs via the ActionId open union.
+export type RegisteredKeybindingConfig = Omit<KeybindingConfig, "actionId"> & {
+  actionId: ActionId;
+};
+
 // "conflict": same combo as an existing binding in an overlapping scope.
 // "shadowed": chord-prefix collision — registering this combo would make either
 // the new binding or the existing chord unreachable (e.g. "Cmd+K" vs "Cmd+K Cmd+S").
-export interface KeybindingConflict extends KeybindingConfig {
+export interface KeybindingConflict extends RegisteredKeybindingConfig {
   kind: "conflict" | "shadowed";
 }
 
 export interface KeybindingResolutionResult {
-  match: KeybindingConfig | undefined;
+  match: RegisteredKeybindingConfig | undefined;
   chordPrefix: boolean;
   shouldConsume: boolean;
 }


### PR DESCRIPTION
## Summary
- Action IDs for keybindings are now typed as `BuiltInActionId` instead of raw `string`, so typos in the defaults get caught at compile time.
- `loadOverrides()` now filters out entries with unknown action IDs and warns, instead of storing them silently. Users hit this when carrying overrides for actions that have since been removed or renamed.
- Dropped the unsafe type cast in `useGlobalKeybindings` that the old loose typing required.

Resolves #8318

## Changes
- `KeybindingConfig.actionId` tightened to `BuiltInActionId` (`src/services/keybindingUtils.ts`)
- Introduced `RegisteredKeybindingConfig` (`actionId: ActionId`) for internal storage and the plugin path
- Warn-and-drop filter added in `KeybindingService.loadOverrides()`
- Unsafe cast removed from `useGlobalKeybindings`
- Quality test: `DEFAULT_KEYBINDINGS` entries checked against action registry (`actionDefinitions.quality.test.ts`)
- 6 new `loadOverrides` unit tests in `KeybindingService.test.ts`
- Test IDs in `ShortcutReferenceDialog.test.ts` fixed to real values

## Testing
- 141 unit tests pass
- TypeScript typecheck clean
- ESLint and Prettier clean