### PR TITLE
Cut idle git-status cost in WorktreeMonitor (closes #8396)

### DIFF
--- a/electron/services/worktree/AdaptivePollingStrategy.ts
+++ b/electron/services/worktree/AdaptivePollingStrategy.ts
@@ -5,6 +5,14 @@ const DEFAULT_MAX_INTERVAL = DEFAULT_CONFIG.monitor?.pollIntervalMax ?? 30000;
 const DEFAULT_ADAPTIVE_BACKOFF = DEFAULT_CONFIG.monitor?.adaptiveBackoff ?? true;
 const DEFAULT_CIRCUIT_BREAKER_THRESHOLD = DEFAULT_CONFIG.monitor?.circuitBreakerThreshold ?? 3;
 
+// Idle backoff: after N consecutive polls observed no state change, lengthen
+// the next interval. Each additional IDLE_MISS_THRESHOLD-sized batch doubles
+// the multiplier (1× → 2× → 4×) up to IDLE_BACKOFF_CEILING_MULTIPLIER, then
+// caps. The final interval is still bounded by `maxInterval`, so this cannot
+// push the cadence past the configured ceiling.
+const IDLE_MISS_THRESHOLD = 3;
+const IDLE_BACKOFF_CEILING_MULTIPLIER = 4;
+
 function normalizeInterval(ms: number | undefined, fallback: number): number {
   if (typeof ms !== "number" || !Number.isFinite(ms)) {
     return fallback;
@@ -52,6 +60,7 @@ export class AdaptivePollingStrategy {
   private lastQueueDelay: number = 0;
   private consecutiveFailures: number = 0;
   private circuitBreakerTripped: boolean = false;
+  private consecutiveUnchangedCount: number = 0;
 
   constructor(config?: Partial<AdaptivePollingConfig>) {
     this.baseInterval = normalizeInterval(config?.baseInterval, DEFAULT_BASE_INTERVAL);
@@ -67,18 +76,32 @@ export class AdaptivePollingStrategy {
   }
 
   public calculateNextInterval(): number {
-    if (!this.adaptiveBackoff || this.lastOperationDuration <= 0) {
-      return this.baseInterval;
-    }
-
-    const adaptiveInterval = Math.ceil(this.lastOperationDuration * 1.5);
-    if (!Number.isFinite(adaptiveInterval) || adaptiveInterval < 1) {
-      return this.baseInterval;
-    }
-
     const boundedMaxInterval = Math.max(this.maxInterval, this.baseInterval);
-    const nextInterval = Math.max(this.baseInterval, adaptiveInterval);
-    return Math.min(nextInterval, boundedMaxInterval);
+    const idleMultiplier = this.idleBackoffMultiplier();
+
+    let baseAdaptive: number;
+    if (!this.adaptiveBackoff || this.lastOperationDuration <= 0) {
+      baseAdaptive = this.baseInterval;
+    } else {
+      const adaptiveInterval = Math.ceil(this.lastOperationDuration * 1.5);
+      if (!Number.isFinite(adaptiveInterval) || adaptiveInterval < 1) {
+        baseAdaptive = this.baseInterval;
+      } else {
+        baseAdaptive = Math.max(this.baseInterval, adaptiveInterval);
+      }
+    }
+
+    const scaled = baseAdaptive * idleMultiplier;
+    return Math.min(scaled, boundedMaxInterval);
+  }
+
+  private idleBackoffMultiplier(): number {
+    if (this.consecutiveUnchangedCount < IDLE_MISS_THRESHOLD) {
+      return 1;
+    }
+    const steps = Math.floor(this.consecutiveUnchangedCount / IDLE_MISS_THRESHOLD);
+    const multiplier = 2 ** steps;
+    return Math.min(multiplier, IDLE_BACKOFF_CEILING_MULTIPLIER);
   }
 
   public recordSuccess(durationMs: number, queueDelayMs: number = 0): void {
@@ -90,6 +113,26 @@ export class AdaptivePollingStrategy {
     if (this.circuitBreakerTripped) {
       this.circuitBreakerTripped = false;
     }
+  }
+
+  /**
+   * A completed poll observed no relevant state change. Lengthens the next
+   * interval (in tandem with the multiplier in `calculateNextInterval`) so a
+   * quiet repo doesn't burn fork-exec cycles on every base-interval tick.
+   * Only call after a real git check; cheap stat-skips bypass this so the
+   * counter measures git-confirmed quiet time, not all quiet ticks.
+   */
+  public recordNoChange(): void {
+    this.consecutiveUnchangedCount++;
+  }
+
+  /**
+   * Reset the idle counter — a poll observed change, a watcher event fired,
+   * or focus shifted to this worktree. The next interval drops back to the
+   * base cadence so the user sees fresh activity right after something moves.
+   */
+  public recordStateChange(): void {
+    this.consecutiveUnchangedCount = 0;
   }
 
   public recordFailure(durationMs: number, queueDelayMs: number = 0): boolean {
@@ -115,6 +158,7 @@ export class AdaptivePollingStrategy {
     this.consecutiveFailures = 0;
     this.lastOperationDuration = 0;
     this.lastQueueDelay = 0;
+    this.consecutiveUnchangedCount = 0;
   }
 
   public getMetrics(): AdaptivePollingMetrics {

--- a/electron/services/worktree/__tests__/AdaptivePollingStrategy.test.ts
+++ b/electron/services/worktree/__tests__/AdaptivePollingStrategy.test.ts
@@ -75,4 +75,82 @@ describe("AdaptivePollingStrategy", () => {
     expect(Number.isFinite(interval)).toBe(true);
     expect(interval).toBeGreaterThanOrEqual(1);
   });
+
+  describe("idle backoff", () => {
+    it("keeps base interval below the miss threshold", () => {
+      const strategy = new AdaptivePollingStrategy({ baseInterval: 2000, maxInterval: 30_000 });
+
+      strategy.recordNoChange();
+      strategy.recordNoChange();
+
+      expect(strategy.calculateNextInterval()).toBe(2000);
+    });
+
+    it("doubles cadence at three consecutive unchanged polls", () => {
+      const strategy = new AdaptivePollingStrategy({ baseInterval: 2000, maxInterval: 30_000 });
+
+      strategy.recordNoChange();
+      strategy.recordNoChange();
+      strategy.recordNoChange();
+
+      expect(strategy.calculateNextInterval()).toBe(4000);
+    });
+
+    it("quadruples cadence at six consecutive unchanged polls", () => {
+      const strategy = new AdaptivePollingStrategy({ baseInterval: 2000, maxInterval: 30_000 });
+
+      for (let i = 0; i < 6; i++) strategy.recordNoChange();
+
+      expect(strategy.calculateNextInterval()).toBe(8000);
+    });
+
+    it("caps at the 4x ceiling beyond six unchanged polls", () => {
+      const strategy = new AdaptivePollingStrategy({ baseInterval: 2000, maxInterval: 30_000 });
+
+      for (let i = 0; i < 100; i++) strategy.recordNoChange();
+
+      expect(strategy.calculateNextInterval()).toBe(8000);
+    });
+
+    it("recordStateChange resets the idle counter", () => {
+      const strategy = new AdaptivePollingStrategy({ baseInterval: 2000, maxInterval: 30_000 });
+
+      for (let i = 0; i < 6; i++) strategy.recordNoChange();
+      expect(strategy.calculateNextInterval()).toBe(8000);
+
+      strategy.recordStateChange();
+      expect(strategy.calculateNextInterval()).toBe(2000);
+    });
+
+    it("reset() zeroes the idle counter alongside other state", () => {
+      const strategy = new AdaptivePollingStrategy({ baseInterval: 2000, maxInterval: 30_000 });
+
+      for (let i = 0; i < 6; i++) strategy.recordNoChange();
+      expect(strategy.calculateNextInterval()).toBe(8000);
+
+      strategy.reset();
+      expect(strategy.calculateNextInterval()).toBe(2000);
+    });
+
+    it("idle multiplier is still bounded by maxInterval", () => {
+      const strategy = new AdaptivePollingStrategy({ baseInterval: 2000, maxInterval: 5000 });
+
+      for (let i = 0; i < 6; i++) strategy.recordNoChange();
+
+      // 2000 * 4 = 8000, capped at maxInterval (5000)
+      expect(strategy.calculateNextInterval()).toBe(5000);
+    });
+
+    it("compounds idle multiplier on top of the adaptive backoff", () => {
+      const strategy = new AdaptivePollingStrategy({ baseInterval: 1000, maxInterval: 30_000 });
+
+      strategy.recordSuccess(3000, 500);
+      // adaptive: ceil(3500 * 1.5) = 5250
+      expect(strategy.calculateNextInterval()).toBe(5250);
+
+      for (let i = 0; i < 3; i++) strategy.recordNoChange();
+      // 5250 * 2 = 10500
+      expect(strategy.calculateNextInterval()).toBe(10500);
+    });
+  });
 });

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -133,12 +133,13 @@ describe("GitFileWatcher", () => {
     expect(watchedPaths).toContain(pathJoin(gitDir, "logs"));
     expect(watchedPaths.filter((path) => path === gitDir)).toHaveLength(1);
 
-    expect(watchedPaths).not.toContain(pathJoin(gitDir, "index"));
+    // HEAD and the branch ref are watched through the gitDir / refs/heads
+    // directory watchers, never as standalone fs.watch handles per file.
     expect(watchedPaths).not.toContain(pathJoin(gitDir, "HEAD"));
     expect(watchedPaths).not.toContain(pathJoin(gitDir, "refs", "heads", "main"));
   });
 
-  it("does not trigger on index changes (avoids git-status feedback loop)", async () => {
+  it("triggers on index changes so external `git add` surfaces without waiting for a poll", async () => {
     const gitDir = pathJoin("/repo", ".git");
     const onChange = vi.fn();
     const gitWatcher = new GitFileWatcher({
@@ -159,14 +160,16 @@ describe("GitFileWatcher", () => {
       | undefined;
     expect(dotGitCallback).toBeDefined();
 
-    dotGitCallback?.("rename", "index");
+    // index.lock → index is the atomic-rename pattern git uses for index
+    // writes. Both events debounce into a single onChange call.
     dotGitCallback?.("rename", "index.lock");
+    dotGitCallback?.("rename", "index");
     await vi.advanceTimersByTimeAsync(250);
-    expect(onChange).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
 
     dotGitCallback?.("rename", "HEAD");
     await vi.advanceTimersByTimeAsync(200);
-    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(2);
   });
 
   it("filters unrelated directory events and debounces matching events", async () => {

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -142,6 +142,12 @@ export class GitFileWatcher {
         this.watchFile(pathJoin(gitDir, sentinelName));
       }
 
+      // Watch .git/index so external `git add` from a terminal triggers an
+      // event-based refresh instead of waiting for the next timed poll.
+      // matchesTrackedFile() already covers the index.lock → index rename
+      // pattern git uses for atomic index writes.
+      this.watchFile(pathJoin(gitDir, "index"));
+
       if (this.watchWorktree) {
         // Fire-and-forget: subscribe() schedules the native watcher
         // asynchronously. Startup failures (ENOSPC, EMFILE) route through

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1,5 +1,5 @@
-import { readFile, access } from "fs/promises";
-import { join as pathJoin } from "path";
+import { readFile, access, stat } from "fs/promises";
+import { isAbsolute, join as pathJoin } from "path";
 import { createHardenedGit, createWslHardenedGit } from "../utils/hardenedGit.js";
 import type { WslGitInvocation } from "../utils/hardenedGit.js";
 import type PQueue from "p-queue";
@@ -35,6 +35,29 @@ const HEARTBEAT_GAP_FLOOR_MS = 30_000;
 // quiet repo doesn't false-positive — 360s leaves ~60s of headroom for
 // timer drift past the expected fire time.
 const HEARTBEAT_GAP_CEILING_MS = 360_000;
+// Startup jitter for the initial git-status poll. Mirrors the
+// FETCH_INITIAL_DELAY_* pattern in FetchScheduler so N background monitors
+// starting together don't all fire updateGitStatus at t=0. Foreground
+// (isCurrent=true) monitors still run immediately so the active card has
+// fresh data on app launch.
+const STATUS_INITIAL_DELAY_MIN_MS = 2_000;
+const STATUS_INITIAL_DELAY_MAX_MS = 5_000;
+// Sentinel for "this git path doesn't exist". Used so the baseline can
+// stably record absence (packed-refs, detached HEAD's branch ref) and still
+// match on the next stat pass without forcing a real git check.
+const STAT_ABSENT_SENTINEL = -1;
+
+function randomBetween(minMs: number, maxMs: number): number {
+  if (maxMs <= minMs) return minMs;
+  return minMs + Math.floor(Math.random() * (maxMs - minMs));
+}
+
+interface GitFileStatBaseline {
+  index: number;
+  head: number;
+  refsHead: number;
+  packedRefs: number;
+}
 
 export interface WorktreeMonitorConfig {
   basePollingInterval: number;
@@ -127,6 +150,21 @@ export class WorktreeMonitor {
   private gitWatchEnabled: boolean;
   private gitWatchDebounceMs: number;
   private lastGitStatusCompletedAt: number = 0;
+  // Stamped by the watcher's onTriggerUpdate hook before a forced refresh
+  // fires. The stat pre-check compares against `lastStatBaselineAt` to know
+  // whether an event arrived since the baseline was captured — if so, the
+  // skip is invalid and we must run the full git check.
+  private lastWatcherEventAt: number = 0;
+  // mtime cache for .git/index, HEAD, refs/heads/<branch>, packed-refs.
+  // Populated after every successful git check. When the next poll finds all
+  // four mtimes unchanged AND no watcher event has fired since, we skip the
+  // simple-git fork-exec. null = no baseline yet (first poll, or post-error).
+  private lastStatBaseline: GitFileStatBaseline | null = null;
+  private lastStatBaselineAt: number = 0;
+  // Timer used to defer the initial `updateGitStatus` call for background
+  // monitors so N monitors starting together don't fork git simultaneously.
+  // Cleared by `clearTimers()` so `stop()` cancels the deferred poll.
+  private initialStatusTimer: NodeJS.Timeout | null = null;
 
   // Extra state
   private _createdAt: number | undefined;
@@ -296,6 +334,11 @@ export class WorktreeMonitor {
         return monitor.lastGitStatusCompletedAt;
       },
       onTriggerUpdate: () => {
+        // Stamp the watcher event time before triggering so the stat
+        // pre-check on the next timed poll knows to invalidate any baseline
+        // captured before this event.
+        monitor.lastWatcherEventAt = Date.now();
+        monitor.pollingStrategy.recordStateChange();
         void monitor.updateGitStatus(true);
       },
       onInotifyLimitReached: (worktreeId: string) =>
@@ -457,6 +500,12 @@ export class WorktreeMonitor {
         this.pollingTimer = null;
         this.scheduleNextPoll();
       }
+    }
+    // Focus gain resets the idle backoff: the user is looking at this
+    // worktree now and expects the base cadence, even if the background
+    // tier had backed off after a quiet stretch.
+    if (changed && value && this._isRunning) {
+      this.pollingStrategy.recordStateChange();
     }
     // Fetch cadence flips between focused (~30-45s) and background (5-10min)
     // based on `isCurrent`. Reschedule from the new tier the moment focus
@@ -740,11 +789,38 @@ export class WorktreeMonitor {
       this.watcherController.start();
     }
 
-    await this.updateGitStatus(true);
+    // Foreground monitors run the initial git status synchronously — the
+    // user is looking at this card and expects fresh data on app launch.
+    // Background monitors defer through a 2-5s jitter so N monitors started
+    // together don't all fork git at t=0. The fetch scheduler already has
+    // its own initial jitter on a separate cadence.
+    if (this._isCurrent) {
+      await this.updateGitStatus(true);
 
-    if (this._isRunning && this.pollingEnabled) {
-      this.scheduleNextPoll();
+      if (this._isRunning && this.pollingEnabled) {
+        this.scheduleNextPoll();
+        this.fetchScheduler.schedule(true);
+      }
+    } else {
       this.fetchScheduler.schedule(true);
+      const delayMs = randomBetween(STATUS_INITIAL_DELAY_MIN_MS, STATUS_INITIAL_DELAY_MAX_MS);
+      this.initialStatusTimer = setTimeout(() => {
+        this.initialStatusTimer = null;
+        if (!this._isRunning) return;
+        // updateGitStatus already surfaces non-removal errors via mood=error
+        // + emit; the catch here just prevents the unhandled rejection from
+        // bubbling out of the fire-and-forget timer.
+        this.updateGitStatus(true)
+          .catch(() => {
+            // Already emitted as error mood inside updateGitStatus
+          })
+          .finally(() => {
+            if (this._isRunning && this.pollingEnabled) {
+              this.scheduleNextPoll();
+            }
+          });
+      }, delayMs);
+      this.initialStatusTimer.unref?.();
     }
   }
 
@@ -958,6 +1034,10 @@ export class WorktreeMonitor {
       clearTimeout(this.resumeTimer);
       this.resumeTimer = null;
     }
+    if (this.initialStatusTimer) {
+      clearTimeout(this.initialStatusTimer);
+      this.initialStatusTimer = null;
+    }
     this.watcherController.clearRetryTimer();
     this.clearResourcePollTimer();
     this.fetchScheduler.clearTimer();
@@ -1156,7 +1236,48 @@ export class WorktreeMonitor {
       return;
     }
 
+    // Cheap stat pre-check: when the four git files we care about haven't
+    // changed since the last baseline and no watcher event has fired since,
+    // the simple-git fork-exec would be redundant. Skip it. This is the
+    // common case on a quiet repo — the per-poll cost drops from ~15-50ms
+    // (fork + git status) to ~1ms (four stat() calls).
+    //
+    // The baseline only exists after the first real check, so this branch
+    // is a no-op on the very first poll. Forced refreshes (watcher events,
+    // user actions) always run the full check.
+    if (!forceRefresh && gitDir && this._hasInitialStatus && this.lastStatBaseline !== null) {
+      const baselineAt = this.lastStatBaselineAt;
+      const checkStartedAt = Date.now();
+      try {
+        const commonDir = await this.resolveCommonDirAsync(gitDir);
+        const fresh = await this.buildStatBaseline(gitDir, commonDir);
+        if (
+          fresh !== null &&
+          this.lastWatcherEventAt <= baselineAt &&
+          this.statBaselineMatches(this.lastStatBaseline, fresh)
+        ) {
+          // Treat the skip as a no-change observation so the idle backoff
+          // ramps up the next interval. lastGitStatusCompletedAt bumps too,
+          // otherwise the heartbeat-gap check would false-positive on a
+          // long quiet streak that only ran stat-skips.
+          this.pollingStrategy.recordNoChange();
+          this.lastStatBaselineAt = checkStartedAt;
+          this.lastGitStatusCompletedAt = Date.now();
+          return;
+        }
+      } catch {
+        // Unexpected stat error — fall through to the full git check.
+        // Don't poison the baseline; the post-check rebuild will refresh it.
+      }
+    }
+
     this._isUpdating = true;
+    // Tracks whether the try block reached a clean exit point — either the
+    // no-change early return or the post-emit fall-through. The catch block
+    // doesn't flip it (so the finally clears the stale baseline) which means
+    // a flaky git that throws here can't get its old baseline re-stamped and
+    // silently suppress the next retry.
+    let checkSucceeded = false;
 
     try {
       if (forceRefresh) {
@@ -1229,14 +1350,21 @@ export class WorktreeMonitor {
       const upstreamChanged =
         nextAheadCount !== this.aheadCount || nextBehindCount !== this.behindCount;
 
-      if (
-        !stateChanged &&
-        !noteChanged &&
-        !branchChanged &&
-        !planChanged &&
-        !upstreamChanged &&
-        !forceRefresh
-      ) {
+      const anythingChanged =
+        stateChanged || noteChanged || branchChanged || planChanged || upstreamChanged;
+
+      // Drive the idle backoff from what the git check actually observed —
+      // a real state change resets, otherwise we count one quiet tick. The
+      // skip path above runs its own recordNoChange so this branch only
+      // sees ticks that paid the full fork-exec cost.
+      if (anythingChanged) {
+        this.pollingStrategy.recordStateChange();
+      } else {
+        this.pollingStrategy.recordNoChange();
+      }
+
+      if (!anythingChanged && !forceRefresh) {
+        checkSucceeded = true;
         return;
       }
 
@@ -1293,6 +1421,7 @@ export class WorktreeMonitor {
       this._hasInitialStatus = true;
 
       this.emitUpdate();
+      checkSucceeded = true;
     } catch (error) {
       if (error instanceof WorktreeRemovedError) {
         this.stop();
@@ -1313,8 +1442,107 @@ export class WorktreeMonitor {
     } finally {
       this._isUpdating = false;
       this.lastGitStatusCompletedAt = Date.now();
+      // Rebuild the stat baseline only when a real git check finished
+      // cleanly. On failure (anything that didn't set checkSucceeded — git
+      // throw, WorktreeRemovedError, index.lock retry path) we drop the
+      // baseline so the next non-forced poll falls through to a full check
+      // rather than skipping against a snapshot that predates the failure.
+      if (checkSucceeded && gitDir) {
+        try {
+          const commonDir = await this.resolveCommonDirAsync(gitDir);
+          const fresh = await this.buildStatBaseline(gitDir, commonDir);
+          if (fresh !== null) {
+            this.lastStatBaseline = fresh;
+            this.lastStatBaselineAt = Date.now();
+          } else {
+            this.lastStatBaseline = null;
+          }
+        } catch {
+          this.lastStatBaseline = null;
+        }
+      } else {
+        this.lastStatBaseline = null;
+      }
       this.watcherController.flushPendingIfReady(true);
     }
+  }
+
+  /**
+   * Resolve the common git directory for a linked worktree (the `gitDir`
+   * inside `<repo>/.git/worktrees/<name>/` points at `commondir`, which
+   * holds packed-refs and the shared refs/heads tree). Returns `gitDir`
+   * itself for the main worktree, or when the commondir file is missing.
+   * Mirrors `GitFileWatcher.resolveCommonDir` but uses async `readFile`.
+   */
+  private async resolveCommonDirAsync(gitDir: string): Promise<string> {
+    try {
+      const commondirContent = await readFile(pathJoin(gitDir, "commondir"), "utf-8");
+      const trimmed = commondirContent.trim();
+      if (!trimmed) return gitDir;
+      return isAbsolute(trimmed) ? trimmed : pathJoin(gitDir, trimmed);
+    } catch {
+      return gitDir;
+    }
+  }
+
+  /**
+   * Capture mtimeMs for the four git files whose changes would invalidate
+   * the previous status snapshot: index, HEAD, refs/heads/<branch>, and
+   * packed-refs. Returns `null` if any unexpected error occurs (caller
+   * falls back to a full git check). ENOENT is normal for packed-refs and
+   * the branch ref (detached HEAD, or branch not pushed yet) — those paths
+   * return STAT_ABSENT_SENTINEL and the baseline comparison still works.
+   */
+  private async buildStatBaseline(
+    gitDir: string,
+    commonDir: string
+  ): Promise<GitFileStatBaseline | null> {
+    try {
+      const [indexStat, headStat, refsHeadStat, packedRefsStat] = await Promise.all([
+        this.statMtime(pathJoin(gitDir, "index")),
+        this.statMtime(pathJoin(gitDir, "HEAD")),
+        this._branch
+          ? this.statMtime(pathJoin(commonDir, "refs", "heads", this._branch))
+          : Promise.resolve(STAT_ABSENT_SENTINEL),
+        this.statMtime(pathJoin(commonDir, "packed-refs")),
+      ]);
+      return {
+        index: indexStat,
+        head: headStat,
+        refsHead: refsHeadStat,
+        packedRefs: packedRefsStat,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Stat one git path. Returns `STAT_ABSENT_SENTINEL` when the file is
+   * missing (the most common case for packed-refs and unpushed branch
+   * refs) so the baseline can still compare equal on the next pass without
+   * forcing a full git check. Other errors propagate up so the caller
+   * falls back to the full path — a permission flip or filesystem hiccup
+   * should not silently freeze the cached baseline.
+   */
+  private async statMtime(filePath: string): Promise<number> {
+    try {
+      const result = await stat(filePath);
+      return result.mtimeMs;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === "ENOENT") return STAT_ABSENT_SENTINEL;
+      throw error;
+    }
+  }
+
+  private statBaselineMatches(a: GitFileStatBaseline, b: GitFileStatBaseline): boolean {
+    return (
+      a.index === b.index &&
+      a.head === b.head &&
+      a.refsHead === b.refsHead &&
+      a.packedRefs === b.packedRefs
+    );
   }
 
   private async readCurrentBranch(): Promise<string | undefined> {

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -34,6 +34,7 @@ vi.mock("../../utils/git.js", () => ({
 vi.mock("fs/promises", () => ({
   access: vi.fn().mockRejectedValue(new Error("ENOENT")),
   readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  stat: vi.fn().mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" })),
 }));
 
 vi.mock("simple-git", () => ({
@@ -138,6 +139,8 @@ vi.mock("../../services/worktree/index.js", () => ({
       calculateNextInterval: vi.fn().mockReturnValue(2000),
       recordSuccess: vi.fn(),
       recordFailure: vi.fn(),
+      recordNoChange: vi.fn(),
+      recordStateChange: vi.fn(),
     };
   }),
   NoteFileReader: vi.fn(function () {
@@ -148,6 +151,7 @@ vi.mock("../../services/worktree/index.js", () => ({
 import { WorktreeMonitor } from "../WorktreeMonitor.js";
 import type { WorktreeMonitorConfig, WorktreeMonitorCallbacks } from "../WorktreeMonitor.js";
 import { getGitDir } from "../../utils/gitUtils.js";
+import { stat, readFile } from "fs/promises";
 
 const TEST_WORKTREE: Worktree = {
   id: "/test/worktree",
@@ -173,6 +177,19 @@ function makeCallbacks(overrides?: Partial<WorktreeMonitorCallbacks>): WorktreeM
     onError: vi.fn(),
     ...overrides,
   };
+}
+
+// Matches STATUS_INITIAL_DELAY_MIN_MS in WorktreeMonitor.ts. Background
+// monitors defer their initial updateGitStatus through a 2-5s jitter timer,
+// so tests must advance fake timers past the lower bound before asserting
+// on onUpdate / hasInitialStatus. Math.random() is mocked to 0 in
+// beforeEach, pinning the jitter to the minimum (2000ms). Advance by
+// exactly the minimum so the follow-on poll (scheduled at +2000ms from
+// when the initial fires) doesn't also fire and inflate call counts.
+const STATUS_INITIAL_DELAY_MIN_MS = 2_000;
+
+async function flushInitialStatus(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(STATUS_INITIAL_DELAY_MIN_MS);
 }
 
 describe("WorktreeMonitor", () => {
@@ -207,6 +224,7 @@ describe("WorktreeMonitor", () => {
     const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
 
     await monitor.start();
+    await flushInitialStatus();
 
     expect(callbacks.onRemoved).toHaveBeenCalledWith("/test/worktree");
     expect(callbacks.onUpdate).not.toHaveBeenCalled();
@@ -234,6 +252,7 @@ describe("WorktreeMonitor", () => {
     const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
 
     await monitor.start();
+    await flushInitialStatus();
 
     expect(callbacks.onUpdate).toHaveBeenCalled();
     expect(callbacks.onRemoved).not.toHaveBeenCalled();
@@ -247,9 +266,14 @@ describe("WorktreeMonitor", () => {
     const callbacks = makeCallbacks();
     const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
 
-    await expect(monitor.start()).rejects.toThrow("network timeout");
+    // Background monitor: the deferred initial poll surfaces non-removal
+    // errors via mood=error + emit instead of propagating the rejection.
+    await monitor.start();
+    await flushInitialStatus();
 
     expect(callbacks.onRemoved).not.toHaveBeenCalled();
+    expect(callbacks.onUpdate).toHaveBeenCalled();
+    expect(monitor.getSnapshot().mood).toBe("error");
 
     monitor.stop();
   });
@@ -361,6 +385,7 @@ describe("WorktreeMonitor", () => {
     const callbacks = makeCallbacks();
     const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
     await monitor.start();
+    await flushInitialStatus();
 
     expect(monitor.hasInitialStatus).toBe(true);
 
@@ -397,6 +422,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       const snapshot = monitor.getSnapshot();
       expect(snapshot.aheadCount).toBe(3);
@@ -411,6 +437,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       const snapshot = monitor.getSnapshot();
       expect(snapshot.aheadCount).toBeUndefined();
@@ -427,6 +454,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
       await monitor.updateGitStatus(false);
 
       expect(mockGitRaw).not.toHaveBeenCalledWith(expect.arrayContaining(["rev-list"]));
@@ -442,6 +470,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       const snapshot = monitor.getSnapshot();
       expect(snapshot.aheadCount).toBe(0);
@@ -459,6 +488,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
       expect(monitor.getSnapshot().aheadCount).toBe(2);
       expect(monitor.getSnapshot().behindCount).toBe(1);
 
@@ -478,6 +508,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       const snapshot = monitor.getSnapshot();
       expect(snapshot.aheadCount).toBeUndefined();
@@ -1483,6 +1514,7 @@ describe("WorktreeMonitor", () => {
       };
       const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, makeCallbacks(), "main");
       await monitor.start();
+      await flushInitialStatus();
 
       const lastCall =
         mockGetWorktreeChangesWithStats.mock.calls[
@@ -1507,6 +1539,7 @@ describe("WorktreeMonitor", () => {
         };
         const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, makeCallbacks(), "main");
         await monitor.start();
+        await flushInitialStatus();
 
         const lastCall =
           mockGetWorktreeChangesWithStats.mock.calls[
@@ -1539,6 +1572,7 @@ describe("WorktreeMonitor", () => {
         const callbacks = makeCallbacks();
         const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, callbacks, "main");
         await monitor.start();
+        await flushInitialStatus();
 
         const updateCallsBefore = (callbacks.onUpdate as ReturnType<typeof vi.fn>).mock.calls
           .length;
@@ -1578,6 +1612,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       mockGetWorktreeChangesWithStats.mockClear();
       // Simulate that the last poll completion happened 60s ago in wall time —
@@ -1622,6 +1657,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       mockGetWorktreeChangesWithStats.mockClear();
       // 10s gap > 3x base interval (6s) but < 30s floor.
@@ -1649,6 +1685,7 @@ describe("WorktreeMonitor", () => {
       mockWatcherStartResult = true;
       const monitor = new WorktreeMonitor(TEST_WORKTREE, watcherConfig, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       mockGetWorktreeChangesWithStats.mockClear();
       // Advance most of the way to the heartbeat fire (timer is at +300s).
@@ -1678,6 +1715,7 @@ describe("WorktreeMonitor", () => {
         const callbacks = makeCallbacks();
         const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
         await monitor.start();
+        await flushInitialStatus();
 
         (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
           Date.now() - 60_000;
@@ -1710,6 +1748,7 @@ describe("WorktreeMonitor", () => {
         const callbacks = makeCallbacks();
         const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
         await monitor.start();
+        await flushInitialStatus();
 
         (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
           Date.now() - 60_000;
@@ -1737,6 +1776,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, watcherConfig, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       // 100s past offset on lastCompleted plus the 300s timer fire gives an
       // elapsed of ~400s at fire — above the 360s ceiling. Raw threshold
@@ -1765,6 +1805,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, watcherConfig, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       // After the initial poll, lastCompleted is set and the heartbeat timer
       // is scheduled for +300s. Advance to fire it without mutating
@@ -1790,6 +1831,7 @@ describe("WorktreeMonitor", () => {
         const callbacks = makeCallbacks();
         const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
         await monitor.start();
+        await flushInitialStatus();
 
         mockGetWorktreeChangesWithStats.mockClear();
         // Simulate an in-flight refresh AND an aged completion timestamp.
@@ -1817,6 +1859,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       mockGetWorktreeChangesWithStats.mockReset();
       mockGetWorktreeChangesWithStats.mockRejectedValue(new Error("git stalled"));
@@ -1846,6 +1889,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
         Date.now() - 60_000;
@@ -1871,6 +1915,7 @@ describe("WorktreeMonitor", () => {
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
 
       await monitor.start();
+      await flushInitialStatus();
 
       expect(mockIsRepoOperationInProgress).toHaveBeenCalledWith("/test/worktree/.git");
       expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
@@ -1898,6 +1943,7 @@ describe("WorktreeMonitor", () => {
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
 
       await monitor.start();
+      await flushInitialStatus();
       expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
 
       // Simulate the rebase/merge finishing — sentinels disappear, then a
@@ -1919,6 +1965,7 @@ describe("WorktreeMonitor", () => {
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
 
       await monitor.start();
+      await flushInitialStatus();
 
       // The renderer must still receive a snapshot so the worktree is
       // visible — otherwise it stays invisible until the operation ends.
@@ -1948,6 +1995,7 @@ describe("WorktreeMonitor", () => {
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
 
       await monitor.start();
+      await flushInitialStatus();
 
       expect(mockIsRepoOperationInProgress).not.toHaveBeenCalled();
       expect(mockGetWorktreeChangesWithStats).toHaveBeenCalled();
@@ -2103,6 +2151,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks({ onUpdate });
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       onUpdate.mockClear();
       monitor.setFetchState(1700000000000, false);
@@ -2131,6 +2180,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks({ onUpdate });
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       // Default is false (undefined-on-the-wire) until set.
       expect(monitor.getSnapshot().isGitHubRemote).toBeFalsy();
@@ -2169,6 +2219,7 @@ describe("WorktreeMonitor", () => {
       const callbacks = makeCallbacks({ onUpdate });
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await flushInitialStatus();
 
       onUpdate.mockClear();
       monitor.setFetchState(1700000000000, false, true);
@@ -2181,6 +2232,166 @@ describe("WorktreeMonitor", () => {
       onUpdate.mockClear();
       monitor.setFetchState(1700000000000, false, true);
       expect(onUpdate).not.toHaveBeenCalled();
+
+      monitor.stop();
+    });
+  });
+
+  describe("startup jitter", () => {
+    const CLEAN_CHANGES = {
+      worktreeId: "/test/worktree",
+      rootPath: "/test",
+      changes: [],
+      changedFileCount: 0,
+      lastUpdated: Date.now(),
+    };
+
+    it("defers initial git status for background monitors", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      // start() returns once the jitter timer is armed; updateGitStatus
+      // has not yet been called.
+      expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
+      expect(monitor.hasInitialStatus).toBe(false);
+
+      await flushInitialStatus();
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+      expect(monitor.hasInitialStatus).toBe(true);
+
+      monitor.stop();
+    });
+
+    it("runs initial git status synchronously for current monitors", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(
+        { ...TEST_WORKTREE, isCurrent: true },
+        TEST_CONFIG,
+        callbacks,
+        "main"
+      );
+
+      await monitor.start();
+      // Foreground path runs synchronously — the snapshot is already there
+      // when start() resolves.
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+      expect(monitor.hasInitialStatus).toBe(true);
+
+      monitor.stop();
+    });
+
+    it("stop() before the jitter window suppresses the deferred poll", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      monitor.stop();
+      await flushInitialStatus();
+      // Advance well past any potential follow-on poll too.
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
+      expect(callbacks.onUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("stat pre-check", () => {
+    const CLEAN_CHANGES = {
+      worktreeId: "/test/worktree",
+      rootPath: "/test",
+      changes: [],
+      changedFileCount: 0,
+      lastUpdated: Date.now(),
+    };
+
+    beforeEach(() => {
+      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      // No commondir file → commondir defaults to gitDir for the test worktree
+      vi.mocked(readFile).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+    });
+
+    function makeStatResult(mtimeMs: number): Awaited<ReturnType<typeof stat>> {
+      return { mtimeMs } as unknown as Awaited<ReturnType<typeof stat>>;
+    }
+
+    it("skips the simple-git fork when stat mtimes are unchanged", async () => {
+      vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      // First run builds the baseline.
+      await monitor.start();
+      await flushInitialStatus();
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+
+      // Second non-forced run: stats match baseline → no git fork.
+      await monitor.updateGitStatus(false);
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+
+      monitor.stop();
+    });
+
+    it("falls through to the full check when index mtime moved", async () => {
+      vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      await flushInitialStatus();
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+
+      // Advance the mtime — the next non-forced poll must run the full check.
+      vi.mocked(stat).mockResolvedValue(makeStatResult(2_000));
+      await monitor.updateGitStatus(false);
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(2);
+
+      monitor.stop();
+    });
+
+    it("falls through when a watcher event fired after the baseline was captured", async () => {
+      vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      await flushInitialStatus();
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+
+      // Simulate a watcher event arriving after the baseline timestamp.
+      const baselineAt = (monitor as unknown as { lastStatBaselineAt: number }).lastStatBaselineAt;
+      (monitor as unknown as { lastWatcherEventAt: number }).lastWatcherEventAt = baselineAt + 1;
+
+      await monitor.updateGitStatus(false);
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(2);
+
+      monitor.stop();
+    });
+
+    it("a failed git check does not let the next non-forced poll skip", async () => {
+      vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
+      mockGetWorktreeChangesWithStats.mockReset();
+      mockGetWorktreeChangesWithStats.mockRejectedValueOnce(new Error("git stalled"));
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      // Initial deferred poll throws inside the timer callback; the .catch in
+      // start() swallows it but mood=error has already been emitted.
+      await monitor.start();
+      await flushInitialStatus();
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+      expect(monitor.getSnapshot().mood).toBe("error");
+
+      // Next non-forced poll: stats haven't moved, but the previous error
+      // cleared the baseline so the stat pre-check can't short-circuit.
+      await monitor.updateGitStatus(false);
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(2);
 
       monitor.stop();
     });


### PR DESCRIPTION
## Summary

Closes #8396. Four independent optimizations that cut the steady-state cost of `WorktreeMonitor`'s 2s git-status poll on a quiet repo.

- **Watch `.git/index`** — `gitFileWatcher` now picks up external `git add` from a terminal so the change surfaces immediately, instead of waiting up to 300s for the watcher-mode fallback poll. One-line addition; reuses the existing `.git/` directory watcher and the existing `index.lock` rename pattern in `matchesTrackedFile`.
- **Stat pre-check before the simple-git fork** — caches `mtimeMs` for `.git/index`, `.git/HEAD`, `.git/refs/heads/<branch>`, and `.git/packed-refs` after each successful check. On the next non-forced poll, if all four match the baseline AND no watcher event arrived since, the `simple-git` fork-exec is skipped entirely (~15-50ms → ~1ms). `STAT_ABSENT_SENTINEL = -1` handles missing packed-refs / detached HEAD without forcing a false miss. Any stat error falls through to the full check.
- **Idle backoff in `AdaptivePollingStrategy`** — adds a `consecutiveUnchangedCount` that lengthens the next interval after 3 consecutive no-change polls (2×), 6 polls (4×), then caps. Multiplier still bounded by the configured `maxInterval`. Counter resets on a watcher event fire, focus gain, real state change, or `reset()`.
- **Startup jitter for background monitors** — `start()` defers the initial `updateGitStatus` through a `randomBetween(2000, 5000)ms` timer when `isCurrent === false`, mirroring `FetchScheduler.FETCH_INITIAL_DELAY_*`. Foreground monitors stay synchronous so the focused card has fresh data on app launch. Timer plumbed through `clearTimers()` so `stop()` cancels it.

The stat baseline is rebuilt only when a check finishes cleanly — a `success` flag gates the finally-block rebuild so a flaky git that throws can't get its old baseline re-stamped and silently suppress the next retry.

Constraints honoured: no new npm deps; `core.fsmonitor` / `core.untrackedCache` untouched (still disabled in `hardenedGit.ts`); `_pendingPollPromise` dedup boundary intact (stat pre-check sits inside `updateGitStatus`, inside the dedup).

## Test plan

- [ ] Watch a quiet repo for 30s — git-status cadence backs off (2s → 4s → 8s)
- [ ] Run `git add` from a terminal — change surfaces inside the debounce window without waiting for the 2s timer
- [ ] Add a new background worktree — initial poll deferred by 2-5s, card populates after jitter window
- [ ] Add a new current worktree — initial poll runs synchronously, no delay
- [ ] Temporarily rename `.git` to provoke a git error — next non-forced poll retries instead of indefinitely skipping
- [ ] `npm run check` clean
- [ ] AdaptivePollingStrategy + WorktreeMonitor + gitFileWatcher tests green (15 + 88 + 42)
