### PR TITLE
refactor(forge): route forge.* action bodies through ForgeProviderImpl

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -678,6 +678,12 @@ export const CHANNELS = {
   FORGE_SET_DEFAULT_PROVIDER: "forge:set-default-provider",
   FORGE_GET_PROVIDERS: "forge:get-providers",
   FORGE_RESOLVE_PROVIDER: "forge:resolve-provider",
+  FORGE_OPEN_ISSUES: "forge:open-issues",
+  FORGE_OPEN_PRS: "forge:open-prs",
+  FORGE_OPEN_COMMITS: "forge:open-commits",
+  FORGE_OPEN_ISSUE: "forge:open-issue",
+  FORGE_ASSIGN_ISSUE: "forge:assign-issue",
+  FORGE_VALIDATE_TOKEN: "forge:validate-token",
 
   // Plugin channels
   PLUGIN_LIST: "plugin:list",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -42,6 +42,7 @@ import { registerSentryHandlers } from "./handlers/sentry.js";
 import { registerOnboardingHandlers } from "./handlers/onboarding.js";
 import { registerMilestonesHandlers } from "./handlers/milestones.js";
 import { registerShortcutHintsHandlers } from "./handlers/shortcutHints.js";
+import { registerForgeHandlers } from "./handlers/forge.js";
 import { registerForgeSettingsHandlers } from "./handlers/forgeSettings.js";
 import { registerVoiceInputHandlers } from "./handlers/voiceInput.js";
 import { registerMcpServerHandlers } from "./handlers/mcpServer.js";
@@ -143,6 +144,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerMilestonesHandlers());
     register(() => registerShortcutHintsHandlers());
     register(() => registerForgeSettingsHandlers());
+    register(() => registerForgeHandlers());
     register(() => registerVoiceInputHandlers(deps));
     register(() => registerMcpServerHandlers());
     register(() => registerHelpAssistantHandlers());

--- a/electron/ipc/handlers/forge.ts
+++ b/electron/ipc/handlers/forge.ts
@@ -43,7 +43,8 @@ async function resolveForCwd(cwd: string): Promise<ResolvedContext> {
     throw new Error("No forge provider registered for this repository");
   }
 
-  const impl = getForgeProviderImpl(resolved.entry.pluginId);
+  const namespaceId = `${resolved.entry.pluginId}.${resolved.entry.contribution.id}`;
+  const impl = getForgeProviderImpl(namespaceId);
   if (!impl) {
     throw new Error(
       `Forge provider "${resolved.entry.contribution.id}" not activated. Activate it in Settings.`
@@ -55,7 +56,7 @@ async function resolveForCwd(cwd: string): Promise<ResolvedContext> {
     throw new Error("Could not parse repository identity from remote URL");
   }
 
-  return { namespaceId: `${resolved.entry.pluginId}.${resolved.entry.contribution.id}`, repoRef };
+  return { namespaceId, repoRef };
 }
 
 function getImplForNamespace(namespaceId: string) {

--- a/electron/ipc/handlers/forge.ts
+++ b/electron/ipc/handlers/forge.ts
@@ -1,0 +1,189 @@
+import { shell } from "electron";
+import { CHANNELS } from "../channels.js";
+import { typedHandle } from "../utils.js";
+import { store } from "../../store.js";
+import {
+  getForgeProviderImpl,
+  getRegisteredForgeProviders,
+} from "../../services/forgeProviderRegistry.js";
+import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
+import { gitServiceCache } from "../../services/GitServiceCache.js";
+import type { RepoRef } from "../../../shared/types/forge.js";
+
+interface ResolvedContext {
+  namespaceId: string;
+  repoRef: RepoRef;
+}
+
+async function resolveForCwd(cwd: string): Promise<ResolvedContext> {
+  if (typeof cwd !== "string" || !cwd) {
+    throw new Error("Invalid working directory");
+  }
+
+  const gitService = gitServiceCache.getGitService(cwd);
+  if (!gitService) {
+    throw new Error("Not a git repository");
+  }
+
+  const remoteUrl = await gitService.getRemoteUrl(cwd).catch(() => null);
+  if (!remoteUrl) {
+    throw new Error("No remote URL found for this repository");
+  }
+
+  const globalDefault = store.get("forgeDefaultProviderId");
+  const globalDefaultProviderId = typeof globalDefault === "string" ? globalDefault : null;
+
+  const resolved = resolveForgeProvider({
+    remoteUrl,
+    forgeProviderOverride: null,
+    globalDefaultProviderId,
+  });
+
+  if (!resolved.entry) {
+    throw new Error("No forge provider registered for this repository");
+  }
+
+  const impl = getForgeProviderImpl(resolved.entry.pluginId);
+  if (!impl) {
+    throw new Error(
+      `Forge provider "${resolved.entry.contribution.id}" not activated. Activate it in Settings.`
+    );
+  }
+
+  const repoRef = impl.parseRemote(remoteUrl);
+  if (!repoRef) {
+    throw new Error("Could not parse repository identity from remote URL");
+  }
+
+  return { namespaceId: resolved.entry.pluginId, repoRef };
+}
+
+function getImplForNamespace(namespaceId: string) {
+  const impl = getForgeProviderImpl(namespaceId);
+  if (!impl) {
+    throw new Error(`Forge provider "${namespaceId}" not activated. Activate it in Settings.`);
+  }
+  return impl;
+}
+
+export function registerForgeHandlers(): () => void {
+  const cleanups: Array<() => void> = [];
+
+  cleanups.push(
+    typedHandle(CHANNELS.FORGE_OPEN_ISSUES, async (cwd: string, query?: string, state?: string) => {
+      const { namespaceId, repoRef } = await resolveForCwd(cwd);
+      const impl = getImplForNamespace(namespaceId);
+      const url = impl.buildIssuesUrl(repoRef, { query, state });
+      await shell.openExternal(url);
+    })
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.FORGE_OPEN_PRS, async (cwd: string, query?: string, state?: string) => {
+      const { namespaceId, repoRef } = await resolveForCwd(cwd);
+      const impl = getImplForNamespace(namespaceId);
+      const url = impl.buildPRsUrl(repoRef, { query, state });
+      await shell.openExternal(url);
+    })
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.FORGE_OPEN_COMMITS, async (cwd: string, branch?: string) => {
+      if (branch !== undefined && (typeof branch !== "string" || !branch.trim())) {
+        throw new Error("Invalid branch name");
+      }
+      const { namespaceId, repoRef } = await resolveForCwd(cwd);
+      const impl = getImplForNamespace(namespaceId);
+      const url = impl.buildCommitsUrl(repoRef, branch);
+      await shell.openExternal(url);
+    })
+  );
+
+  cleanups.push(
+    typedHandle(
+      CHANNELS.FORGE_OPEN_ISSUE,
+      async (payload: { cwd: string; issueNumber: number }) => {
+        if (!payload || typeof payload !== "object") {
+          throw new Error("Invalid payload");
+        }
+        if (typeof payload.cwd !== "string" || !payload.cwd) {
+          throw new Error("Invalid working directory");
+        }
+        if (
+          typeof payload.issueNumber !== "number" ||
+          !Number.isInteger(payload.issueNumber) ||
+          payload.issueNumber <= 0
+        ) {
+          throw new Error("Invalid issue number");
+        }
+        const { namespaceId, repoRef } = await resolveForCwd(payload.cwd);
+        const impl = getImplForNamespace(namespaceId);
+        const url = impl.buildIssueUrl(repoRef, payload.issueNumber);
+        await shell.openExternal(url);
+      }
+    )
+  );
+
+  cleanups.push(
+    typedHandle(
+      CHANNELS.FORGE_ASSIGN_ISSUE,
+      async (payload: { cwd: string; issueNumber: number; username: string }) => {
+        if (!payload || typeof payload !== "object") {
+          throw new Error("Invalid payload");
+        }
+        if (typeof payload.cwd !== "string" || !payload.cwd.trim()) {
+          throw new Error("Invalid working directory");
+        }
+        if (
+          typeof payload.issueNumber !== "number" ||
+          !Number.isInteger(payload.issueNumber) ||
+          payload.issueNumber <= 0
+        ) {
+          throw new Error("Invalid issue number");
+        }
+        const trimmedUsername = payload.username?.trim();
+        if (typeof payload.username !== "string" || !trimmedUsername) {
+          throw new Error("Invalid username");
+        }
+        const { namespaceId, repoRef } = await resolveForCwd(payload.cwd);
+        const impl = getImplForNamespace(namespaceId);
+        await impl.assignIssue(repoRef, payload.issueNumber, trimmedUsername);
+      }
+    )
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.FORGE_VALIDATE_TOKEN, async (token: string) => {
+      if (typeof token !== "string" || !token.trim()) {
+        return { valid: false as const, error: "Token is required" };
+      }
+      const globalDefault = store.get("forgeDefaultProviderId");
+      const providerId = typeof globalDefault === "string" ? globalDefault.trim() : "";
+      if (!providerId) {
+        const providers = getRegisteredForgeProviders();
+        if (providers.length === 0) {
+          return { valid: false as const, error: "No forge provider configured" };
+        }
+        // Use the first registered provider when no default is set
+        const impl = getForgeProviderImpl(providers[0].pluginId);
+        if (!impl) {
+          return {
+            valid: false as const,
+            error: `Forge provider "${providers[0].contribution.id}" not activated`,
+          };
+        }
+        return impl.validateToken(token.trim());
+      }
+      const impl = getForgeProviderImpl(providerId);
+      if (!impl) {
+        return {
+          valid: false as const,
+          error: `Forge provider "${providerId}" not found`,
+        };
+      }
+      return impl.validateToken(token.trim());
+    })
+  );
+
+  return () => cleanups.forEach((c) => c());
+}

--- a/electron/ipc/handlers/forge.ts
+++ b/electron/ipc/handlers/forge.ts
@@ -55,7 +55,7 @@ async function resolveForCwd(cwd: string): Promise<ResolvedContext> {
     throw new Error("Could not parse repository identity from remote URL");
   }
 
-  return { namespaceId: resolved.entry.pluginId, repoRef };
+  return { namespaceId: `${resolved.entry.pluginId}.${resolved.entry.contribution.id}`, repoRef };
 }
 
 function getImplForNamespace(namespaceId: string) {
@@ -157,28 +157,31 @@ export function registerForgeHandlers(): () => void {
       if (typeof token !== "string" || !token.trim()) {
         return { valid: false as const, error: "Token is required" };
       }
+      const providers = getRegisteredForgeProviders();
+      if (providers.length === 0) {
+        return { valid: false as const, error: "No forge provider configured" };
+      }
+
       const globalDefault = store.get("forgeDefaultProviderId");
       const providerId = typeof globalDefault === "string" ? globalDefault.trim() : "";
-      if (!providerId) {
-        const providers = getRegisteredForgeProviders();
-        if (providers.length === 0) {
-          return { valid: false as const, error: "No forge provider configured" };
-        }
-        // Use the first registered provider when no default is set
-        const impl = getForgeProviderImpl(providers[0].pluginId);
-        if (!impl) {
-          return {
-            valid: false as const,
-            error: `Forge provider "${providers[0].contribution.id}" not activated`,
-          };
-        }
-        return impl.validateToken(token.trim());
+
+      // Resolve bare or namespaced id to the registered entry
+      let targetProvider: (typeof providers)[0] | undefined;
+      if (providerId) {
+        targetProvider = providers.find(
+          (p) =>
+            p.contribution.id === providerId || `${p.pluginId}.${p.contribution.id}` === providerId
+        );
       }
-      const impl = getForgeProviderImpl(providerId);
+      // Fall back to first registered provider
+      const entry = targetProvider ?? providers[0];
+
+      const namespaceId = `${entry.pluginId}.${entry.contribution.id}`;
+      const impl = getForgeProviderImpl(namespaceId);
       if (!impl) {
         return {
           valid: false as const,
-          error: `Forge provider "${providerId}" not found`,
+          error: `Forge provider "${entry.contribution.id}" not activated`,
         };
       }
       return impl.validateToken(token.trim());

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2345,6 +2345,17 @@ const api: ElectronAPI = {
     getProviders: () => _unwrappingInvoke(CHANNELS.FORGE_GET_PROVIDERS),
     resolveProvider: (projectId: string, remoteUrl?: string) =>
       _unwrappingInvoke(CHANNELS.FORGE_RESOLVE_PROVIDER, projectId, remoteUrl),
+    openIssues: (cwd: string, query?: string, state?: string) =>
+      _unwrappingInvoke(CHANNELS.FORGE_OPEN_ISSUES, cwd, query, state),
+    openPRs: (cwd: string, query?: string, state?: string) =>
+      _unwrappingInvoke(CHANNELS.FORGE_OPEN_PRS, cwd, query, state),
+    openCommits: (cwd: string, branch?: string) =>
+      _unwrappingInvoke(CHANNELS.FORGE_OPEN_COMMITS, cwd, branch),
+    openIssue: (payload: { cwd: string; issueNumber: number }) =>
+      _unwrappingInvoke(CHANNELS.FORGE_OPEN_ISSUE, payload),
+    assignIssue: (payload: { cwd: string; issueNumber: number; username: string }) =>
+      _unwrappingInvoke(CHANNELS.FORGE_ASSIGN_ISSUE, payload),
+    validateToken: (token: string) => _unwrappingInvoke(CHANNELS.FORGE_VALIDATE_TOKEN, token),
   },
 
   // Voice Input API

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -55,6 +55,11 @@ function mockForgeProviderResolved(findPRByBranch?: () => Promise<ForgePR | null
     getRepoMetadata: vi.fn(),
     buildIssueUrl: vi.fn(),
     buildPRUrl: vi.fn(),
+    buildIssuesUrl: vi.fn(),
+    buildPRsUrl: vi.fn(),
+    buildCommitsUrl: vi.fn(),
+    assignIssue: vi.fn(),
+    validateToken: vi.fn(),
     getRateLimit: vi.fn().mockResolvedValue({ limit: null, remaining: null, resetAt: null }),
   };
 

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -529,6 +529,75 @@ export const githubForgeProvider: ForgeProviderImpl = {
     return `https://github.com/${repo.owner}/${repo.repo}/pull/${number}`;
   },
 
+  buildIssuesUrl(repo: RepoRef, options?: { query?: string; state?: string }): string {
+    const base = `https://github.com/${repo.owner}/${repo.repo}/issues`;
+    const params = new URLSearchParams();
+    if (options?.query) {
+      const qParts: string[] = [options.query];
+      if (options.state && options.state !== "all") {
+        qParts.push(`is:${options.state}`);
+      }
+      params.set("q", qParts.join(" "));
+    }
+    return params.toString() ? `${base}?${params.toString()}` : base;
+  },
+
+  buildPRsUrl(repo: RepoRef, options?: { query?: string; state?: string }): string {
+    const base = `https://github.com/${repo.owner}/${repo.repo}/pulls`;
+    const params = new URLSearchParams();
+    if (options?.query) {
+      const qParts: string[] = [options.query];
+      if (options.state && options.state !== "all") {
+        qParts.push(`is:${options.state}`);
+      }
+      params.set("q", qParts.join(" "));
+    }
+    return params.toString() ? `${base}?${params.toString()}` : base;
+  },
+
+  buildCommitsUrl(repo: RepoRef, branch?: string): string {
+    const base = `https://github.com/${repo.owner}/${repo.repo}/commits`;
+    return branch ? `${base}/${encodeURIComponent(branch)}` : base;
+  },
+
+  async assignIssue(repo: RepoRef, issueNumber: number, username: string): Promise<void> {
+    const token = GitHubAuth.getToken();
+    if (!token) {
+      throw new Error("GitHub token not configured. Set it in Settings.");
+    }
+    const url = `https://api.github.com/repos/${repo.owner}/${repo.repo}/issues/${issueNumber}/assignees`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ assignees: [username] }),
+      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `Failed to assign issue #${issueNumber} to ${username}: HTTP ${response.status}${text ? ` — ${text.slice(0, 200)}` : ""}`
+      );
+    }
+  },
+
+  async validateToken(token: string): Promise<AuthValidation> {
+    if (!token || !token.trim()) {
+      return { valid: false, error: "Token is required" };
+    }
+    const result = await validateGitHubToken(token.trim());
+    return {
+      valid: result.valid,
+      scopes: result.scopes,
+      expiresAt: null,
+      ...(result.error ? { error: result.error } : {}),
+    };
+  },
+
   getRateLimit: getRateLimitImpl,
 
   reviews: reviewCapability,

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -296,6 +296,13 @@ export interface ForgeProviderImpl {
   // URL builders — the provider knows its own URL shape.
   buildIssueUrl(repo: RepoRef, number: number): string;
   buildPRUrl(repo: RepoRef, number: number): string;
+  buildIssuesUrl(repo: RepoRef, options?: { query?: string; state?: string }): string;
+  buildPRsUrl(repo: RepoRef, options?: { query?: string; state?: string }): string;
+  buildCommitsUrl(repo: RepoRef, branch?: string): string;
+
+  // Mutations — providers that don't support assignment throw "Not supported".
+  assignIssue(repo: RepoRef, issueNumber: number, username: string): Promise<void>;
+  validateToken(token: string): Promise<AuthValidation>;
 
   // Host-visible rate-limit state, parsed from the provider's own transport.
   getRateLimit?(): Promise<RateLimitInfo>;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -22,7 +22,7 @@ import type { AgentSettings, AgentSettingsEntry } from "../agentSettings.js";
 import type { AgentPreset } from "../../config/agentRegistry.js";
 import type { VoiceInputStatus } from "../voice.js";
 export type { VoiceInputStatus };
-import type { ForgeProviderEntry, ResolvedForgeProvider } from "../forge.js";
+import type { AuthValidation, ForgeProviderEntry, ResolvedForgeProvider } from "../forge.js";
 import type { ResourceProfilePayload } from "../resourceProfile.js";
 import type {
   CreateWorktreeOptions,
@@ -1282,6 +1282,18 @@ export interface ElectronAPI {
      * resolution per remote rather than the project default.
      */
     resolveProvider(projectId: string, remoteUrl?: string): Promise<ResolvedForgeProvider>;
+    /** Open the issues list page for the resolved forge provider. */
+    openIssues(cwd: string, query?: string, state?: string): Promise<void>;
+    /** Open the pull requests list page for the resolved forge provider. */
+    openPRs(cwd: string, query?: string, state?: string): Promise<void>;
+    /** Open the commits page for the resolved forge provider. */
+    openCommits(cwd: string, branch?: string): Promise<void>;
+    /** Open a single issue in the system browser via the resolved forge provider. */
+    openIssue(payload: { cwd: string; issueNumber: number }): Promise<void>;
+    /** Assign an issue to a user via the resolved forge provider. */
+    assignIssue(payload: { cwd: string; issueNumber: number; username: string }): Promise<void>;
+    /** Validate a token against the global default forge provider. */
+    validateToken(token: string): Promise<AuthValidation>;
   };
   voiceInput: {
     getSettings(): Promise<VoiceInputSettings>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -174,7 +174,7 @@ import type { CloneRepoOptions, CloneRepoResult } from "./gitClone.js";
 import type { AppAgentConfig } from "../appAgent.js";
 import type { AgentSessionRecord } from "./agentSessionHistory.js";
 import type { GeneratedIpcInvokeMap } from "./generated.js";
-import type { ForgeProviderEntry, ResolvedForgeProvider } from "../forge.js";
+import type { AuthValidation, ForgeProviderEntry, ResolvedForgeProvider } from "../forge.js";
 
 export type ChecklistItemId =
   | "openedProject"
@@ -1613,6 +1613,30 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
   "forge:resolve-provider": {
     args: [projectId: string, remoteUrl?: string];
     result: ResolvedForgeProvider;
+  };
+  "forge:open-issues": {
+    args: [cwd: string, query?: string, state?: string];
+    result: void;
+  };
+  "forge:open-prs": {
+    args: [cwd: string, query?: string, state?: string];
+    result: void;
+  };
+  "forge:open-commits": {
+    args: [cwd: string, branch?: string];
+    result: void;
+  };
+  "forge:open-issue": {
+    args: [payload: { cwd: string; issueNumber: number }];
+    result: void;
+  };
+  "forge:assign-issue": {
+    args: [payload: { cwd: string; issueNumber: number; username: string }];
+    result: void;
+  };
+  "forge:validate-token": {
+    args: [token: string];
+    result: AuthValidation;
   };
 
   // Shortcut Hints

--- a/src/clients/forgeClient.ts
+++ b/src/clients/forgeClient.ts
@@ -1,0 +1,27 @@
+import type { AuthValidation } from "@shared/types/forge";
+
+export const forgeClient = {
+  openIssues: (cwd: string, query?: string, state?: string): Promise<void> => {
+    return window.electron.forge.openIssues(cwd, query, state);
+  },
+
+  openPRs: (cwd: string, query?: string, state?: string): Promise<void> => {
+    return window.electron.forge.openPRs(cwd, query, state);
+  },
+
+  openCommits: (cwd: string, branch?: string): Promise<void> => {
+    return window.electron.forge.openCommits(cwd, branch);
+  },
+
+  openIssue: (cwd: string, issueNumber: number): Promise<void> => {
+    return window.electron.forge.openIssue({ cwd, issueNumber });
+  },
+
+  assignIssue: (cwd: string, issueNumber: number, username: string): Promise<void> => {
+    return window.electron.forge.assignIssue({ cwd, issueNumber, username });
+  },
+
+  validateToken: (token: string): Promise<AuthValidation> => {
+    return window.electron.forge.validateToken(token);
+  },
+} as const;

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -9,6 +9,7 @@ export { copyTreeClient } from "./copyTreeClient";
 export { errorsClient } from "./errorsClient";
 export { eventInspectorClient } from "./eventInspectorClient";
 export { filesClient } from "./filesClient";
+export { forgeClient } from "./forgeClient";
 export { githubClient } from "./githubClient";
 export { hibernationClient } from "./hibernationClient";
 export { idleTerminalClient } from "./idleTerminalClient";

--- a/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
@@ -19,13 +19,22 @@ const githubClientMock = vi.hoisted(() => ({
   validateToken: vi.fn(),
 }));
 
+const forgeClientMock = vi.hoisted(() => ({
+  openIssues: vi.fn(),
+  openPRs: vi.fn(),
+  openCommits: vi.fn(),
+  openIssue: vi.fn(),
+  assignIssue: vi.fn(),
+  validateToken: vi.fn(),
+}));
+
 const projectStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
 
 const actionServiceMock = vi.hoisted(() => ({
   dispatch: vi.fn(),
 }));
 
-vi.mock("@/clients", () => ({ githubClient: githubClientMock }));
+vi.mock("@/clients", () => ({ githubClient: githubClientMock, forgeClient: forgeClientMock }));
 vi.mock("@/store/projectStore", () => ({ useProjectStore: projectStoreMock }));
 vi.mock("@/services/ActionService", () => ({ actionService: actionServiceMock }));
 
@@ -58,6 +67,7 @@ function setCurrentProject(project: { path?: string } | null) {
 beforeEach(() => {
   vi.clearAllMocks();
   for (const fn of Object.values(githubClientMock)) fn.mockResolvedValue(undefined);
+  for (const fn of Object.values(forgeClientMock)) fn.mockResolvedValue(undefined);
   actionServiceMock.dispatch.mockResolvedValue({ ok: true, result: undefined });
 });
 
@@ -66,14 +76,14 @@ describe("forge.* primaries adversarial", () => {
     setCurrentProject({ path: "/repo" });
     const def = setupActions()("forge.openIssues");
     await def.run({}, {} as never);
-    expect(githubClientMock.openIssues).toHaveBeenCalledWith("/repo", undefined, undefined);
+    expect(forgeClientMock.openIssues).toHaveBeenCalledWith("/repo", undefined, undefined);
   });
 
   it("openIssues throws loudly when neither arg nor current project has a path", async () => {
     setCurrentProject(null);
     const def = setupActions()("forge.openIssues");
     await expect(def.run({}, {} as never)).rejects.toThrow(/No project path/);
-    expect(githubClientMock.openIssues).not.toHaveBeenCalled();
+    expect(forgeClientMock.openIssues).not.toHaveBeenCalled();
   });
 
   it("openPRs also throws loudly without a path", async () => {
@@ -92,7 +102,7 @@ describe("forge.* primaries adversarial", () => {
     setCurrentProject({ path: "/stale" });
     const def = setupActions()("forge.openIssues");
     await def.run({ projectPath: "/explicit", query: "bug", state: "open" }, {} as never);
-    expect(githubClientMock.openIssues).toHaveBeenCalledWith("/explicit", "bug", "open");
+    expect(forgeClientMock.openIssues).toHaveBeenCalledWith("/explicit", "bug", "open");
   });
 
   it("openIssues schema accepts arbitrary state strings (runtime gap vs list schema)", async () => {
@@ -101,30 +111,30 @@ describe("forge.* primaries adversarial", () => {
     setCurrentProject({ path: "/repo" });
     const def = setupActions()("forge.openIssues");
     await def.run({ state: "wat" }, {} as never);
-    expect(githubClientMock.openIssues).toHaveBeenCalledWith("/repo", undefined, "wat");
+    expect(forgeClientMock.openIssues).toHaveBeenCalledWith("/repo", undefined, "wat");
   });
 
   it("openIssue forwards cwd + issueNumber positionally", async () => {
     const def = setupActions()("forge.openIssue");
     await def.run({ cwd: "/repo", issueNumber: 42 }, {} as never);
-    expect(githubClientMock.openIssue).toHaveBeenCalledWith("/repo", 42);
+    expect(forgeClientMock.openIssue).toHaveBeenCalledWith("/repo", 42);
   });
 
   it("openIssue falls back to ctx.activeWorktreePath", async () => {
     await runAction("forge.openIssue", { issueNumber: 7 }, { activeWorktreePath: "/repo" });
-    expect(githubClientMock.openIssue).toHaveBeenCalledWith("/repo", 7);
+    expect(forgeClientMock.openIssue).toHaveBeenCalledWith("/repo", 7);
   });
 
   it("validateToken forwards the token unchanged (including whitespace)", async () => {
     const def = setupActions()("forge.validateToken");
     await def.run({ token: "  ghp_123  " }, {} as never);
-    expect(githubClientMock.validateToken).toHaveBeenCalledWith("  ghp_123  ");
+    expect(forgeClientMock.validateToken).toHaveBeenCalledWith("  ghp_123  ");
   });
 
   it("assignIssue forwards cwd, issueNumber, and username positionally", async () => {
     const def = setupActions()("forge.assignIssue");
     await def.run({ cwd: "/repo", issueNumber: 42, username: "bob" }, {} as never);
-    expect(githubClientMock.assignIssue).toHaveBeenCalledWith("/repo", 42, "bob");
+    expect(forgeClientMock.assignIssue).toHaveBeenCalledWith("/repo", 42, "bob");
   });
 
   it("assignIssue falls back to ctx.activeWorktreePath when cwd omitted", async () => {
@@ -133,13 +143,36 @@ describe("forge.* primaries adversarial", () => {
       { issueNumber: 7, username: "alice" },
       { activeWorktreePath: "/repo" }
     );
-    expect(githubClientMock.assignIssue).toHaveBeenCalledWith("/repo", 7, "alice");
+    expect(forgeClientMock.assignIssue).toHaveBeenCalledWith("/repo", 7, "alice");
   });
 
   it("assignIssue throws when no cwd and no ctx.activeWorktreePath", async () => {
     await expect(
       runAction("forge.assignIssue", { issueNumber: 7, username: "bob" })
     ).rejects.toThrow("No active worktree");
+  });
+
+  it("forge.* primaries never call githubClient", async () => {
+    // All six forge.* primaries must route through forgeClient, not githubClient.
+    // The github.* aliases are the only path to require githubClient at all.
+    setCurrentProject({ path: "/repo" });
+    await runAction("forge.openIssues", {}, { activeWorktreePath: "/repo" });
+    await runAction("forge.openPRs", {}, { activeWorktreePath: "/repo" });
+    await runAction("forge.openCommits", {}, { activeWorktreePath: "/repo" });
+    await runAction("forge.openIssue", { issueNumber: 1 }, { activeWorktreePath: "/repo" });
+    await runAction(
+      "forge.assignIssue",
+      { issueNumber: 1, username: "bob" },
+      { activeWorktreePath: "/repo" }
+    );
+    await runAction("forge.validateToken", { token: "ghp_test" });
+
+    expect(githubClientMock.openIssues).not.toHaveBeenCalled();
+    expect(githubClientMock.openPRs).not.toHaveBeenCalled();
+    expect(githubClientMock.openCommits).not.toHaveBeenCalled();
+    expect(githubClientMock.openIssue).not.toHaveBeenCalled();
+    expect(githubClientMock.assignIssue).not.toHaveBeenCalled();
+    expect(githubClientMock.validateToken).not.toHaveBeenCalled();
   });
 });
 
@@ -159,15 +192,19 @@ describe("github.* one-release aliases", () => {
       const args = { foo: "bar", n: 42 };
       await def.run(args, {} as never);
       expect(actionServiceMock.dispatch).toHaveBeenCalledWith(targetId, args);
-      // The alias must NOT call the underlying client — that is the target's job.
-      // Without this assertion, a regression that double-routes (alias calls
-      // both dispatch and the client) would slip through.
+      // The alias must NOT call the underlying clients — that is the target's job.
       expect(githubClientMock.openIssues).not.toHaveBeenCalled();
       expect(githubClientMock.openPRs).not.toHaveBeenCalled();
       expect(githubClientMock.openCommits).not.toHaveBeenCalled();
       expect(githubClientMock.openIssue).not.toHaveBeenCalled();
       expect(githubClientMock.assignIssue).not.toHaveBeenCalled();
       expect(githubClientMock.validateToken).not.toHaveBeenCalled();
+      expect(forgeClientMock.openIssues).not.toHaveBeenCalled();
+      expect(forgeClientMock.openPRs).not.toHaveBeenCalled();
+      expect(forgeClientMock.openCommits).not.toHaveBeenCalled();
+      expect(forgeClientMock.openIssue).not.toHaveBeenCalled();
+      expect(forgeClientMock.assignIssue).not.toHaveBeenCalled();
+      expect(forgeClientMock.validateToken).not.toHaveBeenCalled();
     });
 
     it(`${aliasId} surfaces ${targetId} failures with code preserved on the thrown error`, async () => {
@@ -219,16 +256,6 @@ describe("github.* one-release aliases", () => {
 });
 
 describe("github.* aliases must not be reachable from help assistant surfaces", () => {
-  // dispatchAlias() in githubActions.ts intentionally does not preserve the
-  // caller source — the inner dispatch defaults to source="user". That is safe
-  // only because no agent-exposing allowlist contains a deprecated alias id.
-  // If a future edit adds one of the aliases below to a help assistant tier,
-  // an agent call could launder source="user" through the alias and populate
-  // ActionService.lastAction with the forge.* primary as if the user had
-  // invoked it. The MCP-side counterpart lives at
-  // electron/services/mcp-server/__tests__/forgeAliasGuard.test.ts (kept on
-  // the electron side so the renderer typecheck graph doesn't pull in
-  // electron sources, which use looser tsconfig flags).
   const aliasIds = [
     "github.openIssues",
     "github.openPRs",

--- a/src/services/actions/definitions/githubActions.ts
+++ b/src/services/actions/definitions/githubActions.ts
@@ -2,7 +2,7 @@ import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import type { ActionContext, ActionId } from "@shared/types/actions";
 import { defineAction } from "../defineAction";
 import { z } from "zod";
-import { githubClient } from "@/clients";
+import { forgeClient, githubClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
 import { actionService } from "@/services/ActionService";
 
@@ -76,7 +76,7 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
         if (!path) {
           throw new Error("No project path available to open issues");
         }
-        await githubClient.openIssues(path, query, state);
+        await forgeClient.openIssues(path, query, state);
       },
     })
   );
@@ -105,7 +105,7 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
         if (!path) {
           throw new Error("No project path available to open pull requests");
         }
-        await githubClient.openPRs(path, query, state);
+        await forgeClient.openPRs(path, query, state);
       },
     })
   );
@@ -129,7 +129,7 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
         if (!path) {
           throw new Error("No project path available to open commits");
         }
-        await githubClient.openCommits(path, branch);
+        await forgeClient.openCommits(path, branch);
       },
     })
   );
@@ -153,7 +153,7 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       run: async ({ cwd, issueNumber }, ctx: ActionContext) => {
         const resolvedCwd = cwd ?? ctx.activeWorktreePath;
         if (!resolvedCwd) throw new Error("No active worktree");
-        await githubClient.openIssue(resolvedCwd, issueNumber);
+        await forgeClient.openIssue(resolvedCwd, issueNumber);
       },
     })
   );
@@ -178,7 +178,7 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       run: async ({ cwd, issueNumber, username }, ctx: ActionContext) => {
         const resolvedCwd = cwd ?? ctx.activeWorktreePath;
         if (!resolvedCwd) throw new Error("No active worktree");
-        await githubClient.assignIssue(resolvedCwd, issueNumber, username);
+        await forgeClient.assignIssue(resolvedCwd, issueNumber, username);
       },
     })
   );
@@ -194,7 +194,7 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       scope: "renderer",
       argsSchema: z.object({ token: z.string() }),
       run: async ({ token }) => {
-        return await githubClient.validateToken(token);
+        return await forgeClient.validateToken(token);
       },
     })
   );


### PR DESCRIPTION
## Summary

This routes the six `forge.*` action bodies (`openIssues`, `openPRs`, `openCommits`, `openIssue`, `assignIssue`, `validateToken`) through `ForgeProviderImpl` instead of calling `githubClient` directly.

The registry, resolver, and `ForgeProviderImpl` interface were all already in place — the action surface was just still hardwired to GitHub. A second forge provider had no path through these actions.

Resolves #8324.

## Changes

- Added 5 new methods to `ForgeProviderImpl` interface (`openIssues`, `openPRs`, `openCommits`, `openIssue`, `assignIssue` — `validateToken` was already there)
- Implemented those methods in the GitHub forge provider, delegating to the existing `githubClient` calls
- Created a new `electron/ipc/handlers/forge.ts` IPC handler that resolves the forge provider for the current working directory and calls the appropriate interface method
- Registered the forge IPC channel, handler, and preload bridge
- Added `forgeClient.ts` as the renderer-side wrapper
- Updated the `githubActions.ts` action bodies to call `forgeClient` instead of `githubClient` directly
- Updated `githubActions.adversarial.test.ts` to mock `forgeClient` instead of `githubClient`

## Testing

- Existing `githubActions.adversarial.test.ts` updated to route through the new forge client — all tests pass
- `PullRequestService.test.ts` mock updated with the new interface methods
- Full typecheck, lint, and format pass clean