### PR TITLE
feat(worktree): surface cloud-side teardown failure in notification inbox

### DIFF
--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -45,6 +45,7 @@ export class WorkspaceHostEventRouter {
   private inotifyLimitToastSent = false;
   private emfileLimitToastSent = false;
   private forgeRateLimitStates = new Map<string, RateLimitInfo>();
+  private cloudTeardownFailureToastKeys = new Set<string>();
 
   constructor(deps: WorkspaceHostEventRouterDeps) {
     this.emit = deps.emit;
@@ -75,6 +76,35 @@ export class WorkspaceHostEventRouter {
           projectPath: entry.projectPath,
         });
         events.emit("sys:worktree:update", worktree);
+
+        // Cloud-side teardown failure: when `phase: "resource-teardown"` ends in
+        // `failed` or `timed-out`, the user's cloud resource may still be running
+        // and billing — the worktree row is about to disappear, so the inbox is
+        // the only durable surface. Fired in transit (before the next phase's
+        // `running` snapshot overwrites the status) and debounced per
+        // `(worktreeId, startedAt)` so repeated snapshots of the same failure
+        // don't spam.
+        //
+        // Asymmetric: we deliberately do NOT mirror this for `phase: "teardown"`
+        // (local cleanup) failures. The directory is about to be removed and the
+        // user cannot act differently than by ignoring the signal — notify()'s
+        // four-question checklist demotes it. Do not "fix" this asymmetry.
+        const status = worktree.lifecycleStatus;
+        if (
+          status?.phase === "resource-teardown" &&
+          (status.state === "failed" || status.state === "timed-out")
+        ) {
+          const key = `${worktree.worktreeId}:${status.startedAt}`;
+          if (!this.cloudTeardownFailureToastKeys.has(key)) {
+            this.cloudTeardownFailureToastKeys.add(key);
+            broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+              type: "error",
+              title: "Cloud resource may still be running",
+              message:
+                "The teardown script didn't complete — your cloud resource may still be active and billing",
+            });
+          }
+        }
         break;
       }
 

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -102,6 +102,9 @@ export class WorkspaceHostEventRouter {
               title: "Cloud resource may still be running",
               message:
                 "The teardown script didn't complete — your cloud resource may still be active and billing",
+              // Dedicated bucket so an unrelated error burst can't absorb this
+              // billing-critical notification into a generic overflow row.
+              rateLimitKey: "cloud-teardown-failure",
             });
           }
         }

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -159,6 +159,14 @@ describe("WorkspaceHostEventRouter", () => {
       startedAt: number
     ) => ({ phase, state, startedAt });
 
+    const expectedToast = {
+      type: "error",
+      title: "Cloud resource may still be running",
+      message:
+        "The teardown script didn't complete — your cloud resource may still be active and billing",
+      rateLimitKey: "cloud-teardown-failure",
+    };
+
     it("fires inbox notification when resource-teardown fails", () => {
       const entry = makeEntry();
       const event = makeWorktreeUpdateEvent({
@@ -167,12 +175,11 @@ describe("WorkspaceHostEventRouter", () => {
 
       router.routeHostEvent(entry, event);
 
-      expect(broadcastToRenderer).toHaveBeenCalledWith(CHANNELS.NOTIFICATION_SHOW_TOAST, {
-        type: "error",
-        title: "Cloud resource may still be running",
-        message:
-          "The teardown script didn't complete — your cloud resource may still be active and billing",
-      });
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
+      expect(broadcastToRenderer).toHaveBeenCalledWith(
+        CHANNELS.NOTIFICATION_SHOW_TOAST,
+        expectedToast
+      );
     });
 
     it("fires inbox notification when resource-teardown times out", () => {
@@ -183,13 +190,22 @@ describe("WorkspaceHostEventRouter", () => {
 
       router.routeHostEvent(entry, event);
 
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
       expect(broadcastToRenderer).toHaveBeenCalledWith(
         CHANNELS.NOTIFICATION_SHOW_TOAST,
-        expect.objectContaining({
-          type: "error",
-          title: "Cloud resource may still be running",
-        })
+        expectedToast
       );
+    });
+
+    it("still emits the normal worktree-update side-effects when a toast fires", () => {
+      const entry = makeEntry();
+      const event = makeWorktreeUpdateEvent({
+        lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 1000),
+      });
+
+      router.routeHostEvent(entry, event);
+
+      expect(events.emit).toHaveBeenCalledWith("sys:worktree:update", event.worktree);
     });
 
     it("does not fire on resource-teardown running snapshot", () => {
@@ -218,14 +234,15 @@ describe("WorkspaceHostEventRouter", () => {
 
     it("does not fire on local config-teardown failure (asymmetric rule)", () => {
       const entry = makeEntry();
-      router.routeHostEvent(
-        entry,
-        makeWorktreeUpdateEvent({
-          lifecycleStatus: lifecycleStatus("teardown", "failed", 1000),
-        })
-      );
+      const event = makeWorktreeUpdateEvent({
+        lifecycleStatus: lifecycleStatus("teardown", "failed", 1000),
+      });
+
+      router.routeHostEvent(entry, event);
 
       expect(broadcastToRenderer).not.toHaveBeenCalled();
+      // Normal routing must still happen even when the toast is skipped.
+      expect(events.emit).toHaveBeenCalledWith("sys:worktree:update", event.worktree);
     });
 
     it("does not fire on local config-teardown timeout (asymmetric rule)", () => {
@@ -291,6 +308,33 @@ describe("WorkspaceHostEventRouter", () => {
       );
 
       expect(broadcastToRenderer).toHaveBeenCalledTimes(2);
+    });
+
+    it("debounce covers different terminal states of the same attempt", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 1000),
+        })
+      );
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          lifecycleStatus: lifecycleStatus("resource-teardown", "timed-out", 1000),
+        })
+      );
+
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not throw when lifecycleStatus is absent", () => {
+      const entry = makeEntry();
+      const event = makeWorktreeUpdateEvent();
+
+      expect(() => router.routeHostEvent(entry, event)).not.toThrow();
+      expect(broadcastToRenderer).not.toHaveBeenCalled();
+      expect(events.emit).toHaveBeenCalledWith("sys:worktree:update", event.worktree);
     });
   });
 });

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceHostEventRouter } from "../WorkspaceHostEventRouter.js";
+import { CHANNELS } from "../../../ipc/channels.js";
 import type { WorkspaceHostEvent } from "../../../../shared/types/workspace-host.js";
+import type {
+  WorktreeLifecyclePhase,
+  WorktreeLifecycleState,
+} from "../../../../shared/types/worktree.js";
 import type { ProcessEntry, CopyTreeProgressCallback } from "../types.js";
 import type { WorkspaceHostProcess } from "../../WorkspaceHostProcess.js";
 
@@ -144,6 +149,148 @@ describe("WorkspaceHostEventRouter", () => {
       router.routeHostEvent(entry, event);
 
       expect(events.emit).toHaveBeenCalledWith("sys:worktree:update", event.worktree);
+    });
+  });
+
+  describe("cloud resource teardown failure notifications", () => {
+    const lifecycleStatus = (
+      phase: WorktreeLifecyclePhase,
+      state: WorktreeLifecycleState,
+      startedAt: number
+    ) => ({ phase, state, startedAt });
+
+    it("fires inbox notification when resource-teardown fails", () => {
+      const entry = makeEntry();
+      const event = makeWorktreeUpdateEvent({
+        lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 1000),
+      });
+
+      router.routeHostEvent(entry, event);
+
+      expect(broadcastToRenderer).toHaveBeenCalledWith(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+        type: "error",
+        title: "Cloud resource may still be running",
+        message:
+          "The teardown script didn't complete — your cloud resource may still be active and billing",
+      });
+    });
+
+    it("fires inbox notification when resource-teardown times out", () => {
+      const entry = makeEntry();
+      const event = makeWorktreeUpdateEvent({
+        lifecycleStatus: lifecycleStatus("resource-teardown", "timed-out", 1000),
+      });
+
+      router.routeHostEvent(entry, event);
+
+      expect(broadcastToRenderer).toHaveBeenCalledWith(
+        CHANNELS.NOTIFICATION_SHOW_TOAST,
+        expect.objectContaining({
+          type: "error",
+          title: "Cloud resource may still be running",
+        })
+      );
+    });
+
+    it("does not fire on resource-teardown running snapshot", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          lifecycleStatus: lifecycleStatus("resource-teardown", "running", 1000),
+        })
+      );
+
+      expect(broadcastToRenderer).not.toHaveBeenCalled();
+    });
+
+    it("does not fire on resource-teardown success", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          lifecycleStatus: lifecycleStatus("resource-teardown", "success", 1000),
+        })
+      );
+
+      expect(broadcastToRenderer).not.toHaveBeenCalled();
+    });
+
+    it("does not fire on local config-teardown failure (asymmetric rule)", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          lifecycleStatus: lifecycleStatus("teardown", "failed", 1000),
+        })
+      );
+
+      expect(broadcastToRenderer).not.toHaveBeenCalled();
+    });
+
+    it("does not fire on local config-teardown timeout (asymmetric rule)", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          lifecycleStatus: lifecycleStatus("teardown", "timed-out", 1000),
+        })
+      );
+
+      expect(broadcastToRenderer).not.toHaveBeenCalled();
+    });
+
+    it("debounces duplicate snapshots of the same (worktreeId, startedAt)", () => {
+      const entry = makeEntry();
+      const event = makeWorktreeUpdateEvent({
+        lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 1000),
+      });
+
+      router.routeHostEvent(entry, event);
+      router.routeHostEvent(entry, event);
+      router.routeHostEvent(entry, event);
+
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires again for a new teardown attempt with a different startedAt", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 1000),
+        })
+      );
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 2000),
+        })
+      );
+
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(2);
+    });
+
+    it("fires independently for different worktrees with the same startedAt", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          id: "wt-1",
+          worktreeId: "wt-1",
+          lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 1000),
+        })
+      );
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          id: "wt-2",
+          worktreeId: "wt-2",
+          lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 1000),
+        })
+      );
+
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -222,6 +222,13 @@ export interface MainProcessToastPayload {
   type: "success" | "error" | "info" | "warning";
   title?: string;
   message: string;
+  /**
+   * Rate-limit bucket override threaded through to `notify({ rateLimitKey })`.
+   * Without this, payloads share a bucket keyed only on `type` (e.g. all
+   * `"error"` toasts), so an unrelated burst of errors can absorb a billing-
+   * critical notification into a generic overflow row.
+   */
+  rateLimitKey?: string;
   action?: {
     label: string;
     /** IPC channel to invoke when the action button is clicked */

--- a/src/hooks/__tests__/useMainProcessToastListener.test.tsx
+++ b/src/hooks/__tests__/useMainProcessToastListener.test.tsx
@@ -15,6 +15,7 @@ type ToastCallback = (payload: {
   type: "success" | "error" | "info" | "warning";
   title?: string;
   message: string;
+  rateLimitKey?: string;
   action?: { label: string; ipcChannel: string };
 }) => void;
 
@@ -74,8 +75,26 @@ describe("useMainProcessToastListener", () => {
       type: "success",
       title: "CLI installed",
       message: "The daintree command is now available",
+      rateLimitKey: undefined,
       action: undefined,
     });
+  });
+
+  it("threads rateLimitKey through to notify when provided", () => {
+    renderHook(() => useMainProcessToastListener());
+
+    act(() => {
+      capturedCallback!({
+        type: "error",
+        title: "Cloud resource may still be running",
+        message: "Teardown failed",
+        rateLimitKey: "cloud-teardown-failure",
+      });
+    });
+
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ rateLimitKey: "cloud-teardown-failure" })
+    );
   });
 
   it("calls notify with an action that triggers checkForUpdates", () => {

--- a/src/hooks/useMainProcessToastListener.ts
+++ b/src/hooks/useMainProcessToastListener.ts
@@ -40,6 +40,7 @@ export function useMainProcessToastListener(): void {
         type: payload.type,
         title: payload.title,
         message: payload.message,
+        rateLimitKey: payload.rateLimitKey,
         action,
       });
     });


### PR DESCRIPTION
## Summary

- Fires a high-priority error notification from `WorkspaceHostEventRouter` when a `worktree-update` event carries `phase: "resource-teardown"` with `state: "failed"` or `"timed-out"` — the worktree row disappears seconds later, so the inbox is the only durable surface for a billing-critical signal
- Debounced per `(worktreeId, startedAt)` so repeated snapshots of the same failure don't stack; uses a dedicated `rateLimitKey: "cloud-teardown-failure"` bucket so an unrelated burst of error toasts can't absorb this notification into a generic overflow row
- Intentionally asymmetric: `phase: "teardown"` (local cleanup) failures are not mirrored — the directory is about to be gone and the user can't act differently, so the `notify()` four-question checklist demotes it; the comment at the call site documents this so it doesn't get "fixed"

Resolves #8409

## Changes

- `WorkspaceHostEventRouter`: cloud-side teardown failure detection with debounce and dedicated rate-limit bucket; `forgeRateLimitStates` field from develop preserved alongside new `cloudTeardownFailureToastKeys`
- `shared/types/ipc/maps.ts`: `NOTIFICATION_SHOW_TOAST` payload extended with optional `rateLimitKey`
- `useMainProcessToastListener`: threads `rateLimitKey` through to the renderer-side `notify()` call
- Tests: both failure states, debounce, per-worktree independence, asymmetric skip for local-only teardown, and `lifecycleStatus`-absent safety
- "Open full log" action stub omitted pending #8407 (no log path available yet)

## Testing

Unit tests cover all branches in `WorkspaceHostEventRouter.__tests__/WorkspaceHostEventRouter.test.ts` and the renderer hook in `useMainProcessToastListener.test.tsx`. Typecheck and lint pass clean.