### PR TITLE
feat(dev-preview): phased skeleton loading state with Doherty gate

### DIFF
--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -62,6 +62,7 @@ export const AppStateTerminalEntrySchema = z
     browserUrl: z.string().optional(),
     devCommand: z.string().optional(),
     devServerStatus: z.enum(["stopped", "starting", "installing", "running", "error"]).optional(),
+    devServerPhaseLabel: z.string().nullable().optional(),
     devServerUrl: z.string().optional(),
     devServerError: z
       .object({
@@ -121,6 +122,7 @@ export const TerminalSnapshotSchema = z
     browserUrl: z.string().optional(),
     devCommand: z.string().optional(),
     devServerStatus: z.enum(["stopped", "starting", "installing", "running", "error"]).optional(),
+    devServerPhaseLabel: z.string().nullable().optional(),
     devServerUrl: z.string().optional(),
     devServerError: z
       .object({

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -251,7 +251,6 @@ export class DevPreviewSessionService {
           error: null,
           isRestarting: true,
           forceKilled: undefined,
-          phaseLabel: "Restarting",
         });
 
         await this.stopSessionTerminal(session, "restart");
@@ -426,7 +425,7 @@ export class DevPreviewSessionService {
           terminalId: null,
           isRestarting: false,
           forceKilled,
-          phaseLabel: null,
+          phaseLabel: undefined,
         });
       } else {
         this.updateSession(session, {
@@ -436,7 +435,7 @@ export class DevPreviewSessionService {
           error: null,
           terminalId: null,
           isRestarting: false,
-          phaseLabel: null,
+          phaseLabel: undefined,
         });
       }
     });
@@ -544,7 +543,7 @@ export class DevPreviewSessionService {
       generation: 0,
       updatedAt: Date.now(),
       updatedAtPerformanceMs: performance.now(),
-      phaseLabel: null,
+      phaseLabel: undefined,
       cwd: "",
       devCommand: "",
       turbopackEnabled: true,
@@ -582,7 +581,7 @@ export class DevPreviewSessionService {
         generation: 0,
         updatedAt: Date.now(),
         forceKilled: undefined,
-        phaseLabel: null,
+        phaseLabel: undefined,
       };
     }
     return this.toPublicState(session);
@@ -603,7 +602,6 @@ export class DevPreviewSessionService {
       updatedAt: session.updatedAt,
       phaseLabel: session.phaseLabel,
       forceKilled: session.forceKilled,
-      phaseLabel: session.phaseLabel,
     };
   }
 
@@ -622,7 +620,6 @@ export class DevPreviewSessionService {
         | "generation"
         | "phaseLabel"
         | "forceKilled"
-        | "phaseLabel"
       >
     >
   ): void {
@@ -637,7 +634,6 @@ export class DevPreviewSessionService {
     if (updates.generation !== undefined) session.generation = updates.generation;
     if ("phaseLabel" in updates) session.phaseLabel = updates.phaseLabel;
     if ("forceKilled" in updates) session.forceKilled = updates.forceKilled;
-    if (updates.phaseLabel !== undefined) session.phaseLabel = updates.phaseLabel;
     session.updatedAt = Date.now();
     session.updatedAtPerformanceMs = performance.now();
     this.onStateChanged(this.toPublicState(session));
@@ -742,7 +738,6 @@ export class DevPreviewSessionService {
       error: null,
       generation: nextGeneration,
       forceKilled: undefined,
-      phaseLabel: "Starting dev server",
     });
 
     try {
@@ -1045,7 +1040,7 @@ export class DevPreviewSessionService {
       url: null,
       assignedUrl: null,
       isRestarting: false,
-      phaseLabel: null,
+      phaseLabel: undefined,
     });
   }
 
@@ -1083,7 +1078,7 @@ export class DevPreviewSessionService {
         },
         terminalId: null,
         isRestarting: false,
-        phaseLabel: null,
+        phaseLabel: undefined,
       });
       return;
     }
@@ -1107,7 +1102,7 @@ export class DevPreviewSessionService {
         error,
         terminalId: null,
         isRestarting: false,
-        phaseLabel: null,
+        phaseLabel: undefined,
       });
       return;
     }
@@ -1119,7 +1114,7 @@ export class DevPreviewSessionService {
       error: null,
       terminalId: null,
       isRestarting: false,
-      phaseLabel: null,
+      phaseLabel: undefined,
     });
   }
 
@@ -1140,7 +1135,6 @@ export class DevPreviewSessionService {
         type: "missing-dependencies",
         message: `Running ${installCommand}...`,
       },
-      phaseLabel: "Installing dependencies",
     });
 
     try {
@@ -1211,7 +1205,7 @@ export class DevPreviewSessionService {
             url,
             error: null,
             isRestarting: false,
-            phaseLabel: null,
+            phaseLabel: undefined,
           });
           markPerformance(PERF_MARKS.DEVPREVIEW_RUNNING, {
             panelId: session.panelId,
@@ -1229,7 +1223,7 @@ export class DevPreviewSessionService {
               message: `Dev server at ${url} did not respond within ${READINESS_TIMEOUT_MS / 1000} seconds`,
             },
             isRestarting: false,
-            phaseLabel: null,
+            phaseLabel: undefined,
           });
         }
       })
@@ -1255,7 +1249,7 @@ export class DevPreviewSessionService {
             message: `Dev server readiness check failed: ${message}`,
           },
           isRestarting: false,
-          phaseLabel: null,
+          phaseLabel: undefined,
         });
       });
   }

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -47,6 +47,9 @@ interface DevPreviewSession extends DevPreviewSessionState {
   installAttemptedGeneration: number | null;
   startupReplayTimer: ReturnType<typeof setTimeout> | null;
   updatedAtPerformanceMs: number;
+  phaseLabel?: "Compiling";
+  compilingEmitted: boolean;
+  compilingTimer: ReturnType<typeof setTimeout> | null;
   forceKilled?: boolean;
 }
 
@@ -554,6 +557,8 @@ export class DevPreviewSessionService {
       isRunningInstall: false,
       installAttemptedGeneration: null,
       startupReplayTimer: null,
+      compilingEmitted: false,
+      compilingTimer: null,
     };
     this.sessions.set(key, session);
     return session;
@@ -595,6 +600,7 @@ export class DevPreviewSessionService {
       isRestarting: session.isRestarting,
       generation: session.generation,
       updatedAt: session.updatedAt,
+      phaseLabel: session.phaseLabel,
       forceKilled: session.forceKilled,
       phaseLabel: session.phaseLabel,
     };
@@ -613,6 +619,7 @@ export class DevPreviewSessionService {
         | "isRestarting"
         | "worktreeId"
         | "generation"
+        | "phaseLabel"
         | "forceKilled"
         | "phaseLabel"
       >
@@ -627,6 +634,7 @@ export class DevPreviewSessionService {
     if (updates.isRestarting !== undefined) session.isRestarting = updates.isRestarting;
     if (updates.worktreeId !== undefined) session.worktreeId = updates.worktreeId;
     if (updates.generation !== undefined) session.generation = updates.generation;
+    if ("phaseLabel" in updates) session.phaseLabel = updates.phaseLabel;
     if ("forceKilled" in updates) session.forceKilled = updates.forceKilled;
     if (updates.phaseLabel !== undefined) session.phaseLabel = updates.phaseLabel;
     session.updatedAt = Date.now();
@@ -723,6 +731,7 @@ export class DevPreviewSessionService {
     session.lastErrorKey = null;
     session.markerSeen = false;
     session.assignedUrl = assignedUrl;
+    this.clearCompiling(session);
     this.attachTerminal(session, terminalId);
     this.updateSession(session, {
       terminalId,
@@ -855,6 +864,7 @@ export class DevPreviewSessionService {
     session.readinessAbort = null;
     session.pendingUrl = null;
     session.markerSeen = false;
+    this.clearCompiling(session);
     session.needsInstall = false;
     session.isRunningInstall = false;
 
@@ -919,6 +929,17 @@ export class DevPreviewSessionService {
     }
   }
 
+  private clearCompiling(session: DevPreviewSession): void {
+    if (session.compilingTimer !== null) {
+      clearTimeout(session.compilingTimer);
+      session.compilingTimer = null;
+    }
+    session.compilingEmitted = false;
+    if (session.phaseLabel === "Compiling") {
+      session.phaseLabel = undefined;
+    }
+  }
+
   private handleData(id: string, data: string | Uint8Array): void {
     if (this.disposed) return;
     const sessionKey = this.terminalToSession.get(id);
@@ -949,6 +970,8 @@ export class DevPreviewSessionService {
       // readiness marker to accelerate it again.
       session.markerSeen = false;
 
+      this.clearCompiling(session);
+
       this.pollServerReadiness(session, result.url, abort.signal, session.generation);
       urlJustStarted = true;
     }
@@ -966,12 +989,32 @@ export class DevPreviewSessionService {
       this.pollServerReadiness(session, session.pendingUrl, abort.signal, session.generation);
     }
 
-    if (!result.error) {
-      if (session.status === "starting" && session.phaseLabel !== "Compiling") {
-        this.updateSession(session, { phaseLabel: "Compiling" });
-      }
-      return;
+    // A readyMarker without a pending URL (post-install, pre-URL detection)
+    // signals the framework is compiling. Debounce at 600ms to avoid label
+    // flicker from markers that fire on consecutive data chunks.
+    if (
+      result.readyMarker &&
+      !session.compilingEmitted &&
+      session.status === "starting" &&
+      !session.pendingUrl &&
+      !session.isRunningInstall
+    ) {
+      if (session.compilingTimer !== null) return;
+      session.compilingTimer = setTimeout(() => {
+        session.compilingTimer = null;
+        if (
+          session.status === "starting" &&
+          !session.pendingUrl &&
+          !session.url &&
+          !session.compilingEmitted
+        ) {
+          session.compilingEmitted = true;
+          this.updateSession(session, { phaseLabel: "Compiling" });
+        }
+      }, 600);
     }
+
+    if (!result.error) return;
     const errorKey = `${result.error.type}:${result.error.message}`;
     if (errorKey === session.lastErrorKey) return;
     session.lastErrorKey = errorKey;
@@ -983,6 +1026,7 @@ export class DevPreviewSessionService {
     session.readinessAbort = null;
     session.pendingUrl = null;
     session.markerSeen = false;
+    this.clearCompiling(session);
 
     if (result.error.type === "missing-dependencies") {
       session.needsInstall = true;
@@ -1016,6 +1060,7 @@ export class DevPreviewSessionService {
     session.readinessAbort = null;
     session.pendingUrl = null;
     session.markerSeen = false;
+    this.clearCompiling(session);
 
     this.detachTerminal(session);
     session.buffer = "";
@@ -1159,6 +1204,7 @@ export class DevPreviewSessionService {
 
         if (ready) {
           session.needsInstall = false;
+          this.clearCompiling(session);
           this.updateSession(session, {
             status: "running",
             url,

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -129,6 +129,7 @@ export class DevPreviewSessionService {
     for (const session of this.sessions.values()) {
       this.clearStartupReplay(session);
       session.readinessAbort?.abort();
+      this.clearCompiling(session);
     }
     for (const terminalId of this.terminalToSession.keys()) {
       this.ptyClient.setIpcDataMirror(terminalId, false);

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -247,6 +247,7 @@ export class DevPreviewSessionService {
           error: null,
           isRestarting: true,
           forceKilled: undefined,
+          phaseLabel: "Restarting",
         });
 
         await this.stopSessionTerminal(session, "restart");
@@ -537,6 +538,7 @@ export class DevPreviewSessionService {
       generation: 0,
       updatedAt: Date.now(),
       updatedAtPerformanceMs: performance.now(),
+      phaseLabel: null,
       cwd: "",
       devCommand: "",
       turbopackEnabled: true,
@@ -572,6 +574,7 @@ export class DevPreviewSessionService {
         generation: 0,
         updatedAt: Date.now(),
         forceKilled: undefined,
+        phaseLabel: null,
       };
     }
     return this.toPublicState(session);
@@ -591,6 +594,7 @@ export class DevPreviewSessionService {
       generation: session.generation,
       updatedAt: session.updatedAt,
       forceKilled: session.forceKilled,
+      phaseLabel: session.phaseLabel,
     };
   }
 
@@ -608,6 +612,7 @@ export class DevPreviewSessionService {
         | "worktreeId"
         | "generation"
         | "forceKilled"
+        | "phaseLabel"
       >
     >
   ): void {
@@ -621,6 +626,7 @@ export class DevPreviewSessionService {
     if (updates.worktreeId !== undefined) session.worktreeId = updates.worktreeId;
     if (updates.generation !== undefined) session.generation = updates.generation;
     if ("forceKilled" in updates) session.forceKilled = updates.forceKilled;
+    if (updates.phaseLabel !== undefined) session.phaseLabel = updates.phaseLabel;
     session.updatedAt = Date.now();
     session.updatedAtPerformanceMs = performance.now();
     this.onStateChanged(this.toPublicState(session));
@@ -724,6 +730,7 @@ export class DevPreviewSessionService {
       error: null,
       generation: nextGeneration,
       forceKilled: undefined,
+      phaseLabel: "Starting dev server",
     });
 
     try {
@@ -957,7 +964,12 @@ export class DevPreviewSessionService {
       this.pollServerReadiness(session, session.pendingUrl, abort.signal, session.generation);
     }
 
-    if (!result.error) return;
+    if (!result.error) {
+      if (session.status === "starting" && session.phaseLabel !== "Compiling") {
+        this.updateSession(session, { phaseLabel: "Compiling" });
+      }
+      return;
+    }
     const errorKey = `${result.error.type}:${result.error.message}`;
     if (errorKey === session.lastErrorKey) return;
     session.lastErrorKey = errorKey;
@@ -1076,6 +1088,7 @@ export class DevPreviewSessionService {
         type: "missing-dependencies",
         message: `Running ${installCommand}...`,
       },
+      phaseLabel: "Installing dependencies",
     });
 
     try {

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -422,6 +422,7 @@ export class DevPreviewSessionService {
           terminalId: null,
           isRestarting: false,
           forceKilled,
+          phaseLabel: null,
         });
       } else {
         this.updateSession(session, {
@@ -431,6 +432,7 @@ export class DevPreviewSessionService {
           error: null,
           terminalId: null,
           isRestarting: false,
+          phaseLabel: null,
         });
       }
     });
@@ -998,6 +1000,7 @@ export class DevPreviewSessionService {
       url: null,
       assignedUrl: null,
       isRestarting: false,
+      phaseLabel: null,
     });
   }
 
@@ -1034,6 +1037,7 @@ export class DevPreviewSessionService {
         },
         terminalId: null,
         isRestarting: false,
+        phaseLabel: null,
       });
       return;
     }
@@ -1057,6 +1061,7 @@ export class DevPreviewSessionService {
         error,
         terminalId: null,
         isRestarting: false,
+        phaseLabel: null,
       });
       return;
     }
@@ -1068,6 +1073,7 @@ export class DevPreviewSessionService {
       error: null,
       terminalId: null,
       isRestarting: false,
+      phaseLabel: null,
     });
   }
 
@@ -1158,6 +1164,7 @@ export class DevPreviewSessionService {
             url,
             error: null,
             isRestarting: false,
+            phaseLabel: null,
           });
           markPerformance(PERF_MARKS.DEVPREVIEW_RUNNING, {
             panelId: session.panelId,
@@ -1175,6 +1182,7 @@ export class DevPreviewSessionService {
               message: `Dev server at ${url} did not respond within ${READINESS_TIMEOUT_MS / 1000} seconds`,
             },
             isRestarting: false,
+            phaseLabel: null,
           });
         }
       })
@@ -1200,6 +1208,7 @@ export class DevPreviewSessionService {
             message: `Dev server readiness check failed: ${message}`,
           },
           isRestarting: false,
+          phaseLabel: null,
         });
       });
   }

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -993,9 +993,9 @@ export class DevPreviewSessionService {
       !session.compilingEmitted &&
       session.status === "starting" &&
       !session.pendingUrl &&
-      !session.isRunningInstall
+      !session.isRunningInstall &&
+      session.compilingTimer === null
     ) {
-      if (session.compilingTimer !== null) return;
       session.compilingTimer = setTimeout(() => {
         session.compilingTimer = null;
         if (

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -40,6 +40,7 @@ export interface DevPreviewSessionState {
   generation: number;
   updatedAt: number;
   forceKilled?: boolean;
+  phaseLabel: string | null;
 }
 
 export interface DevPreviewStateChangedPayload {

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -39,6 +39,7 @@ export interface DevPreviewSessionState {
   isRestarting: boolean;
   generation: number;
   updatedAt: number;
+  phaseLabel?: "Compiling";
   forceKilled?: boolean;
   phaseLabel: string | null;
 }

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -41,7 +41,6 @@ export interface DevPreviewSessionState {
   updatedAt: number;
   phaseLabel?: "Compiling";
   forceKilled?: boolean;
-  phaseLabel: string | null;
 }
 
 export interface DevPreviewStateChangedPayload {

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -271,6 +271,8 @@ export interface PtyPanelData extends BasePanelData {
   devCommand?: string;
   /** Dev server status for dev-preview panels */
   devServerStatus?: "stopped" | "starting" | "installing" | "running" | "error";
+  /** Dev server phase label for dev-preview panels */
+  devServerPhaseLabel?: string | null;
   /** Dev server URL for dev-preview panels */
   devServerUrl?: string;
   /** Dev server error for dev-preview panels */
@@ -372,6 +374,8 @@ export interface DevPreviewPanelData extends BasePanelData {
   devPreviewConsoleTab?: "output" | "console";
   /** Dev server status */
   devServerStatus?: "stopped" | "starting" | "installing" | "running" | "error";
+  /** Dev server phase label */
+  devServerPhaseLabel?: string | null;
   /** Dev server URL */
   devServerUrl?: string;
   /** Dev server error */
@@ -496,6 +500,8 @@ export interface TerminalInstance {
   devCommand?: string;
   /** Dev server status for dev-preview panels */
   devServerStatus?: "stopped" | "starting" | "installing" | "running" | "error";
+  /** Dev server phase label for dev-preview panels */
+  devServerPhaseLabel?: string | null;
   /** Dev server URL for dev-preview panels */
   devServerUrl?: string;
   /** Dev server error for dev-preview panels */

--- a/src/components/DevPreview/DevPreviewLoadingState.tsx
+++ b/src/components/DevPreview/DevPreviewLoadingState.tsx
@@ -3,70 +3,107 @@ import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { SkeletonHint } from "@/components/ui/Skeleton";
 
 interface DevPreviewLoadingStateProps {
-  isPending: boolean;
-  phaseLabel: string | null;
   variant: "full" | "overlay";
+  isLoading: boolean;
+  phaseLabel: string;
+  onCancel?: () => void;
   className?: string;
 }
 
-export function DevPreviewLoadingState({
-  isPending,
-  phaseLabel,
-  variant,
-  className,
-}: DevPreviewLoadingStateProps) {
-  const showLoader = useDeferredLoading(isPending, UI_DOHERTY_THRESHOLD);
+function SkeletonBone({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`bg-muted rounded animate-pulse-delayed ${className ?? ""}`}
+    />
+  );
+}
 
-  if (!showLoader) return null;
-
-  if (variant === "overlay") {
-    return (
-      <div
-        className={`absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3 ${className ?? ""}`}
-        role="status"
-        aria-busy="true"
-      >
-        {phaseLabel && (
-          <p aria-live="polite" className="text-sm text-daintree-text/60">
-            {phaseLabel}
-          </p>
-        )}
-        <SkeletonHint className="pointer-events-auto" />
-      </div>
-    );
-  }
+function FullSkeleton({ phaseLabel, isLoading }: { phaseLabel: string; isLoading: boolean }) {
+  const showPhaseLabel = useDeferredLoading(isLoading, UI_DOHERTY_THRESHOLD);
 
   return (
     <div
-      className={`absolute inset-0 flex flex-col bg-daintree-bg ${className ?? ""}`}
+      className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg px-6"
       role="status"
       aria-busy="true"
-      aria-label={phaseLabel ?? "Loading dev preview"}
+      aria-label={phaseLabel}
     >
-      <span className="sr-only">{phaseLabel ?? "Loading dev preview"}</span>
+      <span className="sr-only">{phaseLabel}</span>
 
-      {/* Content area skeleton — no header/toolbar (real toolbar renders above) */}
-      <div className="flex-1 min-h-0 p-3 space-y-3" aria-hidden="true">
-        <div className="animate-pulse-delayed h-4 w-3/4 bg-muted rounded" />
-        <div className="animate-pulse-delayed h-4 w-1/2 bg-muted rounded" />
-        <div className="animate-pulse-delayed h-4 w-5/6 bg-muted rounded" />
-        <div className="animate-pulse-delayed h-3 w-2/3 bg-muted rounded" />
-        <div className="animate-pulse-delayed h-32 w-full bg-muted rounded mt-4" />
-        <div className="animate-pulse-delayed h-3 w-1/3 bg-muted rounded" />
-        <div className="animate-pulse-delayed h-3 w-1/4 bg-muted rounded" />
+      <div className="w-full max-w-md flex flex-col gap-4" aria-hidden="true">
+        <SkeletonBone className="h-3.5 w-3/4" />
+        <div className="space-y-2">
+          <SkeletonBone className="h-3 w-full" />
+          <SkeletonBone className="h-3 w-5/6" />
+          <SkeletonBone className="h-3 w-2/3" />
+        </div>
+        <div className="space-y-2 mt-3">
+          <SkeletonBone className="h-2.5 w-full" />
+          <SkeletonBone className="h-2.5 w-4/5" />
+          <SkeletonBone className="h-2.5 w-3/5" />
+        </div>
       </div>
 
-      {/* Phase label */}
-      {phaseLabel && (
-        <p
-          aria-live="polite"
-          className="absolute bottom-12 left-1/2 -translate-x-1/2 text-sm text-daintree-text/60"
-        >
+      {showPhaseLabel && (
+        <p aria-live="polite" className="mt-6 text-xs text-daintree-text/60">
           {phaseLabel}
         </p>
       )}
 
       <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
+    </div>
+  );
+}
+
+function OverlaySkeleton({
+  phaseLabel,
+  isLoading,
+  onCancel,
+}: {
+  phaseLabel: string;
+  isLoading: boolean;
+  onCancel?: () => void;
+}) {
+  const showOverlay = useDeferredLoading(isLoading, UI_DOHERTY_THRESHOLD);
+
+  if (!showOverlay) return null;
+
+  return (
+    <div
+      className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3"
+      role="status"
+      aria-busy="true"
+      aria-label={phaseLabel}
+    >
+      <span className="sr-only">{phaseLabel}</span>
+
+      <p aria-live="polite" className="text-xs text-daintree-text/60">
+        {phaseLabel}
+      </p>
+
+      <SkeletonHint
+        className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto"
+        onCancel={onCancel}
+      />
+    </div>
+  );
+}
+
+export function DevPreviewLoadingState({
+  variant,
+  isLoading,
+  phaseLabel,
+  onCancel,
+  className,
+}: DevPreviewLoadingStateProps) {
+  if (variant === "overlay") {
+    return <OverlaySkeleton phaseLabel={phaseLabel} isLoading={isLoading} onCancel={onCancel} />;
+  }
+
+  return (
+    <div className={className}>
+      <FullSkeleton phaseLabel={phaseLabel} isLoading={isLoading} />
     </div>
   );
 }

--- a/src/components/DevPreview/DevPreviewLoadingState.tsx
+++ b/src/components/DevPreview/DevPreviewLoadingState.tsx
@@ -23,33 +23,35 @@ function FullSkeleton({ phaseLabel, isLoading }: { phaseLabel: string; isLoading
   const showPhaseLabel = useDeferredLoading(isLoading, UI_DOHERTY_THRESHOLD);
 
   return (
-    <div
-      className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg px-6"
-      role="status"
-      aria-busy="true"
-      aria-label={phaseLabel}
-    >
-      <span className="sr-only">{phaseLabel}</span>
+    <div className="relative flex flex-col items-center justify-center h-full bg-daintree-bg px-6">
+      <div
+        className="flex flex-col items-center w-full max-w-md"
+        role="status"
+        aria-busy="true"
+        aria-label={phaseLabel}
+      >
+        <span className="sr-only">{phaseLabel}</span>
 
-      <div className="w-full max-w-md flex flex-col gap-4" aria-hidden="true">
-        <SkeletonBone className="h-3.5 w-3/4" />
-        <div className="space-y-2">
-          <SkeletonBone className="h-3 w-full" />
-          <SkeletonBone className="h-3 w-5/6" />
-          <SkeletonBone className="h-3 w-2/3" />
+        <div className="w-full flex flex-col gap-4" aria-hidden="true">
+          <SkeletonBone className="h-3.5 w-3/4" />
+          <div className="space-y-2">
+            <SkeletonBone className="h-3 w-full" />
+            <SkeletonBone className="h-3 w-5/6" />
+            <SkeletonBone className="h-3 w-2/3" />
+          </div>
+          <div className="space-y-2 mt-3">
+            <SkeletonBone className="h-2.5 w-full" />
+            <SkeletonBone className="h-2.5 w-4/5" />
+            <SkeletonBone className="h-2.5 w-3/5" />
+          </div>
         </div>
-        <div className="space-y-2 mt-3">
-          <SkeletonBone className="h-2.5 w-full" />
-          <SkeletonBone className="h-2.5 w-4/5" />
-          <SkeletonBone className="h-2.5 w-3/5" />
-        </div>
+
+        {showPhaseLabel && (
+          <p aria-live="polite" className="mt-6 text-xs text-daintree-text/60">
+            {phaseLabel}
+          </p>
+        )}
       </div>
-
-      {showPhaseLabel && (
-        <p aria-live="polite" className="mt-6 text-xs text-daintree-text/60">
-          {phaseLabel}
-        </p>
-      )}
 
       <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
     </div>
@@ -70,17 +72,19 @@ function OverlaySkeleton({
   if (!showOverlay) return null;
 
   return (
-    <div
-      className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3"
-      role="status"
-      aria-busy="true"
-      aria-label={phaseLabel}
-    >
-      <span className="sr-only">{phaseLabel}</span>
+    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg">
+      <div
+        className="flex flex-col items-center gap-3"
+        role="status"
+        aria-busy="true"
+        aria-label={phaseLabel}
+      >
+        <span className="sr-only">{phaseLabel}</span>
 
-      <p aria-live="polite" className="text-xs text-daintree-text/60">
-        {phaseLabel}
-      </p>
+        <p aria-live="polite" className="text-xs text-daintree-text/60">
+          {phaseLabel}
+        </p>
+      </div>
 
       <SkeletonHint
         className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto"

--- a/src/components/DevPreview/DevPreviewLoadingState.tsx
+++ b/src/components/DevPreview/DevPreviewLoadingState.tsx
@@ -1,0 +1,72 @@
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { SkeletonHint } from "@/components/ui/Skeleton";
+
+interface DevPreviewLoadingStateProps {
+  isPending: boolean;
+  phaseLabel: string | null;
+  variant: "full" | "overlay";
+  className?: string;
+}
+
+export function DevPreviewLoadingState({
+  isPending,
+  phaseLabel,
+  variant,
+  className,
+}: DevPreviewLoadingStateProps) {
+  const showLoader = useDeferredLoading(isPending, UI_DOHERTY_THRESHOLD);
+
+  if (!showLoader) return null;
+
+  if (variant === "overlay") {
+    return (
+      <div
+        className={`absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3 ${className ?? ""}`}
+        role="status"
+        aria-busy="true"
+      >
+        {phaseLabel && (
+          <p aria-live="polite" className="text-sm text-daintree-text/60">
+            {phaseLabel}
+          </p>
+        )}
+        <SkeletonHint className="pointer-events-auto" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`absolute inset-0 flex flex-col bg-daintree-bg ${className ?? ""}`}
+      role="status"
+      aria-busy="true"
+      aria-label={phaseLabel ?? "Loading dev preview"}
+    >
+      <span className="sr-only">{phaseLabel ?? "Loading dev preview"}</span>
+
+      {/* Content area skeleton — no header/toolbar (real toolbar renders above) */}
+      <div className="flex-1 min-h-0 p-3 space-y-3" aria-hidden="true">
+        <div className="animate-pulse-delayed h-4 w-3/4 bg-muted rounded" />
+        <div className="animate-pulse-delayed h-4 w-1/2 bg-muted rounded" />
+        <div className="animate-pulse-delayed h-4 w-5/6 bg-muted rounded" />
+        <div className="animate-pulse-delayed h-3 w-2/3 bg-muted rounded" />
+        <div className="animate-pulse-delayed h-32 w-full bg-muted rounded mt-4" />
+        <div className="animate-pulse-delayed h-3 w-1/3 bg-muted rounded" />
+        <div className="animate-pulse-delayed h-3 w-1/4 bg-muted rounded" />
+      </div>
+
+      {/* Phase label */}
+      {phaseLabel && (
+        <p
+          aria-live="polite"
+          className="absolute bottom-12 left-1/2 -translate-x-1/2 text-sm text-daintree-text/60"
+        >
+          {phaseLabel}
+        </p>
+      )}
+
+      <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
+    </div>
+  );
+}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -323,47 +323,7 @@ export function DevPreviewPane({
   const isMountedRef = useRef(true);
   const prevStatusRef = useRef(status);
 
-  const PHASE_DEBOUNCE_MS = 600;
   const STALL_DETECTION_MS = 15_000;
-
-  // Phase label debounce — prevents three-label slot machine on warm-cache boots
-  const lastPhaseChangeAtRef = useRef<number>(0);
-  const phaseDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [debouncedPhaseLabel, setDebouncedPhaseLabel] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (phaseLabel === null) {
-      setDebouncedPhaseLabel(null);
-      return;
-    }
-    lastPhaseChangeAtRef.current = Date.now();
-    phaseDebounceTimerRef.current = setTimeout(() => {
-      if (Date.now() - lastPhaseChangeAtRef.current >= PHASE_DEBOUNCE_MS) {
-        setDebouncedPhaseLabel(phaseLabel);
-      }
-    }, PHASE_DEBOUNCE_MS);
-    return () => {
-      if (phaseDebounceTimerRef.current) {
-        clearTimeout(phaseDebounceTimerRef.current);
-        phaseDebounceTimerRef.current = null;
-      }
-    };
-  }, [phaseLabel]);
-
-  // Bypass debounce on deliberate transitions (e.g. restart) so the user sees
-  // the label even when the backend replaces it within the debounce window.
-  useEffect(() => {
-    if (isRestarting) {
-      lastPhaseChangeAtRef.current = 0;
-      if (phaseDebounceTimerRef.current) {
-        clearTimeout(phaseDebounceTimerRef.current);
-        phaseDebounceTimerRef.current = null;
-      }
-      if (phaseLabel) {
-        setDebouncedPhaseLabel(phaseLabel);
-      }
-    }
-  }, [isRestarting]); // eslint-disable-line react-hooks/exhaustive-deps -- phaseLabel is read but not needed as dep; only restart transitions matter
 
   // Stall detection — auto-open console drawer on fatal error or 15s no-phase-progress
   const stallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -323,51 +323,6 @@ export function DevPreviewPane({
   const isMountedRef = useRef(true);
   const prevStatusRef = useRef(status);
 
-  const STALL_DETECTION_MS = 15_000;
-
-  // Stall detection — auto-open console drawer on fatal error or 15s no-phase-progress
-  const stallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const hasAutoOpenedConsoleRef = useRef(false);
-
-  useEffect(() => {
-    if (status === "error" && error) {
-      if (!hasAutoOpenedConsoleRef.current && !isConsoleOpen) {
-        hasAutoOpenedConsoleRef.current = true;
-        setDevPreviewConsoleOpen(id, true);
-      }
-      return;
-    }
-
-    if (status === "running" || status === "stopped") {
-      hasAutoOpenedConsoleRef.current = false;
-      if (stallTimerRef.current) {
-        clearTimeout(stallTimerRef.current);
-        stallTimerRef.current = null;
-      }
-      return;
-    }
-
-    if (status === "starting" || status === "installing") {
-      hasAutoOpenedConsoleRef.current = false;
-      if (stallTimerRef.current) {
-        clearTimeout(stallTimerRef.current);
-      }
-      stallTimerRef.current = setTimeout(() => {
-        if (!hasAutoOpenedConsoleRef.current && !isConsoleOpen) {
-          hasAutoOpenedConsoleRef.current = true;
-          setDevPreviewConsoleOpen(id, true);
-        }
-      }, STALL_DETECTION_MS);
-    }
-
-    return () => {
-      if (stallTimerRef.current) {
-        clearTimeout(stallTimerRef.current);
-        stallTimerRef.current = null;
-      }
-    };
-  }, [status, phaseLabel, error, id, isConsoleOpen, setDevPreviewConsoleOpen]);
-
   const loadTimeoutMs =
     Math.min(Math.max(projectSettings?.devServerLoadTimeout ?? 30, 1), 120) * 1000;
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -6,7 +6,6 @@ import {
   ChevronDown,
   ExternalLink,
   Settings,
-  Square,
   OctagonAlert,
   Play,
 } from "lucide-react";
@@ -19,6 +18,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
+import { Spinner } from "@/components/ui/Spinner";
 import { usePanelStore } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
@@ -465,12 +465,44 @@ export function DevPreviewPane({
     };
   }, [isRecoveringFromEviction, webviewElement]);
 
+  const consoleAutoOpenedErrorRef = useRef<string | null>(null);
+  const consoleAutoOpenedStallRef = useRef(false);
+
+  useEffect(() => {
+    if (status === "error" && error && consoleAutoOpenedErrorRef.current !== error.message) {
+      consoleAutoOpenedErrorRef.current = error.message;
+      setDevPreviewConsoleOpen(id, true);
+    }
+    if (status !== "error") {
+      consoleAutoOpenedErrorRef.current = null;
+    }
+  }, [status, error, id, setDevPreviewConsoleOpen]);
+
+  useEffect(() => {
+    if (
+      (status !== "starting" && status !== "installing") ||
+      url ||
+      phaseLabel ||
+      consoleAutoOpenedStallRef.current
+    ) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if ((status === "starting" || status === "installing") && !url && !phaseLabel) {
+        consoleAutoOpenedStallRef.current = true;
+        setDevPreviewConsoleOpen(id, true);
+      }
+    }, 15_000);
+
+    return () => clearTimeout(timer);
+  }, [status, url, phaseLabel, id, setDevPreviewConsoleOpen]);
+
   const {
     isWebviewReady,
     setIsWebviewReady,
     isLoading,
     setIsLoading,
-    isSlowLoad,
     setIsSlowLoad,
     webviewLoadError,
     setWebviewLoadError,
@@ -1192,8 +1224,14 @@ export function DevPreviewPane({
           {isRestarting || status === "starting" || status === "installing" ? (
             <DevPreviewLoadingState
               variant="full"
-              isPending={true}
-              phaseLabel={debouncedPhaseLabel}
+              isLoading={true}
+              phaseLabel={
+                isRestarting
+                  ? "Restarting"
+                  : status === "installing"
+                    ? "Installing dependencies"
+                    : (phaseLabel ?? "Starting dev server")
+              }
             />
           ) : status === "error" && error ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
@@ -1428,7 +1466,7 @@ export function DevPreviewPane({
                 <>
                   {reconnectAttempt > 0 && !webviewLoadError && (
                     <div className="absolute bottom-0 left-0 right-0 z-20 flex items-center justify-center gap-2 px-3 py-1.5 text-xs bg-status-info/10 border-t border-status-info/20 text-daintree-text/70">
-                      <Spinner size="xs" className="text-status-info" />
+                      <Spinner size="xs" />
                       <span>Reconnecting (attempt {reconnectAttempt} of 5)...</span>
                     </div>
                   )}
@@ -1543,27 +1581,15 @@ export function DevPreviewPane({
                   {isLoading && (
                     <DevPreviewLoadingState
                       variant="overlay"
-                      isPending={true}
-                      phaseLabel={isSlowLoad ? "Taking longer than usual..." : "Loading preview"}
+                      isLoading={isLoading}
+                      phaseLabel="Loading preview"
+                      onCancel={handleCancelLoad}
                     />
-                  )}
-                  {isLoading && isSlowLoad && (
-                    <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-20">
-                      <Button
-                        onClick={handleCancelLoad}
-                        variant="ghost"
-                        size="sm"
-                        className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
-                      >
-                        <Square className="h-3.5 w-3.5" />
-                        <span className="text-xs">Cancel</span>
-                      </Button>
-                    </div>
                   )}
                   {showRecoverySpinner && !webviewLoadError && (
                     <DevPreviewLoadingState
                       variant="overlay"
-                      isPending={true}
+                      isLoading={isRecoveringFromEviction}
                       phaseLabel="Rehydrating preview"
                     />
                   )}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1561,10 +1561,11 @@ export function DevPreviewPane({
                     </div>
                   )}
                   {showRecoverySpinner && !webviewLoadError && (
-                    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
-                      <Spinner size="2xl" className="text-status-info" />
-                      <p className="text-xs text-daintree-text/50">Rehydrating preview...</p>
-                    </div>
+                    <DevPreviewLoadingState
+                      variant="overlay"
+                      isPending={true}
+                      phaseLabel="Rehydrating preview"
+                    />
                   )}
                   {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
                   {findInPage.isOpen && <FindBar find={findInPage} />}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -479,6 +479,9 @@ export function DevPreviewPane({
   }, [status, error, id, setDevPreviewConsoleOpen]);
 
   useEffect(() => {
+    if (status !== "starting" && status !== "installing") {
+      consoleAutoOpenedStallRef.current = false;
+    }
     if (
       (status !== "starting" && status !== "installing") ||
       url ||

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -323,7 +323,10 @@ export function DevPreviewPane({
   const isMountedRef = useRef(true);
   const prevStatusRef = useRef(status);
 
-  // Phase label debounce (600ms) — prevents three-label slot machine on warm-cache boots
+  const PHASE_DEBOUNCE_MS = 600;
+  const STALL_DETECTION_MS = 15_000;
+
+  // Phase label debounce — prevents three-label slot machine on warm-cache boots
   const lastPhaseChangeAtRef = useRef<number>(0);
   const phaseDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [debouncedPhaseLabel, setDebouncedPhaseLabel] = useState<string | null>(null);
@@ -335,10 +338,10 @@ export function DevPreviewPane({
     }
     lastPhaseChangeAtRef.current = Date.now();
     phaseDebounceTimerRef.current = setTimeout(() => {
-      if (Date.now() - lastPhaseChangeAtRef.current >= 600) {
+      if (Date.now() - lastPhaseChangeAtRef.current >= PHASE_DEBOUNCE_MS) {
         setDebouncedPhaseLabel(phaseLabel);
       }
-    }, 600);
+    }, PHASE_DEBOUNCE_MS);
     return () => {
       if (phaseDebounceTimerRef.current) {
         clearTimeout(phaseDebounceTimerRef.current);
@@ -348,7 +351,7 @@ export function DevPreviewPane({
   }, [phaseLabel]);
 
   // Bypass debounce on deliberate transitions (e.g. restart) so the user sees
-  // the label even when the backend replaces it within the 600ms window.
+  // the label even when the backend replaces it within the debounce window.
   useEffect(() => {
     if (isRestarting) {
       lastPhaseChangeAtRef.current = 0;
@@ -394,7 +397,7 @@ export function DevPreviewPane({
           hasAutoOpenedConsoleRef.current = true;
           setDevPreviewConsoleOpen(id, true);
         }
-      }, 15000);
+      }, STALL_DETECTION_MS);
     }
 
     return () => {

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -347,6 +347,21 @@ export function DevPreviewPane({
     };
   }, [phaseLabel]);
 
+  // Bypass debounce on deliberate transitions (e.g. restart) so the user sees
+  // the label even when the backend replaces it within the 600ms window.
+  useEffect(() => {
+    if (isRestarting) {
+      lastPhaseChangeAtRef.current = 0;
+      if (phaseDebounceTimerRef.current) {
+        clearTimeout(phaseDebounceTimerRef.current);
+        phaseDebounceTimerRef.current = null;
+      }
+      if (phaseLabel) {
+        setDebouncedPhaseLabel(phaseLabel);
+      }
+    }
+  }, [isRestarting]); // eslint-disable-line react-hooks/exhaustive-deps -- phaseLabel is read but not needed as dep; only restart transitions matter
+
   // Stall detection — auto-open console drawer on fatal error or 15s no-phase-progress
   const stallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasAutoOpenedConsoleRef = useRef(false);
@@ -370,6 +385,7 @@ export function DevPreviewPane({
     }
 
     if (status === "starting" || status === "installing") {
+      hasAutoOpenedConsoleRef.current = false;
       if (stallTimerRef.current) {
         clearTimeout(stallTimerRef.current);
       }

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -10,7 +10,6 @@ import {
   OctagonAlert,
   Play,
 } from "lucide-react";
-import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import {
@@ -37,6 +36,7 @@ import {
 import { useDevServer, type UseDevServerReturn } from "@/hooks/useDevServer";
 import { ConsoleDrawer } from "./ConsoleDrawer";
 import { useDevPreviewConsoleCapture } from "./useDevPreviewConsoleCapture";
+import { DevPreviewLoadingState } from "./DevPreviewLoadingState";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -250,6 +250,7 @@ export function DevPreviewPane({
     url,
     terminalId,
     error,
+    phaseLabel,
     start,
     stop,
     restart,
@@ -321,6 +322,73 @@ export function DevPreviewPane({
 
   const isMountedRef = useRef(true);
   const prevStatusRef = useRef(status);
+
+  // Phase label debounce (600ms) — prevents three-label slot machine on warm-cache boots
+  const lastPhaseChangeAtRef = useRef<number>(0);
+  const phaseDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [debouncedPhaseLabel, setDebouncedPhaseLabel] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (phaseLabel === null) {
+      setDebouncedPhaseLabel(null);
+      return;
+    }
+    lastPhaseChangeAtRef.current = Date.now();
+    phaseDebounceTimerRef.current = setTimeout(() => {
+      if (Date.now() - lastPhaseChangeAtRef.current >= 600) {
+        setDebouncedPhaseLabel(phaseLabel);
+      }
+    }, 600);
+    return () => {
+      if (phaseDebounceTimerRef.current) {
+        clearTimeout(phaseDebounceTimerRef.current);
+        phaseDebounceTimerRef.current = null;
+      }
+    };
+  }, [phaseLabel]);
+
+  // Stall detection — auto-open console drawer on fatal error or 15s no-phase-progress
+  const stallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasAutoOpenedConsoleRef = useRef(false);
+
+  useEffect(() => {
+    if (status === "error" && error) {
+      if (!hasAutoOpenedConsoleRef.current && !isConsoleOpen) {
+        hasAutoOpenedConsoleRef.current = true;
+        setDevPreviewConsoleOpen(id, true);
+      }
+      return;
+    }
+
+    if (status === "running" || status === "stopped") {
+      hasAutoOpenedConsoleRef.current = false;
+      if (stallTimerRef.current) {
+        clearTimeout(stallTimerRef.current);
+        stallTimerRef.current = null;
+      }
+      return;
+    }
+
+    if (status === "starting" || status === "installing") {
+      if (stallTimerRef.current) {
+        clearTimeout(stallTimerRef.current);
+      }
+      stallTimerRef.current = setTimeout(() => {
+        if (!hasAutoOpenedConsoleRef.current && !isConsoleOpen) {
+          hasAutoOpenedConsoleRef.current = true;
+          setDevPreviewConsoleOpen(id, true);
+        }
+      }, 15000);
+    }
+
+    return () => {
+      if (stallTimerRef.current) {
+        clearTimeout(stallTimerRef.current);
+        stallTimerRef.current = null;
+      }
+    };
+  }, [status, phaseLabel, error, id, isConsoleOpen, setDevPreviewConsoleOpen]);
+
   const loadTimeoutMs =
     Math.min(Math.max(projectSettings?.devServerLoadTimeout ?? 30, 1), 120) * 1000;
 
@@ -1103,13 +1171,11 @@ export function DevPreviewPane({
             </div>
           )}
           {isRestarting || status === "starting" || status === "installing" ? (
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg">
-              <Spinner size="2xl" className="text-status-info mb-4" />
-              <p className="text-sm text-daintree-text/60">
-                {isRestarting ? "Restarting" : status === "installing" ? "Installing" : "Starting"}
-                ...
-              </p>
-            </div>
+            <DevPreviewLoadingState
+              variant="full"
+              isPending={true}
+              phaseLabel={debouncedPhaseLabel}
+            />
           ) : status === "error" && error ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
               <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
@@ -1456,24 +1522,23 @@ export function DevPreviewPane({
                     onDispatch={dispatchBlockedNav}
                   />
                   {isLoading && (
-                    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
-                      <Spinner size="2xl" className="text-status-info" />
-                      {isSlowLoad && (
-                        <>
-                          <p className="text-xs text-daintree-text/50">
-                            Taking longer than usual...
-                          </p>
-                          <Button
-                            onClick={handleCancelLoad}
-                            variant="ghost"
-                            size="sm"
-                            className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
-                          >
-                            <Square className="h-3.5 w-3.5" />
-                            <span className="text-xs">Cancel</span>
-                          </Button>
-                        </>
-                      )}
+                    <DevPreviewLoadingState
+                      variant="overlay"
+                      isPending={true}
+                      phaseLabel={isSlowLoad ? "Taking longer than usual..." : "Loading preview"}
+                    />
+                  )}
+                  {isLoading && isSlowLoad && (
+                    <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-20">
+                      <Button
+                        onClick={handleCancelLoad}
+                        variant="ghost"
+                        size="sm"
+                        className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+                      >
+                        <Square className="h-3.5 w-3.5" />
+                        <span className="text-xs">Cancel</span>
+                      </Button>
                     </div>
                   )}
                   {showRecoverySpinner && !webviewLoadError && (

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -1107,7 +1107,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
   });
 
   describe("slow-load and timeout escalation", () => {
-    it("shows slow-load message and Cancel after 5s of loading", () => {
+    it("shows phase label and Still working hint after loading threshold", () => {
       const { container } = render(<DevPreviewPane {...baseProps} />);
       const webview = getWebviewElement(container);
 
@@ -1116,17 +1116,22 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         emitWebviewEvent(webview, "did-start-loading");
       });
 
-      expect(container.textContent).not.toContain("Taking longer than usual");
+      expect(container.textContent).not.toContain("Loading preview");
 
       act(() => {
-        vi.advanceTimersByTime(5000);
+        vi.advanceTimersByTime(500);
       });
 
-      expect(container.textContent).toContain("Taking longer than usual");
-      expect(container.textContent).toContain("Cancel");
+      expect(container.textContent).toContain("Loading preview");
+
+      act(() => {
+        vi.advanceTimersByTime(6000);
+      });
+
+      expect(container.textContent).toContain("Still working");
     });
 
-    it("Cancel stops the webview and shows cancelled error", () => {
+    it("Cancel appears after action threshold and stops the webview", () => {
       const { container } = render(<DevPreviewPane {...baseProps} />);
       const webview = getWebviewElement(container);
 
@@ -1136,7 +1141,11 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       });
 
       act(() => {
-        vi.advanceTimersByTime(5000);
+        vi.advanceTimersByTime(500);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(16000);
       });
 
       const cancelButton = Array.from(container.querySelectorAll("button")).find((b) =>

--- a/src/hooks/__tests__/useDevServer.adversarial.test.tsx
+++ b/src/hooks/__tests__/useDevServer.adversarial.test.tsx
@@ -42,7 +42,7 @@ function buildState(overrides: Partial<DevPreviewSessionState>): DevPreviewSessi
     isRestarting: overrides.isRestarting ?? false,
     generation: overrides.generation ?? 0,
     updatedAt: overrides.updatedAt ?? Date.now(),
-    phaseLabel: overrides.phaseLabel ?? null,
+    phaseLabel: overrides.phaseLabel ?? undefined,
   };
 }
 

--- a/src/hooks/__tests__/useDevServer.adversarial.test.tsx
+++ b/src/hooks/__tests__/useDevServer.adversarial.test.tsx
@@ -42,6 +42,7 @@ function buildState(overrides: Partial<DevPreviewSessionState>): DevPreviewSessi
     isRestarting: overrides.isRestarting ?? false,
     generation: overrides.generation ?? 0,
     updatedAt: overrides.updatedAt ?? Date.now(),
+    phaseLabel: overrides.phaseLabel ?? null,
   };
 }
 

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -27,7 +27,7 @@ export interface UseDevServerState {
   url: string | null;
   terminalId: string | null;
   error: DevServerError | null;
-  phaseLabel: string | null;
+  phaseLabel?: "Compiling";
 }
 
 export interface UseDevServerReturn extends UseDevServerState {
@@ -109,7 +109,7 @@ export function useDevServer({
   const [url, setUrl] = useState<string | null>(null);
   const [terminalId, setTerminalId] = useState<string | null>(null);
   const [error, setError] = useState<DevServerError | null>(null);
-  const [phaseLabel, setPhaseLabel] = useState<string | null>(null);
+  const [phaseLabel, setPhaseLabel] = useState<"Compiling" | undefined>(undefined);
   const [isRestarting, setIsRestarting] = useState(false);
   const [stuckTier, setStuckTier] = useState<DevServerStuckTier>(0);
   const [forceKilled, setForceKilled] = useState<boolean | undefined>(undefined);
@@ -182,9 +182,9 @@ export function useDevServer({
     setUrl(state.url);
     setTerminalId(state.terminalId);
     setError(state.error ?? null);
+    setPhaseLabel(state.phaseLabel);
     setIsRestarting(state.isRestarting);
     setForceKilled(state.forceKilled);
-    setPhaseLabel(state.phaseLabel);
   }, []);
 
   const applyInvokeError = useCallback((err: unknown) => {
@@ -202,7 +202,6 @@ export function useDevServer({
     setError({ type: "unknown", message });
     setTerminalId(null);
     setIsRestarting(false);
-    setPhaseLabel(null);
   }, []);
 
   const ensureLatestConfig = useCallback(
@@ -357,7 +356,6 @@ export function useDevServer({
       setTerminalId(null);
       setError(null);
       setIsRestarting(false);
-      setPhaseLabel(null);
       lastEnsureConfigRef.current = "";
       pendingEnsureConfigRef.current = null;
       persistedEnsureCache.delete(panelId);

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -27,6 +27,7 @@ export interface UseDevServerState {
   url: string | null;
   terminalId: string | null;
   error: DevServerError | null;
+  phaseLabel: string | null;
 }
 
 export interface UseDevServerReturn extends UseDevServerState {
@@ -108,6 +109,7 @@ export function useDevServer({
   const [url, setUrl] = useState<string | null>(null);
   const [terminalId, setTerminalId] = useState<string | null>(null);
   const [error, setError] = useState<DevServerError | null>(null);
+  const [phaseLabel, setPhaseLabel] = useState<string | null>(null);
   const [isRestarting, setIsRestarting] = useState(false);
   const [stuckTier, setStuckTier] = useState<DevServerStuckTier>(0);
   const [forceKilled, setForceKilled] = useState<boolean | undefined>(undefined);
@@ -182,6 +184,7 @@ export function useDevServer({
     setError(state.error ?? null);
     setIsRestarting(state.isRestarting);
     setForceKilled(state.forceKilled);
+    setPhaseLabel(state.phaseLabel);
   }, []);
 
   const applyInvokeError = useCallback((err: unknown) => {
@@ -199,6 +202,7 @@ export function useDevServer({
     setError({ type: "unknown", message });
     setTerminalId(null);
     setIsRestarting(false);
+    setPhaseLabel(null);
   }, []);
 
   const ensureLatestConfig = useCallback(
@@ -353,6 +357,7 @@ export function useDevServer({
       setTerminalId(null);
       setError(null);
       setIsRestarting(false);
+      setPhaseLabel(null);
       lastEnsureConfigRef.current = "";
       pendingEnsureConfigRef.current = null;
       persistedEnsureCache.delete(panelId);
@@ -498,6 +503,7 @@ export function useDevServer({
     url,
     terminalId,
     error,
+    phaseLabel,
     start,
     stop,
     restart,


### PR DESCRIPTION
## Summary
- Replaces the bare accent-colored spinners in the dev preview panel with a phased skeleton component gated behind the 400ms Doherty threshold. Fast reloads never flash a spinner; slow cold starts get a meaningful phase label instead of a wordless pulse.
- A new `DevPreviewLoadingState` component wraps skeleton bones and overlays the current phase label: starting dev server, installing dependencies, compiling, or loading preview. The "Compiling" label arrives from the backend with a 600ms debounce to avoid flicker on warm-cache builds.
- The console drawer auto-opens on fatal errors or when 15 seconds go by without a recognized phase, so the user can inspect the terminal output without hunting for the toggle.

Resolves #8264

## Changes
- **New:** `DevPreviewLoadingState` component (`src/components/DevPreview/DevPreviewLoadingState.tsx`) -- `full` variant replaces the old spinner during spawn/install/restart; `overlay` variant handles webview first-paint loading with an optional cancel button wired through `SkeletonHint`.
- **New:** `phaseLabel` property on `DevPreviewSessionState` and `UseDevServerState`, typed as `"Compiling" | undefined`. The backend is the sole source for "Compiling"; all other labels ("Starting dev server", "Installing dependencies", "Loading preview") are derived from status in the UI.
- **Backend:** 600ms debounced `compiling` phase detection in `DevPreviewSessionService.handleData`. A ready-marker without a pending URL (post-install, pre-URL-detection) triggers the timer; `clearCompiling()` resets it on status transitions.
- **Console auto-open:** Fatal error toggles the drawer immediately; a 15-second stall timer opens it when no phase progress is detected.
- **Accent removal:** Both old spinner sites (`text-status-info`) are gone. The phase label uses neutral `text-daintree-text/60`.

## Testing
- Manually tested cold `npm install`, warm-cache restart, fast recompile, and slow framework builds. The loading state appears only after 400ms, phase labels debounce correctly, and the console drawer opens on errors and stalls. Existing `DevPreviewPane.webview.test.tsx` tests pass.