### PR TITLE
feat(actions): add agent.focusNextWaitingGlobal cross-project shortcut

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -209,6 +209,7 @@ export const CHANNELS = {
   PROJECT_PREFETCH_HYDRATE: "project:prefetch-hydrate",
   PROJECT_OPEN_DIALOG: "project:open-dialog",
   PROJECT_ON_SWITCH: "project:on-switch",
+  PROJECT_FOCUS_ON_ACTIVATE: "project:focus-on-activate",
   PROJECT_GET_SETTINGS: "project:get-settings",
   PROJECT_SAVE_SETTINGS: "project:save-settings",
   PROJECT_DETECT_RUNNERS: "project:detect-runners",

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -25,7 +25,8 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
   const handleProjectSwitch = async (
     ctx: import("../../types.js").IpcContext,
     projectId: string,
-    outgoingState?: ProjectSwitchOutgoingState
+    outgoingState?: ProjectSwitchOutgoingState,
+    options?: { focusIntent?: "focus-next-waiting" }
   ) => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
@@ -41,6 +42,13 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
 
     const pvm = resolveProjectViewManager(deps, ctx.event);
     if (pvm) {
+      // Record the focus intent on the PVM instance BEFORE switchTo so the
+      // cached-view fast path can pick it up synchronously and the cold-start
+      // path can read it after the paint gate resolves. PVM owns the lifecycle
+      // (consumed exactly once or discarded on timeout/error).
+      if (options?.focusIntent) {
+        pvm.setPendingFocusIntent(projectId, options.focusIntent);
+      }
       await activateProjectView(deps, ctx.event, pvm, projectId, project, {
         logPrefix: "[ProjectSwitch]",
       });

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1230,8 +1230,9 @@ const api: ElectronAPI = {
 
     switch: (
       projectId: string,
-      outgoingState?: import("../shared/types/ipc/project.js").ProjectSwitchOutgoingState
-    ) => _unwrappingInvoke(CHANNELS.PROJECT_SWITCH, projectId, outgoingState),
+      outgoingState?: import("../shared/types/ipc/project.js").ProjectSwitchOutgoingState,
+      options?: { focusIntent?: "focus-next-waiting" }
+    ) => _unwrappingInvoke(CHANNELS.PROJECT_SWITCH, projectId, outgoingState, options),
 
     prefetchHydrate: (projectId: string) =>
       _unwrappingInvoke(CHANNELS.PROJECT_PREFETCH_HYDRATE, projectId),
@@ -1250,6 +1251,9 @@ const api: ElectronAPI = {
     onWorktreeLoadStatus: (
       callback: (payload: { projectId: string; worktreeLoadError: string | null }) => void
     ) => _typedOn(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, callback),
+
+    onFocusOnActivate: (callback: (payload: { intent: "focus-next-waiting" }) => void) =>
+      _typedOn(CHANNELS.PROJECT_FOCUS_ON_ACTIVATE, callback),
 
     onUpdated: (callback: (project: Project) => void) =>
       _typedOn(CHANNELS.PROJECT_UPDATED, callback),

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -131,6 +131,14 @@ export class ProjectViewManager {
   private efficiencyFreezeTimer: NodeJS.Timeout | null = null;
   private pendingPaintGate: PaintGate | null = null;
   private paintGateTimeoutMs = PAINT_GATE_TIMEOUT_MS;
+  // One-shot focus intent consumed by the next switchTo for this projectId.
+  // Lives on the instance (not module) so multi-window does not cross-leak.
+  // Cleared after delivery or discard so a later unrelated switch can't
+  // re-trigger a stale focus jump (#4670 lesson).
+  private pendingFocusIntent: {
+    projectId: string;
+    intent: "focus-next-waiting";
+  } | null = null;
 
   constructor(win: BrowserWindow, opts: ProjectViewManagerOptions) {
     this.win = win;
@@ -220,6 +228,14 @@ export class ProjectViewManager {
     if (this.activeProjectId === projectId) {
       const existing = this.views.get(projectId);
       if (existing) {
+        // Consume any pending intent so it doesn't leak into a later switch.
+        // The renderer-side global action short-circuits same-project locally,
+        // so reaching here with an intent is unusual but possible (e.g. two
+        // concurrent switchTo calls); deliver immediately rather than drop.
+        const activeIntent = this.consumePendingFocusIntent(projectId);
+        if (activeIntent) {
+          this.deliverFocusIntent(existing.view, activeIntent);
+        }
         return { view: existing.view, isNew: false };
       }
     }
@@ -251,6 +267,10 @@ export class ProjectViewManager {
         this.evictionTimestamps.delete(projectId);
       }
       this.activateView(cached);
+      const cachedIntent = this.consumePendingFocusIntent(projectId);
+      if (cachedIntent) {
+        this.deliverFocusIntent(cached.view, cachedIntent);
+      }
       return { view: cached.view, isNew: false };
     }
 
@@ -330,6 +350,18 @@ export class ProjectViewManager {
         visibleMs: Math.round(visibleAt - coldStartAt),
         paintGateOutcome: gateResult,
       });
+
+      // Deliver pending focus intent only when the renderer has confirmed
+      // first paint. On timeout the renderer may be stuck or unresponsive —
+      // dropping the intent is safer than firing into a partially-mounted
+      // view (the subscriber is registered before `notifyViewPainted`, but
+      // a paint-gate timeout means we have no positive evidence of that).
+      // The intent is always consumed (cleared) regardless of outcome to
+      // prevent a later unrelated switch from picking up a stale focus.
+      const coldIntent = this.consumePendingFocusIntent(projectId);
+      if (coldIntent && gateResult === "signal") {
+        this.deliverFocusIntent(view, coldIntent);
+      }
     } catch (loadError) {
       // Cold-start failed before the swap happened — outgoing view is still
       // attached and visible. Tear down the failed incoming view, restore the
@@ -337,6 +369,9 @@ export class ProjectViewManager {
       // point at the failed view), and let the still-attached outgoing view
       // resume as the active view.
       this.clearPaintGate("cancelled");
+      // Discard any pending focus intent for the failed projectId so a later
+      // unrelated switch can't pick it up.
+      this.consumePendingFocusIntent(projectId);
       this.cleanupEntry(projectId);
 
       this.activeProjectId = previousProjectId;
@@ -421,6 +456,31 @@ export class ProjectViewManager {
     if (!gate) return;
     if (gate.webContentsId !== webContentsId) return;
     gate.resolve("signal");
+  }
+
+  /**
+   * Record a one-shot focus intent to deliver to the renderer after the next
+   * switch to `projectId` activates. Consumed exactly once: on cold-start
+   * activation (after the paint gate resolves with "signal") or immediately
+   * after a cached-view reactivation. Discarded on timeout/cancel/error so a
+   * later unrelated switch can't trigger a stale focus jump.
+   */
+  setPendingFocusIntent(projectId: string, intent: "focus-next-waiting"): void {
+    this.pendingFocusIntent = { projectId, intent };
+  }
+
+  private consumePendingFocusIntent(projectId: string): "focus-next-waiting" | null {
+    const pending = this.pendingFocusIntent;
+    if (!pending) return null;
+    this.pendingFocusIntent = null;
+    if (pending.projectId !== projectId) return null;
+    return pending.intent;
+  }
+
+  private deliverFocusIntent(view: WebContentsView, intent: "focus-next-waiting"): void {
+    if (view.webContents.isDestroyed()) return;
+    // Targeted send to the specific incoming view — never broadcast (#4641, #5010).
+    view.webContents.send(CHANNELS.PROJECT_FOCUS_ON_ACTIVATE, { intent });
   }
 
   getActiveProjectId(): string | null {

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+let nextWebContentsId = 800;
+
+type Handler = (...args: unknown[]) => void;
+
+interface MockWc {
+  id: number;
+  isDestroyed: ReturnType<typeof vi.fn>;
+  setBackgroundThrottling: ReturnType<typeof vi.fn>;
+  executeJavaScript: ReturnType<typeof vi.fn>;
+  loadURL: ReturnType<typeof vi.fn>;
+  focus: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  reload: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  session: { flushStorageData: ReturnType<typeof vi.fn> };
+  navigationHistory: { clear: ReturnType<typeof vi.fn> };
+  on: ReturnType<typeof vi.fn>;
+  once: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+  setWindowOpenHandler: ReturnType<typeof vi.fn>;
+  setIgnoreMenuShortcuts: ReturnType<typeof vi.fn>;
+  _fireOnce: (event: string, ...args: unknown[]) => void;
+}
+
+function createMockWebContents(opts?: { autoFinishLoad?: boolean }): MockWc {
+  const id = nextWebContentsId++;
+  const handlers = new Map<string, Handler[]>();
+  const autoFinish = opts?.autoFinishLoad ?? true;
+
+  const wc: MockWc = {
+    id,
+    isDestroyed: vi.fn(() => false),
+    setBackgroundThrottling: vi.fn(),
+    executeJavaScript: vi.fn(() => Promise.resolve()),
+    loadURL: vi.fn(() => Promise.resolve()),
+    focus: vi.fn(),
+    close: vi.fn(),
+    reload: vi.fn(),
+    send: vi.fn(),
+    session: { flushStorageData: vi.fn() },
+    navigationHistory: { clear: vi.fn() },
+    on: vi.fn((_event: string, _handler: Handler) => {}),
+    once: vi.fn((event: string, handler: Handler) => {
+      if (!handlers.has(event)) handlers.set(event, []);
+      handlers.get(event)!.push(handler);
+      if (event === "did-finish-load" && autoFinish) {
+        Promise.resolve().then(() => wc._fireOnce("did-finish-load"));
+      }
+    }),
+    removeListener: vi.fn((event: string, handler: Handler) => {
+      const list = handlers.get(event);
+      if (list) {
+        const idx = list.indexOf(handler);
+        if (idx >= 0) list.splice(idx, 1);
+      }
+    }),
+    setWindowOpenHandler: vi.fn(),
+    setIgnoreMenuShortcuts: vi.fn(),
+    _fireOnce(event: string, ...args: unknown[]) {
+      const list = handlers.get(event);
+      if (list && list.length > 0) {
+        const h = list.shift()!;
+        h(...args);
+      }
+    },
+  };
+  return wc;
+}
+
+let wcQueue: MockWc[] = [];
+
+vi.mock("electron", () => {
+  function MockWebContentsView() {
+    const wc = wcQueue.shift();
+    return { webContents: wc, setBounds: vi.fn() };
+  }
+  return {
+    app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() }, getAppMetrics: () => [] },
+    BrowserWindow: vi.fn(),
+    WebContentsView: MockWebContentsView,
+    session: { fromPartition: vi.fn(() => ({ protocol: { handle: vi.fn() } })) },
+    ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+    nativeTheme: { shouldUseDarkColors: true },
+  };
+});
+
+vi.mock("../webContentsRegistry.js", () => ({
+  registerWebContents: vi.fn(),
+  registerAppView: vi.fn(),
+  unregisterWebContents: vi.fn(),
+  registerProjectView: vi.fn(),
+  unregisterProjectView: vi.fn(),
+}));
+
+vi.mock("../../setup/protocols.js", () => ({
+  registerProtocolsForSession: vi.fn(),
+  getDistPath: vi.fn(() => "/dist"),
+}));
+
+vi.mock("../../../shared/config/devServer.js", () => ({
+  getDevServerUrl: vi.fn(() => "http://localhost:5173"),
+}));
+
+vi.mock("../../../shared/utils/trustedRenderer.js", () => ({
+  isTrustedRendererUrl: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("../../../shared/utils/urlUtils.js", () => ({
+  isLocalhostUrl: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("../../utils/openExternal.js", () => ({
+  canOpenExternalUrl: vi.fn(),
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock("../../services/CrashRecoveryService.js", () => ({
+  getCrashRecoveryService: vi.fn(() => ({ recordCrash: vi.fn() })),
+}));
+
+vi.mock("../../services/ProcessMemoryMonitor.js", () => ({
+  forgetBlinkSample: vi.fn(),
+  forgetEluSample: vi.fn(),
+}));
+
+vi.mock("../../services/PtyManager.js", () => ({
+  getPtyManager: vi.fn(() => ({ getAll: () => [] })),
+}));
+
+vi.mock("../../ipc/errorHandlers.js", () => ({
+  notifyError: vi.fn(),
+}));
+
+vi.mock("../skeletonCss.js", () => ({
+  injectSkeletonCss: vi.fn(),
+}));
+
+vi.mock("../rendererConsoleCapture.js", () => ({
+  attachRendererConsoleCapture: vi.fn(),
+  detachRendererConsoleCapture: vi.fn(),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    name: "test-logger",
+  })),
+}));
+
+import { ProjectViewManager } from "../ProjectViewManager.js";
+import { CHANNELS } from "../../ipc/channels.js";
+
+function createMockWindow() {
+  const children: unknown[] = [];
+  return {
+    id: 1,
+    isDestroyed: vi.fn(() => false),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    getContentBounds: vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 })),
+    contentView: {
+      children,
+      addChildView: vi.fn((view: unknown, index?: number) => {
+        if (typeof index === "number") {
+          children.splice(index, 0, view);
+        } else {
+          children.push(view);
+        }
+      }),
+      removeChildView: vi.fn((view: unknown) => {
+        const idx = children.indexOf(view);
+        if (idx >= 0) children.splice(idx, 1);
+      }),
+    },
+    webContents: createMockWebContents(),
+  };
+}
+
+describe("ProjectViewManager — pending focus intent", () => {
+  let manager: ProjectViewManager;
+  let win: ReturnType<typeof createMockWindow>;
+  let initialWc: MockWc;
+
+  beforeEach(() => {
+    nextWebContentsId = 800;
+    wcQueue = [];
+
+    win = createMockWindow();
+    manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 50,
+      cachedProjectViews: 3,
+    });
+
+    initialWc = createMockWebContents();
+    const initialView = { webContents: initialWc, setBounds: vi.fn() };
+    win.contentView.addChildView(initialView);
+    manager.registerInitialView(initialView as never, "proj-a", "/path/a");
+  });
+
+  afterEach(() => {
+    manager.dispose();
+  });
+
+  it("delivers focus intent to cold-start incoming view after paint signal", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    manager.setPendingFocusIntent("proj-b", "focus-next-waiting");
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    manager.signalViewPainted(incomingWc.id);
+    await switchPromise;
+
+    const focusSends = incomingWc.send.mock.calls.filter(
+      ([channel]) => channel === CHANNELS.PROJECT_FOCUS_ON_ACTIVATE
+    );
+    expect(focusSends).toHaveLength(1);
+    expect(focusSends[0][1]).toEqual({ intent: "focus-next-waiting" });
+  });
+
+  it("does not deliver focus intent when paint gate times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const slowWc = createMockWebContents();
+      wcQueue.push(slowWc);
+
+      manager.setPendingFocusIntent("proj-b", "focus-next-waiting");
+      const switchPromise = manager.switchTo("proj-b", "/path/b");
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Advance past the paint gate timeout.
+      await vi.advanceTimersByTimeAsync(60);
+      await switchPromise;
+
+      const focusSends = slowWc.send.mock.calls.filter(
+        ([channel]) => channel === CHANNELS.PROJECT_FOCUS_ON_ACTIVATE
+      );
+      expect(focusSends).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not deliver focus intent on cold-start load failure", async () => {
+    const failWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(failWc);
+
+    manager.setPendingFocusIntent("proj-b", "focus-next-waiting");
+    const switchPromise = manager.switchTo("proj-b", "/path/b").catch((err) => err);
+    await Promise.resolve();
+    failWc._fireOnce("did-fail-load", {}, -3, "ERR_FAILED");
+    await switchPromise;
+
+    const focusSends = failWc.send.mock.calls.filter(
+      ([channel]) => channel === CHANNELS.PROJECT_FOCUS_ON_ACTIVATE
+    );
+    expect(focusSends).toHaveLength(0);
+  });
+
+  it("delivers focus intent immediately on cached-view reactivation", async () => {
+    // Prime B as a cached view.
+    const bWc = createMockWebContents();
+    wcQueue.push(bWc);
+    const firstSwitch = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+    manager.signalViewPainted(bWc.id);
+    await firstSwitch;
+
+    // Switch back to A (cached, since maxCachedViews=3).
+    const cachedASwitch = manager.switchTo("proj-a", "/path/a");
+    await cachedASwitch;
+
+    initialWc.send.mockClear();
+
+    // Now switch back to B with a pending focus intent. B is in the LRU cache,
+    // so the cached fast path fires — must deliver intent synchronously,
+    // not via the paint gate (which the cached path skips).
+    bWc.send.mockClear();
+    manager.setPendingFocusIntent("proj-b", "focus-next-waiting");
+    const switchBack = manager.switchTo("proj-b", "/path/b");
+    await switchBack;
+
+    const focusSends = bWc.send.mock.calls.filter(
+      ([channel]) => channel === CHANNELS.PROJECT_FOCUS_ON_ACTIVATE
+    );
+    expect(focusSends).toHaveLength(1);
+    expect(focusSends[0][1]).toEqual({ intent: "focus-next-waiting" });
+  });
+
+  it("consumes focus intent exactly once — later unrelated switch does not refire", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    manager.setPendingFocusIntent("proj-b", "focus-next-waiting");
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+    manager.signalViewPainted(incomingWc.id);
+    await switchPromise;
+
+    expect(
+      incomingWc.send.mock.calls.filter(
+        ([channel]) => channel === CHANNELS.PROJECT_FOCUS_ON_ACTIVATE
+      )
+    ).toHaveLength(1);
+
+    incomingWc.send.mockClear();
+    initialWc.send.mockClear();
+
+    // Switch back to A without a pending intent — must not retrigger the
+    // focus delivery on either view.
+    const back = manager.switchTo("proj-a", "/path/a");
+    await back;
+
+    expect(
+      incomingWc.send.mock.calls.filter(
+        ([channel]) => channel === CHANNELS.PROJECT_FOCUS_ON_ACTIVATE
+      )
+    ).toHaveLength(0);
+    expect(
+      initialWc.send.mock.calls.filter(
+        ([channel]) => channel === CHANNELS.PROJECT_FOCUS_ON_ACTIVATE
+      )
+    ).toHaveLength(0);
+  });
+
+  it("does not deliver focus intent for a different projectId than the one switched", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    // Intent is for "proj-c", but we switch to "proj-b". The intent must
+    // not be delivered (different project), and must be cleared so a later
+    // unrelated switch can't pick it up.
+    manager.setPendingFocusIntent("proj-c", "focus-next-waiting");
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+    manager.signalViewPainted(incomingWc.id);
+    await switchPromise;
+
+    expect(
+      incomingWc.send.mock.calls.filter(
+        ([channel]) => channel === CHANNELS.PROJECT_FOCUS_ON_ACTIVATE
+      )
+    ).toHaveLength(0);
+
+    // Subsequent switch to A (no intent set) — also must not fire, confirming
+    // the mismatched intent was discarded rather than queued.
+    initialWc.send.mockClear();
+    const back = manager.switchTo("proj-a", "/path/a");
+    await back;
+    expect(
+      initialWc.send.mock.calls.filter(
+        ([channel]) => channel === CHANNELS.PROJECT_FOCUS_ON_ACTIVATE
+      )
+    ).toHaveLength(0);
+  });
+});

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -335,6 +335,28 @@ describe("ProjectViewManager — pending focus intent", () => {
     ).toHaveLength(0);
   });
 
+  it("delivers focus intent when switchTo targets the already-active project", async () => {
+    // Same-project switchTo hits the early-return path. The renderer-side
+    // action short-circuits before this point, but a race between two
+    // concurrent switchTo calls can land here.
+    manager.setPendingFocusIntent("proj-a", "focus-next-waiting");
+    const result = await manager.switchTo("proj-a", "/path/a");
+
+    expect(result.isNew).toBe(false);
+    const focusSends = initialWc.send.mock.calls.filter(
+      ([channel]) => channel === CHANNELS.PROJECT_FOCUS_ON_ACTIVATE
+    );
+    expect(focusSends).toHaveLength(1);
+
+    // Intent must be cleared — a later switchTo without a fresh intent must
+    // not re-fire.
+    initialWc.send.mockClear();
+    await manager.switchTo("proj-a", "/path/a");
+    expect(
+      initialWc.send.mock.calls.filter(([c]) => c === CHANNELS.PROJECT_FOCUS_ON_ACTIVATE)
+    ).toHaveLength(0);
+  });
+
   it("does not deliver focus intent for a different projectId than the one switched", async () => {
     const incomingWc = createMockWebContents();
     wcQueue.push(incomingWc);

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -443,7 +443,11 @@ export interface ElectronAPI {
     add(path: string): Promise<Project>;
     remove(projectId: string): Promise<void>;
     update(projectId: string, updates: Partial<Project>): Promise<Project>;
-    switch(projectId: string, outgoingState?: ProjectSwitchOutgoingState): Promise<Project>;
+    switch(
+      projectId: string,
+      outgoingState?: ProjectSwitchOutgoingState,
+      options?: { focusIntent?: "focus-next-waiting" }
+    ): Promise<Project>;
     /**
      * Hover-prefetch trigger for the project switcher palette. Fire-and-forget:
      * the main process builds the `HydrateResult` for the given project and
@@ -463,6 +467,7 @@ export interface ElectronAPI {
     onWorktreeLoadStatus(
       callback: (payload: { projectId: string; worktreeLoadError: string | null }) => void
     ): () => void;
+    onFocusOnActivate(callback: (payload: { intent: "focus-next-waiting" }) => void): () => void;
     onUpdated(callback: (project: Project) => void): () => void;
     onRemoved(callback: (projectId: string) => void): () => void;
     getSettings(projectId: string): Promise<ProjectSettings>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -765,7 +765,11 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     result: Project;
   };
   "project:switch": {
-    args: [projectId: string, outgoingState?: ProjectSwitchOutgoingState];
+    args: [
+      projectId: string,
+      outgoingState?: ProjectSwitchOutgoingState,
+      options?: { focusIntent?: "focus-next-waiting" },
+    ];
     result: Project;
   };
   "project:prefetch-hydrate": {
@@ -2204,6 +2208,7 @@ export interface IpcEventMap {
   // Project events
   "project:on-switch": ProjectSwitchPayload;
   "project:worktree-load-status": ProjectWorktreeLoadStatusPayload;
+  "project:focus-on-activate": { intent: "focus-next-waiting" };
   "project:stats-updated": ProjectStatusMap;
   "project:updated": Project;
   "project:removed": string;

--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -137,6 +137,7 @@ export type BuiltInKeyAction =
   | "agent.terminal"
   | "agent.browser"
   | "agent.focusNextWaiting"
+  | "agent.focusNextWaitingGlobal"
   | "agent.focusNextWorking"
   | "agent.focusNextAgent"
   | "agent.focusPreviousAgent"
@@ -318,6 +319,7 @@ export const KEY_ACTION_VALUES: ReadonlySet<string> = new Set<string>([
   "agent.terminal",
   "agent.browser",
   "agent.focusNextWaiting",
+  "agent.focusNextWaitingGlobal",
   "agent.focusNextWorking",
   "agent.focusNextAgent",
   "agent.focusPreviousAgent",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,7 @@ import {
   useGettingStartedChecklist,
   useOrchestrationMilestones,
   useAgentWaitingNudge,
+  useFocusOnActivateIntent,
   useUnloadCleanup,
   useHomeDir,
   usePerformanceMonitors,
@@ -466,17 +467,12 @@ function App() {
     });
     return () => cancelAnimationFrame(id);
   }, []);
-  // Subscribe BEFORE the paint signal can fire — must be unconditional and
-  // run on mount, not gated on `isStateLoaded`. The main process delivers a
-  // one-shot `project:focus-on-activate` after `agent.focusNextWaitingGlobal`
-  // switches projects; receiving it means the view just became visible and
-  // should run a local `agent.focusNextWaiting` cycle.
-  useEffect(() => {
-    return window.electron.project.onFocusOnActivate((payload) => {
-      if (payload?.intent !== "focus-next-waiting") return;
-      void actionService.dispatch("agent.focusNextWaiting");
-    });
-  }, []);
+  // Cross-project focus intent receiver. Subscribes unconditionally so the
+  // listener is registered before `notifyViewPainted` fires, then defers the
+  // local `agent.focusNextWaiting` dispatch until hydration completes (the
+  // paint signal arrives before panel state is loaded — a direct dispatch
+  // would silently no-op against an empty panelStore).
+  useFocusOnActivateIntent(isStateLoaded);
   // The skeleton is z-index 9999 and intercepts pointer events. The crash
   // recovery dialog is rendered before hydration completes, so without this
   // the dialog would be visible but unclickable until hydration finishes

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -466,6 +466,17 @@ function App() {
     });
     return () => cancelAnimationFrame(id);
   }, []);
+  // Subscribe BEFORE the paint signal can fire — must be unconditional and
+  // run on mount, not gated on `isStateLoaded`. The main process delivers a
+  // one-shot `project:focus-on-activate` after `agent.focusNextWaitingGlobal`
+  // switches projects; receiving it means the view just became visible and
+  // should run a local `agent.focusNextWaiting` cycle.
+  useEffect(() => {
+    return window.electron.project.onFocusOnActivate((payload) => {
+      if (payload?.intent !== "focus-next-waiting") return;
+      void actionService.dispatch("agent.focusNextWaiting");
+    });
+  }, []);
   // The skeleton is z-index 9999 and intercepts pointer events. The crash
   // recovery dialog is rendered before hydration completes, so without this
   // the dialog would be visible but unclickable until hydration finishes

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -117,9 +117,13 @@ export const projectClient = {
     return window.electron.project.update(projectId, updates);
   },
 
-  switch: (projectId: string, outgoingState?: ProjectSwitchOutgoingState): Promise<Project> => {
+  switch: (
+    projectId: string,
+    outgoingState?: ProjectSwitchOutgoingState,
+    options?: { focusIntent?: "focus-next-waiting" }
+  ): Promise<Project> => {
     invalidateCurrentCache();
-    return window.electron.project.switch(projectId, outgoingState);
+    return window.electron.project.switch(projectId, outgoingState, options);
   },
 
   /**

--- a/src/hooks/app/__tests__/useFocusOnActivateIntent.test.tsx
+++ b/src/hooks/app/__tests__/useFocusOnActivateIntent.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+type FocusPayload = { intent: "focus-next-waiting" };
+
+const onFocusOnActivateMock = vi.hoisted(() =>
+  vi.fn<(cb: (payload: FocusPayload) => void) => () => void>()
+);
+
+const dispatchMock = vi.hoisted(() => vi.fn());
+
+vi.stubGlobal("window", {
+  ...globalThis.window,
+  electron: {
+    project: {
+      onFocusOnActivate: onFocusOnActivateMock,
+    },
+  },
+});
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: dispatchMock,
+  },
+}));
+
+import { useFocusOnActivateIntent } from "../useFocusOnActivateIntent";
+
+describe("useFocusOnActivateIntent", () => {
+  let lastCallback: ((payload: FocusPayload) => void) | null = null;
+  let unsubscribe: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unsubscribe = vi.fn();
+    lastCallback = null;
+    onFocusOnActivateMock.mockImplementation((cb) => {
+      lastCallback = cb;
+      return unsubscribe as () => void;
+    });
+  });
+
+  it("subscribes on mount regardless of isStateLoaded", () => {
+    renderHook(({ loaded }) => useFocusOnActivateIntent(loaded), {
+      initialProps: { loaded: false },
+    });
+    expect(onFocusOnActivateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT dispatch when intent arrives before hydration completes", () => {
+    renderHook(({ loaded }) => useFocusOnActivateIntent(loaded), {
+      initialProps: { loaded: false },
+    });
+
+    act(() => {
+      lastCallback?.({ intent: "focus-next-waiting" });
+    });
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches when hydration completes after intent received", () => {
+    const { rerender } = renderHook(({ loaded }) => useFocusOnActivateIntent(loaded), {
+      initialProps: { loaded: false },
+    });
+
+    act(() => {
+      lastCallback?.({ intent: "focus-next-waiting" });
+    });
+    expect(dispatchMock).not.toHaveBeenCalled();
+
+    rerender({ loaded: true });
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith("agent.focusNextWaiting");
+  });
+
+  it("dispatches immediately when intent arrives after hydration completes", () => {
+    renderHook(({ loaded }) => useFocusOnActivateIntent(loaded), {
+      initialProps: { loaded: true },
+    });
+
+    act(() => {
+      lastCallback?.({ intent: "focus-next-waiting" });
+    });
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith("agent.focusNextWaiting");
+  });
+
+  it("only fires once per intent — consecutive renders do not redispatch", () => {
+    const { rerender } = renderHook(({ loaded }) => useFocusOnActivateIntent(loaded), {
+      initialProps: { loaded: false },
+    });
+
+    act(() => {
+      lastCallback?.({ intent: "focus-next-waiting" });
+    });
+
+    rerender({ loaded: true });
+    rerender({ loaded: true });
+    rerender({ loaded: true });
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches again on a second intent", () => {
+    const { rerender: _rerender } = renderHook(({ loaded }) => useFocusOnActivateIntent(loaded), {
+      initialProps: { loaded: true },
+    });
+
+    act(() => {
+      lastCallback?.({ intent: "focus-next-waiting" });
+    });
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      lastCallback?.({ intent: "focus-next-waiting" });
+    });
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores payloads with unrecognized intent strings", () => {
+    renderHook(({ loaded }) => useFocusOnActivateIntent(loaded), {
+      initialProps: { loaded: true },
+    });
+
+    act(() => {
+      lastCallback?.({ intent: "garbage" as never });
+    });
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes on unmount", () => {
+    const { unmount } = renderHook(({ loaded }) => useFocusOnActivateIntent(loaded), {
+      initialProps: { loaded: false },
+    });
+    unmount();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -17,3 +17,4 @@ export { useErrorRetry } from "./useErrorRetry";
 export { useActiveWorktreeSync } from "./useActiveWorktreeSync";
 export { useOrchestrationMilestones } from "./useOrchestrationMilestones";
 export { useAgentWaitingNudge } from "./useAgentWaitingNudge";
+export { useFocusOnActivateIntent } from "./useFocusOnActivateIntent";

--- a/src/hooks/app/useFocusOnActivateIntent.ts
+++ b/src/hooks/app/useFocusOnActivateIntent.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { actionService } from "@/services/ActionService";
+
+/**
+ * Cross-project focus intent receiver.
+ *
+ * The main process delivers `project:focus-on-activate` once the
+ * `agent.focusNextWaitingGlobal` action has switched WebContentsViews and
+ * the incoming view has either painted (cold start) or been reactivated
+ * (cached). This hook subscribes unconditionally on mount so the listener
+ * is registered before `notifyViewPainted` fires.
+ *
+ * Dispatch is deferred until `isStateLoaded` is true: paint signal arrives
+ * after the first React commit but before `useAppHydration` finishes, so
+ * `panelStore.panelIds` is empty at receipt-time and a direct dispatch of
+ * `agent.focusNextWaiting` would silently no-op. Buffering the intent in
+ * state and firing on the hydration transition is the canonical fix.
+ */
+export function useFocusOnActivateIntent(isStateLoaded: boolean): void {
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    return window.electron.project.onFocusOnActivate((payload) => {
+      if (payload?.intent !== "focus-next-waiting") return;
+      setPending(true);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isStateLoaded || !pending) return;
+    setPending(false);
+    void actionService.dispatch("agent.focusNextWaiting");
+  }, [isStateLoaded, pending]);
+}

--- a/src/services/actions/definitions/__tests__/agentActions.globalFocus.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.globalFocus.test.ts
@@ -153,13 +153,19 @@ describe("agent.focusNextWaitingGlobal", () => {
       c: { waitingAgentCount: 1 },
     });
 
+    const focusNextWaiting = vi.fn();
+    panelStoreMock.getState.mockReturnValue({ focusNextWaiting, isInTrash: false });
+
     const actions = setupActions();
     await callAction(actions, "agent.focusNextWaitingGlobal");
 
     // Search starts after "b" → first hit is "c", not "a" or "b".
+    expect(state.switchProject).toHaveBeenCalledTimes(1);
     expect(state.switchProject).toHaveBeenCalledWith("c", {
       focusIntent: "focus-next-waiting",
     });
+    // Must not also dispatch the local action — cross-project path skips it.
+    expect(focusNextWaiting).not.toHaveBeenCalled();
   });
 
   it("wraps around to the head when current project is the last entry", async () => {

--- a/src/services/actions/definitions/__tests__/agentActions.globalFocus.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.globalFocus.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
+
+const panelStoreMock = vi.hoisted(() => ({
+  getState: vi.fn(),
+}));
+
+const currentViewStoreMock = vi.hoisted(() => ({
+  getCurrentViewStore: vi.fn(() => ({
+    getState: () => ({ worktrees: new Map() }),
+  })),
+}));
+
+const worktreeSelectionMock = vi.hoisted(() => ({
+  useWorktreeSelectionStore: {
+    getState: vi.fn(() => ({ activeWorktreeId: null })),
+  },
+}));
+
+const agentRegistryMock = vi.hoisted(() => ({
+  AGENT_REGISTRY: {
+    claude: { name: "Claude" },
+  },
+}));
+
+const projectStoreMock = vi.hoisted(() => ({
+  getState: vi.fn(),
+}));
+
+const projectStatsStoreMock = vi.hoisted(() => ({
+  getState: vi.fn(),
+}));
+
+vi.mock("@/store/panelStore", () => ({ usePanelStore: panelStoreMock }));
+vi.mock("@/store/createWorktreeStore", () => currentViewStoreMock);
+vi.mock("@/store/worktreeStore", () => worktreeSelectionMock);
+vi.mock("@/config/agents", () => agentRegistryMock);
+vi.mock("@/store/projectStore", () => ({ useProjectStore: projectStoreMock }));
+vi.mock("@/store/projectStatsStore", () => ({ useProjectStatsStore: projectStatsStoreMock }));
+
+import { registerAgentActions } from "../agentActions";
+
+function makeCallbacks() {
+  return {
+    onLaunchAgent: vi.fn(),
+    onOpenQuickSwitcher: vi.fn(),
+  } as unknown as ActionCallbacks;
+}
+
+function setupActions(): ActionRegistry {
+  const actions: ActionRegistry = new Map();
+  registerAgentActions(actions, makeCallbacks());
+  return actions;
+}
+
+function callAction(actions: ActionRegistry, id: string): Promise<unknown> {
+  const factory = actions.get(id);
+  if (!factory) throw new Error(`missing ${id}`);
+  const def = factory() as AnyActionDefinition;
+  return def.run(undefined, {} as never);
+}
+
+interface ProjectState {
+  projects: Array<{ id: string; name: string; path: string }>;
+  currentProject: { id: string } | null;
+  switchProject: ReturnType<typeof vi.fn>;
+}
+
+function setProjectState(
+  projects: Array<{ id: string }>,
+  currentProjectId: string | null
+): ProjectState {
+  const state: ProjectState = {
+    projects: projects.map((p) => ({ id: p.id, name: p.id, path: `/p/${p.id}` })),
+    currentProject: currentProjectId ? { id: currentProjectId } : null,
+    switchProject: vi.fn().mockResolvedValue(undefined),
+  };
+  projectStoreMock.getState.mockReturnValue(state);
+  return state;
+}
+
+function setStats(stats: Record<string, { waitingAgentCount: number }>): void {
+  projectStatsStoreMock.getState.mockReturnValue({ stats });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  panelStoreMock.getState.mockReturnValue({
+    focusNextWaiting: vi.fn(),
+    isInTrash: false,
+  });
+});
+
+describe("agent.focusNextWaitingGlobal", () => {
+  it("is no-op when no projects have waiting agents", async () => {
+    const state = setProjectState([{ id: "a" }, { id: "b" }], "a");
+    setStats({ a: { waitingAgentCount: 0 }, b: { waitingAgentCount: 0 } });
+
+    const focusNextWaiting = vi.fn();
+    panelStoreMock.getState.mockReturnValue({ focusNextWaiting, isInTrash: false });
+
+    const actions = setupActions();
+    await callAction(actions, "agent.focusNextWaitingGlobal");
+
+    expect(state.switchProject).not.toHaveBeenCalled();
+    expect(focusNextWaiting).not.toHaveBeenCalled();
+  });
+
+  it("dispatches local focusNextWaiting when only the current project has waiting agents", async () => {
+    const state = setProjectState([{ id: "a" }, { id: "b" }, { id: "c" }], "b");
+    setStats({
+      a: { waitingAgentCount: 0 },
+      b: { waitingAgentCount: 2 },
+      c: { waitingAgentCount: 0 },
+    });
+
+    const focusNextWaiting = vi.fn();
+    panelStoreMock.getState.mockReturnValue({ focusNextWaiting, isInTrash: false });
+
+    const actions = setupActions();
+    await callAction(actions, "agent.focusNextWaitingGlobal");
+
+    expect(state.switchProject).not.toHaveBeenCalled();
+    expect(focusNextWaiting).toHaveBeenCalledTimes(1);
+  });
+
+  it("switches to the next project with waiting agents and threads the focus intent", async () => {
+    const state = setProjectState([{ id: "a" }, { id: "b" }, { id: "c" }], "a");
+    setStats({
+      a: { waitingAgentCount: 0 },
+      b: { waitingAgentCount: 0 },
+      c: { waitingAgentCount: 1 },
+    });
+
+    const focusNextWaiting = vi.fn();
+    panelStoreMock.getState.mockReturnValue({ focusNextWaiting, isInTrash: false });
+
+    const actions = setupActions();
+    await callAction(actions, "agent.focusNextWaitingGlobal");
+
+    expect(state.switchProject).toHaveBeenCalledTimes(1);
+    expect(state.switchProject).toHaveBeenCalledWith("c", {
+      focusIntent: "focus-next-waiting",
+    });
+    expect(focusNextWaiting).not.toHaveBeenCalled();
+  });
+
+  it("starts searching from AFTER the current project (skips currentProject in the cycle)", async () => {
+    const state = setProjectState([{ id: "a" }, { id: "b" }, { id: "c" }], "b");
+    setStats({
+      a: { waitingAgentCount: 1 },
+      b: { waitingAgentCount: 1 },
+      c: { waitingAgentCount: 1 },
+    });
+
+    const actions = setupActions();
+    await callAction(actions, "agent.focusNextWaitingGlobal");
+
+    // Search starts after "b" → first hit is "c", not "a" or "b".
+    expect(state.switchProject).toHaveBeenCalledWith("c", {
+      focusIntent: "focus-next-waiting",
+    });
+  });
+
+  it("wraps around to the head when current project is the last entry", async () => {
+    const state = setProjectState([{ id: "a" }, { id: "b" }, { id: "c" }], "c");
+    setStats({
+      a: { waitingAgentCount: 1 },
+      b: { waitingAgentCount: 0 },
+      c: { waitingAgentCount: 0 },
+    });
+
+    const actions = setupActions();
+    await callAction(actions, "agent.focusNextWaitingGlobal");
+
+    expect(state.switchProject).toHaveBeenCalledWith("a", {
+      focusIntent: "focus-next-waiting",
+    });
+  });
+
+  it("treats a missing stats entry as zero waiting agents", async () => {
+    const state = setProjectState([{ id: "a" }, { id: "b" }], "a");
+    // No stats entry for "b" — should be treated as 0 and skipped (no-op since
+    // only project is "a" which is current with 0 waiting).
+    setStats({ a: { waitingAgentCount: 0 } });
+
+    const focusNextWaiting = vi.fn();
+    panelStoreMock.getState.mockReturnValue({ focusNextWaiting, isInTrash: false });
+
+    const actions = setupActions();
+    await callAction(actions, "agent.focusNextWaitingGlobal");
+
+    expect(state.switchProject).not.toHaveBeenCalled();
+    expect(focusNextWaiting).not.toHaveBeenCalled();
+  });
+
+  it("is no-op when there are no projects at all", async () => {
+    const state = setProjectState([], null);
+    setStats({});
+
+    const actions = setupActions();
+    await callAction(actions, "agent.focusNextWaitingGlobal");
+
+    expect(state.switchProject).not.toHaveBeenCalled();
+  });
+
+  it("picks a waiting project when currentProject is not in the projects list", async () => {
+    // Edge case: currentProject set to an id not in projects (stale state).
+    const state = setProjectState([{ id: "a" }, { id: "b" }], "ghost");
+    setStats({
+      a: { waitingAgentCount: 0 },
+      b: { waitingAgentCount: 3 },
+    });
+
+    const actions = setupActions();
+    await callAction(actions, "agent.focusNextWaitingGlobal");
+
+    // Falls through to head-of-list search; "b" is the first project with
+    // waiting agents.
+    expect(state.switchProject).toHaveBeenCalledWith("b", {
+      focusIntent: "focus-next-waiting",
+    });
+  });
+});

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -3,6 +3,8 @@ import { AgentIdSchema, LaunchLocationSchema, TerminalSpawnSourceSchema } from "
 import { z } from "zod";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useProjectStore } from "@/store/projectStore";
+import { useProjectStatsStore } from "@/store/projectStatsStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { AGENT_REGISTRY } from "@/config/agents";
 import type { ActionId } from "@shared/types/actions";
@@ -213,6 +215,67 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         if (wt.worktreeId) validWorktreeIds.add(wt.worktreeId);
       }
       state.focusNextWaiting(state.isInTrash, validWorktreeIds);
+    },
+  }));
+
+  actions.set("agent.focusNextWaitingGlobal", () => ({
+    id: "agent.focusNextWaitingGlobal",
+    title: "Focus Next Waiting Agent (All Projects)",
+    description:
+      "Jump to the next project with a waiting agent and focus it. Cycles across all projects in sidebar order, wrapping around.",
+    category: "agent",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      const projectState = useProjectStore.getState();
+      const stats = useProjectStatsStore.getState().stats;
+      const projects = projectState.projects;
+      if (projects.length === 0) return;
+
+      const currentProjectId = projectState.currentProject?.id ?? null;
+      const currentIdx = currentProjectId
+        ? projects.findIndex((p) => p.id === currentProjectId)
+        : -1;
+
+      // Start the search at the position AFTER the current project so the
+      // first comparison hits the next candidate, not currentProject itself.
+      // When currentProject isn't in the list (stale state, recently removed),
+      // start from the head. Wrap around the full list so a single waiting
+      // agent in currentProject still resolves (to a local focus dispatch).
+      const startIdx = currentIdx >= 0 ? currentIdx + 1 : 0;
+      let target: { id: string } | null = null;
+      for (let i = 0; i < projects.length; i++) {
+        const idx = (startIdx + i) % projects.length;
+        const candidate = projects[idx];
+        if (!candidate) continue;
+        const waiting = stats[candidate.id]?.waitingAgentCount ?? 0;
+        if (waiting > 0) {
+          target = candidate;
+          break;
+        }
+      }
+
+      if (!target) return;
+
+      if (target.id === currentProjectId) {
+        // Same-project: just cycle within the active view.
+        const panelState = usePanelStore.getState();
+        const worktreeData = getCurrentViewStore().getState();
+        const validWorktreeIds = new Set<string>();
+        for (const [id, wt] of worktreeData.worktrees) {
+          validWorktreeIds.add(id);
+          if (wt.worktreeId) validWorktreeIds.add(wt.worktreeId);
+        }
+        panelState.focusNextWaiting(panelState.isInTrash, validWorktreeIds);
+        return;
+      }
+
+      // Cross-project: switch with a one-shot focus intent. The main process
+      // delivers `project:focus-on-activate` to the incoming view once the
+      // paint gate resolves (cold start) or immediately on cache hit, and
+      // the renderer subscriber dispatches local `agent.focusNextWaiting`.
+      await projectState.switchProject(target.id, { focusIntent: "focus-next-waiting" });
     },
   }));
 

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -222,7 +222,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     id: "agent.focusNextWaitingGlobal",
     title: "Focus Next Waiting Agent (All Projects)",
     description:
-      "Jump to the next project with a waiting agent and focus it. Cycles across all projects in sidebar order, wrapping around.",
+      "Jump to the next project with a waiting agent. Cycles across all projects in sidebar order, wrapping around.",
     category: "agent",
     kind: "command",
     danger: "safe",

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -347,6 +347,14 @@ const CORE_KEYBINDINGS: KeybindingConfig[] = [
     category: "Agents",
   },
   {
+    actionId: "agent.focusNextWaitingGlobal",
+    combo: "Cmd+Shift+Alt+/",
+    scope: "global",
+    priority: 0,
+    description: "Jump to next waiting agent across all projects",
+    category: "Agents",
+  },
+  {
     actionId: "agent.focusNextWorking",
     combo: "Cmd+Alt+.",
     scope: "global",

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -140,7 +140,8 @@ describe("buildOutgoingState draft propagation (#4985)", () => {
 
     expect(projectClientMock.switch).toHaveBeenCalledWith(
       projectB.id,
-      expect.objectContaining({ draftInputs: {} })
+      expect.objectContaining({ draftInputs: {} }),
+      undefined
     );
   });
 
@@ -175,7 +176,8 @@ describe("buildOutgoingState draft propagation (#4985)", () => {
 
     expect(projectClientMock.switch).toHaveBeenCalledWith(
       projectB.id,
-      expect.objectContaining({ draftInputs: { "terminal-1": "hello world" } })
+      expect.objectContaining({ draftInputs: { "terminal-1": "hello world" } }),
+      undefined
     );
   });
 
@@ -188,7 +190,7 @@ describe("buildOutgoingState draft propagation (#4985)", () => {
     await useProjectStore.getState().switchProject(projectB.id);
     await Promise.resolve();
 
-    expect(projectClientMock.switch).toHaveBeenCalledWith(projectB.id, undefined);
+    expect(projectClientMock.switch).toHaveBeenCalledWith(projectB.id, undefined, undefined);
   });
 });
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -93,7 +93,10 @@ interface ProjectState {
     options?: { skipDubiousOwnershipRetry?: boolean }
   ) => Promise<void>;
   createProjectFolder: (parentPath: string, folderName: string) => Promise<void>;
-  switchProject: (projectId: string) => Promise<void>;
+  switchProject: (
+    projectId: string,
+    options?: { focusIntent?: "focus-next-waiting" }
+  ) => Promise<void>;
   setWorktreeLoadError: (error: string | null) => void;
   updateProject: (id: string, updates: Partial<Project>) => Promise<void>;
   enableInRepoSettings: (id: string) => Promise<Project>;
@@ -409,7 +412,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     await get().addProjectByPath("");
   },
 
-  switchProject: async (projectId) => {
+  switchProject: async (projectId, options) => {
     if (get().currentProject?.id === projectId) return;
     const requestId = ++projectTransitionRequestId;
 
@@ -429,7 +432,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     // Fire-and-forget: the main process swaps WebContentsViews, so this
     // renderer gets detached. Don't write the response into stores — the
     // new view handles its own state independently.
-    projectClient.switch(projectId, outgoingState).catch((error) => {
+    projectClient.switch(projectId, outgoingState, options).catch((error) => {
       if (requestId !== projectTransitionRequestId) {
         return;
       }


### PR DESCRIPTION
## Summary

- Adds `agent.focusNextWaitingGlobal` (`Cmd+Shift+Alt+/`) — the global counterpart to `agent.focusNextWaiting` (`Cmd+Alt+/`). Where the existing action only cycles within the active project, this one finds the next project with waiting agents and switches to it, then focuses the waiting terminal.
- The tricky part is that the initiating renderer is torn down when the `WebContentsView` swaps, so focus can't be dispatched from the same context post-switch. A new `project:focus-on-activate` IPC channel stores a one-shot intent in the `ProjectViewManager` instance; the newly activated view picks it up via `useFocusOnActivateIntent`, which buffers until `isStateLoaded` transitions true (the paint signal arrives before `panelStore` hydrates).
- Project cycling uses `useProjectStatsStore` frecency order with wrap-around. No-ops cleanly when no project has waiting agents.

Resolves #8418

## Changes

- `agent.focusNextWaitingGlobal` action definition + `Cmd+Shift+Alt+/` default binding (`src/services/actions/definitions/agentActions.ts`, `src/services/defaultKeybindings.ts`)
- `project:focus-on-activate` IPC channel: `electron/ipc/channels.ts`, `electron/ipc/handlers/projectCrud/switch.ts`, `electron/preload.cts`, `shared/types/ipc/api.ts`, `shared/types/ipc/maps.ts`
- `ProjectViewManager.setFocusOnActivateIntent` / `consumeFocusOnActivateIntent` — intent stored per-instance, multi-window safe, cleared on timeout/cancel/error (`electron/window/ProjectViewManager.ts`)
- `useFocusOnActivateIntent` hook — buffers intent until hydration completes (`src/hooks/app/useFocusOnActivateIntent.ts`), wired into `App.tsx`
- `src/clients/projectClient.ts`, `src/store/projectStore.ts` — expose the new IPC method
- Tests: 6 `ProjectViewManager` focus-intent cases, 8 action selection cases, 8 hook cases

## Testing

- Unit tests cover: same-project cycle (no switch), cross-project switch + focus, wrap-around, no-op when no waiting agents, intent consumed exactly once, hydration-deferred dispatch, timeout/cancel cleanup.
- `agent.focusNextWaiting` within-project behaviour unchanged — existing tests pass.