### PR TITLE
fix(workspace): replace topology suppress window with path-keyed pending sets

### DIFF
--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import PQueue from "p-queue";
 import { existsSync } from "fs";
 import { stat, readFile, access, mkdir } from "fs/promises";
-import { resolve as pathResolve, isAbsolute, dirname } from "path";
+import { resolve as pathResolve, isAbsolute, dirname, basename } from "path";
 import { validateBranchName } from "../../shared/utils/pathPattern.js";
 import { generateProjectId, settingsFilePath } from "../services/projectStorePaths.js";
 import { SimpleGit, BranchSummary } from "simple-git";
@@ -110,7 +110,18 @@ export class WorkspaceService {
   private topologyWatcherSubscription = new MutableDisposable();
   private topologyReconcileQueue = new PQueue({ concurrency: 1 });
   private topologyReconcilePending = false;
-  private topologyWatchSuppressUntil = 0;
+  // App-owned worktree create/delete register the metadata-subdir basename
+  // here so the watcher event their own `git worktree add/remove` produces is
+  // recognized and dropped — instead of blanket-suppressing *all* watcher
+  // events for a fixed window, which silently swallowed concurrent external
+  // `git worktree remove` calls (#8412). External events whose basename isn't
+  // pending still flow through to reconciliation.
+  private topologyPendingCreate = new Set<string>();
+  private topologyPendingDelete = new Set<string>();
+  private topologyPendingSafetyTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  // Events accumulate here across the 300ms debounce window and are filtered
+  // against the pending sets at drain time, preserving burst coalescing.
+  private topologyEventBuffer: Array<{ path: string }> = [];
   private topologyWatchCooldownUntil = 0;
   private topologyWatchCooldownDirty = false;
   private topologyDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -948,14 +959,20 @@ export class WorkspaceService {
     if (!existsSync(metadataDir)) return;
 
     const generation = ++this.topologyWatcherGeneration;
-    const schedule = () => this.scheduleTopologyReconcile();
+    const drain = () => this.drainTopologyEventBuffer();
 
     parcelWatcher
-      .subscribe(metadataDir, (_err, _events) => {
+      .subscribe(metadataDir, (_err, events) => {
+        if (Array.isArray(events)) {
+          for (const ev of events) {
+            const path = (ev as { path?: unknown } | null)?.path;
+            if (typeof path === "string") this.topologyEventBuffer.push({ path });
+          }
+        }
         if (this.topologyDebounceTimer) {
           clearTimeout(this.topologyDebounceTimer);
         }
-        this.topologyDebounceTimer = setTimeout(schedule, 300);
+        this.topologyDebounceTimer = setTimeout(drain, 300);
       })
       .then((subscription) => {
         if (generation !== this.topologyWatcherGeneration) {
@@ -985,14 +1002,73 @@ export class WorkspaceService {
       clearTimeout(this.topologyDebounceTimer);
       this.topologyDebounceTimer = null;
     }
+    this.topologyEventBuffer = [];
     this.topologyReconcilePending = false;
     this.topologyWatchCooldownDirty = false;
+  }
+
+  // The basename of `.git/worktrees/<name>` is exactly what @parcel/watcher
+  // reports for the create/delete of the metadata subdir, so it's the key we
+  // match watcher events against. Resolve first so a trailing slash or a
+  // relative path normalizes to the same leaf as the event path.
+  private topologyMetadataKey(worktreePath: string): string {
+    return basename(pathResolve(worktreePath));
+  }
+
+  private topologyMarkPending(key: string, set: Set<string>): void {
+    set.add(key);
+    const existing = this.topologyPendingSafetyTimers.get(key);
+    if (existing) clearTimeout(existing);
+    // Safety valve: if the watcher event never arrives (slow FS, missed
+    // event), the entry must not suppress a later real external change
+    // indefinitely. Clear-only — the cooldown/dirty path already reschedules
+    // any reconcile genuinely needed.
+    const timer = setTimeout(() => {
+      this.topologyPendingCreate.delete(key);
+      this.topologyPendingDelete.delete(key);
+      this.topologyPendingSafetyTimers.delete(key);
+    }, 5000);
+    timer.unref?.();
+    this.topologyPendingSafetyTimers.set(key, timer);
+  }
+
+  private topologyClearPending(key: string): void {
+    this.topologyPendingCreate.delete(key);
+    this.topologyPendingDelete.delete(key);
+    const timer = this.topologyPendingSafetyTimers.get(key);
+    if (timer) {
+      clearTimeout(timer);
+      this.topologyPendingSafetyTimers.delete(key);
+    }
+  }
+
+  private drainTopologyEventBuffer(): void {
+    const events = this.topologyEventBuffer;
+    this.topologyEventBuffer = [];
+
+    let hasUnmatched = false;
+    for (const ev of events) {
+      const key = basename(ev.path);
+      if (this.topologyPendingCreate.has(key) || this.topologyPendingDelete.has(key)) {
+        // App-owned op produced this event — drain the pending entry (and
+        // cancel its safety valve) so a *subsequent* external change to the
+        // same name is no longer treated as ours.
+        this.topologyClearPending(key);
+      } else {
+        hasUnmatched = true;
+      }
+    }
+
+    // Empty payloads can't be classified, so fall back to the pre-fix
+    // behavior of always reconciling rather than risk dropping a real change.
+    if (events.length === 0 || hasUnmatched) {
+      this.scheduleTopologyReconcile();
+    }
   }
 
   private scheduleTopologyReconcile(): void {
     if (!this.topologyWatcherEnabled) return;
     if (!this.pollingEnabled) return;
-    if (Date.now() < this.topologyWatchSuppressUntil) return;
     if (Date.now() < this.topologyWatchCooldownUntil) {
       this.topologyWatchCooldownDirty = true;
       return;
@@ -1278,6 +1354,9 @@ export class WorkspaceService {
     rootPath: string,
     options: CreateWorktreeOptions
   ): Promise<void> {
+    // Hoisted so the catch can clear the pending entry even though
+    // absoluteCreatePath is block-scoped to the try.
+    let pendingCreateKey: string | null = null;
     try {
       const git = createHardenedGit(rootPath);
       const { baseBranch, path } = options;
@@ -1366,10 +1445,11 @@ export class WorkspaceService {
       // `--end-of-options` after the subcommand flags so any leading-dash ref
       // or path that slipped past validation is treated as positional.
 
-      // Suppress the topology watcher during app-owned worktree creation so
-      // the `.git/worktrees/<name>/` directory creation doesn't trigger a
-      // redundant discoverAndSyncWorktrees pass.
-      this.topologyWatchSuppressUntil = Date.now() + 60000;
+      // Mark the metadata-subdir basename pending so the watcher event our own
+      // `git worktree add` produces is recognized and dropped — without
+      // blanket-suppressing concurrent external `git worktree remove` events.
+      pendingCreateKey = this.topologyMetadataKey(absoluteCreatePath);
+      this.topologyMarkPending(pendingCreateKey, this.topologyPendingCreate);
 
       if (useExistingBranch) {
         await git.raw(["worktree", "add", "--end-of-options", path, newBranch]);
@@ -1444,10 +1524,11 @@ export class WorkspaceService {
       // authoritative and would remove every other non-main monitor.
       await this.addNewWorktreeMonitor(createdWorktree, isActive, true);
 
-      // Reset suppression: the monitor is registered, metadata writes will
-      // settle within 500ms. The short post-op window absorbs any remaining
-      // filesystem events from the git worktree add.
-      this.topologyWatchSuppressUntil = Date.now() + 500;
+      // Monitor is registered. Drop the pending entry now: any still-buffered
+      // create event for this name will be matched by the next drain (the
+      // safety valve is cancelled here so the happy path can't spuriously
+      // reconcile 5s later).
+      this.topologyClearPending(pendingCreateKey);
 
       if (options.worktreeMode && options.worktreeMode !== "local") {
         const m = this.monitors.get(canonicalWorktreeId);
@@ -1487,7 +1568,9 @@ export class WorkspaceService {
         console.warn("[WorkspaceHost] createWorktree async tail failed:", err);
       });
     } catch (error) {
-      this.topologyWatchSuppressUntil = Date.now() + 500;
+      // Create failed — drop any pending entry so a real external change to
+      // that name isn't masked, and cancel its safety valve.
+      if (pendingCreateKey) this.topologyClearPending(pendingCreateKey);
       this.sendEvent({
         type: "create-worktree-result",
         requestId,
@@ -1552,6 +1635,9 @@ export class WorkspaceService {
     force: boolean = false,
     deleteBranch: boolean = false
   ): Promise<void> {
+    // Hoisted so the catch can clear the pending entry even though `monitor`
+    // is block-scoped to the try.
+    let pendingDeleteKey: string | null = null;
     try {
       const monitor = this.monitors.get(worktreeId);
       if (!monitor) {
@@ -1600,10 +1686,11 @@ export class WorkspaceService {
 
       await this.runLifecycleTeardown(worktreeId, monitor, force);
 
-      // Suppress the topology watcher during app-owned worktree deletion so
-      // the `.git/worktrees/<name>/` directory removal doesn't trigger a
-      // redundant discoverAndSyncWorktrees pass.
-      this.topologyWatchSuppressUntil = Date.now() + 60000;
+      // Mark the metadata-subdir basename pending so the watcher event our own
+      // `git worktree remove` produces is recognized and dropped — without
+      // blanket-suppressing concurrent external worktree changes.
+      pendingDeleteKey = this.topologyMetadataKey(monitor.path);
+      this.topologyMarkPending(pendingDeleteKey, this.topologyPendingDelete);
 
       if (this.git) {
         // #6669: if the directory is already gone (deleted externally), skip
@@ -1667,9 +1754,10 @@ export class WorkspaceService {
       monitor.stop();
       this.monitors.delete(worktreeId);
 
-      // Reset suppression: monitor is cleaned up, metadata writes will settle
-      // within 500ms.
-      this.topologyWatchSuppressUntil = Date.now() + 500;
+      // Monitor is cleaned up. Drop the pending entry now (cancelling its
+      // safety valve): any still-buffered delete event for this name is
+      // matched by the next drain.
+      this.topologyClearPending(pendingDeleteKey);
 
       this.sendEvent({
         type: "worktree-removed",
@@ -1702,7 +1790,9 @@ export class WorkspaceService {
 
       this.sendEvent({ type: "delete-worktree-result", requestId, success: true });
     } catch (error) {
-      this.topologyWatchSuppressUntil = Date.now() + 500;
+      // Delete failed — drop any pending entry so a real external change to
+      // that name isn't masked, and cancel its safety valve.
+      if (pendingDeleteKey) this.topologyClearPending(pendingDeleteKey);
       this.sendEvent({
         type: "delete-worktree-result",
         requestId,
@@ -2168,6 +2258,12 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   dispose(): void {
     this._shutdownController.abort();
     this.stopTopologyWatcher();
+    for (const timer of this.topologyPendingSafetyTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.topologyPendingSafetyTimers.clear();
+    this.topologyPendingCreate.clear();
+    this.topologyPendingDelete.clear();
     this.topologyReconcileQueue.clear();
     this.prService.cleanup();
     this.resourceActionExecutor.dispose();

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -121,7 +121,7 @@ export class WorkspaceService {
   private topologyPendingSafetyTimers = new Map<string, ReturnType<typeof setTimeout>>();
   // Events accumulate here across the 300ms debounce window and are filtered
   // against the pending sets at drain time, preserving burst coalescing.
-  private topologyEventBuffer: Array<{ path: string }> = [];
+  private topologyEventBuffer: Array<{ path: string; type?: string }> = [];
   private topologyWatchCooldownUntil = 0;
   private topologyWatchCooldownDirty = false;
   private topologyDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -965,8 +965,13 @@ export class WorkspaceService {
       .subscribe(metadataDir, (_err, events) => {
         if (Array.isArray(events)) {
           for (const ev of events) {
-            const path = (ev as { path?: unknown } | null)?.path;
-            if (typeof path === "string") this.topologyEventBuffer.push({ path });
+            const e = ev as { path?: unknown; type?: unknown } | null;
+            if (typeof e?.path === "string") {
+              this.topologyEventBuffer.push({
+                path: e.path,
+                type: typeof e.type === "string" ? e.type : undefined,
+              });
+            }
           }
         }
         if (this.topologyDebounceTimer) {
@@ -1003,6 +1008,15 @@ export class WorkspaceService {
       this.topologyDebounceTimer = null;
     }
     this.topologyEventBuffer = [];
+    // Drop pending entries: with no watcher running nothing will drain them,
+    // and a stale entry surviving a pause/resume could suppress a real
+    // external change for up to 5s after the watcher restarts.
+    for (const timer of this.topologyPendingSafetyTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.topologyPendingSafetyTimers.clear();
+    this.topologyPendingCreate.clear();
+    this.topologyPendingDelete.clear();
     this.topologyReconcilePending = false;
     this.topologyWatchCooldownDirty = false;
   }
@@ -1049,7 +1063,17 @@ export class WorkspaceService {
     let hasUnmatched = false;
     for (const ev of events) {
       const key = basename(ev.path);
-      if (this.topologyPendingCreate.has(key) || this.topologyPendingDelete.has(key)) {
+      // Gate on event type so a pending *create* can't swallow an external
+      // *delete* of a same-named worktree (and vice versa). An absent/unknown
+      // type falls back to either set — better an idempotent reconcile than a
+      // dropped external change.
+      const matched =
+        ev.type === "create"
+          ? this.topologyPendingCreate.has(key)
+          : ev.type === "delete"
+            ? this.topologyPendingDelete.has(key)
+            : this.topologyPendingCreate.has(key) || this.topologyPendingDelete.has(key);
+      if (matched) {
         // App-owned op produced this event — drain the pending entry (and
         // cancel its safety valve) so a *subsequent* external change to the
         // same name is no longer treated as ours.
@@ -2257,13 +2281,8 @@ ${lines.map((l) => "+" + l).join("\n")}`;
 
   dispose(): void {
     this._shutdownController.abort();
+    // stopTopologyWatcher clears the pending sets and their safety timers.
     this.stopTopologyWatcher();
-    for (const timer of this.topologyPendingSafetyTimers.values()) {
-      clearTimeout(timer);
-    }
-    this.topologyPendingSafetyTimers.clear();
-    this.topologyPendingCreate.clear();
-    this.topologyPendingDelete.clear();
     this.topologyReconcileQueue.clear();
     this.prService.cleanup();
     this.resourceActionExecutor.dispose();

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -408,35 +408,109 @@ describe("WorkspaceService external worktree removal", () => {
       vi.useRealTimers();
     });
 
-    it("respects suppression window during app-owned create", async () => {
+    it("suppresses the app-owned create event and drains the pending entry", async () => {
       vi.useFakeTimers();
       const discoverSpy = vi
         .spyOn(service as any, "discoverAndSyncWorktrees")
         .mockResolvedValue(undefined);
 
-      // Simulate suppression set by createWorktree
-      service["topologyWatchSuppressUntil"] = Date.now() + 60000;
+      // Simulate the pending entry createWorktree registers before its own
+      // `git worktree add`.
+      service["topologyMarkPending"]("new-wt", service["topologyPendingCreate"]);
 
       service["startTopologyWatcher"]();
-      await vi.runAllTimersAsync();
+      await vi.advanceTimersByTimeAsync(0);
 
       parcelWatcherCallbacks[0]!(null, [
         { type: "create", path: "/test/root/.git/worktrees/new-wt" },
       ]);
       await vi.advanceTimersByTimeAsync(350);
 
-      // Suppression active — reconciliation should not fire
+      // App-owned event matched the pending entry — no reconciliation.
       expect(discoverSpy).not.toHaveBeenCalled();
+      // ...and the pending entry (plus its safety timer) is drained.
+      expect(service["topologyPendingCreate"].has("new-wt")).toBe(false);
+      expect(service["topologyPendingSafetyTimers"].has("new-wt")).toBe(false);
 
-      // Clear suppression
-      service["topologyWatchSuppressUntil"] = 0;
+      // A later external change to the same name is no longer masked.
       parcelWatcherCallbacks[0]!(null, [
-        { type: "create", path: "/test/root/.git/worktrees/another" },
+        { type: "delete", path: "/test/root/.git/worktrees/new-wt" },
+      ]);
+      await vi.advanceTimersByTimeAsync(350);
+      expect(discoverSpy).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it("does not swallow an external delete during an app-owned create (#8412)", async () => {
+      vi.useFakeTimers();
+      const discoverSpy = vi
+        .spyOn(service as any, "discoverAndSyncWorktrees")
+        .mockResolvedValue(undefined);
+
+      // App-owned create in flight for "my-wt".
+      service["topologyMarkPending"]("my-wt", service["topologyPendingCreate"]);
+
+      service["startTopologyWatcher"]();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Concurrent external `git worktree remove other-wt`.
+      parcelWatcherCallbacks[0]!(null, [
+        { type: "delete", path: "/test/root/.git/worktrees/other-wt" },
       ]);
       await vi.advanceTimersByTimeAsync(350);
 
+      // The external delete is not pending → reconciliation fires.
       expect(discoverSpy).toHaveBeenCalledTimes(1);
+      // The app-owned pending entry is untouched.
+      expect(service["topologyPendingCreate"].has("my-wt")).toBe(true);
       vi.useRealTimers();
+    });
+
+    it("reconciles a mixed batch with a matched create and an unmatched delete", async () => {
+      vi.useFakeTimers();
+      const discoverSpy = vi
+        .spyOn(service as any, "discoverAndSyncWorktrees")
+        .mockResolvedValue(undefined);
+
+      service["topologyMarkPending"]("my-wt", service["topologyPendingCreate"]);
+
+      service["startTopologyWatcher"]();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Both events coalesce into one debounce window.
+      const cb = parcelWatcherCallbacks[0]!;
+      cb(null, [{ type: "create", path: "/test/root/.git/worktrees/my-wt" }]);
+      cb(null, [{ type: "delete", path: "/test/root/.git/worktrees/other-wt" }]);
+      await vi.advanceTimersByTimeAsync(350);
+
+      // Unmatched external delete forces exactly one reconciliation...
+      expect(discoverSpy).toHaveBeenCalledTimes(1);
+      // ...and the matched create still drained its pending entry.
+      expect(service["topologyPendingCreate"].has("my-wt")).toBe(false);
+      vi.useRealTimers();
+    });
+
+    it("safety valve clears a pending entry after 5s with no reconcile", async () => {
+      vi.useFakeTimers();
+      const discoverSpy = vi
+        .spyOn(service as any, "discoverAndSyncWorktrees")
+        .mockResolvedValue(undefined);
+
+      service["topologyMarkPending"]("stuck-wt", service["topologyPendingDelete"]);
+      expect(service["topologyPendingDelete"].has("stuck-wt")).toBe(true);
+
+      // No watcher event ever arrives.
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(service["topologyPendingDelete"].has("stuck-wt")).toBe(false);
+      expect(service["topologyPendingSafetyTimers"].has("stuck-wt")).toBe(false);
+      expect(discoverSpy).not.toHaveBeenCalled();
+      vi.useRealTimers();
+    });
+
+    it("no longer exposes a topologyWatchSuppressUntil field", () => {
+      expect("topologyWatchSuppressUntil" in service).toBe(false);
+      expect((service as any)["topologyWatchSuppressUntil"]).toBeUndefined();
     });
 
     it("respects post-reconciliation cooldown", async () => {

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -513,6 +513,56 @@ describe("WorkspaceService external worktree removal", () => {
       expect((service as any)["topologyWatchSuppressUntil"]).toBeUndefined();
     });
 
+    it("does not let a pending create swallow an external delete of the same basename", async () => {
+      vi.useFakeTimers();
+      const discoverSpy = vi
+        .spyOn(service as any, "discoverAndSyncWorktrees")
+        .mockResolvedValue(undefined);
+
+      // App-owned create pending for "foo"; an external `git worktree remove`
+      // for a pre-existing worktree whose metadata dir is also "foo" fires a
+      // DELETE event — it must not be drained by the pending *create*.
+      service["topologyMarkPending"]("foo", service["topologyPendingCreate"]);
+
+      service["startTopologyWatcher"]();
+      await vi.advanceTimersByTimeAsync(0);
+
+      parcelWatcherCallbacks[0]!(null, [{ type: "delete", path: "/test/root/.git/worktrees/foo" }]);
+      await vi.advanceTimersByTimeAsync(350);
+
+      expect(discoverSpy).toHaveBeenCalledTimes(1);
+      // The pending create entry is untouched by the unrelated delete.
+      expect(service["topologyPendingCreate"].has("foo")).toBe(true);
+      vi.useRealTimers();
+    });
+
+    it("clears pending entries and safety timers on stopTopologyWatcher", async () => {
+      vi.useFakeTimers();
+      const discoverSpy = vi
+        .spyOn(service as any, "discoverAndSyncWorktrees")
+        .mockResolvedValue(undefined);
+
+      service["topologyMarkPending"]("paused-wt", service["topologyPendingDelete"]);
+      expect(service["topologyPendingDelete"].has("paused-wt")).toBe(true);
+      expect(service["topologyPendingSafetyTimers"].has("paused-wt")).toBe(true);
+
+      // Pause/teardown clears all pending state.
+      service["stopTopologyWatcher"]();
+      expect(service["topologyPendingDelete"].has("paused-wt")).toBe(false);
+      expect(service["topologyPendingSafetyTimers"].has("paused-wt")).toBe(false);
+
+      // After resume, an external change to that same name still reconciles.
+      service["startTopologyWatcher"]();
+      await vi.advanceTimersByTimeAsync(0);
+      parcelWatcherCallbacks.at(-1)!(null, [
+        { type: "delete", path: "/test/root/.git/worktrees/paused-wt" },
+      ]);
+      await vi.advanceTimersByTimeAsync(350);
+
+      expect(discoverSpy).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
     it("respects post-reconciliation cooldown", async () => {
       vi.useFakeTimers();
       const discoverSpy = vi


### PR DESCRIPTION
## Summary

- `topologyWatchSuppressUntil` was a 60-second blanket window that silently dropped any `@parcel/watcher` topology event during that period — including external `git worktree remove` runs, leaving stale worktrees in the cache until the next adaptive poll (up to ~30s later)
- Replaces the blanket window with `topologyPendingCreate` and `topologyPendingDelete` sets, keyed by the `.git/worktrees/<name>` basename; events buffer across the existing 300ms debounce then filter at drain — app-owned events matching a pending entry of the right type are dropped, anything unmatched still reconciles normally
- 5s clear-only safety valve guards against a missed drain; cancelled on the happy-path; pending state cleared on `stop`/dispose

Resolves #8412

## Changes

- `electron/workspace-host/WorkspaceService.ts`: remove `topologyWatchSuppressUntil` timestamp, add `topologyPendingCreate`/`topologyPendingDelete` `Set<string>` fields, add `topologyPendingSafetyTimer`, rewrite suppress logic in `createWorktree`/`deleteWorktree` and the watcher drain path; clear sets in `stopTopologyWatcher`
- `electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts`: 21 tests covering concurrent external removes, concurrent external creates, removes outside the window, safety-valve expiry, and stop/dispose cleanup

## Testing

All 21 tests in `WorkspaceService.externalRemoval.test.ts` pass. Full `npm run check` clean.