### PR TITLE
fix(clone): surface GitHub-aware recovery action on auth failure

### DIFF
--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -23,7 +23,8 @@ import type {
 } from "../../../../shared/types/ipc/gitClone.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { validateFolderName } from "../../../../shared/utils/folderName.js";
-import { AppError } from "../../../utils/errorTypes.js";
+import { classifyGitError } from "../../../../shared/utils/gitOperationErrors.js";
+import { AppError, GitOperationError } from "../../../utils/errorTypes.js";
 
 const GH_AUTH_PROBE_TIMEOUT_MS = 3_000;
 const GH_CLONE_TIMEOUT_MS = 5 * 60 * 1_000;
@@ -372,11 +373,11 @@ export function registerGitCloneHandlers(): () => void {
 
       const errorMessage = formatErrorMessage(error, "Failed to clone repository");
       emitProgress("error", 0, `Clone failed: ${errorMessage}`);
-      throw new AppError({
-        code: "INTERNAL",
-        message: errorMessage,
-        context: { targetPath },
+      const reason = classifyGitError(error);
+      throw new GitOperationError(reason, errorMessage, {
+        op: "clone",
         cause: error instanceof Error ? error : undefined,
+        context: { targetPath, url },
       });
     } finally {
       activeControllers.delete(localController);

--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -374,10 +374,13 @@ export function registerGitCloneHandlers(): () => void {
       const errorMessage = formatErrorMessage(error, "Failed to clone repository");
       emitProgress("error", 0, `Clone failed: ${errorMessage}`);
       const reason = classifyGitError(error);
+      // `url` deliberately omitted from context — it can carry embedded
+      // credentials (e.g. https://x-access-token:TOKEN@github.com/...) and
+      // the renderer already has the input URL in local state.
       throw new GitOperationError(reason, errorMessage, {
         op: "clone",
         cause: error instanceof Error ? error : undefined,
-        context: { targetPath, url },
+        context: { targetPath },
       });
     } finally {
       activeControllers.delete(localController);

--- a/electron/workspace-host/worktreeUtils.ts
+++ b/electron/workspace-host/worktreeUtils.ts
@@ -3,7 +3,10 @@ import { mkdir, writeFile, stat } from "fs/promises";
 import { join as pathJoin, dirname } from "path";
 import { getGitDir } from "../utils/gitUtils.js";
 import { getGitLocaleEnv } from "../utils/hardenedGit.js";
+import { isGitHubRemoteUrl } from "../../shared/utils/githubUrl.js";
 import { NOTE_PATH } from "./types.js";
+
+export { isGitHubRemoteUrl };
 
 // Hard ceiling on the `git lfs version` probe. `git` is already on PATH, so a
 // healthy probe returns in milliseconds; the 3 s cap only matters on slow/
@@ -66,19 +69,6 @@ export function probeGitLfsAvailable(): Promise<boolean> {
 
 export function escapeBranchRegex(name: string): string {
   return name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/**
- * Detect github.com remotes in either HTTPS or SSH form. Inlined here rather
- * than imported from `../services/github/...` to keep the workspace-host's
- * dependency direction one-way (workspace-host → utils, never → main services).
- */
-const GITHUB_REMOTE_URL_PATTERN =
-  /^(?:https?:\/\/(?:[^@/]+@)?github\.com\/|git@github\.com:|ssh:\/\/git@github\.com\/)/i;
-
-export function isGitHubRemoteUrl(url: string | undefined): boolean {
-  if (!url) return false;
-  return GITHUB_REMOTE_URL_PATTERN.test(url.trim());
 }
 
 export function parseCheckedOutBranches(porcelainOutput: string): Set<string> {

--- a/shared/utils/__tests__/githubUrl.test.ts
+++ b/shared/utils/__tests__/githubUrl.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { isGitHubRemoteUrl } from "../githubUrl.js";
+
+describe("isGitHubRemoteUrl", () => {
+  it.each([
+    "https://github.com/owner/repo",
+    "https://github.com/owner/repo.git",
+    "http://github.com/owner/repo",
+    "https://user@github.com/owner/repo.git",
+    "https://x-access-token:abc@github.com/owner/repo.git",
+    "git@github.com:owner/repo.git",
+    "ssh://git@github.com/owner/repo.git",
+    "  https://github.com/owner/repo.git  ",
+    "HTTPS://GitHub.com/Owner/Repo.git",
+  ])("matches GitHub URL: %s", (url) => {
+    expect(isGitHubRemoteUrl(url)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "owner/repo",
+    "https://gitlab.com/owner/repo.git",
+    "https://bitbucket.org/owner/repo.git",
+    "git@gitlab.com:owner/repo.git",
+    "https://github.example.com/owner/repo.git",
+    "https://ghe.example.com/owner/repo.git",
+    "https://example.com/github.com/owner/repo",
+    "ssh://git@gitlab.com/owner/repo.git",
+  ])("does not match non-GitHub URL: %s", (url) => {
+    expect(isGitHubRemoteUrl(url)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isGitHubRemoteUrl(undefined)).toBe(false);
+  });
+});

--- a/shared/utils/githubUrl.ts
+++ b/shared/utils/githubUrl.ts
@@ -1,0 +1,12 @@
+/**
+ * Detect github.com remotes in HTTPS or SSH form. Lives in `shared/` so both
+ * the main-process workspace host (worktree monitoring) and the renderer
+ * (clone dialog recovery banner) can import a single source of truth.
+ */
+const GITHUB_REMOTE_URL_PATTERN =
+  /^(?:https?:\/\/(?:[^@/]+@)?github\.com\/|git@github\.com:|ssh:\/\/git@github\.com\/)/i;
+
+export function isGitHubRemoteUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  return GITHUB_REMOTE_URL_PATTERN.test(url.trim());
+}

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -332,9 +332,10 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
           </div>
         )}
 
-        {/* Error (not from progress events) */}
+        {/* Error block — rendered alongside the progress log so the recovery
+            banner is reachable even when emitProgress("error") has already
+            queued an "error" row in the log. */}
         {error &&
-          !progressEvents.some((e) => e.stage === "error") &&
           (() => {
             const showGitHubAuth =
               error.gitReason === "auth-failed" && isGitHubRemoteUrl(normalizeCloneUrl(url));

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -160,6 +160,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
         // `gitReason` is reattached duck-typed across the IPC realm boundary
         // (see `deserializeError` in shared/utils/ipcErrorSerialization.ts);
         // `instanceof GitOperationError` would fail here.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- intentional duck-type read across IPC realm
         const gitReason = (err as { gitReason?: GitOperationReason })?.gitReason;
         setError({
           message: formatErrorMessage(err, "Failed to clone repository"),

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -1,13 +1,22 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
-import { Check, AlertCircle, FolderOpen, X } from "lucide-react";
+import { Check, AlertCircle, FolderOpen, LogIn, X } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { FolderGit2 } from "@/components/icons";
+import { InlineStatusBanner, type BannerAction } from "@/components/Terminal/InlineStatusBanner";
 import { projectClient } from "@/clients";
+import { actionService } from "@/services/ActionService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { validateFolderName } from "@shared/utils/folderName";
+import { isGitHubRemoteUrl } from "@shared/utils/githubUrl";
 import type { CloneRepoProgressEvent } from "@shared/types/ipc/gitClone";
+import type { GitOperationReason } from "@shared/types/ipc/errors";
+
+interface CloneError {
+  message: string;
+  gitReason?: GitOperationReason;
+}
 
 interface CloneRepoDialogProps {
   isOpen: boolean;
@@ -54,7 +63,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   const [shallowClone, setShallowClone] = useState(false);
   const [progressEvents, setProgressEvents] = useState<CloneRepoProgressEvent[]>([]);
   const [isCloning, setIsCloning] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<CloneError | null>(null);
   const [isComplete, setIsComplete] = useState(false);
   const [clonedPath, setClonedPath] = useState<string | null>(null);
   const logEndRef = useRef<HTMLDivElement>(null);
@@ -148,7 +157,14 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
       // CANCELLED is the user aborting via the cancel button — not a failure.
       const code = (err as { code?: string })?.code;
       if (code !== "CANCELLED") {
-        setError(formatErrorMessage(err, "Failed to clone repository"));
+        // `gitReason` is reattached duck-typed across the IPC realm boundary
+        // (see `deserializeError` in shared/utils/ipcErrorSerialization.ts);
+        // `instanceof GitOperationError` would fail here.
+        const gitReason = (err as { gitReason?: GitOperationReason })?.gitReason;
+        setError({
+          message: formatErrorMessage(err, "Failed to clone repository"),
+          gitReason,
+        });
       }
     } finally {
       setIsCloning(false);
@@ -317,15 +333,49 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
         )}
 
         {/* Error (not from progress events) */}
-        {error && !progressEvents.some((e) => e.stage === "error") && (
-          <div className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive flex items-start gap-2">
-            <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-            <div>
-              <div className="font-medium">Clone Failed</div>
-              <div className="text-xs mt-1">{error}</div>
-            </div>
-          </div>
-        )}
+        {error &&
+          !progressEvents.some((e) => e.stage === "error") &&
+          (() => {
+            const showGitHubAuth =
+              error.gitReason === "auth-failed" && isGitHubRemoteUrl(normalizeCloneUrl(url));
+            if (showGitHubAuth) {
+              const actions: BannerAction[] = [
+                {
+                  id: "signin-github",
+                  label: "Sign in with GitHub",
+                  icon: LogIn,
+                  variant: "accent",
+                  onClick: () => {
+                    void actionService.dispatch(
+                      "app.settings.openTab",
+                      { tab: "github" },
+                      { source: "user" }
+                    );
+                  },
+                  title: "Open GitHub sign-in",
+                  ariaLabel: "Sign in with GitHub",
+                },
+              ];
+              return (
+                <InlineStatusBanner
+                  icon={AlertCircle}
+                  title="Clone Failed"
+                  description={error.message}
+                  severity="error"
+                  actions={actions}
+                />
+              );
+            }
+            return (
+              <div className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive flex items-start gap-2">
+                <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                <div>
+                  <div className="font-medium">Clone Failed</div>
+                  <div className="text-xs mt-1">{error.message}</div>
+                </div>
+              </div>
+            );
+          })()}
 
         {/* Actions */}
         <div className="flex justify-end gap-2">

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -271,6 +271,62 @@ describe("CloneRepoDialog", () => {
     });
   });
 
+  it("shows GitHub sign-in CTA even after an 'error' progress event is emitted", async () => {
+    // Reproduces the production flow: the handler calls emitProgress("error",
+    // ...) before throwing, so the renderer's progressEvents list contains
+    // {stage:"error"} by the time setError runs. The banner must still render.
+    let rejectClone: (err: unknown) => void = () => {};
+    cloneRepoMock.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectClone = reject;
+        })
+    );
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    fireEvent.change(urlInput, {
+      target: { value: "https://github.com/acme/private.git" },
+    });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    const cloneBtn = screen.getByText("Clone");
+    await act(async () => {
+      fireEvent.click(cloneBtn);
+    });
+
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+
+    // Emit the error progress event first (matches handler ordering), then
+    // reject the invoke — the banner must still appear.
+    act(() => {
+      progressHandler?.({
+        stage: "error",
+        progress: 0,
+        message: "Clone failed: Authentication failed",
+        timestamp: Date.now(),
+      });
+    });
+
+    await act(async () => {
+      rejectClone(
+        Object.assign(new Error("Authentication failed"), {
+          name: "GitOperationError",
+          gitReason: "auth-failed",
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign in with GitHub")).toBeTruthy();
+    });
+  });
+
   it("shows GitHub sign-in CTA when auth fails against a github.com URL", async () => {
     cloneRepoMock.mockRejectedValue(
       Object.assign(new Error("Authentication failed for 'https://github.com/acme/private.git/'"), {

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -1,17 +1,42 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, beforeAll, afterEach } from "vitest";
 import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import type { ReactNode, ButtonHTMLAttributes } from "react";
 import type { CloneRepoProgressEvent } from "@shared/types/ipc/gitClone";
 
-const { cloneRepoMock, onCloneProgressMock, openDialogMock, cancelCloneMock } = vi.hoisted(() => ({
-  cloneRepoMock: vi.fn(),
-  onCloneProgressMock: vi.fn(),
-  openDialogMock: vi.fn(),
-  cancelCloneMock: vi.fn(),
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const { cloneRepoMock, onCloneProgressMock, openDialogMock, cancelCloneMock, dispatchMock } =
+  vi.hoisted(() => ({
+    cloneRepoMock: vi.fn(),
+    onCloneProgressMock: vi.fn(),
+    openDialogMock: vi.fn(),
+    cancelCloneMock: vi.fn(),
+    dispatchMock: vi.fn(),
+  }));
 
 vi.mock("@/clients", () => ({
   projectClient: {
@@ -19,6 +44,12 @@ vi.mock("@/clients", () => ({
     onCloneProgress: onCloneProgressMock,
     openDialog: openDialogMock,
     cancelClone: cancelCloneMock,
+  },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: dispatchMock,
   },
 }));
 
@@ -238,6 +269,136 @@ describe("CloneRepoDialog", () => {
       expect(screen.getByText("Auth failed")).toBeTruthy();
       expect(screen.getByText("Retry")).toBeTruthy();
     });
+  });
+
+  it("shows GitHub sign-in CTA when auth fails against a github.com URL", async () => {
+    cloneRepoMock.mockRejectedValue(
+      Object.assign(new Error("Authentication failed for 'https://github.com/acme/private.git/'"), {
+        name: "GitOperationError",
+        gitReason: "auth-failed",
+      })
+    );
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    fireEvent.change(urlInput, {
+      target: { value: "https://github.com/acme/private.git" },
+    });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    const cloneBtn = screen.getByText("Clone");
+    await act(async () => {
+      fireEvent.click(cloneBtn);
+    });
+
+    const signInBtn = await waitFor(() => screen.getByText("Sign in with GitHub"));
+    expect(signInBtn).toBeTruthy();
+    expect(screen.getByText("Clone Failed")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(signInBtn);
+    });
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "github" },
+      { source: "user" }
+    );
+  });
+
+  it("shows GitHub sign-in CTA when auth fails on owner/repo shorthand", async () => {
+    cloneRepoMock.mockRejectedValue(
+      Object.assign(new Error("Authentication failed"), {
+        name: "GitOperationError",
+        gitReason: "auth-failed",
+      })
+    );
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    fireEvent.change(urlInput, { target: { value: "acme/private" } });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    const cloneBtn = screen.getByText("Clone");
+    await act(async () => {
+      fireEvent.click(cloneBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign in with GitHub")).toBeTruthy();
+    });
+  });
+
+  it("does not show GitHub CTA when auth fails on a non-GitHub URL", async () => {
+    cloneRepoMock.mockRejectedValue(
+      Object.assign(new Error("Authentication failed"), {
+        name: "GitOperationError",
+        gitReason: "auth-failed",
+      })
+    );
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    fireEvent.change(urlInput, {
+      target: { value: "https://gitlab.com/acme/private.git" },
+    });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    const cloneBtn = screen.getByText("Clone");
+    await act(async () => {
+      fireEvent.click(cloneBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Clone Failed")).toBeTruthy();
+    });
+    expect(screen.queryByText("Sign in with GitHub")).toBeNull();
+  });
+
+  it("does not show GitHub CTA when failure reason is not auth-failed", async () => {
+    cloneRepoMock.mockRejectedValue(
+      Object.assign(new Error("Could not resolve host: github.com"), {
+        name: "GitOperationError",
+        gitReason: "network-unavailable",
+      })
+    );
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    fireEvent.change(urlInput, {
+      target: { value: "https://github.com/acme/private.git" },
+    });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    const cloneBtn = screen.getByText("Clone");
+    await act(async () => {
+      fireEvent.click(cloneBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Clone Failed")).toBeTruthy();
+    });
+    expect(screen.queryByText("Sign in with GitHub")).toBeNull();
   });
 
   it("is not dismissible while cloning", async () => {


### PR DESCRIPTION
## Summary

- When cloning a private repo fails due to an auth error and the URL is a GitHub URL, the dialog now shows an `InlineStatusBanner` with a "Sign in with GitHub" CTA that opens the GitHub settings tab directly
- `gitClone.ts` now throws `GitOperationError` with a `gitReason` field instead of a generic `AppError`, so the renderer can branch on the specific failure class
- Added a shared `isGitHubRemoteUrl` utility in `shared/utils/githubUrl.ts`; `worktreeUtils.ts` is updated to import from there instead of duplicating the pattern

Resolves #8411

## Changes

- `shared/utils/githubUrl.ts` — new `isGitHubRemoteUrl(url)` utility covering HTTPS and SSH GitHub remotes
- `electron/ipc/handlers/projectCrud/gitClone.ts` — throws `GitOperationError` with classified `gitReason` on auth failure (URL omitted from the error context to avoid embedded-credential leaks in dev mode)
- `src/components/Project/CloneRepoDialog.tsx` — error state widened to `{ message, gitReason? }`; renders the `InlineStatusBanner` recovery path when `gitReason === "auth-failed"` and the URL resolves to a GitHub remote; dropped the `!progressEvents.some(...)` guard that was blocking the banner from rendering after a progress-then-error sequence
- `shared/utils/__tests__/githubUrl.test.ts` — unit tests for matched and unmatched URL patterns
- `src/components/Project/__tests__/CloneRepoDialog.test.tsx` — 5 new cases: GitHub HTTPS auth-failed, owner/repo shorthand, GitLab rejection (no banner), network-unavailable rejection (no banner), and the progress-event + rejection ordering regression

## Testing

All 110 tests pass. Typecheck, lint, format, and build are clean.