### PR TITLE
refactor(fleet): make fleet-scope restoration race-safe with a typed token

### DIFF
--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -2,6 +2,14 @@ import type { FileChangeDetail, WorktreeChanges } from "./git.js";
 import type { GitHubPRCIStatus } from "./github.js";
 import type { PluginWorktreeLinked } from "./plugin.js";
 
+/**
+ * Opaque ownership token for an active fleet scope. Minted by
+ * `enterFleetScope()` and required by `exitFleetScope(token)` so a stale exit
+ * whose async continuation runs after a newer `enterFleetScope()` becomes a
+ * structural no-op (token mismatch) rather than racing a mutable slot.
+ */
+export type FleetScopeToken = string & { readonly __brand: unique symbol };
+
 /** Worktree mood indicator */
 export type WorktreeMood = "stable" | "active" | "stale" | "error";
 

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -293,7 +293,13 @@ export function registerFleetActions(actions: ActionRegistry): void {
     run: async () => {
       const flag = useFleetScopeFlagStore.getState();
       if (!flag.isHydrated || flag.mode !== "scoped") return;
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      // Read the live token synchronously at dispatch time and pass it
+      // through. `exitFleetScope` re-validates it against the store before any
+      // async work, so a scope torn down between this read and the call is a
+      // structural no-op rather than a misfired restore.
+      const token = useWorktreeSelectionStore.getState()._fleetScopeToken;
+      if (token === null) return;
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
     },
   }));
 

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalRefreshTier } from "@shared/types/panel";
+import type { FleetScopeToken } from "@shared/types/worktree";
 
 const {
   appSetStateMock,
@@ -450,37 +451,83 @@ describe("worktreeStore", () => {
   });
 
   describe("fleet scope", () => {
-    it("starts inactive with no previous worktree captured", () => {
+    it("starts inactive with no previous worktree or token captured", () => {
       const state = useWorktreeSelectionStore.getState();
       expect(state.isFleetScopeActive).toBe(false);
       expect(state._previousActiveWorktreeId).toBeNull();
+      expect(state._fleetScopeToken).toBeNull();
     });
 
-    it("enterFleetScope captures current activeWorktreeId", () => {
+    it("enterFleetScope captures current activeWorktreeId and mints a token", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-active" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
       const state = useWorktreeSelectionStore.getState();
       expect(state.isFleetScopeActive).toBe(true);
       expect(state._previousActiveWorktreeId).toBe("wt-active");
+      expect(typeof token).toBe("string");
+      expect(state._fleetScopeToken).toBe(token);
     });
 
-    it("enterFleetScope is idempotent — repeated calls preserve the original capture", () => {
+    it("enterFleetScope is idempotent — repeated calls preserve the capture and return the same token", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-original" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token1 = useWorktreeSelectionStore.getState().enterFleetScope();
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-changed" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token2 = useWorktreeSelectionStore.getState().enterFleetScope();
       expect(useWorktreeSelectionStore.getState()._previousActiveWorktreeId).toBe("wt-original");
+      expect(token2).toBe(token1);
     });
 
     it("exitFleetScope restores the previously captured activeWorktreeId", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-original" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
       useWorktreeSelectionStore.setState({ activeWorktreeId: null });
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
       const state = useWorktreeSelectionStore.getState();
       expect(state.isFleetScopeActive).toBe(false);
       expect(state._previousActiveWorktreeId).toBeNull();
+      expect(state._fleetScopeToken).toBeNull();
       expect(state.activeWorktreeId).toBe("wt-original");
+    });
+
+    it("exitFleetScope with a stale token from a superseded scope is a no-op", () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-first" });
+      const staleToken = useWorktreeSelectionStore.getState().enterFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(staleToken);
+      // A fresh scope is entered, minting a new token.
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-second" });
+      const liveToken = useWorktreeSelectionStore.getState().enterFleetScope();
+      expect(liveToken).not.toBe(staleToken);
+
+      // The stale exit (e.g. its async caller fired late) must not tear down
+      // the live scope or restore against the wrong worktree.
+      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+      useWorktreeSelectionStore.getState().exitFleetScope(staleToken);
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.isFleetScopeActive).toBe(true);
+      expect(state._fleetScopeToken).toBe(liveToken);
+      expect(state.activeWorktreeId).toBeNull();
+    });
+
+    it("re-entering scope during a stale exit's async window does not restore focus", async () => {
+      setMockTerminals([
+        { id: "term-active", worktreeId: "wt-pre", location: "grid" },
+        { id: "term-primary", worktreeId: "wt-pre", location: "grid" },
+      ]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
+      const token1 = useWorktreeSelectionStore.getState().enterFleetScope();
+      lastArmedIdForFleet = "term-primary";
+      setFocusedMock.mockClear();
+
+      // Exit fires, then a new scope is entered before the deferred
+      // focus-restore microtask resolves. The non-null token guard must
+      // suppress the stale focus restore.
+      useWorktreeSelectionStore.getState().exitFleetScope(token1);
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setFocusedMock).not.toHaveBeenCalledWith("term-primary");
+      lastArmedIdForFleet = null;
     });
 
     it("exitFleetScope persists the restored activeWorktreeId", async () => {
@@ -488,10 +535,10 @@ describe("worktreeStore", () => {
       // from earlier tests that touched "wt-original" via setActiveWorktree.
       const restoreId = "wt-fleet-exit-persist";
       useWorktreeSelectionStore.setState({ activeWorktreeId: restoreId });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
       useWorktreeSelectionStore.setState({ activeWorktreeId: null });
       appSetStateMock.mockClear();
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
       // persistActiveWorktree loads the clients module via dynamic import,
       // so the setState call is deferred to a microtask.
       await Promise.resolve();
@@ -505,10 +552,10 @@ describe("worktreeStore", () => {
         { id: "term-b", worktreeId: "wt-other", location: "grid" },
       ]);
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-original" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
       useWorktreeSelectionStore.setState({ activeWorktreeId: null });
       applyRendererPolicyMock.mockClear();
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
       await Promise.resolve();
       await Promise.resolve();
       expect(applyRendererPolicyMock).toHaveBeenCalledWith("term-a", TerminalRefreshTier.VISIBLE);
@@ -520,7 +567,9 @@ describe("worktreeStore", () => {
 
     it("exitFleetScope is a no-op when scope is not active", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-current" });
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      useWorktreeSelectionStore
+        .getState()
+        .exitFleetScope("orphan-token" as unknown as FleetScopeToken);
       const state = useWorktreeSelectionStore.getState();
       expect(state.isFleetScopeActive).toBe(false);
       expect(state.activeWorktreeId).toBe("wt-current");
@@ -533,6 +582,7 @@ describe("worktreeStore", () => {
       const state = useWorktreeSelectionStore.getState();
       expect(state.isFleetScopeActive).toBe(false);
       expect(state._previousActiveWorktreeId).toBeNull();
+      expect(state._fleetScopeToken).toBeNull();
     });
 
     it("enterFleetScope clears any active maximize so the scope grid is visible", async () => {
@@ -557,14 +607,14 @@ describe("worktreeStore", () => {
 
     it("exitFleetScope clears any lingering preMaximizeLayout snapshot", async () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre-scope" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
       await Promise.resolve();
       await Promise.resolve();
 
       terminalStoreState.preMaximizeLayout = { gridCols: 3 };
       panelSetStateMock.mockClear();
 
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
       await Promise.resolve();
       await Promise.resolve();
 
@@ -574,9 +624,9 @@ describe("worktreeStore", () => {
 
     it("enterFleetScope's deferred maximize-clear bails if scope was exited first", async () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-race" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
       // Exit scope synchronously before the deferred .then() resolves.
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
 
       // Simulate the user manually re-maximizing a panel after the exit.
       terminalStoreState.maximizedId = "term-user-maxed";
@@ -600,11 +650,11 @@ describe("worktreeStore", () => {
         { id: "term-primary", worktreeId: "wt-pre", location: "grid" },
       ]);
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
       lastArmedIdForFleet = "term-primary";
       setFocusedMock.mockClear();
 
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
       await Promise.resolve();
       await Promise.resolve();
 
@@ -615,11 +665,11 @@ describe("worktreeStore", () => {
     it("exitFleetScope does not call setFocused when lastArmedId is null", async () => {
       setMockTerminals([{ id: "term-active", worktreeId: "wt-pre", location: "grid" }]);
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
       lastArmedIdForFleet = null;
       setFocusedMock.mockClear();
 
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
       await Promise.resolve();
       await Promise.resolve();
 
@@ -636,11 +686,11 @@ describe("worktreeStore", () => {
         { id: "term-primary", worktreeId: "wt-other", location: "grid" },
       ]);
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
       lastArmedIdForFleet = "term-primary";
       setFocusedMock.mockClear();
 
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
       await Promise.resolve();
       await Promise.resolve();
 
@@ -654,11 +704,11 @@ describe("worktreeStore", () => {
         { id: "term-primary", worktreeId: "wt-pre", location: "trash" },
       ]);
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
       lastArmedIdForFleet = "term-primary";
       setFocusedMock.mockClear();
 
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
       await Promise.resolve();
       await Promise.resolve();
 
@@ -672,11 +722,11 @@ describe("worktreeStore", () => {
         { id: "term-primary", worktreeId: "wt-pre", location: "dock" },
       ]);
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
       lastArmedIdForFleet = "term-primary";
       setFocusedMock.mockClear();
 
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
       await Promise.resolve();
       await Promise.resolve();
 
@@ -690,11 +740,11 @@ describe("worktreeStore", () => {
         { id: "term-primary", worktreeId: "wt-pre", location: "grid" },
       ]);
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
-      useWorktreeSelectionStore.getState().enterFleetScope();
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
       lastArmedIdForFleet = "term-primary";
       setFocusedMock.mockClear();
 
-      useWorktreeSelectionStore.getState().exitFleetScope();
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
       // Simulate a newer store change (e.g. another worktree switch) that
       // bumps _policyGeneration before the deferred focus-restore resolves.
       useWorktreeSelectionStore.setState((s) => ({ _policyGeneration: s._policyGeneration + 5 }));

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -622,6 +622,46 @@ describe("worktreeStore", () => {
       expect(terminalStoreState.preMaximizeLayout).toBeNull();
     });
 
+    it("exitFleetScope's deferred preMaximizeLayout clear bails if scope re-entered", async () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre-scope" });
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      terminalStoreState.preMaximizeLayout = { gridCols: 3 };
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
+      // A fresh scope is entered before the exit's deferred clear drains.
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      panelSetStateMock.mockClear();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The stale exit-side clear must not wipe the new scope's snapshot.
+      expect(panelSetStateMock).not.toHaveBeenCalledWith({ preMaximizeLayout: null });
+    });
+
+    it("reset during exitFleetScope's focus-restore window does not call setFocused", async () => {
+      setMockTerminals([
+        { id: "term-active", worktreeId: "wt-pre", location: "grid" },
+        { id: "term-primary", worktreeId: "wt-pre", location: "grid" },
+      ]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
+      const token = useWorktreeSelectionStore.getState().enterFleetScope();
+      lastArmedIdForFleet = "term-primary";
+      setFocusedMock.mockClear();
+
+      useWorktreeSelectionStore.getState().exitFleetScope(token);
+      // reset() bumps _policyGeneration, invalidating the pending focus-restore
+      // microtask whose token guard alone can't catch this (post-reset token
+      // is null, matching the exit-side null comparison).
+      useWorktreeSelectionStore.getState().reset();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setFocusedMock).not.toHaveBeenCalled();
+      lastArmedIdForFleet = null;
+    });
+
     it("enterFleetScope's deferred maximize-clear bails if scope was exited first", async () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-race" });
       const token = useWorktreeSelectionStore.getState().enterFleetScope();

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -595,8 +595,11 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     // target isn't corrupted by a double-enter. Return the existing token so
     // a caller that re-enters still holds a token that matches the live scope.
     if (get().isFleetScopeActive) {
+      // Non-null in this branch: an active scope always has a live token.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- branded token narrowing
       return get()._fleetScopeToken as FleetScopeToken;
     }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- branding an opaque uuid
     const token = crypto.randomUUID() as FleetScopeToken;
     const activeWorktreeId = get().activeWorktreeId;
     const generation = get()._policyGeneration + 1;

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -659,6 +659,11 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     // scope entry. The restored worktree's layout should be computed fresh.
     void loadTerminalStoreModule()
       .then(({ usePanelStore }) => {
+        // Symmetric to the enter-side maximize-clear guard: if a fresh scope
+        // was entered before this microtask drained, `_fleetScopeToken` is
+        // non-null and clearing preMaximizeLayout would clobber the new
+        // scope's legitimate snapshot.
+        if (get()._fleetScopeToken !== null) return;
         usePanelStore.setState({ preMaximizeLayout: null });
       })
       .catch(() => {});
@@ -736,6 +741,12 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       isFleetScopeActive: false,
       _previousActiveWorktreeId: null,
       _fleetScopeToken: null,
+      // Bump the generation so any in-flight deferred policy/focus-restore
+      // microtask (which captured an older generation) sees a mismatch and
+      // bails — clearing the token alone can't invalidate them because the
+      // post-reset token is null and the exit-side guard compares against
+      // null.
+      _policyGeneration: get()._policyGeneration + 1,
     }),
 });
 

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -3,6 +3,7 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@shared/types/panel";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
+import type { FleetScopeToken } from "@shared/types/worktree";
 import { useFocusStore } from "@/store/focusStore";
 import { logErrorWithContext } from "@/utils/errorContext";
 import { PERF_MARKS } from "@shared/perf/marks";
@@ -51,6 +52,7 @@ interface WorktreeSelectionState {
   lastFocusedTerminalByWorktree: Map<string, string>;
   isFleetScopeActive: boolean;
   _previousActiveWorktreeId: string | null;
+  _fleetScopeToken: FleetScopeToken | null;
 
   setActiveWorktree: (id: string | null) => void;
   setFocusedWorktree: (id: string | null) => void;
@@ -77,8 +79,8 @@ interface WorktreeSelectionState {
   closeCrossWorktreeDiff: () => void;
   trackTerminalFocus: (worktreeId: string, terminalId: string) => void;
   clearWorktreeFocusTracking: (worktreeId: string) => void;
-  enterFleetScope: () => void;
-  exitFleetScope: () => void;
+  enterFleetScope: () => FleetScopeToken;
+  exitFleetScope: (token: FleetScopeToken) => void;
   reset: () => void;
 }
 
@@ -259,6 +261,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
   lastFocusedTerminalByWorktree: new Map<string, string>(),
   isFleetScopeActive: false,
   _previousActiveWorktreeId: null,
+  _fleetScopeToken: null,
 
   setActiveWorktree: (id) => {
     const previousId = get().activeWorktreeId;
@@ -589,13 +592,18 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
 
   enterFleetScope: () => {
     // Idempotent: first pre-scope activeWorktreeId wins so the restoration
-    // target isn't corrupted by a double-enter.
-    if (get().isFleetScopeActive) return;
+    // target isn't corrupted by a double-enter. Return the existing token so
+    // a caller that re-enters still holds a token that matches the live scope.
+    if (get().isFleetScopeActive) {
+      return get()._fleetScopeToken as FleetScopeToken;
+    }
+    const token = crypto.randomUUID() as FleetScopeToken;
     const activeWorktreeId = get().activeWorktreeId;
     const generation = get()._policyGeneration + 1;
     set({
       isFleetScopeActive: true,
       _previousActiveWorktreeId: activeWorktreeId,
+      _fleetScopeToken: token,
       _policyGeneration: generation,
     });
     // Clear any active maximize so the fleet-scope render path isn't shadowed
@@ -608,7 +616,10 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     // we must not wipe a maximize the user set after the exit.
     void loadTerminalStoreModule()
       .then(({ usePanelStore }) => {
-        if (!get().isFleetScopeActive) return;
+        // Token equality (not `isFleetScopeActive`): if the caller exited and
+        // re-entered scope back-to-back, `isFleetScopeActive` is true again but
+        // for a *different* scope — wiping its maximize would be wrong.
+        if (get()._fleetScopeToken !== token) return;
         usePanelStore.setState({
           maximizedId: null,
           maximizeTarget: null,
@@ -620,10 +631,16 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     // instances actually stream live output inside the fleet grid. The
     // policy function consults `isFleetScopeActive` + the armed set.
     applyWorktreeTerminalPolicy(get, set, activeWorktreeId, generation);
+    return token;
   },
 
-  exitFleetScope: () => {
-    if (!get().isFleetScopeActive) return;
+  exitFleetScope: (token) => {
+    // Token-equality guard: a stale exit whose async caller fired after a
+    // newer `enterFleetScope()` carries an outdated token and is structurally
+    // a no-op here — it can't restore against the wrong scope. This replaces
+    // the prior `isFleetScopeActive` boolean check, which couldn't tell a
+    // stale exit apart from a legitimate one.
+    if (get()._fleetScopeToken !== token) return;
     const restoreId = get()._previousActiveWorktreeId;
     const generation = get()._policyGeneration + 1;
     // Snapshot the primary (most-recently-armed) terminal BEFORE `set()` so
@@ -632,6 +649,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     set({
       isFleetScopeActive: false,
       _previousActiveWorktreeId: null,
+      _fleetScopeToken: null,
       activeWorktreeId: restoreId,
       focusedWorktreeId: restoreId,
       _policyGeneration: generation,
@@ -647,8 +665,12 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     // Focus the primary (most-recently-armed) terminal so the user lands on
     // a known pane instead of whatever `focusedId` happened to be during
     // fleet scope. Guarded by:
+    //   - token: a new `enterFleetScope()` during this async window mints a
+    //     fresh token (non-null), so restoring focus would fight the new
+    //     scope. `_fleetScopeToken === null` means no scope re-entered.
     //   - generation: prevents a stale microtask from overwriting a newer
-    //     worktree switch.
+    //     worktree switch (also catches concurrent setActiveWorktree /
+    //     selectWorktree that don't touch the token).
     //   - worktreeId match: the user's scope-exit intent is "restore the
     //     pre-scope worktree". If the primary lives elsewhere, focusing it
     //     would let `rendererStoreOrchestrator`'s focusedId subscription
@@ -659,6 +681,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     if (primaryTerminalId && restoreId) {
       void loadTerminalStoreModule()
         .then(({ usePanelStore }) => {
+          if (get()._fleetScopeToken !== null) return;
           if (get()._policyGeneration !== generation) return;
           const terminal = usePanelStore.getState().panelsById[primaryTerminalId];
           if (!terminal) return;
@@ -712,6 +735,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       lastFocusedTerminalByWorktree: new Map<string, string>(),
       isFleetScopeActive: false,
       _previousActiveWorktreeId: null,
+      _fleetScopeToken: null,
     }),
 });
 


### PR DESCRIPTION
## Summary

- `_previousActiveWorktreeId` was a mutable string slot that a new `enterFleetScope` could overwrite before a stale exit's async continuation read it — the existing three-way runtime guards didn't cover every variant of this race
- Introduces a branded `FleetScopeToken` returned by `enterFleetScope` and required by `exitFleetScope`, so stale exits are structural no-ops via token mismatch rather than relying on runtime checks
- `exitFleetScope` reads the current `_fleetScopeToken` synchronously and short-circuits immediately on a mismatch; the deferred maximize-clear and focus-restore microtask are both guarded by the same token equality check

Resolves #8404

## Changes

- `shared/types/worktree.ts` — branded `FleetScopeToken` type
- `src/store/worktreeStore.ts` — `_fleetScopeToken` store slot; `enterFleetScope()` returns the existing token on idempotent re-enter, mints a new UUID on fresh entry; `exitFleetScope(token)` early-returns on token mismatch; `reset()` bumps `_policyGeneration` to invalidate in-flight microtasks
- `src/services/actions/definitions/fleetActions.ts` — `fleet.scope.exit` reads `_fleetScopeToken` synchronously and threads it to `exitFleetScope`
- `src/store/__tests__/worktreeStore.test.ts` — all callers updated; regression tests added for stale-token no-op, re-enter during stale exit's async window, exit-side `preMaximizeLayout` re-enter guard, and reset-during-focus-restore-window

## Testing

38 unit tests pass. Typecheck clean, lint at baseline, prettier clean.