### PR TITLE
fix(workspace): persistent indicator + recovery for watcher degradation

### DIFF
--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -727,6 +727,7 @@ export class WorkspaceHostProcess extends EventEmitter {
       case "copytree:progress":
       case "inotify-limit-reached":
       case "emfile-limit-reached":
+      case "watcher-recovered":
         this.emit("host-event", event);
         break;
 

--- a/electron/services/__tests__/WorkspaceHostProcess.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.test.ts
@@ -220,6 +220,25 @@ describe("WorkspaceHostProcess", () => {
 
     host.dispose();
   });
+
+  it("routes watcher-recovered as host-event (spontaneous event)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const onHostEvent = vi.fn();
+    host.on("host-event", onHostEvent);
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "watcher-recovered" });
+
+    expect(onHostEvent).toHaveBeenCalledWith({ type: "watcher-recovered" });
+
+    host.dispose();
+  });
 });
 
 // ── BrokerError contract tests ──

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -234,6 +234,15 @@ export class WorkspaceHostEventRouter {
         });
         break;
       }
+
+      case "watcher-recovered": {
+        // Recursive coverage restored. Reset the one-shot toast guards so a
+        // subsequent relapse re-notifies. No toast — recovery is conveyed by
+        // the persistent indicator disappearing (Tier-1 ambient signal).
+        this.inotifyLimitToastSent = false;
+        this.emfileLimitToastSent = false;
+        break;
+      }
     }
   }
 }

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -130,6 +130,38 @@ describe("WorkspaceHostEventRouter", () => {
     });
   });
 
+  describe("watcher-recovered resets one-shot toast guards", () => {
+    it("does not emit a toast itself", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(entry, { type: "watcher-recovered" });
+
+      expect(broadcastToRenderer).not.toHaveBeenCalled();
+    });
+
+    it("re-arms the inotify toast so a relapse re-notifies", () => {
+      const entry = makeEntry();
+
+      router.routeHostEvent(entry, { type: "inotify-limit-reached" });
+      router.routeHostEvent(entry, { type: "inotify-limit-reached" });
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
+
+      router.routeHostEvent(entry, { type: "watcher-recovered" });
+      router.routeHostEvent(entry, { type: "inotify-limit-reached" });
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(2);
+    });
+
+    it("re-arms the emfile toast so a relapse re-notifies", () => {
+      const entry = makeEntry();
+
+      router.routeHostEvent(entry, { type: "emfile-limit-reached" });
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
+
+      router.routeHostEvent(entry, { type: "watcher-recovered" });
+      router.routeHostEvent(entry, { type: "emfile-limit-reached" });
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe("inotify and emfile are independent", () => {
     it("allows both limit types to fire independently", () => {
       const entry = makeEntry();

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -59,6 +59,13 @@ const DIRECT_RENDERER_EVENTS = new Set([
   "pr-detection-state",
   "issue-detected",
   "issue-not-found",
+  // Watcher degradation/recovery — delivered direct so each per-view store
+  // can drive the persistent degraded indicator. The one-shot toast still
+  // routes through the main-process relay (WorkspaceHostEventRouter); the two
+  // paths are independent and both fire (dual delivery, existing pattern).
+  "inotify-limit-reached",
+  "emfile-limit-reached",
+  "watcher-recovered",
 ]);
 
 function sendToWorktreePorts(event: WorkspaceHostEvent): void {
@@ -83,7 +90,12 @@ async function handleWorktreePortRequest(
       case "get-all-states": {
         const states = workspaceService.getSnapshotsSync();
         const { epoch, seq } = workspaceService.getVersion();
-        result = { states, epoch, seq };
+        result = {
+          states,
+          epoch,
+          seq,
+          watcherDegraded: workspaceService.isWatcherDegraded(),
+        };
         break;
       }
 

--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -197,6 +197,11 @@ export class WatcherController {
       }
       this.watcherRetryCount = 0;
       this.retryBudgetResetCount = 0;
+      // A true shutdown / feature-disable ends the degradation episode, so a
+      // later re-arm is a fresh start, not a recovery. Benign rotations
+      // (stop(false) via update()) preserve the flag so a legitimate
+      // recovery still signals — mirrors the retry-budget lifecycle.
+      this.wasDegraded = false;
     }
     this.gitWatchRefreshPending = false;
   }

--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -33,6 +33,13 @@ export interface WatcherControllerHost {
   onTriggerUpdate(): void;
   onInotifyLimitReached(worktreeId: string): void;
   onEmfileLimitReached(worktreeId: string): void;
+  /**
+   * Fired when a recursive watcher successfully re-arms after a prior
+   * degradation (ENOSPC/EMFILE or any runtime failure that forced the
+   * git-only fallback). Lets the host reset its one-shot degradation
+   * guards and clear the persistent degraded indicator.
+   */
+  onWatcherRecovered?(): void;
 }
 
 /**
@@ -53,6 +60,13 @@ export class WatcherController {
   private retryBudgetResetCount = 0;
   private downgradeTimer: NodeJS.Timeout | null = null;
   private disposed = false;
+  /**
+   * Set when the watcher drops to the git-only fallback after a recursive
+   * failure; cleared when the recursive arm is restored. Drives the
+   * `onWatcherRecovered` signal so recovery only fires after a genuine
+   * degradation — not on the normal "none" → "recursive" cold start.
+   */
+  private wasDegraded = false;
 
   constructor(private readonly host: WatcherControllerHost) {}
 
@@ -122,12 +136,23 @@ export class WatcherController {
     if (started) {
       this.gitWatcher.value = toDisposable(() => watcher.dispose());
       this.gitWatcherMode = mode;
+      if (mode === "recursive" && this.wasDegraded) {
+        // Recursive coverage restored after a degradation. Signal recovery
+        // exactly once per degradation episode so the host can reset its
+        // one-shot guards and clear the persistent degraded indicator.
+        this.wasDegraded = false;
+        this.host.onWatcherRecovered?.();
+      }
       // Retry budget is managed by stop(true) (reset) and scheduleRetry()
       // (increment). Resetting it here would defeat exhaustion — a failing
       // git-only fallback path would keep getting fresh budget every cycle.
     } else {
       watcher.dispose();
       if (mode === "recursive") {
+        // Recursive arm failed — mark degraded so the eventual successful
+        // re-arm signals recovery, even if the watcher returned false without
+        // routing through `onWatcherFailed`.
+        this.wasDegraded = true;
         // The recursive watcher fires `onWatcherFailed` synchronously on
         // startup ENOSPC/EMFILE before returning false, so handleWatcherFailed
         // may have already installed a git-only fallback by this point. Only
@@ -382,6 +407,11 @@ export class WatcherController {
    */
   private handleWatcherFailed(): void {
     if (this.disposed) return;
+    // Universal degradation point: GitFileWatcher fires onWatcherFailed for
+    // ENOSPC/EMFILE limits (in addition to the limit callbacks) and for any
+    // other runtime failure. Arm the recovery signal for the next successful
+    // recursive re-arm.
+    this.wasDegraded = true;
     this.gitWatcher.clear();
     this.gitWatcherMode = "none";
     this.start("git-only");

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -520,6 +520,7 @@ export class WorkspaceService {
         this.resourceActionExecutor.cleanupResourceActionState(id);
         monitor.stop();
         this.monitors.delete(id);
+        this.recoverWatcherIfNoMonitorsRemain();
         clearGitDirCache(monitor.path);
         invalidateGitStatusCache(monitor.path);
         this.sendEvent({
@@ -967,6 +968,20 @@ export class WorkspaceService {
     return this.inotifyLimitNotified || this.emfileLimitNotified;
   }
 
+  /**
+   * Called after a monitor is removed. If the last monitor is gone while the
+   * degradation guards are still set, the degraded watcher was torn down
+   * before it could recover — there is no longer anything degraded, so treat
+   * it as recovered. Otherwise a stale `watcherDegraded: true` would ride the
+   * next `get-all-states` handshake and pin the indicator on with no way to
+   * clear it.
+   */
+  private recoverWatcherIfNoMonitorsRemain(): void {
+    if (this.monitors.size === 0 && this.isWatcherDegraded()) {
+      this.handleWatcherRecovered();
+    }
+  }
+
   private worktreeMetadataDirPath(): string | null {
     if (!this.projectRootPath) return null;
     const commonDir = getGitCommonDir(this.projectRootPath);
@@ -1195,6 +1210,7 @@ export class WorkspaceService {
     this.resourceActionExecutor.cleanupResourceActionState(worktreeId);
     monitor.stop();
     this.monitors.delete(worktreeId);
+    this.recoverWatcherIfNoMonitorsRemain();
 
     clearGitDirCache(monitor.path);
     invalidateGitStatusCache(monitor.path);
@@ -1801,6 +1817,7 @@ export class WorkspaceService {
       this.resourceActionExecutor.cleanupResourceActionState(worktreeId);
       monitor.stop();
       this.monitors.delete(worktreeId);
+      this.recoverWatcherIfNoMonitorsRemain();
 
       // Monitor is cleaned up. Drop the pending entry now (cancelling its
       // safety valve): any still-buffered delete event for this name is

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -713,6 +713,7 @@ export class WorkspaceService {
         },
         onInotifyLimitReached: () => this.handleInotifyLimitReached(),
         onEmfileLimitReached: () => this.handleEmfileLimitReached(),
+        onWatcherRecovered: () => this.handleWatcherRecovered(),
         onScheduleFetch: async (worktreeId, _isCurrent, force) => {
           const target = this.monitors.get(worktreeId);
           if (!target || !target.isRunning) return;
@@ -941,6 +942,29 @@ export class WorkspaceService {
     if (this.emfileLimitNotified) return;
     this.emfileLimitNotified = true;
     this.sendEvent({ type: "emfile-limit-reached" });
+  }
+
+  /**
+   * A recursive watcher re-armed after a degradation. Clear the one-shot
+   * notification guards so a later relapse can re-signal, and emit
+   * `watcher-recovered` so the renderer hides the persistent degraded
+   * indicator and the main-process router resets its toast guards. Idempotent
+   * — firing when nothing was degraded is a harmless no-op downstream.
+   */
+  private handleWatcherRecovered(): void {
+    this.inotifyLimitNotified = false;
+    this.emfileLimitNotified = false;
+    this.sendEvent({ type: "watcher-recovered" });
+  }
+
+  /**
+   * Whether any worktree's recursive watcher is currently degraded to the
+   * polling/git-only fallback. Bundled into the `get-all-states` handshake so
+   * a late-mounting view hydrates the persistent indicator without waiting
+   * for a live event.
+   */
+  isWatcherDegraded(): boolean {
+    return this.inotifyLimitNotified || this.emfileLimitNotified;
   }
 
   private worktreeMetadataDirPath(): string | null {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -77,6 +77,7 @@ export interface WorktreeMonitorCallbacks {
   onResourceStatusPoll?: (worktreeId: string) => Promise<unknown> | void;
   onInotifyLimitReached?: (worktreeId: string) => void;
   onEmfileLimitReached?: (worktreeId: string) => void;
+  onWatcherRecovered?: (worktreeId: string) => void;
   /**
    * Schedule a background `git fetch` for this worktree's repo. Routed through
    * `WorkspaceService` so per-repo serialization and failure-cache state are
@@ -345,6 +346,7 @@ export class WorktreeMonitor {
         monitor.callbacks.onInotifyLimitReached?.(worktreeId),
       onEmfileLimitReached: (worktreeId: string) =>
         monitor.callbacks.onEmfileLimitReached?.(worktreeId),
+      onWatcherRecovered: () => monitor.callbacks.onWatcherRecovered?.(monitor.id),
     };
     this.watcherController = new WatcherController(watcherHost);
 

--- a/electron/workspace-host/__tests__/WatcherController.test.ts
+++ b/electron/workspace-host/__tests__/WatcherController.test.ts
@@ -196,6 +196,44 @@ describe("WatcherController", () => {
     expect(host.onWatcherRecovered).toHaveBeenCalledTimes(1);
   });
 
+  it("does not fire a false onWatcherRecovered after disable then re-enable", () => {
+    // Degrade, then simulate a feature-disable (stop with budget reset) and a
+    // later re-enable that arms recursive cleanly. No real recovery occurred,
+    // so onWatcherRecovered must not fire.
+    mockRecursiveStartResult = false;
+    mockGitOnlyStartResult = true;
+    const host = makeHost({ isCurrent: true });
+    const ctrl = new WatcherController(host as WatcherControllerHost);
+
+    ctrl.start();
+    expect(ctrl.currentMode).toBe("git-only");
+
+    ctrl.stop(); // feature disable — ends the degradation episode
+    mockRecursiveStartResult = true;
+    ctrl.start("recursive");
+
+    expect(ctrl.currentMode).toBe("recursive");
+    expect(host.onWatcherRecovered).not.toHaveBeenCalled();
+  });
+
+  it("preserves the recovery signal across a benign rotation (stop(false))", () => {
+    // update() calls stop(false) then start(); a degraded watcher rotating
+    // this way must still signal recovery when recursive finally arms.
+    mockRecursiveStartResult = false;
+    mockGitOnlyStartResult = true;
+    const host = makeHost({ isCurrent: true });
+    const ctrl = new WatcherController(host as WatcherControllerHost);
+
+    ctrl.start();
+    expect(ctrl.currentMode).toBe("git-only");
+
+    mockRecursiveStartResult = true;
+    ctrl.update(); // stop(false) + start() — preserves wasDegraded
+
+    expect(ctrl.currentMode).toBe("recursive");
+    expect(host.onWatcherRecovered).toHaveBeenCalledTimes(1);
+  });
+
   it("fires onWatcherRecovered after a synchronous onWatcherFailed fallback recovers", () => {
     // Recursive fails + fires onWatcherFailed synchronously; git-only succeeds.
     mockRecursiveStartResult = false;

--- a/electron/workspace-host/__tests__/WatcherController.test.ts
+++ b/electron/workspace-host/__tests__/WatcherController.test.ts
@@ -63,6 +63,7 @@ interface MutableHost {
   onTriggerUpdate: ReturnType<typeof vi.fn>;
   onInotifyLimitReached: ReturnType<typeof vi.fn>;
   onEmfileLimitReached: ReturnType<typeof vi.fn>;
+  onWatcherRecovered: ReturnType<typeof vi.fn>;
 }
 
 function makeHost(overrides: Partial<MutableHost> = {}): MutableHost {
@@ -79,6 +80,7 @@ function makeHost(overrides: Partial<MutableHost> = {}): MutableHost {
     onTriggerUpdate: vi.fn(),
     onInotifyLimitReached: vi.fn(),
     onEmfileLimitReached: vi.fn(),
+    onWatcherRecovered: vi.fn(),
     ...overrides,
   };
 }
@@ -165,6 +167,52 @@ describe("WatcherController", () => {
     mockRecursiveStartResult = true;
     vi.advanceTimersByTime(31_000);
     expect(ctrl.currentMode).toBe("recursive");
+  });
+
+  it("does not fire onWatcherRecovered on a clean cold start", () => {
+    mockWatcherStartResult = true;
+    const host = makeHost({ isCurrent: true });
+    const ctrl = new WatcherController(host as WatcherControllerHost);
+
+    ctrl.start();
+    expect(ctrl.currentMode).toBe("recursive");
+    expect(host.onWatcherRecovered).not.toHaveBeenCalled();
+  });
+
+  it("fires onWatcherRecovered once when the recursive arm recovers via retry", () => {
+    mockRecursiveStartResult = false;
+    mockGitOnlyStartResult = true;
+    const host = makeHost({ isCurrent: true });
+    const ctrl = new WatcherController(host as WatcherControllerHost);
+
+    ctrl.start();
+    expect(ctrl.currentMode).toBe("git-only");
+    expect(host.onWatcherRecovered).not.toHaveBeenCalled();
+
+    // Retry succeeds — recovery should signal exactly once.
+    mockRecursiveStartResult = true;
+    vi.advanceTimersByTime(31_000);
+    expect(ctrl.currentMode).toBe("recursive");
+    expect(host.onWatcherRecovered).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onWatcherRecovered after a synchronous onWatcherFailed fallback recovers", () => {
+    // Recursive fails + fires onWatcherFailed synchronously; git-only succeeds.
+    mockRecursiveStartResult = false;
+    mockGitOnlyStartResult = true;
+    mockWatcherStartFiresFailure = true;
+    const host = makeHost({ isCurrent: true });
+    const ctrl = new WatcherController(host as WatcherControllerHost);
+
+    ctrl.start();
+    expect(ctrl.currentMode).toBe("git-only");
+    expect(host.onWatcherRecovered).not.toHaveBeenCalled();
+
+    mockRecursiveStartResult = true;
+    mockWatcherStartFiresFailure = false;
+    vi.advanceTimersByTime(31_000);
+    expect(ctrl.currentMode).toBe("recursive");
+    expect(host.onWatcherRecovered).toHaveBeenCalledTimes(1);
   });
 
   it("does not schedule a retry for background worktrees", () => {

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -449,6 +449,10 @@ export type WorkspaceHostEvent =
   // macOS-only: fired once per host-process lifetime when the recursive file
   // watcher hits the FSEvents file descriptor ceiling (EMFILE).
   | { type: "emfile-limit-reached" }
+  // Fired when a previously-degraded recursive watcher successfully re-arms.
+  // Clears the one-shot degradation guards so a later relapse can re-signal,
+  // and hides the persistent degraded indicator in the renderer.
+  | { type: "watcher-recovered" }
   // PR events
   | {
       type: "pr-detected";

--- a/shared/types/worktree-port.ts
+++ b/shared/types/worktree-port.ts
@@ -26,7 +26,9 @@ export interface WorktreePortProtocol {
     // comparison baseline to the host's actual `(epoch, seq)` position rather
     // than a renderer-minted counter (#8403). `seq` is the high-water mark at
     // snapshot time — a state description, not a new event.
-    result: { states: WorktreeSnapshot[] } & WorktreeEventVersion;
+    // `watcherDegraded` hydrates the persistent watcher-degraded indicator on
+    // late-mounting views without waiting for a live event (#8413).
+    result: { states: WorktreeSnapshot[]; watcherDegraded: boolean } & WorktreeEventVersion;
   };
   "set-active": {
     payload: { worktreeId: string };

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -89,6 +89,7 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
     isInitialized: true,
     isReconnecting: false,
     reconnectingAt: null,
+    watcherDegraded: false,
     applySnapshot: () => {},
     applyUpdate: () => {},
     applyRemove: () => {},
@@ -98,6 +99,7 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
     setError: () => {},
     setFatalError: () => {},
     setReconnecting: () => {},
+    setWatcherDegraded: () => {},
   }));
   setCurrentViewStore(store);
 }

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -224,6 +224,7 @@ export function Toolbar({
     activeWorktreeId ? state.worktrees.get(activeWorktreeId) : null
   );
   const branchName = activeWorktree?.branch;
+  const watcherDegraded = useWorktreeStore((state) => state.watcherDegraded);
 
   useEffect(() => {
     loadProjects();
@@ -709,6 +710,7 @@ export function Toolbar({
           <ToolbarProblemsButton
             key="problems"
             errorCount={errorCount}
+            watcherDegraded={watcherDegraded}
             onToggleProblems={onToggleProblems}
             data-toolbar-item=""
           />
@@ -761,6 +763,7 @@ export function Toolbar({
       onPreloadSettings,
       onToggleProblems,
       errorCount,
+      watcherDegraded,
       showDeveloperTools,
       notificationsEnabled,
       pluginButtonIds,

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -715,7 +715,10 @@ export function Toolbar({
             data-toolbar-item=""
           />
         ),
-        isAvailable: showDeveloperTools,
+        // Auto-surface the Problems button when the watcher is degraded so
+        // the persistent Tier-1 indicator is visible even for users who
+        // haven't enabled developer tools (the default).
+        isAvailable: showDeveloperTools || watcherDegraded,
       },
       "assistant-toggle": {
         render: () => <ToolbarAssistantButton key="assistant-toggle" data-toolbar-item="" />,

--- a/src/components/Layout/ToolbarProblemsButton.tsx
+++ b/src/components/Layout/ToolbarProblemsButton.tsx
@@ -19,12 +19,19 @@ const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text";
 
 interface ToolbarProblemsButtonProps {
   errorCount: number;
+  /**
+   * True while the project's recursive file watcher is degraded to the
+   * polling/git-only fallback (ENOSPC/EMFILE). Surfaces a persistent Tier-1
+   * warning pip that clears automatically when the watcher recovers.
+   */
+  watcherDegraded?: boolean;
   onToggleProblems?: () => void;
   "data-toolbar-item"?: string;
 }
 
 export function ToolbarProblemsButton({
   errorCount,
+  watcherDegraded = false,
   onToggleProblems,
   "data-toolbar-item": dataToolbarItem,
 }: ToolbarProblemsButtonProps) {
@@ -46,7 +53,9 @@ export function ToolbarProblemsButton({
               data-toolbar-item={dataToolbarItem}
               onClick={onToggleProblems}
               className={cn(toolbarIconButtonClass, "relative")}
-              aria-label={`Problems: ${errorCount} error${errorCount !== 1 ? "s" : ""}`}
+              aria-label={`Problems: ${errorCount} error${errorCount !== 1 ? "s" : ""}${
+                watcherDegraded ? ", file watching degraded" : ""
+              }`}
               aria-keyshortcuts={diagnosticsAriaShortcut}
               aria-expanded={isDockOpen}
               aria-controls={DIAGNOSTICS_DOCK_REGION_ID}
@@ -55,6 +64,15 @@ export function ToolbarProblemsButton({
               <span
                 data-visible={errorCount > 0}
                 className="toolbar-problems-badge toolbar-badge absolute top-1.5 right-1.5 w-2 h-2 rounded-full"
+              />
+              {/* Persistent watcher-degraded pip. 6px + ring-daintree-sidebar
+                  per the toolbar pip vocabulary (semantic-status dot); pinned
+                  to the opposite corner so it never collides with the 8px
+                  error badge when both are visible. */}
+              <span
+                data-testid="watcher-degraded-badge"
+                data-visible={watcherDegraded}
+                className="toolbar-badge absolute bottom-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-status-warning ring-1 ring-daintree-sidebar"
               />
               <ShortcutRevealChip actionId="panel.toggleDiagnostics" />
             </Button>

--- a/src/components/Layout/__tests__/ToolbarProblemsButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarProblemsButton.test.tsx
@@ -113,3 +113,41 @@ describe("ToolbarProblemsButton — single-signal error treatment", () => {
     expect(badge?.getAttribute("data-visible")).toBe("false");
   });
 });
+
+describe("ToolbarProblemsButton — watcher-degraded pip", () => {
+  beforeEach(() => {
+    useDiagnosticsStore.setState({ isOpen: false });
+  });
+
+  it("keeps the watcher pip hidden by default", () => {
+    const { getByTestId } = render(<ToolbarProblemsButton errorCount={0} />);
+    expect(getByTestId("watcher-degraded-badge").getAttribute("data-visible")).toBe("false");
+  });
+
+  it("shows the watcher pip when watcherDegraded is true", () => {
+    const { getByTestId } = render(<ToolbarProblemsButton errorCount={0} watcherDegraded />);
+    expect(getByTestId("watcher-degraded-badge").getAttribute("data-visible")).toBe("true");
+  });
+
+  it("is independent of errorCount (both pips can show together)", () => {
+    const { container, getByTestId } = render(
+      <ToolbarProblemsButton errorCount={2} watcherDegraded />
+    );
+    expect(container.querySelector(".toolbar-problems-badge")?.getAttribute("data-visible")).toBe(
+      "true"
+    );
+    expect(getByTestId("watcher-degraded-badge").getAttribute("data-visible")).toBe("true");
+  });
+
+  it("reflects watcher degradation in the accessible label", () => {
+    const { container } = render(<ToolbarProblemsButton errorCount={0} watcherDegraded />);
+    expect(container.querySelector("button")?.getAttribute("aria-label")).toBe(
+      "Problems: 0 errors, file watching degraded"
+    );
+  });
+
+  it("omits the degraded clause from the label when healthy", () => {
+    const { container } = render(<ToolbarProblemsButton errorCount={1} />);
+    expect(container.querySelector("button")?.getAttribute("aria-label")).toBe("Problems: 1 error");
+  });
+});

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -138,8 +138,20 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
 
       worktreePort
         .request("get-all-states")
-        .then(async (response: { states: WorktreeSnapshot[]; epoch: string; seq: number }) => {
+        .then(async (response: {
+          states: WorktreeSnapshot[];
+          epoch: string;
+          seq: number;
+          watcherDegraded: boolean;
+        }) => {
           if (thisGen !== generation) return;
+
+          // Hydrate the persistent watcher-degraded indicator from the
+          // handshake so a late-mounting view reflects current state without
+          // waiting for a live event. Set before the async associations fetch
+          // so a degradation/recovery event delivered during that await wins
+          // over this now-stale snapshot value.
+          store.getState().setWatcherDegraded(response.watcherDegraded ?? false);
 
           // Hydrate manual issue associations from electron store.
           // Auto-detected issues (from branch names) arrive in the snapshots,
@@ -458,6 +470,26 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           },
           overlayVersion(store.getState().version)
         );
+      })
+    );
+
+    // Watcher degradation/recovery — service-wide ambient signals, not keyed
+    // to a worktree. Use `.getState()` (not a captured ref) since these fire
+    // async; the store action's functional updater keeps them race-safe
+    // against the get-all-states hydration.
+    cleanups.push(
+      worktreePort.onEvent("inotify-limit-reached", () => {
+        store.getState().setWatcherDegraded(true);
+      })
+    );
+    cleanups.push(
+      worktreePort.onEvent("emfile-limit-reached", () => {
+        store.getState().setWatcherDegraded(true);
+      })
+    );
+    cleanups.push(
+      worktreePort.onEvent("watcher-recovered", () => {
+        store.getState().setWatcherDegraded(false);
       })
     );
 

--- a/src/contexts/__tests__/WorktreeStoreContext.watcherDegraded.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.watcherDegraded.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useContext } from "react";
+
+import { useProjectStore } from "@/store/projectStore";
+import type { WorktreeSnapshot } from "@shared/types";
+import type { Project } from "@shared/types/project";
+
+type PortEventName =
+  | "worktree-update"
+  | "worktree-removed"
+  | "worktree-activated"
+  | "pr-detected"
+  | "pr-cleared"
+  | "pr-detection-state"
+  | "issue-detected"
+  | "issue-not-found"
+  | "inotify-limit-reached"
+  | "emfile-limit-reached"
+  | "watcher-recovered";
+
+const listeners = new Map<PortEventName, Set<(data: unknown) => void>>();
+
+function emit(name: PortEventName, data: unknown): void {
+  const set = listeners.get(name);
+  if (!set) return;
+  for (const cb of set) cb(data);
+}
+
+function setCurrentProject(path: string | null): void {
+  const project = path ? ({ id: "p1", name: "p1", path } as unknown as Project) : null;
+  useProjectStore.setState({ currentProject: project });
+}
+
+let initialWatcherDegraded = false;
+
+beforeEach(() => {
+  listeners.clear();
+  initialWatcherDegraded = false;
+  setCurrentProject("/repo/proj");
+
+  (globalThis as unknown as { window: Window }).window.electron = {
+    worktreePort: {
+      isReady: () => true,
+      request: (_name: string) =>
+        Promise.resolve({
+          states: [] as WorktreeSnapshot[],
+          watcherDegraded: initialWatcherDegraded,
+        }),
+      onEvent: (name: PortEventName, cb: (data: unknown) => void) => {
+        let set = listeners.get(name);
+        if (!set) {
+          set = new Set();
+          listeners.set(name, set);
+        }
+        set.add(cb);
+        return () => set?.delete(cb);
+      },
+      onReady: (_cb: () => void) => () => {},
+      onDisconnected: (_cb: () => void) => () => {},
+      onFatalDisconnect: (_cb: () => void) => () => {},
+    },
+    worktree: {
+      getAllIssueAssociations: () => Promise.resolve({}),
+      getPRStatus: () => Promise.resolve(null),
+    },
+  } as unknown as typeof window.electron;
+});
+
+afterEach(() => {
+  listeners.clear();
+  setCurrentProject(null);
+  vi.restoreAllMocks();
+});
+
+async function renderProvider() {
+  const { WorktreeStoreProvider, WorktreeStoreContext } = await import("../WorktreeStoreContext");
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <WorktreeStoreProvider>{children}</WorktreeStoreProvider>
+  );
+  const { result } = renderHook(() => useContext(WorktreeStoreContext), { wrapper });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  if (!result.current) throw new Error("WorktreeStoreContext is null");
+  return result.current;
+}
+
+describe("WorktreeStoreProvider — watcher degraded indicator", () => {
+  it("defaults watcherDegraded to false when the handshake reports healthy", async () => {
+    const store = await renderProvider();
+    expect(store.getState().watcherDegraded).toBe(false);
+  });
+
+  it("hydrates watcherDegraded from the get-all-states handshake (late-mount path)", async () => {
+    initialWatcherDegraded = true;
+    const store = await renderProvider();
+    expect(store.getState().watcherDegraded).toBe(true);
+  });
+
+  it("sets watcherDegraded on inotify-limit-reached", async () => {
+    const store = await renderProvider();
+    expect(store.getState().watcherDegraded).toBe(false);
+
+    act(() => {
+      emit("inotify-limit-reached", { type: "inotify-limit-reached" });
+    });
+
+    expect(store.getState().watcherDegraded).toBe(true);
+  });
+
+  it("sets watcherDegraded on emfile-limit-reached", async () => {
+    const store = await renderProvider();
+
+    act(() => {
+      emit("emfile-limit-reached", { type: "emfile-limit-reached" });
+    });
+
+    expect(store.getState().watcherDegraded).toBe(true);
+  });
+
+  it("clears watcherDegraded on watcher-recovered", async () => {
+    const store = await renderProvider();
+
+    act(() => {
+      emit("inotify-limit-reached", { type: "inotify-limit-reached" });
+    });
+    expect(store.getState().watcherDegraded).toBe(true);
+
+    act(() => {
+      emit("watcher-recovered", { type: "watcher-recovered" });
+    });
+    expect(store.getState().watcherDegraded).toBe(false);
+  });
+
+  it("survives a degrade → recover → degrade cycle", async () => {
+    const store = await renderProvider();
+
+    act(() => emit("emfile-limit-reached", { type: "emfile-limit-reached" }));
+    expect(store.getState().watcherDegraded).toBe(true);
+
+    act(() => emit("watcher-recovered", { type: "watcher-recovered" }));
+    expect(store.getState().watcherDegraded).toBe(false);
+
+    act(() => emit("inotify-limit-reached", { type: "inotify-limit-reached" }));
+    expect(store.getState().watcherDegraded).toBe(true);
+  });
+});

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -380,6 +380,7 @@ describe("destructive-action danger metadata", () => {
       isInitialized: true,
       isReconnecting: false,
       reconnectingAt: null,
+      watcherDegraded: false,
       applySnapshot: () => {},
       applyUpdate: () => {},
       applyRemove: () => {},
@@ -389,6 +390,7 @@ describe("destructive-action danger metadata", () => {
       setError: () => {},
       setFatalError: () => {},
       setReconnecting: () => {},
+      setWatcherDegraded: () => {},
     }));
     setCurrentViewStore(viewStore);
     const contextOverride = {

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -86,6 +86,13 @@ export interface WorktreeViewState {
   isInitialized: boolean;
   isReconnecting: boolean;
   reconnectingAt: number | null;
+  /**
+   * True while this project's recursive file watcher is degraded to the
+   * polling/git-only fallback (ENOSPC/EMFILE). Drives the persistent
+   * Tier-1 indicator. Hydrated from the `get-all-states` handshake and
+   * updated by watcher degradation/recovery port events.
+   */
+  watcherDegraded: boolean;
 }
 
 export interface WorktreeViewActions {
@@ -102,6 +109,7 @@ export interface WorktreeViewActions {
   setError(error: string | null): void;
   setFatalError(message: string): void;
   setReconnecting(reconnecting: boolean): void;
+  setWatcherDegraded(degraded: boolean): void;
 }
 
 export type WorktreeViewStore = WorktreeViewState & WorktreeViewActions;
@@ -118,6 +126,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
     isInitialized: false,
     isReconnecting: false,
     reconnectingAt: null,
+    watcherDegraded: false,
 
     applySnapshot(
       states: WorktreeSnapshot[],
@@ -317,6 +326,13 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
             : Date.now()
           : null,
       });
+    },
+
+    setWatcherDegraded(degraded: boolean) {
+      // Functional updater: degradation/recovery events can race the
+      // get-all-states hydration; merge against the latest state so a
+      // concurrent update isn't dropped by a stale closure.
+      set((prev) => (prev.watcherDegraded === degraded ? prev : { watcherDegraded: degraded }));
     },
   }));
 }


### PR DESCRIPTION
## Summary

- Adds a persistent Tier-1 toolbar pip on `ToolbarProblemsButton` when the file watcher is degraded (ENOSPC/EMFILE), so the signal doesn't disappear with the toast
- Adds a full recovery path: `WatcherController` tracks a `wasDegraded` flag, fires `onWatcherRecovered` on successful recursive re-arm, and the event bubbles through `WorktreeMonitor` → `WorkspaceService` → `WorkspaceHostEventRouter`, resetting toast guards without showing a new toast
- `watcherDegraded` is bundled into the `get-all-states` handshake for late-mounting views and delivered live via per-view `MessagePort` events; `createWorktreeStore` holds the flag with a race-safe setter and `WorktreeStoreContext` hydrates + subscribes

Resolves #8413

## Changes

- `WatcherController` — `wasDegraded` flag, `onWatcherRecovered` callback
- `WorktreeMonitor` / `WorkspaceService` — bubble recovery event, clear one-shot notify guards on recovery
- `WorkspaceHostEventRouter` — reset toast guards on `watcher-recovered` (no toast on recovery)
- `shared/types/workspace-host.ts` + `worktree-port.ts` — `watcher-recovered` event types
- `createWorktreeStore` — `watcherDegraded` slice with race-safe setter
- `WorktreeStoreContext` — hydrate from handshake, subscribe to live `MessagePort` events
- `ToolbarProblemsButton` — 6px warning pip, auto-surfaces Problems button when degraded
- Existing "Copy fix command" toast action retained

## Testing

- 138 targeted unit tests pass across all touched layers (watcher controller, workspace service, event router, store, context, toolbar button)
- Typecheck, lint, format, channel/IPC consistency, and help-prompt checks all pass