### PR TITLE
fix(help): broaden Daintree assistant forge CLI allowlist

### DIFF
--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -1396,8 +1396,32 @@ export class HelpSessionService {
     }
     return {
       permissions: {
-        allow: ["Read(**)", "Glob(**)", "Grep(**)", "LS(**)", "WebFetch"],
-        deny: ["Write(**)", "Edit(**)", "MultiEdit(**)", "Bash(**)"],
+        allow: [
+          "Read(**)",
+          "Glob(**)",
+          "Grep(**)",
+          "LS(**)",
+          "WebFetch",
+          "mcp__daintree-docs__*",
+          "Bash(gh *)",
+          "Bash(glab *)",
+          "Bash(tea *)",
+        ],
+        deny: [
+          "Write(**)",
+          "Edit(**)",
+          "MultiEdit(**)",
+          "Bash(gh issue create*)",
+          "Bash(gh pr create*)",
+          "Bash(gh pr merge*)",
+          "Bash(gh repo create*)",
+          "Bash(gh repo delete*)",
+          "Bash(glab issue create*)",
+          "Bash(glab mr create*)",
+          "Bash(glab mr merge*)",
+          "Bash(tea issue create*)",
+          "Bash(tea pr create*)",
+        ],
       },
     };
   }

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -1360,6 +1360,11 @@ export class HelpSessionService {
     const merged = deepClonePlainJson(baseline);
     if (!merged.permissions) merged.permissions = {};
     if (!Array.isArray(merged.permissions.allow)) merged.permissions.allow = [];
+    // A malformed bundled file could pass the object guard in
+    // readBundledSettings with a non-array deny (e.g. the bare string
+    // "Bash(**)"). Claude Code's handling of a non-array deny is undefined,
+    // so normalize it here the same way we normalize allow.
+    if (!Array.isArray(merged.permissions.deny)) merged.permissions.deny = [];
 
     if (settings.daintreeControl && !merged.permissions.allow.includes("mcp__daintree__*")) {
       merged.permissions.allow.push("mcp__daintree__*");
@@ -1420,7 +1425,10 @@ export class HelpSessionService {
           "Bash(glab mr create*)",
           "Bash(glab mr merge*)",
           "Bash(tea issue create*)",
+          "Bash(tea issues create*)",
           "Bash(tea pr create*)",
+          "Bash(tea pulls create*)",
+          "Bash(tea pulls merge*)",
         ],
       },
     };

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -88,8 +88,32 @@ async function makeBundledHelpFolder(root: string): Promise<string> {
     path.join(helpDir, ".claude", "settings.json"),
     JSON.stringify({
       permissions: {
-        allow: ["Read(**)", "WebFetch", "mcp__daintree-docs__*", "Bash(gh issue list*)"],
-        deny: ["Write(**)", "Edit(**)", "Bash(**)"],
+        allow: [
+          "Read(**)",
+          "Glob(**)",
+          "Grep(**)",
+          "LS(**)",
+          "WebFetch",
+          "mcp__daintree-docs__*",
+          "Bash(gh *)",
+          "Bash(glab *)",
+          "Bash(tea *)",
+        ],
+        deny: [
+          "Write(**)",
+          "Edit(**)",
+          "MultiEdit(**)",
+          "Bash(gh issue create*)",
+          "Bash(gh pr create*)",
+          "Bash(gh pr merge*)",
+          "Bash(gh repo create*)",
+          "Bash(gh repo delete*)",
+          "Bash(glab issue create*)",
+          "Bash(glab mr create*)",
+          "Bash(glab mr merge*)",
+          "Bash(tea issue create*)",
+          "Bash(tea pr create*)",
+        ],
       },
     })
   );
@@ -245,6 +269,24 @@ describe("HelpSessionService", () => {
     expect(settings.permissions.allow).toContain("mcp__daintree__*");
     expect(settings.permissions.allow).toContain("mcp__daintree-docs__*");
     expect(settings.permissions.deny).toContain("Write(**)");
+  });
+
+  it("opens the full forge CLI surface without a blanket Bash deny (#8360)", async () => {
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+
+    const settings = JSON.parse(
+      await fs.readFile(path.join(result.sessionPath, ".claude", "settings.json"), "utf-8")
+    );
+    // A blanket Bash(**) deny would win over every Bash allow (deny > allow),
+    // silently killing the gh/glab/tea allowlist — the #8360 root cause.
+    expect(settings.permissions.deny).not.toContain("Bash(**)");
+    expect(settings.permissions.allow).toContain("Bash(gh *)");
+    expect(settings.permissions.allow).toContain("Bash(glab *)");
+    expect(settings.permissions.allow).toContain("Bash(tea *)");
+    // Destructive write paths stay gated behind confirmation.
+    expect(settings.permissions.deny).toContain("Bash(gh issue create*)");
+    expect(settings.permissions.deny).toContain("Bash(gh pr merge*)");
   });
 
   it("sets defaultMode=bypassPermissions and tier=system when legacy skipPermissions is true", async () => {
@@ -1894,8 +1936,32 @@ describe("HelpSessionService", () => {
         path.join(altHelp, ".claude", "settings.json"),
         JSON.stringify({
           permissions: {
-            allow: ["Read(**)", "WebFetch", "mcp__daintree-docs__*", "Bash(gh issue list*)"],
-            deny: ["Write(**)", "Edit(**)", "Bash(**)"],
+            allow: [
+              "Read(**)",
+              "Glob(**)",
+              "Grep(**)",
+              "LS(**)",
+              "WebFetch",
+              "mcp__daintree-docs__*",
+              "Bash(gh *)",
+              "Bash(glab *)",
+              "Bash(tea *)",
+            ],
+            deny: [
+              "Write(**)",
+              "Edit(**)",
+              "MultiEdit(**)",
+              "Bash(gh issue create*)",
+              "Bash(gh pr create*)",
+              "Bash(gh pr merge*)",
+              "Bash(gh repo create*)",
+              "Bash(gh repo delete*)",
+              "Bash(glab issue create*)",
+              "Bash(glab mr create*)",
+              "Bash(glab mr merge*)",
+              "Bash(tea issue create*)",
+              "Bash(tea pr create*)",
+            ],
           },
         })
       );

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -112,7 +112,10 @@ async function makeBundledHelpFolder(root: string): Promise<string> {
           "Bash(glab mr create*)",
           "Bash(glab mr merge*)",
           "Bash(tea issue create*)",
+          "Bash(tea issues create*)",
           "Bash(tea pr create*)",
+          "Bash(tea pulls create*)",
+          "Bash(tea pulls merge*)",
         ],
       },
     })
@@ -284,9 +287,58 @@ describe("HelpSessionService", () => {
     expect(settings.permissions.allow).toContain("Bash(gh *)");
     expect(settings.permissions.allow).toContain("Bash(glab *)");
     expect(settings.permissions.allow).toContain("Bash(tea *)");
-    // Destructive write paths stay gated behind confirmation.
-    expect(settings.permissions.deny).toContain("Bash(gh issue create*)");
-    expect(settings.permissions.deny).toContain("Bash(gh pr merge*)");
+    // All destructive write paths stay hard-blocked — a partial drop of
+    // this list must fail the test, not slip through.
+    for (const denied of [
+      "Bash(gh issue create*)",
+      "Bash(gh pr create*)",
+      "Bash(gh pr merge*)",
+      "Bash(gh repo create*)",
+      "Bash(gh repo delete*)",
+      "Bash(glab issue create*)",
+      "Bash(glab mr create*)",
+      "Bash(glab mr merge*)",
+      "Bash(tea issue create*)",
+      "Bash(tea issues create*)",
+      "Bash(tea pr create*)",
+      "Bash(tea pulls create*)",
+      "Bash(tea pulls merge*)",
+    ]) {
+      expect(settings.permissions.deny).toContain(denied);
+    }
+    // Pin the #8360 root-cause pattern: no deny entry may shadow the
+    // broad forge allows. Any of these would silently kill the allowlist.
+    for (const shadow of ["Bash(*)", "Bash(**)", "Bash(gh *)", "Bash(glab *)", "Bash(tea *)"]) {
+      expect(settings.permissions.deny).not.toContain(shadow);
+    }
+  });
+
+  it("the bundled .claude/settings.json matches the in-code fallback baseline (#8360)", async () => {
+    // The fallback in readBundledSettings is the safety net for a corrupted
+    // install; if it drifts from the bundled file the #8360 bug reappears
+    // whenever the file read fails. Reading the real repo file (not a test
+    // fixture) catches that drift.
+    // Vitest runs from the repo root, so the real bundled file is at a
+    // stable relative path — not a test fixture.
+    const bundledPath = path.join(process.cwd(), "help", ".claude", "settings.json");
+    const bundled = JSON.parse(await fs.readFile(bundledPath, "utf-8"));
+
+    // Delete the bundled fixture's settings so readBundledSettings is
+    // forced down its hardcoded fallback path.
+    await fs.rm(path.join(helpFolder, ".claude", "settings.json"));
+
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+    const fallback = JSON.parse(
+      await fs.readFile(path.join(result.sessionPath, ".claude", "settings.json"), "utf-8")
+    );
+
+    // mcp__daintree__* is appended at provision time; compare the static
+    // forge surface only.
+    expect(new Set(fallback.permissions.deny)).toEqual(new Set(bundled.permissions.deny));
+    for (const allowed of bundled.permissions.allow) {
+      expect(fallback.permissions.allow).toContain(allowed);
+    }
   });
 
   it("sets defaultMode=bypassPermissions and tier=system when legacy skipPermissions is true", async () => {
@@ -1960,7 +2012,10 @@ describe("HelpSessionService", () => {
               "Bash(glab mr create*)",
               "Bash(glab mr merge*)",
               "Bash(tea issue create*)",
+              "Bash(tea issues create*)",
               "Bash(tea pr create*)",
+              "Bash(tea pulls create*)",
+              "Bash(tea pulls merge*)",
             ],
           },
         })

--- a/help/.claude/settings.json
+++ b/help/.claude/settings.json
@@ -7,11 +7,24 @@
       "LS(**)",
       "WebFetch",
       "mcp__daintree-docs__*",
-      "Bash(gh issue list*)",
-      "Bash(gh issue view*)",
-      "Bash(gh issue search*)",
-      "Bash(gh search issues*)"
+      "Bash(gh *)",
+      "Bash(glab *)",
+      "Bash(tea *)"
     ],
-    "deny": ["Write(**)", "Edit(**)", "MultiEdit(**)", "Bash(**)"]
+    "deny": [
+      "Write(**)",
+      "Edit(**)",
+      "MultiEdit(**)",
+      "Bash(gh issue create*)",
+      "Bash(gh pr create*)",
+      "Bash(gh pr merge*)",
+      "Bash(gh repo create*)",
+      "Bash(gh repo delete*)",
+      "Bash(glab issue create*)",
+      "Bash(glab mr create*)",
+      "Bash(glab mr merge*)",
+      "Bash(tea issue create*)",
+      "Bash(tea pr create*)"
+    ]
   }
 }

--- a/help/.claude/settings.json
+++ b/help/.claude/settings.json
@@ -24,7 +24,10 @@
       "Bash(glab mr create*)",
       "Bash(glab mr merge*)",
       "Bash(tea issue create*)",
-      "Bash(tea pr create*)"
+      "Bash(tea issues create*)",
+      "Bash(tea pr create*)",
+      "Bash(tea pulls create*)",
+      "Bash(tea pulls merge*)"
     ]
   }
 }

--- a/help/README.md
+++ b/help/README.md
@@ -110,7 +110,7 @@ The authoritative tier definitions live in `shared/config/helpAssistantTierAllow
 
 ## Permission Lockdown
 
-Claude and Codex block file writes and edits at the tool layer; Gemini's `shell` tool is allowlisted but constrained by instruction-level guardrails. All three open the full read surface of the forge CLIs (`gh`, `glab`, `tea`) for searching/viewing issues and PRs; creating issues or PRs always requires user confirmation. All three also have tier-gated access to the local `daintree` MCP tool surface when local MCP is enabled — Claude and Codex at the `action` tier, Gemini pinned to read-only introspection by `--approval-mode=plan`.
+Claude and Codex block file writes and edits at the tool layer; Gemini's `shell` tool is allowlisted but constrained by instruction-level guardrails. All three open the full read surface of the forge CLIs (`gh`, `glab`, `tea`) for searching/viewing issues and PRs, while the destructive write paths (issue/PR/repo creation, PR merge, repo delete) are hard-blocked at the CLI tool layer — the assistant opens issues/PRs through the tier-gated `daintree` MCP surface (a `system`-tier capability the user must enable), not by shelling out. All three also have tier-gated access to the local `daintree` MCP tool surface when local MCP is enabled — Claude and Codex at the `action` tier, Gemini pinned to read-only introspection by `--approval-mode=plan`.
 
 Claude Code evaluates permissions in order **deny → ask → allow**, and the first matching rule wins — a deny always beats an allow. The allowlist is therefore structured as a broad forge-CLI allow with narrow deny entries for the destructive write paths, rather than a blanket `Bash(**)` deny (which would silently shadow every `Bash` allow). The `gh`/`glab`/`tea` entries are pre-wired so future forge providers work without a service change; the allow is inert when a binary is absent.
 
@@ -118,7 +118,7 @@ Claude Code evaluates permissions in order **deny → ask → allow**, and the f
 
 - Allows: `Read(**)`, `Glob(**)`, `Grep(**)`, `LS(**)`, `WebFetch`, `mcp__daintree-docs__*`
 - Allows (auto-approved): `Bash(gh *)`, `Bash(glab *)`, `Bash(tea *)` — the full read surface of each forge CLI
-- Denies: `Write(**)`, `Edit(**)`, `MultiEdit(**)`, plus the destructive forge write paths (`Bash(gh issue create*)`, `Bash(gh pr create*)`, `Bash(gh pr merge*)`, `Bash(gh repo create*)`, `Bash(gh repo delete*)`, and the `glab`/`tea` equivalents) so issue/PR creation and merges still require user confirmation
+- Denies: `Write(**)`, `Edit(**)`, `MultiEdit(**)`, plus the destructive forge write paths (`Bash(gh issue create*)`, `Bash(gh pr create*)`, `Bash(gh pr merge*)`, `Bash(gh repo create*)`, `Bash(gh repo delete*)`, and the `glab`/`tea` equivalents including tea's `issues`/`pulls` plural aliases). A Claude Code `deny` is a hard block, not a confirmation prompt — these commands cannot be invoked at the tool layer at all, so autonomous issue/PR creation via the CLI is impossible regardless of the model's reasoning
 - At provision time, `HelpSessionService` adds `mcp__daintree__*` to the allow list when the user has local MCP enabled, and sets `defaultMode: "bypassPermissions"` when skip-permissions is enabled. The session tier (`workbench` / `action` / `system`) gates the actual `mcp__daintree__*` tool surface server-side.
 
 **Gemini** (`.gemini/settings.json` + spawn-time `--approval-mode=plan`):

--- a/help/README.md
+++ b/help/README.md
@@ -110,13 +110,15 @@ The authoritative tier definitions live in `shared/config/helpAssistantTierAllow
 
 ## Permission Lockdown
 
-Claude and Codex block file writes, edits, and arbitrary shell commands at the tool layer; Gemini's `shell` tool is allowlisted but constrained by instruction-level guardrails. All three share a `gh` allowlist for searching/viewing GitHub issues; creating issues always requires user confirmation. All three also have tier-gated access to the local `daintree` MCP tool surface when local MCP is enabled — Claude and Codex at the `action` tier, Gemini pinned to read-only introspection by `--approval-mode=plan`.
+Claude and Codex block file writes and edits at the tool layer; Gemini's `shell` tool is allowlisted but constrained by instruction-level guardrails. All three open the full read surface of the forge CLIs (`gh`, `glab`, `tea`) for searching/viewing issues and PRs; creating issues or PRs always requires user confirmation. All three also have tier-gated access to the local `daintree` MCP tool surface when local MCP is enabled — Claude and Codex at the `action` tier, Gemini pinned to read-only introspection by `--approval-mode=plan`.
+
+Claude Code evaluates permissions in order **deny → ask → allow**, and the first matching rule wins — a deny always beats an allow. The allowlist is therefore structured as a broad forge-CLI allow with narrow deny entries for the destructive write paths, rather than a blanket `Bash(**)` deny (which would silently shadow every `Bash` allow). The `gh`/`glab`/`tea` entries are pre-wired so future forge providers work without a service change; the allow is inert when a binary is absent.
 
 **Claude** (`.claude/settings.json`):
 
 - Allows: `Read(**)`, `Glob(**)`, `Grep(**)`, `LS(**)`, `WebFetch`, `mcp__daintree-docs__*`
-- Allows (auto-approved): `Bash(gh issue list*)`, `Bash(gh issue view*)`, `Bash(gh issue search*)`, `Bash(gh search issues*)`
-- Denies: `Write(**)`, `Edit(**)`, `MultiEdit(**)`, `Bash(**)` (catches `gh issue create`, requiring user confirmation)
+- Allows (auto-approved): `Bash(gh *)`, `Bash(glab *)`, `Bash(tea *)` — the full read surface of each forge CLI
+- Denies: `Write(**)`, `Edit(**)`, `MultiEdit(**)`, plus the destructive forge write paths (`Bash(gh issue create*)`, `Bash(gh pr create*)`, `Bash(gh pr merge*)`, `Bash(gh repo create*)`, `Bash(gh repo delete*)`, and the `glab`/`tea` equivalents) so issue/PR creation and merges still require user confirmation
 - At provision time, `HelpSessionService` adds `mcp__daintree__*` to the allow list when the user has local MCP enabled, and sets `defaultMode: "bypassPermissions"` when skip-permissions is enabled. The session tier (`workbench` / `action` / `system`) gates the actual `mcp__daintree__*` tool surface server-side.
 
 **Gemini** (`.gemini/settings.json` + spawn-time `--approval-mode=plan`):


### PR DESCRIPTION
## Summary

- Root cause of #8360: a blanket `Bash(**)` deny in `help/.claude/settings.json` was silently shadowing every `Bash(...)` allow entry — forge CLI commands were always blocked regardless of the allowlist
- Removes the blanket deny, adds broad `allow` entries for `gh *`, `glab *`, and `tea *` patterns, plus narrow destructive-write denies to keep the surface safe
- Syncs the `HelpSessionService.ts` bundled-settings fallback baseline and adds a deny-array normalization guard so new entries don't silently break

Resolves #8360

## Changes

- `help/.claude/settings.json` — remove blanket `Bash(**)` deny; add `gh`/`glab`/`tea` allows plus narrow destructive denies
- `electron/services/HelpSessionService.ts` — sync fallback baseline; add normalization guard for the deny array
- `electron/services/__tests__/HelpSessionService.test.ts` — update byte-identical fixtures, add #8360 regression test and bundled-vs-fallback drift test (127 tests pass)
- `help/README.md` — correct permission model docs: `deny` → `ask` → `allow` ordering; clarify deny is a hard block, not a confirmation prompt

## Testing

- 127 unit tests pass, including the new regression test that would have caught the original bug
- Bundled-vs-fallback drift test guards against the fallback baseline getting out of sync with `help/.claude/settings.json`
- Typecheck, lint, format, and `check:help/ipc/channels` all pass