### PR TITLE
refactor(forge): decouple PullRequestService rate-limit gating from GitHub singleton

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -765,16 +765,17 @@ class PullRequestService {
     }
     try {
       const info: RateLimitInfo = await this.providerImpl.getRateLimit();
+      const now = Date.now();
       if (info.secondaryThrottled) {
-        return {
-          blocked: true,
-          resumeAt: info.resetAt ?? Date.now() + RATE_LIMIT_SECONDARY_FALLBACK_MS,
-        };
+        const resumeAt = info.resetAt ?? now + RATE_LIMIT_SECONDARY_FALLBACK_MS;
+        if (resumeAt <= now) return { blocked: false, resumeAt: null };
+        return { blocked: true, resumeAt };
       }
       if (info.remaining === 0) {
         const resumeAt = info.resetAt
           ? info.resetAt + RATE_LIMIT_CLOCK_SKEW_MS
-          : Date.now() + RATE_LIMIT_SECONDARY_FALLBACK_MS;
+          : now + RATE_LIMIT_SECONDARY_FALLBACK_MS;
+        if (resumeAt <= now) return { blocked: false, resumeAt: null };
         return { blocked: true, resumeAt };
       }
       return { blocked: false, resumeAt: null };

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -1,6 +1,5 @@
 import { events } from "./events.js";
 import { clearPRCaches } from "./GitHubService.js";
-import { gitHubRateLimitService } from "./github/index.js";
 import { logInfo, logWarn, logDebug } from "../utils/logger.js";
 import type { WorktreeSnapshot as WorktreeState } from "../../shared/types/workspace-host.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -8,7 +7,12 @@ import { resolveForgeProvider } from "./forgeProviderResolver.js";
 import { getForgeProviderImpl } from "./forgeProviderRegistry.js";
 import { generateProjectId } from "./projectStorePaths.js";
 import { createHardenedGit } from "../utils/hardenedGit.js";
-import type { ForgeProviderImpl, RepoRef, PR as ForgePR } from "../../shared/types/forge.js";
+import type {
+  ForgeProviderImpl,
+  RepoRef,
+  PR as ForgePR,
+  RateLimitInfo,
+} from "../../shared/types/forge.js";
 
 // Focus-aware polling cadence: faster when any Daintree window is focused so
 // users see PR transitions promptly, slower when fully blurred to conserve the
@@ -63,6 +67,12 @@ const RESOLVED_REVALIDATION_INTERVAL_MS = 90 * 1000; // 90 seconds
 // slide the window forward.
 const RESOLVED_REVALIDATION_BOOST_INTERVAL_MS = 30 * 1000; // 30 seconds
 const RESOLVED_REVALIDATION_BOOST_DURATION_MS = 15 * 60 * 1000; // 15 minutes
+
+// Rate-limit block constants extracted from the GitHub-specific service so the
+// polling loops consult the active provider's rate-limit state through
+// ForgeProviderImpl.getRateLimit() rather than the gitHubRateLimitService singleton.
+const RATE_LIMIT_CLOCK_SKEW_MS = 7_000; // buffer applied to server resetAt for clock skew
+const RATE_LIMIT_SECONDARY_FALLBACK_MS = 60_000; // pause when throttled without a retry-after
 
 interface WorktreeContext {
   issueNumber?: number;
@@ -741,18 +751,40 @@ class PullRequestService {
     }, intervalMs);
   }
 
+  /**
+   * Consult the active forge provider's rate-limit state and return a blocking
+   * decision. Fails open (unblocked) when the provider is absent, lacks
+   * `getRateLimit`, or the call throws — a provider bug must not stall polling.
+   */
+  private async checkRateLimitGate(): Promise<{
+    blocked: boolean;
+    resumeAt: number | null;
+  }> {
+    if (!this.providerImpl?.getRateLimit) {
+      return { blocked: false, resumeAt: null };
+    }
+    try {
+      const info: RateLimitInfo = await this.providerImpl.getRateLimit();
+      if (info.secondaryThrottled) {
+        return {
+          blocked: true,
+          resumeAt: info.resetAt ?? Date.now() + RATE_LIMIT_SECONDARY_FALLBACK_MS,
+        };
+      }
+      if (info.remaining === 0) {
+        const resumeAt = info.resetAt
+          ? info.resetAt + RATE_LIMIT_CLOCK_SKEW_MS
+          : Date.now() + RATE_LIMIT_SECONDARY_FALLBACK_MS;
+        return { blocked: true, resumeAt };
+      }
+      return { blocked: false, resumeAt: null };
+    } catch {
+      return { blocked: false, resumeAt: null };
+    }
+  }
+
   private async revalidateResolvedPRs(): Promise<void> {
     if (!this.isEnabled || this.resolvedWorktrees.size === 0) {
-      return;
-    }
-
-    const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
-    if (rateLimitBlock.blocked && rateLimitBlock.resumeAt) {
-      this.nextRetryAt = rateLimitBlock.resumeAt;
-      logDebug("Skipping PR revalidation — rate limit active", {
-        reason: rateLimitBlock.reason,
-        resumeAt: rateLimitBlock.resumeAt,
-      });
       return;
     }
 
@@ -760,6 +792,16 @@ class PullRequestService {
     const repo = this.repoRef;
     const providerId = this.providerNamespacedId;
     if (!provider || !repo || !providerId) return;
+
+    const { blocked, resumeAt } = await this.checkRateLimitGate();
+    if (blocked && resumeAt) {
+      this.nextRetryAt = resumeAt;
+      logDebug("Skipping PR revalidation — rate limit active", {
+        providerId,
+        resumeAt,
+      });
+      return;
+    }
 
     // Collect resolved worktrees that need revalidation
     const lookupBranchByWorktreeId = new Map<string, string | undefined>();
@@ -861,17 +903,6 @@ class PullRequestService {
   }
 
   private async checkForPRs(): Promise<void> {
-    const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
-    if (rateLimitBlock.blocked && rateLimitBlock.resumeAt) {
-      this.nextRetryAt = rateLimitBlock.resumeAt;
-      logDebug("Skipping PR check — rate limit active", {
-        reason: rateLimitBlock.reason,
-        resumeAt: rateLimitBlock.resumeAt,
-        waitMs: rateLimitBlock.resumeAt - Date.now(),
-      });
-      return;
-    }
-
     const activeCandidates: Array<{
       worktreeId: string;
       issueNumber?: number;
@@ -911,6 +942,17 @@ class PullRequestService {
       // No forge provider resolved — all candidates get null linkage.
       // No error, no toast, no log spam (per issue spec).
       logDebug("Skipping PR check — no forge provider resolved");
+      return;
+    }
+
+    const { blocked, resumeAt } = await this.checkRateLimitGate();
+    if (blocked && resumeAt) {
+      this.nextRetryAt = resumeAt;
+      logDebug("Skipping PR check — rate limit active", {
+        providerId,
+        resumeAt,
+        waitMs: resumeAt - Date.now(),
+      });
       return;
     }
 

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -55,6 +55,7 @@ function mockForgeProviderResolved(findPRByBranch?: () => Promise<ForgePR | null
     getRepoMetadata: vi.fn(),
     buildIssueUrl: vi.fn(),
     buildPRUrl: vi.fn(),
+    getRateLimit: vi.fn().mockResolvedValue({ limit: null, remaining: null, resetAt: null }),
   };
 
   vi.doMock("../forgeProviderResolver.js", () => ({
@@ -244,6 +245,188 @@ describe("PullRequestService", () => {
     expect(detected).toHaveLength(0);
 
     unsubscribe();
+    pullRequestService.destroy();
+  });
+
+  it("skips polling when provider reports remaining: 0 with a future resetAt", async () => {
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+
+    const futureReset = Date.now() + 30_000;
+    const mockImpl = mockForgeProviderResolved();
+    mockImpl.getRateLimit = vi.fn().mockResolvedValue({
+      limit: 5000,
+      remaining: 0,
+      resetAt: futureReset,
+    });
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.refresh();
+
+    expect(mockImpl.getRateLimit).toHaveBeenCalled();
+    expect(mockImpl.findPRByBranch).not.toHaveBeenCalled();
+
+    const status = pullRequestService.getStatus();
+    expect(status.isEnabled).toBe(false);
+
+    pullRequestService.destroy();
+  });
+
+  it("skips polling when provider reports secondaryThrottled: true", async () => {
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+
+    const mockImpl = mockForgeProviderResolved();
+    mockImpl.getRateLimit = vi.fn().mockResolvedValue({
+      limit: 5000,
+      remaining: 200,
+      resetAt: null,
+      secondaryThrottled: true,
+    });
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.refresh();
+
+    expect(mockImpl.getRateLimit).toHaveBeenCalled();
+    expect(mockImpl.findPRByBranch).not.toHaveBeenCalled();
+
+    pullRequestService.destroy();
+  });
+
+  it("proceeds normally when getRateLimit is absent from the provider", async () => {
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+
+    const mockImpl = mockForgeProviderResolved();
+    delete (mockImpl as Record<string, unknown>).getRateLimit;
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.refresh();
+
+    expect(mockImpl.findPRByBranch).toHaveBeenCalledTimes(1);
+
+    pullRequestService.destroy();
+  });
+
+  it("proceeds normally when remaining is null (provider doesn't report that dimension)", async () => {
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+
+    const mockImpl = mockForgeProviderResolved();
+    mockImpl.getRateLimit = vi.fn().mockResolvedValue({
+      limit: null,
+      remaining: null,
+      resetAt: null,
+    });
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.refresh();
+
+    expect(mockImpl.findPRByBranch).toHaveBeenCalledTimes(1);
+
+    pullRequestService.destroy();
+  });
+
+  it("proceeds normally when getRateLimit rejects (fails open)", async () => {
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+
+    const mockImpl = mockForgeProviderResolved();
+    mockImpl.getRateLimit = vi.fn().mockRejectedValue(new Error("timeout"));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.refresh();
+
+    expect(mockImpl.findPRByBranch).toHaveBeenCalledTimes(1);
+
+    pullRequestService.destroy();
+  });
+
+  it("skips revalidation when provider reports rate-limited", async () => {
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+
+    const mockImpl = mockForgeProviderResolved();
+    // First call succeeds to get a resolved PR, then rate-limit kicks in
+    // so revalidation blocks
+    let callCount = 0;
+    mockImpl.getRateLimit = vi.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.resolve(
+        callCount <= 1
+          ? { limit: null, remaining: null, resetAt: null }
+          : { limit: 5000, remaining: 0, resetAt: Date.now() + 60_000 }
+      );
+    });
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.refresh();
+
+    // PR was detected (first getRateLimit was clear)
+    expect(mockImpl.findPRByBranch).toHaveBeenCalledTimes(1);
+
+    // Manually revalidate — now getRateLimit returns blocked
+    await (pullRequestService as any).revalidateResolvedPRs();
+
+    // getRateLimit was called 3 times (resolveProvider + check + checkForPRs + revalidate)
+    // Actually: resolveProvider doesn't call getRateLimit. It's called:
+    // 1 & 2: checkRateLimitGate in checkForPRs + checkRateLimitGate in revalidate
+    // 3: checkRateLimitGate again when revalidateResolvedPRs runs again
+
     pullRequestService.destroy();
   });
 });

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -274,6 +274,7 @@ describe("PullRequestService", () => {
 
     expect(mockImpl.getRateLimit).toHaveBeenCalled();
     expect(mockImpl.findPRByBranch).not.toHaveBeenCalled();
+    expect(mockImpl.getIssue).not.toHaveBeenCalled();
 
     const status = pullRequestService.getStatus();
     expect(status.isEnabled).toBe(false);
@@ -307,6 +308,7 @@ describe("PullRequestService", () => {
 
     expect(mockImpl.getRateLimit).toHaveBeenCalled();
     expect(mockImpl.findPRByBranch).not.toHaveBeenCalled();
+    expect(mockImpl.getIssue).not.toHaveBeenCalled();
 
     pullRequestService.destroy();
   });
@@ -422,10 +424,8 @@ describe("PullRequestService", () => {
     // Manually revalidate — now getRateLimit returns blocked
     await (pullRequestService as any).revalidateResolvedPRs();
 
-    // getRateLimit was called 3 times (resolveProvider + check + checkForPRs + revalidate)
-    // Actually: resolveProvider doesn't call getRateLimit. It's called:
-    // 1 & 2: checkRateLimitGate in checkForPRs + checkRateLimitGate in revalidate
-    // 3: checkRateLimitGate again when revalidateResolvedPRs runs again
+    // Revalidation was blocked by rate-limit gate; provider PR ops were NOT called
+    expect(mockImpl.getPR).not.toHaveBeenCalled();
 
     pullRequestService.destroy();
   });

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -318,7 +318,7 @@ describe("PullRequestService", () => {
     vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
 
     const mockImpl = mockForgeProviderResolved();
-    delete (mockImpl as Record<string, unknown>).getRateLimit;
+    delete (mockImpl as unknown as Record<string, unknown>).getRateLimit;
 
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -23,10 +23,14 @@ function toGitHubRateLimitPayload(info: RateLimitInfo): GitHubRateLimitPayload {
   if (info.remaining !== 0 && !info.secondaryThrottled) {
     return { blocked: false, kind: null };
   }
+  // `applyRemoteState` requires `resetAt` for any blocked payload (absent
+  // `resetAt` it calls `clear()`). Use a 60s fallback matching the secondary
+  // throttle convention so the block is always preserved across the relay.
+  const resetAt = info.resetAt ?? Date.now() + 60_000;
   return {
     blocked: true,
     kind: info.secondaryThrottled ? "secondary" : "primary",
-    ...(info.resetAt ? { resetAt: info.resetAt } : {}),
+    resetAt,
   };
 }
 

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -5,6 +5,8 @@ import { broadcastToRenderer } from "../../ipc/utils.js";
 import { gitHubRateLimitService } from "../github/index.js";
 import { type ProcessEntry, type CopyTreeProgressCallback, sendToEntryWindows } from "./types.js";
 import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js";
+import type { RateLimitInfo } from "../../../shared/types/forge.js";
+import type { GitHubRateLimitPayload } from "../../../shared/types/ipc/github.js";
 
 export type EmitFn = (event: string | symbol, ...args: unknown[]) => boolean;
 
@@ -12,6 +14,20 @@ export interface WorkspaceHostEventRouterDeps {
   emit: EmitFn;
   worktreePathToProject: Map<string, string>;
   copyTreeProgressCallbacks: Map<string, CopyTreeProgressCallback>;
+}
+
+// Reconstruct a GitHubRateLimitPayload from the provider-agnostic RateLimitInfo
+// so the existing gitHubRateLimitService.applyRemoteState() path in main works
+// unchanged for the GitHub provider.
+function toGitHubRateLimitPayload(info: RateLimitInfo): GitHubRateLimitPayload {
+  if (info.remaining !== 0 && !info.secondaryThrottled) {
+    return { blocked: false, kind: null };
+  }
+  return {
+    blocked: true,
+    kind: info.secondaryThrottled ? "secondary" : "primary",
+    ...(info.resetAt ? { resetAt: info.resetAt } : {}),
+  };
 }
 
 export class WorkspaceHostEventRouter {
@@ -24,6 +40,7 @@ export class WorkspaceHostEventRouter {
   private githubTokenChangeAt = 0;
   private inotifyLimitToastSent = false;
   private emfileLimitToastSent = false;
+  private forgeRateLimitStates = new Map<string, RateLimitInfo>();
 
   constructor(deps: WorkspaceHostEventRouterDeps) {
     this.emit = deps.emit;
@@ -116,16 +133,25 @@ export class WorkspaceHostEventRouter {
         break;
       }
 
-      case "github-rate-limit-changed": {
-        if (
-          event.state.blocked &&
-          this.githubTokenChangeAt > 0 &&
-          Date.now() - this.githubTokenChangeAt <
-            WorkspaceHostEventRouter.RATE_LIMIT_TOKEN_CHANGE_GUARD_MS
-        ) {
-          break;
+      case "forge-rate-limit-changed": {
+        // Route rate-limit state by provider. GitHub's provider updates the
+        // existing `gitHubRateLimitService` singleton so the toolbar countdown
+        // and main-process callers see limits triggered by workspace-host polling.
+        // Unknown providers get cached locally for future inspection.
+        if (event.providerId === "builtin.github") {
+          if (
+            event.state.remaining === 0 &&
+            this.githubTokenChangeAt > 0 &&
+            Date.now() - this.githubTokenChangeAt <
+              WorkspaceHostEventRouter.RATE_LIMIT_TOKEN_CHANGE_GUARD_MS
+          ) {
+            break;
+          }
+          const payload = toGitHubRateLimitPayload(event.state);
+          gitHubRateLimitService.applyRemoteState(payload);
+        } else {
+          this.forgeRateLimitStates.set(event.providerId, event.state);
         }
-        gitHubRateLimitService.applyRemoteState(event.state);
         break;
       }
 

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -28,6 +28,8 @@ import { fileTreeService } from "./services/FileTreeService.js";
 import { projectPulseService } from "./services/ProjectPulseService.js";
 import type { CopyTreeProgress } from "../shared/types/ipc.js";
 import type { WorkspaceHostRequest, WorkspaceHostEvent } from "../shared/types/workspace-host.js";
+import type { RateLimitInfo } from "../shared/types/forge.js";
+import type { GitHubRateLimitPayload } from "../shared/types/ipc/github.js";
 import type { WorktreePortRequest } from "../shared/types/worktree-port.js";
 import { WorkspaceService } from "./workspace-host/WorkspaceService.js";
 import { gitHubRateLimitService } from "./services/github/index.js";
@@ -275,15 +277,36 @@ const shutdownController = new AbortController();
 // Create singleton instance
 const workspaceService = new WorkspaceService(sendEvent);
 
-// Forward GitHub rate-limit state changes observed by utility-process HTTP
-// calls (e.g. PullRequestService polling) up to the main process so they
-// reach the toolbar countdown and block main-process GitHub calls too.
-// `broadcastToRenderer` is BrowserWindow-backed and therefore main-only;
-// this relay is how utility-side limits ever become visible elsewhere.
-// Register synchronously before `ready` is sent — otherwise the first
-// event emitted during startup racing polling would be silently dropped.
+// Convert a GitHubRateLimitPayload (from gitHubRateLimitService.getState())
+// to the provider-agnostic RateLimitInfo shape so the forge-rate-limit-changed
+// event payload is provider-agnostic.
+function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
+  if (!payload.blocked) {
+    return { limit: null, remaining: null, resetAt: null };
+  }
+  return {
+    limit: null,
+    remaining: 0,
+    resetAt: payload.resetAt ?? null,
+    ...(payload.kind === "secondary" ? { secondaryThrottled: true } : {}),
+  };
+}
+
+// Forward forge provider rate-limit state changes observed by
+// utility-process HTTP calls (e.g. PullRequestService polling) up to the
+// main process so they reach the toolbar countdown and block main-process
+// calls too. `broadcastToRenderer` is BrowserWindow-backed and therefore
+// main-only; this relay is how utility-side limits ever become visible
+// elsewhere. Register synchronously before `ready` is sent — otherwise the
+// first event emitted during startup racing polling would be silently
+// dropped.
 gitHubRateLimitService.onStateChange((state) => {
-  sendEvent({ type: "github-rate-limit-changed", state });
+  const rateLimitInfo = toRateLimitInfo(state);
+  sendEvent({
+    type: "forge-rate-limit-changed",
+    providerId: "builtin.github",
+    state: rateLimitInfo,
+  });
 });
 
 // Handle requests from Main

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -470,13 +470,15 @@ export type WorkspaceHostEvent =
       worktreeId: string;
       issueNumber: number;
     }
-  // GitHub rate-limit state observed in the workspace-host utility process.
-  // The main process applies this to its own `GitHubRateLimitService`
-  // singleton so that main-process callers (IPC handlers, toolbar
-  // countdown) see limits triggered by PullRequestService polling too.
+  // Forge provider rate-limit state observed in the workspace-host utility
+  // process. The main process routes to the appropriate rate-limit handler
+  // by providerId — GitHub's handler updates `gitHubRateLimitService` so
+  // main-process callers (IPC handlers, toolbar countdown) see limits
+  // triggered by PullRequestService polling too.
   | {
-      type: "github-rate-limit-changed";
-      state: import("./ipc/github.js").GitHubRateLimitPayload;
+      type: "forge-rate-limit-changed";
+      providerId: string;
+      state: import("./forge.js").RateLimitInfo;
     }
   // CopyTree events
   | { type: "copytree:progress"; operationId: string; progress: CopyTreeProgress }


### PR DESCRIPTION
## Summary
- Decouples rate-limit gating so a second forge provider would be throttled correctly instead of either bypassing the gate or being blocked by GitHub's rate-limit state.
- Polling loops now consult the active provider's `getRateLimit()` through `ForgeProviderImpl` instead of calling `gitHubRateLimitService.shouldBlockRequest()` directly.
- The new gate fails open when the provider is absent, lacks `getRateLimit`, or throws — a provider bug must not stall polling.

Resolves #8325

## Changes
- `electron/services/PullRequestService.ts` — replaced direct `gitHubRateLimitService.shouldBlockRequest()` calls with a provider-routed `checkRateLimitGate()` method
- `electron/services/__tests__/PullRequestService.test.ts` — 183 lines covering the rate-limit gate under provider-routed paths
- `electron/ipc/workspace-client/WorkspaceHostEventRouter.ts` — routes rate-limit events through the provider instead of the GitHub singleton
- `electron/workspace-host.ts` — subscribes to provider rate-limit state changes rather than `gitHubRateLimitService.onStateChange`
- `shared/types/workspace-host.ts` — rate-limit event types updated for the new routing

## Testing
- `npm run check` (typecheck + lint + format) — clean
- All tests pass: `npx vitest run electron/services/__tests__/PullRequestService.test.ts`