### PR TITLE
feat(mcp): replace sticky tier elevation with time-bounded per-tool grants (#8442)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -567,11 +567,33 @@ export const CHANNELS = {
    */
   MCP_TIER_NOT_PERMITTED: "mcp-server:tier-not-permitted",
   /**
-   * Elevate the tier of an active help-session (Approve once). Mutates
+   * Elevate the tier of an active help-session (Always allow). Mutates
    * `sessionTierMap` in-place — never downgrades, so a malicious renderer
-   * cannot drop its own privileges.
+   * cannot drop its own privileges. The per-tool "Approve once" flow now
+   * uses {@link MCP_SERVER_ISSUE_GRANT} instead — this channel is reserved
+   * for the standing-permission path that pairs with a project-level
+   * `daintreeMcpTier` write (#8442).
    */
   MCP_SERVER_SET_SESSION_TIER: "mcp-server:set-session-tier",
+  /**
+   * Mint a per-`(sessionId, toolId)` time-bounded grant for the named tool
+   * (Approve once). The main process owns the TTL constant. Caller-pin
+   * checked: only the renderer that minted the help-session can issue
+   * grants on its behalf.
+   */
+  MCP_SERVER_ISSUE_GRANT: "mcp-server:issue-grant",
+  /**
+   * Revoke every grant currently held by the named session. Returns the
+   * count of revoked grants for the renderer's confirmation copy. Caller-
+   * pin checked.
+   */
+  MCP_SERVER_REVOKE_SESSION_GRANTS: "mcp-server:revoke-session-grants",
+  /**
+   * Push channel: a grant lifecycle event (`issued`, `expired`, `revoked`)
+   * fired for the help-session pinned to this renderer. Targeted send —
+   * grant state is session-scoped and never broadcast.
+   */
+  MCP_GRANT_LIFECYCLE: "mcp-server:grant-lifecycle",
 
   // Voice Input channels
   VOICE_INPUT_GET_SETTINGS: "voice-input:get-settings",

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -195,8 +195,8 @@ describe("mcpServer IPC adversarial", () => {
     expect(serviceMock.clearAuditLog).toHaveBeenCalledTimes(1);
   });
 
-  it("cleanup removes all thirteen registered handlers", () => {
-    expect(ipcHandlers.size).toBe(13);
+  it("cleanup removes all fifteen registered handlers", () => {
+    expect(ipcHandlers.size).toBe(15);
     cleanup();
     expect(ipcHandlers.size).toBe(0);
   });

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -146,6 +146,45 @@ export function registerMcpServerHandlers(): () => void {
     )
   );
 
+  handlers.push(
+    typedHandleWithContext(
+      CHANNELS.MCP_SERVER_ISSUE_GRANT,
+      async (ctx, payload: { sessionId: string; toolId: string }) => {
+        if (!payload || typeof payload !== "object") {
+          throw new Error("Invalid payload");
+        }
+        const { sessionId, toolId } = payload;
+        if (typeof sessionId !== "string" || !sessionId) {
+          throw new Error("Invalid sessionId");
+        }
+        if (typeof toolId !== "string" || !toolId) {
+          throw new Error("Invalid toolId");
+        }
+        const svc = await getMcpServerService();
+        // Same caller-pin invariant as `setSessionTier` — only the
+        // renderer that minted the session can issue grants for it.
+        return svc.issueGrant(sessionId, toolId, ctx.webContentsId);
+      }
+    )
+  );
+
+  handlers.push(
+    typedHandleWithContext(
+      CHANNELS.MCP_SERVER_REVOKE_SESSION_GRANTS,
+      async (ctx, payload: { sessionId: string }) => {
+        if (!payload || typeof payload !== "object") {
+          throw new Error("Invalid payload");
+        }
+        const { sessionId } = payload;
+        if (typeof sessionId !== "string" || !sessionId) {
+          throw new Error("Invalid sessionId");
+        }
+        const svc = await getMcpServerService();
+        return svc.revokeSessionGrants(sessionId, ctx.webContentsId);
+      }
+    )
+  );
+
   // Push runtime-state transitions to every renderer. Subscribed lazily so
   // we don't pay the McpServerService import cost just to register a no-op
   // listener — but cleanup MUST observe whichever side won the race:

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2456,6 +2456,10 @@ const api: ElectronAPI = {
       _typedOn(CHANNELS.MCP_SERVER_RUNTIME_STATE_CHANGED, callback),
     setSessionTier: (sessionId: string, tier: "workbench" | "action" | "system") =>
       _unwrappingInvoke(CHANNELS.MCP_SERVER_SET_SESSION_TIER, { sessionId, tier }),
+    issueGrant: (sessionId: string, toolId: string) =>
+      _unwrappingInvoke(CHANNELS.MCP_SERVER_ISSUE_GRANT, { sessionId, toolId }),
+    revokeSessionGrants: (sessionId: string) =>
+      _unwrappingInvoke(CHANNELS.MCP_SERVER_REVOKE_SESSION_GRANTS, { sessionId }),
     onTierNotPermitted: (
       callback: (payload: {
         sessionId: string;
@@ -2464,6 +2468,16 @@ const api: ElectronAPI = {
         targetTier: "workbench" | "action" | "system" | null;
       }) => void
     ) => _typedOn(CHANNELS.MCP_TIER_NOT_PERMITTED, callback),
+    onGrantLifecycle: (
+      callback: (payload: {
+        type: "grant.issued" | "grant.expired" | "grant.revoked";
+        sessionId: string;
+        toolId: string;
+        ttlMs: number;
+        expiresAt?: number;
+        revokedReason?: "user" | "session-ended" | "session-idle";
+      }) => void
+    ) => _typedOn(CHANNELS.MCP_GRANT_LIFECYCLE, callback),
   },
 
   helpAssistant: {

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -1,11 +1,16 @@
 import { randomUUID } from "node:crypto";
+import { webContents as webContentsModule } from "electron";
 import { store } from "../store.js";
+import { CHANNELS } from "../ipc/channels.js";
 import type { WindowRegistry } from "../window/WindowRegistry.js";
 import { getWindowRegistry } from "../window/windowRef.js";
 import type {
   AssistantTurnRecord,
   McpAuditRecord,
   McpAuditStats,
+  McpGrantLifecyclePayload,
+  McpIssueGrantResult,
+  McpRevokeSessionGrantsResult,
   McpRuntimeSnapshot,
   McpRuntimeState,
   TurnOutcomeClass,
@@ -64,13 +69,18 @@ export class McpServerService {
   private readonly runtimeStateListeners = new Set<(snapshot: McpRuntimeSnapshot) => void>();
 
   constructor() {
-    this.sessionStore = new SessionStore((sessionId) => {
-      cleanupResourceSubscriptions(sessionId, this.sessionStore);
-    });
-
     this.auditService = new AuditService(
       (patch) => this.persistConfig(patch),
       () => this.getConfig()
+    );
+
+    this.sessionStore = new SessionStore(
+      (sessionId) => {
+        cleanupResourceSubscriptions(sessionId, this.sessionStore);
+      },
+      {
+        emitGrantLifecycle: (sessionId, payload) => this.emitGrantLifecycle(sessionId, payload),
+      }
     );
 
     this.turnOutcomeService = new TurnOutcomeService({
@@ -380,6 +390,57 @@ export class McpServerService {
     callerWcId?: number
   ): { sessionId: string; tier: McpTier } {
     return this.httpLifecycle.setSessionTier(sessionId, tier, callerWcId);
+  }
+
+  /**
+   * Mint a per-`(sessionId, toolId)` grant for the named tool (Approve
+   * once). Validates caller pin against the WebContents the session was
+   * minted in — only that renderer can issue grants on its behalf.
+   * Returns the grant metadata so the renderer can render a countdown.
+   */
+  issueGrant(sessionId: string, toolId: string, callerWcId?: number): McpIssueGrantResult {
+    return this.httpLifecycle.issueGrant(sessionId, toolId, callerWcId);
+  }
+
+  /**
+   * Revoke every grant for a session in one call. Caller-pin checked
+   * identically to {@link issueGrant}. Returns the count of grants
+   * dropped so the renderer can show a confirmation toast.
+   */
+  revokeSessionGrants(sessionId: string, callerWcId?: number): McpRevokeSessionGrantsResult {
+    return this.httpLifecycle.revokeSessionGrants(sessionId, callerWcId);
+  }
+
+  /**
+   * Emitter wired into the {@link SessionStore}'s `GrantCache` at
+   * construction time. Writes an audit-log entry and pushes a targeted
+   * lifecycle event to the renderer pinned at session handshake. Send
+   * is always targeted — grant state is session-scoped and broadcasting
+   * to every WebContents would leak security state to other windows.
+   */
+  private emitGrantLifecycle(sessionId: string, payload: McpGrantLifecyclePayload): void {
+    try {
+      this.auditService.appendGrantRecord({
+        type: payload.type,
+        sessionId: payload.sessionId,
+        toolId: payload.toolId,
+        ttlMs: payload.ttlMs,
+        expiresAt: payload.expiresAt,
+        revokedReason: payload.revokedReason,
+      });
+    } catch (err) {
+      console.error("[MCP] Failed to append grant audit record:", err);
+    }
+
+    const id = this.sessionStore.sessionWebContentsMap.get(sessionId);
+    if (id === undefined) return;
+    const wc = webContentsModule.fromId(id);
+    if (!wc || wc.isDestroyed()) return;
+    try {
+      wc.send(CHANNELS.MCP_GRANT_LIFECYCLE, payload);
+    } catch (err) {
+      console.error("[MCP] grant lifecycle send failed:", err);
+    }
   }
 
   // Delegates for test access — tests call .bind(service) on these.

--- a/electron/services/mcp-server/__tests__/grantCache.test.ts
+++ b/electron/services/mcp-server/__tests__/grantCache.test.ts
@@ -1,0 +1,360 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GrantCache } from "../grantCache.js";
+import type { McpGrantLifecyclePayload } from "../../../../shared/types/ipc/mcpServer.js";
+
+interface EmittedEvent {
+  sessionId: string;
+  payload: McpGrantLifecyclePayload;
+}
+
+function newCache(opts?: {
+  ttlMs?: number;
+  sweepIntervalMs?: number;
+  denialSilenceThreshold?: number;
+  now?: () => number;
+}): { cache: GrantCache; emitted: EmittedEvent[] } {
+  const emitted: EmittedEvent[] = [];
+  const cache = new GrantCache({
+    ttlMs: opts?.ttlMs ?? 1000,
+    // Disable the sweep by default so the only timer in the test is the
+    // one each test explicitly drives; the lazy-eviction path on `check`
+    // is the contract we care about most.
+    sweepIntervalMs: opts?.sweepIntervalMs ?? 0,
+    denialSilenceThreshold: opts?.denialSilenceThreshold ?? 2,
+    now: opts?.now,
+    emit: (sessionId, payload) => {
+      emitted.push({ sessionId, payload });
+    },
+  });
+  return { cache, emitted };
+}
+
+describe("GrantCache.issueGrant + check", () => {
+  it("issueGrant returns an entry and emits grant.issued", () => {
+    const { cache, emitted } = newCache();
+    const entry = cache.issueGrant("s1", "git.commit");
+    expect(entry.ttlMs).toBeGreaterThan(0);
+    expect(entry.expiresAt).toBe(entry.issuedAt + entry.ttlMs);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      sessionId: "s1",
+      payload: { type: "grant.issued", sessionId: "s1", toolId: "git.commit" },
+    });
+    cache.dispose();
+  });
+
+  it("check returns granted + issuedAt for a fresh grant", () => {
+    const { cache } = newCache();
+    const entry = cache.issueGrant("s1", "git.commit");
+    const result = cache.check("s1", "git.commit");
+    expect(result.granted).toBe(true);
+    if (result.granted) {
+      expect(result.issuedAt).toBe(entry.issuedAt);
+      expect(result.expiresAt).toBe(entry.expiresAt);
+    }
+    cache.dispose();
+  });
+
+  it("check returns not granted for an unknown (sessionId, toolId)", () => {
+    const { cache } = newCache();
+    cache.issueGrant("s1", "git.commit");
+    const a = cache.check("s2", "git.commit"); // different session
+    const b = cache.check("s1", "git.push"); // different tool
+    expect(a.granted).toBe(false);
+    expect(b.granted).toBe(false);
+    cache.dispose();
+  });
+});
+
+describe("GrantCache lazy expiry", () => {
+  it("check lazily evicts and emits grant.expired after the TTL passes", () => {
+    let now = 0;
+    const { cache, emitted } = newCache({ ttlMs: 1000, now: () => now });
+    cache.issueGrant("s1", "git.commit");
+    emitted.length = 0;
+
+    // Just before expiry: still granted, no eviction.
+    now = 999;
+    expect(cache.check("s1", "git.commit").granted).toBe(true);
+    expect(emitted).toHaveLength(0);
+
+    // Just after expiry: lazy eviction + emit.
+    now = 1001;
+    expect(cache.check("s1", "git.commit").granted).toBe(false);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload.type).toBe("grant.expired");
+    expect(emitted[0].payload.toolId).toBe("git.commit");
+
+    // Subsequent check returns false but does NOT re-emit (entry gone).
+    expect(cache.check("s1", "git.commit").granted).toBe(false);
+    expect(emitted).toHaveLength(1);
+
+    cache.dispose();
+  });
+
+  it("sweep evicts expired entries and emits one grant.expired per entry", () => {
+    let now = 0;
+    const { cache, emitted } = newCache({ ttlMs: 1000, now: () => now });
+    cache.issueGrant("s1", "git.commit");
+    cache.issueGrant("s2", "worktree.delete");
+    emitted.length = 0;
+
+    now = 5000;
+    const evicted = cache.sweep();
+    expect(evicted).toBe(2);
+    expect(emitted.map((e) => e.payload.type)).toEqual(["grant.expired", "grant.expired"]);
+
+    cache.dispose();
+  });
+});
+
+describe("GrantCache.refresh — race guard (#2243)", () => {
+  it("refresh extends expiresAt when issuedAt matches", () => {
+    let now = 0;
+    const { cache } = newCache({ ttlMs: 1000, now: () => now });
+    const entry = cache.issueGrant("s1", "git.commit");
+
+    now = 500;
+    const refreshed = cache.refresh("s1", "git.commit", entry.issuedAt);
+    expect(refreshed).toBe(true);
+
+    // Original expiresAt was 1000; refresh at 500 with TTL 1000 → 1500.
+    const peeked = cache._peek("s1", "git.commit");
+    expect(peeked?.expiresAt).toBe(1500);
+    cache.dispose();
+  });
+
+  it("refresh with stale issuedAt no-ops (revoke + reissue race)", () => {
+    let now = 0;
+    const { cache } = newCache({ ttlMs: 1000, now: () => now });
+    const original = cache.issueGrant("s1", "git.commit");
+
+    // Simulate: revoke (deletes entry), then issueGrant again (fresh issuedAt).
+    cache.revokeSession("s1", "user");
+    now = 100;
+    const reissued = cache.issueGrant("s1", "git.commit");
+    expect(reissued.issuedAt).not.toBe(original.issuedAt);
+
+    // An in-flight dispatch refreshes with the OLD issuedAt — must no-op.
+    now = 200;
+    const refreshed = cache.refresh("s1", "git.commit", original.issuedAt);
+    expect(refreshed).toBe(false);
+
+    // Entry kept its reissue expiresAt (100 + 1000 = 1100), not extended.
+    const peeked = cache._peek("s1", "git.commit");
+    expect(peeked?.issuedAt).toBe(reissued.issuedAt);
+    expect(peeked?.expiresAt).toBe(1100);
+
+    cache.dispose();
+  });
+
+  it("refresh of a missing entry no-ops", () => {
+    const { cache } = newCache();
+    expect(cache.refresh("s1", "git.commit", 0)).toBe(false);
+    cache.dispose();
+  });
+});
+
+describe("GrantCache.revokeSession", () => {
+  it("revokes all grants for the named session and emits grant.revoked per entry", () => {
+    const { cache, emitted } = newCache();
+    cache.issueGrant("s1", "git.commit");
+    cache.issueGrant("s1", "git.push");
+    cache.issueGrant("s2", "git.commit");
+    emitted.length = 0;
+
+    const revoked = cache.revokeSession("s1", "user");
+    expect(revoked).toBe(2);
+    expect(emitted).toHaveLength(2);
+    expect(emitted.every((e) => e.payload.type === "grant.revoked")).toBe(true);
+    expect(emitted.every((e) => e.payload.revokedReason === "user")).toBe(true);
+
+    // s2 untouched.
+    expect(cache.check("s2", "git.commit").granted).toBe(true);
+    cache.dispose();
+  });
+
+  it("revokeSession on an unknown session returns 0 and emits nothing", () => {
+    const { cache, emitted } = newCache();
+    expect(cache.revokeSession("ghost", "user")).toBe(0);
+    expect(emitted).toHaveLength(0);
+    cache.dispose();
+  });
+
+  it("session-idle reason is propagated to the emitted record", () => {
+    const { cache, emitted } = newCache();
+    cache.issueGrant("s1", "git.commit");
+    emitted.length = 0;
+    cache.revokeSession("s1", "session-idle");
+    expect(emitted[0].payload.revokedReason).toBe("session-idle");
+    cache.dispose();
+  });
+});
+
+describe("GrantCache denial counters", () => {
+  it("incrementDenial counts per (sessionId, toolId) — cross-tool isolated", () => {
+    const { cache } = newCache({ denialSilenceThreshold: 2 });
+    expect(cache.incrementDenial("s1", "git.commit")).toBe(1);
+    expect(cache.incrementDenial("s1", "git.commit")).toBe(2);
+    expect(cache.incrementDenial("s1", "git.push")).toBe(1);
+    expect(cache.getDenialCount("s1", "git.commit")).toBe(2);
+    expect(cache.getDenialCount("s1", "git.push")).toBe(1);
+    cache.dispose();
+  });
+
+  it("shouldSuppressBanner is true only after threshold denials have already counted", () => {
+    const { cache } = newCache({ denialSilenceThreshold: 2 });
+    // 1st denial: count=1, suppress=false.
+    cache.incrementDenial("s1", "t");
+    expect(cache.shouldSuppressBanner("s1", "t")).toBe(false);
+    // 2nd denial: count=2, suppress=false (still fires).
+    cache.incrementDenial("s1", "t");
+    expect(cache.shouldSuppressBanner("s1", "t")).toBe(false);
+    // 3rd denial: count=3, suppress=true.
+    cache.incrementDenial("s1", "t");
+    expect(cache.shouldSuppressBanner("s1", "t")).toBe(true);
+    cache.dispose();
+  });
+
+  it("issueGrant zeroes the denial counter for the pair (re-arms the banner)", () => {
+    const { cache } = newCache({ denialSilenceThreshold: 2 });
+    cache.incrementDenial("s1", "t");
+    cache.incrementDenial("s1", "t");
+    cache.incrementDenial("s1", "t");
+    expect(cache.shouldSuppressBanner("s1", "t")).toBe(true);
+
+    cache.issueGrant("s1", "t");
+    expect(cache.getDenialCount("s1", "t")).toBe(0);
+    expect(cache.shouldSuppressBanner("s1", "t")).toBe(false);
+
+    cache.dispose();
+  });
+});
+
+describe("GrantCache.clearSessionState", () => {
+  it("clears grants and denial counters for the session quietly (no events)", () => {
+    const { cache, emitted } = newCache();
+    cache.issueGrant("s1", "t");
+    cache.incrementDenial("s1", "t");
+    cache.issueGrant("s2", "t");
+    emitted.length = 0;
+
+    cache.clearSessionState("s1");
+    expect(emitted).toHaveLength(0);
+    expect(cache.check("s1", "t").granted).toBe(false);
+    expect(cache.getDenialCount("s1", "t")).toBe(0);
+    // Other sessions untouched.
+    expect(cache.check("s2", "t").granted).toBe(true);
+    cache.dispose();
+  });
+});
+
+describe("GrantCache.dispose + clearAll", () => {
+  it("dispose stops the sweep interval and clears state; further issueGrant throws", () => {
+    const { cache } = newCache({ sweepIntervalMs: 50 });
+    cache.issueGrant("s1", "t");
+    cache.dispose();
+    expect(cache.check("s1", "t").granted).toBe(false);
+    expect(() => cache.issueGrant("s2", "t")).toThrow();
+    // Idempotent.
+    cache.dispose();
+  });
+
+  it("clearAll drops state but keeps the cache usable after a subsequent issueGrant", () => {
+    const { cache, emitted } = newCache();
+    cache.issueGrant("s1", "t");
+    cache.incrementDenial("s2", "t");
+    emitted.length = 0;
+
+    cache.clearAll();
+    expect(cache.check("s1", "t").granted).toBe(false);
+    expect(cache.getDenialCount("s2", "t")).toBe(0);
+
+    // Still usable.
+    cache.issueGrant("s3", "t");
+    expect(cache.check("s3", "t").granted).toBe(true);
+    cache.dispose();
+  });
+
+  it("sweep timer fires periodically when sweepIntervalMs > 0", () => {
+    vi.useFakeTimers();
+    try {
+      const emitted: EmittedEvent[] = [];
+      let now = 0;
+      const cache = new GrantCache({
+        ttlMs: 100,
+        sweepIntervalMs: 50,
+        now: () => now,
+        emit: (sessionId, payload) => emitted.push({ sessionId, payload }),
+      });
+      cache.issueGrant("s1", "t");
+      emitted.length = 0;
+
+      // Advance now past expiry, then tick the sweep interval.
+      now = 200;
+      vi.advanceTimersByTime(50);
+      expect(emitted.map((e) => e.payload.type)).toEqual(["grant.expired"]);
+
+      cache.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("GrantCache.getActiveGrants", () => {
+  it("returns snapshot for all sessions or filtered by sessionId", () => {
+    const { cache } = newCache();
+    cache.issueGrant("s1", "a");
+    cache.issueGrant("s1", "b");
+    cache.issueGrant("s2", "a");
+
+    const all = cache.getActiveGrants();
+    expect(all).toHaveLength(3);
+
+    const s1 = cache.getActiveGrants("s1");
+    expect(s1).toHaveLength(2);
+    expect(s1.map((g) => g.toolId).sort()).toEqual(["a", "b"]);
+    cache.dispose();
+  });
+});
+
+describe("GrantCache emitter resilience", () => {
+  it("a throwing emitter does not wedge subsequent cache mutations", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const cache = new GrantCache({
+        sweepIntervalMs: 0,
+        emit: () => {
+          throw new Error("boom");
+        },
+      });
+      expect(() => cache.issueGrant("s1", "t")).not.toThrow();
+      expect(cache.check("s1", "t").granted).toBe(true);
+      cache.dispose();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("session-level integration assumptions", () => {
+  // Sanity assertions that the cache's behaviour matches the contract
+  // sessionStore/sessionServer rely on; if any of these flip we want a
+  // test failure here, not a runtime surprise.
+  it("colon-free tool IDs survive the flat key encoding", () => {
+    const { cache } = newCache();
+    cache.issueGrant("uuid-with-dashes", "namespace.action");
+    expect(cache.check("uuid-with-dashes", "namespace.action").granted).toBe(true);
+    cache.dispose();
+  });
+});
+
+// Unused, but documents intent.
+beforeEach(() => {
+  // no-op; per-test caches are constructed inside each `it`.
+});

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -12,6 +12,7 @@ import { createSessionServer } from "../sessionServer.js";
 import type { SessionServerDeps } from "../sessionServer.js";
 import type { SessionStore } from "../sessionStore.js";
 import { SessionStore as RealSessionStore } from "../sessionStore.js";
+import { GrantCache } from "../grantCache.js";
 import {
   buildToolError,
   buildMcpErrorPayload,
@@ -27,6 +28,10 @@ import {
 function fakeSessionStore(
   tier: "workbench" | "action" | "system" | "external" = "workbench"
 ): SessionStore {
+  // Real GrantCache instance with sweeping disabled — tests drive lazy
+  // eviction via the optional `now` clock when they need to assert
+  // expiry, and they call dispose() at teardown.
+  const grantCache = new GrantCache({ sweepIntervalMs: 0 });
   const store = {
     sessions: new Map(),
     httpSessions: new Map(),
@@ -35,6 +40,7 @@ function fakeSessionStore(
     resourceSubscriptions: new Map(),
     dedupInFlight: new Map(),
     dedupResultCache: new Map(),
+    grantCache,
     drain: vi.fn(),
     getTier: vi.fn(() => tier),
     createIdleTimer: vi.fn(() => setTimeout(() => {}, 1_000_000)),
@@ -1213,5 +1219,177 @@ describe("Resource error envelope (integration through sessionServer)", () => {
       expect((err as McpError).code).toBe(ErrorCode.InvalidRequest);
       expect((err as McpError).message).toContain("Unknown resource URI");
     }
+  });
+});
+
+describe("sessionServer grant cache fallback (#8442)", () => {
+  async function callTool(
+    server: ReturnType<typeof createSessionServer>,
+    params: { name: string; arguments?: Record<string, unknown> }
+  ) {
+    const handlers = (
+      server as unknown as {
+        _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<unknown>>;
+      }
+    )._requestHandlers;
+    const handler = handlers.get("tools/call");
+    if (!handler) throw new Error("tools/call handler not found");
+    return handler(
+      {
+        method: "tools/call",
+        params,
+        jsonrpc: "2.0",
+        id: 1,
+      },
+      {
+        signal: new AbortController().signal,
+        _meta: {},
+        sendNotification: vi.fn(),
+        requestId: 1,
+      }
+    );
+  }
+
+  it("floor-permitted tool never consults the grant cache", async () => {
+    const sessionStore = fakeSessionStore("workbench");
+    const checkSpy = vi.spyOn(sessionStore.grantCache, "check");
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    // worktree.list is in WORKBENCH_TOOLS → static floor permits.
+    await callTool(server, { name: "worktree.list", arguments: {} });
+
+    expect(dispatchAction).toHaveBeenCalled();
+    expect(checkSpy).not.toHaveBeenCalled();
+    sessionStore.grantCache.dispose();
+  });
+
+  it("denied tool with an active grant dispatches and refreshes TTL on success", async () => {
+    const sessionStore = fakeSessionStore("workbench");
+    sessionStore.sessions.set("s", {
+      transport: {} as never,
+      idleTimer: setTimeout(() => {}, 1_000_000),
+    });
+    const resetIdle = sessionStore.resetIdleTimer as ReturnType<typeof vi.fn>;
+    resetIdle.mockClear();
+    sessionStore.grantCache.issueGrant("s", "worktree.delete");
+    const refreshSpy = vi.spyOn(sessionStore.grantCache, "refresh");
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const notify = vi.fn();
+    const deps = fakeDeps({ sessionStore, dispatchAction, notifyTierMismatch: notify });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: {},
+    })) as { isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    expect(dispatchAction).toHaveBeenCalledWith("worktree.delete", expect.any(Object), false);
+    expect(notify).not.toHaveBeenCalled();
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(resetIdle).toHaveBeenCalledWith("s");
+    sessionStore.grantCache.dispose();
+  });
+
+  it("grant for tool A does not authorize tool B in the same session", async () => {
+    const sessionStore = fakeSessionStore("workbench");
+    sessionStore.grantCache.issueGrant("s", "worktree.delete");
+    const dispatchAction = vi.fn();
+    const notify = vi.fn();
+    const deps = fakeDeps({ sessionStore, dispatchAction, notifyTierMismatch: notify });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    // worktree.createWithRecipe is action-tier, distinct from worktree.delete.
+    const result = (await callTool(server, {
+      name: "worktree.createWithRecipe",
+      arguments: { branchName: "x" },
+    })) as { isError?: boolean };
+
+    expect(result.isError).toBe(true);
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ toolId: "worktree.createWithRecipe" })
+    );
+    sessionStore.grantCache.dispose();
+  });
+
+  it("failed dispatch through a grant does not refresh the TTL", async () => {
+    const sessionStore = fakeSessionStore("workbench");
+    sessionStore.grantCache.issueGrant("s", "worktree.delete");
+    const refreshSpy = vi.spyOn(sessionStore.grantCache, "refresh");
+    const dispatchAction = vi.fn().mockResolvedValue({
+      result: { ok: false, error: { code: "BOOM", message: "boom" } },
+    });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    await callTool(server, { name: "worktree.delete", arguments: {} });
+
+    expect(dispatchAction).toHaveBeenCalled();
+    expect(refreshSpy).not.toHaveBeenCalled();
+    sessionStore.grantCache.dispose();
+  });
+
+  it("denials below the silence threshold fire the banner", async () => {
+    const sessionStore = fakeSessionStore("workbench");
+    const notify = vi.fn();
+    const audit = vi.fn();
+    const deps = fakeDeps({
+      sessionStore,
+      notifyTierMismatch: notify,
+      appendAuditRecord: audit,
+    });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    // 1st denial.
+    await callTool(server, { name: "worktree.delete", arguments: {} });
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    // 2nd denial: still fires (threshold = 2 means 1st AND 2nd fire).
+    await callTool(server, { name: "worktree.delete", arguments: {} });
+    expect(notify).toHaveBeenCalledTimes(2);
+
+    // 3rd denial: suppressed but audited.
+    await callTool(server, { name: "worktree.delete", arguments: {} });
+    expect(notify).toHaveBeenCalledTimes(2);
+
+    // Every denial wrote an audit record.
+    const unauthorizedRecords = audit.mock.calls.filter(
+      (call) => call[0]?.outcome?.kind === "unauthorized"
+    );
+    expect(unauthorizedRecords).toHaveLength(3);
+    // The third record carries bannerSuppressed: true.
+    expect(unauthorizedRecords[2][0]).toMatchObject({ bannerSuppressed: true });
+    expect(unauthorizedRecords[0][0].bannerSuppressed).toBeUndefined();
+    expect(unauthorizedRecords[1][0].bannerSuppressed).toBeUndefined();
+
+    sessionStore.grantCache.dispose();
+  });
+
+  it("issueGrant zeroes the denial counter — banner re-arms after explicit approval", async () => {
+    const sessionStore = fakeSessionStore("workbench");
+    const notify = vi.fn();
+    const deps = fakeDeps({ sessionStore, notifyTierMismatch: notify });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    // Push the counter past the silence threshold.
+    await callTool(server, { name: "worktree.delete", arguments: {} });
+    await callTool(server, { name: "worktree.delete", arguments: {} });
+    await callTool(server, { name: "worktree.delete", arguments: {} });
+    expect(sessionStore.grantCache.shouldSuppressBanner("s", "worktree.delete")).toBe(true);
+
+    // Approval mints a grant + resets counter.
+    sessionStore.grantCache.issueGrant("s", "worktree.delete");
+    expect(sessionStore.grantCache.shouldSuppressBanner("s", "worktree.delete")).toBe(false);
+
+    sessionStore.grantCache.dispose();
   });
 });

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1392,4 +1392,45 @@ describe("sessionServer grant cache fallback (#8442)", () => {
 
     sessionStore.grantCache.dispose();
   });
+
+  it("terminal.waitUntilIdle refreshes the grant TTL and resets idle timer on success", async () => {
+    const sessionStore = fakeSessionStore("workbench");
+    sessionStore.sessions.set("s", {
+      transport: {} as never,
+      idleTimer: setTimeout(() => {}, 1_000_000),
+    });
+    const resetIdle = sessionStore.resetIdleTimer as ReturnType<typeof vi.fn>;
+    resetIdle.mockClear();
+    sessionStore.grantCache.issueGrant("s", "terminal.waitUntilIdle");
+    const refreshSpy = vi.spyOn(sessionStore.grantCache, "refresh");
+
+    // waitUntilIdle is a main-process short-circuit, NOT a renderer
+    // dispatch — it has its own success-path block that must apply the
+    // grant-refresh + idle-timer reset.
+    const handleWaitUntilIdle = vi.fn().mockResolvedValue({
+      idleReason: "idle" as const,
+      durationMs: 1000,
+      finalState: "idle",
+    });
+    const dispatchAction = vi.fn();
+    const deps = fakeDeps({
+      sessionStore,
+      handleWaitUntilIdle,
+      dispatchAction,
+    });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "terminal.waitUntilIdle",
+      arguments: { terminalId: "t1", timeoutMs: 1000 },
+    })) as { isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    expect(handleWaitUntilIdle).toHaveBeenCalled();
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(resetIdle).toHaveBeenCalledWith("s");
+    sessionStore.grantCache.dispose();
+  });
 });

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionStore } from "../sessionStore.js";
-import type { McpSseSession, McpHttpSession } from "../shared.js";
+import { MCP_SSE_IDLE_TIMEOUT_MS, type McpSseSession, type McpHttpSession } from "../shared.js";
 
 function fakeSseSession(): McpSseSession {
   return {
@@ -34,6 +34,13 @@ describe("SessionStore.sessionWebContentsMap (#7002)", () => {
   });
 
   afterEach(() => {
+    // GrantCache owns a recurring sweep interval (`unref`'d) so the test
+    // runner can't be kept alive by it, but `vi.useFakeTimers` advances
+    // every registered timer regardless — we must explicitly dispose so
+    // tests can `vi.runAllTimers()`-equivalents without hitting the
+    // sweep loop. SessionStore.drain() keeps the cache usable; only
+    // dispose tears down the sweep timer.
+    store.grantCache.dispose();
     vi.useRealTimers();
   });
 
@@ -64,7 +71,9 @@ describe("SessionStore.sessionWebContentsMap (#7002)", () => {
     clearTimeout(session.idleTimer);
     session.idleTimer = store.createIdleTimer(sessionId);
 
-    vi.runAllTimers();
+    // Advance past the idle window only — running every timer would
+    // re-fire the GrantCache sweep interval indefinitely.
+    vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS + 1);
 
     expect(store.sessions.has(sessionId)).toBe(false);
     expect(store.sessionTierMap.has(sessionId)).toBe(false);
@@ -82,12 +91,58 @@ describe("SessionStore.sessionWebContentsMap (#7002)", () => {
     clearTimeout(session.idleTimer);
     session.idleTimer = store.createHttpIdleTimer(sessionId);
 
-    vi.runAllTimers();
+    // Advance past the idle window only — running every timer would
+    // re-fire the GrantCache sweep interval indefinitely.
+    vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS + 1);
 
     expect(store.httpSessions.has(sessionId)).toBe(false);
     expect(store.sessionTierMap.has(sessionId)).toBe(false);
     expect(store.sessionWebContentsMap.has(sessionId)).toBe(false);
     expect(resourceCleanups).toContain(sessionId);
+  });
+
+  it("drain() clears the grant cache without disposing it (cache stays usable across stop/start)", () => {
+    store.grantCache.issueGrant("s1", "git.commit");
+    expect(store.grantCache.check("s1", "git.commit").granted).toBe(true);
+
+    store.drain();
+    expect(store.grantCache.check("s1", "git.commit").granted).toBe(false);
+
+    // Cache is still alive — a subsequent issueGrant should not throw.
+    expect(() => store.grantCache.issueGrant("s2", "git.commit")).not.toThrow();
+    expect(store.grantCache.check("s2", "git.commit").granted).toBe(true);
+  });
+
+  it("SSE idle-timer expiry calls revokeSession with the session-idle reason", () => {
+    const sessionId = "sse-2";
+    const session = fakeSseSession();
+    store.sessions.set(sessionId, session);
+    // Spy on `revokeSession` directly — observing emissions is brittle
+    // because the GrantCache's sweep interval and 15-min lazy expiry
+    // both race with the 30-min SSE idle timer during a fast-forward
+    // and can emit `grant.expired` before the reaper runs.
+    const revokeSpy = vi.spyOn(store.grantCache, "revokeSession");
+
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createIdleTimer(sessionId);
+
+    vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS + 1);
+
+    expect(revokeSpy).toHaveBeenCalledWith(sessionId, "session-idle");
+  });
+
+  it("HTTP idle-timer expiry calls revokeSession with the session-idle reason", () => {
+    const sessionId = "http-2";
+    const session = fakeHttpSession();
+    store.httpSessions.set(sessionId, session);
+    const revokeSpy = vi.spyOn(store.grantCache, "revokeSession");
+
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createHttpIdleTimer(sessionId);
+
+    vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS + 1);
+
+    expect(revokeSpy).toHaveBeenCalledWith(sessionId, "session-idle");
   });
 
   it("idle-timer for a session that was already removed is a no-op (does not stomp another session's pin)", () => {
@@ -105,7 +160,9 @@ describe("SessionStore.sessionWebContentsMap (#7002)", () => {
     store.sessions.delete("evicted");
     store.sessionWebContentsMap.delete("evicted");
 
-    vi.runAllTimers();
+    // Advance past the idle window only — running every timer would
+    // re-fire the GrantCache sweep interval indefinitely.
+    vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS + 1);
 
     // The other session's pin must remain untouched.
     expect(store.sessionWebContentsMap.get("alive")).toBe(1);

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -4,6 +4,10 @@ import type {
   McpAuditResult,
   McpAuditStats,
   McpConfirmationDecision,
+  McpGrantRecord,
+  McpGrantRecordType,
+  McpGrantRevokedReason,
+  McpLogRecord,
 } from "../../../shared/types/ipc/mcpServer.js";
 import {
   MCP_AUDIT_DEFAULT_MAX_RECORDS,
@@ -20,8 +24,19 @@ import {
   minimumPermittingTier,
 } from "./shared.js";
 
+/**
+ * Hydrate predicate: existing on-disk records predate the discriminated
+ * union (#8442) and have no `type` field; new entries written by
+ * `appendGrantRecord` carry one. The union narrows on the presence of
+ * the field, never on a sentinel value, so legacy records remain plain
+ * `McpAuditRecord` instances.
+ */
+function isGrantRecord(record: McpLogRecord): record is McpGrantRecord {
+  return "type" in record && typeof (record as McpGrantRecord).type === "string";
+}
+
 export class AuditService {
-  private records: McpAuditRecord[] = [];
+  private records: McpLogRecord[] = [];
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private hydrated = false;
   /**
@@ -98,6 +113,7 @@ export class AuditService {
     outcome: AuditOutcome;
     confirmationDecision?: McpConfirmationDecision;
     argsSummary: string;
+    bannerSuppressed?: boolean;
   }): void {
     if (this.readConfig().auditEnabled === false) return;
     this.hydrate();
@@ -125,14 +141,55 @@ export class AuditService {
     }
     if (classification.result === "unauthorized") {
       record.tierHint = minimumPermittingTier(input.toolId);
+      if (input.bannerSuppressed) {
+        record.bannerSuppressed = true;
+      }
     }
 
     this.records.push(record);
+    this.enforceCap();
+    this.scheduleFlush();
+  }
+
+  /**
+   * Append a grant-lifecycle record to the same ring buffer as dispatch
+   * audit entries. Sharing the buffer keeps the audit-log surface honest:
+   * a reader walking the records in order sees grants minted, dispatches
+   * authorised under them, and the eventual expiry or revocation as a
+   * single chronological trail.
+   */
+  appendGrantRecord(input: {
+    type: McpGrantRecordType;
+    sessionId: string;
+    toolId: string;
+    ttlMs: number;
+    expiresAt?: number;
+    revokedReason?: McpGrantRevokedReason;
+  }): void {
+    if (this.readConfig().auditEnabled === false) return;
+    this.hydrate();
+
+    const record: McpGrantRecord = {
+      id: randomUUID(),
+      timestamp: Date.now(),
+      type: input.type,
+      sessionId: input.sessionId,
+      toolId: input.toolId,
+      ttlMs: input.ttlMs,
+    };
+    if (input.expiresAt !== undefined) record.expiresAt = input.expiresAt;
+    if (input.revokedReason !== undefined) record.revokedReason = input.revokedReason;
+
+    this.records.push(record);
+    this.enforceCap();
+    this.scheduleFlush();
+  }
+
+  private enforceCap(): void {
     const cap = this.normalizeMaxRecords(this.readConfig().auditMaxRecords);
     if (this.records.length > cap) {
       this.records.splice(0, this.records.length - cap);
     }
-    this.scheduleFlush();
   }
 
   /**
@@ -180,7 +237,27 @@ export class AuditService {
     this.flush();
   }
 
+  /**
+   * Newest-first view of dispatch records only. Grant lifecycle records
+   * (#8442) are filtered out for the legacy renderer surface that still
+   * shows `result`-keyed columns. {@link getLogRecords} returns the full
+   * union for callers that understand the new discriminator.
+   */
   getRecords(): McpAuditRecord[] {
+    this.hydrate();
+    const out: McpAuditRecord[] = [];
+    for (const record of this.records) {
+      if (!isGrantRecord(record)) out.push(record);
+    }
+    return out.reverse();
+  }
+
+  /**
+   * Newest-first view of the full log union — audit + grant records
+   * interleaved chronologically. Reserved for the audit panel surface
+   * that explicitly handles both shapes.
+   */
+  getLogRecords(): McpLogRecord[] {
     this.hydrate();
     return [...this.records].reverse();
   }

--- a/electron/services/mcp-server/grantCache.ts
+++ b/electron/services/mcp-server/grantCache.ts
@@ -1,0 +1,336 @@
+import type {
+  McpGrantLifecyclePayload,
+  McpGrantRecordType,
+  McpGrantRevokedReason,
+} from "../../../shared/types/ipc/mcpServer.js";
+import {
+  MCP_DENIAL_SILENCE_THRESHOLD,
+  MCP_GRANT_SWEEP_INTERVAL_MS,
+  MCP_GRANT_TTL_MS,
+} from "./shared.js";
+
+/**
+ * A single per-`(sessionId, toolId)` grant. The `issuedAt` field doubles as
+ * an opaque token for the race guard in {@link GrantCache.refresh}: a
+ * `refresh` call carrying a stale `issuedAt` (because the entry was revoked
+ * and re-issued between `check` and dispatch completion) becomes a no-op,
+ * so a successful dispatch through the original grant can never resurrect
+ * the revoked one. Mirrors the in-flight-fetch lesson from #2243.
+ */
+export interface GrantEntry {
+  issuedAt: number;
+  expiresAt: number;
+  ttlMs: number;
+}
+
+export type GrantCheckResult =
+  | { granted: true; issuedAt: number; expiresAt: number }
+  | { granted: false };
+
+export interface GrantLifecycleEmitter {
+  (sessionId: string, payload: McpGrantLifecyclePayload): void;
+}
+
+interface GrantCacheOptions {
+  ttlMs?: number;
+  sweepIntervalMs?: number;
+  denialSilenceThreshold?: number;
+  /**
+   * Hook invoked synchronously for every grant lifecycle transition
+   * (`issued`, `expired`, `revoked`). Implementation is responsible for
+   * writing an audit record and broadcasting to the pinned renderer.
+   * Errors are caught so a broken emitter cannot wedge cache mutations.
+   */
+  emit?: GrantLifecycleEmitter;
+  /**
+   * Custom clock for tests. Defaults to `Date.now`.
+   */
+  now?: () => number;
+}
+
+function key(sessionId: string, toolId: string): string {
+  return `${sessionId}:${toolId}`;
+}
+
+/**
+ * Per-`(sessionId, toolId)` time-bounded grants replacing sticky session
+ * tier elevation (#8442). Storage is a single `Map` keyed by the composite
+ * `${sessionId}:${toolId}`. Tool IDs never contain `:` (they are dotted
+ * `BuiltInActionId` strings) and session IDs are UUIDs, so the flat key
+ * is collision-free.
+ *
+ * Expiry is lazy on read — `check()` evicts and emits `grant.expired`
+ * when `now > expiresAt`. A periodic sweep is a memory-hygiene pass for
+ * grants that age out without anyone reading them; lazy eviction stays
+ * the source of truth so tests can drive the cache deterministically by
+ * faking time and calling `check()` rather than waiting for the sweep.
+ *
+ * Denial counters live alongside the grants because they share the same
+ * `(sessionId, toolId)` keyspace and are cleared at the same lifecycle
+ * points (session drain, idle expiry, grant issuance for the pair).
+ */
+export class GrantCache {
+  private readonly grants = new Map<string, GrantEntry>();
+  private readonly denialCounts = new Map<string, number>();
+  private readonly ttlMs: number;
+  private readonly sweepIntervalMs: number;
+  private readonly denialSilenceThreshold: number;
+  private readonly emit?: GrantLifecycleEmitter;
+  private readonly now: () => number;
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  private disposed = false;
+
+  constructor(options: GrantCacheOptions = {}) {
+    this.ttlMs = options.ttlMs ?? MCP_GRANT_TTL_MS;
+    this.sweepIntervalMs = options.sweepIntervalMs ?? MCP_GRANT_SWEEP_INTERVAL_MS;
+    this.denialSilenceThreshold = options.denialSilenceThreshold ?? MCP_DENIAL_SILENCE_THRESHOLD;
+    this.emit = options.emit;
+    this.now = options.now ?? Date.now;
+
+    if (this.sweepIntervalMs > 0) {
+      this.sweepTimer = setInterval(() => this.sweep(), this.sweepIntervalMs);
+      this.sweepTimer.unref?.();
+    }
+  }
+
+  /**
+   * Mint a fresh grant for the pair. Clears any accumulated denial counter
+   * so the renderer banner re-arms after a deliberate user approval. If a
+   * grant already exists it is replaced (with a fresh `issuedAt`); the
+   * caller has effectively re-approved, so the race guard's identity check
+   * intentionally fires against the new token.
+   */
+  issueGrant(sessionId: string, toolId: string): GrantEntry {
+    if (this.disposed) {
+      throw new Error("GrantCache has been disposed");
+    }
+    const issuedAt = this.now();
+    const entry: GrantEntry = {
+      issuedAt,
+      expiresAt: issuedAt + this.ttlMs,
+      ttlMs: this.ttlMs,
+    };
+    this.grants.set(key(sessionId, toolId), entry);
+    this.denialCounts.delete(key(sessionId, toolId));
+    this.emitSafely(sessionId, {
+      type: "grant.issued",
+      sessionId,
+      toolId,
+      ttlMs: entry.ttlMs,
+      expiresAt: entry.expiresAt,
+    });
+    return entry;
+  }
+
+  /**
+   * Lookup the grant for the pair. Lazily evicts and emits `grant.expired`
+   * if the entry has aged out. The returned `issuedAt` is the token that
+   * `refresh()` must echo back to update the entry safely.
+   */
+  check(sessionId: string, toolId: string): GrantCheckResult {
+    const k = key(sessionId, toolId);
+    const entry = this.grants.get(k);
+    if (!entry) return { granted: false };
+    if (this.now() > entry.expiresAt) {
+      this.grants.delete(k);
+      this.emitSafely(sessionId, {
+        type: "grant.expired",
+        sessionId,
+        toolId,
+        ttlMs: entry.ttlMs,
+      });
+      return { granted: false };
+    }
+    return { granted: true, issuedAt: entry.issuedAt, expiresAt: entry.expiresAt };
+  }
+
+  /**
+   * Extend the grant's expiry window. The `issuedAt` argument is the token
+   * the caller obtained from `check()` — if a `revokeSession` (or a manual
+   * re-issue) ran between then and this call, the stored `issuedAt` will
+   * have moved on and this refresh is a silent no-op. That's the #2243
+   * resurrection-race fix: a winning revoke must not be undone by a
+   * dispatch that started before it.
+   */
+  refresh(sessionId: string, toolId: string, issuedAt: number): boolean {
+    const k = key(sessionId, toolId);
+    const entry = this.grants.get(k);
+    if (!entry) return false;
+    if (entry.issuedAt !== issuedAt) return false;
+    entry.expiresAt = this.now() + entry.ttlMs;
+    return true;
+  }
+
+  /**
+   * Drop every grant held by the session. Emits `grant.revoked` per
+   * entry so the audit log and renderer broadcast both see them. The
+   * `reason` field lets callers distinguish a user-initiated revoke from
+   * an automatic session-end cleanup.
+   */
+  revokeSession(sessionId: string, reason: McpGrantRevokedReason = "user"): number {
+    let revoked = 0;
+    const prefix = `${sessionId}:`;
+    for (const k of [...this.grants.keys()]) {
+      if (!k.startsWith(prefix)) continue;
+      const entry = this.grants.get(k);
+      this.grants.delete(k);
+      revoked += 1;
+      // toolId is the suffix after the first `:` — sessionIds are UUIDs
+      // with no `:`, so substring(prefix.length) gives the tool id verbatim.
+      const toolId = k.substring(prefix.length);
+      this.emitSafely(sessionId, {
+        type: "grant.revoked",
+        sessionId,
+        toolId,
+        ttlMs: entry?.ttlMs ?? this.ttlMs,
+        revokedReason: reason,
+      });
+    }
+    return revoked;
+  }
+
+  /**
+   * Drop every grant and denial counter for the session without emitting
+   * `grant.revoked` events. Used by the idle reaper and full-store drain
+   * — those pathways tear down sessions wholesale and don't need audit
+   * noise for each per-tool grant. The audit log retains the originating
+   * `grant.issued` record so the absence of a closing `grant.revoked`
+   * does not look like a leak; the corresponding session-cleanup signal
+   * is the {@link revokeSession} call sites pass `session-idle` or
+   * `session-ended` when they want the trail.
+   *
+   * In practice the SessionStore idle reaper calls `revokeSession` with
+   * `session-idle` for full traceability; `clearSessionState` exists as
+   * a quiet variant for the wholesale `drain()` path during shutdown
+   * where every session is going away simultaneously.
+   */
+  clearSessionState(sessionId: string): void {
+    const prefix = `${sessionId}:`;
+    for (const k of [...this.grants.keys()]) {
+      if (k.startsWith(prefix)) this.grants.delete(k);
+    }
+    for (const k of [...this.denialCounts.keys()]) {
+      if (k.startsWith(prefix)) this.denialCounts.delete(k);
+    }
+  }
+
+  /**
+   * Increment the consecutive-denial counter for the pair and return the
+   * new count. The session-server uses the return value to decide whether
+   * to fire the renderer banner this round.
+   */
+  incrementDenial(sessionId: string, toolId: string): number {
+    const k = key(sessionId, toolId);
+    const next = (this.denialCounts.get(k) ?? 0) + 1;
+    this.denialCounts.set(k, next);
+    return next;
+  }
+
+  getDenialCount(sessionId: string, toolId: string): number {
+    return this.denialCounts.get(key(sessionId, toolId)) ?? 0;
+  }
+
+  /**
+   * True when the current denial for the pair should suppress the renderer
+   * banner. The audit record is still written; this controls only the UI
+   * surface. The check uses the post-increment count: with threshold = 2
+   * the 1st and 2nd consecutive denials fire the banner, the 3rd and
+   * beyond are suppressed. A successful `issueGrant` zeroes the counter,
+   * so re-arming requires deliberate user approval rather than time
+   * passing.
+   */
+  shouldSuppressBanner(sessionId: string, toolId: string): boolean {
+    return this.getDenialCount(sessionId, toolId) > this.denialSilenceThreshold;
+  }
+
+  /**
+   * Test/inspection hook. Returns a shallow snapshot of live grants —
+   * iteration order is insertion order so callers can rely on it for
+   * deterministic assertions.
+   */
+  getActiveGrants(sessionId?: string): Array<{ sessionId: string; toolId: string } & GrantEntry> {
+    const out: Array<{ sessionId: string; toolId: string } & GrantEntry> = [];
+    for (const [k, entry] of this.grants) {
+      const colon = k.indexOf(":");
+      if (colon < 0) continue;
+      const sid = k.substring(0, colon);
+      if (sessionId !== undefined && sid !== sessionId) continue;
+      out.push({ sessionId: sid, toolId: k.substring(colon + 1), ...entry });
+    }
+    return out;
+  }
+
+  /**
+   * Periodic sweep — removes expired grants without anyone having to read
+   * them. Emits `grant.expired` for each so audit and broadcast match the
+   * lazy-eviction path.
+   */
+  sweep(): number {
+    if (this.disposed) return 0;
+    let evicted = 0;
+    const now = this.now();
+    for (const [k, entry] of [...this.grants]) {
+      if (now <= entry.expiresAt) continue;
+      this.grants.delete(k);
+      evicted += 1;
+      const colon = k.indexOf(":");
+      if (colon < 0) continue;
+      const sessionId = k.substring(0, colon);
+      const toolId = k.substring(colon + 1);
+      this.emitSafely(sessionId, {
+        type: "grant.expired",
+        sessionId,
+        toolId,
+        ttlMs: entry.ttlMs,
+      });
+    }
+    return evicted;
+  }
+
+  /**
+   * Drop every grant and denial counter without stopping the sweep timer.
+   * Used by {@link import("./sessionStore.js").SessionStore.drain} on
+   * HTTP-server stop/restart, where the `SessionStore` instance lives on
+   * and will accept fresh sessions after the next `start()`. The sweep
+   * timer is `.unref()`'d so it cannot keep the process alive on its own.
+   */
+  clearAll(): void {
+    if (this.disposed) return;
+    this.grants.clear();
+    this.denialCounts.clear();
+  }
+
+  /**
+   * Stop the sweep interval and drop all state. Mandatory before
+   * discarding the cache permanently (test teardown, app shutdown) —
+   * otherwise the libuv handle keeps the test runner alive even with
+   * `.unref()` because `unref` is best-effort. Idempotent.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.sweepTimer !== null) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+    this.grants.clear();
+    this.denialCounts.clear();
+  }
+
+  private emitSafely(sessionId: string, payload: McpGrantLifecyclePayload): void {
+    if (!this.emit) return;
+    try {
+      this.emit(sessionId, payload);
+    } catch (err) {
+      console.error("[MCP] Grant lifecycle emitter threw:", err);
+    }
+  }
+
+  // Test access — kept narrow on purpose.
+  /** @internal */
+  _peek(sessionId: string, toolId: string): GrantEntry | undefined {
+    return this.grants.get(key(sessionId, toolId));
+  }
+}
+
+export type { McpGrantRecordType, McpGrantRevokedReason };

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -18,7 +18,6 @@ import type {
   McpTier,
 } from "./shared.js";
 import type {
-  McpGrantLifecyclePayload,
   McpIssueGrantResult,
   McpRevokeSessionGrantsResult,
 } from "../../../shared/types/ipc/mcpServer.js";

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -17,6 +17,11 @@ import type {
   HelpSessionActionContextResolver,
   McpTier,
 } from "./shared.js";
+import type {
+  McpGrantLifecyclePayload,
+  McpIssueGrantResult,
+  McpRevokeSessionGrantsResult,
+} from "../../../shared/types/ipc/mcpServer.js";
 import {
   extractBearerToken,
   isAuthorized,
@@ -834,6 +839,64 @@ export class HttpLifecycle {
     }
     this.deps.sessionStore.sessionTierMap.set(sessionId, tier);
     return { sessionId, tier };
+  }
+
+  /**
+   * Mint a time-bounded per-`(sessionId, toolId)` grant — the "Approve
+   * once" pathway that replaces sticky session-tier elevation for single
+   * tool calls (#8442). Validates the same caller-pin invariant as
+   * {@link setSessionTier}: only the renderer that minted the session
+   * can issue grants on its behalf.
+   */
+  issueGrant(sessionId: string, toolId: string, callerWcId?: number): McpIssueGrantResult {
+    if (!sessionId || typeof sessionId !== "string") {
+      throw new Error("Invalid sessionId");
+    }
+    if (!toolId || typeof toolId !== "string") {
+      throw new Error("Invalid toolId");
+    }
+    if (
+      !this.deps.sessionStore.sessions.has(sessionId) &&
+      !this.deps.sessionStore.httpSessions.has(sessionId)
+    ) {
+      throw new Error("Session is no longer active");
+    }
+    const pinnedWcId = this.deps.sessionStore.sessionWebContentsMap.get(sessionId);
+    if (pinnedWcId === undefined) {
+      throw new Error("Session is not eligible for renderer tier elevation");
+    }
+    if (callerWcId !== undefined && callerWcId !== pinnedWcId) {
+      throw new Error("Caller is not the pinned renderer for this session");
+    }
+    const entry = this.deps.sessionStore.grantCache.issueGrant(sessionId, toolId);
+    return {
+      sessionId,
+      toolId,
+      ttlMs: entry.ttlMs,
+      expiresAt: entry.expiresAt,
+    };
+  }
+
+  /**
+   * Drop every grant currently held by the session. Caller-pin checked
+   * identically to {@link issueGrant}. Returns the count of revoked
+   * grants for the renderer's confirmation copy.
+   */
+  revokeSessionGrants(sessionId: string, callerWcId?: number): McpRevokeSessionGrantsResult {
+    if (!sessionId || typeof sessionId !== "string") {
+      throw new Error("Invalid sessionId");
+    }
+    // Caller-pin is enforced when the session is still alive; if the
+    // session has already drained (idle reaper / explicit close) the
+    // pin map is empty and the revoke becomes an idempotent no-op so
+    // the renderer's cleanup pass after a banner dismissal succeeds
+    // even though there's nothing left to drop.
+    const pinnedWcId = this.deps.sessionStore.sessionWebContentsMap.get(sessionId);
+    if (pinnedWcId !== undefined && callerWcId !== undefined && callerWcId !== pinnedWcId) {
+      throw new Error("Caller is not the pinned renderer for this session");
+    }
+    const revokedCount = this.deps.sessionStore.grantCache.revokeSession(sessionId, "user");
+    return { sessionId, revokedCount };
   }
 
   getStatus(): {

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -541,8 +541,15 @@ export class HttpLifecycle {
           this.deps.sessionStore.sessions.delete(sessionId);
         }
         this.deps.sessionStore.sessionTierMap.delete(sessionId);
+        // Revoke before deleting the WebContents pin so the lifecycle
+        // emitter can still find the pinned renderer for the
+        // `grant.revoked` push. The audit record carries the
+        // `session-ended` reason. Without this, grants accumulate
+        // forever in the cache across a long-running session lifecycle.
+        this.deps.sessionStore.grantCache.revokeSession(sessionId, "session-ended");
         this.deps.sessionStore.sessionWebContentsMap.delete(sessionId);
         this.deps.sessionStore.sessionContextMap.delete(sessionId);
+        this.deps.sessionStore.clearDedupState(sessionId);
         cleanupResourceSubscriptions(sessionId, this.deps.sessionStore);
       };
 
@@ -552,8 +559,12 @@ export class HttpLifecycle {
         clearTimeout(idleTimer);
         this.deps.sessionStore.sessions.delete(sessionId);
         this.deps.sessionStore.sessionTierMap.delete(sessionId);
+        // Same pin-before-clear ordering — the connect failure path
+        // mirrors normal close cleanup.
+        this.deps.sessionStore.grantCache.revokeSession(sessionId, "session-ended");
         this.deps.sessionStore.sessionWebContentsMap.delete(sessionId);
         this.deps.sessionStore.sessionContextMap.delete(sessionId);
+        this.deps.sessionStore.clearDedupState(sessionId);
         transport.onclose = undefined;
         await transport.close().catch(() => {});
         throw err;
@@ -657,8 +668,12 @@ export class HttpLifecycle {
         this.deps.sessionStore.httpSessions.delete(id);
       }
       this.deps.sessionStore.sessionTierMap.delete(id);
+      // Pin-before-revoke ordering identical to the SSE path above —
+      // see `transport.onclose` in the GET /sse branch.
+      this.deps.sessionStore.grantCache.revokeSession(id, "session-ended");
       this.deps.sessionStore.sessionWebContentsMap.delete(id);
       this.deps.sessionStore.sessionContextMap.delete(id);
+      this.deps.sessionStore.clearDedupState(id);
       cleanupResourceSubscriptions(id, this.deps.sessionStore);
     };
 
@@ -675,13 +690,17 @@ export class HttpLifecycle {
           this.deps.sessionStore.httpSessions.delete(id);
         }
         this.deps.sessionStore.sessionTierMap.delete(id);
+        this.deps.sessionStore.grantCache.revokeSession(id, "session-ended");
         this.deps.sessionStore.sessionWebContentsMap.delete(id);
         this.deps.sessionStore.sessionContextMap.delete(id);
+        this.deps.sessionStore.clearDedupState(id);
         cleanupResourceSubscriptions(id, this.deps.sessionStore);
       } else {
         this.deps.sessionStore.sessionTierMap.delete(newSessionId);
+        this.deps.sessionStore.grantCache.revokeSession(newSessionId, "session-ended");
         this.deps.sessionStore.sessionWebContentsMap.delete(newSessionId);
         this.deps.sessionStore.sessionContextMap.delete(newSessionId);
+        this.deps.sessionStore.clearDedupState(newSessionId);
         cleanupResourceSubscriptions(newSessionId, this.deps.sessionStore);
       }
       await transport.close().catch(() => {});

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -287,6 +287,20 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
           try {
             const result = await waitUntilIdle(args, extra.signal);
             outcome = { kind: "result", value: { ok: true, result } };
+            // Mirror the post-dispatch grant refresh in the main path:
+            // when the call was authorized by a grant, extend the TTL
+            // window and reset the idle timer on success. `waitUntilIdle`
+            // can run up to 30 minutes (longer than the 15-min grant
+            // window), so this is the only block that prevents the grant
+            // from silently aging out during a long wait (#8442).
+            if (grantIssuedAt !== undefined) {
+              sessionStore.grantCache.refresh(sessionId, actionId, grantIssuedAt);
+              if (sessionStore.sessions.has(sessionId)) {
+                sessionStore.resetIdleTimer(sessionId);
+              } else if (sessionStore.httpSessions.has(sessionId)) {
+                sessionStore.resetHttpIdleTimer(sessionId);
+              }
+            }
             return {
               content: [{ type: "text" as const, text: safeSerializeToolResult(result) }],
               structuredContent: result as unknown as Record<string, unknown>,

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -82,6 +82,7 @@ export interface SessionServerDeps {
     durationMs: number;
     outcome: AuditOutcome;
     confirmationDecision?: import("../../../shared/types/ipc/mcpServer.js").McpConfirmationDecision;
+    bannerSuppressed?: boolean;
   }) => void;
   getCachedManifest: () => import("../../../shared/types/actions.js").ActionManifestEntry[] | null;
   getFullToolSurface: () => boolean;
@@ -155,35 +156,64 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     const tier = sessionStore.getTier(sessionId);
     const fullToolSurface = getFullToolSurface();
 
+    // Layered authorization (#8442):
+    //   1. Static tier floor (`TIER_ALLOWLISTS`) — workbench/action/system
+    //      membership stays the default. The "Always allow" project setting
+    //      elevates the session tier so this check passes for everything
+    //      below the chosen tier.
+    //   2. Per-`(sessionId, toolId)` grant cache — the "Approve once" flow
+    //      mints time-bounded grants that authorise a single tool without
+    //      elevating the whole session. If the static check denies but a
+    //      live grant exists, the dispatch proceeds and the grant's TTL
+    //      is refreshed on success.
+    //
+    // The order means that a session whose static tier already permits the
+    // action never consults the grant cache — grants are an additive layer,
+    // never required when the floor already grants access.
+    let grantIssuedAt: number | undefined;
     if (!isTierPermitted(tier, actionId, fullToolSurface)) {
-      try {
-        appendAuditRecord({
-          toolId: actionId,
-          sessionId,
-          tier,
-          args,
-          durationMs: Date.now() - startedAt,
-          outcome: { kind: "unauthorized" },
-        });
-      } catch (err) {
-        console.error("[MCP] Failed to append audit record:", err);
-      }
-      if (notifyTierMismatch) {
+      const grant = sessionStore.grantCache.check(sessionId, actionId);
+      if (!grant.granted) {
+        // Increment first, then ask the cache whether to suppress. The
+        // post-increment count reflects "this denial counted"; the cache's
+        // threshold compares against that. With threshold=2 the 1st and
+        // 2nd denials fire the banner and the 3rd+ are suppressed.
+        sessionStore.grantCache.incrementDenial(sessionId, actionId);
+        const suppressBanner = sessionStore.grantCache.shouldSuppressBanner(sessionId, actionId);
         try {
-          notifyTierMismatch({
-            sessionId,
+          appendAuditRecord({
             toolId: actionId,
+            sessionId,
             tier,
-            targetTier: minimumPermittingTier(actionId),
+            args,
+            durationMs: Date.now() - startedAt,
+            outcome: { kind: "unauthorized" },
+            bannerSuppressed: suppressBanner ? true : undefined,
           });
         } catch (err) {
-          console.error("[MCP] Failed to notify tier-mismatch:", err);
+          console.error("[MCP] Failed to append audit record:", err);
         }
+        if (notifyTierMismatch && !suppressBanner) {
+          try {
+            notifyTierMismatch({
+              sessionId,
+              toolId: actionId,
+              tier,
+              targetTier: minimumPermittingTier(actionId),
+            });
+          } catch (err) {
+            console.error("[MCP] Failed to notify tier-mismatch:", err);
+          }
+        }
+        return buildToolError({
+          code: TIER_NOT_PERMITTED_CODE,
+          message: `action '${actionId}' is not permitted for the '${tier}' tier.`,
+        });
       }
-      return buildToolError({
-        code: TIER_NOT_PERMITTED_CODE,
-        message: `action '${actionId}' is not permitted for the '${tier}' tier.`,
-      });
+      // Grant authorised the call. Capture the `issuedAt` token so the
+      // post-dispatch refresh can verify the entry wasn't revoked and
+      // re-issued under us (race guard, lesson #2243).
+      grantIssuedAt = grant.issuedAt;
     }
 
     // Idempotency dedup for the creation-tool allowlist. Same-moment duplicates
@@ -322,6 +352,21 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         }
 
         if (outcome.value.ok) {
+          // Sliding-TTL refresh: a successful dispatch through a grant
+          // extends its window AND resets the session idle timer. Without
+          // resetting the idle timer, a 15-min grant could be silently
+          // truncated by a 30-min idle reaper that started before the
+          // grant was issued (#8442). The `grantIssuedAt` token guards
+          // against a revoke-and-reissue race (#2243): if the entry was
+          // replaced mid-dispatch, `refresh` is a silent no-op.
+          if (grantIssuedAt !== undefined) {
+            sessionStore.grantCache.refresh(sessionId, actionId, grantIssuedAt);
+            if (sessionStore.sessions.has(sessionId)) {
+              sessionStore.resetIdleTimer(sessionId);
+            } else if (sessionStore.httpSessions.has(sessionId)) {
+              sessionStore.resetHttpIdleTimer(sessionId);
+            }
+          }
           const structuredContent = buildStructuredContent(entry, outcome.value.result);
           return {
             content: [

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -2,6 +2,18 @@ import type { ActionContext } from "../../../shared/types/actions.js";
 import type { McpTier, McpSseSession, McpHttpSession } from "./shared.js";
 import { MCP_SSE_IDLE_TIMEOUT_MS } from "./shared.js";
 import type { CallToolResultLike, DedupCacheEntry } from "./sessionDedup.js";
+import { GrantCache, type GrantLifecycleEmitter } from "./grantCache.js";
+
+export interface SessionStoreOptions {
+  /**
+   * Lifecycle emitter wired through to the {@link GrantCache} so audit
+   * entries and renderer broadcasts fire for every `issued`/`expired`/
+   * `revoked` transition. Optional so the bare `new SessionStore(...)`
+   * test fixture path still constructs without an emitter (the cache
+   * defaults to silent).
+   */
+  emitGrantLifecycle?: GrantLifecycleEmitter;
+}
 
 export class SessionStore {
   readonly sessions = new Map<string, McpSseSession>();
@@ -24,11 +36,22 @@ export class SessionStore {
   // return the original result). Cleared on drain and idle expiry.
   readonly dedupInFlight = new Map<string, Map<string, Promise<CallToolResultLike>>>();
   readonly dedupResultCache = new Map<string, Map<string, DedupCacheEntry>>();
+  /**
+   * Per-`(sessionId, toolId)` time-bounded grants — replaces the sticky
+   * `sessionTierMap` elevation pathway for the "Approve once" flow (#8442).
+   * Co-located with the other session-scoped maps so a single drain or
+   * idle-timer firing tears them down in lockstep.
+   */
+  readonly grantCache: GrantCache;
 
   private readonly cleanupResourceSubscriptionsFn: (sessionId: string) => void;
 
-  constructor(cleanupResourceSubscriptions: (sessionId: string) => void) {
+  constructor(
+    cleanupResourceSubscriptions: (sessionId: string) => void,
+    options: SessionStoreOptions = {}
+  ) {
     this.cleanupResourceSubscriptionsFn = cleanupResourceSubscriptions;
+    this.grantCache = new GrantCache({ emit: options.emitGrantLifecycle });
   }
 
   clearDedupState(sessionId: string): void {
@@ -45,6 +68,10 @@ export class SessionStore {
       this.sessionWebContentsMap.delete(sessionId);
       this.sessionContextMap.delete(sessionId);
       this.clearDedupState(sessionId);
+      // Revoke through the audit-emitting path so the trail closes
+      // (`grant.revoked` with `session-idle` reason) instead of silently
+      // dropping the entries.
+      this.grantCache.revokeSession(sessionId, "session-idle");
       this.cleanupResourceSubscriptionsFn(sessionId);
       session.transport.close().catch(() => {
         // ignore close errors during idle timeout cleanup
@@ -70,6 +97,7 @@ export class SessionStore {
       this.sessionWebContentsMap.delete(sessionId);
       this.sessionContextMap.delete(sessionId);
       this.clearDedupState(sessionId);
+      this.grantCache.revokeSession(sessionId, "session-idle");
       this.cleanupResourceSubscriptionsFn(sessionId);
       session.transport.close().catch(() => {
         // ignore close errors during idle timeout cleanup
@@ -123,6 +151,12 @@ export class SessionStore {
     this.sessionTierMap.clear();
     this.sessionWebContentsMap.clear();
     this.sessionContextMap.clear();
+    // Wholesale teardown: drop grants without per-entry audit noise but
+    // keep the sweep timer so the store can be reused after a subsequent
+    // `start()`. The audit ring buffer still carries each grant's original
+    // `grant.issued` entry; teardown is an environmental event, not a user
+    // action worth a `grant.revoked` per tool.
+    this.grantCache.clearAll();
 
     for (const bucket of this.resourceSubscriptions.values()) {
       for (const unsub of bucket.values()) {

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -65,13 +65,14 @@ export class SessionStore {
       if (!session) return;
       this.sessions.delete(sessionId);
       this.sessionTierMap.delete(sessionId);
+      // Revoke BEFORE deleting the WebContents pin so the lifecycle
+      // emitter can still resolve the pinned renderer and dispatch the
+      // `grant.revoked` event. The audit-record write tolerates a
+      // missing pin (it doesn't need one); the targeted `wc.send` does.
+      this.grantCache.revokeSession(sessionId, "session-idle");
       this.sessionWebContentsMap.delete(sessionId);
       this.sessionContextMap.delete(sessionId);
       this.clearDedupState(sessionId);
-      // Revoke through the audit-emitting path so the trail closes
-      // (`grant.revoked` with `session-idle` reason) instead of silently
-      // dropping the entries.
-      this.grantCache.revokeSession(sessionId, "session-idle");
       this.cleanupResourceSubscriptionsFn(sessionId);
       session.transport.close().catch(() => {
         // ignore close errors during idle timeout cleanup
@@ -94,10 +95,12 @@ export class SessionStore {
       if (!session) return;
       this.httpSessions.delete(sessionId);
       this.sessionTierMap.delete(sessionId);
+      // Revoke BEFORE deleting the WebContents pin — same reasoning
+      // as `createIdleTimer` above.
+      this.grantCache.revokeSession(sessionId, "session-idle");
       this.sessionWebContentsMap.delete(sessionId);
       this.sessionContextMap.delete(sessionId);
       this.clearDedupState(sessionId);
-      this.grantCache.revokeSession(sessionId, "session-idle");
       this.cleanupResourceSubscriptionsFn(sessionId);
       session.transport.close().catch(() => {
         // ignore close errors during idle timeout cleanup

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -67,6 +67,30 @@ export const DEFAULT_PORT = 45454;
 export const MAX_PORT_RETRIES = 10;
 export const MCP_SSE_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 
+/**
+ * Sliding-TTL window for per-tool grants minted via "Approve once". A grant
+ * issued for `(sessionId, toolId)` permits that exact tool for this session
+ * for the duration, and any successful dispatch through the grant refreshes
+ * the window. Sized comfortably below `MCP_SSE_IDLE_TIMEOUT_MS` so the
+ * 30-minute idle reaper can never silently cut a grant short — see #8442.
+ */
+export const MCP_GRANT_TTL_MS = 15 * 60 * 1000;
+
+/**
+ * Periodic sweep cadence for the grant cache's lazy-expiry map. Lazy
+ * eviction on read is the source of truth; the sweep is a memory-hygiene
+ * pass that keeps idle sessions' expired entries from accumulating between
+ * reads.
+ */
+export const MCP_GRANT_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Number of consecutive `(sessionId, toolId)` denials before the renderer
+ * banner is silenced. The audit record is always written. The counter
+ * resets when a grant is issued for the pair or when the session ends.
+ */
+export const MCP_DENIAL_SILENCE_THRESHOLD = 2;
+
 export const MCP_MANIFEST_REQUEST_TIMEOUT_MS = 5_000;
 export const MCP_DISPATCH_TIMEOUT_MS = 30_000;
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1412,13 +1412,32 @@ export interface ElectronAPI {
       callback: (snapshot: import("./mcpServer.js").McpRuntimeSnapshot) => void
     ): () => void;
     /**
-     * Elevate an active help-session's tier (Approve once). Server-side
-     * validates that the new tier is not a downgrade.
+     * Elevate an active help-session's tier (Always allow — pairs with a
+     * project-level `daintreeMcpTier` write). Server-side validates that
+     * the new tier is not a downgrade. The per-tool "Approve once" flow
+     * uses {@link issueGrant} instead (#8442).
      */
     setSessionTier(
       sessionId: string,
       tier: "workbench" | "action" | "system"
     ): Promise<{ sessionId: string; tier: "workbench" | "action" | "system" }>;
+    /**
+     * Mint a per-`(sessionId, toolId)` time-bounded grant — the "Approve
+     * once" pathway that replaces sticky session-tier elevation for one-
+     * off tool calls. Returns the TTL window so the renderer can render
+     * a countdown without polling (#8442).
+     */
+    issueGrant(
+      sessionId: string,
+      toolId: string
+    ): Promise<import("./mcpServer.js").McpIssueGrantResult>;
+    /**
+     * Drop every grant currently held by the session. Returns the count
+     * of revoked grants for the renderer's confirmation copy.
+     */
+    revokeSessionGrants(
+      sessionId: string
+    ): Promise<import("./mcpServer.js").McpRevokeSessionGrantsResult>;
     /**
      * Subscribe to tier-not-permitted pushes for the pinned help-session in
      * this WebContents. The callback fires when a tool call is denied because
@@ -1431,6 +1450,14 @@ export interface ElectronAPI {
         tier: string;
         targetTier: "workbench" | "action" | "system" | null;
       }) => void
+    ): () => void;
+    /**
+     * Subscribe to grant lifecycle events (`issued`, `expired`, `revoked`)
+     * for the pinned help-session in this WebContents. Targeted send —
+     * grant state is session-scoped (#8442).
+     */
+    onGrantLifecycle(
+      callback: (payload: import("./mcpServer.js").McpGrantLifecyclePayload) => void
     ): () => void;
   };
   helpAssistant: {

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1788,6 +1788,14 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [payload: { sessionId: string; tier: "workbench" | "action" | "system" }];
     result: { sessionId: string; tier: "workbench" | "action" | "system" };
   };
+  "mcp-server:issue-grant": {
+    args: [payload: { sessionId: string; toolId: string }];
+    result: import("./mcpServer.js").McpIssueGrantResult;
+  };
+  "mcp-server:revoke-session-grants": {
+    args: [payload: { sessionId: string }];
+    result: import("./mcpServer.js").McpRevokeSessionGrantsResult;
+  };
 
   // Webview console capture
   "webview:start-console-capture": {
@@ -2193,6 +2201,12 @@ export interface IpcEventMap {
     tier: string;
     targetTier: "workbench" | "action" | "system" | null;
   };
+
+  /**
+   * Targeted push: a grant lifecycle event for an MCP tool approval.
+   * Sent to the pinned WebContents so the renderer can track grant state.
+   */
+  "mcp-server:grant-lifecycle": import("./mcpServer.js").McpGrantLifecyclePayload;
 
   // Error events
   "error:notify": ErrorRecord;

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -69,6 +69,98 @@ export interface McpAuditRecord {
    * non-unauthorized outcomes.
    */
   tierHint?: "workbench" | "action" | "system" | null;
+  /**
+   * For `unauthorized` outcomes only, true when the renderer banner was
+   * suppressed for this denial because the per-`(sessionId, toolId)`
+   * consecutive-denial counter had reached `MCP_DENIAL_SILENCE_THRESHOLD`.
+   * The audit record is still written so persistent denials remain visible
+   * in the audit panel even when no banner fired. See #8442.
+   */
+  bannerSuppressed?: boolean;
+}
+
+/**
+ * Lifecycle event for a per-`(sessionId, toolId)` grant minted via the
+ * "Approve once" flow that replaces sticky session-tier elevation (#8442).
+ * Written in parallel with the dispatch audit ring buffer; renderers
+ * subscribe to a separate live broadcast for the same payload shape.
+ *
+ * - `grant.issued`: the renderer's `Approve once` minted a fresh grant.
+ *   `expiresAt` is set; `revokedReason` is absent.
+ * - `grant.expired`: a `check()` lazily evicted an entry whose `expiresAt`
+ *   passed. Emitted at most once per `(sessionId, toolId)` per grant. The
+ *   periodic sweep also drives this when an idle session's grant ages out
+ *   without a follow-up read.
+ * - `grant.revoked`: an explicit `revokeSessionGrants` IPC, a session
+ *   teardown, or an idle reaper firing wiped the grant before its TTL
+ *   elapsed. `revokedReason` distinguishes those sources.
+ */
+export type McpGrantRecordType = "grant.issued" | "grant.expired" | "grant.revoked";
+
+export type McpGrantRevokedReason = "user" | "session-ended" | "session-idle";
+
+export interface McpGrantRecord {
+  type: McpGrantRecordType;
+  id: string;
+  timestamp: number;
+  sessionId: string;
+  toolId: string;
+  /** TTL the grant was minted with, in milliseconds. */
+  ttlMs: number;
+  /**
+   * Absolute epoch millis when the grant would expire without refresh.
+   * Set on `grant.issued`; absent on `grant.expired`/`grant.revoked` (the
+   * grant has already been deleted by record-write time).
+   */
+  expiresAt?: number;
+  /** Source of the revocation; only set on `grant.revoked`. */
+  revokedReason?: McpGrantRevokedReason;
+}
+
+/**
+ * Union of all records persisted to the MCP server's ring buffer. Existing
+ * `McpAuditRecord` entries are implicitly the `dispatch` kind — they have
+ * no `type` field — and predate this union; the discriminator lives only
+ * on `McpGrantRecord` to keep the legacy on-disk shape unchanged. Readers
+ * narrow with `"type" in record` rather than a typeof check on a missing
+ * field.
+ */
+export type McpLogRecord = McpAuditRecord | McpGrantRecord;
+
+/**
+ * Live event payload broadcast to the pinned renderer for a grant
+ * transition. Mirrors `McpGrantRecord` because renderers want the same
+ * fields they'd see in the audit log. Send is targeted (never broadcast)
+ * because grant state is session-scoped.
+ */
+export interface McpGrantLifecyclePayload {
+  type: McpGrantRecordType;
+  sessionId: string;
+  toolId: string;
+  ttlMs: number;
+  expiresAt?: number;
+  revokedReason?: McpGrantRevokedReason;
+}
+
+/**
+ * Result of a renderer-driven `revokeSessionGrants` IPC. The handler
+ * deletes every grant for the named session and reports how many entries
+ * were affected — useful for UI confirmation copy ("Revoked N grants").
+ */
+export interface McpRevokeSessionGrantsResult {
+  sessionId: string;
+  revokedCount: number;
+}
+
+/**
+ * Result of a renderer-driven `issueGrant` IPC. Returns the `expiresAt`
+ * and `ttlMs` so the renderer can render a countdown without polling.
+ */
+export interface McpIssueGrantResult {
+  sessionId: string;
+  toolId: string;
+  ttlMs: number;
+  expiresAt: number;
 }
 
 /** Minimum and maximum values accepted for the configurable ring-buffer cap. */

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -471,6 +471,12 @@ beforeEach(() => {
         mcpServer: {
           onTierNotPermitted: vi.fn(() => () => {}),
           setSessionTier: vi.fn().mockResolvedValue({ sessionId: "", tier: "workbench" }),
+          issueGrant: vi.fn().mockResolvedValue({
+            sessionId: "",
+            toolId: "",
+            ttlMs: 900_000,
+            expiresAt: Date.now() + 900_000,
+          }),
         },
         git: {
           snapshotGet: vi.fn().mockResolvedValue(null),

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -404,6 +404,12 @@ beforeEach(() => {
         mcpServer: {
           onTierNotPermitted: vi.fn(() => () => {}),
           setSessionTier: vi.fn().mockResolvedValue({ sessionId: "", tier: "workbench" }),
+          issueGrant: vi.fn().mockResolvedValue({
+            sessionId: "",
+            toolId: "",
+            ttlMs: 900_000,
+            expiresAt: Date.now() + 900_000,
+          }),
         },
         git: {
           snapshotGet: vi.fn().mockResolvedValue(null),

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -628,27 +628,31 @@ export class HelpSessionController {
   approveTierOnce(): void {
     const current = this._snapshot.tierMismatch;
     if (!current?.targetTier || this._snapshot.isApprovingTier) return;
-    const { targetTier, sessionId, toolId } = current;
+    const { sessionId, toolId } = current;
     this._patch({ isApprovingTier: true });
     safeFireAndForget(
       window.electron.mcpServer
-        .setSessionTier(sessionId, targetTier)
+        // "Approve once" mints a per-tool, time-bounded grant for this
+        // session — it does NOT elevate the session tier. The "Always
+        // allow" path is the only remaining caller of `setSessionTier`
+        // (#8442).
+        .issueGrant(sessionId, toolId)
         .then(() => {
           this._clearTierMismatchIfStillCurrent(sessionId, toolId);
         })
         .catch((err) => {
-          logError("HelpPanel: setSessionTier failed", err);
+          logError("HelpPanel: issueGrant failed", err);
           // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
           notify({
             type: "error",
             title: "Couldn't approve tool",
-            message: formatErrorMessage(err, "Couldn't elevate the assistant's tier."),
+            message: formatErrorMessage(err, "Couldn't grant access to this tool."),
           });
         })
         .finally(() => {
           this._patch({ isApprovingTier: false });
         }),
-      { context: "HelpPanel:setSessionTier" }
+      { context: "HelpPanel:issueGrant" }
     );
   }
 

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockMcpOnTierNotPermitted,
   mockMcpSetSessionTier,
+  mockMcpIssueGrant,
   mockSystemSleepOnSuspend,
   mockSystemSleepOnWake,
   systemSleepListeners,
@@ -14,6 +15,12 @@ const {
 } = vi.hoisted(() => ({
   mockMcpOnTierNotPermitted: vi.fn(),
   mockMcpSetSessionTier: vi.fn().mockResolvedValue(undefined),
+  mockMcpIssueGrant: vi.fn().mockResolvedValue({
+    sessionId: "",
+    toolId: "",
+    ttlMs: 900_000,
+    expiresAt: Date.now() + 900_000,
+  }),
   mockSystemSleepOnSuspend: vi.fn(),
   mockSystemSleepOnWake: vi.fn(),
   systemSleepListeners: {
@@ -122,6 +129,13 @@ beforeEach(() => {
   });
   mockMcpSetSessionTier.mockReset();
   mockMcpSetSessionTier.mockResolvedValue(undefined);
+  mockMcpIssueGrant.mockReset();
+  mockMcpIssueGrant.mockResolvedValue({
+    sessionId: "",
+    toolId: "",
+    ttlMs: 900_000,
+    expiresAt: Date.now() + 900_000,
+  });
   mockSystemSleepOnSuspend.mockReset();
   mockSystemSleepOnSuspend.mockImplementation((cb: () => void) => {
     systemSleepListeners.suspend.push(cb);
@@ -164,6 +178,7 @@ beforeEach(() => {
         mcpServer: {
           onTierNotPermitted: mockMcpOnTierNotPermitted,
           setSessionTier: mockMcpSetSessionTier,
+          issueGrant: mockMcpIssueGrant,
         },
         git: { snapshotGet: vi.fn().mockResolvedValue(null) },
         terminal: { gracefulKill: vi.fn().mockResolvedValue(null) },
@@ -316,7 +331,7 @@ describe("HelpSessionController — syncInputs", () => {
 });
 
 describe("HelpSessionController — tier-mismatch handlers", () => {
-  it("approveTierOnce() calls setSessionTier and clears banner on success", async () => {
+  it("approveTierOnce() calls issueGrant (per-tool) and clears banner on success", async () => {
     const ctrl = new HelpSessionController();
     ctrl.start();
     tierListeners[0]?.({
@@ -329,7 +344,10 @@ describe("HelpSessionController — tier-mismatch handlers", () => {
 
     ctrl.approveTierOnce();
     expect(ctrl.getSnapshot().isApprovingTier).toBe(true);
-    expect(mockMcpSetSessionTier).toHaveBeenCalledWith("s1", "action");
+    // "Approve once" is now a per-tool grant (#8442) — it must NOT
+    // elevate the session tier, only mint a grant for this exact tool.
+    expect(mockMcpIssueGrant).toHaveBeenCalledWith("s1", "t1");
+    expect(mockMcpSetSessionTier).not.toHaveBeenCalled();
 
     await vi.waitFor(() => {
       expect(ctrl.getSnapshot().isApprovingTier).toBe(false);
@@ -348,9 +366,9 @@ describe("HelpSessionController — tier-mismatch handlers", () => {
       targetTier: "action",
     });
     ctrl.approveTierOnce();
-    const callsBefore = mockMcpSetSessionTier.mock.calls.length;
+    const callsBefore = mockMcpIssueGrant.mock.calls.length;
     ctrl.approveTierOnce();
-    expect(mockMcpSetSessionTier.mock.calls.length).toBe(callsBefore);
+    expect(mockMcpIssueGrant.mock.calls.length).toBe(callsBefore);
     ctrl.stop();
   });
 


### PR DESCRIPTION
## Summary

Previously, approving any tool kept the entire MCP session elevated until it ended — the same request-fatigue anti-pattern Azure PIM documents. One approval, unlimited blast radius, for the session lifetime.

This replaces that with a per-`(sessionId, toolId)` grant cache with a 15-minute sliding TTL. Grants are scoped, time-bounded, and lazy-expiring. Denial-silencing kicks in after 2 dismissals so we stop re-prompting when the user has made their intent clear.

The "always allow" path still calls `setSessionTier` — that's an intentional standing permission, not an oversight.

## Changes

**Grant cache (`grantCache.ts`)**
- Per-`(sessionId, toolId)` grant records with 15-min sliding TTL and lazy expiry
- Race-guard token: `refresh()` accepts the `issuedAt` token from `check()`; a revoke+reissue between check and dispatch completion silently no-ops the refresh
- Grant cache cleared on transport close

**Authorization layers**
- Static `TIER_ALLOWLISTS` remain the floor
- Grant cache is the additive fallback — either a static allowlist hit or a valid grant entry authorizes the request

**Idle-reaper race**
- Successful grant dispatch resets the session idle timer, so a 15-min grant can't be silently truncated by the 30-min idle reaper

**Audit + IPC**
- New `McpGrantRecord` audit variant in `auditLog.ts`
- Targeted `MCP_GRANT_LIFECYCLE` broadcast in `httpLifecycle.ts`
- Session-level revoke IPC wired into `channels.ts`, `handlers/mcpServer.ts`, `preload.cts`, and the typed IPC maps

**Renderer**
- `HelpSessionController.approveTierOnce` now calls `window.electron.mcpServer.issueGrant(sessionId, toolId)` instead of `setSessionTier`

## Testing

- 21 new `grantCache` unit tests covering TTL, TTL refresh, lazy expiry, race guard, denial-silencing, and transport-close clearing
- 6 new `sessionServer` grant-fallback tests
- `sessionStore` idle-timer ordering test
- `waitUntilIdle` TTL refresh test
- Updated `HelpSessionController` and `HelpPanel` test mocks

Closes #8442