### PR TITLE
perf(sidebar): inline StaticWorktreeRow to stop full-list re-renders on poll

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -991,22 +991,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       ? groupedSections.reduce((n, s) => n + 1 + s.worktrees.length, 0)
       : filteredWorktrees.length);
 
-  const renderWorktreeCard = (worktree: WorktreeState, ariaRowIndex: number) => (
-    <StaticWorktreeRow
-      key={worktree.id}
-      worktreeId={worktree.id}
-      activeWorktreeId={activeWorktreeId}
-      focusedWorktreeId={focusedWorktreeId}
-      totalWorktreeCount={deferredWorktrees.length}
-      selectWorktree={selectWorktree}
-      worktreeActions={worktreeActions}
-      availability={availability}
-      agentSettings={agentSettings}
-      homeDir={homeDir}
-      ariaRowIndex={ariaRowIndex}
-    />
-  );
-
   return (
     <div className="flex flex-col h-full">
       {worktreeLoadErrorBanner}
@@ -1136,7 +1120,19 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             className="shrink-0"
             style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
           >
-            {renderWorktreeCard(integrationWorktree, integrationRowIndex)}
+            <StaticWorktreeRow
+              key={integrationWorktree.id}
+              worktreeId={integrationWorktree.id}
+              activeWorktreeId={activeWorktreeId}
+              focusedWorktreeId={focusedWorktreeId}
+              totalWorktreeCount={deferredWorktrees.length}
+              selectWorktree={selectWorktree}
+              worktreeActions={worktreeActions}
+              availability={availability}
+              agentSettings={agentSettings}
+              homeDir={homeDir}
+              ariaRowIndex={integrationRowIndex}
+            />
           </div>
         )}
 
@@ -1204,9 +1200,21 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                     let nextRowIndex = firstScrollableRowIndex;
                     return groupedSections.map((section) => {
                       const headerRowIndex = nextRowIndex++;
-                      const sectionWorktreeRows = section.worktrees.map((worktree) =>
-                        renderWorktreeCard(worktree, nextRowIndex++)
-                      );
+                      const sectionWorktreeRows = section.worktrees.map((worktree) => (
+                        <StaticWorktreeRow
+                          key={worktree.id}
+                          worktreeId={worktree.id}
+                          activeWorktreeId={activeWorktreeId}
+                          focusedWorktreeId={focusedWorktreeId}
+                          totalWorktreeCount={deferredWorktrees.length}
+                          selectWorktree={selectWorktree}
+                          worktreeActions={worktreeActions}
+                          availability={availability}
+                          agentSettings={agentSettings}
+                          homeDir={homeDir}
+                          ariaRowIndex={nextRowIndex++}
+                        />
+                      ));
                       return (
                         <div key={section.type} role="rowgroup">
                           <div

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -331,6 +331,55 @@ describe("Worktree list keyboard grid — issue #6422", () => {
     });
   });
 
+  describe("issue #8389 — per-row sidebar subscription stops full-list re-renders", () => {
+    let source: string;
+    let staticSource: string;
+    beforeEach(async () => {
+      source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+      staticSource = await fs.readFile(STATIC_ROW_PATH, "utf-8");
+    });
+
+    it("StaticWorktreeRow subscribes to its own store slice by id (not a prop object)", () => {
+      // The row reads exactly its own snapshot via a primitive Map-get
+      // selector, so an unrelated worktree changing in the poll cycle does
+      // not invalidate this row's selector result.
+      expect(staticSource).toMatch(
+        /useWorktreeStore\(\s*\(state\)\s*=>\s*state\.worktrees\.get\(worktreeId\)\s*\)/
+      );
+      // The row's public prop is the id, never a full WorktreeState object.
+      expect(staticSource).toContain("worktreeId: string;");
+      expect(staticSource).not.toMatch(/worktree:\s*WorktreeState;/);
+    });
+
+    it("removes the per-render renderWorktreeCard closure that re-created every row element each poll", () => {
+      // A closure rebuilt on every SidebarContent render produced a fresh
+      // element factory each poll, defeating the React Compiler's per-row
+      // memoization. Rows must be authored as inline JSX so each element is
+      // memoized by its own (id-only) props.
+      expect(source).not.toMatch(/const renderWorktreeCard\s*=/);
+      expect(source).not.toMatch(/renderWorktreeCard\(/);
+    });
+
+    it("renders the integration and grouped-section rows as <StaticWorktreeRow worktreeId={...}/> (id only)", () => {
+      // Integration (pinned) row.
+      expect(source).toMatch(
+        /<StaticWorktreeRow\s+key=\{integrationWorktree\.id\}\s+worktreeId=\{integrationWorktree\.id\}/
+      );
+      // Grouped-section rows.
+      expect(source).toMatch(
+        /section\.worktrees\.map\(\(worktree\)\s*=>\s*\(\s*<StaticWorktreeRow\s+key=\{worktree\.id\}\s+worktreeId=\{worktree\.id\}/
+      );
+      // No render path threads a full worktree object into the row.
+      expect(source).not.toMatch(/<StaticWorktreeRow[^>]*\bworktree=\{/);
+    });
+
+    it("preserves the side-effecting aria-rowindex counter in the grouped path", () => {
+      // The 1-based aria-rowindex slot advances per rendered data row; the
+      // inline conversion must keep the post-increment exactly.
+      expect(source).toMatch(/ariaRowIndex=\{nextRowIndex\+\+\}/);
+    });
+  });
+
   describe("issue #7972 — sortable sidebar drop indicator and keyboard reorder", () => {
     describe("SortableWorktreeCard directional drop indicator", () => {
       let source: string;

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -358,6 +358,12 @@ describe("Worktree list keyboard grid — issue #6422", () => {
       // memoized by its own (id-only) props.
       expect(source).not.toMatch(/const renderWorktreeCard\s*=/);
       expect(source).not.toMatch(/renderWorktreeCard\(/);
+      // Guard against the same anti-pattern resurfacing under a different
+      // name — any per-render closure that returns a <StaticWorktreeRow/>
+      // factory re-creates row elements each poll and defeats memoization.
+      expect(source).not.toMatch(
+        /const \w*(?:render|make|build)\w*(?:Row|Card)\w*\s*=\s*\([^)]*\)\s*=>\s*\(?\s*<StaticWorktreeRow/
+      );
     });
 
     it("renders the integration and grouped-section rows as <StaticWorktreeRow worktreeId={...}/> (id only)", () => {


### PR DESCRIPTION
## Summary

Every worktree card in the sidebar was re-rendering on each 2-second poll. Two things caused it:

1. `SidebarContent` allocated a fresh `worktrees` array each tick, so every row got a new prop reference regardless of whether anything changed.
2. The inline `renderWorktreeCard` closure rebuilt the row element factory on every render, defeating React Compiler's per-row memoization.

Fix removes the closure and inlines `<StaticWorktreeRow worktreeId={id} />` directly at the integration-branch and grouped-section call sites, matching the same id-only prop pattern already used by the main worktree row. Each row subscribes to its own normalized store slice via `useWorktreeStore((s) => s.worktrees.get(worktreeId))` — the `snapshotsEqual` identity guard already in place means a poll only touches rows whose data actually changed.

`GroupedSection<T>` is intentionally unchanged (exported, 3+ external callers). The `aria-rowindex` counter is preserved at the call sites.

Resolves #8389

## Changes

- `SidebarContent.tsx` — removed `renderWorktreeCard` closure; inlined `<StaticWorktreeRow>` with id-only props at both call sites; preserved `aria-rowindex` counter
- `SidebarContent.grid.test.ts` — added contract tests: per-row store-slice subscription, closure-removed + broadened anti-pattern guard, id-only render boundary, `aria-rowindex` counter

## Testing

- `vitest SidebarContent.grid.test.ts` — 64 tests pass
- Full typecheck pass
- Lint clean (4 pre-existing warnings on develop baseline, confirmed via `git stash`)
- Prettier clean

Behavioral RTL render tests deliberately avoided — `SidebarContent` has no RTL tests anywhere in the file; adding context-hook leaf components crashes isolated component tests (known repo lesson).