### PR TITLE
fix(worktree): accumulate teardown phase results instead of overwriting

### DIFF
--- a/electron/workspace-host/WorktreeLifecycleService.ts
+++ b/electron/workspace-host/WorktreeLifecycleService.ts
@@ -7,6 +7,11 @@ import { scrubSecrets } from "../utils/secretScrubber.js";
 import { buildProbeEnv } from "../utils/spawnEnv.js";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
 import type { WorktreeMonitor } from "./WorktreeMonitor.js";
+import type {
+  WorktreeLifecyclePhase,
+  WorktreeLifecyclePhaseCategory,
+  WorktreeLifecycleState,
+} from "../../shared/types/worktree.js";
 import { applyResourceConfigToMonitor } from "./resourceConfigHelpers.js";
 
 const OUTPUT_TAIL_BYTES = 8192;
@@ -97,6 +102,19 @@ export interface RunCommandsResult {
   aborted?: boolean;
   /** Absolute path to the persisted full-output log file, when one was written. */
   logPath?: string;
+  /**
+   * Exit code of the first failing command (or 0 on success), captured
+   * structurally from the child-process `close` event. `null` when the
+   * process was killed by a signal or never produced an exit code.
+   */
+  exitCode?: number | null;
+  /**
+   * Signal name that terminated the first failing command (e.g. "SIGKILL"
+   * after timeout escalation). `null` for a normal exit. Kept separate from
+   * `exitCode` so an aborted/killed run is distinguishable from a self-
+   * inflicted non-zero exit (lesson #4054).
+   */
+  signalName?: string | null;
 }
 
 async function fileExists(p: string): Promise<boolean> {
@@ -241,6 +259,8 @@ export class WorktreeLifecycleService {
           aborted: true,
           error: "Aborted",
           logPath,
+          exitCode: null,
+          signalName: null,
         };
       }
 
@@ -255,6 +275,8 @@ export class WorktreeLifecycleService {
           timedOut: true,
           error: `Timed out before running command ${i + 1}: ${command}`,
           logPath,
+          exitCode: null,
+          signalName: null,
         };
       }
 
@@ -277,6 +299,8 @@ export class WorktreeLifecycleService {
           aborted: true,
           error: "Aborted",
           logPath,
+          exitCode: result.exitCode ?? null,
+          signalName: result.signalName ?? null,
         };
       }
 
@@ -288,12 +312,20 @@ export class WorktreeLifecycleService {
           timedOut: result.timedOut,
           error: result.error,
           logPath,
+          exitCode: result.exitCode ?? null,
+          signalName: result.signalName ?? null,
         };
       }
     }
 
     const logPath = await this.persistRunLog(outputChunks, logDir);
-    return { success: true, output: tailOutput(outputChunks, logPath), logPath };
+    return {
+      success: true,
+      output: tailOutput(outputChunks, logPath),
+      logPath,
+      exitCode: 0,
+      signalName: null,
+    };
   }
 
   private runSingleCommand(
@@ -303,9 +335,22 @@ export class WorktreeLifecycleService {
     timeoutMs: number,
     outputChunks: string[],
     signal?: AbortSignal
-  ): Promise<{ success: boolean; timedOut?: boolean; aborted?: boolean; error?: string }> {
+  ): Promise<{
+    success: boolean;
+    timedOut?: boolean;
+    aborted?: boolean;
+    error?: string;
+    exitCode?: number | null;
+    signalName?: string | null;
+  }> {
     if (signal?.aborted) {
-      return Promise.resolve({ success: false, aborted: true, error: "Aborted" });
+      return Promise.resolve({
+        success: false,
+        aborted: true,
+        error: "Aborted",
+        exitCode: null,
+        signalName: null,
+      });
     }
 
     const isWin = process.platform === "win32";
@@ -358,6 +403,9 @@ export class WorktreeLifecycleService {
 
       const onAbort = () => {
         aborted = true;
+        // Append the marker before killing so it lands in the captured tail
+        // even if no further output arrives after the kill.
+        outputChunks.push(`\n[Process aborted: ${command}]\n`);
         killProcess();
       };
 
@@ -367,6 +415,7 @@ export class WorktreeLifecycleService {
 
       const timeoutHandle = setTimeout(() => {
         timedOut = true;
+        outputChunks.push(`\n[Process timed out after ${timeoutMs}ms: ${command}]\n`);
         killProcess();
       }, timeoutMs);
 
@@ -381,15 +430,21 @@ export class WorktreeLifecycleService {
       child.on("error", (err) => {
         clearTimeout(timeoutHandle);
         signal?.removeEventListener("abort", onAbort);
-        resolve({ success: false, error: err.message });
+        resolve({ success: false, error: err.message, exitCode: null, signalName: null });
       });
 
-      child.on("close", (code) => {
+      // `closeSignal` is the OS signal name (e.g. "SIGKILL") on Unix when the
+      // process was killed; `null` on a normal exit. Named distinctly from the
+      // `signal` AbortSignal param to avoid shadowing.
+      child.on("close", (code, closeSignal) => {
         clearTimeout(timeoutHandle);
         signal?.removeEventListener("abort", onAbort);
 
+        const exitCode = code ?? null;
+        const signalName = closeSignal ?? null;
+
         if (aborted) {
-          resolve({ success: false, aborted: true, error: "Aborted" });
+          resolve({ success: false, aborted: true, error: "Aborted", exitCode, signalName });
           return;
         }
 
@@ -398,16 +453,21 @@ export class WorktreeLifecycleService {
             success: false,
             timedOut: true,
             error: `Command timed out: ${command}`,
+            exitCode,
+            signalName,
           });
           return;
         }
 
         if (code === 0) {
-          resolve({ success: true });
+          resolve({ success: true, exitCode, signalName });
         } else {
+          const signalSuffix = signalName ? ` (killed by ${signalName})` : "";
           resolve({
             success: false,
-            error: `Command exited with code ${code}: ${command}`,
+            error: `Command exited with code ${code}${signalSuffix}: ${command}`,
+            exitCode,
+            signalName,
           });
         }
       });
@@ -481,6 +541,20 @@ export class WorktreeLifecycleService {
       "teardown-logs",
       sanitizePathSegment(worktreeName)
     );
+  }
+
+  /**
+   * Classify a phase's failure severity. Resource teardown can leave cloud
+   * resources running and billing, so its failures are billing-critical;
+   * everything else is local cleanup whose directory is about to be deleted.
+   */
+  private phaseCategory(phase: WorktreeLifecyclePhase): WorktreeLifecyclePhaseCategory {
+    return phase === "resource-teardown" ? "billing-critical" : "cosmetic";
+  }
+
+  /** Map a RunCommandsResult onto a WorktreeLifecycleState. */
+  private resultState(result: { success: boolean; timedOut?: boolean }): WorktreeLifecycleState {
+    return result.timedOut ? "timed-out" : result.success ? "success" : "failed";
   }
 
   async loadProjectResourceEnvironments(
@@ -771,6 +845,11 @@ export class WorktreeLifecycleService {
       return;
     }
 
+    // Start a fresh accumulation for this teardown run. Owned by the
+    // orchestrator (not coupled to setLifecycleStatus(undefined)) so a monitor
+    // reset elsewhere can't silently drop billing-critical failure data.
+    monitor.clearLifecyclePhaseResults();
+
     const vars = this.buildVariables(monitor.path, projectRootPath, monitor.name, monitor.branch);
     const sub = (cmd: string) => this.substituteVariables(cmd, vars);
     const env = this.buildEnv(
@@ -825,19 +904,30 @@ export class WorktreeLifecycleService {
 
         const m = ctx.getMonitor(worktreeId);
         if (m) {
+          const state = this.resultState(resourceResult);
+          const completedAt = Date.now();
           m.setLifecycleStatus({
             phase: "resource-teardown",
-            state: resourceResult.timedOut
-              ? "timed-out"
-              : resourceResult.success
-                ? "success"
-                : "failed",
+            state,
             totalCommands: resourceTeardownCommands.length,
             output: resourceResult.output,
             error: resourceResult.error,
             startedAt: resourceStartedAt,
-            completedAt: Date.now(),
+            completedAt,
             logPath: resourceResult.logPath,
+          });
+          m.recordLifecyclePhaseResult({
+            phase: "resource-teardown",
+            state,
+            category: this.phaseCategory("resource-teardown"),
+            exitCode: resourceResult.exitCode ?? null,
+            signalName: resourceResult.signalName ?? null,
+            output: resourceResult.output,
+            error: resourceResult.error,
+            startedAt: resourceStartedAt,
+            completedAt,
+            timedOut: resourceResult.timedOut,
+            aborted: resourceResult.aborted,
           });
           ctx.emitUpdate(m);
         }
@@ -851,13 +941,24 @@ export class WorktreeLifecycleService {
       } catch (err) {
         const m = ctx.getMonitor(worktreeId);
         if (m) {
+          const completedAt = Date.now();
           m.setLifecycleStatus({
             phase: "resource-teardown",
             state: "failed",
             totalCommands: resourceTeardownCommands.length,
             error: (err as Error).message,
             startedAt: resourceStartedAt,
-            completedAt: Date.now(),
+            completedAt,
+          });
+          m.recordLifecyclePhaseResult({
+            phase: "resource-teardown",
+            state: "failed",
+            category: this.phaseCategory("resource-teardown"),
+            exitCode: null,
+            signalName: null,
+            error: (err as Error).message,
+            startedAt: resourceStartedAt,
+            completedAt,
           });
           ctx.emitUpdate(m);
         }
@@ -911,15 +1012,30 @@ export class WorktreeLifecycleService {
 
       const finalMonitor = ctx.getMonitor(worktreeId);
       if (finalMonitor) {
+        const state = this.resultState(result);
+        const completedAt = Date.now();
         finalMonitor.setLifecycleStatus({
           phase: "teardown",
-          state: result.timedOut ? "timed-out" : result.success ? "success" : "failed",
+          state,
           totalCommands: commands.length,
           output: result.output,
           error: result.error,
           startedAt: teardownStartedAt,
-          completedAt: Date.now(),
+          completedAt,
           logPath: result.logPath,
+        });
+        finalMonitor.recordLifecyclePhaseResult({
+          phase: "teardown",
+          state,
+          category: this.phaseCategory("teardown"),
+          exitCode: result.exitCode ?? null,
+          signalName: result.signalName ?? null,
+          output: result.output,
+          error: result.error,
+          startedAt: teardownStartedAt,
+          completedAt,
+          timedOut: result.timedOut,
+          aborted: result.aborted,
         });
         ctx.emitUpdate(finalMonitor);
       }
@@ -933,13 +1049,24 @@ export class WorktreeLifecycleService {
     } catch (err) {
       const finalMonitor = ctx.getMonitor(worktreeId);
       if (finalMonitor) {
+        const completedAt = Date.now();
         finalMonitor.setLifecycleStatus({
           phase: "teardown",
           state: "failed",
           totalCommands: commands.length,
           error: (err as Error).message,
           startedAt: teardownStartedAt,
-          completedAt: Date.now(),
+          completedAt,
+        });
+        finalMonitor.recordLifecyclePhaseResult({
+          phase: "teardown",
+          state: "failed",
+          category: this.phaseCategory("teardown"),
+          exitCode: null,
+          signalName: null,
+          error: (err as Error).message,
+          startedAt: teardownStartedAt,
+          completedAt,
         });
         ctx.emitUpdate(finalMonitor);
       }

--- a/electron/workspace-host/WorktreeLifecycleService.ts
+++ b/electron/workspace-host/WorktreeLifecycleService.ts
@@ -840,15 +840,17 @@ export class WorktreeLifecycleService {
       }
     }
 
+    // Start a fresh accumulation for this teardown invocation. Owned by the
+    // orchestrator (not coupled to setLifecycleStatus(undefined)) so a monitor
+    // reset elsewhere can't silently drop billing-critical failure data.
+    // Cleared before the early-return guard so a re-invocation whose config no
+    // longer has teardown commands doesn't leave stale results in the snapshot.
+    monitor.clearLifecyclePhaseResults();
+
     const hasResourceTeardown = teardownResource?.teardown?.length && monitor.hasResourceConfig;
     if (!config?.teardown?.length && !hasResourceTeardown) {
       return;
     }
-
-    // Start a fresh accumulation for this teardown run. Owned by the
-    // orchestrator (not coupled to setLifecycleStatus(undefined)) so a monitor
-    // reset elsewhere can't silently drop billing-critical failure data.
-    monitor.clearLifecyclePhaseResults();
 
     const vars = this.buildVariables(monitor.path, projectRootPath, monitor.name, monitor.branch);
     const sub = (cmd: string) => this.substituteVariables(cmd, vars);

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -8,6 +8,7 @@ import type {
   Worktree,
   WorktreeMood,
   WorktreeLifecycleStatus,
+  WorktreeLifecyclePhaseResult,
 } from "../../shared/types/worktree.js";
 import type { GitHubPRCIStatus } from "../../shared/types/github.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
@@ -170,6 +171,10 @@ export class WorktreeMonitor {
   // Extra state
   private _createdAt: number | undefined;
   private _lifecycleStatus: WorktreeLifecycleStatus | undefined;
+  // Accumulated per-phase teardown results. Lifecycle owned by
+  // WorktreeLifecycleService.runLifecycleTeardown (cleared at run start, upserted
+  // per phase) so a later phase no longer overwrites an earlier phase's outcome.
+  private _lifecyclePhaseResults: WorktreeLifecyclePhaseResult[] = [];
 
   // Resource state
   private _resourceStatus:
@@ -614,6 +619,29 @@ export class WorktreeMonitor {
     this._lifecycleStatus = status;
   }
 
+  get lifecyclePhaseResults(): readonly WorktreeLifecyclePhaseResult[] {
+    return this._lifecyclePhaseResults;
+  }
+
+  /** Reset the per-phase accumulator. Called at the start of a teardown run. */
+  clearLifecyclePhaseResults(): void {
+    this._lifecyclePhaseResults = [];
+  }
+
+  /**
+   * Record a settled phase result. Upserts by `phase` so a re-entered phase
+   * replaces its prior entry rather than duplicating, while distinct phases
+   * (resource-teardown then teardown) both accumulate.
+   */
+  recordLifecyclePhaseResult(result: WorktreeLifecyclePhaseResult): void {
+    const idx = this._lifecyclePhaseResults.findIndex((r) => r.phase === result.phase);
+    if (idx >= 0) {
+      this._lifecyclePhaseResults[idx] = result;
+    } else {
+      this._lifecyclePhaseResults.push(result);
+    }
+  }
+
   get resourceStatus():
     | import("../../shared/types/worktree.js").WorktreeResourceStatus
     | undefined {
@@ -947,6 +975,8 @@ export class WorktreeMonitor {
       worktreeId: this.id,
       timestamp: Date.now(),
       lifecycleStatus: this._lifecycleStatus,
+      lifecyclePhaseResults:
+        this._lifecyclePhaseResults.length > 0 ? [...this._lifecyclePhaseResults] : undefined,
       resourceStatus,
       resourceConnectCommand: this._resourceConnectCommand,
       hasResourceConfig: this._hasResourceConfig || undefined,

--- a/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
@@ -1456,5 +1456,58 @@ describe("WorktreeLifecycleService", () => {
         exitCode: 0,
       });
     });
+
+    it("records only the billing-critical phase for a resource-only teardown", async () => {
+      const config = { resource: { teardown: ["terraform destroy"], provider: "akash" } };
+      mockAccess.mockImplementation(async (p: unknown) => {
+        if (n(p as string).endsWith("/root/.daintree/config.json")) return undefined;
+        throw new Error("ENOENT");
+      });
+      mockReadFile.mockResolvedValue(JSON.stringify(config) as never);
+      mockSpawn.mockImplementation(() => {
+        const listeners: Record<string, ((...a: unknown[]) => void)[]> = {};
+        const child = {
+          pid: 1234,
+          stdout: { on: vi.fn() },
+          stderr: { on: vi.fn() },
+          on: vi.fn((event: string, cb: (...a: unknown[]) => void) => {
+            (listeners[event] ??= []).push(cb);
+            if (event === "close") setTimeout(() => cb(0), 0);
+          }),
+          kill: vi.fn(),
+        };
+        return child as never;
+      });
+
+      const monitor = makeTeardownMonitor();
+      await service.runLifecycleTeardown("wt-1", monitor as never, false, makeCtx(monitor));
+
+      const results = monitor.lifecyclePhaseResults;
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        phase: "resource-teardown",
+        category: "billing-critical",
+      });
+    });
+
+    it("clears stale results when a re-invocation has no teardown configured", async () => {
+      const monitor = makeTeardownMonitor();
+      monitor.recordLifecyclePhaseResult({
+        phase: "resource-teardown",
+        state: "failed",
+        category: "billing-critical",
+        exitCode: 1,
+        signalName: null,
+        startedAt: 1,
+        completedAt: 2,
+      });
+
+      // No config file exists this time → early-return path.
+      mockAccess.mockRejectedValue(new Error("ENOENT"));
+
+      await service.runLifecycleTeardown("wt-1", monitor as never, false, makeCtx(monitor));
+
+      expect(monitor.lifecyclePhaseResults).toHaveLength(0);
+    });
   });
 });

--- a/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
@@ -1132,6 +1132,8 @@ describe("WorktreeLifecycleService", () => {
   describe("runLifecycleTeardown — log persistence wiring", () => {
     function makeTeardownMonitor(opts: { hasResourceConfig?: boolean } = {}) {
       const statuses: unknown[] = [];
+      const phaseResults: import("../../../shared/types/worktree.js").WorktreeLifecyclePhaseResult[] =
+        [];
       return {
         name: "wt-1",
         branch: "feature/x",
@@ -1145,6 +1147,19 @@ describe("WorktreeLifecycleService", () => {
         resourceStatus: undefined,
         setLifecycleStatus(s: unknown) {
           statuses.push(s);
+        },
+        get lifecyclePhaseResults() {
+          return phaseResults;
+        },
+        clearLifecyclePhaseResults() {
+          phaseResults.length = 0;
+        },
+        recordLifecyclePhaseResult(
+          r: import("../../../shared/types/worktree.js").WorktreeLifecyclePhaseResult
+        ) {
+          const idx = phaseResults.findIndex((x) => x.phase === r.phase);
+          if (idx >= 0) phaseResults[idx] = r;
+          else phaseResults.push(r);
         },
       };
     }
@@ -1256,6 +1271,190 @@ describe("WorktreeLifecycleService", () => {
       // Colon in the path must not appear in the persisted directory.
       expect(finalStatus.logPath).not.toContain("my:app");
       expect(n(finalStatus.logPath ?? "")).toContain("/_projects_my_app/teardown-logs/wt-1/");
+    });
+  });
+
+  describe("signal capture and abort/timeout markers", () => {
+    function makeManualChild(pid: number | undefined = 12345) {
+      const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+      const child = {
+        pid,
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+          (listeners[event] ??= []).push(cb);
+        }),
+        kill: vi.fn(),
+      };
+      const fireClose = (code: number | null, signal?: string) =>
+        listeners["close"]?.forEach((cb) => cb(code, signal));
+      return { child, fireClose };
+    }
+
+    it("captures the OS signal name from the close event (not flattened into exit code)", async () => {
+      const { child, fireClose } = makeManualChild();
+      mockSpawn.mockReturnValue(child as never);
+
+      const p = service.runCommands(["slow-cmd"], { cwd: "/t", env: {}, onProgress: vi.fn() });
+      await Promise.resolve();
+      fireClose(null, "SIGTERM");
+      const result = await p;
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBeNull();
+      expect(result.signalName).toBe("SIGTERM");
+      expect(result.error).toContain("killed by SIGTERM");
+    });
+
+    it("captures exit code with a null signal on a normal non-zero exit", async () => {
+      const { child, fireClose } = makeManualChild();
+      mockSpawn.mockReturnValue(child as never);
+
+      const p = service.runCommands(["bad-cmd"], { cwd: "/t", env: {}, onProgress: vi.fn() });
+      await Promise.resolve();
+      fireClose(3);
+      const result = await p;
+
+      expect(result.exitCode).toBe(3);
+      expect(result.signalName).toBeNull();
+      expect(result.error).not.toContain("killed by");
+    });
+
+    it("appends a timeout marker to the captured output before killing", async () => {
+      vi.useFakeTimers();
+      try {
+        const { child, fireClose } = makeManualChild();
+        mockSpawn.mockReturnValue(child as never);
+
+        const p = service.runCommands(["slow-cmd"], {
+          cwd: "/t",
+          env: {},
+          timeoutMs: 1000,
+          onProgress: vi.fn(),
+        });
+        vi.advanceTimersByTime(1001);
+        fireClose(null, "SIGKILL");
+        const result = await p;
+
+        expect(result.timedOut).toBe(true);
+        expect(result.signalName).toBe("SIGKILL");
+        expect(result.output).toContain("[Process timed out after 1000ms");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("appends an abort marker to the captured output", async () => {
+      const ac = new AbortController();
+      const { child, fireClose } = makeManualChild();
+      mockSpawn.mockReturnValue(child as never);
+
+      const p = service.runCommands(["slow-cmd"], {
+        cwd: "/t",
+        env: {},
+        signal: ac.signal,
+        onProgress: vi.fn(),
+      });
+      await Promise.resolve();
+      ac.abort();
+      fireClose(null, "SIGTERM");
+      const result = await p;
+
+      expect(result.aborted).toBe(true);
+      expect(result.output).toContain("[Process aborted:");
+    });
+  });
+
+  describe("runLifecycleTeardown — phase result accumulation", () => {
+    function makeTeardownMonitor() {
+      const phaseResults: import("../../../shared/types/worktree.js").WorktreeLifecyclePhaseResult[] =
+        [];
+      let lifecycleStatus: unknown;
+      return {
+        name: "wt-1",
+        branch: "feature/x",
+        path: "/wt",
+        worktreeMode: "local",
+        hasResourceConfig: true,
+        resourceStatus: undefined,
+        get lifecycleStatus() {
+          return lifecycleStatus;
+        },
+        setLifecycleStatus(s: unknown) {
+          lifecycleStatus = s;
+        },
+        get lifecyclePhaseResults() {
+          return phaseResults;
+        },
+        clearLifecyclePhaseResults() {
+          phaseResults.length = 0;
+        },
+        recordLifecyclePhaseResult(
+          r: import("../../../shared/types/worktree.js").WorktreeLifecyclePhaseResult
+        ) {
+          const idx = phaseResults.findIndex((x) => x.phase === r.phase);
+          if (idx >= 0) phaseResults[idx] = r;
+          else phaseResults.push(r);
+        },
+      };
+    }
+
+    function makeCtx(monitor: ReturnType<typeof makeTeardownMonitor>) {
+      return {
+        projectRootPath: "/root",
+        projectEnvVars: {},
+        getMonitor: () => monitor as unknown,
+        emitUpdate: vi.fn(),
+      } as unknown as import("../WorktreeLifecycleService.js").WorkspaceHostContext;
+    }
+
+    it("accumulates both phases without the later phase overwriting the earlier failure", async () => {
+      const config = {
+        teardown: ["cleanup.sh"],
+        resource: { teardown: ["terraform destroy"], provider: "akash" },
+      };
+      mockAccess.mockImplementation(async (p: unknown) => {
+        if (n(p as string).endsWith("/root/.daintree/config.json")) return undefined;
+        throw new Error("ENOENT");
+      });
+      mockReadFile.mockResolvedValue(JSON.stringify(config) as never);
+
+      // First spawn (resource-teardown) fails; second (local teardown) succeeds.
+      let call = 0;
+      mockSpawn.mockImplementation(() => {
+        call++;
+        const exit = call === 1 ? 1 : 0;
+        const listeners: Record<string, ((...a: unknown[]) => void)[]> = {};
+        const child = {
+          pid: 1234,
+          stdout: { on: vi.fn() },
+          stderr: { on: vi.fn() },
+          on: vi.fn((event: string, cb: (...a: unknown[]) => void) => {
+            (listeners[event] ??= []).push(cb);
+            if (event === "close") setTimeout(() => cb(exit), 0);
+          }),
+          kill: vi.fn(),
+        };
+        return child as never;
+      });
+
+      const monitor = makeTeardownMonitor();
+      await service.runLifecycleTeardown("wt-1", monitor as never, false, makeCtx(monitor));
+
+      const results = monitor.lifecyclePhaseResults;
+      expect(results).toHaveLength(2);
+      expect(results[0]).toMatchObject({
+        phase: "resource-teardown",
+        state: "failed",
+        category: "billing-critical",
+        exitCode: 1,
+      });
+      expect(results[1]).toMatchObject({
+        phase: "teardown",
+        state: "success",
+        category: "cosmetic",
+        exitCode: 0,
+      });
     });
   });
 });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -296,6 +296,68 @@ describe("WorktreeMonitor", () => {
     );
   });
 
+  describe("lifecycle phase results accumulator", () => {
+    function phaseResult(
+      overrides: Partial<import("../../../shared/types/worktree.js").WorktreeLifecyclePhaseResult>
+    ): import("../../../shared/types/worktree.js").WorktreeLifecyclePhaseResult {
+      return {
+        phase: "resource-teardown",
+        state: "success",
+        category: "billing-critical",
+        exitCode: 0,
+        signalName: null,
+        startedAt: 1,
+        completedAt: 2,
+        ...overrides,
+      };
+    }
+
+    it("omits lifecyclePhaseResults from the snapshot when empty", () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      expect(monitor.getSnapshot().lifecyclePhaseResults).toBeUndefined();
+    });
+
+    it("records phase results and surfaces a copy in the snapshot", () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      monitor.recordLifecyclePhaseResult(
+        phaseResult({ phase: "resource-teardown", state: "failed", exitCode: 1 })
+      );
+      monitor.recordLifecyclePhaseResult(
+        phaseResult({ phase: "teardown", state: "success", category: "cosmetic" })
+      );
+
+      const results = monitor.getSnapshot().lifecyclePhaseResults;
+      expect(results).toHaveLength(2);
+      expect(results?.[0]).toMatchObject({
+        phase: "resource-teardown",
+        state: "failed",
+        category: "billing-critical",
+        exitCode: 1,
+      });
+      expect(results?.[1]).toMatchObject({ phase: "teardown", category: "cosmetic" });
+      // Snapshot must be a copy — mutating internal state later must not leak.
+      monitor.clearLifecyclePhaseResults();
+      expect(results).toHaveLength(2);
+    });
+
+    it("upserts by phase rather than duplicating", () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      monitor.recordLifecyclePhaseResult(phaseResult({ phase: "resource-teardown", exitCode: 1 }));
+      monitor.recordLifecyclePhaseResult(phaseResult({ phase: "resource-teardown", exitCode: 0 }));
+
+      const results = monitor.getSnapshot().lifecyclePhaseResults;
+      expect(results).toHaveLength(1);
+      expect(results?.[0].exitCode).toBe(0);
+    });
+
+    it("clearLifecyclePhaseResults resets the accumulator", () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      monitor.recordLifecyclePhaseResult(phaseResult({}));
+      monitor.clearLifecyclePhaseResults();
+      expect(monitor.getSnapshot().lifecyclePhaseResults).toBeUndefined();
+    });
+  });
+
   it("includes prTitle and issueTitle in snapshot after setPRInfo", () => {
     const callbacks = makeCallbacks();
     const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -21,6 +21,7 @@ import type {
   Worktree,
   WorktreeMood,
   WorktreeLifecycleStatus,
+  WorktreeLifecyclePhaseResult,
   WorktreeResourceStatus,
 } from "./worktree.js";
 import type { Credentials } from "./forge.js";
@@ -111,6 +112,14 @@ export interface WorktreeSnapshot {
   timestamp?: number;
   /** Current or last completed lifecycle script status */
   lifecycleStatus?: WorktreeLifecycleStatus;
+
+  /**
+   * Per-phase teardown results, accumulated across a multi-phase teardown run
+   * (resource-teardown then teardown). Distinct from `lifecycleStatus`, which
+   * only reflects the last-active phase — a later phase no longer overwrites an
+   * earlier phase's outcome here. Omitted when no teardown has run.
+   */
+  lifecyclePhaseResults?: WorktreeLifecyclePhaseResult[];
 
   /** Whether a plan file (TODO.md, PLAN.md, etc.) exists in the worktree root */
   hasPlanFile?: boolean;

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -45,6 +45,36 @@ export interface WorktreeLifecycleStatus {
   logPath?: string;
 }
 
+/**
+ * Failure-severity classification for a settled lifecycle phase.
+ * `billing-critical` — the failure may leave cloud resources running and
+ * billing (resource teardown). `cosmetic` — local cleanup failed but the
+ * worktree directory is about to be deleted anyway.
+ */
+export type WorktreeLifecyclePhaseCategory = "billing-critical" | "cosmetic";
+
+/**
+ * Settled result for a single lifecycle phase, accumulated across multi-phase
+ * runs (resource-teardown then teardown) so a later phase no longer overwrites
+ * an earlier phase's outcome. All fields are primitives for structured-clone
+ * IPC transport. `exitCode`/`signalName` capture the child-process `close`
+ * event structurally — a SIGKILL after timeout escalation is categorically
+ * different from a self-inflicted non-zero exit.
+ */
+export interface WorktreeLifecyclePhaseResult {
+  phase: WorktreeLifecyclePhase;
+  state: WorktreeLifecycleState;
+  category: WorktreeLifecyclePhaseCategory;
+  exitCode: number | null;
+  signalName: string | null;
+  output?: string;
+  error?: string;
+  startedAt: number;
+  completedAt: number;
+  timedOut?: boolean;
+  aborted?: boolean;
+}
+
 /** Resource status from the last manual status check */
 export interface WorktreeResourceStatus {
   /** Raw status string from CLI output (e.g., "ready", "paused", "running") */

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -465,6 +465,7 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     resourceStatusEqual(a.resourceStatus, b.resourceStatus) &&
     worktreeChangesEqual(a.worktreeChanges, b.worktreeChanges) &&
     lifecycleStatusEqual(a.lifecycleStatus, b.lifecycleStatus) &&
+    lifecyclePhaseResultsEqual(a.lifecyclePhaseResults, b.lifecyclePhaseResults) &&
     linkedEqual(a.linked ?? null, b.linked ?? null)
   );
 }
@@ -523,6 +524,37 @@ function lifecycleStatusEqual(
     a.completedAt === b.completedAt &&
     a.error === b.error
   );
+}
+
+function lifecyclePhaseResultsEqual(
+  a: WorktreeSnapshot["lifecyclePhaseResults"],
+  b: WorktreeSnapshot["lifecyclePhaseResults"]
+): boolean {
+  if (a === b) return true;
+  // getSnapshot omits the field when empty, so treat undefined and [] alike.
+  const al = a?.length ?? 0;
+  const bl = b?.length ?? 0;
+  if (al !== bl) return false;
+  if (al === 0) return true;
+  for (let i = 0; i < al; i++) {
+    const x = a![i]!;
+    const y = b![i]!;
+    if (
+      x.phase !== y.phase ||
+      x.state !== y.state ||
+      x.category !== y.category ||
+      x.exitCode !== y.exitCode ||
+      x.signalName !== y.signalName ||
+      x.error !== y.error ||
+      x.startedAt !== y.startedAt ||
+      x.completedAt !== y.completedAt ||
+      x.timedOut !== y.timedOut ||
+      x.aborted !== y.aborted
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function linkedEqual(


### PR DESCRIPTION
## Summary

- `runLifecycleTeardown` ran two phases (`resource-teardown` then `teardown`) and called `setLifecycleStatus` sequentially, so the second phase's result silently overwrote the first — failures in `resource-teardown` were lost the moment `teardown` completed
- `runSingleCommand`'s `close` handler discarded the OS signal argument, making SIGKILL/SIGTERM aborts indistinguishable from a plain non-zero exit
- Fix accumulates results from both phases via a new `WorktreeLifecyclePhaseResult` type (upsert-by-phase on `WorktreeMonitor`), captures `exitCode` and `signalName` from the `child_process` close event, appends abort/timeout markers to captured output before `killProcess()`, and surfaces everything on `WorktreeSnapshot`

Resolves #8406

## Changes

- `WorktreeLifecyclePhaseResult` type — `phase`, `state`, `category` (billing-critical | cosmetic), `exitCode`, `signalName`, `output`, `error`, `timestamps`, `timedOut`, `aborted`
- Phase results accumulated on `WorktreeMonitor` via upsert-by-phase; orchestrator clears before the early-return guard (fixes stale-result regression)
- `close` event arg renamed `closeSignal` to avoid shadowing the `AbortSignal` param; error message appends ` (killed by SIGNAL)` when a signal is present
- `lifecyclePhaseResults` surfaced via `WorktreeSnapshot` with a matching store comparator
- Scope is data-foundation only — no renderer notification UI (tracked separately)

## Testing

Tests added for: signal capture, normal non-zero exit, timeout/abort output markers, two-phase no-overwrite accumulation, resource-only teardown, stale-result clearing, and monitor accumulator (omit-when-empty, record, upsert, clear). `npm run check` passes clean.