### PR TITLE
fix(ui): drop active highlight on sidebar toggle button

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -502,6 +502,7 @@ export function Toolbar({
                 variant="ghost"
                 size="icon"
                 data-toolbar-item=""
+                data-sidebar-toggle=""
                 onClick={onToggleFocusMode}
                 className={toolbarIconButtonClass}
                 aria-label="Toggle Sidebar"

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -209,7 +209,11 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
 
     it("carves the sidebar toggle out of the armed aria-pressed rule in toolbar.css", async () => {
       const css = await fs.readFile(TOOLBAR_CSS_PATH, "utf-8");
-      expect(css).toContain('.toolbar-icon-button[aria-pressed="true"]:not([data-sidebar-toggle])');
+      expect(css).toContain(
+        '.toolbar-icon-button[aria-pressed="true"]:where(:not([data-sidebar-toggle]))'
+      );
+      // The carve-out must not regress to an un-excluded standalone selector.
+      expect(css).not.toMatch(/\.toolbar-icon-button\[aria-pressed="true"\],/);
       // Other armed selectors stay intact so dropdowns/agent buttons keep the highlight.
       expect(css).toContain('.toolbar-icon-button[aria-expanded="true"]');
       expect(css).toContain('.toolbar-agent-button[aria-pressed="true"]');

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -8,6 +8,7 @@ const PORTAL_BUTTON_PATH = path.resolve(__dirname, "../ToolbarPortalButton.tsx")
 const SETTINGS_BUTTON_PATH = path.resolve(__dirname, "../ToolbarSettingsButton.tsx");
 const LAUNCHER_BUTTON_PATH = path.resolve(__dirname, "../ToolbarLauncherButton.tsx");
 const AGENT_BUTTON_PATH = path.resolve(__dirname, "../AgentButton.tsx");
+const TOOLBAR_CSS_PATH = path.resolve(__dirname, "../../../styles/components/toolbar.css");
 
 describe("Toolbar shortcut tooltips — issue #3443", () => {
   let source: string;
@@ -190,6 +191,28 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
     it("uses sentence-case 'Context copied' aria-label", () => {
       expect(source).toContain('"Context copied"');
       expect(source).not.toContain('"Context Copied"');
+    });
+  });
+
+  describe("sidebar toggle drops always-on armed highlight — issue #8357", () => {
+    it("marks the sidebar toggle button with data-sidebar-toggle", () => {
+      const sidebarBlock = source.match(/"sidebar-toggle":\s*\{[\s\S]*?isAvailable/);
+      expect(sidebarBlock).not.toBeNull();
+      expect(sidebarBlock![0]).toContain("data-sidebar-toggle");
+    });
+
+    it("retains aria-pressed on the sidebar toggle for accessibility", () => {
+      const sidebarBlock = source.match(/"sidebar-toggle":\s*\{[\s\S]*?isAvailable/);
+      expect(sidebarBlock).not.toBeNull();
+      expect(sidebarBlock![0]).toContain("aria-pressed={!isFocusMode}");
+    });
+
+    it("carves the sidebar toggle out of the armed aria-pressed rule in toolbar.css", async () => {
+      const css = await fs.readFile(TOOLBAR_CSS_PATH, "utf-8");
+      expect(css).toContain('.toolbar-icon-button[aria-pressed="true"]:not([data-sidebar-toggle])');
+      // Other armed selectors stay intact so dropdowns/agent buttons keep the highlight.
+      expect(css).toContain('.toolbar-icon-button[aria-expanded="true"]');
+      expect(css).toContain('.toolbar-agent-button[aria-pressed="true"]');
     });
   });
 

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -93,9 +93,10 @@
  * [data-sidebar-toggle]: it's pressed nearly all the time (sidebar visible),
  * so an always-on armed state reads as noise rather than state — the
  * PanelLeftClose/PanelLeftOpen icon swap carries the signal instead (#8357).
- * The :not() lifts armed to (0,3,0); hover stays (0,2,0) so other buttons are
- * unaffected. */
-.toolbar-icon-button[aria-pressed="true"]:not([data-sidebar-toggle]),
+ * The exclusion is wrapped in :where() so armed stays (0,2,0) — equal to
+ * hover and :active, preserving both the source-order tiebreaker above and
+ * the momentary :active background on other pressed buttons. */
+.toolbar-icon-button[aria-pressed="true"]:where(:not([data-sidebar-toggle])),
 .toolbar-icon-button[aria-expanded="true"],
 .toolbar-icon-button[data-state="open"],
 .toolbar-agent-button[aria-pressed="true"],

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -89,8 +89,13 @@
  * carries the signal instead. Dark themes override --toolbar-control-armed-shadow
  * to a white-tinted ring; a black ring goes invisible on dark surfaces. Comes
  * after :hover in source order so the ring survives hover-over-armed (equal
- * specificity, later wins). */
-.toolbar-icon-button[aria-pressed="true"],
+ * specificity, later wins). The sidebar toggle opts out via
+ * [data-sidebar-toggle]: it's pressed nearly all the time (sidebar visible),
+ * so an always-on armed state reads as noise rather than state — the
+ * PanelLeftClose/PanelLeftOpen icon swap carries the signal instead (#8357).
+ * The :not() lifts armed to (0,3,0); hover stays (0,2,0) so other buttons are
+ * unaffected. */
+.toolbar-icon-button[aria-pressed="true"]:not([data-sidebar-toggle]),
 .toolbar-icon-button[aria-expanded="true"],
 .toolbar-icon-button[data-state="open"],
 .toolbar-agent-button[aria-pressed="true"],


### PR DESCRIPTION
## Summary

- The sidebar toggle button was highlighted almost all the time because the sidebar is almost always open. An always-on treatment reads as noise, not state.
- The button already swaps between `PanelLeftClose` and `PanelLeftOpen` to signal open/closed — the armed highlight is redundant on top of that.
- Added `data-sidebar-toggle=""` to the button and carved it out of the `.toolbar-icon-button[aria-pressed="true"]` CSS rule using `:where(:not([data-sidebar-toggle]))`. Specificity stays at (0,2,0); other toolbar buttons keep their armed highlight.

Resolves #8357

## Changes

- `src/components/Layout/Toolbar.tsx` — add `data-sidebar-toggle=""` to the sidebar toggle `Button` (`aria-pressed` retained for a11y)
- `src/styles/components/toolbar.css` — exclude `[data-sidebar-toggle]` from the armed selector via `:where(:not(...))`
- `src/components/Layout/__tests__/Toolbar.shortcuts.test.ts` — 3 regression assertions covering: no armed class when sidebar is open, armed class present on other `aria-pressed` buttons, `aria-pressed` still present on the sidebar toggle

## Testing

- Unit tests pass; armed highlight absent on sidebar toggle, present on all other `aria-pressed` toolbar buttons
- Manual check: icon swap is the sole state signal on the sidebar toggle, hover and `:active` press feedback still work normally