### PR TITLE
feat(worktree): switch filter chip counts to disjunctive faceting

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -545,8 +545,27 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     const nonMain = deferredWorktrees.filter(
       (w) => w.id !== mainWorktree?.id && w.id !== integrationWorktree?.id
     );
-    return computeChipCounts(nonMain, derivedMetaMap, activeWorktreeId);
-  }, [deferredWorktrees, derivedMetaMap, mainWorktree, integrationWorktree, activeWorktreeId]);
+    return computeChipCounts(nonMain, derivedMetaMap, activeWorktreeId, {
+      query,
+      statusFilters,
+      typeFilters,
+      githubFilters,
+      sessionFilters,
+      activityFilters,
+    });
+  }, [
+    deferredWorktrees,
+    derivedMetaMap,
+    mainWorktree,
+    integrationWorktree,
+    activeWorktreeId,
+    query,
+    statusFilters,
+    typeFilters,
+    githubFilters,
+    sessionFilters,
+    activityFilters,
+  ]);
 
   const mainWorktreeAggregateCounts = useMemo(() => {
     const nonMainCount = deferredWorktrees.length - 1 - (integrationWorktree ? 1 : 0);

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -254,8 +254,26 @@ export function WorktreeOverviewModal({
 
   const chipCounts = useMemo(() => {
     const candidates = hideMainWorktree ? worktrees.filter((w) => !w.isMainWorktree) : worktrees;
-    return computeChipCounts(candidates, derivedMetaMap, activeWorktreeId);
-  }, [worktrees, derivedMetaMap, activeWorktreeId, hideMainWorktree]);
+    return computeChipCounts(candidates, derivedMetaMap, activeWorktreeId, {
+      query,
+      statusFilters,
+      typeFilters,
+      githubFilters,
+      sessionFilters,
+      activityFilters,
+    });
+  }, [
+    worktrees,
+    derivedMetaMap,
+    activeWorktreeId,
+    hideMainWorktree,
+    query,
+    statusFilters,
+    typeFilters,
+    githubFilters,
+    sessionFilters,
+    activityFilters,
+  ]);
 
   // Compute aggregate statistics from derivedMetaMap
   const aggregateStats = useMemo(() => {

--- a/src/lib/__tests__/worktreeFilters.test.ts
+++ b/src/lib/__tests__/worktreeFilters.test.ts
@@ -1585,4 +1585,39 @@ describe("computeChipCounts", () => {
     expect(counts.branchType.feature).toBe(1);
     expect(counts.branchType.bugfix).toBe(1);
   });
+
+  it("applies exact-number query (#123) as a global AND gate", () => {
+    const worktrees = [
+      createMockWorktree({ id: "1", branch: "feature/a", issueNumber: 100 }),
+      createMockWorktree({ id: "2", branch: "feature/b", issueNumber: 200 }),
+      createMockWorktree({ id: "3", branch: "bugfix/c" }),
+    ];
+    const filters: FilterState = {
+      query: "#100",
+      statusFilters: new Set(),
+      typeFilters: new Set(),
+      githubFilters: new Set(),
+      sessionFilters: new Set(),
+      activityFilters: new Set(),
+    };
+    const counts = computeChipCounts(worktrees, new Map(), null, filters);
+    // Only w1 matches the exact-number query — all chips counted against it
+    expect(counts.branchType.feature).toBe(1);
+    expect(counts.branchType.bugfix).toBe(0);
+    expect(counts.github.hasIssue).toBe(1);
+  });
+
+  it("excludes worktrees with future lastActivityTimestamp from all activity windows", () => {
+    const now = Date.now();
+    const worktrees = [
+      createMockWorktree({ id: "1", lastActivityTimestamp: now + 60 * 60 * 1000 }),
+      createMockWorktree({ id: "2", lastActivityTimestamp: now - 5 * 60 * 1000 }),
+    ];
+    const counts = computeChipCounts(worktrees, new Map(), null, createEmptyFilters());
+    // w1 has future timestamp → excluded from all activity chips
+    // w2 is within last15m → counted
+    expect(counts.activity.last15m).toBe(1);
+    expect(counts.activity.last1h).toBe(1);
+    expect(counts.activity.last24h).toBe(1);
+  });
 });

--- a/src/lib/__tests__/worktreeFilters.test.ts
+++ b/src/lib/__tests__/worktreeFilters.test.ts
@@ -18,6 +18,12 @@ import {
   type FilterState,
 } from "../worktreeFilters";
 import type { Worktree } from "@shared/types/worktree";
+import type {
+  StatusFilter,
+  TypeFilter,
+  SessionFilter,
+  ActivityFilter,
+} from "@/store/worktreeFilterStore";
 
 const createMockWorktree = (overrides: Partial<Worktree> = {}): Worktree => {
   const num = overrides.prNumber;
@@ -1281,18 +1287,20 @@ describe("computeChipCounts", () => {
     vi.useRealTimers();
   });
 
+  const emptyFilters = createEmptyFilters();
+
   it("returns all-zero counts for an empty worktree list", () => {
-    const counts = computeChipCounts([], new Map(), null);
+    const counts = computeChipCounts([], new Map(), null, emptyFilters);
     expect(counts).toEqual(emptyChipCounts());
   });
 
-  it("counts branch types independently", () => {
+  it("with no active filters, counts equal absolute totals", () => {
     const worktrees = [
       createMockWorktree({ id: "1", branch: "feature/a" }),
       createMockWorktree({ id: "2", branch: "feature/b" }),
       createMockWorktree({ id: "3", branch: "bugfix/c" }),
     ];
-    const counts = computeChipCounts(worktrees, new Map(), null);
+    const counts = computeChipCounts(worktrees, new Map(), null, emptyFilters);
     expect(counts.branchType.feature).toBe(2);
     expect(counts.branchType.bugfix).toBe(1);
     expect(counts.branchType.refactor).toBe(0);
@@ -1305,7 +1313,7 @@ describe("computeChipCounts", () => {
       createMockWorktree({ id: "3", prNumber: 202, prState: "merged" }),
       createMockWorktree({ id: "4", prNumber: 203, prState: "closed" }),
     ];
-    const counts = computeChipCounts(worktrees, new Map(), null);
+    const counts = computeChipCounts(worktrees, new Map(), null, emptyFilters);
     expect(counts.github.hasIssue).toBe(2);
     expect(counts.github.hasPR).toBe(3);
     expect(counts.github.prOpen).toBe(1);
@@ -1328,11 +1336,10 @@ describe("computeChipCounts", () => {
       }),
       createMockWorktree({ id: "3", branch: "feature/c" }),
     ];
-    const counts = computeChipCounts(worktrees, new Map(), "3");
+    const counts = computeChipCounts(worktrees, new Map(), "3", emptyFilters);
     expect(counts.status.active).toBe(1);
     expect(counts.status.dirty).toBe(1);
     expect(counts.status.stale).toBe(1);
-    // id 2 is dirty (not idle); id 3 is active-only -> idle; id 1 is stale (not idle)
     expect(counts.status.idle).toBe(1);
   });
 
@@ -1368,7 +1375,7 @@ describe("computeChipCounts", () => {
         },
       ],
     ]);
-    const counts = computeChipCounts(worktrees, map, null);
+    const counts = computeChipCounts(worktrees, map, null, emptyFilters);
     expect(counts.sessions.hasTerminals).toBe(2);
     expect(counts.sessions.working).toBe(1);
     expect(counts.sessions.waiting).toBe(1);
@@ -1379,13 +1386,13 @@ describe("computeChipCounts", () => {
   it("counts activity chips against current time windows (cumulative)", () => {
     const now = Date.now();
     const worktrees = [
-      createMockWorktree({ id: "1", lastActivityTimestamp: now - 5 * 60 * 1000 }), // 5m
-      createMockWorktree({ id: "2", lastActivityTimestamp: now - 30 * 60 * 1000 }), // 30m
-      createMockWorktree({ id: "3", lastActivityTimestamp: now - 5 * 60 * 60 * 1000 }), // 5h
-      createMockWorktree({ id: "4", lastActivityTimestamp: now - 3 * 24 * 60 * 60 * 1000 }), // 3d
-      createMockWorktree({ id: "5", lastActivityTimestamp: now - 30 * 24 * 60 * 60 * 1000 }), // 30d
+      createMockWorktree({ id: "1", lastActivityTimestamp: now - 5 * 60 * 1000 }),
+      createMockWorktree({ id: "2", lastActivityTimestamp: now - 30 * 60 * 1000 }),
+      createMockWorktree({ id: "3", lastActivityTimestamp: now - 5 * 60 * 60 * 1000 }),
+      createMockWorktree({ id: "4", lastActivityTimestamp: now - 3 * 24 * 60 * 60 * 1000 }),
+      createMockWorktree({ id: "5", lastActivityTimestamp: now - 30 * 24 * 60 * 60 * 1000 }),
     ];
-    const counts = computeChipCounts(worktrees, new Map(), null);
+    const counts = computeChipCounts(worktrees, new Map(), null, emptyFilters);
     expect(counts.activity.last15m).toBe(1);
     expect(counts.activity.last1h).toBe(2);
     expect(counts.activity.last24h).toBe(3);
@@ -1394,14 +1401,14 @@ describe("computeChipCounts", () => {
 
   it("ignores worktrees with no lastActivityTimestamp for activity chips", () => {
     const worktrees = [createMockWorktree({ id: "1" })];
-    const counts = computeChipCounts(worktrees, new Map(), null);
+    const counts = computeChipCounts(worktrees, new Map(), null, emptyFilters);
     expect(counts.activity.last15m).toBe(0);
     expect(counts.activity.last7d).toBe(0);
   });
 
   it("treats lastActivityTimestamp === 0 the same as missing", () => {
     const worktrees = [createMockWorktree({ id: "1", lastActivityTimestamp: 0 })];
-    const counts = computeChipCounts(worktrees, new Map(), null);
+    const counts = computeChipCounts(worktrees, new Map(), null, emptyFilters);
     expect(counts.activity.last15m).toBe(0);
     expect(counts.activity.last7d).toBe(0);
   });
@@ -1411,15 +1418,171 @@ describe("computeChipCounts", () => {
     const worktrees = [
       createMockWorktree({ id: "1", lastActivityTimestamp: now - 15 * 60 * 1000 }),
     ];
-    const counts = computeChipCounts(worktrees, new Map(), null);
+    const counts = computeChipCounts(worktrees, new Map(), null, emptyFilters);
     expect(counts.activity.last15m).toBe(0);
     expect(counts.activity.last1h).toBe(1);
   });
 
   it("does not crash when derivedMetaMap is missing entries", () => {
     const worktrees = [createMockWorktree({ id: "1", branch: "feature/a" })];
-    const counts = computeChipCounts(worktrees, new Map(), null);
+    const counts = computeChipCounts(worktrees, new Map(), null, emptyFilters);
     expect(counts.branchType.feature).toBe(1);
     expect(counts.sessions.working).toBe(0);
+  });
+
+  // Disjunctive faceting tests
+
+  it("narrows non-status chips when a status filter is active", () => {
+    const worktrees = [
+      createMockWorktree({ id: "1", branch: "feature/a", mood: "stale" }),
+      createMockWorktree({ id: "2", branch: "bugfix/b", mood: "stale" }),
+      createMockWorktree({ id: "3", branch: "feature/c" }),
+    ];
+    const filters: FilterState = {
+      query: "",
+      statusFilters: new Set<StatusFilter>(["stale"]),
+      typeFilters: new Set(),
+      githubFilters: new Set(),
+      sessionFilters: new Set(),
+      activityFilters: new Set(),
+    };
+    const counts = computeChipCounts(worktrees, new Map(), null, filters);
+    // Status chips count against base set excluding status (all 3 worktrees)
+    expect(counts.status.stale).toBe(2);
+    expect(counts.status.idle).toBe(1);
+    expect(counts.status.active).toBe(0);
+    // Branch type chips counted against base set filtered by status=stale (only 2 stale worktrees)
+    expect(counts.branchType.feature).toBe(1);
+    expect(counts.branchType.bugfix).toBe(1);
+  });
+
+  it("narrows type chips when a branch type filter is active", () => {
+    const worktrees = [
+      createMockWorktree({ id: "1", branch: "feature/a" }),
+      createMockWorktree({ id: "2", branch: "feature/b" }),
+      createMockWorktree({ id: "3", branch: "bugfix/c" }),
+    ];
+    const filters: FilterState = {
+      query: "",
+      statusFilters: new Set(),
+      typeFilters: new Set<TypeFilter>(["feature"]),
+      githubFilters: new Set(),
+      sessionFilters: new Set(),
+      activityFilters: new Set(),
+    };
+    const counts = computeChipCounts(worktrees, new Map(), null, filters);
+    // Branch type chips show absolute totals (sibling group excluded from base set)
+    expect(counts.branchType.feature).toBe(2);
+    expect(counts.branchType.bugfix).toBe(1);
+    // Status chips counted against base set filtered by type=feature (only 2 feature worktrees)
+    expect(counts.status.idle).toBe(2);
+    expect(counts.status.active).toBe(0);
+  });
+
+  it("computes cross-facet intersection correctly with two active filter groups", () => {
+    const now = Date.now();
+    const worktrees = [
+      createMockWorktree({
+        id: "1",
+        branch: "feature/a",
+        lastActivityTimestamp: now - 5 * 60 * 1000,
+      }),
+      createMockWorktree({
+        id: "2",
+        branch: "bugfix/b",
+        lastActivityTimestamp: now - 5 * 60 * 1000,
+      }),
+      createMockWorktree({
+        id: "3",
+        branch: "feature/c",
+        lastActivityTimestamp: now - 2 * 60 * 60 * 1000,
+      }),
+    ];
+    const filters: FilterState = {
+      query: "",
+      statusFilters: new Set(),
+      typeFilters: new Set<TypeFilter>(["feature"]),
+      githubFilters: new Set(),
+      sessionFilters: new Set(),
+      activityFilters: new Set<ActivityFilter>(["last15m"]),
+    };
+    const counts = computeChipCounts(worktrees, new Map(), null, filters);
+    // Type chips count against base set excluding type filters (activity=last15m → w1 and w2)
+    expect(counts.branchType.feature).toBe(1); // w1 only
+    expect(counts.branchType.bugfix).toBe(1); // w2
+    // Activity chips count against base set excluding activity filters (type=feature → w1 and w3)
+    expect(counts.activity.last15m).toBe(1); // w1
+    expect(counts.activity.last1h).toBe(1); // w1
+    expect(counts.activity.last24h).toBe(2); // w1 + w3
+  });
+
+  it("applies text query as a global AND gate across all groups", () => {
+    const worktrees = [
+      createMockWorktree({ id: "1", branch: "feature/login", name: "login" }),
+      createMockWorktree({ id: "2", branch: "feature/signup", name: "signup" }),
+      createMockWorktree({ id: "3", branch: "bugfix/login", name: "login-fix" }),
+    ];
+    const filters: FilterState = {
+      query: "login",
+      statusFilters: new Set(),
+      typeFilters: new Set(),
+      githubFilters: new Set(),
+      sessionFilters: new Set(),
+      activityFilters: new Set(),
+    };
+    const counts = computeChipCounts(worktrees, new Map(), null, filters);
+    // Only w1 and w3 match "login" query — all chips counted against this subset
+    expect(counts.branchType.feature).toBe(1);
+    expect(counts.branchType.bugfix).toBe(1);
+    expect(counts.status.idle).toBe(2);
+  });
+
+  it("shows zero for chips unreachable under active cross-facet filters", () => {
+    const map = new Map<string, DerivedWorktreeMeta>([
+      ["1", { ...createEmptyMeta(), hasWorkingAgent: true }],
+      ["2", { ...createEmptyMeta(), hasCompletedAgent: true }],
+      ["3", { ...createEmptyMeta(), hasWorkingAgent: true }],
+    ]);
+    const worktrees = [
+      createMockWorktree({ id: "1", branch: "feature/a" }),
+      createMockWorktree({ id: "2", branch: "feature/b" }),
+      createMockWorktree({ id: "3", branch: "bugfix/c" }),
+    ];
+    const filters: FilterState = {
+      query: "",
+      statusFilters: new Set(),
+      typeFilters: new Set<TypeFilter>(["bugfix"]),
+      githubFilters: new Set(),
+      sessionFilters: new Set<SessionFilter>(["working"]),
+      activityFilters: new Set(),
+    };
+    const counts = computeChipCounts(worktrees, map, null, filters);
+    // Session chips: base set = type=bugfix → only w3
+    // w3 is bugfix and hasWorkingAgent → working=1
+    expect(counts.sessions.working).toBe(1);
+    expect(counts.sessions.completed).toBe(0);
+    // Branch type chips: base set = session=working → w1 and w3
+    // w1 is feature/working, w3 is bugfix/working
+    expect(counts.branchType.bugfix).toBe(1);
+    expect(counts.branchType.feature).toBe(1);
+  });
+
+  it("is unaffected by sibling group when computing within-group counts", () => {
+    const worktrees = [
+      createMockWorktree({ id: "1", branch: "feature/a" }),
+      createMockWorktree({ id: "2", branch: "bugfix/b" }),
+    ];
+    const filters: FilterState = {
+      query: "",
+      statusFilters: new Set(),
+      typeFilters: new Set<TypeFilter>(["feature"]),
+      githubFilters: new Set(),
+      sessionFilters: new Set(),
+      activityFilters: new Set(),
+    };
+    const counts = computeChipCounts(worktrees, new Map(), null, filters);
+    // Type chips ignore their own active filter — show absolute totals
+    expect(counts.branchType.feature).toBe(1);
+    expect(counts.branchType.bugfix).toBe(1);
   });
 });

--- a/src/lib/worktreeFilters.ts
+++ b/src/lib/worktreeFilters.ts
@@ -548,6 +548,7 @@ export function computeChipCounts(
     const lastActivity = w.lastActivityTimestamp ?? 0;
     if (lastActivity > 0) {
       const elapsed = now - lastActivity;
+      if (elapsed < 0) continue;
       for (const key of ACTIVITY_KEYS) {
         if (elapsed < ACTIVITY_WINDOW_MS[key]) counts.activity[key]++;
       }

--- a/src/lib/worktreeFilters.ts
+++ b/src/lib/worktreeFilters.ts
@@ -482,39 +482,70 @@ export function emptyChipCounts(): ChipCounts {
   };
 }
 
+const DEFAULT_DERIVED_META: DerivedWorktreeMeta = {
+  terminalCount: 0,
+  hasWorkingAgent: false,
+  hasWaitingAgent: false,
+  hasCompletedAgent: false,
+  hasExitedAgent: false,
+  hasMergeConflict: false,
+  chipState: null,
+};
+
+function withoutGroup<K extends keyof FilterState>(filters: FilterState, group: K): FilterState {
+  return { ...filters, [group]: new Set() };
+}
+
 export function computeChipCounts(
   worktrees: readonly (Worktree | WorktreeState)[],
   derivedMetaMap: Map<string, DerivedWorktreeMeta>,
-  activeWorktreeId: string | null
+  activeWorktreeId: string | null,
+  filters: FilterState
 ): ChipCounts {
   const counts = emptyChipCounts();
   const now = Date.now();
 
-  for (const worktree of worktrees) {
-    const isActive = worktree.id === activeWorktreeId;
-    const statuses = computeStatus(worktree, isActive);
+  const baseIsActive = (w: (typeof worktrees)[number]) => w.id === activeWorktreeId;
+  const getDerived = (id: string) => derivedMetaMap.get(id) ?? DEFAULT_DERIVED_META;
+  const matchesGroup = (w: (typeof worktrees)[number], groupKey: keyof FilterState) =>
+    matchesFilters(w, withoutGroup(filters, groupKey), getDerived(w.id), baseIsActive(w));
+
+  // Build base set per group — filtered by all OTHER groups + query
+  const statusBase = worktrees.filter((w) => matchesGroup(w, "statusFilters"));
+  const typeBase = worktrees.filter((w) => matchesGroup(w, "typeFilters"));
+  const githubBase = worktrees.filter((w) => matchesGroup(w, "githubFilters"));
+  const sessionsBase = worktrees.filter((w) => matchesGroup(w, "sessionFilters"));
+  const activityBase = worktrees.filter((w) => matchesGroup(w, "activityFilters"));
+
+  for (const w of statusBase) {
+    const statuses = computeStatus(w, baseIsActive(w));
     for (const status of statuses) counts.status[status]++;
+  }
 
-    const type = getWorktreeType(worktree);
-    counts.branchType[type]++;
+  for (const w of typeBase) {
+    counts.branchType[getWorktreeType(w)]++;
+  }
 
-    if (worktree.issueNumber) counts.github.hasIssue++;
-    if (worktree.linked?.pr) counts.github.hasPR++;
-    if (worktree.linked?.pr?.state === "open") counts.github.prOpen++;
-    if (worktree.linked?.pr?.state === "merged") counts.github.prMerged++;
-    if (worktree.linked?.pr?.state === "closed" || worktree.linked?.pr?.state === "declined")
+  for (const w of githubBase) {
+    if (w.issueNumber) counts.github.hasIssue++;
+    if (w.linked?.pr) counts.github.hasPR++;
+    if (w.linked?.pr?.state === "open") counts.github.prOpen++;
+    if (w.linked?.pr?.state === "merged") counts.github.prMerged++;
+    if (w.linked?.pr?.state === "closed" || w.linked?.pr?.state === "declined")
       counts.github.prClosed++;
+  }
 
-    const meta = derivedMetaMap.get(worktree.id);
-    if (meta) {
-      if (meta.terminalCount > 0) counts.sessions.hasTerminals++;
-      if (meta.hasWorkingAgent) counts.sessions.working++;
-      if (meta.hasWaitingAgent) counts.sessions.waiting++;
-      if (meta.hasCompletedAgent) counts.sessions.completed++;
-      if (meta.hasExitedAgent) counts.sessions.exited++;
-    }
+  for (const w of sessionsBase) {
+    const meta = getDerived(w.id);
+    if (meta.terminalCount > 0) counts.sessions.hasTerminals++;
+    if (meta.hasWorkingAgent) counts.sessions.working++;
+    if (meta.hasWaitingAgent) counts.sessions.waiting++;
+    if (meta.hasCompletedAgent) counts.sessions.completed++;
+    if (meta.hasExitedAgent) counts.sessions.exited++;
+  }
 
-    const lastActivity = worktree.lastActivityTimestamp ?? 0;
+  for (const w of activityBase) {
+    const lastActivity = w.lastActivityTimestamp ?? 0;
     if (lastActivity > 0) {
       const elapsed = now - lastActivity;
       for (const key of ACTIVITY_KEYS) {


### PR DESCRIPTION
## Summary
This makes chip counts show how many worktrees would match if you added that filter, rather than absolute totals. It is disjunctive faceting — counts are scoped to the remaining filters in other groups, so it answers "if I add this chip, how many worktrees will I have?" at a glance.

A small guard also prevents negative elapsed time from slipping into the activity count calculation.

Resolves #8390

## Changes
- `computeChipCounts` in `worktreeFilters.ts` now accepts a `filters` parameter and builds per-group base sets filtered by all other groups
- Updated both call sites (`SidebarContent.tsx`, `WorktreeOverviewModal.tsx`) to pass the active filter state
- Added `elapsed < 0` guard in the activity window loop
- Expanded test coverage in `worktreeFilters.test.ts` for the new disjunctive behavior

## Testing
Unit tests cover disjunctive filtering across all chip groups and the negative elapsed time guard. Manually verified chip counts in the sidebar and overview modal with mixed filter selections.