### PR TITLE
fix(devPreview): surface tiered restart vocabulary with ConfirmDialog gates

### DIFF
--- a/shared/config/actionIds.ts
+++ b/shared/config/actionIds.ts
@@ -408,8 +408,6 @@ export const BUILT_IN_ACTION_IDS = [
 
   // -- devServerActions --
   "devServer.start",
-  "devPreview.restartClearCache",
-  "devPreview.reinstall",
   "devPreview.stop",
 
   // -- devPreviewActions --

--- a/shared/utils/__tests__/devServerErrors.test.ts
+++ b/shared/utils/__tests__/devServerErrors.test.ts
@@ -15,7 +15,7 @@ describe("devServerErrors", () => {
           type: "port-conflict",
           message: "Port 3000 is already in use. Stop the other server or use a different port.",
           port: "3000",
-          recommendedActionId: "devPreview.restartClearCache",
+          recommendedActionId: "devPreview.restartAndClearCache",
         });
       });
 
@@ -26,7 +26,7 @@ describe("devServerErrors", () => {
           type: "port-conflict",
           message: "Port 5173 is already in use. Stop the other server or use a different port.",
           port: "5173",
-          recommendedActionId: "devPreview.restartClearCache",
+          recommendedActionId: "devPreview.restartAndClearCache",
         });
       });
 
@@ -37,7 +37,7 @@ describe("devServerErrors", () => {
           type: "port-conflict",
           message: "Port 8080 is already in use. Stop the other server or use a different port.",
           port: "8080",
-          recommendedActionId: "devPreview.restartClearCache",
+          recommendedActionId: "devPreview.restartAndClearCache",
         });
       });
 
@@ -56,7 +56,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependency: vite",
           module: "vite",
-          recommendedActionId: "devPreview.reinstall",
+          recommendedActionId: "devPreview.reinstallAndRestart",
         });
       });
 
@@ -67,7 +67,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependencies detected",
           module: undefined,
-          recommendedActionId: "devPreview.reinstall",
+          recommendedActionId: "devPreview.reinstallAndRestart",
         });
       });
 
@@ -78,7 +78,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependencies detected",
           module: undefined,
-          recommendedActionId: "devPreview.reinstall",
+          recommendedActionId: "devPreview.reinstallAndRestart",
         });
       });
 
@@ -89,7 +89,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependency: react",
           module: "react",
-          recommendedActionId: "devPreview.reinstall",
+          recommendedActionId: "devPreview.reinstallAndRestart",
         });
       });
 
@@ -100,7 +100,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependencies detected",
           module: undefined,
-          recommendedActionId: "devPreview.reinstall",
+          recommendedActionId: "devPreview.reinstallAndRestart",
         });
       });
 
@@ -111,7 +111,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependency: node-pty",
           module: "node-pty",
-          recommendedActionId: "devPreview.reinstall",
+          recommendedActionId: "devPreview.reinstallAndRestart",
         });
       });
 
@@ -123,7 +123,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependencies detected",
           module: undefined,
-          recommendedActionId: "devPreview.reinstall",
+          recommendedActionId: "devPreview.reinstallAndRestart",
         });
       });
     });
@@ -217,12 +217,12 @@ describe("devServerErrors", () => {
       const error = detectDevServerError(
         "Error: listen EADDRINUSE: address already in use :::3000"
       );
-      expect(error?.recommendedActionId).toBe("devPreview.restartClearCache");
+      expect(error?.recommendedActionId).toBe("devPreview.restartAndClearCache");
     });
 
     it("maps missing-dependencies to the reinstall remedy", () => {
       const error = detectDevServerError("Error: Cannot find module 'vite'");
-      expect(error?.recommendedActionId).toBe("devPreview.reinstall");
+      expect(error?.recommendedActionId).toBe("devPreview.reinstallAndRestart");
     });
 
     it("leaves permission errors without a recommended action", () => {

--- a/shared/utils/devServerErrors.ts
+++ b/shared/utils/devServerErrors.ts
@@ -57,7 +57,7 @@ export function detectDevServerError(output: string): DevServerError | null {
           type: "port-conflict",
           message: `Port ${port} is already in use. Stop the other server or use a different port.`,
           port,
-          recommendedActionId: "devPreview.restartClearCache",
+          recommendedActionId: "devPreview.restartAndClearCache",
         };
       }
     }
@@ -72,7 +72,7 @@ export function detectDevServerError(output: string): DevServerError | null {
         type: "missing-dependencies",
         message: module ? `Missing dependency: ${module}` : "Missing dependencies detected",
         module,
-        recommendedActionId: "devPreview.reinstall",
+        recommendedActionId: "devPreview.reinstallAndRestart",
       };
     }
   }

--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -1,8 +1,15 @@
 import { Suspense, useState, useCallback, useEffect } from "react";
-import { ChevronUp, RotateCw, CircleStop } from "lucide-react";
+import { ChevronUp, ChevronDown, RotateCw, CircleStop } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
 import { XtermAdapter } from "../Terminal/XtermAdapter";
 import { terminalInstanceService } from "../../services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
@@ -15,7 +22,10 @@ interface ConsoleDrawerProps {
   onOpenChange?: (isOpen: boolean) => void;
   defaultOpen?: boolean;
   isRestarting?: boolean;
-  onHardRestart?: () => void;
+  onReloadPreview?: () => void;
+  onRestartDevServer?: () => void;
+  onRequestRestartAndClearCache?: () => void;
+  onRequestReinstallAndRestart?: () => void;
   onStop?: () => void;
 }
 
@@ -62,7 +72,10 @@ export function ConsoleDrawer({
   onOpenChange,
   defaultOpen = false,
   isRestarting = false,
-  onHardRestart,
+  onReloadPreview,
+  onRestartDevServer,
+  onRequestRestartAndClearCache,
+  onRequestReinstallAndRestart,
   onStop,
 }: ConsoleDrawerProps) {
   const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(defaultOpen);
@@ -88,11 +101,13 @@ export function ConsoleDrawer({
     ? { label: "Restarting", textClass: "text-server-starting", dotClass: "bg-server-starting" }
     : (STATUS_LABEL[status] ?? STATUS_LABEL.stopped);
   const toggleLabel = isOpen ? "Hide Terminal" : "Show Terminal";
-  const hardRestartDisabled = !onHardRestart || isRestarting || status === "starting";
+  const hasRestartControls = !!onRestartDevServer;
+  const restartDisabled = !hasRestartControls || isRestarting || status === "starting";
+  const chevronDisabled = restartDisabled;
   const restartTooltip =
     status === "installing"
-      ? "Hard restart dev preview (may interrupt installation)"
-      : "Hard restart dev preview";
+      ? "Restart dev server (may interrupt installation)"
+      : "Restart dev server";
   const stopVisible =
     onStop &&
     (status === "starting" ||
@@ -102,7 +117,7 @@ export function ConsoleDrawer({
   const stopDisabled = isRestarting || status === "stopping";
   const statusClass = cn(
     "inline-flex min-h-8 items-center px-3 text-[10px] font-semibold uppercase tracking-wide",
-    (onHardRestart || stopVisible) && "border-r border-overlay/70",
+    (hasRestartControls || stopVisible) && "border-r border-overlay/70",
     statusLabel.textClass
   );
 
@@ -152,27 +167,77 @@ export function ConsoleDrawer({
           </Tooltip>
         )}
 
-        {onHardRestart && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <button
-                  type="button"
-                  onClick={onHardRestart}
-                  disabled={hardRestartDisabled}
-                  className={cn(
-                    "p-1.5 rounded hover:bg-overlay-medium disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors",
-                    isRestarting && "animate-spin"
-                  )}
-                  aria-label={restartTooltip}
-                  aria-busy={isRestarting}
+        {hasRestartControls && (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <button
+                    type="button"
+                    onClick={onRestartDevServer}
+                    disabled={restartDisabled}
+                    className={cn(
+                      "p-1.5 rounded-r-none hover:bg-overlay-medium disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors",
+                      isRestarting && "animate-spin"
+                    )}
+                    aria-label={restartTooltip}
+                    aria-busy={isRestarting}
+                  >
+                    <RotateCw className="h-3.5 w-3.5" />
+                  </button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{restartTooltip}</TooltipContent>
+            </Tooltip>
+            <DropdownMenu>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <span className="inline-flex">
+                      <button
+                        type="button"
+                        disabled={chevronDisabled}
+                        className={cn(
+                          "p-1 rounded-l-none hover:bg-overlay-medium disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors"
+                        )}
+                        aria-label="More restart options"
+                        aria-disabled={chevronDisabled || undefined}
+                        onClick={(e) => {
+                          if (chevronDisabled) e.preventDefault();
+                        }}
+                      >
+                        <ChevronDown className="h-3.5 w-3.5" />
+                      </button>
+                    </span>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">More restart options</TooltipContent>
+              </Tooltip>
+              <DropdownMenuContent
+                align="end"
+                sideOffset={4}
+                className="min-w-[14rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
+              >
+                <DropdownMenuItem onSelect={onReloadPreview}>Reload preview</DropdownMenuItem>
+                <DropdownMenuItem onSelect={onRestartDevServer}>
+                  Restart dev server
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  disabled={isRestarting || status === "installing"}
+                  onSelect={onRequestRestartAndClearCache}
                 >
-                  <RotateCw className="h-3.5 w-3.5" />
-                </button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{restartTooltip}</TooltipContent>
-          </Tooltip>
+                  Restart and clear cache
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={isRestarting || status === "installing"}
+                  onSelect={onRequestReinstallAndRestart}
+                >
+                  Reinstall dependencies
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </>
         )}
       </div>
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -44,7 +44,6 @@ import { findDevServerCandidate } from "@/utils/devServerDetection";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { projectClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
-import type { ActionId } from "@shared/types/actions";
 import { useWebviewThrottle } from "@/hooks/useWebviewThrottle";
 import { useHasBeenVisible } from "@/hooks/useHasBeenVisible";
 import { useWebviewEviction } from "@/hooks/useWebviewEviction";
@@ -774,9 +773,15 @@ export function DevPreviewPane({
     if (!tier || !currentProjectId) return;
 
     confirmRestartInFlightRef.current = true;
-    resetPreviewWebviewState();
 
-    const done = () => {
+    const onSuccess = () => {
+      resetPreviewWebviewState();
+      confirmRestartInFlightRef.current = false;
+      setPendingRestartTier(null);
+    };
+
+    const onError = (err: unknown) => {
+      console.warn("[DevPreviewPane] Restart confirm failed", err);
       confirmRestartInFlightRef.current = false;
       setPendingRestartTier(null);
     };
@@ -784,25 +789,21 @@ export function DevPreviewPane({
     if (tier === "restartAndClearCache") {
       window.electron.devPreview
         .restartAndClearCache({ panelId: id, projectId: currentProjectId })
-        .then(done, done);
+        .then(onSuccess, onError);
     } else {
       window.electron.devPreview
         .reinstallAndRestart({ panelId: id, projectId: currentProjectId })
-        .then(done, done);
+        .then(onSuccess, onError);
     }
   }, [pendingRestartTier, currentProjectId, id, resetPreviewWebviewState]);
 
-  const handleStuckRemedy = useCallback(
-    (actionId: string) => {
-      if (!currentProjectId) return;
-      void actionService.dispatch(
-        actionId as ActionId,
-        { panelId: id, projectId: currentProjectId },
-        { source: "user" }
-      );
-    },
-    [currentProjectId, id]
-  );
+  const handleStuckRemedy = useCallback((actionId: string) => {
+    if (actionId === "devPreview.restartAndClearCache") {
+      setPendingRestartTier("restartAndClearCache");
+    } else if (actionId === "devPreview.reinstallAndRestart") {
+      setPendingRestartTier("reinstallAndRestart");
+    }
+  }, []);
 
   const handleAutoDetect = useCallback(async () => {
     if (!currentProjectId || isAutoDetecting) return;

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -3,6 +3,7 @@ import { useBrowserActionListeners } from "@/hooks/useBrowserActionListeners";
 import {
   AlertTriangle,
   RotateCw,
+  ChevronDown,
   ExternalLink,
   Settings,
   Square,
@@ -11,6 +12,14 @@ import {
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
 import { usePanelStore } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
@@ -29,6 +38,7 @@ import { useDevServer, type UseDevServerReturn } from "@/hooks/useDevServer";
 import { ConsoleDrawer } from "./ConsoleDrawer";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { computeDevServerUrl } from "./urlSync";
 import { findDevServerCandidate } from "@/utils/devServerDetection";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
@@ -189,8 +199,8 @@ export interface DevPreviewPaneProps extends BasePanelProps {
 }
 
 const STUCK_REMEDY_LABELS: Record<string, string> = {
-  "devPreview.restartClearCache": "Restart and clear cache",
-  "devPreview.reinstall": "Reinstall dependencies",
+  "devPreview.restartAndClearCache": "Restart and clear cache",
+  "devPreview.reinstallAndRestart": "Reinstall dependencies",
 };
 
 interface DevPreviewStuckBannerProps {
@@ -713,9 +723,7 @@ export function DevPreviewPane({
     void start();
   }, [start]);
 
-  const handleHardRestart = useCallback(() => {
-    // Invalidate any in-flight async scroll captures so they can't write
-    // stale data back over the cleared position.
+  const resetPreviewWebviewState = useCallback(() => {
     scrollCaptureGenerationRef.current += 1;
     setDevPreviewScrollPosition(id, undefined);
     clearLoadTimers();
@@ -726,10 +734,8 @@ export function DevPreviewPane({
     setIsSlowLoad(false);
     setIsWebviewReady(false);
     setWebviewLoadError(null);
-    void restart();
   }, [
     id,
-    restart,
     setBrowserUrl,
     setDevPreviewScrollPosition,
     clearLoadTimers,
@@ -738,6 +744,53 @@ export function DevPreviewPane({
     setIsWebviewReady,
     setWebviewLoadError,
   ]);
+
+  const handleRestartDevServer = useCallback(() => {
+    resetPreviewWebviewState();
+    void restart();
+  }, [resetPreviewWebviewState, restart]);
+
+  const confirmRestartInFlightRef = useRef(false);
+  const [pendingRestartTier, setPendingRestartTier] = useState<
+    "restartAndClearCache" | "reinstallAndRestart" | null
+  >(null);
+  const isRestartConfirmOpen = pendingRestartTier !== null;
+
+  const handleRequestRestartAndClearCache = useCallback(() => {
+    setPendingRestartTier("restartAndClearCache");
+  }, []);
+
+  const handleRequestReinstallAndRestart = useCallback(() => {
+    setPendingRestartTier("reinstallAndRestart");
+  }, []);
+
+  const handleRestartConfirmClose = useCallback(() => {
+    setPendingRestartTier(null);
+  }, []);
+
+  const handleRestartConfirm = useCallback(() => {
+    if (confirmRestartInFlightRef.current) return;
+    const tier = pendingRestartTier;
+    if (!tier || !currentProjectId) return;
+
+    confirmRestartInFlightRef.current = true;
+    resetPreviewWebviewState();
+
+    const done = () => {
+      confirmRestartInFlightRef.current = false;
+      setPendingRestartTier(null);
+    };
+
+    if (tier === "restartAndClearCache") {
+      window.electron.devPreview
+        .restartAndClearCache({ panelId: id, projectId: currentProjectId })
+        .then(done, done);
+    } else {
+      window.electron.devPreview
+        .reinstallAndRestart({ panelId: id, projectId: currentProjectId })
+        .then(done, done);
+    }
+  }, [pendingRestartTier, currentProjectId, id, resetPreviewWebviewState]);
 
   const handleStuckRemedy = useCallback(
     (actionId: string) => {
@@ -1047,7 +1100,7 @@ export function DevPreviewPane({
             tier={stuckTier >= 3 ? 3 : 2}
             error={error}
             isRestarting={isRestarting}
-            onRestart={handleHardRestart}
+            onRestart={handleRestartDevServer}
             onRemedy={handleStuckRemedy}
           />
         )}
@@ -1255,23 +1308,74 @@ export function DevPreviewPane({
                         {webviewLoadError.message}
                       </p>
                       <div className="flex items-center gap-1">
-                        <Button
-                          onClick={
-                            webviewLoadError.code === "connection_refused"
-                              ? handleHardRestart
-                              : handleRetryWebviewLoad
-                          }
-                          variant="ghost"
-                          size="sm"
-                          className="gap-1.5 px-2.5 py-1.5 group"
-                        >
-                          <RotateCw className="h-3.5 w-3.5" />
-                          <span className="text-xs">
-                            {webviewLoadError.code === "connection_refused"
-                              ? "Hard restart"
-                              : "Retry"}
-                          </span>
-                        </Button>
+                        {webviewLoadError.code === "connection_refused" ? (
+                          <>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  onClick={handleRestartDevServer}
+                                  variant="ghost"
+                                  size="sm"
+                                  disabled={isRestarting}
+                                  className="gap-1.5 px-2.5 py-1.5 rounded-r-none group"
+                                >
+                                  <RotateCw
+                                    className={cn("h-3.5 w-3.5", isRestarting && "animate-spin")}
+                                  />
+                                  <span className="text-xs">Restart dev server</span>
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent side="bottom">Restart dev server</TooltipContent>
+                            </Tooltip>
+                            <DropdownMenu>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <DropdownMenuTrigger asChild>
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      disabled={isRestarting}
+                                      className="px-1.5 rounded-l-none group"
+                                      aria-label="More restart options"
+                                    >
+                                      <ChevronDown className="h-3.5 w-3.5" />
+                                    </Button>
+                                  </DropdownMenuTrigger>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom">More restart options</TooltipContent>
+                              </Tooltip>
+                              <DropdownMenuContent
+                                align="end"
+                                sideOffset={4}
+                                className="min-w-[14rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
+                              >
+                                <DropdownMenuItem onSelect={handleHardReload}>
+                                  Reload preview
+                                </DropdownMenuItem>
+                                <DropdownMenuItem onSelect={handleRestartDevServer}>
+                                  Restart dev server
+                                </DropdownMenuItem>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem onSelect={handleRequestRestartAndClearCache}>
+                                  Restart and clear cache
+                                </DropdownMenuItem>
+                                <DropdownMenuItem onSelect={handleRequestReinstallAndRestart}>
+                                  Reinstall dependencies
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </>
+                        ) : (
+                          <Button
+                            onClick={handleRetryWebviewLoad}
+                            variant="ghost"
+                            size="sm"
+                            className="gap-1.5 px-2.5 py-1.5 group"
+                          >
+                            <RotateCw className="h-3.5 w-3.5" />
+                            <span className="text-xs">Retry</span>
+                          </Button>
+                        )}
                         {currentUrl && (
                           <Button
                             onClick={handleOpenExternal}
@@ -1378,10 +1482,36 @@ export function DevPreviewPane({
             isOpen={isConsoleOpen}
             onOpenChange={(nextOpen) => setDevPreviewConsoleOpen(id, nextOpen)}
             isRestarting={isRestarting}
-            onHardRestart={handleHardRestart}
+            onReloadPreview={handleHardReload}
+            onRestartDevServer={handleRestartDevServer}
+            onRequestRestartAndClearCache={handleRequestRestartAndClearCache}
+            onRequestReinstallAndRestart={handleRequestReinstallAndRestart}
             onStop={stop}
           />
         )}
+        <ConfirmDialog
+          isOpen={isRestartConfirmOpen}
+          onClose={handleRestartConfirmClose}
+          variant="destructive"
+          title={
+            pendingRestartTier === "restartAndClearCache"
+              ? "Clear cache and restart?"
+              : "Reinstall dependencies?"
+          }
+          description={
+            pendingRestartTier === "restartAndClearCache"
+              ? "This will delete framework build caches (.next, .vite, .turbo) and respawn the dev server. Source files and installed dependencies are not affected."
+              : "This will delete node_modules and reinstall all dependencies, then respawn the dev server. Source files and git state are not affected."
+          }
+          confirmLabel={
+            pendingRestartTier === "restartAndClearCache" ? "Clear cache" : "Reinstall dependencies"
+          }
+          onConfirm={handleRestartConfirm}
+        >
+          {pendingRestartTier === "reinstallAndRestart" && (
+            <p className="text-xs text-daintree-text/50 font-mono break-all">{cwd}/node_modules</p>
+          )}
+        </ConfirmDialog>
       </div>
     </ContentPanel>
   );

--- a/src/components/DevPreview/__tests__/ConsoleDrawer.test.tsx
+++ b/src/components/DevPreview/__tests__/ConsoleDrawer.test.tsx
@@ -32,6 +32,31 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onSelect} disabled={disabled} role="menuitem">
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr role="separator" />,
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuRadioGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuRadioItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuCheckboxItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuShortcut: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 describe("ConsoleDrawer", () => {
   const mockTerminalId = "test-terminal-id";
   const getToggleButton = () => screen.getByRole("button", { name: /(?:show|hide) terminal/i });
@@ -169,103 +194,163 @@ describe("ConsoleDrawer", () => {
     });
   });
 
-  describe("hard restart action", () => {
-    it("does not render restart button without handler", () => {
+  describe("tiered restart actions", () => {
+    it("does not render restart controls without handler", () => {
       render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
-      expect(screen.queryByRole("button", { name: "Hard restart dev preview" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Restart dev server" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "More restart options" })).toBeNull();
     });
 
-    it("renders restart button when handler is provided", () => {
+    it("renders primary restart button and chevron when handler is provided", () => {
       render(
         <ConsoleDrawer
           terminalId={mockTerminalId}
           defaultOpen={false}
-          onHardRestart={vi.fn()}
+          onRestartDevServer={vi.fn()}
           status="running"
         />
       );
-      expect(screen.getByRole("button", { name: "Hard restart dev preview" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Restart dev server" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "More restart options" })).toBeTruthy();
     });
 
-    it("renders restart button as icon-only with no visible text", () => {
+    it("renders all four tier options in dropdown", () => {
       render(
         <ConsoleDrawer
           terminalId={mockTerminalId}
           defaultOpen={false}
-          onHardRestart={vi.fn()}
+          onReloadPreview={vi.fn()}
+          onRestartDevServer={vi.fn()}
+          onRequestRestartAndClearCache={vi.fn()}
+          onRequestReinstallAndRestart={vi.fn()}
           status="running"
         />
       );
-      const restartButton = screen.getByRole("button", { name: "Hard restart dev preview" });
-      expect(restartButton.textContent).toBe("");
-      expect(restartButton.querySelector("svg")).toBeTruthy();
+      expect(screen.getByRole("menuitem", { name: "Reload preview" })).toBeTruthy();
+      expect(screen.getByRole("menuitem", { name: "Restart dev server" })).toBeTruthy();
+      expect(screen.getByRole("menuitem", { name: "Restart and clear cache" })).toBeTruthy();
+      expect(screen.getByRole("menuitem", { name: "Reinstall dependencies" })).toBeTruthy();
     });
 
-    it("calls onHardRestart when restart button is clicked", () => {
-      const onHardRestart = vi.fn();
+    it("calls onRestartDevServer when primary button is clicked", () => {
+      const onRestartDevServer = vi.fn();
       render(
         <ConsoleDrawer
           terminalId={mockTerminalId}
           defaultOpen={false}
-          onHardRestart={onHardRestart}
+          onRestartDevServer={onRestartDevServer}
           status="running"
         />
       );
 
-      const restartButton = screen.getByRole("button", { name: "Hard restart dev preview" });
+      const restartButton = screen.getByRole("button", { name: "Restart dev server" });
       fireEvent.click(restartButton);
 
-      expect(onHardRestart).toHaveBeenCalledTimes(1);
+      expect(onRestartDevServer).toHaveBeenCalledTimes(1);
     });
 
-    it("disables restart button while restarting", () => {
+    it("calls tier callbacks when dropdown items are selected", () => {
+      const onReloadPreview = vi.fn();
+      const onRestartDevServer = vi.fn();
+      const onRequestRestartAndClearCache = vi.fn();
+      const onRequestReinstallAndRestart = vi.fn();
+
       render(
         <ConsoleDrawer
           terminalId={mockTerminalId}
           defaultOpen={false}
-          onHardRestart={vi.fn()}
+          onReloadPreview={onReloadPreview}
+          onRestartDevServer={onRestartDevServer}
+          onRequestRestartAndClearCache={onRequestRestartAndClearCache}
+          onRequestReinstallAndRestart={onRequestReinstallAndRestart}
+          status="running"
+        />
+      );
+
+      fireEvent.click(screen.getByRole("menuitem", { name: "Reload preview" }));
+      expect(onReloadPreview).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByRole("menuitem", { name: "Restart dev server" }));
+      expect(onRestartDevServer).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByRole("menuitem", { name: "Restart and clear cache" }));
+      expect(onRequestRestartAndClearCache).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByRole("menuitem", { name: "Reinstall dependencies" }));
+      expect(onRequestReinstallAndRestart).toHaveBeenCalledTimes(1);
+    });
+
+    it("disables primary button and chevron while restarting", () => {
+      render(
+        <ConsoleDrawer
+          terminalId={mockTerminalId}
+          defaultOpen={false}
+          onRestartDevServer={vi.fn()}
           status="running"
           isRestarting={true}
         />
       );
 
-      const restartButton = screen.getByRole("button", { name: "Hard restart dev preview" });
+      const restartButton = screen.getByRole("button", { name: "Restart dev server" });
       expect(restartButton.getAttribute("disabled")).not.toBeNull();
       expect(restartButton.getAttribute("aria-busy")).toBe("true");
       expect(screen.getByText("Restarting")).toBeTruthy();
+
+      const chevron = screen.getByRole("button", { name: "More restart options" });
+      expect(chevron.getAttribute("disabled")).not.toBeNull();
     });
 
-    it("disables restart button while starting", () => {
+    it("disables primary button and chevron while starting", () => {
       render(
         <ConsoleDrawer
           terminalId={mockTerminalId}
           defaultOpen={false}
-          onHardRestart={vi.fn()}
+          onRestartDevServer={vi.fn()}
           status="starting"
         />
       );
 
-      const restartButton = screen.getByRole("button", { name: "Hard restart dev preview" });
+      const restartButton = screen.getByRole("button", { name: "Restart dev server" });
       expect(restartButton.getAttribute("disabled")).not.toBeNull();
+
+      const chevron = screen.getByRole("button", { name: "More restart options" });
+      expect(chevron.getAttribute("disabled")).not.toBeNull();
     });
 
-    it("enables restart button while installing with warning tooltip", () => {
+    it("enables primary while installing with warning tooltip", () => {
       render(
         <ConsoleDrawer
           terminalId={mockTerminalId}
           defaultOpen={false}
-          onHardRestart={vi.fn()}
+          onRestartDevServer={vi.fn()}
           status="installing"
         />
       );
 
       const restartButton = screen.getByRole("button", {
-        name: "Hard restart dev preview (may interrupt installation)",
+        name: "Restart dev server (may interrupt installation)",
       });
       expect(restartButton.getAttribute("disabled")).toBeNull();
-      expect(restartButton.getAttribute("aria-label")).toBe(
-        "Hard restart dev preview (may interrupt installation)"
+    });
+
+    it("disables destructive dropdown items while restarting or installing", () => {
+      render(
+        <ConsoleDrawer
+          terminalId={mockTerminalId}
+          defaultOpen={false}
+          onRestartDevServer={vi.fn()}
+          onRequestRestartAndClearCache={vi.fn()}
+          onRequestReinstallAndRestart={vi.fn()}
+          status="installing"
+        />
       );
+
+      expect(
+        screen.getByRole("menuitem", { name: "Restart and clear cache" }).getAttribute("disabled")
+      ).not.toBeNull();
+      expect(
+        screen.getByRole("menuitem", { name: "Reinstall dependencies" }).getAttribute("disabled")
+      ).not.toBeNull();
     });
   });
 

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -153,6 +153,7 @@ const {
 
 vi.mock("@/store", () => ({
   usePanelStore: usePanelStoreMock,
+  usePortalStore: () => ({ isOpen: false, width: 0 }),
 }));
 
 vi.mock("@/store/projectStore", () => ({
@@ -201,15 +202,34 @@ vi.mock("@/components/Panel", () => ({
   ),
 }));
 
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuSeparator: () => null,
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
 vi.mock("@/components/DevPreview/ConsoleDrawer", () => ({
-  ConsoleDrawer: ({ onHardRestart }: { onHardRestart?: () => void }) => (
+  ConsoleDrawer: ({ onRestartDevServer }: { onRestartDevServer?: () => void }) => (
     <button
       type="button"
       data-testid="hard-restart"
-      onClick={() => onHardRestart?.()}
+      onClick={() => onRestartDevServer?.()}
       aria-label="hard-restart"
     >
-      Hard restart
+      Restart dev server
     </button>
   ),
 }));

--- a/src/services/actions/definitions/devServerActions.ts
+++ b/src/services/actions/definitions/devServerActions.ts
@@ -1,13 +1,7 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import type { ActionContext } from "@shared/types/actions";
-import { z } from "zod";
 import { projectClient } from "@/clients";
 import { usePanelStore } from "@/store/panelStore";
-
-const devPreviewTargetSchema = z.object({
-  panelId: z.string(),
-  projectId: z.string(),
-});
 
 export function registerDevServerActions(
   actions: ActionRegistry,
@@ -39,42 +33,6 @@ export function registerDevServerActions(
         location: "grid",
         devCommand: devServerCommand || undefined,
       });
-    },
-  }));
-
-  // Tier 3 stuck-start remedies (#8276). The dedicated cache-clear and
-  // dependency-reinstall recovery tiers land in #8274; until then both
-  // remedies degrade to a full dev-server restart, which is the strongest
-  // recovery currently available — it kills and respawns the process
-  // (freeing a still-bound port) and re-runs the dev command (which
-  // re-triggers install for missing-dependency cases).
-  actions.set("devPreview.restartClearCache", () => ({
-    id: "devPreview.restartClearCache",
-    title: "Restart and clear cache",
-    description: "Restart the dev server and clear its build cache",
-    category: "devServer",
-    kind: "command",
-    danger: "safe",
-    scope: "renderer",
-    argsSchema: devPreviewTargetSchema,
-    run: async (args: unknown) => {
-      const { panelId, projectId } = devPreviewTargetSchema.parse(args);
-      await window.electron.devPreview.restart({ panelId, projectId });
-    },
-  }));
-
-  actions.set("devPreview.reinstall", () => ({
-    id: "devPreview.reinstall",
-    title: "Reinstall dependencies",
-    description: "Reinstall dependencies and restart the dev server",
-    category: "devServer",
-    kind: "command",
-    danger: "safe",
-    scope: "renderer",
-    argsSchema: devPreviewTargetSchema,
-    run: async (args: unknown) => {
-      const { panelId, projectId } = devPreviewTargetSchema.parse(args);
-      await window.electron.devPreview.restart({ panelId, projectId });
     },
   }));
 


### PR DESCRIPTION
## Summary
- Replaces the single ambiguous Hard Restart button with a tiered restart popover in ConsoleDrawer and webviewLoadError overlay. Four tiers: Reload preview, Restart dev server, Restart and clear cache, Reinstall and restart.
- Restart and clear cache (D1) and Reinstall and restart (D2) are gated behind ConfirmDialog -- the D2 tier shows what directories get deleted and the resolved install command before it fires.
- Fixes an action ID mismatch in devServerErrors where the discovery module pointed at the old `devPreview.restartClearCache` and `devPreview.reinstall` IDs instead of the new `devPreview.restartAndClearCache` and `devPreview.reinstallAndRestart` IDs.

Resolves #8275.

## Changes
- **ConsoleDrawer.tsx** -- tiered restart popover with Restart dev server as the primary action and the other tiers behind a chevron dropdown
- **DevPreviewPane.tsx** -- same treatment in the webviewLoadError overlay, plus ConfirmDialog wiring for the destructive tiers
- **devServerErrors.ts** -- corrected `recommendedActionId` to use the new tiered action ID prefix
- **actionIds.ts / devServerActions.ts** -- removed the old stub `devPreview.restartClearCache` and `devPreview.reinstall` action IDs and definitions that degraded to a plain restart
- **Tests** -- expanded coverage for the tiered popover rendering and action dispatch in ConsoleDrawer

## Testing
- Unit tests for ConsoleDrawer tiered popover rendering and action dispatch
- Unit tests for devServerErrors action ID matching
- Visually verified ConfirmDialog rendering for D1 and D2 tiers in the error overlay