### PR TITLE
fix(worktree): make lifecycle setup failures recoverable on the card

### DIFF
--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -3,6 +3,7 @@ import { events } from "../events.js";
 import { CHANNELS } from "../../ipc/channels.js";
 import { broadcastToRenderer } from "../../ipc/utils.js";
 import { gitHubRateLimitService } from "../github/index.js";
+import { notifyError } from "../../ipc/errorHandlers.js";
 import { type ProcessEntry, type CopyTreeProgressCallback, sendToEntryWindows } from "./types.js";
 import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js";
 import type { RateLimitInfo } from "../../../shared/types/forge.js";
@@ -214,6 +215,19 @@ export class WorkspaceHostEventRouter {
             ipcChannel: CHANNELS.CLIPBOARD_WRITE_TEXT,
             data: "sudo sysctl fs.inotify.max_user_watches=524288",
           },
+        });
+        break;
+      }
+
+      case "lifecycle-setup-error": {
+        const err = new Error(event.message);
+        if (event.details !== undefined) {
+          err.stack = event.details;
+        }
+        notifyError(err, {
+          source: "worktree-lifecycle",
+          context: { worktreeId: event.worktreeId },
+          retryability: "user-gated",
         });
         break;
       }

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -168,6 +168,12 @@ async function handleWorktreePortRequest(
         break;
       }
 
+      case "run-lifecycle-setup": {
+        await workspaceService.retryLifecycleSetup(msg.payload.worktreeId);
+        result = { ok: true };
+        break;
+      }
+
       case "switch-worktree-environment": {
         const requestId = `port-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         await workspaceService.switchWorktreeEnvironment(

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1629,7 +1629,16 @@ export class WorkspaceService {
           options.provisionResource ?? options.worktreeMode === "remote-worker"
         );
       })().catch((err) => {
+        const message =
+          err instanceof Error ? err.message : `createWorktree async tail failed: ${String(err)}`;
+        const stack = err instanceof Error ? err.stack : undefined;
         console.warn("[WorkspaceHost] createWorktree async tail failed:", err);
+        this.sendEvent({
+          type: "lifecycle-setup-error",
+          worktreeId: canonicalWorktreeId,
+          message,
+          details: stack,
+        });
       });
     } catch (error) {
       // Create failed — drop any pending entry so a real external change to
@@ -1679,6 +1688,27 @@ export class WorkspaceService {
     if (shouldProvision && this.projectRootPath) {
       await this.runResourceAction(`auto-provision-${worktreeId}`, worktreeId, "provision");
     }
+  }
+
+  /**
+   * Re-run the lifecycle setup script for an existing worktree without
+   * recreating it. Surfaced via the `run-lifecycle-setup` port action so the
+   * worktree card can offer a "Retry setup" affordance after a failed/timed-out
+   * setup. Same idempotence assumption as resource provisioning — the user
+   * authors setup scripts knowing they may be re-run in place.
+   */
+  async retryLifecycleSetup(worktreeId: string): Promise<void> {
+    const monitor = this.monitors.get(worktreeId);
+    if (!monitor) {
+      throw new Error(`Worktree not found: ${worktreeId}`);
+    }
+    if (!this.projectRootPath) {
+      throw new Error("Cannot retry setup before a project is loaded");
+    }
+    if (monitor.lifecycleStatus?.state === "running") {
+      throw new Error("Setup is already running");
+    }
+    await this.runLifecycleSetup(worktreeId, monitor.path, this.projectRootPath, false);
   }
 
   private async runLifecycleTeardown(
@@ -2257,10 +2287,21 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         await this.runLifecycleSetup(worktreeId, monitor.path, this.projectRootPath, false, envKey);
       }
     } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : `switchWorktreeEnvironment lifecycle setup failed: ${String(err)}`;
+      const stack = err instanceof Error ? err.stack : undefined;
       console.warn(
         `[WorkspaceService] switchWorktreeEnvironment config resolution failed (non-fatal):`,
         err
       );
+      this.sendEvent({
+        type: "lifecycle-setup-error",
+        worktreeId,
+        message,
+        details: stack,
+      });
     }
 
     this.emitUpdate(monitor);

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1708,6 +1708,18 @@ export class WorkspaceService {
     if (monitor.lifecycleStatus?.state === "running") {
       throw new Error("Setup is already running");
     }
+
+    // Set running synchronously *before* the first await so a second concurrent
+    // request (rapid clicks, multi-window, retry-after-error) sees the in-flight
+    // state and is rejected by the guard above. `runLifecycleSetup` re-sets the
+    // same state with full command-progress metadata once config loads.
+    monitor.setLifecycleStatus({
+      phase: "setup",
+      state: "running",
+      startedAt: Date.now(),
+    });
+    this.emitUpdate(monitor);
+
     await this.runLifecycleSetup(worktreeId, monitor.path, this.projectRootPath, false);
   }
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1629,8 +1629,7 @@ export class WorkspaceService {
           options.provisionResource ?? options.worktreeMode === "remote-worker"
         );
       })().catch((err) => {
-        const message =
-          err instanceof Error ? err.message : `createWorktree async tail failed: ${String(err)}`;
+        const message = formatErrorMessage(err, "createWorktree async tail failed");
         const stack = err instanceof Error ? err.stack : undefined;
         console.warn("[WorkspaceHost] createWorktree async tail failed:", err);
         this.sendEvent({
@@ -1885,12 +1884,20 @@ export class WorkspaceService {
             console.log(`[WorkspaceHost] Branch already deleted: ${branchToDelete}`);
           } else if (errorMsg.includes("not fully merged")) {
             throw new Error(
-              `Branch '${branchToDelete}' has unmerged changes. Enable force delete to remove it.`
+              `Branch '${branchToDelete}' has unmerged changes. Enable force delete to remove it.`,
+              { cause: branchError }
             );
           } else if (errorMsg.includes("checked out at") || errorMsg.includes("Cannot delete")) {
-            throw new Error(`Cannot delete branch '${branchToDelete}': ${errorMsg.split("\n")[0]}`);
+            throw new Error(
+              `Cannot delete branch '${branchToDelete}': ${errorMsg.split("\n")[0]}`,
+              {
+                cause: branchError,
+              }
+            );
           } else {
-            throw new Error(`Failed to delete branch '${branchToDelete}': ${errorMsg}`);
+            throw new Error(`Failed to delete branch '${branchToDelete}': ${errorMsg}`, {
+              cause: branchError,
+            });
           }
         }
       }
@@ -2299,10 +2306,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         await this.runLifecycleSetup(worktreeId, monitor.path, this.projectRootPath, false, envKey);
       }
     } catch (err) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : `switchWorktreeEnvironment lifecycle setup failed: ${String(err)}`;
+      const message = formatErrorMessage(err, "switchWorktreeEnvironment lifecycle setup failed");
       const stack = err instanceof Error ? err.stack : undefined;
       console.warn(
         `[WorkspaceService] switchWorktreeEnvironment config resolution failed (non-fatal):`,

--- a/electron/workspace-host/WorktreeLifecycleService.ts
+++ b/electron/workspace-host/WorktreeLifecycleService.ts
@@ -203,12 +203,9 @@ export class WorktreeLifecycleService {
       return;
     }
 
-    try {
-      // force:false preserves any files already present in dest (e.g. worktree-level overrides)
-      await cp(src, dest, { recursive: true, force: false, errorOnExist: false });
-    } catch (err) {
-      console.warn("[WorktreeLifecycle] Failed to copy .daintree dir:", err);
-    }
+    // force:false preserves any files already present in dest (e.g. worktree-level overrides).
+    // Caller is expected to catch — they hold the `worktreeId` needed to surface the error.
+    await cp(src, dest, { recursive: true, force: false, errorOnExist: false });
   }
 
   /**

--- a/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
@@ -197,14 +197,20 @@ describe("WorktreeLifecycleService", () => {
       );
     });
 
-    it("does not throw if cp fails", async () => {
+    it("propagates the error if cp fails so the caller can surface it", async () => {
+      // Per #8401, copyDaintreeDir no longer swallows its error — the caller
+      // (WorkspaceService createWorktree async tail) has `worktreeId` in scope
+      // and routes the failure through `notify-error` so the worktree card can
+      // show it instead of disappearing into `console.warn`.
       mockAccess.mockImplementation(async (p: string) => {
         if ((p as string).includes(path.join("/main/repo", ".daintree"))) return undefined;
         throw new Error("ENOENT");
       });
       mockCp.mockRejectedValue(new Error("Permission denied"));
 
-      await expect(service.copyDaintreeDir("/main/repo", "/new/worktree")).resolves.toBeUndefined();
+      await expect(service.copyDaintreeDir("/main/repo", "/new/worktree")).rejects.toThrow(
+        "Permission denied"
+      );
     });
   });
 

--- a/shared/config/actionIds.ts
+++ b/shared/config/actionIds.ts
@@ -63,6 +63,9 @@ export const BUILT_IN_ACTION_IDS = [
   "worktree.resource.config.get",
   "worktree.resource.config.set",
 
+  // -- worktreeLifecycleActions --
+  "worktree.lifecycle.retrySetup",
+
   // -- worktreeSessionActions --
   "worktree.sessions.minimizeAll",
   "worktree.sessions.maximizeAll",

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -443,6 +443,18 @@ export type WorkspaceHostEvent =
   // Spontaneous updates (no requestId - these are pushed events)
   | { type: "worktree-update"; worktree: WorktreeSnapshot; epoch: string; seq: number }
   | { type: "worktree-removed"; worktreeId: string; epoch: string; seq: number }
+  // Per-worktree lifecycle setup failure surfaced to the renderer's error
+  // banner. Emitted from sites that previously swallowed errors to
+  // `console.warn` (the `createWorktree` async tail and the
+  // `switchWorktreeEnvironment` catch). The main-process router translates
+  // this into a `notifyError` with `context.worktreeId` so the failure shows
+  // on the matching worktree card alongside the lifecycle status.
+  | {
+      type: "lifecycle-setup-error";
+      worktreeId: string;
+      message: string;
+      details?: string;
+    }
   // Linux-only: fired once per host-process lifetime when the recursive file
   // watcher hits the inotify watch limit (ENOSPC).
   | { type: "inotify-limit-reached" }

--- a/shared/types/worktree-port.ts
+++ b/shared/types/worktree-port.ts
@@ -62,6 +62,10 @@ export interface WorktreePortProtocol {
     payload: { worktreeId: string; action: WorktreePortResourceAction };
     result: { ok: true };
   };
+  "run-lifecycle-setup": {
+    payload: { worktreeId: string };
+    result: { ok: true };
+  };
   "switch-worktree-environment": {
     payload: { worktreeId: string; envKey: string };
     result: { ok: true };

--- a/src/clients/worktreeClient.ts
+++ b/src/clients/worktreeClient.ts
@@ -108,6 +108,10 @@ export const worktreeClient = {
     await window.electron.worktreePort.request("resource-action", { worktreeId, action });
   },
 
+  retrySetup: async (worktreeId: string): Promise<void> => {
+    await window.electron.worktreePort.request("run-lifecycle-setup", { worktreeId });
+  },
+
   switchEnvironment: async (worktreeId: string, envKey: string): Promise<void> => {
     await window.electron.worktreePort.request("switch-worktree-environment", {
       worktreeId,

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { WorktreeState } from "@/types";
 import type { RetryAction } from "@/store";
 import type { ErrorRecord } from "@/store/errorStore";
@@ -14,14 +14,16 @@ import { getGravatarUrl, isBotAuthor } from "@/utils/gravatar";
 import {
   Activity,
   AlertTriangle,
+  ChevronDown,
   ChevronRight,
   GitCommitHorizontal,
   Plug,
   Play,
+  RotateCcw,
   Square,
   Trash2,
 } from "lucide-react";
-import { Spinner } from "@/components/ui/Spinner";
+import { actionService } from "@/services/ActionService";
 import type { ComputedSubtitle, WorktreeReviewState } from "./hooks/useWorktreeStatus";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -129,6 +131,27 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
   const showReviewHubButton = !!onOpenReviewHub && hasChanges;
   const rightButtonGroupShown = showReviewHubButton;
 
+  const lifecycleState = worktree.lifecycleStatus?.state;
+  const lifecycleFailed = lifecycleState === "failed" || lifecycleState === "timed-out";
+  const lifecycleError = worktree.lifecycleStatus?.error;
+  const lifecycleOutput = worktree.lifecycleStatus?.output;
+  const hasLifecycleDetails = lifecycleFailed && Boolean(lifecycleError || lifecycleOutput);
+  const [isRetryingSetup, setIsRetryingSetup] = useState(false);
+  const handleRetrySetup = async (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.stopPropagation();
+    if (isRetryingSetup) return;
+    setIsRetryingSetup(true);
+    try {
+      await actionService.dispatch(
+        "worktree.lifecycle.retrySetup",
+        { worktreeId: worktree.id },
+        { source: "user" }
+      );
+    } finally {
+      setIsRetryingSetup(false);
+    }
+  };
+
   const rsLower = resourceStatus?.toLowerCase();
   const showResourceResume =
     hasResourceConfig &&
@@ -183,259 +206,302 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
           </div>
         </div>
       ) : (
-        <div className="-m-3 flex items-stretch">
-          <div
-            onClick={onToggleExpand}
-            className={cn(
-              "worktree-section-button relative flex min-w-0 flex-1 items-center justify-between px-3 py-2.5 text-left transition-colors",
-              rightButtonGroupShown ? "rounded-l-[var(--radius-lg)]" : "rounded-[var(--radius-lg)]"
-            )}
-          >
-            <button
-              type="button"
-              aria-expanded={false}
-              aria-controls={detailsPanelId}
-              id={`${detailsId}-button`}
-              aria-label="Show details"
+        <div className="-m-3 flex flex-col">
+          <div className="flex items-stretch">
+            <div
+              onClick={onToggleExpand}
               className={cn(
-                "absolute inset-0",
+                "worktree-section-button relative flex min-w-0 flex-1 items-center justify-between px-3 py-2.5 text-left transition-colors",
                 rightButtonGroupShown
                   ? "rounded-l-[var(--radius-lg)]"
-                  : "rounded-[var(--radius-lg)]",
-                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
+                  : "rounded-[var(--radius-lg)]"
               )}
-            />
-            <span className="relative z-10 text-xs truncate min-w-0 flex-1 pointer-events-none">
-              {isLifecycleRunning && lifecycleLabel ? (
-                <span className="flex items-center gap-1.5 text-text-secondary">
-                  <Spinner size="xs" className="shrink-0" />
-                  <span className="truncate">{lifecycleLabel}</span>
-                </span>
-              ) : lifecycleLabel &&
-                !isLifecycleRunning &&
-                worktree.lifecycleStatus?.state !== "success" ? (
-                <span className="text-status-error">{lifecycleLabel}</span>
-              ) : isConflicted ? (
-                <span className="flex items-center gap-1.5 text-status-error">
-                  <AlertTriangle className="w-3 h-3 shrink-0" aria-hidden="true" />
-                  <span className="truncate">Conflicts need review</span>
-                </span>
-              ) : hasChanges && worktree.worktreeChanges ? (
-                <span className="flex items-center gap-1.5 text-text-secondary">
-                  <span ref={countScope} className="inline-block">
-                    {worktree.worktreeChanges.changedFileCount} file
-                    {worktree.worktreeChanges.changedFileCount !== 1 ? "s" : ""}
+            >
+              <button
+                type="button"
+                aria-expanded={false}
+                aria-controls={detailsPanelId}
+                id={`${detailsId}-button`}
+                aria-label="Show details"
+                className={cn(
+                  "absolute inset-0",
+                  rightButtonGroupShown
+                    ? "rounded-l-[var(--radius-lg)]"
+                    : "rounded-[var(--radius-lg)]",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
+                )}
+              />
+              <span className="relative z-10 text-xs truncate min-w-0 flex-1 pointer-events-none">
+                {isLifecycleRunning && lifecycleLabel ? (
+                  <span className="flex items-center gap-1.5 text-text-secondary">
+                    <span
+                      aria-hidden="true"
+                      className="inline-block w-2 h-2 rounded-full bg-text-secondary animate-pulse-immediate shrink-0"
+                    />
+                    <span className="truncate">{lifecycleLabel}</span>
                   </span>
-                  {((worktree.worktreeChanges.insertions ?? 0) > 0 ||
-                    (worktree.worktreeChanges.deletions ?? 0) > 0) && (
-                    <span className="flex items-center gap-0.5">
-                      {(worktree.worktreeChanges.insertions ?? 0) > 0 && (
-                        <span className="text-status-success">
-                          +{worktree.worktreeChanges.insertions}
-                        </span>
-                      )}
-                      {(worktree.worktreeChanges.insertions ?? 0) > 0 &&
-                        (worktree.worktreeChanges.deletions ?? 0) > 0 && (
-                          <span className="text-text-muted">/</span>
-                        )}
-                      {(worktree.worktreeChanges.deletions ?? 0) > 0 && (
-                        <span className="text-status-error">
-                          -{worktree.worktreeChanges.deletions}
-                        </span>
-                      )}
+                ) : lifecycleLabel &&
+                  !isLifecycleRunning &&
+                  worktree.lifecycleStatus?.state !== "success" ? (
+                  <span className="text-status-error">{lifecycleLabel}</span>
+                ) : isConflicted ? (
+                  <span className="flex items-center gap-1.5 text-status-error">
+                    <AlertTriangle className="w-3 h-3 shrink-0" aria-hidden="true" />
+                    <span className="truncate">Conflicts need review</span>
+                  </span>
+                ) : hasChanges && worktree.worktreeChanges ? (
+                  <span className="flex items-center gap-1.5 text-text-secondary">
+                    <span ref={countScope} className="inline-block">
+                      {worktree.worktreeChanges.changedFileCount} file
+                      {worktree.worktreeChanges.changedFileCount !== 1 ? "s" : ""}
                     </span>
-                  )}
-                </span>
-              ) : (
-                <span
-                  className={cn(
-                    computedSubtitle.tone === "warning" && "text-status-warning",
-                    computedSubtitle.tone === "info" && "text-status-info",
-                    computedSubtitle.tone === "muted" && "text-text-muted"
-                  )}
-                >
-                  {computedSubtitle.text}
-                </span>
-              )}
-            </span>
+                    {((worktree.worktreeChanges.insertions ?? 0) > 0 ||
+                      (worktree.worktreeChanges.deletions ?? 0) > 0) && (
+                      <span className="flex items-center gap-0.5">
+                        {(worktree.worktreeChanges.insertions ?? 0) > 0 && (
+                          <span className="text-status-success">
+                            +{worktree.worktreeChanges.insertions}
+                          </span>
+                        )}
+                        {(worktree.worktreeChanges.insertions ?? 0) > 0 &&
+                          (worktree.worktreeChanges.deletions ?? 0) > 0 && (
+                            <span className="text-text-muted">/</span>
+                          )}
+                        {(worktree.worktreeChanges.deletions ?? 0) > 0 && (
+                          <span className="text-status-error">
+                            -{worktree.worktreeChanges.deletions}
+                          </span>
+                        )}
+                      </span>
+                    )}
+                  </span>
+                ) : (
+                  <span
+                    className={cn(
+                      computedSubtitle.tone === "warning" && "text-status-warning",
+                      computedSubtitle.tone === "info" && "text-status-info",
+                      computedSubtitle.tone === "muted" && "text-text-muted"
+                    )}
+                  >
+                    {computedSubtitle.text}
+                  </span>
+                )}
+              </span>
 
-            {hasResourceConfig && (
-              <ContextMenu>
-                <ContextMenuTrigger asChild>
-                  <span className="sr-only">Resource actions</span>
-                </ContextMenuTrigger>
-                <ContextMenuContent onClick={(e) => e.stopPropagation()}>
-                  {showResourceResume && onResourceResume && (
-                    <ContextMenuItem onClick={onResourceResume}>
-                      <Play className="w-3.5 h-3.5 mr-2" />
-                      Resume
-                    </ContextMenuItem>
-                  )}
-                  {showResourcePause && onResourcePause && (
-                    <ContextMenuItem onClick={onResourcePause}>
-                      <Square className="w-3.5 h-3.5 mr-2" />
-                      Pause
-                    </ContextMenuItem>
-                  )}
-                  {showResourceConnect && (
-                    <ContextMenuItem onClick={onResourceConnect}>
-                      <Plug className="w-3.5 h-3.5 mr-2" />
-                      Connect
-                    </ContextMenuItem>
-                  )}
-                  {(showResourceResume || showResourcePause || showResourceConnect) &&
-                    onResourceStatus && <ContextMenuSeparator />}
-                  {onResourceStatus && (
-                    <ContextMenuItem onClick={onResourceStatus}>
-                      <Activity className="w-3.5 h-3.5 mr-2" />
-                      Check Status
-                    </ContextMenuItem>
-                  )}
-                  {onResourceTeardown && (
-                    <>
-                      <ContextMenuSeparator />
-                      <ContextMenuItem onClick={onResourceTeardown} className="text-status-error">
-                        <Trash2 className="w-3.5 h-3.5 mr-2" />
-                        Teardown
+              {hasResourceConfig && (
+                <ContextMenu>
+                  <ContextMenuTrigger asChild>
+                    <span className="sr-only">Resource actions</span>
+                  </ContextMenuTrigger>
+                  <ContextMenuContent onClick={(e) => e.stopPropagation()}>
+                    {showResourceResume && onResourceResume && (
+                      <ContextMenuItem onClick={onResourceResume}>
+                        <Play className="w-3.5 h-3.5 mr-2" />
+                        Resume
                       </ContextMenuItem>
-                    </>
-                  )}
-                </ContextMenuContent>
-              </ContextMenu>
-            )}
-
-            {hasResourceConfig &&
-              (showResourceResume || showResourcePause || showResourceConnect) && (
-                <span className="relative z-10 ml-1 inline-flex shrink-0 items-center gap-0.5">
-                  {showResourceResume && onResourceResume && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onResourceResume();
-                          }}
-                          className="shrink-0 p-1 rounded transition-colors text-status-success/70 hover:text-status-success hover:bg-overlay-emphasis focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-                          aria-label="Resume Resource"
-                        >
-                          <Play className="w-3 h-3" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">Resume Resource</TooltipContent>
-                    </Tooltip>
-                  )}
-                  {showResourcePause && onResourcePause && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onResourcePause();
-                          }}
-                          className="shrink-0 p-1 rounded transition-colors text-status-error/70 hover:text-status-error hover:bg-overlay-emphasis focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-                          aria-label="Pause Resource"
-                        >
-                          <Square className="w-3 h-3" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">Pause Resource</TooltipContent>
-                    </Tooltip>
-                  )}
-                  {showResourceConnect && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onResourceConnect!();
-                          }}
-                          className="shrink-0 p-1 rounded transition-colors text-status-info/70 hover:text-status-info hover:bg-overlay-emphasis focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-                          aria-label="Connect to Resource"
-                        >
-                          <Plug className="w-3 h-3" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">Connect to Resource</TooltipContent>
-                    </Tooltip>
-                  )}
-                </span>
+                    )}
+                    {showResourcePause && onResourcePause && (
+                      <ContextMenuItem onClick={onResourcePause}>
+                        <Square className="w-3.5 h-3.5 mr-2" />
+                        Pause
+                      </ContextMenuItem>
+                    )}
+                    {showResourceConnect && (
+                      <ContextMenuItem onClick={onResourceConnect}>
+                        <Plug className="w-3.5 h-3.5 mr-2" />
+                        Connect
+                      </ContextMenuItem>
+                    )}
+                    {(showResourceResume || showResourcePause || showResourceConnect) &&
+                      onResourceStatus && <ContextMenuSeparator />}
+                    {onResourceStatus && (
+                      <ContextMenuItem onClick={onResourceStatus}>
+                        <Activity className="w-3.5 h-3.5 mr-2" />
+                        Check Status
+                      </ContextMenuItem>
+                    )}
+                    {onResourceTeardown && (
+                      <>
+                        <ContextMenuSeparator />
+                        <ContextMenuItem onClick={onResourceTeardown} className="text-status-error">
+                          <Trash2 className="w-3.5 h-3.5 mr-2" />
+                          Teardown
+                        </ContextMenuItem>
+                      </>
+                    )}
+                  </ContextMenuContent>
+                </ContextMenu>
               )}
 
-            {worktree.worktreeChanges?.lastCommitTimestampMs != null && (
+              {hasResourceConfig &&
+                (showResourceResume || showResourcePause || showResourceConnect) && (
+                  <span className="relative z-10 ml-1 inline-flex shrink-0 items-center gap-0.5">
+                    {showResourceResume && onResourceResume && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onResourceResume();
+                            }}
+                            className="shrink-0 p-1 rounded transition-colors text-status-success/70 hover:text-status-success hover:bg-overlay-emphasis focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                            aria-label="Resume Resource"
+                          >
+                            <Play className="w-3 h-3" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">Resume Resource</TooltipContent>
+                      </Tooltip>
+                    )}
+                    {showResourcePause && onResourcePause && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onResourcePause();
+                            }}
+                            className="shrink-0 p-1 rounded transition-colors text-status-error/70 hover:text-status-error hover:bg-overlay-emphasis focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                            aria-label="Pause Resource"
+                          >
+                            <Square className="w-3 h-3" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">Pause Resource</TooltipContent>
+                      </Tooltip>
+                    )}
+                    {showResourceConnect && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onResourceConnect!();
+                            }}
+                            className="shrink-0 p-1 rounded transition-colors text-status-info/70 hover:text-status-info hover:bg-overlay-emphasis focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                            aria-label="Connect to Resource"
+                          >
+                            <Plug className="w-3 h-3" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">Connect to Resource</TooltipContent>
+                      </Tooltip>
+                    )}
+                  </span>
+                )}
+
+              {worktree.worktreeChanges?.lastCommitTimestampMs != null && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="relative z-10 ml-3 flex shrink-0 items-center gap-1 text-xs text-text-muted">
+                      {worktree.worktreeChanges?.lastCommitAuthor && (
+                        <Avatar
+                          src={getGravatarUrl(worktree.worktreeChanges.lastCommitAuthor.email, 32)}
+                          alt={worktree.worktreeChanges.lastCommitAuthor.name}
+                          shape={
+                            isBotAuthor(worktree.worktreeChanges.lastCommitAuthor.name)
+                              ? "square"
+                              : "circle"
+                          }
+                          className="w-4 h-4"
+                        />
+                      )}
+                      <LiveTimeAgo
+                        timestamp={worktree.worktreeChanges.lastCommitTimestampMs}
+                        noTooltip
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {worktree.worktreeChanges?.lastCommitMessage
+                      ? `"${worktree.worktreeChanges.lastCommitMessage}"`
+                      : "Last commit"}
+                    {worktree.worktreeChanges?.lastCommitAuthor
+                      ? ` by ${worktree.worktreeChanges.lastCommitAuthor.name}`
+                      : ""}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <div className="relative z-10 ml-3 flex shrink-0 items-center gap-1 text-xs text-text-muted">
-                    {worktree.worktreeChanges?.lastCommitAuthor && (
-                      <Avatar
-                        src={getGravatarUrl(worktree.worktreeChanges.lastCommitAuthor.email, 32)}
-                        alt={worktree.worktreeChanges.lastCommitAuthor.name}
-                        shape={
-                          isBotAuthor(worktree.worktreeChanges.lastCommitAuthor.name)
-                            ? "square"
-                            : "circle"
-                        }
-                        className="w-4 h-4"
-                      />
+                  <div className="relative z-10 ml-3 flex shrink-0 items-center gap-1.5 text-xs text-text-muted">
+                    {worktree.lastActivityTimestamp != null ? (
+                      <>
+                        <ActivityLight
+                          lastActivityTimestamp={worktree.lastActivityTimestamp}
+                          className="w-1.5 h-1.5"
+                        />
+                        <LiveTimeAgo timestamp={worktree.lastActivityTimestamp} noTooltip />
+                      </>
+                    ) : (
+                      <span>No activity</span>
                     )}
-                    <LiveTimeAgo
-                      timestamp={worktree.worktreeChanges.lastCommitTimestampMs}
-                      noTooltip
-                    />
                   </div>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
-                  {worktree.worktreeChanges?.lastCommitMessage
-                    ? `"${worktree.worktreeChanges.lastCommitMessage}"`
-                    : "Last commit"}
-                  {worktree.worktreeChanges?.lastCommitAuthor
-                    ? ` by ${worktree.worktreeChanges.lastCommitAuthor.name}`
-                    : ""}
+                  {worktree.lastActivityTimestamp != null
+                    ? `Last activity: ${new Date(worktree.lastActivityTimestamp).toLocaleString()}`
+                    : "No recent activity recorded"}
                 </TooltipContent>
               </Tooltip>
-            )}
+            </div>
 
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="relative z-10 ml-3 flex shrink-0 items-center gap-1.5 text-xs text-text-muted">
-                  {worktree.lastActivityTimestamp != null ? (
-                    <>
-                      <ActivityLight
-                        lastActivityTimestamp={worktree.lastActivityTimestamp}
-                        className="w-1.5 h-1.5"
-                      />
-                      <LiveTimeAgo timestamp={worktree.lastActivityTimestamp} noTooltip />
-                    </>
-                  ) : (
-                    <span>No activity</span>
-                  )}
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {worktree.lastActivityTimestamp != null
-                  ? `Last activity: ${new Date(worktree.lastActivityTimestamp).toLocaleString()}`
-                  : "No recent activity recorded"}
-              </TooltipContent>
-            </Tooltip>
+            {showReviewHubButton && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={onOpenReviewHub}
+                    className={cn(
+                      "shrink-0 border-l border-border-default px-2 py-1 transition-colors",
+                      "text-[var(--color-state-active)]/70 hover:bg-[var(--color-state-active)]/10 hover:text-[var(--color-state-active)]",
+                      "rounded-r-[var(--radius-lg)]",
+                      "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
+                    )}
+                    aria-label="Open Review & Commit"
+                  >
+                    <GitCommitHorizontal className="w-3.5 h-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Review & Commit</TooltipContent>
+              </Tooltip>
+            )}
           </div>
 
-          {showReviewHubButton && (
-            <Tooltip>
-              <TooltipTrigger asChild>
+          {lifecycleFailed && (
+            <div className="flex flex-col gap-2 border-t border-border-default px-3 py-2">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs text-text-muted truncate">
+                  Setup didn't finish. Re-run when you're ready.
+                </span>
                 <button
-                  onClick={onOpenReviewHub}
+                  type="button"
+                  onClick={handleRetrySetup}
+                  disabled={isRetryingSetup}
                   className={cn(
-                    "shrink-0 border-l border-border-default px-2 py-1 transition-colors",
-                    "text-[var(--color-state-active)]/70 hover:bg-[var(--color-state-active)]/10 hover:text-[var(--color-state-active)]",
-                    "rounded-r-[var(--radius-lg)]",
+                    "shrink-0 inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors",
+                    "text-status-error hover:bg-status-error/10",
+                    "disabled:opacity-50 disabled:cursor-not-allowed",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
                   )}
-                  aria-label="Open Review & Commit"
+                  aria-label="Retry setup"
                 >
-                  <GitCommitHorizontal className="w-3.5 h-3.5" />
+                  <RotateCcw className="w-3 h-3" aria-hidden="true" />
+                  {isRetryingSetup ? "Retrying…" : "Retry setup"}
                 </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Review & Commit</TooltipContent>
-            </Tooltip>
+              </div>
+              {hasLifecycleDetails && (
+                <details className="text-xs">
+                  <summary className="flex items-center gap-1 text-text-muted cursor-pointer select-none">
+                    <ChevronDown className="w-3 h-3" aria-hidden="true" />
+                    Show details
+                  </summary>
+                  <pre className="mt-1.5 max-h-32 overflow-auto rounded bg-status-error/5 p-2 font-mono text-[11px] text-text-secondary whitespace-pre-wrap break-all select-text">
+                    {[lifecycleError, lifecycleOutput].filter(Boolean).join("\n\n")}
+                  </pre>
+                </details>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -142,10 +142,12 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
     if (isRetryingSetup) return;
     setIsRetryingSetup(true);
     try {
+      // Pin the action context to this card's worktree so `isEnabled` evaluates
+      // against the failed card, not whichever worktree happens to be focused.
       await actionService.dispatch(
         "worktree.lifecycle.retrySetup",
         { worktreeId: worktree.id },
-        { source: "user" }
+        { source: "user", contextOverride: { focusedWorktreeId: worktree.id } }
       );
     } finally {
       setIsRetryingSetup(false);

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -6,6 +6,7 @@ import { registerWorktreeNavigationActions } from "./worktreeNavigationActions";
 import { registerWorktreeContextActions } from "./worktreeContextActions";
 import { registerWorktreeGitHubActions } from "./worktreeGitHubActions";
 import { registerWorktreeResourceActions } from "./worktreeResourceActions";
+import { registerWorktreeLifecycleActions } from "./worktreeLifecycleActions";
 
 export function registerWorktreeActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   registerWorktreeQueryActions(actions, callbacks);
@@ -15,4 +16,5 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
   registerWorktreeContextActions(actions, callbacks);
   registerWorktreeGitHubActions(actions, callbacks);
   registerWorktreeResourceActions(actions, callbacks);
+  registerWorktreeLifecycleActions(actions);
 }

--- a/src/services/actions/definitions/worktreeLifecycleActions.ts
+++ b/src/services/actions/definitions/worktreeLifecycleActions.ts
@@ -1,0 +1,68 @@
+import type { ActionRegistry } from "../actionTypes";
+import { defineAction } from "../defineAction";
+import { z } from "zod";
+import type { ActionContext } from "@shared/types/actions";
+import { worktreeClient } from "@/clients";
+import { getCurrentViewStore } from "@/store/createWorktreeStore";
+import { notify } from "@/lib/notify";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+export function registerWorktreeLifecycleActions(actions: ActionRegistry): void {
+  actions.set("worktree.lifecycle.retrySetup", () =>
+    defineAction({
+      id: "worktree.lifecycle.retrySetup",
+      title: "Retry setup",
+      description: "Re-run the worktree lifecycle setup script in place",
+      category: "worktree",
+      kind: "command",
+      danger: "safe",
+      scope: "renderer",
+      argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
+      isEnabled: (ctx: ActionContext) => {
+        const worktreeId = ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+        if (!worktreeId) return false;
+        const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
+        const state = worktree?.lifecycleStatus?.state;
+        return state === "failed" || state === "timed-out";
+      },
+      disabledReason: (ctx: ActionContext) => {
+        const worktreeId = ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+        if (!worktreeId) return "No worktree selected";
+        const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
+        const state = worktree?.lifecycleStatus?.state;
+        if (state === "running") return "Setup is already running";
+        if (state !== "failed" && state !== "timed-out") {
+          return "No failed setup to retry";
+        }
+        return undefined;
+      },
+      run: async (args, ctx: ActionContext) => {
+        const worktreeId = args?.worktreeId;
+        const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+        if (!targetWorktreeId) throw new Error("No worktree selected");
+        try {
+          await worktreeClient.retrySetup(targetWorktreeId);
+        } catch (err) {
+          const message = formatErrorMessage(err, "Setup retry failed") || "Setup retry failed";
+          notify({
+            type: "error",
+            priority: "high",
+            title: "Setup retry failed",
+            message,
+            action: {
+              label: "Copy details",
+              successLabel: "Copied",
+              onClick: async () => {
+                try {
+                  await navigator.clipboard.writeText(message);
+                } catch {
+                  // clipboard write is non-critical
+                }
+              },
+            },
+          });
+        }
+      },
+    })
+  );
+}


### PR DESCRIPTION
## Summary

- Two silent error paths (`copyDaintreeDir` and the `createWorktree` async tail) were swallowing failures to `console.warn` with no UI signal. They now propagate through `notifyError` → `useErrorStore` → the per-worktree error banner.
- The failed-lifecycle card row now exposes `lifecycleStatus.error` and `lifecycleStatus.output` via a `<details>` disclosure, so users can see what actually went wrong.
- A new `worktree.lifecycle.retrySetup` action (plus a `run-lifecycle-setup` port action) lets users re-run setup in place without deleting and recreating the worktree.

Resolves #8401

## Changes

- `worktreeLifecycleActions.ts` — new file; `retrySetup` action with `danger: "safe"`, `isEnabled` guard, and `contextOverride` that pins `focusedWorktreeId` to the failed card
- `WorkspaceService` + `WorktreeLifecycleService` — error propagation through the two previously silent paths; new `lifecycle-setup-error` host event routed to `WorkspaceHostEventRouter`
- `WorktreeDetailsSection` — `<details>` disclosure on the failed-state row; `animate-pulse-immediate` dot replaces `Spinner` on the running-state row
- Concurrent retry race fixed: `retryLifecycleSetup` sets state to `"running"` synchronously before any `await`, so a second click hits the guard

## Testing

- tsc clean, vitest 26 tests pass, lint warnings at 873 (down from 888 baseline), format clean, build successful