### PR TITLE
feat(settings): merge GitHub and Forge tabs into unified Code Forge tab

### DIFF
--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -1425,7 +1425,7 @@ describe("errorHandlers", () => {
       expect(sentError.recoveryAction).toEqual({
         label: "Sign in with GitHub",
         actionId: "app.settings.openTab",
-        args: { tab: "github" },
+        args: { tab: "code-forge", subtab: "github" },
       });
       expect(sentError.recoveryHint).toContain("credentials");
       expect(sentError.type).toBe("git");

--- a/electron/utils/__tests__/errorClassification.test.ts
+++ b/electron/utils/__tests__/errorClassification.test.ts
@@ -63,7 +63,7 @@ describe("classifyError", () => {
     expect(result.recoveryAction).toEqual({
       label: "Sign in with GitHub",
       actionId: "app.settings.openTab",
-      args: { tab: "github" },
+      args: { tab: "code-forge", subtab: "github" },
     });
   });
 

--- a/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
@@ -212,7 +212,7 @@ describe("WorkspaceService.fetchPRBranch", () => {
         recoveryAction: {
           label: "Sign in with GitHub",
           actionId: "app.settings.openTab",
-          args: { tab: "github" },
+          args: { tab: "code-forge", subtab: "github" },
         },
       })
     );

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -912,7 +912,7 @@ describe("GitHubResourceList no-token empty state", () => {
 
     expect(dispatchMock).toHaveBeenCalledWith(
       "app.settings.openTab",
-      { tab: "github", sectionId: "github-token" },
+      { tab: "code-forge", subtab: "github", sectionId: "github-token" },
       { source: "user" }
     );
     expect(onClose).toHaveBeenCalled();

--- a/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
@@ -477,7 +477,7 @@ export function GitHubResourceList({
   const handleOpenGitHubSettings = useCallback(() => {
     void actionService.dispatch(
       "app.settings.openTab",
-      { tab: "github", sectionId: "github-token" },
+      { tab: "code-forge", subtab: "github", sectionId: "github-token" },
       { source: "user" }
     );
     handleClose();

--- a/shared/utils/__tests__/gitOperationErrors.test.ts
+++ b/shared/utils/__tests__/gitOperationErrors.test.ts
@@ -273,7 +273,7 @@ describe("getGitRecoveryAction", () => {
     expect(getGitRecoveryAction("auth-failed")).toEqual({
       label: "Sign in with GitHub",
       actionId: "app.settings.openTab",
-      args: { tab: "github" },
+      args: { tab: "code-forge", subtab: "github" },
     });
     expect(getGitRecoveryAction("push-rejected-outdated")).toEqual({
       label: "Pull and rebase",

--- a/shared/utils/gitOperationErrors.ts
+++ b/shared/utils/gitOperationErrors.ts
@@ -148,7 +148,7 @@ const RECOVERY_ACTIONS: Partial<Record<GitOperationReason, RecoveryAction>> = {
   "auth-failed": {
     label: "Sign in with GitHub",
     actionId: "app.settings.openTab",
-    args: { tab: "github" },
+    args: { tab: "code-forge", subtab: "github" },
   },
   "push-rejected-outdated": { label: "Pull and rebase", actionId: "git.pullRebase" },
   "conflict-unresolved": { label: "Resolve conflicts", actionId: "worktree.openReviewHub" },

--- a/src/components/Errors/__tests__/ErrorBanner.test.tsx
+++ b/src/components/Errors/__tests__/ErrorBanner.test.tsx
@@ -644,7 +644,7 @@ describe("ErrorBanner", () => {
       const actionWithArgs = {
         label: "Sign in with GitHub",
         actionId: "app.settings.openTab",
-        args: { tab: "github" },
+        args: { tab: "code-forge", subtab: "github" },
       };
       render(
         <ErrorBanner
@@ -657,7 +657,7 @@ describe("ErrorBanner", () => {
       });
       expect(mockDispatch).toHaveBeenCalledWith(
         "app.settings.openTab",
-        { tab: "github" },
+        { tab: "code-forge", subtab: "github" },
         { source: "user" }
       );
     });

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -564,7 +564,7 @@ export const GitHubStatsToolbarButton = memo(
     const openSettingsForToken = useCallback(() => {
       void actionService.dispatch(
         "app.settings.openTab",
-        { tab: "github", sectionId: "github-token" },
+        { tab: "code-forge", subtab: "github", sectionId: "github-token" },
         { source: "user" }
       );
     }, []);
@@ -690,7 +690,7 @@ export const GitHubStatsToolbarButton = memo(
                   setIssueSearchQuery("");
                   void actionService.dispatch(
                     "app.settings.openTab",
-                    { tab: "github", sectionId: "github-token" },
+                    { tab: "code-forge", subtab: "github", sectionId: "github-token" },
                     { source: "user" }
                   );
                   return;
@@ -795,7 +795,7 @@ export const GitHubStatsToolbarButton = memo(
                   setPrSearchQuery("");
                   void actionService.dispatch(
                     "app.settings.openTab",
-                    { tab: "github", sectionId: "github-token" },
+                    { tab: "code-forge", subtab: "github", sectionId: "github-token" },
                     { source: "user" }
                   );
                   return;

--- a/src/components/Recovery/GitHubTokenBanner.tsx
+++ b/src/components/Recovery/GitHubTokenBanner.tsx
@@ -9,7 +9,9 @@ export function GitHubTokenBanner() {
 
   const handleReconnect = () => {
     window.dispatchEvent(
-      new CustomEvent("daintree:open-settings-tab", { detail: { tab: "github" } })
+      new CustomEvent("daintree:open-settings-tab", {
+        detail: { tab: "code-forge", subtab: "github" },
+      })
     );
   };
 

--- a/src/components/Recovery/__tests__/GitHubTokenBanner.test.tsx
+++ b/src/components/Recovery/__tests__/GitHubTokenBanner.test.tsx
@@ -51,7 +51,7 @@ describe("GitHubTokenBanner", () => {
 
     expect(listener).toHaveBeenCalledOnce();
     const event = listener.mock.calls[0]![0] as CustomEvent<{ tab: string }>;
-    expect(event.detail.tab).toBe("github");
+    expect(event.detail.tab).toBe("code-forge");
 
     window.removeEventListener("daintree:open-settings-tab", listener as EventListener);
   });

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -35,6 +35,7 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
       .then((loaded) => {
         if (cancelled) return;
         setProviders(loaded);
+        setLoadTimedOut(false);
       })
       .catch((err) => {
         if (cancelled) return;

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState, useMemo } from "react";
+import type { ForgeProviderEntry } from "@shared/types";
+import {
+  ForgeProviderSelectorDropdown,
+  type ForgeProviderOption,
+} from "./ForgeProviderSelectorDropdown";
+import { GitHubSettingsTab } from "./GitHubSettingsTab";
+import { ForgeIntegrationsTab } from "./ForgeIntegrationsTab";
+import { useSettingsTabValidation } from "./SettingsValidationRegistry";
+import { logError } from "@/utils/logger";
+
+const GENERAL_ID = "general";
+const GITHUB_ID = "github";
+
+interface CodeForgeSettingsTabProps {
+  activeSubtab: string | null;
+  onSubtabChange: (id: string) => void;
+}
+
+export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForgeSettingsTabProps) {
+  const [providers, setProviders] = useState<ForgeProviderEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadTimedOut, setLoadTimedOut] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadTimedOut(false);
+    const timer = setTimeout(() => {
+      if (!cancelled) setLoadTimedOut(true);
+    }, 10_000);
+
+    window.electron.forge
+      .getProviders()
+      .then((loaded) => {
+        if (cancelled) return;
+        setProviders(loaded);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setLoadError("Couldn't load forge providers");
+        logError("Failed to load forge providers for CodeForgeSettingsTab", err);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, []);
+
+  const providerOptions = useMemo<ForgeProviderOption[]>(
+    () =>
+      providers.map((entry) => ({
+        id: entry.contribution.id,
+        name: entry.contribution.name,
+        pluginId: entry.pluginId,
+      })),
+    [providers]
+  );
+
+  const effectiveSubtab =
+    activeSubtab &&
+    (activeSubtab === GENERAL_ID || providerOptions.some((p) => p.id === activeSubtab))
+      ? activeSubtab
+      : GITHUB_ID;
+
+  useSettingsTabValidation("code-forge", Boolean(loadError) || loadTimedOut);
+
+  if (loading) {
+    if (loadTimedOut) {
+      return (
+        <div className="flex flex-col items-center justify-center h-32 gap-3">
+          <div className="text-status-error text-sm">Settings load timed out</div>
+          <button
+            onClick={() => window.location.reload()}
+            className="text-xs px-3 py-1.5 border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
+          >
+            Reload Application
+          </button>
+        </div>
+      );
+    }
+    return (
+      <div className="flex items-center justify-center h-32">
+        <div className="text-daintree-text/60 text-sm">Loading forge settings...</div>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex flex-col items-center justify-center h-32 gap-3">
+        <div className="text-status-error text-sm">{loadError}</div>
+        <button
+          onClick={() => window.location.reload()}
+          className="text-xs px-3 py-1.5 border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
+        >
+          Reload Application
+        </button>
+      </div>
+    );
+  }
+
+  const isGeneral = effectiveSubtab === GENERAL_ID;
+  const isGitHub = effectiveSubtab === GITHUB_ID;
+  const selectedEntry = !isGeneral
+    ? providers.find((p) => p.contribution.id === effectiveSubtab)
+    : null;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h4 className="text-sm font-medium mb-1">Code Forge</h4>
+        <p className="text-xs text-daintree-text/50 select-text">
+          Configure forge providers and authentication
+        </p>
+      </div>
+
+      <ForgeProviderSelectorDropdown
+        providerOptions={providerOptions}
+        activeSubtab={effectiveSubtab}
+        onSubtabChange={onSubtabChange}
+      />
+
+      {isGeneral && <ForgeIntegrationsTab />}
+
+      {isGitHub && <GitHubSettingsTab />}
+
+      {!isGeneral && !isGitHub && selectedEntry && (
+        <ProviderSettingsCard
+          name={selectedEntry.contribution.name}
+          pluginId={selectedEntry.pluginId}
+          capabilities={selectedEntry.contribution.capabilities}
+        />
+      )}
+    </div>
+  );
+}
+
+interface ProviderSettingsCardProps {
+  name: string;
+  pluginId: string;
+  capabilities?: string[];
+}
+
+function ProviderSettingsCard({ name, pluginId, capabilities }: ProviderSettingsCardProps) {
+  return (
+    <div className="rounded-[var(--radius-lg)] border border-daintree-border bg-surface p-4 space-y-3">
+      <div>
+        <h4 className="text-sm font-medium text-daintree-text">{name}</h4>
+        <p className="text-xs text-daintree-text/50 mt-0.5 font-mono">{pluginId}</p>
+      </div>
+      {capabilities && capabilities.length > 0 && (
+        <div>
+          <p className="text-xs font-medium text-daintree-text/70 mb-1">Capabilities</p>
+          <ul className="text-xs text-daintree-text/50 space-y-0.5">
+            {capabilities.map((cap) => (
+              <li key={cap} className="list-disc list-inside">
+                {cap}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div className="pt-2 border-t border-daintree-border">
+        <p className="text-xs text-daintree-text/50">No configuration needed</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/ForgeProviderSelectorDropdown.tsx
+++ b/src/components/Settings/ForgeProviderSelectorDropdown.tsx
@@ -94,7 +94,7 @@ export function ForgeProviderSelectorDropdown({
           className={cn(
             "flex items-center gap-2 w-full px-3 py-2 text-sm rounded-[var(--radius-md)]",
             "border border-daintree-border bg-daintree-bg text-daintree-text",
-            "hover:border-daintree-accent/50 transition-colors",
+            "hover:border-daintree-border-strong transition-colors",
             "focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50"
           )}
         >

--- a/src/components/Settings/ForgeProviderSelectorDropdown.tsx
+++ b/src/components/Settings/ForgeProviderSelectorDropdown.tsx
@@ -94,7 +94,7 @@ export function ForgeProviderSelectorDropdown({
           className={cn(
             "flex items-center gap-2 w-full px-3 py-2 text-sm rounded-[var(--radius-md)]",
             "border border-daintree-border bg-daintree-bg text-daintree-text",
-            "hover:border-daintree-border-strong transition-colors",
+            "hover:border-border-strong transition-colors",
             "focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50"
           )}
         >

--- a/src/components/Settings/ForgeProviderSelectorDropdown.tsx
+++ b/src/components/Settings/ForgeProviderSelectorDropdown.tsx
@@ -1,0 +1,207 @@
+import { useState, useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { GitBranch, ChevronDown, Search } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+export interface ForgeProviderOption {
+  id: string;
+  name: string;
+  pluginId: string;
+}
+
+interface ForgeProviderSelectorDropdownProps {
+  providerOptions: ForgeProviderOption[];
+  activeSubtab: string;
+  onSubtabChange: (id: string) => void;
+}
+
+type DropdownItem =
+  | { kind: "general"; id: "general" }
+  | { kind: "provider"; id: string; provider: ForgeProviderOption };
+
+const GENERAL_ID = "general";
+
+export function ForgeProviderSelectorDropdown({
+  providerOptions,
+  activeSubtab,
+  onSubtabChange,
+}: ForgeProviderSelectorDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const [filterQuery, setFilterQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const activeItemRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const items: DropdownItem[] = (() => {
+    const q = filterQuery.trim().toLowerCase();
+    const generalItem: DropdownItem = { kind: "general", id: GENERAL_ID };
+    const providerItems: DropdownItem[] = providerOptions
+      .filter((p) => !q || p.name.toLowerCase().includes(q))
+      .map((p) => ({ kind: "provider" as const, id: p.id, provider: p }));
+    return [generalItem, ...providerItems];
+  })();
+
+  useEffect(() => {
+    const q = filterQuery.trim();
+    setActiveIndex(q && items.length > 1 ? 1 : 0);
+  }, [filterQuery]); // eslint-disable-line react-hooks/exhaustive-deps -- items derived from filterQuery
+
+  useEffect(() => {
+    activeItemRef.current?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  useEffect(() => {
+    if (!open) {
+      setFilterQuery("");
+    }
+  }, [open]);
+
+  const handleSelect = (id: string) => {
+    onSubtabChange(id);
+    setOpen(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex((prev) => Math.min(prev + 1, items.length - 1));
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex((prev) => Math.max(prev - 1, 0));
+        break;
+      case "Enter":
+        if (activeIndex >= 0 && activeIndex < items.length) {
+          e.preventDefault();
+          handleSelect(items[activeIndex]!.id);
+        }
+        break;
+    }
+  };
+
+  const selectedProvider =
+    activeSubtab !== GENERAL_ID ? providerOptions.find((p) => p.id === activeSubtab) : null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          data-testid="forge-provider-selector-trigger"
+          className={cn(
+            "flex items-center gap-2 w-full px-3 py-2 text-sm rounded-[var(--radius-md)]",
+            "border border-daintree-border bg-daintree-bg text-daintree-text",
+            "hover:border-daintree-accent/50 transition-colors",
+            "focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50"
+          )}
+        >
+          {selectedProvider ? (
+            <>
+              <GitBranch size={16} className="text-daintree-text/60" />
+              <span className="flex-1 text-left truncate">{selectedProvider.name}</span>
+            </>
+          ) : (
+            <>
+              <GitBranch size={16} className="text-daintree-text/60" />
+              <span className="flex-1 text-left truncate">General</span>
+            </>
+          )}
+          <ChevronDown
+            size={14}
+            className={cn(
+              "shrink-0 text-daintree-text/40 transition-transform",
+              open && "rotate-180"
+            )}
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        className="p-0"
+        style={{ width: "var(--radix-popover-trigger-width)" }}
+        onEscapeKeyDown={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-1.5 px-3 py-2 border-b border-daintree-border">
+          <Search size={14} className="shrink-0 text-daintree-text/40" aria-hidden="true" />
+          <input
+            ref={inputRef}
+            type="text"
+            autoFocus
+            placeholder="Filter providers…"
+            value={filterQuery}
+            onChange={(e) => setFilterQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            role="combobox"
+            aria-label="Filter providers"
+            aria-expanded={open}
+            aria-autocomplete="list"
+            aria-controls="forge-provider-selector-list"
+            aria-activedescendant={
+              items[activeIndex]
+                ? `forge-provider-selector-item-${items[activeIndex].id}`
+                : undefined
+            }
+            className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden"
+          />
+        </div>
+        <div
+          role="listbox"
+          id="forge-provider-selector-list"
+          aria-label="Forge providers"
+          className="overflow-y-auto max-h-60 p-1"
+        >
+          {items.map((item, index) => {
+            const isActive = index === activeIndex;
+            const isSelected =
+              item.kind === "general" ? activeSubtab === GENERAL_ID : activeSubtab === item.id;
+
+            return (
+              <div
+                key={item.id}
+                ref={isActive ? activeItemRef : undefined}
+                id={`forge-provider-selector-item-${item.id}`}
+                role="option"
+                aria-selected={isSelected}
+                data-highlighted={isActive || undefined}
+                onClick={() => handleSelect(item.id)}
+                onMouseEnter={() => setActiveIndex(index)}
+                className={cn(
+                  "flex items-center gap-2 px-2 py-1.5 rounded-[var(--radius-sm)] cursor-pointer text-sm",
+                  isActive && "bg-overlay-selected",
+                  isSelected && "text-daintree-text font-medium",
+                  !isActive && !isSelected && "text-daintree-text"
+                )}
+              >
+                {item.kind === "general" ? (
+                  <>
+                    <GitBranch size={16} className="shrink-0 text-daintree-text/60" />
+                    <div className="flex-1 min-w-0">
+                      <div className="truncate">General</div>
+                      <div className="text-xs text-daintree-text/40 truncate">
+                        Global forge settings
+                      </div>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <GitBranch size={16} className="shrink-0 text-daintree-text/60" />
+                    <span className="flex-1 min-w-0 truncate">{item.provider.name}</span>
+                  </>
+                )}
+              </div>
+            );
+          })}
+          {items.length === 1 && filterQuery && (
+            <div className="px-2 py-3 text-xs text-daintree-text/40 text-center">
+              No providers match "{filterQuery}"
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -153,7 +153,7 @@ export function GitHubSettingsTab() {
     );
   };
 
-  useSettingsTabValidation("github", Boolean(loadError) || loadTimedOut);
+  useSettingsTabValidation("code-forge", Boolean(loadError) || loadTimedOut);
 
   if (isLoading) {
     if (loadTimedOut) {

--- a/src/components/Settings/__tests__/AgentSettings.subtabs.test.ts
+++ b/src/components/Settings/__tests__/AgentSettings.subtabs.test.ts
@@ -75,21 +75,21 @@ describe("AgentSettings subtab derivation logic", () => {
 
 describe("SettingsDialog subtab state", () => {
   it("Partial<Record<SettingsTab, string>> allows per-tab memory", () => {
-    type SettingsTab = "general" | "agents" | "github";
+    type SettingsTab = "general" | "agents" | "code-forge";
     const state: Partial<Record<SettingsTab, string>> = {};
 
     // Navigating to agents tab sets subtab for agents only
     const updated: Partial<Record<SettingsTab, string>> = { ...state, agents: "gemini" };
     expect(updated.agents).toBe("gemini");
-    expect(updated.github).toBeUndefined();
+    expect(updated["code-forge"]).toBeUndefined();
 
-    // Switching to github tab does not clear agents subtab
-    const afterGitHub = { ...updated };
-    expect(afterGitHub.agents).toBe("gemini");
+    // Switching to code-forge tab does not clear agents subtab
+    const afterForge = { ...updated };
+    expect(afterForge.agents).toBe("gemini");
   });
 
   it("undefined subtab in nav target does not override stored subtab", () => {
-    type SettingsTab = "general" | "agents" | "github";
+    type SettingsTab = "general" | "agents" | "code-forge";
     let activeSubtabs: Partial<Record<SettingsTab, string>> = { agents: "codex" };
 
     // Simulating handleResultClick without subtab (no subtab in search result)
@@ -102,7 +102,7 @@ describe("SettingsDialog subtab state", () => {
   });
 
   it("explicit subtab in nav target updates stored subtab", () => {
-    type SettingsTab = "general" | "agents" | "github";
+    type SettingsTab = "general" | "agents" | "code-forge";
     let activeSubtabs: Partial<Record<SettingsTab, string>> = { agents: "codex" };
 
     const target = { tab: "agents" as SettingsTab, sectionId: "agents-enable", subtab: "gemini" };
@@ -113,7 +113,7 @@ describe("SettingsDialog subtab state", () => {
   });
 
   it('navigating to agents-default-agent search result sets subtab to "general"', () => {
-    type SettingsTab = "general" | "agents" | "github";
+    type SettingsTab = "general" | "agents" | "code-forge";
     let activeSubtabs: Partial<Record<SettingsTab, string>> = {};
 
     const target = {

--- a/src/components/Settings/__tests__/SettingsDialog.rememberTab.test.ts
+++ b/src/components/Settings/__tests__/SettingsDialog.rememberTab.test.ts
@@ -8,7 +8,7 @@ const VALID_TABS: SettingsTab[] = [
   "terminalAppearance",
   "worktree",
   "agents",
-  "github",
+  "code-forge",
   "portal",
   "toolbar",
   "notifications",
@@ -49,7 +49,7 @@ describe("Settings remembered-tab fallback logic", () => {
   });
 
   it("uses defaultTab when explicitly provided (targeted open)", () => {
-    expect(deriveActiveTab("github", "privacy")).toBe("github");
+    expect(deriveActiveTab("code-forge", "privacy")).toBe("code-forge");
   });
 
   it('defaults to "general" when both defaultTab is undefined and rememberedTab is "general"', () => {
@@ -129,8 +129,8 @@ describe("Untargeted open scope derivation (issue #4657)", () => {
   });
 
   it("targeted open preserves scope from defaultTab (global tab)", () => {
-    const result = deriveUntargetedOpenState(true, "github", "privacy");
-    expect(result).toEqual({ scope: "global", tab: "github" });
+    const result = deriveUntargetedOpenState(true, "code-forge", "privacy");
+    expect(result).toEqual({ scope: "global", tab: "code-forge" });
   });
 
   it("targeted open preserves scope from defaultTab (project tab)", () => {
@@ -140,7 +140,7 @@ describe("Untargeted open scope derivation (issue #4657)", () => {
 
   it("does not derive state when dialog is closed", () => {
     expect(deriveUntargetedOpenState(false, undefined, "privacy")).toBeNull();
-    expect(deriveUntargetedOpenState(false, "github", "privacy")).toBeNull();
+    expect(deriveUntargetedOpenState(false, "code-forge", "privacy")).toBeNull();
   });
 
   it("untargeted open is idempotent (calling twice gives same result)", () => {

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -37,7 +37,7 @@ const GOLDEN_QUERIES = [
   { query: "microphone", expectedTopResults: ["tab-nav-voice", "voice-enable"] },
   { query: "appearance", expectedTopResults: ["tab-nav-terminalAppearance", "appearance-theme"] },
   { query: "hibernate", expectedTopResults: ["general-hibernation"] },
-  { query: "github", expectedTopResults: ["github-token", "tab-nav-github"] },
+  { query: "github", expectedTopResults: ["github-token", "tab-nav-code-forge"] },
 ] as const;
 
 describe("filterSettings", () => {
@@ -138,8 +138,8 @@ describe("countMatchesPerTab", () => {
     for (const count of Object.values(counts)) {
       expect(count).toBeGreaterThan(0);
     }
-    // And github should be one of the tabs with matches
-    expect(counts.github).toBeGreaterThanOrEqual(1);
+    // And code-forge should be one of the tabs with matches
+    expect(counts["code-forge"]).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -289,7 +289,7 @@ describe("SETTINGS_SEARCH_INDEX", () => {
       "terminalAppearance",
       "worktree",
       "agents",
-      "github",
+      "code-forge",
       "portal",
       "toolbar",
       "notifications",
@@ -347,8 +347,7 @@ describe("SETTINGS_SEARCH_INDEX", () => {
       terminalAppearance: "Appearance",
       worktree: "Worktree",
       agents: "CLI agents",
-      github: "GitHub",
-      forge: "Forge integrations",
+      "code-forge": "Code Forge",
       portal: "Portal",
       toolbar: "Toolbar",
       notifications: "Notifications",
@@ -385,8 +384,7 @@ describe("SETTINGS_SEARCH_INDEX", () => {
       terminalAppearance: "Appearance",
       worktree: "Worktree Paths",
       agents: "CLI agents",
-      github: "GitHub Integration",
-      forge: "Forge Integrations",
+      "code-forge": "Code Forge",
       portal: "Portal Links",
       toolbar: "Toolbar Customization",
       notifications: "Notifications",
@@ -443,7 +441,7 @@ describe("voice tab coverage", () => {
 
 describe("tab-name ranking", () => {
   it("tab-nav entry ranks first for exact tab name queries", () => {
-    const queries = ["Panel Grid", "Keyboard", "GitHub"];
+    const queries = ["Panel Grid", "Keyboard", "Code Forge"];
     for (const query of queries) {
       const results = filterSettings(SETTINGS_SEARCH_INDEX, query);
       expect(
@@ -626,7 +624,7 @@ describe("@modified filter", () => {
   });
 
   it("compound @modified query returns empty when no modified tabs match", () => {
-    const modifiedTabs = new Set<SettingsTab>(["github"]);
+    const modifiedTabs = new Set<SettingsTab>(["code-forge"]);
     const results = filterSettings(SETTINGS_SEARCH_INDEX, "font @modified", { modifiedTabs });
     expect(results).toHaveLength(0);
   });

--- a/src/components/Settings/__tests__/settingsTabRegistry.test.ts
+++ b/src/components/Settings/__tests__/settingsTabRegistry.test.ts
@@ -19,12 +19,12 @@ const globalEntries = allEntries.filter((e) => e.scope === "global");
 const projectEntries = allEntries.filter((e) => e.scope === "project");
 
 describe("SETTINGS_REGISTRY", () => {
-  it("has 26 entries (18 global + 8 project)", () => {
-    expect(SETTINGS_REGISTRY).toHaveLength(26);
+  it("has 25 entries (17 global + 8 project)", () => {
+    expect(SETTINGS_REGISTRY).toHaveLength(25);
   });
 
-  it("has 18 global entries", () => {
-    expect(globalEntries).toHaveLength(18);
+  it("has 17 global entries", () => {
+    expect(globalEntries).toHaveLength(17);
   });
 
   it("has 8 project entries", () => {
@@ -77,9 +77,9 @@ describe("SETTINGS_REGISTRY", () => {
     expect(eager[0]!.id).toBe("general");
   });
 
-  it("has 25 lazy entries (17 global + 8 project)", () => {
+  it("has 24 lazy entries (16 global + 8 project)", () => {
     const lazy = SETTINGS_REGISTRY.filter((e) => e.importKind === "lazy");
-    expect(lazy).toHaveLength(25);
+    expect(lazy).toHaveLength(24);
   });
 
   it("all global entries belong to known global groups", () => {
@@ -213,10 +213,10 @@ describe("getSettingsNavGroups", () => {
     ]);
   });
 
-  it("all 18 global entries are distributed across global groups", () => {
+  it("all 17 global entries are distributed across global groups", () => {
     const groups = getSettingsNavGroups("global");
     const totalEntries = groups.reduce((sum, g) => sum + g.entries.length, 0);
-    expect(totalEntries).toBe(18);
+    expect(totalEntries).toBe(17);
   });
 
   it("global groups contain only global-scoped entries", () => {
@@ -253,8 +253,8 @@ describe("getSettingsNavGroups", () => {
 });
 
 describe("SettingsTab type coverage", () => {
-  it("union of registry IDs equals 26", () => {
+  it("union of registry IDs equals 25", () => {
     const allIds = new Set(SETTINGS_REGISTRY.map((e) => e.id));
-    expect(allIds.size).toBe(26);
+    expect(allIds.size).toBe(25);
   });
 });

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -4,7 +4,6 @@ import {
   Command,
   FileCode,
   GitBranch,
-  Github,
   LayoutGrid,
   Mic,
   PanelRight,
@@ -85,15 +84,14 @@ export interface ProjectSettingsTabSearchMeta {
 const importAgentSettings = () => import("./AgentSettings");
 const importTerminalSettingsTab = () => import("./TerminalSettingsTab");
 const importTerminalAppearanceTab = () => import("./TerminalAppearanceTab");
-const importGitHubSettingsTab = () => import("./GitHubSettingsTab");
 const importTroubleshootingTab = () => import("./TroubleshootingTab");
+const importCodeForgeSettingsTab = () => import("./CodeForgeSettingsTab");
 const importNotificationSettingsTab = () => import("./NotificationSettingsTab");
 const importPortalSettingsTab = () => import("./PortalSettingsTab");
 const importKeyboardShortcutsTab = () => import("./KeyboardShortcutsTab");
 const importWorktreeSettingsTab = () => import("./WorktreeSettingsTab");
 const importToolbarSettingsTab = () => import("./ToolbarSettingsTab");
 const importIntegrationsTab = () => import("./IntegrationsTab");
-const importForgeIntegrationsTab = () => import("./ForgeIntegrationsTab");
 const importVoiceInputSettingsTab = () => import("./VoiceInputSettingsTab");
 const importMcpServerSettingsTab = () => import("./McpServerSettingsTab");
 const importDaintreeAssistantSettingsTab = () => import("./DaintreeAssistantSettingsTab");
@@ -119,9 +117,6 @@ const LazyTerminalSettingsTab = lazy(() =>
 const LazyTerminalAppearanceTab = lazy(() =>
   importTerminalAppearanceTab().then((m) => ({ default: m.TerminalAppearanceTab }))
 );
-const LazyGitHubSettingsTab = lazy(() =>
-  importGitHubSettingsTab().then((m) => ({ default: m.GitHubSettingsTab }))
-);
 const LazyTroubleshootingTab = lazy(() =>
   importTroubleshootingTab().then((m) => ({ default: m.TroubleshootingTab }))
 );
@@ -143,8 +138,8 @@ const LazyToolbarSettingsTab = lazy(() =>
 const LazyIntegrationsTab = lazy(() =>
   importIntegrationsTab().then((m) => ({ default: m.IntegrationsTab }))
 );
-const LazyForgeIntegrationsTab = lazy(() =>
-  importForgeIntegrationsTab().then((m) => ({ default: m.ForgeIntegrationsTab }))
+const LazyCodeForgeSettingsTab = lazy(() =>
+  importCodeForgeSettingsTab().then((m) => ({ default: m.CodeForgeSettingsTab }))
 );
 const LazyVoiceInputSettingsTab = lazy(() =>
   importVoiceInputSettingsTab().then((m) => ({ default: m.VoiceInputSettingsTab }))
@@ -1030,53 +1025,45 @@ export const SETTINGS_REGISTRY = [
   } satisfies LazySettingsTabEntry,
 
   {
-    id: "github",
+    id: "code-forge",
     scope: "global",
     group: "Integrations",
-    label: "GitHub",
-    headerTitle: "GitHub Integration",
-    icon: <Github className="w-4 h-4" />,
-    importKind: "lazy",
-    importer: importGitHubSettingsTab,
-    LazyComponent: LazyGitHubSettingsTab,
-    searchNavDescription: "GitHub personal access token and authentication",
-    searchNavKeywords: ["integrations", "github", "token", "authentication"],
-    sections: [
-      {
-        id: "github-token",
-        section: "Personal access token",
-        title: "GitHub personal access token",
-        description: "Configure GitHub authentication token. Required scopes: repo, read:org",
-        keywords: ["github", "token", "authentication", "auth", "PAT", "access", "scopes", "API"],
-      },
-    ],
-  } satisfies LazySettingsTabEntry,
-
-  {
-    id: "forge",
-    scope: "global",
-    group: "Integrations",
-    label: "Forge integrations",
-    headerTitle: "Forge Integrations",
+    label: "Code Forge",
+    headerTitle: "Code Forge",
     icon: <GitBranch className="w-4 h-4" />,
     importKind: "lazy",
-    importer: importForgeIntegrationsTab,
-    LazyComponent: LazyForgeIntegrationsTab,
-    searchNavDescription: "Default forge provider for new projects (GitHub, GitLab, Gitea, ...)",
+    importer: importCodeForgeSettingsTab,
+    LazyComponent: LazyCodeForgeSettingsTab,
+    needsSubtabs: true,
+    searchNavDescription:
+      "Configure forge providers (GitHub, GitLab, Gitea, ...) and authentication",
     searchNavKeywords: [
       "forge",
       "provider",
-      "plugin",
+      "code",
       "github",
       "gitlab",
       "gitea",
       "bitbucket",
+      "authentication",
+      "token",
       "default",
       "integrations",
     ],
     sections: [
       {
+        id: "github-token",
+        subtab: "github",
+        subtabLabel: "GitHub",
+        section: "Personal access token",
+        title: "GitHub personal access token",
+        description: "Configure GitHub authentication token. Required scopes: repo, read:org",
+        keywords: ["github", "token", "authentication", "auth", "PAT", "access", "scopes", "API"],
+      },
+      {
         id: "forge-default-provider",
+        subtab: "general",
+        subtabLabel: "General",
         section: "Default forge provider",
         title: "Default forge provider",
         description:
@@ -1095,6 +1082,8 @@ export const SETTINGS_REGISTRY = [
       },
       {
         id: "forge-active-project-routing",
+        subtab: "general",
+        subtabLabel: "General",
         section: "Active project routing",
         title: "Active project routing",
         description:
@@ -1689,6 +1678,7 @@ export const PROJECT_SETTINGS_SECTIONS: Readonly<
     searchNavKeywords: [
       "project",
       "forge",
+      "code",
       "github",
       "remote",
       "origin",
@@ -1702,7 +1692,7 @@ export const PROJECT_SETTINGS_SECTIONS: Readonly<
         section: "Forge Remote",
         title: "Forge Remote",
         description: "Select which git remote to use for forge integration",
-        keywords: ["forge", "github", "remote", "origin", "git", "repository", "fetch", "push"],
+        keywords: ["forge", "code", "github", "remote", "origin", "git", "repository", "fetch", "push"],
       },
     ],
   },
@@ -1734,8 +1724,7 @@ export const globalTabIcons: Record<GlobalSettingsTab, ReactNode> = {
   worktree: <FolderGit2 className="w-5 h-5 text-text-secondary" />,
   agents: <Plug className="w-5 h-5 text-text-secondary" />,
   assistant: <DaintreeIcon className="w-5 h-5 text-text-secondary" size={20} />,
-  github: <Github className="w-5 h-5 text-text-secondary" />,
-  forge: <GitBranch className="w-5 h-5 text-text-secondary" />,
+  "code-forge": <GitBranch className="w-5 h-5 text-text-secondary" />,
   portal: <PanelRight className="w-5 h-5 text-text-secondary" />,
   toolbar: <SettingsIcon className="w-5 h-5 text-text-secondary" />,
   notifications: <Bell className="w-5 h-5 text-text-secondary" />,

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -1362,7 +1362,7 @@ export function ReviewHubContent({
                 case "settings-github":
                   void actionService.dispatch(
                     "app.settings.openTab",
-                    { tab: "github" },
+                    { tab: "code-forge", subtab: "github" },
                     { source: "user" }
                   );
                   return;

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -1747,7 +1747,7 @@ describe("ReviewHub", () => {
 
       expect(actionDispatchMock).toHaveBeenCalledWith(
         "app.settings.openTab",
-        { tab: "github" },
+        { tab: "code-forge", subtab: "github" },
         { source: "user" }
       );
     });

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -35,7 +35,7 @@ export function UpstreamSyncBadge({
     event.stopPropagation();
     void actionService.dispatch(
       "app.settings.openTab",
-      { tab: "github", sectionId: "github-token" },
+      { tab: "code-forge", subtab: "github", sectionId: "github-token" },
       { source: "user" }
     );
   }, []);

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -991,7 +991,7 @@ describe("WorktreeHeader token-missing badge behavior", () => {
     fireEvent.click(issueButton);
     expect(actionService.dispatch).toHaveBeenCalledWith(
       "app.settings.openTab",
-      { tab: "github", sectionId: "github-token" },
+      { tab: "code-forge", subtab: "github", sectionId: "github-token" },
       { source: "user" }
     );
     expect(onOpenIssue).not.toHaveBeenCalled();
@@ -1030,7 +1030,7 @@ describe("WorktreeHeader token-missing badge behavior", () => {
     fireEvent.click(prButton);
     expect(actionService.dispatch).toHaveBeenCalledWith(
       "app.settings.openTab",
-      { tab: "github", sectionId: "github-token" },
+      { tab: "code-forge", subtab: "github", sectionId: "github-token" },
       { source: "user" }
     );
     expect(onOpenPR).not.toHaveBeenCalled();
@@ -1228,7 +1228,7 @@ describe("WorktreeHeader upstream sync indicator", () => {
     fireEvent.click(indicator);
     expect(actionService.dispatch).toHaveBeenCalledWith(
       "app.settings.openTab",
-      { tab: "github", sectionId: "github-token" },
+      { tab: "code-forge", subtab: "github", sectionId: "github-token" },
       { source: "user" }
     );
   });

--- a/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeTooltip.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeTooltip.ts
@@ -35,7 +35,7 @@ export function useGitHubBadgeTooltip({
     if (missingToken) {
       void actionService.dispatch(
         "app.settings.openTab",
-        { tab: "github", sectionId: "github-token" },
+        { tab: "code-forge", subtab: "github", sectionId: "github-token" },
         { source: "user" }
       );
       return;

--- a/src/hooks/__tests__/useGitHubTokenExpiryNotification.test.tsx
+++ b/src/hooks/__tests__/useGitHubTokenExpiryNotification.test.tsx
@@ -101,14 +101,15 @@ describe("useGitHubTokenExpiryNotification", () => {
     expect(payload.action?.label).toBe("Open GitHub settings");
     expect(payload.action?.actionId).toBe("app.settings.openTab");
     expect(payload.action?.actionArgs).toEqual({
-      tab: "github",
+      tab: "code-forge",
+      subtab: "github",
       sectionId: "github-token",
     });
 
     payload.action?.onClick();
     expect(dispatchMock).toHaveBeenCalledWith(
       "app.settings.openTab",
-      { tab: "github", sectionId: "github-token" },
+      { tab: "code-forge", subtab: "github", sectionId: "github-token" },
       { source: "user" }
     );
   });

--- a/src/hooks/app/useSettingsDialog.ts
+++ b/src/hooks/app/useSettingsDialog.ts
@@ -16,10 +16,35 @@ export function useSettingsDialog() {
   }, []);
 
   const handleOpenSettingsTab = useCallback((target: SettingsNavTarget) => {
-    const tab = isSettingsTab(target.tab) ? target.tab : "general";
+    // TODO(#8329): remove stale-ID normalization after 1 release
+    let normalized = target;
+    if (target.tab === "github") {
+      if (import.meta.env.DEV) {
+        console.warn(
+          "[useSettingsDialog] stale tab ID 'github' normalized to 'code-forge' — update the call site"
+        );
+      }
+      normalized = {
+        tab: "code-forge",
+        subtab: target.subtab ?? "github",
+        sectionId: target.sectionId,
+      };
+    } else if (target.tab === "forge") {
+      if (import.meta.env.DEV) {
+        console.warn(
+          "[useSettingsDialog] stale tab ID 'forge' normalized to 'code-forge' — update the call site"
+        );
+      }
+      normalized = {
+        tab: "code-forge",
+        subtab: target.subtab ?? "general",
+        sectionId: target.sectionId,
+      };
+    }
+    const tab = isSettingsTab(normalized.tab) ? normalized.tab : "general";
     setSettingsTab(tab);
-    setSettingsSubtab(target.subtab);
-    setSettingsSectionId(target.sectionId);
+    setSettingsSubtab(normalized.subtab);
+    setSettingsSectionId(normalized.sectionId);
     setIsSettingsOpen(true);
   }, []);
 

--- a/src/hooks/useGitHubTokenExpiryNotification.ts
+++ b/src/hooks/useGitHubTokenExpiryNotification.ts
@@ -42,11 +42,11 @@ export function useGitHubTokenExpiryNotification(isTokenError: boolean): void {
         action: {
           label: "Open GitHub settings",
           actionId: "app.settings.openTab",
-          actionArgs: { tab: "github", sectionId: "github-token" },
+          actionArgs: { tab: "code-forge", subtab: "github", sectionId: "github-token" },
           onClick: () => {
             void actionService.dispatch(
               "app.settings.openTab",
-              { tab: "github", sectionId: "github-token" },
+              { tab: "code-forge", subtab: "github", sectionId: "github-token" },
               { source: "user" }
             );
           },

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -25,7 +25,7 @@ export const SettingsTabSchema = z.enum([
   "worktree",
   "agents",
   "assistant",
-  "github",
+  "code-forge",
   "portal",
   "toolbar",
   "integrations",


### PR DESCRIPTION
## Summary

Merged the separate GitHub and Forge integrations tabs into a single Code Forge tab, cleaning up a split that stopped making sense once we had multiple forge providers. The tab uses a provider selector dropdown -- same pattern as `AgentSelectorDropdown` -- to switch between providers. A General section handles the global default provider and per-remote routing.

Resolves #8329.

## Changes

- New `CodeForgeSettingsTab` replaces both the old `GitHubSettingsTab` and `ForgeIntegrationsTab` at the registry level
- `ForgeProviderSelectorDropdown` provides the provider picker, patterned after `AgentSelectorDropdown`
- Updated tab IDs across settings search, remember-tab persistence, and action definitions
- Fixed references throughout the codebase: `GitHubTokenBanner`, `GitHubStatsToolbarButton`, `useSettingsDialog`, `ReviewHubContent`, `UpstreamSyncBadge`, and related hooks

## Testing

- Settings tab test suite updated for the new merged tab structure
- Agent settings subtab tests updated for the new forge tab ID
- Settings search tests cover the new tab and its sections
- All existing tests pass