### PR TITLE
fix(worktree): signal force-delete escalation in delete dialog button and banner

### DIFF
--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -106,7 +106,64 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     }
   };
 
-  const deleteButtonLabel = "Delete worktree";
+  const deleteButtonLabel = !force
+    ? "Delete worktree"
+    : isHighTier
+      ? `Force delete '${confirmTarget}'`
+      : "Force delete worktree";
+
+  let advisoryBanner: React.ReactNode = null;
+  if (hasChanges) {
+    if (!force) {
+      advisoryBanner = (
+        <div
+          role="alert"
+          className="flex items-start gap-2 p-3 bg-status-warning/10 border border-status-warning/20 rounded text-status-warning text-xs"
+        >
+          <AlertTriangle className="w-4 h-4 shrink-0" />
+          <p>
+            This worktree has{" "}
+            {hasTrackedChanges && hasUntrackedFiles
+              ? `${trackedChangeCount} uncommitted file${trackedChangeCount === 1 ? "" : "s"} and ${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`
+              : hasTrackedChanges
+                ? `${trackedChangeCount} uncommitted file${trackedChangeCount === 1 ? "" : "s"}`
+                : `${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`}
+            . Standard deletion will fail.
+          </p>
+        </div>
+      );
+    } else if (hasTrackedChanges) {
+      advisoryBanner = (
+        <div
+          role="alert"
+          className="flex items-start gap-2 p-3 bg-status-error/10 border border-status-error/20 rounded text-status-error text-xs"
+        >
+          <AlertTriangle className="w-4 h-4 shrink-0" />
+          <p>
+            Force delete will discard {trackedChangeCount} uncommitted tracked file
+            {trackedChangeCount === 1 ? "" : "s"}
+            {hasUntrackedFiles
+              ? ` and ${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`
+              : ""}
+            . This is irreversible.
+          </p>
+        </div>
+      );
+    } else {
+      advisoryBanner = (
+        <div
+          role="alert"
+          className="flex items-start gap-2 p-3 bg-status-error/10 border border-status-error/20 rounded text-status-error text-xs"
+        >
+          <AlertTriangle className="w-4 h-4 shrink-0" />
+          <p>
+            Force delete will permanently remove {untrackedFileCount} untracked file
+            {untrackedFileCount === 1 ? "" : "s"}.
+          </p>
+        </div>
+      );
+    }
+  }
 
   return (
     <AppDialog
@@ -196,20 +253,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
               {worktree.path}
             </div>
 
-            {hasChanges && !force && (
-              <div className="flex items-start gap-2 p-3 bg-status-warning/10 border border-status-warning/20 rounded text-status-warning text-xs">
-                <AlertTriangle className="w-4 h-4 shrink-0" />
-                <p>
-                  This worktree has{" "}
-                  {hasTrackedChanges && hasUntrackedFiles
-                    ? `${trackedChangeCount} uncommitted file${trackedChangeCount === 1 ? "" : "s"} and ${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`
-                    : hasTrackedChanges
-                      ? `${trackedChangeCount} uncommitted file${trackedChangeCount === 1 ? "" : "s"}`
-                      : `${untrackedFileCount} untracked file${untrackedFileCount === 1 ? "" : "s"}`}
-                  . Standard deletion will fail.
-                </p>
-              </div>
-            )}
+            {advisoryBanner}
 
             {error && (
               <div
@@ -299,6 +343,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
           variant="destructive"
           onClick={handleDelete}
           disabled={!canSubmit}
+          aria-live="polite"
           data-testid="delete-worktree-confirm"
         >
           {isDeleting ? "Deleting…" : deleteButtonLabel}

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -192,7 +192,7 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     expect(warning.textContent).toContain("1 uncommitted file.");
   });
 
-  it("hides warning when force is checked", () => {
+  it("persists banner with escalated copy when force is checked for tracked changes", () => {
     const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
@@ -202,6 +202,39 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     fireEvent.click(forceCheckbox);
 
     expect(screen.queryByText(/Standard deletion will fail/)).toBeNull();
+    expect(screen.getByText(/Force delete will discard/)).toBeDefined();
+    expect(screen.getByText(/1 uncommitted tracked file. This is irreversible./)).toBeDefined();
+  });
+
+  it("persists banner with escalated copy when force is checked for untracked-only files", () => {
+    const worktree = makeWorktree(makeChanges([{ path: "new.txt", status: "untracked" }]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    expect(screen.getByText(/Standard deletion will fail/)).toBeDefined();
+
+    const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
+    fireEvent.click(forceCheckbox);
+
+    expect(screen.queryByText(/Standard deletion will fail/)).toBeNull();
+    expect(screen.getByText(/Force delete will permanently remove/)).toBeDefined();
+    expect(screen.getByText(/1 untracked file./)).toBeDefined();
+  });
+
+  it("shows combined counts in force banner when both tracked and untracked files exist", () => {
+    const worktree = makeWorktree(
+      makeChanges([
+        { path: "src/app.ts", status: "modified" },
+        { path: "new.txt", status: "untracked" },
+      ])
+    );
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
+    fireEvent.click(forceCheckbox);
+
+    const banner = screen.getByText(/Force delete will discard/);
+    expect(banner.textContent).toContain("and 1 untracked file");
+    expect(banner.textContent).toContain("This is irreversible.");
   });
 
   it('shows "remove untracked files" on force label when only untracked files exist', () => {
@@ -439,7 +472,7 @@ describe("WorktreeDeleteDialog — medium tier (no name confirmation)", () => {
     expect(screen.queryByTestId("delete-worktree-confirm-input")).toBeNull();
     const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
     expect(button.disabled).toBe(false);
-    expect(button.textContent).toBe("Delete worktree");
+    expect(button.textContent).toBe("Force delete worktree");
   });
 
   it("dispatches delete on click without typing", async () => {
@@ -500,7 +533,7 @@ describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
 
     expect(screen.getByTestId("delete-worktree-confirm-input")).toBeDefined();
     const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
-    expect(button.textContent).toBe("Delete worktree");
+    expect(button.textContent).toBe("Force delete 'main'");
     expect(button.disabled).toBe(true);
   });
 
@@ -573,7 +606,7 @@ describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
 
     const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
-    expect(button.textContent).toBe("Delete worktree");
+    expect(button.textContent).toBe("Force delete 'abc1234'");
     expect(button.disabled).toBe(true);
 
     const input = screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement;
@@ -592,7 +625,7 @@ describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
 
     const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
-    expect(button.textContent).toBe("Delete worktree");
+    expect(button.textContent).toBe("Force delete 'abc1234'");
 
     const input = screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "abc1234" } });


### PR DESCRIPTION
## Summary
- The worktree delete dialog under-signalled the force-delete escalation. The button label always read "Delete worktree" regardless of tier, and the yellow advisory banner disappeared right when the user toggled force on — exactly the wrong moment for the warning to vanish.
- This makes the button label dynamic across the three escalation tiers: "Delete worktree", "Force delete worktree", and "Force delete '<branch>'". The banner now persists across the toggle, switching from a warning variant to an error variant instead of disappearing.
- Added `aria-live="polite"` to the destructive button so screen readers re-announce when the label changes.

Resolves #8398

## Changes
- `src/components/Worktree/WorktreeDeleteDialog.tsx` — dynamic button label, persistent banner with variant escalation, aria-live
- `src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx` — updated and new test cases for the three banner states and button label assertions

## Testing
- Unit tests cover all three banner states: standard warning (force off), error with tracked + untracked counts (force on + tracked), error with untracked-only (force on + no tracked)
- Button label assertions updated across medium and high tier tests to verify the dynamic labels