### PR TITLE
fix(mcp): make tool annotations and outputSchema spec-truthful

### DIFF
--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -626,14 +626,14 @@ describe("McpServerService", () => {
     });
     expect(dangerousTool?.inputSchema.properties?._meta).toBeUndefined();
 
-    // Annotations — query tool. Spec-conservative defaults: destructiveHint
-    // and openWorldHint are true unless overridden; readOnly/idempotent still
-    // derive from kind: "query".
+    // Annotations — query tool. readOnly/idempotent from kind: "query";
+    // destructiveHint is false for queries (already declared read-only);
+    // openWorldHint defaults to true per spec.
     expect(safeTool?.annotations).toEqual({
       title: "List Actions",
       readOnlyHint: true,
       idempotentHint: true,
-      destructiveHint: true,
+      destructiveHint: false,
       openWorldHint: true,
     });
 
@@ -716,12 +716,13 @@ describe("McpServerService", () => {
 
     // Explicit `false` overrides must win over kind-derived defaults —
     // this would silently break if `??` were ever swapped for `||`.
-    // destructiveHint/openWorldHint now default to true per spec.
+    // destructiveHint is false for queries (!isQuery); openWorldHint defaults
+    // to true per spec.
     expect(queryFalse?.annotations).toEqual({
       title: "Query With False Overrides",
       readOnlyHint: false,
       idempotentHint: false,
-      destructiveHint: true,
+      destructiveHint: false,
       openWorldHint: true,
     });
   });

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -626,13 +626,15 @@ describe("McpServerService", () => {
     });
     expect(dangerousTool?.inputSchema.properties?._meta).toBeUndefined();
 
-    // Annotations — query tool
+    // Annotations — query tool. Spec-conservative defaults: destructiveHint
+    // and openWorldHint are true unless overridden; readOnly/idempotent still
+    // derive from kind: "query".
     expect(safeTool?.annotations).toEqual({
       title: "List Actions",
       readOnlyHint: true,
       idempotentHint: true,
-      destructiveHint: false,
-      openWorldHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
     });
 
     // Annotations — destructive tool. `destructiveHint: true` is the
@@ -643,7 +645,7 @@ describe("McpServerService", () => {
       readOnlyHint: false,
       idempotentHint: false,
       destructiveHint: true,
-      openWorldHint: false,
+      openWorldHint: true,
     });
   });
 
@@ -693,47 +695,56 @@ describe("McpServerService", () => {
     const queryFalse = result.tools.find((t) => t.name === "test.queryOverriddenFalse");
 
     // Override flips destructiveHint off; readOnlyHint/idempotentHint still
-    // come from the `kind: "query"` default.
+    // come from the `kind: "query"` default. openWorldHint now defaults to true.
     expect(generate?.annotations).toEqual({
       title: "Generate Context",
       readOnlyHint: true,
       idempotentHint: true,
       destructiveHint: false,
-      openWorldHint: false,
+      openWorldHint: true,
     });
 
-    // Override flips readOnly/idempotent on; destructiveHint still comes from
-    // the `danger: "safe"` default.
+    // Override flips readOnly/idempotent on; destructiveHint and openWorldHint
+    // now come from the spec-conservative true defaults.
     expect(readOnlyCmd?.annotations).toEqual({
       title: "Read Only Command",
       readOnlyHint: true,
       idempotentHint: true,
-      destructiveHint: false,
-      openWorldHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
     });
 
-    // Explicit `false` overrides must win over the `kind: "query"` default —
+    // Explicit `false` overrides must win over kind-derived defaults —
     // this would silently break if `??` were ever swapped for `||`.
+    // destructiveHint/openWorldHint now default to true per spec.
     expect(queryFalse?.annotations).toEqual({
       title: "Query With False Overrides",
       readOnlyHint: false,
       idempotentHint: false,
-      destructiveHint: false,
-      openWorldHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
     });
   });
 
-  it("ignores attempts to override openWorldHint via mcpAnnotations", async () => {
+  it("allows overriding openWorldHint via mcpAnnotations", async () => {
     storeState.mcpServer.fullToolSurface = true;
     const { window } = createMockWindow({
       getManifest: () => [
-        // openWorldHint is category-derived; mcpAnnotations exposes only the
-        // three hint fields, so this entry's `category: "github"` must yield
-        // `openWorldHint: true` regardless of any per-action override.
+        // openWorldHint defaults to true; explicit false override must win.
+        createManifestEntry({
+          id: "keybinding.resetAll" as ActionId,
+          title: "Reset All Keybindings",
+          description: "Local-only destructive action",
+          category: "settings",
+          kind: "command",
+          danger: "confirm",
+          mcpAnnotations: { openWorldHint: false },
+        }),
+        // No override — must default to true (spec-conservative).
         createManifestEntry({
           id: "github.someTool" as ActionId,
           title: "Some GitHub Tool",
-          description: "Tool in an open-world category",
+          description: "Tool without openWorldHint override",
           category: "github",
           kind: "command",
           danger: "safe",
@@ -751,12 +762,14 @@ describe("McpServerService", () => {
     transports.push(transport);
 
     const result = await client.listTools();
-    const tool = result.tools.find((t) => t.name === "github.someTool");
+    const localTool = result.tools.find((t) => t.name === "keybinding.resetAll");
+    const ghTool = result.tools.find((t) => t.name === "github.someTool");
 
-    expect(tool?.annotations?.openWorldHint).toBe(true);
+    expect(localTool?.annotations?.openWorldHint).toBe(false);
+    expect(ghTool?.annotations?.openWorldHint).toBe(true);
   });
 
-  it("sets openWorldHint true for network-bound categories and false for local ones", async () => {
+  it("defaults openWorldHint to true for all categories per spec", async () => {
     storeState.mcpServer.fullToolSurface = true;
     const { window } = createMockWindow({
       getManifest: () => [
@@ -795,7 +808,7 @@ describe("McpServerService", () => {
 
     expect(ghTool?.annotations?.openWorldHint).toBe(true);
     expect(systemTool?.annotations?.openWorldHint).toBe(true);
-    expect(wtTool?.annotations?.openWorldHint).toBe(false);
+    expect(wtTool?.annotations?.openWorldHint).toBe(true);
   });
 
   it("falls back to renderer-modal dispatch when the client does not support elicitation", async () => {

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -27,7 +27,6 @@ import {
   SYSTEM_TIER_ADDONS as SYSTEM_TIER_ADDONS_LIST,
   WORKBENCH_TIER_TOOLS as WORKBENCH_TIER_TOOLS_LIST,
 } from "../../../shared/config/helpAssistantTierAllowlists.js";
-import { RISK_BAND_OPEN_WORLD_CATEGORIES } from "../../../shared/utils/actionRiskBand.js";
 
 export {
   type WaitUntilIdleResult,
@@ -210,8 +209,6 @@ export function buildToolError(input: {
     isError: true,
   };
 }
-
-export { RISK_BAND_OPEN_WORLD_CATEGORIES as OPEN_WORLD_CATEGORIES };
 
 export type McpTier = "workbench" | "action" | "system" | "external";
 

--- a/electron/services/mcp-server/tierAuth.ts
+++ b/electron/services/mcp-server/tierAuth.ts
@@ -131,7 +131,7 @@ export function buildAnnotations(entry: ActionManifestEntry): ToolAnnotations {
     title: entry.title,
     readOnlyHint: overrides?.readOnlyHint ?? isQuery,
     idempotentHint: overrides?.idempotentHint ?? isQuery,
-    destructiveHint: overrides?.destructiveHint ?? true,
+    destructiveHint: overrides?.destructiveHint ?? !isQuery,
     openWorldHint: overrides?.openWorldHint ?? true,
   };
 }

--- a/electron/services/mcp-server/tierAuth.ts
+++ b/electron/services/mcp-server/tierAuth.ts
@@ -4,7 +4,7 @@ import { deriveBand, BAND_OVERRIDES } from "../../../shared/utils/actionRiskBand
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { mcpPaneConfigService } from "../McpPaneConfigService.js";
 import type { HelpTokenValidator } from "./shared.js";
-import { type McpTier, OPEN_WORLD_CATEGORIES, TIER_ALLOWLISTS } from "./shared.js";
+import { type McpTier, TIER_ALLOWLISTS } from "./shared.js";
 
 export { deriveBand, BAND_OVERRIDES };
 
@@ -131,8 +131,8 @@ export function buildAnnotations(entry: ActionManifestEntry): ToolAnnotations {
     title: entry.title,
     readOnlyHint: overrides?.readOnlyHint ?? isQuery,
     idempotentHint: overrides?.idempotentHint ?? isQuery,
-    destructiveHint: overrides?.destructiveHint ?? entry.danger === "confirm",
-    openWorldHint: OPEN_WORLD_CATEGORIES.has(entry.category),
+    destructiveHint: overrides?.destructiveHint ?? true,
+    openWorldHint: overrides?.openWorldHint ?? true,
   };
 }
 

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -17,19 +17,17 @@ export type RiskBand =
 export type ActionScope = "renderer";
 
 /**
- * Explicit MCP tool annotation overrides. Only the hints that can be
- * meaningfully decoupled from `kind`/`danger` are exposed here — `title` is
- * always sourced from the action title and `openWorldHint` is derived from the
- * action category. Provide an override only when the heuristic from `kind` and
- * `danger` doesn't reflect the action's true semantics for an MCP client (for
- * example, a query that requires UX confirmation, or a status command that is
- * read-only). Defined inline (no `@modelcontextprotocol/sdk` import) so this
- * type stays usable from the renderer.
+ * Explicit MCP tool annotation overrides. The spec defaults to a conservative
+ * posture (destructive, open-world) — override only when the action's true
+ * semantics differ from that default. `title` is always sourced from the action
+ * title. Defined inline (no `@modelcontextprotocol/sdk` import) so this type
+ * stays usable from the renderer.
  */
 export interface ActionMcpAnnotations {
   readOnlyHint?: boolean;
   destructiveHint?: boolean;
   idempotentHint?: boolean;
+  openWorldHint?: boolean;
 }
 
 export type BuiltInActionId = BuiltInKeyAction | BuiltInRuntimeActionId;
@@ -105,7 +103,8 @@ export interface ActionDefinition<
   keywords?: string[];
   /**
    * Per-action MCP tool annotation overrides. Use sparingly — only when the
-   * defaults derived from `kind` and `danger` would mislead an MCP client.
+   * spec-conservative defaults (destructive, open-world) would mislead an MCP
+   * client.
    */
   mcpAnnotations?: ActionMcpAnnotations;
   /**
@@ -120,6 +119,14 @@ export interface ActionDefinition<
    * same reasoning the model would. Required when `danger !== "safe"`.
    */
   dangerRationale?: string;
+  /**
+   * Opt-in flag to expose `outputSchema` on the MCP tool manifest. When true
+   * and `resultSchema` is set, the Zod schema is converted to JSON Schema and
+   * surfaced as `outputSchema`, enabling structured `structuredContent` on
+   * `tools/call` responses. Use sparingly — only for naturally-structured
+   * results where the schema adds real value for programmatic consumers.
+   */
+  mcpOutputSchema?: boolean;
 }
 
 export interface ActionManifestEntry {

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -98,10 +98,13 @@ function isElectronApiAvailable(): boolean {
 /**
  * Converts a zod schema to JSON Schema format using Zod v4's native toJSONSchema.
  */
-function zodSchemaToJsonSchema(schema: z.ZodType): Record<string, unknown> | undefined {
+function zodSchemaToJsonSchema(
+  schema: z.ZodType,
+  io: "input" | "output" = "input"
+): Record<string, unknown> | undefined {
   try {
     return z.toJSONSchema(schema, {
-      io: "input",
+      io,
       unrepresentable: "any",
       reused: "inline",
       cycles: "ref",
@@ -175,9 +178,10 @@ function computeManifestPartials(definition: AnyActionDefinition): CachedManifes
     inputSchema: definition.argsSchema
       ? zodSchemaToJsonSchema(definition.argsSchema)
       : definition.rawInputSchema,
-    outputSchema: definition.resultSchema
-      ? zodSchemaToJsonSchema(definition.resultSchema)
-      : definition.rawOutputSchema,
+    outputSchema:
+      definition.mcpOutputSchema && definition.resultSchema
+        ? zodSchemaToJsonSchema(definition.resultSchema, "output")
+        : definition.rawOutputSchema,
     requiresArgs: definition.argsSchema
       ? !definition.argsSchema.safeParse(undefined).success &&
         !definition.argsSchema.safeParse({}).success

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -181,7 +181,9 @@ function computeManifestPartials(definition: AnyActionDefinition): CachedManifes
     outputSchema:
       definition.mcpOutputSchema && definition.resultSchema
         ? zodSchemaToJsonSchema(definition.resultSchema, "output")
-        : definition.rawOutputSchema,
+        : definition.mcpOutputSchema
+          ? definition.rawOutputSchema
+          : undefined,
     requiresArgs: definition.argsSchema
       ? !definition.argsSchema.safeParse(undefined).success &&
         !definition.argsSchema.safeParse({}).success

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -166,6 +166,7 @@ describe("ActionService", () => {
         danger: "safe",
         scope: "renderer",
         rawOutputSchema: rawOutput,
+        mcpOutputSchema: true,
         run: vi.fn().mockResolvedValue({ ok: true }),
       };
       service.register(action as unknown as ActionDefinition);
@@ -186,6 +187,7 @@ describe("ActionService", () => {
         scope: "renderer",
         resultSchema: z.object({ canonical: z.string() }),
         rawOutputSchema: rawOutput,
+        mcpOutputSchema: true,
         run: vi.fn().mockResolvedValue({ canonical: "x" }),
       };
       service.register(action as unknown as ActionDefinition);

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -42,6 +42,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         location: LaunchLocationSchema,
       })
       .nullable(),
+    mcpOutputSchema: true,
     run: async (args: unknown) => {
       const {
         agentId,

--- a/src/services/actions/definitions/keybindingActions.ts
+++ b/src/services/actions/definitions/keybindingActions.ts
@@ -64,6 +64,7 @@ export function registerKeybindingActions(
     dangerRationale:
       "Resets all keybinding overrides to defaults. All custom shortcuts are permanently lost.",
     keywords: ["shortcuts", "hotkeys", "defaults", "restore"],
+    mcpAnnotations: { openWorldHint: false },
     run: async () => {
       await keybindingService.resetAllOverrides();
       return keybindingService.getOverridesSnapshot();


### PR DESCRIPTION
## Summary
- Flips `destructiveHint` and `openWorldHint` defaults to match the MCP spec's conservative posture — both now default to `true`, with `destructiveHint` set to `false` for read-only queries. Per-action overrides suppress explicitly when an action genuinely isn't destructive or open-world.
- Removes the `OPEN_WORLD_CATEGORIES` set, replaced by the `openWorldHint` field on `ActionMcpAnnotations` so every action can express its own semantics instead of being lumped into a coarse category bucket.
- Gates `outputSchema` behind an opt-in `mcpOutputSchema` flag on `ActionDefinition`. The seed cohort is `agent.launch`.

Resolves #8464

## Changes
- `buildAnnotations` in `tierAuth.ts`: defaults flipped to spec-conservative (`destructiveHint: !isQuery`, `openWorldHint: true`)
- `ActionMcpAnnotations` in `shared/types/actions.ts`: `openWorldHint` added to the override surface
- `ActionDefinition` in `shared/types/actions.ts`: new `mcpOutputSchema` opt-in flag
- `ActionService.ts`: `outputSchema` derivation gated on `mcpOutputSchema`; `io: "output"` passed to `z.toJSONSchema` for correct JSON Schema direction
- `agentActions.ts`: `agent.launch` gets `mcpOutputSchema: true`
- `keybindingActions.ts`: `keybinding.resetAll` gets `openWorldHint: false` (local-only)
- Tests updated across `McpServerService.test.ts` for the new defaults and override behavior

## Testing
- `McpServerService.test.ts` — annotation defaults, override precedence, `openWorldHint` per-action override, `outputSchema` presence
- Full typecheck passes (renderer + main + preload)
- Prettier and ESLint clean