### PR TITLE
fix(mcp-server): anchor session idle timers to wall clock across suspend/resume

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -4,6 +4,7 @@ import { store } from "../store.js";
 import { CHANNELS } from "../ipc/channels.js";
 import type { WindowRegistry } from "../window/WindowRegistry.js";
 import { getWindowRegistry } from "../window/windowRef.js";
+import { getSystemSleepService } from "./SystemSleepService.js";
 import type {
   AssistantTurnRecord,
   McpAuditRecord,
@@ -118,6 +119,14 @@ export class McpServerService {
       this.turnOutcomeService.dropTerminal(payload.terminalId);
     });
     this.persistentListeners.push(offExited);
+
+    try {
+      getSystemSleepService().onWake(() => {
+        this.sessionStore.recomputeIdleTimers();
+      });
+    } catch {
+      // SystemSleepService may not be initialized yet at early startup.
+    }
 
     this.bridge = createRendererBridge(
       this.pendingManifests,

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -166,6 +166,13 @@ vi.mock("../McpPaneConfigService.js", () => ({
   },
 }));
 
+vi.mock("../SystemSleepService.js", () => ({
+  getSystemSleepService: vi.fn(() => ({
+    getAwakeTimeSince: vi.fn(() => Number.MAX_SAFE_INTEGER),
+    onWake: vi.fn(() => () => {}),
+  })),
+}));
+
 import { McpServerService } from "../McpServerService.js";
 
 type DispatchRequest = {

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -77,13 +77,13 @@ describe("SessionStore.sessionWebContentsMap (#7002)", () => {
   });
 
   it("SSE idle-timer expiry deletes the session's pin so an evicted session does not leak the WebContents id", () => {
+    setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS);
     const session = fakeSseSession();
     const sessionId = "sse-1";
     store.sessions.set(sessionId, session);
     store.sessionTierMap.set(sessionId, "action");
     store.sessionWebContentsMap.set(sessionId, 42);
 
-    // Replace with a fresh idle timer that we can fast-forward.
     clearTimeout(session.idleTimer);
     session.idleTimer = store.createIdleTimer(sessionId);
 
@@ -98,6 +98,7 @@ describe("SessionStore.sessionWebContentsMap (#7002)", () => {
   });
 
   it("Streamable-HTTP idle-timer expiry deletes the session's pin", () => {
+    setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS);
     const session = fakeHttpSession();
     const sessionId = "http-1";
     store.httpSessions.set(sessionId, session);
@@ -162,7 +163,7 @@ describe("SessionStore.sessionWebContentsMap (#7002)", () => {
   });
 
   it("idle-timer for a session that was already removed is a no-op (does not stomp another session's pin)", () => {
-    // Set up two sessions; one gets removed before its timer fires.
+    setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS);
     store.sessions.set("alive", fakeSseSession());
     store.sessionWebContentsMap.set("alive", 1);
     store.sessionWebContentsMap.set("evicted", 2);
@@ -249,6 +250,9 @@ describe("SessionStore.recomputeIdleTimers", () => {
     vi.advanceTimersByTime(halfTimeout - 1);
     expect(store.sessions.has("sse-2")).toBe(true);
 
+    // The timer callback's defense-in-depth checks getAwakeTimeSince().
+    // Set it to expired so it proceeds to actual expiry.
+    setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS);
     vi.advanceTimersByTime(2);
     expect(store.sessions.has("sse-2")).toBe(false);
   });
@@ -270,6 +274,7 @@ describe("SessionStore.recomputeIdleTimers", () => {
     vi.advanceTimersByTime(halfTimeout - 1);
     expect(store.httpSessions.has("http-2")).toBe(true);
 
+    setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS);
     vi.advanceTimersByTime(2);
     expect(store.httpSessions.has("http-2")).toBe(false);
   });
@@ -322,17 +327,30 @@ describe("SessionStore.recomputeIdleTimers", () => {
     expect(() => store.recomputeIdleTimers()).not.toThrow();
   });
 
-  it("timer callback cleans up timestamp entries", () => {
+  it("timer callback cleans up timestamp entries on expiry", () => {
+    setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS);
     const session = fakeSseSession();
     store.sessions.set("sse-ts", session);
     clearTimeout(session.idleTimer);
     session.idleTimer = store.createIdleTimer("sse-ts");
 
-    setAwakeTime(0);
     vi.runAllTimers();
 
     expect(store.sessions.has("sse-ts")).toBe(false);
     expect(() => store.drain()).not.toThrow();
+  });
+
+  it("timer callback re-arms when awake time is below threshold (defense-in-depth)", () => {
+    setAwakeTime(0);
+    const session = fakeSseSession();
+    store.sessions.set("sse-survive", session);
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createIdleTimer("sse-survive");
+
+    vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS);
+
+    // Session should survive because awake time is below threshold.
+    expect(store.sessions.has("sse-survive")).toBe(true);
   });
 
   it("is a no-op when no sessions exist", () => {
@@ -347,5 +365,33 @@ describe("SessionStore.recomputeIdleTimers", () => {
     store.recomputeIdleTimers();
 
     expect(store.sessions.has("no-ts")).toBe(true);
+  });
+
+  it("repeated recompute calls do not extend idle lifetime (accumulated awake time is preserved)", () => {
+    // Simulate: idle for 10 min, sleep, wake (recompute), idle 10 min, sleep,
+    // wake (recompute), idle 10 min, sleep, wake (recompute). The session has
+    // accumulated 30+ min of awake idle time and should expire on the third wake.
+    const thirdOfTimeout = MCP_SSE_IDLE_TIMEOUT_MS / 3;
+    setAwakeTime(0);
+    const session = fakeSseSession();
+    store.sessions.set("acc", session);
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createIdleTimer("acc");
+
+    // First cycle: 10 min awake, recompute on wake.
+    setAwakeTime(thirdOfTimeout);
+    store.recomputeIdleTimers();
+    expect(store.sessions.has("acc")).toBe(true);
+
+    // Second cycle: 20 min awake, recompute on wake.
+    setAwakeTime(thirdOfTimeout * 2);
+    store.recomputeIdleTimers();
+    expect(store.sessions.has("acc")).toBe(true);
+
+    // Third cycle: 30 min awake — should expire.
+    setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS);
+    store.recomputeIdleTimers();
+    expect(store.sessions.has("acc")).toBe(false);
+    expect(resourceCleanups).toContain("acc");
   });
 });

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -1,4 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MCP_SSE_IDLE_TIMEOUT_MS } from "../shared.js";
+
+// Mutable test state controlled per-test.
+let mockAwakeTimeSince = 0;
+
+vi.mock("../../SystemSleepService.js", () => ({
+  getSystemSleepService: vi.fn(() => ({
+    getAwakeTimeSince: vi.fn(() => mockAwakeTimeSince),
+    onWake: vi.fn(() => () => {}),
+  })),
+}));
+
 import { SessionStore } from "../sessionStore.js";
 import { MCP_SSE_IDLE_TIMEOUT_MS, type McpSseSession, type McpHttpSession } from "../shared.js";
 
@@ -19,6 +31,10 @@ function fakeHttpSession(): McpHttpSession {
     server: {} as McpHttpSession["server"],
     idleTimer: setTimeout(() => {}, 1_000_000),
   };
+}
+
+function setAwakeTime(ms: number): void {
+  mockAwakeTimeSince = ms;
 }
 
 describe("SessionStore.sessionWebContentsMap (#7002)", () => {
@@ -166,5 +182,170 @@ describe("SessionStore.sessionWebContentsMap (#7002)", () => {
 
     // The other session's pin must remain untouched.
     expect(store.sessionWebContentsMap.get("alive")).toBe(1);
+  });
+});
+
+describe("SessionStore.recomputeIdleTimers", () => {
+  let store: SessionStore;
+  let resourceCleanups: string[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockAwakeTimeSince = 0;
+    resourceCleanups = [];
+    store = new SessionStore((sessionId) => {
+      resourceCleanups.push(sessionId);
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("expires an SSE session when awake elapsed >= MCP_SSE_IDLE_TIMEOUT_MS", () => {
+    setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS);
+    const session = fakeSseSession();
+    store.sessions.set("sse-1", session);
+    store.sessionTierMap.set("sse-1", "action");
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createIdleTimer("sse-1");
+
+    store.recomputeIdleTimers();
+
+    expect(store.sessions.has("sse-1")).toBe(false);
+    expect(store.sessionTierMap.has("sse-1")).toBe(false);
+    expect(resourceCleanups).toContain("sse-1");
+  });
+
+  it("expires an HTTP session when awake elapsed >= MCP_SSE_IDLE_TIMEOUT_MS", () => {
+    setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS);
+    const session = fakeHttpSession();
+    store.httpSessions.set("http-1", session);
+    store.sessionTierMap.set("http-1", "action");
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createHttpIdleTimer("http-1");
+
+    store.recomputeIdleTimers();
+
+    expect(store.httpSessions.has("http-1")).toBe(false);
+    expect(store.sessionTierMap.has("http-1")).toBe(false);
+    expect(resourceCleanups).toContain("http-1");
+  });
+
+  it("resets SSE timer with remaining awake time when not yet expired", () => {
+    const halfTimeout = MCP_SSE_IDLE_TIMEOUT_MS / 2;
+    setAwakeTime(halfTimeout);
+    const session = fakeSseSession();
+    store.sessions.set("sse-2", session);
+    clearTimeout(session.idleTimer);
+    const originalTimer = store.createIdleTimer("sse-2");
+    session.idleTimer = originalTimer;
+
+    store.recomputeIdleTimers();
+
+    expect(store.sessions.has("sse-2")).toBe(true);
+    expect(session.idleTimer).not.toBe(originalTimer);
+
+    vi.advanceTimersByTime(halfTimeout - 1);
+    expect(store.sessions.has("sse-2")).toBe(true);
+
+    vi.advanceTimersByTime(2);
+    expect(store.sessions.has("sse-2")).toBe(false);
+  });
+
+  it("resets HTTP timer with remaining awake time when not yet expired", () => {
+    const halfTimeout = MCP_SSE_IDLE_TIMEOUT_MS / 2;
+    setAwakeTime(halfTimeout);
+    const session = fakeHttpSession();
+    store.httpSessions.set("http-2", session);
+    clearTimeout(session.idleTimer);
+    const originalTimer = store.createHttpIdleTimer("http-2");
+    session.idleTimer = originalTimer;
+
+    store.recomputeIdleTimers();
+
+    expect(store.httpSessions.has("http-2")).toBe(true);
+    expect(session.idleTimer).not.toBe(originalTimer);
+
+    vi.advanceTimersByTime(halfTimeout - 1);
+    expect(store.httpSessions.has("http-2")).toBe(true);
+
+    vi.advanceTimersByTime(2);
+    expect(store.httpSessions.has("http-2")).toBe(false);
+  });
+
+  it("resetIdleTimer updates the timestamp so recompute reflects the reset", () => {
+    setAwakeTime(0);
+    const session = fakeSseSession();
+    store.sessions.set("sse-3", session);
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createIdleTimer("sse-3");
+
+    setAwakeTime(20 * 60 * 1000);
+    store.resetIdleTimer("sse-3");
+
+    setAwakeTime(5 * 60 * 1000);
+    store.recomputeIdleTimers();
+
+    expect(store.sessions.has("sse-3")).toBe(true);
+  });
+
+  it("resetHttpIdleTimer updates the timestamp so recompute reflects the reset", () => {
+    setAwakeTime(0);
+    const session = fakeHttpSession();
+    store.httpSessions.set("http-3", session);
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createHttpIdleTimer("http-3");
+
+    setAwakeTime(20 * 60 * 1000);
+    store.resetHttpIdleTimer("http-3");
+
+    setAwakeTime(5 * 60 * 1000);
+    store.recomputeIdleTimers();
+
+    expect(store.httpSessions.has("http-3")).toBe(true);
+  });
+
+  it("drain() clears timestamp maps so no stale entries survive", () => {
+    const session = fakeSseSession();
+    store.sessions.set("a", session);
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createIdleTimer("a");
+    const httpSession = fakeHttpSession();
+    store.httpSessions.set("b", httpSession);
+    clearTimeout(httpSession.idleTimer);
+    httpSession.idleTimer = store.createHttpIdleTimer("b");
+
+    store.drain();
+
+    setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS);
+    expect(() => store.recomputeIdleTimers()).not.toThrow();
+  });
+
+  it("timer callback cleans up timestamp entries", () => {
+    const session = fakeSseSession();
+    store.sessions.set("sse-ts", session);
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createIdleTimer("sse-ts");
+
+    setAwakeTime(0);
+    vi.runAllTimers();
+
+    expect(store.sessions.has("sse-ts")).toBe(false);
+    expect(() => store.drain()).not.toThrow();
+  });
+
+  it("is a no-op when no sessions exist", () => {
+    expect(() => store.recomputeIdleTimers()).not.toThrow();
+  });
+
+  it("uses fallback timestamp for sessions missing idleStartedAt (does not expire immediately)", () => {
+    setAwakeTime(0);
+    const session = fakeSseSession();
+    store.sessions.set("no-ts", session);
+
+    store.recomputeIdleTimers();
+
+    expect(store.sessions.has("no-ts")).toBe(true);
   });
 });

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MCP_SSE_IDLE_TIMEOUT_MS } from "../shared.js";
+import { MCP_SSE_IDLE_TIMEOUT_MS, type McpSseSession, type McpHttpSession } from "../shared.js";
 
 // Mutable test state controlled per-test.
 let mockAwakeTimeSince = 0;
@@ -12,7 +12,6 @@ vi.mock("../../SystemSleepService.js", () => ({
 }));
 
 import { SessionStore } from "../sessionStore.js";
-import { MCP_SSE_IDLE_TIMEOUT_MS, type McpSseSession, type McpHttpSession } from "../shared.js";
 
 function fakeSseSession(): McpSseSession {
   return {
@@ -200,6 +199,9 @@ describe("SessionStore.recomputeIdleTimers", () => {
   });
 
   afterEach(() => {
+    // GrantCache owns a recurring sweep interval; dispose so `vi.runAllTimers()`
+    // in tests doesn't loop indefinitely on the sweep schedule.
+    store.grantCache.dispose();
     vi.useRealTimers();
   });
 
@@ -334,7 +336,9 @@ describe("SessionStore.recomputeIdleTimers", () => {
     clearTimeout(session.idleTimer);
     session.idleTimer = store.createIdleTimer("sse-ts");
 
-    vi.runAllTimers();
+    // Use advanceTimersByTime rather than runAllTimers — GrantCache's recurring
+    // sweep interval would otherwise trigger vitest's infinite-loop guard.
+    vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS + 1);
 
     expect(store.sessions.has("sse-ts")).toBe(false);
     expect(() => store.drain()).not.toThrow();

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -88,9 +88,26 @@ export class SessionStore {
 
   createIdleTimer(sessionId: string): ReturnType<typeof setTimeout> {
     this.idleStartedAt.set(sessionId, Date.now());
-    const timer = setTimeout(() => {
+    const checkAndExpire = () => {
+      const session = this.sessions.get(sessionId);
+      if (!session) return;
+      const startedAt = this.idleStartedAt.get(sessionId);
+      if (startedAt !== undefined) {
+        try {
+          const awakeElapsed = getSystemSleepService().getAwakeTimeSince(startedAt);
+          if (awakeElapsed < MCP_SSE_IDLE_TIMEOUT_MS) {
+            const remaining = Math.max(1, MCP_SSE_IDLE_TIMEOUT_MS - awakeElapsed);
+            session.idleTimer = setTimeout(checkAndExpire, remaining);
+            (session.idleTimer as ReturnType<typeof setTimeout>).unref?.();
+            return;
+          }
+        } catch {
+          // Fall through to expiry.
+        }
+      }
       this.expireSseSession(sessionId);
-    }, MCP_SSE_IDLE_TIMEOUT_MS);
+    };
+    const timer = setTimeout(checkAndExpire, MCP_SSE_IDLE_TIMEOUT_MS);
     timer.unref?.();
     return timer;
   }
@@ -122,9 +139,26 @@ export class SessionStore {
 
   createHttpIdleTimer(sessionId: string): ReturnType<typeof setTimeout> {
     this.httpIdleStartedAt.set(sessionId, Date.now());
-    const timer = setTimeout(() => {
+    const checkAndExpire = () => {
+      const session = this.httpSessions.get(sessionId);
+      if (!session) return;
+      const startedAt = this.httpIdleStartedAt.get(sessionId);
+      if (startedAt !== undefined) {
+        try {
+          const awakeElapsed = getSystemSleepService().getAwakeTimeSince(startedAt);
+          if (awakeElapsed < MCP_SSE_IDLE_TIMEOUT_MS) {
+            const remaining = Math.max(1, MCP_SSE_IDLE_TIMEOUT_MS - awakeElapsed);
+            session.idleTimer = setTimeout(checkAndExpire, remaining);
+            (session.idleTimer as ReturnType<typeof setTimeout>).unref?.();
+            return;
+          }
+        } catch {
+          // Fall through to expiry.
+        }
+      }
       this.expireHttpSession(sessionId);
-    }, MCP_SSE_IDLE_TIMEOUT_MS);
+    };
+    const timer = setTimeout(checkAndExpire, MCP_SSE_IDLE_TIMEOUT_MS);
     timer.unref?.();
     return timer;
   }
@@ -157,7 +191,6 @@ export class SessionStore {
             this.expireSseSession(sessionId);
           }, remaining);
           (session.idleTimer as ReturnType<typeof setTimeout>).unref?.();
-          this.idleStartedAt.set(sessionId, Date.now());
         }
       } catch {
         // SystemSleepService may not be initialized; keep existing timer.
@@ -183,7 +216,6 @@ export class SessionStore {
             this.expireHttpSession(sessionId);
           }, remaining);
           (session.idleTimer as ReturnType<typeof setTimeout>).unref?.();
-          this.httpIdleStartedAt.set(sessionId, Date.now());
         }
       } catch {
         // SystemSleepService may not be initialized; keep existing timer.

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -3,6 +3,7 @@ import type { McpTier, McpSseSession, McpHttpSession } from "./shared.js";
 import { MCP_SSE_IDLE_TIMEOUT_MS } from "./shared.js";
 import type { DedupCacheEntry, DedupInFlightEntry } from "./sessionDedup.js";
 import { GrantCache, type GrantLifecycleEmitter } from "./grantCache.js";
+import { getSystemSleepService } from "../SystemSleepService.js";
 
 export interface SessionStoreOptions {
   /**
@@ -44,6 +45,12 @@ export class SessionStore {
    */
   readonly grantCache: GrantCache;
 
+  // Wall-clock timestamps recording when each session's idle timer was armed.
+  // Used by recomputeIdleTimers() to calculate awake elapsed time across
+  // suspend/resume cycles via SystemSleepService.getAwakeTimeSince().
+  private readonly idleStartedAt = new Map<string, number>();
+  private readonly httpIdleStartedAt = new Map<string, number>();
+
   private readonly cleanupResourceSubscriptionsFn: (sessionId: string) => void;
 
   constructor(
@@ -59,24 +66,30 @@ export class SessionStore {
     this.dedupResultCache.delete(sessionId);
   }
 
+  private expireSseSession(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) return;
+    this.sessions.delete(sessionId);
+    this.sessionTierMap.delete(sessionId);
+    // Revoke BEFORE deleting the WebContents pin so the lifecycle
+    // emitter can still resolve the pinned renderer and dispatch the
+    // `grant.revoked` event. The audit-record write tolerates a
+    // missing pin (it doesn't need one); the targeted `wc.send` does.
+    this.grantCache.revokeSession(sessionId, "session-idle");
+    this.sessionWebContentsMap.delete(sessionId);
+    this.sessionContextMap.delete(sessionId);
+    this.clearDedupState(sessionId);
+    this.idleStartedAt.delete(sessionId);
+    this.cleanupResourceSubscriptionsFn(sessionId);
+    session.transport.close().catch(() => {
+      // ignore close errors during idle timeout cleanup
+    });
+  }
+
   createIdleTimer(sessionId: string): ReturnType<typeof setTimeout> {
+    this.idleStartedAt.set(sessionId, Date.now());
     const timer = setTimeout(() => {
-      const session = this.sessions.get(sessionId);
-      if (!session) return;
-      this.sessions.delete(sessionId);
-      this.sessionTierMap.delete(sessionId);
-      // Revoke BEFORE deleting the WebContents pin so the lifecycle
-      // emitter can still resolve the pinned renderer and dispatch the
-      // `grant.revoked` event. The audit-record write tolerates a
-      // missing pin (it doesn't need one); the targeted `wc.send` does.
-      this.grantCache.revokeSession(sessionId, "session-idle");
-      this.sessionWebContentsMap.delete(sessionId);
-      this.sessionContextMap.delete(sessionId);
-      this.clearDedupState(sessionId);
-      this.cleanupResourceSubscriptionsFn(sessionId);
-      session.transport.close().catch(() => {
-        // ignore close errors during idle timeout cleanup
-      });
+      this.expireSseSession(sessionId);
     }, MCP_SSE_IDLE_TIMEOUT_MS);
     timer.unref?.();
     return timer;
@@ -89,22 +102,28 @@ export class SessionStore {
     session.idleTimer = this.createIdleTimer(sessionId);
   }
 
+  private expireHttpSession(sessionId: string): void {
+    const session = this.httpSessions.get(sessionId);
+    if (!session) return;
+    this.httpSessions.delete(sessionId);
+    this.sessionTierMap.delete(sessionId);
+    // Revoke BEFORE deleting the WebContents pin — same reasoning
+    // as `expireSseSession` above.
+    this.grantCache.revokeSession(sessionId, "session-idle");
+    this.sessionWebContentsMap.delete(sessionId);
+    this.sessionContextMap.delete(sessionId);
+    this.clearDedupState(sessionId);
+    this.httpIdleStartedAt.delete(sessionId);
+    this.cleanupResourceSubscriptionsFn(sessionId);
+    session.transport.close().catch(() => {
+      // ignore close errors during idle timeout cleanup
+    });
+  }
+
   createHttpIdleTimer(sessionId: string): ReturnType<typeof setTimeout> {
+    this.httpIdleStartedAt.set(sessionId, Date.now());
     const timer = setTimeout(() => {
-      const session = this.httpSessions.get(sessionId);
-      if (!session) return;
-      this.httpSessions.delete(sessionId);
-      this.sessionTierMap.delete(sessionId);
-      // Revoke BEFORE deleting the WebContents pin — same reasoning
-      // as `createIdleTimer` above.
-      this.grantCache.revokeSession(sessionId, "session-idle");
-      this.sessionWebContentsMap.delete(sessionId);
-      this.sessionContextMap.delete(sessionId);
-      this.clearDedupState(sessionId);
-      this.cleanupResourceSubscriptionsFn(sessionId);
-      session.transport.close().catch(() => {
-        // ignore close errors during idle timeout cleanup
-      });
+      this.expireHttpSession(sessionId);
     }, MCP_SSE_IDLE_TIMEOUT_MS);
     timer.unref?.();
     return timer;
@@ -115,6 +134,61 @@ export class SessionStore {
     if (!session) return;
     clearTimeout(session.idleTimer);
     session.idleTimer = this.createHttpIdleTimer(sessionId);
+  }
+
+  recomputeIdleTimers(): void {
+    // Snapshot entries to avoid mutation-during-iteration from timer callbacks.
+    const sseEntries = Array.from(this.sessions.entries());
+    for (const [sessionId, session] of sseEntries) {
+      let startedAt = this.idleStartedAt.get(sessionId);
+      if (startedAt === undefined) {
+        console.warn(`[MCP] Missing idleStartedAt for SSE session ${sessionId}, resetting`);
+        startedAt = Date.now();
+        this.idleStartedAt.set(sessionId, startedAt);
+      }
+      try {
+        const awakeElapsed = getSystemSleepService().getAwakeTimeSince(startedAt);
+        if (awakeElapsed >= MCP_SSE_IDLE_TIMEOUT_MS) {
+          this.expireSseSession(sessionId);
+        } else {
+          clearTimeout(session.idleTimer);
+          const remaining = Math.max(1, MCP_SSE_IDLE_TIMEOUT_MS - awakeElapsed);
+          session.idleTimer = setTimeout(() => {
+            this.expireSseSession(sessionId);
+          }, remaining);
+          (session.idleTimer as ReturnType<typeof setTimeout>).unref?.();
+          this.idleStartedAt.set(sessionId, Date.now());
+        }
+      } catch {
+        // SystemSleepService may not be initialized; keep existing timer.
+      }
+    }
+
+    const httpEntries = Array.from(this.httpSessions.entries());
+    for (const [sessionId, session] of httpEntries) {
+      let startedAt = this.httpIdleStartedAt.get(sessionId);
+      if (startedAt === undefined) {
+        console.warn(`[MCP] Missing httpIdleStartedAt for HTTP session ${sessionId}, resetting`);
+        startedAt = Date.now();
+        this.httpIdleStartedAt.set(sessionId, startedAt);
+      }
+      try {
+        const awakeElapsed = getSystemSleepService().getAwakeTimeSince(startedAt);
+        if (awakeElapsed >= MCP_SSE_IDLE_TIMEOUT_MS) {
+          this.expireHttpSession(sessionId);
+        } else {
+          clearTimeout(session.idleTimer);
+          const remaining = Math.max(1, MCP_SSE_IDLE_TIMEOUT_MS - awakeElapsed);
+          session.idleTimer = setTimeout(() => {
+            this.expireHttpSession(sessionId);
+          }, remaining);
+          (session.idleTimer as ReturnType<typeof setTimeout>).unref?.();
+          this.httpIdleStartedAt.set(sessionId, Date.now());
+        }
+      } catch {
+        // SystemSleepService may not be initialized; keep existing timer.
+      }
+    }
   }
 
   getTier(sessionId: string): McpTier {
@@ -139,6 +213,7 @@ export class SessionStore {
       }
     }
     this.sessions.clear();
+    this.idleStartedAt.clear();
 
     for (const session of this.httpSessions.values()) {
       clearTimeout(session.idleTimer);
@@ -151,6 +226,7 @@ export class SessionStore {
       }
     }
     this.httpSessions.clear();
+    this.httpIdleStartedAt.clear();
     this.sessionTierMap.clear();
     this.sessionWebContentsMap.clear();
     this.sessionContextMap.clear();


### PR DESCRIPTION
## Summary
- Anchors MCP session idle timers to wall clock so they survive laptop suspend/resume. Previously, bare `setTimeout` timers would fire incorrectly after wake -- either immediately or with the full suspend delay -- causing sessions to die too early or stay alive too long.
- Subscribes to `SystemSleepService.onWake` in `McpServerService` to trigger a recompute of all session timers when the system wakes. Wall-clock expiry maps stored in `sessionStore` let us compute the true remaining time.
- Timer callbacks keep a defense-in-depth wall-clock expiry check so that even if the wake recompute races or misses a session, the callback refuses to revoke prematurely.

Resolves #8466

## Changes
- `electron/services/mcp-server/sessionStore.ts` -- wall-clock `expiresAt` maps for SSE and HTTP sessions, `recomputeIdleTimers()` for wake-driven recalculation, defense-in-depth checks in expiry callbacks
- `electron/services/McpServerService.ts` -- `SystemSleepService.onWake()` subscription dispatches `recomputeIdleTimers()` across all sessions
- `electron/services/mcp-server/__tests__/sessionStore.test.ts` -- 10 new tests covering wall-clock anchoring, wake recompute, suspend-edge behavior, and defense-in-depth expiry

## Testing
- 16 sessionStore tests + 17 httpLifecycle tests = 33 passing, 0 failing
- Typecheck, lint, and format all clean