### PR TITLE
fix(terminal): prevent focus jumping from xterm back to hybrid input on agent panes

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -63,6 +63,7 @@ import { useHostReparent } from "./hooks/useHostReparent";
 export interface HybridInputBarHandle {
   focus: () => void;
   focusWithCursorAtEnd: () => void;
+  cancelPendingFocus: () => void;
 }
 
 export interface HybridInputBarProps {
@@ -160,6 +161,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
     const menuRef = useRef<HTMLDivElement | null>(null);
     const rootRef = useRef<HTMLDivElement | null>(null);
     const lastEmittedValueRef = useRef<string>(value);
+    const focusGenerationRef = useRef(0);
     const [atContext, setAtContext] = useState<AtFileContext | null>(null);
     const [slashContext, setSlashContext] = useState<SlashCommandContext | null>(null);
     const [diffContext, setDiffContext] = useState<AtDiffContext | null>(null);
@@ -485,7 +487,12 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       const view = editorViewRef.current;
       if (!view) return;
       view.focus();
-      requestAnimationFrame(() => view.focus());
+      const gen = focusGenerationRef.current;
+      requestAnimationFrame(() => {
+        if (focusGenerationRef.current !== gen) return;
+        if (usePanelStore.getState().preferredTerminalFocusTarget !== "hybridInput") return;
+        view.focus();
+      });
     };
 
     const handleHistoryNavigation = (direction: "up" | "down"): boolean => {
@@ -538,14 +545,20 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         focusWithCursorAtEnd: () => {
           const view = editorViewRef.current;
           if (!view) return;
+          const gen = focusGenerationRef.current;
           requestAnimationFrame(() => {
+            if (focusGenerationRef.current !== gen) return;
             if (editorViewRef.current !== view) return;
             view.dispatch({
               selection: EditorSelection.cursor(view.state.doc.length),
               scrollIntoView: true,
             });
+            if (usePanelStore.getState().preferredTerminalFocusTarget !== "hybridInput") return;
             view.focus();
           });
+        },
+        cancelPendingFocus: () => {
+          focusGenerationRef.current += 1;
         },
       }),
       [focusEditor]

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -490,6 +490,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       const gen = focusGenerationRef.current;
       requestAnimationFrame(() => {
         if (focusGenerationRef.current !== gen) return;
+        if (editorViewRef.current !== view) return;
         if (usePanelStore.getState().preferredTerminalFocusTarget !== "hybridInput") return;
         view.focus();
       });
@@ -549,11 +550,11 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
           requestAnimationFrame(() => {
             if (focusGenerationRef.current !== gen) return;
             if (editorViewRef.current !== view) return;
+            if (usePanelStore.getState().preferredTerminalFocusTarget !== "hybridInput") return;
             view.dispatch({
               selection: EditorSelection.cursor(view.state.doc.length),
               scrollIntoView: true,
             });
-            if (usePanelStore.getState().preferredTerminalFocusTarget !== "hybridInput") return;
             view.focus();
           });
         },

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -800,6 +800,7 @@ function TerminalPaneComponent({
         cancelled = true;
         cancelAnimationFrame(outerRafId);
         if (innerRafId !== undefined) cancelAnimationFrame(innerRafId);
+        inputBarRef.current?.cancelPendingFocus();
       };
     }
 


### PR DESCRIPTION
## Summary
- Orphaned `requestAnimationFrame` callbacks in `HybridInputBar`'s imperative handle were stealing focus back from xterm after the user clicked into the terminal.
- Added a generation counter (`focusGenerationRef`) and `cancelPendingFocus()` to the imperative handle so stale RAFs bail before firing.
- `TerminalPane` calls `cancelPendingFocus()` in its focus effect cleanup to invalidate any in-flight RAFs when focus changes.

Resolves #8487

## Changes
- `HybridInputBar.tsx` -- added `focusGenerationRef` + `cancelPendingFocus()` to the imperative handle; gated `focusEditor`'s second RAF and `focusWithCursorAtEnd`'s RAF on generation staleness + fresh `preferredTerminalFocusTarget`; added stale-editor guard to `focusEditor`
- `TerminalPane.tsx` -- hoisted preference check above `view.dispatch()` so cursor doesn't silently jump when the preference flips; calls `cancelPendingFocus()` in the focus effect cleanup

## Testing
All 639 terminal tests pass. Typecheck, eslint, and format:check all clean.