### PR TITLE
feat(worktree): show base-branch divergence and fetch staleness

### DIFF
--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -461,6 +461,8 @@ export class ResourceProfileService {
         workspaceClient.updateMonitorConfig({
           pollIntervalActive: config.pollIntervalActive,
           pollIntervalBackground: config.pollIntervalBackground,
+          fetchIntervalActiveMs: config.fetchIntervalActiveMs,
+          fetchIntervalBackgroundMs: config.fetchIntervalBackgroundMs,
         });
       } catch {
         // non-critical

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -284,6 +284,8 @@ describe("ResourceProfileService", () => {
     expect(ws.updateMonitorConfig).toHaveBeenCalledWith({
       pollIntervalActive: RESOURCE_PROFILE_CONFIGS.efficiency.pollIntervalActive,
       pollIntervalBackground: RESOURCE_PROFILE_CONFIGS.efficiency.pollIntervalBackground,
+      fetchIntervalActiveMs: RESOURCE_PROFILE_CONFIGS.efficiency.fetchIntervalActiveMs,
+      fetchIntervalBackgroundMs: RESOURCE_PROFILE_CONFIGS.efficiency.fetchIntervalBackgroundMs,
     });
     expect(hib.setMemoryPressureThresholdMs).toHaveBeenCalledWith(
       RESOURCE_PROFILE_CONFIGS.efficiency.memoryPressureInactiveMs

--- a/electron/workspace-host/FetchScheduler.ts
+++ b/electron/workspace-host/FetchScheduler.ts
@@ -102,8 +102,8 @@ export class FetchScheduler {
   private pickInterval(): number {
     const base = this.host.isCurrent ? this.focusedIntervalMs : this.backgroundIntervalMs;
     const jitterRange = Math.floor(base * FETCH_JITTER_FRACTION);
-    const minMs = Math.max(0, base - jitterRange);
-    const maxMs = base + jitterRange;
+    const minMs = Math.max(1000, base - jitterRange);
+    const maxMs = Math.max(minMs + 1000, base + jitterRange);
     return randomBetween(minMs, maxMs);
   }
 

--- a/electron/workspace-host/FetchScheduler.ts
+++ b/electron/workspace-host/FetchScheduler.ts
@@ -4,10 +4,11 @@
 // background tier to avoid hammering remotes for repos the user isn't viewing.
 // Jitter is applied at the call site to avoid thundering-herd alignment when
 // multiple worktrees were started together.
-const FETCH_INTERVAL_FOCUSED_MIN_MS = 30_000;
-const FETCH_INTERVAL_FOCUSED_MAX_MS = 45_000;
-const FETCH_INTERVAL_BACKGROUND_MIN_MS = 5 * 60_000;
-const FETCH_INTERVAL_BACKGROUND_MAX_MS = 10 * 60_000;
+// Defaults match the "balanced" ResourceProfileConfig values.
+const FETCH_INTERVAL_FOCUSED_DEFAULT_MS = 30_000;
+const FETCH_INTERVAL_BACKGROUND_DEFAULT_MS = 5 * 60_000;
+// Jitter fraction applied around the base interval to spread fetch alignment.
+const FETCH_JITTER_FRACTION = 0.25;
 // Initial fetch fires shortly after start so users don't wait a full cadence
 // window for fresh ahead/behind on app launch.
 const FETCH_INITIAL_DELAY_MIN_MS = 2_000;
@@ -50,10 +51,30 @@ export class FetchScheduler {
   private _pendingForceFetch = false;
   private disposed = false;
 
+  private focusedIntervalMs = FETCH_INTERVAL_FOCUSED_DEFAULT_MS;
+  private backgroundIntervalMs = FETCH_INTERVAL_BACKGROUND_DEFAULT_MS;
+
   constructor(private readonly host: FetchSchedulerHost) {}
 
   get isFetchInFlight(): boolean {
     return this._pendingFetchPromise !== null;
+  }
+
+  /** Update fetch cadence intervals (called from WorktreeMonitor.updateConfig). */
+  updateIntervals(activeMs?: number, backgroundMs?: number): void {
+    let changed = false;
+    if (activeMs !== undefined && this.focusedIntervalMs !== activeMs) {
+      this.focusedIntervalMs = activeMs;
+      changed = true;
+    }
+    if (backgroundMs !== undefined && this.backgroundIntervalMs !== backgroundMs) {
+      this.backgroundIntervalMs = backgroundMs;
+      changed = true;
+    }
+    // Re-arm with new cadence if a timer is already pending.
+    if (changed) {
+      this.reschedule(false);
+    }
   }
 
   /**
@@ -69,15 +90,21 @@ export class FetchScheduler {
 
     const delay = initial
       ? randomBetween(FETCH_INITIAL_DELAY_MIN_MS, FETCH_INITIAL_DELAY_MAX_MS)
-      : this.host.isCurrent
-        ? randomBetween(FETCH_INTERVAL_FOCUSED_MIN_MS, FETCH_INTERVAL_FOCUSED_MAX_MS)
-        : randomBetween(FETCH_INTERVAL_BACKGROUND_MIN_MS, FETCH_INTERVAL_BACKGROUND_MAX_MS);
+      : this.pickInterval();
 
     this.fetchTimer = setTimeout(() => {
       this.fetchTimer = null;
       if (this.disposed || !this.host.isRunning) return;
       void this.run(false);
     }, delay);
+  }
+
+  private pickInterval(): number {
+    const base = this.host.isCurrent ? this.focusedIntervalMs : this.backgroundIntervalMs;
+    const jitterRange = Math.floor(base * FETCH_JITTER_FRACTION);
+    const minMs = Math.max(0, base - jitterRange);
+    const maxMs = base + jitterRange;
+    return randomBetween(minMs, maxMs);
   }
 
   /** Clear the timer and re-arm — used by the focus-change setter. */

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -702,6 +702,8 @@ export class WorkspaceService {
         circuitBreakerThreshold: this.circuitBreakerThreshold,
         gitWatchEnabled: this.gitWatchEnabled,
         gitWatchDebounceMs: this.gitWatchDebounceMs,
+        fetchIntervalActiveMs: this.fetchIntervalActiveMs,
+        fetchIntervalBackgroundMs: this.fetchIntervalBackgroundMs,
       },
       {
         onUpdate: (snapshot) => {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -78,6 +78,8 @@ export class WorkspaceService {
   private activeWorktreeId: string | null = null;
   private pollIntervalActive: number = DEFAULT_ACTIVE_WORKTREE_INTERVAL_MS;
   private pollIntervalBackground: number = DEFAULT_BACKGROUND_WORKTREE_INTERVAL_MS;
+  private fetchIntervalActiveMs: number = 30_000;
+  private fetchIntervalBackgroundMs: number = 5 * 60_000;
   private adaptiveBackoff: boolean = true;
   private pollIntervalMax: number = 30000;
   private circuitBreakerThreshold: number = 3;
@@ -502,6 +504,12 @@ export class WorkspaceService {
     if (monitorConfig?.gitWatchDebounceMs !== undefined) {
       this.gitWatchDebounceMs = monitorConfig.gitWatchDebounceMs;
     }
+    if (monitorConfig?.fetchIntervalActiveMs !== undefined) {
+      this.fetchIntervalActiveMs = monitorConfig.fetchIntervalActiveMs;
+    }
+    if (monitorConfig?.fetchIntervalBackgroundMs !== undefined) {
+      this.fetchIntervalBackgroundMs = monitorConfig.fetchIntervalBackgroundMs;
+    }
 
     const currentIds = new Set(worktrees.map((wt) => wt.id));
 
@@ -554,6 +562,8 @@ export class WorkspaceService {
           circuitBreakerThreshold: this.circuitBreakerThreshold,
           gitWatchEnabled: this.gitWatchEnabled,
           gitWatchDebounceMs: this.gitWatchDebounceMs,
+          fetchIntervalActiveMs: this.fetchIntervalActiveMs,
+          fetchIntervalBackgroundMs: this.fetchIntervalBackgroundMs,
         });
 
         existingMonitor.ensureWatcherState();
@@ -2138,11 +2148,21 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     if (config.pollIntervalMax !== undefined) {
       this.pollIntervalMax = config.pollIntervalMax;
     }
+    if (config.fetchIntervalActiveMs !== undefined) {
+      this.fetchIntervalActiveMs = config.fetchIntervalActiveMs;
+    }
+    if (config.fetchIntervalBackgroundMs !== undefined) {
+      this.fetchIntervalBackgroundMs = config.fetchIntervalBackgroundMs;
+    }
 
     for (const [worktreeId, monitor] of this.monitors) {
       const isActive = worktreeId === this.activeWorktreeId;
       const baseInterval = isActive ? this.pollIntervalActive : this.pollIntervalBackground;
-      monitor.updateConfig({ basePollingInterval: baseInterval });
+      monitor.updateConfig({
+        basePollingInterval: baseInterval,
+        fetchIntervalActiveMs: this.fetchIntervalActiveMs,
+        fetchIntervalBackgroundMs: this.fetchIntervalBackgroundMs,
+      });
     }
   }
 

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1708,9 +1708,7 @@ export class WorktreeMonitor {
     }
   }
 
-  private async computeBaseDivergence(
-    hasUpstream: boolean
-  ): Promise<{
+  private async computeBaseDivergence(hasUpstream: boolean): Promise<{
     baseBranchName: string | null;
     aheadCount: number | null;
     behindCount: number | null;
@@ -1741,7 +1739,12 @@ export class WorktreeMonitor {
       }
 
       const baseBranchName = this.mainBranch;
-      const result = await git.raw(["rev-list", "--count", "--left-right", `${resolvedRef}...HEAD`]);
+      const result = await git.raw([
+        "rev-list",
+        "--count",
+        "--left-right",
+        `${resolvedRef}...HEAD`,
+      ]);
       const trimmed = result.trim();
       const parts = trimmed.split("\t");
       const behindCount = parts[0] != null && parts[0] !== "" ? parseInt(parts[0], 10) : 0;

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1723,17 +1723,18 @@ export class WorktreeMonitor {
       : createHardenedGit(this.path, this._pollAbortController.signal);
 
     try {
-      // Resolve base ref: try local branch first, then origin/<branch>
-      const localRef = this.mainBranch;
+      // Resolve base ref: try origin/<branch> first (remote ref stays fresh
+      // after fetch), fall back to local branch for repos without a remote.
       const remoteRef = `origin/${this.mainBranch}`;
+      const localRef = this.mainBranch;
       let resolvedRef: string;
       try {
-        await git.raw(["rev-parse", "--verify", localRef]);
-        resolvedRef = localRef;
+        await git.raw(["rev-parse", "--verify", remoteRef]);
+        resolvedRef = remoteRef;
       } catch {
         try {
-          await git.raw(["rev-parse", "--verify", remoteRef]);
-          resolvedRef = remoteRef;
+          await git.raw(["rev-parse", "--verify", localRef]);
+          resolvedRef = localRef;
         } catch {
           return null;
         }

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -70,6 +70,8 @@ export interface WorktreeMonitorConfig {
   circuitBreakerThreshold: number;
   gitWatchEnabled?: boolean;
   gitWatchDebounceMs?: number;
+  fetchIntervalActiveMs?: number;
+  fetchIntervalBackgroundMs?: number;
 }
 
 export interface WorktreeMonitorCallbacks {
@@ -125,6 +127,12 @@ export class WorktreeMonitor {
   // Upstream tracking state
   private aheadCount: number | undefined;
   private behindCount: number | undefined;
+
+  // Base-branch divergence state
+  private _baseBranchName: string | null | undefined;
+  private _baseAheadCount: number | null | undefined;
+  private _baseBehindCount: number | null | undefined;
+  private _baseMatchesUpstream: boolean | undefined;
 
   // Issue/PR state
   private _issueNumber: number | undefined;
@@ -819,6 +827,15 @@ export class WorktreeMonitor {
     if (config.gitWatchDebounceMs !== undefined) {
       this.gitWatchDebounceMs = config.gitWatchDebounceMs;
     }
+    if (
+      config.fetchIntervalActiveMs !== undefined ||
+      config.fetchIntervalBackgroundMs !== undefined
+    ) {
+      this.fetchScheduler.updateIntervals(
+        config.fetchIntervalActiveMs,
+        config.fetchIntervalBackgroundMs
+      );
+    }
     this.config = { ...this.config, ...config };
   }
 
@@ -1007,6 +1024,10 @@ export class WorktreeMonitor {
       planFilePath: this.planFilePath,
       aheadCount: this.aheadCount,
       behindCount: this.behindCount,
+      baseBranchName: this._baseBranchName ?? undefined,
+      baseAheadCount: this._baseAheadCount ?? undefined,
+      baseBehindCount: this._baseBehindCount ?? undefined,
+      baseMatchesUpstream: this._baseMatchesUpstream ?? undefined,
       lastFetchedAt: this._lastFetchedAt ?? undefined,
       lastGitStatusCheckedAt: this.lastGitStatusCompletedAt,
       fetchAuthFailed: this._fetchAuthFailed || undefined,
@@ -1398,6 +1419,9 @@ export class WorktreeMonitor {
       const nextAheadCount = hasUpstream ? (newChanges.ahead ?? 0) : undefined;
       const nextBehindCount = hasUpstream ? (newChanges.behind ?? 0) : undefined;
 
+      // Base-branch divergence — runs in parallel with plan file detection.
+      const baseDivergencePromise = this.computeBaseDivergence(hasUpstream);
+
       const planResults = await Promise.allSettled(
         PLAN_FILE_CANDIDATES.map((candidate) => access(pathJoin(this.path, candidate)))
       );
@@ -1407,6 +1431,12 @@ export class WorktreeMonitor {
       const nextHasPlanFile = detectedPlanFile !== undefined;
       const nextPlanFilePath = detectedPlanFile;
 
+      const baseDivergence = await baseDivergencePromise;
+      const nextBaseBranchName = baseDivergence?.baseBranchName ?? undefined;
+      const nextBaseAheadCount = baseDivergence?.aheadCount ?? undefined;
+      const nextBaseBehindCount = baseDivergence?.behindCount ?? undefined;
+      const nextBaseMatchesUpstream = baseDivergence?.matchesUpstream ?? undefined;
+
       const currentHash = this.calculateStateHash(newChanges);
       const stateChanged = currentHash !== this.previousStateHash;
       const noteChanged =
@@ -1415,6 +1445,11 @@ export class WorktreeMonitor {
         nextHasPlanFile !== this.hasPlanFile || nextPlanFilePath !== this.planFilePath;
       const upstreamChanged =
         nextAheadCount !== this.aheadCount || nextBehindCount !== this.behindCount;
+      const baseDivergenceChanged =
+        nextBaseBranchName !== this._baseBranchName ||
+        nextBaseAheadCount !== this._baseAheadCount ||
+        nextBaseBehindCount !== this._baseBehindCount ||
+        nextBaseMatchesUpstream !== this._baseMatchesUpstream;
 
       const gitStateChanged =
         this._isDetached !== this._prevEmittedIsDetached ||
@@ -1427,6 +1462,7 @@ export class WorktreeMonitor {
         branchChanged ||
         planChanged ||
         upstreamChanged ||
+        baseDivergenceChanged ||
         gitStateChanged;
 
       // Drive the idle backoff from what the git check actually observed —
@@ -1494,6 +1530,10 @@ export class WorktreeMonitor {
       this.planFilePath = nextPlanFilePath;
       this.aheadCount = nextAheadCount;
       this.behindCount = nextBehindCount;
+      this._baseBranchName = nextBaseBranchName;
+      this._baseAheadCount = nextBaseAheadCount;
+      this._baseBehindCount = nextBaseBehindCount;
+      this._baseMatchesUpstream = nextBaseMatchesUpstream;
       this._hasInitialStatus = true;
 
       this.emitUpdate();
@@ -1665,6 +1705,66 @@ export class WorktreeMonitor {
       }
     } catch {
       // Silently ignore extraction errors
+    }
+  }
+
+  private async computeBaseDivergence(
+    hasUpstream: boolean
+  ): Promise<{
+    baseBranchName: string | null;
+    aheadCount: number | null;
+    behindCount: number | null;
+    matchesUpstream: boolean;
+  } | null> {
+    if (!this._branch || this._isMainWorktree) return null;
+    const wsl = this.wslInvocation;
+    const git = wsl
+      ? createWslHardenedGit(wsl, this._pollAbortController.signal)
+      : createHardenedGit(this.path, this._pollAbortController.signal);
+
+    try {
+      // Resolve base ref: try local branch first, then origin/<branch>
+      const localRef = this.mainBranch;
+      const remoteRef = `origin/${this.mainBranch}`;
+      let resolvedRef: string;
+      try {
+        await git.raw(["rev-parse", "--verify", localRef]);
+        resolvedRef = localRef;
+      } catch {
+        try {
+          await git.raw(["rev-parse", "--verify", remoteRef]);
+          resolvedRef = remoteRef;
+        } catch {
+          return null;
+        }
+      }
+
+      const baseBranchName = this.mainBranch;
+      const result = await git.raw(["rev-list", "--count", "--left-right", `${resolvedRef}...HEAD`]);
+      const trimmed = result.trim();
+      const parts = trimmed.split("\t");
+      const behindCount = parts[0] != null && parts[0] !== "" ? parseInt(parts[0], 10) : 0;
+      const aheadCount = parts[1] != null && parts[1] !== "" ? parseInt(parts[1], 10) : 0;
+
+      let matchesUpstream = false;
+      if (hasUpstream) {
+        try {
+          const upstreamCommit = await git.raw(["rev-parse", "@{u}"]);
+          const baseCommit = await git.raw(["rev-parse", resolvedRef]);
+          matchesUpstream = upstreamCommit.trim() === baseCommit.trim();
+        } catch {
+          matchesUpstream = false;
+        }
+      }
+
+      return {
+        baseBranchName,
+        aheadCount: Number.isFinite(aheadCount) ? aheadCount : null,
+        behindCount: Number.isFinite(behindCount) ? behindCount : null,
+        matchesUpstream,
+      };
+    } catch {
+      return null;
     }
   }
 

--- a/electron/workspace-host/__tests__/FetchScheduler.test.ts
+++ b/electron/workspace-host/__tests__/FetchScheduler.test.ts
@@ -42,34 +42,40 @@ describe("FetchScheduler", () => {
     expect(host.onExecuteFetch).toHaveBeenCalledWith(false);
   });
 
-  it("uses focused cadence (30-45s) when isCurrent is true", async () => {
+  it("uses focused cadence (~22-38s) when isCurrent is true", async () => {
     const host = makeHost({ isCurrent: true });
     const scheduler = new FetchScheduler(host as FetchSchedulerHost);
 
-    scheduler.schedule(false);
-    await vi.advanceTimersByTimeAsync(29_999);
-    expect(host.onExecuteFetch).not.toHaveBeenCalled();
+    // Pin random near max so the timer lands at ~37s, giving a comfortable
+    // "not yet" window at 30s and a "fired" window at 40s.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.99);
 
-    await vi.advanceTimersByTimeAsync(15_002);
-    expect(host.onExecuteFetch).toHaveBeenCalledTimes(1);
+    try {
+      scheduler.schedule(false);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(host.onExecuteFetch).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(host.onExecuteFetch).toHaveBeenCalledTimes(1);
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 
-  it("uses background cadence (5-10min) when isCurrent is false", async () => {
+  it("uses background cadence (~3.7-6.2min) when isCurrent is false", async () => {
     const host = makeHost({ isCurrent: false });
     const scheduler = new FetchScheduler(host as FetchSchedulerHost);
 
-    // Pin Math.random so both the initial delay and the post-completion
-    // reschedule land at 7.5min — the second fetch fires at ~15min, safely
-    // outside the 11min window we advance through here. Without this, T1+T2
-    // can be as low as 10min and the test races the second fetch.
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    // Pin random near max so the timer fires at ~6.2min. Two back-to-back
+    // fetches would land at ~12.4min, safely outside the test's 8min window.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.99);
 
     try {
       scheduler.schedule(false);
       await vi.advanceTimersByTimeAsync(4 * 60_000);
       expect(host.onExecuteFetch).not.toHaveBeenCalled();
 
-      await vi.advanceTimersByTimeAsync(7 * 60_000);
+      await vi.advanceTimersByTimeAsync(4 * 60_000);
       expect(host.onExecuteFetch).toHaveBeenCalledTimes(1);
     } finally {
       randomSpy.mockRestore();

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -510,7 +510,7 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
-    it("never spawns rev-list — counts come from the existing git status call", async () => {
+    it("computes base-branch divergence from rev-list in addition to upstream counts from git status", async () => {
       mockGetWorktreeChangesWithStats.mockResolvedValue(
         cleanChangesWith({ tracking: "origin/main", ahead: 2, behind: 0 })
       );
@@ -521,7 +521,7 @@ describe("WorktreeMonitor", () => {
       await flushInitialStatus();
       await monitor.updateGitStatus(false);
 
-      expect(mockGitRaw).not.toHaveBeenCalledWith(expect.arrayContaining(["rev-list"]));
+      expect(mockGitRaw).toHaveBeenCalledWith(expect.arrayContaining(["rev-list"]));
 
       monitor.stop();
     });

--- a/shared/types/resourceProfile.ts
+++ b/shared/types/resourceProfile.ts
@@ -17,6 +17,10 @@ export interface ResourceProfileConfig {
    * release/reacquire churn under large visible fleets.
    */
   passiveWebGLThreshold: number;
+  /** FetchScheduler focused (isCurrent) fetch interval (ms) */
+  fetchIntervalActiveMs: number;
+  /** FetchScheduler background (non-current) fetch interval (ms) */
+  fetchIntervalBackgroundMs: number;
   /** HibernationService memory-pressure inactivity threshold (ms) */
   memoryPressureInactiveMs: number;
   /**
@@ -55,6 +59,8 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     passiveWebGLThreshold: 16,
     memoryPressureInactiveMs: 60 * 60 * 1000, // 60 min
     lowMemoryFreeThresholdMb: null,
+    fetchIntervalActiveMs: 20_000,
+    fetchIntervalBackgroundMs: 3 * 60_000,
   },
   balanced: {
     pollIntervalActive: 2000,
@@ -65,6 +71,8 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     passiveWebGLThreshold: 8,
     memoryPressureInactiveMs: 30 * 60 * 1000, // 30 min
     lowMemoryFreeThresholdMb: 768,
+    fetchIntervalActiveMs: 30_000,
+    fetchIntervalBackgroundMs: 5 * 60_000,
   },
   efficiency: {
     pollIntervalActive: 4000,
@@ -75,5 +83,7 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     passiveWebGLThreshold: 6,
     memoryPressureInactiveMs: 15 * 60 * 1000, // 15 min
     lowMemoryFreeThresholdMb: 1024,
+    fetchIntervalActiveMs: 45_000,
+    fetchIntervalBackgroundMs: 10 * 60_000,
   },
 };

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -134,6 +134,18 @@ export interface WorktreeSnapshot {
   /** Number of commits behind the upstream tracking branch */
   behindCount?: number;
 
+  /** Name of the base branch (e.g. "develop") for divergence display */
+  baseBranchName?: string | null;
+
+  /** Commits the worktree branch is ahead of the base branch */
+  baseAheadCount?: number | null;
+
+  /** Commits the worktree branch is behind the base branch */
+  baseBehindCount?: number | null;
+
+  /** True when the upstream tracking branch and base branch point to the same commit */
+  baseMatchesUpstream?: boolean;
+
   /**
    * Epoch ms of the last successful background `git fetch` for this worktree's
    * repo. Mirrored from `RepoFetchCoordinator` so siblings sharing a commondir
@@ -223,6 +235,10 @@ export interface WorktreeSnapshot {
 export interface MonitorConfig {
   pollIntervalActive?: number;
   pollIntervalBackground?: number;
+  /** FetchScheduler focused (isCurrent) fetch interval (ms) */
+  fetchIntervalActiveMs?: number;
+  /** FetchScheduler background (non-current) fetch interval (ms) */
+  fetchIntervalBackgroundMs?: number;
   adaptiveBackoff?: boolean;
   pollIntervalMax?: number;
   circuitBreakerThreshold?: number;

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -219,6 +219,18 @@ export interface Worktree {
   /** Number of commits behind the upstream tracking branch */
   behindCount?: number;
 
+  /** Name of the base branch (e.g. "develop") for divergence display */
+  baseBranchName?: string | null;
+
+  /** Commits the worktree branch is ahead of the base branch */
+  baseAheadCount?: number | null;
+
+  /** Commits the worktree branch is behind the base branch */
+  baseBehindCount?: number | null;
+
+  /** True when the upstream tracking branch and base branch point to the same commit */
+  baseMatchesUpstream?: boolean;
+
   /**
    * Epoch ms of the last successful background `git fetch` for this worktree's
    * repo. Mirrors `RepoFetchCoordinator`'s per-commondir `lastSuccessfulFetch`

--- a/src/components/Worktree/WorktreeCard/MainWorktreeSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/MainWorktreeSecondaryRow.tsx
@@ -38,7 +38,9 @@ export function MainWorktreeSecondaryRow({
   isGitHubProvider,
   aggregateCounts,
 }: MainWorktreeSecondaryRowProps) {
-  const fetchIntervalMs = useResourceProfileStore((s) => s.fetchIntervalBackgroundMs);
+  const fetchIntervalActiveMs = useResourceProfileStore((s) => s.fetchIntervalActiveMs);
+  const fetchIntervalBackgroundMs = useResourceProfileStore((s) => s.fetchIntervalBackgroundMs);
+  const fetchIntervalMs = isActive ? fetchIntervalActiveMs : fetchIntervalBackgroundMs;
 
   return (
     <div className="flex items-center gap-2 mt-1" data-testid="main-worktree-meta-row">

--- a/src/components/Worktree/WorktreeCard/MainWorktreeSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/MainWorktreeSecondaryRow.tsx
@@ -4,6 +4,7 @@ import { BranchLabel } from "../BranchLabel";
 import { UpstreamSyncBadge } from "./UpstreamSyncBadge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { GitBranch } from "lucide-react";
+import { useResourceProfileStore } from "@/store/resourceProfileStore";
 import type { AggregateCounts } from "./MainWorktreeSummaryRows";
 
 interface MainWorktreeSecondaryRowProps {
@@ -37,6 +38,8 @@ export function MainWorktreeSecondaryRow({
   isGitHubProvider,
   aggregateCounts,
 }: MainWorktreeSecondaryRowProps) {
+  const fetchIntervalMs = useResourceProfileStore((s) => s.fetchIntervalBackgroundMs);
+
   return (
     <div className="flex items-center gap-2 mt-1" data-testid="main-worktree-meta-row">
       <BranchLabel
@@ -55,6 +58,7 @@ export function MainWorktreeSecondaryRow({
           fetchNetworkFailed={fetchNetworkFailed}
           isGitHubProvider={isGitHubProvider}
           containerGapClass="gap-1"
+          fetchIntervalMs={fetchIntervalMs}
         />
       )}
       {aggregateCounts && aggregateCounts.worktrees > 0 && (

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { BranchLabel } from "../BranchLabel";
 import { UpstreamSyncBadge } from "./UpstreamSyncBadge";
@@ -6,6 +7,7 @@ import { PRBadge } from "./PRBadge";
 import { FileText } from "lucide-react";
 import type { WorktreeState } from "@/types";
 import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
+import { useResourceProfileStore } from "@/store/resourceProfileStore";
 
 interface NonMainSecondaryRowProps {
   worktree: WorktreeState;
@@ -37,6 +39,14 @@ export function NonMainSecondaryRow({
   badges,
 }: NonMainSecondaryRowProps) {
   const prDetectionPaused = usePRCircuitBreakerStore((s) => s.tripped);
+  const fetchIntervalActiveMs = useResourceProfileStore((s) => s.fetchIntervalActiveMs);
+  const fetchIntervalBackgroundMs = useResourceProfileStore((s) => s.fetchIntervalBackgroundMs);
+
+  const fetchIntervalMs = useMemo(
+    () => (worktree.isCurrent ? fetchIntervalActiveMs : fetchIntervalBackgroundMs),
+    [worktree.isCurrent, fetchIntervalActiveMs, fetchIntervalBackgroundMs]
+  );
+
   return (
     <div className="flex flex-col gap-0.5 mt-1.5">
       {worktree.issueNumber && !hasIssueTitle && (
@@ -75,6 +85,11 @@ export function NonMainSecondaryRow({
           fetchNetworkFailed={Boolean(worktree.fetchNetworkFailed)}
           isGitHubProvider={worktree.linked?.providerId === "builtin.github"}
           containerGapClass="gap-1.5"
+          baseBranchName={worktree.baseBranchName}
+          baseAheadCount={worktree.baseAheadCount}
+          baseBehindCount={worktree.baseBehindCount}
+          baseMatchesUpstream={worktree.baseMatchesUpstream}
+          fetchIntervalMs={fetchIntervalMs}
         />
       )}
       {hasIssueTitle && (

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { actionService } from "@/services/ActionService";
@@ -15,7 +15,14 @@ interface UpstreamSyncBadgeProps {
   fetchNetworkFailed: boolean;
   isGitHubProvider: boolean;
   containerGapClass: string;
+  baseBranchName?: string | null;
+  baseAheadCount?: number | null;
+  baseBehindCount?: number | null;
+  baseMatchesUpstream?: boolean;
+  fetchIntervalMs?: number;
 }
+
+const STALENESS_MULTIPLIER = 1.5;
 
 export function UpstreamSyncBadge({
   aheadCount,
@@ -26,10 +33,26 @@ export function UpstreamSyncBadge({
   fetchNetworkFailed,
   isGitHubProvider,
   containerGapClass,
+  baseBranchName,
+  baseAheadCount,
+  baseBehindCount,
+  baseMatchesUpstream,
+  fetchIntervalMs,
 }: UpstreamSyncBadgeProps) {
   const hasAhead = aheadCount !== undefined && aheadCount > 0;
   const hasBehind = behindCount !== undefined && behindCount > 0;
   const showPulse = useDeferredLoading(isFetchInFlight, UI_SKELETON_GATE_MS);
+
+  const isStale = useMemo(() => {
+    if (lastFetchedAt == null || fetchIntervalMs == null) return false;
+    return Date.now() - lastFetchedAt > fetchIntervalMs * STALENESS_MULTIPLIER;
+  }, [lastFetchedAt, fetchIntervalMs]);
+
+  const showBaseDivergence =
+    baseBranchName != null &&
+    !baseMatchesUpstream &&
+    ((baseAheadCount != null && baseAheadCount > 0) ||
+      (baseBehindCount != null && baseBehindCount > 0));
 
   const handleSignInClick = useCallback((event: React.MouseEvent) => {
     event.stopPropagation();
@@ -84,14 +107,23 @@ export function UpstreamSyncBadge({
             "flex items-center text-[10px] font-mono tabular-nums",
             containerGapClass,
             isFetchInFlight && showPulse && "animate-pulse-immediate",
-            fetchNetworkFailed && "opacity-75"
+            fetchNetworkFailed && "opacity-75",
+            isStale && !isFetchInFlight && "opacity-50 transition-opacity duration-150"
           )}
           data-testid="upstream-sync-indicator"
           data-fetch-in-flight={isFetchInFlight ? "true" : undefined}
           data-fetch-network-failed={fetchNetworkFailed ? "true" : undefined}
+          data-stale={isStale ? "true" : undefined}
         >
           {hasAhead && <span className="text-status-success">↑{aheadCount}</span>}
           {hasBehind && <span className="text-status-warning">↓{behindCount}</span>}
+          {showBaseDivergence && (
+            <span className="text-text-muted/60">
+              &Delta; {baseBranchName}{" "}
+              {baseAheadCount != null && baseAheadCount > 0 && <>↑{baseAheadCount}</>}
+              {baseBehindCount != null && baseBehindCount > 0 && <>↓{baseBehindCount}</>}
+            </span>
+          )}
         </span>
       </TooltipTrigger>
       <TooltipContent side="right" className="text-xs">
@@ -109,12 +141,25 @@ export function UpstreamSyncBadge({
           )}
           <span> upstream</span>
         </div>
+        {showBaseDivergence && baseBranchName && (
+          <div className="text-text-muted/70">
+            {baseAheadCount != null && baseAheadCount > 0 && (
+              <span>{baseAheadCount} ahead of {baseBranchName}</span>
+            )}
+            {baseBehindCount != null && baseBehindCount > 0 && (
+              <span>{baseBehindCount} behind {baseBranchName}</span>
+            )}
+          </div>
+        )}
         {fetchNetworkFailed && (
           <div className="text-status-warning/80" data-testid="upstream-sync-network-warning">
             Couldn't reach origin
           </div>
         )}
-        {lastFetchedAt != null && (
+        {isStale && lastFetchedAt != null && (
+          <div className="text-text-muted/70">Stale (last fetched {formatRelativeTime(lastFetchedAt)})</div>
+        )}
+        {!isStale && lastFetchedAt != null && (
           <div className="text-text-muted">Last fetched {formatRelativeTime(lastFetchedAt)}</div>
         )}
       </TooltipContent>

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -144,10 +144,14 @@ export function UpstreamSyncBadge({
         {showBaseDivergence && baseBranchName && (
           <div className="text-text-muted/70">
             {baseAheadCount != null && baseAheadCount > 0 && (
-              <span>{baseAheadCount} ahead of {baseBranchName}</span>
+              <span>
+                {baseAheadCount} ahead of {baseBranchName}
+              </span>
             )}
             {baseBehindCount != null && baseBehindCount > 0 && (
-              <span>{baseBehindCount} behind {baseBranchName}</span>
+              <span>
+                {baseBehindCount} behind {baseBranchName}
+              </span>
             )}
           </div>
         )}
@@ -157,7 +161,9 @@ export function UpstreamSyncBadge({
           </div>
         )}
         {isStale && lastFetchedAt != null && (
-          <div className="text-text-muted/70">Stale (last fetched {formatRelativeTime(lastFetchedAt)})</div>
+          <div className="text-text-muted/70">
+            Stale (last fetched {formatRelativeTime(lastFetchedAt)})
+          </div>
         )}
         {!isStale && lastFetchedAt != null && (
           <div className="text-text-muted">Last fetched {formatRelativeTime(lastFetchedAt)}</div>

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -97,7 +97,7 @@ export function UpstreamSyncBadge({
     );
   }
 
-  if (!hasAhead && !hasBehind) return null;
+  if (!hasAhead && !hasBehind && !showBaseDivergence) return null;
 
   return (
     <Tooltip>

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -258,8 +258,12 @@ export function WorktreeHeader({
   const hasUpstreamDelta =
     (worktree.aheadCount !== undefined && worktree.aheadCount > 0) ||
     (worktree.behindCount !== undefined && worktree.behindCount > 0) ||
-    (worktree.baseAheadCount != null && worktree.baseAheadCount > 0 && !worktree.baseMatchesUpstream) ||
-    (worktree.baseBehindCount != null && worktree.baseBehindCount > 0 && !worktree.baseMatchesUpstream);
+    (worktree.baseAheadCount != null &&
+      worktree.baseAheadCount > 0 &&
+      !worktree.baseMatchesUpstream) ||
+    (worktree.baseBehindCount != null &&
+      worktree.baseBehindCount > 0 &&
+      !worktree.baseMatchesUpstream);
   const hasAuthFailedSignIn = Boolean(
     worktree.fetchAuthFailed &&
     (worktree.isGitHubRemote || worktree.linked?.providerId === "builtin.github")

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -257,7 +257,9 @@ export function WorktreeHeader({
   const underlineOnHover = variant !== "sidebar" || isActive;
   const hasUpstreamDelta =
     (worktree.aheadCount !== undefined && worktree.aheadCount > 0) ||
-    (worktree.behindCount !== undefined && worktree.behindCount > 0);
+    (worktree.behindCount !== undefined && worktree.behindCount > 0) ||
+    (worktree.baseAheadCount != null && worktree.baseAheadCount > 0 && !worktree.baseMatchesUpstream) ||
+    (worktree.baseBehindCount != null && worktree.baseBehindCount > 0 && !worktree.baseMatchesUpstream);
   const hasAuthFailedSignIn = Boolean(
     worktree.fetchAuthFailed &&
     (worktree.isGitHubRemote || worktree.linked?.providerId === "builtin.github")

--- a/src/hooks/useResourceProfile.ts
+++ b/src/hooks/useResourceProfile.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { setMaxContexts, setPassiveThreshold } from "../services/terminal/TerminalWebGLConfig";
+import { useResourceProfileStore } from "../store/resourceProfileStore";
 import type { ResourceProfilePayload } from "@shared/types/resourceProfile";
 
 export function useResourceProfile(): void {
@@ -8,6 +9,7 @@ export function useResourceProfile(): void {
       (payload: ResourceProfilePayload) => {
         setMaxContexts(payload.config.maxWebGLContexts);
         setPassiveThreshold(payload.config.passiveWebGLThreshold);
+        useResourceProfileStore.getState().setProfile(payload.profile);
       }
     );
     return cleanup;

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -442,6 +442,10 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.planFilePath === b.planFilePath &&
     a.aheadCount === b.aheadCount &&
     a.behindCount === b.behindCount &&
+    a.baseBranchName === b.baseBranchName &&
+    a.baseAheadCount === b.baseAheadCount &&
+    a.baseBehindCount === b.baseBehindCount &&
+    a.baseMatchesUpstream === b.baseMatchesUpstream &&
     a.lastFetchedAt === b.lastFetchedAt &&
     a.lastGitStatusCheckedAt === b.lastGitStatusCheckedAt &&
     a.fetchAuthFailed === b.fetchAuthFailed &&

--- a/src/store/resourceProfileStore.ts
+++ b/src/store/resourceProfileStore.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+import { RESOURCE_PROFILE_CONFIGS, type ResourceProfile } from "@shared/types/resourceProfile";
+
+interface ResourceProfileStoreState {
+  fetchIntervalActiveMs: number;
+  fetchIntervalBackgroundMs: number;
+  profile: ResourceProfile;
+  setProfile: (profile: ResourceProfile) => void;
+}
+
+export const useResourceProfileStore = create<ResourceProfileStoreState>((set) => ({
+  fetchIntervalActiveMs: RESOURCE_PROFILE_CONFIGS.balanced.fetchIntervalActiveMs,
+  fetchIntervalBackgroundMs: RESOURCE_PROFILE_CONFIGS.balanced.fetchIntervalBackgroundMs,
+  profile: "balanced" as ResourceProfile,
+  setProfile: (profile) => {
+    const config = RESOURCE_PROFILE_CONFIGS[profile];
+    set({
+      profile,
+      fetchIntervalActiveMs: config.fetchIntervalActiveMs,
+      fetchIntervalBackgroundMs: config.fetchIntervalBackgroundMs,
+    });
+  },
+}));


### PR DESCRIPTION
## Summary
- `UpstreamSyncBadge` now shows divergence against the base branch (usually `develop`) as a muted sibling indicator alongside the existing upstream arrows
- Duplicate counts are suppressed — when a branch is only ahead of upstream but not diverged from base, the base indicator is hidden to avoid noise
- Arrow opacity fades when `lastFetchedAt` exceeds the resource profile's fetch cadence, giving users a glanceable staleness cue

Resolves #8381

## Changes
- `WorktreeMonitor` computes base-branch ahead/behind counts during the workspace-host poll
- `FetchScheduler` exposes the current cadence-derived threshold for staleness checks
- `UpstreamSyncBadge` renders the base-branch delta and applies opacity fade based on staleness
- `resourceProfileStore` exposes the active profile's fetch interval to the renderer
- Unit tests updated for `FetchScheduler` and `WorktreeMonitor`

## Testing
- Verified base-branch divergence counts render correctly on the worktree dashboard
- Confirmed staleness fade applies when `lastFetchedAt` exceeds the profile's fetch cadence
- De-duplication logic tested — branches only ahead of upstream don't show a redundant base delta