### PR TITLE
feat(forge): canonicalize forge provider ids (#8451)

### DIFF
--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -266,14 +266,39 @@ describe("registerForgeSettingsHandlers", () => {
     );
   });
 
-  it("resolveProvider passes globalDefaultProviderId from the store to the resolver", async () => {
+  it("resolveProvider passes globalDefaultProviderId from the store to the resolver (canonical form)", async () => {
+    storeMock._data["forgeDefaultProviderId"] = "daintree.github.github";
+    resolverMock.resolveForgeProvider.mockReturnValueOnce({ entry: null, resolvedVia: null });
+    registerForgeSettingsHandlers();
+    const resolveProvider = findHandler("forge:resolve-provider");
+    await resolveProvider(null, "project-1");
+    expect(resolverMock.resolveForgeProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ globalDefaultProviderId: "daintree.github.github" })
+    );
+  });
+
+  it("getSettings normalizes legacy 'builtin.github' to canonical 'daintree.github.github' (#8451)", () => {
+    storeMock._data["forgeDefaultProviderId"] = "builtin.github";
+    registerForgeSettingsHandlers();
+    const getSettings = findHandler("forge:get-settings");
+    expect(getSettings(null)).toEqual({ defaultProviderId: "daintree.github.github" });
+  });
+
+  it("getSettings normalizes legacy bare 'github' to canonical 'daintree.github.github' (#8451)", () => {
+    storeMock._data["forgeDefaultProviderId"] = "github";
+    registerForgeSettingsHandlers();
+    const getSettings = findHandler("forge:get-settings");
+    expect(getSettings(null)).toEqual({ defaultProviderId: "daintree.github.github" });
+  });
+
+  it("resolveProvider normalizes legacy stored ids before delegating to the resolver", async () => {
     storeMock._data["forgeDefaultProviderId"] = "builtin.github";
     resolverMock.resolveForgeProvider.mockReturnValueOnce({ entry: null, resolvedVia: null });
     registerForgeSettingsHandlers();
     const resolveProvider = findHandler("forge:resolve-provider");
     await resolveProvider(null, "project-1");
     expect(resolverMock.resolveForgeProvider).toHaveBeenCalledWith(
-      expect.objectContaining({ globalDefaultProviderId: "builtin.github" })
+      expect.objectContaining({ globalDefaultProviderId: "daintree.github.github" })
     );
   });
 });

--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -150,6 +150,22 @@ describe("registerForgeSettingsHandlers", () => {
     expect(storeMock.set).toHaveBeenCalledWith("forgeDefaultProviderId", "acme.gitea");
   });
 
+  it("setDefaultProvider canonicalizes a legacy 'builtin.github' input before persisting (#8451)", () => {
+    registerForgeSettingsHandlers();
+    const setDefault = findHandler("forge:set-default-provider");
+    expect(setDefault(null, "builtin.github")).toEqual({
+      defaultProviderId: "daintree.github.github",
+    });
+    expect(storeMock.set).toHaveBeenCalledWith("forgeDefaultProviderId", "daintree.github.github");
+  });
+
+  it("setDefaultProvider canonicalizes a legacy bare 'github' input before persisting (#8451)", () => {
+    registerForgeSettingsHandlers();
+    const setDefault = findHandler("forge:set-default-provider");
+    expect(setDefault(null, "github")).toEqual({ defaultProviderId: "daintree.github.github" });
+    expect(storeMock.set).toHaveBeenCalledWith("forgeDefaultProviderId", "daintree.github.github");
+  });
+
   it("getSettings treats whitespace-only stored values as null", () => {
     storeMock._data["forgeDefaultProviderId"] = "   ";
     registerForgeSettingsHandlers();

--- a/electron/ipc/handlers/forge.ts
+++ b/electron/ipc/handlers/forge.ts
@@ -9,6 +9,10 @@ import {
 import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
 import { gitServiceCache } from "../../services/GitServiceCache.js";
 import type { RepoRef } from "../../../shared/types/forge.js";
+import {
+  makeForgeProviderId,
+  normalizeProviderId,
+} from "../../../shared/utils/forgeProviderIds.js";
 
 interface ResolvedContext {
   namespaceId: string;
@@ -30,8 +34,7 @@ async function resolveForCwd(cwd: string): Promise<ResolvedContext> {
     throw new Error("No remote URL found for this repository");
   }
 
-  const globalDefault = store.get("forgeDefaultProviderId");
-  const globalDefaultProviderId = typeof globalDefault === "string" ? globalDefault : null;
+  const globalDefaultProviderId = normalizeProviderId(store.get("forgeDefaultProviderId"));
 
   const resolved = resolveForgeProvider({
     remoteUrl,
@@ -43,7 +46,7 @@ async function resolveForCwd(cwd: string): Promise<ResolvedContext> {
     throw new Error("No forge provider registered for this repository");
   }
 
-  const namespaceId = `${resolved.entry.pluginId}.${resolved.entry.contribution.id}`;
+  const namespaceId = makeForgeProviderId(resolved.entry.pluginId, resolved.entry.contribution.id);
   const impl = getForgeProviderImpl(namespaceId);
   if (!impl) {
     throw new Error(
@@ -163,21 +166,22 @@ export function registerForgeHandlers(): () => void {
         return { valid: false as const, error: "No forge provider configured" };
       }
 
-      const globalDefault = store.get("forgeDefaultProviderId");
-      const providerId = typeof globalDefault === "string" ? globalDefault.trim() : "";
+      const providerId = normalizeProviderId(store.get("forgeDefaultProviderId"));
 
-      // Resolve bare or namespaced id to the registered entry
+      // Match canonical first; bare `contribution.id` fallback preserves
+      // third-party providers whose stored ids predate canonicalization.
       let targetProvider: (typeof providers)[0] | undefined;
       if (providerId) {
         targetProvider = providers.find(
           (p) =>
-            p.contribution.id === providerId || `${p.pluginId}.${p.contribution.id}` === providerId
+            makeForgeProviderId(p.pluginId, p.contribution.id) === providerId ||
+            p.contribution.id === providerId
         );
       }
       // Fall back to first registered provider
       const entry = targetProvider ?? providers[0];
 
-      const namespaceId = `${entry.pluginId}.${entry.contribution.id}`;
+      const namespaceId = makeForgeProviderId(entry.pluginId, entry.contribution.id);
       const impl = getForgeProviderImpl(namespaceId);
       if (!impl) {
         return {

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -27,16 +27,12 @@ export function registerForgeSettingsHandlers(): () => void {
 
   cleanups.push(
     typedHandle(CHANNELS.FORGE_SET_DEFAULT_PROVIDER, (providerId: unknown) => {
-      let next: string | null = null;
-      if (typeof providerId === "string") {
-        const trimmed = providerId.trim();
-        if (trimmed.length > 0) next = trimmed;
-      }
-      if (next === null) {
-        store.set("forgeDefaultProviderId", null);
-      } else {
-        store.set("forgeDefaultProviderId", next);
-      }
+      // Normalize on the write path so a caller that still sends a legacy
+      // alias (`"github"` / `"builtin.github"`) persists the canonical form,
+      // keeping the set→get round-trip consistent and avoiding a brief
+      // "Unknown provider" flash in the renderer (#8451).
+      const next = normalizeProviderId(providerId);
+      store.set("forgeDefaultProviderId", next);
       return { defaultProviderId: next };
     })
   );

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -5,12 +5,15 @@ import { getRegisteredForgeProviders } from "../../services/forgeProviderRegistr
 import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import { gitServiceCache } from "../../services/GitServiceCache.js";
+import { normalizeProviderId } from "../../../shared/utils/forgeProviderIds.js";
 
+/**
+ * Read the persisted global default provider id, normalizing legacy forms
+ * (`"github"`, `"builtin.github"`) to the canonical `{pluginId}.{contributionId}`
+ * shape (#8451) so downstream resolution does not need to know about aliases.
+ */
 function readDefaultProviderId(): string | null {
-  const value = store.get("forgeDefaultProviderId");
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
+  return normalizeProviderId(store.get("forgeDefaultProviderId"));
 }
 
 export function registerForgeSettingsHandlers(): () => void {
@@ -64,8 +67,7 @@ export function registerForgeSettingsHandlers(): () => void {
           effectiveRemoteUrl = await gitService.getRemoteUrl(project.path).catch(() => null);
         }
 
-        const globalDefault = store.get("forgeDefaultProviderId");
-        const globalDefaultProviderId = typeof globalDefault === "string" ? globalDefault : null;
+        const globalDefaultProviderId = readDefaultProviderId();
 
         return resolveForgeProvider({
           remoteUrl: effectiveRemoteUrl,

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -5,6 +5,7 @@ import type { WorktreeSnapshot as WorktreeState } from "../../shared/types/works
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { resolveForgeProvider } from "./forgeProviderResolver.js";
 import { getForgeProviderImpl } from "./forgeProviderRegistry.js";
+import { makeForgeProviderId } from "../../shared/utils/forgeProviderIds.js";
 import { generateProjectId } from "./projectStorePaths.js";
 import { createHardenedGit } from "../utils/hardenedGit.js";
 import type {
@@ -359,7 +360,7 @@ class PullRequestService {
         return;
       }
       const { pluginId, contribution } = registered.entry;
-      const namespacedId = `${pluginId}.${contribution.id}`;
+      const namespacedId = makeForgeProviderId(pluginId, contribution.id);
       const impl = getForgeProviderImpl(namespacedId);
       if (!impl) {
         this.providerNamespacedId = null;

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -12,6 +12,7 @@ import { GitHubAuth } from "./github/GitHubAuth.js";
 import { BrokerError } from "./rpc/RequestResponseBroker.js";
 import { createLogger } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../../shared/utils/forgeProviderIds.js";
 
 const logger = createLogger("main:WorkspaceHost");
 const logInfo = (msg: string, ctx?: Record<string, unknown>) =>
@@ -623,7 +624,7 @@ export class WorkspaceHostProcess extends EventEmitter {
         if (token) {
           this.send({
             type: "update-forge-credentials",
-            providerId: "builtin.github",
+            providerId: BUILTIN_GITHUB_PROVIDER_ID,
             credentials: { kind: "bearer" as const, value: token },
           });
         }

--- a/electron/services/__tests__/ProjectSettingsManager.test.ts
+++ b/electron/services/__tests__/ProjectSettingsManager.test.ts
@@ -231,12 +231,36 @@ describe("ProjectSettingsManager caching", () => {
   it("round-trips forgeProviderOverride through save/load", async () => {
     await manager.saveProjectSettings(projectId, {
       runCommands: [],
-      forgeProviderOverride: "github",
+      forgeProviderOverride: "daintree.github.github",
     });
 
     const freshManager = new ProjectSettingsManager(tempDir, createMockStore());
     const loaded = await freshManager.getProjectSettings(projectId);
-    expect(loaded.forgeProviderOverride).toBe("github");
+    expect(loaded.forgeProviderOverride).toBe("daintree.github.github");
+  });
+
+  it("canonicalizes legacy 'github' on load to 'daintree.github.github' (#8451)", async () => {
+    const settingsPath = path.join(tempDir, projectId, "settings.json");
+    await fs.writeFile(
+      settingsPath,
+      JSON.stringify({ runCommands: [], forgeProviderOverride: "github" }),
+      "utf-8"
+    );
+
+    const loaded = await manager.getProjectSettings(projectId);
+    expect(loaded.forgeProviderOverride).toBe("daintree.github.github");
+  });
+
+  it("canonicalizes legacy 'builtin.github' on load to 'daintree.github.github' (#8451)", async () => {
+    const settingsPath = path.join(tempDir, projectId, "settings.json");
+    await fs.writeFile(
+      settingsPath,
+      JSON.stringify({ runCommands: [], forgeProviderOverride: "builtin.github" }),
+      "utf-8"
+    );
+
+    const loaded = await manager.getProjectSettings(projectId);
+    expect(loaded.forgeProviderOverride).toBe("daintree.github.github");
   });
 
   it("treats missing forgeProviderOverride as undefined", async () => {

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -76,7 +76,7 @@ function mockForgeProviderResolved(
   vi.doMock("../forgeProviderResolver.js", () => ({
     resolveForgeProvider: vi.fn().mockReturnValue({
       entry: {
-        pluginId: "builtin",
+        pluginId: "daintree.github",
         contribution: { id: "github", name: "GitHub", matches: ["github.com"] },
       },
       resolvedVia: "hostname",
@@ -162,7 +162,7 @@ describe("PullRequestService", () => {
       prUrl: "https://github.com/o/r/pull/42",
       prState: "open",
       prTitle: "Add new feature",
-      providerId: "builtin.github",
+      providerId: "daintree.github.github",
     });
     expect(detected[0].issueNumber).toBeUndefined();
 

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -819,14 +819,14 @@ describe("WorkspaceClient multi-process manager", () => {
       await readyAndResolveLoad(0);
       await load1;
 
-      client.updateForgeCredentials("builtin.github", {
+      client.updateForgeCredentials("daintree.github.github", {
         kind: "bearer",
         value: "test-token",
       });
 
       expect(h(0).send).toHaveBeenCalledWith({
         type: "update-forge-credentials",
-        providerId: "builtin.github",
+        providerId: "daintree.github.github",
         credentials: { kind: "bearer", value: "test-token" },
       });
     });
@@ -836,11 +836,11 @@ describe("WorkspaceClient multi-process manager", () => {
       await readyAndResolveLoad(0);
       await load1;
 
-      client.updateForgeCredentials("builtin.github", null);
+      client.updateForgeCredentials("daintree.github.github", null);
 
       expect(h(0).send).toHaveBeenCalledWith({
         type: "update-forge-credentials",
-        providerId: "builtin.github",
+        providerId: "daintree.github.github",
         credentials: null,
       });
     });

--- a/electron/services/__tests__/forgeProviderIds.integration.test.ts
+++ b/electron/services/__tests__/forgeProviderIds.integration.test.ts
@@ -1,0 +1,95 @@
+/**
+ * End-to-end proof that the canonical forge provider id (#8451) the registry
+ * builds from the on-disk built-in plugin manifest is the same canonical id
+ * the resolver returns, and the same one the read-boundary normalizer arrives
+ * at from any of the legacy alias forms. Loads the real
+ * `plugins/builtin/github/plugin.json` so a future rename of either the plugin
+ * or its contribution would surface here as a failure.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  BUILTIN_GITHUB_PROVIDER_ID,
+  makeForgeProviderId,
+  normalizeProviderId,
+} from "../../../shared/utils/forgeProviderIds.js";
+import {
+  clearForgeProviderImplRegistry,
+  clearForgeProviderRegistry,
+  registerForgeProviders,
+} from "../forgeProviderRegistry.js";
+import { resolveForgeProvider } from "../forgeProviderResolver.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const MANIFEST_PATH = path.resolve(HERE, "../../../plugins/builtin/github/plugin.json");
+
+interface BuiltInGitHubManifest {
+  name: string;
+  contributes: {
+    forgeProviders: Array<{
+      id: string;
+      name: string;
+      matches: string[];
+      capabilities?: string[];
+    }>;
+  };
+}
+
+function loadBuiltInGitHubManifest(): BuiltInGitHubManifest {
+  const raw = fs.readFileSync(MANIFEST_PATH, "utf8");
+  return JSON.parse(raw) as BuiltInGitHubManifest;
+}
+
+beforeEach(() => {
+  clearForgeProviderRegistry();
+  clearForgeProviderImplRegistry();
+});
+
+describe("forge provider canonical id (real built-in GitHub plugin)", () => {
+  it("matches what the manifest declares + helper computes", () => {
+    const manifest = loadBuiltInGitHubManifest();
+    const contribution = manifest.contributes.forgeProviders[0];
+    expect(contribution).toBeDefined();
+    expect(makeForgeProviderId(manifest.name, contribution.id)).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+  });
+
+  it("registers the manifest and resolves a github.com remote to the canonical id", () => {
+    const manifest = loadBuiltInGitHubManifest();
+    registerForgeProviders(manifest.name, manifest.contributes.forgeProviders);
+
+    const resolved = resolveForgeProvider({
+      remoteUrl: "https://github.com/owner/repo.git",
+      forgeProviderOverride: null,
+      globalDefaultProviderId: null,
+    });
+
+    expect(resolved.entry).not.toBeNull();
+    const { pluginId, contribution } = resolved.entry!;
+    expect(makeForgeProviderId(pluginId, contribution.id)).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+    expect(resolved.resolvedVia).toBe("hostname");
+  });
+
+  it("resolves an override stored as the canonical id", () => {
+    const manifest = loadBuiltInGitHubManifest();
+    registerForgeProviders(manifest.name, manifest.contributes.forgeProviders);
+
+    const resolved = resolveForgeProvider({
+      remoteUrl: "https://github.com/owner/repo.git",
+      forgeProviderOverride: BUILTIN_GITHUB_PROVIDER_ID,
+      globalDefaultProviderId: null,
+    });
+
+    expect(resolved.entry).not.toBeNull();
+    const { pluginId, contribution } = resolved.entry!;
+    expect(makeForgeProviderId(pluginId, contribution.id)).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+    expect(resolved.resolvedVia).toBe("override");
+  });
+
+  it("normalizes every legacy alias to the same canonical id the resolver returns", () => {
+    expect(normalizeProviderId("github")).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+    expect(normalizeProviderId("builtin.github")).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+    expect(normalizeProviderId(BUILTIN_GITHUB_PROVIDER_ID)).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+  });
+});

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -449,7 +449,7 @@ export type DaintreeEventMap = {
     issueTitle?: string;
     /** Branch the lookup was initiated against; receivers drop the overlay if the worktree's branch has changed. */
     branchName?: string;
-    /** Provider that resolved the PR (e.g. "builtin.github"). */
+    /** Provider that resolved the PR (e.g. `"daintree.github.github"`). */
     providerId?: string;
     /** Provider-agnostic CI status (forge format). */
     ciStatus?: import("../../shared/types/forge.js").CIStatus;
@@ -475,7 +475,7 @@ export type DaintreeEventMap = {
     issueTitle: string;
     /** Branch the lookup was initiated against; receivers drop the overlay if the worktree's branch has changed. */
     branchName?: string;
-    /** Provider that resolved the issue (e.g. "builtin.github"). */
+    /** Provider that resolved the issue (e.g. `"daintree.github.github"`). */
     providerId?: string;
     timestamp: number;
   };

--- a/electron/services/forgeProviderRegistry.ts
+++ b/electron/services/forgeProviderRegistry.ts
@@ -4,6 +4,7 @@ import type {
   RegisteredForgeProvider,
   RepoRef,
 } from "../../shared/types/forge.js";
+import { makeForgeProviderId } from "../../shared/utils/forgeProviderIds.js";
 
 export type { RegisteredForgeProvider } from "../../shared/types/forge.js";
 
@@ -23,12 +24,12 @@ const PLUGIN_FORGE_PROVIDERS = new Map<string, ForgeProviderContribution[]>();
 
 /**
  * Runtime implementation handlers bound via `host.registerForgeProvider`.
- * Keyed by the namespaced provider id `{pluginId}.{contributionId}` so the
- * router can resolve an impl from a descriptor without a second lookup
- * (built-in GitHub uses bare `github`). Separate from {@link PLUGIN_FORGE_PROVIDERS}
- * because descriptors register eagerly from the manifest while impls bind
- * lazily during `activate()` — callers must handle "descriptor present but
- * impl not yet bound" by treating an `undefined` result as absent.
+ * Keyed by the canonical provider id `{pluginId}.{contributionId}` (#8451) so
+ * the router can resolve an impl from a descriptor without a second lookup.
+ * Separate from {@link PLUGIN_FORGE_PROVIDERS} because descriptors register
+ * eagerly from the manifest while impls bind lazily during `activate()` —
+ * callers must handle "descriptor present but impl not yet bound" by treating
+ * an `undefined` result as absent.
  */
 const PLUGIN_FORGE_PROVIDER_IMPLS = new Map<string, ForgeProviderImpl>();
 
@@ -128,11 +129,11 @@ export function unregisterForgeProviderImpls(pluginId: string): void {
 }
 
 /**
- * Look up a runtime impl by its namespaced id (`{pluginId}.{contributionId}`,
- * or bare `github` for the built-in). Returns `undefined` when the descriptor
- * is registered but the plugin's `activate()` has not yet bound an impl, or
- * after the plugin unloads. Callers must treat `undefined` as "no impl
- * currently available" and avoid throwing.
+ * Look up a runtime impl by its canonical id (`{pluginId}.{contributionId}`).
+ * Returns `undefined` when the descriptor is registered but the plugin's
+ * `activate()` has not yet bound an impl, or after the plugin unloads.
+ * Callers must treat `undefined` as "no impl currently available" and avoid
+ * throwing.
  */
 export function getForgeProviderImpl(namespacedId: string): ForgeProviderImpl | undefined {
   if (typeof namespacedId !== "string" || namespacedId.length === 0) return undefined;
@@ -145,7 +146,7 @@ export function clearForgeProviderImplRegistry(): void {
 }
 
 function buildImplKey(pluginId: string, contributionId: string): string {
-  return `${pluginId}.${contributionId}`;
+  return makeForgeProviderId(pluginId, contributionId);
 }
 
 export function getRegisteredForgeProviders(): RegisteredForgeProvider[] {

--- a/electron/services/forgeProviderResolver.ts
+++ b/electron/services/forgeProviderResolver.ts
@@ -1,4 +1,5 @@
 import type { RegisteredForgeProvider, ResolvedForgeProvider } from "../../shared/types/forge.js";
+import { makeForgeProviderId } from "../../shared/utils/forgeProviderIds.js";
 import { getRegisteredForgeProviders, listMatchingProviders } from "./forgeProviderRegistry.js";
 
 const NO_MATCH: ResolvedForgeProvider = { entry: null, resolvedVia: null };
@@ -7,11 +8,13 @@ export interface ResolveForgeProviderInputs {
   /** Project's `origin` remote URL. Used for hostname matching when no override
    *  resolves. `null`/`undefined` skips hostname matching (no candidates). */
   remoteUrl: string | null | undefined;
-  /** Per-project override (`forgeProviderOverride`). Bare id (`"github"`) or
-   *  namespaced (`"builtin.github"`); both accepted. Set wins over default. */
+  /** Per-project override (`forgeProviderOverride`). Canonical id
+   *  (`"daintree.github.github"`, #8451). The storage read boundary normalizes
+   *  the known built-in aliases — third-party bare ids fall through unchanged
+   *  and `findById` still accepts them for backward compatibility. Set wins
+   *  over default. */
   forgeProviderOverride: string | null | undefined;
-  /** Global default (`forgeDefaultProviderId`). Same id forms as override.
-   *  Only matches when present in the remote's candidate set. */
+  /** Global default (`forgeDefaultProviderId`). Canonical id, same caveat. */
   globalDefaultProviderId: string | null | undefined;
 }
 
@@ -69,7 +72,13 @@ function findById(
   providers: RegisteredForgeProvider[],
   id: string
 ): RegisteredForgeProvider | undefined {
+  // Prefer the canonical `{pluginId}.{contributionId}` form (#8451). The bare
+  // `contribution.id` fallback stays for third-party plugins whose stored
+  // overrides predate the canonicalization migration — `normalizeProviderId`
+  // only rewrites the known built-in aliases and passes unknown strings
+  // through unchanged, so a legacy `"gitea"` value would otherwise stop
+  // resolving against an `acme.gitea` plugin.
   return providers.find(
-    (p) => p.contribution.id === id || `${p.pluginId}.${p.contribution.id}` === id
+    (p) => makeForgeProviderId(p.pluginId, p.contribution.id) === id || p.contribution.id === id
   );
 }

--- a/electron/services/projectSettingsCodec.ts
+++ b/electron/services/projectSettingsCodec.ts
@@ -24,6 +24,7 @@ import type {
 } from "../../shared/types/project.js";
 import type { CommandOverride } from "../../shared/types/commands.js";
 import type { NotificationSettings } from "../../shared/types/ipc/api.js";
+import { normalizeProviderId } from "../../shared/utils/forgeProviderIds.js";
 
 export const PROJECT_SETTINGS_SCHEMA_VERSION = 1;
 
@@ -219,7 +220,10 @@ function decodeBranchPrefixMode(raw: unknown): "none" | "username" | "custom" | 
 }
 
 function decodeForgeProviderOverride(raw: unknown): string | null | undefined {
-  if (typeof raw === "string" && raw.trim()) return raw.trim();
+  if (typeof raw === "string") {
+    const normalized = normalizeProviderId(raw);
+    return normalized ?? undefined;
+  }
   if (raw === null) return null;
   return undefined;
 }

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -8,6 +8,7 @@ import { type ProcessEntry, type CopyTreeProgressCallback, sendToEntryWindows } 
 import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js";
 import type { RateLimitInfo } from "../../../shared/types/forge.js";
 import type { GitHubRateLimitPayload } from "../../../shared/types/ipc/github.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../shared/utils/forgeProviderIds.js";
 
 export type EmitFn = (event: string | symbol, ...args: unknown[]) => boolean;
 
@@ -179,8 +180,8 @@ export class WorkspaceHostEventRouter {
         // existing `gitHubRateLimitService` singleton so the toolbar countdown
         // and main-process callers see limits triggered by workspace-host polling.
         // Unknown providers get cached locally for future inspection.
-        if (event.providerId === "builtin.github") {
-          const ghChangeAt = this.forgeCredentialChangeAt.get("builtin.github") ?? 0;
+        if (event.providerId === BUILTIN_GITHUB_PROVIDER_ID) {
+          const ghChangeAt = this.forgeCredentialChangeAt.get(BUILTIN_GITHUB_PROVIDER_ID) ?? 0;
           if (
             event.state.remaining === 0 &&
             ghChangeAt > 0 &&

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -8,6 +8,7 @@ import { type ProcessEntry, sendToEntryWindows } from "./types.js";
 import type { WorkspaceClientConfig } from "../../../shared/types/workspace-host.js";
 import { projectStore } from "../ProjectStore.js";
 import { generateProjectId } from "../projectStorePaths.js";
+import { normalizeProviderId } from "../../../shared/utils/forgeProviderIds.js";
 
 const CLEANUP_GRACE_MS = 180_000;
 const MAX_WARM_ENTRIES = 3;
@@ -30,8 +31,7 @@ async function readForgeSettingsForProject(projectPath: string): Promise<{
   } catch {
     forgeProviderOverride = null;
   }
-  const rawDefault = store.get("forgeDefaultProviderId");
-  const forgeDefaultProviderId = typeof rawDefault === "string" ? rawDefault : null;
+  const forgeDefaultProviderId = normalizeProviderId(store.get("forgeDefaultProviderId"));
   return { forgeProviderOverride, forgeDefaultProviderId };
 }
 

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -35,6 +35,7 @@ import { WorkspaceService } from "./workspace-host/WorkspaceService.js";
 import { gitHubRateLimitService } from "./services/github/index.js";
 import { ensureSerializable } from "../shared/utils/serialization.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../shared/utils/forgeProviderIds.js";
 
 // Validate we're running in UtilityProcess context
 if (!process.parentPort) {
@@ -323,7 +324,7 @@ gitHubRateLimitService.onStateChange((state) => {
   const rateLimitInfo = toRateLimitInfo(state);
   sendEvent({
     type: "forge-rate-limit-changed",
-    providerId: "builtin.github",
+    providerId: BUILTIN_GITHUB_PROVIDER_ID,
     state: rateLimitInfo,
   });
 });

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -2,6 +2,10 @@ import type { TypedEventBus } from "../services/events.js";
 import type { GitHubPRCIStatus } from "../../shared/types/github.js";
 import type { PRServiceStatus, WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import { GitHubAuth } from "../services/github/GitHubAuth.js";
+import {
+  BUILTIN_GITHUB_PROVIDER_ID,
+  normalizeProviderId,
+} from "../../shared/utils/forgeProviderIds.js";
 
 interface PullRequestServiceLike {
   initialize(rootPath: string): void;
@@ -33,7 +37,7 @@ export interface PRIntegrationCallbacks {
       issueLastUpdatedAt?: number;
       /** Branch the lookup was initiated against — used by the renderer to drop stale overlays. */
       branchName?: string;
-      /** Provider that resolved the PR (e.g. "builtin.github"). */
+      /** Provider that resolved the PR (e.g. `"daintree.github.github"`). */
       providerId?: string;
       /** Provider-agnostic CI status (forge format). */
       ciStatus?: import("../../shared/types/forge.js").CIStatus;
@@ -48,7 +52,7 @@ export interface PRIntegrationCallbacks {
       issueLastUpdatedAt?: number;
       /** Branch the lookup was initiated against — used by the renderer to drop stale overlays. */
       branchName?: string;
-      /** Provider that resolved the issue (e.g. "builtin.github"). */
+      /** Provider that resolved the issue (e.g. `"daintree.github.github"`). */
       providerId?: string;
     }
   ): void;
@@ -195,7 +199,7 @@ export class PRIntegrationService {
     credentials: import("../../shared/types/forge.js").Credentials | null,
     projectRootPath: string | null
   ): void {
-    if (providerId === "github" || providerId === "builtin.github") {
+    if (normalizeProviderId(providerId) === BUILTIN_GITHUB_PROVIDER_ID) {
       if (credentials === null) {
         GitHubAuth.setMemoryToken(null);
       } else if (credentials.kind === "bearer") {

--- a/plugins/builtin/github/main/GitHubTokenOrchestrator.ts
+++ b/plugins/builtin/github/main/GitHubTokenOrchestrator.ts
@@ -2,12 +2,13 @@ import type { GitHubTokenValidation } from "./GitHubAuth.js";
 import { GitHubAuth } from "./GitHubAuth.js";
 import { setGitHubToken, clearGitHubToken, validateGitHubToken } from "./GitHubToken.js";
 import { gitHubTokenHealthService } from "./GitHubTokenHealthService.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../../shared/utils/forgeProviderIds.js";
 
 async function syncWorkspaceToken(token: string | null): Promise<void> {
   try {
     const { getWorkspaceClient } = await import("../../../../electron/services/WorkspaceClient.js");
     const credentials = token ? { kind: "bearer" as const, value: token } : null;
-    getWorkspaceClient().updateForgeCredentials("builtin.github", credentials);
+    getWorkspaceClient().updateForgeCredentials(BUILTIN_GITHUB_PROVIDER_ID, credentials);
   } catch {
     // WorkspaceClient may not be initialized yet
   }

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -515,7 +515,7 @@ export type WorkspaceHostEvent =
       issueLastUpdatedAt?: number;
       /** Branch the lookup was initiated against — receiver drops the overlay if the worktree's branch has since changed. */
       branchName?: string;
-      /** Provider that resolved the PR (e.g. "builtin.github"). */
+      /** Provider that resolved the PR (e.g. `"daintree.github.github"`). */
       providerId?: string;
       /** Provider-agnostic linked projection (dual-shipped alongside legacy fields during migration). */
       linked?: PluginWorktreeLinked | null;
@@ -542,7 +542,7 @@ export type WorkspaceHostEvent =
       issueLastUpdatedAt?: number;
       /** Branch the lookup was initiated against — receiver drops the overlay if the worktree's branch has since changed. */
       branchName?: string;
-      /** Provider that resolved the issue (e.g. "builtin.github"). */
+      /** Provider that resolved the issue (e.g. `"daintree.github.github"`). */
       providerId?: string;
     }
   | {

--- a/shared/utils/__tests__/forgeProviderIds.test.ts
+++ b/shared/utils/__tests__/forgeProviderIds.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import {
+  makeForgeProviderId,
+  normalizeProviderId,
+  BUILTIN_GITHUB_PROVIDER_ID,
+} from "../forgeProviderIds.js";
+
+describe("makeForgeProviderId", () => {
+  it("joins plugin and contribution with a dot", () => {
+    expect(makeForgeProviderId("daintree.github", "github")).toBe("daintree.github.github");
+  });
+
+  it("preserves literal types in the return", () => {
+    const id: "acme.gitea.gitea" = makeForgeProviderId("acme.gitea", "gitea");
+    expect(id).toBe("acme.gitea.gitea");
+  });
+});
+
+describe("BUILTIN_GITHUB_PROVIDER_ID", () => {
+  it("matches the canonical pluginId.contributionId form from plugin.json", () => {
+    expect(BUILTIN_GITHUB_PROVIDER_ID).toBe("daintree.github.github");
+  });
+});
+
+describe("normalizeProviderId", () => {
+  it("maps bare 'github' to canonical", () => {
+    expect(normalizeProviderId("github")).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+  });
+
+  it("maps legacy 'builtin.github' to canonical", () => {
+    expect(normalizeProviderId("builtin.github")).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+  });
+
+  it("is idempotent on the canonical id", () => {
+    expect(normalizeProviderId(BUILTIN_GITHUB_PROVIDER_ID)).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+  });
+
+  it("passes unknown third-party ids through unchanged", () => {
+    expect(normalizeProviderId("acme.gitea.gitea")).toBe("acme.gitea.gitea");
+    expect(normalizeProviderId("some.other.id")).toBe("some.other.id");
+  });
+
+  it("trims surrounding whitespace before classifying", () => {
+    expect(normalizeProviderId("  builtin.github  ")).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+    expect(normalizeProviderId("\tgithub\n")).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+  });
+
+  it("returns null for empty/whitespace/non-string inputs", () => {
+    expect(normalizeProviderId("")).toBeNull();
+    expect(normalizeProviderId("   ")).toBeNull();
+    expect(normalizeProviderId(null)).toBeNull();
+    expect(normalizeProviderId(undefined)).toBeNull();
+    expect(normalizeProviderId(42)).toBeNull();
+    expect(normalizeProviderId({})).toBeNull();
+  });
+});

--- a/shared/utils/forgeProviderIds.ts
+++ b/shared/utils/forgeProviderIds.ts
@@ -1,0 +1,61 @@
+/**
+ * Canonical forge provider IDs.
+ *
+ * A registered forge provider's runtime id is `{pluginId}.{contributionId}` —
+ * the impl registry keys, IPC payloads, codec values, and renderer comparisons
+ * all need to agree on this shape (#8451). Three legacy forms still appear in
+ * persisted data: bare `"github"`, `"builtin.github"` from before the plugin
+ * was renamed to `daintree.github`, and the canonical form itself. Normalize
+ * those at read boundaries so the rest of the codebase only ever sees the
+ * canonical id.
+ *
+ * Lives in `shared/` so the main process, the workspace-host UtilityProcess,
+ * and the renderer can all import the same constant + helpers without dragging
+ * any runtime bindings across the process boundary.
+ */
+
+/**
+ * Build a canonical forge provider id from its plugin and contribution parts.
+ * The `const` type parameters preserve the literal types so callers that pass
+ * string literals get a precise template literal return type — useful for the
+ * built-in constant below, and for any future built-ins that want type-level
+ * proof of their id.
+ */
+export function makeForgeProviderId<const P extends string, const C extends string>(
+  pluginId: P,
+  contributionId: C
+): `${P}.${C}` {
+  return `${pluginId}.${contributionId}`;
+}
+
+/** Canonical id of the built-in GitHub forge provider. */
+export const BUILTIN_GITHUB_PROVIDER_ID = makeForgeProviderId("daintree.github", "github");
+
+export type BuiltInForgeProviderId = typeof BUILTIN_GITHUB_PROVIDER_ID;
+
+/**
+ * Open union — built-in ids autocomplete while still allowing any
+ * `{pluginId}.{contributionId}` string from third-party plugins. The
+ * `(string & {})` branch keeps the literal members visible (collapsing to
+ * `string` would erase the autocomplete benefit). Precedent: PR #4489 used
+ * the same pattern for action ids.
+ */
+export type ForgeProviderId = BuiltInForgeProviderId | (string & {});
+
+/**
+ * Map known legacy id forms to their canonical equivalent. Unknown non-empty
+ * strings pass through unchanged — third-party providers may have stored ids
+ * we do not recognize, and silently rewriting them would clear valid overrides.
+ *
+ * Returns `null` for non-string, empty, or whitespace-only inputs so callers
+ * can treat the result as "no provider override" without a second guard.
+ */
+export function normalizeProviderId(raw: unknown): ForgeProviderId | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed === "github" || trimmed === "builtin.github") {
+    return BUILTIN_GITHUB_PROVIDER_ID;
+  }
+  return trimmed;
+}

--- a/src/components/Project/CodeForgeTab.tsx
+++ b/src/components/Project/CodeForgeTab.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
 import type { RemoteInfo } from "@shared/types/ipc/github";
 import type { RegisteredForgeProvider } from "@shared/types/forge";
 
@@ -82,7 +83,9 @@ export function CodeForgeTab({
 
   const savedProviderKnown =
     forgeProviderOverride === null ||
-    providers.some((p) => p.contribution.id === forgeProviderOverride);
+    providers.some(
+      (p) => makeForgeProviderId(p.pluginId, p.contribution.id) === forgeProviderOverride
+    );
 
   return (
     <div className="space-y-6">
@@ -130,11 +133,14 @@ export function CodeForgeTab({
             className="w-full px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
           >
             <option value="">Default (GitHub)</option>
-            {providers.map((p) => (
-              <option key={`${p.pluginId}:${p.contribution.id}`} value={p.contribution.id}>
-                {p.contribution.name}
-              </option>
-            ))}
+            {providers.map((p) => {
+              const providerId = makeForgeProviderId(p.pluginId, p.contribution.id);
+              return (
+                <option key={providerId} value={providerId}>
+                  {p.contribution.name}
+                </option>
+              );
+            })}
             {!savedProviderKnown && forgeProviderOverride !== null ? (
               <option value={forgeProviderOverride}>{forgeProviderOverride} (unavailable)</option>
             ) : null}

--- a/src/components/Settings/ForgeIntegrationsTab.tsx
+++ b/src/components/Settings/ForgeIntegrationsTab.tsx
@@ -13,6 +13,7 @@ import { useProjectStore } from "@/store";
 import { useDeferredLoading } from "@/hooks";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
 import { logError } from "@/utils/logger";
 
 // Non-empty sentinel because Radix's `SelectItem` rejects an empty string value
@@ -162,7 +163,7 @@ export function ForgeIntegrationsTab() {
       ...providers.map((entry) => {
         const matches = entry.contribution.matches.join(", ");
         return {
-          value: entry.contribution.id,
+          value: makeForgeProviderId(entry.pluginId, entry.contribution.id),
           label: entry.contribution.name,
           description: matches ? `Matches: ${matches}` : undefined,
         };
@@ -172,7 +173,9 @@ export function ForgeIntegrationsTab() {
     if (
       storedId !== null &&
       storedId.length > 0 &&
-      !providers.some((entry) => entry.contribution.id === storedId)
+      !providers.some(
+        (entry) => makeForgeProviderId(entry.pluginId, entry.contribution.id) === storedId
+      )
     ) {
       base.push({
         value: storedId,

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -8,6 +8,7 @@ import { FileText } from "lucide-react";
 import type { WorktreeState } from "@/types";
 import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
 import { useResourceProfileStore } from "@/store/resourceProfileStore";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
 interface NonMainSecondaryRowProps {
   worktree: WorktreeState;
@@ -83,7 +84,7 @@ export function NonMainSecondaryRow({
           lastFetchedAt={worktree.lastFetchedAt}
           fetchAuthFailed={Boolean(worktree.fetchAuthFailed)}
           fetchNetworkFailed={Boolean(worktree.fetchNetworkFailed)}
-          isGitHubProvider={worktree.linked?.providerId === "builtin.github"}
+          isGitHubProvider={worktree.linked?.providerId === BUILTIN_GITHUB_PROVIDER_ID}
           containerGapClass="gap-1.5"
           baseBranchName={worktree.baseBranchName}
           baseAheadCount={worktree.baseAheadCount}

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -15,6 +15,7 @@ import { MainWorktreeSecondaryRow } from "./MainWorktreeSecondaryRow";
 import { NonMainSecondaryRow } from "./NonMainSecondaryRow";
 import { scheduleFlip } from "@/utils/flipScheduler";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
 export interface WorktreeHeaderProps {
   worktree: WorktreeState;
@@ -266,7 +267,7 @@ export function WorktreeHeader({
       !worktree.baseMatchesUpstream);
   const hasAuthFailedSignIn = Boolean(
     worktree.fetchAuthFailed &&
-    (worktree.isGitHubRemote || worktree.linked?.providerId === "builtin.github")
+    (worktree.isGitHubRemote || worktree.linked?.providerId === BUILTIN_GITHUB_PROVIDER_ID)
   );
   const isMainStandardLayout = !!(isMainOnStandardBranch && !hasIssueTitle);
 
@@ -420,7 +421,7 @@ export function WorktreeHeader({
           lastFetchedAt={worktree.lastFetchedAt}
           fetchAuthFailed={Boolean(worktree.fetchAuthFailed)}
           fetchNetworkFailed={Boolean(worktree.fetchNetworkFailed)}
-          isGitHubProvider={worktree.linked?.providerId === "builtin.github"}
+          isGitHubProvider={worktree.linked?.providerId === BUILTIN_GITHUB_PROVIDER_ID}
           aggregateCounts={aggregateCounts}
         />
       )}

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -46,9 +46,15 @@ const noop = () => {};
 function prLinked(num: number, state: "open" | "merged" | "closed" | "declined" = "open") {
   return {
     linked: {
-      providerId: "builtin.github",
+      providerId: "daintree.github.github",
       pr: {
-        ref: { providerId: "builtin.github", owner: "", repo: "", number: num, rawData: null },
+        ref: {
+          providerId: "daintree.github.github",
+          owner: "",
+          repo: "",
+          number: num,
+          rawData: null,
+        },
         state,
         url: `https://github.com/test/repo/pull/${num}`,
       },
@@ -1165,7 +1171,7 @@ describe("WorktreeHeader upstream sync indicator", () => {
         behindCount: 2,
         fetchAuthFailed: true,
         isGitHubRemote: true,
-        linked: { providerId: "builtin.github" },
+        linked: { providerId: "daintree.github.github" },
       },
     });
     const indicator = screen.getByTestId("upstream-sync-indicator");
@@ -1187,7 +1193,7 @@ describe("WorktreeHeader upstream sync indicator", () => {
         behindCount: 0,
         fetchAuthFailed: true,
         isGitHubRemote: true,
-        linked: { providerId: "builtin.github" },
+        linked: { providerId: "daintree.github.github" },
       },
     });
     const indicator = screen.getByTestId("upstream-sync-indicator");
@@ -1225,7 +1231,7 @@ describe("WorktreeHeader upstream sync indicator", () => {
         aheadCount: 1,
         fetchAuthFailed: true,
         isGitHubRemote: true,
-        linked: { providerId: "builtin.github" },
+        linked: { providerId: "daintree.github.github" },
       },
     });
     const indicator = screen.getByTestId("upstream-sync-indicator");
@@ -1279,7 +1285,7 @@ describe("WorktreeHeader upstream sync indicator", () => {
         fetchAuthFailed: true,
         fetchNetworkFailed: true,
         isGitHubRemote: true,
-        linked: { providerId: "builtin.github" },
+        linked: { providerId: "daintree.github.github" },
       },
     });
     const indicator = screen.getByTestId("upstream-sync-indicator");


### PR DESCRIPTION
## Summary

- The built-in GitHub plugin registers with `pluginId="daintree.github"` and `contributionId="github"`, making the canonical provider ID `daintree.github.github`. Three competing forms (`"github"`, `"builtin.github"`, and canonical) were in circulation — this is foundational cleanup that the rest of the forge-migration work depends on.
- New `shared/utils/forgeProviderIds.ts` adds `makeForgeProviderId`, `BUILTIN_GITHUB_PROVIDER_ID`, the `ForgeProviderId` open-union type, and `normalizeProviderId`. All hard-coded legacy IDs are replaced at emission sites (workspace-host, event router, PR integration, token orchestrator) and renderer components (`ForgeIntegrationsTab`, `CodeForgeTab`, worktree card headers).
- Migration runs silently at all read boundaries — the project settings codec, `forgeSettings` handler, `forge.ts` resolver and token validator, `WorkspaceHostPool`, and the `FORGE_SET_DEFAULT_PROVIDER` write path all normalize `"github"` and `"builtin.github"` to canonical; unknown third-party IDs pass through unchanged.

Resolves #8451

## Changes

- `shared/utils/forgeProviderIds.ts` — new helper module
- `shared/utils/__tests__/forgeProviderIds.test.ts` — 8 unit cases for `makeForgeProviderId` and `normalizeProviderId`
- `electron/services/__tests__/forgeProviderIds.integration.test.ts` — loads the real `plugins/builtin/github/plugin.json` and asserts registry + resolver agree on canonical ID
- Replaced all remaining `"builtin.github"` / bare `"github"` literals across `electron/` and `src/` with `BUILTIN_GITHUB_PROVIDER_ID`
- Updated `PullRequestService`, `WorkspaceClient`, `forgeSettings`, and `PRIntegrationService` tests to use canonical ID

## Testing

177 vitest tests pass. `npx tsc --noEmit` clean. `npm run check` (typecheck + lint + format + ratchet) clean; lint ratchet improved by 1.

Manual:
- Open Settings → Forge Integrations → pick "GitHub" as default, restart — confirm selection persists and selector still shows "GitHub"
- Open a project with a github.com remote — confirm worktree cards still recognize GitHub provider (auth-failed sign-in indicator works)
- Set `forgeDefaultProviderId` to `"builtin.github"` in the electron store directly, restart — confirm it silently upgrades to `"daintree.github.github"` on next read