### PR TITLE
feat(mcp): add filters, search, NDJSON export, and latency SLO bands

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -543,6 +543,8 @@ export const CHANNELS = {
    * because pre-dispatch auth failures never reach the record ring buffer.
    */
   MCP_SERVER_GET_AUDIT_STATS: "mcp-server:get-audit-stats",
+  /** Export filtered audit records as scrubbed NDJSON via OS save dialog. */
+  MCP_SERVER_EXPORT_AUDIT_LOG: "mcp-server:export-audit-log",
   /**
    * Mount-time hydration of the runtime-state snapshot. Distinct from
    * `MCP_SERVER_GET_STATUS` (which exposes config — enabled/port/apiKey)

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -195,8 +195,8 @@ describe("mcpServer IPC adversarial", () => {
     expect(serviceMock.clearAuditLog).toHaveBeenCalledTimes(1);
   });
 
-  it("cleanup removes all fifteen registered handlers", () => {
-    expect(ipcHandlers.size).toBe(15);
+  it("cleanup removes all sixteen registered handlers", () => {
+    expect(ipcHandlers.size).toBe(16);
     cleanup();
     expect(ipcHandlers.size).toBe(0);
   });

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -1,6 +1,10 @@
+import { dialog } from "electron";
+import { writeFile } from "fs/promises";
 import { CHANNELS } from "../channels.js";
 import type * as McpServerServiceModule from "../../services/McpServerService.js";
 import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../utils.js";
+import { sanitizePath } from "../../utils/pathScrubber.js";
+import { scrubSecrets } from "../../utils/secretScrubber.js";
 
 type McpServerSingleton = typeof McpServerServiceModule.mcpServerService;
 
@@ -117,6 +121,34 @@ export function registerMcpServerHandlers(): () => void {
       const svc = await getMcpServerService();
       return svc.getRuntimeState();
     })
+  );
+
+  handlers.push(
+    typedHandleWithContext(
+      CHANNELS.MCP_SERVER_EXPORT_AUDIT_LOG,
+      async (ctx, records: unknown): Promise<boolean> => {
+        if (!Array.isArray(records)) throw new Error("records must be an array");
+        const ndjsonLines = records.map((record) => {
+          const line = JSON.stringify(record);
+          return scrubSecrets(sanitizePath(line));
+        });
+        const ndjsonContent = ndjsonLines.join("\n") + "\n";
+        const win = ctx.senderWindow ?? undefined;
+        const now = Date.now();
+        const defaultFilename = `mcp-audit-log-${new Date(now).toISOString().replace(/[:.]/g, "-")}.ndjson`;
+        const dialogOptions: Electron.SaveDialogOptions = {
+          title: "Export MCP Audit Log",
+          defaultPath: defaultFilename,
+          filters: [{ name: "NDJSON Files", extensions: ["ndjson"] }],
+        };
+        const { filePath, canceled } = win
+          ? await dialog.showSaveDialog(win, dialogOptions)
+          : await dialog.showSaveDialog(dialogOptions);
+        if (canceled || !filePath) return false;
+        await writeFile(filePath, ndjsonContent, "utf-8");
+        return true;
+      }
+    )
   );
 
   handlers.push(

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -128,9 +128,13 @@ export function registerMcpServerHandlers(): () => void {
       CHANNELS.MCP_SERVER_EXPORT_AUDIT_LOG,
       async (ctx, records: unknown): Promise<boolean> => {
         if (!Array.isArray(records)) throw new Error("records must be an array");
-        const ndjsonLines = records.map((record) => {
-          const line = JSON.stringify(record);
-          return scrubSecrets(sanitizePath(line));
+        const ndjsonLines = records.map((rawRecord) => {
+          const record = rawRecord as Record<string, unknown>;
+          const cleaned: Record<string, unknown> = {};
+          for (const [key, value] of Object.entries(record)) {
+            cleaned[key] = typeof value === "string" ? sanitizePath(value) : value;
+          }
+          return scrubSecrets(JSON.stringify(cleaned));
         });
         const ndjsonContent = ndjsonLines.join("\n") + "\n";
         const win = ctx.senderWindow ?? undefined;

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2454,6 +2454,8 @@ const api: ElectronAPI = {
     getRuntimeState: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_RUNTIME_STATE),
     onRuntimeStateChanged: (callback: (snapshot: McpRuntimeSnapshot) => void) =>
       _typedOn(CHANNELS.MCP_SERVER_RUNTIME_STATE_CHANGED, callback),
+    exportAuditLog: (records: McpAuditRecord[]) =>
+      _unwrappingInvoke(CHANNELS.MCP_SERVER_EXPORT_AUDIT_LOG, records),
     setSessionTier: (sessionId: string, tier: "workbench" | "action" | "system") =>
       _unwrappingInvoke(CHANNELS.MCP_SERVER_SET_SESSION_TIER, { sessionId, tier }),
     issueGrant: (sessionId: string, toolId: string) =>

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -14,7 +14,7 @@ import { isTrustedRendererUrl } from "../shared/utils/trustedRenderer.js";
 import { isIpcEnvelope } from "../shared/types/ipc/errors.js";
 import { deserializeError } from "../shared/utils/ipcErrorSerialization.js";
 import type { AppErrorCode } from "../shared/types/appError.js";
-import type { McpRuntimeSnapshot } from "../shared/types/ipc/mcpServer.js";
+import type { McpAuditRecord, McpRuntimeSnapshot } from "../shared/types/ipc/mcpServer.js";
 import type { ActionContext } from "../shared/types/actions.js";
 import type { PushProgressEvent } from "../shared/types/ipc/gitPush.js";
 import type { HelpAssistantTier } from "../shared/types/ipc/maps.js";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1443,6 +1443,8 @@ export interface ElectronAPI {
      * this WebContents. The callback fires when a tool call is denied because
      * the session tier doesn't permit it.
      */
+    /** Export filtered audit records as scrubbed NDJSON via OS save dialog. Returns false if canceled. */
+    exportAuditLog(records: import("./mcpServer.js").McpAuditRecord[]): Promise<boolean>;
     onTierNotPermitted(
       callback: (payload: {
         sessionId: string;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1784,6 +1784,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [];
     result: import("./mcpServer.js").McpRuntimeSnapshot;
   };
+  "mcp-server:export-audit-log": {
+    args: [records: import("./mcpServer.js").McpAuditRecord[]];
+    result: boolean;
+  };
   "mcp-server:set-session-tier": {
     args: [payload: { sessionId: string; tier: "workbench" | "action" | "system" }];
     result: { sessionId: string; tier: "workbench" | "action" | "system" };

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -119,10 +119,12 @@ export function DaintreeAssistantSettingsTab() {
   const [auditStats, setAuditStats] = useState<McpAuditStats | null>(null);
   const [auditLoading, setAuditLoading] = useState(true);
   const [auditCopied, setAuditCopied] = useState(false);
+  const [auditExported, setAuditExported] = useState(false);
   const [showClearAuditConfirm, setShowClearAuditConfirm] = useState(false);
   const [isClearingAudit, setIsClearingAudit] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const auditCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const auditExportTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // customArgs is a free-form text input; persisting on every keystroke would
   // spam IPC. We track a pending edit alongside the persisted value: when the
@@ -209,6 +211,7 @@ export function DaintreeAssistantSettingsTab() {
       cancelled = true;
       unsubscribe();
       if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      if (auditExportTimeoutRef.current) clearTimeout(auditExportTimeoutRef.current);
     };
   }, []);
 
@@ -279,6 +282,29 @@ export function DaintreeAssistantSettingsTab() {
       }
       setError(formatErrorMessage(err, "Couldn't copy audit log"));
       logError("Failed to copy MCP audit log from assistant tab", err);
+    }
+  };
+
+  const handleExportAuditAsNdjson = async (records: McpAuditRecord[]) => {
+    try {
+      setError(null);
+      const written = await window.electron.mcpServer.exportAuditLog(records);
+      if (written) {
+        setAuditExported(true);
+        if (auditExportTimeoutRef.current) clearTimeout(auditExportTimeoutRef.current);
+        auditExportTimeoutRef.current = setTimeout(
+          () => setAuditExported(false),
+          COPY_RESET_DELAY_MS
+        );
+      }
+    } catch (err) {
+      setAuditExported(false);
+      if (auditExportTimeoutRef.current) {
+        clearTimeout(auditExportTimeoutRef.current);
+        auditExportTimeoutRef.current = null;
+      }
+      setError(formatErrorMessage(err, "Couldn't export audit log"));
+      logError("Failed to export MCP audit log from assistant tab", err);
     }
   };
 
@@ -589,6 +615,8 @@ export function DaintreeAssistantSettingsTab() {
           onClear={() => setShowClearAuditConfirm(true)}
           copyFlashActive={auditCopied}
           includeRecord={(record) => record.tier !== "external"}
+          onExport={handleExportAuditAsNdjson}
+          exportFlashActive={auditExported}
         />
         <McpAuditLatencyTable
           records={auditRecords}

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -120,6 +120,7 @@ export function DaintreeAssistantSettingsTab() {
   const [auditLoading, setAuditLoading] = useState(true);
   const [auditCopied, setAuditCopied] = useState(false);
   const [auditExported, setAuditExported] = useState(false);
+  const [isExportingAudit, setIsExportingAudit] = useState(false);
   const [showClearAuditConfirm, setShowClearAuditConfirm] = useState(false);
   const [isClearingAudit, setIsClearingAudit] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -286,6 +287,8 @@ export function DaintreeAssistantSettingsTab() {
   };
 
   const handleExportAuditAsNdjson = async (records: McpAuditRecord[]) => {
+    if (isExportingAudit) return;
+    setIsExportingAudit(true);
     try {
       setError(null);
       const written = await window.electron.mcpServer.exportAuditLog(records);
@@ -305,6 +308,8 @@ export function DaintreeAssistantSettingsTab() {
       }
       setError(formatErrorMessage(err, "Couldn't export audit log"));
       logError("Failed to export MCP audit log from assistant tab", err);
+    } finally {
+      setIsExportingAudit(false);
     }
   };
 

--- a/src/components/Settings/McpAuditLatencyTable.tsx
+++ b/src/components/Settings/McpAuditLatencyTable.tsx
@@ -57,7 +57,7 @@ function sloBand(p95: number): SloBand {
   if (p95 <= 0) return { label: "", className: "" };
   if (p95 < 200) return { label: "Instant", className: "text-status-success" };
   if (p95 < 1000) return { label: "Fast", className: "text-status-success" };
-  if (p95 < 5000) return { label: "Standard", className: "text-status-warning" };
+  if (p95 <= 5000) return { label: "Standard", className: "text-status-warning" };
   return { label: "Slow", className: "text-status-danger" };
 }
 

--- a/src/components/Settings/McpAuditLatencyTable.tsx
+++ b/src/components/Settings/McpAuditLatencyTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { McpAuditRecord } from "@shared/types";
@@ -12,11 +12,21 @@ interface McpAuditLatencyTableProps {
   includeRecord?: (record: McpAuditRecord) => boolean;
 }
 
-interface ToolStats {
-  toolId: string;
-  count: number;
+interface ToolLatencyBlock {
   p50: number;
   p95: number;
+  count: number;
+}
+
+interface ToolLatencyStats {
+  toolId: string;
+  success: ToolLatencyBlock;
+  failed: ToolLatencyBlock;
+}
+
+interface SloBand {
+  label: string;
+  className: string;
 }
 
 /**
@@ -33,34 +43,71 @@ function percentile(sortedAsc: number[], p: number): number {
   return lower + f * (upper - lower);
 }
 
+function computeBlock(durations: number[]): ToolLatencyBlock {
+  if (durations.length === 0) return { p50: 0, p95: 0, count: 0 };
+  const sorted = [...durations].sort((a, b) => a - b);
+  return {
+    p50: Math.round(percentile(sorted, 0.5)),
+    p95: Math.round(percentile(sorted, 0.95)),
+    count: sorted.length,
+  };
+}
+
+function sloBand(p95: number): SloBand {
+  if (p95 <= 0) return { label: "", className: "" };
+  if (p95 < 200) return { label: "Instant", className: "text-status-success" };
+  if (p95 < 1000) return { label: "Fast", className: "text-status-success" };
+  if (p95 < 5000) return { label: "Standard", className: "text-status-warning" };
+  return { label: "Slow", className: "text-status-danger" };
+}
+
 export function McpAuditLatencyTable({ records, includeRecord }: McpAuditLatencyTableProps) {
   const [isOpen, setIsOpen] = useState(true);
 
-  const stats = useMemo<ToolStats[]>(() => {
-    // Only success records meaningfully reflect tool latency. Errors and
-    // unauthorized results often short-circuit before the work runs and
-    // would skew p50/p95 downward.
-    const buckets = new Map<string, number[]>();
+  const stats = useMemo<ToolLatencyStats[]>(() => {
+    const successBuckets = new Map<string, number[]>();
+    const failedBuckets = new Map<string, number[]>();
     for (const record of records) {
       if (includeRecord && !includeRecord(record)) continue;
-      if (record.result !== "success") continue;
-      const list = buckets.get(record.toolId);
+      const map = record.result === "success" ? successBuckets : failedBuckets;
+      const list = map.get(record.toolId);
       if (list) list.push(record.durationMs);
-      else buckets.set(record.toolId, [record.durationMs]);
+      else map.set(record.toolId, [record.durationMs]);
     }
-    const out: ToolStats[] = [];
-    for (const [toolId, durations] of buckets) {
-      const sorted = [...durations].sort((a, b) => a - b);
+    const allToolIds = new Set([...successBuckets.keys(), ...failedBuckets.keys()]);
+    const out: ToolLatencyStats[] = [];
+    for (const toolId of allToolIds) {
       out.push({
         toolId,
-        count: sorted.length,
-        p50: Math.round(percentile(sorted, 0.5)),
-        p95: Math.round(percentile(sorted, 0.95)),
+        success: computeBlock(successBuckets.get(toolId) ?? []),
+        failed: computeBlock(failedBuckets.get(toolId) ?? []),
       });
     }
-    out.sort((a, b) => b.p95 - a.p95);
+    out.sort(
+      (a, b) => Math.max(b.success.p95, b.failed.p95) - Math.max(a.success.p95, a.failed.p95)
+    );
     return out;
   }, [records, includeRecord]);
+
+  const hasRecords = stats.length > 0;
+
+  const renderBlock = (block: ToolLatencyBlock, blockLabel: string) => {
+    if (block.count === 0) return null;
+    const band = sloBand(block.p95);
+    return (
+      <tr className="text-daintree-text/70">
+        <td className="py-1 pl-6 pr-2 text-[10px] text-daintree-text/50 truncate">{blockLabel}</td>
+        <td className="py-1 px-2 text-right text-daintree-text/50 tabular-nums">{block.count}</td>
+        <td className="py-1 px-2 text-right tabular-nums">{block.p50}ms</td>
+        <td className="py-1 pl-2 text-right tabular-nums">
+          {block.p95}ms
+          {band.label && (
+            <span className={cn("ml-1.5 text-[10px]", band.className)}>{band.label}</span>
+          )}
+        </td>
+      </tr>
+    );
+  };
 
   return (
     <div className="rounded-[var(--radius-md)] border border-daintree-border bg-overlay-subtle/40">
@@ -82,34 +129,38 @@ export function McpAuditLatencyTable({ records, includeRecord }: McpAuditLatency
           />
           <span>
             Latency by tool
-            {stats.length > 0 && (
-              <span className="text-daintree-text/50"> ({stats.length} tools)</span>
-            )}
+            {hasRecords && <span className="text-daintree-text/50"> ({stats.length} tools)</span>}
           </span>
         </span>
       </button>
       {isOpen && (
         <div className="px-3 pb-3 pt-1">
-          {stats.length === 0 ? (
-            <p className="text-xs text-daintree-text/50">No successful dispatches recorded yet.</p>
+          {!hasRecords ? (
+            <p className="text-xs text-daintree-text/50">No dispatches recorded yet.</p>
           ) : (
             <table className="w-full table-fixed text-xs font-mono tabular-nums">
               <thead>
                 <tr className="text-daintree-text/50">
                   <th className="text-left font-medium py-1 pr-2 truncate">Tool</th>
-                  <th className="text-right font-medium py-1 px-2 w-14">n</th>
-                  <th className="text-right font-medium py-1 px-2 w-20">p50</th>
-                  <th className="text-right font-medium py-1 pl-2 w-20">p95</th>
+                  <th className="text-right font-medium py-1 px-2 w-12">n</th>
+                  <th className="text-right font-medium py-1 px-2 w-18">p50</th>
+                  <th className="text-right font-medium py-1 pl-2 w-30">p95</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-daintree-border">
+              <tbody className="divide-y divide-daintree-border/50">
                 {stats.map((row) => (
-                  <tr key={row.toolId} className="text-daintree-text/80">
-                    <td className="py-1 pr-2 truncate">{row.toolId}</td>
-                    <td className="py-1 px-2 text-right text-daintree-text/60">{row.count}</td>
-                    <td className="py-1 px-2 text-right">{row.p50}ms</td>
-                    <td className="py-1 pl-2 text-right">{row.p95}ms</td>
-                  </tr>
+                  <React.Fragment key={row.toolId}>
+                    <tr className="text-daintree-text/80">
+                      <td className="py-1 pr-2 truncate font-medium">{row.toolId}</td>
+                      <td className="py-1 px-2 text-right text-daintree-text/60 tabular-nums">
+                        {row.success.count + row.failed.count}
+                      </td>
+                      <td />
+                      <td />
+                    </tr>
+                    {renderBlock(row.success, "success")}
+                    {renderBlock(row.failed, "failed")}
+                  </React.Fragment>
                 ))}
               </tbody>
             </table>

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from "react";
-import { Check, Copy, RefreshCw, ShieldOff } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Check, Copy, Download, RefreshCw, ShieldOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
@@ -29,8 +29,18 @@ const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
   dedup: "bg-status-info",
 };
 
-function formatRelativeTimestamp(ts: number): string {
-  const diffMs = Date.now() - ts;
+const TIME_RANGE_MS: Record<Exclude<TimeRange, "all">, number> = {
+  "5m": 300_000,
+  "1h": 3_600_000,
+  "24h": 86_400_000,
+};
+
+const RELATIVE_TIMESTAMP_REFRESH_MS = 30_000;
+
+type TimeRange = "5m" | "1h" | "24h" | "all";
+
+function formatRelativeTimestamp(ts: number, now: number): string {
+  const diffMs = now - ts;
   if (diffMs < 0) return "just now";
   const sec = Math.floor(diffMs / 1000);
   if (sec < 60) return `${sec}s ago`;
@@ -56,6 +66,10 @@ interface McpAuditLogViewerProps {
   maxRecords?: number;
   /** Set when a copy succeeded so the UI can flash a confirmation. */
   copyFlashActive?: boolean;
+  /** Triggers the NDJSON export via OS save dialog with the filtered records. */
+  onExport?: (records: McpAuditRecord[]) => Promise<void> | void;
+  /** Set when an export succeeded so the UI can flash a confirmation. */
+  exportFlashActive?: boolean;
 }
 
 export function McpAuditLogViewer({
@@ -67,9 +81,19 @@ export function McpAuditLogViewer({
   includeRecord,
   maxRecords,
   copyFlashActive,
+  onExport,
+  exportFlashActive,
 }: McpAuditLogViewerProps) {
   const [toolFilter, setToolFilter] = useState("");
   const [resultFilter, setResultFilter] = useState<AuditResultFilter>("all");
+  const [timeRange, setTimeRange] = useState<TimeRange>("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [nowTick, setNowTick] = useState(Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNowTick(Date.now()), RELATIVE_TIMESTAMP_REFRESH_MS);
+    return () => clearInterval(id);
+  }, []);
 
   const visibleRecords = useMemo(() => {
     if (!includeRecord) return records;
@@ -83,12 +107,17 @@ export function McpAuditLogViewer({
 
   const filteredRecords = useMemo(() => {
     const needle = toolFilter.trim().toLowerCase();
+    const searchNeedle = searchQuery.trim().toLowerCase();
+    const cutoffMs = timeRange !== "all" ? nowTick - TIME_RANGE_MS[timeRange] : undefined;
     return visibleRecords.filter((record) => {
+      if (cutoffMs !== undefined && record.timestamp < cutoffMs) return false;
       if (resultFilter !== "all" && record.result !== resultFilter) return false;
       if (needle.length > 0 && !record.toolId.toLowerCase().includes(needle)) return false;
+      if (searchNeedle.length > 0 && !record.argsSummary.toLowerCase().includes(searchNeedle))
+        return false;
       return true;
     });
-  }, [visibleRecords, resultFilter, toolFilter]);
+  }, [visibleRecords, resultFilter, toolFilter, timeRange, searchQuery, nowTick]);
 
   const showCopyAll = filteredRecords.length === visibleRecords.length;
 
@@ -106,6 +135,14 @@ export function McpAuditLogViewer({
           placeholder="Filter by tool ID"
           aria-label="Filter audit by tool name"
           className="flex-1 min-w-[160px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        />
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search arguments"
+          aria-label="Search audit arguments"
+          className="w-40 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
         />
         <select
           value={resultFilter}
@@ -131,6 +168,22 @@ export function McpAuditLogViewer({
           <option value="confirmation-pending">Awaiting confirmation</option>
           <option value="unauthorized">Unauthorized</option>
           <option value="dedup">Deduplicated</option>
+        </select>
+        <select
+          value={timeRange}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (value === "5m" || value === "1h" || value === "24h" || value === "all") {
+              setTimeRange(value);
+            }
+          }}
+          aria-label="Filter audit by time range"
+          className="bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        >
+          <option value="all">All</option>
+          <option value="5m">Last 5 minutes</option>
+          <option value="1h">Last hour</option>
+          <option value="24h">Last 24 hours</option>
         </select>
         {unauthorizedCount > 0 && resultFilter !== "unauthorized" && (
           <button
@@ -203,7 +256,7 @@ export function McpAuditLogViewer({
                   )}
                 </div>
                 <div className="text-right text-daintree-text/40 whitespace-nowrap">
-                  <div>{formatRelativeTimestamp(record.timestamp)}</div>
+                  <div>{formatRelativeTimestamp(record.timestamp, nowTick)}</div>
                   <div>{record.durationMs}ms</div>
                 </div>
               </li>
@@ -238,6 +291,28 @@ export function McpAuditLogViewer({
           {copyFlashActive ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
           {copyFlashActive ? "Copied!" : `Copy ${showCopyAll ? "all" : "filtered"} as JSON`}
         </button>
+        {onExport && (
+          <button
+            type="button"
+            onClick={() => void onExport(filteredRecords)}
+            disabled={filteredRecords.length === 0}
+            className={cn(
+              "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
+              filteredRecords.length === 0
+                ? "border-daintree-border text-daintree-text/30 cursor-not-allowed"
+                : exportFlashActive
+                  ? "text-status-success border-status-success/30"
+                  : "border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
+            )}
+          >
+            {exportFlashActive ? (
+              <Check className="w-3.5 h-3.5" />
+            ) : (
+              <Download className="w-3.5 h-3.5" />
+            )}
+            {exportFlashActive ? "Exported!" : "Export as NDJSON"}
+          </button>
+        )}
         {onClear && (
           <button
             type="button"
@@ -254,7 +329,10 @@ export function McpAuditLogViewer({
           </button>
         )}
         <span className="ml-auto text-xs text-daintree-text/40">
-          {resultFilter !== "all" || toolFilter.trim().length > 0
+          {resultFilter !== "all" ||
+          toolFilter.trim().length > 0 ||
+          timeRange !== "all" ||
+          searchQuery.trim().length > 0
             ? `${filteredRecords.length} of ${visibleRecords.length}`
             : maxRecords !== undefined
               ? `${visibleRecords.length} of ${maxRecords}`

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -113,7 +113,10 @@ export function McpAuditLogViewer({
       if (cutoffMs !== undefined && record.timestamp < cutoffMs) return false;
       if (resultFilter !== "all" && record.result !== resultFilter) return false;
       if (needle.length > 0 && !record.toolId.toLowerCase().includes(needle)) return false;
-      if (searchNeedle.length > 0 && !record.argsSummary.toLowerCase().includes(searchNeedle))
+      if (
+        searchNeedle.length > 0 &&
+        !(record.argsSummary || "").toLowerCase().includes(searchNeedle)
+      )
         return false;
       return true;
     });

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -57,6 +57,7 @@ export function McpServerSettingsTab() {
   const [copiedKey, setCopiedKey] = useState(false);
   const [copiedAudit, setCopiedAudit] = useState(false);
   const [exportedAudit, setExportedAudit] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
   const configCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const apiKeyCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const auditCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -314,6 +315,8 @@ export function McpServerSettingsTab() {
   };
 
   const handleExportAuditLog = async (records: McpAuditRecord[]) => {
+    if (isExporting) return;
+    setIsExporting(true);
     try {
       setError(null);
       const written = await window.electron.mcpServer.exportAuditLog(records);
@@ -330,6 +333,8 @@ export function McpServerSettingsTab() {
       }
       setError(formatErrorMessage(err, "Failed to export audit log"));
       logError("Failed to export MCP audit log", err);
+    } finally {
+      setIsExporting(false);
     }
   };
 

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -37,6 +37,7 @@ interface McpServerStatus {
 }
 
 const COPY_FEEDBACK_MS = 2000;
+const STATUS_LOAD_TIMEOUT_MS = 10_000;
 
 const MASKED_KEY = "•".repeat(24);
 
@@ -55,9 +56,11 @@ export function McpServerSettingsTab() {
   const [showApiKey, setShowApiKey] = useState(false);
   const [copiedKey, setCopiedKey] = useState(false);
   const [copiedAudit, setCopiedAudit] = useState(false);
+  const [exportedAudit, setExportedAudit] = useState(false);
   const configCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const apiKeyCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const auditCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const auditExportTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [auditRecords, setAuditRecords] = useState<McpAuditRecord[]>([]);
   const [auditEnabled, setAuditEnabled] = useState(true);
@@ -88,7 +91,7 @@ export function McpServerSettingsTab() {
       setError("Couldn't load MCP server settings. Restart Daintree and try again.");
       setLoading(false);
       logError("MCP status load timed out");
-    }, 10_000);
+    }, STATUS_LOAD_TIMEOUT_MS);
 
     Promise.all([
       window.electron.mcpServer.getStatus(),
@@ -140,6 +143,7 @@ export function McpServerSettingsTab() {
       if (configCopyTimeoutRef.current) clearTimeout(configCopyTimeoutRef.current);
       if (apiKeyCopyTimeoutRef.current) clearTimeout(apiKeyCopyTimeoutRef.current);
       if (auditCopyTimeoutRef.current) clearTimeout(auditCopyTimeoutRef.current);
+      if (auditExportTimeoutRef.current) clearTimeout(auditExportTimeoutRef.current);
     };
   }, []);
 
@@ -306,6 +310,26 @@ export function McpServerSettingsTab() {
       }
       setError(formatErrorMessage(err, "Failed to copy audit log"));
       logError("Failed to copy MCP audit log", err);
+    }
+  };
+
+  const handleExportAuditLog = async (records: McpAuditRecord[]) => {
+    try {
+      setError(null);
+      const written = await window.electron.mcpServer.exportAuditLog(records);
+      if (written) {
+        setExportedAudit(true);
+        if (auditExportTimeoutRef.current) clearTimeout(auditExportTimeoutRef.current);
+        auditExportTimeoutRef.current = setTimeout(() => setExportedAudit(false), COPY_FEEDBACK_MS);
+      }
+    } catch (err) {
+      setExportedAudit(false);
+      if (auditExportTimeoutRef.current) {
+        clearTimeout(auditExportTimeoutRef.current);
+        auditExportTimeoutRef.current = null;
+      }
+      setError(formatErrorMessage(err, "Failed to export audit log"));
+      logError("Failed to export MCP audit log", err);
     }
   };
 
@@ -573,6 +597,8 @@ export function McpServerSettingsTab() {
                 onClear={() => setShowClearConfirm(true)}
                 copyFlashActive={copiedAudit}
                 maxRecords={auditMaxRecords}
+                onExport={handleExportAuditLog}
+                exportFlashActive={exportedAudit}
               />
             </div>
           </SettingsSection>


### PR DESCRIPTION
## Summary

This polishes the MCP audit settings surface with a few features that make the audit log actually usable for forensics and debugging.

- A time-range filter (Last 5 minutes, Last hour, Last 24 hours, All) so you can scope a session quickly without scrolling.
- Full-text search against `argsSummary` so you can find the one call you care about without memorizing tool names.
- NDJSON export with a `scrubSecrets` + `sanitizePath` second pass -- safer than the clipboard path, and the format imports cleanly into analysis tools.
- The latency table now shows success and failure as separate stat blocks per tool, with SLO band labels so you can spot which tools are slow at a glance.

Resolves #8437

## Changes

- **`McpAuditLogViewer.tsx`** -- added time-range dropdown, full-text search input, and Export as NDJSON button
- **`McpAuditLatencyTable.tsx`** -- split stats into `success`/`failed` blocks per tool, added SLO band labels (Instant/Fast/Standard/Slow) using status colors
- **`electron/ipc/channels.ts`** and **`electron/ipc/handlers/mcpServer.ts`** -- new `mcp:export-audit-ndjson` IPC channel with `scrubSecrets` + `sanitizePath` defense
- **`electron/preload.cts`** -- exposed the export channel
- **`shared/types/ipc/api.ts`** and **`shared/types/ipc/maps.ts`** -- typed the new IPC contract
- **`McpServerSettingsTab.tsx`** and **`DaintreeAssistantSettingsTab.tsx`** -- wired the export action and tab entry point

## Testing

- Verified the time-range filter and search compose correctly in combination
- Confirmed NDJSON export writes one record per line with proper scrubbing
- Checked the latency table displays both stat blocks and SLO bands for tools with mixed success/failure history