### PR TITLE
refactor(worktreeStore): eliminate dynamic-import microtask

### DIFF
--- a/src/store/__tests__/worktreeStore.circularInit.test.ts
+++ b/src/store/__tests__/worktreeStore.circularInit.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+//
+// Cold-module-graph regression gate for issue #8402.
+//
+// `worktreeStore.ts` and `panelStore.ts` form a circular import: panelStore
+// statically imports `useWorktreeSelectionStore`, and (post-#8402) worktreeStore
+// statically imports `usePanelStore`. This test proves the cycle is init-safe in
+// BOTH evaluation orders from a cold module graph — neither store reads the
+// other's export during module evaluation, so the live binding resolves before
+// any action runs. If either order throws, the static-import approach is unsafe
+// and the storeAccessors indirection must be used instead.
+//
+// Only the leaf dependencies are mocked. The two stores under test are NEVER
+// mocked — that is the whole point of the gate.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/controllers", () => ({
+  terminalRegistryController: {
+    kill: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    destroy: vi.fn(),
+    detachForProjectSwitch: vi.fn(),
+    suppressResizesDuringProjectSwitch: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    wake: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/terminal/panelDuplicationService", () => ({
+  buildPanelSnapshotOptions: vi.fn((p: { id: string }) => ({ id: p.id })),
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: vi.fn(() => "mock-notification-id"),
+}));
+
+vi.mock("@/store/terminalInputStore", () => ({
+  useTerminalInputStore: {
+    getState: () => ({ clearAllDraftInputs: vi.fn() }),
+  },
+}));
+
+vi.mock("@/clients", () => ({
+  appClient: { setState: vi.fn().mockResolvedValue(undefined) },
+  projectClient: { setTerminals: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock("@/store/persistence/panelPersistence", () => ({
+  panelPersistence: {
+    setProjectIdGetter: vi.fn(),
+    save: vi.fn(),
+    saveTabGroups: vi.fn(),
+    flush: vi.fn(),
+    load: vi.fn().mockReturnValue([]),
+  },
+}));
+
+(globalThis as Record<string, unknown>).window = globalThis.window ?? {};
+
+function assertLiveStore(store: { getState?: () => unknown } | undefined, label: string) {
+  expect(store, `${label} export should be defined`).toBeDefined();
+  const getState = store?.getState;
+  expect(typeof getState, `${label}.getState should be callable`).toBe("function");
+  // Reading state forces the zustand state-creator to have run, which is where
+  // a TDZ/circular-eval failure would surface.
+  expect(() => getState?.()).not.toThrow();
+}
+
+describe("worktreeStore ↔ panelStore circular init", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("is init-safe when panelStore is evaluated before worktreeStore", async () => {
+    const panelMod = await import("@/store/panelStore");
+    const worktreeMod = await import("@/store/worktreeStore");
+
+    assertLiveStore(panelMod.usePanelStore, "usePanelStore");
+    assertLiveStore(worktreeMod.useWorktreeSelectionStore, "useWorktreeSelectionStore");
+  });
+
+  it("is init-safe when worktreeStore is evaluated before panelStore", async () => {
+    const worktreeMod = await import("@/store/worktreeStore");
+    const panelMod = await import("@/store/panelStore");
+
+    assertLiveStore(worktreeMod.useWorktreeSelectionStore, "useWorktreeSelectionStore");
+    assertLiveStore(panelMod.usePanelStore, "usePanelStore");
+  });
+
+  it("is init-safe when an internal panelRegistry slice is the cold-graph entry point", async () => {
+    // Regression for the #8402 init-order trap: panelStore's top-level
+    // create() calls createPanelRegistrySlice(), so if a consumer enters the
+    // graph via panelRegistrySlice (white-box slice tests do exactly this),
+    // panelStore must not evaluate while panelRegistrySlice is still mid-eval.
+    // The worktreeStore→panelStore static edge previously closed that loop
+    // through panelRegistry/addPanel; addPanel now uses the storeAccessors
+    // snapshot instead of importing worktreeStore, breaking the cycle.
+    const sliceMod = await import("@/store/slices/panelRegistrySlice");
+    const worktreeMod = await import("@/store/worktreeStore");
+    const panelMod = await import("@/store/panelStore");
+
+    expect(typeof sliceMod.createPanelRegistrySlice).toBe("function");
+    assertLiveStore(panelMod.usePanelStore, "usePanelStore");
+    assertLiveStore(worktreeMod.useWorktreeSelectionStore, "useWorktreeSelectionStore");
+  });
+
+  it("worktreeStore can read panelStore state synchronously after cold load", async () => {
+    const worktreeMod = await import("@/store/worktreeStore");
+    const panelMod = await import("@/store/panelStore");
+
+    // selectWorktree → applyWorktreeTerminalPolicy reads usePanelStore.getState()
+    // synchronously post-#8402. With an empty panel registry this must not throw.
+    expect(() =>
+      worktreeMod.useWorktreeSelectionStore.getState().selectWorktree("wt-cold-graph")
+    ).not.toThrow();
+    expect(worktreeMod.useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-cold-graph");
+    expect(panelMod.usePanelStore.getState().panelIds).toEqual([]);
+  });
+});

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -364,7 +364,7 @@ describe("worktreeStore", () => {
     expect(wakeMock).toHaveBeenCalledWith("term-a");
   });
 
-  it("applies renderer policy synchronously per selection, leaving the latest winner correct", () => {
+  it("applies renderer policy synchronously per selection, leaving the latest winner correct", async () => {
     setMockTerminals([
       { id: "term-a", worktreeId: "wt-a", location: "grid" },
       { id: "term-b", worktreeId: "wt-b", location: "grid" },
@@ -386,6 +386,16 @@ describe("worktreeStore", () => {
     ]);
     // The final wake reflects the winning selection.
     expect(wakeMock.mock.calls).toEqual([["term-a"], ["term-b"]]);
+
+    // Proof-by-drain: the old dynamic import left deferred work on the
+    // microtask queue. Flushing must produce no additional policy/focus
+    // calls — confirming nothing is queued post-#8402.
+    const policyCallsBeforeDrain = applyRendererPolicyMock.mock.calls.length;
+    const setFocusedCallsBeforeDrain = setFocusedMock.mock.calls.length;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(applyRendererPolicyMock.mock.calls.length).toBe(policyCallsBeforeDrain);
+    expect(setFocusedMock.mock.calls.length).toBe(setFocusedCallsBeforeDrain);
   });
 
   it("wakes active worktree PTY terminals even when policy tier is already visible", () => {
@@ -596,7 +606,7 @@ describe("worktreeStore", () => {
       expect(terminalStoreState.preMaximizeLayout).toBeNull();
     });
 
-    it("enterFleetScope clears maximize in-tick so a later user maximize is preserved", () => {
+    it("enterFleetScope clears maximize in-tick so a later user maximize is preserved", async () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-race" });
       const token = useWorktreeSelectionStore.getState().enterFleetScope();
       // Post-#8402 the maximize-clear is synchronous — it has already fired by
@@ -608,7 +618,11 @@ describe("worktreeStore", () => {
       terminalStoreState.maximizeTarget = { type: "panel", id: "term-user-maxed" };
       panelSetStateMock.mockClear();
 
-      // Nothing runs later, so the user's new maximize is never wiped.
+      // Proof-by-drain: flush the microtask queue to prove no deferred .then()
+      // from the old dynamic-import path is still pending to wipe the maximize.
+      await Promise.resolve();
+      await Promise.resolve();
+
       expect(panelSetStateMock).not.toHaveBeenCalledWith(
         expect.objectContaining({ maximizedId: null })
       );

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -326,7 +326,7 @@ describe("worktreeStore", () => {
     }
   });
 
-  it("clears stale pending worktree selection without reapplying renderer policy", async () => {
+  it("clears stale pending worktree selection without reapplying renderer policy", () => {
     useWorktreeSelectionStore.setState({
       activeWorktreeId: "wt-b",
       pendingWorktreeId: "wt-a",
@@ -334,14 +334,12 @@ describe("worktreeStore", () => {
     });
 
     useWorktreeSelectionStore.getState().applyPendingWorktreeSelection("wt-a");
-    await Promise.resolve();
-    await Promise.resolve();
 
     expect(useWorktreeSelectionStore.getState().pendingWorktreeId).toBeNull();
     expect(applyRendererPolicyMock).not.toHaveBeenCalled();
   });
 
-  it("applies pending worktree selection only for the still-active worktree", async () => {
+  it("applies pending worktree selection only for the still-active worktree", () => {
     setMockTerminals([
       { id: "term-a", worktreeId: "wt-a", location: "grid" },
       { id: "term-b", worktreeId: "wt-b", location: "grid" },
@@ -354,10 +352,8 @@ describe("worktreeStore", () => {
     });
 
     useWorktreeSelectionStore.getState().applyPendingWorktreeSelection("wt-a");
-    await vi.waitFor(() => {
-      expect(applyRendererPolicyMock).toHaveBeenCalledTimes(3);
-    });
 
+    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(3);
     expect(useWorktreeSelectionStore.getState().pendingWorktreeId).toBeNull();
     expect(applyRendererPolicyMock.mock.calls).toEqual([
       ["term-a", TerminalRefreshTier.VISIBLE],
@@ -368,28 +364,31 @@ describe("worktreeStore", () => {
     expect(wakeMock).toHaveBeenCalledWith("term-a");
   });
 
-  it("ignores stale renderer policy work from an earlier selection", async () => {
+  it("applies renderer policy synchronously per selection, leaving the latest winner correct", () => {
     setMockTerminals([
       { id: "term-a", worktreeId: "wt-a", location: "grid" },
       { id: "term-b", worktreeId: "wt-b", location: "grid" },
     ]);
 
+    // Post-#8402 the policy runs in-tick, so back-to-back selections each
+    // complete fully rather than the first being dropped by a stale-microtask
+    // generation guard. The net result must still leave the latest winner
+    // (wt-b) VISIBLE and the previous worktree BACKGROUND.
     useWorktreeSelectionStore.getState().selectWorktree("wt-a");
     useWorktreeSelectionStore.getState().selectWorktree("wt-b");
-    await vi.waitFor(() => {
-      expect(applyRendererPolicyMock).toHaveBeenCalledTimes(2);
-    });
 
     expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-b");
     expect(applyRendererPolicyMock.mock.calls).toEqual([
+      ["term-a", TerminalRefreshTier.VISIBLE],
+      ["term-b", TerminalRefreshTier.BACKGROUND],
       ["term-a", TerminalRefreshTier.BACKGROUND],
       ["term-b", TerminalRefreshTier.VISIBLE],
     ]);
-    expect(wakeMock).toHaveBeenCalledTimes(1);
-    expect(wakeMock).toHaveBeenCalledWith("term-b");
+    // The final wake reflects the winning selection.
+    expect(wakeMock.mock.calls).toEqual([["term-a"], ["term-b"]]);
   });
 
-  it("wakes active worktree PTY terminals even when policy tier is already visible", async () => {
+  it("wakes active worktree PTY terminals even when policy tier is already visible", () => {
     setMockTerminals([
       { id: "agent-a", worktreeId: "wt-a", location: "grid", kind: "terminal" },
       { id: "plain-a", worktreeId: "wt-a", location: "grid", kind: "terminal" },
@@ -399,9 +398,8 @@ describe("worktreeStore", () => {
     ]);
 
     useWorktreeSelectionStore.getState().selectWorktree("wt-a");
-    await vi.waitFor(() => {
-      expect(applyRendererPolicyMock).toHaveBeenCalledTimes(5);
-    });
+
+    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(5);
 
     expect(wakeMock.mock.calls).toEqual([["agent-a"], ["plain-a"]]);
   });
@@ -435,18 +433,24 @@ describe("worktreeStore", () => {
     expect(state.focusedWorktreeId).toBeNull();
   });
 
-  it("does not restore stale terminal focus after a newer worktree selection wins", async () => {
+  it("restores each worktree's own tracked terminal and does not re-focus the previous one", () => {
     setMockTerminals([
       { id: "term-a", worktreeId: "wt-a", location: "grid" },
       { id: "term-b", worktreeId: "wt-b", location: "grid" },
     ]);
     useWorktreeSelectionStore.getState().trackTerminalFocus("wt-a", "term-a");
+    useWorktreeSelectionStore.getState().trackTerminalFocus("wt-b", "term-b");
 
+    // Post-#8402 focus restore runs in-tick: selecting wt-a focuses its own
+    // tracked terminal immediately.
     useWorktreeSelectionStore.getState().selectWorktree("wt-a");
-    useWorktreeSelectionStore.getState().selectWorktree("wt-b");
-    await Promise.resolve();
-    await Promise.resolve();
+    expect(setFocusedMock).toHaveBeenCalledWith("term-a");
 
+    setFocusedMock.mockClear();
+
+    // Switching to wt-b must restore wt-b's terminal, never re-focus wt-a's.
+    useWorktreeSelectionStore.getState().selectWorktree("wt-b");
+    expect(setFocusedMock).toHaveBeenCalledWith("term-b");
     expect(setFocusedMock).not.toHaveBeenCalledWith("term-a");
   });
 
@@ -508,28 +512,6 @@ describe("worktreeStore", () => {
       expect(state.activeWorktreeId).toBeNull();
     });
 
-    it("re-entering scope during a stale exit's async window does not restore focus", async () => {
-      setMockTerminals([
-        { id: "term-active", worktreeId: "wt-pre", location: "grid" },
-        { id: "term-primary", worktreeId: "wt-pre", location: "grid" },
-      ]);
-      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
-      const token1 = useWorktreeSelectionStore.getState().enterFleetScope();
-      lastArmedIdForFleet = "term-primary";
-      setFocusedMock.mockClear();
-
-      // Exit fires, then a new scope is entered before the deferred
-      // focus-restore microtask resolves. The non-null token guard must
-      // suppress the stale focus restore.
-      useWorktreeSelectionStore.getState().exitFleetScope(token1);
-      useWorktreeSelectionStore.getState().enterFleetScope();
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(setFocusedMock).not.toHaveBeenCalledWith("term-primary");
-      lastArmedIdForFleet = null;
-    });
-
     it("exitFleetScope persists the restored activeWorktreeId", async () => {
       // Unique id to avoid module-level persistActiveWorktree dedup bleeding
       // from earlier tests that touched "wt-original" via setActiveWorktree.
@@ -546,7 +528,7 @@ describe("worktreeStore", () => {
       expect(appSetStateMock).toHaveBeenCalledWith({ activeWorktreeId: restoreId });
     });
 
-    it("exitFleetScope reapplies terminal streaming policy for the restored worktree", async () => {
+    it("exitFleetScope reapplies terminal streaming policy for the restored worktree", () => {
       setMockTerminals([
         { id: "term-a", worktreeId: "wt-original", location: "grid" },
         { id: "term-b", worktreeId: "wt-other", location: "grid" },
@@ -556,8 +538,6 @@ describe("worktreeStore", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: null });
       applyRendererPolicyMock.mockClear();
       useWorktreeSelectionStore.getState().exitFleetScope(token);
-      await Promise.resolve();
-      await Promise.resolve();
       expect(applyRendererPolicyMock).toHaveBeenCalledWith("term-a", TerminalRefreshTier.VISIBLE);
       expect(applyRendererPolicyMock).toHaveBeenCalledWith(
         "term-b",
@@ -585,15 +565,13 @@ describe("worktreeStore", () => {
       expect(state._fleetScopeToken).toBeNull();
     });
 
-    it("enterFleetScope clears any active maximize so the scope grid is visible", async () => {
+    it("enterFleetScope clears any active maximize so the scope grid is visible", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-with-maximize" });
       terminalStoreState.maximizedId = "term-maxed";
       terminalStoreState.maximizeTarget = { type: "panel", id: "term-maxed" };
       terminalStoreState.preMaximizeLayout = { gridCols: 2 };
 
       useWorktreeSelectionStore.getState().enterFleetScope();
-      await Promise.resolve();
-      await Promise.resolve();
 
       expect(panelSetStateMock).toHaveBeenCalledWith({
         maximizedId: null,
@@ -605,86 +583,39 @@ describe("worktreeStore", () => {
       expect(terminalStoreState.preMaximizeLayout).toBeNull();
     });
 
-    it("exitFleetScope clears any lingering preMaximizeLayout snapshot", async () => {
+    it("exitFleetScope clears any lingering preMaximizeLayout snapshot", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre-scope" });
       const token = useWorktreeSelectionStore.getState().enterFleetScope();
-      await Promise.resolve();
-      await Promise.resolve();
 
       terminalStoreState.preMaximizeLayout = { gridCols: 3 };
       panelSetStateMock.mockClear();
 
       useWorktreeSelectionStore.getState().exitFleetScope(token);
-      await Promise.resolve();
-      await Promise.resolve();
 
       expect(panelSetStateMock).toHaveBeenCalledWith({ preMaximizeLayout: null });
       expect(terminalStoreState.preMaximizeLayout).toBeNull();
     });
 
-    it("exitFleetScope's deferred preMaximizeLayout clear bails if scope re-entered", async () => {
-      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre-scope" });
-      const token = useWorktreeSelectionStore.getState().enterFleetScope();
-      await Promise.resolve();
-      await Promise.resolve();
-
-      terminalStoreState.preMaximizeLayout = { gridCols: 3 };
-      useWorktreeSelectionStore.getState().exitFleetScope(token);
-      // A fresh scope is entered before the exit's deferred clear drains.
-      useWorktreeSelectionStore.getState().enterFleetScope();
-      panelSetStateMock.mockClear();
-      await Promise.resolve();
-      await Promise.resolve();
-
-      // The stale exit-side clear must not wipe the new scope's snapshot.
-      expect(panelSetStateMock).not.toHaveBeenCalledWith({ preMaximizeLayout: null });
-    });
-
-    it("reset during exitFleetScope's focus-restore window does not call setFocused", async () => {
-      setMockTerminals([
-        { id: "term-active", worktreeId: "wt-pre", location: "grid" },
-        { id: "term-primary", worktreeId: "wt-pre", location: "grid" },
-      ]);
-      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
-      const token = useWorktreeSelectionStore.getState().enterFleetScope();
-      lastArmedIdForFleet = "term-primary";
-      setFocusedMock.mockClear();
-
-      useWorktreeSelectionStore.getState().exitFleetScope(token);
-      // reset() bumps _policyGeneration, invalidating the pending focus-restore
-      // microtask whose token guard alone can't catch this (post-reset token
-      // is null, matching the exit-side null comparison).
-      useWorktreeSelectionStore.getState().reset();
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(setFocusedMock).not.toHaveBeenCalled();
-      lastArmedIdForFleet = null;
-    });
-
-    it("enterFleetScope's deferred maximize-clear bails if scope was exited first", async () => {
+    it("enterFleetScope clears maximize in-tick so a later user maximize is preserved", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-race" });
       const token = useWorktreeSelectionStore.getState().enterFleetScope();
-      // Exit scope synchronously before the deferred .then() resolves.
+      // Post-#8402 the maximize-clear is synchronous — it has already fired by
+      // the time enterFleetScope() returns. No deferred .then() lingers.
       useWorktreeSelectionStore.getState().exitFleetScope(token);
 
-      // Simulate the user manually re-maximizing a panel after the exit.
+      // The user manually re-maximizes a panel after the enter/exit cycle.
       terminalStoreState.maximizedId = "term-user-maxed";
       terminalStoreState.maximizeTarget = { type: "panel", id: "term-user-maxed" };
       panelSetStateMock.mockClear();
 
-      // Flush the microtask queue so the deferred import/then runs.
-      await Promise.resolve();
-      await Promise.resolve();
-
-      // The enterFleetScope .then() MUST NOT wipe the user's new maximize.
+      // Nothing runs later, so the user's new maximize is never wiped.
       expect(panelSetStateMock).not.toHaveBeenCalledWith(
         expect.objectContaining({ maximizedId: null })
       );
       expect(terminalStoreState.maximizedId).toBe("term-user-maxed");
     });
 
-    it("exitFleetScope focuses the primary armed terminal when it lives in the restore worktree", async () => {
+    it("exitFleetScope focuses the primary armed terminal when it lives in the restore worktree", () => {
       setMockTerminals([
         { id: "term-active", worktreeId: "wt-pre", location: "grid" },
         { id: "term-primary", worktreeId: "wt-pre", location: "grid" },
@@ -695,14 +626,12 @@ describe("worktreeStore", () => {
       setFocusedMock.mockClear();
 
       useWorktreeSelectionStore.getState().exitFleetScope(token);
-      await Promise.resolve();
-      await Promise.resolve();
 
       expect(setFocusedMock).toHaveBeenCalledWith("term-primary");
       lastArmedIdForFleet = null;
     });
 
-    it("exitFleetScope does not call setFocused when lastArmedId is null", async () => {
+    it("exitFleetScope does not call setFocused when lastArmedId is null", () => {
       setMockTerminals([{ id: "term-active", worktreeId: "wt-pre", location: "grid" }]);
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
       const token = useWorktreeSelectionStore.getState().enterFleetScope();
@@ -710,13 +639,11 @@ describe("worktreeStore", () => {
       setFocusedMock.mockClear();
 
       useWorktreeSelectionStore.getState().exitFleetScope(token);
-      await Promise.resolve();
-      await Promise.resolve();
 
       expect(setFocusedMock).not.toHaveBeenCalled();
     });
 
-    it("exitFleetScope does not focus a cross-worktree primary — avoids orchestrator switch-back", async () => {
+    it("exitFleetScope does not focus a cross-worktree primary — avoids orchestrator switch-back", () => {
       // Restoring `activeWorktreeId` to `wt-pre` then focusing a terminal in
       // `wt-other` would trigger rendererStoreOrchestrator's focusedId
       // subscription, which calls selectWorktree(terminal.worktreeId) and
@@ -731,14 +658,12 @@ describe("worktreeStore", () => {
       setFocusedMock.mockClear();
 
       useWorktreeSelectionStore.getState().exitFleetScope(token);
-      await Promise.resolve();
-      await Promise.resolve();
 
       expect(setFocusedMock).not.toHaveBeenCalledWith("term-primary");
       lastArmedIdForFleet = null;
     });
 
-    it("exitFleetScope skips focus restore when the primary terminal is trashed", async () => {
+    it("exitFleetScope skips focus restore when the primary terminal is trashed", () => {
       setMockTerminals([
         { id: "term-active", worktreeId: "wt-pre", location: "grid" },
         { id: "term-primary", worktreeId: "wt-pre", location: "trash" },
@@ -749,14 +674,12 @@ describe("worktreeStore", () => {
       setFocusedMock.mockClear();
 
       useWorktreeSelectionStore.getState().exitFleetScope(token);
-      await Promise.resolve();
-      await Promise.resolve();
 
       expect(setFocusedMock).not.toHaveBeenCalled();
       lastArmedIdForFleet = null;
     });
 
-    it("exitFleetScope skips focus restore when the primary terminal is docked", async () => {
+    it("exitFleetScope skips focus restore when the primary terminal is docked", () => {
       setMockTerminals([
         { id: "term-active", worktreeId: "wt-pre", location: "grid" },
         { id: "term-primary", worktreeId: "wt-pre", location: "dock" },
@@ -767,35 +690,12 @@ describe("worktreeStore", () => {
       setFocusedMock.mockClear();
 
       useWorktreeSelectionStore.getState().exitFleetScope(token);
-      await Promise.resolve();
-      await Promise.resolve();
 
       expect(setFocusedMock).not.toHaveBeenCalled();
       lastArmedIdForFleet = null;
     });
 
-    it("exitFleetScope skips focus restore if policy generation advances first", async () => {
-      setMockTerminals([
-        { id: "term-active", worktreeId: "wt-pre", location: "grid" },
-        { id: "term-primary", worktreeId: "wt-pre", location: "grid" },
-      ]);
-      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
-      const token = useWorktreeSelectionStore.getState().enterFleetScope();
-      lastArmedIdForFleet = "term-primary";
-      setFocusedMock.mockClear();
-
-      useWorktreeSelectionStore.getState().exitFleetScope(token);
-      // Simulate a newer store change (e.g. another worktree switch) that
-      // bumps _policyGeneration before the deferred focus-restore resolves.
-      useWorktreeSelectionStore.setState((s) => ({ _policyGeneration: s._policyGeneration + 5 }));
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(setFocusedMock).not.toHaveBeenCalledWith("term-primary");
-      lastArmedIdForFleet = null;
-    });
-
-    it("enterFleetScope pins armed cross-worktree terminals to VISIBLE", async () => {
+    it("enterFleetScope pins armed cross-worktree terminals to VISIBLE", () => {
       setMockTerminals([
         { id: "term-active", worktreeId: "wt-pre-scope", location: "grid" },
         { id: "term-armed-remote", worktreeId: "wt-other", location: "grid" },
@@ -806,8 +706,6 @@ describe("worktreeStore", () => {
       applyRendererPolicyMock.mockClear();
 
       useWorktreeSelectionStore.getState().enterFleetScope();
-      await Promise.resolve();
-      await Promise.resolve();
 
       expect(applyRendererPolicyMock).toHaveBeenCalledWith(
         "term-active",

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -12,7 +12,7 @@ import { getTerminalAppearanceSnapshot } from "@/hooks/useTerminalAppearance";
 import { getScrollbackForType, PERFORMANCE_MODE_SCROLLBACK } from "@/utils/scrollbackConfig";
 import { getXtermOptions } from "@/config/xtermConfig";
 import { deriveTerminalRuntimeIdentity } from "@/utils/terminalChrome";
-import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { getWorktreeSelectionSnapshot } from "@/store/storeAccessors";
 import { useLayoutConfigStore } from "@/store/layoutConfigStore";
 import { usePanelLimitStore, evaluatePanelLimit } from "@/store/panelLimitStore";
 import { notify } from "@/lib/notify";
@@ -138,7 +138,7 @@ export const createAddPanelActions = (
         requestedLocation === "grid" && currentGridCount >= maxCapacity
           ? "dock"
           : requestedLocation;
-      const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
+      const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
       const isInActiveWorktree = (options.worktreeId ?? null) === (activeWorktreeId ?? null);
       const shouldBackground = location === "dock" || (location === "grid" && !isInActiveWorktree);
       const runtimeStatus: TerminalRuntimeStatus = shouldBackground ? "background" : "running";
@@ -293,7 +293,7 @@ export const createAddPanelActions = (
       requestedLocation === "grid" && currentGridGroupCount >= maxCapacity
         ? "dock"
         : requestedLocation;
-    const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
+    const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
     // When activeWorktreeId is null (worktree store not yet hydrated — common during
     // project switch), treat the terminal as being in the active worktree to avoid
     // incorrectly backgrounding it. applyWorktreeTerminalPolicy will reconcile
@@ -520,7 +520,7 @@ export const createAddPanelActions = (
       // Prewarm ALL terminal types to ensure managed instance exists.
       // This is critical for terminals in inactive worktrees - they need a managed
       // instance for proper BACKGROUND→VISIBLE tier transitions when worktree activates.
-      const currentActiveWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
+      const currentActiveWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
       // When activeWorktreeId is null (hydration in progress), don't treat the
       // terminal as offscreen — it would be prewarmed in the offscreen container
       // at -20000px and backgrounded, suppressing data flow from the pty-host.

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -5,6 +5,7 @@ import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
 import type { FleetScopeToken } from "@shared/types/worktree";
 import { useFocusStore } from "@/store/focusStore";
+import { usePanelStore } from "@/store/panelStore";
 import { logErrorWithContext } from "@/utils/errorContext";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
@@ -85,10 +86,8 @@ interface WorktreeSelectionState {
 }
 
 type ClientsModule = typeof import("@/clients");
-type TerminalStoreModule = typeof import("@/store/panelStore");
 
 let clientsModulePromise: Promise<ClientsModule> | null = null;
-let terminalStoreModulePromise: Promise<TerminalStoreModule> | null = null;
 let lastPersistedActiveWorktreeId: string | null | undefined;
 let pendingPersistActiveWorktreeId: string | null | undefined;
 let persistRequestVersion = 0;
@@ -170,34 +169,6 @@ function loadClientsModule(): Promise<ClientsModule> {
       });
   }
   return clientsModulePromise;
-}
-
-function loadTerminalStoreModule(): Promise<TerminalStoreModule> {
-  if (!terminalStoreModulePromise) {
-    const startedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
-    markRendererPerformance("dynamic_import_start", { module: "@/store/panelStore" });
-    terminalStoreModulePromise = import("@/store/panelStore")
-      .then((module) => {
-        const now = typeof performance !== "undefined" ? performance.now() : Date.now();
-        markRendererPerformance("dynamic_import_end", {
-          module: "@/store/panelStore",
-          durationMs: Number((now - startedAt).toFixed(3)),
-          ok: true,
-        });
-        return module;
-      })
-      .catch((error) => {
-        const now = typeof performance !== "undefined" ? performance.now() : Date.now();
-        markRendererPerformance("dynamic_import_end", {
-          module: "@/store/panelStore",
-          durationMs: Number((now - startedAt).toFixed(3)),
-          ok: false,
-          error: formatErrorMessage(error, "Failed to load @/store/panelStore module"),
-        });
-        throw error;
-      });
-  }
-  return terminalStoreModulePromise;
 }
 
 function persistActiveWorktree(id: string | null): void {
@@ -328,12 +299,8 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
 
     // Record worktree MRU on explicit selection (suppressed during hydration)
     if (!mruRecordingSuppressed) {
-      void loadTerminalStoreModule()
-        .then(({ usePanelStore }) => {
-          usePanelStore.getState().recordMru(`worktree:${id}`);
-          persistMruList(usePanelStore.getState().mruList);
-        })
-        .catch(() => {});
+      usePanelStore.getState().recordMru(`worktree:${id}`);
+      persistMruList(usePanelStore.getState().mruList);
     }
 
     applyWorktreeTerminalPolicy(get, set, id, generation, () => {
@@ -344,30 +311,17 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       });
     });
 
-    // Restore the last focused terminal for this worktree
+    // Restore the last focused terminal for this worktree. Runs synchronously
+    // in the same tick as the set() above, so the prior generation/active
+    // guards are now dead — nothing between the set() and here can change
+    // them. Only the terminal-validity checks remain load-bearing.
     const lastFocusedTerminalId = get().lastFocusedTerminalByWorktree.get(id);
     if (lastFocusedTerminalId) {
-      void loadTerminalStoreModule()
-        .then(({ usePanelStore }) => {
-          // Check generation to ensure we're not applying stale focus from a previous switch
-          if (get()._policyGeneration !== generation) return;
-          // Verify the worktree hasn't changed
-          if (get().activeWorktreeId !== id) return;
-
-          const terminal = usePanelStore.getState().panelsById[lastFocusedTerminalId];
-
-          // Validate terminal still exists, belongs to this worktree, and isn't in trash
-          if (terminal && terminal.worktreeId === id && terminal.location !== "trash") {
-            usePanelStore.getState().setFocused(lastFocusedTerminalId);
-          }
-        })
-        .catch((error) => {
-          logErrorWithContext(error, {
-            operation: "import_terminal_store_for_focus_restore",
-            component: "worktreeStore",
-            details: { worktreeId: id, lastFocusedTerminalId },
-          });
-        });
+      const terminal = usePanelStore.getState().panelsById[lastFocusedTerminalId];
+      // Validate terminal still exists, belongs to this worktree, and isn't in trash
+      if (terminal && terminal.worktreeId === id && terminal.location !== "trash") {
+        usePanelStore.getState().setFocused(lastFocusedTerminalId);
+      }
     }
   },
 
@@ -384,6 +338,11 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     if (state.activeWorktreeId !== worktreeId) {
       return;
     }
+    // Read _policyGeneration WITHOUT incrementing: this applies a pending
+    // selection that was queued before the active worktree settled, so it
+    // must not supersede an in-flight explicit transition that bumped the
+    // generation after the pending was set — passing the current value lets
+    // applyWorktreeTerminalPolicy's guard bail if that happened.
     const generation = state._policyGeneration;
     applyWorktreeTerminalPolicy(get, set, worktreeId, generation);
   },
@@ -612,24 +571,17 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     // Clear any active maximize so the fleet-scope render path isn't shadowed
     // by the single-panel/group maximize branch in ContentGrid. Also clear the
     // preMaximizeLayout snapshot so exiting scope later doesn't restore a
-    // stale layout captured against a different worktree.
-    //
-    // Guard inside the resolved callback: the dynamic import resolves on a
-    // later microtask, so if the caller entered and exited scope back-to-back
-    // we must not wipe a maximize the user set after the exit.
-    void loadTerminalStoreModule()
-      .then(({ usePanelStore }) => {
-        // Token equality (not `isFleetScopeActive`): if the caller exited and
-        // re-entered scope back-to-back, `isFleetScopeActive` is true again but
-        // for a *different* scope — wiping its maximize would be wrong.
-        if (get()._fleetScopeToken !== token) return;
-        usePanelStore.setState({
-          maximizedId: null,
-          maximizeTarget: null,
-          preMaximizeLayout: null,
-        });
-      })
-      .catch(() => {});
+    // stale layout captured against a different worktree. The earlier
+    // idempotency guard already ensures we only reach here when scope is
+    // active, so no further re-check is needed now that this runs in-tick
+    // (the token-equality guard the dynamic-import path used inside its
+    // microtask callback was solely to protect against a back-to-back
+    // exit+re-enter that drained later — that race is structurally gone now).
+    usePanelStore.setState({
+      maximizedId: null,
+      maximizeTarget: null,
+      preMaximizeLayout: null,
+    });
     // Promote armed cross-worktree terminals to VISIBLE so their xterm
     // instances actually stream live output inside the fleet grid. The
     // policy function consults `isFleetScopeActive` + the armed set.
@@ -647,7 +599,8 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     const restoreId = get()._previousActiveWorktreeId;
     const generation = get()._policyGeneration + 1;
     // Snapshot the primary (most-recently-armed) terminal BEFORE `set()` so
-    // it's stable across the async focus-restore microtask below.
+    // the value used for focus restore is stable against any reads/writes
+    // the in-tick clears below might trigger.
     const primaryTerminalId = getFleetLastArmedId();
     set({
       isFleetScopeActive: false,
@@ -660,25 +613,14 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     persistActiveWorktree(restoreId);
     // Defensive: drop any preMaximizeLayout snapshot that may have survived
     // scope entry. The restored worktree's layout should be computed fresh.
-    void loadTerminalStoreModule()
-      .then(({ usePanelStore }) => {
-        // Symmetric to the enter-side maximize-clear guard: if a fresh scope
-        // was entered before this microtask drained, `_fleetScopeToken` is
-        // non-null and clearing preMaximizeLayout would clobber the new
-        // scope's legitimate snapshot.
-        if (get()._fleetScopeToken !== null) return;
-        usePanelStore.setState({ preMaximizeLayout: null });
-      })
-      .catch(() => {});
+    usePanelStore.setState({ preMaximizeLayout: null });
     // Focus the primary (most-recently-armed) terminal so the user lands on
     // a known pane instead of whatever `focusedId` happened to be during
-    // fleet scope. Guarded by:
-    //   - token: a new `enterFleetScope()` during this async window mints a
-    //     fresh token (non-null), so restoring focus would fight the new
-    //     scope. `_fleetScopeToken === null` means no scope re-entered.
-    //   - generation: prevents a stale microtask from overwriting a newer
-    //     worktree switch (also catches concurrent setActiveWorktree /
-    //     selectWorktree that don't touch the token).
+    // fleet scope. Runs in-tick now, so the prior token/generation guards
+    // inside the async callback are structurally dead — the set() above
+    // already cleared `_fleetScopeToken` and bumped the generation in the
+    // same tick, and nothing between that set() and here can mutate them.
+    // Still guarded by:
     //   - worktreeId match: the user's scope-exit intent is "restore the
     //     pre-scope worktree". If the primary lives elsewhere, focusing it
     //     would let `rendererStoreOrchestrator`'s focusedId subscription
@@ -687,29 +629,16 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     //     focus would activate the dock rather than a grid pane, and
     //     trashed/background terminals aren't valid focus targets.
     if (primaryTerminalId && restoreId) {
-      void loadTerminalStoreModule()
-        .then(({ usePanelStore }) => {
-          if (get()._fleetScopeToken !== null) return;
-          if (get()._policyGeneration !== generation) return;
-          const terminal = usePanelStore.getState().panelsById[primaryTerminalId];
-          if (!terminal) return;
-          if (terminal.worktreeId !== restoreId) return;
-          if (
-            terminal.location === "trash" ||
-            terminal.location === "background" ||
-            terminal.location === "dock"
-          ) {
-            return;
-          }
-          usePanelStore.getState().setFocused(primaryTerminalId);
-        })
-        .catch((error) => {
-          logErrorWithContext(error, {
-            operation: "import_terminal_store_for_fleet_exit_focus",
-            component: "worktreeStore",
-            details: { primaryTerminalId },
-          });
-        });
+      const terminal = usePanelStore.getState().panelsById[primaryTerminalId];
+      if (
+        terminal &&
+        terminal.worktreeId === restoreId &&
+        terminal.location !== "trash" &&
+        terminal.location !== "background" &&
+        terminal.location !== "dock"
+      ) {
+        usePanelStore.getState().setFocused(primaryTerminalId);
+      }
     }
     // Reconcile terminal streaming tiers: consumers may have mutated
     // activeWorktreeId during scope, so the renderer policy must be
@@ -767,80 +696,71 @@ function applyWorktreeTerminalPolicy(
   // Reliability: terminals from inactive worktrees should not stream output to the renderer.
   // They remain alive in the backend headless model and will be restored on wake.
   // Terminals in the active worktree must be activated to resume streaming.
-  void loadTerminalStoreModule()
-    .then(({ usePanelStore }) => {
-      // Check generation to ensure we're not applying a stale policy from a previous switch
-      if (get()._policyGeneration !== generation) return;
-      // Double check that the active worktree hasn't changed underneath us
-      if ((get().activeWorktreeId ?? null) !== (targetWorktreeId ?? null)) return;
+  //
+  // Runs synchronously: callers invoke this immediately after their own set(),
+  // so the generation/active guards below are defensive (they no longer guard a
+  // microtask boundary, but are kept because applyPendingWorktreeSelection
+  // passes a generation captured at a different point).
+  if (get()._policyGeneration !== generation) return;
+  if ((get().activeWorktreeId ?? null) !== (targetWorktreeId ?? null)) return;
 
-      const { panelsById, panelIds } = usePanelStore.getState();
-      const activeDockTerminalId = usePanelStore.getState().activeDockTerminalId;
+  const { panelsById, panelIds } = usePanelStore.getState();
+  const activeDockTerminalId = usePanelStore.getState().activeDockTerminalId;
 
-      // Fleet scope pins armed grid/agent terminals to VISIBLE regardless of
-      // worktree affiliation — the whole point of the scope view is to see
-      // live output across worktrees. Without this, cross-worktree armed
-      // terminals would get demoted to BACKGROUND and show stale/frozen
-      // content even though they are mounted in the fleet grid. We fetch the
-      // armed set through the shared accessor module to avoid a cyclic import.
-      const fleetActive = get().isFleetScopeActive;
-      const armedIds = fleetActive ? getFleetArmedIds() : null;
+  // Fleet scope pins armed grid/agent terminals to VISIBLE regardless of
+  // worktree affiliation — the whole point of the scope view is to see
+  // live output across worktrees. Without this, cross-worktree armed
+  // terminals would get demoted to BACKGROUND and show stale/frozen
+  // content even though they are mounted in the fleet grid. We fetch the
+  // armed set through the shared accessor module to avoid a cyclic import.
+  const fleetActive = get().isFleetScopeActive;
+  const armedIds = fleetActive ? getFleetArmedIds() : null;
 
-      for (const id of panelIds) {
-        const terminal = panelsById[id];
-        if (!terminal) continue;
-        const isInActiveWorktree = (terminal.worktreeId ?? null) === (targetWorktreeId ?? null);
+  for (const id of panelIds) {
+    const terminal = panelsById[id];
+    if (!terminal) continue;
+    const isInActiveWorktree = (terminal.worktreeId ?? null) === (targetWorktreeId ?? null);
 
-        const location = terminal.location ?? "grid";
-        const isDockOrTrash = location === "dock" || location === "trash";
+    const location = terminal.location ?? "grid";
+    const isDockOrTrash = location === "dock" || location === "trash";
 
-        // Let DockedTerminalItem manage open/closed dock policy, but if the active dock
-        // terminal is not in the active worktree, force it to BACKGROUND.
-        if (terminal.id === activeDockTerminalId && isDockOrTrash && isInActiveWorktree) {
-          continue;
-        }
+    // Let DockedTerminalItem manage open/closed dock policy, but if the active dock
+    // terminal is not in the active worktree, force it to BACKGROUND.
+    if (terminal.id === activeDockTerminalId && isDockOrTrash && isInActiveWorktree) {
+      continue;
+    }
 
-        const isArmedInFleetScope = armedIds?.has(terminal.id) && !isDockOrTrash;
+    const isArmedInFleetScope = armedIds?.has(terminal.id) && !isDockOrTrash;
 
-        const targetTier =
-          isArmedInFleetScope || (isInActiveWorktree && !isDockOrTrash)
-            ? TerminalRefreshTier.VISIBLE
-            : TerminalRefreshTier.BACKGROUND;
+    const targetTier =
+      isArmedInFleetScope || (isInActiveWorktree && !isDockOrTrash)
+        ? TerminalRefreshTier.VISIBLE
+        : TerminalRefreshTier.BACKGROUND;
 
-        // Apply appropriate renderer policy based on worktree membership.
-        // Avoid waking dock/trash terminals - they manage their own visibility.
-        // `applyRendererPolicy(VISIBLE)` only restores on a real
-        // BACKGROUND->active transition. It returns early on same-tier VISIBLE,
-        // so pair active grid promotion with an explicit wake to pull any bytes
-        // that arrived while the renderer was hidden or not yet mounted.
-        terminalInstanceService.applyRendererPolicy(terminal.id, targetTier);
-        if (
-          targetTier !== TerminalRefreshTier.BACKGROUND &&
-          terminal.hasPty !== false &&
-          panelKindHasPty(terminal.kind ?? "terminal")
-        ) {
-          try {
-            terminalInstanceService.wake(terminal.id);
-          } catch (error) {
-            logErrorWithContext(error, {
-              operation: "wake_visible_worktree_terminal",
-              component: "worktreeStore",
-              errorType: "process",
-              details: { terminalId: terminal.id, targetWorktreeId, generation },
-            });
-          }
-        }
+    // Apply appropriate renderer policy based on worktree membership.
+    // Avoid waking dock/trash terminals - they manage their own visibility.
+    // `applyRendererPolicy(VISIBLE)` only restores on a real
+    // BACKGROUND->active transition. It returns early on same-tier VISIBLE,
+    // so pair active grid promotion with an explicit wake to pull any bytes
+    // that arrived while the renderer was hidden or not yet mounted.
+    terminalInstanceService.applyRendererPolicy(terminal.id, targetTier);
+    if (
+      targetTier !== TerminalRefreshTier.BACKGROUND &&
+      terminal.hasPty !== false &&
+      panelKindHasPty(terminal.kind ?? "terminal")
+    ) {
+      try {
+        terminalInstanceService.wake(terminal.id);
+      } catch (error) {
+        logErrorWithContext(error, {
+          operation: "wake_visible_worktree_terminal",
+          component: "worktreeStore",
+          errorType: "process",
+          details: { terminalId: terminal.id, targetWorktreeId, generation },
+        });
       }
+    }
+  }
 
-      onComplete?.();
-    })
-    .catch((error) => {
-      logErrorWithContext(error, {
-        operation: "apply_terminal_streaming_policy",
-        component: "worktreeStore",
-        errorType: "process",
-        details: { targetWorktreeId, generation },
-      });
-      onComplete?.();
-    });
+  onComplete?.();
 }


### PR DESCRIPTION
## Summary

- Replaces `import("@/store/panelStore")` with a static top-level import in `worktreeStore.ts`, making all six async callsites synchronous
- Removes `loadTerminalStoreModule`, `terminalStoreModulePromise`, `TerminalStoreModule`, and the associated dynamic-import perf marks; collapses now-dead generation guards in the focus-restore and maximize-clear paths
- The static edge exposed a latent init cycle (`panelStore` → `panelRegistrySlice` → `addPanel` → `worktreeStore`); fixed by switching `addPanel.ts` to the existing read-only `getWorktreeSelectionSnapshot()` accessor — behaviour-preserving, no app impact

Resolves #8402

## Changes

- `src/store/worktreeStore.ts` — static import, six synchronous callsites, dead guards removed, WHY comment added at `applyPendingWorktreeSelection`
- `src/store/slices/panelRegistry/addPanel.ts` — use `getWorktreeSelectionSnapshot()` instead of direct `worktreeStore` import to break init cycle
- `src/store/__tests__/worktreeStore.circularInit.test.ts` — new cold-graph regression gate, four cases including slice-first entry order
- `src/store/__tests__/worktreeStore.test.ts` — rewrote/removed three tests whose premises depended on eliminated microtask staleness; proof-by-drain hardening on remainder

## Testing

341 tests pass across 17 files. `npm run check` fully green (typecheck, lint 880 warnings → 880, format, channels, IPC, help). Cold-graph regression gate explicitly covers the init cycle with `vi.resetModules()` in both import orders.