### PR TITLE
fix(dock): move Open in grid button into PanelHeader control slot

### DIFF
--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -259,6 +259,7 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
                 terminal={terminal}
                 onPopoverClose={handlePopoverClose}
                 onAddTab={isSinglePanel ? () => handleAddTabForPanel(terminal) : undefined}
+                showRestoreControl={isSinglePanel}
               />
             </div>
           </DockPopoverChildProvider>

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDndMonitor } from "@dnd-kit/core";
-import { SquareArrowOutUpRight } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn, getBaseTitle } from "@/lib/utils";
 import {
@@ -159,11 +158,6 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     },
     [terminal.id, openDockTerminal, closeDockTerminal]
   );
-
-  const handlePopOut = useCallback(() => {
-    const moved = moveTerminalToGrid(terminal.id);
-    if (moved) closeDockTerminal();
-  }, [terminal.id, moveTerminalToGrid, closeDockTerminal]);
 
   const presetCustomPresets = useAgentSettingsStore((s) =>
     terminal.launchAgentId ? s.settings?.agents?.[terminal.launchAgentId]?.customPresets : undefined
@@ -381,23 +375,6 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
               className="w-full h-full flex flex-col"
               data-dock-portal-target={terminal.id}
             />
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handlePopOut();
-                  }}
-                  onPointerDown={(e) => e.stopPropagation()}
-                  className="absolute top-1.5 right-1.5 p-1 rounded text-daintree-text/40 hover:text-daintree-text hover:bg-daintree-text/10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                  aria-label="Open in grid"
-                >
-                  <SquareArrowOutUpRight className="w-3.5 h-3.5" aria-hidden="true" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Open in grid</TooltipContent>
-            </Tooltip>
           </div>
         </PopoverContent>
       </Popover>

--- a/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
@@ -357,41 +357,8 @@ describe("DockedTerminalItem lifecycle and pop-out (#8160)", () => {
     expect(calls.some((c) => c[1] === TerminalRefreshTier.BACKGROUND)).toBe(true);
   });
 
-  it("renders an 'Open in grid' button that pops the terminal to the grid", () => {
-    mockActiveDockTerminalId = "t-1";
-
-    const { container } = render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
-
-    const popOut = container.querySelector(
-      'button[aria-label="Open in grid"]'
-    ) as HTMLButtonElement | null;
-    expect(popOut).not.toBeNull();
-
-    moveTerminalToGridMock.mockReturnValue(true);
-    act(() => {
-      popOut?.click();
-    });
-
-    expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
-    expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not close the dock when moveTerminalToGrid returns false", () => {
-    mockActiveDockTerminalId = "t-1";
-
-    const { container } = render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
-
-    const popOut = container.querySelector(
-      'button[aria-label="Open in grid"]'
-    ) as HTMLButtonElement | null;
-    expect(popOut).not.toBeNull();
-
-    moveTerminalToGridMock.mockReturnValue(false);
-    act(() => {
-      popOut?.click();
-    });
-
-    expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
-    expect(closeDockTerminalMock).not.toHaveBeenCalled();
-  });
+  // The "Open in grid" affordance moved out of DockedTerminalItem's overlay and
+  // into PanelHeader's control slot (#8359). Button rendering + onRestore wiring
+  // is covered by PanelHeader.test.tsx; the conditional dock-close lives in
+  // DockedPanel.handleRestore.
 });

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -43,6 +43,7 @@ export interface BasePanelProps {
   onTitleChange?: (newTitle: string) => void;
   onMinimize?: () => void;
   onRestore?: () => void;
+  showRestoreControl?: boolean;
 }
 
 export interface ContentPanelProps extends BasePanelProps {
@@ -138,6 +139,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     onTitleChange,
     onMinimize,
     onRestore,
+    showRestoreControl,
     children,
     headerContent,
     headerActions,
@@ -464,6 +466,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
           onTitleChange={onTitleChange}
           onMinimize={onMinimize}
           onRestore={onRestore}
+          showRestoreControl={showRestoreControl}
           onRestart={onRestart}
           isPinged={isPinged}
           wasJustSelected={wasJustSelected}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -105,6 +105,13 @@ export interface PanelHeaderProps {
   onTitleChange?: (newTitle: string) => void;
   onMinimize?: () => void;
   onRestore?: () => void;
+  /**
+   * Render the inline "Open in grid" control in the dock header. Gated so it
+   * isn't duplicated by DockedTabGroup's own restore button on grouped panels
+   * (single-panel dock only). onRestore still powers double-click + the
+   * overflow-menu "Restore to Grid" item regardless of this flag.
+   */
+  showRestoreControl?: boolean;
   onRestart?: () => void;
 
   // Visual states
@@ -172,6 +179,7 @@ function PanelHeaderComponent({
   onTitleChange,
   onMinimize,
   onRestore,
+  showRestoreControl,
   onRestart,
   isPinged,
   wasJustSelected = false,
@@ -1000,7 +1008,9 @@ function PanelHeaderComponent({
           </Tooltip>
         )}
 
-        {/* Middle control: Collapse-to-Dock + Open-in-grid (dock) / Maximize / Exit Focus */}
+        {/* Middle control: Collapse-to-Dock + Open-in-grid (dock) / Maximize / Exit Focus.
+            Dock panels never receive onToggleMaximize, so this branch owns the
+            slot whenever location is "dock" regardless of onMinimize. */}
         {location === "dock" ? (
           <>
             {onMinimize && (
@@ -1025,7 +1035,7 @@ function PanelHeaderComponent({
                 </TooltipContent>
               </Tooltip>
             )}
-            {onRestore && (
+            {onRestore && showRestoreControl && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -24,6 +24,7 @@ import {
   PanelBottomClose,
   PanelTopClose,
   Pencil,
+  SquareArrowOutUpRight,
   Trash2,
   Unlock,
 } from "lucide-react";
@@ -999,28 +1000,51 @@ function PanelHeaderComponent({
           </Tooltip>
         )}
 
-        {/* Middle control: Collapse-to-Dock / Maximize / Exit Focus */}
-        {location === "dock" && onMinimize ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onMinimize();
-                }}
-                onPointerDown={(e) => e.stopPropagation()}
-                className="p-1.5 hover:bg-daintree-text/10 focus-visible:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors"
-                aria-label="Collapse to Dock"
-                aria-keyshortcuts={toggleDockAriaShortcut}
-                data-testid="panel-collapse-to-dock"
-              >
-                <PanelBottomClose className="w-3 h-3" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {createTooltipContent("Collapse to Dock", toggleDockShortcut)}
-            </TooltipContent>
-          </Tooltip>
+        {/* Middle control: Collapse-to-Dock + Open-in-grid (dock) / Maximize / Exit Focus */}
+        {location === "dock" ? (
+          <>
+            {onMinimize && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onMinimize();
+                    }}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    className="p-1.5 hover:bg-daintree-text/10 focus-visible:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors"
+                    aria-label="Collapse to Dock"
+                    aria-keyshortcuts={toggleDockAriaShortcut}
+                    data-testid="panel-collapse-to-dock"
+                  >
+                    <PanelBottomClose className="w-3 h-3" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {createTooltipContent("Collapse to Dock", toggleDockShortcut)}
+                </TooltipContent>
+              </Tooltip>
+            )}
+            {onRestore && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRestore();
+                    }}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    className="p-1.5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:bg-daintree-text/10 focus-visible:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-[opacity,color,background-color] duration-150"
+                    aria-label="Open in grid"
+                    data-testid="panel-open-in-grid"
+                  >
+                    <SquareArrowOutUpRight className="w-3 h-3" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Open in grid</TooltipContent>
+              </Tooltip>
+            )}
+          </>
         ) : onToggleMaximize && isMaximized ? (
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -420,6 +420,34 @@ describe("PanelHeader", () => {
     });
   });
 
+  describe("Open in grid button", () => {
+    it("renders when location is dock and onRestore is provided", () => {
+      const onRestore = vi.fn();
+      render(<PanelHeader {...makeProps({ location: "dock", onRestore })} />);
+      const btn = screen.getByTestId("panel-open-in-grid");
+      expect(btn).toBeDefined();
+      expect(btn.getAttribute("aria-label")).toBe("Open in grid");
+    });
+
+    it("calls onRestore when clicked", () => {
+      const onRestore = vi.fn();
+      render(<PanelHeader {...makeProps({ location: "dock", onRestore })} />);
+      screen.getByTestId("panel-open-in-grid").click();
+      expect(onRestore).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not render when onRestore is not provided", () => {
+      render(<PanelHeader {...makeProps({ location: "dock", onMinimize: vi.fn() })} />);
+      expect(screen.queryByTestId("panel-open-in-grid")).toBeNull();
+    });
+
+    it("does not render when location is grid", () => {
+      const onRestore = vi.fn();
+      render(<PanelHeader {...makeProps({ location: "grid", onRestore })} />);
+      expect(screen.queryByTestId("panel-open-in-grid")).toBeNull();
+    });
+  });
+
   describe("Restore to Grid in overflow menu", () => {
     it("renders 'Restore to Grid' menu item when docked with onRestore", () => {
       render(<PanelHeader {...makeProps({ location: "dock", onRestore: vi.fn() })} />);

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -421,9 +421,11 @@ describe("PanelHeader", () => {
   });
 
   describe("Open in grid button", () => {
-    it("renders when location is dock and onRestore is provided", () => {
+    it("renders when docked with onRestore and showRestoreControl", () => {
       const onRestore = vi.fn();
-      render(<PanelHeader {...makeProps({ location: "dock", onRestore })} />);
+      render(
+        <PanelHeader {...makeProps({ location: "dock", onRestore, showRestoreControl: true })} />
+      );
       const btn = screen.getByTestId("panel-open-in-grid");
       expect(btn).toBeDefined();
       expect(btn.getAttribute("aria-label")).toBe("Open in grid");
@@ -431,20 +433,58 @@ describe("PanelHeader", () => {
 
     it("calls onRestore when clicked", () => {
       const onRestore = vi.fn();
-      render(<PanelHeader {...makeProps({ location: "dock", onRestore })} />);
+      render(
+        <PanelHeader {...makeProps({ location: "dock", onRestore, showRestoreControl: true })} />
+      );
       screen.getByTestId("panel-open-in-grid").click();
       expect(onRestore).toHaveBeenCalledTimes(1);
     });
 
+    it("does not render when showRestoreControl is false (grouped dock panel)", () => {
+      const onRestore = vi.fn();
+      render(
+        <PanelHeader {...makeProps({ location: "dock", onRestore, showRestoreControl: false })} />
+      );
+      expect(screen.queryByTestId("panel-open-in-grid")).toBeNull();
+    });
+
     it("does not render when onRestore is not provided", () => {
-      render(<PanelHeader {...makeProps({ location: "dock", onMinimize: vi.fn() })} />);
+      render(
+        <PanelHeader
+          {...makeProps({ location: "dock", onMinimize: vi.fn(), showRestoreControl: true })}
+        />
+      );
       expect(screen.queryByTestId("panel-open-in-grid")).toBeNull();
     });
 
     it("does not render when location is grid", () => {
       const onRestore = vi.fn();
-      render(<PanelHeader {...makeProps({ location: "grid", onRestore })} />);
+      render(
+        <PanelHeader {...makeProps({ location: "grid", onRestore, showRestoreControl: true })} />
+      );
       expect(screen.queryByTestId("panel-open-in-grid")).toBeNull();
+    });
+
+    it("renders alongside Collapse to Dock, each firing only its own handler", () => {
+      const onRestore = vi.fn();
+      const onMinimize = vi.fn();
+      render(
+        <PanelHeader
+          {...makeProps({
+            location: "dock",
+            onRestore,
+            onMinimize,
+            showRestoreControl: true,
+          })}
+        />
+      );
+      screen.getByTestId("panel-open-in-grid").click();
+      expect(onRestore).toHaveBeenCalledTimes(1);
+      expect(onMinimize).not.toHaveBeenCalled();
+
+      screen.getByTestId("panel-collapse-to-dock").click();
+      expect(onMinimize).toHaveBeenCalledTimes(1);
+      expect(onRestore).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/Terminal/DockedPanel.tsx
+++ b/src/components/Terminal/DockedPanel.tsx
@@ -15,9 +15,16 @@ export interface DockedPanelProps {
   terminal: TerminalInstance;
   onPopoverClose?: () => void;
   onAddTab?: () => void;
+  /** Show the inline "Open in grid" header control (single-panel dock only). */
+  showRestoreControl?: boolean;
 }
 
-export function DockedPanel({ terminal, onPopoverClose, onAddTab }: DockedPanelProps) {
+export function DockedPanel({
+  terminal,
+  onPopoverClose,
+  onAddTab,
+  showRestoreControl,
+}: DockedPanelProps) {
   const moveTerminalToGrid = usePanelStore((state) => state.moveTerminalToGrid);
   const closeDockTerminal = usePanelStore((state) => state.closeDockTerminal);
 
@@ -83,6 +90,7 @@ export function DockedPanel({ terminal, onPopoverClose, onAddTab }: DockedPanelP
           onMinimize: handleMinimize,
           onTitleChange: handleTitleChange,
           onAddTab,
+          showRestoreControl,
         },
       }),
     [
@@ -94,6 +102,7 @@ export function DockedPanel({ terminal, onPopoverClose, onAddTab }: DockedPanelP
       handleMinimize,
       handleTitleChange,
       onAddTab,
+      showRestoreControl,
     ]
   );
 

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -211,6 +211,7 @@ export interface TerminalPaneProps {
   onTitleChange?: (newTitle: string) => void;
   onMinimize?: () => void;
   onRestore?: () => void;
+  showRestoreControl?: boolean;
   location?: "grid" | "dock";
   restartKey?: number;
   restartError?: TerminalRestartError;
@@ -255,6 +256,7 @@ function TerminalPaneComponent({
   onTitleChange,
   onMinimize,
   onRestore,
+  showRestoreControl,
   location = "grid",
   restartKey = 0,
   restartError,
@@ -1013,6 +1015,7 @@ function TerminalPaneComponent({
       onTitleChange={onTitleChange}
       onMinimize={onMinimize}
       onRestore={onRestore}
+      showRestoreControl={showRestoreControl}
       headerActions={agentHeaderActions}
       onRestart={handleRestart}
       isExited={isExited}

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -42,6 +42,7 @@ export interface PanelComponentProps {
   onTitleChange?: (newTitle: string) => void;
   onMinimize?: () => void;
   onRestore?: () => void;
+  showRestoreControl?: boolean;
   gridPanelCount?: number;
   extensionState?: Record<string, unknown>;
   [key: string]: unknown;


### PR DESCRIPTION
## Summary

- The "Open in grid" button in the docked agent panel was absolutely positioned (`top-1.5 right-1.5`) as an overlay, which caused it to overlap the status indicator in the panel header beneath it.
- Moved the button into `PanelHeader`'s middle-control slot, reusing the existing `onRestore` prop already threaded through `DockedPanel` → `ContentPanel` → `PanelHeader` (also powers double-click and overflow-menu restore).
- Added a `showRestoreControl` prop gated on `isSinglePanel`, threaded through `DockPanelOffscreenContainer` → `DockedPanel` → `TerminalPane` → `ContentPanel` → `PanelHeader`, so the inline button isn't duplicated by `DockedTabGroup`'s own restore button on grouped panels.

Resolves #8359

## Changes

- `PanelHeader.tsx` — added `showRestoreControl` prop; renders "Open in grid" in middle-control slot (mutually exclusive with Maximize, matching render order: Collapse to Dock → Open in grid → Close)
- `ContentPanel.tsx`, `TerminalPane.tsx`, `DockedPanel.tsx`, `DockPanelOffscreenContainer.tsx` — thread `showRestoreControl` prop down the stack
- `DockedTerminalItem.tsx` — removed overlay button and `handlePopOut`
- `registry.tsx` — minor cleanup
- `PanelHeader.test.tsx` — 6 new tests covering the "Open in grid button" behaviour
- `DockedTerminalItem.mountGuard.test.tsx` — removed 2 obsolete overlay tests

## Testing

- 69 unit tests pass, including 6 new `PanelHeader` tests
- `tsc --noEmit` clean
- ESLint ratchet unchanged at 880