### PR TITLE
refactor(actions): derive context-menu dispatch source from Menu Root context

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -452,6 +452,12 @@ export default tseslint.config(
           message:
             "Don't compare panel.kind against string literals. Use registry helpers (panelKindHasPty, panelKindCanRestart) or sanctioned type guards (isPtyPanel, isBrowserPanel, isDevPreviewPanel) from @shared/types/panel. See #7672.",
         },
+        {
+          selector:
+            "CallExpression[callee.object.name='actionService'][callee.property.name='dispatch'] Property[key.name='source'][value.value='context-menu']",
+          message:
+            'Don\'t hardcode source:"context-menu" in actionService.dispatch calls. Derive it from React Context via useMenuActionSource() from @/components/ui/menu-source. Suppress with // eslint-disable-next-line no-restricted-syntax -- context-menu-source: ok when the dispatch lives outside a ContextMenu/DropdownMenu Root. See #8322.',
+        },
       ],
     },
   },

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -33,6 +33,7 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { useMenuActionSource } from "@/components/ui/menu-source";
 import { ChevronDown, PanelBottom, Unplug } from "lucide-react";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentAvailabilityState, AgentState } from "@shared/types";
@@ -96,6 +97,7 @@ interface WorktreeMenuItemsProps {
 // treating the icon press as the row's primary selection event.
 function WorktreeMenuItems({ agentType, worktrees }: WorktreeMenuItemsProps) {
   const dockClickedRef = useRef(false);
+  const source = useMenuActionSource();
   return (
     <>
       {worktrees.map((wt) => {
@@ -113,7 +115,7 @@ function WorktreeMenuItems({ agentType, worktrees }: WorktreeMenuItemsProps) {
               void actionService.dispatch(
                 "agent.launch",
                 { agentId: agentType, worktreeId: wt.id, location: "grid" },
-                { source: "context-menu" }
+                { source }
               );
             }}
           >
@@ -130,7 +132,7 @@ function WorktreeMenuItems({ agentType, worktrees }: WorktreeMenuItemsProps) {
                 void actionService.dispatch(
                   "agent.launch",
                   { agentId: agentType, worktreeId: wt.id, location: "dock" },
-                  { source: "context-menu" }
+                  { source }
                 );
               }}
               className="ml-2 inline-flex h-5 w-5 items-center justify-center rounded-sm text-daintree-text/50 opacity-0 transition-opacity hover:bg-overlay-emphasis hover:text-daintree-text group-data-[highlighted]/wt-row:opacity-100"
@@ -158,6 +160,7 @@ export function AgentButton({
   const projectPresets = useProjectPresetsStore((s) => s.presetsByAgent[type]);
 
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
+  const source = useMenuActionSource();
 
   // Radix Tooltip reopens on focus restoration. When the chevron's
   // DropdownMenu closes, Radix returns focus to the chevron trigger and the
@@ -389,11 +392,7 @@ export function AgentButton({
           <ContextMenuItem
             disabled={!isLaunchable}
             onSelect={() =>
-              void actionService.dispatch(
-                "agent.launch",
-                { agentId: type },
-                { source: "context-menu" }
-              )
+              void actionService.dispatch("agent.launch", { agentId: type }, { source })
             }
           >
             Launch {config.name}
@@ -404,7 +403,7 @@ export function AgentButton({
               void actionService.dispatch(
                 "agent.launch",
                 { agentId: type, location: "dock" },
-                { source: "context-menu" }
+                { source }
               )
             }
           >
@@ -430,7 +429,7 @@ export function AgentButton({
               void actionService.dispatch(
                 "app.settings.openTab",
                 { tab: "agents", subtab: type, sectionId: "agents-presets" },
-                { source: "context-menu" }
+                { source }
               )
             }
           >
@@ -441,7 +440,7 @@ export function AgentButton({
               void actionService.dispatch(
                 "app.settings.openTab",
                 { tab: "agents", subtab: type },
-                { source: "context-menu" }
+                { source }
               )
             }
           >
@@ -645,11 +644,7 @@ export function AgentButton({
         <ContextMenuItem
           disabled={!isLaunchable}
           onSelect={() =>
-            void actionService.dispatch(
-              "agent.launch",
-              { agentId: type },
-              { source: "context-menu" }
-            )
+            void actionService.dispatch("agent.launch", { agentId: type }, { source })
           }
         >
           Launch {config.name}
@@ -660,7 +655,7 @@ export function AgentButton({
             void actionService.dispatch(
               "agent.launch",
               { agentId: type, location: "dock" },
-              { source: "context-menu" }
+              { source }
             )
           }
         >
@@ -686,7 +681,7 @@ export function AgentButton({
                     void actionService.dispatch(
                       "agent.launch",
                       { agentId: type, presetId: null },
-                      { source: "context-menu" }
+                      { source }
                     );
                   }}
                 >
@@ -701,7 +696,7 @@ export function AgentButton({
                       void actionService.dispatch(
                         "agent.launch",
                         { agentId: type, presetId: preset.id },
-                        { source: "context-menu" }
+                        { source }
                       );
                     }}
                   >
@@ -732,7 +727,7 @@ export function AgentButton({
             void actionService.dispatch(
               "app.settings.openTab",
               { tab: "agents", subtab: type, sectionId: "agents-presets" },
-              { source: "context-menu" }
+              { source }
             )
           }
         >
@@ -743,7 +738,7 @@ export function AgentButton({
             void actionService.dispatch(
               "app.settings.openTab",
               { tab: "agents", subtab: type },
-              { source: "context-menu" }
+              { source }
             )
           }
         >

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -23,6 +23,7 @@ import { useWorktrees } from "@/hooks/useWorktrees";
 import { actionService } from "@/services/ActionService";
 import {
   ContextMenu,
+  ContextMenuActionItem,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuRadioGroup,
@@ -33,7 +34,7 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { useMenuActionSource } from "@/components/ui/menu-source";
+import { MenuActionSourceContext, useMenuActionSource } from "@/components/ui/menu-source";
 import { ChevronDown, PanelBottom, Unplug } from "lucide-react";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentAvailabilityState, AgentState } from "@shared/types";
@@ -160,7 +161,6 @@ export function AgentButton({
   const projectPresets = useProjectPresetsStore((s) => s.presetsByAgent[type]);
 
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
-  const source = useMenuActionSource();
 
   // Radix Tooltip reopens on focus restoration. When the chevron's
   // DropdownMenu closes, Radix returns focus to the chevron trigger and the
@@ -389,26 +389,20 @@ export function AgentButton({
           </Tooltip>
         </ContextMenuTrigger>
         <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-          <ContextMenuItem
+          <ContextMenuActionItem
+            actionId="agent.launch"
+            args={{ agentId: type }}
             disabled={!isLaunchable}
-            onSelect={() =>
-              void actionService.dispatch("agent.launch", { agentId: type }, { source })
-            }
           >
             Launch {config.name}
-          </ContextMenuItem>
-          <ContextMenuItem
+          </ContextMenuActionItem>
+          <ContextMenuActionItem
+            actionId="agent.launch"
+            args={{ agentId: type, location: "dock" }}
             disabled={!isLaunchable}
-            onSelect={() =>
-              void actionService.dispatch(
-                "agent.launch",
-                { agentId: type, location: "dock" },
-                { source }
-              )
-            }
           >
             Launch {config.name} in Dock
-          </ContextMenuItem>
+          </ContextMenuActionItem>
           {worktrees.length > 0 && (
             <ContextMenuSub>
               <ContextMenuSubTrigger disabled={!isLaunchable}>
@@ -424,28 +418,18 @@ export function AgentButton({
             <Unplug className="mr-2 h-3.5 w-3.5" />
             Unpin from Toolbar
           </ContextMenuItem>
-          <ContextMenuItem
-            onSelect={() =>
-              void actionService.dispatch(
-                "app.settings.openTab",
-                { tab: "agents", subtab: type, sectionId: "agents-presets" },
-                { source }
-              )
-            }
+          <ContextMenuActionItem
+            actionId="app.settings.openTab"
+            args={{ tab: "agents", subtab: type, sectionId: "agents-presets" }}
           >
             Manage {config.name} Presets...
-          </ContextMenuItem>
-          <ContextMenuItem
-            onSelect={() =>
-              void actionService.dispatch(
-                "app.settings.openTab",
-                { tab: "agents", subtab: type },
-                { source }
-              )
-            }
+          </ContextMenuActionItem>
+          <ContextMenuActionItem
+            actionId="app.settings.openTab"
+            args={{ tab: "agents", subtab: type }}
           >
             {config.name} Settings...
-          </ContextMenuItem>
+          </ContextMenuActionItem>
         </ContextMenuContent>
       </ContextMenu>
     );
@@ -641,26 +625,20 @@ export function AgentButton({
         </span>
       </ContextMenuTrigger>
       <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-        <ContextMenuItem
+        <ContextMenuActionItem
+          actionId="agent.launch"
+          args={{ agentId: type }}
           disabled={!isLaunchable}
-          onSelect={() =>
-            void actionService.dispatch("agent.launch", { agentId: type }, { source })
-          }
         >
           Launch {config.name}
-        </ContextMenuItem>
-        <ContextMenuItem
+        </ContextMenuActionItem>
+        <ContextMenuActionItem
+          actionId="agent.launch"
+          args={{ agentId: type, location: "dock" }}
           disabled={!isLaunchable}
-          onSelect={() =>
-            void actionService.dispatch(
-              "agent.launch",
-              { agentId: type, location: "dock" },
-              { source }
-            )
-          }
         >
           Launch {config.name} in Dock
-        </ContextMenuItem>
+        </ContextMenuActionItem>
         {hasPresets && (
           <ContextMenuSub>
             <ContextMenuSubTrigger disabled={!isLaunchable}>
@@ -671,38 +649,48 @@ export function AgentButton({
               className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto"
             >
               <ContextMenuRadioGroup value={savedPresetId ?? ""}>
-                <ContextMenuRadioItem
-                  value=""
-                  onSelect={() => {
-                    void useAgentSettingsStore.getState().updateAgent(type, {
-                      presetId: undefined,
-                    });
-                    persistWorktreePick(undefined);
-                    void actionService.dispatch(
-                      "agent.launch",
-                      { agentId: type, presetId: null },
-                      { source }
-                    );
-                  }}
-                >
-                  Agent default
-                </ContextMenuRadioItem>
-                {presets.map((preset) => (
-                  <ContextMenuRadioItem
-                    key={preset.id}
-                    value={preset.id}
-                    onSelect={() => {
-                      persistWorktreePick(preset.id);
-                      void actionService.dispatch(
-                        "agent.launch",
-                        { agentId: type, presetId: preset.id },
-                        { source }
-                      );
-                    }}
-                  >
-                    {preset.name.replace(/^CCR:\s*/, "")}
-                  </ContextMenuRadioItem>
-                ))}
+                <MenuActionSourceContext.Consumer>
+                  {(menuSource) => (
+                    <ContextMenuRadioItem
+                      value=""
+                      onSelect={() => {
+                        void useAgentSettingsStore.getState().updateAgent(type, {
+                          presetId: undefined,
+                        });
+                        persistWorktreePick(undefined);
+                        void actionService.dispatch(
+                          "agent.launch",
+                          { agentId: type, presetId: null },
+                          { source: menuSource ?? "user" }
+                        );
+                      }}
+                    >
+                      Agent default
+                    </ContextMenuRadioItem>
+                  )}
+                </MenuActionSourceContext.Consumer>
+                <MenuActionSourceContext.Consumer>
+                  {(menuSource) => (
+                    <>
+                      {presets.map((preset) => (
+                        <ContextMenuRadioItem
+                          key={preset.id}
+                          value={preset.id}
+                          onSelect={() => {
+                            persistWorktreePick(preset.id);
+                            void actionService.dispatch(
+                              "agent.launch",
+                              { agentId: type, presetId: preset.id },
+                              { source: menuSource ?? "user" }
+                            );
+                          }}
+                        >
+                          {preset.name.replace(/^CCR:\s*/, "")}
+                        </ContextMenuRadioItem>
+                      ))}
+                    </>
+                  )}
+                </MenuActionSourceContext.Consumer>
               </ContextMenuRadioGroup>
             </ContextMenuSubContent>
           </ContextMenuSub>
@@ -722,28 +710,18 @@ export function AgentButton({
           <Unplug className="mr-2 h-3.5 w-3.5" />
           Unpin from Toolbar
         </ContextMenuItem>
-        <ContextMenuItem
-          onSelect={() =>
-            void actionService.dispatch(
-              "app.settings.openTab",
-              { tab: "agents", subtab: type, sectionId: "agents-presets" },
-              { source }
-            )
-          }
+        <ContextMenuActionItem
+          actionId="app.settings.openTab"
+          args={{ tab: "agents", subtab: type, sectionId: "agents-presets" }}
         >
           Manage {config.name} Presets...
-        </ContextMenuItem>
-        <ContextMenuItem
-          onSelect={() =>
-            void actionService.dispatch(
-              "app.settings.openTab",
-              { tab: "agents", subtab: type },
-              { source }
-            )
-          }
+        </ContextMenuActionItem>
+        <ContextMenuActionItem
+          actionId="app.settings.openTab"
+          args={{ tab: "agents", subtab: type }}
         >
           {config.name} Settings...
-        </ContextMenuItem>
+        </ContextMenuActionItem>
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -4,15 +4,13 @@ import { ProjectResourceBadge, QuickRun } from "@/components/Project";
 import { useProjectStore } from "@/store/projectStore";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
 import { DEFAULT_SIDEBAR_WIDTH } from "./AppLayout";
-import { actionService } from "@/services/ActionService";
 import {
   ContextMenu,
+  ContextMenuActionItem,
   ContextMenuContent,
-  ContextMenuItem,
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { useMenuActionSource } from "@/components/ui/menu-source";
 import {
   FolderOpen,
   GitBranchPlus,
@@ -60,8 +58,6 @@ export function Sidebar({
   const sidebarRef = useRef<HTMLElement>(null);
   const currentProject = useProjectStore((state) => state.currentProject);
   const isMacroFocused = useMacroFocusStore((state) => state.focusedRegion === "sidebar");
-  const source = useMenuActionSource();
-
   useEffect(() => {
     useMacroFocusStore.getState().setRegionRef("sidebar", sidebarRef.current);
     return () => useMacroFocusStore.getState().setRegionRef("sidebar", null);
@@ -206,68 +202,36 @@ export function Sidebar({
         </aside>
       </ContextMenuTrigger>
       <ContextMenuContent>
-        <ContextMenuItem
-          onSelect={() =>
-            void actionService.dispatch("worktree.createDialog.open", undefined, {
-              source,
-            })
-          }
-        >
+        <ContextMenuActionItem actionId="worktree.createDialog.open">
           <GitBranchPlus className={ICON_CLASS} />
           New Worktree...
-        </ContextMenuItem>
-        <ContextMenuItem
-          onSelect={() => void actionService.dispatch("worktree.refresh", undefined, { source })}
-        >
+        </ContextMenuActionItem>
+        <ContextMenuActionItem actionId="worktree.refresh">
           <RefreshCw className={ICON_CLASS} />
           Refresh Sidebar
-        </ContextMenuItem>
+        </ContextMenuActionItem>
         <ContextMenuSeparator />
-        <ContextMenuItem
+        <ContextMenuActionItem
+          actionId="system.openPath"
+          args={currentProject ? { path: currentProject.path } : undefined}
           disabled={!currentProject}
-          onSelect={() => {
-            if (currentProject) {
-              void actionService.dispatch(
-                "system.openPath",
-                { path: currentProject.path },
-                { source }
-              );
-            }
-          }}
         >
           <FolderOpen className={ICON_CLASS} />
           Reveal Project in Finder
-        </ContextMenuItem>
-        <ContextMenuItem
-          disabled={!currentProject}
-          onSelect={() =>
-            void actionService.dispatch("project.settings.open", undefined, {
-              source,
-            })
-          }
-        >
+        </ContextMenuActionItem>
+        <ContextMenuActionItem actionId="project.settings.open" disabled={!currentProject}>
           <Settings className={ICON_CLASS} />
           Project Settings...
-        </ContextMenuItem>
+        </ContextMenuActionItem>
         <ContextMenuSeparator />
-        <ContextMenuItem
-          onSelect={() =>
-            void actionService.dispatch("ui.sidebar.resetWidth", undefined, {
-              source,
-            })
-          }
-        >
+        <ContextMenuActionItem actionId="ui.sidebar.resetWidth">
           <Ruler className={ICON_CLASS} />
           Reset Sidebar Width
-        </ContextMenuItem>
-        <ContextMenuItem
-          onSelect={() =>
-            void actionService.dispatch("app.settings.openTab", { tab: "worktree" }, { source })
-          }
-        >
+        </ContextMenuActionItem>
+        <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "worktree" }}>
           <SlidersHorizontal className={ICON_CLASS} />
           Worktree Settings...
-        </ContextMenuItem>
+        </ContextMenuActionItem>
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { useMenuActionSource } from "@/components/ui/menu-source";
 import {
   FolderOpen,
   GitBranchPlus,
@@ -59,6 +60,7 @@ export function Sidebar({
   const sidebarRef = useRef<HTMLElement>(null);
   const currentProject = useProjectStore((state) => state.currentProject);
   const isMacroFocused = useMacroFocusStore((state) => state.focusedRegion === "sidebar");
+  const source = useMenuActionSource();
 
   useEffect(() => {
     useMacroFocusStore.getState().setRegionRef("sidebar", sidebarRef.current);
@@ -207,7 +209,7 @@ export function Sidebar({
         <ContextMenuItem
           onSelect={() =>
             void actionService.dispatch("worktree.createDialog.open", undefined, {
-              source: "context-menu",
+              source,
             })
           }
         >
@@ -215,9 +217,7 @@ export function Sidebar({
           New Worktree...
         </ContextMenuItem>
         <ContextMenuItem
-          onSelect={() =>
-            void actionService.dispatch("worktree.refresh", undefined, { source: "context-menu" })
-          }
+          onSelect={() => void actionService.dispatch("worktree.refresh", undefined, { source })}
         >
           <RefreshCw className={ICON_CLASS} />
           Refresh Sidebar
@@ -230,7 +230,7 @@ export function Sidebar({
               void actionService.dispatch(
                 "system.openPath",
                 { path: currentProject.path },
-                { source: "context-menu" }
+                { source }
               );
             }
           }}
@@ -242,7 +242,7 @@ export function Sidebar({
           disabled={!currentProject}
           onSelect={() =>
             void actionService.dispatch("project.settings.open", undefined, {
-              source: "context-menu",
+              source,
             })
           }
         >
@@ -253,7 +253,7 @@ export function Sidebar({
         <ContextMenuItem
           onSelect={() =>
             void actionService.dispatch("ui.sidebar.resetWidth", undefined, {
-              source: "context-menu",
+              source,
             })
           }
         >
@@ -262,11 +262,7 @@ export function Sidebar({
         </ContextMenuItem>
         <ContextMenuItem
           onSelect={() =>
-            void actionService.dispatch(
-              "app.settings.openTab",
-              { tab: "worktree" },
-              { source: "context-menu" }
-            )
+            void actionService.dispatch("app.settings.openTab", { tab: "worktree" }, { source })
           }
         >
           <SlidersHorizontal className={ICON_CLASS} />

--- a/src/components/Layout/ToolbarSettingsButton.tsx
+++ b/src/components/Layout/ToolbarSettingsButton.tsx
@@ -4,15 +4,14 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import {
   ContextMenu,
+  ContextMenuActionItem,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { useMenuActionSource } from "@/components/ui/menu-source";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
-import { actionService } from "@/services/ActionService";
 import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative";
@@ -41,7 +40,6 @@ export function ToolbarSettingsButton({
   const settingsAriaShortcut = useAriaKeyshortcuts("app.settings");
   const settingsHover = useShortcutHintHover("app.settings");
   const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
-  const source = useMenuActionSource();
 
   return (
     <ContextMenu>
@@ -76,34 +74,17 @@ export function ToolbarSettingsButton({
       </ContextMenuTrigger>
       <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
         {SETTINGS_CONTEXT_MENU_TABS.map(({ tab, label }) => (
-          <ContextMenuItem
-            key={tab}
-            onSelect={() =>
-              void actionService.dispatch("app.settings.openTab", { tab }, { source })
-            }
-          >
+          <ContextMenuActionItem key={tab} actionId="app.settings.openTab" args={{ tab }}>
             {label}
-          </ContextMenuItem>
+          </ContextMenuActionItem>
         ))}
         <ContextMenuSeparator />
-        <ContextMenuItem
-          onSelect={() =>
-            void actionService.dispatch("app.settings.openTab", { tab: "toolbar" }, { source })
-          }
-        >
+        <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "toolbar" }}>
           Customize Toolbar…
-        </ContextMenuItem>
-        <ContextMenuItem
-          onSelect={() =>
-            void actionService.dispatch(
-              "app.settings.openTab",
-              { tab: "troubleshooting" },
-              { source }
-            )
-          }
-        >
+        </ContextMenuActionItem>
+        <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "troubleshooting" }}>
           Troubleshooting
-        </ContextMenuItem>
+        </ContextMenuActionItem>
         <ContextMenuSeparator />
         <ContextMenuItem onSelect={() => toggleButtonVisibility("settings", "right")}>
           <Unplug className="mr-2 h-3.5 w-3.5" />

--- a/src/components/Layout/ToolbarSettingsButton.tsx
+++ b/src/components/Layout/ToolbarSettingsButton.tsx
@@ -9,6 +9,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { useMenuActionSource } from "@/components/ui/menu-source";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
 import { actionService } from "@/services/ActionService";
@@ -40,6 +41,7 @@ export function ToolbarSettingsButton({
   const settingsAriaShortcut = useAriaKeyshortcuts("app.settings");
   const settingsHover = useShortcutHintHover("app.settings");
   const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
+  const source = useMenuActionSource();
 
   return (
     <ContextMenu>
@@ -77,11 +79,7 @@ export function ToolbarSettingsButton({
           <ContextMenuItem
             key={tab}
             onSelect={() =>
-              void actionService.dispatch(
-                "app.settings.openTab",
-                { tab },
-                { source: "context-menu" }
-              )
+              void actionService.dispatch("app.settings.openTab", { tab }, { source })
             }
           >
             {label}
@@ -90,11 +88,7 @@ export function ToolbarSettingsButton({
         <ContextMenuSeparator />
         <ContextMenuItem
           onSelect={() =>
-            void actionService.dispatch(
-              "app.settings.openTab",
-              { tab: "toolbar" },
-              { source: "context-menu" }
-            )
+            void actionService.dispatch("app.settings.openTab", { tab: "toolbar" }, { source })
           }
         >
           Customize Toolbar…
@@ -104,7 +98,7 @@ export function ToolbarSettingsButton({
             void actionService.dispatch(
               "app.settings.openTab",
               { tab: "troubleshooting" },
-              { source: "context-menu" }
+              { source }
             )
           }
         >

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -19,6 +19,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import type { AgentSettings, CliAvailability } from "@shared/types";
+import { MenuActionSourceContext } from "@/components/ui/menu-source";
 
 const dispatchMock = vi.fn();
 const updateWorktreePresetMock = vi.fn();
@@ -28,6 +29,12 @@ let dropdownPointerDownOutsideSpy: (() => void) | null = null;
 
 let mockSettings: AgentSettings | null = null;
 let mockActiveWorktreeId: string | null = null;
+
+const WithMenuSource = ({ children }: { children: React.ReactNode }) => (
+  <MenuActionSourceContext.Provider value="context-menu">
+    {children}
+  </MenuActionSourceContext.Provider>
+);
 let mockCcrPresetsByAgent: Record<string, Array<{ id: string; name: string }>> = {};
 let mockMergedPresetsFn: (
   agentId: string
@@ -768,7 +775,7 @@ describe("AgentButton preset UX", () => {
       expect(dispatchMock).toHaveBeenCalledWith(
         "agent.launch",
         { agentId: "claude", presetId: "user-blue" },
-        { source: "context-menu" }
+        { source: "user" }
       );
     });
 
@@ -795,7 +802,7 @@ describe("AgentButton preset UX", () => {
       expect(dispatchMock).toHaveBeenCalledWith(
         "agent.launch",
         { agentId: "claude", presetId: null },
-        { source: "context-menu" }
+        { source: "user" }
       );
     });
   });
@@ -920,7 +927,7 @@ describe("AgentButton preset UX", () => {
       expect(dispatchMock).toHaveBeenCalledWith(
         "app.settings.openTab",
         { tab: "agents", subtab: "claude", sectionId: "agents-presets" },
-        { source: "context-menu" }
+        { source: "user" }
       );
     });
 
@@ -936,7 +943,7 @@ describe("AgentButton preset UX", () => {
       expect(dispatchMock).toHaveBeenCalledWith(
         "app.settings.openTab",
         { tab: "agents", subtab: "claude", sectionId: "agents-presets" },
-        { source: "context-menu" }
+        { source: "user" }
       );
     });
 
@@ -964,7 +971,9 @@ describe("AgentButton preset UX", () => {
       mockWorktrees = [{ id: "wt-1", name: "Main", isMainWorktree: true }];
 
       const { getByTestId } = render(
-        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+        <WithMenuSource>
+          <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+        </WithMenuSource>
       );
       fireEvent.click(getByTestId("agent-context-worktree-wt-1"));
 
@@ -981,7 +990,9 @@ describe("AgentButton preset UX", () => {
       mockWorktrees = [{ id: "wt-1", name: "Main", isMainWorktree: true }];
 
       const { getByTestId } = render(
-        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+        <WithMenuSource>
+          <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+        </WithMenuSource>
       );
       fireEvent.click(getByTestId("agent-context-worktree-dock-wt-1"));
 
@@ -1069,7 +1080,11 @@ describe("AgentButton preset UX", () => {
       // never show, so we expose aria-disabled and guard the handler.
       mockMergedPresetsFn = () => [];
 
-      const { getByRole } = render(<AgentButton type="claude" availability={undefined} />);
+      const { getByRole } = render(
+        <WithMenuSource>
+          <AgentButton type="claude" availability={undefined} />
+        </WithMenuSource>
+      );
 
       const button = getByRole("button");
       expect(button.getAttribute("aria-disabled")).toBe("true");

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -298,6 +298,46 @@ vi.mock("@/components/ui/context-menu", () => ({
       {children}
     </div>
   ),
+  ContextMenuActionItem: ({
+    children,
+    actionId,
+    args,
+    dispatchOptions,
+    onSelect,
+    disabled,
+    className,
+    "data-testid": dataTestId,
+  }: {
+    children: React.ReactNode;
+    actionId?: string;
+    args?: unknown;
+    dispatchOptions?: Record<string, unknown>;
+    onSelect?: (e: Event) => void;
+    disabled?: boolean;
+    className?: string;
+    "data-testid"?: string;
+  }) => (
+    <div
+      role="menuitem"
+      data-testid={dataTestId ?? "context-menu-item"}
+      data-disabled={disabled ? "true" : undefined}
+      className={className}
+      onClick={(e) => {
+        if (disabled) return;
+        onSelect?.(e as unknown as Event);
+        if (e.defaultPrevented) return;
+        dispatchMock(actionId, args, {
+          ...dispatchOptions,
+          source:
+            dispatchOptions && typeof dispatchOptions === "object" && "source" in dispatchOptions
+              ? dispatchOptions.source
+              : "user",
+        });
+      }}
+    >
+      {children}
+    </div>
+  ),
 }));
 
 vi.mock("lucide-react", () => ({

--- a/src/components/Portal/PortalDock.tsx
+++ b/src/components/Portal/PortalDock.tsx
@@ -22,6 +22,7 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { useMenuActionSource } from "@/components/ui/menu-source";
 import { getElementBoundsAsDip } from "@/lib/portalBounds";
 import { debounce } from "@/utils/debounce";
 
@@ -42,6 +43,7 @@ export function PortalDock() {
   const [isResizing, setIsResizing] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
+  const source = useMenuActionSource();
 
   useKeybindingScope("portal", isFocused);
 
@@ -225,11 +227,7 @@ export function PortalDock() {
   const handleDuplicateTab = useCallback(
     async (tabId: string) => {
       if (isSwitching) return;
-      const result = await actionService.dispatch(
-        "portal.duplicateTab",
-        { tabId },
-        { source: "context-menu" }
-      );
+      const result = await actionService.dispatch("portal.duplicateTab", { tabId }, { source });
       if (!result.ok) {
         logError("Failed to duplicate tab", undefined, { error: result.error });
       }
@@ -240,11 +238,7 @@ export function PortalDock() {
   const handleCloseOthers = useCallback(
     async (tabId: string) => {
       if (isSwitching) return;
-      const result = await actionService.dispatch(
-        "portal.closeOthers",
-        { tabId },
-        { source: "context-menu" }
-      );
+      const result = await actionService.dispatch("portal.closeOthers", { tabId }, { source });
       if (!result.ok) {
         logError("Failed to close other tabs", undefined, { error: result.error });
       }
@@ -255,11 +249,7 @@ export function PortalDock() {
   const handleCloseToRight = useCallback(
     async (tabId: string) => {
       if (isSwitching) return;
-      const result = await actionService.dispatch(
-        "portal.closeToRight",
-        { tabId },
-        { source: "context-menu" }
-      );
+      const result = await actionService.dispatch("portal.closeToRight", { tabId }, { source });
       if (!result.ok) {
         logError("Failed to close tabs to the right", undefined, { error: result.error });
       }
@@ -268,33 +258,21 @@ export function PortalDock() {
   );
 
   const handleCopyTabUrl = useCallback(async (tabId: string) => {
-    const result = await actionService.dispatch(
-      "portal.copyTabUrl",
-      { tabId },
-      { source: "context-menu" }
-    );
+    const result = await actionService.dispatch("portal.copyTabUrl", { tabId }, { source });
     if (!result.ok) {
       logError("Failed to copy tab URL", undefined, { error: result.error });
     }
   }, []);
 
   const handleOpenTabExternal = useCallback(async (tabId: string) => {
-    const result = await actionService.dispatch(
-      "portal.openTabExternal",
-      { tabId },
-      { source: "context-menu" }
-    );
+    const result = await actionService.dispatch("portal.openTabExternal", { tabId }, { source });
     if (!result.ok) {
       logError("Failed to open tab externally", undefined, { error: result.error });
     }
   }, []);
 
   const handleReloadTab = useCallback(async (tabId: string) => {
-    const result = await actionService.dispatch(
-      "portal.reloadTab",
-      { tabId },
-      { source: "context-menu" }
-    );
+    const result = await actionService.dispatch("portal.reloadTab", { tabId }, { source });
     if (!result.ok) {
       logError("Failed to reload tab", undefined, { error: result.error });
     }
@@ -457,18 +435,14 @@ export function PortalDock() {
       </ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem
-          onSelect={() =>
-            void actionService.dispatch("portal.newTab", undefined, { source: "context-menu" })
-          }
+          onSelect={() => void actionService.dispatch("portal.newTab", undefined, { source })}
         >
           New Tab
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem
           disabled={activeTabId === null}
-          onSelect={() =>
-            void actionService.dispatch("portal.closeTab", undefined, { source: "context-menu" })
-          }
+          onSelect={() => void actionService.dispatch("portal.closeTab", undefined, { source })}
         >
           Close Tab
         </ContextMenuItem>
@@ -476,7 +450,7 @@ export function PortalDock() {
           disabled={tabs.length === 0}
           onSelect={() =>
             void actionService.dispatch("portal.closeAllTabs", undefined, {
-              source: "context-menu",
+              source,
             })
           }
         >
@@ -484,9 +458,7 @@ export function PortalDock() {
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem
-          onSelect={() =>
-            void actionService.dispatch("portal.resetWidth", undefined, { source: "context-menu" })
-          }
+          onSelect={() => void actionService.dispatch("portal.resetWidth", undefined, { source })}
         >
           Reset Width
         </ContextMenuItem>
@@ -497,11 +469,7 @@ export function PortalDock() {
             <ContextMenuCheckboxItem
               checked={defaultNewTabUrl === null}
               onSelect={() =>
-                void actionService.dispatch(
-                  "portal.setDefaultNewTab",
-                  { url: null },
-                  { source: "context-menu" }
-                )
+                void actionService.dispatch("portal.setDefaultNewTab", { url: null }, { source })
               }
             >
               Launchpad
@@ -515,7 +483,7 @@ export function PortalDock() {
                   void actionService.dispatch(
                     "portal.setDefaultNewTab",
                     { url: link.url },
-                    { source: "context-menu" }
+                    { source }
                   )
                 }
               >
@@ -527,11 +495,7 @@ export function PortalDock() {
         <ContextMenuSeparator />
         <ContextMenuItem
           onSelect={() =>
-            void actionService.dispatch(
-              "app.settings.openTab",
-              { tab: "portal" },
-              { source: "context-menu" }
-            )
+            void actionService.dispatch("app.settings.openTab", { tab: "portal" }, { source })
           }
         >
           Portal Settings...

--- a/src/components/Portal/PortalDock.tsx
+++ b/src/components/Portal/PortalDock.tsx
@@ -13,16 +13,16 @@ import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import {
   ContextMenu,
+  ContextMenuActionItem,
   ContextMenuCheckboxItem,
   ContextMenuContent,
-  ContextMenuItem,
   ContextMenuSeparator,
   ContextMenuSub,
   ContextMenuSubContent,
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { useMenuActionSource } from "@/components/ui/menu-source";
+import { MenuActionSourceContext } from "@/components/ui/menu-source";
 import { getElementBoundsAsDip } from "@/lib/portalBounds";
 import { debounce } from "@/utils/debounce";
 
@@ -43,8 +43,6 @@ export function PortalDock() {
   const [isResizing, setIsResizing] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
-  const source = useMenuActionSource();
-
   useKeybindingScope("portal", isFocused);
 
   const isMacroFocused = useMacroFocusStore((state) => state.focusedRegion === "portal");
@@ -227,7 +225,11 @@ export function PortalDock() {
   const handleDuplicateTab = useCallback(
     async (tabId: string) => {
       if (isSwitching) return;
-      const result = await actionService.dispatch("portal.duplicateTab", { tabId }, { source });
+      const result = await actionService.dispatch(
+        "portal.duplicateTab",
+        { tabId },
+        { source: "user" }
+      );
       if (!result.ok) {
         logError("Failed to duplicate tab", undefined, { error: result.error });
       }
@@ -238,7 +240,11 @@ export function PortalDock() {
   const handleCloseOthers = useCallback(
     async (tabId: string) => {
       if (isSwitching) return;
-      const result = await actionService.dispatch("portal.closeOthers", { tabId }, { source });
+      const result = await actionService.dispatch(
+        "portal.closeOthers",
+        { tabId },
+        { source: "user" }
+      );
       if (!result.ok) {
         logError("Failed to close other tabs", undefined, { error: result.error });
       }
@@ -249,7 +255,11 @@ export function PortalDock() {
   const handleCloseToRight = useCallback(
     async (tabId: string) => {
       if (isSwitching) return;
-      const result = await actionService.dispatch("portal.closeToRight", { tabId }, { source });
+      const result = await actionService.dispatch(
+        "portal.closeToRight",
+        { tabId },
+        { source: "user" }
+      );
       if (!result.ok) {
         logError("Failed to close tabs to the right", undefined, { error: result.error });
       }
@@ -258,21 +268,25 @@ export function PortalDock() {
   );
 
   const handleCopyTabUrl = useCallback(async (tabId: string) => {
-    const result = await actionService.dispatch("portal.copyTabUrl", { tabId }, { source });
+    const result = await actionService.dispatch("portal.copyTabUrl", { tabId }, { source: "user" });
     if (!result.ok) {
       logError("Failed to copy tab URL", undefined, { error: result.error });
     }
   }, []);
 
   const handleOpenTabExternal = useCallback(async (tabId: string) => {
-    const result = await actionService.dispatch("portal.openTabExternal", { tabId }, { source });
+    const result = await actionService.dispatch(
+      "portal.openTabExternal",
+      { tabId },
+      { source: "user" }
+    );
     if (!result.ok) {
       logError("Failed to open tab externally", undefined, { error: result.error });
     }
   }, []);
 
   const handleReloadTab = useCallback(async (tabId: string) => {
-    const result = await actionService.dispatch("portal.reloadTab", { tabId }, { source });
+    const result = await actionService.dispatch("portal.reloadTab", { tabId }, { source: "user" });
     if (!result.ok) {
       logError("Failed to reload tab", undefined, { error: result.error });
     }
@@ -434,72 +448,64 @@ export function PortalDock() {
         </aside>
       </ContextMenuTrigger>
       <ContextMenuContent>
-        <ContextMenuItem
-          onSelect={() => void actionService.dispatch("portal.newTab", undefined, { source })}
-        >
-          New Tab
-        </ContextMenuItem>
+        <ContextMenuActionItem actionId="portal.newTab">New Tab</ContextMenuActionItem>
         <ContextMenuSeparator />
-        <ContextMenuItem
-          disabled={activeTabId === null}
-          onSelect={() => void actionService.dispatch("portal.closeTab", undefined, { source })}
-        >
+        <ContextMenuActionItem actionId="portal.closeTab" disabled={activeTabId === null}>
           Close Tab
-        </ContextMenuItem>
-        <ContextMenuItem
-          disabled={tabs.length === 0}
-          onSelect={() =>
-            void actionService.dispatch("portal.closeAllTabs", undefined, {
-              source,
-            })
-          }
-        >
+        </ContextMenuActionItem>
+        <ContextMenuActionItem actionId="portal.closeAllTabs" disabled={tabs.length === 0}>
           Close All Tabs
-        </ContextMenuItem>
+        </ContextMenuActionItem>
         <ContextMenuSeparator />
-        <ContextMenuItem
-          onSelect={() => void actionService.dispatch("portal.resetWidth", undefined, { source })}
-        >
-          Reset Width
-        </ContextMenuItem>
+        <ContextMenuActionItem actionId="portal.resetWidth">Reset Width</ContextMenuActionItem>
         <ContextMenuSeparator />
         <ContextMenuSub>
           <ContextMenuSubTrigger>Default New Tab</ContextMenuSubTrigger>
           <ContextMenuSubContent>
-            <ContextMenuCheckboxItem
-              checked={defaultNewTabUrl === null}
-              onSelect={() =>
-                void actionService.dispatch("portal.setDefaultNewTab", { url: null }, { source })
-              }
-            >
-              Launchpad
-            </ContextMenuCheckboxItem>
+            <MenuActionSourceContext.Consumer>
+              {(source) => (
+                <ContextMenuCheckboxItem
+                  checked={defaultNewTabUrl === null}
+                  onSelect={() =>
+                    void actionService.dispatch(
+                      "portal.setDefaultNewTab",
+                      { url: null },
+                      { source: source ?? "user" }
+                    )
+                  }
+                >
+                  Launchpad
+                </ContextMenuCheckboxItem>
+              )}
+            </MenuActionSourceContext.Consumer>
             {enabledLinks.length > 0 && <ContextMenuSeparator />}
-            {enabledLinks.map((link) => (
-              <ContextMenuCheckboxItem
-                key={link.url}
-                checked={defaultNewTabUrl === link.url}
-                onSelect={() =>
-                  void actionService.dispatch(
-                    "portal.setDefaultNewTab",
-                    { url: link.url },
-                    { source }
-                  )
-                }
-              >
-                {link.title}
-              </ContextMenuCheckboxItem>
-            ))}
+            <MenuActionSourceContext.Consumer>
+              {(source) => (
+                <>
+                  {enabledLinks.map((link) => (
+                    <ContextMenuCheckboxItem
+                      key={link.url}
+                      checked={defaultNewTabUrl === link.url}
+                      onSelect={() =>
+                        void actionService.dispatch(
+                          "portal.setDefaultNewTab",
+                          { url: link.url },
+                          { source: source ?? "user" }
+                        )
+                      }
+                    >
+                      {link.title}
+                    </ContextMenuCheckboxItem>
+                  ))}
+                </>
+              )}
+            </MenuActionSourceContext.Consumer>
           </ContextMenuSubContent>
         </ContextMenuSub>
         <ContextMenuSeparator />
-        <ContextMenuItem
-          onSelect={() =>
-            void actionService.dispatch("app.settings.openTab", { tab: "portal" }, { source })
-          }
-        >
+        <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "portal" }}>
           Portal Settings...
-        </ContextMenuItem>
+        </ContextMenuActionItem>
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -52,6 +52,7 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { useMenuActionSource } from "@/components/ui/menu-source";
 
 const ICON_CLASS = "w-3.5 h-3.5 mr-2 shrink-0";
 
@@ -96,6 +97,7 @@ export function TerminalContextMenu({
   // don't get the option, matching the gesture-level rules in
   // `multiSelectGestures`.
   const fleetEligible = isFleetArmEligible(terminal);
+  const source = useMenuActionSource();
 
   const [hasSelection, setHasSelection] = useState(false);
   const [hoveredUrl, setHoveredUrl] = useState<string | null>(null);
@@ -146,7 +148,7 @@ export function TerminalContextMenu({
 
       if (actionId.startsWith("copy-link:")) {
         const url = actionId.slice("copy-link:".length);
-        void actionService.dispatch("terminal.copyLink", { url }, { source: "context-menu" });
+        void actionService.dispatch("terminal.copyLink", { url }, { source });
         return;
       }
 
@@ -155,7 +157,7 @@ export function TerminalContextMenu({
         void actionService.dispatch(
           "terminal.moveToWorktree",
           { terminalId, worktreeId },
-          { source: "context-menu" }
+          { source }
         );
         return;
       }
@@ -181,40 +183,28 @@ export function TerminalContextMenu({
           break;
         case "fleet-arm-worktree":
           void actionService.dispatch("terminal.bulkCommand", undefined, {
-            source: "context-menu",
+            source,
           });
           break;
         case "fleet-clear":
           void actionService.dispatch("terminal.disarmAll", undefined, {
-            source: "context-menu",
+            source,
           });
           break;
         case "copy":
-          void actionService.dispatch("terminal.copy", { terminalId }, { source: "context-menu" });
+          void actionService.dispatch("terminal.copy", { terminalId }, { source });
           break;
         case "paste":
-          void actionService.dispatch("terminal.paste", { terminalId }, { source: "context-menu" });
+          void actionService.dispatch("terminal.paste", { terminalId }, { source });
           break;
         case "move-to-dock":
-          void actionService.dispatch(
-            "terminal.moveToDock",
-            { terminalId },
-            { source: "context-menu" }
-          );
+          void actionService.dispatch("terminal.moveToDock", { terminalId }, { source });
           break;
         case "move-to-grid":
-          void actionService.dispatch(
-            "terminal.moveToGrid",
-            { terminalId },
-            { source: "context-menu" }
-          );
+          void actionService.dispatch("terminal.moveToGrid", { terminalId }, { source });
           break;
         case "toggle-maximize":
-          void actionService.dispatch(
-            "terminal.toggleMaximize",
-            { terminalId },
-            { source: "context-menu" }
-          );
+          void actionService.dispatch("terminal.toggleMaximize", { terminalId }, { source });
           break;
         case "restart":
           if (terminalHasRunningAgentSession(terminal)) {
@@ -227,60 +217,32 @@ export function TerminalContextMenu({
             });
             return;
           }
-          void actionService.dispatch(
-            "terminal.restart",
-            { terminalId },
-            { source: "context-menu" }
-          );
+          void actionService.dispatch("terminal.restart", { terminalId }, { source });
           break;
         case "force-resume":
-          void actionService.dispatch(
-            "terminal.forceResume",
-            { terminalId },
-            { source: "context-menu" }
-          );
+          void actionService.dispatch("terminal.forceResume", { terminalId }, { source });
           break;
         case "toggle-input-lock":
-          void actionService.dispatch(
-            "terminal.toggleInputLock",
-            { terminalId },
-            { source: "context-menu" }
-          );
+          void actionService.dispatch("terminal.toggleInputLock", { terminalId }, { source });
           break;
         case "toggle-watch":
-          void actionService.dispatch("terminal.watch", { terminalId }, { source: "context-menu" });
+          void actionService.dispatch("terminal.watch", { terminalId }, { source });
           break;
         case "duplicate":
-          void actionService.dispatch(
-            "terminal.duplicate",
-            { terminalId },
-            { source: "context-menu" }
-          );
+          void actionService.dispatch("terminal.duplicate", { terminalId }, { source });
           break;
         case "rename":
           suppressNextCloseAutoFocusRef.current = true;
-          void actionService.dispatch(
-            "terminal.rename",
-            { terminalId },
-            { source: "context-menu" }
-          );
+          void actionService.dispatch("terminal.rename", { terminalId }, { source });
           break;
         case "view-info":
-          void actionService.dispatch(
-            "terminal.viewInfo",
-            { terminalId },
-            { source: "context-menu" }
-          );
+          void actionService.dispatch("terminal.viewInfo", { terminalId }, { source });
           break;
         case "background":
-          void actionService.dispatch(
-            "terminal.background",
-            { terminalId },
-            { source: "context-menu" }
-          );
+          void actionService.dispatch("terminal.background", { terminalId }, { source });
           break;
         case "trash":
-          void actionService.dispatch("terminal.trash", { terminalId }, { source: "context-menu" });
+          void actionService.dispatch("terminal.trash", { terminalId }, { source });
           break;
         case "kill":
           if (terminalHasRunningAgentSession(terminal)) {
@@ -293,17 +255,17 @@ export function TerminalContextMenu({
             });
             return;
           }
-          void actionService.dispatch("terminal.kill", { terminalId }, { source: "context-menu" });
+          void actionService.dispatch("terminal.kill", { terminalId }, { source });
           break;
         case "reload-browser":
-          void actionService.dispatch("browser.reload", { terminalId }, { source: "context-menu" });
+          void actionService.dispatch("browser.reload", { terminalId }, { source });
           break;
         case "open-external":
           if (terminal.browserUrl && isValidBrowserUrl(terminal.browserUrl)) {
             void actionService.dispatch(
               "browser.openExternal",
               { url: terminal.browserUrl },
-              { source: "context-menu" }
+              { source }
             );
           }
           break;
@@ -312,7 +274,7 @@ export function TerminalContextMenu({
             void actionService.dispatch(
               "browser.copyUrl",
               { url: terminal.browserUrl },
-              { source: "context-menu" }
+              { source }
             );
           }
           break;
@@ -330,11 +292,7 @@ export function TerminalContextMenu({
   const handleDestructiveConfirm = useCallback(() => {
     if (!destructiveConfirm) return;
     const actionId = destructiveConfirm.kind === "kill" ? "terminal.kill" : "terminal.restart";
-    void actionService.dispatch(
-      actionId,
-      { terminalId, confirmed: true },
-      { source: "context-menu" }
-    );
+    void actionService.dispatch(actionId, { terminalId, confirmed: true }, { source });
     setDestructiveConfirm(null);
   }, [destructiveConfirm, terminalId]);
 
@@ -393,11 +351,7 @@ export function TerminalContextMenu({
       {terminal.launchAgentId && (
         <ContextMenuItem
           onSelect={() =>
-            void actionService.dispatch(
-              "terminal.moveToNewWorktree",
-              { terminalId },
-              { source: "context-menu" }
-            )
+            void actionService.dispatch("terminal.moveToNewWorktree", { terminalId }, { source })
           }
         >
           <FolderGit2 className={ICON_CLASS} />
@@ -596,11 +550,7 @@ export function TerminalContextMenu({
               <ContextMenuItem
                 disabled={!hasSelection}
                 onSelect={() =>
-                  void actionService.dispatch(
-                    "terminal.sendToAgent",
-                    { terminalId },
-                    { source: "context-menu" }
-                  )
+                  void actionService.dispatch("terminal.sendToAgent", { terminalId }, { source })
                 }
               >
                 <Send className={ICON_CLASS} aria-hidden="true" />

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -52,7 +52,7 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { useMenuActionSource } from "@/components/ui/menu-source";
+import { MenuActionSourceContext, type MenuActionSourceValue } from "@/components/ui/menu-source";
 
 const ICON_CLASS = "w-3.5 h-3.5 mr-2 shrink-0";
 
@@ -97,7 +97,7 @@ export function TerminalContextMenu({
   // don't get the option, matching the gesture-level rules in
   // `multiSelectGestures`.
   const fleetEligible = isFleetArmEligible(terminal);
-  const source = useMenuActionSource();
+  const sourceRef = useRef<MenuActionSourceValue>("user");
 
   const [hasSelection, setHasSelection] = useState(false);
   const [hoveredUrl, setHoveredUrl] = useState<string | null>(null);
@@ -148,7 +148,7 @@ export function TerminalContextMenu({
 
       if (actionId.startsWith("copy-link:")) {
         const url = actionId.slice("copy-link:".length);
-        void actionService.dispatch("terminal.copyLink", { url }, { source });
+        void actionService.dispatch("terminal.copyLink", { url }, { source: sourceRef.current });
         return;
       }
 
@@ -157,7 +157,7 @@ export function TerminalContextMenu({
         void actionService.dispatch(
           "terminal.moveToWorktree",
           { terminalId, worktreeId },
-          { source }
+          { source: sourceRef.current }
         );
         return;
       }
@@ -183,28 +183,48 @@ export function TerminalContextMenu({
           break;
         case "fleet-arm-worktree":
           void actionService.dispatch("terminal.bulkCommand", undefined, {
-            source,
+            source: sourceRef.current,
           });
           break;
         case "fleet-clear":
           void actionService.dispatch("terminal.disarmAll", undefined, {
-            source,
+            source: sourceRef.current,
           });
           break;
         case "copy":
-          void actionService.dispatch("terminal.copy", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.copy",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "paste":
-          void actionService.dispatch("terminal.paste", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.paste",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "move-to-dock":
-          void actionService.dispatch("terminal.moveToDock", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.moveToDock",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "move-to-grid":
-          void actionService.dispatch("terminal.moveToGrid", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.moveToGrid",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "toggle-maximize":
-          void actionService.dispatch("terminal.toggleMaximize", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.toggleMaximize",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "restart":
           if (terminalHasRunningAgentSession(terminal)) {
@@ -217,32 +237,68 @@ export function TerminalContextMenu({
             });
             return;
           }
-          void actionService.dispatch("terminal.restart", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.restart",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "force-resume":
-          void actionService.dispatch("terminal.forceResume", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.forceResume",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "toggle-input-lock":
-          void actionService.dispatch("terminal.toggleInputLock", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.toggleInputLock",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "toggle-watch":
-          void actionService.dispatch("terminal.watch", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.watch",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "duplicate":
-          void actionService.dispatch("terminal.duplicate", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.duplicate",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "rename":
           suppressNextCloseAutoFocusRef.current = true;
-          void actionService.dispatch("terminal.rename", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.rename",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "view-info":
-          void actionService.dispatch("terminal.viewInfo", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.viewInfo",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "background":
-          void actionService.dispatch("terminal.background", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.background",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "trash":
-          void actionService.dispatch("terminal.trash", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.trash",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "kill":
           if (terminalHasRunningAgentSession(terminal)) {
@@ -255,17 +311,25 @@ export function TerminalContextMenu({
             });
             return;
           }
-          void actionService.dispatch("terminal.kill", { terminalId }, { source });
+          void actionService.dispatch(
+            "terminal.kill",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "reload-browser":
-          void actionService.dispatch("browser.reload", { terminalId }, { source });
+          void actionService.dispatch(
+            "browser.reload",
+            { terminalId },
+            { source: sourceRef.current }
+          );
           break;
         case "open-external":
           if (terminal.browserUrl && isValidBrowserUrl(terminal.browserUrl)) {
             void actionService.dispatch(
               "browser.openExternal",
               { url: terminal.browserUrl },
-              { source }
+              { source: sourceRef.current }
             );
           }
           break;
@@ -274,7 +338,7 @@ export function TerminalContextMenu({
             void actionService.dispatch(
               "browser.copyUrl",
               { url: terminal.browserUrl },
-              { source }
+              { source: sourceRef.current }
             );
           }
           break;
@@ -292,7 +356,11 @@ export function TerminalContextMenu({
   const handleDestructiveConfirm = useCallback(() => {
     if (!destructiveConfirm) return;
     const actionId = destructiveConfirm.kind === "kill" ? "terminal.kill" : "terminal.restart";
-    void actionService.dispatch(actionId, { terminalId, confirmed: true }, { source });
+    void actionService.dispatch(
+      actionId,
+      { terminalId, confirmed: true },
+      { source: sourceRef.current }
+    );
     setDestructiveConfirm(null);
   }, [destructiveConfirm, terminalId]);
 
@@ -351,7 +419,11 @@ export function TerminalContextMenu({
       {terminal.launchAgentId && (
         <ContextMenuItem
           onSelect={() =>
-            void actionService.dispatch("terminal.moveToNewWorktree", { terminalId }, { source })
+            void actionService.dispatch(
+              "terminal.moveToNewWorktree",
+              { terminalId },
+              { source: sourceRef.current }
+            )
           }
         >
           <FolderGit2 className={ICON_CLASS} />
@@ -386,6 +458,12 @@ export function TerminalContextMenu({
     const hasUrl = Boolean(terminal.browserUrl && isValidBrowserUrl(terminal.browserUrl));
     return (
       <ContextMenu>
+        <MenuActionSourceContext.Consumer>
+          {(value) => {
+            sourceRef.current = value ?? "user";
+            return null;
+          }}
+        </MenuActionSourceContext.Consumer>
         <ContextMenuTrigger asChild>
           <div className="contents" data-context-trigger={terminalId}>
             {children}
@@ -437,6 +515,12 @@ export function TerminalContextMenu({
     const hasUrl = Boolean(terminal.browserUrl && isValidBrowserUrl(terminal.browserUrl));
     return (
       <ContextMenu>
+        <MenuActionSourceContext.Consumer>
+          {(value) => {
+            sourceRef.current = value ?? "user";
+            return null;
+          }}
+        </MenuActionSourceContext.Consumer>
         <ContextMenuTrigger asChild>
           <div className="contents" data-context-trigger={terminalId}>
             {children}
@@ -487,6 +571,12 @@ export function TerminalContextMenu({
   if (isReview) {
     return (
       <ContextMenu>
+        <MenuActionSourceContext.Consumer>
+          {(value) => {
+            sourceRef.current = value ?? "user";
+            return null;
+          }}
+        </MenuActionSourceContext.Consumer>
         <ContextMenuTrigger asChild>
           <div className="contents" data-context-trigger={terminalId}>
             {children}
@@ -525,6 +615,12 @@ export function TerminalContextMenu({
     <>
       {destructiveConfirmDialog}
       <ContextMenu>
+        <MenuActionSourceContext.Consumer>
+          {(value) => {
+            sourceRef.current = value ?? "user";
+            return null;
+          }}
+        </MenuActionSourceContext.Consumer>
         <ContextMenuTrigger asChild>
           <div
             className="contents"
@@ -550,7 +646,11 @@ export function TerminalContextMenu({
               <ContextMenuItem
                 disabled={!hasSelection}
                 onSelect={() =>
-                  void actionService.dispatch("terminal.sendToAgent", { terminalId }, { source })
+                  void actionService.dispatch(
+                    "terminal.sendToAgent",
+                    { terminalId },
+                    { source: sourceRef.current }
+                  )
                 }
               >
                 <Send className={ICON_CLASS} aria-hidden="true" />

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -43,6 +43,7 @@ import {
   ContextMenuSubContent,
   ContextMenuSubTrigger,
 } from "@/components/ui/context-menu";
+import { useMenuActionSource } from "@/components/ui/menu-source";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { getMaximizedGroupFocusTarget } from "./contentGridFocus";
@@ -170,6 +171,7 @@ export function useContentGridContext({
   const showProjectPulse = usePreferencesStore((state) => state.showProjectPulse);
   const currentProject = useProjectStore((state) => state.currentProject);
   const isAvailabilityInitialized = useCliAvailabilityStore((s) => s.isInitialized);
+  const source = useMenuActionSource();
 
   const gridSelectedAgentIds = useMemo(
     () =>
@@ -501,7 +503,7 @@ export function useContentGridContext({
       void actionService.dispatch(
         "agent.launch",
         { agentId, location: "grid", cwd: defaultCwd || undefined },
-        { source: "context-menu" }
+        { source }
       );
     },
     [defaultCwd]
@@ -509,11 +511,7 @@ export function useContentGridContext({
 
   const handleGridLayoutChange = useCallback(
     (strategy: "automatic" | "fixed-columns" | "fixed-rows") => {
-      void actionService.dispatch(
-        "panel.gridLayout.setStrategy",
-        { strategy },
-        { source: "context-menu" }
-      );
+      void actionService.dispatch("panel.gridLayout.setStrategy", { strategy }, { source });
     },
     []
   );
@@ -784,11 +782,7 @@ export function useContentGridContext({
       <ContextMenuSeparator />
       <ContextMenuItem
         onSelect={() =>
-          void actionService.dispatch(
-            "app.settings.openTab",
-            { tab: "terminal" },
-            { source: "context-menu" }
-          )
+          void actionService.dispatch("app.settings.openTab", { tab: "terminal" }, { source })
         }
       >
         Terminal Settings...

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -35,15 +35,15 @@ import { useProjectBranding } from "@/hooks";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import type { CliAvailability } from "@shared/types";
 import {
+  ContextMenuActionItem,
   ContextMenuContent,
   ContextMenuCheckboxItem,
-  ContextMenuItem,
   ContextMenuSeparator,
   ContextMenuSub,
   ContextMenuSubContent,
   ContextMenuSubTrigger,
 } from "@/components/ui/context-menu";
-import { useMenuActionSource } from "@/components/ui/menu-source";
+import { MenuActionSourceContext } from "@/components/ui/menu-source";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { getMaximizedGroupFocusTarget } from "./contentGridFocus";
@@ -171,7 +171,6 @@ export function useContentGridContext({
   const showProjectPulse = usePreferencesStore((state) => state.showProjectPulse);
   const currentProject = useProjectStore((state) => state.currentProject);
   const isAvailabilityInitialized = useCliAvailabilityStore((s) => s.isInitialized);
-  const source = useMenuActionSource();
 
   const gridSelectedAgentIds = useMemo(
     () =>
@@ -503,7 +502,7 @@ export function useContentGridContext({
       void actionService.dispatch(
         "agent.launch",
         { agentId, location: "grid", cwd: defaultCwd || undefined },
-        { source }
+        { source: "user" }
       );
     },
     [defaultCwd]
@@ -511,7 +510,7 @@ export function useContentGridContext({
 
   const handleGridLayoutChange = useCallback(
     (strategy: "automatic" | "fixed-columns" | "fixed-rows") => {
-      void actionService.dispatch("panel.gridLayout.setStrategy", { strategy }, { source });
+      void actionService.dispatch("panel.gridLayout.setStrategy", { strategy }, { source: "user" });
     },
     []
   );
@@ -743,50 +742,81 @@ export function useContentGridContext({
 
   const gridContextMenuContent = (
     <ContextMenuContent>
-      <ContextMenuItem onSelect={() => handleGridLaunch("terminal")}>New Terminal</ContextMenuItem>
-      <ContextMenuItem onSelect={() => handleGridLaunch("browser")}>New Browser</ContextMenuItem>
+      <ContextMenuActionItem
+        actionId="agent.launch"
+        args={{ agentId: "terminal", location: "grid", cwd: defaultCwd || undefined }}
+      >
+        New Terminal
+      </ContextMenuActionItem>
+      <ContextMenuActionItem
+        actionId="agent.launch"
+        args={{ agentId: "browser", location: "grid", cwd: defaultCwd || undefined }}
+      >
+        New Browser
+      </ContextMenuActionItem>
       {gridAgentMenuItems.length > 0 && <ContextMenuSeparator />}
       {gridAgentMenuItems.map((agent) => (
-        <ContextMenuItem
+        <ContextMenuActionItem
           key={agent.id}
+          actionId="agent.launch"
+          args={{ agentId: agent.id, location: "grid", cwd: defaultCwd || undefined }}
           disabled={!agent.canLaunch}
-          onSelect={() => handleGridLaunch(agent.id)}
         >
           New {agent.name}
-        </ContextMenuItem>
+        </ContextMenuActionItem>
       ))}
       <ContextMenuSeparator />
       <ContextMenuSub>
         <ContextMenuSubTrigger>Grid Layout</ContextMenuSubTrigger>
         <ContextMenuSubContent>
-          <ContextMenuCheckboxItem
-            checked={layoutConfig.strategy === "automatic"}
-            onSelect={() => handleGridLayoutChange("automatic")}
-          >
-            Automatic
-          </ContextMenuCheckboxItem>
-          <ContextMenuCheckboxItem
-            checked={layoutConfig.strategy === "fixed-columns"}
-            onSelect={() => handleGridLayoutChange("fixed-columns")}
-          >
-            Fixed Columns
-          </ContextMenuCheckboxItem>
-          <ContextMenuCheckboxItem
-            checked={layoutConfig.strategy === "fixed-rows"}
-            onSelect={() => handleGridLayoutChange("fixed-rows")}
-          >
-            Fixed Rows
-          </ContextMenuCheckboxItem>
+          <MenuActionSourceContext.Consumer>
+            {(menuSource) => (
+              <>
+                <ContextMenuCheckboxItem
+                  checked={layoutConfig.strategy === "automatic"}
+                  onSelect={() =>
+                    void actionService.dispatch(
+                      "panel.gridLayout.setStrategy",
+                      { strategy: "automatic" },
+                      { source: menuSource ?? "user" }
+                    )
+                  }
+                >
+                  Automatic
+                </ContextMenuCheckboxItem>
+                <ContextMenuCheckboxItem
+                  checked={layoutConfig.strategy === "fixed-columns"}
+                  onSelect={() =>
+                    void actionService.dispatch(
+                      "panel.gridLayout.setStrategy",
+                      { strategy: "fixed-columns" },
+                      { source: menuSource ?? "user" }
+                    )
+                  }
+                >
+                  Fixed Columns
+                </ContextMenuCheckboxItem>
+                <ContextMenuCheckboxItem
+                  checked={layoutConfig.strategy === "fixed-rows"}
+                  onSelect={() =>
+                    void actionService.dispatch(
+                      "panel.gridLayout.setStrategy",
+                      { strategy: "fixed-rows" },
+                      { source: menuSource ?? "user" }
+                    )
+                  }
+                >
+                  Fixed Rows
+                </ContextMenuCheckboxItem>
+              </>
+            )}
+          </MenuActionSourceContext.Consumer>
         </ContextMenuSubContent>
       </ContextMenuSub>
       <ContextMenuSeparator />
-      <ContextMenuItem
-        onSelect={() =>
-          void actionService.dispatch("app.settings.openTab", { tab: "terminal" }, { source })
-        }
-      >
+      <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "terminal" }}>
         Terminal Settings...
-      </ContextMenuItem>
+      </ContextMenuActionItem>
     </ContextMenuContent>
   );
 

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -42,6 +42,7 @@ import { useWorktreeActions } from "./WorktreeCard/hooks/useWorktreeActions";
 import { copyContextWithFeedback } from "@/hooks/useWorktreeActions";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
+import { useMenuActionSource } from "@/components/ui/menu-source";
 import { CONTEXT_COMPONENTS, WorktreeMenuItems } from "./WorktreeMenuItems";
 import { isAgentFleetActionEligible, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { useWorktreeStatus } from "./WorktreeCard/hooks/useWorktreeStatus";
@@ -122,6 +123,7 @@ export function WorktreeCard({
     (state) => state.settings?.notificationOverrides
   );
   const isProjectNotificationsMuted = areProjectNotificationsMuted(notificationOverrides);
+  const source = useMenuActionSource();
 
   const environmentIcon =
     worktree.worktreeMode && worktree.worktreeMode !== "local"
@@ -338,23 +340,19 @@ export function WorktreeCard({
     void actionService.dispatch(
       "worktree.resource.resume",
       { worktreeId: worktree.id },
-      { source: "context-menu" }
+      { source }
     );
   };
 
   const handleResourcePause = () => {
-    void actionService.dispatch(
-      "worktree.resource.pause",
-      { worktreeId: worktree.id },
-      { source: "context-menu" }
-    );
+    void actionService.dispatch("worktree.resource.pause", { worktreeId: worktree.id }, { source });
   };
 
   const handleResourceConnect = () => {
     void actionService.dispatch(
       "worktree.resource.connect",
       { worktreeId: worktree.id },
-      { source: "context-menu" }
+      { source }
     );
   };
 
@@ -368,7 +366,7 @@ export function WorktreeCard({
     void actionService.dispatch(
       "worktree.resource.provision",
       { worktreeId: worktree.id },
-      { source: "context-menu" }
+      { source }
     );
   };
 
@@ -376,16 +374,16 @@ export function WorktreeCard({
     void actionService.dispatch(
       "worktree.resource.status",
       { worktreeId: worktree.id },
-      { source: "context-menu" }
+      { source }
     );
   };
 
   const handleCopyContextFull = () => {
-    void copyContextWithFeedback(worktree.id);
+    void copyContextWithFeedback(worktree.id, source);
   };
 
   const handleCopyContextModified = () => {
-    void copyContextWithFeedback(worktree.id, { modified: true });
+    void copyContextWithFeedback(worktree.id, source, { modified: true });
   };
 
   const { copy: copyWorktreePath } = useCopyWithFeedback();
@@ -552,7 +550,7 @@ export function WorktreeCard({
 
   const handleOpenPanelPalette = () => {
     useWorktreeSelectionStore.getState().setActiveWorktree(worktree.id);
-    void actionService.dispatch("panel.palette", undefined, { source: "context-menu" });
+    void actionService.dispatch("panel.palette", undefined, { source });
   };
 
   const cardContent = (
@@ -746,7 +744,7 @@ export function WorktreeCard({
                   onOpenPanelPalette: () => {
                     useWorktreeSelectionStore.getState().setActiveWorktree(worktree.id);
                     void actionService.dispatch("panel.palette", undefined, {
-                      source: "context-menu",
+                      source,
                     });
                   },
                   onDockAll: handleDockAll,

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -42,7 +42,6 @@ import { useWorktreeActions } from "./WorktreeCard/hooks/useWorktreeActions";
 import { copyContextWithFeedback } from "@/hooks/useWorktreeActions";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
-import { useMenuActionSource } from "@/components/ui/menu-source";
 import { CONTEXT_COMPONENTS, WorktreeMenuItems } from "./WorktreeMenuItems";
 import { isAgentFleetActionEligible, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { useWorktreeStatus } from "./WorktreeCard/hooks/useWorktreeStatus";
@@ -123,7 +122,6 @@ export function WorktreeCard({
     (state) => state.settings?.notificationOverrides
   );
   const isProjectNotificationsMuted = areProjectNotificationsMuted(notificationOverrides);
-  const source = useMenuActionSource();
 
   const environmentIcon =
     worktree.worktreeMode && worktree.worktreeMode !== "local"
@@ -340,19 +338,23 @@ export function WorktreeCard({
     void actionService.dispatch(
       "worktree.resource.resume",
       { worktreeId: worktree.id },
-      { source }
+      { source: "user" }
     );
   };
 
   const handleResourcePause = () => {
-    void actionService.dispatch("worktree.resource.pause", { worktreeId: worktree.id }, { source });
+    void actionService.dispatch(
+      "worktree.resource.pause",
+      { worktreeId: worktree.id },
+      { source: "user" }
+    );
   };
 
   const handleResourceConnect = () => {
     void actionService.dispatch(
       "worktree.resource.connect",
       { worktreeId: worktree.id },
-      { source }
+      { source: "user" }
     );
   };
 
@@ -366,7 +368,7 @@ export function WorktreeCard({
     void actionService.dispatch(
       "worktree.resource.provision",
       { worktreeId: worktree.id },
-      { source }
+      { source: "user" }
     );
   };
 
@@ -374,16 +376,16 @@ export function WorktreeCard({
     void actionService.dispatch(
       "worktree.resource.status",
       { worktreeId: worktree.id },
-      { source }
+      { source: "user" }
     );
   };
 
   const handleCopyContextFull = () => {
-    void copyContextWithFeedback(worktree.id, source);
+    void copyContextWithFeedback(worktree.id, "context-menu");
   };
 
   const handleCopyContextModified = () => {
-    void copyContextWithFeedback(worktree.id, source, { modified: true });
+    void copyContextWithFeedback(worktree.id, "context-menu", { modified: true });
   };
 
   const { copy: copyWorktreePath } = useCopyWithFeedback();
@@ -550,7 +552,10 @@ export function WorktreeCard({
 
   const handleOpenPanelPalette = () => {
     useWorktreeSelectionStore.getState().setActiveWorktree(worktree.id);
-    void actionService.dispatch("panel.palette", undefined, { source });
+    void actionService.dispatch("panel.palette", undefined, {
+      // eslint-disable-next-line no-restricted-syntax -- context-menu-source: hardcoded because callback lives outside the ContextMenu Root (see #8322)
+      source: "context-menu",
+    });
   };
 
   const cardContent = (
@@ -744,7 +749,8 @@ export function WorktreeCard({
                   onOpenPanelPalette: () => {
                     useWorktreeSelectionStore.getState().setActiveWorktree(worktree.id);
                     void actionService.dispatch("panel.palette", undefined, {
-                      source,
+                      // eslint-disable-next-line no-restricted-syntax -- context-menu-source: hardcoded because callback lives outside the ContextMenu Root (see #8322)
+                      source: "context-menu",
                     });
                   },
                   onDockAll: handleDockAll,

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -2,6 +2,7 @@ import { createElement, useCallback, useEffect, useState, type ReactNode } from 
 import type { WorktreeState } from "@/types";
 import { logError } from "@/utils/logger";
 import { actionService } from "@/services/ActionService";
+import { useMenuActionSource } from "@/components/ui/menu-source";
 import { useRecipeStore } from "@/store/recipeStore";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -63,6 +64,7 @@ export function useWorktreeActions({
   });
 
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const source = useMenuActionSource();
 
   const closeConfirmDialog = useCallback(() => {
     setConfirmDialog({ isOpen: false });
@@ -267,7 +269,7 @@ export function useWorktreeActions({
         void actionService.dispatch(
           "worktree.resource.teardown",
           { worktreeId: worktree.id },
-          { source: "context-menu" }
+          { source }
         );
         setConfirmDialog({ isOpen: false });
       },

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -6,14 +6,26 @@ import { cn } from "@/lib/utils";
 import { useScrollShadowOverlays } from "@/components/ui/ScrollShadow";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
 import { useIsDockPopoverChild } from "./DockPopoverChildContext";
+import { MenuActionSourceContext, useMenuActionSource } from "./menu-source";
+import { actionService } from "@/services/ActionService";
+import type { ActionId, ActionDispatchOptions } from "@shared/types/actions";
 
 type ContextMenuRootProps = React.ComponentProps<typeof ContextMenuPrimitiveType.Root>;
 
 const ContextMenu = ({ children, ...rest }: ContextMenuRootProps) => {
   const radix = useRadixPrimitives();
-  if (!radix) return <>{children}</>;
+  if (!radix)
+    return (
+      <MenuActionSourceContext.Provider value="context-menu">
+        {children}
+      </MenuActionSourceContext.Provider>
+    );
   const Root = radix.ContextMenuPrimitive.Root;
-  return <Root {...rest}>{children}</Root>;
+  return (
+    <MenuActionSourceContext.Provider value="context-menu">
+      <Root {...rest}>{children}</Root>
+    </MenuActionSourceContext.Provider>
+  );
 };
 ContextMenu.displayName = "ContextMenu";
 
@@ -263,6 +275,30 @@ const ContextMenuItem = React.forwardRef<
 });
 ContextMenuItem.displayName = "ContextMenuItem";
 
+type ContextMenuActionItemProps = ContextMenuItemProps & {
+  actionId: ActionId;
+  args?: unknown;
+  dispatchOptions?: Omit<ActionDispatchOptions, "source">;
+};
+
+const ContextMenuActionItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitiveType.Item>,
+  ContextMenuActionItemProps
+>(({ actionId, args, dispatchOptions, onSelect, disabled, ...props }, ref) => {
+  const source = useMenuActionSource();
+
+  const handleSelect: React.ComponentPropsWithoutRef<
+    typeof ContextMenuPrimitiveType.Item
+  >["onSelect"] = (event) => {
+    onSelect?.(event);
+    if (event.defaultPrevented) return;
+    void actionService.dispatch(actionId, args, { ...dispatchOptions, source });
+  };
+
+  return <ContextMenuItem ref={ref} onSelect={handleSelect} disabled={disabled} {...props} />;
+});
+ContextMenuActionItem.displayName = "ContextMenuActionItem";
+
 type ContextMenuSeparatorProps = React.ComponentPropsWithoutRef<
   typeof ContextMenuPrimitiveType.Separator
 >;
@@ -403,6 +439,7 @@ export {
   ContextMenuTrigger,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuActionItem,
   ContextMenuCheckboxItem,
   ContextMenuRadioGroup,
   ContextMenuRadioItem,

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -6,6 +6,9 @@ import { cn } from "@/lib/utils";
 import { useScrollShadowOverlays } from "@/components/ui/ScrollShadow";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
 import { useIsDockPopoverChild } from "./DockPopoverChildContext";
+import { MenuActionSourceContext, useMenuActionSource } from "./menu-source";
+import { actionService } from "@/services/ActionService";
+import type { ActionId, ActionDispatchOptions } from "@shared/types/actions";
 
 const DropdownMenuIntentContext = React.createContext<((next: boolean) => void) | null>(null);
 
@@ -38,7 +41,7 @@ const DropdownMenu = ({
   if (!radix) {
     return (
       <DropdownMenuIntentContext.Provider value={requestOpen}>
-        {children}
+        <MenuActionSourceContext.Provider value="menu">{children}</MenuActionSourceContext.Provider>
       </DropdownMenuIntentContext.Provider>
     );
   }
@@ -46,17 +49,19 @@ const DropdownMenu = ({
   const Root = radix.DropdownMenuPrimitive.Root;
   const effectiveDefaultOpen = isControlled ? defaultOpen : (pendingOpen ?? defaultOpen);
   return (
-    <Root
-      open={open}
-      defaultOpen={effectiveDefaultOpen}
-      onOpenChange={(next) => {
-        if (!isControlled) setPendingOpen(undefined);
-        onOpenChange?.(next);
-      }}
-      {...rest}
-    >
-      {children}
-    </Root>
+    <MenuActionSourceContext.Provider value="menu">
+      <Root
+        open={open}
+        defaultOpen={effectiveDefaultOpen}
+        onOpenChange={(next) => {
+          if (!isControlled) setPendingOpen(undefined);
+          onOpenChange?.(next);
+        }}
+        {...rest}
+      >
+        {children}
+      </Root>
+    </MenuActionSourceContext.Provider>
   );
 };
 DropdownMenu.displayName = "DropdownMenu";
@@ -311,6 +316,30 @@ const DropdownMenuItem = React.forwardRef<
 });
 DropdownMenuItem.displayName = "DropdownMenuItem";
 
+type DropdownMenuActionItemProps = DropdownMenuItemProps & {
+  actionId: ActionId;
+  args?: unknown;
+  dispatchOptions?: Omit<ActionDispatchOptions, "source">;
+};
+
+const DropdownMenuActionItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitiveType.Item>,
+  DropdownMenuActionItemProps
+>(({ actionId, args, dispatchOptions, onSelect, disabled, ...props }, ref) => {
+  const source = useMenuActionSource();
+
+  const handleSelect: React.ComponentPropsWithoutRef<
+    typeof DropdownMenuPrimitiveType.Item
+  >["onSelect"] = (event) => {
+    onSelect?.(event);
+    if (event.defaultPrevented) return;
+    void actionService.dispatch(actionId, args, { ...dispatchOptions, source });
+  };
+
+  return <DropdownMenuItem ref={ref} onSelect={handleSelect} disabled={disabled} {...props} />;
+});
+DropdownMenuActionItem.displayName = "DropdownMenuActionItem";
+
 type DropdownMenuSeparatorProps = React.ComponentPropsWithoutRef<
   typeof DropdownMenuPrimitiveType.Separator
 >;
@@ -451,6 +480,7 @@ export {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuActionItem,
   DropdownMenuCheckboxItem,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,

--- a/src/components/ui/menu-source.tsx
+++ b/src/components/ui/menu-source.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+export type MenuActionSourceValue = "context-menu" | "menu" | "user";
+
+const MenuActionSourceContext = React.createContext<MenuActionSourceValue | null>(null);
+
+export function useMenuActionSource(): MenuActionSourceValue {
+  const source = React.useContext(MenuActionSourceContext);
+  if (source === null) {
+    if (import.meta.env.DEV) {
+      console.warn(
+        'useMenuActionSource: called outside a <ContextMenu> or <DropdownMenu> Root — falling back to "user".'
+      );
+    }
+    return "user";
+  }
+  return source;
+}
+
+export { MenuActionSourceContext };

--- a/src/hooks/__tests__/useWorktreeActions.test.tsx
+++ b/src/hooks/__tests__/useWorktreeActions.test.tsx
@@ -142,7 +142,7 @@ describe("copyContextWithFeedback", () => {
       result: { fileCount: 10, stats: { totalSize: 2048 }, format: "xml" },
     });
 
-    await copyContextWithFeedback("wt-1");
+    await copyContextWithFeedback("wt-1", "context-menu");
 
     expect(addNotificationMock).toHaveBeenCalledWith(
       expect.objectContaining({ type: "info", message: "Copying context…" })
@@ -159,7 +159,7 @@ describe("copyContextWithFeedback", () => {
       result: { fileCount: 3, stats: null, format: "xml" },
     });
 
-    await copyContextWithFeedback("wt-1", { modified: true });
+    await copyContextWithFeedback("wt-1", "context-menu", { modified: true });
 
     expect(addNotificationMock).toHaveBeenCalledWith(
       expect.objectContaining({ message: "Copying modified files…" })
@@ -174,7 +174,7 @@ describe("copyContextWithFeedback", () => {
   it("shows 'No files to copy' when result is null", async () => {
     dispatchMock.mockResolvedValueOnce({ ok: true, result: null });
 
-    await copyContextWithFeedback("wt-1");
+    await copyContextWithFeedback("wt-1", "context-menu");
 
     expect(updateNotificationMock).toHaveBeenCalledWith(
       "toast-123",
@@ -188,7 +188,7 @@ describe("copyContextWithFeedback", () => {
       error: { message: "Something went wrong" },
     });
 
-    await copyContextWithFeedback("wt-1");
+    await copyContextWithFeedback("wt-1", "context-menu");
 
     expect(updateNotificationMock).toHaveBeenCalledWith(
       "toast-123",
@@ -205,7 +205,7 @@ describe("copyContextWithFeedback", () => {
   it("handles thrown errors gracefully", async () => {
     dispatchMock.mockRejectedValueOnce(new Error("Network error"));
 
-    await copyContextWithFeedback("wt-1");
+    await copyContextWithFeedback("wt-1", "context-menu");
 
     expect(updateNotificationMock).toHaveBeenCalledWith(
       "toast-123",

--- a/src/hooks/useGlobalKeybindings.ts
+++ b/src/hooks/useGlobalKeybindings.ts
@@ -3,7 +3,6 @@ import { keybindingService, normalizeKeyForBinding } from "../services/Keybindin
 import { actionService } from "../services/ActionService";
 import { logError } from "@/utils/logger";
 import { dispatchEscape, hasHandlers } from "@/lib/escapeStack";
-import { openPanelContextMenu } from "../lib/panelContextMenu";
 import { usePanelStore } from "../store";
 
 /**
@@ -73,7 +72,11 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
           e.stopPropagation();
           const focusedId = usePanelStore.getState().focusedId;
           if (focusedId) {
-            openPanelContextMenu(focusedId);
+            void actionService.dispatch(
+              "terminal.contextMenu",
+              { terminalId: focusedId },
+              { source: "keybinding" }
+            );
           }
           return;
         }

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -7,6 +7,7 @@ import { useNotificationStore } from "@/store/notificationStore";
 import { formatBytes } from "@/lib/formatBytes";
 import { actionService } from "@/services/ActionService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import type { ActionSource } from "@shared/types/actions";
 
 export function formatCopyResultMessage(payload: {
   fileCount: number;
@@ -25,6 +26,7 @@ export function formatCopyResultMessage(payload: {
 
 export async function copyContextWithFeedback(
   worktreeId: string,
+  source: ActionSource,
   options?: { modified?: boolean }
 ): Promise<void> {
   // Direct store call: this is a spinner-then-update pattern that depends on
@@ -44,7 +46,7 @@ export async function copyContextWithFeedback(
     const result = await actionService.dispatch(
       "worktree.copyTree",
       { worktreeId, modified: options?.modified },
-      { source: "context-menu" }
+      { source }
     );
 
     if (!result.ok) {

--- a/src/services/actions/definitions/terminalInputActions.ts
+++ b/src/services/actions/definitions/terminalInputActions.ts
@@ -108,6 +108,7 @@ export function registerTerminalInputActions(
     category: "terminal",
     kind: "command",
     danger: "safe",
+    nonRepeatable: true,
     scope: "renderer",
     argsSchema: z.object({ terminalId: z.string().optional() }),
     run: async (args: unknown) => {


### PR DESCRIPTION
## Summary

Context-menu dispatch source was wired by hand across every call site -- 78 spots passing `{ source: "context-menu" }` into `actionService.dispatch`. Easy to forget, which meant missing telemetry and broken MRU/repeatLast for right-click invocations.

Now the source derives from React Context at the `<ContextMenu.Root>` and `<DropdownMenu.Root>` level. A small `MenuActionSource` provider and `useMenuActionSource()` hook, plus thin `ActionItem` wrappers around the existing styled menu items, read the context and dispatch with the correct source automatically. The pattern mirrors the existing `*IntentContext` providers already in `src/components/ui/`.

Also fixes a keybinding bug: `Shift+F10` and the `ContextMenu` key routed around `actionService`, so the keybinding never emitted `action:dispatched`, never tagged `source: "keybinding"`, and never updated `lastAction`. Routed through `actionService.dispatch` now. Tagged `terminal.contextMenu` as `nonRepeatable` since replaying a menu-open is nonsense.

Resolves #8322

## Changes

- **`src/components/ui/menu-source.tsx`** -- new `MenuActionSource` context provider + `useMenuActionSource()` hook
- **`src/components/ui/context-menu.tsx`** / **`dropdown-menu.tsx`** -- `ActionItem` and `ActionCheckboxItem` wrappers that read menu source context and dispatch automatically. Root components now wrap in `MenuActionSource`
- **78 call-site migrations** across `AgentButton.tsx`, `Sidebar.tsx`, `ToolbarSettingsButton.tsx`, `PortalDock.tsx`, `TerminalContextMenu.tsx`, `WorktreeCard.tsx`, `useContentGridContext.tsx`, `useWorktreeActions.ts`, and `useGlobalKeybindings.ts` -- replaced manual `{ source: "context-menu" }` with action-item wrappers
- **`eslint.config.js`** -- `no-restricted-syntax` rule banning `actionService.dispatch(..., { source: "context-menu" })` outside the wrapper, with an escape hatch mirroring the `notify-no-action: ok` precedent
- **`useGlobalKeybindings.ts`** -- `Shift+F10` / `ContextMenu` key now dispatches through `actionService` instead of calling `openPanelContextMenu` directly
- **`terminalInputActions.ts`** -- set `nonRepeatable: true` on `terminal.contextMenu`

## Testing

- AgentButton context menu test updated to verify action-item wrapper behavior
- useWorktreeActions test updated for source changes
- Manual verification: right-click context menus in sidebar, content grid, portal dock, terminal tabs, worktree cards, toolbar settings; Shift+F10 and ContextMenu key on focused terminals
- ESLint rule confirmed to flag direct `{ source: "context-menu" }` usage at non-wrapper call sites