### PR TITLE
fix(project-switch): surface worktree-load failures, drop split-brain rollback

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -19,6 +19,7 @@ export const CHANNELS = {
   WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS: "worktree:get-all-issue-associations",
   WORKTREE_HOST_DISCONNECTED: "worktree:host-disconnected",
   WORKTREE_RESTART_SERVICE: "worktree:restart-service",
+  WORKTREE_RETRY_PROJECT_LOAD: "worktree:retry-project-load",
 
   TERMINAL_SPAWN: "terminal:spawn",
   TERMINAL_DATA: "terminal:data",

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -20,6 +20,7 @@ export const CHANNELS = {
   WORKTREE_HOST_DISCONNECTED: "worktree:host-disconnected",
   WORKTREE_RESTART_SERVICE: "worktree:restart-service",
   WORKTREE_RETRY_PROJECT_LOAD: "worktree:retry-project-load",
+  PROJECT_WORKTREE_LOAD_STATUS: "project:worktree-load-status",
 
   TERMINAL_SPAWN: "terminal:spawn",
   TERMINAL_DATA: "terminal:data",

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -625,3 +625,72 @@ describe("project:switch outgoing tabGroups pre-apply (#5001)", () => {
     expect(savedState.tabGroups).toEqual([]);
   });
 });
+
+describe("project:switch worktree-load-status (#8400)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function runSwitch(loadProject: () => Promise<void>) {
+    const sendMock = vi.fn();
+    const mockView = {
+      webContents: { id: 300, isDestroyed: () => false, send: sendMock },
+    };
+    const pvm = {
+      switchTo: vi.fn().mockResolvedValue({ view: mockView, isNew: false }),
+      getProjectIdForWebContents: vi.fn(),
+    };
+
+    mockGetWindowForWebContents.mockReturnValue({ id: 7, isDestroyed: () => false });
+
+    projectStoreMock.getCurrentProjectId.mockReturnValue("proj-old");
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-new",
+      name: "New Project",
+      path: "/projects/new",
+    });
+    projectStoreMock.setCurrentProject.mockResolvedValue(undefined);
+
+    const worktreeService = {
+      loadProject: vi.fn(loadProject),
+      attachDirectPort: vi.fn(),
+      getHostForProject: vi.fn(() => null),
+    };
+
+    const deps = {
+      mainWindow: { id: 7 } as unknown,
+      projectViewManager: pvm,
+      worktreeService: worktreeService as never,
+    } as unknown as HandlerDependencies;
+
+    registerProjectCrudHandlers(deps);
+
+    const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+    for (const call of (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls) {
+      handleMap.set(call[0] as string, call[1] as (...args: unknown[]) => unknown);
+    }
+
+    await handleMap.get(CHANNELS.PROJECT_SWITCH)!({ sender: { id: 300 } }, "proj-new");
+    return sendMock;
+  }
+
+  it("sends the error targeted to the activated view when loadProject throws", async () => {
+    const sendMock = await runSwitch(async () => {
+      throw new Error("Not a git repository");
+    });
+
+    expect(sendMock).toHaveBeenCalledWith(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, {
+      projectId: "proj-new",
+      worktreeLoadError: "Not a git repository",
+    });
+  });
+
+  it("sends a null status on success so a stale banner clears", async () => {
+    const sendMock = await runSwitch(async () => undefined);
+
+    expect(sendMock).toHaveBeenCalledWith(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, {
+      projectId: "proj-new",
+      worktreeLoadError: null,
+    });
+  });
+});

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -5,6 +5,7 @@ import { distributePortsToView } from "../../../window/portDistribution.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import { scratchStore } from "../../../services/ScratchStore.js";
 import { ProjectSwitchService } from "../../../services/ProjectSwitchService.js";
+import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import {
   sanitizeTerminals,
   sanitizeTerminalSizes,
@@ -192,6 +193,12 @@ async function activateProjectView(
     const senderWindow = getWindowForWebContents(event.sender);
     const windowId = senderWindow?.id ?? deps.mainWindow?.id;
     if (windowId !== undefined) {
+      // Forward-fail: the view swap already committed to the new project, so a
+      // load failure surfaces as a Tier 3 recovery banner rather than reverting
+      // (#8400). Send a targeted status to *this* view only (broadcastToRenderer
+      // would also hit LRU-cached other-project views); null on success clears a
+      // stale banner when a previously-failed view is reactivated successfully.
+      let worktreeLoadError: string | null = null;
       try {
         await deps.worktreeService.loadProject(project.path, windowId);
 
@@ -209,6 +216,13 @@ async function activateProjectView(
         }
       } catch (err) {
         console.error(`${options.logPrefix} Failed to load worktrees:`, err);
+        worktreeLoadError = formatErrorMessage(err, "Failed to load worktrees");
+      }
+      if (!view.webContents.isDestroyed()) {
+        view.webContents.send(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, {
+          projectId,
+          worktreeLoadError,
+        });
       }
     }
 

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -130,7 +130,7 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     try {
       await deps.worktreeService.loadProject(project.path, windowId);
     } catch (error) {
-      throw new Error(formatErrorMessage(error, "Failed to load worktrees"));
+      throw new Error(formatErrorMessage(error, "Failed to load worktrees"), { cause: error });
     }
   };
   handlers.push(

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -1,5 +1,7 @@
 import { CHANNELS } from "../../channels.js";
 import { store } from "../../../store.js";
+import { projectStore } from "../../../services/ProjectStore.js";
+import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 import type { WorktreeSetActivePayload, WorktreeDeletePayload } from "../../../types/index.js";
 import type { WorktreeState } from "../../../../shared/types/worktree.js";
@@ -107,6 +109,32 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
   };
   handlers.push(
     typedHandleWithContext(CHANNELS.WORKTREE_RESTART_SERVICE, handleWorktreeRestartService)
+  );
+
+  // Recovery path for a project switch whose worktree load threw (#8400).
+  // The switch forward-fails to the new project, so the current project is
+  // already the one whose load failed — re-run loadProject for it rather than
+  // re-issuing a no-op same-project switch.
+  const handleWorktreeRetryProjectLoad = async (ctx: IpcContext): Promise<void> => {
+    if (!deps.worktreeService) {
+      throw new Error("Workspace service is not available");
+    }
+    const windowId = ctx.senderWindow?.id;
+    if (windowId === undefined) {
+      throw new Error("Couldn't identify the window to reload");
+    }
+    const project = projectStore.getCurrentProject();
+    if (!project) {
+      throw new Error("No active project to reload");
+    }
+    try {
+      await deps.worktreeService.loadProject(project.path, windowId);
+    } catch (error) {
+      throw new Error(formatErrorMessage(error, "Failed to load worktrees"));
+    }
+  };
+  handlers.push(
+    typedHandleWithContext(CHANNELS.WORKTREE_RETRY_PROJECT_LOAD, handleWorktreeRetryProjectLoad)
   );
 
   const handleWorktreeDelete = async (ctx: IpcContext, payload: WorktreeDeletePayload) => {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -724,6 +724,8 @@ const api: ElectronAPI = {
 
     restartService: (): Promise<void> => _unwrappingInvoke(CHANNELS.WORKTREE_RESTART_SERVICE),
 
+    retryProjectLoad: (): Promise<void> => _unwrappingInvoke(CHANNELS.WORKTREE_RETRY_PROJECT_LOAD),
+
     onUpdate: (callback: (state: WorktreeState) => void) =>
       _eventBusOn("worktree:update", (payload) => callback(payload.worktree)),
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1247,6 +1247,10 @@ const api: ElectronAPI = {
       }) => void
     ) => _typedOn(CHANNELS.PROJECT_ON_SWITCH, callback),
 
+    onWorktreeLoadStatus: (
+      callback: (payload: { projectId: string; worktreeLoadError: string | null }) => void
+    ) => _typedOn(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, callback),
+
     onUpdated: (callback: (project: Project) => void) =>
       _typedOn(CHANNELS.PROJECT_UPDATED, callback),
 

--- a/electron/services/ProjectSwitchService.ts
+++ b/electron/services/ProjectSwitchService.ts
@@ -124,21 +124,12 @@ export class ProjectSwitchService {
       // Drain the in-flight save so it can't race with a subsequent switch's
       // write to the same outgoing project state file.
       await saveOutgoingPromise.catch(() => {});
-      console.error("[ProjectSwitch] Project switch failed, rolling back:", error);
-      try {
-        if (previousProjectId) {
-          const previousProject = projectStore.getProjectById(previousProjectId);
-          this.deps.ptyClient!.onProjectSwitch(
-            this.windowId!,
-            previousProjectId,
-            previousProject?.path
-          );
-        } else {
-          this.deps.ptyClient!.setActiveProject(this.windowId!, null);
-        }
-      } catch (rollbackError) {
-        console.error("[ProjectSwitch] Rollback failed:", rollbackError);
-      }
+      // No PTY rollback: the project store, git cache, log buffer, and context
+      // tracker have already committed to the new project by the time we get
+      // here. Reverting only the PTY would leave a split-brain state. Forward-
+      // fail to the new project instead and surface the failure to the renderer
+      // via the worktreeLoadError payload (see #8400).
+      console.error("[ProjectSwitch] Project switch failed:", error);
       throw error;
     } finally {
       markPerformance(PERF_MARKS.PROJECT_SWITCH_END, {

--- a/electron/services/ProjectSwitchService.ts
+++ b/electron/services/ProjectSwitchService.ts
@@ -118,6 +118,14 @@ export class ProjectSwitchService {
         ...(hydrateResult ? { hydrateResult } : {}),
       });
 
+      // Dedicated load-status event consumed by the renderer's Tier 3 banner
+      // (#8400). Mirrors the targeted send on the production view-swap path so
+      // both paths drive the same listener; null clears any stale banner.
+      broadcastToRenderer(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, {
+        projectId,
+        worktreeLoadError: worktreeLoadError ?? null,
+      });
+
       console.log("[ProjectSwitch] Project switch complete, switchId:", switchId);
       return updatedProject;
     } catch (error) {

--- a/electron/services/__tests__/ProjectSwitchService.test.ts
+++ b/electron/services/__tests__/ProjectSwitchService.test.ts
@@ -298,6 +298,11 @@ describe("ProjectSwitchService", () => {
         worktreeLoadError: "Not a git repository",
       })
     );
+    // Dedicated load-status event the renderer banner listens on (#8400).
+    expect(sendToRendererMock).toHaveBeenCalledWith(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, {
+      projectId: "project-new",
+      worktreeLoadError: "Not a git repository",
+    });
   });
 
   it("does not include worktreeLoadError when loadProject succeeds", async () => {
@@ -305,8 +310,16 @@ describe("ProjectSwitchService", () => {
 
     await service.switchProject("project-new");
 
-    const payload = sendToRendererMock.mock.calls[0][1];
-    expect(payload).not.toHaveProperty("worktreeLoadError");
+    const onSwitchPayload = sendToRendererMock.mock.calls.find(
+      (c: unknown[]) => c[0] === CHANNELS.PROJECT_ON_SWITCH
+    )?.[1];
+    expect(onSwitchPayload).not.toHaveProperty("worktreeLoadError");
+    // The load-status event still fires, with a null error so a stale banner
+    // on a reactivated view clears.
+    expect(sendToRendererMock).toHaveBeenCalledWith(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, {
+      projectId: "project-new",
+      worktreeLoadError: null,
+    });
   });
 
   it("includes pre-built hydrateResult in switch payload", async () => {

--- a/electron/services/__tests__/ProjectSwitchService.test.ts
+++ b/electron/services/__tests__/ProjectSwitchService.test.ts
@@ -477,18 +477,22 @@ describe("ProjectSwitchService", () => {
     expect(secondResolved).toBe(true);
   });
 
-  it("preserves original switch error when rollback throws", async () => {
+  it("propagates the switch error without attempting a PTY rollback (#8400)", async () => {
     const originalError = new Error("setCurrent failed");
     projectStoreMock.setCurrentProject.mockRejectedValue(originalError);
 
-    const { service } = createService({
-      ptyClient: {
-        onProjectSwitch: () => {
-          throw new Error("rollback failed");
-        },
-      },
-    });
+    const { service, ptyClient } = createService();
 
     await expect(service.switchProject("project-new")).rejects.toThrow("setCurrent failed");
+
+    // The catch branch no longer reverts the PTY to the previous project —
+    // the forward-cleanup call targets the *new* project, never "project-old",
+    // and setActiveProject(null) is never used as a fallback rollback.
+    expect(ptyClient.onProjectSwitch).not.toHaveBeenCalledWith(
+      MOCK_WINDOW_ID,
+      "project-old",
+      expect.anything()
+    );
+    expect(ptyClient.setActiveProject).not.toHaveBeenCalled();
   });
 });

--- a/shared/config/actionIds.ts
+++ b/shared/config/actionIds.ts
@@ -27,6 +27,7 @@ export const BUILT_IN_ACTION_IDS = [
   "worktree.refresh",
   "worktree.refreshPullRequests",
   "worktree.restartService",
+  "worktree.retryProjectLoad",
   "worktree.setActive",
   "worktree.create",
   "worktree.delete",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -212,6 +212,7 @@ export interface ElectronAPI {
     getIssueAssociation(worktreeId: string): Promise<IssueAssociation | null>;
     getAllIssueAssociations(): Promise<Record<string, IssueAssociation>>;
     restartService(): Promise<void>;
+    retryProjectLoad(): Promise<void>;
     onUpdate(callback: (state: WorktreeState) => void): () => void;
     onRemove(callback: (data: { worktreeId: string }) => void): () => void;
     onActivated(callback: (data: { worktreeId: string }) => void): () => void;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -460,6 +460,9 @@ export interface ElectronAPI {
         hydrateResult?: import("./app.js").HydrateResult;
       }) => void
     ): () => void;
+    onWorktreeLoadStatus(
+      callback: (payload: { projectId: string; worktreeLoadError: string | null }) => void
+    ): () => void;
     onUpdated(callback: (project: Project) => void): () => void;
     onRemoved(callback: (projectId: string) => void): () => void;
     getSettings(projectId: string): Promise<ProjectSettings>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -99,6 +99,7 @@ import type {
   ProjectStatusMap,
   ProjectSwitchPayload,
   ProjectSwitchOutgoingState,
+  ProjectWorktreeLoadStatusPayload,
 } from "./project.js";
 import type {
   RepositoryStats,
@@ -297,6 +298,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     result: Record<string, IssueAssociation>;
   };
   "worktree:restart-service": {
+    args: [];
+    result: void;
+  };
+  "worktree:retry-project-load": {
     args: [];
     result: void;
   };
@@ -2191,6 +2196,7 @@ export interface IpcEventMap {
 
   // Project events
   "project:on-switch": ProjectSwitchPayload;
+  "project:worktree-load-status": ProjectWorktreeLoadStatusPayload;
   "project:stats-updated": ProjectStatusMap;
   "project:updated": Project;
   "project:removed": string;

--- a/shared/types/ipc/project.ts
+++ b/shared/types/ipc/project.ts
@@ -28,6 +28,20 @@ export interface ProjectSwitchPayload {
   hydrateResult?: HydrateResult;
 }
 
+/**
+ * Targeted `project:worktree-load-status` event. Sent to a single activated
+ * project view (production view-swap path) or broadcast on the legacy switch
+ * path. `worktreeLoadError` is the formatted failure string, or null when the
+ * load succeeded (so a stale banner on a reactivated cached view clears). See
+ * #8400.
+ */
+export interface ProjectWorktreeLoadStatusPayload {
+  /** The project whose worktree load this status describes. */
+  projectId: string;
+  /** Formatted load failure, or null when the load succeeded. */
+  worktreeLoadError: string | null;
+}
+
 /** Result from project:close operation. Failures throw `AppError`. */
 export interface ProjectCloseResult {
   /** Total number of processes killed */

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -146,6 +146,12 @@ export const projectClient = {
     return window.electron.project.onSwitch(callback);
   },
 
+  onWorktreeLoadStatus: (
+    callback: (payload: { projectId: string; worktreeLoadError: string | null }) => void
+  ): (() => void) => {
+    return window.electron.project.onWorktreeLoadStatus(callback);
+  },
+
   getSettings: (projectId: string): Promise<ProjectSettings> => {
     // Subscribe to project switch so external switches (multi-window,
     // app menu, IPC) clear the per-projectId settings cache. Cheap to

--- a/src/clients/worktreeClient.ts
+++ b/src/clients/worktreeClient.ts
@@ -89,6 +89,10 @@ export const worktreeClient = {
     return window.electron.worktree.restartService();
   },
 
+  retryProjectLoad: (): Promise<void> => {
+    return window.electron.worktree.retryProjectLoad();
+  },
+
   onRemove: (callback: (data: { worktreeId: string }) => void): (() => void) => {
     return window.electron.worktree.onRemove(callback);
   },

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -831,21 +831,26 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
           </div>
 
-          <EmptyState
-            variant="zero-data"
-            scale="sidebar"
-            icon={<FolderOpen />}
-            title="Open a Git repository to get started"
-            action={
-              <span className="text-xs text-daintree-text/50">
-                Use{" "}
-                <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-xs">
-                  File → Open Directory
-                </kbd>
-              </span>
-            }
-            className="flex-1"
-          />
+          {/* A failed load already has an open project — the "Open a Git
+              repository" nudge would contradict the banner, so the banner
+              stands alone as the actionable state. */}
+          {!worktreeLoadError && (
+            <EmptyState
+              variant="zero-data"
+              scale="sidebar"
+              icon={<FolderOpen />}
+              title="Open a Git repository to get started"
+              action={
+                <span className="text-xs text-daintree-text/50">
+                  Use{" "}
+                  <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-xs">
+                    File → Open Directory
+                  </kbd>
+                </span>
+              }
+              className="flex-1"
+            />
+          )}
         </div>
         {newWorktreeDialogElement}
       </>

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -60,6 +60,7 @@ import type { WorktreeState } from "@/types";
 import { actionService } from "@/services/ActionService";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { SidebarWorktreeRow } from "./SidebarWorktreeRow";
+import { WorktreeLoadErrorBanner } from "./WorktreeLoadErrorBanner";
 import { StaticWorktreeRow } from "./StaticWorktreeRow";
 import { useScrollIndicator } from "./useScrollIndicator";
 import { useRecipeDialogState } from "./useRecipeDialogState";
@@ -256,6 +257,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   // takes 2–4s to recover, well past the threshold.
   const showReconnecting = useDeferredLoading(isReconnecting, UI_DOHERTY_THRESHOLD);
   const currentProject = useProjectStore((state) => state.currentProject);
+  const worktreeLoadError = useProjectStore((state) => state.worktreeLoadError);
   useProjectSettings();
   const { availability, agentSettings } = useAgentLauncher();
   const {
@@ -757,9 +759,18 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       </ErrorBoundary>
     );
 
+  // Hoisted before the early returns so the failed-switch banner (#8400)
+  // surfaces regardless of which loading/empty/error branch the sidebar is in
+  // — when a switch's worktree load throws, the store stays empty so every
+  // other branch would otherwise show no trace of the failure.
+  const worktreeLoadErrorBanner = worktreeLoadError ? (
+    <WorktreeLoadErrorBanner error={worktreeLoadError} />
+  ) : null;
+
   if (isLoading && worktrees.length === 0) {
     return (
       <div className="flex flex-col h-full">
+        {worktreeLoadErrorBanner}
         <div className="flex items-center px-4 py-4 border-b border-divider shrink-0">
           <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
         </div>
@@ -782,6 +793,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   if (error) {
     return (
       <div className="flex flex-col h-full">
+        {worktreeLoadErrorBanner}
         <div className="flex items-center px-4 py-4 border-b border-divider shrink-0">
           <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
         </div>
@@ -814,6 +826,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     return (
       <>
         <div className="flex flex-col h-full">
+          {worktreeLoadErrorBanner}
           <div className="flex items-center px-4 py-4 border-b border-divider shrink-0">
             <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
           </div>
@@ -991,6 +1004,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
   return (
     <div className="flex flex-col h-full">
+      {worktreeLoadErrorBanner}
       {/* Header Section */}
       <div className="group/header flex items-center justify-between px-4 py-2 border-b border-divider bg-transparent shrink-0">
         <div className="flex items-baseline gap-1.5">

--- a/src/components/Sidebar/WorktreeLoadErrorBanner.tsx
+++ b/src/components/Sidebar/WorktreeLoadErrorBanner.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useState } from "react";
+import { AlertCircle, RotateCcw } from "lucide-react";
+import { InlineStatusBanner, type BannerAction } from "@/components/Terminal/InlineStatusBanner";
+import { boundedErrorText } from "@/utils/errorText";
+import { actionService } from "@/services/ActionService";
+
+export interface WorktreeLoadErrorBannerProps {
+  /** Raw error string from the failed worktree load (sanitized before render). */
+  error: string;
+  className?: string;
+  /**
+   * Retry override for tests. In production this is undefined and the banner
+   * dispatches `worktree.retryProjectLoad`, which re-runs the failed load and
+   * clears the banner on success.
+   */
+  onRetry?: () => void | Promise<void>;
+}
+
+/**
+ * Tier 3 inline recovery banner for a project switch that committed to the new
+ * project but whose worktree load threw (#8400). Modeled on SpawnErrorBanner /
+ * TerminalRestartStatusBanner — surfaces the failure with a single Retry action
+ * instead of leaving the sidebar stuck on an empty skeleton.
+ */
+export function WorktreeLoadErrorBanner({
+  error,
+  className,
+  onRetry,
+}: WorktreeLoadErrorBannerProps) {
+  const [isRetrying, setIsRetrying] = useState(false);
+
+  const handleRetry = useCallback(async () => {
+    if (isRetrying) return;
+    setIsRetrying(true);
+    try {
+      if (onRetry) {
+        await onRetry();
+      } else {
+        await actionService.dispatch("worktree.retryProjectLoad", undefined, { source: "user" });
+      }
+    } finally {
+      setIsRetrying(false);
+    }
+  }, [isRetrying, onRetry]);
+
+  const actions: BannerAction[] = [
+    {
+      id: "retry",
+      label: "Retry",
+      icon: RotateCcw,
+      variant: "primary",
+      onClick: () => void handleRetry(),
+      title: "Retry loading worktrees",
+      ariaLabel: "Retry loading worktrees",
+      loading: isRetrying,
+    },
+  ];
+
+  return (
+    <InlineStatusBanner
+      icon={AlertCircle}
+      title="Couldn't load worktrees"
+      description={boundedErrorText(error)}
+      severity="error"
+      actions={actions}
+      className={className}
+    />
+  );
+}

--- a/src/components/Sidebar/__tests__/WorktreeLoadErrorBanner.test.tsx
+++ b/src/components/Sidebar/__tests__/WorktreeLoadErrorBanner.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const dispatchMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (...args: unknown[]) => dispatchMock(...args),
+  },
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { WorktreeLoadErrorBanner } from "../WorktreeLoadErrorBanner";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  dispatchMock.mockReset();
+  dispatchMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("WorktreeLoadErrorBanner (#8400)", () => {
+  it("renders the title and the sanitized, length-bounded error", () => {
+    render(<WorktreeLoadErrorBanner error={"[31mNot a git repository[0m"} />);
+
+    expect(screen.getByText("Couldn't load worktrees")).toBeTruthy();
+    // ANSI escape sequences are stripped before render.
+    expect(screen.getByText("Not a git repository")).toBeTruthy();
+  });
+
+  it("dispatches worktree.retryProjectLoad when Retry is clicked", async () => {
+    render(<WorktreeLoadErrorBanner error="Not a git repository" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry loading worktrees" }));
+
+    await waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledWith("worktree.retryProjectLoad", undefined, {
+        source: "user",
+      });
+    });
+  });
+
+  it("uses the onRetry override and blocks concurrent retries", async () => {
+    let resolveRetry: () => void = () => {};
+    const onRetry = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRetry = resolve;
+        })
+    );
+    render(<WorktreeLoadErrorBanner error="boom" onRetry={onRetry} />);
+
+    const button = screen.getByRole("button", { name: "Retry loading worktrees" });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).not.toHaveBeenCalled();
+
+    resolveRetry();
+    await waitFor(() =>
+      expect(
+        (screen.getByRole("button", { name: "Retry loading worktrees" }) as HTMLButtonElement)
+          .disabled
+      ).toBe(false)
+    );
+  });
+});

--- a/src/services/actions/definitions/__tests__/worktreeRetryProjectLoad.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeRetryProjectLoad.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const retryProjectLoadMock = vi.fn<() => Promise<void>>();
+const setWorktreeLoadErrorMock = vi.fn<(error: string | null) => void>();
+
+let worktreeLoadError: string | null = null;
+
+vi.mock("@/clients", () => ({
+  worktreeClient: {
+    retryProjectLoad: () => retryProjectLoadMock(),
+  },
+}));
+
+vi.mock("@/store/createWorktreeStore", () => ({
+  getCurrentViewStoreOrNull: () => null,
+}));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: {
+    getState: () => ({
+      worktreeLoadError,
+      setWorktreeLoadError: setWorktreeLoadErrorMock,
+    }),
+  },
+}));
+
+const { registerWorktreeServiceActions } = await import("../worktreeServiceActions");
+
+type Registry = Map<string, () => { [k: string]: unknown }>;
+
+function buildRegistry(): Registry {
+  const registry: Registry = new Map();
+  registerWorktreeServiceActions(registry as never, {} as never);
+  return registry;
+}
+
+function getAction() {
+  const factory = buildRegistry().get("worktree.retryProjectLoad");
+  if (!factory) throw new Error("worktree.retryProjectLoad not registered");
+  return factory() as {
+    danger: string;
+    isEnabled: (ctx: unknown) => boolean;
+    disabledReason: (ctx: unknown) => string | undefined;
+    run: (args: unknown, ctx: unknown) => Promise<void>;
+  };
+}
+
+describe("worktree.retryProjectLoad (#8400)", () => {
+  beforeEach(() => {
+    retryProjectLoadMock.mockReset();
+    retryProjectLoadMock.mockResolvedValue(undefined);
+    setWorktreeLoadErrorMock.mockReset();
+    worktreeLoadError = null;
+  });
+
+  it("is a safe action (no confirm gate)", () => {
+    expect(getAction().danger).toBe("safe");
+  });
+
+  it("is disabled when there is no worktree load failure", () => {
+    worktreeLoadError = null;
+    const action = getAction();
+    expect(action.isEnabled({})).toBe(false);
+    expect(action.disabledReason({})).toBe("No worktree load failure to retry");
+  });
+
+  it("is enabled while a worktree load failure is present", () => {
+    worktreeLoadError = "Not a git repository";
+    const action = getAction();
+    expect(action.isEnabled({})).toBe(true);
+    expect(action.disabledReason({})).toBeUndefined();
+  });
+
+  it("clears the banner after a successful retry", async () => {
+    worktreeLoadError = "Not a git repository";
+    await getAction().run(undefined, {});
+    expect(retryProjectLoadMock).toHaveBeenCalledTimes(1);
+    expect(setWorktreeLoadErrorMock).toHaveBeenCalledWith(null);
+  });
+
+  it("leaves the banner in place when the retry fails", async () => {
+    worktreeLoadError = "Not a git repository";
+    retryProjectLoadMock.mockRejectedValue(new Error("still broken"));
+    await expect(getAction().run(undefined, {})).rejects.toThrow("still broken");
+    expect(setWorktreeLoadErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/actions/definitions/__tests__/worktreeRetryProjectLoad.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeRetryProjectLoad.test.ts
@@ -85,4 +85,23 @@ describe("worktree.retryProjectLoad (#8400)", () => {
     await expect(getAction().run(undefined, {})).rejects.toThrow("still broken");
     expect(setWorktreeLoadErrorMock).not.toHaveBeenCalled();
   });
+
+  it("does not clobber a new error that arrived mid-retry", async () => {
+    worktreeLoadError = "Not a git repository";
+    let resolveRetry: () => void = () => {};
+    retryProjectLoadMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRetry = resolve;
+      })
+    );
+
+    const runPromise = getAction().run(undefined, {});
+    // A concurrent switch surfaces a different failure while the retry is in
+    // flight — the success path must not wipe it.
+    worktreeLoadError = "A different project failed";
+    resolveRetry();
+    await runPromise;
+
+    expect(setWorktreeLoadErrorMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/services/actions/definitions/worktreeServiceActions.ts
+++ b/src/services/actions/definitions/worktreeServiceActions.ts
@@ -2,6 +2,7 @@ import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { defineAction } from "../defineAction";
 import { z } from "zod";
 import { getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
+import { useProjectStore } from "@/store/projectStore";
 import { worktreeClient } from "@/clients";
 
 export function registerWorktreeServiceActions(
@@ -62,6 +63,29 @@ export function registerWorktreeServiceActions(
     },
     run: async () => {
       await worktreeClient.restartService();
+    },
+  }));
+
+  actions.set("worktree.retryProjectLoad", () => ({
+    id: "worktree.retryProjectLoad",
+    title: "Retry loading worktrees",
+    description: "Retry loading worktrees after a project switch failed to load them",
+    category: "worktree",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    nonRepeatable: true,
+    keywords: ["reload", "recover", "switch", "worktree"],
+    isEnabled: () => useProjectStore.getState().worktreeLoadError !== null,
+    disabledReason: () =>
+      useProjectStore.getState().worktreeLoadError === null
+        ? "No worktree load failure to retry"
+        : undefined,
+    run: async () => {
+      await worktreeClient.retryProjectLoad();
+      // The reload succeeded — clear the banner. A failure rejects above and
+      // leaves worktreeLoadError set so the banner stays visible.
+      useProjectStore.getState().setWorktreeLoadError(null);
     },
   }));
 

--- a/src/services/actions/definitions/worktreeServiceActions.ts
+++ b/src/services/actions/definitions/worktreeServiceActions.ts
@@ -82,10 +82,15 @@ export function registerWorktreeServiceActions(
         ? "No worktree load failure to retry"
         : undefined,
     run: async () => {
+      const retriedError = useProjectStore.getState().worktreeLoadError;
       await worktreeClient.retryProjectLoad();
-      // The reload succeeded — clear the banner. A failure rejects above and
-      // leaves worktreeLoadError set so the banner stays visible.
-      useProjectStore.getState().setWorktreeLoadError(null);
+      // Clear only if the banner still shows the same failure we retried — a
+      // concurrent switch may have set a *new* worktreeLoadError mid-flight,
+      // and that one must not be wiped by this success. A failure rejects above
+      // and leaves the banner untouched.
+      if (useProjectStore.getState().worktreeLoadError === retriedError) {
+        useProjectStore.getState().setWorktreeLoadError(null);
+      }
     },
   }));
 

--- a/src/store/__tests__/projectStore.addProject.test.ts
+++ b/src/store/__tests__/projectStore.addProject.test.ts
@@ -10,6 +10,7 @@ const projectClientMock = {
   switch: vi.fn().mockResolvedValue(null),
   openDialog: vi.fn(),
   onSwitch: vi.fn(() => () => {}),
+  onWorktreeLoadStatus: vi.fn(() => () => {}),
   getSettings: vi.fn(),
   saveSettings: vi.fn(),
   detectRunners: vi.fn(),

--- a/src/store/__tests__/projectStore.adversarial.test.ts
+++ b/src/store/__tests__/projectStore.adversarial.test.ts
@@ -35,6 +35,7 @@ const projectClientMock = vi.hoisted(() => ({
   locate: vi.fn(),
   close: vi.fn(),
   createFolder: vi.fn(),
+  onWorktreeLoadStatus: vi.fn(() => () => {}),
 }));
 
 const notifyMock = vi.hoisted(() => vi.fn());

--- a/src/store/__tests__/projectStore.persistence.test.ts
+++ b/src/store/__tests__/projectStore.persistence.test.ts
@@ -11,6 +11,7 @@ const projectClientMock = {
   reopen: vi.fn(),
   openDialog: vi.fn(),
   onSwitch: vi.fn(() => () => {}),
+  onWorktreeLoadStatus: vi.fn(() => () => {}),
   getSettings: vi.fn(),
   saveSettings: vi.fn(),
   detectRunners: vi.fn(),

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -11,6 +11,7 @@ const projectClientMock = {
   reopen: vi.fn().mockResolvedValue(undefined),
   openDialog: vi.fn(),
   onSwitch: vi.fn(() => () => {}),
+  onWorktreeLoadStatus: vi.fn(() => () => {}),
   getSettings: vi.fn(),
   saveSettings: vi.fn(),
   detectRunners: vi.fn(),
@@ -514,29 +515,39 @@ describe("worktreeLoadError surfacing (#8400)", () => {
     expect(useProjectStore.getState().worktreeLoadError).toBeNull();
   });
 
-  it("stores worktreeLoadError from the project switch broadcast and clears it on a clean switch", async () => {
+  it("applies the worktree-load-status event, guarding on projectId", async () => {
     delete (globalThis as { __daintreeProjectStoreListenerState?: unknown })
       .__daintreeProjectStoreListenerState;
     // The module-init listener block only registers when window.electron.project
-    // is present; provide a minimal stub so projectClient.onSwitch is wired.
+    // is present; provide a minimal stub so the listener is wired.
     (window as unknown as { electron: unknown }).electron = {
       project: { onUpdated: vi.fn(), onRemoved: vi.fn() },
     };
-    const { useProjectStore } = await import("../projectStore");
-
-    const onSwitchCb = projectClientMock.onSwitch.mock.calls.at(-1)?.[0] as
-      | ((payload: {
-          project: typeof projectB;
-          switchId: string;
-          worktreeLoadError?: string;
-        }) => void)
+    let statusCb:
+      | ((payload: { projectId: string; worktreeLoadError: string | null }) => void)
       | undefined;
-    expect(typeof onSwitchCb).toBe("function");
+    projectClientMock.onWorktreeLoadStatus.mockImplementation((cb: typeof statusCb) => {
+      statusCb = cb;
+      return () => {};
+    });
 
-    onSwitchCb!({ project: projectB, switchId: "s1", worktreeLoadError: "Not a git repository" });
+    const { useProjectStore } = await import("../projectStore");
+    expect(typeof statusCb).toBe("function");
+
+    // Permissive: accepted while currentProject is still null (cold view).
+    useProjectStore.setState({ currentProject: null, worktreeLoadError: null });
+    statusCb!({ projectId: projectB.id, worktreeLoadError: "Not a git repository" });
     expect(useProjectStore.getState().worktreeLoadError).toBe("Not a git repository");
 
-    onSwitchCb!({ project: projectB, switchId: "s2" });
+    // Applied when the payload's project matches this view's current project.
+    useProjectStore.setState({ currentProject: projectB });
+    statusCb!({ projectId: projectB.id, worktreeLoadError: null });
+    expect(useProjectStore.getState().worktreeLoadError).toBeNull();
+
+    // Ignored when the payload targets a different project (cross-view broadcast
+    // contamination guard).
+    useProjectStore.setState({ currentProject: projectB, worktreeLoadError: null });
+    statusCb!({ projectId: projectA.id, worktreeLoadError: "Other project failed" });
     expect(useProjectStore.getState().worktreeLoadError).toBeNull();
   });
 });

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -11,7 +11,10 @@ const projectClientMock = {
   reopen: vi.fn().mockResolvedValue(undefined),
   openDialog: vi.fn(),
   onSwitch: vi.fn(() => () => {}),
-  onWorktreeLoadStatus: vi.fn(() => () => {}),
+  onWorktreeLoadStatus:
+    vi.fn<
+      (cb: (p: { projectId: string; worktreeLoadError: string | null }) => void) => () => void
+    >(),
   getSettings: vi.fn(),
   saveSettings: vi.fn(),
   detectRunners: vi.fn(),
@@ -523,15 +526,9 @@ describe("worktreeLoadError surfacing (#8400)", () => {
     (window as unknown as { electron: unknown }).electron = {
       project: { onUpdated: vi.fn(), onRemoved: vi.fn() },
     };
-    let statusCb:
-      | ((payload: { projectId: string; worktreeLoadError: string | null }) => void)
-      | undefined;
-    projectClientMock.onWorktreeLoadStatus.mockImplementation((cb: typeof statusCb) => {
-      statusCb = cb;
-      return () => {};
-    });
-
     const { useProjectStore } = await import("../projectStore");
+
+    const statusCb = projectClientMock.onWorktreeLoadStatus.mock.calls[0]?.[0];
     expect(typeof statusCb).toBe("function");
 
     // Permissive: accepted while currentProject is still null (cold view).

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -487,3 +487,56 @@ describe("fleet arming clear on project switch (#5298)", () => {
     expect(clearSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("worktreeLoadError surfacing (#8400)", () => {
+  it("clears a stale worktreeLoadError atomically when a switch starts", async () => {
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({
+      projects: [projectA, projectB],
+      currentProject: projectA,
+      worktreeLoadError: "Not a git repository",
+    });
+
+    await useProjectStore.getState().switchProject(projectB.id);
+
+    expect(useProjectStore.getState().worktreeLoadError).toBeNull();
+    expect(useProjectStore.getState().error).toBeNull();
+    expect(useProjectStore.getState().isLoading).toBe(true);
+  });
+
+  it("setWorktreeLoadError sets and clears the slice", async () => {
+    const { useProjectStore } = await import("../projectStore");
+
+    useProjectStore.getState().setWorktreeLoadError("boom");
+    expect(useProjectStore.getState().worktreeLoadError).toBe("boom");
+
+    useProjectStore.getState().setWorktreeLoadError(null);
+    expect(useProjectStore.getState().worktreeLoadError).toBeNull();
+  });
+
+  it("stores worktreeLoadError from the project switch broadcast and clears it on a clean switch", async () => {
+    delete (globalThis as { __daintreeProjectStoreListenerState?: unknown })
+      .__daintreeProjectStoreListenerState;
+    // The module-init listener block only registers when window.electron.project
+    // is present; provide a minimal stub so projectClient.onSwitch is wired.
+    (window as unknown as { electron: unknown }).electron = {
+      project: { onUpdated: vi.fn(), onRemoved: vi.fn() },
+    };
+    const { useProjectStore } = await import("../projectStore");
+
+    const onSwitchCb = projectClientMock.onSwitch.mock.calls.at(-1)?.[0] as
+      | ((payload: {
+          project: typeof projectB;
+          switchId: string;
+          worktreeLoadError?: string;
+        }) => void)
+      | undefined;
+    expect(typeof onSwitchCb).toBe("function");
+
+    onSwitchCb!({ project: projectB, switchId: "s1", worktreeLoadError: "Not a git repository" });
+    expect(useProjectStore.getState().worktreeLoadError).toBe("Not a git repository");
+
+    onSwitchCb!({ project: projectB, switchId: "s2" });
+    expect(useProjectStore.getState().worktreeLoadError).toBeNull();
+  });
+});

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -25,6 +25,7 @@ const createMockProjectClient = () => ({
   prefetchHydrate: vi.fn().mockResolvedValue(undefined),
   openDialog: vi.fn().mockResolvedValue(null),
   onSwitch: vi.fn().mockReturnValue(() => {}),
+  onWorktreeLoadStatus: vi.fn().mockReturnValue(() => {}),
   getSettings: vi.fn().mockResolvedValue({}),
   saveSettings: vi.fn().mockResolvedValue(undefined),
   detectRunners: vi.fn().mockResolvedValue([]),

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -17,6 +17,7 @@ const createMockProjectClient = () => ({
   prefetchHydrate: vi.fn().mockResolvedValue(undefined),
   openDialog: vi.fn().mockResolvedValue(null),
   onSwitch: vi.fn().mockReturnValue(() => {}),
+  onWorktreeLoadStatus: vi.fn().mockReturnValue(() => {}),
   getSettings: vi.fn().mockResolvedValue({}),
   saveSettings: vi.fn().mockResolvedValue(undefined),
   detectRunners: vi.fn().mockResolvedValue([]),

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -781,7 +781,12 @@ if (typeof window !== "undefined" && window.electron?.project) {
       listenerState.applyRemoved?.(projectId);
     });
   }
-  if (!listenerState.worktreeLoadStatusRegistered) {
+  // Guarded like onUpdated/onRemoved above: partial environments (and test
+  // doubles that only stub the methods they exercise) may not expose this.
+  if (
+    typeof projectClient.onWorktreeLoadStatus === "function" &&
+    !listenerState.worktreeLoadStatusRegistered
+  ) {
     listenerState.worktreeLoadStatusRegistered = true;
     projectClient.onWorktreeLoadStatus((payload) => {
       listenerState.applyWorktreeLoadStatus?.(payload);

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -132,10 +132,12 @@ interface ProjectState {
 interface ProjectStoreListenerState {
   applyUpdated: ((project: Project) => void) | null;
   applyRemoved: ((projectId: string) => void) | null;
-  applySwitch: ((worktreeLoadError: string | null) => void) | null;
+  applyWorktreeLoadStatus:
+    | ((payload: { projectId: string; worktreeLoadError: string | null }) => void)
+    | null;
   updatedRegistered: boolean;
   removedRegistered: boolean;
-  switchRegistered: boolean;
+  worktreeLoadStatusRegistered: boolean;
 }
 
 const PROJECT_STORE_LISTENER_STATE_KEY = "__daintreeProjectStoreListenerState";
@@ -155,10 +157,10 @@ function getProjectStoreListenerState(): ProjectStoreListenerState {
   const created: ProjectStoreListenerState = {
     applyUpdated: null,
     applyRemoved: null,
-    applySwitch: null,
+    applyWorktreeLoadStatus: null,
     updatedRegistered: false,
     removedRegistered: false,
-    switchRegistered: false,
+    worktreeLoadStatusRegistered: false,
   };
   target[PROJECT_STORE_LISTENER_STATE_KEY] = created;
   return created;
@@ -749,11 +751,20 @@ if (typeof window !== "undefined" && window.electron?.project) {
       return { projects, currentProject };
     });
   };
-  // A switch broadcast resolves the banner state for the project this view now
-  // shows: surface the failure when the new project's worktree load threw, or
-  // clear a stale banner when the switch (or a cross-view switch) succeeded.
-  listenerState.applySwitch = (worktreeLoadError) => {
-    useProjectStore.setState({ worktreeLoadError });
+  // The worktree-load-status event resolves the banner for the project this
+  // view now shows. The production path targets a single view, but the legacy
+  // path broadcasts to every view (incl. LRU-cached other-project views), so
+  // ignore events whose projectId doesn't match this view's current project.
+  // The guard is *permissive*: a cold-started view may receive the event before
+  // `getCurrentProject()` has populated `currentProject`, so a null
+  // currentProject still accepts the targeted event rather than dropping it.
+  listenerState.applyWorktreeLoadStatus = (payload) => {
+    useProjectStore.setState((state) => {
+      if (state.currentProject && state.currentProject.id !== payload.projectId) {
+        return state;
+      }
+      return { worktreeLoadError: payload.worktreeLoadError };
+    });
   };
 
   const projectApi = window.electron.project;
@@ -770,10 +781,10 @@ if (typeof window !== "undefined" && window.electron?.project) {
       listenerState.applyRemoved?.(projectId);
     });
   }
-  if (!listenerState.switchRegistered) {
-    listenerState.switchRegistered = true;
-    projectClient.onSwitch((payload) => {
-      listenerState.applySwitch?.(payload.worktreeLoadError ?? null);
+  if (!listenerState.worktreeLoadStatusRegistered) {
+    listenerState.worktreeLoadStatusRegistered = true;
+    projectClient.onWorktreeLoadStatus((payload) => {
+      listenerState.applyWorktreeLoadStatus?.(payload);
     });
   }
 }

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -74,6 +74,12 @@ interface ProjectState {
   currentProject: Project | null;
   isLoading: boolean;
   error: string | null;
+  /**
+   * Set when a project switch committed to the new project but its worktree
+   * load threw (#8400). Surfaced as a Tier 3 inline recovery banner. Transient
+   * — never persisted, cleared on the next switch start or a successful retry.
+   */
+  worktreeLoadError: string | null;
   gitInitDialogOpen: boolean;
   gitInitDirectoryPath: string | null;
   createFolderDialogOpen: boolean;
@@ -88,6 +94,7 @@ interface ProjectState {
   ) => Promise<void>;
   createProjectFolder: (parentPath: string, folderName: string) => Promise<void>;
   switchProject: (projectId: string) => Promise<void>;
+  setWorktreeLoadError: (error: string | null) => void;
   updateProject: (id: string, updates: Partial<Project>) => Promise<void>;
   enableInRepoSettings: (id: string) => Promise<Project>;
   disableInRepoSettings: (id: string) => Promise<Project>;
@@ -125,8 +132,10 @@ interface ProjectState {
 interface ProjectStoreListenerState {
   applyUpdated: ((project: Project) => void) | null;
   applyRemoved: ((projectId: string) => void) | null;
+  applySwitch: ((worktreeLoadError: string | null) => void) | null;
   updatedRegistered: boolean;
   removedRegistered: boolean;
+  switchRegistered: boolean;
 }
 
 const PROJECT_STORE_LISTENER_STATE_KEY = "__daintreeProjectStoreListenerState";
@@ -146,8 +155,10 @@ function getProjectStoreListenerState(): ProjectStoreListenerState {
   const created: ProjectStoreListenerState = {
     applyUpdated: null,
     applyRemoved: null,
+    applySwitch: null,
     updatedRegistered: false,
     removedRegistered: false,
+    switchRegistered: false,
   };
   target[PROJECT_STORE_LISTENER_STATE_KEY] = created;
   return created;
@@ -226,6 +237,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
   createFolderDialogOpen: false,
   cloneRepoDialogOpen: false,
   error: null,
+  worktreeLoadError: null,
 
   addProjectByPath: async (path, options) => {
     set({ isLoading: true, error: null });
@@ -408,7 +420,10 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     const currentProjectId = get().currentProject?.id;
     const outgoingState = currentProjectId ? buildOutgoingState(currentProjectId) : undefined;
 
-    set({ isLoading: true, error: null });
+    // Clear any stale worktree-load banner atomically with the switch start so
+    // the previous project's failure never coexists with the new project (#8400,
+    // mirrors the #4451 atomic-swap fix).
+    set({ isLoading: true, error: null, worktreeLoadError: null });
     // Fire-and-forget: the main process swaps WebContentsViews, so this
     // renderer gets detached. Don't write the response into stores — the
     // new view handles its own state independently.
@@ -438,6 +453,10 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       });
       set({ error: message, isLoading: false });
     });
+  },
+
+  setWorktreeLoadError: (worktreeLoadError) => {
+    set({ worktreeLoadError });
   },
 
   updateProject: async (id, updates) => {
@@ -564,7 +583,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     const currentProjectId = get().currentProject?.id;
     const outgoingState = currentProjectId ? buildOutgoingState(currentProjectId) : undefined;
 
-    set({ isLoading: true, error: null });
+    set({ isLoading: true, error: null, worktreeLoadError: null });
     projectClient.reopen(projectId, outgoingState).catch((error) => {
       if (requestId !== projectTransitionRequestId) {
         return;
@@ -730,6 +749,12 @@ if (typeof window !== "undefined" && window.electron?.project) {
       return { projects, currentProject };
     });
   };
+  // A switch broadcast resolves the banner state for the project this view now
+  // shows: surface the failure when the new project's worktree load threw, or
+  // clear a stale banner when the switch (or a cross-view switch) succeeded.
+  listenerState.applySwitch = (worktreeLoadError) => {
+    useProjectStore.setState({ worktreeLoadError });
+  };
 
   const projectApi = window.electron.project;
   if (projectApi.onUpdated && !listenerState.updatedRegistered) {
@@ -743,6 +768,12 @@ if (typeof window !== "undefined" && window.electron?.project) {
     listenerState.removedRegistered = true;
     projectApi.onRemoved((projectId) => {
       listenerState.applyRemoved?.(projectId);
+    });
+  }
+  if (!listenerState.switchRegistered) {
+    listenerState.switchRegistered = true;
+    projectClient.onSwitch((payload) => {
+      listenerState.applySwitch?.(payload.worktreeLoadError ?? null);
     });
   }
 }


### PR DESCRIPTION
## Summary

- Removes the PTY-only rollback from `ProjectSwitchService.performSwitch` catch — store, git-cache, log-buffer, and context-tracker had already committed to the new project before the catch ran, so reverting only the PTY left a half-reverted state. Forward-fails to the new project instead.
- Surfaces worktree-load failures as a Tier 3 inline recovery banner (`WorktreeLoadErrorBanner`) in the worktree sidebar with a Retry action. Adds a dedicated `project:worktree-load-status` IPC event (the production view-swap path never broadcast `PROJECT_ON_SWITCH`, so the original field was dead on the live path); the legacy `ProjectSwitchService` path emits the same event. Renderer guards on `projectId` to avoid cross-window contamination.
- Adds `worktree.retryProjectLoad` action + IPC that re-runs `loadProject` for the current project.

Resolves #8400

## Changes

- `electron/services/ProjectSwitchService.ts` — drop PTY-only rollback; forward-fail on switch error
- `electron/ipc/handlers/projectCrud/switch.ts` + `worktree/lifecycle.ts` — emit `project:worktree-load-status` on both switch paths with targeted `projectId` send on production path
- `electron/ipc/channels.ts` + `shared/types/ipc/` — new `project:worktree-load-status` event channel and types
- `src/clients/projectClient.ts` + `worktreeClient.ts` — expose `onWorktreeLoadStatus` and `retryProjectLoad`
- `src/store/projectStore.ts` — subscribe to `onWorktreeLoadStatus`, guard on `projectId`, expose `worktreeLoadError` state
- `src/components/Sidebar/WorktreeLoadErrorBanner.tsx` + `SidebarContent.tsx` — new inline error banner with retry
- `src/services/actions/definitions/worktreeServiceActions.ts` — `worktree:retry-project-load` action

## Testing

- Rollback removal, dedicated event on both paths, production-path targeted send, `projectId` guard, mid-retry race, banner render and retry
- 113 tests pass across affected suites
- Full `npm run check` gate green
- `ProjectViewManager` view-plane rollback is out of scope (separate concern)