### PR TITLE
fix(worktree): add second recovery action to zero-result empty states

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1166,15 +1166,18 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                   action={
                     <>
                       <button
+                        type="button"
                         onClick={clearAllFilters}
                         className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
                       >
                         Show all worktrees
                       </button>
                       <button
+                        type="button"
                         onClick={onOpenOverview}
                         className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors ml-1"
                         title={formatButtonTitle("Open overview", overviewShortcut)}
+                        aria-keyshortcuts={overviewAriaShortcut}
                       >
                         Open overview
                       </button>
@@ -1197,15 +1200,18 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                   action={
                     <>
                       <button
+                        type="button"
                         onClick={clearAllFilters}
                         className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
                       >
                         Show all worktrees
                       </button>
                       <button
+                        type="button"
                         onClick={onOpenOverview}
                         className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors ml-1"
                         title={formatButtonTitle("Open overview", overviewShortcut)}
+                        aria-keyshortcuts={overviewAriaShortcut}
                       >
                         Open overview
                       </button>

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1164,12 +1164,21 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                       : `No ${quickStateFilter} worktrees`
                   }
                   action={
-                    <button
-                      onClick={clearAllFilters}
-                      className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-                    >
-                      Show all worktrees
-                    </button>
+                    <>
+                      <button
+                        onClick={clearAllFilters}
+                        className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
+                      >
+                        Show all worktrees
+                      </button>
+                      <button
+                        onClick={onOpenOverview}
+                        className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors ml-1"
+                        title={formatButtonTitle("Open overview", overviewShortcut)}
+                      >
+                        Open overview
+                      </button>
+                    </>
                   }
                 />
               ) : filteredWorktrees.length === 0 &&
@@ -1186,12 +1195,21 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                       : "No matching worktrees"
                   }
                   action={
-                    <button
-                      onClick={clearAllFilters}
-                      className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-                    >
-                      Show all worktrees
-                    </button>
+                    <>
+                      <button
+                        onClick={clearAllFilters}
+                        className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
+                      >
+                        Show all worktrees
+                      </button>
+                      <button
+                        onClick={onOpenOverview}
+                        className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors ml-1"
+                        title={formatButtonTitle("Open overview", overviewShortcut)}
+                      >
+                        Open overview
+                      </button>
+                    </>
                   }
                 />
               ) : groupedSections ? (

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -135,25 +135,26 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       expect(branch).toContain('variant="filtered-empty"');
     });
 
-    it("collapses the quick-state empty state to a single 'Show all worktrees' CTA wired to clearAllFilters — issue #7971", () => {
-      // #6934 collapsed the dual-CTA shape ('Show all states' + 'Clear all
-      // filters') to a single button wired to clearAll(); #7971 renamed the
-      // label from "Clear filters" to "Show all worktrees" so the button
-      // describes the outcome rather than the action.
+    it("renders the quick-state empty state with dual recovery actions: clear filters and open overview — issue #8383", () => {
+      // #6934 collapsed the dual-CTA shape to a single button wired to
+      // clearAll(). #8383 intentionally restores a second action: "Open
+      // overview" gives users an alternative escape path to the full
+      // worktrees overview modal instead of clearing filters.
       const branchStart = source.indexOf("showQuickStateEmptyState ?");
       const branchEnd = source.indexOf(") : filteredWorktrees.length === 0 &&", branchStart);
       const branch = source.slice(branchStart, branchEnd);
       expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Show all worktrees\s*</);
-      expect(branch).not.toContain("Show all states");
-      expect(branch).not.toContain("clearQuickStateFilter");
-      // Exactly one button — guards against the dual-CTA pattern returning by
-      // any other shape (e.g. an additional secondary action being added).
+      expect(branch).toMatch(/onClick=\{onOpenOverview\}[\s\S]*?>\s*Open overview\s*</);
+      // Two buttons — "Show all worktrees" and "Open overview"
       const buttonMatches = branch.match(/<button\b/g) ?? [];
-      expect(buttonMatches).toHaveLength(1);
+      expect(buttonMatches).toHaveLength(2);
     });
 
-    it("does not render two recovery CTAs side-by-side in the quick-state branch", () => {
-      // Regression guard against the dual-button anti-pattern returning.
+    it("renders the dual recovery actions in the quick-state branch with the overview shortcut in the title — issue #8383", () => {
+      // The "Open overview" button surfaces the keyboard shortcut via
+      // formatButtonTitle in a title attribute, matching the toolbar pattern.
+      // The old "Show all states" / "Clear all filters" strings from the
+      // pre-#6934 dual-CTA shape must not reappear.
       expect(source).not.toContain("Show all states");
       expect(source).not.toContain("Clear all filters");
     });
@@ -180,6 +181,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       expect(branch).toMatch(/hasQuery/);
       expect(branch).toMatch(/truncateSearchQuery/);
       expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Show all worktrees\s*</);
+      expect(branch).toMatch(/onClick=\{onOpenOverview\}[\s\S]*?>\s*Open overview\s*</);
     });
   });
 });

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -157,6 +157,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       // pre-#6934 dual-CTA shape must not reappear.
       expect(source).not.toContain("Show all states");
       expect(source).not.toContain("Clear all filters");
+      expect(source).toContain('title={formatButtonTitle("Open overview", overviewShortcut)}');
     });
 
     it("does not render a description in the quick-state branch (single CTA conveys recovery)", () => {

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -555,9 +555,14 @@ export function WorktreeOverviewModal({
                   filters
                 </p>
               </div>
-              <Button variant="subtle" size="sm" onClick={clearAllFilters} className="mt-2">
-                Clear all filters
-              </Button>
+              <div className="flex items-center gap-2 mt-2">
+                <Button variant="subtle" size="sm" onClick={clearAllFilters}>
+                  Clear all filters
+                </Button>
+                <Button variant="subtle" size="sm" onClick={onClose}>
+                  Close overview
+                </Button>
+              </div>
             </div>
           ) : groupedSections ? (
             <div className="space-y-6">


### PR DESCRIPTION
## Summary
- Sidebar zero-result empty states now offer an "Open overview" button alongside "Show all worktrees", with the keyboard shortcut surfaced in the title attribute.
- The worktree overview modal's own filter-zero empty state gets a "Close overview" button next to "Clear all filters".
- Test assertions updated to match the dual-action pattern and verify accessibility attributes.

Resolves #8383

## Changes
- `src/components/Sidebar/SidebarContent.tsx` — both empty-state branches (quick-state filter and facet/search filter) now render a second button that opens the overview. Each button gets `type="button"`, a `title` with the keyboard shortcut from `formatButtonTitle`, and `aria-keyshortcuts`.
- `src/components/Worktree/WorktreeOverviewModal.tsx` — the modal's zero-result state adds a "Close overview" button so the user isn't forced to clear filters when they'd rather dismiss the modal.
- `src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts` — asserts two buttons in the quick-state branch, verifies the overview click handler and title attribute, and removes the old single-button regression guards.

## Testing
- TypeScript passes (`tsc --noEmit` clean).
- Prettier and ESLint pass with no changes.
- Test assertions updated to reflect the dual-action pattern; existing empty-state coverage exercises both branches.