### PR TITLE
feat(terminal): surface PTY data-loss as structured OSC 57301 marker

### DIFF
--- a/docs/architecture/terminal-lifecycle.md
+++ b/docs/architecture/terminal-lifecycle.md
@@ -22,6 +22,19 @@ This document describes the runtime lifecycle state for terminals across rendere
 - Renderer visibility updates (`isVisible`) convert `running` to `background` when a terminal is not visible.
 - PTY exit events set `runtimeStatus` to `exited` before trashing or preserving the terminal.
 
+## Data-loss pulse
+
+`data-loss` is a **transient pulse**, not a durable runtime state. The PTY host emits it when the IPC fallback queue discards bytes during a heavy-output burst. The host policy is **drop-don't-block**: blocking the producer to guarantee delivery risks freezing the main process under a runaway flood, so bytes are intentionally discarded and the gap is surfaced instead of hidden.
+
+Because it is a pulse, it is excluded from persistence at the type level: `PersistableFlowStatus = Exclude<TerminalFlowStatus, "data-loss">` (`shared/types/panel.ts`). The renderer store never freezes the terminal on `data-loss`; it fires the marker and immediately resumes the prior status.
+
+### Recovery contract
+
+- The dropped bytes are **not replayed** — there is no retransmit path. The signal is informational.
+- The pty-host carries the signal in-band as a structured private-use **OSC 57301** sequence (wire format `ESC ] 57301 ; <droppedBytes> ; <reasonCode> BEL`), written via `injectDataLossMarker` in `TerminalInstanceService`. Presentation is kept off the wire.
+- The OSC handler registered in `TerminalParserHandler` parses the payload, consumes the sequence (it never reaches the buffer as text), and fires an `onDataLoss` callback. The callback draws the user-visible yellow `⚠ Output dropped` line into xterm scrollback, deferred via `queueMicrotask` to avoid write-during-parse reentrancy.
+- The marker is a gap indicator only. Recovery is the xterm scrollback above and below it; the user sees a clearly-marked discontinuity rather than a silent corruption.
+
 ## Notes
 
 - Runtime status is not persisted; it is derived from live events and UI visibility.

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -744,16 +744,36 @@ class TerminalInstanceService {
   }
 
   /**
-   * Inject a visible discontinuity marker into the xterm buffer at the point
-   * where the PTY host discarded bytes from the IPC fallback queue. The
-   * leading `\x18` (CAN) cancels any partial in-progress escape sequence so
-   * the styled marker renders correctly mid-stream.
+   * Signal a PTY data-loss discontinuity at the point where the pty-host
+   * discarded bytes from the IPC fallback queue. Instead of writing a styled
+   * ANSI line directly (which embeds presentation in the wire format and can't
+   * be asserted in WebGL-disabled E2E), this writes a structured private-use
+   * OSC 57301 sequence carrying the dropped byte count and a reason code. The
+   * handler registered in `TerminalParserHandler` parses it and fires the
+   * `onDataLoss` callback wired in `getOrCreate`, which draws the yellow
+   * marker. The leading `\x18` (CAN) cancels any partial in-progress escape
+   * sequence so the OSC parses cleanly mid-stream.
    */
   injectDataLossMarker(id: string, droppedBytes: number): void {
     const managed = this.instances.get(id);
     if (!managed || managed.isHibernated) return;
-    const label = droppedBytes > 0 ? `~${droppedBytes} bytes` : "output";
-    managed.terminal.write(`\x18\r\n\x1b[33m⚠ Output dropped (${label})\x1b[0m\r\n`);
+    managed.terminal.write(`\x18\x1b]57301;${droppedBytes};backpressure\x07`);
+  }
+
+  /**
+   * Draw the user-visible yellow data-loss marker. Deferred via
+   * `queueMicrotask` because it is reached from inside the OSC 57301 parse
+   * callback — calling `terminal.write` synchronously during parsing would be
+   * reentrant. Re-checks instance state because hibernation can occur between
+   * the OSC write and this microtask.
+   */
+  private drawDataLossMarker(id: string, droppedBytes: number): void {
+    queueMicrotask(() => {
+      const managed = this.instances.get(id);
+      if (!managed || managed.isHibernated) return;
+      const label = droppedBytes > 0 ? `~${droppedBytes} bytes` : "output";
+      managed.terminal.write(`\r\n\x1b[33m⚠ Output dropped (${label})\x1b[0m\r\n`);
+    });
   }
 
   getOrCreate(
@@ -890,9 +910,15 @@ class TerminalInstanceService {
       onInput,
     };
 
-    managed.parserHandler = new TerminalParserHandler(managed, () => {
-      this.resizeController.applyDeferredResize(id);
-    });
+    managed.parserHandler = new TerminalParserHandler(
+      managed,
+      () => {
+        this.resizeController.applyDeferredResize(id);
+      },
+      (droppedBytes) => {
+        this.drawDataLossMarker(id, droppedBytes);
+      }
+    );
 
     installTerminalBoundListeners(terminal, managed, id, this.makeListenerInstallDeps());
 

--- a/src/services/terminal/TerminalParserHandler.ts
+++ b/src/services/terminal/TerminalParserHandler.ts
@@ -89,8 +89,13 @@ export class TerminalParserHandler {
     const dataLossHandler = terminal.parser.registerOscHandler(OSC_DATA_LOSS, (data) => {
       const sepIdx = data.indexOf(";");
       if (sepIdx === -1) return true;
-      const droppedBytes = Number(data.slice(0, sepIdx));
-      if (!Number.isSafeInteger(droppedBytes) || droppedBytes < 0) return true;
+      const bytesField = data.slice(0, sepIdx);
+      // Strict decimal-only: reject "", "0x10", "1e3", "+1", " ", which
+      // Number() would otherwise coerce. Defensive against a crafted stream
+      // deliberately targeting this private-use OSC.
+      if (!/^\d+$/.test(bytesField)) return true;
+      const droppedBytes = Number(bytesField);
+      if (!Number.isSafeInteger(droppedBytes)) return true;
       this.onDataLoss?.(droppedBytes);
       return true;
     });

--- a/src/services/terminal/TerminalParserHandler.ts
+++ b/src/services/terminal/TerminalParserHandler.ts
@@ -7,10 +7,17 @@ import { getAgentConfig } from "@/config/agents";
 // Mode 1049: Save cursor + switch to alternate screen buffer (most common)
 const ALT_SCREEN_MODES = new Set([47, 1047, 1049]);
 
+// Private-use OSC identifier carrying the PTY data-loss signal. Chosen from
+// the high private range (57300+) to avoid clashing with emulator OSC numbers
+// (iTerm2 1337, rxvt 777, WezTerm 1000-range) or our own OSC 11/52 handlers.
+// Wire format: ESC ] 57301 ; <droppedBytes> ; <reasonCode> BEL
+const OSC_DATA_LOSS = 57301;
+
 export class TerminalParserHandler {
   private managed: ManagedTerminal;
   private disposables: Array<{ dispose: () => void }> = [];
   private onBufferExit?: () => void;
+  private onDataLoss?: (droppedBytes: number) => void;
 
   private normalizeCsiParams(params: Array<number | number[]> | undefined): number[] {
     if (!params) return [];
@@ -25,9 +32,14 @@ export class TerminalParserHandler {
     return flat;
   }
 
-  constructor(managed: ManagedTerminal, onBufferExit?: () => void) {
+  constructor(
+    managed: ManagedTerminal,
+    onBufferExit?: () => void,
+    onDataLoss?: (droppedBytes: number) => void
+  ) {
     this.managed = managed;
     this.onBufferExit = onBufferExit;
+    this.onDataLoss = onDataLoss;
     this.attachHandlers();
   }
 
@@ -66,6 +78,23 @@ export class TerminalParserHandler {
     // Unconditional — all terminal kinds must block this attack vector.
     const osc52Handler = terminal.parser.registerOscHandler(52, () => true);
     this.disposables.push(osc52Handler);
+
+    // PTY data-loss marker. The pty-host drops bytes (drop-don't-block) during
+    // heavy-output bursts and signals it through this private-use OSC instead
+    // of a raw ANSI write, keeping the wire format free of presentation. xterm
+    // strips the identifier + first semicolon, so `data` is "<bytes>;<reason>".
+    // Always consume (return true) so a malformed payload never leaks into the
+    // buffer. The callback is fired synchronously; the caller is responsible
+    // for deferring any terminal.write to avoid write-during-parse reentrancy.
+    const dataLossHandler = terminal.parser.registerOscHandler(OSC_DATA_LOSS, (data) => {
+      const sepIdx = data.indexOf(";");
+      if (sepIdx === -1) return true;
+      const droppedBytes = Number(data.slice(0, sepIdx));
+      if (!Number.isSafeInteger(droppedBytes) || droppedBytes < 0) return true;
+      this.onDataLoss?.(droppedBytes);
+      return true;
+    });
+    this.disposables.push(dataLossHandler);
 
     // Track alternate screen buffer exit via DEC private mode sequences.
     // Note: Buffer state (isAltBuffer) is primarily tracked via xterm.js's

--- a/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
@@ -86,7 +86,10 @@ describe("injectDataLossMarker", () => {
     // Leading CAN cancels any partial in-flight sequence; OSC carries the
     // byte count + reason code and is BEL-terminated. Presentation (the
     // yellow ANSI line) must NOT be on the wire.
-    expect(oscWrite).toMatch(/\x18\x1b\]57301;1234;backpressure\x07/);
+    const CAN = String.fromCharCode(0x18);
+    const BEL = String.fromCharCode(0x07);
+    const expectedPattern = `${CAN}\x1b]57301;1234;backpressure${BEL}`;
+    expect(oscWrite).toBe(expectedPattern);
     expect(oscWrite).not.toContain("Output dropped");
     expect(oscWrite).not.toContain("\x1b[33m");
   });

--- a/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    resize: vi.fn(),
+    onData: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    write: vi.fn(),
+    setActivityTier: vi.fn(),
+    wake: vi.fn(),
+    getSerializedState: vi.fn(),
+    getSharedBuffers: vi.fn(async () => ({
+      visualBuffers: [],
+      signalBuffer: null,
+    })),
+    acknowledgeData: vi.fn(),
+    acknowledgePortData: vi.fn(),
+  },
+  systemClient: { openExternal: vi.fn() },
+  appClient: { getHydrationState: vi.fn() },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+    onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+  })),
+}));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(() => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: { dispose: vi.fn() },
+    searchAddon: {},
+    fileLinksDisposable: { dispose: vi.fn() },
+    webLinksAddon: { dispose: vi.fn() },
+  })),
+  createImageAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+vi.mock("@/store/scrollbackStore", () => ({
+  useScrollbackStore: { getState: () => ({ scrollbackLines: 5000 }) },
+}));
+
+vi.mock("@/store/performanceModeStore", () => ({
+  usePerformanceModeStore: { getState: () => ({ performanceMode: false }) },
+}));
+
+vi.mock("@/store/projectSettingsStore", () => ({
+  useProjectSettingsStore: { getState: () => ({ settings: null }) },
+}));
+
+const { terminalInstanceService } = await import("../TerminalInstanceService");
+
+function createManagedTerminal(id: string) {
+  return terminalInstanceService.getOrCreate(id, undefined, {
+    rows: 24,
+    cols: 80,
+    allowProposedApi: true,
+  });
+}
+
+describe("injectDataLossMarker", () => {
+  beforeEach(() => {
+    terminalInstanceService.dispose();
+  });
+
+  it("writes a structured OSC 57301 sequence, not a raw ANSI line", () => {
+    const managed = createManagedTerminal("dl-1");
+    const writeSpy = vi.spyOn(managed.terminal, "write");
+
+    terminalInstanceService.injectDataLossMarker("dl-1", 1234);
+
+    const oscWrite = writeSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes("\x1b]57301;"));
+    expect(oscWrite).toBeDefined();
+    // Leading CAN cancels any partial in-flight sequence; OSC carries the
+    // byte count + reason code and is BEL-terminated. Presentation (the
+    // yellow ANSI line) must NOT be on the wire.
+    expect(oscWrite).toMatch(/\x18\x1b\]57301;1234;backpressure\x07/);
+    expect(oscWrite).not.toContain("Output dropped");
+    expect(oscWrite).not.toContain("\x1b[33m");
+  });
+
+  it("is a no-op for an unknown terminal id", () => {
+    expect(() => terminalInstanceService.injectDataLossMarker("nope", 10)).not.toThrow();
+  });
+
+  it("does not write when the terminal is hibernated", () => {
+    const managed = createManagedTerminal("dl-2");
+    terminalInstanceService.hibernate("dl-2");
+    const writeSpy = vi.spyOn(managed.terminal, "write");
+
+    terminalInstanceService.injectDataLossMarker("dl-2", 99);
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders the yellow marker via the OSC handler round-trip", async () => {
+    createManagedTerminal("dl-3");
+    terminalInstanceService.injectDataLossMarker("dl-3", 2048);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    const text = terminalInstanceService.captureBufferText("dl-3");
+    expect(text).toContain("Output dropped (~2048 bytes)");
+    // The raw OSC sequence is consumed by the handler and never reaches the
+    // buffer as visible text.
+    expect(text).not.toContain("57301");
+  });
+
+  it("uses a generic label when the dropped byte count is zero", async () => {
+    createManagedTerminal("dl-4");
+    terminalInstanceService.injectDataLossMarker("dl-4", 0);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    const text = terminalInstanceService.captureBufferText("dl-4");
+    expect(text).toContain("Output dropped (output)");
+  });
+});

--- a/src/services/terminal/__tests__/TerminalParserHandler.test.ts
+++ b/src/services/terminal/__tests__/TerminalParserHandler.test.ts
@@ -107,9 +107,10 @@ describe("TerminalParserHandler", () => {
     );
     expect(dynamicBlockers.some((h) => h.handler([1049]))).toBe(false);
     expect(dynamicBlockers.some((h) => h.handler([1000]))).toBe(false);
-    // OSC 52 clipboard block applies unconditionally to all terminal kinds
-    expect(oscHandlers).toHaveLength(1);
-    expect(oscHandlers[0].ident).toBe(52);
+    // OSC 52 clipboard block + OSC 57301 data-loss marker apply
+    // unconditionally to all terminal kinds.
+    expect(oscHandlers).toHaveLength(2);
+    expect(oscHandlers.map((h) => h.ident).sort()).toEqual([52, 57301]);
   });
 
   it("should NOT block alt screen for OpenCode agent", () => {
@@ -192,5 +193,56 @@ describe("TerminalParserHandler", () => {
 
     handler.dispose();
     expect(osc52.disposable.dispose).toHaveBeenCalled();
+  });
+
+  describe("OSC 57301 data-loss marker", () => {
+    it("registers the OSC 57301 handler unconditionally", () => {
+      new TerminalParserHandler(mockManaged);
+      const osc = oscHandlers.find((h) => h.ident === 57301);
+      expect(osc).toBeDefined();
+    });
+
+    it("parses a valid payload and fires onDataLoss with the byte count", () => {
+      const onDataLoss = vi.fn();
+      new TerminalParserHandler(mockManaged, undefined, onDataLoss);
+      const osc = oscHandlers.find((h) => h.ident === 57301);
+
+      expect(osc.handler("1234;backpressure")).toBe(true);
+      expect(onDataLoss).toHaveBeenCalledWith(1234);
+    });
+
+    it("fires onDataLoss with 0 when no bytes were counted", () => {
+      const onDataLoss = vi.fn();
+      new TerminalParserHandler(mockManaged, undefined, onDataLoss);
+      const osc = oscHandlers.find((h) => h.ident === 57301);
+
+      expect(osc.handler("0;backpressure")).toBe(true);
+      expect(onDataLoss).toHaveBeenCalledWith(0);
+    });
+
+    it("consumes but ignores malformed payloads", () => {
+      const onDataLoss = vi.fn();
+      new TerminalParserHandler(mockManaged, undefined, onDataLoss);
+      const osc = oscHandlers.find((h) => h.ident === 57301);
+
+      for (const bad of ["abc;backpressure", "-1;backpressure", "", "1234", "1.5;x"]) {
+        expect(osc.handler(bad)).toBe(true);
+      }
+      expect(onDataLoss).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when no onDataLoss callback is provided", () => {
+      new TerminalParserHandler(mockManaged);
+      const osc = oscHandlers.find((h) => h.ident === 57301);
+      expect(() => osc.handler("1234;backpressure")).not.toThrow();
+      expect(osc.handler("1234;backpressure")).toBe(true);
+    });
+
+    it("disposes the OSC 57301 handler", () => {
+      const handler = new TerminalParserHandler(mockManaged);
+      const osc = oscHandlers.find((h) => h.ident === 57301);
+      handler.dispose();
+      expect(osc.disposable.dispose).toHaveBeenCalled();
+    });
   });
 });

--- a/src/services/terminal/__tests__/TerminalParserHandler.test.ts
+++ b/src/services/terminal/__tests__/TerminalParserHandler.test.ts
@@ -209,6 +209,7 @@ describe("TerminalParserHandler", () => {
 
       expect(osc.handler("1234;backpressure")).toBe(true);
       expect(onDataLoss).toHaveBeenCalledWith(1234);
+      expect(onDataLoss).toHaveBeenCalledTimes(1);
     });
 
     it("fires onDataLoss with 0 when no bytes were counted", () => {
@@ -225,7 +226,20 @@ describe("TerminalParserHandler", () => {
       new TerminalParserHandler(mockManaged, undefined, onDataLoss);
       const osc = oscHandlers.find((h) => h.ident === 57301);
 
-      for (const bad of ["abc;backpressure", "-1;backpressure", "", "1234", "1.5;x"]) {
+      const malformed = [
+        "abc;backpressure",
+        "-1;backpressure",
+        "",
+        "1234",
+        "1.5;x",
+        // Number() would coerce these; strict decimal parsing must reject them.
+        "0x10;backpressure",
+        "1e3;backpressure",
+        "+1;backpressure",
+        " ;backpressure",
+        ";backpressure",
+      ];
+      for (const bad of malformed) {
         expect(osc.handler(bad)).toBe(true);
       }
       expect(onDataLoss).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Replaces the raw ANSI write in `TerminalInstanceService.injectDataLossMarker` with a private-use OSC 57301 sequence carrying dropped byte count and reason code, keeping the wire format free of presentation logic
- A handler in `TerminalParserHandler` (alongside the existing OSC 11/52 handlers) consumes the sequence before it reaches the buffer and fires an `onDataLoss` callback; the callback draws the existing yellow warning line via `queueMicrotask` to avoid xterm write-during-parse reentrancy -- user-visible appearance is unchanged
- Documents the data-loss transient pulse, drop-don't-block design, and the no-replay recovery contract in `docs/architecture/terminal-lifecycle.md`

Resolves #8362

## Changes

- `TerminalParserHandler`: register OSC 57301 handler with strict decimal validation; consume sequence, fire callback
- `TerminalInstanceService`: rewrite `injectDataLossMarker` to emit `ESC ] 57301 ; <droppedBytes> ; <reasonCode> BEL`; add `onDataLoss` callback wiring
- `docs/architecture/terminal-lifecycle.md`: document the data-loss pulse and its design contracts
- Tests: 6 new OSC 57301 handler unit tests + 5 new `injectDataLossMarker` round-trip tests; updated existing OSC-count assertion

## Testing

All 23 targeted tests pass. Full verify (typecheck, lint, format, build, ratchet) clean. The structured sequence is assertable without a rendered pixel -- which also unblocks E2E coverage that the old ANSI marker couldn't support.