### PR TITLE
feat(sidebar): surface filter scope and drag-disabled reason in header

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -566,123 +566,126 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     };
   }, [deferredWorktrees.length, integrationWorktree, quickStateCounts]);
 
-  const { filteredWorktrees, groupedSections, hasResultsWithoutQuickState } = useMemo(() => {
-    const filters: FilterState = {
+  const { filteredWorktrees, groupedSections, hasResultsWithoutQuickState, totalCount } =
+    useMemo(() => {
+      const filters: FilterState = {
+        query,
+        statusFilters,
+        typeFilters,
+        githubFilters,
+        sessionFilters,
+        activityFilters,
+      };
+
+      // Filter non-main worktrees only (exclude main and integration by ID)
+      const nonMain = deferredWorktrees.filter(
+        (w) => w.id !== mainWorktree?.id && w.id !== integrationWorktree?.id
+      );
+      let withoutQuickStateMatch = false;
+      const filtered = nonMain.filter((worktree) => {
+        const derived = derivedMetaMap.get(worktree.id) ?? {
+          terminalCount: 0,
+          hasWorkingAgent: false,
+          hasWaitingAgent: false,
+          hasCompletedAgent: false,
+          hasExitedAgent: false,
+          hasMergeConflict: false,
+          chipState: null,
+        };
+        const isActive = worktree.id === activeWorktreeId;
+        const hasActiveQuery = query.trim().length > 0;
+
+        // Counterfactual: would this worktree be visible if the quick state
+        // filter were "all"? Mirrors the same precedence below (active /
+        // waiting bypasses → matchesFilters), with quickStateFilter forced
+        // to "all". Short-circuit once we find any match — only the boolean
+        // matters for the empty-state branch.
+        if (!withoutQuickStateMatch && quickStateFilter !== "all") {
+          if (alwaysShowActive && isActive && !hasActiveQuery && !hasFacetFiltersActive) {
+            withoutQuickStateMatch = true;
+          } else if (
+            alwaysShowWaiting &&
+            derived.hasWaitingAgent &&
+            !hasActiveQuery &&
+            !hasFacetFiltersActive
+          ) {
+            withoutQuickStateMatch = true;
+          } else if (matchesFilters(worktree, filters, derived, isActive)) {
+            withoutQuickStateMatch = true;
+          }
+        }
+
+        if (
+          alwaysShowActive &&
+          isActive &&
+          !hasActiveQuery &&
+          quickStateFilter === "all" &&
+          !hasFacetFiltersActive
+        ) {
+          return true;
+        }
+
+        if (
+          alwaysShowWaiting &&
+          derived.hasWaitingAgent &&
+          !hasActiveQuery &&
+          quickStateFilter === "all" &&
+          !hasFacetFiltersActive
+        ) {
+          return true;
+        }
+
+        if (quickStateFilter !== "all" && !matchesQuickStateFilter(quickStateFilter, derived)) {
+          return false;
+        }
+
+        return matchesFilters(worktree, filters, derived, isActive);
+      });
+
+      const existingWorktreeIds = new Set(deferredWorktrees.map((w) => w.id));
+      const validPinnedWorktrees = pinnedWorktrees.filter((id) => existingWorktreeIds.has(id));
+
+      const hasQuery = query.trim().length > 0;
+      const sorted = hasQuery
+        ? sortWorktreesByRelevance(filtered, query, orderBy, validPinnedWorktrees, manualOrder)
+        : sortWorktrees(filtered, orderBy, validPinnedWorktrees, manualOrder);
+
+      if (isGroupedByType && !hasQuery) {
+        return {
+          filteredWorktrees: sorted,
+          groupedSections: groupByType(sorted, orderBy, validPinnedWorktrees),
+          hasResultsWithoutQuickState: withoutQuickStateMatch,
+          totalCount: nonMain.length,
+        };
+      }
+
+      return {
+        filteredWorktrees: sorted,
+        groupedSections: null,
+        hasResultsWithoutQuickState: withoutQuickStateMatch,
+        totalCount: nonMain.length,
+      };
+    }, [
+      deferredWorktrees,
       query,
+      orderBy,
+      isGroupedByType,
       statusFilters,
       typeFilters,
       githubFilters,
       sessionFilters,
       activityFilters,
-    };
-
-    // Filter non-main worktrees only (exclude main and integration by ID)
-    const nonMain = deferredWorktrees.filter(
-      (w) => w.id !== mainWorktree?.id && w.id !== integrationWorktree?.id
-    );
-    let withoutQuickStateMatch = false;
-    const filtered = nonMain.filter((worktree) => {
-      const derived = derivedMetaMap.get(worktree.id) ?? {
-        terminalCount: 0,
-        hasWorkingAgent: false,
-        hasWaitingAgent: false,
-        hasCompletedAgent: false,
-        hasExitedAgent: false,
-        hasMergeConflict: false,
-        chipState: null,
-      };
-      const isActive = worktree.id === activeWorktreeId;
-      const hasActiveQuery = query.trim().length > 0;
-
-      // Counterfactual: would this worktree be visible if the quick state
-      // filter were "all"? Mirrors the same precedence below (active /
-      // waiting bypasses → matchesFilters), with quickStateFilter forced
-      // to "all". Short-circuit once we find any match — only the boolean
-      // matters for the empty-state branch.
-      if (!withoutQuickStateMatch && quickStateFilter !== "all") {
-        if (alwaysShowActive && isActive && !hasActiveQuery && !hasFacetFiltersActive) {
-          withoutQuickStateMatch = true;
-        } else if (
-          alwaysShowWaiting &&
-          derived.hasWaitingAgent &&
-          !hasActiveQuery &&
-          !hasFacetFiltersActive
-        ) {
-          withoutQuickStateMatch = true;
-        } else if (matchesFilters(worktree, filters, derived, isActive)) {
-          withoutQuickStateMatch = true;
-        }
-      }
-
-      if (
-        alwaysShowActive &&
-        isActive &&
-        !hasActiveQuery &&
-        quickStateFilter === "all" &&
-        !hasFacetFiltersActive
-      ) {
-        return true;
-      }
-
-      if (
-        alwaysShowWaiting &&
-        derived.hasWaitingAgent &&
-        !hasActiveQuery &&
-        quickStateFilter === "all" &&
-        !hasFacetFiltersActive
-      ) {
-        return true;
-      }
-
-      if (quickStateFilter !== "all" && !matchesQuickStateFilter(quickStateFilter, derived)) {
-        return false;
-      }
-
-      return matchesFilters(worktree, filters, derived, isActive);
-    });
-
-    const existingWorktreeIds = new Set(deferredWorktrees.map((w) => w.id));
-    const validPinnedWorktrees = pinnedWorktrees.filter((id) => existingWorktreeIds.has(id));
-
-    const hasQuery = query.trim().length > 0;
-    const sorted = hasQuery
-      ? sortWorktreesByRelevance(filtered, query, orderBy, validPinnedWorktrees, manualOrder)
-      : sortWorktrees(filtered, orderBy, validPinnedWorktrees, manualOrder);
-
-    if (isGroupedByType && !hasQuery) {
-      return {
-        filteredWorktrees: sorted,
-        groupedSections: groupByType(sorted, orderBy, validPinnedWorktrees),
-        hasResultsWithoutQuickState: withoutQuickStateMatch,
-      };
-    }
-
-    return {
-      filteredWorktrees: sorted,
-      groupedSections: null,
-      hasResultsWithoutQuickState: withoutQuickStateMatch,
-    };
-  }, [
-    deferredWorktrees,
-    query,
-    orderBy,
-    isGroupedByType,
-    statusFilters,
-    typeFilters,
-    githubFilters,
-    sessionFilters,
-    activityFilters,
-    alwaysShowActive,
-    alwaysShowWaiting,
-    pinnedWorktrees,
-    manualOrder,
-    mainWorktree,
-    integrationWorktree,
-    derivedMetaMap,
-    activeWorktreeId,
-    quickStateFilter,
-    hasFacetFiltersActive,
-  ]);
+      alwaysShowActive,
+      alwaysShowWaiting,
+      pinnedWorktrees,
+      manualOrder,
+      mainWorktree,
+      integrationWorktree,
+      derivedMetaMap,
+      activeWorktreeId,
+      quickStateFilter,
+      hasFacetFiltersActive,
+    ]);
 
   const { hiddenAbove, hiddenBelow, scrollToTop, scrollToBottom } = useScrollIndicator({
     scrollContainerRef,
@@ -977,6 +980,14 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const isSortDisabled = isGroupedByType || hasQuery;
   isSortDisabledRef.current = isSortDisabled;
 
+  const filteredCount = filteredWorktrees.length;
+  const showScope = hasActiveFilters() && filteredCount !== totalCount;
+  const dragDisabledReason = hasQuery
+    ? "Sorting disabled while searching"
+    : isGroupedByType
+      ? "Sorting disabled while grouped by type"
+      : null;
+
   // 1-based aria-rowindex slots for the pinned rows.
   const mainRowIndex = mainVisible ? 1 : 0;
   const integrationRowIndex = integrationVisible ? mainRowIndex + 1 : mainRowIndex;
@@ -1061,6 +1072,26 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             <Plus className="w-3.5 h-3.5" />
           </button>
         </div>
+      </div>
+
+      {/* Filter scope and sort-disabled status */}
+      <div className="px-4 min-h-5 shrink-0">
+        {(showScope || dragDisabledReason) && (
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="text-xs text-daintree-text/50 leading-5"
+          >
+            {showScope && (
+              <span>
+                {filteredCount} of {totalCount} worktrees
+              </span>
+            )}
+            {showScope && dragDisabledReason && <span> · </span>}
+            {dragDisabledReason && <span>{dragDisabledReason}</span>}
+          </div>
+        )}
       </div>
 
       {/* Inline search bar — only when there are non-main worktrees */}

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -41,7 +41,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
     it("returns hasResultsWithoutQuickState alongside the filtered list", () => {
       expect(source).toContain("hasResultsWithoutQuickState");
       expect(source).toMatch(
-        /const \{ filteredWorktrees, groupedSections, hasResultsWithoutQuickState.*\} = useMemo/
+        /const \{ filteredWorktrees, groupedSections, hasResultsWithoutQuickState[\s\S]*\} = useMemo/
       );
     });
 

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -41,7 +41,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
     it("returns hasResultsWithoutQuickState alongside the filtered list", () => {
       expect(source).toContain("hasResultsWithoutQuickState");
       expect(source).toMatch(
-        /const \{ filteredWorktrees, groupedSections, hasResultsWithoutQuickState \} = useMemo/
+        /const \{ filteredWorktrees, groupedSections, hasResultsWithoutQuickState.*\} = useMemo/
       );
     });
 

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -41,7 +41,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
     it("returns hasResultsWithoutQuickState alongside the filtered list", () => {
       expect(source).toContain("hasResultsWithoutQuickState");
       expect(source).toMatch(
-        /const \{ filteredWorktrees, groupedSections, hasResultsWithoutQuickState[\s\S]*\} = useMemo/
+        /const \{ filteredWorktrees, groupedSections, hasResultsWithoutQuickState[\s\S]*\}\s*=\s*useMemo/
       );
     });
 

--- a/src/components/Sidebar/__tests__/SidebarContent.test.tsx
+++ b/src/components/Sidebar/__tests__/SidebarContent.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const SIDEBAR_CONTENT_PATH = path.resolve(__dirname, "../SidebarContent.tsx");
+
+describe("SidebarContent filter scope and sort status — issue #8391", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  // Slice from the header group to the inline search bar comment to isolate
+  // the status line region. This sits between the header and the search bar.
+  function statusLineRegion(src: string): string {
+    const start = src.indexOf("{/* Filter scope and sort-disabled status */}");
+    const end = src.indexOf("{/* Inline search bar", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    return src.slice(start, end);
+  }
+
+  it("renders a stable-height container between header and search bar", () => {
+    const region = statusLineRegion(source);
+    expect(region).toContain("min-h-5");
+    expect(region).toContain("shrink-0");
+  });
+
+  it("uses ARIA live region for screen reader announcements", () => {
+    const region = statusLineRegion(source);
+    expect(region).toContain('role="status"');
+    expect(region).toContain('aria-live="polite"');
+    expect(region).toContain('aria-atomic="true"');
+  });
+
+  it("renders scope text 'N of M worktrees' pattern when filters narrow results", () => {
+    // The source uses template literals for dynamic counts
+    expect(source).toContain("{filteredCount} of {totalCount} worktrees");
+  });
+
+  it("renders drag-disabled reason for search", () => {
+    expect(source).toContain("Sorting disabled while searching");
+  });
+
+  it("renders drag-disabled reason for group-by-type", () => {
+    expect(source).toContain("Sorting disabled while grouped by type");
+  });
+
+  it("separates scope and drag reason with a middle dot when both present", () => {
+    const region = statusLineRegion(source);
+    expect(region).toContain(" · ");
+  });
+
+  it("gates visible content on showScope or dragDisabledReason", () => {
+    expect(source).toMatch(/showScope\s*\|\|\s*dragDisabledReason/);
+  });
+
+  it("derives drag-disabled reason with query taking priority over group-by-type", () => {
+    // Query-first precedence: hasQuery ? "searching" : isGroupedByType ? "grouped by type" : null
+    expect(source).toMatch(/hasQuery\s*\?[\s\S]*?Sorting disabled while searching/);
+    expect(source).toMatch(/isGroupedByType\s*\?[\s\S]*?Sorting disabled while grouped by type/);
+  });
+
+  it("exports totalCount from the filter useMemo alongside filteredWorktrees", () => {
+    expect(source).toContain("totalCount: nonMain.length");
+  });
+
+  it("computes showScope from hasActiveFilters and count comparison", () => {
+    expect(source).toMatch(
+      /showScope\s*=\s*hasActiveFilters\(\)\s*&&\s*filteredCount\s*!==\s*totalCount/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two small visibility fixes for the worktree sidebar header. When filters or search narrowed the list, there was no persistent indicator of scope -- you'd just see fewer items and have to remember what the unfiltered count was. And when drag reorder was disabled because of search or group-by-type, there was no explanation at all -- the handle just vanished.

This adds a status line in the header that shows the filtered count vs. total, and the reason sort is disabled when it is.

Resolves #8391

## Changes

- Added totalCount to the existing filter memo so we can compare filtered vs. total
- Added a role=status status line in the sidebar header that renders when filters are active or drag is disabled
- Shows filtered count vs total worktrees when the visible set is smaller
- Shows the drag-disabled reason (search or group-by-type)
- Added tests for the status line visibility and content

## Testing

- Unit tests cover both the filter scope display and the drag-disabled reason text
- Existing empty-state tests updated for the new totalCount field