### PR TITLE
fix(terminal): gate renderer xterm writes for backgrounded panels

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -68,8 +68,9 @@ function canAutoInitializeTerminalIngest(): boolean {
 
 class TerminalInstanceService {
   private instances = new Map<string, ManagedTerminal>();
-  private dataBuffer = new TerminalOutputIngestService((id, data) =>
-    this.writeToTerminal(id, data)
+  private dataBuffer = new TerminalOutputIngestService(
+    (id, data) => this.writeToTerminal(id, data),
+    (id) => this.instances.get(id)?.getRefreshTier?.() ?? TerminalRefreshTier.FOCUSED
   );
   private suppressedExitUntil = new Map<string, number>();
   private unseenTracker = new TerminalUnseenOutputTracker();
@@ -153,6 +154,7 @@ class TerminalInstanceService {
         return this.wakeManager.wakeAndRestore(id);
       },
       onPostWake: (id) => this.handlePostWake(id),
+      onResumeFlush: (id) => this.dataBuffer.resumeFlush(id),
       applyDeferredResize: (id) => this.resizeController.applyDeferredResize(id),
       onTierApplied: (id, tier, managed) => {
         if (this.isHibernationEligible(tier, managed) && !managed.isVisible) {

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -909,6 +909,11 @@ class TerminalInstanceService {
     // lastAppliedTier so that a later promotion is seen as an upgrade.
     if (initialTier === TerminalRefreshTier.BACKGROUND) {
       managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+      // Seed the renderer-policy backend tier so the first promotion is seen
+      // as a real BACKGROUND→active transition. Without this, lastBackendTier
+      // is unset, prevBackendTier defaults to "active", and the wake/flush
+      // path is skipped — bytes held by the background gate would never drain.
+      this.rendererPolicy.initializeBackendTier(id, "background");
       try {
         managed.imageAddon?.dispose();
       } catch {

--- a/src/services/terminal/TerminalOutputIngestService.ts
+++ b/src/services/terminal/TerminalOutputIngestService.ts
@@ -1,4 +1,5 @@
 import type { TerminalOutputWorkerInboundMessage } from "@shared/types/terminal-output-worker-messages";
+import { TerminalRefreshTier } from "@shared/types/panel";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 import { logDebug } from "@/utils/logger";
@@ -25,7 +26,10 @@ export class TerminalOutputIngestService {
   private perfSampleCounter = 0;
   private queues = new Map<string, TerminalIngestQueue>();
 
-  constructor(private readonly writeToTerminal: (id: string, data: string | Uint8Array) => void) {}
+  constructor(
+    private readonly writeToTerminal: (id: string, data: string | Uint8Array) => void,
+    private readonly getTier?: (id: string) => TerminalRefreshTier
+  ) {}
 
   public async initialize(): Promise<void> {
     if (this.initializePromise) return this.initializePromise;
@@ -74,6 +78,18 @@ export class TerminalOutputIngestService {
   public notifyParsed(id: string): void {
     const queue = this.queues.get(id);
     if (!queue || queue.chunks.length === 0 || queue.drainScheduled) return;
+    this.tryDrain(id, queue);
+  }
+
+  /**
+   * Drain bytes held while a panel was backgrounded. Routed through tryDrain
+   * (not forceDrain) so the 256KB COALESCE_BATCH_CAP_BYTES cap is respected —
+   * a backgrounded panel may have accumulated a large in-flight batch, and a
+   * single multi-MB xterm.write() on wake would block the main thread (#4853).
+   */
+  public resumeFlush(id: string): void {
+    const queue = this.queues.get(id);
+    if (!queue || queue.chunks.length === 0) return;
     this.tryDrain(id, queue);
   }
 
@@ -149,6 +165,15 @@ export class TerminalOutputIngestService {
     const bytes = this.chunkByteSize(data);
     queue.chunks.push(data);
     queue.queuedBytes += bytes;
+
+    // Backgrounded panels: hold bytes in the queue without parsing them into
+    // xterm. The producer-side gate in pty-host suppresses most output, but
+    // in-flight MessagePort batches still arrive after backgrounding; parsing
+    // them burns renderer main-thread CPU for a pane the user can't see. The
+    // queue is flushed via resumeFlush() when the tier upgrades back to active.
+    if (this.getTier?.(id) === TerminalRefreshTier.BACKGROUND) {
+      return;
+    }
 
     const stringData = typeof data === "string" ? data : "";
     if (stringData) {

--- a/src/services/terminal/TerminalOutputIngestService.ts
+++ b/src/services/terminal/TerminalOutputIngestService.ts
@@ -70,6 +70,7 @@ export class TerminalOutputIngestService {
     const queue = this.queues.get(id);
     if (!queue) return;
     queue.inFlightBytes = Math.max(0, queue.inFlightBytes - bytes);
+    if (this.isBackgrounded(id)) return;
     if (queue.inFlightBytes <= RENDERER_LOW_WATERMARK_BYTES && queue.chunks.length > 0) {
       this.tryDrain(id, queue);
     }
@@ -78,6 +79,7 @@ export class TerminalOutputIngestService {
   public notifyParsed(id: string): void {
     const queue = this.queues.get(id);
     if (!queue || queue.chunks.length === 0 || queue.drainScheduled) return;
+    if (this.isBackgrounded(id)) return;
     this.tryDrain(id, queue);
   }
 
@@ -88,6 +90,7 @@ export class TerminalOutputIngestService {
    * single multi-MB xterm.write() on wake would block the main thread (#4853).
    */
   public resumeFlush(id: string): void {
+    if (this.isBackgrounded(id)) return;
     const queue = this.queues.get(id);
     if (!queue || queue.chunks.length === 0) return;
     this.tryDrain(id, queue);
@@ -131,6 +134,10 @@ export class TerminalOutputIngestService {
     }, 50);
   }
 
+  private isBackgrounded(id: string): boolean {
+    return this.getTier?.(id) === TerminalRefreshTier.BACKGROUND;
+  }
+
   private markTerminalDataReceived(id: string, data: string | Uint8Array): void {
     this.perfSampleCounter += 1;
     if (this.perfSampleCounter % 64 !== 0) return;
@@ -171,7 +178,7 @@ export class TerminalOutputIngestService {
     // in-flight MessagePort batches still arrive after backgrounding; parsing
     // them burns renderer main-thread CPU for a pane the user can't see. The
     // queue is flushed via resumeFlush() when the tier upgrades back to active.
-    if (this.getTier?.(id) === TerminalRefreshTier.BACKGROUND) {
+    if (this.isBackgrounded(id)) {
       return;
     }
 

--- a/src/services/terminal/TerminalRendererPolicy.ts
+++ b/src/services/terminal/TerminalRendererPolicy.ts
@@ -103,6 +103,12 @@ export class TerminalRendererPolicy {
     this.setBackendTier(id, backendTier);
 
     if (backendTier === "background" && prevBackendTier === "active") {
+      // Invalidate any in-flight wake: if a BACKGROUND→active wake is still
+      // pending when the terminal is re-backgrounded, its resolved callback
+      // must not refresh/flush into a now-hidden pane (reintroduces the CPU
+      // burn this gate eliminates). The next real activation starts a fresh
+      // generation.
+      this.bumpWakeGeneration(id);
       managed.needsWake = true;
     }
 

--- a/src/services/terminal/TerminalRendererPolicy.ts
+++ b/src/services/terminal/TerminalRendererPolicy.ts
@@ -7,6 +7,7 @@ export interface RendererPolicyDeps {
   getInstance: (id: string) => ManagedTerminal | undefined;
   wakeAndRestore: (id: string) => Promise<boolean>;
   onPostWake?: (id: string) => void;
+  onResumeFlush?: (id: string) => void;
   onTierApplied?: (id: string, tier: TerminalRefreshTier, managed: ManagedTerminal) => void;
   applyDeferredResize?: (id: string) => void;
 }
@@ -127,6 +128,11 @@ export class TerminalRendererPolicy {
             if (ok) {
               this.deps.onPostWake?.(id);
             }
+
+            // Flush bytes held while backgrounded AFTER scrollback restore +
+            // refresh. wakeAndRestore calls terminal.reset() during replay;
+            // flushing earlier would wipe these bytes.
+            this.deps.onResumeFlush?.(id);
           })
           .catch(() => {
             if (this.wakeGeneration.get(id) !== wakeGeneration) return;
@@ -139,12 +145,20 @@ export class TerminalRendererPolicy {
             // whatever content it has, preventing stuck display states.
             this.deps.applyDeferredResize?.(id);
             current.terminal.refresh(0, current.terminal.rows - 1);
+
+            // Wake failed, but the terminal is active again — flush held
+            // bytes so the user isn't left with a stalled pane.
+            this.deps.onResumeFlush?.(id);
           });
       } else {
         // needsWake is false, but we're transitioning to active tier.
         // Force a refresh to ensure the terminal renderer is in sync.
         this.deps.applyDeferredResize?.(id);
         managed.terminal.refresh(0, managed.terminal.rows - 1);
+
+        // No wake needed, but transitioning to active — flush any bytes
+        // held while backgrounded.
+        this.deps.onResumeFlush?.(id);
       }
     }
 

--- a/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
+++ b/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
@@ -544,6 +544,76 @@ describe("TerminalOutputIngestService", () => {
       expect(writeToTerminal).not.toHaveBeenCalled();
     });
 
+    it("notifyWriteComplete does not drain while tier is BACKGROUND", () => {
+      const writeToTerminal = vi.fn();
+      const tiers = new Map<string, TerminalRefreshTier>([["term-1", TerminalRefreshTier.FOCUSED]]);
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        (id) => tiers.get(id) ?? TerminalRefreshTier.FOCUSED
+      );
+
+      // Active large write pushes inFlightBytes over the high watermark.
+      const largeData = "x".repeat(140_000);
+      service.bufferData("term-1", largeData);
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+
+      // Tier flips to BACKGROUND; subsequent data is held.
+      tiers.set("term-1", TerminalRefreshTier.BACKGROUND);
+      service.bufferData("term-1", "held-while-bg");
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+
+      // Acknowledging the in-flight write must NOT drain the held bytes.
+      service.notifyWriteComplete("term-1", 140_000);
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+
+      // Back to active + resume → held bytes flush.
+      tiers.set("term-1", TerminalRefreshTier.FOCUSED);
+      service.resumeFlush("term-1");
+      expect(writeToTerminal).toHaveBeenCalledTimes(2);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-1", "held-while-bg");
+    });
+
+    it("notifyParsed does not bypass the background gate", () => {
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        () => TerminalRefreshTier.BACKGROUND
+      );
+
+      service.bufferData("term-1", "queued-bg");
+      service.notifyParsed("term-1");
+      expect(writeToTerminal).not.toHaveBeenCalled();
+    });
+
+    it("scheduled ink-erase drain does not fire while backgrounded", () => {
+      vi.useFakeTimers();
+      const writeToTerminal = vi.fn();
+      const tiers = new Map<string, TerminalRefreshTier>([["term-1", TerminalRefreshTier.FOCUSED]]);
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        (id) => tiers.get(id) ?? TerminalRefreshTier.FOCUSED
+      );
+
+      // Active ink-erase first half → drain scheduled via setTimeout.
+      service.bufferData("term-1", "\x1b[2K");
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      service.notifyWriteComplete("term-1", 4);
+
+      // Tier flips to BACKGROUND before the deferred drain fires.
+      tiers.set("term-1", TerminalRefreshTier.BACKGROUND);
+      service.bufferData("term-1", "\x1b[1Acontent");
+      vi.advanceTimersByTime(0);
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+
+      // Back to active + resume → held bytes flush.
+      tiers.set("term-1", TerminalRefreshTier.FOCUSED);
+      service.resumeFlush("term-1");
+      expect(writeToTerminal).toHaveBeenCalledTimes(2);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-1", "\x1b[1Acontent");
+
+      vi.useRealTimers();
+    });
+
     it("isolates the background gate per terminal", () => {
       const writeToTerminal = vi.fn();
       const tiers = new Map<string, TerminalRefreshTier>([

--- a/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
+++ b/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/clients", () => ({
 }));
 
 import { TerminalOutputIngestService } from "../TerminalOutputIngestService";
+import { TerminalRefreshTier } from "@shared/types/panel";
 
 type WorkerMessage = { type: string };
 
@@ -415,5 +416,150 @@ describe("TerminalOutputIngestService", () => {
     // No buffered data — notifyParsed should be a no-op
     service.notifyParsed("term-1");
     expect(writeToTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  describe("background tier gate", () => {
+    it("holds bytes without writing to xterm while tier is BACKGROUND", () => {
+      const writeToTerminal = vi.fn();
+      const tiers = new Map<string, TerminalRefreshTier>([
+        ["term-1", TerminalRefreshTier.BACKGROUND],
+      ]);
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        (id) => tiers.get(id) ?? TerminalRefreshTier.FOCUSED
+      );
+
+      service.bufferData("term-1", "while-backgrounded-1");
+      service.bufferData("term-1", "while-backgrounded-2");
+
+      // Nothing parsed into xterm while backgrounded.
+      expect(writeToTerminal).not.toHaveBeenCalled();
+    });
+
+    it("flushes held bytes via resumeFlush after tier upgrades to active", () => {
+      const writeToTerminal = vi.fn();
+      const tiers = new Map<string, TerminalRefreshTier>([
+        ["term-1", TerminalRefreshTier.BACKGROUND],
+      ]);
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        (id) => tiers.get(id) ?? TerminalRefreshTier.FOCUSED
+      );
+
+      service.bufferData("term-1", "held-a");
+      service.bufferData("term-1", "held-b");
+      expect(writeToTerminal).not.toHaveBeenCalled();
+
+      // Tier upgrades back to active, then the policy triggers the flush.
+      tiers.set("term-1", TerminalRefreshTier.FOCUSED);
+      service.resumeFlush("term-1");
+
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-1", "held-aheld-b");
+    });
+
+    it("resumeFlush respects the 256KB coalesce cap (never a single multi-MB write)", () => {
+      const writeToTerminal = vi.fn();
+      const tiers = new Map<string, TerminalRefreshTier>([
+        ["term-1", TerminalRefreshTier.BACKGROUND],
+      ]);
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        (id) => tiers.get(id) ?? TerminalRefreshTier.FOCUSED
+      );
+
+      // Accumulate 3 × 150KB = 450KB while backgrounded.
+      const chunk150k = "a".repeat(150_000);
+      service.bufferData("term-1", chunk150k);
+      service.bufferData("term-1", chunk150k);
+      service.bufferData("term-1", chunk150k);
+      expect(writeToTerminal).not.toHaveBeenCalled();
+
+      tiers.set("term-1", TerminalRefreshTier.FOCUSED);
+      service.resumeFlush("term-1");
+
+      // First capped batch: do-while takes first chunk unconditionally,
+      // 150k + 150k > 256KB cap, so only one chunk = 150,000 bytes.
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      const firstBatch = writeToTerminal.mock.calls[0]![1] as string;
+      expect(firstBatch.length).toBe(150_000);
+
+      // Drain remainder on acknowledgment.
+      service.notifyWriteComplete("term-1", 150_000);
+      expect(writeToTerminal).toHaveBeenCalledTimes(2);
+      const secondBatch = writeToTerminal.mock.calls[1]![1] as string;
+      expect(secondBatch.length).toBe(150_000);
+    });
+
+    it("discards background-held bytes on resetForTerminal (hibernation/destroy)", () => {
+      const writeToTerminal = vi.fn();
+      const tiers = new Map<string, TerminalRefreshTier>([
+        ["term-1", TerminalRefreshTier.BACKGROUND],
+      ]);
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        (id) => tiers.get(id) ?? TerminalRefreshTier.FOCUSED
+      );
+
+      service.bufferData("term-1", "transient");
+      service.resetForTerminal("term-1");
+
+      // After reset, a tier upgrade + flush must not replay stale bytes —
+      // headless serialized state is the scrollback source of truth.
+      tiers.set("term-1", TerminalRefreshTier.FOCUSED);
+      service.resumeFlush("term-1");
+      expect(writeToTerminal).not.toHaveBeenCalled();
+    });
+
+    it("writes immediately for non-background tiers", () => {
+      const writeToTerminal = vi.fn();
+      const tiers = new Map<string, TerminalRefreshTier>([["term-1", TerminalRefreshTier.VISIBLE]]);
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        (id) => tiers.get(id) ?? TerminalRefreshTier.FOCUSED
+      );
+
+      service.bufferData("term-1", "visible-output");
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-1", "visible-output");
+    });
+
+    it("behaves as before when no tier provider is supplied", () => {
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(writeToTerminal);
+
+      service.bufferData("term-1", "no-gate");
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-1", "no-gate");
+    });
+
+    it("resumeFlush is a no-op when nothing is held", () => {
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        () => TerminalRefreshTier.FOCUSED
+      );
+
+      service.resumeFlush("unknown");
+      expect(writeToTerminal).not.toHaveBeenCalled();
+    });
+
+    it("isolates the background gate per terminal", () => {
+      const writeToTerminal = vi.fn();
+      const tiers = new Map<string, TerminalRefreshTier>([
+        ["bg", TerminalRefreshTier.BACKGROUND],
+        ["fg", TerminalRefreshTier.FOCUSED],
+      ]);
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        (id) => tiers.get(id) ?? TerminalRefreshTier.FOCUSED
+      );
+
+      service.bufferData("bg", "held");
+      service.bufferData("fg", "live");
+
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("fg", "live");
+    });
   });
 });

--- a/src/services/terminal/__tests__/TerminalRendererPolicy.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalRendererPolicy.adversarial.test.ts
@@ -210,6 +210,77 @@ describe("TerminalRendererPolicy adversarial", () => {
     expect(managed.terminal.refresh).not.toHaveBeenCalled();
   });
 
+  it("BACKGROUND_SEEDED_TERMINAL_FLUSHES_ON_FIRST_ACTIVATION", async () => {
+    // Mirrors the initial-BACKGROUND wiring: TerminalInstanceService seeds
+    // the backend tier via initializeBackendTier("id","background") so the
+    // first promotion is a real BACKGROUND→active transition that flushes.
+    const wake = deferred<boolean>();
+    const managed = createManagedTerminal({
+      lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+      getRefreshTier: () => TerminalRefreshTier.FOCUSED,
+      needsWake: true,
+    });
+    const deps: RendererPolicyDeps = {
+      getInstance: vi.fn(() => managed),
+      wakeAndRestore: vi.fn(() => wake.promise),
+      onResumeFlush: vi.fn(),
+      onPostWake: vi.fn(),
+    };
+
+    const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
+    const policy = new TerminalRendererPolicy(deps);
+    policy.initializeBackendTier("terminal-1", "background");
+
+    policy.applyRendererPolicy("terminal-1", TerminalRefreshTier.FOCUSED);
+    expect(deps.wakeAndRestore).toHaveBeenCalledTimes(1);
+
+    wake.resolve(true);
+    await wake.promise;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(managed.terminal.refresh).toHaveBeenCalled();
+    expect(deps.onResumeFlush).toHaveBeenCalledWith("terminal-1");
+  });
+
+  it("REBACKGROUND_DURING_WAKE_DOES_NOT_FLUSH_HIDDEN_PANE", async () => {
+    const wake = deferred<boolean>();
+    const managed = createManagedTerminal({
+      lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+      getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
+      needsWake: true,
+    });
+    const deps: RendererPolicyDeps = {
+      getInstance: vi.fn(() => managed),
+      wakeAndRestore: vi.fn(() => wake.promise),
+      onResumeFlush: vi.fn(),
+      onPostWake: vi.fn(),
+    };
+
+    const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
+    const policy = new TerminalRendererPolicy(deps);
+    policy.initializeBackendTier("terminal-1", "background");
+
+    // BACKGROUND→FOCUSED starts a wake (generation G1).
+    policy.applyRendererPolicy("terminal-1", TerminalRefreshTier.FOCUSED);
+    expect(deps.wakeAndRestore).toHaveBeenCalledTimes(1);
+
+    // Re-backgrounded before the wake resolves (downgrade → hysteresis timer).
+    policy.applyRendererPolicy("terminal-1", TerminalRefreshTier.BACKGROUND);
+    vi.advanceTimersByTime(1000);
+
+    // The previously in-flight wake now resolves — it must be a no-op:
+    // the terminal is hidden again, so no refresh/flush into a dead pane.
+    wake.resolve(true);
+    await wake.promise;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(managed.terminal.refresh).not.toHaveBeenCalled();
+    expect(deps.onPostWake).not.toHaveBeenCalled();
+    expect(deps.onResumeFlush).not.toHaveBeenCalled();
+  });
+
   it("CLEAR_TIER_STATE_CANCELS_PENDING_WAKE_AND_RELEASES_GENERATION", async () => {
     const wake = deferred<boolean>();
     const managed = createManagedTerminal({


### PR DESCRIPTION
## Summary

- Gates `TerminalOutputIngestService.enqueueChunk` so incoming bytes are held in-queue when `tier === BACKGROUND` instead of being parsed into xterm on the renderer main thread
- Flushes via `resumeFlush(id)` through `tryDrain` (256KB cap preserved, never `forceDrain`) wired into all three active-transition paths: after scrollback restore, after `terminal.refresh`, and on tier upgrade
- Closes three races: bumps `wakeGeneration` on re-background to prevent stale-wake flush into a hidden pane; seeds `initializeBackendTier` for terminals that start in `BACKGROUND`; guards `notifyWriteComplete`, `notifyParsed`, and `resumeFlush` with `isBackgrounded()`

Resolves #8365

## Changes

- `TerminalOutputIngestService` — hold bytes in queue when backgrounded; drain on tier upgrade via `resumeFlush`
- `TerminalRendererPolicy` — new `RendererPolicyDeps.onResumeFlush` callback + `isBackgrounded()` guard on write-complete and parsed notifications
- `TerminalInstanceService` — wire `onResumeFlush` through all three active-transition paths
- New tests: background-gate behaviour + adversarial stale-wake regression (`TerminalOutputIngestService.test.ts`, `TerminalRendererPolicy.adversarial.test.ts`)

## Testing

781 unit tests passing, including new background-gate tests and an adversarial stale-wake regression. `npm run check` clean.