### PR TITLE
docs(terminal): document Chromium throttling and atlas-resync rationale

### DIFF
--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -259,12 +259,15 @@ export const IPC_LOW_WATERMARK_PERCENT = 33; // Resume PTY when drops to 33% (~1
 // occluded:
 //   - BackgroundTimerThrottling: setTimeout/setInterval clamped to 1Hz immediately.
 //   - requestAnimationFrame: suspended entirely (0Hz) while the document is hidden.
-//   - IntensiveWakeUpThrottling: with QuickIntensiveThrottling default-on in
-//     Chromium 146, this escalates at the 10s-hidden mark (not the historical 5min),
-//     clamping wakeups to 1/minute.
-// 10s aligns the forced resume with the IntensiveWakeUpThrottling boundary: if a
-// paused PTY isn't resumed before that escalation, a backgrounded pane could go up
-// to 60s between drain ticks and freeze visibly. (history: #3508, #4682, #4683)
+//   - IntensiveWakeUpThrottling: escalates wakeups to 1/minute. With
+//     QuickIntensiveWakeUpThrottlingAfterLoading default-on in Chromium 146,
+//     this engages at the 60s-hidden mark for fully-loaded pages (the baseline
+//     without that flag is 5min).
+// 10s keeps the forced resume comfortably below the 60s IntensiveWakeUpThrottling
+// boundary: it fires the drain while still only under 1Hz BackgroundTimerThrottling,
+// before the far worse 1/minute intensive throttle can engage. Without it, a paused
+// PTY left untouched past 60s could go a full minute between drain ticks and freeze
+// visibly. (history: #3508, #4682, #4683)
 export const IPC_MAX_PAUSE_MS = 10000;
 
 // MessagePort adaptive batching configuration

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -253,7 +253,19 @@ export const GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS = 100;
 export const IPC_MAX_QUEUE_BYTES = 3 * 1024 * 1024; // 3MB max per terminal
 export const IPC_HIGH_WATERMARK_PERCENT = 67; // Pause PTY at 67% full (~2MB)
 export const IPC_LOW_WATERMARK_PERCENT = 33; // Resume PTY when drops to 33% (~1MB)
-export const IPC_MAX_PAUSE_MS = 10000; // Force resume after 10s — accommodates degraded background-tab parse rates
+// Force resume after 10s. The renderer drain loop (not PTY I/O — that runs in a
+// UtilityProcess unaffected by renderer throttling) is subject to Chromium 146's
+// tiered background-throttling policies the moment the document is hidden or fully
+// occluded:
+//   - BackgroundTimerThrottling: setTimeout/setInterval clamped to 1Hz immediately.
+//   - requestAnimationFrame: suspended entirely (0Hz) while the document is hidden.
+//   - IntensiveWakeUpThrottling: with QuickIntensiveThrottling default-on in
+//     Chromium 146, this escalates at the 10s-hidden mark (not the historical 5min),
+//     clamping wakeups to 1/minute.
+// 10s aligns the forced resume with the IntensiveWakeUpThrottling boundary: if a
+// paused PTY isn't resumed before that escalation, a backgrounded pane could go up
+// to 60s between drain ticks and freeze visibly. (history: #3508, #4682, #4683)
+export const IPC_MAX_PAUSE_MS = 10000;
 
 // MessagePort adaptive batching configuration
 export const PORT_BATCH_THRESHOLD_BYTES = 64 * 1024; // 64KB — sync-flush when buffered data exceeds this

--- a/src/services/terminal/TerminalOutputIngestService.ts
+++ b/src/services/terminal/TerminalOutputIngestService.ts
@@ -3,6 +3,12 @@ import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 import { logDebug } from "@/utils/logger";
 
+// Renderer-side backpressure layer that throttles xterm consumption. The
+// IPC-layer counterparts (the burst absorber between PTY host and renderer) live
+// in electron/services/pty/types.ts: IPC_MAX_QUEUE_BYTES (3MB ceiling),
+// IPC_HIGH_WATERMARK_PERCENT (67, pause PTY), IPC_LOW_WATERMARK_PERCENT (33,
+// resume PTY). These two layers are independent: the IPC queue absorbs PTY
+// bursts, these watermarks pace how fast xterm drains them.
 const RENDERER_HIGH_WATERMARK_BYTES = 128 * 1024;
 const RENDERER_LOW_WATERMARK_BYTES = 32 * 1024;
 const COALESCE_BATCH_CAP_BYTES = 256 * 1024;

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -165,6 +165,10 @@ export class TerminalWebGLManager {
   // run only the local resize-like reset through the pinned 0.19 internal shape
   // and follow with a full terminal.refresh(). If that internal shape drifts,
   // fall back to releasing/reacquiring only this context.
+  // Recurrence signature to watch for when triaging: ~12 concurrent agents, a
+  // Claude Code status line rewritten via \r at 1Hz, and visible-but-unfocused
+  // panes that take no further writes staying corrupted until a resize or
+  // atlasResync (see #8080).
   private atlasResyncPending = new Set<string>();
   private atlasResyncRafId: number | null = null;
 


### PR DESCRIPTION
## Summary

Documentation-only change — no code behaviour affected, `IPC_MAX_PAUSE_MS` constant value unchanged at 10000.

Three inline comment amendments:

- `electron/services/pty/types.ts` — expanded the `IPC_MAX_PAUSE_MS` comment to name the three Chromium 146 background-throttling policies that make 10 s correct: `BackgroundTimerThrottling` (1Hz on hidden), suspended `requestAnimationFrame` (0Hz hidden), and `IntensiveWakeUpThrottling` (1/min, engaging at 60 s via `QuickIntensiveWakeUpThrottlingAfterLoading` default-on in Chromium 146). Notes that PTY I/O runs in an unaffected `UtilityProcess`, and that 10 s fires the drain while still under 1Hz throttling and well below the 60 s intensive boundary.
- `src/services/terminal/TerminalOutputIngestService.ts` — added a cross-reference from the renderer watermark constants back to their IPC-layer counterparts in `pty/types.ts`.
- `src/services/terminal/TerminalWebGLManager.ts` — recorded the #8080 recurrence signature on the atlas-resync block: ~12 concurrent agents, Claude Code status line rewritten via `\r` at 1Hz, visible-but-unfocused panes staying corrupted until resize or atlas resync.

Resolves #8366

## Changes

- `electron/services/pty/types.ts`: `IPC_MAX_PAUSE_MS` comment expanded with Chromium policy names and threshold reasoning
- `src/services/terminal/TerminalOutputIngestService.ts`: cross-reference added to IPC watermark constants
- `src/services/terminal/TerminalWebGLManager.ts`: #8080 recurrence signature recorded on atlas-resync block

## Testing

`npm run check` passes clean — typecheck, lint ratchet (880 baseline), and format all green. No runtime changes to verify.