### PR TITLE
fix(sidebar): polish worktree empty states and stale-data handling

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -9,9 +9,10 @@ import {
   useState,
   useTransition,
 } from "react";
-import { FolderOpen, LayoutGrid, Plus, RefreshCw, Zap } from "lucide-react";
+import { AlertTriangle, FolderOpen, LayoutGrid, Plus, RefreshCw, Zap } from "lucide-react";
 import { HollowCircle } from "@/components/icons";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { ScrollIndicator } from "@/components/Worktree/ScrollIndicator";
 import {
@@ -70,6 +71,7 @@ import { RecipeManager } from "@/components/TerminalRecipe/RecipeManager";
 import { isAgentTerminal } from "@/utils/terminalType";
 import { isTerminalVisible } from "@/lib/terminalVisibility";
 import { useWorktreeIds } from "@/hooks/useTerminalSelectors";
+import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { logError } from "@/utils/logger";
 import { useWorktreeGridRovingFocus } from "./useWorktreeGridRovingFocus";
 
@@ -233,6 +235,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     },
   });
   const { worktrees, isLoading, isReconnecting, reconnectingAt, error, refresh } = useWorktrees();
+  const setError = useWorktreeStore((state) => state.setError);
+  const onBannerDismiss = useCallback(() => setError(null), [setError]);
   worktreesRef.current = worktrees;
 
   // 1Hz tick that drives the escalated "Reconnecting… last updated X ago"
@@ -813,38 +817,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     );
   }
 
-  if (error) {
-    return (
-      <div className="flex flex-col h-full">
-        {worktreeLoadErrorBanner}
-        <div className="flex items-center px-4 py-4 border-b border-divider shrink-0">
-          <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
-        </div>
-        <div className="px-4 py-4">
-          <div className="text-[var(--color-status-error)] text-sm mb-2">{error}</div>
-          <button
-            onClick={() => setIsRestartConfirmOpen(true)}
-            className="text-xs px-2 py-1 border border-divider rounded hover:bg-tint/[0.06] text-daintree-text"
-          >
-            Restart Service
-          </button>
-          <ConfirmDialog
-            isOpen={isRestartConfirmOpen}
-            onClose={() => setIsRestartConfirmOpen(false)}
-            title="Restart workspace service?"
-            description="Restarts the workspace monitoring process. Git status and worktree data will be temporarily unavailable."
-            confirmLabel="Restart service"
-            variant="destructive"
-            onConfirm={() => {
-              void actionService.dispatch("worktree.restartService", undefined, { source: "user" });
-              setIsRestartConfirmOpen(false);
-            }}
-          />
-        </div>
-      </div>
-    );
-  }
-
   if (worktrees.length === 0) {
     return (
       <>
@@ -1143,6 +1115,27 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         <WorktreeSidebarSearchBar inputRef={searchInputRef} chipCounts={chipCounts} />
       )}
 
+      {error && (
+        <InlineStatusBanner
+          icon={AlertTriangle}
+          title="Workspace service unavailable"
+          contextLine={error}
+          severity="warning"
+          role="status"
+          ariaLive="polite"
+          onClose={onBannerDismiss}
+          closeAriaLabel="Dismiss error"
+          actions={[
+            {
+              id: "restart-workspace-service",
+              label: "Restart Service",
+              variant: "primary",
+              onClick: () => setIsRestartConfirmOpen(true),
+            },
+          ]}
+        />
+      )}
+
       {/* SR-only live region for keyboard reorder announcements. dnd-kit's
           built-in announcer can't see external mutations like Alt+Arrow, so
           announce here. */}
@@ -1226,18 +1219,16 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                   trailing={armMatchingButton}
                 />
               )}
-              {showQuickStateEmptyState ? (
+              {showQuickStateEmptyState && !hasFacetFiltersActive ? (
+                <EmptyState variant="user-cleared" scale="sidebar" title="All caught up" />
+              ) : showQuickStateEmptyState && hasFacetFiltersActive ? (
                 <EmptyState
                   variant="filtered-empty"
                   scale="sidebar"
                   instant
-                  title={
-                    hasFacetFiltersActive && activeFacetFilterCount > 0
-                      ? `No worktrees match ${QUICK_STATE_LABELS[quickStateFilter]} with ${activeFacetFilterCount} ${
-                          activeFacetFilterCount === 1 ? "filter" : "filters"
-                        }`
-                      : `No ${quickStateFilter} worktrees`
-                  }
+                  title={`No worktrees match ${QUICK_STATE_LABELS[quickStateFilter]} with ${activeFacetFilterCount} ${
+                    activeFacetFilterCount === 1 ? "filter" : "filters"
+                  }`}
                   action={
                     <>
                       <button
@@ -1442,6 +1433,19 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       >
         <FleetPickerPalette isOpen={isFleetPickerOpen} onClose={closeFleetPicker} />
       </ErrorBoundary>
+
+      <ConfirmDialog
+        isOpen={isRestartConfirmOpen}
+        onClose={() => setIsRestartConfirmOpen(false)}
+        title="Restart workspace service?"
+        description="Restarts the workspace monitoring process. Git status and worktree data will be temporarily unavailable."
+        confirmLabel="Restart service"
+        variant="destructive"
+        onConfirm={() => {
+          void actionService.dispatch("worktree.restartService", undefined, { source: "user" });
+          setIsRestartConfirmOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -823,6 +823,24 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       />
     ) : null;
 
+  // Mounted in both the zero-worktree early return and the main return path so
+  // the errorBanner's "Restart Service" action stays reachable when
+  // `setFatalError` fires before the first snapshot hydrates.
+  const restartConfirmDialog = (
+    <ConfirmDialog
+      isOpen={isRestartConfirmOpen}
+      onClose={() => setIsRestartConfirmOpen(false)}
+      title="Restart workspace service?"
+      description="Restarts the workspace monitoring process. Git status and worktree data will be temporarily unavailable."
+      confirmLabel="Restart service"
+      variant="destructive"
+      onConfirm={() => {
+        void actionService.dispatch("worktree.restartService", undefined, { source: "user" });
+        setIsRestartConfirmOpen(false);
+      }}
+    />
+  );
+
   if (isLoading && worktrees.length === 0) {
     return (
       <div className="flex flex-col h-full">
@@ -878,6 +896,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           )}
         </div>
         {newWorktreeDialogElement}
+        {restartConfirmDialog}
       </>
     );
   }
@@ -1445,18 +1464,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         <FleetPickerPalette isOpen={isFleetPickerOpen} onClose={closeFleetPicker} />
       </ErrorBoundary>
 
-      <ConfirmDialog
-        isOpen={isRestartConfirmOpen}
-        onClose={() => setIsRestartConfirmOpen(false)}
-        title="Restart workspace service?"
-        description="Restarts the workspace monitoring process. Git status and worktree data will be temporarily unavailable."
-        confirmLabel="Restart service"
-        variant="destructive"
-        onConfirm={() => {
-          void actionService.dispatch("worktree.restartService", undefined, { source: "user" });
-          setIsRestartConfirmOpen(false);
-        }}
-      />
+      {restartConfirmDialog}
     </div>
   );
 }

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -71,7 +71,6 @@ import { RecipeManager } from "@/components/TerminalRecipe/RecipeManager";
 import { isAgentTerminal } from "@/utils/terminalType";
 import { isTerminalVisible } from "@/lib/terminalVisibility";
 import { useWorktreeIds } from "@/hooks/useTerminalSelectors";
-import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { logError } from "@/utils/logger";
 import { useWorktreeGridRovingFocus } from "./useWorktreeGridRovingFocus";
 
@@ -235,8 +234,11 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     },
   });
   const { worktrees, isLoading, isReconnecting, reconnectingAt, error, refresh } = useWorktrees();
-  const setError = useWorktreeStore((state) => state.setError);
-  const onBannerDismiss = useCallback(() => setError(null), [setError]);
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+  useEffect(() => {
+    setBannerDismissed(false);
+  }, [error]);
+  const onBannerDismiss = useCallback(() => setBannerDismissed(true), []);
   worktreesRef.current = worktrees;
 
   // 1Hz tick that drives the escalated "Reconnecting… last updated X ago"
@@ -794,6 +796,33 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     <WorktreeLoadErrorBanner error={worktreeLoadError} />
   ) : null;
 
+  // Workspace-service error banner overlays cached data so the user can keep
+  // working through transient poll failures. Hoisted before the early returns
+  // so a `setFatalError` that fires before the first snapshot is still
+  // actionable from the zero-worktrees branch — its only recovery path is the
+  // banner's "Restart Service" button.
+  const errorBanner =
+    error !== null && !bannerDismissed ? (
+      <InlineStatusBanner
+        icon={AlertTriangle}
+        title="Workspace service unavailable"
+        contextLine={error}
+        severity="warning"
+        role="status"
+        ariaLive="polite"
+        onClose={onBannerDismiss}
+        closeAriaLabel="Dismiss error"
+        actions={[
+          {
+            id: "restart-workspace-service",
+            label: "Restart Service",
+            variant: "primary",
+            onClick: () => setIsRestartConfirmOpen(true),
+          },
+        ]}
+      />
+    ) : null;
+
   if (isLoading && worktrees.length === 0) {
     return (
       <div className="flex flex-col h-full">
@@ -825,6 +854,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           <div className="flex items-center px-4 py-4 border-b border-divider shrink-0">
             <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
           </div>
+          {errorBanner}
 
           {/* A failed load already has an open project — the "Open a Git
               repository" nudge would contradict the banner, so the banner
@@ -1115,26 +1145,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         <WorktreeSidebarSearchBar inputRef={searchInputRef} chipCounts={chipCounts} />
       )}
 
-      {error && (
-        <InlineStatusBanner
-          icon={AlertTriangle}
-          title="Workspace service unavailable"
-          contextLine={error}
-          severity="warning"
-          role="status"
-          ariaLive="polite"
-          onClose={onBannerDismiss}
-          closeAriaLabel="Dismiss error"
-          actions={[
-            {
-              id: "restart-workspace-service",
-              label: "Restart Service",
-              variant: "primary",
-              onClick: () => setIsRestartConfirmOpen(true),
-            },
-          ]}
-        />
-      )}
+      {errorBanner}
 
       {/* SR-only live region for keyboard reorder announcements. dnd-kit's
           built-in announcer can't see external mutations like Alt+Arrow, so
@@ -1219,7 +1230,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                   trailing={armMatchingButton}
                 />
               )}
-              {showQuickStateEmptyState && !hasFacetFiltersActive ? (
+              {showQuickStateEmptyState && !hasFacetFiltersActive && !hasQuery ? (
                 <EmptyState variant="user-cleared" scale="sidebar" title="All caught up" />
               ) : showQuickStateEmptyState && hasFacetFiltersActive ? (
                 <EmptyState

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -77,32 +77,43 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
 
   describe("empty-state branch ordering and copy", () => {
     it("renders the quick-state empty state before the generic filter-mismatch branch", () => {
-      const quickStateIdx = source.indexOf("showQuickStateEmptyState ?");
+      const quickStateIdx = source.indexOf("showQuickStateEmptyState && !hasFacetFiltersActive ?");
       const genericIdx = source.indexOf(") : filteredWorktrees.length === 0 &&");
       expect(quickStateIdx).toBeGreaterThan(0);
       expect(genericIdx).toBeGreaterThan(0);
       expect(quickStateIdx).toBeLessThan(genericIdx);
     });
 
-    it("titles the quick-state empty state with the active filter label via the EmptyState primitive", () => {
-      // Single-axis fallback when no facet filters are active alongside the
-      // quick-state filter (still the default copy).
-      expect(source).toMatch(/: `No \$\{quickStateFilter\} worktrees`/);
+    it("uses the user-cleared variant when only quick-state filter is active (no facet filters)", () => {
+      // When the quick-state filter is the only active filter (no facet
+      // filters), zero results means the user genuinely cleared their
+      // working/waiting queue — route to the completion-oriented
+      // user-cleared variant with a single "All caught up" title.
+      const branchStart = source.indexOf("showQuickStateEmptyState && !hasFacetFiltersActive ?");
+      const branchEnd = source.indexOf(
+        ") : showQuickStateEmptyState && hasFacetFiltersActive ?",
+        branchStart
+      );
+      const branch = source.slice(branchStart, branchEnd);
+      expect(branch).toContain("<EmptyState");
+      expect(branch).toContain('variant="user-cleared"');
+      expect(branch).toContain('title="All caught up"');
+      expect(branch).not.toContain("action=");
     });
 
     it("names both axes when a facet filter is active alongside the quick-state — issue #7971", () => {
       // When the quick-state filter and one or more facet filters are active
       // together and produce zero results, the title must call out both axes
-      // (e.g. "No worktrees match Working with 2 filters") instead of picking
-      // only one. The fallback to "No {quickStateFilter} worktrees" stays for
-      // the quick-state-only case.
-      const branchStart = source.indexOf("showQuickStateEmptyState ?");
+      // (e.g. "No worktrees match Working with 2 filters"). The dual-axis
+      // branch is now gated on `showQuickStateEmptyState && hasFacetFiltersActive`
+      // (only entered when facet filters are active alongside quick-state).
+      const branchStart = source.indexOf("showQuickStateEmptyState && hasFacetFiltersActive ?");
       const branchEnd = source.indexOf(") : filteredWorktrees.length === 0 &&", branchStart);
       const branch = source.slice(branchStart, branchEnd);
-      expect(branch).toContain("hasFacetFiltersActive && activeFacetFilterCount > 0");
       expect(branch).toMatch(
         /`No worktrees match \$\{QUICK_STATE_LABELS\[quickStateFilter\]\} with \$\{activeFacetFilterCount\} \$\{[\s\S]*?activeFacetFilterCount === 1 \? "filter" : "filters"[\s\S]*?\}`/
       );
+      expect(branch).toContain('variant="filtered-empty"');
     });
 
     it("derives the active facet filter count from the five facet Set sizes — issue #7971", () => {
@@ -124,23 +135,25 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       );
     });
 
-    it("uses the EmptyState filtered-empty variant for the quick-state branch", () => {
-      // The quick-state empty state migrated from raw markup to the canonical
-      // EmptyState primitive (#6934). The variant carries role=status and
-      // aria-live=polite at the component level.
-      const branchStart = source.indexOf("showQuickStateEmptyState ?");
-      const branchEnd = source.indexOf(") : filteredWorktrees.length === 0 &&", branchStart);
-      const branch = source.slice(branchStart, branchEnd);
-      expect(branch).toContain("<EmptyState");
+    it("uses both user-cleared and filtered-empty variants in the quick-state branch", () => {
+      // When only the quick-state filter is active (no facet filters), the
+      // user-cleared variant celebrates completion. When facet filters are
+      // active alongside the quick-state, filtered-empty describes the
+      // absence.
+      const quickStateIdx = source.indexOf("showQuickStateEmptyState && !hasFacetFiltersActive ?");
+      const genericIdx = source.indexOf(") : filteredWorktrees.length === 0 &&");
+      const branch = source.slice(quickStateIdx, genericIdx);
+      expect(branch).toContain('variant="user-cleared"');
       expect(branch).toContain('variant="filtered-empty"');
     });
 
-    it("renders the quick-state empty state with dual recovery actions: clear filters and open overview — issue #8383", () => {
-      // #6934 collapsed the dual-CTA shape to a single button wired to
-      // clearAll(). #8383 intentionally restores a second action: "Open
-      // overview" gives users an alternative escape path to the full
-      // worktrees overview modal instead of clearing filters.
-      const branchStart = source.indexOf("showQuickStateEmptyState ?");
+    it("renders dual recovery actions in the facet-filtered branch: clear filters and open overview — issues #7971, #8383", () => {
+      // The user-cleared variant (only quick-state, no facets) forbids actions
+      // by design — completed-result states stay quiet per CLAUDE.md. The
+      // facet-filtered branch carries both recovery paths: "Show all
+      // worktrees" clears filters; "Open overview" gives an alternative
+      // escape to the full worktrees overview modal (#8383).
+      const branchStart = source.indexOf("showQuickStateEmptyState && hasFacetFiltersActive ?");
       const branchEnd = source.indexOf(") : filteredWorktrees.length === 0 &&", branchStart);
       const branch = source.slice(branchStart, branchEnd);
       expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Show all worktrees\s*</);
@@ -160,13 +173,11 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       expect(source).toContain('title={formatButtonTitle("Open overview", overviewShortcut)}');
     });
 
-    it("does not render a description in the quick-state branch (single CTA conveys recovery)", () => {
-      // CLAUDE.md popover/sidebar empty-state rule: when the filter input above
-      // explains the cause and the title + CTA convey recovery, an additional
-      // description is redundant. The `description` prop is intentionally
-      // omitted; the visible filter chips above the empty state carry any
-      // additional active-filter signal.
-      const branchStart = source.indexOf("showQuickStateEmptyState ?");
+    it("does not render a description in the quick-state branch", () => {
+      // The user-cleared variant forbids description by design; the
+      // filtered-empty sidebar variant omits description per CLAUDE.md
+      // empty-state rules.
+      const branchStart = source.indexOf("showQuickStateEmptyState && !hasFacetFiltersActive ?");
       const branchEnd = source.indexOf(") : filteredWorktrees.length === 0 &&", branchStart);
       const branch = source.slice(branchStart, branchEnd);
       expect(branch).not.toMatch(/description=/);
@@ -320,7 +331,7 @@ describe("SidebarContent initial loading skeleton — issue #7215", () => {
 
   it("renders the Skeleton primitive in the initial-loading branch with a context-specific label", () => {
     const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
-    const branchEnd = source.indexOf("if (error)", branchStart);
+    const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);
     expect(branchStart).toBeGreaterThan(0);
     expect(branchEnd).toBeGreaterThan(branchStart);
     const branch = source.slice(branchStart, branchEnd);
@@ -330,7 +341,7 @@ describe("SidebarContent initial loading skeleton — issue #7215", () => {
 
   it("preserves the Worktrees header in the loading branch to avoid layout shift on reveal", () => {
     const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
-    const branchEnd = source.indexOf("if (error)", branchStart);
+    const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);
     const branch = source.slice(branchStart, branchEnd);
     expect(branch).toMatch(/<h2[^>]*>Worktrees<\/h2>/);
   });
@@ -340,7 +351,7 @@ describe("SidebarContent initial loading skeleton — issue #7215", () => {
     // animate-pulse-delayed enforces the gate automatically. Do not stack a
     // useDeferredLoading hook on top of it (double-gating).
     const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
-    const branchEnd = source.indexOf("if (error)", branchStart);
+    const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);
     const branch = source.slice(branchStart, branchEnd);
     expect(branch).toContain("animate-pulse-delayed");
     expect(branch).not.toContain("animate-pulse-immediate");
@@ -351,8 +362,75 @@ describe("SidebarContent initial loading skeleton — issue #7215", () => {
     // The wrapper carries role=status + aria-busy=true for the live-region
     // announcement; the placeholder bones must not pollute the AT tree.
     const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
-    const branchEnd = source.indexOf("if (error)", branchStart);
+    const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);
     const branch = source.slice(branchStart, branchEnd);
     expect(branch).toContain('aria-hidden="true"');
+  });
+});
+
+describe("SidebarContent workspace error banner — issue #8394", () => {
+  let source: string;
+
+  beforeAll(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  it("imports InlineStatusBanner from the Terminal directory", () => {
+    expect(source).toMatch(
+      /import \{ InlineStatusBanner \} from "@\/components\/Terminal\/InlineStatusBanner"/
+    );
+  });
+
+  it("imports AlertTriangle from lucide-react for the banner icon", () => {
+    const importLine = source.match(/import \{[^}]*\} from "lucide-react"/);
+    expect(importLine).not.toBeNull();
+    expect(importLine![0]).toContain("AlertTriangle");
+  });
+
+  it("does not have an if (error) early return that hides the worktree list", () => {
+    expect(source).not.toMatch(/if \(error\) \{\s*return/);
+  });
+
+  it("renders InlineStatusBanner with severity=warning, role=status, ariaLive=polite", () => {
+    expect(source).toContain('severity="warning"');
+    expect(source).toContain('role="status"');
+    expect(source).toContain('ariaLive="polite"');
+  });
+
+  it("wires the error text as contextLine and a Restart Service action", () => {
+    expect(source).toMatch(/contextLine=\{error\}/);
+    expect(source).toContain('"Restart Service"');
+    expect(source).toContain('id: "restart-workspace-service"');
+  });
+
+  it("wires dismiss to setError(null) via useWorktreeStore", () => {
+    expect(source).toContain("useWorktreeStore((state) => state.setError)");
+    expect(source).toMatch(/onClose=\{onBannerDismiss\}/);
+  });
+
+  it("keeps ConfirmDialog in the main return path, not inside an early return", () => {
+    const mainReturnStart = source.lastIndexOf("return (");
+    const afterMainReturn = source.slice(mainReturnStart);
+    expect(afterMainReturn).toContain("<ConfirmDialog");
+    expect(afterMainReturn).toContain('title="Restart workspace service?"');
+    expect(afterMainReturn).toContain("isRestartConfirmOpen");
+  });
+});
+
+describe("SidebarContent quick-state user-cleared variant — issue #8394", () => {
+  let source: string;
+
+  beforeAll(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  it("routes no-facet-filter zero to user-cleared with 'All caught up' title", () => {
+    expect(source).toContain('variant="user-cleared"');
+    expect(source).toContain('title="All caught up"');
+  });
+
+  it("keeps filtered-empty when facet filters are active alongside quick-state", () => {
+    expect(source).toContain("showQuickStateEmptyState && hasFacetFiltersActive ?");
+    expect(source).toContain('variant="filtered-empty"');
   });
 });

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -77,7 +77,9 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
 
   describe("empty-state branch ordering and copy", () => {
     it("renders the quick-state empty state before the generic filter-mismatch branch", () => {
-      const quickStateIdx = source.indexOf("showQuickStateEmptyState && !hasFacetFiltersActive ?");
+      const quickStateIdx = source.indexOf(
+        "showQuickStateEmptyState && !hasFacetFiltersActive && !hasQuery ?"
+      );
       const genericIdx = source.indexOf(") : filteredWorktrees.length === 0 &&");
       expect(quickStateIdx).toBeGreaterThan(0);
       expect(genericIdx).toBeGreaterThan(0);
@@ -89,7 +91,9 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       // filters), zero results means the user genuinely cleared their
       // working/waiting queue — route to the completion-oriented
       // user-cleared variant with a single "All caught up" title.
-      const branchStart = source.indexOf("showQuickStateEmptyState && !hasFacetFiltersActive ?");
+      const branchStart = source.indexOf(
+        "showQuickStateEmptyState && !hasFacetFiltersActive && !hasQuery ?"
+      );
       const branchEnd = source.indexOf(
         ") : showQuickStateEmptyState && hasFacetFiltersActive ?",
         branchStart
@@ -140,7 +144,9 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       // user-cleared variant celebrates completion. When facet filters are
       // active alongside the quick-state, filtered-empty describes the
       // absence.
-      const quickStateIdx = source.indexOf("showQuickStateEmptyState && !hasFacetFiltersActive ?");
+      const quickStateIdx = source.indexOf(
+        "showQuickStateEmptyState && !hasFacetFiltersActive && !hasQuery ?"
+      );
       const genericIdx = source.indexOf(") : filteredWorktrees.length === 0 &&");
       const branch = source.slice(quickStateIdx, genericIdx);
       expect(branch).toContain('variant="user-cleared"');
@@ -403,9 +409,23 @@ describe("SidebarContent workspace error banner — issue #8394", () => {
     expect(source).toContain('id: "restart-workspace-service"');
   });
 
-  it("wires dismiss to setError(null) via useWorktreeStore", () => {
-    expect(source).toContain("useWorktreeStore((state) => state.setError)");
+  it("uses local bannerDismissed state for dismiss instead of clearing store error", () => {
+    // Dismiss uses local state so the store's `error` stays non-null and
+    // `worktree.restartService` remains enabled even after banner dismissal.
+    expect(source).toContain("bannerDismissed");
+    expect(source).toContain("setBannerDismissed");
     expect(source).toMatch(/onClose=\{onBannerDismiss\}/);
+    expect(source).not.toContain("useWorktreeStore");
+  });
+
+  it("renders errorBanner in the zero-worktree branch so fatal errors are visible before first snapshot", () => {
+    // When setFatalError fires before the first snapshot hydrates (worktrees=[],
+    // isLoading=false, error="..."), the zero-worktree early return must still
+    // show the error banner so the user can restart the service.
+    const branchStart = source.indexOf("if (worktrees.length === 0) {");
+    const branchEnd = source.indexOf("const hasNonMainWorktrees", branchStart);
+    const branch = source.slice(branchStart, branchEnd);
+    expect(branch).toContain("{errorBanner}");
   });
 
   it("keeps ConfirmDialog in the main return path, not inside an early return", () => {
@@ -424,7 +444,11 @@ describe("SidebarContent quick-state user-cleared variant — issue #8394", () =
     source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
   });
 
-  it("routes no-facet-filter zero to user-cleared with 'All caught up' title", () => {
+  it("routes no-facet-filter, no-query zero to user-cleared with 'All caught up' title", () => {
+    // The user-cleared variant fires only when no facet filters AND no text
+    // query are active. A text query narrowing results to zero is a genuine
+    // filter constraint, not queue completion — it should use filtered-empty.
+    expect(source).toContain("showQuickStateEmptyState && !hasFacetFiltersActive && !hasQuery");
     expect(source).toContain('variant="user-cleared"');
     expect(source).toContain('title="All caught up"');
   });

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -428,12 +428,25 @@ describe("SidebarContent workspace error banner — issue #8394", () => {
     expect(branch).toContain("{errorBanner}");
   });
 
-  it("keeps ConfirmDialog in the main return path, not inside an early return", () => {
+  it("mounts the Restart Service ConfirmDialog in both the zero-worktree branch and the main return path", () => {
+    // The dialog must be reachable in both code paths so that clicking
+    // "Restart Service" from the errorBanner works whether the first snapshot
+    // has hydrated (main return) or `setFatalError` fired before it
+    // (zero-worktree early return). The shared `restartConfirmDialog` variable
+    // is the single source of truth — defined once above both early returns
+    // and rendered in each path.
+    expect(source).toContain("const restartConfirmDialog =");
+    expect(source).toContain('title="Restart workspace service?"');
+    expect(source).toContain("isOpen={isRestartConfirmOpen}");
+
+    const branchStart = source.indexOf("if (worktrees.length === 0) {");
+    const branchEnd = source.indexOf("const hasNonMainWorktrees", branchStart);
+    const zeroBranch = source.slice(branchStart, branchEnd);
+    expect(zeroBranch).toContain("{restartConfirmDialog}");
+
     const mainReturnStart = source.lastIndexOf("return (");
     const afterMainReturn = source.slice(mainReturnStart);
-    expect(afterMainReturn).toContain("<ConfirmDialog");
-    expect(afterMainReturn).toContain('title="Restart workspace service?"');
-    expect(afterMainReturn).toContain("isRestartConfirmOpen");
+    expect(afterMainReturn).toContain("{restartConfirmDialog}");
   });
 });
 


### PR DESCRIPTION
Two sidebar UI fixes.

When the working or waiting quick-state filter has no matching worktrees, the sidebar now uses the `user-cleared` variant with "All caught up" instead of the generic `filtered-empty` variant. A zero count with no other filters active is inbox-zero -- the user just finished triaging. Treating it as a search failure was misleading.

When the workspace service errors, the sidebar now shows a dismissible inline warning banner over the cached worktree list instead of replacing everything with a hard error screen. The stale data is still interactive so the user can keep working through transient poll failures.

Resolves #8394.

## Changes
- `src/components/Sidebar/SidebarContent.tsx` -- removed early return that replaced worktree list with hard error screen; added dismissible `InlineStatusBanner` (Tier-2 warning) for workspace errors overlaying cached data; split quick-state empty state by filter context
- `src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts` -- 44 tests covering error banner rendering, dismiss behavior, and quick-state empty variants

## Testing
All 44 tests pass. Typecheck and linting are clean.