### PR TITLE
feat(sidebar): show disabled drag handle when reorder is unavailable

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -328,6 +328,23 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       quickStateFilter: state.quickStateFilter,
     }))
   );
+
+  const isSortDisabledPrevRef = useRef(isGroupedByType || query.trim().length > 0);
+  useEffect(() => {
+    const current = isGroupedByType || query.trim().length > 0;
+    const prev = isSortDisabledPrevRef.current;
+    isSortDisabledPrevRef.current = current;
+    if (prev && !current) {
+      if (reorderAnnouncementTimerRef.current !== null) {
+        clearTimeout(reorderAnnouncementTimerRef.current);
+      }
+      reorderAnnouncementTimerRef.current = setTimeout(() => {
+        reorderAnnouncementTimerRef.current = null;
+        setKeyboardReorderAnnouncement("Manual reorder available");
+      }, KEYBOARD_REORDER_ANNOUNCEMENT_DEBOUNCE_MS);
+    }
+  }, [isGroupedByType, query]);
+
   const clearAllFilters = useWorktreeFilterStore((state) => state.clearAll);
   const hasActiveFilters = useWorktreeFilterStore((state) => state.hasActiveFilters);
   const hasFacetFilters = useWorktreeFilterStore((state) => state.hasFacetFilters);

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -343,6 +343,12 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         setKeyboardReorderAnnouncement("Manual reorder available");
       }, KEYBOARD_REORDER_ANNOUNCEMENT_DEBOUNCE_MS);
     }
+    return () => {
+      if (reorderAnnouncementTimerRef.current !== null) {
+        clearTimeout(reorderAnnouncementTimerRef.current);
+        reorderAnnouncementTimerRef.current = null;
+      }
+    };
   }, [isGroupedByType, query]);
 
   const clearAllFilters = useWorktreeFilterStore((state) => state.clearAll);
@@ -1329,6 +1335,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                           agentSettings={agentSettings}
                           homeDir={homeDir}
                           ariaRowIndex={nextRowIndex++}
+                          isDragHandleDisabled
                         />
                       ));
                       return (

--- a/src/components/Sidebar/SidebarWorktreeRow.tsx
+++ b/src/components/Sidebar/SidebarWorktreeRow.tsx
@@ -74,7 +74,8 @@ function SidebarWorktreeRow({
     [worktreeActions, worktreeId]
   );
 
-  const showDragHandle = !isSortDisabled && !isPinned;
+  const showDragHandle = !isPinned;
+  const dragEnabled = !isSortDisabled && !isPinned;
 
   const handleMoveBy = useCallback(
     (delta: -1 | 1) => {
@@ -100,64 +101,20 @@ function SidebarWorktreeRow({
   const isActive = worktreeId === activeWorktreeId;
   const isFocused = worktreeId === focusedWorktreeId;
   const isSingleWorktree = totalWorktreeCount === 1;
-  const moveUpHandler = showDragHandle ? onMoveUp : undefined;
-  const moveDownHandler = showDragHandle ? onMoveDown : undefined;
-  const canMoveUp = showDragHandle && rowIndex > 0;
-  const canMoveDown = showDragHandle && rowIndex < dragStartOrder.length - 1;
-
-  if (showDragHandle) {
-    return (
-      <SortableWorktreeCard
-        worktreeId={worktreeId}
-        dragStartOrder={dragStartOrder}
-        disabled={isSortDisabled || isPinned}
-        ariaRowIndex={ariaRowIndex}
-        isActive={isActive}
-      >
-        {({ isDraggingSort, dragHandleListeners, dragHandleActivatorRef }) => (
-          <ErrorBoundary
-            variant="component"
-            componentName="WorktreeCard"
-            fallback={WorktreeCardErrorFallback}
-            resetKeys={[worktreeId]}
-            context={{ worktreeId }}
-          >
-            <WorktreeCard
-              worktree={worktree}
-              isActive={isActive}
-              isFocused={isFocused}
-              isSingleWorktree={isSingleWorktree}
-              onSelect={onSelect}
-              onCopyTree={onCopyTree}
-              onOpenEditor={onOpenEditor}
-              onSaveLayout={onSaveLayout}
-              onLaunchAgent={onLaunchAgent}
-              agentAvailability={availability}
-              agentSettings={agentSettings}
-              homeDir={homeDir}
-              dragHandleListeners={dragHandleListeners}
-              dragHandleActivatorRef={dragHandleActivatorRef}
-              isDraggingSort={isDraggingSort}
-              onMoveUp={moveUpHandler}
-              onMoveDown={moveDownHandler}
-              canMoveUp={canMoveUp}
-              canMoveDown={canMoveDown}
-            />
-          </ErrorBoundary>
-        )}
-      </SortableWorktreeCard>
-    );
-  }
+  const moveUpHandler = dragEnabled ? onMoveUp : undefined;
+  const moveDownHandler = dragEnabled ? onMoveDown : undefined;
+  const canMoveUp = dragEnabled && rowIndex > 0;
+  const canMoveDown = dragEnabled && rowIndex < dragStartOrder.length - 1;
 
   return (
     <SortableWorktreeCard
       worktreeId={worktreeId}
       dragStartOrder={dragStartOrder}
-      disabled={true}
+      disabled={isSortDisabled || isPinned}
       ariaRowIndex={ariaRowIndex}
       isActive={isActive}
     >
-      {({ isDraggingSort }) => (
+      {({ isDraggingSort, dragHandleListeners, dragHandleActivatorRef }) => (
         <ErrorBoundary
           variant="component"
           componentName="WorktreeCard"
@@ -178,7 +135,14 @@ function SidebarWorktreeRow({
             agentAvailability={availability}
             agentSettings={agentSettings}
             homeDir={homeDir}
+            dragHandleListeners={showDragHandle ? dragHandleListeners : undefined}
+            dragHandleActivatorRef={showDragHandle ? dragHandleActivatorRef : undefined}
             isDraggingSort={isDraggingSort}
+            isDragHandleDisabled={showDragHandle && isSortDisabled}
+            onMoveUp={moveUpHandler}
+            onMoveDown={moveDownHandler}
+            canMoveUp={canMoveUp}
+            canMoveDown={canMoveDown}
           />
         </ErrorBoundary>
       )}

--- a/src/components/Sidebar/StaticWorktreeRow.tsx
+++ b/src/components/Sidebar/StaticWorktreeRow.tsx
@@ -18,6 +18,7 @@ interface StaticWorktreeRowProps {
   agentSettings: UseAgentLauncherReturn["agentSettings"];
   homeDir: string | undefined;
   aggregateCounts?: WorktreeCardProps["aggregateCounts"];
+  isDragHandleDisabled?: boolean;
   ariaRowIndex: number;
 }
 
@@ -32,6 +33,7 @@ function StaticWorktreeRow({
   agentSettings,
   homeDir,
   aggregateCounts,
+  isDragHandleDisabled,
   ariaRowIndex,
 }: StaticWorktreeRowProps) {
   const worktreeSnap = useWorktreeStore((state) => state.worktrees.get(worktreeId));
@@ -99,6 +101,7 @@ function StaticWorktreeRow({
             agentAvailability={availability}
             agentSettings={agentSettings}
             homeDir={homeDir}
+            isDragHandleDisabled={isDragHandleDisabled}
           />
         </ErrorBoundary>
       </div>

--- a/src/components/Sidebar/__tests__/SidebarContent.keyboardReorder.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.keyboardReorder.test.ts
@@ -122,4 +122,10 @@ describe("SidebarContent reorder re-enable announcement — issue #8395", () => 
   it("gates on prev===true && current===false transition", () => {
     expect(source).toMatch(/prev\s*&&\s*!current/);
   });
+
+  it("cleans up the pending timer on effect teardown", () => {
+    expect(source).toMatch(
+      /return\s*\(\)\s*=>\s*\{[\s\S]*clearTimeout\(reorderAnnouncementTimerRef\.current\)[\s\S]*reorderAnnouncementTimerRef\.current\s*=\s*null/
+    );
+  });
 });

--- a/src/components/Sidebar/__tests__/SidebarContent.keyboardReorder.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.keyboardReorder.test.ts
@@ -80,3 +80,46 @@ describe("SidebarContent keyboard reorder announcement — issue #8013", () => {
     });
   });
 });
+
+// Issue #8395 — When isSortDisabled transitions from true to false (filter
+// cleared or group-by-type toggled off), fire an sr-only announcement so
+// screen-reader users know reorder is available again.
+describe("SidebarContent reorder re-enable announcement — issue #8395", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  it("tracks the previous sort-disabled state in a ref", () => {
+    expect(source).toMatch(
+      /const\s+isSortDisabledPrevRef\s*=\s*useRef\(isGroupedByType\s*\|\|\s*query\.trim\(\)\.length\s*>\s*0\)/
+    );
+  });
+
+  it("fires useEffect when isGroupedByType or query changes", () => {
+    expect(source).toMatch(
+      /useEffect\(\(\)\s*=>\s*\{[\s\S]*isSortDisabledPrevRef[\s\S]*\},\s*\[isGroupedByType,\s*query\]\)/
+    );
+  });
+
+  it("announces 'Manual reorder available' on the enable transition", () => {
+    expect(source).toContain('setKeyboardReorderAnnouncement("Manual reorder available")');
+  });
+
+  it("debounces the re-enable announcement via the shared timer ref", () => {
+    expect(source).toMatch(
+      /reorderAnnouncementTimerRef\.current\s*=\s*setTimeout[\s\S]*"Manual reorder available"/
+    );
+  });
+
+  it("clears any pending reorder announcement before scheduling the re-enable", () => {
+    expect(source).toMatch(
+      /if\s*\(reorderAnnouncementTimerRef\.current\s*!==\s*null\)[\s\S]*clearTimeout[\s\S]*reorderAnnouncementTimerRef\.current\s*=\s*setTimeout[\s\S]*"Manual reorder available"/
+    );
+  });
+
+  it("gates on prev===true && current===false transition", () => {
+    expect(source).toMatch(/prev\s*&&\s*!current/);
+  });
+});

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -719,7 +719,7 @@ export function WorktreeCard({
             </Tooltip>
           )}
           <div className="relative z-10 flex">
-            {dragHandleListeners &&
+            {(dragHandleListeners || isDragHandleDisabled) &&
               (isDragHandleDisabled ? (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -753,7 +753,12 @@ export function WorktreeCard({
                   <GripVertical className="w-3 h-3" />
                 </div>
               ))}
-            <div className={cn("flex-1 min-w-0 py-3", dragHandleListeners ? "pl-1 pr-4" : "px-4")}>
+            <div
+              className={cn(
+                "flex-1 min-w-0 py-3",
+                dragHandleListeners || isDragHandleDisabled ? "pl-1 pr-4" : "px-4"
+              )}
+            >
               <WorktreeHeader
                 worktree={worktree}
                 isActive={isActive}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -78,6 +78,7 @@ export interface WorktreeCardProps {
   dragHandleListeners?: SyntheticListenerMap;
   dragHandleActivatorRef?: (node: HTMLElement | null) => void;
   isDraggingSort?: boolean;
+  isDragHandleDisabled?: boolean;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
   canMoveUp?: boolean;
@@ -104,6 +105,7 @@ export function WorktreeCard({
   dragHandleListeners,
   dragHandleActivatorRef,
   isDraggingSort,
+  isDragHandleDisabled = false,
   onMoveUp,
   onMoveDown,
   canMoveUp,
@@ -717,22 +719,40 @@ export function WorktreeCard({
             </Tooltip>
           )}
           <div className="relative z-10 flex">
-            {dragHandleListeners && (
-              <div
-                ref={dragHandleActivatorRef}
-                data-worktree-row-drag-handle=""
-                className={cn(
-                  "shrink-0 w-4 flex items-center justify-center cursor-grab active:cursor-grabbing touch-none select-none transition-colors group-hover/card:delay-[50ms] motion-reduce:transition-none",
-                  isDraggingSort
-                    ? "bg-overlay-emphasis text-text-primary"
-                    : "text-text-primary/25 group-hover/card:text-text-primary/40 group-hover/card:bg-overlay-soft"
-                )}
-                aria-label="Drag to reorder"
-                {...dragHandleListeners}
-              >
-                <GripVertical className="w-3 h-3" />
-              </div>
-            )}
+            {dragHandleListeners &&
+              (isDragHandleDisabled ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div
+                      ref={dragHandleActivatorRef}
+                      data-worktree-row-drag-handle=""
+                      className="shrink-0 w-4 flex items-center justify-center cursor-not-allowed opacity-30 touch-none select-none transition-colors motion-reduce:transition-none"
+                      aria-label="Manual reorder paused while filter is active"
+                      aria-disabled="true"
+                    >
+                      <GripVertical className="w-3 h-3" />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="left" className="text-xs">
+                    Manual reorder paused while filter is active
+                  </TooltipContent>
+                </Tooltip>
+              ) : (
+                <div
+                  ref={dragHandleActivatorRef}
+                  data-worktree-row-drag-handle=""
+                  className={cn(
+                    "shrink-0 w-4 flex items-center justify-center cursor-grab active:cursor-grabbing touch-none select-none transition-colors group-hover/card:delay-[50ms] motion-reduce:transition-none",
+                    isDraggingSort
+                      ? "bg-overlay-emphasis text-text-primary"
+                      : "text-text-primary/25 group-hover/card:text-text-primary/40 group-hover/card:bg-overlay-soft"
+                  )}
+                  aria-label="Drag to reorder"
+                  {...dragHandleListeners}
+                >
+                  <GripVertical className="w-3 h-3" />
+                </div>
+              ))}
             <div className={cn("flex-1 min-w-0 py-3", dragHandleListeners ? "pl-1 pr-4" : "px-4")}>
               <WorktreeHeader
                 worktree={worktree}

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -139,3 +139,43 @@ describe("WorktreeCard row affordances polish (issue #8099)", () => {
     expect(envPopoverSource).toContain("focus-visible:outline-2");
   });
 });
+
+// Issue #8395 — Replace silent disable of sidebar reorder with a disabled
+// drag handle. The grip always renders for non-pinned rows, but shows disabled
+// styling and a tooltip when group-by-type or search is active.
+describe("WorktreeCard disabled drag handle (issue #8395)", () => {
+  it("accepts isDragHandleDisabled as an optional boolean prop", () => {
+    expect(cardSource).toMatch(/isDragHandleDisabled\s*\?\s*:\s*boolean/);
+    expect(cardSource).toMatch(/isDragHandleDisabled\s*=\s*false/);
+  });
+
+  it("renders the disabled grip with cursor-not-allowed and opacity-30", () => {
+    expect(cardSource).toContain("cursor-not-allowed opacity-30");
+  });
+
+  it("sets aria-disabled on the disabled grip", () => {
+    expect(cardSource).toContain('aria-disabled="true"');
+  });
+
+  it("labels the disabled grip for screen readers", () => {
+    expect(cardSource).toContain('aria-label="Manual reorder paused while filter is active"');
+  });
+
+  it("shows the disabled explanation in a TooltipContent", () => {
+    expect(cardSource).toContain("Manual reorder paused while filter is active");
+  });
+
+  it("wraps the disabled grip in a Tooltip with TooltipTrigger asChild", () => {
+    expect(cardSource).toMatch(/isDragHandleDisabled\s*\?\s*\(\s*<Tooltip>/);
+    expect(cardSource).toMatch(/<TooltipTrigger asChild>/);
+  });
+
+  it("keeps the enabled grip with cursor-grab and dragHandleListeners", () => {
+    expect(cardSource).toContain("cursor-grab active:cursor-grabbing");
+    expect(cardSource).toContain('aria-label="Drag to reorder"');
+  });
+
+  it("preserves the group-hover delay on the enabled grip", () => {
+    expect(cardSource).toContain("group-hover/card:delay-[50ms]");
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -178,4 +178,8 @@ describe("WorktreeCard disabled drag handle (issue #8395)", () => {
   it("preserves the group-hover delay on the enabled grip", () => {
     expect(cardSource).toContain("group-hover/card:delay-[50ms]");
   });
+
+  it("gates the grip block on dragHandleListeners OR isDragHandleDisabled", () => {
+    expect(cardSource).toMatch(/\(dragHandleListeners\s*\|\|\s*isDragHandleDisabled\)\s*&&/);
+  });
 });


### PR DESCRIPTION
## Summary
The sidebar drag handle and Alt+Arrow manual reorder used to silently disappear when grouping or filtering was active. Now the grip renders in a disabled state with a tooltip explaining why, and keyboard reorder is gated on the same condition. An sr-only announcement fires when reorder re-enables so screen-reader users know it is available again.

Resolves #8395

## Changes
- `WorktreeCard`: added `isDragHandleDisabled` prop, disabled grip renders with tooltip and `cursor-not-allowed`/`opacity-30`
- `SidebarWorktreeRow`: unified two render branches, changed `showDragHandle` to `!isPinned`, added `dragEnabled` gate for move handlers
- `StaticWorktreeRow`: forwards `isDragHandleDisabled` to `WorktreeCard`
- `SidebarContent`: useEffect announces "Manual reorder available" when sort re-enabled with cleanup to prevent stale announcements; passes `isDragHandleDisabled=true` to grouped-section cards

## Testing
- 9 new assertions in `WorktreeCardInteraction.test.tsx` covering disabled grip rendering, tooltip presence, and the `dragHandleListeners` gate
- 7 new assertions in `SidebarContent.keyboardReorder.test.ts` covering keyboard gating and the sr-only announcement