### PR TITLE
feat(worktree): disambiguate badge freshness with cause-specific glyphs and tooltips

### DIFF
--- a/src/components/Layout/FreshnessUtils.tsx
+++ b/src/components/Layout/FreshnessUtils.tsx
@@ -1,6 +1,8 @@
 import { Clock } from "lucide-react";
 import type { FreshnessLevel } from "@/hooks/useRepositoryStats";
 
+export type BadgeFreshnessCause = "stale" | "rate-limit" | "circuit-breaker";
+
 export function freshnessClass(level: FreshnessLevel): string {
   switch (level) {
     case "aging":
@@ -49,6 +51,33 @@ export function freshnessSuffix(
     case "errored":
       return " · couldn't reach GitHub";
     case "fresh":
+    default:
+      return "";
+  }
+}
+
+export function badgeFreshnessSuffix(
+  cause: BadgeFreshnessCause | undefined,
+  lastUpdated: number | null,
+  now: number,
+  resetAt?: number | null
+): string {
+  switch (cause) {
+    case "stale":
+      return ` · updated ${formatTimeSince(lastUpdated, now)}`;
+    case "rate-limit": {
+      let suffix = " · rate limited";
+      if (resetAt != null && resetAt > now) {
+        const retryTime = new Intl.DateTimeFormat("en-US", {
+          hour: "numeric",
+          minute: "2-digit",
+        }).format(new Date(resetAt));
+        suffix += `, retry at ${retryTime}`;
+      }
+      return suffix;
+    }
+    case "circuit-breaker":
+      return " · data may be stale — PR detection paused";
     default:
       return "";
   }

--- a/src/components/Layout/__tests__/FreshnessUtils.test.tsx
+++ b/src/components/Layout/__tests__/FreshnessUtils.test.tsx
@@ -6,6 +6,7 @@ import {
   FreshnessGlyph,
   formatTimeSince,
   freshnessSuffix,
+  badgeFreshnessSuffix,
 } from "../FreshnessUtils";
 
 describe("freshnessClass", () => {
@@ -117,5 +118,42 @@ describe("freshnessSuffix", () => {
 
   it("returns error message for errored level", () => {
     expect(freshnessSuffix("errored", null, now)).toBe(" · couldn't reach GitHub");
+  });
+});
+
+describe("badgeFreshnessSuffix", () => {
+  const now = 10_000_000_000;
+
+  it("returns empty string for undefined cause", () => {
+    expect(badgeFreshnessSuffix(undefined, null, now)).toBe("");
+  });
+
+  it("returns aging suffix with time for stale cause", () => {
+    const suffix = badgeFreshnessSuffix("stale", now - 120_000, now);
+    expect(suffix).toContain("updated");
+    expect(suffix).toContain("2m ago");
+  });
+
+  it("returns rate limited suffix without reset time when resetAt is null", () => {
+    const suffix = badgeFreshnessSuffix("rate-limit", null, now, null);
+    expect(suffix).toBe(" · rate limited");
+  });
+
+  it("returns rate limited suffix without reset time when resetAt is in the past", () => {
+    const suffix = badgeFreshnessSuffix("rate-limit", null, now, now - 1000);
+    expect(suffix).toBe(" · rate limited");
+  });
+
+  it("returns rate limited suffix with retry time when resetAt is in the future", () => {
+    // 1 hour from now
+    const resetAt = now + 3_600_000;
+    const suffix = badgeFreshnessSuffix("rate-limit", null, now, resetAt);
+    expect(suffix).toContain("rate limited");
+    expect(suffix).toContain("retry at");
+  });
+
+  it("returns circuit-breaker suffix", () => {
+    const suffix = badgeFreshnessSuffix("circuit-breaker", null, now);
+    expect(suffix).toBe(" · data may be stale — PR detection paused");
   });
 });

--- a/src/components/Worktree/WorktreeCard/IssueBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/IssueBadge.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useMemo, useRef } from "react";
 import { cn } from "@/lib/utils";
-import { CircleDot } from "lucide-react";
+import { CircleDot, Clock, CloudOff } from "lucide-react";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { useIssueTooltip } from "@/hooks/useGitHubTooltip";
 import { useGitHubBadgeTooltip } from "./hooks/useGitHubBadgeTooltip";
 import { useGitHubBadgeFreshness } from "./hooks/useGitHubBadgeFreshness";
-import { freshnessClass, freshnessSuffix } from "@/components/Layout/FreshnessUtils";
+import { freshnessClass, badgeFreshnessSuffix } from "@/components/Layout/FreshnessUtils";
 import { IssueTooltipContent, TooltipLoading, TokenMissingTooltip } from "./GitHubTooltipContent";
 
 interface IssueBadgeProps {
@@ -19,6 +19,8 @@ interface IssueBadgeProps {
   isActive?: boolean;
   underlineOnHover?: boolean;
   rowLastUpdatedAt?: number;
+  /** Service-wide PR detection circuit breaker tripped — issue data may be stale. */
+  prDetectionPaused?: boolean;
 }
 
 export function IssueBadge({
@@ -30,6 +32,7 @@ export function IssueBadge({
   isActive,
   underlineOnHover,
   rowLastUpdatedAt,
+  prDetectionPaused,
 }: IssueBadgeProps) {
   // Detects the cold-title gap by comparing issueNumber to its previous-render
   // value via a ref; the lag (ref written in effect, no re-render) is what
@@ -63,15 +66,23 @@ export function IssueBadge({
     prevIssueNumber.current = issueNumber;
   }, [issueNumber]);
 
-  const { freshnessLevel, cacheLastUpdatedAt, now } = useGitHubBadgeFreshness(
-    "issue",
-    rowLastUpdatedAt
-  );
+  const { freshnessLevel, freshnessCause, cacheLastUpdatedAt, rateLimitResetAt, now } =
+    useGitHubBadgeFreshness("issue", rowLastUpdatedAt);
 
   const freshnessSuffixStr = useMemo(
-    () => freshnessSuffix(freshnessLevel, cacheLastUpdatedAt, now),
-    [freshnessLevel, cacheLastUpdatedAt, now]
+    () =>
+      badgeFreshnessSuffix(
+        freshnessCause,
+        rowLastUpdatedAt ?? cacheLastUpdatedAt,
+        now,
+        rateLimitResetAt
+      ),
+    [freshnessCause, rowLastUpdatedAt, cacheLastUpdatedAt, rateLimitResetAt, now]
   );
+
+  const showStaleGlyph = freshnessCause === "stale" && !missingToken;
+  const showPausedGlyph =
+    (freshnessCause === "rate-limit" || (prDetectionPaused ?? false)) && !missingToken;
 
   return (
     <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300}>
@@ -124,6 +135,16 @@ export function IssueBadge({
                 </span>
               ))}
           </span>
+          {showStaleGlyph && (
+            <Clock
+              className="w-3 h-3 shrink-0 text-text-muted"
+              strokeWidth={2.5}
+              aria-hidden="true"
+            />
+          )}
+          {showPausedGlyph && (
+            <CloudOff className="w-3 h-3 shrink-0 text-text-muted" aria-hidden="true" />
+          )}
         </button>
       </TooltipTrigger>
       <TooltipContent side="right" align="start" className="p-3">

--- a/src/components/Worktree/WorktreeCard/IssueBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/IssueBadge.tsx
@@ -19,8 +19,6 @@ interface IssueBadgeProps {
   isActive?: boolean;
   underlineOnHover?: boolean;
   rowLastUpdatedAt?: number;
-  /** Service-wide PR detection circuit breaker tripped — issue data may be stale. */
-  prDetectionPaused?: boolean;
 }
 
 export function IssueBadge({
@@ -32,7 +30,6 @@ export function IssueBadge({
   isActive,
   underlineOnHover,
   rowLastUpdatedAt,
-  prDetectionPaused,
 }: IssueBadgeProps) {
   // Detects the cold-title gap by comparing issueNumber to its previous-render
   // value via a ref; the lag (ref written in effect, no re-render) is what
@@ -81,8 +78,7 @@ export function IssueBadge({
   );
 
   const showStaleGlyph = freshnessCause === "stale" && !missingToken;
-  const showPausedGlyph =
-    (freshnessCause === "rate-limit" || (prDetectionPaused ?? false)) && !missingToken;
+  const showPausedGlyph = freshnessCause === "rate-limit" && !missingToken;
 
   return (
     <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300}>

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -5,6 +5,7 @@ import { IssueBadge } from "./IssueBadge";
 import { PRBadge } from "./PRBadge";
 import { FileText } from "lucide-react";
 import type { WorktreeState } from "@/types";
+import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
 
 interface NonMainSecondaryRowProps {
   worktree: WorktreeState;
@@ -35,6 +36,7 @@ export function NonMainSecondaryRow({
   hasPlanFile,
   badges,
 }: NonMainSecondaryRowProps) {
+  const prDetectionPaused = usePRCircuitBreakerStore((s) => s.tripped);
   return (
     <div className="flex flex-col gap-0.5 mt-1.5">
       {worktree.issueNumber && !hasIssueTitle && (
@@ -45,6 +47,7 @@ export function NonMainSecondaryRow({
           isActive={isActive}
           underlineOnHover={underlineOnHover}
           rowLastUpdatedAt={worktree.issueLastUpdatedAt}
+          prDetectionPaused={prDetectionPaused}
         />
       )}
       {worktree.linked?.pr &&
@@ -60,6 +63,7 @@ export function NonMainSecondaryRow({
             isActive={isActive}
             underlineOnHover={underlineOnHover}
             rowLastUpdatedAt={worktree.prLastUpdatedAt}
+            prDetectionPaused={prDetectionPaused}
           />
         )}
       {(hasUpstreamDelta || hasAuthFailedSignIn) && (

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -47,7 +47,6 @@ export function NonMainSecondaryRow({
           isActive={isActive}
           underlineOnHover={underlineOnHover}
           rowLastUpdatedAt={worktree.issueLastUpdatedAt}
-          prDetectionPaused={prDetectionPaused}
         />
       )}
       {worktree.linked?.pr &&

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -83,7 +83,11 @@ export function PRBadge({
     : (ciVisual
         ? `Open ${prStateLabel} pull request #${prNumber} on GitHub — ${ciVisual.ariaLabel}`
         : `Open ${prStateLabel} pull request #${prNumber} on GitHub`) +
-      (showPausedGlyph ? " — PR detection paused" : "");
+      (freshnessCause === "rate-limit"
+        ? " — GitHub rate limited"
+        : freshnessCause === "circuit-breaker" || (prDetectionPaused ?? false)
+          ? " — PR detection paused"
+          : "");
 
   const freshnessSuffixStr = useMemo(
     () =>

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -1,13 +1,13 @@
 import { useMemo } from "react";
 import { cn } from "@/lib/utils";
-import { Clock, CornerDownRight, GitPullRequest } from "lucide-react";
+import { Clock, CloudOff, CornerDownRight, GitPullRequest } from "lucide-react";
 import type { CIStatus } from "@shared/types/forge";
 import type { NormalizedPRState } from "@shared/types/forge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { usePRTooltip } from "@/hooks/useGitHubTooltip";
 import { useGitHubBadgeTooltip } from "./hooks/useGitHubBadgeTooltip";
 import { useGitHubBadgeFreshness } from "./hooks/useGitHubBadgeFreshness";
-import { freshnessSuffix } from "@/components/Layout/FreshnessUtils";
+import { badgeFreshnessSuffix } from "@/components/Layout/FreshnessUtils";
 import { PRTooltipContent, TooltipLoading, TokenMissingTooltip } from "./GitHubTooltipContent";
 import { getCIStatusVisual } from "@/lib/worktreeCIStatus";
 
@@ -21,6 +21,8 @@ interface PRBadgeProps {
   isActive?: boolean;
   underlineOnHover?: boolean;
   rowLastUpdatedAt?: number;
+  /** Service-wide PR detection circuit breaker tripped — this rollup may be stale. */
+  prDetectionPaused?: boolean;
 }
 
 export function PRBadge({
@@ -33,6 +35,7 @@ export function PRBadge({
   isActive,
   underlineOnHover,
   rowLastUpdatedAt,
+  prDetectionPaused,
 }: PRBadgeProps) {
   const { data, loading, error, missingToken, fetchTooltip, reset } = usePRTooltip(
     worktreePath,
@@ -47,7 +50,7 @@ export function PRBadge({
     onOpen,
   });
 
-  const { freshnessLevel, cacheLastUpdatedAt, now } = useGitHubBadgeFreshness(
+  const { freshnessCause, cacheLastUpdatedAt, rateLimitResetAt, now } = useGitHubBadgeFreshness(
     "pr",
     rowLastUpdatedAt
   );
@@ -68,15 +71,29 @@ export function PRBadge({
 
   const ciVisual = getCIStatusVisual(prCiStatus);
 
+  const showStaleGlyph = freshnessCause === "stale" && !missingToken;
+  const showPausedGlyph =
+    (freshnessCause === "rate-limit" ||
+      freshnessCause === "circuit-breaker" ||
+      (prDetectionPaused ?? false)) &&
+    !missingToken;
+
   const ariaLabel = missingToken
     ? "Configure GitHub token to see PR details"
-    : ciVisual
-      ? `Open ${prStateLabel} pull request #${prNumber} on GitHub — ${ciVisual.ariaLabel}`
-      : `Open ${prStateLabel} pull request #${prNumber} on GitHub`;
+    : (ciVisual
+        ? `Open ${prStateLabel} pull request #${prNumber} on GitHub — ${ciVisual.ariaLabel}`
+        : `Open ${prStateLabel} pull request #${prNumber} on GitHub`) +
+      (showPausedGlyph ? " — PR detection paused" : "");
 
   const freshnessSuffixStr = useMemo(
-    () => freshnessSuffix(freshnessLevel, rowLastUpdatedAt ?? cacheLastUpdatedAt, now),
-    [freshnessLevel, rowLastUpdatedAt, cacheLastUpdatedAt, now]
+    () =>
+      badgeFreshnessSuffix(
+        freshnessCause,
+        rowLastUpdatedAt ?? cacheLastUpdatedAt,
+        now,
+        rateLimitResetAt
+      ),
+    [freshnessCause, rowLastUpdatedAt, cacheLastUpdatedAt, rateLimitResetAt, now]
   );
 
   return (
@@ -126,12 +143,15 @@ export function PRBadge({
               )}
             </span>
           )}
-          {freshnessLevel === "aging" && !missingToken && (
+          {showStaleGlyph && (
             <Clock
               className="w-3 h-3 shrink-0 text-text-muted"
               strokeWidth={2.5}
               aria-hidden="true"
             />
+          )}
+          {showPausedGlyph && (
+            <CloudOff className="w-3 h-3 shrink-0 text-text-muted" aria-hidden="true" />
           )}
         </button>
       </TooltipTrigger>

--- a/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import type { WorktreeState } from "@/types";
+import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
+
+const prBadgeProps: Array<Record<string, unknown>> = [];
+const issueBadgeProps: Array<Record<string, unknown>> = [];
+
+vi.mock("../PRBadge", () => ({
+  PRBadge: (props: Record<string, unknown>) => {
+    prBadgeProps.push(props);
+    return <div data-testid="pr-badge" />;
+  },
+}));
+
+vi.mock("../IssueBadge", () => ({
+  IssueBadge: (props: Record<string, unknown>) => {
+    issueBadgeProps.push(props);
+    return <div data-testid="issue-badge" />;
+  },
+}));
+
+import { NonMainSecondaryRow } from "../NonMainSecondaryRow";
+
+const worktree = {
+  id: "wt-1",
+  path: "/repo",
+  name: "feature",
+  branch: "feature/test",
+  issueNumber: 123,
+  prNumber: 42,
+  prState: "open",
+  linked: {
+    providerId: "github",
+    pr: {
+      ref: { providerId: "github", owner: "test", repo: "test", number: 42, rawData: {} },
+      state: "open",
+      url: "https://github.com/test/repo/pull/42",
+    },
+  },
+} as unknown as WorktreeState;
+
+function renderRow() {
+  return render(
+    <NonMainSecondaryRow
+      worktree={worktree}
+      branchLabel="feature/test"
+      isActive
+      underlineOnHover={false}
+      hasUpstreamDelta={false}
+      hasAuthFailedSignIn={false}
+      hasIssueTitle={false}
+      hasPlanFile={false}
+      badges={{}}
+    />
+  );
+}
+
+describe("NonMainSecondaryRow → badge circuit-breaker wiring", () => {
+  beforeEach(() => {
+    prBadgeProps.length = 0;
+    issueBadgeProps.length = 0;
+    usePRCircuitBreakerStore.setState({ tripped: false });
+  });
+
+  it("passes prDetectionPaused=false to PRBadge when the breaker is not tripped", () => {
+    renderRow();
+    expect(prBadgeProps.at(-1)?.prDetectionPaused).toBe(false);
+  });
+
+  it("passes prDetectionPaused=true to PRBadge when the breaker is tripped", () => {
+    usePRCircuitBreakerStore.setState({ tripped: true });
+    renderRow();
+    expect(prBadgeProps.at(-1)?.prDetectionPaused).toBe(true);
+  });
+
+  it("passes prDetectionPaused=false to IssueBadge when the breaker is not tripped", () => {
+    renderRow();
+    expect(issueBadgeProps.at(-1)?.prDetectionPaused).toBe(false);
+  });
+
+  it("passes prDetectionPaused=true to IssueBadge when the breaker is tripped", () => {
+    usePRCircuitBreakerStore.setState({ tripped: true });
+    renderRow();
+    expect(issueBadgeProps.at(-1)?.prDetectionPaused).toBe(true);
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
@@ -3,23 +3,22 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
 import type { WorktreeState } from "@/types";
 import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 const prBadgeProps: Array<Record<string, unknown>> = [];
-const issueBadgeProps: Array<Record<string, unknown>> = [];
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: ReactNode) => children };
+});
 
 vi.mock("../PRBadge", () => ({
   PRBadge: (props: Record<string, unknown>) => {
     prBadgeProps.push(props);
     return <div data-testid="pr-badge" />;
-  },
-}));
-
-vi.mock("../IssueBadge", () => ({
-  IssueBadge: (props: Record<string, unknown>) => {
-    issueBadgeProps.push(props);
-    return <div data-testid="issue-badge" />;
   },
 }));
 
@@ -45,46 +44,36 @@ const worktree = {
 
 function renderRow() {
   return render(
-    <NonMainSecondaryRow
-      worktree={worktree}
-      branchLabel="feature/test"
-      isActive
-      underlineOnHover={false}
-      hasUpstreamDelta={false}
-      hasAuthFailedSignIn={false}
-      hasIssueTitle={false}
-      hasPlanFile={false}
-      badges={{}}
-    />
+    <TooltipProvider>
+      <NonMainSecondaryRow
+        worktree={worktree}
+        branchLabel="feature/test"
+        isActive
+        underlineOnHover={false}
+        hasUpstreamDelta={false}
+        hasAuthFailedSignIn={false}
+        hasIssueTitle={false}
+        hasPlanFile={false}
+        badges={{}}
+      />
+    </TooltipProvider>
   );
 }
 
-describe("NonMainSecondaryRow → badge circuit-breaker wiring", () => {
+describe("NonMainSecondaryRow → PRBadge circuit-breaker wiring", () => {
   beforeEach(() => {
     prBadgeProps.length = 0;
-    issueBadgeProps.length = 0;
     usePRCircuitBreakerStore.setState({ tripped: false });
   });
 
-  it("passes prDetectionPaused=false to PRBadge when the breaker is not tripped", () => {
+  it("passes prDetectionPaused=false when the breaker is not tripped", () => {
     renderRow();
     expect(prBadgeProps.at(-1)?.prDetectionPaused).toBe(false);
   });
 
-  it("passes prDetectionPaused=true to PRBadge when the breaker is tripped", () => {
+  it("passes prDetectionPaused=true when the breaker is tripped", () => {
     usePRCircuitBreakerStore.setState({ tripped: true });
     renderRow();
     expect(prBadgeProps.at(-1)?.prDetectionPaused).toBe(true);
-  });
-
-  it("passes prDetectionPaused=false to IssueBadge when the breaker is not tripped", () => {
-    renderRow();
-    expect(issueBadgeProps.at(-1)?.prDetectionPaused).toBe(false);
-  });
-
-  it("passes prDetectionPaused=true to IssueBadge when the breaker is tripped", () => {
-    usePRCircuitBreakerStore.setState({ tripped: true });
-    renderRow();
-    expect(issueBadgeProps.at(-1)?.prDetectionPaused).toBe(true);
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/PRBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/PRBadge.test.tsx
@@ -143,4 +143,20 @@ describe("PRBadge freshness glyphs", () => {
 
     expect(screen.getAllByText(/data may be stale/).length).toBeGreaterThan(0);
   });
+
+  it("uses rate-limit aria label when freshnessCause is rate-limit", () => {
+    mockFreshnessCause = "rate-limit";
+    renderBadge();
+
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-label")).toContain("GitHub rate limited");
+    expect(button.getAttribute("aria-label")).not.toContain("PR detection paused");
+  });
+
+  it("uses circuit-breaker aria label when prDetectionPaused is true", () => {
+    renderBadge({ prDetectionPaused: true });
+
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-label")).toContain("PR detection paused");
+  });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/PRBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/PRBadge.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: ReactNode) => children };
+});
+
+let mockMissingToken = false;
+let mockFreshnessCause: "stale" | "rate-limit" | "circuit-breaker" | undefined = undefined;
+
+vi.mock("@/hooks/useGitHubTooltip", () => ({
+  usePRTooltip: () => ({
+    data: null,
+    loading: false,
+    error: null,
+    missingToken: mockMissingToken,
+    fetchTooltip: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/useGitHubBadgeTooltip", () => ({
+  useGitHubBadgeTooltip: () => ({
+    isOpen: true,
+    handleOpenChange: vi.fn(),
+    handleClick: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/useGitHubBadgeFreshness", () => ({
+  useGitHubBadgeFreshness: () => ({
+    freshnessLevel: mockFreshnessCause ? "aging" : "fresh",
+    freshnessCause: mockFreshnessCause,
+    cacheLastUpdatedAt: null,
+    rateLimitResetAt: null,
+    now: Date.now(),
+  }),
+}));
+
+import { PRBadge } from "../PRBadge";
+
+function renderBadge(extra: Partial<Parameters<typeof PRBadge>[0]> = {}) {
+  return render(
+    <TooltipProvider>
+      <PRBadge
+        prNumber={42}
+        prState="open"
+        isSubordinate={false}
+        worktreePath="/repo"
+        isActive
+        {...extra}
+      />
+    </TooltipProvider>
+  );
+}
+
+describe("PRBadge freshness glyphs", () => {
+  beforeEach(() => {
+    mockMissingToken = false;
+    mockFreshnessCause = undefined;
+  });
+
+  it("shows the CloudOff glyph when prDetectionPaused is true", () => {
+    const { container } = renderBadge({ prDetectionPaused: true });
+
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-label")).toContain("PR detection paused");
+    expect(button.querySelector(".lucide-cloud-off")).toBeTruthy();
+    expect(container).toBeTruthy();
+  });
+
+  it("does not show the CloudOff glyph when prDetectionPaused is false", () => {
+    renderBadge({ prDetectionPaused: false });
+
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-label")).not.toContain("PR detection paused");
+    expect(button.querySelector(".lucide-cloud-off")).toBeNull();
+  });
+
+  it("does not show the CloudOff glyph when prDetectionPaused is undefined", () => {
+    renderBadge();
+
+    const button = screen.getByRole("button");
+    expect(button.querySelector(".lucide-cloud-off")).toBeNull();
+  });
+
+  it("keeps the badge button at full opacity (no dimming classes)", () => {
+    renderBadge({ prDetectionPaused: true });
+
+    const button = screen.getByRole("button");
+    expect(button.className).not.toMatch(/opacity-/);
+  });
+
+  it("suppresses the paused signal when the GitHub token is missing", () => {
+    mockMissingToken = true;
+    renderBadge({ prDetectionPaused: true });
+
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-label")).not.toContain("PR detection paused");
+    expect(button.querySelector(".lucide-cloud-off")).toBeNull();
+  });
+
+  it("shows Clock glyph when freshnessCause is stale", () => {
+    mockFreshnessCause = "stale";
+    renderBadge();
+
+    const button = screen.getByRole("button");
+    expect(button.querySelector(".lucide-clock")).toBeTruthy();
+  });
+
+  it("does not show Clock glyph when freshnessCause is undefined", () => {
+    renderBadge();
+
+    const button = screen.getByRole("button");
+    expect(button.querySelector(".lucide-clock")).toBeNull();
+  });
+
+  it("shows CloudOff when freshnessCause is rate-limit", () => {
+    mockFreshnessCause = "rate-limit";
+    renderBadge();
+
+    const button = screen.getByRole("button");
+    expect(button.querySelector(".lucide-cloud-off")).toBeTruthy();
+  });
+
+  it("shows CloudOff when freshnessCause is circuit-breaker", () => {
+    mockFreshnessCause = "circuit-breaker";
+    renderBadge();
+
+    const button = screen.getByRole("button");
+    expect(button.querySelector(".lucide-cloud-off")).toBeTruthy();
+  });
+
+  it("shows circuit-breaker tooltip suffix text when freshnessCause is circuit-breaker", () => {
+    mockFreshnessCause = "circuit-breaker";
+    renderBadge();
+
+    expect(screen.getAllByText(/data may be stale/).length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
@@ -229,4 +229,89 @@ describe("useGitHubBadgeFreshness", () => {
 
     expect(result.current.freshnessLevel).toBe("aging");
   });
+
+  // -- freshnessCause discriminator --
+
+  it("returns undefined freshnessCause when fresh", () => {
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", FIXED_NOW));
+    expect(result.current.freshnessLevel).toBe("fresh");
+    expect(result.current.freshnessCause).toBeUndefined();
+  });
+
+  it("returns freshnessCause 'stale' when past age threshold", () => {
+    const rowTime = FIXED_NOW - (STALE_THRESHOLD_MS + 1);
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    expect(result.current.freshnessLevel).toBe("aging");
+    expect(result.current.freshnessCause).toBe("stale");
+  });
+
+  it("returns freshnessCause 'rate-limit' while rate-limit pause is active", () => {
+    useGitHubRateLimitStore.setState({
+      blocked: true,
+      kind: "primary",
+      resetAt: Date.now() + 60_000,
+    });
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", Date.now()));
+    expect(result.current.freshnessCause).toBe("rate-limit");
+  });
+
+  it("returns freshnessCause 'circuit-breaker' for PR type when breaker tripped", () => {
+    usePRCircuitBreakerStore.setState({ tripped: true });
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", Date.now()));
+    expect(result.current.freshnessCause).toBe("circuit-breaker");
+  });
+
+  it("does not return circuit-breaker cause for issue type when breaker tripped", () => {
+    usePRCircuitBreakerStore.setState({ tripped: true });
+    const { result } = renderHook(() => useGitHubBadgeFreshness("issue", Date.now()));
+    expect(result.current.freshnessLevel).toBe("fresh");
+    expect(result.current.freshnessCause).toBeUndefined();
+  });
+
+  it("rate-limit takes precedence over circuit-breaker for cause", () => {
+    useGitHubRateLimitStore.setState({
+      blocked: true,
+      kind: "primary",
+      resetAt: Date.now() + 60_000,
+    });
+    usePRCircuitBreakerStore.setState({ tripped: true });
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", Date.now()));
+    expect(result.current.freshnessCause).toBe("rate-limit");
+  });
+
+  it("rate-limit takes precedence over age threshold for cause", () => {
+    const rowTime = FIXED_NOW - (STALE_THRESHOLD_MS + 1);
+    useGitHubRateLimitStore.setState({
+      blocked: true,
+      kind: "secondary",
+      resetAt: Date.now() + 60_000,
+    });
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    expect(result.current.freshnessCause).toBe("rate-limit");
+  });
+
+  it("circuit-breaker takes precedence over age threshold for cause", () => {
+    const rowTime = FIXED_NOW - (STALE_THRESHOLD_MS + 1);
+    usePRCircuitBreakerStore.setState({ tripped: true });
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    expect(result.current.freshnessCause).toBe("circuit-breaker");
+  });
+
+  // -- rateLimitResetAt passthrough --
+
+  it("returns rateLimitResetAt from the rate-limit store", () => {
+    const resetTime = Date.now() + 120_000;
+    useGitHubRateLimitStore.setState({
+      blocked: true,
+      kind: "primary",
+      resetAt: resetTime,
+    });
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", Date.now()));
+    expect(result.current.rateLimitResetAt).toBe(resetTime);
+  });
+
+  it("returns null rateLimitResetAt when rate limit is not blocked", () => {
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", FIXED_NOW));
+    expect(result.current.rateLimitResetAt).toBeNull();
+  });
 });

--- a/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from "react";
 import type { FreshnessLevel } from "@/hooks/useRepositoryStats";
+import type { BadgeFreshnessCause } from "@/components/Layout/FreshnessUtils";
 import { getCache, buildCacheKey } from "@/lib/githubResourceCache";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { useProjectStore } from "@/store/projectStore";
@@ -13,9 +14,11 @@ const STALE_THRESHOLD_MS = 3 * 60 * 1000;
 
 const noopSubscribe = () => () => {};
 
-interface UseGitHubBadgeFreshnessResult {
+export interface UseGitHubBadgeFreshnessResult {
   freshnessLevel: FreshnessLevel;
+  freshnessCause?: BadgeFreshnessCause;
   cacheLastUpdatedAt: number | null;
+  rateLimitResetAt: number | null;
   now: number;
 }
 
@@ -26,6 +29,7 @@ export function useGitHubBadgeFreshness(
   const projectPath = useProjectStore((s) => s.currentProject?.path);
   const tick = useGlobalMinuteTicker();
   const rateLimitBlocked = useGitHubRateLimitStore((s) => s.blocked);
+  const rateLimitResetAt = useGitHubRateLimitStore((s) => s.resetAt);
   const prCircuitBreakerTripped = usePRCircuitBreakerStore((s) => s.tripped);
 
   const cacheKey = projectPath
@@ -39,18 +43,19 @@ export function useGitHubBadgeFreshness(
   const cacheLastUpdatedAt = cacheEntry?.timestamp ?? null;
   const now = tick > 0 ? Date.now() : Date.now();
 
-  // While GitHub-wide rate-limit pause OR the PR detection circuit breaker is
-  // active, badge data may be older than its timestamp suggests — polling is
-  // suspended, so a `fresh` badge would be misleading. Treat as `aging` until
-  // the block clears. (The circuit-breaker downgrade only meaningfully affects
-  // PR badges; issue badges aren't gated by `PullRequestService`, but the
-  // store is `false` whenever PR detection is healthy so this is a no-op there.)
-  const freshnessLevel: FreshnessLevel =
-    rateLimitBlocked || (type === "pr" && prCircuitBreakerTripped)
-      ? "aging"
-      : rowLastUpdatedAt != null && now - rowLastUpdatedAt > STALE_THRESHOLD_MS
-        ? "aging"
-        : "fresh";
+  // Precedence: rate-limit > circuit-breaker > age threshold.
+  // Circuit-breaker only applies to PR badges; issue badges get circuit-breaker
+  // visibility through the `prDetectionPaused` prop instead.
+  let freshnessCause: BadgeFreshnessCause | undefined;
+  if (rateLimitBlocked) {
+    freshnessCause = "rate-limit";
+  } else if (type === "pr" && prCircuitBreakerTripped) {
+    freshnessCause = "circuit-breaker";
+  } else if (rowLastUpdatedAt != null && now - rowLastUpdatedAt > STALE_THRESHOLD_MS) {
+    freshnessCause = "stale";
+  }
 
-  return { freshnessLevel, cacheLastUpdatedAt, now };
+  const freshnessLevel: FreshnessLevel = freshnessCause ? "aging" : "fresh";
+
+  return { freshnessLevel, freshnessCause, cacheLastUpdatedAt, rateLimitResetAt, now };
 }


### PR DESCRIPTION
## Summary
Worktree-card badges used a single "aging" state for three distinct problems: stale data, GitHub rate-limiting, and a tripped circuit breaker. Each needs a different remedy, but the badges all looked the same. This PR disambiguates the cause and surfaces it through glyphs and tooltips on both the PR and Issue badges.

`freshnessOpacityClass` is retired entirely. Opacity-as-stale reads as a disabled control on clickable pills; staleness now lives in the glyph + tooltip suffix alone.

Resolves #8388.

## Changes
- Added `freshnessCause` discriminator to `useGitHubBadgeFreshness` (`stale`, `rate-limit`, `circuit-breaker`)
- Removed `freshnessOpacityClass` and its tests — last caller was the Issue badge
- Added inline `Clock` and `CloudOff` glyphs to `IssueBadge`, matching the existing PR badge vocabulary
- Gated PR badge glyphs on the specific cause, branched `aria-label` on cause
- Added `badgeFreshnessSuffix` with cause-specific tooltip copy for both badge types
- Fixed `IssueBadge` timestamp asymmetry between display and aria-label

## Testing
- 85 new and updated test cases across `useGitHubBadgeFreshness.test.ts`, `PRBadge.test.ts`, `FreshnessUtils.test.ts`, and `NonMainSecondaryRow.test.ts`
- All existing tests pass (0 regressions)
- Typecheck, lint, and format all clean