### PR TITLE
fix(a11y): replace opacity-based staleness with border+italic encoding

### DIFF
--- a/shared/theme/__tests__/contrast.test.ts
+++ b/shared/theme/__tests__/contrast.test.ts
@@ -212,6 +212,74 @@ describe("getThemeContrastWarnings", () => {
     }
   });
 
+  it("emits freshness opacity warning when attenuated text-primary fails threshold", () => {
+    // #777777 on #ffffff is ~4.51:1 at full opacity (passes), but at 50% it
+    // blends to #bbbbbb on #ffffff → ~1.88:1 (fails 4.5).
+    const scheme = makeScheme({
+      "text-primary": "#777777" as AppColorSchemeTokens["text-primary"],
+      "surface-canvas": "#ffffff" as AppColorSchemeTokens["surface-canvas"],
+    });
+    const warnings = getThemeContrastWarnings(scheme);
+    const freshnessWarnings = warnings.filter(
+      (w) => w.message.includes("opacity") && w.message.includes("text-primary")
+    );
+    expect(freshnessWarnings.length).toBeGreaterThan(0);
+    const errored50 = freshnessWarnings.find((w) => w.message.includes("50% opacity (errored)"));
+    expect(errored50).toBeDefined();
+  });
+
+  it("includes tier label in freshness opacity warning message", () => {
+    // #666666 on #ffffff is ~5.73:1 bare but ~2.12:1 at 50%.
+    const scheme = makeScheme({
+      "text-primary": "#666666" as AppColorSchemeTokens["text-primary"],
+      "surface-sidebar": "#ffffff" as AppColorSchemeTokens["surface-sidebar"],
+    });
+    const warnings = getThemeContrastWarnings(scheme);
+    const freshnessWarnings = warnings.filter(
+      (w) => w.message.includes("opacity") && w.message.includes("text-primary")
+    );
+    expect(freshnessWarnings.length).toBeGreaterThan(0);
+    expect(freshnessWarnings.some((w) => w.message.includes("(stale-disk)"))).toBe(true);
+    expect(freshnessWarnings.some((w) => w.message.includes("(aging)"))).toBe(true);
+    expect(freshnessWarnings.some((w) => w.message.includes("(errored)"))).toBe(true);
+  });
+
+  it("emits no freshness warnings at 75% opacity for high-contrast themes", () => {
+    // #000000 on #ffffff at 75% blends to #404040 on #ffffff → ~10.4:1, well above 4.5.
+    // Override all 5 surfaces so the test doesn't depend on the base theme's other surfaces.
+    const scheme = makeScheme({
+      "text-primary": "#000000" as AppColorSchemeTokens["text-primary"],
+      "surface-grid": "#ffffff" as AppColorSchemeTokens["surface-grid"],
+      "surface-sidebar": "#ffffff" as AppColorSchemeTokens["surface-sidebar"],
+      "surface-canvas": "#ffffff" as AppColorSchemeTokens["surface-canvas"],
+      "surface-panel": "#ffffff" as AppColorSchemeTokens["surface-panel"],
+      "surface-panel-elevated": "#ffffff" as AppColorSchemeTokens["surface-panel-elevated"],
+    });
+    const warnings = getThemeContrastWarnings(scheme);
+    const aging75 = warnings.filter((w) => w.message.includes("75% opacity (aging)"));
+    expect(aging75).toHaveLength(0);
+  });
+
+  it("skips freshness checks for non-hex text-primary without crashing", () => {
+    const scheme = makeScheme({
+      "text-primary": "oklch(0.5 0.1 200)" as AppColorSchemeTokens["text-primary"],
+    });
+    const warnings = getThemeContrastWarnings(scheme);
+    const freshnessWarnings = warnings.filter((w) => w.message.includes("opacity"));
+    expect(freshnessWarnings).toHaveLength(0);
+  });
+
+  it("aging (75%) produces zero freshness warnings across all built-in themes", () => {
+    for (const scheme of BUILT_IN_APP_SCHEMES) {
+      const warnings = getThemeContrastWarnings(scheme);
+      const agingFailures = warnings.filter((w) => w.message.includes("75% opacity (aging)"));
+      expect(
+        agingFailures,
+        `${scheme.id}: aging tier must not produce contrast warnings`
+      ).toHaveLength(0);
+    }
+  });
+
   it("emits no warnings when status-* tokens meet 3.0:1 against surface-panel", () => {
     // Pure black on white is 21:1 — well above any threshold.
     const scheme = makeScheme({

--- a/shared/theme/__tests__/contrast.test.ts
+++ b/shared/theme/__tests__/contrast.test.ts
@@ -212,26 +212,25 @@ describe("getThemeContrastWarnings", () => {
     }
   });
 
-  it("emits freshness opacity warning when attenuated text-primary fails threshold", () => {
-    // #777777 on #ffffff is ~4.51:1 at full opacity (passes), but at 50% it
-    // blends to #bbbbbb on #ffffff → ~1.88:1 (fails 4.5).
+  it("emits freshness opacity warning when attenuated text-primary at 75% fails threshold", () => {
+    // #999999 on #ffffff at 75% blends to #a5a5a5 on #ffffff → ~2.59:1 (fails 4.5).
+    // Only the aging tier (75%) is checked since stale-disk/errored now use border+italic.
     const scheme = makeScheme({
-      "text-primary": "#777777" as AppColorSchemeTokens["text-primary"],
+      "text-primary": "#999999" as AppColorSchemeTokens["text-primary"],
       "surface-canvas": "#ffffff" as AppColorSchemeTokens["surface-canvas"],
     });
     const warnings = getThemeContrastWarnings(scheme);
     const freshnessWarnings = warnings.filter(
       (w) => w.message.includes("opacity") && w.message.includes("text-primary")
     );
-    expect(freshnessWarnings.length).toBeGreaterThan(0);
-    const errored50 = freshnessWarnings.find((w) => w.message.includes("50% opacity (errored)"));
-    expect(errored50).toBeDefined();
+    // 5 surfaces × 1 tier = exactly 5 warnings for a low-contrast foreground
+    expect(freshnessWarnings.length).toBe(5);
+    expect(freshnessWarnings.every((w) => w.message.includes("75% opacity (aging)"))).toBe(true);
   });
 
-  it("includes tier label in freshness opacity warning message", () => {
-    // #666666 on #ffffff is ~5.73:1 bare but ~2.12:1 at 50%.
+  it("includes aging tier label in freshness opacity warning message", () => {
     const scheme = makeScheme({
-      "text-primary": "#666666" as AppColorSchemeTokens["text-primary"],
+      "text-primary": "#999999" as AppColorSchemeTokens["text-primary"],
       "surface-sidebar": "#ffffff" as AppColorSchemeTokens["surface-sidebar"],
     });
     const warnings = getThemeContrastWarnings(scheme);
@@ -239,9 +238,7 @@ describe("getThemeContrastWarnings", () => {
       (w) => w.message.includes("opacity") && w.message.includes("text-primary")
     );
     expect(freshnessWarnings.length).toBeGreaterThan(0);
-    expect(freshnessWarnings.some((w) => w.message.includes("(stale-disk)"))).toBe(true);
-    expect(freshnessWarnings.some((w) => w.message.includes("(aging)"))).toBe(true);
-    expect(freshnessWarnings.some((w) => w.message.includes("(errored)"))).toBe(true);
+    expect(freshnessWarnings.every((w) => w.message.includes("75% opacity (aging)"))).toBe(true);
   });
 
   it("emits no freshness warnings at 75% opacity for high-contrast themes", () => {
@@ -260,13 +257,15 @@ describe("getThemeContrastWarnings", () => {
     expect(aging75).toHaveLength(0);
   });
 
-  it("skips freshness checks for non-hex text-primary without crashing", () => {
+  it("skips freshness checks for non-hex text-primary without crashing, base warnings still fire", () => {
     const scheme = makeScheme({
       "text-primary": "oklch(0.5 0.1 200)" as AppColorSchemeTokens["text-primary"],
     });
     const warnings = getThemeContrastWarnings(scheme);
     const freshnessWarnings = warnings.filter((w) => w.message.includes("opacity"));
     expect(freshnessWarnings).toHaveLength(0);
+    const baseUnevaluable = warnings.filter((w) => w.message.includes("Cannot evaluate contrast"));
+    expect(baseUnevaluable.length).toBeGreaterThan(0);
   });
 
   it("aging (75%) produces zero freshness warnings across all built-in themes", () => {

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -29,6 +29,42 @@ function isHexColor(value: string): boolean {
   return /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(value.trim());
 }
 
+function hexToRgb(hex: string): [number, number, number] {
+  const clean = hex.trim().replace("#", "");
+  if (clean.length === 3 || clean.length === 4) {
+    const expanded = clean
+      .slice(0, 3)
+      .split("")
+      .map((c) => `${c}${c}`)
+      .join("");
+    return [
+      parseInt(expanded.slice(0, 2), 16),
+      parseInt(expanded.slice(2, 4), 16),
+      parseInt(expanded.slice(4, 6), 16),
+    ];
+  }
+  return [
+    parseInt(clean.slice(0, 2), 16),
+    parseInt(clean.slice(2, 4), 16),
+    parseInt(clean.slice(4, 6), 16),
+  ];
+}
+
+function blendOverBackground(fgHex: string, bgHex: string, opacity: number): string {
+  const [fr, fg, fb] = hexToRgb(fgHex);
+  const [br, bg, bb] = hexToRgb(bgHex);
+  const r = Math.round(fr * opacity + br * (1 - opacity));
+  const g = Math.round(fg * opacity + bg * (1 - opacity));
+  const b = Math.round(fb * opacity + bb * (1 - opacity));
+  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+}
+
+const FRESHNESS_OPACITY_TIERS: Array<{ opacity: number; tier: string }> = [
+  { opacity: 0.75, tier: "aging" },
+  { opacity: 0.6, tier: "stale-disk" },
+  { opacity: 0.5, tier: "errored" },
+];
+
 function hexToLinear(channel: number): number {
   const normalized = channel / 255;
   return normalized <= 0.04045 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
@@ -86,6 +122,22 @@ export function getThemeContrastWarnings(scheme: AppColorScheme): AppThemeValida
       warnings.push({
         message: `${pair.foreground} on ${pair.background} is ${ratio.toFixed(2)}:1; target is ${pair.minimum.toFixed(1)}:1`,
       });
+    }
+  }
+
+  const textPrimaryPairs = CONTRAST_PAIRS.filter((p) => p.foreground === "text-primary");
+  for (const pair of textPrimaryPairs) {
+    const fg = scheme.tokens[pair.foreground];
+    const bg = scheme.tokens[pair.background];
+    if (!isHexColor(fg) || !isHexColor(bg)) continue;
+    for (const { opacity, tier } of FRESHNESS_OPACITY_TIERS) {
+      const blended = blendOverBackground(fg, bg, opacity);
+      const ratio = contrastRatio(blended, bg);
+      if (ratio < pair.minimum) {
+        warnings.push({
+          message: `text-primary on ${pair.background} at ${Math.round(opacity * 100)}% opacity (${tier}) is ${ratio.toFixed(2)}:1; target is ${pair.minimum.toFixed(1)}:1`,
+        });
+      }
     }
   }
 

--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -61,8 +61,6 @@ function blendOverBackground(fgHex: string, bgHex: string, opacity: number): str
 
 const FRESHNESS_OPACITY_TIERS: Array<{ opacity: number; tier: string }> = [
   { opacity: 0.75, tier: "aging" },
-  { opacity: 0.6, tier: "stale-disk" },
-  { opacity: 0.5, tier: "errored" },
 ];
 
 function hexToLinear(channel: number): number {

--- a/src/components/Layout/FreshnessUtils.tsx
+++ b/src/components/Layout/FreshnessUtils.tsx
@@ -1,14 +1,14 @@
 import { Clock } from "lucide-react";
 import type { FreshnessLevel } from "@/hooks/useRepositoryStats";
 
-export function freshnessOpacityClass(level: FreshnessLevel): string {
+export function freshnessClass(level: FreshnessLevel): string {
   switch (level) {
     case "aging":
       return "opacity-75";
     case "stale-disk":
-      return "opacity-60";
+      return "border-l-2 border-border-default italic";
     case "errored":
-      return "opacity-50";
+      return "border-l-2 border-border-default italic";
     case "fresh":
     default:
       return "";

--- a/src/components/Layout/__tests__/FreshnessUtils.test.tsx
+++ b/src/components/Layout/__tests__/FreshnessUtils.test.tsx
@@ -17,18 +17,16 @@ describe("freshnessClass", () => {
     expect(freshnessClass("aging")).toBe("opacity-75");
   });
 
-  it("returns border-l-2 + italic for stale-disk level, not opacity", () => {
+  it("returns border-l-2 border-border-default italic for stale-disk level, not opacity", () => {
     const result = freshnessClass("stale-disk");
-    expect(result).toContain("border-l-2");
-    expect(result).toContain("italic");
-    expect(result).not.toMatch(/opacity-[56]0/);
+    expect(result).toBe("border-l-2 border-border-default italic");
+    expect(result).not.toMatch(/\bopacity-/);
   });
 
-  it("returns border-l-2 + italic for errored level, not opacity", () => {
+  it("returns border-l-2 border-border-default italic for errored level, not opacity", () => {
     const result = freshnessClass("errored");
-    expect(result).toContain("border-l-2");
-    expect(result).toContain("italic");
-    expect(result).not.toMatch(/opacity-[56]0/);
+    expect(result).toBe("border-l-2 border-border-default italic");
+    expect(result).not.toMatch(/\bopacity-/);
   });
 });
 

--- a/src/components/Layout/__tests__/FreshnessUtils.test.tsx
+++ b/src/components/Layout/__tests__/FreshnessUtils.test.tsx
@@ -2,27 +2,33 @@
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import {
-  freshnessOpacityClass,
+  freshnessClass,
   FreshnessGlyph,
   formatTimeSince,
   freshnessSuffix,
 } from "../FreshnessUtils";
 
-describe("freshnessOpacityClass", () => {
+describe("freshnessClass", () => {
   it("returns empty string for fresh level", () => {
-    expect(freshnessOpacityClass("fresh")).toBe("");
+    expect(freshnessClass("fresh")).toBe("");
   });
 
   it("returns opacity-75 for aging level", () => {
-    expect(freshnessOpacityClass("aging")).toBe("opacity-75");
+    expect(freshnessClass("aging")).toBe("opacity-75");
   });
 
-  it("returns opacity-60 for stale-disk level", () => {
-    expect(freshnessOpacityClass("stale-disk")).toBe("opacity-60");
+  it("returns border-l-2 + italic for stale-disk level, not opacity", () => {
+    const result = freshnessClass("stale-disk");
+    expect(result).toContain("border-l-2");
+    expect(result).toContain("italic");
+    expect(result).not.toMatch(/opacity-[56]0/);
   });
 
-  it("returns opacity-50 for errored level", () => {
-    expect(freshnessOpacityClass("errored")).toBe("opacity-50");
+  it("returns border-l-2 + italic for errored level, not opacity", () => {
+    const result = freshnessClass("errored");
+    expect(result).toContain("border-l-2");
+    expect(result).toContain("italic");
+    expect(result).not.toMatch(/opacity-[56]0/);
   });
 });
 

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshness.test.ts
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshness.test.ts
@@ -30,11 +30,12 @@ describe("GitHubStatsToolbarButton freshness wiring", () => {
     expect(source).toContain("freshnessSuffix");
   });
 
-  it("does not import or use freshnessOpacityClass (issue #8180)", () => {
+  it("does not import or use freshnessOpacityClass or freshnessClass (issue #8180)", () => {
     // Opacity-as-stale reads as a disabled control on always-clickable pills
     // (WCAG 1.4.3/1.4.11/4.1.2). Staleness is carried by FreshnessGlyph + the
     // freshnessSuffix tooltip copy instead.
     expect(source).not.toContain("freshnessOpacityClass");
+    expect(source).not.toContain("freshnessClass");
   });
 
   it("passes FreshnessGlyph to all three GitHubStatPill instances", () => {

--- a/src/components/Worktree/WorktreeCard/IssueBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/IssueBadge.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { useIssueTooltip } from "@/hooks/useGitHubTooltip";
 import { useGitHubBadgeTooltip } from "./hooks/useGitHubBadgeTooltip";
 import { useGitHubBadgeFreshness } from "./hooks/useGitHubBadgeFreshness";
-import { freshnessOpacityClass, freshnessSuffix } from "@/components/Layout/FreshnessUtils";
+import { freshnessClass, freshnessSuffix } from "@/components/Layout/FreshnessUtils";
 import { IssueTooltipContent, TooltipLoading, TokenMissingTooltip } from "./GitHubTooltipContent";
 
 interface IssueBadgeProps {
@@ -82,7 +82,7 @@ export function IssueBadge({
           data-no-dnd
           className={cn(
             "flex items-center gap-1.5 text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
-            freshnessOpacityClass(freshnessLevel),
+            freshnessClass(freshnessLevel),
             isHeadline ? "text-[13px]" : "text-xs"
           )}
           aria-disabled={!isActive || undefined}
@@ -112,7 +112,7 @@ export function IssueBadge({
                   ? isActive
                     ? "text-text-primary font-medium"
                     : "text-text-secondary font-medium"
-                  : "text-text-primary/90"
+                  : "text-text-primary"
             )}
           >
             {issueTitle ||


### PR DESCRIPTION
## Summary
- Replaced low-contrast opacity tiers (`stale-disk` 60%, `errored` 50%) with `border-l-2 border-border-default italic` -- the old opacity values read as disabled controls and failed WCAG 1.4.3 contrast at those levels.
- Kept `opacity-75` for the `aging` tier, which blends `text-primary` against every app surface above 4.5:1 in all 14 built-in themes.
- Added a freshness opacity contrast validator to the theme checker that flags themes where the aging tier would fall below the 4.5:1 threshold.

Resolves #8387

## Changes
- `FreshnessUtils.tsx` -- renamed `freshnessOpacityClass` to `freshnessClass`, replaced stale-disk/errored opacity with border+italic
- `contrast.ts` -- added `hexToRgb`, `blendOverBackground`, and a freshness opacity check across all surfaces for the aging tier
- `contrast.test.ts` -- added coverage for aging-tier warnings, non-hex tokens, and a zero-warning assertion across all 14 built-in themes
- `IssueBadge.tsx` -- updated import, removed `text-primary/90` artifact

## Testing
- All 14 built-in themes validated with zero aging-tier contrast warnings
- Unit tests confirm correct class output for every freshness level
- Typecheck passes cleanly