### PR TITLE
feat(forge): batch PR detection via findPRsByBranches capability

### DIFF
--- a/docs/architecture/forge-provider-abstraction.md
+++ b/docs/architecture/forge-provider-abstraction.md
@@ -222,6 +222,14 @@ interface RateLimitInfo {
 
 Plugins parse their own transport (GraphQL `rateLimit` node for GitHub) and populate this shape. The host renders the rate-limit indicator from this projection.
 
+### Batching as the Quota-Reduction Strategy
+
+GitHub's GraphQL endpoint does not support ETag conditional requests — that's a REST-only header — so providers cannot rely on `If-None-Match` to cheaply confirm "nothing changed." The primary lever for reducing per-poll quota burn is **batching**: collapsing N round-trips into one aliased query when the host has a list of identifiers to resolve.
+
+The optional `findPRsByBranches(repo, branches): Map<string, PR | null>` capability on `ForgeProviderImpl` is the canonical example. `PullRequestService.checkForPRs` polls many worktree branches at once; with the capability present, the GitHub plugin issues one aliased `repository { pullRequests(headRefName: ...) }` block per branch in chunks (default 20) instead of one search query per branch. The host probes for the capability via a truthiness guard, calls it when present, and falls back to per-branch `findPRByBranch` when the batched call throws so a single transient chunk error doesn't blank every row's PR state.
+
+Other forge providers can omit the capability — the host degrades gracefully — or implement it natively (GitLab's REST `/projects/:id/merge_requests?source_branch[]=...` accepts repeated query params for the same effect).
+
 ## Worktree Snapshot: Breaking Change
 
 `PluginWorktreeSnapshot` in `shared/utils/pluginWorktreeSnapshot.ts` currently leaks GitHub-shaped fields (`issueNumber`, `issueTitle`, `prNumber`, `prUrl`, `prState`, `prTitle`). These get replaced with a provider-agnostic projection:

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -518,7 +518,10 @@ class PullRequestService {
     // semantics of a manual refresh.
     this.resolvedWorktrees.clear();
     // Re-resolve the forge provider on manual refresh so token changes
-    // and provider installs/uninstalls take effect immediately.
+    // and provider installs/uninstalls take effect immediately. Clear the
+    // in-flight branch-lookup dedup so a stale promise from the previous
+    // provider can't bind a wrong-repo PR to a worktree after refresh.
+    this.inFlightBranchLookups.clear();
     this.invalidateProvider();
     await this.resolveProvider();
     // Manual refresh is an explicit "I want fresh data now" — bypass the 5s

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -1005,24 +1005,12 @@ class PullRequestService {
         );
       }
 
-      // Per-branch PR lookups with concurrency limit
+      // Resolve unique branches → PR. Prefer the optional batch capability
+      // when present; on failure fall back per-branch so a single transient
+      // error doesn't blank every row's PR state. Truthiness guard per the
+      // forge.ts capability convention.
       const branches = [...uniqueBranches.keys()];
-      const prResults = await mapWithConcurrencyLimit(
-        branches,
-        5,
-        (branch): Promise<{ branch: string; pr: ForgePR | null }> => {
-          const existing = this.inFlightBranchLookups.get(branch);
-          if (existing) {
-            return existing.then((pr) => ({ branch, pr }));
-          }
-          const promise = provider.findPRByBranch(repo, branch).catch(() => null);
-          this.inFlightBranchLookups.set(branch, promise);
-          promise.finally(() => {
-            this.inFlightBranchLookups.delete(branch);
-          });
-          return promise.then((pr) => ({ branch, pr }));
-        }
-      );
+      const prResults = await this.resolvePRsForBranches(provider, repo, branches);
 
       // Fire issue lookups in parallel with PR lookups
       await Promise.allSettled(issueLookups);
@@ -1079,6 +1067,73 @@ class PullRequestService {
     } catch (error) {
       this.handleError(formatErrorMessage(error, "PR check failed"));
     }
+  }
+
+  /**
+   * Resolve a list of unique branches to PRs. Prefers the optional batch
+   * capability `findPRsByBranches` to collapse N round-trips into ceil(N/chunk)
+   * GraphQL requests. If the batch call throws — single transient error from
+   * one chunk shouldn't blank every row's PR state — falls back to the
+   * existing per-branch concurrency-5 path; branches missing from the batch
+   * result Map likewise get the per-branch fallback.
+   */
+  private async resolvePRsForBranches(
+    provider: ForgeProviderImpl,
+    repo: RepoRef,
+    branches: string[]
+  ): Promise<Array<{ branch: string; pr: ForgePR | null }>> {
+    if (branches.length === 0) return [];
+
+    if (provider.findPRsByBranches) {
+      try {
+        const batchMap = await provider.findPRsByBranches(repo, branches);
+        const results: Array<{ branch: string; pr: ForgePR | null }> = [];
+        const missing: string[] = [];
+        for (const branch of branches) {
+          if (batchMap.has(branch)) {
+            results.push({ branch, pr: batchMap.get(branch) ?? null });
+          } else {
+            missing.push(branch);
+          }
+        }
+        if (missing.length > 0) {
+          const fallback = await this.perBranchFallback(provider, repo, missing);
+          results.push(...fallback);
+        }
+        return results;
+      } catch (error) {
+        logWarn("Batched PR lookup failed; retrying per-branch", {
+          branchCount: branches.length,
+          error: formatErrorMessage(error, "findPRsByBranches failed"),
+        });
+        // Fall through to per-branch path below.
+      }
+    }
+
+    return this.perBranchFallback(provider, repo, branches);
+  }
+
+  private perBranchFallback(
+    provider: ForgeProviderImpl,
+    repo: RepoRef,
+    branches: string[]
+  ): Promise<Array<{ branch: string; pr: ForgePR | null }>> {
+    return mapWithConcurrencyLimit(
+      branches,
+      5,
+      (branch): Promise<{ branch: string; pr: ForgePR | null }> => {
+        const existing = this.inFlightBranchLookups.get(branch);
+        if (existing) {
+          return existing.then((pr) => ({ branch, pr }));
+        }
+        const promise = provider.findPRByBranch(repo, branch).catch(() => null);
+        this.inFlightBranchLookups.set(branch, promise);
+        promise.finally(() => {
+          this.inFlightBranchLookups.delete(branch);
+        });
+        return promise.then((pr) => ({ branch, pr }));
+      }
+    );
   }
 
   /**

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -39,7 +39,10 @@ function makeMockForgePR(overrides?: Partial<ForgePR>): ForgePR {
   };
 }
 
-function mockForgeProviderResolved(findPRByBranch?: () => Promise<ForgePR | null>) {
+function mockForgeProviderResolved(
+  findPRByBranch?: () => Promise<ForgePR | null>,
+  findPRsByBranches?: (repo: RepoRef, branches: string[]) => Promise<Map<string, ForgePR | null>>
+) {
   const mockImpl: ForgeProviderImpl = {
     getCredentials: vi.fn(),
     validateCredentials: vi.fn(),
@@ -51,6 +54,13 @@ function mockForgeProviderResolved(findPRByBranch?: () => Promise<ForgePR | null
     findPRByBranch: vi
       .fn<() => Promise<ForgePR | null>>()
       .mockImplementation(findPRByBranch ?? (async () => makeMockForgePR())),
+    ...(findPRsByBranches
+      ? {
+          findPRsByBranches: vi
+            .fn<(repo: RepoRef, branches: string[]) => Promise<Map<string, ForgePR | null>>>()
+            .mockImplementation(findPRsByBranches),
+        }
+      : {}),
     getCIStatus: vi.fn().mockResolvedValue(null),
     getRepoMetadata: vi.fn(),
     buildIssueUrl: vi.fn(),
@@ -223,6 +233,136 @@ describe("PullRequestService", () => {
     expect(cleared[0]).toMatchObject({ worktreeId: "wt-1", timestamp: expect.any(Number) });
 
     unsubscribeCleared();
+    pullRequestService.destroy();
+  });
+
+  it("uses findPRsByBranches batch capability when present (single round-trip for many branches)", async () => {
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+
+    const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+      const map = new Map<string, ForgePR | null>();
+      for (const branch of branches) {
+        map.set(
+          branch,
+          makeMockForgePR({
+            number: branch === "feature/a" ? 1 : 2,
+            headRef: branch,
+            url: `https://github.com/o/r/pull/${branch === "feature/a" ? 1 : 2}`,
+          })
+        );
+      }
+      return map;
+    });
+
+    const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+    const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+    pullRequestService.initialize("/repo");
+
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+    );
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/b" })
+    );
+
+    await pullRequestService.refresh();
+
+    expect(batchSpy).toHaveBeenCalledTimes(1);
+    expect(batchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "testowner", repo: "testrepo" }),
+      expect.arrayContaining(["feature/a", "feature/b"])
+    );
+    // Per-branch path must NOT be used when the batch capability is present and succeeds.
+    expect(mockImpl.findPRByBranch).not.toHaveBeenCalled();
+    expect(detected).toHaveLength(2);
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
+  it("falls back to per-branch findPRByBranch when batch capability throws", async () => {
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+
+    const batchSpy = vi.fn(async () => {
+      throw new Error("transient batch failure");
+    });
+
+    const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+    const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+    pullRequestService.initialize("/repo");
+
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+    );
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/b" })
+    );
+
+    await pullRequestService.refresh();
+
+    expect(batchSpy).toHaveBeenCalledTimes(1);
+    // Per-branch fallback fires for each unique branch on batch failure.
+    expect(mockImpl.findPRByBranch).toHaveBeenCalledTimes(2);
+    // Detection still completes — a single transient batch error must not blank every row.
+    expect(detected).toHaveLength(2);
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
+  it("uses per-branch fallback for branches the batch result omits", async () => {
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+
+    const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+      const map = new Map<string, ForgePR | null>();
+      // Resolve only the first branch — omit the second to exercise the partial-result path.
+      if (branches.length > 0) {
+        map.set(branches[0], makeMockForgePR({ number: 10 }));
+      }
+      return map;
+    });
+
+    const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+    );
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/b" })
+    );
+
+    await pullRequestService.refresh();
+
+    expect(batchSpy).toHaveBeenCalledTimes(1);
+    // Exactly one per-branch fallback call — for the omitted branch.
+    expect(mockImpl.findPRByBranch).toHaveBeenCalledTimes(1);
+
     pullRequestService.destroy();
   });
 

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -285,6 +285,64 @@ describe("PullRequestService", () => {
     expect(mockImpl.findPRByBranch).not.toHaveBeenCalled();
     expect(detected).toHaveLength(2);
 
+    const byWorktree = new Map(detected.map((d) => [d.worktreeId, d]));
+    expect(byWorktree.get("wt-1")).toMatchObject({
+      prNumber: 1,
+      prUrl: expect.stringMatching(/\/1$/),
+    });
+    expect(byWorktree.get("wt-2")).toMatchObject({
+      prNumber: 2,
+      prUrl: expect.stringMatching(/\/2$/),
+    });
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
+  it("fans out a single batched PR result to every worktree on the same branch", async () => {
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+
+    const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+      const map = new Map<string, ForgePR | null>();
+      for (const branch of branches) {
+        map.set(branch, makeMockForgePR({ number: 99, headRef: branch }));
+      }
+      return map;
+    });
+
+    mockForgeProviderResolved(undefined, batchSpy);
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+    const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+    pullRequestService.initialize("/repo");
+
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-a", branch: "shared/branch" })
+    );
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-b", branch: "shared/branch" })
+    );
+
+    await pullRequestService.refresh();
+
+    // Branch deduplication: one batch call with a single unique branch
+    expect(batchSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.arrayContaining(["shared/branch"])
+    );
+    // Both worktrees get a detection event from the single PR
+    expect(detected).toHaveLength(2);
+    const worktreeIds = detected.map((d) => d.worktreeId).sort();
+    expect(worktreeIds).toEqual(["wt-a", "wt-b"]);
+    expect(detected.every((d) => d.prNumber === 99)).toBe(true);
+
     unsubscribe();
     pullRequestService.destroy();
   });
@@ -362,6 +420,10 @@ describe("PullRequestService", () => {
     expect(batchSpy).toHaveBeenCalledTimes(1);
     // Exactly one per-branch fallback call — for the omitted branch.
     expect(mockImpl.findPRByBranch).toHaveBeenCalledTimes(1);
+    expect(mockImpl.findPRByBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "testowner", repo: "testrepo" }),
+      "feature/b"
+    );
 
     pullRequestService.destroy();
   });

--- a/plugins/builtin/github/main/GitHubQueries.ts
+++ b/plugins/builtin/github/main/GitHubQueries.ts
@@ -635,6 +635,69 @@ export function buildBatchPRQuery(
 }
 
 /**
+ * Per-chunk cap for {@link buildBatchBranchPRQuery}. GitHub's GraphQL gateway
+ * caps complexity per request, and aliased `repository { pullRequests(...) }`
+ * blocks each carry a `first: 1` PR connection. 20 aliases per chunk is the
+ * empirically safe ceiling — well under the alias resource limit and small
+ * enough that retry blast radius stays bounded if one chunk fails.
+ */
+export const BATCH_BRANCH_CHUNK_SIZE = 20;
+
+/**
+ * Build a batched GraphQL query that resolves the most-recent PR for each of
+ * `branches` in a single round-trip. Returns one aliased
+ * `repository { pullRequests(headRefName: ..., first: 1, ...) }` block per
+ * branch; the alias name is index-based (`b0`, `b1`, …) so branch values with
+ * special characters never appear as identifiers — only as escaped string
+ * literals via {@link escapeGraphQLString}. The caller maps each result back
+ * to its branch using the same index order it passed in.
+ *
+ * The branch list is expected to be ≤ {@link BATCH_BRANCH_CHUNK_SIZE}; the
+ * implementation does not chunk internally because chunks must be separate
+ * HTTP requests (cost rolls up per-request on the rate limit).
+ *
+ * Returns an empty string for an empty `branches` array so the caller can
+ * skip the request entirely.
+ *
+ * Field shape matches the per-branch `SEARCH_QUERY` PR fragment subset that
+ * `toForgePR` reads: number, title, bodyText, url, state, isDraft, merged,
+ * baseRefName, headRefName, createdAt, updatedAt, closedAt, mergedAt, author.
+ */
+export function buildBatchBranchPRQuery(owner: string, repo: string, branches: string[]): string {
+  if (branches.length === 0) return "";
+  const escapedOwner = escapeGraphQLString(owner);
+  const escapedRepo = escapeGraphQLString(repo);
+
+  const parts = branches.map((branch, i) => {
+    const escapedBranch = escapeGraphQLString(branch);
+    return `
+      b${i}: repository(owner: "${escapedOwner}", name: "${escapedRepo}") {
+        pullRequests(first: 1, states: [OPEN, MERGED, CLOSED], headRefName: "${escapedBranch}", orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            number
+            title
+            bodyText
+            url
+            state
+            isDraft
+            merged
+            baseRefName
+            headRefName
+            createdAt
+            updatedAt
+            closedAt
+            mergedAt
+            author { login avatarUrl }
+          }
+        }
+      }
+    `;
+  });
+
+  return `query { ${parts.join("\n")} rateLimit { cost remaining resetAt } }`;
+}
+
+/**
  * Build a batched GraphQL query that fetches statusCheckRollup.contexts with per-context
  * `isRequired` flags for each supplied PR number. `pullRequestNumber` must be inlined
  * as an integer literal per alias — GraphQL variables are global to an operation and

--- a/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  BATCH_BRANCH_CHUNK_SIZE,
+  buildBatchBranchPRQuery,
   buildBatchPRQuery,
   buildBatchRequiredChecksQuery,
   REPO_STATS_QUERY,
@@ -332,5 +334,96 @@ describe("buildBatchPRQuery", () => {
       const query = buildBatchRequiredChecksQuery("owner", "repo", [12]);
       expect(query).toContain("rateLimit {");
     });
+  });
+});
+
+describe("buildBatchBranchPRQuery", () => {
+  it("returns empty string for an empty branch list (caller must skip the request)", () => {
+    expect(buildBatchBranchPRQuery("owner", "repo", [])).toBe("");
+  });
+
+  it("uses index-based aliases (b0, b1, …) so special characters in branch names never appear as identifiers", () => {
+    const query = buildBatchBranchPRQuery("owner", "repo", [
+      "feature/x",
+      'has"quote',
+      "with spaces",
+    ]);
+    expect(query).toContain("b0: repository");
+    expect(query).toContain("b1: repository");
+    expect(query).toContain("b2: repository");
+  });
+
+  it("escapes owner, repo, and branch values in generated GraphQL query", () => {
+    const query = buildBatchBranchPRQuery('my"owner', "repo\\name", ['feat"branch']);
+    expect(query).toContain('owner: "my\\"owner"');
+    expect(query).toContain('name: "repo\\\\name"');
+    expect(query).toContain('headRefName: "feat\\"branch"');
+  });
+
+  it("queries one PR per branch with first: 1 and all PR states", () => {
+    const query = buildBatchBranchPRQuery("owner", "repo", ["main"]);
+    expect(query).toContain("first: 1");
+    expect(query).toContain("states: [OPEN, MERGED, CLOSED]");
+  });
+
+  it("uses inline orderBy literal (avoids the IssueOrder/PullRequestOrder variable trap)", () => {
+    // Past lesson #3339: Repository.pullRequests.orderBy expects IssueOrder,
+    // not PullRequestOrder. Inlining sidesteps the variable type entirely.
+    const query = buildBatchBranchPRQuery("owner", "repo", ["main"]);
+    expect(query).toContain("orderBy: {field: UPDATED_AT, direction: DESC}");
+    expect(query).not.toContain("PullRequestOrder");
+  });
+
+  it("does not declare a $query variable (rejected by @octokit/graphql)", () => {
+    // Past lesson #1376: @octokit/graphql reserves `query` for the operation
+    // document. The inline builder pattern sidesteps the trap entirely.
+    const query = buildBatchBranchPRQuery("owner", "repo", ["main", "dev"]);
+    expect(query).not.toContain("$query");
+  });
+
+  it("returns the PR fields toForgePR reads (number, title, bodyText, url, state, draft, merged, refs, timestamps, author)", () => {
+    const query = buildBatchBranchPRQuery("owner", "repo", ["main"]);
+    expect(query).toContain("number");
+    expect(query).toContain("title");
+    expect(query).toContain("bodyText");
+    expect(query).toContain("url");
+    expect(query).toContain("state");
+    expect(query).toContain("isDraft");
+    expect(query).toContain("merged");
+    expect(query).toContain("baseRefName");
+    expect(query).toContain("headRefName");
+    expect(query).toContain("createdAt");
+    expect(query).toContain("updatedAt");
+    expect(query).toContain("closedAt");
+    expect(query).toContain("mergedAt");
+    expect(query).toContain("author { login avatarUrl }");
+  });
+
+  it("uses bodyText (not body) — parity with SEARCH_QUERY and getPRTooltip", () => {
+    const query = buildBatchBranchPRQuery("owner", "repo", ["main"]);
+    expect(query).toContain("bodyText");
+    // Word-boundary match avoids matching `bodyText`.
+    expect(query).not.toMatch(/\bbody\b(?!Text)/);
+  });
+
+  it("includes rateLimit at operation root so rate-limit state stays in sync", () => {
+    const query = buildBatchBranchPRQuery("owner", "repo", ["main"]);
+    expect(query).toContain("rateLimit {");
+    expect(query).toContain("cost");
+    expect(query).toContain("remaining");
+    expect(query).toContain("resetAt");
+  });
+
+  it("emits one aliased block per branch in the caller's chunk", () => {
+    const branches = Array.from({ length: BATCH_BRANCH_CHUNK_SIZE }, (_, i) => `branch-${i}`);
+    const query = buildBatchBranchPRQuery("owner", "repo", branches);
+    for (let i = 0; i < branches.length; i++) {
+      expect(query).toContain(`b${i}: repository`);
+      expect(query).toContain(`headRefName: "branch-${i}"`);
+    }
+  });
+
+  it("exports BATCH_BRANCH_CHUNK_SIZE as 20 (per-chunk cap)", () => {
+    expect(BATCH_BRANCH_CHUNK_SIZE).toBe(20);
   });
 });

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGraphQLClient = vi.fn();
+
+vi.mock("../GitHubAuth.js", () => ({
+  GitHubAuth: {
+    getToken: vi.fn(() => "test-token"),
+    createClient: vi.fn(() => mockGraphQLClient),
+  },
+  GITHUB_API_TIMEOUT_MS: 5000,
+}));
+
+vi.mock("../GitHubRateLimitService.js", () => ({
+  gitHubRateLimitService: {
+    updateFromGraphQL: vi.fn(),
+    getState: vi.fn(() => ({ blocked: false })),
+  },
+}));
+
+vi.mock("../GitHubErrors.js", () => ({
+  parseGitHubError: (e: unknown) => (e instanceof Error ? e.message : "unknown error"),
+}));
+
+import { githubForgeProvider } from "../forgeProvider.js";
+import type { RepoRef } from "../../../../../shared/types/forge.js";
+
+const repo: RepoRef = { host: "github.com", owner: "owner", repo: "repo", rawData: null };
+
+function makePRNode(number: number, headRefName: string) {
+  return {
+    number,
+    title: `PR ${number}`,
+    bodyText: "",
+    url: `https://github.com/owner/repo/pull/${number}`,
+    state: "OPEN",
+    isDraft: false,
+    merged: false,
+    baseRefName: "main",
+    headRefName,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    closedAt: null,
+    mergedAt: null,
+    author: { login: "user", avatarUrl: "" },
+  };
+}
+
+describe("findPRsByBranches", () => {
+  beforeEach(() => {
+    mockGraphQLClient.mockReset();
+  });
+
+  it("returns an empty Map for an empty branch list without issuing a request", async () => {
+    const result = await githubForgeProvider.findPRsByBranches!(repo, []);
+    expect(result.size).toBe(0);
+    expect(mockGraphQLClient).not.toHaveBeenCalled();
+  });
+
+  it("maps each alias back to the correct branch in input order (≤ chunk size)", async () => {
+    mockGraphQLClient.mockResolvedValueOnce({
+      b0: { pullRequests: { nodes: [makePRNode(1, "feature/a")] } },
+      b1: { pullRequests: { nodes: [makePRNode(2, "feature/b")] } },
+      b2: { pullRequests: { nodes: [] } },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+
+    const result = await githubForgeProvider.findPRsByBranches!(repo, [
+      "feature/a",
+      "feature/b",
+      "feature/c",
+    ]);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+    expect(result.get("feature/a")?.number).toBe(1);
+    expect(result.get("feature/b")?.number).toBe(2);
+    expect(result.get("feature/c")).toBeNull();
+  });
+
+  it("chunks at BATCH_BRANCH_CHUNK_SIZE (20) and maps the 21st branch to alias b0 of the second chunk", async () => {
+    const branches = Array.from({ length: 21 }, (_, i) => `branch-${i}`);
+
+    // First chunk: branches 0..19 → b0..b19
+    const firstResponse: Record<string, unknown> = {
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    };
+    for (let i = 0; i < 20; i++) {
+      firstResponse[`b${i}`] = { pullRequests: { nodes: [makePRNode(100 + i, `branch-${i}`)] } };
+    }
+    // Second chunk: branch 20 → b0
+    const secondResponse = {
+      b0: { pullRequests: { nodes: [makePRNode(120, "branch-20")] } },
+      rateLimit: { cost: 1, remaining: 4998, resetAt: "" },
+    };
+
+    mockGraphQLClient.mockResolvedValueOnce(firstResponse).mockResolvedValueOnce(secondResponse);
+
+    const result = await githubForgeProvider.findPRsByBranches!(repo, branches);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+    expect(result.get("branch-0")?.number).toBe(100);
+    expect(result.get("branch-19")?.number).toBe(119);
+    expect(result.get("branch-20")?.number).toBe(120); // alias b0 of second chunk
+  });
+
+  it("omits a branch from the result Map when its alias is missing from the response (partial GraphQL response)", async () => {
+    // b1 is missing — the alias key is absent, not null. The caller routes
+    // omitted branches to per-branch fallback rather than silently recording null.
+    mockGraphQLClient.mockResolvedValueOnce({
+      b0: { pullRequests: { nodes: [makePRNode(1, "feature/a")] } },
+      // b1 intentionally omitted
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+
+    const result = await githubForgeProvider.findPRsByBranches!(repo, ["feature/a", "feature/b"]);
+
+    expect(result.has("feature/a")).toBe(true);
+    expect(result.has("feature/b")).toBe(false);
+  });
+
+  it("treats a present-but-null alias the same as a missing alias (omits the branch)", async () => {
+    mockGraphQLClient.mockResolvedValueOnce({
+      b0: { pullRequests: { nodes: [makePRNode(1, "feature/a")] } },
+      b1: null,
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+
+    const result = await githubForgeProvider.findPRsByBranches!(repo, ["feature/a", "feature/b"]);
+
+    expect(result.has("feature/a")).toBe(true);
+    expect(result.has("feature/b")).toBe(false);
+  });
+
+  it("isolates per-chunk failures so a single transient error doesn't blank every branch", async () => {
+    const branches = Array.from({ length: 21 }, (_, i) => `branch-${i}`);
+
+    // First chunk succeeds for all 20 branches
+    const firstResponse: Record<string, unknown> = {
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    };
+    for (let i = 0; i < 20; i++) {
+      firstResponse[`b${i}`] = { pullRequests: { nodes: [makePRNode(100 + i, `branch-${i}`)] } };
+    }
+    // Second chunk throws
+    mockGraphQLClient
+      .mockResolvedValueOnce(firstResponse)
+      .mockRejectedValueOnce(new Error("transient chunk failure"));
+
+    const result = await githubForgeProvider.findPRsByBranches!(repo, branches);
+
+    // First-chunk branches present, second-chunk branch omitted → caller falls back per-branch
+    expect(result.size).toBe(20);
+    expect(result.has("branch-0")).toBe(true);
+    expect(result.has("branch-19")).toBe(true);
+    expect(result.has("branch-20")).toBe(false);
+  });
+
+  it("deduplicates duplicate branches in input (one alias per unique value)", async () => {
+    mockGraphQLClient.mockResolvedValueOnce({
+      b0: { pullRequests: { nodes: [makePRNode(1, "shared")] } },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+
+    const result = await githubForgeProvider.findPRsByBranches!(repo, [
+      "shared",
+      "shared",
+      "shared",
+    ]);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+    // Result Map has one entry for the unique branch; consumers fan out
+    // to multiple worktrees via their own iteration of uniqueBranches.
+    expect(result.size).toBe(1);
+    expect(result.get("shared")?.number).toBe(1);
+
+    // The query body should reference the branch exactly once.
+    const calledQuery = mockGraphQLClient.mock.calls[0][0] as string;
+    const matches = calledQuery.match(/headRefName: "shared"/g);
+    expect(matches?.length).toBe(1);
+  });
+});

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { formatErrorMessage } from "../../../../../shared/utils/errorMessage.js";
 
 const mockGraphQLClient = vi.fn();
 
@@ -18,7 +19,7 @@ vi.mock("../GitHubRateLimitService.js", () => ({
 }));
 
 vi.mock("../GitHubErrors.js", () => ({
-  parseGitHubError: (e: unknown) => (e instanceof Error ? e.message : "unknown error"),
+  parseGitHubError: (e: unknown) => formatErrorMessage(e, "unknown error"),
 }));
 
 import { githubForgeProvider } from "../forgeProvider.js";

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -320,8 +320,8 @@ async function findPRsByBranchesImpl(
   const result = new Map<string, PR | null>();
   if (branches.length === 0) return result;
 
-  // Deduplicate while preserving order; record original branches for each unique value
-  // so the result Map carries an entry for every input even when the caller passed duplicates.
+  // Deduplicate while preserving order. Duplicates in the input still land
+  // in the result via the same key, but each unique value is queried once.
   const unique: string[] = [];
   const seen = new Set<string>();
   for (const branch of branches) {
@@ -331,19 +331,34 @@ async function findPRsByBranchesImpl(
     }
   }
 
-  // Chunks run sequentially to keep rate-limit cost predictable; parallel
-  // chunks would spike GraphQL points during a fleet-wide refresh.
+  // Chunks run sequentially (parallel would spike GraphQL points during a
+  // fleet-wide refresh). Per-chunk failures are caught so a single transient
+  // chunk error doesn't blank every branch — the caller falls back per-branch
+  // for any branch the result Map omits.
   for (let start = 0; start < unique.length; start += BATCH_BRANCH_CHUNK_SIZE) {
     const chunk = unique.slice(start, start + BATCH_BRANCH_CHUNK_SIZE);
     const query = buildBatchBranchPRQuery(repo.owner, repo.repo, chunk);
-    const response = await runQuery(query, {});
+    let response: Record<string, unknown>;
+    try {
+      response = (await runQuery(query, {})) as Record<string, unknown>;
+    } catch {
+      // Omit this chunk's branches from the result — caller's missing-key
+      // fallback path handles them.
+      continue;
+    }
 
     for (let i = 0; i < chunk.length; i++) {
       const branch = chunk[i];
-      const aliasNode = (response as Record<string, unknown>)[`b${i}`] as
+      // A missing alias key (vs. a present key with empty nodes) indicates a
+      // partial GraphQL response. Omit so the caller routes to fallback rather
+      // than silently recording "no PR found".
+      if (!(`b${i}` in response)) continue;
+      const aliasNode = response[`b${i}`] as
         | { pullRequests?: { nodes?: unknown[] } }
+        | null
         | undefined;
-      const nodes = (aliasNode?.pullRequests?.nodes ?? []) as Array<Record<string, unknown>>;
+      if (aliasNode == null) continue;
+      const nodes = (aliasNode.pullRequests?.nodes ?? []) as Array<Record<string, unknown>>;
       const first = nodes.find(Boolean);
       result.set(branch, first ? toForgePR(first) : null);
     }

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -28,6 +28,8 @@ import {
   GET_ISSUE_QUERY,
   GET_PR_QUERY,
   GET_PR_REVIEW_THREADS_QUERY,
+  BATCH_BRANCH_CHUNK_SIZE,
+  buildBatchBranchPRQuery,
 } from "./GitHubQueries.js";
 import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
 import { parseGitHubError } from "./GitHubErrors.js";
@@ -311,6 +313,45 @@ async function getPRImpl(repo: RepoRef, number: number): Promise<PR | null> {
   return pr ? toForgePR(pr) : null;
 }
 
+async function findPRsByBranchesImpl(
+  repo: RepoRef,
+  branches: string[]
+): Promise<Map<string, PR | null>> {
+  const result = new Map<string, PR | null>();
+  if (branches.length === 0) return result;
+
+  // Deduplicate while preserving order; record original branches for each unique value
+  // so the result Map carries an entry for every input even when the caller passed duplicates.
+  const unique: string[] = [];
+  const seen = new Set<string>();
+  for (const branch of branches) {
+    if (!seen.has(branch)) {
+      seen.add(branch);
+      unique.push(branch);
+    }
+  }
+
+  // Chunks run sequentially to keep rate-limit cost predictable; parallel
+  // chunks would spike GraphQL points during a fleet-wide refresh.
+  for (let start = 0; start < unique.length; start += BATCH_BRANCH_CHUNK_SIZE) {
+    const chunk = unique.slice(start, start + BATCH_BRANCH_CHUNK_SIZE);
+    const query = buildBatchBranchPRQuery(repo.owner, repo.repo, chunk);
+    const response = await runQuery(query, {});
+
+    for (let i = 0; i < chunk.length; i++) {
+      const branch = chunk[i];
+      const aliasNode = (response as Record<string, unknown>)[`b${i}`] as
+        | { pullRequests?: { nodes?: unknown[] } }
+        | undefined;
+      const nodes = (aliasNode?.pullRequests?.nodes ?? []) as Array<Record<string, unknown>>;
+      const first = nodes.find(Boolean);
+      result.set(branch, first ? toForgePR(first) : null);
+    }
+  }
+
+  return result;
+}
+
 async function findPRByBranchImpl(repo: RepoRef, branchName: string): Promise<PR | null> {
   // Quote the branch name so refs containing spaces or characters that would
   // otherwise be parsed as a separate search operator (`sort:`, `head:`,
@@ -518,6 +559,7 @@ export const githubForgeProvider: ForgeProviderImpl = {
   getIssue: getIssueImpl,
   getPR: getPRImpl,
   findPRByBranch: findPRByBranchImpl,
+  findPRsByBranches: findPRsByBranchesImpl,
   getCIStatus: getCIStatusImpl,
   getRepoMetadata: getRepoMetadataImpl,
 

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -290,6 +290,17 @@ export interface ForgeProviderImpl {
   getIssue(repo: RepoRef, number: number): Promise<Issue | null>;
   getPR(repo: RepoRef, number: number): Promise<PR | null>;
   findPRByBranch(repo: RepoRef, branchName: string): Promise<PR | null>;
+  /**
+   * Optional batch variant of {@link findPRByBranch}. When present, callers
+   * resolving PRs for many branches in a single sweep (e.g. the worktree
+   * dashboard's PR-detection poll) should prefer this over N per-branch calls
+   * so the provider can amortize the round-trip. The returned `Map` is keyed
+   * by branch name; absent or `null` values mean no PR was found for that
+   * branch. Branches the implementation could not resolve (transient errors
+   * within a chunk) may be omitted; callers should treat omissions as the
+   * fallback path's responsibility.
+   */
+  findPRsByBranches?(repo: RepoRef, branches: string[]): Promise<Map<string, PR | null>>;
   getCIStatus(repo: RepoRef, prNumber: number): Promise<CIStatus | null>;
   getRepoMetadata(repo: RepoRef): Promise<RepoMetadata>;
 
@@ -335,6 +346,7 @@ export type ForgeCapabilityHint =
   | "releases"
   | "project-boards"
   | "milestones"
+  | "batch-branch-prs"
   | (string & {});
 
 /**


### PR DESCRIPTION
## Summary

- Adds `findPRsByBranches` to `ForgeProviderImpl` and a new `ForgeCapabilityHint` `batch-branch-prs`, giving providers a way to advertise and serve batched PR lookups
- GitHub plugin gets `buildBatchBranchPRQuery` — a GraphQL builder that composes aliased `pullRequests` blocks chunked to 20 per request, staying clear of the 256-char search limit; per-chunk error isolation means a single bad chunk doesn't kill the whole batch
- `PullRequestService` gains a `resolvePRsForBranches` helper that probes the capability and does batch-then-individual-fallback per branch; `refresh()` now clears `inFlightBranchLookups` so a stale in-flight promise can't bind a wrong-repo PR after a provider switch

Resolves #8384

## Changes

- `shared/types/forge.ts` — `findPRsByBranches(repo, branches): Promise<Map<string, PR | null>>` on `ForgeProviderImpl`; new `batch-branch-prs` hint
- `plugins/builtin/github/main/GitHubQueries.ts` — `buildBatchBranchPRQuery` with aliased blocks, `BATCH_BRANCH_CHUNK_SIZE = 20`, no `$query`/`PullRequestOrder` dependencies
- `plugins/builtin/github/main/forgeProvider.ts` — `findPRsByBranchesImpl`: dedup, sequential chunks, per-chunk failure isolation, missing/null aliases omitted so caller routes to fallback
- `electron/services/PullRequestService.ts` — `resolvePRsForBranches` helper, `refresh()` clears `inFlightBranchLookups`
- 22 new tests across `GitHubQueries.test.ts`, `PullRequestService.test.ts`, and `forgeProvider.test.ts` covering chunk boundaries, alias handling, partial failures, and same-branch fan-out
- `docs/architecture/forge-provider-abstraction.md` — "Batching as the Quota-Reduction Strategy" subsection

## Testing

Unit tests cover the full surface: query builder shape and escaping, alias indexing, all `toForgePR` fields, rate-limit presence, batch happy path, per-chunk failure isolation, partial responses routed to fallback, and `inFlightBranchLookups` cleared on `refresh`.