### PR TITLE
feat(mcp): non-retryable error codes for stale MCP session bindings

### DIFF
--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -208,9 +208,7 @@ describe("rendererBridge — per-session pinned dispatch (#7002)", () => {
     await expect(bridge.requestManifestForWebContents(999)).rejects.toBeInstanceOf(
       SessionBindingError
     );
-    await expect(bridge.requestManifestForWebContents(999)).rejects.toThrow(
-      /Do not retry/
-    );
+    await expect(bridge.requestManifestForWebContents(999)).rejects.toThrow(/Do not retry/);
     await expect(
       bridge.dispatchActionForWebContents(999, "actions.list", {}, false)
     ).rejects.toBeInstanceOf(SessionBindingError);
@@ -227,9 +225,7 @@ describe("rendererBridge — per-session pinned dispatch (#7002)", () => {
     await expect(bridge.requestManifestForWebContents(404)).rejects.toBeInstanceOf(
       SessionBindingError
     );
-    await expect(bridge.requestManifestForWebContents(404)).rejects.toThrow(
-      /Do not retry/
-    );
+    await expect(bridge.requestManifestForWebContents(404)).rejects.toThrow(/Do not retry/);
     await expect(
       bridge.dispatchActionForWebContents(404, "actions.list", {}, false)
     ).rejects.toBeInstanceOf(SessionBindingError);

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -42,7 +42,7 @@ vi.mock("../../../window/windowRef.js", () => ({
   getProjectViewManager: () => null,
 }));
 
-import { createRendererBridge } from "../rendererBridge.js";
+import { createRendererBridge, SessionBindingError } from "../rendererBridge.js";
 import type { PendingRequest, DispatchEnvelope } from "../shared.js";
 import type { ActionManifestEntry } from "../../../../shared/types/actions.js";
 
@@ -205,12 +205,18 @@ describe("rendererBridge — per-session pinned dispatch (#7002)", () => {
 
   it("fails closed when the pinned view has been destroyed (#7002 — never silently re-routes)", async () => {
     // No entry for id=999 → webContents.fromId returns undefined.
+    await expect(bridge.requestManifestForWebContents(999)).rejects.toBeInstanceOf(
+      SessionBindingError
+    );
     await expect(bridge.requestManifestForWebContents(999)).rejects.toThrow(
-      /MCP pinned view 999 no longer available/
+      /Do not retry/
     );
     await expect(
       bridge.dispatchActionForWebContents(999, "actions.list", {}, false)
-    ).rejects.toThrow(/MCP pinned view 999 no longer available/);
+    ).rejects.toBeInstanceOf(SessionBindingError);
+    await expect(
+      bridge.dispatchActionForWebContents(999, "actions.list", {}, false)
+    ).rejects.toThrow(/Do not retry/);
   });
 
   it("fails closed when the pinned view exists but reports isDestroyed", async () => {
@@ -218,12 +224,18 @@ describe("rendererBridge — per-session pinned dispatch (#7002)", () => {
     wc.isDestroyed.mockReturnValue(true);
     mockWebContentsRegistry.set(404, wc);
 
+    await expect(bridge.requestManifestForWebContents(404)).rejects.toBeInstanceOf(
+      SessionBindingError
+    );
     await expect(bridge.requestManifestForWebContents(404)).rejects.toThrow(
-      /MCP pinned view 404 no longer available/
+      /Do not retry/
     );
     await expect(
       bridge.dispatchActionForWebContents(404, "actions.list", {}, false)
-    ).rejects.toThrow(/MCP pinned view 404 no longer available/);
+    ).rejects.toBeInstanceOf(SessionBindingError);
+    await expect(
+      bridge.dispatchActionForWebContents(404, "actions.list", {}, false)
+    ).rejects.toThrow(/Do not retry/);
     // Must not have attempted to send to a destroyed view.
     expect(wc.send).not.toHaveBeenCalled();
   });

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -19,11 +19,13 @@ import {
   RETRIABLE_ERROR_CODES,
   TIER_NOT_PERMITTED_CODE,
   EXECUTION_ERROR_CODE,
+  SESSION_BINDING_GONE,
   CONFIRMATION_TIMEOUT_CODE,
   USER_REJECTED_CODE,
   ELICITATION_FAILED_CODE,
   unwrapDispatchResult,
 } from "../shared.js";
+import { SessionBindingError } from "../rendererBridge.js";
 
 function fakeSessionStore(
   tier: "workbench" | "action" | "system" | "external" = "workbench"
@@ -1098,6 +1100,38 @@ describe("CallTool error envelope (integration through sessionServer)", () => {
     expect(parsed.code).toBe(EXECUTION_ERROR_CODE);
     expect(parsed.retriable).toBe(true);
     expect(parsed.message).toContain("transport went away");
+  });
+
+  it("maps SessionBindingError to SESSION_BINDING_GONE with retriable=false (#8432)", async () => {
+    const manifest = [
+      {
+        id: "files.search",
+        title: "Files: search",
+        description: "Search",
+        category: "files",
+        danger: "safe" as const,
+        source: ["agent"] as const,
+      },
+    ] as unknown as import("../../../../shared/types/actions.js").ActionManifestEntry[];
+    const deps = fakeDeps({
+      requestManifest: vi.fn().mockResolvedValue(manifest),
+      getCachedManifest: vi.fn(() => manifest),
+      dispatchAction: vi.fn().mockRejectedValue(new SessionBindingError(42)),
+    });
+    const server = createSessionServer("s-binding", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "files.search",
+      arguments: {},
+    })) as { isError: boolean; content: { type: string; text: string }[] };
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.code).toBe(SESSION_BINDING_GONE);
+    expect(parsed.retriable).toBe(false);
+    expect(parsed.message).toContain("Do not retry");
+    expect(parsed.message).toContain("42");
   });
 });
 

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -7,6 +7,19 @@ import { CHANNELS } from "../../ipc/channels.js";
 import type { PendingRequest, DispatchEnvelope } from "./shared.js";
 import { MCP_MANIFEST_REQUEST_TIMEOUT_MS, MCP_DISPATCH_TIMEOUT_MS } from "./shared.js";
 
+export class SessionBindingError extends Error {
+  readonly code = "SESSION_BINDING_GONE";
+  readonly webContentsId: number;
+
+  constructor(webContentsId: number) {
+    super(
+      `MCP pinned view ${webContentsId} no longer available — the renderer session this MCP session was bound to has been destroyed. Do not retry.`
+    );
+    this.name = "SessionBindingError";
+    this.webContentsId = webContentsId;
+  }
+}
+
 export function createRendererBridge(
   pendingManifests: Map<string, PendingRequest<ActionManifestEntry[]>>,
   pendingDispatches: Map<string, PendingRequest<DispatchEnvelope>>,
@@ -44,7 +57,7 @@ export function createRendererBridge(
   function getPinnedWebContents(id: number): Electron.WebContents {
     const wc = electronWebContents.fromId(id);
     if (!wc || wc.isDestroyed()) {
-      throw new Error(`MCP pinned view ${id} no longer available`);
+      throw new SessionBindingError(id);
     }
     return wc;
   }

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -45,9 +45,11 @@ import {
   MCP_DEDUP_MAX_ENTRIES_PER_SESSION,
   minimumPermittingTier,
   EXECUTION_ERROR_CODE,
+  SESSION_BINDING_GONE,
   buildToolError,
   buildMcpErrorPayload,
 } from "./shared.js";
+import { SessionBindingError } from "./rendererBridge.js";
 import { buildDedupKey, readDedupCache, type CallToolResultLike } from "./sessionDedup.js";
 import {
   shouldExposeTool,
@@ -362,6 +364,12 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
           confirmationDecision = confirmationDecision ?? envelope.confirmationDecision;
         } catch (err) {
           outcome = { kind: "throw", error: err };
+          if (err instanceof SessionBindingError) {
+            return buildToolError({
+              code: SESSION_BINDING_GONE,
+              message: err.message,
+            });
+          }
           return buildToolError({
             code: EXECUTION_ERROR_CODE,
             message: formatErrorMessage(err, "Action dispatch failed"),

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -129,6 +129,8 @@ export const USER_REJECTED_CODE = "USER_REJECTED";
 export const CONFIRMATION_TIMEOUT_CODE = "CONFIRMATION_TIMEOUT";
 export const ELICITATION_FAILED_CODE = "ELICITATION_FAILED";
 export const EXECUTION_ERROR_CODE = "EXECUTION_ERROR";
+export const BINDING_STALE = "BINDING_STALE";
+export const SESSION_BINDING_GONE = "SESSION_BINDING_GONE";
 
 /**
  * Application-level convention: codes here flag transient failures that a
@@ -147,6 +149,7 @@ export interface McpErrorPayload {
   message: string;
   details?: unknown;
   retriable: boolean;
+  errorCategory?: "transient" | "validation" | "business" | "permission";
 }
 
 /**
@@ -172,6 +175,9 @@ export function buildMcpErrorPayload(input: {
     message: input.message,
     retriable: RETRIABLE_ERROR_CODES.has(input.code),
   };
+  if (input.code === BINDING_STALE || input.code === SESSION_BINDING_GONE) {
+    payload.errorCategory = "business";
+  }
   if (input.details !== undefined) {
     let safeDetails: unknown = input.details;
     try {

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -167,7 +167,8 @@ export type ActionErrorCode =
   | "EXECUTION_ERROR"
   | "USER_REJECTED"
   | "CONFIRMATION_TIMEOUT"
-  | "ELICITATION_FAILED";
+  | "ELICITATION_FAILED"
+  | "BINDING_STALE";
 
 export interface ActionError {
   code: ActionErrorCode;

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -255,6 +255,22 @@ export class ActionService {
 
     const context = options?.contextOverride ?? this.getActionContext();
 
+    if (options?.contextOverride) {
+      const liveContext = this.getActionContext();
+      if (
+        liveContext.projectId &&
+        options.contextOverride.projectId &&
+        liveContext.projectId !== options.contextOverride.projectId
+      ) {
+        const error: ActionError = {
+          code: "BINDING_STALE",
+          message:
+            "The session context no longer matches live state — this session was bound to a project that is no longer active. Do not retry.",
+        };
+        return { ok: false, error };
+      }
+    }
+
     let validatedArgs = args;
     if (definition.argsSchema) {
       const validation = definition.argsSchema.safeParse(args);

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -496,6 +496,82 @@ describe("ActionService", () => {
         expect(result.error.message).toContain("Execution failed");
       }
     });
+
+    it("returns BINDING_STALE when contextOverride projectId differs from live context (#8432)", async () => {
+      const mockRun = vi.fn().mockResolvedValue(undefined);
+      const action: ActionDefinition = {
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description: "A test action",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: mockRun,
+      };
+
+      service.register(action);
+      service.setContextProvider(() => ({ projectId: "project-B" }));
+
+      const result = await service.dispatch("actions.list", undefined, {
+        contextOverride: { projectId: "project-A" },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("BINDING_STALE");
+        expect(result.error.message).toContain("Do not retry");
+      }
+      expect(mockRun).not.toHaveBeenCalled();
+    });
+
+    it("allows contextOverride when projectId matches live context (#8432)", async () => {
+      const mockRun = vi.fn().mockResolvedValue("ok");
+      const action: ActionDefinition<undefined, string> = {
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description: "A test action",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: mockRun,
+      };
+
+      service.register(action);
+      service.setContextProvider(() => ({ projectId: "project-A" }));
+
+      const result = await service.dispatch("actions.list", undefined, {
+        contextOverride: { projectId: "project-A" },
+      });
+
+      expect(result.ok).toBe(true);
+      expect(mockRun).toHaveBeenCalled();
+    });
+
+    it("allows contextOverride when liveContext has no projectId (#8432)", async () => {
+      const mockRun = vi.fn().mockResolvedValue("ok");
+      const action: ActionDefinition<undefined, string> = {
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description: "A test action",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: mockRun,
+      };
+
+      service.register(action);
+      service.setContextProvider(() => ({}));
+
+      const result = await service.dispatch("actions.list", undefined, {
+        contextOverride: { projectId: "project-A" },
+      });
+
+      expect(result.ok).toBe(true);
+      expect(mockRun).toHaveBeenCalled();
+    });
   });
 
   describe("list", () => {


### PR DESCRIPTION
## Summary
- Two new non-retryable error codes for stale MCP session bindings. `SESSION_BINDING_GONE` replaces a generic `Error` when the WebContents is destroyed. `BINDING_STALE` is returned before the action runs when the project has changed since the session was provisioned.
- Both signal "do not retry" so the model SDK doesn't loop on a dead binding.
- 8 files changed -- mostly type wiring, error-handling paths, and tests.

Resolves #8432

## Changes
- `SessionBindingError` (custom error class, code `SESSION_BINDING_GONE`) replaces the plain `Error` thrown from `getPinnedWebContents` in `rendererBridge.ts`
- `sessionServer.ts` catches `SessionBindingError` and returns it with `retriable: false` instead of flattening to `EXECUTION_ERROR`
- `ActionService.dispatch` validates that the `contextOverride.projectId` matches live state before dispatching -- returns `BINDING_STALE` on mismatch
- `BINDING_STALE` added to the `ActionErrorCode` union; both codes exported from `shared.ts` with `errorCategory: "business"` so they're excluded from the retriable set

## Testing
- Unit tests for `SessionBindingError` in `rendererBridge.test.ts` and `sessionServer.test.ts`
- Unit tests for stale-context detection in `ActionService.test.ts` (mismatch, match, and no-live-context cases)
- Typecheck, lint, and format all clean