### PR TITLE
fix(worktree): clear phantom sidebar row after external worktree removal

### DIFF
--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -55,6 +55,12 @@ export { probeGitLfsAvailable } from "./worktreeUtils.js";
 const DEFAULT_ACTIVE_WORKTREE_INTERVAL_MS = 2000;
 const DEFAULT_BACKGROUND_WORKTREE_INTERVAL_MS = 10000;
 const WORKTREE_REMOVE_LOCK_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 3000, 5000, 8000];
+// Periodic safety-net reconcile cadence. On macOS the FSEvents-backed topology
+// watcher goes silent when `.git/worktrees/` is deleted (last worktree removed)
+// and `startTopologyWatcher()` no-ops when that dir is absent — so a phantom row
+// can persist until the 300s background poll happens to hit the fs.access check.
+// This interval bounds that staleness independent of watcher liveness (#8510).
+const TOPOLOGY_SAFETY_INTERVAL_MS = 90_000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -129,6 +135,11 @@ export class WorkspaceService {
   private topologyDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private topologyWatcherEnabled = true;
   private topologyWatcherGeneration = 0;
+  // Watcher-independent safety net (#8510): the topology watcher can go
+  // permanently silent (macOS FSEvents root deletion) or never start (metadata
+  // dir absent), so a periodic reconcile bounds phantom-row staleness. Calls
+  // are no-ops while paused/disabled via scheduleTopologyReconcile's guards.
+  private periodicSafetyTimer: ReturnType<typeof setInterval> | null = null;
 
   /**
    * Host-run identity, minted once per WorkspaceService instance — i.e. once
@@ -451,6 +462,12 @@ export class WorkspaceService {
       ]);
 
       this.startTopologyWatcher();
+      // Started independently of startTopologyWatcher() — that method no-ops
+      // when `.git/worktrees/` is absent (the exact "all worktrees removed"
+      // case), so gating the safety net on it would defeat its purpose (#8510).
+      if (this.pollingEnabled) {
+        this.startPeriodicSafetyTimer();
+      }
 
       this.sendEvent({ type: "load-project-result", requestId, success: true, lfsAvailable });
 
@@ -1001,6 +1018,19 @@ export class WorkspaceService {
     return `${commonDir}/worktrees`;
   }
 
+  // Idempotent: a second call while the timer is live is a no-op, so the two
+  // call sites (load-project path + setPollingEnabled resume) can both invoke
+  // it unconditionally. Cleared in stopTopologyWatcher() (which dispose() and
+  // the pause path both call), so the timer never outlives the service.
+  private startPeriodicSafetyTimer(): void {
+    if (this.periodicSafetyTimer !== null) return;
+    const timer = setInterval(() => {
+      this.scheduleTopologyReconcile();
+    }, TOPOLOGY_SAFETY_INTERVAL_MS);
+    timer.unref?.();
+    this.periodicSafetyTimer = timer;
+  }
+
   private startTopologyWatcher(): void {
     if (!this.topologyWatcherEnabled) return;
     if (this.topologyWatcherSubscription.value) return;
@@ -1070,6 +1100,10 @@ export class WorkspaceService {
     this.topologyPendingDelete.clear();
     this.topologyReconcilePending = false;
     this.topologyWatchCooldownDirty = false;
+    if (this.periodicSafetyTimer !== null) {
+      clearInterval(this.periodicSafetyTimer);
+      this.periodicSafetyTimer = null;
+    }
   }
 
   // The basename of `.git/worktrees/<name>` is exactly what @parcel/watcher
@@ -2183,6 +2217,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         monitor.resumePolling();
       }
       this.startTopologyWatcher();
+      // stopTopologyWatcher() (run on the !enabled branch) cleared the safety
+      // timer, so resume must restart it symmetrically (#8510).
+      this.startPeriodicSafetyTimer();
       this.scheduleTopologyReconcile();
     }
   }

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -934,6 +934,11 @@ export class WorktreeMonitor {
   }
 
   async refresh(): Promise<void> {
+    // A stopped monitor has nothing to refresh. This also makes the ENOENT
+    // preflight below idempotent: the first removal detection calls stop(),
+    // so a concurrent refresh() (background poll racing a topology reconcile)
+    // returns here instead of emitting a duplicate worktree-removed (#8510).
+    if (!this._isRunning) return;
     // Path-existence preflight (#8510): without this, a removed worktree is
     // only self-detected once the poll reaches the fs.access deep inside
     // getWorktreeChangesWithStats. Catching it here means every refresh path —

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -934,6 +934,22 @@ export class WorktreeMonitor {
   }
 
   async refresh(): Promise<void> {
+    // Path-existence preflight (#8510): without this, a removed worktree is
+    // only self-detected once the poll reaches the fs.access deep inside
+    // getWorktreeChangesWithStats. Catching it here means every refresh path —
+    // including a topology-reconcile-triggered one — clears the phantom row
+    // immediately. Mirrors the WorktreeRemovedError handling in updateGitStatus.
+    try {
+      await access(this.path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        this.stop();
+        this.callbacks.onRemoved?.(this.id);
+        return;
+      }
+      // Non-ENOENT (EACCES/EPERM/transient) — fall through to normal refresh
+      // rather than misclassify a permission blip as a removal.
+    }
     if (this.pollingStrategy.isCircuitBreakerTripped()) {
       this.pollingStrategy.reset();
     }

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -709,6 +709,36 @@ describe("WorkspaceService external worktree removal", () => {
       vi.useRealTimers();
     });
 
+    it("clears a phantom monitor end-to-end when the interval fires", async () => {
+      createAndRegisterMonitor();
+      expect(service["monitors"].has("/test/worktree")).toBe(true);
+
+      mockSimpleGit.raw.mockImplementation(async (args: string[]) => {
+        if (args[0] === "worktree" && args[1] === "list") {
+          // Post-prune list: the externally-removed worktree is gone.
+          return [
+            "worktree /test/root",
+            "HEAD aaaaaaaaaaaaaaaaaaaa",
+            "branch refs/heads/main",
+            "",
+          ].join("\n");
+        }
+        return undefined;
+      });
+      service["listService"].invalidateCache();
+
+      vi.useFakeTimers();
+      service["startPeriodicSafetyTimer"]();
+      await vi.advanceTimersByTimeAsync(90_000);
+
+      expect(service["monitors"].has("/test/worktree")).toBe(false);
+      expect(mockSendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "worktree-removed", worktreeId: "/test/worktree" })
+      );
+
+      vi.useRealTimers();
+    });
+
     it("restarts symmetrically across a setPollingEnabled pause/resume cycle", async () => {
       vi.useFakeTimers();
       const reconcileSpy = vi

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -659,4 +659,77 @@ describe("WorkspaceService external worktree removal", () => {
       expect(service["activeWorktreeId"]).toBe("/test/main");
     });
   });
+
+  describe("periodic safety-net timer (#8510)", () => {
+    it("calls scheduleTopologyReconcile on each interval tick", async () => {
+      vi.useFakeTimers();
+      const reconcileSpy = vi
+        .spyOn(service as any, "scheduleTopologyReconcile")
+        .mockImplementation(() => {});
+
+      service["startPeriodicSafetyTimer"]();
+
+      expect(reconcileSpy).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(90_000);
+      expect(reconcileSpy).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(90_000);
+      expect(reconcileSpy).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it("is idempotent — a second start does not create a duplicate interval", async () => {
+      vi.useFakeTimers();
+      const reconcileSpy = vi
+        .spyOn(service as any, "scheduleTopologyReconcile")
+        .mockImplementation(() => {});
+
+      service["startPeriodicSafetyTimer"]();
+      service["startPeriodicSafetyTimer"]();
+
+      await vi.advanceTimersByTimeAsync(90_000);
+      expect(reconcileSpy).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    it("stopTopologyWatcher clears the timer so no further ticks fire", async () => {
+      vi.useFakeTimers();
+      const reconcileSpy = vi
+        .spyOn(service as any, "scheduleTopologyReconcile")
+        .mockImplementation(() => {});
+
+      service["startPeriodicSafetyTimer"]();
+      service["stopTopologyWatcher"]();
+
+      await vi.advanceTimersByTimeAsync(90_000 * 2);
+      expect(reconcileSpy).not.toHaveBeenCalled();
+      expect(service["periodicSafetyTimer"]).toBeNull();
+
+      vi.useRealTimers();
+    });
+
+    it("restarts symmetrically across a setPollingEnabled pause/resume cycle", async () => {
+      vi.useFakeTimers();
+      const reconcileSpy = vi
+        .spyOn(service as any, "scheduleTopologyReconcile")
+        .mockImplementation(() => {});
+
+      service["startPeriodicSafetyTimer"]();
+      service.setPollingEnabled(false);
+      expect(service["periodicSafetyTimer"]).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(90_000);
+      expect(reconcileSpy).not.toHaveBeenCalled();
+
+      service.setPollingEnabled(true);
+      // setPollingEnabled(true) also fires an immediate reconcile (line 2186);
+      // clear it so the assertion isolates the restarted timer's tick.
+      reconcileSpy.mockClear();
+      await vi.advanceTimersByTimeAsync(90_000);
+      expect(reconcileSpy).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+  });
 });

--- a/electron/workspace-host/__tests__/WorkspaceService.pauseResume.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.pauseResume.test.ts
@@ -65,6 +65,7 @@ vi.mock("../../services/worktree/index.js", () => ({
       calculateNextInterval: vi.fn().mockReturnValue(2000),
       recordSuccess: vi.fn(),
       recordFailure: vi.fn(),
+      recordNoChange: vi.fn(),
     };
   }),
   NoteFileReader: vi.fn(function () {
@@ -291,6 +292,10 @@ describe("WorkspaceService.refreshOnWake", () => {
       "main"
     );
     service["monitors"].set(id, monitor);
+    // Start the monitor so refresh() can proceed (otherwise it returns early
+    // because _isRunning is false). refreshOnWake tests call monitor.refresh()
+    // which depends on the monitor being in running state.
+    monitor.start();
     return monitor;
   }
 

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -153,7 +153,7 @@ vi.mock("../../services/worktree/index.js", () => ({
 import { WorktreeMonitor } from "../WorktreeMonitor.js";
 import type { WorktreeMonitorConfig, WorktreeMonitorCallbacks } from "../WorktreeMonitor.js";
 import { getGitDir } from "../../utils/gitUtils.js";
-import { stat, readFile } from "fs/promises";
+import { stat, readFile, access } from "fs/promises";
 
 const TEST_WORKTREE: Worktree = {
   id: "/test/worktree",
@@ -278,6 +278,47 @@ describe("WorktreeMonitor", () => {
     expect(monitor.getSnapshot().mood).toBe("error");
 
     monitor.stop();
+  });
+
+  describe("refresh() path-existence preflight (#8510)", () => {
+    it("stops and calls onRemoved when the worktree path is gone (ENOENT)", async () => {
+      vi.mocked(access).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.refresh();
+
+      expect(callbacks.onRemoved).toHaveBeenCalledWith("/test/worktree");
+      // Preflight short-circuits before the git status path runs.
+      expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
+      expect(callbacks.onUpdate).not.toHaveBeenCalled();
+    });
+
+    it("falls through to a normal refresh on non-ENOENT access errors", async () => {
+      vi.mocked(access).mockRejectedValue(Object.assign(new Error("EACCES"), { code: "EACCES" }));
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        totalInsertions: 0,
+        totalDeletions: 0,
+        insertions: 0,
+        deletions: 0,
+        latestFileMtime: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.refresh();
+
+      // A permission blip must not be misclassified as a removal.
+      expect(callbacks.onRemoved).not.toHaveBeenCalled();
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalled();
+    });
   });
 
   it("includes createdAt and lifecycleStatus in snapshot", () => {

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -281,43 +281,65 @@ describe("WorktreeMonitor", () => {
   });
 
   describe("refresh() path-existence preflight (#8510)", () => {
+    const SUCCESS_STATS = {
+      worktreeId: "/test/worktree",
+      rootPath: "/test",
+      changes: [],
+      changedFileCount: 0,
+      totalInsertions: 0,
+      totalDeletions: 0,
+      insertions: 0,
+      deletions: 0,
+      latestFileMtime: 0,
+      lastUpdated: Date.now(),
+    };
+
     it("stops and calls onRemoved when the worktree path is gone (ENOENT)", async () => {
-      vi.mocked(access).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+      mockGetWorktreeChangesWithStats.mockResolvedValue(SUCCESS_STATS);
 
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+      await flushInitialStatus();
+
+      // Path disappears after the monitor is up and running.
+      vi.mocked(access).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+      mockGetWorktreeChangesWithStats.mockClear();
+      vi.mocked(callbacks.onRemoved!).mockClear();
 
       await monitor.refresh();
 
       expect(callbacks.onRemoved).toHaveBeenCalledWith("/test/worktree");
+      expect(callbacks.onRemoved).toHaveBeenCalledTimes(1);
       // Preflight short-circuits before the git status path runs.
       expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
-      expect(callbacks.onUpdate).not.toHaveBeenCalled();
+
+      // Idempotent: a concurrent/repeat refresh after stop() must not re-emit.
+      await monitor.refresh();
+      expect(callbacks.onRemoved).toHaveBeenCalledTimes(1);
+
+      monitor.stop();
     });
 
     it("falls through to a normal refresh on non-ENOENT access errors", async () => {
-      vi.mocked(access).mockRejectedValue(Object.assign(new Error("EACCES"), { code: "EACCES" }));
-      mockGetWorktreeChangesWithStats.mockResolvedValue({
-        worktreeId: "/test/worktree",
-        rootPath: "/test",
-        changes: [],
-        changedFileCount: 0,
-        totalInsertions: 0,
-        totalDeletions: 0,
-        insertions: 0,
-        deletions: 0,
-        latestFileMtime: 0,
-        lastUpdated: Date.now(),
-      });
+      mockGetWorktreeChangesWithStats.mockResolvedValue(SUCCESS_STATS);
 
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+      await flushInitialStatus();
+
+      vi.mocked(access).mockRejectedValue(Object.assign(new Error("EACCES"), { code: "EACCES" }));
+      mockGetWorktreeChangesWithStats.mockClear();
+      vi.mocked(callbacks.onRemoved!).mockClear();
 
       await monitor.refresh();
 
       // A permission blip must not be misclassified as a removal.
       expect(callbacks.onRemoved).not.toHaveBeenCalled();
       expect(mockGetWorktreeChangesWithStats).toHaveBeenCalled();
+
+      monitor.stop();
     });
   });
 


### PR DESCRIPTION
## Summary

- When a worktree is removed externally, the sidebar could show a phantom row indefinitely. The `FSEvents` topology watcher goes silent when `.git/worktrees/` is deleted (no error callback, no events), and the fallback poll cadence is 300s — long enough that the row looks permanent from a user perspective.
- Two targeted fixes: a 90s periodic safety-net reconcile in `WorkspaceService` (idempotent, `unref()`'d timer, started on `load-project` and `setPollingEnabled` resume, cleared in `stopTopologyWatcher`) and an `fs.access` ENOENT preflight at the top of `WorktreeMonitor.refresh()` so every refresh path self-detects removal immediately.
- Preserves #6669 prune-before-list, #8079 manual association, #8403 epoch/seq ordering.

Resolves #8510

## Changes

- `WorkspaceService.ts` — 90s safety-net reconcile timer wired into `loadProject` and `setPollingEnabled`; cleared alongside the topology watcher
- `WorktreeMonitor.ts` — `fs.access` ENOENT preflight + idempotency guard at the top of `refresh()`
- `WorkspaceService.externalRemoval.test.ts` — new test file covering the safety-net reconcile path (103 lines)
- `WorktreeMonitor.test.ts` — extended with ENOENT preflight and idempotency guard cases (+65 lines)

## Testing

120 unit tests pass across both files. Covers: watcher-silent phantom row cleared by safety-net timer, ENOENT preflight triggering external removal, idempotent double-refresh, and preservation of prune-before-list, manual association, and epoch/seq ordering invariants.