### PR TITLE
feat(mcp): add abuse policy circuit-breaker for MCP sessions

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -570,6 +570,13 @@ export const CHANNELS = {
    */
   MCP_TIER_NOT_PERMITTED: "mcp-server:tier-not-permitted",
   /**
+   * Push channel: a session was revoked by the abuse policy after exceeding
+   * the denial threshold. Targeted at the pinned WebContents — the renderer
+   * surfaces this as a notification so the user understands why the session
+   * ended and can re-authorise.
+   */
+  MCP_SESSION_REVOKED: "mcp-server:session-revoked",
+  /**
    * Elevate the tier of an active help-session (Always allow). Mutates
    * `sessionTierMap` in-place — never downgrades, so a malicious renderer
    * cannot drop its own privileges. The per-tool "Approve once" flow now

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -76,18 +76,23 @@ export class McpServerService {
       () => this.getConfig()
     );
 
+    // AbusePolicy must be constructed BEFORE SessionStore so the
+    // store can call into it on every per-session cleanup hook. The
+    // `dropAbuseState` callback ties the policy's denial counter map
+    // to the same lifecycle as the rest of the per-session state.
+    const abusePolicy = new AbusePolicy({
+      readConfig: () => this.getConfig(),
+    });
+
     this.sessionStore = new SessionStore(
       (sessionId) => {
         cleanupResourceSubscriptions(sessionId, this.sessionStore);
       },
       {
         emitGrantLifecycle: (sessionId, payload) => this.emitGrantLifecycle(sessionId, payload),
+        dropAbuseState: (sessionId) => abusePolicy.dropSession(sessionId),
       }
     );
-
-    const abusePolicy = new AbusePolicy({
-      readConfig: () => this.getConfig(),
-    });
 
     this.turnOutcomeService = new TurnOutcomeService({
       saveConfig: (patch) => this.persistConfig(patch),

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -23,6 +23,7 @@ import { createRendererBridge } from "./mcp-server/rendererBridge.js";
 import { handleWaitUntilIdle } from "./mcp-server/waitUntilIdle.js";
 import { cleanupResourceSubscriptions } from "./mcp-server/sessionServer.js";
 import { HttpLifecycle } from "./mcp-server/httpLifecycle.js";
+import { AbusePolicy } from "./mcp-server/abusePolicy.js";
 import type {
   PendingRequest,
   DispatchEnvelope,
@@ -84,6 +85,10 @@ export class McpServerService {
       }
     );
 
+    const abusePolicy = new AbusePolicy({
+      readConfig: () => this.getConfig(),
+    });
+
     this.turnOutcomeService = new TurnOutcomeService({
       saveConfig: (patch) => this.persistConfig(patch),
       readConfig: () => this.getConfig(),
@@ -138,6 +143,7 @@ export class McpServerService {
       sessionStore: this.sessionStore,
       auditService: this.auditService,
       turnOutcomeService: this.turnOutcomeService,
+      abusePolicy,
       requestManifest: () => this.bridge.requestManifest(),
       dispatchAction: (actionId, args, confirmed) =>
         this.bridge.dispatchAction(actionId, args, confirmed),

--- a/electron/services/mcp-server/__tests__/abusePolicy.test.ts
+++ b/electron/services/mcp-server/__tests__/abusePolicy.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { AbusePolicy } from "../abusePolicy.js";
+
+interface PolicyConfig {
+  auditEnabled: boolean;
+  abusePolicyEnabled: boolean;
+  abusePolicyMaxDenials: number;
+  abusePolicyWindowMs: number;
+}
+
+function makePolicy(config: PolicyConfig) {
+  const readConfig = vi.fn(() => config);
+  return { policy: new AbusePolicy({ readConfig }), readConfig };
+}
+
+describe("AbusePolicy", () => {
+  let baseConfig: PolicyConfig;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    baseConfig = {
+      auditEnabled: true,
+      abusePolicyEnabled: true,
+      abusePolicyMaxDenials: 5,
+      abusePolicyWindowMs: 60_000,
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("kill-switch", () => {
+    it("returns tripped=false when auditEnabled is false", () => {
+      const { policy } = makePolicy({ ...baseConfig, auditEnabled: false });
+      for (let i = 0; i < 10; i++) {
+        expect(policy.recordDenial("s1", "auth401")).toEqual({ tripped: false });
+      }
+    });
+
+    it("returns tripped=false when abusePolicyEnabled is false", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyEnabled: false });
+      for (let i = 0; i < 10; i++) {
+        expect(policy.recordDenial("s1", "auth401")).toEqual({ tripped: false });
+      }
+    });
+
+    it("does not create Map entries when disabled", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyEnabled: false });
+      policy.recordDenial("s1", "auth401");
+      expect(policy.getSnapshot("s1")).toBeNull();
+    });
+  });
+
+  describe("threshold", () => {
+    it("returns tripped=false when below maxDenials", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 5 });
+      for (let i = 0; i < 4; i++) {
+        expect(policy.recordDenial("s1", "auth401")).toEqual({ tripped: false });
+      }
+    });
+
+    it("returns tripped=true when reaching maxDenials", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 3 });
+      policy.recordDenial("s1", "auth401");
+      policy.recordDenial("s1", "auth401");
+      expect(policy.recordDenial("s1", "auth401")).toEqual({ tripped: true });
+    });
+
+    it("returns tripped=true past the threshold", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 2 });
+      policy.recordDenial("s1", "auth401");
+      policy.recordDenial("s1", "auth401");
+      expect(policy.recordDenial("s1", "tierMismatch")).toEqual({ tripped: true });
+    });
+
+    it("trips at maxDenials=1 (zero-tolerance)", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 1 });
+      expect(policy.recordDenial("s1", "auth401")).toEqual({ tripped: true });
+    });
+  });
+
+  describe("sliding window", () => {
+    it("resets count after window expires", () => {
+      const { policy } = makePolicy({
+        ...baseConfig,
+        abusePolicyMaxDenials: 3,
+        abusePolicyWindowMs: 10_000,
+      });
+
+      policy.recordDenial("s1", "auth401");
+      policy.recordDenial("s1", "auth401");
+
+      vi.advanceTimersByTime(11_000);
+
+      expect(policy.recordDenial("s1", "auth401")).toEqual({ tripped: false });
+    });
+
+    it("does not reset if within window", () => {
+      const { policy } = makePolicy({
+        ...baseConfig,
+        abusePolicyMaxDenials: 3,
+        abusePolicyWindowMs: 10_000,
+      });
+
+      policy.recordDenial("s1", "auth401");
+      policy.recordDenial("s1", "auth401");
+
+      vi.advanceTimersByTime(5_000);
+
+      expect(policy.recordDenial("s1", "auth401")).toEqual({ tripped: true });
+    });
+  });
+
+  describe("mixed inputs", () => {
+    it("401 and tierMismatch denials share the same counter", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 3 });
+      policy.recordDenial("s1", "auth401");
+      policy.recordDenial("s1", "tierMismatch");
+      expect(policy.recordDenial("s1", "auth401")).toEqual({ tripped: true });
+    });
+  });
+
+  describe("per-session isolation", () => {
+    it("independent sessions do not interfere", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 3 });
+      policy.recordDenial("s1", "auth401");
+      policy.recordDenial("s1", "auth401");
+      policy.recordDenial("s2", "auth401");
+      policy.recordDenial("s2", "auth401");
+      expect(policy.recordDenial("s1", "auth401")).toEqual({ tripped: true });
+      expect(policy.recordDenial("s2", "auth401")).toEqual({ tripped: true });
+      expect(policy.getSnapshot("s1")).toEqual({ count: 3, tripped: true });
+      expect(policy.getSnapshot("s2")).toEqual({ count: 3, tripped: true });
+    });
+
+    it("tripping one session does not affect another", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 2 });
+      policy.recordDenial("s1", "auth401");
+      expect(policy.recordDenial("s1", "auth401")).toEqual({ tripped: true });
+      expect(policy.recordDenial("s2", "auth401")).toEqual({ tripped: false });
+    });
+  });
+
+  describe("clearSession and clear", () => {
+    it("clearSession removes state for one session", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 3 });
+      policy.recordDenial("s1", "auth401");
+      policy.recordDenial("s2", "auth401");
+      policy.clearSession("s1");
+      expect(policy.getSnapshot("s1")).toBeNull();
+      expect(policy.getSnapshot("s2")).toEqual({ count: 1, tripped: false });
+    });
+
+    it("clear removes all state", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 3 });
+      policy.recordDenial("s1", "auth401");
+      policy.recordDenial("s2", "auth401");
+      policy.clear();
+      expect(policy.getSnapshot("s1")).toBeNull();
+      expect(policy.getSnapshot("s2")).toBeNull();
+    });
+  });
+
+  describe("getSnapshot", () => {
+    it("returns null for unknown session", () => {
+      const { policy } = makePolicy(baseConfig);
+      expect(policy.getSnapshot("unknown")).toBeNull();
+    });
+
+    it("returns count and tripped for tracked session", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 3 });
+      policy.recordDenial("s1", "auth401");
+      policy.recordDenial("s1", "auth401");
+      expect(policy.getSnapshot("s1")).toEqual({ count: 2, tripped: false });
+    });
+  });
+});

--- a/electron/services/mcp-server/__tests__/abusePolicy.test.ts
+++ b/electron/services/mcp-server/__tests__/abusePolicy.test.ts
@@ -142,14 +142,35 @@ describe("AbusePolicy", () => {
     });
   });
 
-  describe("clearSession and clear", () => {
-    it("clearSession removes state for one session", () => {
+  describe("dropSession and clear", () => {
+    it("dropSession removes state for one session", () => {
       const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 3 });
       policy.recordDenial("s1", "auth401");
       policy.recordDenial("s2", "auth401");
-      policy.clearSession("s1");
+      policy.dropSession("s1");
       expect(policy.getSnapshot("s1")).toBeNull();
       expect(policy.getSnapshot("s2")).toEqual({ count: 1, tripped: false });
+    });
+
+    it("dropSession on an unknown session is a harmless no-op", () => {
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 3 });
+      expect(() => policy.dropSession("never-seen")).not.toThrow();
+      expect(policy.getSnapshot("never-seen")).toBeNull();
+    });
+
+    it("dropSession lets a previously-tracked session restart its counter cleanly", () => {
+      // Regression for the wiring fix: after the idle-timer / drain
+      // hooks call dropSession, the same session id (typically a fresh
+      // session minted with a new uuid, but identity-preserving in
+      // principle) must start from zero — proving the entry was
+      // genuinely removed and not just zeroed in place.
+      const { policy } = makePolicy({ ...baseConfig, abusePolicyMaxDenials: 3 });
+      policy.recordDenial("s1", "auth401");
+      policy.recordDenial("s1", "auth401");
+      expect(policy.getSnapshot("s1")).toEqual({ count: 2, tripped: false });
+      policy.dropSession("s1");
+      expect(policy.recordDenial("s1", "auth401")).toEqual({ tripped: false });
+      expect(policy.getSnapshot("s1")).toEqual({ count: 1, tripped: false });
     });
 
     it("clear removes all state", () => {

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -56,6 +56,7 @@ function fakeDeps(overrides?: Partial<HttpLifecycleDeps>): HttpLifecycleDeps {
       createHttpIdleTimer: vi.fn(() => setTimeout(() => {}, 1_000_000)),
       resetIdleTimer: vi.fn(),
       resetHttpIdleTimer: vi.fn(),
+      revokeSession: vi.fn(() => false),
     },
     auditService: {
       hydrate: vi.fn(),
@@ -86,6 +87,12 @@ function fakeDeps(overrides?: Partial<HttpLifecycleDeps>): HttpLifecycleDeps {
     emitStatusChange: vi.fn(),
     emitRuntimeStateChange: vi.fn(),
     setConfig: vi.fn(),
+    abusePolicy: {
+      recordDenial: vi.fn(() => ({ tripped: false })),
+      clearSession: vi.fn(),
+      clear: vi.fn(),
+      getSnapshot: vi.fn(() => null),
+    },
     ...overrides,
   } as unknown as HttpLifecycleDeps;
 }

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -89,7 +89,7 @@ function fakeDeps(overrides?: Partial<HttpLifecycleDeps>): HttpLifecycleDeps {
     setConfig: vi.fn(),
     abusePolicy: {
       recordDenial: vi.fn(() => ({ tripped: false })),
-      clearSession: vi.fn(),
+      dropSession: vi.fn(),
       clear: vi.fn(),
       getSnapshot: vi.fn(() => null),
     },

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -399,3 +399,95 @@ describe("SessionStore.recomputeIdleTimers", () => {
     expect(resourceCleanups).toContain("acc");
   });
 });
+
+describe("SessionStore.revokeSession", () => {
+  let store: SessionStore;
+  let resourceCleanups: string[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resourceCleanups = [];
+    store = new SessionStore((sessionId) => {
+      resourceCleanups.push(sessionId);
+    });
+  });
+
+  afterEach(() => {
+    store.grantCache.dispose();
+    vi.useRealTimers();
+  });
+
+  it("revokes an SSE session and cleans all maps", () => {
+    const session = fakeSseSession();
+    const closeSpy = session.transport.close as ReturnType<typeof vi.fn>;
+    store.sessions.set("sse-1", session);
+    store.sessionTierMap.set("sse-1", "action");
+    store.sessionWebContentsMap.set("sse-1", 42);
+    store.sessionContextMap.set("sse-1", { worktreeId: "w1" } as never);
+
+    const result = store.revokeSession("sse-1");
+
+    expect(result).toBe(true);
+    expect(store.sessions.has("sse-1")).toBe(false);
+    expect(store.sessionTierMap.has("sse-1")).toBe(false);
+    expect(store.sessionWebContentsMap.has("sse-1")).toBe(false);
+    expect(store.sessionContextMap.has("sse-1")).toBe(false);
+    expect(resourceCleanups).toContain("sse-1");
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it("revokes a Streamable-HTTP session", () => {
+    const session = fakeHttpSession();
+    const closeSpy = session.transport.close as ReturnType<typeof vi.fn>;
+    store.httpSessions.set("http-1", session);
+    store.sessionTierMap.set("http-1", "system");
+    store.sessionWebContentsMap.set("http-1", 99);
+
+    const result = store.revokeSession("http-1");
+
+    expect(result).toBe(true);
+    expect(store.httpSessions.has("http-1")).toBe(false);
+    expect(store.sessionTierMap.has("http-1")).toBe(false);
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it("returns false for unknown session", () => {
+    expect(store.revokeSession("ghost")).toBe(false);
+  });
+
+  it("is idempotent — double revoke is harmless", () => {
+    const session = fakeSseSession();
+    store.sessions.set("sse-1", session);
+    store.sessionTierMap.set("sse-1", "action");
+
+    expect(store.revokeSession("sse-1")).toBe(true);
+    expect(store.revokeSession("sse-1")).toBe(false);
+  });
+
+  it("only revokes the target session, leaving others intact", () => {
+    const s1 = fakeSseSession();
+    const s2 = fakeSseSession();
+    store.sessions.set("s1", s1);
+    store.sessions.set("s2", s2);
+    store.sessionTierMap.set("s1", "action");
+    store.sessionTierMap.set("s2", "system");
+
+    store.revokeSession("s1");
+
+    expect(store.sessions.has("s1")).toBe(false);
+    expect(store.sessions.has("s2")).toBe(true);
+    expect(store.sessionTierMap.get("s2")).toBe("system");
+  });
+
+  it("clears dedup state for the revoked session", () => {
+    const session = fakeSseSession();
+    store.sessions.set("sse-1", session);
+    store.dedupInFlight.set("sse-1", new Map([["k", Promise.resolve({}) as never]]));
+    store.dedupResultCache.set("sse-1", new Map());
+
+    store.revokeSession("sse-1");
+
+    expect(store.dedupInFlight.has("sse-1")).toBe(false);
+    expect(store.dedupResultCache.has("sse-1")).toBe(false);
+  });
+});

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -507,12 +507,12 @@ describe("SessionStore.revokeSession", () => {
 });
 
 describe("SessionStore dropAbuseState wiring (#8467)", () => {
-  let dropAbuseSpy: ReturnType<typeof vi.fn>;
+  let dropAbuseSpy: ReturnType<typeof vi.fn<(sessionId: string) => void>>;
   let store: SessionStore;
 
   beforeEach(() => {
     vi.useFakeTimers();
-    dropAbuseSpy = vi.fn();
+    dropAbuseSpy = vi.fn<(sessionId: string) => void>();
     store = new SessionStore(() => {}, { dropAbuseState: dropAbuseSpy });
   });
 

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -490,4 +490,70 @@ describe("SessionStore.revokeSession", () => {
     expect(store.dedupInFlight.has("sse-1")).toBe(false);
     expect(store.dedupResultCache.has("sse-1")).toBe(false);
   });
+
+  it("revokes the session's grants via grantCache.revokeSession (#8467)", () => {
+    // Without this hop the renderer never receives the `revoked`
+    // lifecycle event for outstanding per-tool grants on the
+    // session being torn down by the abuse-policy circuit-breaker.
+    const session = fakeSseSession();
+    store.sessions.set("sse-1", session);
+    store.sessionWebContentsMap.set("sse-1", 42);
+    const grantRevokeSpy = vi.spyOn(store.grantCache, "revokeSession");
+
+    store.revokeSession("sse-1");
+
+    expect(grantRevokeSpy).toHaveBeenCalledWith("sse-1", "session-ended");
+  });
+});
+
+describe("SessionStore dropAbuseState wiring (#8467)", () => {
+  let dropAbuseSpy: ReturnType<typeof vi.fn>;
+  let store: SessionStore;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    dropAbuseSpy = vi.fn();
+    store = new SessionStore(() => {}, { dropAbuseState: dropAbuseSpy });
+  });
+
+  afterEach(() => {
+    store.grantCache.dispose();
+    vi.useRealTimers();
+  });
+
+  it("invokes dropAbuseState on SSE idle expiry", () => {
+    const session = fakeSseSession();
+    store.sessions.set("s1", session);
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createIdleTimer("s1");
+
+    vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS + 1);
+
+    expect(dropAbuseSpy).toHaveBeenCalledWith("s1");
+  });
+
+  it("invokes dropAbuseState on Streamable-HTTP idle expiry", () => {
+    const session = fakeHttpSession();
+    store.httpSessions.set("h1", session);
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createHttpIdleTimer("h1");
+
+    vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS + 1);
+
+    expect(dropAbuseSpy).toHaveBeenCalledWith("h1");
+  });
+
+  it("invokes dropAbuseState on explicit revokeSession", () => {
+    const session = fakeSseSession();
+    store.sessions.set("s1", session);
+
+    store.revokeSession("s1");
+
+    expect(dropAbuseSpy).toHaveBeenCalledWith("s1");
+  });
+
+  it("does not fire dropAbuseState when revokeSession returns false (unknown session)", () => {
+    expect(store.revokeSession("ghost")).toBe(false);
+    expect(dropAbuseSpy).not.toHaveBeenCalled();
+  });
 });

--- a/electron/services/mcp-server/abusePolicy.ts
+++ b/electron/services/mcp-server/abusePolicy.ts
@@ -1,0 +1,59 @@
+type DenialKind = "auth401" | "tierMismatch";
+
+interface AbusePolicyConfig {
+  readConfig: () => {
+    auditEnabled: boolean;
+    abusePolicyEnabled: boolean;
+    abusePolicyMaxDenials: number;
+    abusePolicyWindowMs: number;
+  };
+}
+
+interface DenialState {
+  count: number;
+  windowStart: number;
+}
+
+export class AbusePolicy {
+  private readonly state = new Map<string, DenialState>();
+  private readonly readConfig: AbusePolicyConfig["readConfig"];
+
+  constructor(config: AbusePolicyConfig) {
+    this.readConfig = config.readConfig;
+  }
+
+  recordDenial(sessionId: string, _kind: DenialKind): { tripped: boolean } {
+    const cfg = this.readConfig();
+    if (cfg.auditEnabled === false || cfg.abusePolicyEnabled === false) {
+      return { tripped: false };
+    }
+
+    const now = Date.now();
+    const existing = this.state.get(sessionId);
+
+    if (!existing || now - existing.windowStart > cfg.abusePolicyWindowMs) {
+      this.state.set(sessionId, { count: 1, windowStart: now });
+      return { tripped: cfg.abusePolicyMaxDenials <= 1 };
+    }
+
+    existing.count += 1;
+    const tripped = existing.count >= cfg.abusePolicyMaxDenials;
+    return { tripped };
+  }
+
+  clearSession(sessionId: string): void {
+    this.state.delete(sessionId);
+  }
+
+  clear(): void {
+    this.state.clear();
+  }
+
+  /** Exposed for tests — returns a snapshot of the tracked denial count for a session. */
+  getSnapshot(sessionId: string): { count: number; tripped: boolean } | null {
+    const cfg = this.readConfig();
+    const s = this.state.get(sessionId);
+    if (!s) return null;
+    return { count: s.count, tripped: s.count >= cfg.abusePolicyMaxDenials };
+  }
+}

--- a/electron/services/mcp-server/abusePolicy.ts
+++ b/electron/services/mcp-server/abusePolicy.ts
@@ -41,7 +41,15 @@ export class AbusePolicy {
     return { tripped };
   }
 
-  clearSession(sessionId: string): void {
+  /**
+   * Drop the per-session denial counter. Called from the SessionStore
+   * lifecycle hooks (idle expiry, explicit revoke, drain) and from the
+   * abuse-trip handler in HttpLifecycle once the session has been
+   * revoked. Otherwise the `state` Map grows unboundedly across normal
+   * session churn — the only previous prune path was the trip itself,
+   * which the vast majority of well-behaved sessions never hit.
+   */
+  dropSession(sessionId: string): void {
     this.state.delete(sessionId);
   }
 

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -516,8 +516,9 @@ export class HttpLifecycle {
       if (claimedSessionId) {
         const result = this.deps.abusePolicy.recordDenial(claimedSessionId, "auth401");
         if (result.tripped) {
-          this.deps.sessionStore.revokeSession(claimedSessionId);
           const pinnedId = this.deps.sessionStore.sessionWebContentsMap.get(claimedSessionId);
+          this.deps.sessionStore.revokeSession(claimedSessionId);
+          this.deps.abusePolicy.clearSession(claimedSessionId);
           if (pinnedId !== undefined) {
             const wc = webContentsModule.fromId(pinnedId);
             if (wc && !wc.isDestroyed()) {
@@ -827,7 +828,9 @@ export class HttpLifecycle {
 
     const notifySessionRevoked: import("./sessionServer.js").SessionServerDeps["notifySessionRevoked"] =
       (payload) => {
-        const id = this.deps.sessionStore.sessionWebContentsMap.get(payload.sessionId);
+        const id =
+          payload.pinnedWebContentsId ??
+          this.deps.sessionStore.sessionWebContentsMap.get(payload.sessionId);
         if (id === undefined) return;
         const wc = webContentsModule.fromId(id);
         if (!wc || wc.isDestroyed()) return;
@@ -863,6 +866,9 @@ export class HttpLifecycle {
       notifyTierMismatch,
       recordDenial,
       notifySessionRevoked,
+      clearDenialState: (sessionId) => {
+        this.deps.abusePolicy.clearSession(sessionId);
+      },
     };
   }
 

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -301,6 +301,10 @@ export class HttpLifecycle {
 
     // Drain sessions
     this.deps.sessionStore.drain();
+    // Mirror the planned-stop path so an unexpected close also wipes
+    // the abuse-policy state. Otherwise denial counters would leak
+    // into the lifetime of any subsequent restart.
+    this.deps.abusePolicy.clear();
 
     for (const cleanup of this.deps.cleanupListeners) {
       try {
@@ -390,6 +394,12 @@ export class HttpLifecycle {
         this.deps.auditService.flushNow();
         this.deps.turnOutcomeService.flushNow();
         this.deps.sessionStore.drain();
+        // The drain wipes session-scoped state (grants, dedup, pins);
+        // the abuse-policy denial Map is owned alongside but lives on
+        // `HttpLifecycle.deps` so we clear it here in lockstep. Without
+        // this, the policy retains denial counters across a stop/start
+        // cycle for sessionIds that will never reappear.
+        this.deps.abusePolicy.clear();
 
         for (const cleanup of this.deps.cleanupListeners) {
           try {
@@ -518,7 +528,7 @@ export class HttpLifecycle {
         if (result.tripped) {
           const pinnedId = this.deps.sessionStore.sessionWebContentsMap.get(claimedSessionId);
           this.deps.sessionStore.revokeSession(claimedSessionId);
-          this.deps.abusePolicy.clearSession(claimedSessionId);
+          this.deps.abusePolicy.dropSession(claimedSessionId);
           if (pinnedId !== undefined) {
             const wc = webContentsModule.fromId(pinnedId);
             if (wc && !wc.isDestroyed()) {
@@ -585,6 +595,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionWebContentsMap.delete(sessionId);
         this.deps.sessionStore.sessionContextMap.delete(sessionId);
         this.deps.sessionStore.clearDedupState(sessionId);
+        this.deps.abusePolicy.dropSession(sessionId);
         cleanupResourceSubscriptions(sessionId, this.deps.sessionStore);
       };
 
@@ -600,6 +611,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionWebContentsMap.delete(sessionId);
         this.deps.sessionStore.sessionContextMap.delete(sessionId);
         this.deps.sessionStore.clearDedupState(sessionId);
+        this.deps.abusePolicy.dropSession(sessionId);
         transport.onclose = undefined;
         await transport.close().catch(() => {});
         throw err;
@@ -709,6 +721,7 @@ export class HttpLifecycle {
       this.deps.sessionStore.sessionWebContentsMap.delete(id);
       this.deps.sessionStore.sessionContextMap.delete(id);
       this.deps.sessionStore.clearDedupState(id);
+      this.deps.abusePolicy.dropSession(id);
       cleanupResourceSubscriptions(id, this.deps.sessionStore);
     };
 
@@ -729,6 +742,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionWebContentsMap.delete(id);
         this.deps.sessionStore.sessionContextMap.delete(id);
         this.deps.sessionStore.clearDedupState(id);
+        this.deps.abusePolicy.dropSession(id);
         cleanupResourceSubscriptions(id, this.deps.sessionStore);
       } else {
         this.deps.sessionStore.sessionTierMap.delete(newSessionId);
@@ -736,6 +750,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionWebContentsMap.delete(newSessionId);
         this.deps.sessionStore.sessionContextMap.delete(newSessionId);
         this.deps.sessionStore.clearDedupState(newSessionId);
+        this.deps.abusePolicy.dropSession(newSessionId);
         cleanupResourceSubscriptions(newSessionId, this.deps.sessionStore);
       }
       await transport.close().catch(() => {});
@@ -867,7 +882,7 @@ export class HttpLifecycle {
       recordDenial,
       notifySessionRevoked,
       clearDenialState: (sessionId) => {
-        this.deps.abusePolicy.clearSession(sessionId);
+        this.deps.abusePolicy.dropSession(sessionId);
       },
     };
   }

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -31,6 +31,7 @@ import { createSessionServer, cleanupResourceSubscriptions } from "./sessionServ
 import type { SessionStore } from "./sessionStore.js";
 import type { AuditService } from "./auditLog.js";
 import type { TurnOutcomeService } from "./turnOutcomeLog.js";
+import type { AbusePolicy } from "./abusePolicy.js";
 import {
   DEFAULT_PORT,
   MAX_PORT_RETRIES,
@@ -46,6 +47,7 @@ export interface HttpLifecycleDeps {
   sessionStore: SessionStore;
   auditService: AuditService;
   turnOutcomeService: TurnOutcomeService;
+  abusePolicy: AbusePolicy;
   requestManifest: () => Promise<import("../../../shared/types/actions.js").ActionManifestEntry[]>;
   dispatchAction: (
     actionId: string,
@@ -493,9 +495,44 @@ export class HttpLifecycle {
       return;
     }
 
+    const url = new URL(req.url ?? "/", `http://127.0.0.1:${this.port}`);
+
+    // Extract the claimed session identifier before the auth gate so a 401 on
+    // a session-carrying request feeds the per-session abuse policy. Handshake-
+    // level requests (GET /sse, initial Streamable HTTP without a session
+    // header) have no session to associate with and remain global-only.
+    let claimedSessionId: string | undefined;
+    if (req.method === "POST" && url.pathname === "/messages") {
+      claimedSessionId = url.searchParams.get("sessionId") ?? undefined;
+    } else if (url.pathname === "/mcp") {
+      const headerValue = req.headers["mcp-session-id"];
+      const mcpSessionId = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+      if (mcpSessionId) claimedSessionId = mcpSessionId;
+    }
+
     const authHeader = req.headers.authorization ?? "";
     if (!isAuthorized(authHeader, this.apiKeyBearerHash, this.helpTokenValidator)) {
       this.deps.auditService.recordAuth401();
+      if (claimedSessionId) {
+        const result = this.deps.abusePolicy.recordDenial(claimedSessionId, "auth401");
+        if (result.tripped) {
+          this.deps.sessionStore.revokeSession(claimedSessionId);
+          const pinnedId = this.deps.sessionStore.sessionWebContentsMap.get(claimedSessionId);
+          if (pinnedId !== undefined) {
+            const wc = webContentsModule.fromId(pinnedId);
+            if (wc && !wc.isDestroyed()) {
+              try {
+                wc.send(CHANNELS.MCP_SESSION_REVOKED, {
+                  sessionId: claimedSessionId,
+                  denialKind: "auth401",
+                });
+              } catch (err) {
+                console.error("[MCP] session-revoked send failed:", err);
+              }
+            }
+          }
+        }
+      }
       res.writeHead(401, {
         "Content-Type": "text/plain",
         "WWW-Authenticate": 'Bearer realm="Daintree MCP"',
@@ -503,8 +540,6 @@ export class HttpLifecycle {
       res.end("Unauthorized");
       return;
     }
-
-    const url = new URL(req.url ?? "/", `http://127.0.0.1:${this.port}`);
 
     if (req.method === "GET" && url.pathname === "/sse") {
       const allowedHosts = [`127.0.0.1:${this.port}`, `localhost:${this.port}`];
@@ -783,6 +818,29 @@ export class HttpLifecycle {
         }
       };
 
+    const recordDenial: import("./sessionServer.js").SessionServerDeps["recordDenial"] = (
+      sessionId,
+      kind
+    ) => {
+      return this.deps.abusePolicy.recordDenial(sessionId, kind);
+    };
+
+    const notifySessionRevoked: import("./sessionServer.js").SessionServerDeps["notifySessionRevoked"] =
+      (payload) => {
+        const id = this.deps.sessionStore.sessionWebContentsMap.get(payload.sessionId);
+        if (id === undefined) return;
+        const wc = webContentsModule.fromId(id);
+        if (!wc || wc.isDestroyed()) return;
+        try {
+          wc.send(CHANNELS.MCP_SESSION_REVOKED, {
+            sessionId: payload.sessionId,
+            denialKind: payload.denialKind,
+          });
+        } catch (err) {
+          console.error("[MCP] session-revoked send failed:", err);
+        }
+      };
+
     return {
       sessionStore: this.deps.sessionStore,
       requestManifest,
@@ -803,6 +861,8 @@ export class HttpLifecycle {
       getCachedManifest,
       getFullToolSurface: () => this.getConfig().fullToolSurface === true,
       notifyTierMismatch,
+      recordDenial,
+      notifySessionRevoked,
     };
   }
 

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -126,7 +126,17 @@ export interface SessionServerDeps {
    * notification. External / api-key sessions have no associated UI so the
    * callback is a no-op.
    */
-  notifySessionRevoked?: (payload: { sessionId: string; denialKind: string }) => void;
+  notifySessionRevoked?: (payload: {
+    sessionId: string;
+    denialKind: string;
+    /** Saved before revokeSession clears the map, so the callback can route. */
+    pinnedWebContentsId?: number;
+  }) => void;
+  /**
+   * Remove a session from the abuse policy state so a reconnected session
+   * doesn't inherit stale counters. Called after revokeSession and drain().
+   */
+  clearDenialState?: (sessionId: string) => void;
 }
 
 export function createSessionServer(sessionId: string, deps: SessionServerDeps): Server {
@@ -141,6 +151,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     notifyTierMismatch,
     recordDenial,
     notifySessionRevoked,
+    clearDenialState,
   } = deps;
 
   const server = new Server(
@@ -236,10 +247,16 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         if (recordDenial) {
           const result = recordDenial(sessionId, "tierMismatch");
           if (result.tripped) {
+            const pinnedId = sessionStore.sessionWebContentsMap.get(sessionId);
             sessionStore.revokeSession(sessionId);
+            clearDenialState?.(sessionId);
             if (notifySessionRevoked) {
               try {
-                notifySessionRevoked({ sessionId, denialKind: "tierMismatch" });
+                notifySessionRevoked({
+                  sessionId,
+                  denialKind: "tierMismatch",
+                  pinnedWebContentsId: pinnedId,
+                });
               } catch (err) {
                 console.error("[MCP] Failed to notify session-revoked:", err);
               }

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -112,6 +112,21 @@ export interface SessionServerDeps {
      */
     targetTier: "workbench" | "action" | "system" | null;
   }) => void;
+  /**
+   * Feed a denial into the abuse policy — both 401s and tier-mismatches
+   * share the same per-session sliding-window counter. Returns
+   * `{ tripped: true }` when the threshold is exceeded. Implemented by
+   * httpLifecycle; absent in test fixtures that don't wire the policy.
+   */
+  recordDenial?: (sessionId: string, kind: "auth401" | "tierMismatch") => { tripped: boolean };
+  /**
+   * Optional renderer notifier fired when a session is revoked by the abuse
+   * policy. Follows the same pinned-WebContents pattern as
+   * `notifyTierMismatch` so only help-session bearers surface the
+   * notification. External / api-key sessions have no associated UI so the
+   * callback is a no-op.
+   */
+  notifySessionRevoked?: (payload: { sessionId: string; denialKind: string }) => void;
 }
 
 export function createSessionServer(sessionId: string, deps: SessionServerDeps): Server {
@@ -124,6 +139,8 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     getCachedManifest,
     getFullToolSurface,
     notifyTierMismatch,
+    recordDenial,
+    notifySessionRevoked,
   } = deps;
 
   const server = new Server(
@@ -214,6 +231,19 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             });
           } catch (err) {
             console.error("[MCP] Failed to notify tier-mismatch:", err);
+          }
+        }
+        if (recordDenial) {
+          const result = recordDenial(sessionId, "tierMismatch");
+          if (result.tripped) {
+            sessionStore.revokeSession(sessionId);
+            if (notifySessionRevoked) {
+              try {
+                notifySessionRevoked({ sessionId, denialKind: "tierMismatch" });
+              } catch (err) {
+                console.error("[MCP] Failed to notify session-revoked:", err);
+              }
+            }
           }
         }
         return buildToolError({

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -14,6 +14,15 @@ export interface SessionStoreOptions {
    * defaults to silent).
    */
   emitGrantLifecycle?: GrantLifecycleEmitter;
+  /**
+   * Callback fired alongside the other per-session cleanup hooks
+   * (idle expiry, explicit revoke, drain) so the {@link AbusePolicy}
+   * denial counter can be pruned in lockstep. Without this, the
+   * policy's internal Map grows for every session that ever opens
+   * and is only pruned on the rare abuse-trip path. Optional so test
+   * fixtures construct without one.
+   */
+  dropAbuseState?: (sessionId: string) => void;
 }
 
 export class SessionStore {
@@ -52,12 +61,14 @@ export class SessionStore {
   private readonly httpIdleStartedAt = new Map<string, number>();
 
   private readonly cleanupResourceSubscriptionsFn: (sessionId: string) => void;
+  private readonly dropAbuseStateFn: (sessionId: string) => void;
 
   constructor(
     cleanupResourceSubscriptions: (sessionId: string) => void,
     options: SessionStoreOptions = {}
   ) {
     this.cleanupResourceSubscriptionsFn = cleanupResourceSubscriptions;
+    this.dropAbuseStateFn = options.dropAbuseState ?? (() => {});
     this.grantCache = new GrantCache({ emit: options.emitGrantLifecycle });
   }
 
@@ -80,6 +91,7 @@ export class SessionStore {
     this.sessionContextMap.delete(sessionId);
     this.clearDedupState(sessionId);
     this.idleStartedAt.delete(sessionId);
+    this.dropAbuseStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
     session.transport.close().catch(() => {
       // ignore close errors during idle timeout cleanup
@@ -131,6 +143,7 @@ export class SessionStore {
     this.sessionContextMap.delete(sessionId);
     this.clearDedupState(sessionId);
     this.httpIdleStartedAt.delete(sessionId);
+    this.dropAbuseStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
     session.transport.close().catch(() => {
       // ignore close errors during idle timeout cleanup
@@ -244,9 +257,17 @@ export class SessionStore {
     }
 
     this.sessionTierMap.delete(sessionId);
+    // Revoke BEFORE deleting the WebContents pin so the lifecycle
+    // emitter can still resolve the pinned renderer for the
+    // `grant.revoked` push. Without this, any outstanding per-tool
+    // grants would be left in the cache while the session entry is
+    // torn down — the renderer would never receive the `revoked`
+    // lifecycle event and the grant state would leak (#8467).
+    this.grantCache.revokeSession(sessionId, "session-ended");
     this.sessionWebContentsMap.delete(sessionId);
     this.sessionContextMap.delete(sessionId);
     this.clearDedupState(sessionId);
+    this.dropAbuseStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
     return true;
   }

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -227,6 +227,30 @@ export class SessionStore {
     return this.sessionTierMap.get(sessionId) ?? "workbench";
   }
 
+  revokeSession(sessionId: string): boolean {
+    const sseSession = this.sessions.get(sessionId);
+    const httpSession = this.httpSessions.get(sessionId);
+    if (!sseSession && !httpSession) return false;
+
+    if (sseSession) {
+      clearTimeout(sseSession.idleTimer);
+      this.sessions.delete(sessionId);
+      sseSession.transport.close().catch(() => {});
+    }
+    if (httpSession) {
+      clearTimeout(httpSession.idleTimer);
+      this.httpSessions.delete(sessionId);
+      httpSession.transport.close().catch(() => {});
+    }
+
+    this.sessionTierMap.delete(sessionId);
+    this.sessionWebContentsMap.delete(sessionId);
+    this.sessionContextMap.delete(sessionId);
+    this.clearDedupState(sessionId);
+    this.cleanupResourceSubscriptionsFn(sessionId);
+    return true;
+  }
+
   drain(): void {
     // Clear dedup state up-front so an in-flight `.finally()` resolving
     // after drain finds no session to write back into and does not

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -200,6 +200,9 @@ export interface StoreSchema {
     auditMaxRecords: number;
     auditLog?: McpAuditRecord[];
     turnOutcomeLog?: AssistantTurnRecord[];
+    abusePolicyEnabled: boolean;
+    abusePolicyMaxDenials: number;
+    abusePolicyWindowMs: number;
   };
   /**
    * Help-assistant settings. Includes audit/permission configuration plus
@@ -400,6 +403,9 @@ const storeOptions = {
       fullToolSurface: false,
       auditEnabled: true,
       auditMaxRecords: MCP_AUDIT_DEFAULT_MAX_RECORDS,
+      abusePolicyEnabled: false,
+      abusePolicyMaxDenials: 5,
+      abusePolicyWindowMs: 60_000,
     },
     helpAssistant: {
       docSearch: true,


### PR DESCRIPTION
## Summary

This adds an abuse-policy circuit-breaker to MCP sessions. Repeated auth failures and tier-mismatch denials are counted, and when a session crosses a threshold within a time window, it gets revoked.

The mechanism ships behind the existing `auditEnabled` kill-switch, which is off by default. A misbehaving or prompt-injected model that fires a steady stream of unauthorized calls now hits a hard stop instead of running unchecked.

Resolves #8467

## Changes

- New `abusePolicy` module that tracks per-session failure counts (401s and tier-mismatch denials) with a configurable time-window threshold
- Integration into `httpLifecycle` (401 path) and `sessionServer` (tier-mismatch path) so both failure types feed the same circuit-breaker
- Session revocation path surfaces a notification explaining why the session ended, so the user isn't left wondering what happened
- New `sessionStore` methods and `sessionWebContentsMap` teardown for clean session cleanup in the abuse path
- Test coverage for the abuse policy module, session store revocation, and related integration points

## Testing

- Unit tests cover the abuse policy threshold logic, expiry of old failures, and the session revocation flow
- Integration tests verify the http lifecycle and session store interact correctly under abuse conditions
- Manual verification that the `auditEnabled` kill-switch gates the entire mechanism