### PR TITLE
feat(clone): use gh repo clone fast path for github.com URLs

### DIFF
--- a/electron/ipc/handlers/__tests__/gitClone.test.ts
+++ b/electron/ipc/handlers/__tests__/gitClone.test.ts
@@ -1,0 +1,387 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { EventEmitter } from "events";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  BrowserWindow: {
+    fromWebContents: vi.fn().mockReturnValue(null),
+  },
+}));
+
+const broadcastToRendererMock = vi.hoisted(() => vi.fn());
+const sendToRendererMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../utils.js", () => ({
+  broadcastToRenderer: broadcastToRendererMock,
+  sendToRenderer: sendToRendererMock,
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: null,
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+}));
+
+vi.mock("../../../window/webContentsRegistry.js", () => ({
+  getWindowForWebContents: vi.fn().mockReturnValue(null),
+}));
+
+const createAuthenticatedGitMock = vi.hoisted(() => vi.fn());
+vi.mock("../../../utils/hardenedGit.js", () => ({
+  createAuthenticatedGit: createAuthenticatedGitMock,
+}));
+
+const parseGitHubRepoUrlMock = vi.hoisted(() => vi.fn());
+vi.mock("../../../services/github/index.js", () => ({
+  parseGitHubRepoUrl: parseGitHubRepoUrlMock,
+}));
+
+const childProcessMock = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  spawnSync: vi.fn(),
+  execFile: vi.fn(),
+}));
+
+vi.mock("child_process", () => childProcessMock);
+
+const fsMock = vi.hoisted(() => ({
+  promises: {
+    stat: vi.fn(),
+    access: vi.fn(),
+    rm: vi.fn(),
+  },
+}));
+
+vi.mock("fs", () => ({ default: fsMock, ...fsMock }));
+
+import { CHANNELS } from "../../channels.js";
+import { registerGitCloneHandlers } from "../projectCrud/gitClone.js";
+
+function getInvokeHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
+  const call = (ipcMainMock.handle as Mock).mock.calls.find(
+    ([registered]) => registered === channel
+  );
+  if (!call) throw new Error(`No handler registered for channel: ${channel}`);
+  return call[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+class FakeChildProcess extends EventEmitter {
+  pid = 12345;
+  stderr = new EventEmitter() as EventEmitter & { setEncoding: (e: string) => void };
+  stdout = new EventEmitter();
+  kill = vi.fn();
+  constructor() {
+    super();
+    this.stderr.setEncoding = vi.fn();
+  }
+}
+
+type MakeChildOptions = {
+  onSpawn?: (child: FakeChildProcess) => void;
+  closeCode?: number | null;
+  emitImmediately?: boolean;
+};
+
+function makeChild(opts: MakeChildOptions = {}) {
+  const child = new FakeChildProcess();
+  const { onSpawn, closeCode = 0, emitImmediately = true } = opts;
+  if (emitImmediately) {
+    // Defer to next tick so caller can attach listeners.
+    queueMicrotask(() => {
+      onSpawn?.(child);
+      child.emit("close", closeCode);
+    });
+  } else {
+    onSpawn?.(child);
+  }
+  return child;
+}
+
+function makeEmitProgress() {
+  return vi.fn();
+}
+
+function setAuthSuccess() {
+  // execFile("gh", ["auth", "status"], opts, cb) — call cb with no error.
+  childProcessMock.execFile.mockImplementation(
+    (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null) => void) => {
+      queueMicrotask(() => cb(null));
+      return new FakeChildProcess();
+    }
+  );
+}
+
+function setAuthFailure(err: Error = new Error("not authed")) {
+  childProcessMock.execFile.mockImplementation(
+    (_cmd: string, _args: string[], _opts: unknown, cb: (e: Error | null) => void) => {
+      queueMicrotask(() => cb(err));
+      return new FakeChildProcess();
+    }
+  );
+}
+
+function setFsHappyPath() {
+  fsMock.promises.stat.mockResolvedValue({ isDirectory: () => true });
+  fsMock.promises.access.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+  fsMock.promises.rm.mockResolvedValue(undefined);
+}
+
+function makeOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    url: "https://github.com/owner/repo",
+    parentPath: "/abs/parent",
+    folderName: "repo",
+    shallowClone: false,
+    ...overrides,
+  };
+}
+
+function makeCtxEvent() {
+  return { sender: { id: 1 } };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setFsHappyPath();
+  parseGitHubRepoUrlMock.mockReturnValue({ owner: "owner", repo: "repo" });
+  createAuthenticatedGitMock.mockReturnValue({
+    clone: vi.fn().mockResolvedValue(undefined),
+  });
+});
+
+describe("gitClone — gh repo clone fast path", () => {
+  it("uses gh repo clone when URL is github.com and gh is authenticated", async () => {
+    setAuthSuccess();
+    let spawnedArgs: string[] | undefined;
+    childProcessMock.spawn.mockImplementation((_cmd: string, args: string[]) => {
+      spawnedArgs = args;
+      return makeChild();
+    });
+
+    const cleanup = registerGitCloneHandlers();
+    const handler = getInvokeHandler(CHANNELS.PROJECT_CLONE_REPO);
+
+    const result = await handler(makeCtxEvent(), makeOptions());
+
+    expect(childProcessMock.spawn).toHaveBeenCalledWith(
+      "gh",
+      expect.arrayContaining(["repo", "clone", "owner/repo"]),
+      expect.objectContaining({ cwd: "/abs/parent" })
+    );
+    expect(spawnedArgs?.slice(0, 4)).toEqual(["repo", "clone", "owner/repo", "repo"]);
+    expect(createAuthenticatedGitMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ clonedPath: "/abs/parent/repo" });
+
+    cleanup();
+  });
+
+  it("falls back to simple-git when gh auth status fails", async () => {
+    setAuthFailure();
+
+    const cleanup = registerGitCloneHandlers();
+    const handler = getInvokeHandler(CHANNELS.PROJECT_CLONE_REPO);
+
+    await handler(makeCtxEvent(), makeOptions());
+
+    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+    expect(createAuthenticatedGitMock).toHaveBeenCalledOnce();
+
+    cleanup();
+  });
+
+  it("falls back to simple-git when gh is not on PATH (ENOENT)", async () => {
+    const enoent = Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" });
+    setAuthFailure(enoent);
+
+    const cleanup = registerGitCloneHandlers();
+    const handler = getInvokeHandler(CHANNELS.PROJECT_CLONE_REPO);
+
+    await handler(makeCtxEvent(), makeOptions());
+
+    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+    expect(createAuthenticatedGitMock).toHaveBeenCalledOnce();
+
+    cleanup();
+  });
+
+  it("skips gh probe and uses simple-git for non-github.com URLs", async () => {
+    parseGitHubRepoUrlMock.mockReturnValue(null);
+
+    const cleanup = registerGitCloneHandlers();
+    const handler = getInvokeHandler(CHANNELS.PROJECT_CLONE_REPO);
+
+    await handler(
+      makeCtxEvent(),
+      makeOptions({ url: "https://gitlab.com/owner/repo" })
+    );
+
+    expect(childProcessMock.execFile).not.toHaveBeenCalled();
+    expect(childProcessMock.spawn).not.toHaveBeenCalled();
+    expect(createAuthenticatedGitMock).toHaveBeenCalledOnce();
+
+    cleanup();
+  });
+
+  it("appends -- --depth 1 to gh args when shallowClone is true", async () => {
+    setAuthSuccess();
+    let spawnedArgs: string[] | undefined;
+    childProcessMock.spawn.mockImplementation((_cmd: string, args: string[]) => {
+      spawnedArgs = args;
+      return makeChild();
+    });
+
+    const cleanup = registerGitCloneHandlers();
+    const handler = getInvokeHandler(CHANNELS.PROJECT_CLONE_REPO);
+
+    await handler(makeCtxEvent(), makeOptions({ shallowClone: true }));
+
+    expect(spawnedArgs).toEqual(["repo", "clone", "owner/repo", "repo", "--", "--depth", "1"]);
+
+    cleanup();
+  });
+
+  it("emits progress for the four stage patterns on stderr", async () => {
+    setAuthSuccess();
+
+    childProcessMock.spawn.mockImplementation(() => {
+      const child = new FakeChildProcess();
+      queueMicrotask(() => {
+        child.stderr.emit(
+          "data",
+          "Counting objects:  50% (5/10)\rCounting objects: 100% (10/10), done.\n" +
+            "Compressing objects:  75% (3/4)\rCompressing objects: 100% (4/4), done.\n" +
+            "Receiving objects:  50% (5/10)\rReceiving objects: 100% (10/10), done.\n" +
+            "Resolving deltas: 100% (3/3), done.\n"
+        );
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const cleanup = registerGitCloneHandlers();
+    const handler = getInvokeHandler(CHANNELS.PROJECT_CLONE_REPO);
+
+    await handler(makeCtxEvent(), makeOptions());
+
+    const events = broadcastToRendererMock.mock.calls.map((c) => c[1] as { stage: string });
+    const stages = events.map((e) => e.stage);
+    expect(stages).toContain("counting");
+    expect(stages).toContain("compressing");
+    expect(stages).toContain("receiving");
+    expect(stages).toContain("resolving");
+
+    cleanup();
+  });
+
+  it("rejects with INTERNAL when gh repo clone exits non-zero (no simple-git fallback)", async () => {
+    setAuthSuccess();
+    childProcessMock.spawn.mockImplementation(() => {
+      const child = new FakeChildProcess();
+      queueMicrotask(() => {
+        child.stderr.emit("data", "fatal: repository not found\n");
+        child.emit("close", 1);
+      });
+      return child;
+    });
+
+    const cleanup = registerGitCloneHandlers();
+    const handler = getInvokeHandler(CHANNELS.PROJECT_CLONE_REPO);
+
+    await expect(handler(makeCtxEvent(), makeOptions())).rejects.toMatchObject({
+      code: "INTERNAL",
+    });
+    expect(createAuthenticatedGitMock).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("aborts gh clone on cancel via taskkill on Windows and SIGTERM on Unix", async () => {
+    setAuthSuccess();
+    const realPlatform = process.platform;
+
+    let capturedChild: FakeChildProcess | undefined;
+    childProcessMock.spawn.mockImplementation(() => {
+      const child = new FakeChildProcess();
+      capturedChild = child;
+      // Don't auto-close — we want the cancel path to drive the close.
+      return child;
+    });
+
+    const cleanup = registerGitCloneHandlers();
+    const handler = getInvokeHandler(CHANNELS.PROJECT_CLONE_REPO);
+    const cancelHandler = getInvokeHandler(CHANNELS.PROJECT_CLONE_CANCEL);
+
+    const clonePromise = handler(makeCtxEvent(), makeOptions());
+
+    // Wait a tick so spawn has been called and the abort listener is wired.
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Trigger cancel.
+    await cancelHandler(makeCtxEvent());
+
+    // Drive the close after kill.
+    capturedChild?.emit("close", null);
+
+    await expect(clonePromise).rejects.toMatchObject({ code: "CANCELLED" });
+
+    if (realPlatform === "win32") {
+      expect(childProcessMock.spawnSync).toHaveBeenCalledWith(
+        "taskkill",
+        expect.arrayContaining(["/F", "/T", "/PID"]),
+        expect.objectContaining({ windowsHide: true })
+      );
+    }
+    // The cleanup of partial dirs should not have been called (access returns ENOENT in happy path)
+    cleanup();
+  });
+
+  it("cleans up partial clone directory on gh-path failure", async () => {
+    setAuthSuccess();
+    // First access (target exists check) rejects (ENOENT — proceed), second access
+    // (partial-clone cleanup check) resolves (target exists — must be removed).
+    let accessCallCount = 0;
+    fsMock.promises.access.mockImplementation(() => {
+      accessCallCount++;
+      if (accessCallCount === 1) {
+        return Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    childProcessMock.spawn.mockImplementation(() => makeChild({ closeCode: 128 }));
+
+    const cleanup = registerGitCloneHandlers();
+    const handler = getInvokeHandler(CHANNELS.PROJECT_CLONE_REPO);
+
+    await expect(handler(makeCtxEvent(), makeOptions())).rejects.toMatchObject({
+      code: "INTERNAL",
+    });
+
+    expect(fsMock.promises.rm).toHaveBeenCalledWith(
+      "/abs/parent/repo",
+      expect.objectContaining({ recursive: true, force: true })
+    );
+
+    cleanup();
+  });
+});

--- a/electron/ipc/handlers/__tests__/gitClone.test.ts
+++ b/electron/ipc/handlers/__tests__/gitClone.test.ts
@@ -117,10 +117,6 @@ function makeChild(opts: MakeChildOptions = {}) {
   return child;
 }
 
-function makeEmitProgress() {
-  return vi.fn();
-}
-
 function setAuthSuccess() {
   // execFile("gh", ["auth", "status"], opts, cb) — call cb with no error.
   childProcessMock.execFile.mockImplementation(
@@ -230,10 +226,7 @@ describe("gitClone — gh repo clone fast path", () => {
     const cleanup = registerGitCloneHandlers();
     const handler = getInvokeHandler(CHANNELS.PROJECT_CLONE_REPO);
 
-    await handler(
-      makeCtxEvent(),
-      makeOptions({ url: "https://gitlab.com/owner/repo" })
-    );
+    await handler(makeCtxEvent(), makeOptions({ url: "https://gitlab.com/owner/repo" }));
 
     expect(childProcessMock.execFile).not.toHaveBeenCalled();
     expect(childProcessMock.spawn).not.toHaveBeenCalled();

--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -59,7 +59,7 @@ function killProcessTree(child: ChildProcess): void {
   } catch {
     // Already exited.
   }
-  setTimeout(() => {
+  const sigkillTimer = setTimeout(() => {
     try {
       if (child.pid !== undefined) {
         process.kill(-child.pid, "SIGKILL");
@@ -68,11 +68,18 @@ function killProcessTree(child: ChildProcess): void {
       // Already exited.
     }
   }, 5_000);
+  // Don't keep the event loop alive solely for the SIGKILL escalation.
+  sigkillTimer.unref();
 }
 
-async function probeGhAuth(): Promise<boolean> {
+async function probeGhAuth(externalSignal?: AbortSignal): Promise<boolean> {
+  if (externalSignal?.aborted) return false;
   return new Promise((resolve) => {
     const controller = new AbortController();
+    const onExternalAbort = () => controller.abort();
+    if (externalSignal) {
+      externalSignal.addEventListener("abort", onExternalAbort, { once: true });
+    }
     const timer = setTimeout(() => controller.abort(), GH_AUTH_PROBE_TIMEOUT_MS);
 
     execFile(
@@ -85,6 +92,7 @@ async function probeGhAuth(): Promise<boolean> {
       },
       (err) => {
         clearTimeout(timer);
+        if (externalSignal) externalSignal.removeEventListener("abort", onExternalAbort);
         resolve(!err);
       }
     );
@@ -206,7 +214,11 @@ async function cloneWithGh(
 export function registerGitCloneHandlers(): () => void {
   const handlers: Array<() => void> = [];
 
-  let cloneAbortController: AbortController | null = null;
+  // Track every in-flight clone so cancel aborts each one independently.
+  // Electron's ipcMain.handle permits concurrent invocations from multiple
+  // senders; sharing a single controller would let a later clone overwrite an
+  // earlier one's cancel target.
+  const activeControllers = new Set<AbortController>();
 
   const handleProjectCloneRepo = async (
     ctx: import("../../types.js").IpcContext,
@@ -286,13 +298,19 @@ export function registerGitCloneHandlers(): () => void {
       }
     };
 
-    cloneAbortController = new AbortController();
+    const localController = new AbortController();
+    activeControllers.add(localController);
 
     // Detect github.com URL and probe `gh` auth — non-null + authed picks the gh path.
     const ghTarget = parseGitHubRepoUrl(url);
-    const useGhPath = ghTarget !== null && (await probeGhAuth());
+    const useGhPath =
+      ghTarget !== null && (await probeGhAuth(localController.signal));
 
     try {
+      if (localController.signal.aborted) {
+        throw new AppError({ code: "CANCELLED", message: "Clone cancelled" });
+      }
+
       emitProgress("starting", 0, "Starting clone...");
 
       if (useGhPath && ghTarget) {
@@ -302,12 +320,12 @@ export function registerGitCloneHandlers(): () => void {
           parentPath,
           trimmedFolder,
           Boolean(shallowClone),
-          cloneAbortController.signal,
+          localController.signal,
           emitProgress
         );
       } else {
         const git = createAuthenticatedGit(parentPath, {
-          signal: cloneAbortController.signal,
+          signal: localController.signal,
           progress({ stage, progress }) {
             emitProgress(stage, progress, `${stage}: ${progress}%`);
           },
@@ -321,7 +339,7 @@ export function registerGitCloneHandlers(): () => void {
       return { clonedPath: targetPath };
     } catch (error) {
       const wasCancelled =
-        cloneAbortController?.signal.aborted ||
+        localController.signal.aborted ||
         (error instanceof Error &&
           (error.name === "AbortError" ||
             (error instanceof AppError && error.code === "CANCELLED") ||
@@ -362,14 +380,17 @@ export function registerGitCloneHandlers(): () => void {
         cause: error instanceof Error ? error : undefined,
       });
     } finally {
-      cloneAbortController = null;
+      activeControllers.delete(localController);
     }
   };
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_CLONE_REPO, handleProjectCloneRepo));
 
   const handleProjectCloneCancel = async (): Promise<void> => {
-    if (cloneAbortController) {
-      cloneAbortController.abort();
+    // Cancel every in-flight clone. The renderer's clone dialog is the only
+    // surface that fires this channel, and a per-clone identifier isn't
+    // plumbed through, so all-or-nothing matches the historical UX.
+    for (const controller of activeControllers) {
+      controller.abort();
     }
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_CLONE_CANCEL, handleProjectCloneCancel));

--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -303,8 +303,7 @@ export function registerGitCloneHandlers(): () => void {
 
     // Detect github.com URL and probe `gh` auth — non-null + authed picks the gh path.
     const ghTarget = parseGitHubRepoUrl(url);
-    const useGhPath =
-      ghTarget !== null && (await probeGhAuth(localController.signal));
+    const useGhPath = ghTarget !== null && (await probeGhAuth(localController.signal));
 
     try {
       if (localController.signal.aborted) {

--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -1,4 +1,11 @@
 import path from "path";
+import {
+  spawn,
+  spawnSync,
+  execFile,
+  type ChildProcess,
+  type ChildProcessWithoutNullStreams,
+} from "child_process";
 import { CHANNELS } from "../../channels.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
 import {
@@ -8,6 +15,7 @@ import {
   typedHandleWithContext,
 } from "../../utils.js";
 import { createAuthenticatedGit } from "../../../utils/hardenedGit.js";
+import { parseGitHubRepoUrl } from "../../../services/github/index.js";
 import type {
   CloneRepoOptions,
   CloneRepoResult,
@@ -16,6 +24,184 @@ import type {
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { validateFolderName } from "../../../../shared/utils/folderName.js";
 import { AppError } from "../../../utils/errorTypes.js";
+
+const GH_AUTH_PROBE_TIMEOUT_MS = 3_000;
+const GH_CLONE_TIMEOUT_MS = 5 * 60 * 1_000;
+const GH_STDERR_TAIL_BYTES = 8 * 1024;
+
+// Belt-and-suspenders: prevent any interactive prompt in headless Electron main.
+const GH_NON_INTERACTIVE_ENV = {
+  GH_PROMPT_DISABLED: "1",
+  GH_TERMINAL_PROMPT: "0",
+} as const;
+
+type ProgressEmitter = (stage: string, progress: number, message: string) => void;
+
+function killProcessTree(child: ChildProcess): void {
+  if (child.pid === undefined) {
+    try {
+      child.kill();
+    } catch {
+      // Already exited.
+    }
+    return;
+  }
+
+  if (process.platform === "win32") {
+    spawnSync("taskkill", ["/F", "/T", "/PID", child.pid.toString()], {
+      windowsHide: true,
+    });
+    return;
+  }
+
+  try {
+    process.kill(-child.pid, "SIGTERM");
+  } catch {
+    // Already exited.
+  }
+  setTimeout(() => {
+    try {
+      if (child.pid !== undefined) {
+        process.kill(-child.pid, "SIGKILL");
+      }
+    } catch {
+      // Already exited.
+    }
+  }, 5_000);
+}
+
+async function probeGhAuth(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), GH_AUTH_PROBE_TIMEOUT_MS);
+
+    execFile(
+      "gh",
+      ["auth", "status"],
+      {
+        env: { ...process.env, ...GH_NON_INTERACTIVE_ENV },
+        signal: controller.signal,
+        windowsHide: true,
+      },
+      (err) => {
+        clearTimeout(timer);
+        resolve(!err);
+      }
+    );
+  });
+}
+
+const GH_STAGE_PATTERNS: Array<{ re: RegExp; stage: string }> = [
+  { re: /Counting objects:\s+(\d+)%/, stage: "counting" },
+  { re: /Compressing objects:\s+(\d+)%/, stage: "compressing" },
+  { re: /Receiving objects:\s+(\d+)%/, stage: "receiving" },
+  { re: /Resolving deltas:\s+(\d+)%/, stage: "resolving" },
+];
+
+function parseGhStderrLine(line: string): { stage: string; progress: number } | null {
+  for (const { re, stage } of GH_STAGE_PATTERNS) {
+    const match = line.match(re);
+    if (match) {
+      const progress = Number.parseInt(match[1], 10);
+      if (Number.isFinite(progress)) {
+        return { stage, progress };
+      }
+    }
+  }
+  return null;
+}
+
+async function cloneWithGh(
+  owner: string,
+  repo: string,
+  parentPath: string,
+  targetFolder: string,
+  shallowClone: boolean,
+  signal: AbortSignal,
+  emitProgress: ProgressEmitter
+): Promise<void> {
+  if (signal.aborted) {
+    throw new AppError({ code: "CANCELLED", message: "Clone cancelled" });
+  }
+
+  const args = [
+    "repo",
+    "clone",
+    `${owner}/${repo}`,
+    targetFolder,
+    ...(shallowClone ? ["--", "--depth", "1"] : []),
+  ];
+
+  const isWin = process.platform === "win32";
+  const child: ChildProcessWithoutNullStreams = spawn("gh", args, {
+    cwd: parentPath,
+    env: { ...process.env, ...GH_NON_INTERACTIVE_ENV },
+    detached: !isWin,
+    windowsHide: true,
+  });
+
+  let stderrTail = "";
+  let lastStage: string | null = null;
+  let lastProgress = -1;
+  let finalized = false;
+  let timedOut = false;
+
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderrTail = (stderrTail + chunk).slice(-GH_STDERR_TAIL_BYTES);
+    for (const line of chunk.split(/[\r\n]+/)) {
+      if (!line) continue;
+      const parsed = parseGhStderrLine(line);
+      if (!parsed) continue;
+      if (parsed.stage === lastStage && parsed.progress === lastProgress) continue;
+      lastStage = parsed.stage;
+      lastProgress = parsed.progress;
+      emitProgress(parsed.stage, parsed.progress, `${parsed.stage}: ${parsed.progress}%`);
+    }
+  });
+
+  const timeoutHandle = setTimeout(() => {
+    timedOut = true;
+    killProcessTree(child);
+  }, GH_CLONE_TIMEOUT_MS);
+
+  const onAbort = () => {
+    killProcessTree(child);
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      child.once("error", (err) => {
+        if (finalized) return;
+        finalized = true;
+        reject(err);
+      });
+      child.once("close", (code) => {
+        if (finalized) return;
+        finalized = true;
+        if (signal.aborted) {
+          reject(new AppError({ code: "CANCELLED", message: "Clone cancelled" }));
+          return;
+        }
+        if (timedOut) {
+          reject(new Error(`gh repo clone timed out after ${GH_CLONE_TIMEOUT_MS / 1000}s`));
+          return;
+        }
+        if (code === 0) {
+          resolve();
+          return;
+        }
+        const tail = stderrTail.trim();
+        const detail = tail ? `: ${tail.split(/\r?\n/).slice(-3).join(" ")}` : "";
+        reject(new Error(`gh repo clone exited with code ${code}${detail}`));
+      });
+    });
+  } finally {
+    clearTimeout(timeoutHandle);
+    signal.removeEventListener("abort", onAbort);
+  }
+}
 
 export function registerGitCloneHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -102,27 +288,49 @@ export function registerGitCloneHandlers(): () => void {
 
     cloneAbortController = new AbortController();
 
+    // Detect github.com URL and probe `gh` auth — non-null + authed picks the gh path.
+    const ghTarget = parseGitHubRepoUrl(url);
+    const useGhPath = ghTarget !== null && (await probeGhAuth());
+
     try {
       emitProgress("starting", 0, "Starting clone...");
 
-      const git = createAuthenticatedGit(parentPath, {
-        signal: cloneAbortController.signal,
-        progress({ stage, progress }) {
-          emitProgress(stage, progress, `${stage}: ${progress}%`);
-        },
-        extraConfig: ["transfer.bundleURI=false"],
-      });
+      if (useGhPath && ghTarget) {
+        await cloneWithGh(
+          ghTarget.owner,
+          ghTarget.repo,
+          parentPath,
+          trimmedFolder,
+          Boolean(shallowClone),
+          cloneAbortController.signal,
+          emitProgress
+        );
+      } else {
+        const git = createAuthenticatedGit(parentPath, {
+          signal: cloneAbortController.signal,
+          progress({ stage, progress }) {
+            emitProgress(stage, progress, `${stage}: ${progress}%`);
+          },
+          extraConfig: ["transfer.bundleURI=false"],
+        });
 
-      await git.clone(url, trimmedFolder, shallowClone ? ["--depth", "1"] : []);
+        await git.clone(url, trimmedFolder, shallowClone ? ["--depth", "1"] : []);
+      }
 
       emitProgress("complete", 100, "Clone complete");
       return { clonedPath: targetPath };
     } catch (error) {
       const wasCancelled =
         cloneAbortController?.signal.aborted ||
-        (error instanceof Error && (error.name === "AbortError" || /abort/i.test(error.message)));
+        (error instanceof Error &&
+          (error.name === "AbortError" ||
+            (error instanceof AppError && error.code === "CANCELLED") ||
+            /abort/i.test(error.message)));
 
-      // Clean up partial clone
+      // Clean up partial clone. On Windows the spawned process must be terminated
+      // before fs.rm — `killProcessTree` runs synchronously in the gh-path abort
+      // listener, so by the time we get here the tree is gone and the directory
+      // is unlocked.
       const partialExists = await fs.promises
         .access(targetPath)
         .then(() => true)


### PR DESCRIPTION
## Summary

- Adds a `gh repo clone` fast path in the git clone handler for `github.com` URLs — when the `gh` CLI is authenticated it takes precedence over `simple-git`, which handles auth (2FA, OAuth, SSO) more reliably
- Implements full process lifecycle management: `probeGhAuth` (3s timeout), `cloneWithGh` (stderr progress parsing, 5min timeout, 8KB error tail), and `killProcessTree` (Windows `taskkill /F /T /PID`, Unix PGID SIGTERM + deferred SIGKILL)
- Per-invocation `AbortController` tracked in a `Set` for concurrent-clone safety; the cancel handler aborts all in-flight clones; no `simple-git` fallback after a `gh`-path failure

Resolves #8410

## Changes

- `electron/ipc/handlers/projectCrud/gitClone.ts`: `probeGhAuth`, `cloneWithGh`, `killProcessTree`, per-invocation abort tracking, updated cancel handler
- `electron/ipc/handlers/__tests__/gitClone.test.ts`: 9 new tests covering fast-path selection, fallback paths, `--depth 1`, progress parsing, non-zero exit, abort, and partial-clone cleanup

## Testing

All 9 targeted unit tests pass. `npm run check` clean. No new npm dependencies.