### PR TITLE
feat(mcp): add reasoning-loop outcome class for repeated tool calls

### DIFF
--- a/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
+++ b/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
@@ -136,6 +136,78 @@ describe("classifyTurnOutcome", () => {
     ).toBe("tool-error");
   });
 
+  it("returns reasoning-loop when 3+ identical (toolId, argsSummary) calls exist in the turn window", () => {
+    const records = [
+      makeAuditRecord({ id: "r1", toolId: "agent.getState", argsSummary: "{}" }),
+      makeAuditRecord({ id: "r2", toolId: "agent.getState", argsSummary: "{}" }),
+      makeAuditRecord({ id: "r3", toolId: "agent.getState", argsSummary: "{}" }),
+    ];
+    expect(
+      classifyTurnOutcome({
+        transition: makeTransition(),
+        recentOutput: "Let me check the state again.".padEnd(120, " "),
+        recentAuditRecords: records,
+        sessionId: "session-1",
+      })
+    ).toBe("reasoning-loop");
+  });
+
+  it("does not trigger reasoning-loop below the threshold (2 identical calls)", () => {
+    const records = [
+      makeAuditRecord({ id: "r1", toolId: "agent.getState", argsSummary: "{}" }),
+      makeAuditRecord({ id: "r2", toolId: "agent.getState", argsSummary: "{}" }),
+    ];
+    expect(
+      classifyTurnOutcome({
+        transition: makeTransition(),
+        recentOutput: "Here is the answer you asked for: the file was updated and tests pass.",
+        recentAuditRecords: records,
+        sessionId: "session-1",
+      })
+    ).toBe("answered");
+  });
+
+  it("counts interleaved identical calls toward the reasoning-loop threshold", () => {
+    const records = [
+      makeAuditRecord({ id: "r5", toolId: "agent.getState", argsSummary: "{}" }),
+      makeAuditRecord({ id: "r4", toolId: "files.list", argsSummary: '{"path":"/foo"}' }),
+      makeAuditRecord({ id: "r3", toolId: "agent.getState", argsSummary: "{}" }),
+      makeAuditRecord({ id: "r2", toolId: "terminal.run", argsSummary: '{"cmd":"ls"}' }),
+      makeAuditRecord({ id: "r1", toolId: "agent.getState", argsSummary: "{}" }),
+    ];
+    expect(
+      classifyTurnOutcome({
+        transition: makeTransition(),
+        recentOutput: "Let me check once more.".padEnd(120, " "),
+        recentAuditRecords: records,
+        sessionId: "session-1",
+      })
+    ).toBe("reasoning-loop");
+  });
+
+  it("returns tool-error over reasoning-loop when the most recent record is an error", () => {
+    const records = [
+      makeAuditRecord({
+        id: "r4",
+        toolId: "agent.getState",
+        argsSummary: "{}",
+        result: "error",
+        errorCode: "DISPATCH_THREW",
+      }),
+      makeAuditRecord({ id: "r3", toolId: "agent.getState", argsSummary: "{}" }),
+      makeAuditRecord({ id: "r2", toolId: "agent.getState", argsSummary: "{}" }),
+      makeAuditRecord({ id: "r1", toolId: "agent.getState", argsSummary: "{}" }),
+    ];
+    expect(
+      classifyTurnOutcome({
+        transition: makeTransition(),
+        recentOutput: "Let me try again.".padEnd(120, " "),
+        recentAuditRecords: records,
+        sessionId: "session-1",
+      })
+    ).toBe("tool-error");
+  });
+
   it("ignores audit records from other sessions", () => {
     const audit = makeAuditRecord({
       sessionId: "session-other",

--- a/electron/services/mcp-server/turnOutcomeLog.ts
+++ b/electron/services/mcp-server/turnOutcomeLog.ts
@@ -42,6 +42,8 @@ const MIN_CLASSIFY_LENGTH = 50;
  * avoid false matches on later output that happens to mention "no sessions".
  */
 const RESUME_STALE_PROBE_CHARS = 500;
+/** Number of identical (toolId, argsSummary) calls within a turn window that triggers `reasoning-loop`. */
+const REASONING_LOOP_THRESHOLD = 3;
 
 // eslint-disable-next-line no-control-regex
 const ANSI_PATTERN = /\[[0-9;?]*[A-Za-z]|\][^]*(?:|\\)/g;
@@ -149,6 +151,18 @@ export function classifyTurnOutcome(args: {
       }
       if (lastRecord.result === "error") {
         return "tool-error";
+      }
+    }
+
+    const callCounts = new Map<string, number>();
+    for (const r of recentAuditRecords) {
+      if (r.sessionId === sessionId && r.timestamp >= turnStartTimestamp) {
+        const key = `${r.toolId}::${r.argsSummary}`;
+        const count = (callCounts.get(key) ?? 0) + 1;
+        if (count >= REASONING_LOOP_THRESHOLD) {
+          return "reasoning-loop";
+        }
+        callCounts.set(key, count);
       }
     }
   }

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -198,6 +198,9 @@ export interface McpAuditStats {
  *   agent went silent without resolving its turn.
  * - `tool-error`: the most recent tool dispatch in this session resolved
  *   with `result: "error"` (and is not a tier rejection).
+ * - `reasoning-loop`: the agent called the same tool with the same arguments
+ *   at least 3 times within the turn window — a tight tool-call loop not
+ *   covered by the watchdog-driven `agent-stuck` class.
  * - `refused`: the agent's recent output indicates it declined to act.
  * - `hedged`: the agent expressed uncertainty without producing a concrete
  *   answer.
@@ -219,6 +222,7 @@ export type TurnOutcomeClass =
   | "mcp-not-ready"
   | "agent-stuck"
   | "tool-error"
+  | "reasoning-loop"
   | "hibernate-resume-stale"
   | "unknown";
 


### PR DESCRIPTION
## Summary
- Adds a `reasoning-loop` classification to `TurnOutcomeClass` that catches agents calling the same tool with the same arguments in a tight loop.
- Distinct from `agent-stuck`, which only fires on watchdog timeouts. A three-repeat threshold catches loops the watchdog misses.
- Sits between `tool-error` and the output-text branches in the waterfall, so a fresh tool error still takes priority.

Resolves #8463

## Changes
- New `reasoning-loop` variant in the `TurnOutcomeClass` union with JSDoc
- Count-based branch in `classifyTurnOutcome` that groups audit records by `(toolId, argsSummary)` and returns `reasoning-loop` at 3+ repeats
- Four tests: triggers at threshold, stays quiet below it, counts interleaved identical calls, defers to `tool-error`

## Testing
- `npm test -- electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts` passes
- `npm run check` clean (typecheck + lint + format)