### PR TITLE
feat(mcp): correlate audit records to assistant turns with explicit turnId

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -551,6 +551,7 @@ export const CHANNELS = {
    * because the renderer needs the derived `disabled|starting|ready|failed`
    * state plus `lastError` to drive the dock-button readiness pip.
    */
+  MCP_SERVER_GET_TURN_OUTCOME_RECORDS: "mcp-server:get-turn-outcome-records",
   MCP_SERVER_GET_RUNTIME_STATE: "mcp-server:get-runtime-state",
   /** Push channel for runtime-state transitions. */
   MCP_SERVER_RUNTIME_STATE_CHANGED: "mcp-server:runtime-state-changed",

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -195,8 +195,8 @@ describe("mcpServer IPC adversarial", () => {
     expect(serviceMock.clearAuditLog).toHaveBeenCalledTimes(1);
   });
 
-  it("cleanup removes all sixteen registered handlers", () => {
-    expect(ipcHandlers.size).toBe(16);
+  it("cleanup removes all seventeen registered handlers", () => {
+    expect(ipcHandlers.size).toBe(17);
     cleanup();
     expect(ipcHandlers.size).toBe(0);
   });

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -117,6 +117,13 @@ export function registerMcpServerHandlers(): () => void {
   // needs the derived 4-state snapshot (`disabled|starting|ready|failed`)
   // plus `lastError`, not just config + bound port.
   handlers.push(
+    typedHandle(CHANNELS.MCP_SERVER_GET_TURN_OUTCOME_RECORDS, async () => {
+      const svc = await getMcpServerService();
+      return svc.getTurnOutcomeRecords();
+    })
+  );
+
+  handlers.push(
     typedHandle(CHANNELS.MCP_SERVER_GET_RUNTIME_STATE, async () => {
       const svc = await getMcpServerService();
       return svc.getRuntimeState();

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2446,6 +2446,7 @@ const api: ElectronAPI = {
     getAuditRecords: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_AUDIT_RECORDS),
     getAuditConfig: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_AUDIT_CONFIG),
     getAuditStats: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_AUDIT_STATS),
+    getTurnOutcomeRecords: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_TURN_OUTCOME_RECORDS),
     clearAuditLog: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_CLEAR_AUDIT_LOG),
     setAuditEnabled: (enabled: boolean) =>
       _unwrappingInvoke(CHANNELS.MCP_SERVER_SET_AUDIT_ENABLED, enabled),

--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -116,6 +116,121 @@ describe("AuditService.appendRecord", () => {
   });
 });
 
+describe("AuditService.appendRecord — turnId, severity, schemaVersion", () => {
+  it("persists turnId when provided", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.terminal",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 10,
+      outcome: successOutcome,
+      argsSummary: "{}",
+      turnId: "turn-uuid-123",
+    });
+    const [record] = service.getRecords();
+    expect(record!.turnId).toBe("turn-uuid-123");
+  });
+
+  it("turnId is absent when not provided", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.terminal",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 10,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    const [record] = service.getRecords();
+    expect(record!.turnId).toBeUndefined();
+  });
+
+  it("new records carry schemaVersion 1", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.terminal",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 10,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    const [record] = service.getRecords();
+    expect(record!.schemaVersion).toBe(1);
+  });
+
+  it("derives severity: success → info", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.terminal",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 10,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    const [record] = service.getRecords();
+    expect(record!.severity).toBe("info");
+  });
+
+  it("derives severity: unauthorized → warning", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.terminal",
+      sessionId: "sess-1",
+      tier: "workbench",
+      args: {},
+      durationMs: 0,
+      outcome: unauthorizedOutcome,
+      argsSummary: "{}",
+    });
+    const [record] = service.getRecords();
+    expect(record!.severity).toBe("warning");
+  });
+
+  it("derives severity: dedup → info", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.terminal",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 10,
+      outcome: { kind: "dedup" },
+      argsSummary: "{}",
+    });
+    const [record] = service.getRecords();
+    expect(record!.severity).toBe("info");
+  });
+});
+
+describe("AuditService hydrate — backward compat", () => {
+  it("tolerates persisted records missing schemaVersion and severity", () => {
+    const { service } = makeFixture({
+      auditLog: [
+        {
+          id: "old-1",
+          timestamp: 1000,
+          toolId: "agent.terminal",
+          sessionId: "sess-1",
+          tier: "action",
+          argsSummary: "{}",
+          result: "success",
+          durationMs: 5,
+        },
+      ],
+    });
+    const records = service.getRecords();
+    expect(records).toHaveLength(1);
+    expect(records[0]!.id).toBe("old-1");
+  });
+});
+
 describe("AuditService.recordAuth401 / getAuditStats", () => {
   it("starts at zero", () => {
     const { service } = makeFixture();

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -72,6 +72,7 @@ function fakeDeps(overrides?: Partial<HttpLifecycleDeps>): HttpLifecycleDeps {
       recordDirectOutcome: vi.fn(),
       getRecords: vi.fn(() => []),
       clear: vi.fn(),
+      getCurrentTurnIdForSession: vi.fn(() => null),
     },
     requestManifest: vi.fn().mockResolvedValue([]),
     dispatchAction: vi.fn().mockResolvedValue({ result: { ok: true, result: null } }),
@@ -333,6 +334,61 @@ describe("HttpLifecycle", () => {
       const deps = fakeDeps();
       const lc = new HttpLifecycle(deps);
       expect(() => lc.setSessionTier("", "system")).toThrow(/Invalid sessionId/);
+    });
+  });
+
+  describe("buildSessionServerDeps — appendAuditRecord turnId stamping", () => {
+    it("stamps turnId on appendRecord when getCurrentTurnIdForSession returns a value", () => {
+      const deps = fakeDeps();
+      (
+        deps.turnOutcomeService.getCurrentTurnIdForSession as ReturnType<typeof vi.fn>
+      ).mockReturnValue("turn-uuid-abc");
+      const lc = new HttpLifecycle(deps);
+      const deps_ = (
+        lc as unknown as {
+          buildSessionServerDeps: (sessionId: string) => {
+            appendAuditRecord: (input: Record<string, unknown>) => void;
+          };
+        }
+      ).buildSessionServerDeps("session-1");
+      deps_.appendAuditRecord({
+        toolId: "agent.terminal",
+        sessionId: "session-1",
+        tier: "action",
+        args: {},
+        durationMs: 5,
+        outcome: { kind: "result", value: { ok: true, result: null } },
+      });
+      expect(deps.auditService.appendRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ turnId: "turn-uuid-abc" })
+      );
+    });
+
+    it("omits turnId when getCurrentTurnIdForSession returns null", () => {
+      const deps = fakeDeps();
+      (
+        deps.turnOutcomeService.getCurrentTurnIdForSession as ReturnType<typeof vi.fn>
+      ).mockReturnValue(null);
+      const lc = new HttpLifecycle(deps);
+      const deps_ = (
+        lc as unknown as {
+          buildSessionServerDeps: (sessionId: string) => {
+            appendAuditRecord: (input: Record<string, unknown>) => void;
+          };
+        }
+      ).buildSessionServerDeps("session-1");
+      deps_.appendAuditRecord({
+        toolId: "agent.terminal",
+        sessionId: "session-1",
+        tier: "action",
+        args: {},
+        durationMs: 5,
+        outcome: { kind: "result", value: { ok: true, result: null } },
+      });
+      const callArgs = (deps.auditService.appendRecord as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[0];
+      expect(callArgs).toBeDefined();
+      expect(callArgs.turnId).toBeUndefined();
     });
   });
 

--- a/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
+++ b/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
@@ -20,6 +20,8 @@ function makeAuditRecord(overrides: Partial<McpAuditRecord>): McpAuditRecord {
     argsSummary: overrides.argsSummary ?? "{}",
     result: overrides.result ?? "success",
     durationMs: overrides.durationMs ?? 12,
+    schemaVersion: overrides.schemaVersion ?? 1,
+    severity: overrides.severity ?? "info",
     ...(overrides.errorCode !== undefined ? { errorCode: overrides.errorCode } : {}),
     ...(overrides.confirmationDecision !== undefined
       ? { confirmationDecision: overrides.confirmationDecision }
@@ -610,5 +612,112 @@ describe("TurnOutcomeService.clear", () => {
       makeTransition({ previousState: "waiting", state: "idle", trigger: "timeout" })
     );
     expect(f.service.getRecords()).toHaveLength(1);
+  });
+});
+
+describe("TurnOutcomeService turnId lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("mints a turnId on active entry and stamps the outcome record", () => {
+    const f = makeFixture();
+    f.service.appendOutput("term-1", "Done — the file was updated and tests pass cleanly.");
+    f.service.handleTransition(
+      makeTransition({ previousState: "idle", state: "working", trigger: "input" })
+    );
+    f.service.handleTransition(
+      makeTransition({ previousState: "working", state: "idle", trigger: "output" })
+    );
+    f.flushPersist();
+    const records = f.service.getRecords();
+    expect(records).toHaveLength(1);
+    expect(records[0]?.turnId).toBeDefined();
+    expect(records[0]?.turnId?.length).toBeGreaterThan(0);
+  });
+
+  it("getCurrentTurnIdForSession returns the active turnId", () => {
+    const f = makeFixture();
+    f.service.handleTransition(
+      makeTransition({ previousState: "idle", state: "working", trigger: "input" })
+    );
+    const turnId = f.service.getCurrentTurnIdForSession("session-1");
+    expect(turnId).toBeDefined();
+    expect(typeof turnId).toBe("string");
+  });
+
+  it("getCurrentTurnIdForSession returns null for unknown session", () => {
+    const f = makeFixture();
+    f.service.handleTransition(
+      makeTransition({ previousState: "idle", state: "working", trigger: "input" })
+    );
+    expect(f.service.getCurrentTurnIdForSession("nonexistent")).toBeNull();
+  });
+
+  it("getCurrentTurnIdForSession returns null when session not bound at mint time", () => {
+    const f = makeFixture({ sessionId: null });
+    f.service.handleTransition(
+      makeTransition({ previousState: "idle", state: "working", trigger: "input" })
+    );
+    expect(f.service.getCurrentTurnIdForSession("session-1")).toBeNull();
+  });
+
+  it("rapid consecutive active transitions produce distinct turnIds", () => {
+    const f = makeFixture();
+    f.service.appendOutput("term-1", "Done — the file was updated and the tests pass cleanly.");
+    // First turn
+    f.service.handleTransition(
+      makeTransition({ previousState: "idle", state: "working", trigger: "input" })
+    );
+    f.service.handleTransition(
+      makeTransition({ previousState: "working", state: "idle", trigger: "output" })
+    );
+    // Second turn
+    f.service.handleTransition(
+      makeTransition({ previousState: "idle", state: "working", trigger: "input" })
+    );
+    f.service.handleTransition(
+      makeTransition({ previousState: "working", state: "idle", trigger: "output" })
+    );
+    const records = f.service.getRecords();
+    expect(records).toHaveLength(2);
+    expect(records[0]?.turnId).toBeDefined();
+    expect(records[1]?.turnId).toBeDefined();
+    expect(records[0]?.turnId).not.toBe(records[1]?.turnId);
+  });
+
+  it("dropTerminal clears turnId entries", () => {
+    const f = makeFixture();
+    f.service.handleTransition(
+      makeTransition({ previousState: "idle", state: "working", trigger: "input" })
+    );
+    expect(f.service.getCurrentTurnIdForSession("session-1")).toBeDefined();
+    f.service.dropTerminal("term-1");
+    expect(f.service.getCurrentTurnIdForSession("session-1")).toBeNull();
+  });
+
+  it("clear resets turnId maps", () => {
+    const f = makeFixture();
+    f.service.handleTransition(
+      makeTransition({ previousState: "idle", state: "working", trigger: "input" })
+    );
+    expect(f.service.getCurrentTurnIdForSession("session-1")).toBeDefined();
+    f.service.clear();
+    expect(f.service.getCurrentTurnIdForSession("session-1")).toBeNull();
+  });
+
+  it("turnId is absent on recordDirectOutcome (pre-turn failures)", () => {
+    const f = makeFixture();
+    f.service.recordDirectOutcome({
+      outcome: "mcp-not-ready",
+      sessionId: "sess-failed",
+      detail: "Probe failed",
+    });
+    const records = f.service.getRecords();
+    expect(records[0]?.outcome).toBe("mcp-not-ready");
+    expect(records[0]?.turnId).toBeUndefined();
   });
 });

--- a/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
+++ b/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
@@ -720,4 +720,20 @@ describe("TurnOutcomeService turnId lifecycle", () => {
     expect(records[0]?.outcome).toBe("mcp-not-ready");
     expect(records[0]?.turnId).toBeUndefined();
   });
+
+  it("clears turnIdBySession after turn end so post-turn dispatches are not stamped", () => {
+    const f = makeFixture();
+    f.service.appendOutput("term-1", "Done — the file was updated and the tests pass cleanly.");
+    // Turn start
+    f.service.handleTransition(
+      makeTransition({ previousState: "idle", state: "working", trigger: "input" })
+    );
+    expect(f.service.getCurrentTurnIdForSession("session-1")).toBeDefined();
+    // Turn end
+    f.service.handleTransition(
+      makeTransition({ previousState: "working", state: "idle", trigger: "output" })
+    );
+    // After turn ends, session should have no active turnId
+    expect(f.service.getCurrentTurnIdForSession("session-1")).toBeNull();
+  });
 });

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -118,6 +118,7 @@ export class AuditService {
     confirmationDecision?: McpConfirmationDecision;
     argsSummary: string;
     bannerSuppressed?: boolean;
+    turnId?: string;
   }): void {
     if (this.readConfig().auditEnabled === false) return;
     this.hydrate();
@@ -136,6 +137,8 @@ export class AuditService {
       argsSummary: input.argsSummary,
       result: classification.result,
       durationMs: Math.max(0, Math.round(input.durationMs)),
+      schemaVersion: 1,
+      severity: auditSeverityFromResult(classification.result),
     };
     if (classification.errorCode !== undefined) {
       record.errorCode = classification.errorCode;
@@ -148,6 +151,9 @@ export class AuditService {
       if (input.bannerSuppressed) {
         record.bannerSuppressed = true;
       }
+    }
+    if (input.turnId !== undefined) {
+      record.turnId = input.turnId;
     }
 
     this.records.push(record);
@@ -295,6 +301,22 @@ export class AuditService {
     this.saveConfig({ auditMaxRecords: normalized });
     this.flushNow();
     return this.getAuditConfig();
+  }
+}
+
+function auditSeverityFromResult(
+  result: McpAuditResult
+): import("../../../shared/types/ipc/mcpServer.js").McpAuditSeverity {
+  switch (result) {
+    case "success":
+    case "dedup":
+      return "info";
+    case "confirmation-pending":
+      return "notice";
+    case "unauthorized":
+      return "warning";
+    case "error":
+      return "error";
   }
 }
 

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -793,9 +793,11 @@ export class HttpLifecycle {
         // `summarizeMcpArgs` — running the scrubber after truncation would
         // miss bearer tokens whose body got cut below the scrubber's
         // 8-char minimum match length.
+        const turnId = this.deps.turnOutcomeService.getCurrentTurnIdForSession(sessionId);
         this.deps.auditService.appendRecord({
           ...input,
           argsSummary: summarizeMcpArgs(input.args, (s) => scrubSecrets(sanitizePath(s))),
+          ...(turnId !== null ? { turnId } : {}),
         });
       },
       getCachedManifest,

--- a/electron/services/mcp-server/turnOutcomeLog.ts
+++ b/electron/services/mcp-server/turnOutcomeLog.ts
@@ -222,6 +222,18 @@ export class TurnOutcomeService {
    * a prior turn doesn't poison the current classification.
    */
   private turnStartByTerminal = new Map<string, number>();
+  /**
+   * Per-terminal UUID minted at the `toGroup === "active"` transition.
+   * Shared with audit records written during the same turn window.
+   */
+  private turnIdByTerminal = new Map<string, string>();
+  /**
+   * Session-keyed mirror of `turnIdByTerminal` for O(1) audit-stamp lookup.
+   * Populated eagerly at mint time when the terminal is already bound to a
+   * help session; empty for unbound terminals (correct: pre-session turn
+   * dispatches should carry no turnId).
+   */
+  private turnIdBySession = new Map<string, string>();
 
   constructor(private readonly deps: TurnOutcomeServiceDeps) {}
 
@@ -250,10 +262,25 @@ export class TurnOutcomeService {
     this.recentOutput.delete(terminalId);
     this.stuckRecorded.delete(terminalId);
     this.turnStartByTerminal.delete(terminalId);
+    this.turnIdByTerminal.delete(terminalId);
+    const sessionId = this.deps.getSessionIdForTerminal(terminalId);
+    if (sessionId !== null) {
+      this.turnIdBySession.delete(sessionId);
+    }
   }
 
   getRecentOutput(terminalId: string): string {
     return this.recentOutput.get(terminalId) ?? "";
+  }
+
+  /**
+   * Return the current turnId for a help session, or null when the session
+   * has no active turn. Called from the audit-write closure in
+   * `buildSessionServerDeps` to stamp every dispatch with the turn it
+   * belongs to.
+   */
+  getCurrentTurnIdForSession(sessionId: string): string | null {
+    return this.turnIdBySession.get(sessionId) ?? null;
   }
 
   hydrate(): void {
@@ -295,10 +322,17 @@ export class TurnOutcomeService {
     // append its own record. Resetting on the *exit* would prevent the
     // very recording we just guarded against. Also stamp the turn-start
     // timestamp so the classifier can ignore audit records from prior
-    // turns when this turn ends.
+    // turns when this turn ends, and mint a fresh turnId to correlate
+    // audit records written inside this window with the turn outcome.
     if (toGroup === "active") {
       this.stuckRecorded.delete(transition.terminalId);
       this.turnStartByTerminal.set(transition.terminalId, transition.timestamp);
+      const turnId = randomUUID();
+      this.turnIdByTerminal.set(transition.terminalId, turnId);
+      const sessionId = this.deps.getSessionIdForTerminal(transition.terminalId);
+      if (sessionId !== null) {
+        this.turnIdBySession.set(sessionId, turnId);
+      }
     }
 
     const isStuckTimeout =
@@ -331,6 +365,7 @@ export class TurnOutcomeService {
       turnStartTimestamp,
     });
 
+    const turnId = this.turnIdByTerminal.get(transition.terminalId);
     const record: AssistantTurnRecord = {
       id: randomUUID(),
       timestamp: transition.timestamp,
@@ -341,6 +376,9 @@ export class TurnOutcomeService {
       state: transition.state,
       previousState: transition.previousState,
     };
+    if (turnId !== undefined) {
+      record.turnId = turnId;
+    }
     this.appendRecordInternal(record);
     // Drain the ring so the next active turn classifies on its own output
     // rather than re-matching the prior turn's trailing text.
@@ -421,6 +459,8 @@ export class TurnOutcomeService {
     this.stuckRecorded.clear();
     this.recentOutput.clear();
     this.turnStartByTerminal.clear();
+    this.turnIdByTerminal.clear();
+    this.turnIdBySession.clear();
     this.flushNow();
   }
 }

--- a/electron/services/mcp-server/turnOutcomeLog.ts
+++ b/electron/services/mcp-server/turnOutcomeLog.ts
@@ -262,10 +262,20 @@ export class TurnOutcomeService {
     this.recentOutput.delete(terminalId);
     this.stuckRecorded.delete(terminalId);
     this.turnStartByTerminal.delete(terminalId);
+    const terminalTurnId = this.turnIdByTerminal.get(terminalId);
     this.turnIdByTerminal.delete(terminalId);
     const sessionId = this.deps.getSessionIdForTerminal(terminalId);
     if (sessionId !== null) {
       this.turnIdBySession.delete(sessionId);
+    } else if (terminalTurnId !== undefined) {
+      // Session binding was already revoked — fall back to a value scan
+      // so the entry doesn't leak for the process lifetime.
+      for (const [sid, tid] of this.turnIdBySession.entries()) {
+        if (tid === terminalTurnId) {
+          this.turnIdBySession.delete(sid);
+          break;
+        }
+      }
     }
   }
 
@@ -383,6 +393,11 @@ export class TurnOutcomeService {
     // Drain the ring so the next active turn classifies on its own output
     // rather than re-matching the prior turn's trailing text.
     this.recentOutput.delete(transition.terminalId);
+    // Clear the turnId so post-turn MCP dispatches (between this boundary
+    // and the next active entry) are not incorrectly stamped with the prior
+    // turn's ID. turnIdByTerminal is re-set on the next active transition.
+    this.turnIdBySession.delete(sessionId);
+    this.turnIdByTerminal.delete(transition.terminalId);
   }
 
   /**

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -329,6 +329,10 @@ export type {
   McpAuditRecord,
   McpAuditResult,
   McpAuditStats,
+  McpAuditSeverity,
+  McpConfirmationDecision,
+  AssistantTurnRecord,
+  TurnOutcomeClass,
   McpRuntimeSnapshot,
   McpRuntimeState,
 } from "./ipc/mcpServer.js";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1395,6 +1395,8 @@ export interface ElectronAPI {
      * since-launch 401 counter). Resets on app restart.
      */
     getAuditStats(): Promise<import("./mcpServer.js").McpAuditStats>;
+    /** Read the turn-outcome record ring buffer (newest first). */
+    getTurnOutcomeRecords(): Promise<import("./mcpServer.js").AssistantTurnRecord[]>;
     /** Clear all audit records from the ring buffer and persistence. */
     clearAuditLog(): Promise<void>;
     /** Toggle audit-log capture without losing existing records. */

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1780,6 +1780,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [max: number];
     result: { enabled: boolean; maxRecords: number };
   };
+  "mcp-server:get-turn-outcome-records": {
+    args: [];
+    result: import("./mcpServer.js").AssistantTurnRecord[];
+  };
   "mcp-server:get-runtime-state": {
     args: [];
     result: import("./mcpServer.js").McpRuntimeSnapshot;

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -51,6 +51,19 @@ export type McpAuditResult =
  */
 export type McpConfirmationDecision = "approved" | "rejected" | "timeout";
 
+/**
+ * Audit-record severity tier. Derived from the dispatch result at record-write
+ * time so readers can triage without re-deriving from errorCode + result.
+ *
+ * - `info`: success or dedup — nominal dispatch.
+ * - `notice`: confirmation-pending — gate waiting on user approval.
+ * - `warning`: tier-rejected — legit user action blocked by policy.
+ * - `error`: dispatch threw, timed out, or returned an error other than
+ *   confirmation-pending/unauthorized.
+ * - `critical`: reserved for systemic failures (not yet emitted).
+ */
+export type McpAuditSeverity = "info" | "notice" | "warning" | "error" | "critical";
+
 export interface McpAuditRecord {
   id: string;
   timestamp: number;
@@ -78,6 +91,17 @@ export interface McpAuditRecord {
    * in the audit panel even when no banner fired. See #8442.
    */
   bannerSuppressed?: boolean;
+  /**
+   * Stable correlation ID for the assistant turn this dispatch belongs to.
+   * Minted at the `active` FSM transition boundary in `TurnOutcomeService`
+   * and stamped on every audit record written within that turn window.
+   * Absent on pre-auth rejections and dispatches outside a turn boundary.
+   */
+  turnId?: string;
+  /** Schema version for forward-compat. New records always carry the current version. */
+  schemaVersion: number;
+  /** Derived severity so readers can triage without re-deriving from result/errorCode. */
+  severity: McpAuditSeverity;
 }
 
 /**
@@ -255,6 +279,12 @@ export interface AssistantTurnRecord {
   previousState?: string;
   /** Free-text diagnostic for non-classified failures (e.g. mcp-not-ready reason). */
   detail?: string;
+  /**
+   * Stable correlation ID shared with `McpAuditRecord.turnId` for every
+   * dispatch inside this turn window. Minted at the `active` FSM transition
+   * boundary and absent on pre-turn failures (`mcp-not-ready`).
+   */
+  turnId?: string;
 }
 
 /**

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -36,6 +36,7 @@ import type {
   HelpAssistantTier,
   McpAuditRecord,
   McpAuditStats,
+  AssistantTurnRecord,
 } from "@shared/types";
 import {
   HELP_TIER_CUMULATIVE,
@@ -117,6 +118,7 @@ export function DaintreeAssistantSettingsTab() {
   const [showBlastRadius, setShowBlastRadius] = useState(false);
   const [auditRecords, setAuditRecords] = useState<McpAuditRecord[]>([]);
   const [auditStats, setAuditStats] = useState<McpAuditStats | null>(null);
+  const [turnRecords, setTurnRecords] = useState<AssistantTurnRecord[]>([]);
   const [auditLoading, setAuditLoading] = useState(true);
   const [auditCopied, setAuditCopied] = useState(false);
   const [auditExported, setAuditExported] = useState(false);
@@ -221,9 +223,10 @@ export function DaintreeAssistantSettingsTab() {
   // viewer hydrate independently of the settings + MCP status round-trips.
   // `allSettled` so a stats failure doesn't silently blank the record list.
   const refreshAuditRecords = async (): Promise<void> => {
-    const [recordsResult, statsResult] = await Promise.allSettled([
+    const [recordsResult, statsResult, turnsResult] = await Promise.allSettled([
       window.electron.mcpServer.getAuditRecords(),
       window.electron.mcpServer.getAuditStats(),
+      window.electron.mcpServer.getTurnOutcomeRecords(),
     ]);
     if (recordsResult.status === "fulfilled") {
       setAuditRecords(recordsResult.value);
@@ -235,6 +238,11 @@ export function DaintreeAssistantSettingsTab() {
     } else {
       logError("Failed to load MCP audit stats for assistant tab", statsResult.reason);
     }
+    if (turnsResult.status === "fulfilled") {
+      setTurnRecords(turnsResult.value);
+    } else {
+      logError("Failed to load MCP turn outcomes for assistant tab", turnsResult.reason);
+    }
   };
 
   useEffect(() => {
@@ -244,8 +252,9 @@ export function DaintreeAssistantSettingsTab() {
       Promise.allSettled([
         window.electron.mcpServer.getAuditRecords(),
         window.electron.mcpServer.getAuditStats(),
+        window.electron.mcpServer.getTurnOutcomeRecords(),
       ])
-        .then(([recordsResult, statsResult]) => {
+        .then(([recordsResult, statsResult, turnsResult]) => {
           if (cancelled) return;
           if (recordsResult.status === "fulfilled") {
             setAuditRecords(recordsResult.value);
@@ -256,6 +265,11 @@ export function DaintreeAssistantSettingsTab() {
             setAuditStats(statsResult.value);
           } else {
             logError("Failed initial audit stats load for assistant tab", statsResult.reason);
+          }
+          if (turnsResult.status === "fulfilled") {
+            setTurnRecords(turnsResult.value);
+          } else {
+            logError("Failed initial turn outcomes load for assistant tab", turnsResult.reason);
           }
         })
         .finally(() => {
@@ -614,6 +628,7 @@ export function DaintreeAssistantSettingsTab() {
         />
         <McpAuditLogViewer
           records={auditRecords}
+          turnRecords={turnRecords}
           loading={auditLoading}
           onRefresh={refreshAuditRecords}
           onCopy={handleCopyAuditAsJson}

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
-import { Check, Copy, Download, RefreshCw, ShieldOff } from "lucide-react";
+import { Check, Copy, Download, Layers, RefreshCw, ShieldOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
-import type { McpAuditRecord, McpAuditResult } from "@shared/types";
+import type { McpAuditRecord, McpAuditResult, AssistantTurnRecord } from "@shared/types";
 
 type AuditResultFilter = "all" | McpAuditResult;
 
@@ -31,6 +31,8 @@ const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
   collision: "bg-status-warning",
 };
 
+type TimeRange = "5m" | "1h" | "24h" | "all";
+
 const TIME_RANGE_MS: Record<Exclude<TimeRange, "all">, number> = {
   "5m": 300_000,
   "1h": 3_600_000,
@@ -39,7 +41,68 @@ const TIME_RANGE_MS: Record<Exclude<TimeRange, "all">, number> = {
 
 const RELATIVE_TIMESTAMP_REFRESH_MS = 30_000;
 
-type TimeRange = "5m" | "1h" | "24h" | "all";
+const OUTCOME_LABEL: Record<string, string> = {
+  answered: "Answered",
+  hedged: "Hedged",
+  refused: "Refused",
+  "docs-empty": "No docs found",
+  "tier-rejected": "Tier rejected",
+  "mcp-not-ready": "MCP not ready",
+  "agent-stuck": "Agent stuck",
+  "tool-error": "Tool error",
+  "hibernate-resume-stale": "Resume stale",
+  unknown: "Unknown",
+};
+
+export interface TurnGroup {
+  turnId: string;
+  turnRecord: AssistantTurnRecord;
+  records: McpAuditRecord[];
+  callCount: number;
+  unauthorizedCount: number;
+  errorCount: number;
+  totalDurationMs: number;
+}
+
+export function groupRecordsByTurn(
+  records: McpAuditRecord[],
+  turnRecords: AssistantTurnRecord[]
+): { groups: TurnGroup[]; unassociated: McpAuditRecord[] } {
+  const turnById = new Map<string, AssistantTurnRecord>();
+  for (const t of turnRecords) {
+    if (t.turnId) turnById.set(t.turnId, t);
+  }
+
+  const grouped = new Map<string, McpAuditRecord[]>();
+  const unassociated: McpAuditRecord[] = [];
+
+  for (const r of records) {
+    if (r.turnId && turnById.has(r.turnId)) {
+      const list = grouped.get(r.turnId);
+      if (list) list.push(r);
+      else grouped.set(r.turnId, [r]);
+    } else {
+      unassociated.push(r);
+    }
+  }
+
+  const groups: TurnGroup[] = [];
+  for (const [turnId, recs] of grouped) {
+    const turnRecord = turnById.get(turnId)!;
+    groups.push({
+      turnId,
+      turnRecord,
+      records: recs,
+      callCount: recs.length,
+      unauthorizedCount: recs.filter((r) => r.result === "unauthorized").length,
+      errorCount: recs.filter((r) => r.result === "error").length,
+      totalDurationMs: recs.reduce((sum, r) => sum + r.durationMs, 0),
+    });
+  }
+  groups.sort((a, b) => b.turnRecord.timestamp - a.turnRecord.timestamp);
+
+  return { groups, unassociated };
+}
 
 function formatRelativeTimestamp(ts: number, now: number): string {
   const diffMs = now - ts;
@@ -56,17 +119,13 @@ function formatRelativeTimestamp(ts: number, now: number): string {
 
 interface McpAuditLogViewerProps {
   records: McpAuditRecord[];
+  turnRecords?: AssistantTurnRecord[];
   loading: boolean;
   onRefresh: () => Promise<void> | void;
   onCopy: (records: McpAuditRecord[]) => Promise<void> | void;
   onClear?: () => void;
-  /**
-   * Predicate applied before filters render — used by the Daintree Assistant
-   * Privacy section to hide `external` MCP traffic.
-   */
   includeRecord?: (record: McpAuditRecord) => boolean;
   maxRecords?: number;
-  /** Set when a copy succeeded so the UI can flash a confirmation. */
   copyFlashActive?: boolean;
   /** Triggers the NDJSON export via OS save dialog with the filtered records. */
   onExport?: (records: McpAuditRecord[]) => Promise<void> | void;
@@ -76,6 +135,7 @@ interface McpAuditLogViewerProps {
 
 export function McpAuditLogViewer({
   records,
+  turnRecords,
   loading,
   onRefresh,
   onCopy,
@@ -91,6 +151,7 @@ export function McpAuditLogViewer({
   const [timeRange, setTimeRange] = useState<TimeRange>("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [nowTick, setNowTick] = useState(Date.now());
+  const [groupByTurn, setGroupByTurn] = useState(false);
 
   useEffect(() => {
     const id = setInterval(() => setNowTick(Date.now()), RELATIVE_TIMESTAMP_REFRESH_MS);
@@ -123,6 +184,11 @@ export function McpAuditLogViewer({
       return true;
     });
   }, [visibleRecords, resultFilter, toolFilter, timeRange, searchQuery, nowTick]);
+
+  const turnGroups = useMemo(() => {
+    if (!groupByTurn || !turnRecords || turnRecords.length === 0) return null;
+    return groupRecordsByTurn(filteredRecords, turnRecords);
+  }, [groupByTurn, turnRecords, filteredRecords]);
 
   const showCopyAll = filteredRecords.length === visibleRecords.length;
 
@@ -202,6 +268,21 @@ export function McpAuditLogViewer({
             Show tier rejections ({unauthorizedCount})
           </button>
         )}
+        {turnRecords && turnRecords.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setGroupByTurn((v) => !v)}
+            className={cn(
+              "flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
+              groupByTurn
+                ? "bg-overlay-subtle border-daintree-border text-daintree-text"
+                : "border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
+            )}
+          >
+            <Layers className="w-3.5 h-3.5" />
+            Group by turn
+          </button>
+        )}
       </div>
 
       <div className="max-h-64 overflow-y-auto rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg">
@@ -225,6 +306,110 @@ export function McpAuditLogViewer({
               title="No records match the current filters"
             />
           )
+        ) : groupByTurn && turnGroups ? (
+          <ul className="divide-y divide-daintree-border">
+            {turnGroups.groups.map((group) => (
+              <li key={group.turnId} className="p-2 text-xs">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="font-medium text-daintree-text/90">
+                    {OUTCOME_LABEL[group.turnRecord.outcome] ?? group.turnRecord.outcome}
+                  </span>
+                  <span className="text-daintree-text/40">
+                    {formatRelativeTimestamp(group.turnRecord.timestamp, nowTick)}
+                  </span>
+                  <span className="text-daintree-text/40">
+                    {group.callCount} call{group.callCount !== 1 ? "s" : ""}
+                  </span>
+                  {group.unauthorizedCount > 0 && (
+                    <span className="text-status-danger/70">
+                      {group.unauthorizedCount} unauthorized
+                    </span>
+                  )}
+                  {group.errorCount > 0 && (
+                    <span className="text-status-danger/70">
+                      {group.errorCount} error{group.errorCount !== 1 ? "s" : ""}
+                    </span>
+                  )}
+                  <span className="text-daintree-text/40">{group.totalDurationMs}ms</span>
+                </div>
+                <ul className="ml-3 space-y-1 border-l-2 border-daintree-border/50 pl-3">
+                  {group.records.map((record) => (
+                    <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 py-0.5">
+                      <span
+                        className={cn(
+                          "mt-1 h-1.5 w-1.5 rounded-full shrink-0",
+                          RESULT_DOT_CLASS[record.result]
+                        )}
+                        aria-label={RESULT_LABEL[record.result]}
+                        title={RESULT_LABEL[record.result]}
+                      />
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono text-daintree-text/80 truncate">
+                            {record.toolId}
+                          </span>
+                          {record.errorCode && (
+                            <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
+                              {record.errorCode}
+                            </span>
+                          )}
+                        </div>
+                        <div className="font-mono text-daintree-text/50 truncate">
+                          {record.argsSummary || "{}"}
+                        </div>
+                      </div>
+                      <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                        <div>{record.durationMs}ms</div>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+            {turnGroups.unassociated.length > 0 && (
+              <li className="p-2 text-xs">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="font-medium text-daintree-text/60">Unassociated</span>
+                  <span className="text-daintree-text/40">
+                    {turnGroups.unassociated.length} record
+                    {turnGroups.unassociated.length !== 1 ? "s" : ""}
+                  </span>
+                </div>
+                <ul className="ml-3 space-y-1 border-l-2 border-daintree-border/50 pl-3">
+                  {turnGroups.unassociated.map((record) => (
+                    <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 py-0.5">
+                      <span
+                        className={cn(
+                          "mt-1 h-1.5 w-1.5 rounded-full shrink-0",
+                          RESULT_DOT_CLASS[record.result]
+                        )}
+                        aria-label={RESULT_LABEL[record.result]}
+                        title={RESULT_LABEL[record.result]}
+                      />
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono text-daintree-text/80 truncate">
+                            {record.toolId}
+                          </span>
+                          {record.errorCode && (
+                            <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
+                              {record.errorCode}
+                            </span>
+                          )}
+                        </div>
+                        <div className="font-mono text-daintree-text/50 truncate">
+                          {record.argsSummary || "{}"}
+                        </div>
+                      </div>
+                      <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                        <div>{record.durationMs}ms</div>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            )}
+          </ul>
         ) : (
           <ul className="divide-y divide-daintree-border">
             {filteredRecords.map((record) => (

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -24,6 +24,7 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
 import {
   type McpAuditRecord,
+  type AssistantTurnRecord,
   MCP_AUDIT_DEFAULT_MAX_RECORDS,
   MCP_AUDIT_MAX_RECORDS,
   MCP_AUDIT_MIN_RECORDS,
@@ -64,6 +65,7 @@ export function McpServerSettingsTab() {
   const auditExportTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [auditRecords, setAuditRecords] = useState<McpAuditRecord[]>([]);
+  const [turnRecords, setTurnRecords] = useState<AssistantTurnRecord[]>([]);
   const [auditEnabled, setAuditEnabled] = useState(true);
   const [auditMaxRecords, setAuditMaxRecords] = useState(MCP_AUDIT_DEFAULT_MAX_RECORDS);
   const [maxRecordsInput, setMaxRecordsInput] = useState(MCP_AUDIT_DEFAULT_MAX_RECORDS.toString());
@@ -78,8 +80,12 @@ export function McpServerSettingsTab() {
 
   const refreshAuditRecords = async (): Promise<void> => {
     try {
-      const records = await window.electron.mcpServer.getAuditRecords();
+      const [records, turns] = await Promise.all([
+        window.electron.mcpServer.getAuditRecords(),
+        window.electron.mcpServer.getTurnOutcomeRecords(),
+      ]);
       setAuditRecords(records);
+      setTurnRecords(turns);
     } catch (err) {
       logError("Failed to load MCP audit log", err);
     }
@@ -98,8 +104,9 @@ export function McpServerSettingsTab() {
       window.electron.mcpServer.getStatus(),
       window.electron.mcpServer.getAuditConfig(),
       window.electron.mcpServer.getAuditRecords(),
+      window.electron.mcpServer.getTurnOutcomeRecords(),
     ])
-      .then(([s, auditCfg, records]) => {
+      .then(([s, auditCfg, records, turns]) => {
         if (settled) return;
         setStatus(s);
         setPortInput(s.configuredPort?.toString() ?? "");
@@ -108,6 +115,7 @@ export function McpServerSettingsTab() {
         setAuditMaxRecords(auditCfg.maxRecords);
         setMaxRecordsInput(auditCfg.maxRecords.toString());
         setAuditRecords(records);
+        setTurnRecords(turns);
         setError(null);
       })
       .catch((err) => {
@@ -596,6 +604,7 @@ export function McpServerSettingsTab() {
 
               <McpAuditLogViewer
                 records={auditRecords}
+                turnRecords={turnRecords}
                 loading={auditLoading}
                 onRefresh={refreshAuditRecords}
                 onCopy={handleCopyAuditAsJson}

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -164,6 +164,7 @@ interface McpServerApi {
   onRuntimeStateChanged: ReturnType<typeof vi.fn>;
   getAuditRecords: ReturnType<typeof vi.fn>;
   getAuditStats: ReturnType<typeof vi.fn>;
+  getTurnOutcomeRecords: ReturnType<typeof vi.fn>;
   clearAuditLog: ReturnType<typeof vi.fn>;
 }
 
@@ -200,6 +201,7 @@ function installApi(
     onRuntimeStateChanged: vi.fn(() => () => {}),
     getAuditRecords: vi.fn().mockResolvedValue([]),
     getAuditStats: vi.fn().mockResolvedValue({ auth401Count: 0 }),
+    getTurnOutcomeRecords: vi.fn().mockResolvedValue([]),
     clearAuditLog: vi.fn().mockResolvedValue(undefined),
   };
   window.electron = {

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -78,6 +78,7 @@ function createMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {})
     getConfigSnippet: vi.fn().mockResolvedValue("http://127.0.0.1:9020/sse"),
     rotateApiKey: vi.fn().mockResolvedValue("dnt-key-rotated789"),
     getAuditRecords: vi.fn().mockResolvedValue([]),
+    getTurnOutcomeRecords: vi.fn().mockResolvedValue([]),
     getAuditConfig: vi.fn().mockResolvedValue({ enabled: true, maxRecords: 500 }),
     clearAuditLog: vi.fn().mockResolvedValue(undefined),
     setAuditEnabled: vi.fn().mockResolvedValue({ enabled: true, maxRecords: 500 }),


### PR DESCRIPTION
## Summary
The audit log and turn-outcome log have been two parallel streams you had to join by eye. This gives every audit record written inside an assistant turn a `turnId`, so the viewer can group records by turn and show call count, unauthorized count, error count, and outcome at a glance.

Resolves #8430

## What changed
- `turnId` is minted at the existing `active` state transition in `turnOutcomeLog.ts` that already stamps `turnStartByTerminal`
- `httpLifecycle.ts` looks up the current `turnId` for the session and stamps every `appendRecord` call
- `AssistantTurnRecord` carries the same `turnId` when the boundary completes, so the two streams join by ID
- `McpAuditLogViewer` gets a "Group by turn" toggle that collapses child records under a parent row showing turn outcome, call count, unauthorized count, error count, and total duration
- `turnId` is optional — pre-existing records and out-of-session writes (pre-auth 401s) leave it unset
- `turnIdBySession` is cleared at turn end to prevent stale correlation across terminals

## Testing
- Extended `turnOutcomeLog.test.ts` with tests for turnId minting, drop on terminal trash, and audit-stamp invariant within a window
- Extended `httpLifecycle.test.ts` with audit-stamp coverage
- Extended `auditLog.test.ts` with turn correlation verification