### PR TITLE
feat(mcp): add in-process anomaly detector for audit signals

### DIFF
--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { AuditService, type AuditOutcome } from "../auditLog.js";
+import type { McpAuditResult } from "../../../../shared/types/ipc/mcpServer.js";
 
 function makeFixture(initialConfig: Record<string, unknown> = {}) {
   const config: Record<string, unknown> = {
@@ -288,7 +289,7 @@ describe("AuditService anomaly detection", () => {
                 kind: "result",
                 value: {
                   ok: false,
-                  error: { code: "ERR", message: "fail" },
+                  error: { code: "EXECUTION_ERROR", message: "fail" },
                 } as import("../../../../shared/types/actions.js").ActionDispatchResult,
               }
             : opts.result === "unauthorized"
@@ -446,7 +447,7 @@ describe("AuditService anomaly detection", () => {
         kind: "result",
         value: {
           ok: false,
-          error: { code: "ERR", message: "fail" },
+          error: { code: "EXECUTION_ERROR", message: "fail" },
         } as import("../../../../shared/types/actions.js").ActionDispatchResult,
       },
       argsSummary: "{}",
@@ -482,7 +483,7 @@ describe("AuditService anomaly detection", () => {
           kind: "result",
           value: {
             ok: false,
-            error: { code: "ERR", message: "fail" },
+            error: { code: "EXECUTION_ERROR", message: "fail" },
           } as import("../../../../shared/types/actions.js").ActionDispatchResult,
         },
         argsSummary: "{}",
@@ -518,7 +519,7 @@ describe("AuditService anomaly detection", () => {
           kind: "result",
           value: {
             ok: false,
-            error: { code: "ERR", message: "fail" },
+            error: { code: "EXECUTION_ERROR", message: "fail" },
           } as import("../../../../shared/types/actions.js").ActionDispatchResult,
         },
         argsSummary: "{}",
@@ -554,7 +555,7 @@ describe("AuditService anomaly detection", () => {
           kind: "result",
           value: {
             ok: false,
-            error: { code: "ERR", message: "fail" },
+            error: { code: "EXECUTION_ERROR", message: "fail" },
           } as import("../../../../shared/types/actions.js").ActionDispatchResult,
         },
         argsSummary: "{}",

--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -234,7 +234,7 @@ describe("AuditService hydrate — backward compat", () => {
 describe("AuditService.recordAuth401 / getAuditStats", () => {
   it("starts at zero", () => {
     const { service } = makeFixture();
-    expect(service.getAuditStats()).toEqual({ auth401Count: 0 });
+    expect(service.getAuditStats().auth401Count).toBe(0);
   });
 
   it("increments on each call", () => {
@@ -242,14 +242,14 @@ describe("AuditService.recordAuth401 / getAuditStats", () => {
     service.recordAuth401();
     service.recordAuth401();
     service.recordAuth401();
-    expect(service.getAuditStats()).toEqual({ auth401Count: 3 });
+    expect(service.getAuditStats().auth401Count).toBe(3);
   });
 
   it("does not increment when audit is disabled", () => {
     const { service } = makeFixture({ auditEnabled: false });
     service.recordAuth401();
     service.recordAuth401();
-    expect(service.getAuditStats()).toEqual({ auth401Count: 0 });
+    expect(service.getAuditStats().auth401Count).toBe(0);
   });
 
   it("is not reset by clear() — counter is session-scoped, not log-scoped", () => {
@@ -257,6 +257,362 @@ describe("AuditService.recordAuth401 / getAuditStats", () => {
     service.recordAuth401();
     service.recordAuth401();
     service.clear();
-    expect(service.getAuditStats()).toEqual({ auth401Count: 2 });
+    const stats = service.getAuditStats();
+    expect(stats.auth401Count).toBe(2);
+  });
+});
+
+describe("AuditService anomaly detection", () => {
+  function makeRecords(
+    count: number,
+    factory: (i: number) => Partial<{
+      toolId: string;
+      sessionId: string;
+      tier: string;
+      durationMs: number;
+      result: McpAuditResult;
+    }>
+  ) {
+    const { service } = makeFixture();
+    for (let i = 0; i < count; i++) {
+      const opts = factory(i);
+      service.appendRecord({
+        toolId: opts.toolId ?? "test.tool",
+        sessionId: opts.sessionId ?? "sess-1",
+        tier: (opts.tier as "workbench" | "action" | "system" | "external") ?? "action",
+        args: {},
+        durationMs: opts.durationMs ?? 10,
+        outcome:
+          opts.result === "error"
+            ? {
+                kind: "result",
+                value: {
+                  ok: false,
+                  error: { code: "ERR", message: "fail" },
+                } as import("../../../../shared/types/actions.js").ActionDispatchResult,
+              }
+            : opts.result === "unauthorized"
+              ? { kind: "unauthorized" }
+              : successOutcome,
+        argsSummary: "{}",
+      });
+    }
+    return service;
+  }
+
+  it("first-run guard: returns zero signals and suppressed when under 50 records", () => {
+    const service = makeRecords(49, () => ({ durationMs: 10 }));
+    const stats = service.getAuditStats();
+    expect(stats.anomalySuppressed).toBe(true);
+    expect(stats.anomalySignals).toHaveLength(0);
+  });
+
+  it("first-run guard: not suppressed at 50 records", () => {
+    const service = makeRecords(50, () => ({ durationMs: 10 }));
+    const stats = service.getAuditStats();
+    expect(stats.anomalySuppressed).toBe(false);
+  });
+
+  it("first-seen: seeds known combos from existing records on first call", () => {
+    const service = makeRecords(50, (i) => ({
+      toolId: i % 2 === 0 ? "tool.a" : "tool.b",
+      tier: "action",
+      durationMs: 10,
+    }));
+    const stats = service.getAuditStats();
+    const firstSeen = stats.anomalySignals.filter((s) => s.kind === "first-seen-combination");
+    expect(firstSeen).toHaveLength(0);
+  });
+
+  it("first-seen: emits signal for new combo added after first call", () => {
+    const service = makeRecords(50, () => ({
+      toolId: "tool.a",
+      tier: "action",
+      durationMs: 10,
+    }));
+    service.getAuditStats(); // seed known combos
+
+    service.appendRecord({
+      toolId: "tool.new",
+      sessionId: "sess-1",
+      tier: "external",
+      args: {},
+      durationMs: 5,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    const stats = service.getAuditStats();
+    const firstSeen = stats.anomalySignals.filter((s) => s.kind === "first-seen-combination");
+    expect(firstSeen).toHaveLength(1);
+    expect(firstSeen[0]!.toolId).toBe("tool.new");
+    expect(firstSeen[0]!.tier).toBe("external");
+  });
+
+  it("first-seen: knownCombinations survives clear()", () => {
+    const service = makeRecords(50, () => ({
+      toolId: "tool.a",
+      tier: "action",
+      durationMs: 10,
+    }));
+    service.getAuditStats(); // seed
+    service.clear();
+
+    service.appendRecord({
+      toolId: "tool.a",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 5,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    // Need 50 records again to pass the guard.
+    for (let i = 0; i < 49; i++) {
+      service.appendRecord({
+        toolId: "tool.a",
+        sessionId: "sess-1",
+        tier: "action",
+        args: {},
+        durationMs: 5,
+        outcome: successOutcome,
+        argsSummary: "{}",
+      });
+    }
+    const stats = service.getAuditStats();
+    const firstSeen = stats.anomalySignals.filter((s) => s.kind === "first-seen-combination");
+    expect(firstSeen).toHaveLength(0);
+  });
+
+  it("latency-drift: no signal when all durations are uniform", () => {
+    const service = makeRecords(50, () => ({ durationMs: 10 }));
+    const stats = service.getAuditStats();
+    const drift = stats.anomalySignals.filter((s) => s.kind === "latency-drift");
+    expect(drift).toHaveLength(0);
+  });
+
+  it("latency-drift: emits signal for outlier duration", () => {
+    const { service } = makeFixture();
+    // 49 records with some natural variance so MAD > 0.
+    for (let i = 0; i < 49; i++) {
+      service.appendRecord({
+        toolId: "test.tool",
+        sessionId: "sess-1",
+        tier: "action",
+        args: {},
+        durationMs: 10 + (i % 5) * 2,
+        outcome: successOutcome,
+        argsSummary: "{}",
+      });
+    }
+    // One extreme outlier.
+    service.appendRecord({
+      toolId: "test.tool",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 5000,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    const stats = service.getAuditStats();
+    const drift = stats.anomalySignals.filter((s) => s.kind === "latency-drift");
+    expect(drift.length).toBeGreaterThanOrEqual(1);
+    const outlier = drift.find((s) => s.recordIds.length > 0);
+    expect(outlier).toBeDefined();
+    expect(outlier!.zScore).toBeGreaterThanOrEqual(3);
+  });
+
+  it("latency-drift: excludes non-success records from baseline", () => {
+    // 50 success records at 10ms, one error at 5000ms — error excluded.
+    const { service } = makeFixture();
+    for (let i = 0; i < 50; i++) {
+      service.appendRecord({
+        toolId: "test.tool",
+        sessionId: "sess-1",
+        tier: "action",
+        args: {},
+        durationMs: 10,
+        outcome: successOutcome,
+        argsSummary: "{}",
+      });
+    }
+    service.appendRecord({
+      toolId: "test.tool",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 5000,
+      outcome: {
+        kind: "result",
+        value: {
+          ok: false,
+          error: { code: "ERR", message: "fail" },
+        } as import("../../../../shared/types/actions.js").ActionDispatchResult,
+      },
+      argsSummary: "{}",
+    });
+    const stats = service.getAuditStats();
+    const drift = stats.anomalySignals.filter((s) => s.kind === "latency-drift");
+    // The 5000ms error is non-success, so it should NOT appear as latency drift.
+    expect(drift).toHaveLength(0);
+  });
+
+  it("failure-cluster: fires when 3 failures in a 10-record window", () => {
+    const { service } = makeFixture();
+    for (let i = 0; i < 47; i++) {
+      service.appendRecord({
+        toolId: "test.tool",
+        sessionId: "sess-1",
+        tier: "action",
+        args: {},
+        durationMs: 10,
+        outcome: successOutcome,
+        argsSummary: "{}",
+      });
+    }
+    // 3 consecutive failures.
+    for (let i = 0; i < 3; i++) {
+      service.appendRecord({
+        toolId: "test.tool",
+        sessionId: "sess-1",
+        tier: "action",
+        args: {},
+        durationMs: 5,
+        outcome: {
+          kind: "result",
+          value: {
+            ok: false,
+            error: { code: "ERR", message: "fail" },
+          } as import("../../../../shared/types/actions.js").ActionDispatchResult,
+        },
+        argsSummary: "{}",
+      });
+    }
+    const stats = service.getAuditStats();
+    const clusters = stats.anomalySignals.filter((s) => s.kind === "failure-cluster");
+    expect(clusters.length).toBeGreaterThanOrEqual(1);
+    expect(clusters[0]!.clusterSize).toBeGreaterThanOrEqual(3);
+  });
+
+  it("failure-cluster: does not fire for only 2 failures in a window", () => {
+    const { service } = makeFixture();
+    for (let i = 0; i < 48; i++) {
+      service.appendRecord({
+        toolId: "test.tool",
+        sessionId: "sess-1",
+        tier: "action",
+        args: {},
+        durationMs: 10,
+        outcome: successOutcome,
+        argsSummary: "{}",
+      });
+    }
+    for (let i = 0; i < 2; i++) {
+      service.appendRecord({
+        toolId: "test.tool",
+        sessionId: "sess-1",
+        tier: "action",
+        args: {},
+        durationMs: 5,
+        outcome: {
+          kind: "result",
+          value: {
+            ok: false,
+            error: { code: "ERR", message: "fail" },
+          } as import("../../../../shared/types/actions.js").ActionDispatchResult,
+        },
+        argsSummary: "{}",
+      });
+    }
+    const stats = service.getAuditStats();
+    const clusters = stats.anomalySignals.filter((s) => s.kind === "failure-cluster");
+    expect(clusters).toHaveLength(0);
+  });
+
+  it("failure-cluster: separates counts by toolId", () => {
+    const { service } = makeFixture();
+    for (let i = 0; i < 48; i++) {
+      service.appendRecord({
+        toolId: "tool.b",
+        sessionId: "sess-1",
+        tier: "action",
+        args: {},
+        durationMs: 10,
+        outcome: successOutcome,
+        argsSummary: "{}",
+      });
+    }
+    // 2 failures for tool.a, 2 failures for tool.b — neither hits threshold.
+    for (const toolId of ["tool.a", "tool.a", "tool.b", "tool.b"]) {
+      service.appendRecord({
+        toolId,
+        sessionId: "sess-1",
+        tier: "action",
+        args: {},
+        durationMs: 5,
+        outcome: {
+          kind: "result",
+          value: {
+            ok: false,
+            error: { code: "ERR", message: "fail" },
+          } as import("../../../../shared/types/actions.js").ActionDispatchResult,
+        },
+        argsSummary: "{}",
+      });
+    }
+    const stats = service.getAuditStats();
+    const clusters = stats.anomalySignals.filter((s) => s.kind === "failure-cluster");
+    expect(clusters).toHaveLength(0);
+  });
+
+  it("p95-z-score: skipped when fewer than 5 distinct tools", () => {
+    const service = makeRecords(50, (i) => ({
+      toolId: `tool.${i % 3}`,
+      durationMs: 10 + i,
+    }));
+    const stats = service.getAuditStats();
+    const p95 = stats.anomalySignals.filter((s) => s.kind === "p95-z-score");
+    expect(p95).toHaveLength(0);
+  });
+
+  it("p95-z-score: emits signal for tool with extreme p95", () => {
+    const { service } = makeFixture();
+    // 5+ tools each with a distinct latency baseline so p95 MAD > 0.
+    const toolBases: [string, number][] = [
+      ["tool.a", 10],
+      ["tool.b", 30],
+      ["tool.c", 50],
+      ["tool.d", 70],
+      ["tool.f", 90],
+    ];
+    for (const [toolId, base] of toolBases) {
+      for (let i = 0; i < 15; i++) {
+        service.appendRecord({
+          toolId,
+          sessionId: "sess-1",
+          tier: "action",
+          args: {},
+          durationMs: base + i,
+          outcome: successOutcome,
+          argsSummary: "{}",
+        });
+      }
+    }
+    // Tool.e has extreme p95.
+    for (let i = 0; i < 15; i++) {
+      service.appendRecord({
+        toolId: "tool.e",
+        sessionId: "sess-1",
+        tier: "action",
+        args: {},
+        durationMs: 5000 + i * 50,
+        outcome: successOutcome,
+        argsSummary: "{}",
+      });
+    }
+    const stats = service.getAuditStats();
+    const p95 = stats.anomalySignals.filter((s) => s.kind === "p95-z-score");
+    expect(p95.length).toBeGreaterThanOrEqual(1);
+    expect(p95[0]!.toolId).toBe("tool.e");
   });
 });

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type {
+  McpAnomalySignal,
   McpAuditRecord,
   McpAuditResult,
   McpAuditStats,
@@ -25,6 +26,23 @@ import {
   minimumPermittingTier,
 } from "./shared.js";
 
+const ANOMALY_MIN_RECORDS = 50;
+const LATENCY_SIGMA_THRESHOLD = 3;
+const FAILURE_CLUSTER_WINDOW = 10;
+const FAILURE_CLUSTER_MIN_FAILURES = 3;
+const MAD_SCALE_FACTOR = 0.6745;
+const P95_Z_SCORE_MIN_TOOLS = 5;
+
+function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 1) return sortedAsc[0]!;
+  const rank = p * (sortedAsc.length - 1);
+  const k = Math.floor(rank);
+  const f = rank - k;
+  const lower = sortedAsc[k]!;
+  const upper = sortedAsc[k + 1] ?? lower;
+  return lower + f * (upper - lower);
+}
+
 /**
  * Hydrate predicate: existing on-disk records predate the discriminated
  * union (#8442) and have no `type` field; new entries written by
@@ -46,6 +64,13 @@ export class AuditService {
    * no `toolId`/`tier` is known. Reset on app restart by design.
    */
   private auth401Count = 0;
+  /**
+   * Known {toolId, tier} combinations observed across the entire process
+   * lifetime. Seeded from hydrated records on the first `getSignals()` call.
+   * Survives `clear()` — clearing the ring frees space but should not
+   * re-trigger first-seen signals for combinations already observed.
+   */
+  private knownCombinations = new Set<string>();
 
   constructor(
     private readonly saveConfig: (patch: Record<string, unknown>) => void,
@@ -218,7 +243,197 @@ export class AuditService {
    * Read the session-scoped audit health counters. Renderer-facing.
    */
   getAuditStats(): McpAuditStats {
-    return { auth401Count: this.auth401Count };
+    const signals = this.getSignals();
+    return {
+      auth401Count: this.auth401Count,
+      anomalySignals: signals,
+      anomalySuppressed: this.dispatchRecordCount() < ANOMALY_MIN_RECORDS,
+      anomalyRecordFloor: ANOMALY_MIN_RECORDS,
+    };
+  }
+
+  /**
+   * Count of dispatch records (excluding grant-lifecycle entries) currently
+   * in the ring buffer. Anomaly detection operates strictly on dispatch
+   * records, so the suppression floor is measured against this count.
+   */
+  private dispatchRecordCount(): number {
+    let n = 0;
+    for (const r of this.records) {
+      if (!isGrantRecord(r)) n += 1;
+    }
+    return n;
+  }
+
+  getSignals(): McpAnomalySignal[] {
+    this.hydrate();
+    const records: McpAuditRecord[] = [];
+    for (const r of this.records) {
+      if (!isGrantRecord(r)) records.push(r);
+    }
+    if (records.length < ANOMALY_MIN_RECORDS) return [];
+
+    const signals: McpAnomalySignal[] = [];
+
+    // Seed knownCombinations from all records on first call so existing
+    // combos don't fire first-seen signals retroactively.
+    const firstCall = this.knownCombinations.size === 0;
+    if (firstCall) {
+      for (const r of records) {
+        this.knownCombinations.add(`${r.toolId} ${r.tier}`);
+      }
+    }
+
+    // 1. First-seen combinations — only for combos not yet in the set.
+    for (const r of records) {
+      const key = `${r.toolId} ${r.tier}`;
+      if (!this.knownCombinations.has(key)) {
+        this.knownCombinations.add(key);
+        signals.push({
+          id: `first-seen:${r.toolId}:${r.tier}`,
+          kind: "first-seen-combination",
+          toolId: r.toolId,
+          tier: r.tier,
+          severity: "danger",
+          timestamp: r.timestamp,
+          recordIds: [r.id],
+        });
+      }
+    }
+
+    // 2. Latency drift — per-tool modified z-score (MAD-based).
+    const latencySignals = this.computeLatencyDrift(records);
+    signals.push(...latencySignals);
+
+    // 3. Failure clustering — sliding window over chronological records.
+    const failureSignals = this.computeFailureClusters(records);
+    signals.push(...failureSignals);
+
+    // 4. P95 z-score — cross-tool outlier detection.
+    const p95Signals = this.computeP95ZScores(records);
+    signals.push(...p95Signals);
+
+    return signals;
+  }
+
+  private computeLatencyDrift(records: readonly McpAuditRecord[]): McpAnomalySignal[] {
+    const signals: McpAnomalySignal[] = [];
+    const byTool = new Map<string, McpAuditRecord[]>();
+    for (const r of records) {
+      if (r.result !== "success") continue;
+      const list = byTool.get(r.toolId);
+      if (list) list.push(r);
+      else byTool.set(r.toolId, [r]);
+    }
+    for (const [toolId, toolRecords] of byTool) {
+      if (toolRecords.length < 2) continue;
+      const durations = toolRecords.map((r) => r.durationMs);
+      const sortedDurations = [...durations].sort((a, b) => a - b);
+      const median = percentile(sortedDurations, 0.5);
+      const absDeviations = durations.map((d) => Math.abs(d - median));
+      const sortedAbsDeviations = [...absDeviations].sort((a, b) => a - b);
+      const mad = percentile(sortedAbsDeviations, 0.5);
+      if (mad === 0) continue;
+      for (let i = 0; i < toolRecords.length; i++) {
+        const duration = durations[i]!;
+        const zScore = (MAD_SCALE_FACTOR * (duration - median)) / mad;
+        if (zScore >= LATENCY_SIGMA_THRESHOLD) {
+          const record = toolRecords[i]!;
+          signals.push({
+            id: `latency-drift:${record.id}`,
+            kind: "latency-drift",
+            toolId,
+            tier: record.tier,
+            severity: "danger",
+            timestamp: record.timestamp,
+            recordIds: [record.id],
+            zScore: Math.round(zScore * 100) / 100,
+            durationMs: duration,
+            baselineMedianMs: Math.round(median),
+          });
+        }
+      }
+    }
+    return signals;
+  }
+
+  private computeFailureClusters(records: readonly McpAuditRecord[]): McpAnomalySignal[] {
+    const signals: McpAnomalySignal[] = [];
+    const emitted = new Set<string>();
+    for (let start = 0; start <= records.length - FAILURE_CLUSTER_WINDOW; start++) {
+      const windowRecords = records.slice(start, start + FAILURE_CLUSTER_WINDOW);
+      const failuresByTool = new Map<string, McpAuditRecord[]>();
+      for (const r of windowRecords) {
+        if (r.result === "success" || r.result === "dedup") continue;
+        const list = failuresByTool.get(r.toolId);
+        if (list) list.push(r);
+        else failuresByTool.set(r.toolId, [r]);
+      }
+      for (const [toolId, toolFailures] of failuresByTool) {
+        if (toolFailures.length < FAILURE_CLUSTER_MIN_FAILURES) continue;
+        const latest = toolFailures[toolFailures.length - 1]!;
+        const sigId = `failure-cluster:${toolId}:${latest.id}`;
+        if (emitted.has(sigId)) continue;
+        emitted.add(sigId);
+        signals.push({
+          id: sigId,
+          kind: "failure-cluster",
+          toolId,
+          severity: "danger",
+          timestamp: latest.timestamp,
+          recordIds: toolFailures.map((r) => r.id),
+          clusterSize: toolFailures.length,
+          clusterWindow: FAILURE_CLUSTER_WINDOW,
+        });
+      }
+    }
+    return signals;
+  }
+
+  private computeP95ZScores(records: readonly McpAuditRecord[]): McpAnomalySignal[] {
+    const signals: McpAnomalySignal[] = [];
+    const byTool = new Map<string, McpAuditRecord[]>();
+    for (const r of records) {
+      if (r.result !== "success") continue;
+      const list = byTool.get(r.toolId);
+      if (list) list.push(r);
+      else byTool.set(r.toolId, [r]);
+    }
+    if (byTool.size < P95_Z_SCORE_MIN_TOOLS) return signals;
+
+    const toolP95s: { toolId: string; p95: number; latestRecord: McpAuditRecord }[] = [];
+    for (const [toolId, toolRecords] of byTool) {
+      if (toolRecords.length < 2) continue;
+      const sorted = toolRecords.map((r) => r.durationMs).sort((a, b) => a - b);
+      const p95 = percentile(sorted, 0.95);
+      toolP95s.push({ toolId, p95, latestRecord: toolRecords[toolRecords.length - 1]! });
+    }
+    if (toolP95s.length < P95_Z_SCORE_MIN_TOOLS) return signals;
+
+    const p95s = toolP95s.map((t) => t.p95);
+    const sortedP95s = [...p95s].sort((a, b) => a - b);
+    const medianP95 = percentile(sortedP95s, 0.5);
+    const absDeviations = p95s.map((p) => Math.abs(p - medianP95));
+    const sortedAbsDeviations = [...absDeviations].sort((a, b) => a - b);
+    const madP95 = percentile(sortedAbsDeviations, 0.5);
+    if (madP95 === 0) return signals;
+
+    for (const entry of toolP95s) {
+      const zScore = (MAD_SCALE_FACTOR * (entry.p95 - medianP95)) / madP95;
+      if (zScore >= LATENCY_SIGMA_THRESHOLD) {
+        signals.push({
+          id: `p95-z-score:${entry.toolId}`,
+          kind: "p95-z-score",
+          toolId: entry.toolId,
+          severity: "danger",
+          timestamp: entry.latestRecord.timestamp,
+          recordIds: [entry.latestRecord.id],
+          zScore: Math.round(zScore * 100) / 100,
+          p95Ms: Math.round(entry.p95),
+        });
+      }
+    }
+    return signals;
   }
 
   private scheduleFlush(): void {
@@ -284,6 +499,9 @@ export class AuditService {
     this.hydrate();
     this.records = [];
     this.flushNow();
+    // knownCombinations intentionally preserved — clearing the ring frees
+    // space but should not re-trigger first-seen signals for combos already
+    // observed in this process lifetime.
   }
 
   setEnabled(enabled: boolean): { enabled: boolean; maxRecords: number } {

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -33,13 +33,14 @@ const FAILURE_CLUSTER_MIN_FAILURES = 3;
 const MAD_SCALE_FACTOR = 0.6745;
 const P95_Z_SCORE_MIN_TOOLS = 5;
 
-function percentile(sortedAsc: number[], p: number): number {
-  if (sortedAsc.length === 1) return sortedAsc[0]!;
-  const rank = p * (sortedAsc.length - 1);
+function percentile(values: number[], p: number): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  if (sorted.length === 1) return sorted[0]!;
+  const rank = p * (sorted.length - 1);
   const k = Math.floor(rank);
   const f = rank - k;
-  const lower = sortedAsc[k]!;
-  const upper = sortedAsc[k + 1] ?? lower;
+  const lower = sorted[k]!;
+  const upper = sorted[k + 1] ?? lower;
   return lower + f * (upper - lower);
 }
 
@@ -328,11 +329,9 @@ export class AuditService {
     for (const [toolId, toolRecords] of byTool) {
       if (toolRecords.length < 2) continue;
       const durations = toolRecords.map((r) => r.durationMs);
-      const sortedDurations = [...durations].sort((a, b) => a - b);
-      const median = percentile(sortedDurations, 0.5);
+      const median = percentile(durations, 0.5);
       const absDeviations = durations.map((d) => Math.abs(d - median));
-      const sortedAbsDeviations = [...absDeviations].sort((a, b) => a - b);
-      const mad = percentile(sortedAbsDeviations, 0.5);
+      const mad = percentile(absDeviations, 0.5);
       if (mad === 0) continue;
       for (let i = 0; i < toolRecords.length; i++) {
         const duration = durations[i]!;
@@ -411,11 +410,9 @@ export class AuditService {
     if (toolP95s.length < P95_Z_SCORE_MIN_TOOLS) return signals;
 
     const p95s = toolP95s.map((t) => t.p95);
-    const sortedP95s = [...p95s].sort((a, b) => a - b);
-    const medianP95 = percentile(sortedP95s, 0.5);
+    const medianP95 = percentile(p95s, 0.5);
     const absDeviations = p95s.map((p) => Math.abs(p - medianP95));
-    const sortedAbsDeviations = [...absDeviations].sort((a, b) => a - b);
-    const madP95 = percentile(sortedAbsDeviations, 0.5);
+    const madP95 = percentile(absDeviations, 0.5);
     if (madP95 === 0) return signals;
 
     for (const entry of toolP95s) {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -333,6 +333,9 @@ export type {
   McpConfirmationDecision,
   AssistantTurnRecord,
   TurnOutcomeClass,
+  McpAnomalySeverity,
+  McpAnomalyKind,
+  McpAnomalySignal,
   McpRuntimeSnapshot,
   McpRuntimeState,
 } from "./ipc/mcpServer.js";

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -206,6 +206,33 @@ export const MCP_AUDIT_DEFAULT_MAX_RECORDS = 500;
  */
 export interface McpAuditStats {
   auth401Count: number;
+  anomalySignals: McpAnomalySignal[];
+  anomalySuppressed: boolean;
+  anomalyRecordFloor: number;
+}
+
+export type McpAnomalySeverity = "danger";
+
+export type McpAnomalyKind =
+  | "latency-drift"
+  | "first-seen-combination"
+  | "failure-cluster"
+  | "p95-z-score";
+
+export interface McpAnomalySignal {
+  id: string;
+  kind: McpAnomalyKind;
+  toolId: string;
+  tier?: string;
+  severity: McpAnomalySeverity;
+  timestamp: number;
+  recordIds: string[];
+  zScore?: number;
+  durationMs?: number;
+  baselineMedianMs?: number;
+  p95Ms?: number;
+  clusterSize?: number;
+  clusterWindow?: number;
 }
 
 /**

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -1,9 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
-import { Check, Copy, Download, Layers, RefreshCw, ShieldOff } from "lucide-react";
+import { Check, Clock, Copy, Download, Layers, RefreshCw, ShieldOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
-import type { McpAuditRecord, McpAuditResult, AssistantTurnRecord } from "@shared/types";
+import type {
+  McpAuditRecord,
+  McpAuditResult,
+  AssistantTurnRecord,
+  McpAnomalySignal,
+} from "@shared/types";
 
 type AuditResultFilter = "all" | McpAuditResult;
 
@@ -131,6 +136,8 @@ interface McpAuditLogViewerProps {
   onExport?: (records: McpAuditRecord[]) => Promise<void> | void;
   /** Set when an export succeeded so the UI can flash a confirmation. */
   exportFlashActive?: boolean;
+  anomalySignals?: McpAnomalySignal[];
+  anomalySuppressed?: boolean;
 }
 
 export function McpAuditLogViewer({
@@ -145,6 +152,8 @@ export function McpAuditLogViewer({
   copyFlashActive,
   onExport,
   exportFlashActive,
+  anomalySignals = [],
+  anomalySuppressed = true,
 }: McpAuditLogViewerProps) {
   const [toolFilter, setToolFilter] = useState("");
   const [resultFilter, setResultFilter] = useState<AuditResultFilter>("all");
@@ -152,6 +161,7 @@ export function McpAuditLogViewer({
   const [searchQuery, setSearchQuery] = useState("");
   const [nowTick, setNowTick] = useState(Date.now());
   const [groupByTurn, setGroupByTurn] = useState(false);
+  const [ignoreLastHour, setIgnoreLastHour] = useState(false);
 
   useEffect(() => {
     const id = setInterval(() => setNowTick(Date.now()), RELATIVE_TIMESTAMP_REFRESH_MS);
@@ -191,6 +201,32 @@ export function McpAuditLogViewer({
   }, [groupByTurn, turnRecords, filteredRecords]);
 
   const showCopyAll = filteredRecords.length === visibleRecords.length;
+
+  const oneHourAgo = Date.now() - 3_600_000;
+  const visibleSignals = useMemo(() => {
+    if (anomalySuppressed) return [];
+    return ignoreLastHour
+      ? anomalySignals.filter((s) => s.timestamp <= oneHourAgo)
+      : anomalySignals;
+  }, [anomalySignals, anomalySuppressed, ignoreLastHour, oneHourAgo]);
+
+  const signalRecordIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const sig of visibleSignals) {
+      for (const id of sig.recordIds) {
+        set.add(id);
+      }
+    }
+    return set;
+  }, [visibleSignals]);
+
+  const anomalyCountsByKind = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const sig of visibleSignals) {
+      counts[sig.kind] = (counts[sig.kind] ?? 0) + 1;
+    }
+    return counts;
+  }, [visibleSignals]);
 
   const showTierRejections = () => {
     setResultFilter("unauthorized");
@@ -283,7 +319,34 @@ export function McpAuditLogViewer({
             Group by turn
           </button>
         )}
+        {!anomalySuppressed && visibleSignals.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setIgnoreLastHour((v) => !v)}
+            className={cn(
+              "flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
+              ignoreLastHour
+                ? "border-status-warning/20 text-status-warning bg-status-warning/10"
+                : "border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
+            )}
+          >
+            <Clock className="w-3.5 h-3.5" />
+            Ignore last hour
+          </button>
+        )}
       </div>
+
+      {!anomalySuppressed && visibleSignals.length > 0 && (
+        <div className="flex items-start gap-2 p-2.5 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
+          <span className="text-xs text-status-danger">
+            {visibleSignals.length} anomaly signal{visibleSignals.length !== 1 ? "s" : ""}
+            {Object.entries(anomalyCountsByKind).length > 0 &&
+              ` (${Object.entries(anomalyCountsByKind)
+                .map(([kind, count]) => `${count} ${kind}`)
+                .join(", ")})`}
+          </span>
+        </div>
+      )}
 
       <div className="max-h-64 overflow-y-auto rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg">
         {loading ? (
@@ -414,14 +477,19 @@ export function McpAuditLogViewer({
           <ul className="divide-y divide-daintree-border">
             {filteredRecords.map((record) => (
               <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
-                <span
-                  className={cn(
-                    "mt-1 h-2 w-2 rounded-full shrink-0",
-                    RESULT_DOT_CLASS[record.result]
+                <div className="flex items-start gap-1 mt-1">
+                  <span
+                    className={cn("h-2 w-2 rounded-full shrink-0", RESULT_DOT_CLASS[record.result])}
+                    aria-label={RESULT_LABEL[record.result]}
+                    title={RESULT_LABEL[record.result]}
+                  />
+                  {signalRecordIds.has(record.id) && (
+                    <span
+                      className="h-2 w-2 rounded-sm rotate-45 shrink-0 bg-status-danger"
+                      title="Anomaly"
+                    />
                   )}
-                  aria-label={RESULT_LABEL[record.result]}
-                  title={RESULT_LABEL[record.result]}
-                />
+                </div>
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">
                     <span className="font-mono text-daintree-text/90 truncate">

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -319,7 +319,7 @@ export function McpAuditLogViewer({
             Group by turn
           </button>
         )}
-        {!anomalySuppressed && visibleSignals.length > 0 && (
+        {!anomalySuppressed && anomalySignals.length > 0 && (
           <button
             type="button"
             onClick={() => setIgnoreLastHour((v) => !v)}

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -26,6 +26,7 @@ import { logError } from "@/utils/logger";
 import {
   type McpAuditRecord,
   type AssistantTurnRecord,
+  type McpAuditStats,
   MCP_AUDIT_DEFAULT_MAX_RECORDS,
   MCP_AUDIT_MAX_RECORDS,
   MCP_AUDIT_MIN_RECORDS,
@@ -67,6 +68,7 @@ export function McpServerSettingsTab() {
 
   const [auditRecords, setAuditRecords] = useState<McpAuditRecord[]>([]);
   const [turnRecords, setTurnRecords] = useState<AssistantTurnRecord[]>([]);
+  const [auditStats, setAuditStats] = useState<McpAuditStats | null>(null);
   const [auditEnabled, setAuditEnabled] = useState(true);
   const [auditMaxRecords, setAuditMaxRecords] = useState(MCP_AUDIT_DEFAULT_MAX_RECORDS);
   const [maxRecordsInput, setMaxRecordsInput] = useState(MCP_AUDIT_DEFAULT_MAX_RECORDS.toString());
@@ -81,12 +83,14 @@ export function McpServerSettingsTab() {
 
   const refreshAuditRecords = async (): Promise<void> => {
     try {
-      const [records, turns] = await Promise.all([
+      const [records, turns, stats] = await Promise.all([
         window.electron.mcpServer.getAuditRecords(),
         window.electron.mcpServer.getTurnOutcomeRecords(),
+        window.electron.mcpServer.getAuditStats(),
       ]);
       setAuditRecords(records);
       setTurnRecords(turns);
+      setAuditStats(stats);
     } catch (err) {
       logError("Failed to load MCP audit log", err);
     }
@@ -106,8 +110,9 @@ export function McpServerSettingsTab() {
       window.electron.mcpServer.getAuditConfig(),
       window.electron.mcpServer.getAuditRecords(),
       window.electron.mcpServer.getTurnOutcomeRecords(),
+      window.electron.mcpServer.getAuditStats(),
     ])
-      .then(([s, auditCfg, records, turns]) => {
+      .then(([s, auditCfg, records, turns, stats]) => {
         if (settled) return;
         setStatus(s);
         setPortInput(s.configuredPort?.toString() ?? "");
@@ -117,6 +122,7 @@ export function McpServerSettingsTab() {
         setMaxRecordsInput(auditCfg.maxRecords.toString());
         setAuditRecords(records);
         setTurnRecords(turns);
+        setAuditStats(stats);
         setError(null);
       })
       .catch((err) => {
@@ -614,6 +620,8 @@ export function McpServerSettingsTab() {
                 maxRecords={auditMaxRecords}
                 onExport={handleExportAuditLog}
                 exportFlashActive={exportedAudit}
+                anomalySignals={auditStats?.anomalySignals ?? []}
+                anomalySuppressed={auditStats?.anomalySuppressed ?? true}
               />
             </div>
           </SettingsSection>

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -83,14 +83,26 @@ export function McpServerSettingsTab() {
 
   const refreshAuditRecords = async (): Promise<void> => {
     try {
-      const [records, turns, stats] = await Promise.all([
+      const [recordsResult, turnsResult, statsResult] = await Promise.allSettled([
         window.electron.mcpServer.getAuditRecords(),
         window.electron.mcpServer.getTurnOutcomeRecords(),
         window.electron.mcpServer.getAuditStats(),
       ]);
-      setAuditRecords(records);
-      setTurnRecords(turns);
-      setAuditStats(stats);
+      if (recordsResult.status === "fulfilled") {
+        setAuditRecords(recordsResult.value);
+      } else {
+        logError("Failed to load MCP audit log", recordsResult.reason);
+      }
+      if (turnsResult.status === "fulfilled") {
+        setTurnRecords(turnsResult.value);
+      } else {
+        logError("Failed to load MCP turn outcome records", turnsResult.reason);
+      }
+      if (statsResult.status === "fulfilled") {
+        setAuditStats(statsResult.value);
+      } else {
+        logError("Failed to load MCP audit stats", statsResult.reason);
+      }
     } catch (err) {
       logError("Failed to load MCP audit log", err);
     }
@@ -297,6 +309,7 @@ export function McpServerSettingsTab() {
       setError(null);
       await window.electron.mcpServer.clearAuditLog();
       setAuditRecords([]);
+      setAuditStats(null);
       setShowClearConfirm(false);
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to clear audit log"));

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -79,6 +79,12 @@ function createMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {})
     rotateApiKey: vi.fn().mockResolvedValue("dnt-key-rotated789"),
     getAuditRecords: vi.fn().mockResolvedValue([]),
     getAuditConfig: vi.fn().mockResolvedValue({ enabled: true, maxRecords: 500 }),
+    getAuditStats: vi.fn().mockResolvedValue({
+      auth401Count: 0,
+      anomalySignals: [],
+      anomalySuppressed: true,
+      anomalyRecordFloor: 50,
+    }),
     clearAuditLog: vi.fn().mockResolvedValue(undefined),
     setAuditEnabled: vi.fn().mockResolvedValue({ enabled: true, maxRecords: 500 }),
     setAuditMaxRecords: vi.fn().mockResolvedValue({ enabled: true, maxRecords: 500 }),
@@ -897,6 +903,138 @@ describe("McpServerSettingsTab", () => {
     const select = screen.getByLabelText("Filter audit by result") as HTMLSelectElement;
     expect(select).toBeTruthy();
     expect(Array.from(select.options).map((o) => o.value)).toContain("unauthorized");
+  });
+
+  it("renders anomaly banner when getAuditStats returns signals", async () => {
+    installMcpApi({
+      getAuditStats: vi.fn().mockResolvedValue({
+        auth401Count: 0,
+        anomalySignals: [
+          {
+            id: "latency-drift:1",
+            kind: "latency-drift",
+            toolId: "slow.tool",
+            severity: "danger",
+            timestamp: Date.now() - 3_600_001,
+            recordIds: ["r1"],
+            zScore: 4.2,
+            durationMs: 5000,
+            baselineMedianMs: 10,
+          },
+        ],
+        anomalySuppressed: false,
+        anomalyRecordFloor: 50,
+      }),
+      getAuditRecords: vi.fn().mockResolvedValue([
+        {
+          id: "r1",
+          toolId: "slow.tool",
+          argsSummary: "{}",
+          result: "success" as const,
+          timestamp: Date.now(),
+          durationMs: 5000,
+        },
+      ]),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "anomaly signal");
+  });
+
+  it("hides anomaly banner when suppressed", async () => {
+    installMcpApi({
+      getAuditStats: vi.fn().mockResolvedValue({
+        auth401Count: 0,
+        anomalySignals: [
+          {
+            id: "latency-drift:1",
+            kind: "latency-drift",
+            toolId: "slow.tool",
+            severity: "danger",
+            timestamp: Date.now(),
+            recordIds: ["r1"],
+            zScore: 4.2,
+            durationMs: 5000,
+            baselineMedianMs: 10,
+          },
+        ],
+        anomalySuppressed: true,
+        anomalyRecordFloor: 50,
+      }),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "API key active");
+    expect(container.textContent).not.toContain("anomaly signal");
+  });
+
+  it("Ignore last hour chip appears when signals exist and is not suppressed", async () => {
+    installMcpApi({
+      getAuditStats: vi.fn().mockResolvedValue({
+        auth401Count: 0,
+        anomalySignals: [
+          {
+            id: "latency-drift:1",
+            kind: "latency-drift",
+            toolId: "slow.tool",
+            severity: "danger",
+            timestamp: Date.now() - 3_600_001,
+            recordIds: ["r1"],
+            zScore: 4.2,
+            durationMs: 5000,
+            baselineMedianMs: 10,
+          },
+        ],
+        anomalySuppressed: false,
+        anomalyRecordFloor: 50,
+      }),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Ignore last hour");
+  });
+
+  it("anomaly signals do not trigger notify()", async () => {
+    installMcpApi({
+      getAuditStats: vi.fn().mockResolvedValue({
+        auth401Count: 0,
+        anomalySignals: [
+          {
+            id: "latency-drift:1",
+            kind: "latency-drift",
+            toolId: "slow.tool",
+            severity: "danger",
+            timestamp: Date.now(),
+            recordIds: ["r1"],
+            zScore: 4.2,
+            durationMs: 5000,
+            baselineMedianMs: 10,
+          },
+        ],
+        anomalySuppressed: false,
+        anomalyRecordFloor: 50,
+      }),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "anomaly signal");
+    expect(mockedNotify).not.toHaveBeenCalled();
   });
 
   it("copy config and copy API key have independent Copied! timeouts", async () => {


### PR DESCRIPTION
## Summary
The MCP audit viewer had no anomaly surface — latency drift, novel tool/tier
combinations, and failure clusters all passed silently. This adds a small
in-process detector that runs against the existing in-memory audit ring
and surfaces signals as row pips with an inline banner.

## Changes
- Four signal classes: latency drift (EWMA, 2σ/3σ), first-seen `{toolId, tier}`
  combinations, failure clustering (rolling N=10 window, ≥3 threshold), and
  z-score on per-tool p95
- "Ignore last hour" filter chip so intentional testing windows don't poison
  the baseline
- First-run guard suppresses everything until 50 records are in the ring
- Signals surface as row pips and an inline banner above the table — never toasts
- `McpAnomalyDetector` service in `electron/services/mcp-server/auditLog.ts`,
  signals exposed via `getAnomalySignals()` IPC

Resolves #8433

## Testing
- Unit tests for each anomaly class (latency drift, first-seen, failure
  clustering, z-score) in `auditLog.test.ts`
- First-run guard and ignore-last-hour exclusion coverage
- `McpServerSettingsTab` integration test for signal rendering and filter chips