### PR TITLE
fix(dev-preview): surface render-process-gone and unresponsive as inline banners

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -353,6 +353,8 @@ export const CHANNELS = {
   WEBVIEW_DIALOG_RESPONSE: "webview:dialog-response",
   WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut",
   WEBVIEW_NAVIGATION_BLOCKED: "webview:navigation-blocked",
+  WEBVIEW_UNRESPONSIVE: "webview:unresponsive",
+  WEBVIEW_RESPONSIVE: "webview:responsive",
   WEBVIEW_OAUTH_LOOPBACK: "webview:oauth-loopback",
   WEBVIEW_CANCEL_OAUTH_LOOPBACK: "webview:cancel-oauth-loopback",
   WEBVIEW_OAUTH_LOOPBACK_STATUS: "webview:oauth-loopback-status",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1823,6 +1823,10 @@ const api: ElectronAPI = {
     onNavigationBlocked: (
       callback: (payload: { panelId: string; url: string; canOpenExternal: boolean }) => void
     ): (() => void) => _typedOn(CHANNELS.WEBVIEW_NAVIGATION_BLOCKED, callback),
+    onUnresponsive: (callback: (payload: { panelId: string }) => void): (() => void) =>
+      _typedOn(CHANNELS.WEBVIEW_UNRESPONSIVE, callback),
+    onResponsive: (callback: (payload: { panelId: string }) => void): (() => void) =>
+      _typedOn(CHANNELS.WEBVIEW_RESPONSIVE, callback),
     startOAuthLoopback: (
       authUrl: string,
       panelId: string,

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -513,6 +513,26 @@ export function setupWebviewCSP(): void {
           });
         }
       });
+
+      // Forward renderer unresponsive/responsive events to the owning panel.
+      // Chromium emits "unresponsive" only after >5s main-thread hang — that
+      // is the debounce, so we forward immediately. Hide on "responsive".
+      contents.on("unresponsive", () => {
+        const panelId = getWebviewDialogService().getPanelId(contents.id);
+        if (!panelId) return;
+        const parentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
+        if (parentWindow && !parentWindow.isDestroyed()) {
+          getAppWebContents(parentWindow).send(CHANNELS.WEBVIEW_UNRESPONSIVE, { panelId });
+        }
+      });
+      contents.on("responsive", () => {
+        const panelId = getWebviewDialogService().getPanelId(contents.id);
+        if (!panelId) return;
+        const parentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
+        if (parentWindow && !parentWindow.isDestroyed()) {
+          getAppWebContents(parentWindow).send(CHANNELS.WEBVIEW_RESPONSIVE, { panelId });
+        }
+      });
     }
   });
 }

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -457,6 +457,31 @@ export function setupWebviewCSP(): void {
         }
       );
 
+      // Surface render-process hang to the renderer when the guest stops processing
+      // input events for >30s. Auto-clears when `responsive` fires.
+      const notifyUnresponsive = () => {
+        if (contents.isDestroyed()) return;
+        const panelId = getWebviewDialogService().getPanelId(contents.id);
+        if (!panelId) return;
+        const parentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
+        if (parentWindow && !parentWindow.isDestroyed()) {
+          getAppWebContents(parentWindow).send(CHANNELS.WEBVIEW_UNRESPONSIVE, { panelId });
+        }
+      };
+
+      const notifyResponsive = () => {
+        if (contents.isDestroyed()) return;
+        const panelId = getWebviewDialogService().getPanelId(contents.id);
+        if (!panelId) return;
+        const parentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
+        if (parentWindow && !parentWindow.isDestroyed()) {
+          getAppWebContents(parentWindow).send(CHANNELS.WEBVIEW_RESPONSIVE, { panelId });
+        }
+      };
+
+      contents.on("unresponsive", notifyUnresponsive);
+      contents.on("responsive", notifyResponsive);
+
       // Intercept find-in-page shortcuts (Cmd/Ctrl+F, Cmd/Ctrl+G, Escape) from webview guests
       contents.on("before-input-event", (event, input) => {
         if (input.type !== "keyDown") return;

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -513,26 +513,6 @@ export function setupWebviewCSP(): void {
           });
         }
       });
-
-      // Forward renderer unresponsive/responsive events to the owning panel.
-      // Chromium emits "unresponsive" only after >5s main-thread hang — that
-      // is the debounce, so we forward immediately. Hide on "responsive".
-      contents.on("unresponsive", () => {
-        const panelId = getWebviewDialogService().getPanelId(contents.id);
-        if (!panelId) return;
-        const parentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
-        if (parentWindow && !parentWindow.isDestroyed()) {
-          getAppWebContents(parentWindow).send(CHANNELS.WEBVIEW_UNRESPONSIVE, { panelId });
-        }
-      });
-      contents.on("responsive", () => {
-        const panelId = getWebviewDialogService().getPanelId(contents.id);
-        if (!panelId) return;
-        const parentWindow = getWindowForWebContents(contents.hostWebContents ?? contents);
-        if (parentWindow && !parentWindow.isDestroyed()) {
-          getAppWebContents(parentWindow).send(CHANNELS.WEBVIEW_RESPONSIVE, { panelId });
-        }
-      });
     }
   });
 }

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -862,7 +862,6 @@ export interface ElectronAPI {
     ): () => void;
     /** Subscribe to unresponsive events from webview guest render processes */
     onUnresponsive(callback: (payload: { panelId: string }) => void): () => void;
-    /** Subscribe to responsive (recovery) events from webview guest render processes */
     onResponsive(callback: (payload: { panelId: string }) => void): () => void;
     /** Start OAuth loopback flow: system browser for IdP, ephemeral server for callback, CDP for token exchange */
     startOAuthLoopback(

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -860,6 +860,10 @@ export interface ElectronAPI {
     onNavigationBlocked(
       callback: (payload: { panelId: string; url: string; canOpenExternal: boolean }) => void
     ): () => void;
+    /** Subscribe to unresponsive events from webview guest render processes */
+    onUnresponsive(callback: (payload: { panelId: string }) => void): () => void;
+    /** Subscribe to responsive (recovery) events from webview guest render processes */
+    onResponsive(callback: (payload: { panelId: string }) => void): () => void;
     /** Start OAuth loopback flow: system browser for IdP, ephemeral server for callback, CDP for token exchange */
     startOAuthLoopback(
       authUrl: string,

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2293,6 +2293,16 @@ export interface IpcEventMap {
     message?: string;
   };
 
+  // Webview render process became unresponsive (>30s no input processing)
+  "webview:unresponsive": {
+    panelId: string;
+  };
+
+  // Webview render process recovered from unresponsive state
+  "webview:responsive": {
+    panelId: string;
+  };
+
   // Voice input events
   "voice-input:transcription-delta": string;
   "voice-input:transcription-complete": { text: string; willCorrect: boolean };

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -631,10 +631,7 @@ export function DevPreviewPane({
     }
   }, [currentUrl, setWebviewLoadError, setIsSlowLoad, setIsLoading]);
 
-  const handleHardReload = useCallback(() => {
-    setCrashState("none");
-    setCrashDetails(null);
-    crashTimestampsRef.current = [];
+  const performReload = useCallback(() => {
     const webview = webviewRef.current;
     if (!webview || !isWebviewReady) return;
     setWebviewLoadError(null);
@@ -682,11 +679,18 @@ export function DevPreviewPane({
     setDevPreviewConsoleOpen(id, !isConsoleOpen);
   }, [id, isConsoleOpen, setDevPreviewConsoleOpen]);
 
-  // Keep crashReloadRef in sync so onRenderProcessGone can call handleHardReload
+  const handleHardReload = useCallback(() => {
+    setCrashState("none");
+    setCrashDetails(null);
+    crashTimestampsRef.current = [];
+    performReload();
+  }, [performReload]);
+
+  // Keep crashReloadRef in sync so onRenderProcessGone can call performReload
   // before it exists in the lexical scope.
   useEffect(() => {
-    crashReloadRef.current = handleHardReload;
-  }, [handleHardReload]);
+    crashReloadRef.current = performReload;
+  }, [performReload]);
 
   const handleOpenExternal = useCallback(() => {
     if (currentUrl) {

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -738,7 +738,6 @@ export function DevPreviewPane({
     setCrashState("none");
     setCrashDetails(null);
     crashTimestampsRef.current = [];
-    void restart();
   }, [
     id,
     setBrowserUrl,

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -8,6 +8,7 @@ import {
   Settings,
   OctagonAlert,
   Play,
+  XCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
@@ -293,6 +294,13 @@ export function DevPreviewPane({
   });
 
   const [blockedNav, dispatchBlockedNav] = useReducer(blockedNavReducer, null);
+  const [crashState, setCrashState] = useState<"none" | "crashed" | "unresponsive">("none");
+  const [crashDetails, setCrashDetails] = useState<{
+    reason: string;
+    exitCode: number;
+  } | null>(null);
+  const crashTimestampsRef = useRef<number[]>([]);
+  const crashReloadRef = useRef<() => void>(() => {});
   const blockedNavTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastSetUrlRef = useRef<string>("");
   const [consoleTerminalId, setConsoleTerminalId] = useState<string | null>(terminalId);
@@ -417,6 +425,20 @@ export function DevPreviewPane({
     return () => clearTimeout(timer);
   }, [status, url, phaseLabel, id, setDevPreviewConsoleOpen]);
 
+  const handleRenderProcessGone = useCallback((details: { reason: string; exitCode: number }) => {
+    const now = Date.now();
+    const timestamps = crashTimestampsRef.current.filter((ts) => now - ts < 60_000);
+    timestamps.push(now);
+    crashTimestampsRef.current = timestamps;
+
+    setCrashDetails(details);
+    setCrashState("crashed");
+
+    if (timestamps.length < 2) {
+      crashReloadRef.current();
+    }
+  }, []);
+
   const {
     isWebviewReady,
     setIsWebviewReady,
@@ -439,6 +461,7 @@ export function DevPreviewPane({
     originalUaRef,
     setHistory,
     setBlockedNav: dispatchBlockedNav,
+    onRenderProcessGone: handleRenderProcessGone,
   });
 
   useEffect(() => {
@@ -609,6 +632,9 @@ export function DevPreviewPane({
   }, [currentUrl, setWebviewLoadError, setIsSlowLoad, setIsLoading]);
 
   const handleHardReload = useCallback(() => {
+    setCrashState("none");
+    setCrashDetails(null);
+    crashTimestampsRef.current = [];
     const webview = webviewRef.current;
     if (!webview || !isWebviewReady) return;
     setWebviewLoadError(null);
@@ -656,6 +682,12 @@ export function DevPreviewPane({
     setDevPreviewConsoleOpen(id, !isConsoleOpen);
   }, [id, isConsoleOpen, setDevPreviewConsoleOpen]);
 
+  // Keep crashReloadRef in sync so onRenderProcessGone can call handleHardReload
+  // before it exists in the lexical scope.
+  useEffect(() => {
+    crashReloadRef.current = handleHardReload;
+  }, [handleHardReload]);
+
   const handleOpenExternal = useCallback(() => {
     if (currentUrl) {
       safeFireAndForget(window.electron.system.openExternal(currentUrl), {
@@ -699,6 +731,10 @@ export function DevPreviewPane({
     setIsSlowLoad(false);
     setIsWebviewReady(false);
     setWebviewLoadError(null);
+    setCrashState("none");
+    setCrashDetails(null);
+    crashTimestampsRef.current = [];
+    void restart();
   }, [
     id,
     setBrowserUrl,
@@ -1075,6 +1111,50 @@ export function DevPreviewPane({
       }
     };
   }, [id, webviewElement]);
+
+  // Listen for webview unresponsive/responsive events from the main process
+  useEffect(() => {
+    const cleanupUnresponsive = window.electron.webview.onUnresponsive((data) => {
+      if (data.panelId !== id) return;
+      setCrashState((prev) => (prev === "crashed" ? prev : "unresponsive"));
+    });
+    const cleanupResponsive = window.electron.webview.onResponsive((data) => {
+      if (data.panelId !== id) return;
+      setCrashState((prev) => (prev === "unresponsive" ? "none" : prev));
+    });
+    return () => {
+      cleanupUnresponsive();
+      cleanupResponsive();
+    };
+  }, [id]);
+
+  // Clear crash state on successful navigation
+  useEffect(() => {
+    if (crashState === "none") return;
+    if (currentUrl && currentUrl !== "about:blank") {
+      setCrashState("none");
+      setCrashDetails(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- clear on URL change only
+  }, [currentUrl]);
+
+  // Listen for action-driven hard-reload events
+  useEffect(() => {
+    const handleHardReloadEvent = (e: Event) => {
+      if (!(e instanceof CustomEvent)) return;
+      const detail = e.detail as unknown;
+      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
+      if ((detail as { id: string }).id === id) {
+        handleHardReload();
+      }
+    };
+
+    const controller = new AbortController();
+    window.addEventListener("daintree:hard-reload-browser", handleHardReloadEvent, {
+      signal: controller.signal,
+    });
+    return () => controller.abort();
+  }, [id, handleHardReload]);
 
   return (
     <ContentPanel
@@ -1504,6 +1584,62 @@ export function DevPreviewPane({
                     webviewElement={webviewElement}
                     onDispatch={dispatchBlockedNav}
                   />
+                  {crashState === "crashed" && (
+                    <InlineStatusBanner
+                      icon={XCircle}
+                      title="Preview process crashed"
+                      description={
+                        crashDetails
+                          ? `Reason: ${crashDetails.reason} (exit code ${crashDetails.exitCode})`
+                          : "The renderer process terminated unexpectedly."
+                      }
+                      severity="error"
+                      animated={false}
+                      actions={[
+                        {
+                          id: "reload",
+                          label: "Reload",
+                          icon: RotateCw,
+                          variant: "dangerFilled",
+                          onClick: handleHardReload,
+                          ariaLabel: "Reload preview page",
+                        },
+                        {
+                          id: "hard-restart",
+                          label: "Hard restart",
+                          icon: RotateCw,
+                          variant: "danger",
+                          onClick: handleRestartDevServer,
+                          ariaLabel: "Hard restart preview",
+                        },
+                      ]}
+                      onClose={() => {
+                        setCrashState("none");
+                        setCrashDetails(null);
+                        crashTimestampsRef.current = [];
+                      }}
+                    />
+                  )}
+                  {crashState === "unresponsive" && (
+                    <InlineStatusBanner
+                      icon={AlertTriangle}
+                      title="Preview is not responding"
+                      description="The page may be stuck in a long-running operation."
+                      severity="warning"
+                      animated={false}
+                      actions={[
+                        {
+                          id: "hard-restart",
+                          label: "Hard restart",
+                          icon: RotateCw,
+                          variant: "danger",
+                          onClick: handleRestartDevServer,
+                          ariaLabel: "Hard restart preview",
+                        },
+                      ]}
+                      onClose={() => setCrashState("none")}
+                    />
+                  )}
                   {isLoading && (
                     <DevPreviewLoadingState
                       variant="overlay"

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1139,8 +1139,7 @@ export function DevPreviewPane({
       setCrashState("none");
       setCrashDetails(null);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- clear on URL change only
-  }, [currentUrl]);
+  }, [currentUrl, crashState]);
 
   // Listen for action-driven hard-reload events
   useEffect(() => {

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -335,6 +335,8 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onConsoleMessage: vi.fn(() => vi.fn()),
         onConsoleContextCleared: vi.fn(() => vi.fn()),
         reloadIgnoringCache: vi.fn(() => Promise.resolve()),
+        onUnresponsive: vi.fn(() => vi.fn()),
+        onResponsive: vi.fn(() => vi.fn()),
       },
     };
   });
@@ -763,6 +765,8 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         stopConsoleCapture: vi.fn(() => Promise.resolve()),
         onConsoleMessage: vi.fn(() => vi.fn()),
         onConsoleContextCleared: vi.fn(() => vi.fn()),
+        onUnresponsive: vi.fn(() => vi.fn()),
+        onResponsive: vi.fn(() => vi.fn()),
       },
     };
 
@@ -819,6 +823,8 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         stopConsoleCapture: vi.fn(() => Promise.resolve()),
         onConsoleMessage: vi.fn(() => vi.fn()),
         onConsoleContextCleared: vi.fn(() => vi.fn()),
+        onUnresponsive: vi.fn(() => vi.fn()),
+        onResponsive: vi.fn(() => vi.fn()),
       },
     };
 
@@ -865,6 +871,8 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         stopConsoleCapture: vi.fn(() => Promise.resolve()),
         onConsoleMessage: vi.fn(() => vi.fn()),
         onConsoleContextCleared: vi.fn(() => vi.fn()),
+        onUnresponsive: vi.fn(() => vi.fn()),
+        onResponsive: vi.fn(() => vi.fn()),
       },
     };
 

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -765,8 +765,6 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         stopConsoleCapture: vi.fn(() => Promise.resolve()),
         onConsoleMessage: vi.fn(() => vi.fn()),
         onConsoleContextCleared: vi.fn(() => vi.fn()),
-        onUnresponsive: vi.fn(() => vi.fn()),
-        onResponsive: vi.fn(() => vi.fn()),
       },
     };
 
@@ -823,8 +821,6 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         stopConsoleCapture: vi.fn(() => Promise.resolve()),
         onConsoleMessage: vi.fn(() => vi.fn()),
         onConsoleContextCleared: vi.fn(() => vi.fn()),
-        onUnresponsive: vi.fn(() => vi.fn()),
-        onResponsive: vi.fn(() => vi.fn()),
       },
     };
 
@@ -871,8 +867,6 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         stopConsoleCapture: vi.fn(() => Promise.resolve()),
         onConsoleMessage: vi.fn(() => vi.fn()),
         onConsoleContextCleared: vi.fn(() => vi.fn()),
-        onUnresponsive: vi.fn(() => vi.fn()),
-        onResponsive: vi.fn(() => vi.fn()),
       },
     };
 

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -405,11 +405,11 @@ export function useDevPreviewLoadLifecycle({
 
     const handleRenderProcessGone = (e: Event) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      const detail = (e as unknown as { detail?: { reason?: string; exitCode?: number } }).detail;
-      if (!detail || detail.reason === "clean-exit") return;
+      const details = (e as unknown as { details?: { reason?: string; exitCode?: number } }).details;
+      if (!details || details.reason === "clean-exit") return;
       onRenderProcessGone?.({
-        reason: detail.reason ?? "unknown",
-        exitCode: detail.exitCode ?? -1,
+        reason: details.reason ?? "unknown",
+        exitCode: details.exitCode ?? -1,
       });
     };
 

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -434,16 +434,6 @@ export function useDevPreviewLoadLifecycle({
       recordVisit(navigatedUrl);
     };
 
-    const handleRenderProcessGone = (e: Event) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      const details = (e as unknown as { details?: { reason?: string; exitCode?: number } }).details;
-      if (!details || details.reason === "clean-exit") return;
-      onRenderProcessGone?.({
-        reason: details.reason ?? "unknown",
-        exitCode: details.exitCode ?? -1,
-      });
-    };
-
     webview.addEventListener("did-start-loading", handleDidStartLoading);
     webview.addEventListener("did-stop-loading", handleDidStopLoading);
     webview.addEventListener("did-finish-load", handleDidFinishLoad);
@@ -458,7 +448,6 @@ export function useDevPreviewLoadLifecycle({
       handleDidNavigateInPage as unknown as EventListener
     );
     webview.addEventListener("page-title-updated", handlePageTitleUpdated);
-    webview.addEventListener("render-process-gone", handleRenderProcessGone);
 
     return () => {
       webview.removeEventListener("did-start-loading", handleDidStartLoading);
@@ -475,7 +464,6 @@ export function useDevPreviewLoadLifecycle({
         handleDidNavigateInPage as unknown as EventListener
       );
       webview.removeEventListener("page-title-updated", handlePageTitleUpdated);
-      webview.removeEventListener("render-process-gone", handleRenderProcessGone);
       if (failLoadRetryRef.current) {
         clearTimeout(failLoadRetryRef.current);
         failLoadRetryRef.current = null;

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -404,6 +404,7 @@ export function useDevPreviewLoadLifecycle({
     };
 
     const handleRenderProcessGone = (e: Event) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       const detail = (e as unknown as { detail?: { reason?: string; exitCode?: number } }).detail;
       if (!detail || detail.reason === "clean-exit") return;
       onRenderProcessGone?.({

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -42,6 +42,7 @@ interface UseDevPreviewLoadLifecycleParams {
   originalUaRef: React.MutableRefObject<string | null>;
   setHistory: React.Dispatch<React.SetStateAction<BrowserHistory>>;
   setBlockedNav: React.Dispatch<BlockedNavAction>;
+  onRenderProcessGone?: (details: { reason: string; exitCode: number }) => void;
 }
 
 interface UseDevPreviewLoadLifecycleResult {
@@ -69,6 +70,7 @@ export function useDevPreviewLoadLifecycle({
   originalUaRef,
   setHistory,
   setBlockedNav,
+  onRenderProcessGone,
 }: UseDevPreviewLoadLifecycleParams): UseDevPreviewLoadLifecycleResult {
   const [isWebviewReady, setIsWebviewReady] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -401,6 +403,15 @@ export function useDevPreviewLoadLifecycle({
       recordVisit(navigatedUrl);
     };
 
+    const handleRenderProcessGone = (e: Event) => {
+      const detail = (e as unknown as { detail?: { reason?: string; exitCode?: number } }).detail;
+      if (!detail || detail.reason === "clean-exit") return;
+      onRenderProcessGone?.({
+        reason: detail.reason ?? "unknown",
+        exitCode: detail.exitCode ?? -1,
+      });
+    };
+
     webview.addEventListener("did-start-loading", handleDidStartLoading);
     webview.addEventListener("did-stop-loading", handleDidStopLoading);
     webview.addEventListener("did-finish-load", handleDidFinishLoad);
@@ -411,6 +422,7 @@ export function useDevPreviewLoadLifecycle({
       handleDidNavigateInPage as unknown as EventListener
     );
     webview.addEventListener("page-title-updated", handlePageTitleUpdated);
+    webview.addEventListener("render-process-gone", handleRenderProcessGone);
 
     return () => {
       webview.removeEventListener("did-start-loading", handleDidStartLoading);
@@ -423,6 +435,7 @@ export function useDevPreviewLoadLifecycle({
         handleDidNavigateInPage as unknown as EventListener
       );
       webview.removeEventListener("page-title-updated", handlePageTitleUpdated);
+      webview.removeEventListener("render-process-gone", handleRenderProcessGone);
       if (failLoadRetryRef.current) {
         clearTimeout(failLoadRetryRef.current);
         failLoadRetryRef.current = null;
@@ -445,6 +458,7 @@ export function useDevPreviewLoadLifecycle({
     setBlockedNav,
     id,
     originalUaRef,
+    onRenderProcessGone,
   ]);
 
   useEffect(() => {

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -45,6 +45,11 @@ interface UseDevPreviewLoadLifecycleParams {
   onRenderProcessGone?: (details: { reason: string; exitCode: number }) => void;
 }
 
+export interface WebviewCrashInfo {
+  reason: string;
+  exitCode: number;
+}
+
 interface UseDevPreviewLoadLifecycleResult {
   isWebviewReady: boolean;
   setIsWebviewReady: React.Dispatch<React.SetStateAction<boolean>>;
@@ -54,6 +59,8 @@ interface UseDevPreviewLoadLifecycleResult {
   setIsSlowLoad: React.Dispatch<React.SetStateAction<boolean>>;
   webviewLoadError: WebviewLoadError | null;
   setWebviewLoadError: React.Dispatch<React.SetStateAction<WebviewLoadError | null>>;
+  webviewCrashed: WebviewCrashInfo | null;
+  setWebviewCrashed: React.Dispatch<React.SetStateAction<WebviewCrashInfo | null>>;
   reconnectAttempt: number;
   clearLoadTimers: () => void;
   clearRetryState: () => void;
@@ -76,6 +83,7 @@ export function useDevPreviewLoadLifecycle({
   const [isLoading, setIsLoading] = useState(false);
   const [isSlowLoad, setIsSlowLoad] = useState(false);
   const [webviewLoadError, setWebviewLoadError] = useState<WebviewLoadError | null>(null);
+  const [webviewCrashed, setWebviewCrashed] = useState<WebviewCrashInfo | null>(null);
   const [reconnectAttempt, setReconnectAttempt] = useState<number>(0);
 
   // Read projectId through a ref so a late project-hydration transition
@@ -156,9 +164,30 @@ export function useDevPreviewLoadLifecycle({
       }
     };
 
+    const handleRenderProcessGone = (e: Electron.RenderProcessGoneEvent) => {
+      const { reason, exitCode } = e.details;
+      setIsLoading(false);
+      setIsSlowLoad(false);
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
+      if (loadTimeoutRef.current) {
+        clearTimeout(loadTimeoutRef.current);
+        loadTimeoutRef.current = null;
+      }
+      if (failLoadRetryRef.current) {
+        clearTimeout(failLoadRetryRef.current);
+        failLoadRetryRef.current = null;
+      }
+      failLoadRetryCountRef.current = 0;
+      setWebviewCrashed({ reason, exitCode });
+    };
+
     const handleDidStartLoading = () => {
       setIsLoading(true);
       setWebviewLoadError(null);
+      setWebviewCrashed(null);
       setReconnectAttempt(0);
       setIsSlowLoad(false);
       if (slowLoadTimeoutRef.current) {
@@ -215,6 +244,7 @@ export function useDevPreviewLoadLifecycle({
     const handleDidFinishLoad = () => {
       setIsLoading(false);
       setWebviewLoadError(null);
+      setWebviewCrashed(null);
       setReconnectAttempt(0);
       setIsSlowLoad(false);
       if (slowLoadTimeoutRef.current) {
@@ -417,6 +447,10 @@ export function useDevPreviewLoadLifecycle({
     webview.addEventListener("did-stop-loading", handleDidStopLoading);
     webview.addEventListener("did-finish-load", handleDidFinishLoad);
     webview.addEventListener("did-fail-load", handleDidFailLoad as unknown as EventListener);
+    webview.addEventListener(
+      "render-process-gone",
+      handleRenderProcessGone as unknown as EventListener
+    );
     webview.addEventListener("did-navigate", handleDidNavigate as unknown as EventListener);
     webview.addEventListener(
       "did-navigate-in-page",
@@ -430,6 +464,10 @@ export function useDevPreviewLoadLifecycle({
       webview.removeEventListener("did-stop-loading", handleDidStopLoading);
       webview.removeEventListener("did-finish-load", handleDidFinishLoad);
       webview.removeEventListener("did-fail-load", handleDidFailLoad as unknown as EventListener);
+      webview.removeEventListener(
+        "render-process-gone",
+        handleRenderProcessGone as unknown as EventListener
+      );
       webview.removeEventListener("did-navigate", handleDidNavigate as unknown as EventListener);
       webview.removeEventListener(
         "did-navigate-in-page",
@@ -566,6 +604,8 @@ export function useDevPreviewLoadLifecycle({
     setIsSlowLoad,
     webviewLoadError,
     setWebviewLoadError,
+    webviewCrashed,
+    setWebviewCrashed,
     reconnectAttempt,
     clearLoadTimers,
     clearRetryState,

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -182,6 +182,7 @@ export function useDevPreviewLoadLifecycle({
       }
       failLoadRetryCountRef.current = 0;
       setWebviewCrashed({ reason, exitCode });
+      setWebviewLoadError(null);
     };
 
     const handleDidStartLoading = () => {


### PR DESCRIPTION
## Summary

The dev-preview pane now surfaces two previously-silent webview failures as inline banners: renderer process crashes and main-thread hangs.

Before this, if the previewed app's renderer died or became unresponsive, the canvas went quiet with no feedback. There was no way to tell a crash from a slow load.

## Changes

- **`render-process-gone` wired on the webview DOM tag.** A `Tier 3` `InlineStatusBanner` shows the exit reason and code, with Reload and Hard restart actions. The load error state clears on crash so the banner replaces it rather than stacking.
- **`unresponsive`/`responsive` wired via a new IPC channel from the main process.** The main process already listens for these on `WebContents`; they're now forwarded to the renderer through `webview:unresponsive` and `webview:responsive` events. Banner shows when the main thread has been blocked for more than 5 seconds, dismisses automatically on recovery.
- **Crash-loop detection.** Repeated crashes within a 60-second window trigger a hard reload instead of a normal reload, which tears down and re-creates the webview entirely.

Fixes #8270

## Testing

- Unit tests added for crash-loop timestamp filtering and banner state transitions.
- Manually verified crash and unresponsive banners render correctly in the dev-preview pane.