### PR TITLE
fix(actions): thread confirmed flag through action breadcrumb pipeline

### DIFF
--- a/docs/architecture/destructive-action-safeguards.md
+++ b/docs/architecture/destructive-action-safeguards.md
@@ -35,6 +35,7 @@ Columns:
 - **Action / call site** — action ID where it exists, otherwise the component path performing the operation
 - **Current** — `danger` value in the action definition (or `(bypass)` for direct IPC calls)
 - **UI confirm** — does the calling component wire a `ConfirmDialog` today?
+- **Consent in breadcrumb** — does the action emit a `confirmed` value into the `ActionBreadcrumb`? `danger:"confirm"` actions emit a boolean (`true` when an agent explicitly confirmed, absent when user-source — `source:"user"` itself carries sufficient signal for dialog-confirmed actions). `danger:"safe"` actions emit `n/a` (field absent). Bypass paths: `n/a` (not routed through `ActionService`).
 - **Reversibility** — local-undo / local-irreversible / shared-state / catastrophic
 - **Blast** — typical scope per invocation
 - **Tier** — recommended tier from the rubric
@@ -43,133 +44,133 @@ Columns:
 
 ### Git operations
 
-| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `git.stageFile` / `git.unstageFile` | safe | n/a | local-undo (inverse exists) | one file | D0 | Leave | — |
-| `git.stageAll` / `git.unstageAll` | safe | n/a | local-undo (inverse exists) | worktree | D0 | Leave | — |
-| `git.commit` (action) | safe | n/a (caller-supplied msg required) | local-undo (amend / reset until push) | one commit | D0 | Leave action; but every commit _submission_ call site must gate on authored, non-fallback message (see follow-ups) | — |
-| `git.push` (action) | **confirm** (updated #7881) | yes — `GitPushConfirmDialog` (deferred-Promise gate via `gitPushConfirmStore`; the action `run()` awaits confirmation, dialog previews target branch + recent local commits, #8242) | shared-state (force-push to undo) | one branch on origin | D2 | Done (#8242) — palette/keybinding push gates on the same D2 preview | — |
-| `git.snapshotRevert` | confirm | yes — `ConfirmDialog` via `useWorktreeActions` / `WorktreeDialogs` (preview names the snapshot capture time; #8242) | local-irreversible (wipes working tree to snapshot) | one worktree | D1 | Done (#8242) — confirm wired at the WorktreeCard menu call site | — |
-| `git.snapshotDelete` | **confirm** (updated #7881) | none — call site not yet identified | local-irreversible (no recovery once deleted) | one worktree | D1 | Wire `ConfirmDialog` wherever the action is invoked | TBD |
-| `ReviewHubContent.tsx` `handleCommitAndPush(message)` | (bypass — chains `commit` + `runPush`) | yes (`CommitPanel` push confirm — every remote push gates on `ConfirmDialog` with branch pill + commit message preview + per-worktree opt-out, #8025) | shared-state | one branch on origin | D2 | Leave — wired model for bundled commit-and-push | — |
-| `ForcePushConfirmDialog.tsx` `forcePushWithLease` | (bypass, but **dialog already wired**) | yes (`ForcePushConfirmDialog`) | shared-state, recoverable only by lease check | one branch on origin | D2 | Leave — current implementation is the model for D2 confirms | — |
-| `ReviewHubContent.tsx:896` `pullRebase` | (bypass, but **dialog now wired**) | yes — `ConfirmDialog` previews local-ahead vs incoming-behind divergence on the current branch before rebase (#8242); `git.pullRebase` action reclassified `safe`→`confirm` | local-irreversible until pushed (rebase can clobber) | one worktree | D1 | Done (#8242) — confirm + divergence preview wired at the ReviewHub call site | — |
-| `ReviewHubContent.tsx:733` `abortRepositoryOperation` | (bypass) | none | local-undo (abort is the recovery) | one worktree | D0 | Leave (abort _is_ the recovery path) | — |
-| `ReviewHubContent.tsx:778` `checkoutOursTheirs` | (bypass, but **dialog now wired**) | yes — `ConfirmDialog` in `ConflictPanel` previews the file path + side (rebase-aware) before overwriting the conflict buffer (#8242) | local-irreversible (overwrites conflict resolution) | one file | D1 | Done (#8242) — every conflict-buffer overwrite gates on a per-file confirm | — |
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `git.stageFile` / `git.unstageFile` | safe | n/a | n/a | local-undo (inverse exists) | one file | D0 | Leave | — |
+| `git.stageAll` / `git.unstageAll` | safe | n/a | n/a | local-undo (inverse exists) | worktree | D0 | Leave | — |
+| `git.commit` (action) | safe | n/a (caller-supplied msg required) | n/a | local-undo (amend / reset until push) | one commit | D0 | Leave action; but every commit _submission_ call site must gate on authored, non-fallback message (see follow-ups) | — |
+| `git.push` (action) | **confirm** (updated #7881) | yes — `GitPushConfirmDialog` (deferred-Promise gate via `gitPushConfirmStore`; the action `run()` awaits confirmation, dialog previews target branch + recent local commits, #8242) | Boolean via dispatch | shared-state (force-push to undo) | one branch on origin | D2 | Done (#8242) — palette/keybinding push gates on the same D2 preview | — |
+| `git.snapshotRevert` | confirm | yes — `ConfirmDialog` via `useWorktreeActions` / `WorktreeDialogs` (preview names the snapshot capture time; #8242) | Boolean via dispatch | local-irreversible (wipes working tree to snapshot) | one worktree | D1 | Done (#8242) — confirm wired at the WorktreeCard menu call site | — |
+| `git.snapshotDelete` | **confirm** (updated #7881) | none — call site not yet identified | Boolean via dispatch | local-irreversible (no recovery once deleted) | one worktree | D1 | Wire `ConfirmDialog` wherever the action is invoked | TBD |
+| `ReviewHubContent.tsx` `handleCommitAndPush(message)` | (bypass — chains `commit` + `runPush`) | yes (`CommitPanel` push confirm — every remote push gates on `ConfirmDialog` with branch pill + commit message preview + per-worktree opt-out, #8025) | Boolean via dispatch | shared-state | one branch on origin | D2 | Leave — wired model for bundled commit-and-push | — |
+| `ForcePushConfirmDialog.tsx` `forcePushWithLease` | (bypass, but **dialog already wired**) | yes (`ForcePushConfirmDialog`) | n/a (bypass) | shared-state, recoverable only by lease check | one branch on origin | D2 | Leave — current implementation is the model for D2 confirms | — |
+| `ReviewHubContent.tsx:896` `pullRebase` | (bypass, but **dialog now wired**) | yes — `ConfirmDialog` previews local-ahead vs incoming-behind divergence on the current branch before rebase (#8242); `git.pullRebase` action reclassified `safe`→`confirm` | Boolean via dispatch | local-irreversible until pushed (rebase can clobber) | one worktree | D1 | Done (#8242) — confirm + divergence preview wired at the ReviewHub call site | — |
+| `ReviewHubContent.tsx:733` `abortRepositoryOperation` | (bypass) | none | n/a (bypass) | local-undo (abort is the recovery) | one worktree | D0 | Leave (abort _is_ the recovery path) | — |
+| `ReviewHubContent.tsx:778` `checkoutOursTheirs` | (bypass, but **dialog now wired**) | yes — `ConfirmDialog` in `ConflictPanel` previews the file path + side (rebase-aware) before overwriting the conflict buffer (#8242) | n/a (bypass) | local-irreversible (overwrites conflict resolution) | one file | D1 | Done (#8242) — every conflict-buffer overwrite gates on a per-file confirm | — |
 
 ### Worktree operations
 
-| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `worktree.create` / `worktree.quickCreate` / `worktree.createDialog.open` | safe | n/a (creation) | reversible (delete the worktree) | one new worktree | D0 | Leave | — |
-| `worktree.delete` | confirm | yes (`WorktreeDeleteDialog`) | shared-state (working tree + branch on disk) | one worktree, optionally one branch | D2 | Leave — preview shows file count split (tracked vs untracked, see #4927) | — |
-| `worktree.delete` with `force: true` | confirm | yes; force flag is a separate toggle in the dialog, escalates to typed-name gate | shared-state, may discard uncommitted work | one worktree | D2 → escalates to D3 when worktree has uncommitted tracked changes | Done (#8023) — `WorktreeDeleteDialog.isHighTier` escalates to the typed-name gate when `force && hasTrackedChanges` (in addition to protected branch / main worktree); uses `hasTrackedChanges` not `hasChanges` so untracked-only deletes don't escalate (#4927) | — |
-| `worktree.resource.provision` | safe | n/a | reversible (teardown) | one resource | D0 | Leave | — |
-| `worktree.resource.teardown` | **confirm** (updated #8023) | yes (`ConfirmDialog` via `useWorktreeActions` / `WorktreeCard`) — preview lists the actual teardown commands | shared-state (cloud resource destroyed) | one resource | D2 | Done (#8023) — confirm shows the resolved teardown command list before dispatch | — |
-| `worktree.resource.pause` / `worktree.resource.resume` | safe | n/a | reversible | one resource | D0 | Leave | — |
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `worktree.create` / `worktree.quickCreate` / `worktree.createDialog.open` | safe | n/a (creation) | n/a | reversible (delete the worktree) | one new worktree | D0 | Leave | — |
+| `worktree.delete` | confirm | yes (`WorktreeDeleteDialog`) | Boolean via dispatch | shared-state (working tree + branch on disk) | one worktree, optionally one branch | D2 | Leave — preview shows file count split (tracked vs untracked, see #4927) | — |
+| `worktree.delete` with `force: true` | confirm | yes; force flag is a separate toggle in the dialog, escalates to typed-name gate | Boolean via dispatch | shared-state, may discard uncommitted work | one worktree | D2 → escalates to D3 when worktree has uncommitted tracked changes | Done (#8023) — `WorktreeDeleteDialog.isHighTier` escalates to the typed-name gate when `force && hasTrackedChanges` (in addition to protected branch / main worktree); uses `hasTrackedChanges` not `hasChanges` so untracked-only deletes don't escalate (#4927) | — |
+| `worktree.resource.provision` | safe | n/a | n/a | reversible (teardown) | one resource | D0 | Leave | — |
+| `worktree.resource.teardown` | **confirm** (updated #8023) | yes (`ConfirmDialog` via `useWorktreeActions` / `WorktreeCard`) — preview lists the actual teardown commands | Boolean via dispatch | shared-state (cloud resource destroyed) | one resource | D2 | Done (#8023) — confirm shows the resolved teardown command list before dispatch | — |
+| `worktree.resource.pause` / `worktree.resource.resume` | safe | n/a | n/a | reversible | one resource | D0 | Leave | — |
 
 ### Worktree sessions
 
-| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `worktree.sessions.minimizeAll` / `maximizeAll` | safe | n/a | reversible | one worktree | D0 | Leave | — |
-| `worktree.sessions.restartAll` | **confirm** (updated #8245) | yes (`TerminalDestructiveActionConfirmDialog` via `useTerminalPendingDestructiveActionStore`) — fires only when the target worktree has a running agent session | local-irreversible (scrollback lost) | one worktree | D1 | Done (#8245) | — |
-| `worktree.sessions.resetRenderers` | safe | n/a | reversible (just re-renders) | one worktree | D0 | Leave | — |
-| `worktree.sessions.closeCompleted` | safe | n/a | local-irreversible (trashed terminals lose scrollback) | one worktree | D0 | Leave — only targets completed/exited terminals | — |
-| `worktree.sessions.trashAll` | confirm | yes (`useWorktreeActions.ts` `handleCloseAll`, updated #8245) — verb-noun "Trash all sessions" with consequence preview | local-irreversible (scrollback lost; trashed) | one worktree | D1 | Done (#8245) | — |
-| `worktree.sessions.endAll` | confirm | yes (`useWorktreeActions.ts:130-148`) | local-irreversible | one worktree | D1 | Leave — current pattern is the model for D1 confirms | — |
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `worktree.sessions.minimizeAll` / `maximizeAll` | safe | n/a | n/a | reversible | one worktree | D0 | Leave | — |
+| `worktree.sessions.restartAll` | **confirm** (updated #8245) | yes (`TerminalDestructiveActionConfirmDialog` via `useTerminalPendingDestructiveActionStore`) — fires only when the target worktree has a running agent session | Boolean via dispatch | local-irreversible (scrollback lost) | one worktree | D1 | Done (#8245) | — |
+| `worktree.sessions.resetRenderers` | safe | n/a | n/a | reversible (just re-renders) | one worktree | D0 | Leave | — |
+| `worktree.sessions.closeCompleted` | safe | n/a | n/a | local-irreversible (trashed terminals lose scrollback) | one worktree | D0 | Leave — only targets completed/exited terminals | — |
+| `worktree.sessions.trashAll` | confirm | yes (`useWorktreeActions.ts` `handleCloseAll`, updated #8245) — verb-noun "Trash all sessions" with consequence preview | Boolean via dispatch | local-irreversible (scrollback lost; trashed) | one worktree | D1 | Done (#8245) | — |
+| `worktree.sessions.endAll` | confirm | yes (`useWorktreeActions.ts:130-148`) | Boolean via dispatch | local-irreversible | one worktree | D1 | Leave — current pattern is the model for D1 confirms | — |
 
 ### Terminal lifecycle
 
-| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `terminal.close` / `terminal.trash` | safe | n/a | reversible (restore from trash before next gc) | one terminal | D0 | Leave | — |
-| `terminal.background` | safe | n/a | reversible (foreground / focus) | one terminal | D0 | Leave | — |
-| `terminal.kill` | **confirm** (updated #8245) | yes — context menu (local `ConfirmDialog`) and keybinding/palette (app-level `TerminalDestructiveActionConfirmDialog`); fires only when the terminal has a running agent session (`terminalHasRunningAgentSession`), bare PTY stays D0 | local-irreversible (PTY killed, scrollback lost) | one terminal | D1 | Done (#8245) | — |
-| `terminal.killAll` | **confirm** (updated #8245) | yes (`TerminalDestructiveActionConfirmDialog`) — fires when any non-ephemeral terminal has a running agent; label shows total terminals + running-agent count | local-irreversible | every non-ephemeral terminal | D1 | Done (#8245) | — |
-| `terminal.closeAll` | safe | none | reversible (trash, not kill) | every active-worktree terminal | D0 | Leave | — |
-| `terminal.restart` | **confirm** (updated #8245) | yes — context menu + keybinding/palette dialog hosts; fires only when terminal has a running agent session | local-irreversible (scrollback lost; process re-spawned) | one terminal | D1 | Done (#8245) | — |
-| `terminal.restartAll` | **confirm** (updated #8245) | yes (`TerminalDestructiveActionConfirmDialog`) — fires when any non-trash terminal has a running agent | local-irreversible | many terminals | D1 | Done (#8245) | — |
-| `terminal.restartService` | safe | n/a | local-irreversible (all PTY processes restart) | every terminal in the window | D1 | Action is gated on `backendStatus === "disconnected"`; the gate already implies an error state, so leave as-is | — |
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `terminal.close` / `terminal.trash` | safe | n/a | n/a | reversible (restore from trash before next gc) | one terminal | D0 | Leave | — |
+| `terminal.background` | safe | n/a | n/a | reversible (foreground / focus) | one terminal | D0 | Leave | — |
+| `terminal.kill` | **confirm** (updated #8245) | yes — context menu (local `ConfirmDialog`) and keybinding/palette (app-level `TerminalDestructiveActionConfirmDialog`); fires only when the terminal has a running agent session (`terminalHasRunningAgentSession`), bare PTY stays D0 | Boolean via dispatch | local-irreversible (PTY killed, scrollback lost) | one terminal | D1 | Done (#8245) | — |
+| `terminal.killAll` | **confirm** (updated #8245) | yes (`TerminalDestructiveActionConfirmDialog`) — fires when any non-ephemeral terminal has a running agent; label shows total terminals + running-agent count | Boolean via dispatch | local-irreversible | every non-ephemeral terminal | D1 | Done (#8245) | — |
+| `terminal.closeAll` | safe | none | n/a | reversible (trash, not kill) | every active-worktree terminal | D0 | Leave | — |
+| `terminal.restart` | **confirm** (updated #8245) | yes — context menu + keybinding/palette dialog hosts; fires only when terminal has a running agent session | Boolean via dispatch | local-irreversible (scrollback lost; process re-spawned) | one terminal | D1 | Done (#8245) | — |
+| `terminal.restartAll` | **confirm** (updated #8245) | yes (`TerminalDestructiveActionConfirmDialog`) — fires when any non-trash terminal has a running agent | Boolean via dispatch | local-irreversible | many terminals | D1 | Done (#8245) | — |
+| `terminal.restartService` | safe | n/a | n/a | local-irreversible (all PTY processes restart) | every terminal in the window | D1 | Action is gated on `backendStatus === "disconnected"`; the gate already implies an error state, so leave as-is | — |
 
 ### Dev preview
 
-| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `devPreview.stop` | safe | n/a | local-undo (re-start) | one dev server | D0 | Leave | — |
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `devPreview.stop` | safe | n/a | n/a | local-undo (re-start) | one dev server | D0 | Leave | — |
 
 ### Fleet operations
 
-| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `fleet.accept` | safe | n/a (sends affirmative to a prompt) | local-irreversible per prompt | armed waiting agents | D0 | Leave — affirmative response to an already-displayed prompt | — |
-| `fleet.reject` | safe | conditional confirm in `run()` body when 5+ targets | local-irreversible per prompt | armed waiting agents | D0 | Leave — internal confirm is sufficient; `n\r` is the safe default | — |
-| `fleet.interrupt` | safe | conditional confirm in `run()` body when 3+ targets | local-recoverable (re-arm/continue) | armed working agents | D0 | Leave | — |
-| `fleet.restart` | **confirm** (updated #7881) | yes (internal confirm via `useFleetPendingActionStore`) | local-irreversible (scrollback + session lost) | armed agents | D1 | Leave — internal confirm pattern is the canonical example for actions that aren't surfaced via `danger`-driven gates | — |
-| `fleet.kill` | **confirm** (updated #7881) | yes (internal confirm) | local-irreversible | armed terminals | D1 | Leave | — |
-| `fleet.trash` | **confirm** (updated #7881) | yes (internal confirm; threshold 5+) | local-irreversible (scrollback lost) | armed terminals | D1 | Leave; consider lowering threshold to 3+ in a follow-up | TBD |
-| `fleet.armMatchingFilter` / `fleet.armFocused` / `fleet.armAll` | safe | n/a | reversible (disarm) | armed set | D0 | Leave | — |
-| `fleet.saveNamedFleet` | safe | n/a | reversible (delete fleet) | one saved fleet | D0 | Leave | — |
-| `fleet.recallNamedFleet` | safe | n/a | reversible (re-arm) | armed set | D0 | Leave | — |
-| `fleet.deleteNamedFleet` | **confirm** (updated #8023) | yes (`ConfirmDialog` hoisted to `FleetArmingRibbon`, outside the dropdown tree) | local-irreversible (settings entry gone) | one saved fleet | D1 | Done (#8023) — confirm state lifted above the Radix `DropdownMenu` so the dialog survives the menu closing (#2828) | — |
-| `fleet.retryFailures` | safe | n/a | local-undo (just re-fires the last broadcast) | failed broadcast targets | D0 | Leave | — |
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `fleet.accept` | safe | n/a (sends affirmative to a prompt) | n/a | local-irreversible per prompt | armed waiting agents | D0 | Leave — affirmative response to an already-displayed prompt | — |
+| `fleet.reject` | safe | conditional confirm in `run()` body when 5+ targets | n/a | local-irreversible per prompt | armed waiting agents | D0 | Leave — internal confirm is sufficient; `n\r` is the safe default | — |
+| `fleet.interrupt` | safe | conditional confirm in `run()` body when 3+ targets | n/a | local-recoverable (re-arm/continue) | armed working agents | D0 | Leave | — |
+| `fleet.restart` | **confirm** (updated #7881) | yes (internal confirm via `useFleetPendingActionStore`) | Boolean via dispatch | local-irreversible (scrollback + session lost) | armed agents | D1 | Leave — internal confirm pattern is the canonical example for actions that aren't surfaced via `danger`-driven gates | — |
+| `fleet.kill` | **confirm** (updated #7881) | yes (internal confirm) | Boolean via dispatch | local-irreversible | armed terminals | D1 | Leave | — |
+| `fleet.trash` | **confirm** (updated #7881) | yes (internal confirm; threshold 5+) | Boolean via dispatch | local-irreversible (scrollback lost) | armed terminals | D1 | Leave; consider lowering threshold to 3+ in a follow-up | TBD |
+| `fleet.armMatchingFilter` / `fleet.armFocused` / `fleet.armAll` | safe | n/a | n/a | reversible (disarm) | armed set | D0 | Leave | — |
+| `fleet.saveNamedFleet` | safe | n/a | n/a | reversible (delete fleet) | one saved fleet | D0 | Leave | — |
+| `fleet.recallNamedFleet` | safe | n/a | n/a | reversible (re-arm) | armed set | D0 | Leave | — |
+| `fleet.deleteNamedFleet` | **confirm** (updated #8023) | yes (`ConfirmDialog` hoisted to `FleetArmingRibbon`, outside the dropdown tree) | Boolean via dispatch | local-irreversible (settings entry gone) | one saved fleet | D1 | Done (#8023) — confirm state lifted above the Radix `DropdownMenu` so the dialog survives the menu closing (#2828) | — |
+| `fleet.retryFailures` | safe | n/a | n/a | local-undo (just re-fires the last broadcast) | failed broadcast targets | D0 | Leave | — |
 
 ### Project / window
 
-| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `project.add` / `project.cloneRepo` / `project.openDialog` | safe | n/a | reversible | one project | D0 | Leave | — |
-| `project.switch` / `project.switcherPalette` | safe | n/a | reversible (switch back) | one project | D0 | Leave | — |
-| `project.update` / `project.saveSettings` | safe | n/a | reversible (re-edit) | one project | D0 | Leave | — |
-| `project.remove` | **confirm** (updated #8247) | yes (`confirmRemoveProject` in `useProjectSwitcherPalette.ts`; all four entry points funnel through it) | local-irreversible (removed from list; worktrees on disk remain) | one project | D1 | Done (#8247) | #8247 |
-| `project.close` / `project.closeActive` | safe | yes — `callbacks.onConfirmCloseActiveProject` routes through a confirm flow | local-irreversible (terminals killed) | one project | D1 | Leave — confirm flow already exists | — |
-| `window.close` | safe | OS-native warning when unsaved work present | local-irreversible (window state lost) | one window | D0 | Leave — OS provides confirm | — |
-| `window.forceReload` | safe | n/a | local-irreversible (in-flight UI state lost) | one window | D0 | Acceptable: developer affordance; would only escalate if discoverable from non-dev menus | — |
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `project.add` / `project.cloneRepo` / `project.openDialog` | safe | n/a | n/a | reversible | one project | D0 | Leave | — |
+| `project.switch` / `project.switcherPalette` | safe | n/a | n/a | reversible (switch back) | one project | D0 | Leave | — |
+| `project.update` / `project.saveSettings` | safe | n/a | n/a | reversible (re-edit) | one project | D0 | Leave | — |
+| `project.remove` | **confirm** (updated #8247) | yes (`confirmRemoveProject` in `useProjectSwitcherPalette.ts`; all four entry points funnel through it) | Boolean via dispatch | local-irreversible (removed from list; worktrees on disk remain) | one project | D1 | Done (#8247) | #8247 |
+| `project.close` / `project.closeActive` | safe | yes — `callbacks.onConfirmCloseActiveProject` routes through a confirm flow | n/a | local-irreversible (terminals killed) | one project | D1 | Leave — confirm flow already exists | — |
+| `window.close` | safe | OS-native warning when unsaved work present | n/a | local-irreversible (window state lost) | one window | D0 | Leave — OS provides confirm | — |
+| `window.forceReload` | safe | n/a | n/a | local-irreversible (in-flight UI state lost) | one window | D0 | Acceptable: developer affordance; would only escalate if discoverable from non-dev menus | — |
 
 ### GitHub-side
 
 The current GitHub action set is read-only (`openIssues`, `listPullRequests`, etc.) plus token management. No PR merge, no issue close, no comment-post is wired through `ActionService` yet.
 
-| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `github.setToken` / `github.clearToken` | safe | n/a | reversible (re-enter) | local credential | D0 | Leave | — |
-| `github.openIssue` / `github.openPR` / `github.openCommits` / list / get queries | safe | n/a | reversible (navigation only) | navigation | D0 | Leave | — |
-| Merge PR / close issue / dismiss review (future) | n/a — not yet exposed via UI | n/a | shared-state | one PR or issue on origin | D2 | When wired, must be `danger:"confirm"` from day one and ship with target-naming preview | open as needed |
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `github.setToken` / `github.clearToken` | safe | n/a | n/a | reversible (re-enter) | local credential | D0 | Leave | — |
+| `github.openIssue` / `github.openPR` / `github.openCommits` / list / get queries | safe | n/a | n/a | reversible (navigation only) | navigation | D0 | Leave | — |
+| Merge PR / close issue / dismiss review (future) | n/a — not yet exposed via UI | n/a | n/a | shared-state | one PR or issue on origin | D2 | When wired, must be `danger:"confirm"` from day one and ship with target-naming preview | open as needed |
 
 ### Recipes / plugins
 
-| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `recipe.run` | safe | n/a | local-irreversible (spawns processes; not a content mutation) | one recipe → many terminals | D0 | Leave | — |
-| `recipe.editor.open` / `recipe.manager.open` | safe | n/a | reversible | UI | D0 | Leave | — |
-| `recipe.saveToRepo` (with `deleteOriginal: true`) | safe | yes (`RecipeManager.tsx` ConfirmDialog) | local-irreversible (original deleted) | one recipe | D1 | Leave — current pattern is correct | — |
-| `recipe.delete` | **confirm** (added #8247) | yes (`ConfirmDialog` in `RecipeManager.tsx` + `RecipesTab.tsx`; both dispatch through the action) | local-irreversible | one recipe | D1 | Done (#8247) | #8247 |
-| `useRecipeRunner.ts:386` `handleDelete` (RecipeRunner context menu) | (bypass) | none — calls store `deleteRecipe` directly, no `ConfirmDialog` | local-irreversible | one recipe | D1 | Route through `recipe.delete` and wire a `ConfirmDialog` at the RecipeRunner call site | TBD |
-| Plugin install / uninstall (future) | n/a — not yet wired | n/a | shared-state (filesystem + plugin host restart) | one plugin | D1 | When wired, `danger:"confirm"` + show plugin metadata before install/uninstall | open as needed |
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `recipe.run` | safe | n/a | n/a | local-irreversible (spawns processes; not a content mutation) | one recipe → many terminals | D0 | Leave | — |
+| `recipe.editor.open` / `recipe.manager.open` | safe | n/a | n/a | reversible | UI | D0 | Leave | — |
+| `recipe.saveToRepo` (with `deleteOriginal: true`) | safe | yes (`RecipeManager.tsx` ConfirmDialog) | n/a | local-irreversible (original deleted) | one recipe | D1 | Leave — current pattern is correct | — |
+| `recipe.delete` | **confirm** (added #8247) | yes (`ConfirmDialog` in `RecipeManager.tsx` + `RecipesTab.tsx`; both dispatch through the action) | Boolean via dispatch | local-irreversible | one recipe | D1 | Done (#8247) | #8247 |
+| `useRecipeRunner.ts:386` `handleDelete` (RecipeRunner context menu) | (bypass) | none — calls store `deleteRecipe` directly, no `ConfirmDialog` | n/a (bypass) | local-irreversible | one recipe | D1 | Route through `recipe.delete` and wire a `ConfirmDialog` at the RecipeRunner call site | TBD |
+| Plugin install / uninstall (future) | n/a — not yet wired | n/a | n/a | shared-state (filesystem + plugin host restart) | one plugin | D1 | When wired, `danger:"confirm"` + show plugin metadata before install/uninstall | open as needed |
 
 ### Portal / browser
 
-| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `portal.links.add` / `update` / `toggle` / `reorder` | safe | n/a | reversible | one link | D0 | Leave | — |
-| `portal.links.remove` | **confirm** (updated #8023) | yes (`ConfirmDialog` in `PortalSettingsTab`) | local-irreversible (link gone) | one link | D1 | Done (#8023) — confirm wired at the Custom links delete control | — |
-| `portal.closeTab` / `closeOthers` / `closeToRight` / `closeAllTabs` | safe | none | local-irreversible (tab history lost) | 1..N tabs | D0 (single) → D1 (bulk) | Add confirm for `closeAllTabs` and `closeOthers` when 3+ tabs would close | TBD |
-| `portal.duplicateTab` / `reload` / `goBack` / `goForward` | safe | n/a | reversible | one tab | D0 | Leave | — |
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `portal.links.add` / `update` / `toggle` / `reorder` | safe | n/a | n/a | reversible | one link | D0 | Leave | — |
+| `portal.links.remove` | **confirm** (updated #8023) | yes (`ConfirmDialog` in `PortalSettingsTab`) | Boolean via dispatch | local-irreversible (link gone) | one link | D1 | Done (#8023) — confirm wired at the Custom links delete control | — |
+| `portal.closeTab` / `closeOthers` / `closeToRight` / `closeAllTabs` | safe | none | n/a | local-irreversible (tab history lost) | 1..N tabs | D0 (single) → D1 (bulk) | Add confirm for `closeAllTabs` and `closeOthers` when 3+ tabs would close | TBD |
+| `portal.duplicateTab` / `reload` / `goBack` / `goForward` | safe | n/a | n/a | reversible | one tab | D0 | Leave | — |
 
 ### Keybindings / preferences
 
-| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `keybinding.setOverride` / `removeOverride` | safe | n/a | reversible (reset to default) | one binding | D0 | Leave | — |
-| `keybinding.resetAll` | **confirm** (updated #8247) | yes (`ConfirmDialog` at `KeyboardShortcutsTab.tsx:184`, dispatches with `confirmed:true`) | local-irreversible (all overrides lost) | every override | D1 | Done (#8247) | #8247 |
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `keybinding.setOverride` / `removeOverride` | safe | n/a | n/a | reversible (reset to default) | one binding | D0 | Leave | — |
+| `keybinding.resetAll` | **confirm** (updated #8247) | yes (`ConfirmDialog` at `KeyboardShortcutsTab.tsx:184`, dispatches with `confirmed:true`) | Boolean via dispatch | local-irreversible (all overrides lost) | every override | D1 | Done (#8247) | #8247 |
 
 ### Dev preview
 
-| Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `useDevServer.ts:299` `devPreview.restart` (direct IPC) | safe | none — hook calls IPC directly | local-irreversible (PTY killed, dev-server scrollback lost; rebuilds on respawn) | one panel | D1 | Document bypass; sibling UI issue migrates the button to the `devPreview.restart` action so the danger rating can gate it | TBD (UI issue) |
-| `devPreview.restartAndClearCache` | **confirm** | none yet — `ConfirmDialog` wired in sibling UI issue | local-irreversible (framework build caches `.next`/`.vite`/`.turbo` wiped; regenerate on next build) | one panel | D1 | `danger:"confirm"` classification set; wire `ConfirmDialog` at the UI call site | TBD (UI issue) |
-| `devPreview.reinstallAndRestart` | **confirm** | none yet — `ConfirmDialog` wired in sibling UI issue | shared-state (`node_modules` removed; recovery requires a full reinstall, network + lockfile dependent) | one panel | D2 | `danger:"confirm"` classification set; wire `ConfirmDialog` + change preview at the UI call site | TBD (UI issue) |
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `useDevServer.ts:299` `devPreview.restart` (direct IPC) | safe | none — hook calls IPC directly | n/a | local-irreversible (PTY killed, dev-server scrollback lost; rebuilds on respawn) | one panel | D1 | Document bypass; sibling UI issue migrates the button to the `devPreview.restart` action so the danger rating can gate it | TBD (UI issue) |
+| `devPreview.restartAndClearCache` | **confirm** | none yet — `ConfirmDialog` wired in sibling UI issue | Boolean via dispatch | local-irreversible (framework build caches `.next`/`.vite`/`.turbo` wiped; regenerate on next build) | one panel | D1 | `danger:"confirm"` classification set; wire `ConfirmDialog` at the UI call site | TBD (UI issue) |
+| `devPreview.reinstallAndRestart` | **confirm** | none yet — `ConfirmDialog` wired in sibling UI issue | Boolean via dispatch | shared-state (`node_modules` removed; recovery requires a full reinstall, network + lockfile dependent) | one panel | D2 | `danger:"confirm"` classification set; wire `ConfirmDialog` + change preview at the UI call site | TBD (UI issue) |
 
 ## Known bypasses
 

--- a/electron/ipc/handlers/__tests__/events.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/events.handlers.test.ts
@@ -165,4 +165,43 @@ describe("events IPC handler — action:dispatched", () => {
     expect(emit).not.toHaveBeenCalled();
     cleanup();
   });
+
+  it("preserves confirmed:true through normalization", () => {
+    const { emit, cleanup } = setup();
+    ipcMainMock._invoke("events:emit", "action:dispatched", {
+      ...base,
+      confirmed: true,
+    });
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    const normalized = emit.mock.calls[0]![1] as { confirmed?: boolean };
+    expect(normalized.confirmed).toBe(true);
+    cleanup();
+  });
+
+  it("preserves confirmed:false through normalization", () => {
+    const { emit, cleanup } = setup();
+    ipcMainMock._invoke("events:emit", "action:dispatched", {
+      ...base,
+      confirmed: false,
+    });
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    const normalized = emit.mock.calls[0]![1] as { confirmed?: boolean };
+    expect(normalized.confirmed).toBe(false);
+    cleanup();
+  });
+
+  it("strips non-boolean confirmed values", () => {
+    const { emit, cleanup } = setup();
+    ipcMainMock._invoke("events:emit", "action:dispatched", {
+      ...base,
+      confirmed: "true",
+    });
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    const normalized = emit.mock.calls[0]![1] as { confirmed?: unknown };
+    expect(normalized.confirmed).toBeUndefined();
+    cleanup();
+  });
 });

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -174,6 +174,9 @@ function normalizeActionDispatchedPayload(
       ? dangerRaw
       : "safe";
 
+  const confirmed: boolean | undefined =
+    typeof payload.confirmed === "boolean" ? payload.confirmed : undefined;
+
   return {
     actionId,
     args: safeArgs,
@@ -184,6 +187,7 @@ function normalizeActionDispatchedPayload(
     durationMs,
     danger,
     ...(safeBreadcrumbArgs ? { safeArgs: safeBreadcrumbArgs } : {}),
+    ...(confirmed !== undefined ? { confirmed } : {}),
   };
 }
 

--- a/electron/services/ActionBreadcrumbService.ts
+++ b/electron/services/ActionBreadcrumbService.ts
@@ -62,6 +62,7 @@ export class ActionBreadcrumbService {
     durationMs: number;
     danger: ActionDanger;
     safeArgs?: Record<string, unknown>;
+    confirmed?: boolean;
   }): void {
     try {
       const last = this.lastEntry;
@@ -69,9 +70,12 @@ export class ActionBreadcrumbService {
       // Reject negative deltas so an out-of-order emission (a long-running dispatch
       // that started earlier but finishes later) is recorded as a distinct entry
       // rather than merged into a newer fast dispatch of the same actionId.
+      // Also split entries with different confirmed values — merging different
+      // consent states obscures forensic signal in crash diagnostics.
       const isDedup =
         last !== null &&
         last.actionId === payload.actionId &&
+        last.confirmed === payload.confirmed &&
         delta >= 0 &&
         delta <= DEDUP_WINDOW_MS;
 
@@ -93,6 +97,7 @@ export class ActionBreadcrumbService {
         danger: payload.danger,
         ...(payload.safeArgs ? { args: payload.safeArgs } : {}),
         count: 1,
+        ...(payload.confirmed !== undefined ? { confirmed: payload.confirmed } : {}),
       };
 
       this.ring.push(entry);

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -457,6 +457,7 @@ export function addActionBreadcrumb(crumb: ActionBreadcrumb): void {
         durationMs: crumb.durationMs,
         ...(crumb.count > 1 ? { count: crumb.count } : {}),
         ...(crumb.args ? { args: crumb.args } : {}),
+        ...(crumb.confirmed !== undefined ? { confirmed: crumb.confirmed } : {}),
       },
     });
   } catch {

--- a/electron/services/__tests__/ActionBreadcrumbService.test.ts
+++ b/electron/services/__tests__/ActionBreadcrumbService.test.ts
@@ -308,4 +308,36 @@ describe("ActionBreadcrumbService", () => {
       expect(after[49]!.danger).toBe("restricted");
     });
   });
+
+  describe("confirmed", () => {
+    it("stores confirmed:true in the breadcrumb and forwards it to Sentry", () => {
+      emit({ actionId: "worktree.delete", confirmed: true });
+      const recent = service.getRecentActions();
+      expect(recent[0]!.confirmed).toBe(true);
+      expect(addBreadcrumbMock).toHaveBeenCalledTimes(1);
+      expect(addBreadcrumbMock.mock.calls[0]![0].confirmed).toBe(true);
+    });
+
+    it("stores confirmed:false — not dropped by truthiness", () => {
+      emit({ actionId: "worktree.delete", confirmed: false });
+      const recent = service.getRecentActions();
+      expect(recent[0]!.confirmed).toBe(false);
+    });
+
+    it("keeps confirmed absent when not provided", () => {
+      emit({ actionId: "safe.action" });
+      const recent = service.getRecentActions();
+      expect(recent[0]!.confirmed).toBeUndefined();
+    });
+
+    it("does not dedup same actionId with different confirmed values", () => {
+      const t = 10_000;
+      emit({ actionId: "worktree.delete", timestamp: t, confirmed: true });
+      emit({ actionId: "worktree.delete", timestamp: t + 50, confirmed: false });
+      const recent = service.getRecentActions();
+      expect(recent).toHaveLength(2);
+      expect(recent[0]!.confirmed).toBe(true);
+      expect(recent[1]!.confirmed).toBe(false);
+    });
+  });
 });

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -1151,6 +1151,51 @@ describe("addActionBreadcrumb", () => {
       process.env.SENTRY_DSN = original;
     }
   });
+
+  it("forwards confirmed:true in breadcrumb data", async () => {
+    setPrivacy({ telemetryLevel: "errors" });
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+    try {
+      const mod = await loadFreshModule();
+      await mod.initializeTelemetry();
+      mod.addActionBreadcrumb({ ...crumb, confirmed: true });
+      const arg = sentryAddBreadcrumbMock.mock.calls[0]![0];
+      expect(arg.data.confirmed).toBe(true);
+    } finally {
+      process.env.SENTRY_DSN = original;
+    }
+  });
+
+  it("forwards confirmed:false in breadcrumb data", async () => {
+    setPrivacy({ telemetryLevel: "errors" });
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+    try {
+      const mod = await loadFreshModule();
+      await mod.initializeTelemetry();
+      mod.addActionBreadcrumb({ ...crumb, confirmed: false });
+      const arg = sentryAddBreadcrumbMock.mock.calls[0]![0];
+      expect(arg.data.confirmed).toBe(false);
+    } finally {
+      process.env.SENTRY_DSN = original;
+    }
+  });
+
+  it("omits confirmed from breadcrumb data when absent", async () => {
+    setPrivacy({ telemetryLevel: "errors" });
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+    try {
+      const mod = await loadFreshModule();
+      await mod.initializeTelemetry();
+      mod.addActionBreadcrumb(crumb); // no confirmed field
+      const arg = sentryAddBreadcrumbMock.mock.calls[0]![0];
+      expect(arg.data.confirmed).toBeUndefined();
+    } finally {
+      process.env.SENTRY_DSN = original;
+    }
+  });
 });
 
 describe("telemetry preview tap", () => {

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -638,6 +638,8 @@ export type DaintreeEventMap = {
     category: string;
     durationMs: number;
     danger: "safe" | "confirm" | "restricted";
+    /** True when an agent explicitly confirmed a danger:"confirm" action. Absent for user-source and safe actions. */
+    confirmed?: boolean;
   };
 
   // Terminal Trash Events

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -165,6 +165,8 @@ export interface ActionDispatchPayload {
   context: ActionContext;
   source: ActionSource;
   timestamp: number;
+  /** True when an agent explicitly confirmed a danger:"confirm" action. Absent for user-source and safe actions. */
+  confirmed?: boolean;
 }
 
 export interface ActionFrecencyEntry {

--- a/shared/types/ipc/crashRecovery.ts
+++ b/shared/types/ipc/crashRecovery.ts
@@ -12,6 +12,8 @@ export interface ActionBreadcrumb {
   timestamp: number;
   args?: Record<string, unknown>;
   count: number;
+  /** True when an agent explicitly confirmed a danger:"confirm" action. Absent for user-source and safe actions. */
+  confirmed?: boolean;
 }
 
 export interface CrashLogEntry {

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -316,6 +316,7 @@ export class ActionService {
         durationMs,
         danger: definition.danger,
         safeArgs: this.extractSafeBreadcrumbArgs(args, definition),
+        confirmed: options?.confirmed,
       });
       this.emitShortcutHint(actionId, source);
       return { ok: true, result: result as Result };
@@ -502,6 +503,7 @@ export class ActionService {
     durationMs: number;
     danger: ActionDanger;
     safeArgs?: Record<string, unknown>;
+    confirmed?: boolean;
   }): Promise<void> {
     if (!isElectronApiAvailable()) return;
 
@@ -516,6 +518,7 @@ export class ActionService {
         durationMs: payload.durationMs,
         danger: payload.danger,
         ...(payload.safeArgs ? { safeArgs: payload.safeArgs } : {}),
+        ...(payload.confirmed !== undefined ? { confirmed: payload.confirmed } : {}),
       });
     } catch (err) {
       logWarn("Failed to emit action:dispatched event", {

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -910,6 +910,33 @@ describe("ActionService", () => {
         restore();
       }
     });
+
+    it("includes confirmed in payload when agent dispatches confirm action with confirmed:true", async () => {
+      const emit = vi.fn().mockResolvedValue(undefined);
+      const restore = installEmit(emit);
+      try {
+        service.register({
+          id: "worktree.delete" as ActionId,
+          title: "T",
+          description: "T",
+          category: "worktree",
+          kind: "command",
+          danger: "confirm",
+          scope: "renderer",
+          run: vi.fn().mockResolvedValue(undefined),
+        });
+        await service.dispatch("worktree.delete" as ActionId, undefined, {
+          source: "agent",
+          confirmed: true,
+        });
+        await Promise.resolve();
+        expect(emit).toHaveBeenCalledTimes(1);
+        const payload = emit.mock.calls[0]![1] as Record<string, unknown>;
+        expect(payload.confirmed).toBe(true);
+      } finally {
+        restore();
+      }
+    });
   });
 
   describe("lastAction tracking", () => {


### PR DESCRIPTION
## Summary

This threads the `confirmed` flag through the action breadcrumb pipeline so crash logs and telemetry can tell user-confirmed destructive actions apart from agent-auto-confirmed ones. Right now both look identical in a breadcrumb. That has real forensic consequences when something goes wrong.

Resolves #8320.

## Changes

Two commits:

- The first adds the `confirmed` field to `ActionBreadcrumb`, `ActionManifestEntry`, and the events pipeline, so the consent state travels with the breadcrumb from dispatch onward.
- The second ensures the field survives IPC normalization -- it was getting dropped between the renderer and main process.

Tests added in `ActionService`, `ActionBreadcrumbService`, `TelemetryService`, and the events handlers. The destructive-action-safeguards audit table is updated to track which `danger: "confirm"` actions emit a non-`n/a` consent value.

## Testing

New tests verify the `confirmed` flag round-trips through:
- `ActionService.dispatch` emits it on the `action:dispatched` event
- `ActionBreadcrumbService` attaches it to the breadcrumb
- `TelemetryService.addActionBreadcrumb` preserves it in the Sentry breadcrumb
- IPC normalization passes it through for crash recovery