### PR TITLE
feat(github): apply secondary rate-limit protection to GitHub fetcher

### DIFF
--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -129,13 +129,22 @@ function createResponse(options: {
   status: number;
   statusText: string;
   json: () => Promise<unknown>;
+  headers?: Headers;
 }): Response {
+  const headers = options.headers ?? new Headers();
+  const body = JSON.stringify({});
   return {
     ok: options.ok,
     status: options.status,
     statusText: options.statusText,
     json: options.json,
-  } as Response;
+    headers,
+    clone() {
+      return {
+        text: () => Promise.resolve(body),
+      } as unknown as Response;
+    },
+  } as unknown as Response;
 }
 
 function createETagResponse(status: number, etag?: string): Response {

--- a/plugins/builtin/github/main/GitHubAuth.ts
+++ b/plugins/builtin/github/main/GitHubAuth.ts
@@ -1,9 +1,17 @@
 import { graphql } from "@octokit/graphql";
-import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
+import { gitHubRateLimitService, GitHubRateLimitError } from "./GitHubRateLimitService.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 
 export const GITHUB_API_TIMEOUT_MS = 15_000;
 export const GITHUB_AUTH_TIMEOUT_MS = 10_000;
+
+/**
+ * Process-wide ceiling on concurrent GitHub API requests passing through
+ * {@link rateLimitAwareFetch}. GitHub's secondary rate limit kicks in at
+ * 100 concurrent requests per token; capping at 8 keeps us well clear even
+ * across multiple processes that share the same token.
+ */
+export const GITHUB_FETCH_CONCURRENCY = 8;
 
 /**
  * SSO re-authorization URLs returned via `X-GitHub-SSO` expire one hour
@@ -341,6 +349,11 @@ export class GitHubAuth {
           "X-GitHub-Api-Version": "2022-11-28",
         },
         signal: AbortSignal.timeout(GITHUB_AUTH_TIMEOUT_MS),
+        // Validation must succeed even when a previous token left the
+        // circuit-breaker in a blocked state — otherwise the user can never
+        // recover by entering a new token. The semaphore still applies so
+        // a flurry of validate calls can't drown background work.
+        daintreeSkipRateLimitPreflight: true,
       });
 
       if (!response.ok) {
@@ -424,68 +437,185 @@ export class GitHubAuth {
 }
 
 /**
+ * FIFO async semaphore. `acquire()` resolves to a `release` callback the
+ * caller must invoke (in `finally`) to free the slot. Queued waiters are
+ * resolved in order — never starved — and `release()` is idempotent so a
+ * double-call from an over-eager `finally` is harmless.
+ */
+class Semaphore {
+  private active = 0;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(private readonly max: number) {}
+
+  acquire(): Promise<() => void> {
+    return new Promise((resolve) => {
+      const grant = (): void => {
+        let released = false;
+        const release = (): void => {
+          if (released) return;
+          released = true;
+          this.active--;
+          const next = this.waiters.shift();
+          if (next) {
+            this.active++;
+            next();
+          }
+        };
+        resolve(release);
+      };
+      if (this.active < this.max) {
+        this.active++;
+        grant();
+      } else {
+        this.waiters.push(grant);
+      }
+    });
+  }
+
+  /** Test-only inspector. */
+  _getActiveForTests(): number {
+    return this.active;
+  }
+
+  /** Test-only inspector. */
+  _getPendingForTests(): number {
+    return this.waiters.length;
+  }
+
+  /** Test-only reset. Drops any queued waiters and zeroes the active count. */
+  _resetForTests(): void {
+    this.active = 0;
+    this.waiters.length = 0;
+  }
+}
+
+const githubFetchSemaphore = new Semaphore(GITHUB_FETCH_CONCURRENCY);
+
+/** Test-only helper for inspecting the shared semaphore in unit tests. */
+export function _getGithubFetchSemaphoreForTests(): {
+  active: number;
+  pending: number;
+  max: number;
+} {
+  return {
+    active: githubFetchSemaphore._getActiveForTests(),
+    pending: githubFetchSemaphore._getPendingForTests(),
+    max: GITHUB_FETCH_CONCURRENCY,
+  };
+}
+
+/** Test-only helper to reset the shared semaphore between unit tests. */
+export function _resetGithubFetchSemaphoreForTests(): void {
+  githubFetchSemaphore._resetForTests();
+}
+
+/**
  * Custom fetch wrapper used by `@octokit/graphql` via
- * `graphql.defaults({ request: { fetch } })`.
+ * `graphql.defaults({ request: { fetch } })` and by all direct REST callers
+ * in this package. Two protections live here:
+ *
+ * 1. Preflight circuit-breaker: if the rate-limit service is currently
+ *    blocking requests, throw {@link GitHubRateLimitError} before opening
+ *    a socket. Bypassable via `init.daintreeSkipRateLimitPreflight = true`
+ *    for the token-validation path, which must work even when stale state
+ *    from a previous token would otherwise gate it.
+ * 2. Process-wide concurrency cap of {@link GITHUB_FETCH_CONCURRENCY} —
+ *    bursty callers (PR discovery, batch checks) queue rather than fan out
+ *    100+ concurrent requests and trip GitHub's secondary limit.
  *
  * `@octokit/graphql` v9 resolves to the parsed `data.data` payload — the raw
  * `Response` (and its headers) are dropped before the promise resolves.
  * Installing this fetch wrapper is the only reliable place to observe GitHub
  * rate-limit headers on every response (both 2xx and error paths).
  *
- * The wrapper is intentionally two-phase: a synchronous header-only
+ * Response handling is intentionally two-phase: a synchronous header-only
  * classification runs first so the response can return to Octokit
  * immediately, and the body-text classification (used to detect secondary
  * rate limits that GitHub reports via a 403 body rather than a `retry-after`
  * header) runs off the critical path. This prevents a stuck response body
  * from blocking every GitHub call behind the fetch wrapper.
  */
-async function rateLimitAwareFetch(
+export interface RateLimitAwareFetchInit extends RequestInit {
+  /**
+   * Skip the preflight circuit-breaker check for this request. Used by
+   * `GitHubAuth.validate()` so a user explicitly testing a token isn't
+   * blocked by stale rate-limit state from a previous token. The semaphore
+   * is still honored.
+   */
+  daintreeSkipRateLimitPreflight?: boolean;
+}
+
+export async function rateLimitAwareFetch(
   input: RequestInfo | URL,
-  init?: RequestInit
+  init?: RateLimitAwareFetchInit
 ): Promise<Response> {
-  const versionAtStart = GitHubAuth.getTokenVersion();
-  const response = await globalThis.fetch(input, init);
+  const skipPreflight = init?.daintreeSkipRateLimitPreflight === true;
 
-  const requestId = response.headers.get("x-github-request-id") ?? undefined;
-
-  // Phase 1 — header-only classification runs immediately so the Response
-  // can flow back to Octokit without waiting on the body.
-  try {
-    gitHubRateLimitService.update(response.headers, response.status, undefined, requestId);
-  } catch {
-    // Rate-limit bookkeeping must never break the underlying request.
-  }
-
-  // Late-arriving response from a previous token: discard so it can't
-  // clobber `lastAuthMetadata` set by the currently-configured token.
-  // Mirrors the same guard in `GitHubTokenHealthService.runCheck()`.
-  if (GitHubAuth.getTokenVersion() === versionAtStart) {
-    try {
-      captureAuthMetadata(response.headers);
-    } catch {
-      // Metadata capture must never break the underlying request.
+  if (!skipPreflight) {
+    const block = gitHubRateLimitService.shouldBlockRequest();
+    if (block.blocked && block.reason && block.resumeAt) {
+      throw new GitHubRateLimitError(block.reason, block.resumeAt);
     }
   }
 
-  // Phase 2 — secondary-limit fallback classification when the 403/429
-  // response carries no `retry-after` but explains the block in its body.
-  // Scheduled off the hot path; any failures are swallowed.
-  if (!response.ok && (response.status === 403 || response.status === 429)) {
-    void response
-      .clone()
-      .text()
-      .then((bodyText) => {
-        try {
-          gitHubRateLimitService.update(response.headers, response.status, bodyText, requestId);
-        } catch {
-          // Swallow — see Phase 1 comment.
-        }
-      })
-      .catch(() => {
-        // Cloning can fail on aborted streams; header-only classification
-        // is already safe.
-      });
+  // Strip the custom property before forwarding so `globalThis.fetch`
+  // doesn't see an unknown init field.
+  let fetchInit: RequestInit | undefined = init;
+  if (init && "daintreeSkipRateLimitPreflight" in init) {
+    const { daintreeSkipRateLimitPreflight: _ignored, ...rest } = init;
+    void _ignored;
+    fetchInit = rest;
   }
 
-  return response;
+  const release = await githubFetchSemaphore.acquire();
+  const versionAtStart = GitHubAuth.getTokenVersion();
+  try {
+    const response = await globalThis.fetch(input, fetchInit);
+
+    const requestId = response.headers.get("x-github-request-id") ?? undefined;
+
+    // Phase 1 — header-only classification runs immediately so the Response
+    // can flow back to Octokit without waiting on the body.
+    try {
+      gitHubRateLimitService.update(response.headers, response.status, undefined, requestId);
+    } catch {
+      // Rate-limit bookkeeping must never break the underlying request.
+    }
+
+    // Late-arriving response from a previous token: discard so it can't
+    // clobber `lastAuthMetadata` set by the currently-configured token.
+    // Mirrors the same guard in `GitHubTokenHealthService.runCheck()`.
+    if (GitHubAuth.getTokenVersion() === versionAtStart) {
+      try {
+        captureAuthMetadata(response.headers);
+      } catch {
+        // Metadata capture must never break the underlying request.
+      }
+    }
+
+    // Phase 2 — secondary-limit fallback classification when the 403/429
+    // response carries no `retry-after` but explains the block in its body.
+    // Scheduled off the hot path; any failures are swallowed.
+    if (!response.ok && (response.status === 403 || response.status === 429)) {
+      void response
+        .clone()
+        .text()
+        .then((bodyText) => {
+          try {
+            gitHubRateLimitService.update(response.headers, response.status, bodyText, requestId);
+          } catch {
+            // Swallow — see Phase 1 comment.
+          }
+        })
+        .catch(() => {
+          // Cloning can fail on aborted streams; header-only classification
+          // is already safe.
+        });
+    }
+
+    return response;
+  } finally {
+    release();
+  }
 }

--- a/plugins/builtin/github/main/GitHubAuth.ts
+++ b/plugins/builtin/github/main/GitHubAuth.ts
@@ -380,6 +380,29 @@ export class GitHubAuth {
           };
         }
         if (response.status === 403) {
+          // Distinguish a secondary-rate-limit 403 from a permissions 403 —
+          // both share status but mean very different things to the user.
+          // If `retry-after` is present the wrapper's Phase 1 already
+          // registered a secondary block; otherwise inspect the body.
+          const retryAfter = response.headers.get("retry-after");
+          let secondaryHit = retryAfter !== null && retryAfter !== "";
+          if (!secondaryHit) {
+            try {
+              const bodyText = await response.text();
+              const lower = bodyText.toLowerCase();
+              secondaryHit =
+                lower.includes("secondary rate limit") || lower.includes("abuse detection");
+            } catch {
+              // fall through to permissions error
+            }
+          }
+          if (secondaryHit) {
+            return {
+              valid: false,
+              scopes: [],
+              error: "GitHub secondary rate limit triggered. Please retry shortly.",
+            };
+          }
           return { valid: false, scopes: [], error: "Token lacks required permissions" };
         }
         if (response.status >= 500 && response.status <= 599) {
@@ -571,12 +594,23 @@ export async function rateLimitAwareFetch(
   const release = await githubFetchSemaphore.acquire();
   const versionAtStart = GitHubAuth.getTokenVersion();
   try {
+    // Post-acquire re-check: while this request was queued in the semaphore,
+    // another request may have completed and registered a block. Without
+    // this re-check, queued waiters would dispatch into an active block and
+    // amplify the rate-limit violation instead of stopping at the gate.
+    if (!skipPreflight) {
+      const reblock = gitHubRateLimitService.shouldBlockRequest();
+      if (reblock.blocked && reblock.reason && reblock.resumeAt) {
+        throw new GitHubRateLimitError(reblock.reason, reblock.resumeAt);
+      }
+    }
+
     const response = await globalThis.fetch(input, fetchInit);
 
     const requestId = response.headers.get("x-github-request-id") ?? undefined;
 
-    // Phase 1 — header-only classification runs immediately so the Response
-    // can flow back to Octokit without waiting on the body.
+    // Phase 1 — header-only classification runs immediately. Catches the
+    // retry-after path, the primary-limit path, and the 2xx clear path.
     try {
       gitHubRateLimitService.update(response.headers, response.status, undefined, requestId);
     } catch {
@@ -594,24 +628,20 @@ export async function rateLimitAwareFetch(
       }
     }
 
-    // Phase 2 — secondary-limit fallback classification when the 403/429
-    // response carries no `retry-after` but explains the block in its body.
-    // Scheduled off the hot path; any failures are swallowed.
+    // Phase 2 — body-text classification for 403/429 responses that GitHub
+    // reports via body text rather than a `retry-after` header. Runs
+    // *synchronously* before `release()` so the block is registered before
+    // any queued waiter can acquire the slot. The body of a 403/429 is
+    // small and already buffered after `fetch()` resolves, so this adds
+    // only microseconds of latency on the error path.
     if (!response.ok && (response.status === 403 || response.status === 429)) {
-      void response
-        .clone()
-        .text()
-        .then((bodyText) => {
-          try {
-            gitHubRateLimitService.update(response.headers, response.status, bodyText, requestId);
-          } catch {
-            // Swallow — see Phase 1 comment.
-          }
-        })
-        .catch(() => {
-          // Cloning can fail on aborted streams; header-only classification
-          // is already safe.
-        });
+      try {
+        const bodyText = await response.clone().text();
+        gitHubRateLimitService.update(response.headers, response.status, bodyText, requestId);
+      } catch {
+        // Cloning can fail on aborted streams; header-only classification
+        // already covered the headered case.
+      }
     }
 
     return response;

--- a/plugins/builtin/github/main/GitHubIssues.ts
+++ b/plugins/builtin/github/main/GitHubIssues.ts
@@ -1,5 +1,5 @@
 import type { GraphQlQueryResponseData } from "@octokit/graphql";
-import { GitHubAuth, GITHUB_API_TIMEOUT_MS } from "./GitHubAuth.js";
+import { GitHubAuth, GITHUB_API_TIMEOUT_MS, rateLimitAwareFetch } from "./GitHubAuth.js";
 import { LIST_ISSUES_QUERY, SEARCH_QUERY, GET_ISSUE_QUERY } from "./GitHubQueries.js";
 import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
 import { parseGitHubError } from "./GitHubErrors.js";
@@ -121,7 +121,7 @@ export async function assignIssue(
     const url = `https://api.github.com/repos/${context.owner}/${context.repo}/issues/${issueNumber}/assignees`;
 
     try {
-      const response = await fetch(url, {
+      const response = await rateLimitAwareFetch(url, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,

--- a/plugins/builtin/github/main/GitHubPRDiscovery.ts
+++ b/plugins/builtin/github/main/GitHubPRDiscovery.ts
@@ -1,4 +1,4 @@
-import { GitHubAuth, GITHUB_API_TIMEOUT_MS } from "./GitHubAuth.js";
+import { GitHubAuth, GITHUB_API_TIMEOUT_MS, rateLimitAwareFetch } from "./GitHubAuth.js";
 import { buildBatchPRQuery } from "./GitHubQueries.js";
 import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
 import { parseGitHubError, rateLimitMessage, rateLimitMeta } from "./GitHubErrors.js";
@@ -252,16 +252,10 @@ async function probePRChange(
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await rateLimitAwareFetch(url, {
       headers,
       signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
     });
-
-    try {
-      gitHubRateLimitService.update(response.headers, response.status);
-    } catch {
-      // Rate-limit bookkeeping must never break the probe.
-    }
 
     if (response.status === 304 && getETagCacheVersion() === versionAtStart) {
       return "unchanged";
@@ -302,16 +296,10 @@ async function probeBranchPRListChange(
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await rateLimitAwareFetch(url, {
       headers,
       signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
     });
-
-    try {
-      gitHubRateLimitService.update(response.headers, response.status);
-    } catch {
-      // Rate-limit bookkeeping must never break the probe.
-    }
 
     if (response.status === 304 && getETagCacheVersion() === versionAtStart) {
       return "unchanged";

--- a/plugins/builtin/github/main/GitHubRateLimitApi.ts
+++ b/plugins/builtin/github/main/GitHubRateLimitApi.ts
@@ -1,4 +1,4 @@
-import { GitHubAuth, GITHUB_API_TIMEOUT_MS, captureAuthMetadata } from "./GitHubAuth.js";
+import { GitHubAuth, GITHUB_API_TIMEOUT_MS, rateLimitAwareFetch } from "./GitHubAuth.js";
 import { PRIMARY_RESET_BUFFER_MS } from "./GitHubRateLimitService.js";
 import type { GitHubRateLimitDetails } from "../../../../electron/types/index.js";
 
@@ -7,7 +7,7 @@ export async function fetchRateLimitDetails(): Promise<GitHubRateLimitDetails | 
   if (!token) return null;
 
   try {
-    const response = await fetch("https://api.github.com/rate_limit", {
+    const response = await rateLimitAwareFetch("https://api.github.com/rate_limit", {
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github.v3+json",
@@ -15,8 +15,6 @@ export async function fetchRateLimitDetails(): Promise<GitHubRateLimitDetails | 
       signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
     });
     if (!response.ok) return null;
-
-    captureAuthMetadata(response.headers);
 
     const body = (await response.json()) as {
       resources?: Record<

--- a/plugins/builtin/github/main/GitHubRateLimitService.ts
+++ b/plugins/builtin/github/main/GitHubRateLimitService.ts
@@ -14,6 +14,10 @@ export const PRIMARY_RESET_BUFFER_MS = 7_000;
 // no primary-quota signal, matching GitHub's documented minimum.
 const SECONDARY_FALLBACK_PAUSE_MS = 60_000;
 
+// Ceiling on the jittered exponential backoff applied after repeated
+// secondary-limit hits. Keeps the wait bounded even if the limit persists.
+const SECONDARY_BACKOFF_MAX_MS = 5 * 60 * 1000;
+
 // Sentinel key used for blocks that aren't tied to a specific
 // `x-ratelimit-resource` bucket — secondary (abuse-detection) blocks and
 // primary blocks where the response header is absent.
@@ -37,6 +41,10 @@ type StateChangeListener = (state: GitHubRateLimitPayload) => void;
 class GitHubRateLimitServiceImpl {
   private readonly states = new Map<string, BlockState>();
   private readonly listeners = new Set<StateChangeListener>();
+  // Consecutive secondary-limit hits since the last `clear()` or 2xx response.
+  // Drives jittered exponential backoff when GitHub returns a 403/429 without
+  // an explicit `retry-after` header.
+  private consecutiveSecondaryHits = 0;
 
   /**
    * Register a subscriber that fires on every state transition (entering a
@@ -75,6 +83,7 @@ class GitHubRateLimitServiceImpl {
   update(headers: HeadersLike, status: number, bodyText?: string, requestId?: string): void {
     const retryAfter = parseRetryAfter(headers.get("retry-after"));
     if (retryAfter !== null) {
+      this.consecutiveSecondaryHits++;
       this.markBlocked("secondary", Date.now() + retryAfter * 1000, GLOBAL_RESOURCE_KEY, requestId);
       return;
     }
@@ -96,9 +105,10 @@ class GitHubRateLimitServiceImpl {
     }
 
     if ((status === 403 || status === 429) && looksLikeSecondaryLimit(bodyText)) {
+      this.consecutiveSecondaryHits++;
       this.markBlocked(
         "secondary",
-        Date.now() + SECONDARY_FALLBACK_PAUSE_MS,
+        Date.now() + this.computeSecondaryFallbackDelay(),
         GLOBAL_RESOURCE_KEY,
         requestId
       );
@@ -106,10 +116,31 @@ class GitHubRateLimitServiceImpl {
     }
 
     if (status >= 200 && status < 300 && remaining !== null && remaining > 0) {
+      this.consecutiveSecondaryHits = 0;
       if (headers.get("x-ratelimit-resource") !== null) {
         this.clearResource(resource);
       }
     }
+  }
+
+  /**
+   * Compute the wait duration for a fallback secondary-limit block (the
+   * 403/429 + body-classified path where GitHub gave us no `retry-after`).
+   * Applies full jitter on top of an exponential schedule that doubles per
+   * consecutive hit and caps at {@link SECONDARY_BACKOFF_MAX_MS}.
+   *
+   * Schedule: hit 1 → 60–120s, hit 2 → 120–180s, hit 3 → 240–300s,
+   * hit 4+ → capped at 5 min. The lower bound of 60s matches GitHub's
+   * documented minimum wait for headerless secondary blocks.
+   */
+  private computeSecondaryFallbackDelay(): number {
+    const k = Math.max(1, this.consecutiveSecondaryHits);
+    const base = Math.min(
+      SECONDARY_BACKOFF_MAX_MS,
+      SECONDARY_FALLBACK_PAUSE_MS * Math.pow(2, k - 1)
+    );
+    const jitter = Math.random() * SECONDARY_FALLBACK_PAUSE_MS;
+    return Math.min(SECONDARY_BACKOFF_MAX_MS, base + jitter);
   }
 
   /**
@@ -208,6 +239,7 @@ class GitHubRateLimitServiceImpl {
 
   /** Drop any active block (token change, fresh 2xx, manual reset). */
   clear(): void {
+    this.consecutiveSecondaryHits = 0;
     if (this.states.size === 0) return;
     this.states.clear();
     logInfo("GitHub rate limit cleared");
@@ -217,6 +249,12 @@ class GitHubRateLimitServiceImpl {
   /** Test-only helper. */
   _resetForTests(): void {
     this.states.clear();
+    this.consecutiveSecondaryHits = 0;
+  }
+
+  /** Test-only inspector. */
+  _getConsecutiveSecondaryHitsForTests(): number {
+    return this.consecutiveSecondaryHits;
   }
 
   private clearResource(resource: string): void {

--- a/plugins/builtin/github/main/GitHubTokenHealthService.ts
+++ b/plugins/builtin/github/main/GitHubTokenHealthService.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../../../shared/types/ipc/github.js";
 import { logDebug, logInfo, logWarn } from "../../../../electron/utils/logger.js";
 import { GitHubAuth, captureAuthMetadata, getLastAuthMetadata } from "./GitHubAuth.js";
+import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 
 /** How often background probes run when the app is actively used. */
@@ -173,6 +174,18 @@ class GitHubTokenHealthServiceImpl {
         this.lastCheckedAt = this.now();
         this.notifyListeners();
       }
+      return;
+    }
+
+    // Don't probe while a rate-limit block is active — the probe would just
+    // count against the limit. The block clears itself on `resumeAt`, and
+    // the next interval/refresh tick will pick up the check.
+    const block = gitHubRateLimitService.shouldBlockRequest();
+    if (block.blocked) {
+      logDebug("GitHub token health: skipping probe — rate limit active", {
+        reason: block.reason,
+        resumeAt: block.resumeAt,
+      });
       return;
     }
 

--- a/plugins/builtin/github/main/__tests__/GitHubAuth.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubAuth.test.ts
@@ -492,6 +492,140 @@ describe("GitHubAuth", () => {
       );
       expect(_getGithubFetchSemaphoreForTests().active).toBe(before);
     });
+
+    it("re-checks the circuit breaker after acquiring a queued slot so a block registered while queued stops the dispatch", async () => {
+      // Fill all 8 slots with pending fetches we control, then queue 1 more.
+      // While the queued waiter is parked, register a secondary block.
+      // When a slot frees, the queued waiter must NOT dispatch — it must
+      // throw GitHubRateLimitError instead.
+      const pending: Array<{
+        resolve: (response: Response) => void;
+        reject: (err: unknown) => void;
+      }> = [];
+      const mockFetch = vi.fn().mockImplementation(
+        () =>
+          new Promise<Response>((resolve, reject) => {
+            pending.push({ resolve, reject });
+          })
+      );
+      (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
+
+      // Fill the semaphore.
+      const inflight: Array<Promise<Response>> = [];
+      for (let i = 0; i < GITHUB_FETCH_CONCURRENCY; i++) {
+        inflight.push(rateLimitAwareFetch(`https://api.github.com/user?n=${i}`));
+      }
+      // Wait for all 8 slots to be granted.
+      await vi.waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(GITHUB_FETCH_CONCURRENCY);
+      });
+
+      // Queue a 9th request — it will park in the semaphore queue.
+      const queuedPromise = rateLimitAwareFetch("https://api.github.com/user?queued=1");
+
+      // Service registers a block while the 9th request is parked.
+      gitHubRateLimitService.update(new Headers({ "retry-after": "30" }), 429);
+
+      // Release a slot. The post-acquire re-check must fire and throw.
+      pending[0]!.resolve(new Response(null, { status: 200 }));
+
+      await expect(queuedPromise).rejects.toBeInstanceOf(GitHubRateLimitError);
+      // mockFetch should NOT have been called a 9th time — the queued waiter
+      // bailed at the re-check rather than dispatching the network request.
+      expect(mockFetch).toHaveBeenCalledTimes(GITHUB_FETCH_CONCURRENCY);
+
+      // Drain the remaining in-flight to free the test cleanly.
+      for (let i = 1; i < pending.length; i++) {
+        pending[i]!.resolve(new Response(null, { status: 200 }));
+      }
+      await Promise.all(inflight);
+    });
+
+    it("synchronously registers a body-classified secondary block before releasing the slot, stopping queued waiters", async () => {
+      // First request returns a 403 with a secondary-limit body and no
+      // retry-after. The block must be registered BEFORE the slot is
+      // released, so the second queued request fails preflight at the
+      // post-acquire re-check rather than dispatching to GitHub.
+      const body = "You have exceeded a secondary rate limit. Please wait.";
+
+      let resolveA: ((response: Response) => void) | null = null;
+      let resolveB: ((response: Response) => void) | null = null;
+      const mockFetch = vi.fn().mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveA = resolve;
+          })
+      );
+      mockFetch.mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveB = resolve;
+          })
+      );
+      (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
+
+      // Fill the semaphore so that only one slot is left, then queue both
+      // calls. We'll resolve the first one with a 403 secondary-limit body.
+      // Using GITHUB_FETCH_CONCURRENCY = 1 here would be cleaner but the
+      // semaphore is a singleton — so we fill it to N-1 and let our two
+      // calls compete for the last slot + the queue.
+      const filler: Array<{
+        resolve: (response: Response) => void;
+      }> = [];
+      const fillerMock = vi.fn().mockImplementation(
+        () =>
+          new Promise<Response>((resolve) => {
+            filler.push({ resolve });
+          })
+      );
+      (globalThis as unknown as { fetch: Mock }).fetch = fillerMock;
+      const fillers: Array<Promise<Response>> = [];
+      for (let i = 0; i < GITHUB_FETCH_CONCURRENCY - 1; i++) {
+        fillers.push(rateLimitAwareFetch(`https://api.github.com/filler?n=${i}`));
+      }
+      await vi.waitFor(() => {
+        expect(fillerMock).toHaveBeenCalledTimes(GITHUB_FETCH_CONCURRENCY - 1);
+      });
+      // Swap in the real test mock for the next two calls.
+      (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
+
+      const callA = rateLimitAwareFetch("https://api.github.com/A");
+      const callB = rateLimitAwareFetch("https://api.github.com/B");
+
+      // Wait until call A has dispatched (slot 8 taken) — call B is queued.
+      await vi.waitFor(() => {
+        expect(resolveA).not.toBeNull();
+      });
+
+      // Resolve A with a 403 secondary-limit body (no retry-after header).
+      resolveA!(new Response(body, { status: 403 }));
+
+      // B must fail with GitHubRateLimitError because the body-classified
+      // secondary block was registered synchronously before A released.
+      await expect(callB).rejects.toBeInstanceOf(GitHubRateLimitError);
+      // The B fetch must NOT have been invoked — the post-acquire re-check
+      // tripped at the gate.
+      expect(resolveB).toBeNull();
+
+      // Cleanup fillers so the test exits cleanly.
+      for (const f of filler) f.resolve(new Response(null, { status: 200 }));
+      await Promise.all(fillers);
+      // Drain whatever's left for the test mock.
+      await callA;
+    });
+  });
+
+  it("validate() distinguishes a secondary-rate-limit 403 from a permissions 403", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response("You have exceeded a secondary rate limit. Please wait.", { status: 403 })
+    );
+    (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
+
+    const result = await GitHubAuth.validate("ghp_validtoken012345678901234567890123456789");
+    expect(result.valid).toBe(false);
+    // Must NOT report this as a permissions error.
+    expect(result.error).not.toBe("Token lacks required permissions");
+    expect(result.error).toMatch(/secondary rate limit/i);
   });
 
   it("validate returns empty scopes for fine-grained PAT with empty x-oauth-scopes header", async () => {

--- a/plugins/builtin/github/main/__tests__/GitHubAuth.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubAuth.test.ts
@@ -1,11 +1,19 @@
-import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import {
   GitHubAuth,
+  GITHUB_FETCH_CONCURRENCY,
+  _getGithubFetchSemaphoreForTests,
+  _resetGithubFetchSemaphoreForTests,
   captureAuthMetadata,
   getLastAuthMetadata,
   parseSsoHeader,
   parseSsoKind,
+  rateLimitAwareFetch,
 } from "../GitHubAuth.js";
+import {
+  gitHubRateLimitService,
+  GitHubRateLimitError,
+} from "../GitHubRateLimitService.js";
 
 function createStorage() {
   let token: string | undefined;
@@ -24,6 +32,8 @@ describe("GitHubAuth", () => {
   beforeEach(() => {
     GitHubAuth.initializeStorage(createStorage());
     GitHubAuth.clearToken();
+    gitHubRateLimitService._resetForTests();
+    _resetGithubFetchSemaphoreForTests();
   });
 
   it("clears cached user info when memory token changes", () => {
@@ -334,14 +344,21 @@ describe("GitHubAuth", () => {
     GitHubAuth.setToken("ghp_stale00000000000000000000000000000000000");
 
     let resolveFetch: ((value: Response) => void) | null = null;
-    (globalThis as unknown as { fetch: Mock }).fetch = vi.fn().mockImplementation(
+    const mockFetch = vi.fn().mockImplementation(
       () =>
         new Promise<Response>((resolve) => {
           resolveFetch = resolve;
         })
     );
+    (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
 
     const validatePromise = GitHubAuth.validate("ghp_stale00000000000000000000000000000000000");
+
+    // Wait until validate has acquired its semaphore slot and dispatched the
+    // mock fetch. The semaphore introduces one microtask between `validate()`
+    // and the fetch call, so without this we'd rotate the token before the
+    // mock's executor had a chance to capture `resolveFetch`.
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalled());
 
     // Token rotates before the stale response lands.
     GitHubAuth.setToken("ghp_fresh00000000000000000000000000000000000");
@@ -360,6 +377,121 @@ describe("GitHubAuth", () => {
 
     // Stale SSO URL must not leak into current metadata.
     expect(getLastAuthMetadata()?.ssoUrl).toBeUndefined();
+  });
+
+  describe("rateLimitAwareFetch — preflight circuit-breaker", () => {
+    afterEach(() => {
+      gitHubRateLimitService._resetForTests();
+    });
+
+    it("throws GitHubRateLimitError when the service is currently blocked, without making a network request", async () => {
+      const mockFetch = vi.fn();
+      (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
+
+      // Seed an active secondary block.
+      gitHubRateLimitService.update(new Headers({ "retry-after": "30" }), 429);
+
+      await expect(rateLimitAwareFetch("https://api.github.com/user")).rejects.toBeInstanceOf(
+        GitHubRateLimitError
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("bypasses the preflight when daintreeSkipRateLimitPreflight is true", async () => {
+      gitHubRateLimitService.update(new Headers({ "retry-after": "30" }), 429);
+
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response('{"login":"user"}', {
+          status: 200,
+          headers: { "x-oauth-scopes": "repo" },
+        })
+      );
+      (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
+
+      const response = await rateLimitAwareFetch("https://api.github.com/user", {
+        daintreeSkipRateLimitPreflight: true,
+      });
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it("strips daintreeSkipRateLimitPreflight before forwarding init to fetch", async () => {
+      const mockFetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+      (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
+
+      await rateLimitAwareFetch("https://api.github.com/user", {
+        method: "GET",
+        daintreeSkipRateLimitPreflight: true,
+      });
+
+      const forwardedInit = mockFetch.mock.calls[0][1] as Record<string, unknown>;
+      expect(forwardedInit.daintreeSkipRateLimitPreflight).toBeUndefined();
+      expect(forwardedInit.method).toBe("GET");
+    });
+  });
+
+  describe("rateLimitAwareFetch — concurrency cap", () => {
+    afterEach(() => {
+      gitHubRateLimitService._resetForTests();
+    });
+
+    it("queues calls past the concurrency limit instead of dispatching all at once", async () => {
+      const pending: Array<(response: Response) => void> = [];
+      const mockFetch = vi.fn().mockImplementation(
+        () =>
+          new Promise<Response>((resolve) => {
+            pending.push(resolve);
+          })
+      );
+      (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
+
+      const totalRequests = GITHUB_FETCH_CONCURRENCY + 2;
+      const inflight = Array.from({ length: totalRequests }, (_, i) =>
+        rateLimitAwareFetch(`https://api.github.com/user?n=${i}`)
+      );
+
+      // Wait until the semaphore has granted exactly GITHUB_FETCH_CONCURRENCY
+      // slots — the remaining 2 must still be queued, not in flight.
+      await vi.waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(GITHUB_FETCH_CONCURRENCY);
+      });
+      expect(_getGithubFetchSemaphoreForTests().active).toBe(GITHUB_FETCH_CONCURRENCY);
+      expect(_getGithubFetchSemaphoreForTests().pending).toBe(
+        totalRequests - GITHUB_FETCH_CONCURRENCY
+      );
+
+      // Resolve one in-flight request; the next queued call should dispatch.
+      pending[0]!(new Response(null, { status: 200 }));
+      await vi.waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(GITHUB_FETCH_CONCURRENCY + 1);
+      });
+
+      // Drain the rest. Each resolved request may dispatch a new queued
+      // call (adding to `pending`), so loop until every in-flight finishes.
+      let nextIndex = 1;
+      while (nextIndex < totalRequests) {
+        if (nextIndex < pending.length) {
+          pending[nextIndex]!(new Response(null, { status: 200 }));
+          nextIndex++;
+        } else {
+          await new Promise((resolve) => setImmediate(resolve));
+        }
+      }
+      await Promise.all(inflight);
+      expect(_getGithubFetchSemaphoreForTests().active).toBe(0);
+      expect(_getGithubFetchSemaphoreForTests().pending).toBe(0);
+    });
+
+    it("releases the semaphore slot when fetch throws", async () => {
+      const mockFetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+      (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
+
+      const before = _getGithubFetchSemaphoreForTests().active;
+      await expect(rateLimitAwareFetch("https://api.github.com/user")).rejects.toThrow(
+        "ECONNREFUSED"
+      );
+      expect(_getGithubFetchSemaphoreForTests().active).toBe(before);
+    });
   });
 
   it("validate returns empty scopes for fine-grained PAT with empty x-oauth-scopes header", async () => {

--- a/plugins/builtin/github/main/__tests__/GitHubAuth.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubAuth.test.ts
@@ -10,10 +10,7 @@ import {
   parseSsoKind,
   rateLimitAwareFetch,
 } from "../GitHubAuth.js";
-import {
-  gitHubRateLimitService,
-  GitHubRateLimitError,
-} from "../GitHubRateLimitService.js";
+import { gitHubRateLimitService, GitHubRateLimitError } from "../GitHubRateLimitService.js";
 
 function createStorage() {
   let token: string | undefined;
@@ -616,9 +613,11 @@ describe("GitHubAuth", () => {
   });
 
   it("validate() distinguishes a secondary-rate-limit 403 from a permissions 403", async () => {
-    const mockFetch = vi.fn().mockResolvedValue(
-      new Response("You have exceeded a secondary rate limit. Please wait.", { status: 403 })
-    );
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response("You have exceeded a secondary rate limit. Please wait.", { status: 403 })
+      );
     (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
 
     const result = await GitHubAuth.validate("ghp_validtoken012345678901234567890123456789");

--- a/plugins/builtin/github/main/__tests__/GitHubIssues.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubIssues.test.ts
@@ -9,6 +9,10 @@ vi.mock("../GitHubAuth.js", () => ({
     createClient: vi.fn(() => null),
   },
   GITHUB_API_TIMEOUT_MS: 5000,
+  // Thin pass-through so assignIssue's mocked REST path keeps working — the
+  // test stubs globalThis.fetch directly.
+  rateLimitAwareFetch: (input: RequestInfo | URL, init?: RequestInit) =>
+    globalThis.fetch(input, init),
 }));
 
 vi.mock("../GitHubRateLimitService.js", () => ({

--- a/plugins/builtin/github/main/__tests__/GitHubRateLimitService.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubRateLimitService.test.ts
@@ -408,4 +408,107 @@ describe("GitHubRateLimitService", () => {
       expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(true);
     });
   });
+
+  describe("jittered exponential backoff on consecutive secondary hits", () => {
+    it("increments consecutive-hits counter on retry-after secondary block", () => {
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+      expect(gitHubRateLimitService._getConsecutiveSecondaryHitsForTests()).toBe(1);
+
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+      expect(gitHubRateLimitService._getConsecutiveSecondaryHitsForTests()).toBe(2);
+    });
+
+    it("increments counter on body-classified secondary block", () => {
+      gitHubRateLimitService.update(
+        makeHeaders({}),
+        403,
+        "You have exceeded a secondary rate limit."
+      );
+      expect(gitHubRateLimitService._getConsecutiveSecondaryHitsForTests()).toBe(1);
+
+      gitHubRateLimitService.update(makeHeaders({}), 403, "abuse detection");
+      expect(gitHubRateLimitService._getConsecutiveSecondaryHitsForTests()).toBe(2);
+    });
+
+    it("applies exponential backoff on each consecutive body-classified secondary block", () => {
+      // Pin jitter to 0 so the lower bound is the bare exponential schedule.
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+      try {
+        gitHubRateLimitService.update(makeHeaders({}), 403, "secondary rate limit");
+        const hit1 = gitHubRateLimitService.shouldBlockRequest().resumeAt!;
+        const wait1 = hit1 - Date.now();
+        // Hit 1 base: 60s.
+        expect(wait1).toBeGreaterThanOrEqual(58_000);
+        expect(wait1).toBeLessThanOrEqual(62_000);
+
+        // Need to clear the block to register the next hit (otherwise
+        // the same global block is just refreshed in place).
+        gitHubRateLimitService._resetForTests();
+        // _resetForTests zeroes the counter, so re-seed to hit count 2.
+        gitHubRateLimitService.update(makeHeaders({}), 403, "secondary rate limit");
+        // Now we're at hit 1 after reset; do one more to reach hit 2.
+        gitHubRateLimitService.update(makeHeaders({}), 403, "secondary rate limit");
+        const hit2 = gitHubRateLimitService.shouldBlockRequest().resumeAt!;
+        const wait2 = hit2 - Date.now();
+        // Hit 2 base: 120s.
+        expect(wait2).toBeGreaterThanOrEqual(118_000);
+        expect(wait2).toBeLessThanOrEqual(122_000);
+      } finally {
+        randomSpy.mockRestore();
+      }
+    });
+
+    it("caps fallback delay at 5 minutes regardless of consecutive hit count", () => {
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
+      try {
+        // Force counter high.
+        for (let i = 0; i < 10; i++) {
+          gitHubRateLimitService.update(makeHeaders({}), 403, "secondary rate limit");
+        }
+        const resumeAt = gitHubRateLimitService.shouldBlockRequest().resumeAt!;
+        const wait = resumeAt - Date.now();
+        // Cap is 5 min = 300_000ms.
+        expect(wait).toBeLessThanOrEqual(300_500);
+      } finally {
+        randomSpy.mockRestore();
+      }
+    });
+
+    it("resets counter on clear()", () => {
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+      expect(gitHubRateLimitService._getConsecutiveSecondaryHitsForTests()).toBe(1);
+
+      gitHubRateLimitService.clear();
+      expect(gitHubRateLimitService._getConsecutiveSecondaryHitsForTests()).toBe(0);
+    });
+
+    it("resets counter on a successful 2xx with remaining > 0", () => {
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+      expect(gitHubRateLimitService._getConsecutiveSecondaryHitsForTests()).toBe(1);
+
+      gitHubRateLimitService.update(
+        makeHeaders({
+          "x-ratelimit-remaining": "4999",
+          "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 3600),
+        }),
+        200
+      );
+
+      expect(gitHubRateLimitService._getConsecutiveSecondaryHitsForTests()).toBe(0);
+    });
+
+    it("honors explicit retry-after value without applying jitter override", () => {
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
+      try {
+        gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+        const resumeAt = gitHubRateLimitService.shouldBlockRequest().resumeAt!;
+        const wait = resumeAt - Date.now();
+        // Should be ~30s, not 60s+ from the jittered fallback.
+        expect(wait).toBeGreaterThan(25_000);
+        expect(wait).toBeLessThanOrEqual(30_500);
+      } finally {
+        randomSpy.mockRestore();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds three layers of secondary rate-limit protection to the GitHub fetcher to prevent burst conditions from triggering GitHub's secondary limit
- Fixes a UX bug where `validate()` misclassified a secondary-limit 403 as missing token permissions
- Routes all bare-fetch GitHub callers through `rateLimitAwareFetch` and guards `GitHubTokenHealthService` from probing while a block is active

Resolves #8397

## Changes

**Circuit-breaker (preflight + post-acquire re-check):** `rateLimitAwareFetch` now checks the secondary-limit state before acquiring the semaphore, and again immediately after, closing the race window between acquisition and dispatch.

**8-slot FIFO async semaphore:** bursty callers queue at the `rateLimitAwareFetch` wrapper instead of fanning out into concurrent requests.

**Jittered exponential backoff in `GitHubRateLimitService`:** 60s base, 5-minute cap. The jitter prevents thundering-herd re-entry once the block clears.

**Misclassified 403 fix:** `validate()` previously reported a secondary-rate-limit 403 as "Token lacks required permissions". Now correctly identified.

**Caller routing:** `GitHubPRDiscovery`, `GitHubRateLimitApi`, `GitHubIssues`, and other bare-fetch callers all go through the wrapper. `GitHubTokenHealthService` skips its probe while a block is active.

## Testing

534 tests pass in the GitHub plugin. Lint warnings dropped 17. TypeScript clean.