### PR TITLE
feat(worktree): persist full teardown command output to per-run log file

### DIFF
--- a/electron/utils/secretScrubber.ts
+++ b/electron/utils/secretScrubber.ts
@@ -15,6 +15,7 @@
  *   8. AgentInstallService progress stdout/stderr scrubbing
  *   9. AgentHelpService command output scrubbing
  *  10. AgentVersionService error-message scrubbing
+ *  11. WorktreeLifecycleService full-output teardown log write (writeTeardownLog)
  *
  * All patterns use bounded quantifiers for ReDoS safety. See the
  * `secretScrubber.test.ts` sibling for the `safe-regex2` assertion that

--- a/electron/workspace-host/WorktreeLifecycleService.ts
+++ b/electron/workspace-host/WorktreeLifecycleService.ts
@@ -1,15 +1,17 @@
 import { spawn, spawnSync, type ChildProcess } from "child_process";
-import { readFile, access, cp } from "fs/promises";
+import { readFile, access, cp, mkdir, readdir, unlink } from "fs/promises";
 import { join as pathJoin, basename, dirname } from "path";
 import os from "os";
 import { z } from "zod/v4";
 import { scrubSecrets } from "../utils/secretScrubber.js";
 import { buildProbeEnv } from "../utils/spawnEnv.js";
+import { resilientAtomicWriteFile } from "../utils/fs.js";
 import type { WorktreeMonitor } from "./WorktreeMonitor.js";
 import { applyResourceConfigToMonitor } from "./resourceConfigHelpers.js";
 
 const OUTPUT_TAIL_BYTES = 8192;
 const DEFAULT_TIMEOUT_MS = 120_000;
+const MAX_TEARDOWN_LOGS_PER_WORKTREE = 10;
 
 const ResourceTimeoutsSchema = z.object({
   provision: z.number().positive().optional(),
@@ -77,6 +79,14 @@ export interface RunCommandsOptions {
   timeoutMs?: number;
   signal?: AbortSignal;
   onProgress: (commandIndex: number, totalCommands: number, command: string) => void;
+  /**
+   * When set, the full scrubbed output for this run is persisted to a new file
+   * inside this directory. The returned `RunCommandsResult.logPath` is the
+   * absolute path on success, or undefined if the write or directory creation
+   * failed (failures never abort the run — log persistence is best-effort).
+   * Callers that don't want persistence (resource status polls, setup) omit it.
+   */
+  logDir?: string;
 }
 
 export interface RunCommandsResult {
@@ -85,6 +95,8 @@ export interface RunCommandsResult {
   error?: string;
   timedOut?: boolean;
   aborted?: boolean;
+  /** Absolute path to the persisted full-output log file, when one was written. */
+  logPath?: string;
 }
 
 async function fileExists(p: string): Promise<boolean> {
@@ -120,7 +132,7 @@ export class WorktreeLifecycleService {
     worktreePath: string,
     projectRootPath: string
   ): Promise<DaintreeLifecycleConfig | null> {
-    const sanitizedRoot = projectRootPath.replace(/[/\\:*?"<>|]/g, "_");
+    const sanitizedRoot = sanitizePathSegment(projectRootPath);
     const candidates = [
       pathJoin(this.homeDir, ".daintree", "projects", sanitizedRoot, "config.json"),
       pathJoin(worktreePath, ".daintree", "config.json"),
@@ -206,7 +218,7 @@ export class WorktreeLifecycleService {
    * On Unix, process group kill terminates the whole tree; on Windows, taskkill /T is used.
    */
   async runCommands(commands: string[], options: RunCommandsOptions): Promise<RunCommandsResult> {
-    const { cwd, env, onProgress, timeoutMs = DEFAULT_TIMEOUT_MS, signal } = options;
+    const { cwd, env, onProgress, timeoutMs = DEFAULT_TIMEOUT_MS, signal, logDir } = options;
 
     if (!commands.length) {
       return { success: true, output: "" };
@@ -217,11 +229,13 @@ export class WorktreeLifecycleService {
 
     for (let i = 0; i < commands.length; i++) {
       if (signal?.aborted) {
+        const logPath = await this.persistRunLog(outputChunks, logDir);
         return {
           success: false,
-          output: tailOutput(outputChunks),
+          output: tailOutput(outputChunks, logPath),
           aborted: true,
           error: "Aborted",
+          logPath,
         };
       }
 
@@ -229,11 +243,13 @@ export class WorktreeLifecycleService {
       const remainingMs = deadline - Date.now();
 
       if (remainingMs <= 0) {
+        const logPath = await this.persistRunLog(outputChunks, logDir);
         return {
           success: false,
-          output: tailOutput(outputChunks),
+          output: tailOutput(outputChunks, logPath),
           timedOut: true,
           error: `Timed out before running command ${i + 1}: ${command}`,
+          logPath,
         };
       }
 
@@ -249,25 +265,30 @@ export class WorktreeLifecycleService {
       );
 
       if (result.aborted) {
+        const logPath = await this.persistRunLog(outputChunks, logDir);
         return {
           success: false,
-          output: tailOutput(outputChunks),
+          output: tailOutput(outputChunks, logPath),
           aborted: true,
           error: "Aborted",
+          logPath,
         };
       }
 
       if (!result.success) {
+        const logPath = await this.persistRunLog(outputChunks, logDir);
         return {
           success: false,
-          output: tailOutput(outputChunks),
+          output: tailOutput(outputChunks, logPath),
           timedOut: result.timedOut,
           error: result.error,
+          logPath,
         };
       }
     }
 
-    return { success: true, output: tailOutput(outputChunks) };
+    const logPath = await this.persistRunLog(outputChunks, logDir);
+    return { success: true, output: tailOutput(outputChunks, logPath), logPath };
   }
 
   private runSingleCommand(
@@ -388,10 +409,79 @@ export class WorktreeLifecycleService {
     });
   }
 
+  /**
+   * Persist the full scrubbed output of a command run to a new log file inside
+   * `logDir` and prune the directory to `MAX_TEARDOWN_LOGS_PER_WORKTREE`
+   * entries. Best-effort — any failure resolves to `undefined` so the caller
+   * (teardown) can continue. Returns the absolute log path on success.
+   *
+   * Filename uses `Date.now()` so files sort lexicographically by write order,
+   * which keeps the prune step a simple sorted-by-name slice (no per-file
+   * `stat` round-trip). A collision is harmless: an atomic rename overwrite
+   * keeps the newer content.
+   */
+  private async persistRunLog(
+    chunks: string[],
+    logDir: string | undefined
+  ): Promise<string | undefined> {
+    if (!logDir) return undefined;
+    try {
+      const scrubbed = scrubSecrets(chunks.join(""));
+      await mkdir(logDir, { recursive: true });
+      const logPath = pathJoin(logDir, `${Date.now()}.log`);
+      await resilientAtomicWriteFile(logPath, scrubbed, "utf-8");
+      await this.pruneOldLogs(logDir);
+      return logPath;
+    } catch (err) {
+      console.warn("[WorktreeLifecycle] Failed to persist teardown log:", err);
+      return undefined;
+    }
+  }
+
+  /**
+   * Delete the oldest `.log` files beyond `MAX_TEARDOWN_LOGS_PER_WORKTREE`.
+   * Best-effort — every individual unlink is swallowed so one stuck file
+   * doesn't block pruning the rest, and a failed prune never aborts the run.
+   */
+  private async pruneOldLogs(logDir: string): Promise<void> {
+    try {
+      const entries = await readdir(logDir);
+      const logs = entries.filter((name) => name.endsWith(".log")).sort();
+      const excess = logs.length - MAX_TEARDOWN_LOGS_PER_WORKTREE;
+      if (excess <= 0) return;
+      const toDelete = logs.slice(0, excess);
+      for (const name of toDelete) {
+        try {
+          await unlink(pathJoin(logDir, name));
+        } catch {
+          // best-effort; permission errors or already-gone files are non-fatal
+        }
+      }
+    } catch (err) {
+      console.warn("[WorktreeLifecycle] Failed to prune teardown logs:", err);
+    }
+  }
+
+  /**
+   * Compute the per-worktree teardown-log directory under the user-level
+   * project config root. Returns an absolute path; callers don't need to
+   * create the directory — `persistRunLog` does that on demand.
+   */
+  private teardownLogDir(projectRootPath: string, worktreeName: string): string {
+    return pathJoin(
+      this.homeDir,
+      ".daintree",
+      "projects",
+      sanitizePathSegment(projectRootPath),
+      "teardown-logs",
+      sanitizePathSegment(worktreeName)
+    );
+  }
+
   async loadProjectResourceEnvironments(
     projectRootPath: string
   ): Promise<Record<string, ResourceConfig> | null> {
-    const sanitizedRoot = projectRootPath.replace(/[/\\:*?"<>|]/g, "_");
+    const sanitizedRoot = sanitizePathSegment(projectRootPath);
     const candidates = [
       pathJoin(this.homeDir, ".daintree", "projects", sanitizedRoot, "settings.json"),
       pathJoin(projectRootPath, ".daintree", "settings.json"),
@@ -711,6 +801,7 @@ export class WorktreeLifecycleService {
           cwd: monitor.path,
           env,
           timeoutMs: 300_000,
+          logDir: this.teardownLogDir(projectRootPath, monitor.name),
           onProgress: (commandIndex, totalCommands, command) => {
             const m = ctx.getMonitor(worktreeId);
             if (m) {
@@ -741,6 +832,7 @@ export class WorktreeLifecycleService {
             error: resourceResult.error,
             startedAt: resourceStartedAt,
             completedAt: Date.now(),
+            logPath: resourceResult.logPath,
           });
           ctx.emitUpdate(m);
         }
@@ -795,6 +887,7 @@ export class WorktreeLifecycleService {
         cwd: monitor.path,
         env,
         timeoutMs,
+        logDir: this.teardownLogDir(projectRootPath, monitor.name),
         onProgress: (commandIndex, totalCommands, command) => {
           const m = ctx.getMonitor(worktreeId);
           if (m) {
@@ -821,6 +914,7 @@ export class WorktreeLifecycleService {
           error: result.error,
           startedAt: teardownStartedAt,
           completedAt: Date.now(),
+          logPath: result.logPath,
         });
         ctx.emitUpdate(finalMonitor);
       }
@@ -895,11 +989,25 @@ function buildSpawnEnv(customEnv: Record<string, string>): Record<string, string
   return { ...buildProbeEnv(), ...customEnv };
 }
 
-function tailOutput(chunks: string[]): string {
+function tailOutput(chunks: string[], logPath?: string): string {
   const full = chunks.join("");
-  const tail =
-    full.length <= OUTPUT_TAIL_BYTES
-      ? full
-      : "...(truncated)\n" + full.slice(full.length - OUTPUT_TAIL_BYTES);
-  return scrubSecrets(tail);
+  if (full.length <= OUTPUT_TAIL_BYTES) {
+    return scrubSecrets(full);
+  }
+  const dropped =
+    Buffer.byteLength(full, "utf-8") -
+    Buffer.byteLength(full.slice(full.length - OUTPUT_TAIL_BYTES), "utf-8");
+  const where = logPath ? `full log: ${logPath}` : "full log unavailable";
+  const marker = `...(truncated — omitted ${dropped} bytes; ${where})\n`;
+  return scrubSecrets(marker + full.slice(full.length - OUTPUT_TAIL_BYTES));
+}
+
+/**
+ * Sanitize a path segment for the user-level config root so directory names
+ * remain valid on every supported OS. Mirrors the inline pattern already used
+ * in `loadConfig` and `loadProjectResourceEnvironments`. Exported at module
+ * scope so it can be reused by `teardownLogDir` without `this` binding.
+ */
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[/\\:*?"<>|]/g, "_");
 }

--- a/electron/workspace-host/WorktreeLifecycleService.ts
+++ b/electron/workspace-host/WorktreeLifecycleService.ts
@@ -216,6 +216,11 @@ export class WorktreeLifecycleService {
    * Each command is spawned with a minimal env + DAINTREE_* vars.
    * A shared timeout covers the entire set of commands.
    * On Unix, process group kill terminates the whole tree; on Windows, taskkill /T is used.
+   *
+   * When `options.logDir` is set, a per-run scrubbed log is persisted there
+   * after the run completes. Empty command arrays short-circuit with no log
+   * write (callers in `runLifecycleTeardown` already guard against this, so
+   * the early-return has no impact on the teardown log story).
    */
   async runCommands(commands: string[], options: RunCommandsOptions): Promise<RunCommandsResult> {
     const { cwd, env, onProgress, timeoutMs = DEFAULT_TIMEOUT_MS, signal, logDir } = options;
@@ -991,15 +996,18 @@ function buildSpawnEnv(customEnv: Record<string, string>): Record<string, string
 
 function tailOutput(chunks: string[], logPath?: string): string {
   const full = chunks.join("");
-  if (full.length <= OUTPUT_TAIL_BYTES) {
+  const buf = Buffer.from(full, "utf-8");
+  if (buf.length <= OUTPUT_TAIL_BYTES) {
     return scrubSecrets(full);
   }
-  const dropped =
-    Buffer.byteLength(full, "utf-8") -
-    Buffer.byteLength(full.slice(full.length - OUTPUT_TAIL_BYTES), "utf-8");
+  // Byte-accurate slice: matches the named cap (`*_BYTES`) for multibyte
+  // content. A cut mid-codepoint produces a leading U+FFFD in the tail snippet
+  // — acceptable since the persisted log file is the authoritative artifact.
+  const tail = buf.subarray(buf.length - OUTPUT_TAIL_BYTES).toString("utf-8");
+  const dropped = buf.length - OUTPUT_TAIL_BYTES;
   const where = logPath ? `full log: ${logPath}` : "full log unavailable";
   const marker = `...(truncated — omitted ${dropped} bytes; ${where})\n`;
-  return scrubSecrets(marker + full.slice(full.length - OUTPUT_TAIL_BYTES));
+  return scrubSecrets(marker + tail);
 }
 
 /**

--- a/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
@@ -896,6 +896,26 @@ describe("WorktreeLifecycleService", () => {
       expect(result.logPath).toBeDefined();
       expect(mockAtomicWrite).toHaveBeenCalledTimes(1);
     });
+
+    it("truncates byte-accurately for multibyte UTF-8 content", async () => {
+      // 3000 CJK chars × 3 bytes = 9000 bytes, well over OUTPUT_TAIL_BYTES (8192).
+      // The char count (3000) is under the threshold; if the guard were
+      // char-based the output would not truncate — verifies the byte-correct fix.
+      const multibyte = "界".repeat(3000);
+      mockSpawn.mockReturnValue(makeOutputProcess(multibyte, 0));
+
+      const result = await service.runCommands(["./run.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+        logDir: "/some/log/dir",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("...(truncated — omitted ");
+      // Total 9000 bytes − 8192-byte tail = 808 bytes dropped.
+      expect(result.output).toContain("omitted 808 bytes");
+    });
   });
 
   describe("runLifecycleSetup — return value contract", () => {
@@ -1106,6 +1126,136 @@ describe("WorktreeLifecycleService", () => {
       expect(result).toEqual({ shouldProvision: true });
       // No spawn should fire — no setup commands to run before provisioning
       expect(mockSpawn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("runLifecycleTeardown — log persistence wiring", () => {
+    function makeTeardownMonitor(opts: { hasResourceConfig?: boolean } = {}) {
+      const statuses: unknown[] = [];
+      return {
+        name: "wt-1",
+        branch: "feature/x",
+        path: "/wt",
+        worktreeMode: "local",
+        hasResourceConfig: opts.hasResourceConfig ?? false,
+        get lifecycleStatus() {
+          return statuses[statuses.length - 1];
+        },
+        recordedStatuses: statuses,
+        resourceStatus: undefined,
+        setLifecycleStatus(s: unknown) {
+          statuses.push(s);
+        },
+      };
+    }
+
+    function makeCtx(monitor: ReturnType<typeof makeTeardownMonitor>) {
+      return {
+        projectRootPath: "/projects/my-app",
+        projectEnvVars: {},
+        getMonitor: () => monitor as never,
+        emitUpdate: vi.fn(),
+      } as unknown as import("../WorktreeLifecycleService.js").WorkspaceHostContext;
+    }
+
+    function makeSpawnChild(exitCode: number) {
+      return () => {
+        const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+        const child = {
+          pid: 1234,
+          stdout: { on: vi.fn() },
+          stderr: { on: vi.fn() },
+          on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+            listeners[event] ??= [];
+            listeners[event].push(cb);
+            if (event === "close") setTimeout(() => cb(exitCode), 0);
+          }),
+          kill: vi.fn(),
+        };
+        return child as never;
+      };
+    }
+
+    it("propagates logPath into the final teardown lifecycle status", async () => {
+      const config = { teardown: ["docker compose down"] };
+      mockAccess.mockImplementation(async (p: unknown) => {
+        if (n(p as string).endsWith("/projects/my-app/.daintree/config.json")) return undefined;
+        throw new Error("ENOENT");
+      });
+      mockReadFile.mockResolvedValue(JSON.stringify(config) as never);
+      mockSpawn.mockImplementation(makeSpawnChild(0));
+
+      const monitor = makeTeardownMonitor();
+      await service.runLifecycleTeardown("wt-1", monitor as never, false, makeCtx(monitor));
+
+      const finalStatus = monitor.recordedStatuses.at(-1) as {
+        phase: string;
+        state: string;
+        logPath?: string;
+      };
+      expect(finalStatus.phase).toBe("teardown");
+      expect(finalStatus.state).toBe("success");
+      expect(finalStatus.logPath).toBeDefined();
+      expect(n(finalStatus.logPath ?? "")).toContain(
+        "/home/testuser/.daintree/projects/_projects_my-app/teardown-logs/wt-1/"
+      );
+      expect(finalStatus.logPath).toMatch(/\d+\.log$/);
+    });
+
+    it("propagates logPath into the resource-teardown lifecycle status", async () => {
+      const config = {
+        resource: { teardown: ["terraform destroy"] },
+      };
+      mockAccess.mockImplementation(async (p: unknown) => {
+        if (n(p as string).endsWith("/projects/my-app/.daintree/config.json")) return undefined;
+        throw new Error("ENOENT");
+      });
+      mockReadFile.mockResolvedValue(JSON.stringify(config) as never);
+      mockSpawn.mockImplementation(makeSpawnChild(0));
+
+      const monitor = makeTeardownMonitor({ hasResourceConfig: true });
+      await service.runLifecycleTeardown("wt-1", monitor as never, false, makeCtx(monitor));
+
+      const resourceFinal = monitor.recordedStatuses
+        .filter(
+          (s): s is { phase: string; state: string; logPath?: string } =>
+            typeof s === "object" && s !== null && "phase" in s
+        )
+        .find((s) => s.phase === "resource-teardown" && s.state !== "running");
+      expect(resourceFinal).toBeDefined();
+      expect(resourceFinal?.logPath).toBeDefined();
+      expect(n(resourceFinal?.logPath ?? "")).toContain(
+        "/home/testuser/.daintree/projects/_projects_my-app/teardown-logs/wt-1/"
+      );
+    });
+
+    it("sanitizes path-unsafe characters in the project root segment", async () => {
+      const config = { teardown: ["true"] };
+      mockAccess.mockImplementation(async (p: unknown) => {
+        // Match the unsanitized path read; the config-lookup helper itself
+        // already sanitizes the segment to `_projects_my_app_with_colon` so
+        // the access predicate uses that form.
+        if (n(p as string).endsWith("/projects/my:app/.daintree/config.json")) return undefined;
+        throw new Error("ENOENT");
+      });
+      mockReadFile.mockResolvedValue(JSON.stringify(config) as never);
+      mockSpawn.mockImplementation(makeSpawnChild(0));
+
+      const monitor = makeTeardownMonitor();
+      const ctx = {
+        projectRootPath: "/projects/my:app",
+        projectEnvVars: {},
+        getMonitor: () => monitor as never,
+        emitUpdate: vi.fn(),
+      } as unknown as import("../WorktreeLifecycleService.js").WorkspaceHostContext;
+
+      await service.runLifecycleTeardown("wt-1", monitor as never, false, ctx);
+
+      const finalStatus = monitor.recordedStatuses.at(-1) as { logPath?: string };
+      expect(finalStatus.logPath).toBeDefined();
+      // Colon in the path must not appear in the persisted directory.
+      expect(finalStatus.logPath).not.toContain("my:app");
+      expect(n(finalStatus.logPath ?? "")).toContain("/_projects_my_app/teardown-logs/wt-1/");
     });
   });
 });

--- a/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
@@ -8,11 +8,18 @@ vi.mock("fs/promises", () => ({
   readFile: vi.fn(),
   access: vi.fn(),
   cp: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  readdir: vi.fn().mockResolvedValue([]),
+  unlink: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("child_process", () => ({
   spawn: vi.fn(),
   spawnSync: vi.fn(),
+}));
+
+vi.mock("../../utils/fs.js", () => ({
+  resilientAtomicWriteFile: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("WorktreeLifecycleService", () => {
@@ -642,6 +649,252 @@ describe("WorktreeLifecycleService", () => {
         listeners["close"]?.forEach((cb) => cb(1));
         await resultPromise;
       });
+    });
+  });
+
+  describe("teardown log persistence", () => {
+    let mockMkdir: ReturnType<typeof vi.fn>;
+    let mockReaddir: ReturnType<typeof vi.fn>;
+    let mockUnlink: ReturnType<typeof vi.fn>;
+    let mockAtomicWrite: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      const fsModule = await import("fs/promises");
+      mockMkdir = vi.mocked(fsModule.mkdir as unknown as () => Promise<undefined>);
+      mockReaddir = vi.mocked(fsModule.readdir as unknown as () => Promise<string[]>);
+      mockUnlink = vi.mocked(fsModule.unlink as unknown as () => Promise<void>);
+
+      const fsUtilsModule = await import("../../utils/fs.js");
+      mockAtomicWrite = vi.mocked(fsUtilsModule.resilientAtomicWriteFile);
+      mockAtomicWrite.mockResolvedValue(undefined);
+      mockMkdir.mockResolvedValue(undefined);
+      mockReaddir.mockResolvedValue([]);
+      mockUnlink.mockResolvedValue(undefined);
+    });
+
+    function makeOutputProcess(stdout: string, exitCode = 0) {
+      const stdoutListeners: ((chunk: Buffer) => void)[] = [];
+      const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+      const child = {
+        pid: 12345,
+        stdout: {
+          on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+            if (event === "data") stdoutListeners.push(cb);
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+          listeners[event] ??= [];
+          listeners[event].push(cb);
+        }),
+        kill: vi.fn(),
+        emit: (event: string, ...args: unknown[]) => {
+          listeners[event]?.forEach((cb) => cb(...args));
+        },
+      };
+      setTimeout(() => {
+        stdoutListeners.forEach((cb) => cb(Buffer.from(stdout)));
+        child.emit("close", exitCode);
+      }, 0);
+      return child;
+    }
+
+    it("does not create or write a log file when logDir is omitted", async () => {
+      mockSpawn.mockReturnValue(makeOutputProcess("setup output", 0));
+
+      const result = await service.runCommands(["./run.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.logPath).toBeUndefined();
+      expect(mockMkdir).not.toHaveBeenCalled();
+      expect(mockAtomicWrite).not.toHaveBeenCalled();
+    });
+
+    it("writes a scrubbed full-output log when logDir is provided", async () => {
+      const token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789ABCD";
+      const stdout = `starting... token=${token} ...done`;
+      mockSpawn.mockReturnValue(makeOutputProcess(stdout, 0));
+
+      const result = await service.runCommands(["./run.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+        logDir: "/home/testuser/.daintree/projects/_path_root/teardown-logs/wt-1",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.logPath).toBeDefined();
+      expect(result.logPath).toMatch(
+        /\/home\/testuser\/\.daintree\/projects\/_path_root\/teardown-logs\/wt-1\/\d+\.log$/
+      );
+      expect(mockMkdir).toHaveBeenCalledWith(
+        "/home/testuser/.daintree/projects/_path_root/teardown-logs/wt-1",
+        { recursive: true }
+      );
+      const writtenContent = mockAtomicWrite.mock.calls[0][1];
+      expect(writtenContent).not.toContain(token);
+      expect(writtenContent).toContain("[REDACTED]");
+      expect(writtenContent).toContain("starting...");
+      expect(writtenContent).toContain("...done");
+    });
+
+    it("returns undefined logPath when the log write fails (run still succeeds)", async () => {
+      mockSpawn.mockReturnValue(makeOutputProcess("output", 0));
+      mockAtomicWrite.mockRejectedValueOnce(new Error("ENOSPC: no space left"));
+
+      const result = await service.runCommands(["./run.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+        logDir: "/some/log/dir",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.logPath).toBeUndefined();
+    });
+
+    it("returns undefined logPath when mkdir fails (run still succeeds)", async () => {
+      mockSpawn.mockReturnValue(makeOutputProcess("output", 0));
+      mockMkdir.mockRejectedValueOnce(new Error("EACCES: permission denied"));
+
+      const result = await service.runCommands(["./run.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+        logDir: "/some/log/dir",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.logPath).toBeUndefined();
+      expect(mockAtomicWrite).not.toHaveBeenCalled();
+    });
+
+    it("prunes oldest log files beyond MAX_TEARDOWN_LOGS_PER_WORKTREE", async () => {
+      mockSpawn.mockReturnValue(makeOutputProcess("output", 0));
+      // Simulate 12 existing log files (counting the freshly-written one); the
+      // two oldest should be deleted to bring the count back to the cap of 10.
+      const existing = Array.from({ length: 12 }, (_, i) => `${1000 + i}.log`);
+      mockReaddir.mockResolvedValueOnce(existing);
+
+      await service.runCommands(["./run.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+        logDir: "/some/log/dir",
+      });
+
+      expect(mockUnlink).toHaveBeenCalledTimes(2);
+      expect(mockUnlink).toHaveBeenNthCalledWith(1, expect.stringMatching(/1000\.log$/));
+      expect(mockUnlink).toHaveBeenNthCalledWith(2, expect.stringMatching(/1001\.log$/));
+    });
+
+    it("ignores non-.log entries when computing retention", async () => {
+      mockSpawn.mockReturnValue(makeOutputProcess("output", 0));
+      mockReaddir.mockResolvedValueOnce([
+        "README.md",
+        "1000.log",
+        "1001.log",
+        "1002.log",
+        "spurious.txt",
+      ]);
+
+      await service.runCommands(["./run.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+        logDir: "/some/log/dir",
+      });
+
+      // Only 3 .log files: under the cap of 10, so nothing is unlinked.
+      expect(mockUnlink).not.toHaveBeenCalled();
+    });
+
+    it("does not fail the run when readdir-based prune throws", async () => {
+      mockSpawn.mockReturnValue(makeOutputProcess("output", 0));
+      mockReaddir.mockRejectedValueOnce(new Error("EACCES"));
+
+      const result = await service.runCommands(["./run.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+        logDir: "/some/log/dir",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.logPath).toBeDefined();
+    });
+
+    it("does not fail the run when an individual unlink throws during prune", async () => {
+      mockSpawn.mockReturnValue(makeOutputProcess("output", 0));
+      const existing = Array.from({ length: 12 }, (_, i) => `${1000 + i}.log`);
+      mockReaddir.mockResolvedValueOnce(existing);
+      mockUnlink.mockRejectedValueOnce(new Error("EBUSY"));
+
+      const result = await service.runCommands(["./run.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+        logDir: "/some/log/dir",
+      });
+
+      // Both candidates still attempted even though the first throws.
+      expect(mockUnlink).toHaveBeenCalledTimes(2);
+      expect(result.success).toBe(true);
+      expect(result.logPath).toBeDefined();
+    });
+
+    it("includes byte count and log path in the truncation marker when output exceeds the tail cap", async () => {
+      const huge = "a".repeat(10_000); // > OUTPUT_TAIL_BYTES (8192)
+      mockSpawn.mockReturnValue(makeOutputProcess(huge, 0));
+
+      const result = await service.runCommands(["./run.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+        logDir: "/home/testuser/.daintree/projects/_root/teardown-logs/wt-1",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("...(truncated — omitted ");
+      expect(result.output).toContain("bytes");
+      expect(result.output).toContain(`full log: ${result.logPath}`);
+    });
+
+    it("says 'full log unavailable' in the truncation marker when log persistence fails", async () => {
+      const huge = "x".repeat(10_000);
+      mockSpawn.mockReturnValue(makeOutputProcess(huge, 0));
+      mockAtomicWrite.mockRejectedValueOnce(new Error("disk full"));
+
+      const result = await service.runCommands(["./run.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+        logDir: "/some/log/dir",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.logPath).toBeUndefined();
+      expect(result.output).toContain("...(truncated — omitted ");
+      expect(result.output).toContain("full log unavailable");
+    });
+
+    it("writes a log on failure paths (non-zero exit) and surfaces logPath", async () => {
+      mockSpawn.mockReturnValue(makeOutputProcess("failed output", 1));
+
+      const result = await service.runCommands(["./run.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+        logDir: "/some/log/dir",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.logPath).toBeDefined();
+      expect(mockAtomicWrite).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -29,6 +29,12 @@ export interface WorktreeLifecycleStatus {
   startedAt: number;
   completedAt?: number;
   error?: string;
+  /**
+   * Absolute path to the persisted full-output log file for this run, when the
+   * caller (teardown / resource-teardown phases) opted into log persistence.
+   * Undefined for phases that don't persist a log, or when the write failed.
+   */
+  logPath?: string;
 }
 
 /** Resource status from the last manual status check */


### PR DESCRIPTION
## Summary

- The inline view caps at 8 KB — for a script that emits megabytes of progress noise before failing on the last line, the actual error is gone. This persists the full scrubbed output to `~/.daintree/projects/<sanitized-root>/teardown-logs/<sanitized-worktree-name>/<epoch>.log` so nothing is silently dropped.
- Retention is bounded at 10 logs per worktree; oldest are pruned on each write.
- `logPath` surfaces on `RunCommandsResult` and `WorktreeLifecycleStatus` so the renderer can wire a "View full log" action in a follow-up.

Resolves #8407

## Changes

- `WorktreeLifecycleService`: new `writeTeardownLog` helper writes the full output (scrubbed) and prunes old logs; `runCommands` accepts a `logDir` option so only teardown and resource-teardown phases persist (status polls and setup are unaffected); truncation marker now names the omitted byte count and points at the log path, or falls back to "full log unavailable" on write failure; byte-accurate multibyte truncation in `tailOutput`.
- `shared/types/worktree.ts`: `logPath?: string` added to `RunCommandsResult` and `WorktreeLifecycleStatus`.
- `electron/utils/secretScrubber.ts`: approved call site #11 (`writeTeardownLog`) added to the scrub audit list.
- `WorktreeLifecycleService.test.ts`: 13 new tests covering log write, path format, retention pruning, scrubbing, write-failure fallback, multibyte truncation, and integration wiring through `runLifecycleTeardown`. 109 total tests passing.

## Testing

- Unit test suite run locally: 109 tests, all passing.
- Covered: log path format, 10-log retention cap, secrets scrubbed before write, graceful fallback when the log directory is not writable, truncation marker content (byte count + path), and byte-accurate truncation of multibyte content.