### PR TITLE
feat(mcp): rate-limit CallTool path to protect against runaway agent loops

### DIFF
--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1576,10 +1576,11 @@ describe("sessionServer grant cache fallback (#8442)", () => {
   });
 });
 
-function parseToolErrorPayload(result: {
-  content: unknown;
-  isError?: boolean;
-}): { code: string; retriable: boolean; details?: { retryAfter?: number } } {
+function parseToolErrorPayload(result: { content: unknown; isError?: boolean }): {
+  code: string;
+  retriable: boolean;
+  details?: { retryAfter?: number };
+} {
   const text = (result as { content: Array<{ text: string }> }).content[0].text;
   return JSON.parse(text);
 }
@@ -1708,7 +1709,7 @@ describe("SessionStore.consumeRateLimitToken", () => {
       transport: { close: vi.fn().mockResolvedValue(undefined) },
       server: {},
       idleTimer: setTimeout(() => {}, 1_000_000),
-    } as unknown as (typeof store.httpSessions extends Map<string, infer V> ? V : never));
+    } as unknown as typeof store.httpSessions extends Map<string, infer V> ? V : never);
     expect(store.revokeSession("live")).toBe(true);
     expect(store.rateLimitBuckets.has("live")).toBe(false);
     store.drain();
@@ -1883,7 +1884,12 @@ describe("CallTool rate limiting (handler integration)", () => {
 
 describe("MCP_DEDUP_ALLOWLIST widening (#8468)", () => {
   it("retains the original creation-tool cohort", () => {
-    for (const tool of ["terminal.new", "worktree.createWithRecipe", "agent.launch", "recipe.run"]) {
+    for (const tool of [
+      "terminal.new",
+      "worktree.createWithRecipe",
+      "agent.launch",
+      "recipe.run",
+    ]) {
       expect(MCP_DEDUP_ALLOWLIST.has(tool)).toBe(true);
     }
   });

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1690,15 +1690,39 @@ describe("SessionStore.consumeRateLimitToken", () => {
     store.drain();
   });
 
-  it("revokeSession tears down the rate-limit buckets", () => {
+  it("drain() tears down all rate-limit buckets", () => {
     const store = new RealSessionStore(() => {});
     store.consumeRateLimitToken("s", "git.commit", 1000);
     expect(store.rateLimitBuckets.has("s")).toBe(true);
-    store.sessionTierMap.set("s", "system");
-    // No live transport, but revokeSession returns false only when no
-    // session entry exists — drive teardown via drain() which also clears.
     store.drain();
     expect(store.rateLimitBuckets.size).toBe(0);
+  });
+
+  it("revokeSession() tears down the rate-limit buckets for a live session", () => {
+    const store = new RealSessionStore(() => {});
+    store.consumeRateLimitToken("live", "git.commit", 1000);
+    expect(store.rateLimitBuckets.has("live")).toBe(true);
+    // Install a minimal HTTP session so revokeSession() has an entry to
+    // tear down (it returns false and no-ops without one).
+    store.httpSessions.set("live", {
+      transport: { close: vi.fn().mockResolvedValue(undefined) },
+      server: {},
+      idleTimer: setTimeout(() => {}, 1_000_000),
+    } as unknown as (typeof store.httpSessions extends Map<string, infer V> ? V : never));
+    expect(store.revokeSession("live")).toBe(true);
+    expect(store.rateLimitBuckets.has("live")).toBe(false);
+    store.drain();
+  });
+
+  it("does not advance lastRefillMs backward on a clock step-back", () => {
+    const store = new RealSessionStore(() => {});
+    store.consumeRateLimitToken("s", "git.commit", 10000);
+    store.consumeRateLimitToken("s", "git.commit", 9000); // clock went back
+    const bucket = store.rateLimitBuckets.get("s")!.get("git.commit")!;
+    expect(bucket.lastRefillMs).toBe(10000);
+    store.consumeRateLimitToken("s", "git.commit", 10001);
+    expect(bucket.lastRefillMs).toBe(10001);
+    store.drain();
   });
 });
 
@@ -1803,6 +1827,57 @@ describe("CallTool rate limiting (handler integration)", () => {
     expect(result.isError).not.toBe(true);
     expect(sessionStore.consumeRateLimitToken).toHaveBeenCalledWith("rl-5", "files.search");
     expect(dispatchAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("charges a token even when the call is served from the dedup cache", async () => {
+    // Real store so dedup actually caches; spy on the real token bucket to
+    // prove rate-limit runs before dedup for *cached* hits, not just
+    // in-flight ones.
+    const store = new RealSessionStore(() => {});
+    store.sessionTierMap.set("rl-dedup", "system");
+    const consumeSpy = vi.spyOn(store, "consumeRateLimitToken");
+    const dispatchAction = vi
+      .fn()
+      .mockResolvedValue({ result: { ok: true, result: { sha: "abc" } } });
+    const deps = fakeDeps({ sessionStore: store, dispatchAction });
+    const server = createSessionServer("rl-dedup", deps);
+
+    const args = { message: "one" };
+    await callTool(server, { name: "git.commit", arguments: args });
+    await callTool(server, { name: "git.commit", arguments: args });
+
+    // Second call is a dedup cache hit (dispatch ran once) but the token
+    // was still charged on both — runaway loops stay bounded.
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(consumeSpy).toHaveBeenCalledTimes(2);
+    store.drain();
+  });
+
+  it("rate-limits a grant-authorized call (auth passes, rate limit fails)", async () => {
+    // Workbench tier can't call worktree.delete; a per-tool grant lifts the
+    // auth gate. The rate limiter must still reject, and the tier-mismatch
+    // banner must NOT fire (this is not an authorization failure).
+    const sessionStore = fakeSessionStore("workbench");
+    sessionStore.grantCache.issueGrant("rl-grant", "worktree.delete");
+    (sessionStore.consumeRateLimitToken as ReturnType<typeof vi.fn>).mockReturnValue({
+      allowed: false,
+      retryAfter: 4,
+    });
+    const dispatchAction = vi.fn();
+    const notifyTierMismatch = vi.fn();
+    const deps = fakeDeps({ sessionStore, dispatchAction, notifyTierMismatch });
+    const server = createSessionServer("rl-grant", deps);
+
+    const result = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: { worktreeId: "w1" },
+    })) as { content: unknown; isError?: boolean };
+
+    expect(result.isError).toBe(true);
+    expect(parseToolErrorPayload(result).code).toBe(MCP_RATE_LIMITED_CODE);
+    expect(notifyTierMismatch).not.toHaveBeenCalled();
+    expect(dispatchAction).not.toHaveBeenCalled();
+    sessionStore.grantCache.dispose();
   });
 });
 

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -11,7 +11,7 @@ vi.mock("electron", () => ({
 import { createSessionServer } from "../sessionServer.js";
 import type { SessionServerDeps } from "../sessionServer.js";
 import type { SessionStore } from "../sessionStore.js";
-import { SessionStore as RealSessionStore } from "../sessionStore.js";
+import { SessionStore as RealSessionStore, consumeToken } from "../sessionStore.js";
 import { GrantCache } from "../grantCache.js";
 import {
   buildToolError,
@@ -24,6 +24,9 @@ import {
   USER_REJECTED_CODE,
   ELICITATION_FAILED_CODE,
   MCP_DEDUP_KEY_COLLISION_CODE,
+  MCP_DEDUP_ALLOWLIST,
+  MCP_RATE_LIMITED_CODE,
+  RATE_LIMIT_TIERS,
   unwrapDispatchResult,
 } from "../shared.js";
 import { SessionBindingError } from "../rendererBridge.js";
@@ -43,6 +46,7 @@ function fakeSessionStore(
     resourceSubscriptions: new Map(),
     dedupInFlight: new Map(),
     dedupResultCache: new Map(),
+    rateLimitBuckets: new Map(),
     grantCache,
     drain: vi.fn(),
     getTier: vi.fn(() => tier),
@@ -51,6 +55,11 @@ function fakeSessionStore(
     resetIdleTimer: vi.fn(),
     resetHttpIdleTimer: vi.fn(),
     clearDedupState: vi.fn(),
+    // Permissive by default so existing suites aren't throttled; the
+    // rate-limit suite overrides this with a counting stub or the real
+    // implementation.
+    consumeRateLimitToken: vi.fn(() => ({ allowed: true })),
+    clearRateLimitState: vi.fn(),
   } as unknown as SessionStore;
   return store;
 }
@@ -1564,5 +1573,254 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     expect(refreshSpy).toHaveBeenCalledTimes(1);
     expect(resetIdle).toHaveBeenCalledWith("s");
     sessionStore.grantCache.dispose();
+  });
+});
+
+function parseToolErrorPayload(result: {
+  content: unknown;
+  isError?: boolean;
+}): { code: string; retriable: boolean; details?: { retryAfter?: number } } {
+  const text = (result as { content: Array<{ text: string }> }).content[0].text;
+  return JSON.parse(text);
+}
+
+describe("consumeToken (pure token bucket)", () => {
+  const mutation = RATE_LIMIT_TIERS.mutation; // capacity 10, 10/min
+
+  it("allows up to capacity then rejects with a positive retryAfter", () => {
+    const bucket = { tokens: mutation.capacity, lastRefillMs: 1000 };
+    for (let i = 0; i < mutation.capacity; i++) {
+      expect(consumeToken(bucket, mutation, 1000).allowed).toBe(true);
+    }
+    const rejected = consumeToken(bucket, mutation, 1000);
+    expect(rejected.allowed).toBe(false);
+    if (!rejected.allowed) {
+      expect(rejected.retryAfter).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("refills proportionally to elapsed wall-clock", () => {
+    const bucket = { tokens: 0, lastRefillMs: 0 };
+    // 10/min => one token every 6000ms. After 6000ms exactly one token.
+    const r = consumeToken(bucket, mutation, 6000);
+    expect(r.allowed).toBe(true);
+    expect(bucket.tokens).toBeCloseTo(0, 5);
+  });
+
+  it("caps refill at capacity (no unbounded accrual while idle)", () => {
+    const bucket = { tokens: 0, lastRefillMs: 0 };
+    // A huge idle gap must not let the bucket exceed capacity.
+    consumeToken(bucket, mutation, 60 * 60 * 1000);
+    expect(bucket.tokens).toBeLessThanOrEqual(mutation.capacity);
+  });
+
+  it("never returns a sub-second retryAfter", () => {
+    const bucket = { tokens: 0.99, lastRefillMs: 0 };
+    const r = consumeToken(bucket, RATE_LIMIT_TIERS.highFreqRead, 0);
+    expect(r.allowed).toBe(false);
+    if (!r.allowed) expect(r.retryAfter).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("SessionStore.consumeRateLimitToken", () => {
+  it("exhausts the mutation tier (git.commit) after capacity calls", () => {
+    const store = new RealSessionStore(() => {});
+    const cap = RATE_LIMIT_TIERS.mutation.capacity;
+    for (let i = 0; i < cap; i++) {
+      expect(store.consumeRateLimitToken("s", "git.commit", 1000).allowed).toBe(true);
+    }
+    const rejected = store.consumeRateLimitToken("s", "git.commit", 1000);
+    expect(rejected.allowed).toBe(false);
+    store.drain();
+  });
+
+  it("uses the high-frequency tier for read tools (terminal.getStatus)", () => {
+    const store = new RealSessionStore(() => {});
+    const cap = RATE_LIMIT_TIERS.highFreqRead.capacity;
+    for (let i = 0; i < cap; i++) {
+      expect(store.consumeRateLimitToken("s", "terminal.getStatus", 1000).allowed).toBe(true);
+    }
+    expect(store.consumeRateLimitToken("s", "terminal.getStatus", 1000).allowed).toBe(false);
+    store.drain();
+  });
+
+  it("falls back to the standard tier for unmapped tools", () => {
+    const store = new RealSessionStore(() => {});
+    const cap = RATE_LIMIT_TIERS.standard.capacity;
+    for (let i = 0; i < cap; i++) {
+      expect(store.consumeRateLimitToken("s", "files.search", 1000).allowed).toBe(true);
+    }
+    expect(store.consumeRateLimitToken("s", "files.search", 1000).allowed).toBe(false);
+    store.drain();
+  });
+
+  it("isolates buckets per session", () => {
+    const store = new RealSessionStore(() => {});
+    const cap = RATE_LIMIT_TIERS.mutation.capacity;
+    for (let i = 0; i < cap; i++) {
+      store.consumeRateLimitToken("session-a", "git.push", 1000);
+    }
+    expect(store.consumeRateLimitToken("session-a", "git.push", 1000).allowed).toBe(false);
+    // A fresh session is unaffected by session-a's exhausted bucket.
+    expect(store.consumeRateLimitToken("session-b", "git.push", 1000).allowed).toBe(true);
+    store.drain();
+  });
+
+  it("isolates buckets per tool within a session", () => {
+    const store = new RealSessionStore(() => {});
+    const cap = RATE_LIMIT_TIERS.mutation.capacity;
+    for (let i = 0; i < cap; i++) {
+      store.consumeRateLimitToken("s", "git.commit", 1000);
+    }
+    expect(store.consumeRateLimitToken("s", "git.commit", 1000).allowed).toBe(false);
+    expect(store.consumeRateLimitToken("s", "git.push", 1000).allowed).toBe(true);
+    store.drain();
+  });
+
+  it("clearRateLimitState resets the session's buckets", () => {
+    const store = new RealSessionStore(() => {});
+    const cap = RATE_LIMIT_TIERS.mutation.capacity;
+    for (let i = 0; i < cap; i++) {
+      store.consumeRateLimitToken("s", "git.commit", 1000);
+    }
+    expect(store.consumeRateLimitToken("s", "git.commit", 1000).allowed).toBe(false);
+    store.clearRateLimitState("s");
+    // Fresh bucket — full capacity again.
+    expect(store.consumeRateLimitToken("s", "git.commit", 1000).allowed).toBe(true);
+    store.drain();
+  });
+
+  it("revokeSession tears down the rate-limit buckets", () => {
+    const store = new RealSessionStore(() => {});
+    store.consumeRateLimitToken("s", "git.commit", 1000);
+    expect(store.rateLimitBuckets.has("s")).toBe(true);
+    store.sessionTierMap.set("s", "system");
+    // No live transport, but revokeSession returns false only when no
+    // session entry exists — drive teardown via drain() which also clears.
+    store.drain();
+    expect(store.rateLimitBuckets.size).toBe(0);
+  });
+});
+
+describe("CallTool rate limiting (handler integration)", () => {
+  it("rejects with MCP_RATE_LIMITED + retryAfter when the bucket is exhausted", async () => {
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+    const sessionStore = fakeSessionStore("system");
+    (sessionStore.consumeRateLimitToken as ReturnType<typeof vi.fn>).mockReturnValue({
+      allowed: false,
+      retryAfter: 7,
+    });
+    const appendAuditRecord = vi.fn();
+    const deps = fakeDeps({ sessionStore, dispatchAction, appendAuditRecord });
+    const server = createSessionServer("rl-1", deps);
+
+    const result = (await callTool(server, {
+      name: "git.commit",
+      arguments: { message: "x" },
+    })) as { content: unknown; isError?: boolean };
+
+    expect(result.isError).toBe(true);
+    const payload = parseToolErrorPayload(result);
+    expect(payload.code).toBe(MCP_RATE_LIMITED_CODE);
+    expect(payload.retriable).toBe(true);
+    expect(payload.details?.retryAfter).toBe(7);
+    // Rate limit runs before dispatch — the action never ran.
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+
+  it("writes a rate_limited audit record before returning", async () => {
+    const sessionStore = fakeSessionStore("system");
+    (sessionStore.consumeRateLimitToken as ReturnType<typeof vi.fn>).mockReturnValue({
+      allowed: false,
+      retryAfter: 3,
+    });
+    const appendAuditRecord = vi.fn();
+    const deps = fakeDeps({ sessionStore, appendAuditRecord });
+    const server = createSessionServer("rl-2", deps);
+
+    await callTool(server, { name: "git.push", arguments: {} });
+
+    expect(appendAuditRecord).toHaveBeenCalledTimes(1);
+    const arg = appendAuditRecord.mock.calls[0]![0] as {
+      outcome: { kind: string; retryAfter?: number };
+      toolId: string;
+    };
+    expect(arg.toolId).toBe("git.push");
+    expect(arg.outcome.kind).toBe("rate_limited");
+    expect(arg.outcome.retryAfter).toBe(3);
+  });
+
+  it("runs before dedup — an exhausted bucket short-circuits an allowlisted tool", async () => {
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+    const sessionStore = fakeSessionStore("system");
+    (sessionStore.consumeRateLimitToken as ReturnType<typeof vi.fn>).mockReturnValue({
+      allowed: false,
+      retryAfter: 1,
+    });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("rl-3", deps);
+
+    // terminal.new is dedup-allowlisted; rate-limit must win the race.
+    const result = (await callTool(server, {
+      name: "terminal.new",
+      arguments: { spawnedBy: { kind: "user" } },
+    })) as { content: unknown; isError?: boolean };
+
+    expect(result.isError).toBe(true);
+    expect(parseToolErrorPayload(result).code).toBe(MCP_RATE_LIMITED_CODE);
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(sessionStore.dedupInFlight.size).toBe(0);
+  });
+
+  it("does not consume a token for tier-denied calls (auth precedes rate limit)", async () => {
+    // workbench tier cannot call git.commit; the tier check returns first
+    // and the rate-limit token must not be charged.
+    const sessionStore = fakeSessionStore("workbench");
+    const deps = fakeDeps({ sessionStore });
+    const server = createSessionServer("rl-4", deps);
+
+    const result = (await callTool(server, {
+      name: "git.commit",
+      arguments: { message: "x" },
+    })) as { content: unknown; isError?: boolean };
+
+    expect(result.isError).toBe(true);
+    expect(parseToolErrorPayload(result).code).not.toBe(MCP_RATE_LIMITED_CODE);
+    expect(sessionStore.consumeRateLimitToken).not.toHaveBeenCalled();
+  });
+
+  it("lets allowed calls dispatch normally", async () => {
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const sessionStore = fakeSessionStore("system");
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("rl-5", deps);
+
+    const result = (await callTool(server, {
+      name: "files.search",
+      arguments: { query: "x" },
+    })) as { isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    expect(sessionStore.consumeRateLimitToken).toHaveBeenCalledWith("rl-5", "files.search");
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("MCP_DEDUP_ALLOWLIST widening (#8468)", () => {
+  it("retains the original creation-tool cohort", () => {
+    for (const tool of ["terminal.new", "worktree.createWithRecipe", "agent.launch", "recipe.run"]) {
+      expect(MCP_DEDUP_ALLOWLIST.has(tool)).toBe(true);
+    }
+  });
+
+  it("adds the git/forge mutation cohort", () => {
+    for (const tool of ["git.commit", "git.push", "forge.openIssue", "github.openPR"]) {
+      expect(MCP_DEDUP_ALLOWLIST.has(tool)).toBe(true);
+    }
+  });
+
+  it("stays bounded — does not blanket every mutation", () => {
+    expect(MCP_DEDUP_ALLOWLIST.has("git.stageAll")).toBe(false);
+    expect(MCP_DEDUP_ALLOWLIST.has("terminal.sendCommand")).toBe(false);
   });
 });

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -25,6 +25,7 @@ import {
   USER_REJECTED_CODE,
   CONFIRMATION_TIMEOUT_CODE,
   MCP_DEDUP_KEY_COLLISION_CODE,
+  MCP_RATE_LIMITED_CODE,
   minimumPermittingTier,
   PRE_AUTH_FAILED_CODE,
 } from "./shared.js";
@@ -133,6 +134,9 @@ export class AuditService {
     }
     if (outcome.kind === "collision") {
       return { result: "collision", errorCode: MCP_DEDUP_KEY_COLLISION_CODE };
+    }
+    if (outcome.kind === "rate_limited") {
+      return { result: "rate_limited", errorCode: MCP_RATE_LIMITED_CODE };
     }
     const value = outcome.value;
     if (value.ok) return { result: "success" };
@@ -594,4 +598,5 @@ export type AuditOutcome =
   | { kind: "throw"; error: unknown }
   | { kind: "unauthorized" }
   | { kind: "dedup" }
-  | { kind: "collision" };
+  | { kind: "collision" }
+  | { kind: "rate_limited"; retryAfter: number };

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -595,6 +595,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionWebContentsMap.delete(sessionId);
         this.deps.sessionStore.sessionContextMap.delete(sessionId);
         this.deps.sessionStore.clearDedupState(sessionId);
+        this.deps.sessionStore.clearRateLimitState(sessionId);
         this.deps.abusePolicy.dropSession(sessionId);
         cleanupResourceSubscriptions(sessionId, this.deps.sessionStore);
       };
@@ -611,6 +612,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionWebContentsMap.delete(sessionId);
         this.deps.sessionStore.sessionContextMap.delete(sessionId);
         this.deps.sessionStore.clearDedupState(sessionId);
+        this.deps.sessionStore.clearRateLimitState(sessionId);
         this.deps.abusePolicy.dropSession(sessionId);
         transport.onclose = undefined;
         await transport.close().catch(() => {});
@@ -721,6 +723,7 @@ export class HttpLifecycle {
       this.deps.sessionStore.sessionWebContentsMap.delete(id);
       this.deps.sessionStore.sessionContextMap.delete(id);
       this.deps.sessionStore.clearDedupState(id);
+      this.deps.sessionStore.clearRateLimitState(id);
       this.deps.abusePolicy.dropSession(id);
       cleanupResourceSubscriptions(id, this.deps.sessionStore);
     };
@@ -742,6 +745,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionWebContentsMap.delete(id);
         this.deps.sessionStore.sessionContextMap.delete(id);
         this.deps.sessionStore.clearDedupState(id);
+        this.deps.sessionStore.clearRateLimitState(id);
         this.deps.abusePolicy.dropSession(id);
         cleanupResourceSubscriptions(id, this.deps.sessionStore);
       } else {
@@ -750,6 +754,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionWebContentsMap.delete(newSessionId);
         this.deps.sessionStore.sessionContextMap.delete(newSessionId);
         this.deps.sessionStore.clearDedupState(newSessionId);
+        this.deps.sessionStore.clearRateLimitState(newSessionId);
         this.deps.abusePolicy.dropSession(newSessionId);
         cleanupResourceSubscriptions(newSessionId, this.deps.sessionStore);
       }

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -44,6 +44,7 @@ import {
   MCP_DEDUP_TTL_MS,
   MCP_DEDUP_MAX_ENTRIES_PER_SESSION,
   MCP_DEDUP_KEY_COLLISION_CODE,
+  MCP_RATE_LIMITED_CODE,
   minimumPermittingTier,
   EXECUTION_ERROR_CODE,
   SESSION_BINDING_GONE,
@@ -272,6 +273,34 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
       // post-dispatch refresh can verify the entry wasn't revoked and
       // re-issued under us (race guard, lesson #2243).
       grantIssuedAt = grant.issuedAt;
+    }
+
+    // Runaway-loop guard (#8468): charge one token against the
+    // per-`(session, toolId)` bucket before dedup or dispatch. Placed
+    // after the tier/grant check (an unauthorized call shouldn't consume
+    // tokens) and before dedup (a tight loop replaying the same dedup key
+    // must still be bounded — dedup is an idempotency guard, not a
+    // rate-limit bypass). Rejection is an explicit retriable tool-error
+    // with a `retryAfter` hint, never a silent skip.
+    const rateLimit = sessionStore.consumeRateLimitToken(sessionId, actionId);
+    if (!rateLimit.allowed) {
+      try {
+        appendAuditRecord({
+          toolId: actionId,
+          sessionId,
+          tier,
+          args,
+          durationMs: Date.now() - startedAt,
+          outcome: { kind: "rate_limited", retryAfter: rateLimit.retryAfter },
+        });
+      } catch (err) {
+        console.error("[MCP] Failed to append audit record:", err);
+      }
+      return buildToolError({
+        code: MCP_RATE_LIMITED_CODE,
+        message: `Rate limit exceeded for '${actionId}'. Retry after ${rateLimit.retryAfter}s.`,
+        details: { retryAfter: rateLimit.retryAfter },
+      });
     }
 
     // Idempotency dedup for the creation-tool allowlist. Same-moment duplicates

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -1,6 +1,6 @@
 import type { ActionContext } from "../../../shared/types/actions.js";
-import type { McpTier, McpSseSession, McpHttpSession } from "./shared.js";
-import { MCP_SSE_IDLE_TIMEOUT_MS } from "./shared.js";
+import type { McpTier, McpSseSession, McpHttpSession, RateLimitConfig } from "./shared.js";
+import { MCP_SSE_IDLE_TIMEOUT_MS, rateLimitConfigForTool } from "./shared.js";
 import type { DedupCacheEntry, DedupInFlightEntry } from "./sessionDedup.js";
 import { GrantCache, type GrantLifecycleEmitter } from "./grantCache.js";
 import { getSystemSleepService } from "../SystemSleepService.js";
@@ -25,6 +25,42 @@ export interface SessionStoreOptions {
   dropAbuseState?: (sessionId: string) => void;
 }
 
+/**
+ * Mutable token-bucket state for one `(sessionId, toolId)` pair. `tokens`
+ * is the current fractional balance; `lastRefillMs` is the wall-clock of
+ * the most recent refill so the next call can recompute lazily.
+ */
+export interface RateLimitBucket {
+  tokens: number;
+  lastRefillMs: number;
+}
+
+export type ConsumeTokenResult = { allowed: true } | { allowed: false; retryAfter: number };
+
+/**
+ * Pure token-bucket step. Refills `bucket` for the time elapsed since its
+ * last refill (capped at `config.capacity`), then attempts to consume one
+ * token. Mutates `bucket` in place and returns whether the call is allowed;
+ * on rejection `retryAfter` is the whole-seconds wait until one token has
+ * accrued (always `>= 1`). Exported for direct unit coverage independent
+ * of the session-store wiring.
+ */
+export function consumeToken(
+  bucket: RateLimitBucket,
+  config: RateLimitConfig,
+  nowMs: number
+): ConsumeTokenResult {
+  const elapsed = Math.max(0, nowMs - bucket.lastRefillMs);
+  bucket.tokens = Math.min(config.capacity, bucket.tokens + elapsed * config.refillPerMs);
+  bucket.lastRefillMs = nowMs;
+  if (bucket.tokens >= 1) {
+    bucket.tokens -= 1;
+    return { allowed: true };
+  }
+  const retryAfter = Math.max(1, Math.ceil((1 - bucket.tokens) / config.refillPerMs / 1000));
+  return { allowed: false, retryAfter };
+}
+
 export class SessionStore {
   readonly sessions = new Map<string, McpSseSession>();
   readonly httpSessions = new Map<string, McpHttpSession>();
@@ -46,6 +82,11 @@ export class SessionStore {
   // return the original result). Cleared on drain and idle expiry.
   readonly dedupInFlight = new Map<string, Map<string, DedupInFlightEntry>>();
   readonly dedupResultCache = new Map<string, Map<string, DedupCacheEntry>>();
+  // Per-`(sessionId, toolId)` token buckets for the runaway-loop rate
+  // limiter (#8468). Lazily populated on first call to a tool and torn
+  // down in lockstep with the other session-scoped maps on drain, idle
+  // expiry, and explicit revoke.
+  readonly rateLimitBuckets = new Map<string, Map<string, RateLimitBucket>>();
   /**
    * Per-`(sessionId, toolId)` time-bounded grants — replaces the sticky
    * `sessionTierMap` elevation pathway for the "Approve once" flow (#8442).
@@ -77,6 +118,35 @@ export class SessionStore {
     this.dedupResultCache.delete(sessionId);
   }
 
+  /**
+   * Charge one token against the `(sessionId, toolId)` bucket, creating a
+   * full bucket on first use. The tier is resolved from
+   * `rateLimitConfigForTool` so an unmapped tool falls back to `standard`.
+   * Thin wrapper around the pure {@link consumeToken} step.
+   */
+  consumeRateLimitToken(
+    sessionId: string,
+    toolId: string,
+    nowMs: number = Date.now()
+  ): ConsumeTokenResult {
+    const config = rateLimitConfigForTool(toolId);
+    let byTool = this.rateLimitBuckets.get(sessionId);
+    if (!byTool) {
+      byTool = new Map<string, RateLimitBucket>();
+      this.rateLimitBuckets.set(sessionId, byTool);
+    }
+    let bucket = byTool.get(toolId);
+    if (!bucket) {
+      bucket = { tokens: config.capacity, lastRefillMs: nowMs };
+      byTool.set(toolId, bucket);
+    }
+    return consumeToken(bucket, config, nowMs);
+  }
+
+  clearRateLimitState(sessionId: string): void {
+    this.rateLimitBuckets.delete(sessionId);
+  }
+
   private expireSseSession(sessionId: string): void {
     const session = this.sessions.get(sessionId);
     if (!session) return;
@@ -90,6 +160,7 @@ export class SessionStore {
     this.sessionWebContentsMap.delete(sessionId);
     this.sessionContextMap.delete(sessionId);
     this.clearDedupState(sessionId);
+    this.clearRateLimitState(sessionId);
     this.idleStartedAt.delete(sessionId);
     this.dropAbuseStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
@@ -142,6 +213,7 @@ export class SessionStore {
     this.sessionWebContentsMap.delete(sessionId);
     this.sessionContextMap.delete(sessionId);
     this.clearDedupState(sessionId);
+    this.clearRateLimitState(sessionId);
     this.httpIdleStartedAt.delete(sessionId);
     this.dropAbuseStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
@@ -267,6 +339,7 @@ export class SessionStore {
     this.sessionWebContentsMap.delete(sessionId);
     this.sessionContextMap.delete(sessionId);
     this.clearDedupState(sessionId);
+    this.clearRateLimitState(sessionId);
     this.dropAbuseStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
     return true;
@@ -278,6 +351,7 @@ export class SessionStore {
     // resurrect a torn-down session's cache.
     this.dedupInFlight.clear();
     this.dedupResultCache.clear();
+    this.rateLimitBuckets.clear();
 
     for (const session of this.sessions.values()) {
       clearTimeout(session.idleTimer);

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -52,7 +52,10 @@ export function consumeToken(
 ): ConsumeTokenResult {
   const elapsed = Math.max(0, nowMs - bucket.lastRefillMs);
   bucket.tokens = Math.min(config.capacity, bucket.tokens + elapsed * config.refillPerMs);
-  bucket.lastRefillMs = nowMs;
+  // Never move the refill anchor backward: a backward `Date.now()` (NTP
+  // step-back, which Electron can see on macOS) would otherwise let the
+  // next call accrue refill it didn't earn.
+  bucket.lastRefillMs = Math.max(bucket.lastRefillMs, nowMs);
   if (bucket.tokens >= 1) {
     bucket.tokens -= 1;
     return { allowed: true };

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -422,7 +422,7 @@ export const RATE_LIMIT_TOOL_MAP: ReadonlyMap<string, RateLimitConfig> = new Map
   ["git.push", RATE_LIMIT_TIERS.mutation],
   ["forge.openIssue", RATE_LIMIT_TIERS.mutation],
   ["github.openPR", RATE_LIMIT_TIERS.mutation],
-]);
+] as Array<[string, RateLimitConfig]>);
 
 /**
  * Resolve the rate-limit config for a tool — its explicit override or the

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -133,6 +133,7 @@ export const BINDING_STALE = "BINDING_STALE";
 export const SESSION_BINDING_GONE = "SESSION_BINDING_GONE";
 export const MCP_DEDUP_KEY_COLLISION_CODE = "MCP_DEDUP_KEY_COLLISION";
 export const PRE_AUTH_FAILED_CODE = "PRE_AUTH_FAILED";
+export const MCP_RATE_LIMITED_CODE = "MCP_RATE_LIMITED";
 
 /**
  * Application-level convention: codes here flag transient failures that a
@@ -144,6 +145,7 @@ export const PRE_AUTH_FAILED_CODE = "PRE_AUTH_FAILED";
 export const RETRIABLE_ERROR_CODES: ReadonlySet<string> = new Set([
   EXECUTION_ERROR_CODE,
   CONFIRMATION_TIMEOUT_CODE,
+  MCP_RATE_LIMITED_CODE,
 ]);
 
 export interface McpErrorPayload {
@@ -329,12 +331,22 @@ export const TIER_NOT_PERMITTED_CODE = "TIER_NOT_PERMITTED";
 
 /**
  * Creation-tool allowlist for per-session idempotency dedup. LLMs replay
- * tool calls during multi-step planning, especially across reconnects. For
- * these four actions a duplicate call would silently produce a duplicate
- * resource — orphaned terminal, redundant agent, etc. Inside the TTL
- * window the duplicate returns the original result instead of redispatching.
+ * tool calls during multi-step planning, especially across reconnects.
+ * Inside the TTL window a duplicate call returns the original result
+ * instead of redispatching, with an args-hash guard rejecting same-key
+ * different-args replays as a collision (#8429).
  *
- * Deliberately narrow: blanket-applying dedup to all mutations would mask
+ * Inclusion criterion: a mutation tool belongs here when (a) an LLM
+ * retrying after a transient error or reconnect is realistic, and (b) a
+ * duplicate dispatch has an immediately user-visible side effect — an
+ * orphaned terminal, a redundant agent, a duplicate commit/push, or a
+ * duplicate issue/PR. The seed cohort (`terminal.new`,
+ * `worktree.createWithRecipe`, `agent.launch`, `recipe.run`) is widened
+ * to the git/forge mutations (`git.commit`, `git.push`, `forge.openIssue`,
+ * `github.openPR`) now that the args-hash collision guard (#8429) is in
+ * place to make the widening safe.
+ *
+ * Deliberately bounded: blanket-applying dedup to all mutations would mask
  * legitimate "do it again" cases (re-running the same git command, etc.).
  */
 export const MCP_DEDUP_ALLOWLIST: ReadonlySet<string> = new Set([
@@ -342,6 +354,10 @@ export const MCP_DEDUP_ALLOWLIST: ReadonlySet<string> = new Set([
   "worktree.createWithRecipe",
   "agent.launch",
   "recipe.run",
+  "git.commit",
+  "git.push",
+  "forge.openIssue",
+  "github.openPR",
 ]);
 
 /**
@@ -359,6 +375,62 @@ export const MCP_DEDUP_TTL_MS = 120_000;
  * insertion above this cap so memory stays bounded at session lifetime.
  */
 export const MCP_DEDUP_MAX_ENTRIES_PER_SESSION = 256;
+
+/**
+ * Token-bucket configuration for the per-`(session, toolId)` rate limiter
+ * that bounds runaway agent loops on the MCP CallTool path (#8468).
+ *
+ * - `capacity`: maximum burst — tokens available when the bucket is full.
+ * - `refillPerMs`: tokens regenerated per millisecond. Expressed per-ms so
+ *   the bucket can be recomputed lazily from elapsed wall-clock on each call
+ *   without a background timer.
+ */
+export interface RateLimitConfig {
+  capacity: number;
+  refillPerMs: number;
+}
+
+/**
+ * Rate-limit tiers. Intentionally conservative placeholders sized so that no
+ * legitimate agent workflow trips them — a runaway loop hits the burst cap,
+ * then `retryAfter` forces a minimum gap. Tuned post-ship from audit data.
+ *
+ * - `highFreqRead` (60/min): cheap read-only polling tools. The
+ *   `triage_terminals` recipe explicitly tells agents not to busy-loop;
+ *   60/min is generous for legitimate fleet-polling cadences.
+ * - `standard` (30/min): the default for any tool not in
+ *   {@link RATE_LIMIT_TOOL_MAP}.
+ * - `mutation` (10/min): side-effecting tools where a tight loop produces
+ *   duplicate resources (commits, pushes, issues, PRs).
+ */
+export const RATE_LIMIT_TIERS = {
+  highFreqRead: { capacity: 60, refillPerMs: 60 / 60_000 },
+  standard: { capacity: 30, refillPerMs: 30 / 60_000 },
+  mutation: { capacity: 10, refillPerMs: 10 / 60_000 },
+} as const satisfies Record<string, RateLimitConfig>;
+
+/**
+ * Per-tool tier overrides. Tools absent from this map fall back to
+ * {@link RATE_LIMIT_TIERS.standard}. Keep the mutation cohort aligned with
+ * {@link MCP_DEDUP_ALLOWLIST}'s git/forge entries.
+ */
+export const RATE_LIMIT_TOOL_MAP: ReadonlyMap<string, RateLimitConfig> = new Map([
+  ["terminal.getOutput", RATE_LIMIT_TIERS.highFreqRead],
+  ["terminal.getStatus", RATE_LIMIT_TIERS.highFreqRead],
+  ["actions.getContext", RATE_LIMIT_TIERS.highFreqRead],
+  ["git.commit", RATE_LIMIT_TIERS.mutation],
+  ["git.push", RATE_LIMIT_TIERS.mutation],
+  ["forge.openIssue", RATE_LIMIT_TIERS.mutation],
+  ["github.openPR", RATE_LIMIT_TIERS.mutation],
+]);
+
+/**
+ * Resolve the rate-limit config for a tool — its explicit override or the
+ * `standard` fallback.
+ */
+export function rateLimitConfigForTool(toolId: string): RateLimitConfig {
+  return RATE_LIMIT_TOOL_MAP.get(toolId) ?? RATE_LIMIT_TIERS.standard;
+}
 
 /**
  * Compute the minimum non-external tier that permits the given tool. Used to

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -14,6 +14,9 @@
  * - `dedup`: a duplicate creation-tool call was suppressed by the
  *   per-session idempotency guard and the cached or in-flight result was
  *   returned. No second dispatch was performed.
+ * - `rate_limited`: the per-`(session, toolId)` token bucket was exhausted
+ *   and the call was rejected before dispatch with a `retryAfter` hint. No
+ *   dispatch was performed — this is a runaway-loop guard, not a failure.
  */
 export type McpAuditResult =
   | "success"
@@ -21,7 +24,8 @@ export type McpAuditResult =
   | "confirmation-pending"
   | "unauthorized"
   | "dedup"
-  | "collision";
+  | "collision"
+  | "rate_limited";
 
 /**
  * Persisted audit record for a single MCP tool dispatch. Written once per
@@ -57,7 +61,8 @@ export type McpConfirmationDecision = "approved" | "rejected" | "timeout";
  *
  * - `info`: success or dedup — nominal dispatch.
  * - `notice`: confirmation-pending — gate waiting on user approval.
- * - `warning`: tier-rejected — legit user action blocked by policy.
+ * - `warning`: tier-rejected or rate-limited — legit user action blocked
+ *   by policy.
  * - `error`: dispatch threw, timed out, or returned an error other than
  *   confirmation-pending/unauthorized.
  * - `critical`: reserved for systemic failures (not yet emitted).
@@ -73,6 +78,7 @@ const SEVERITY_BY_RESULT: Record<McpAuditResult, McpAuditSeverity> = {
   unauthorized: "error",
   error: "error",
   collision: "warning",
+  rate_limited: "warning",
 };
 
 const SEVERITY_BY_ERROR_CODE: Record<string, McpAuditSeverity> = {

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -25,6 +25,7 @@ const RESULT_LABEL: Record<McpAuditResult, string> = {
   unauthorized: "Unauthorized",
   dedup: "Deduplicated",
   collision: "Key collision",
+  rate_limited: "Rate limited",
 };
 
 const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
@@ -34,6 +35,7 @@ const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
   unauthorized: "bg-status-danger",
   dedup: "bg-status-info",
   collision: "bg-status-warning",
+  rate_limited: "bg-status-warning",
 };
 
 type TimeRange = "5m" | "1h" | "24h" | "all";
@@ -262,7 +264,8 @@ export function McpAuditLogViewer({
               value === "confirmation-pending" ||
               value === "unauthorized" ||
               value === "dedup" ||
-              value === "collision"
+              value === "collision" ||
+              value === "rate_limited"
             ) {
               setResultFilter(value);
             }
@@ -277,6 +280,7 @@ export function McpAuditLogViewer({
           <option value="unauthorized">Unauthorized</option>
           <option value="dedup">Deduplicated</option>
           <option value="collision">Key collision</option>
+          <option value="rate_limited">Rate limited</option>
         </select>
         <select
           value={timeRange}


### PR DESCRIPTION
## Summary

- Adds a per-(session, toolId) token-bucket rate limiter on the MCP server's `CallTool` path. Runaway agent loops are now bounded rather than free to exhaust the server.
- Rejection returns a first-class retriable `MCP_RATE_LIMITED` tool-error carrying `details.retryAfter` — never a silent skip. The check sits after tier/grant auth and before dedup, so auth-denied calls don't consume tokens but dedup-cache hits still do (a loop replaying the same cached key stays bounded).
- `rate_limited` is a first-class audit result (severity `warning`) surfaced in the audit-log viewer.

Resolves #8468

## Changes

- **`shared.ts`** — `consumeToken()` pure token-bucket implementation; `RATE_LIMIT_TOOL_MAP` assigns three tiers: `highFreqRead` 60/min (`terminal.getOutput`, `terminal.getStatus`, `actions.getContext`), `mutation` 10/min (`git.commit`, `git.push`, `forge.openIssue`, `github.openPR`), `standard` 30/min (default).
- **`sessionStore.ts`** — `rateLimitBuckets` map on each session; `consumeRateLimit()` wrapper; `clearRateLimitState()` helper. Buckets torn down in every session-teardown path: SSE/HTTP idle expiry, `revokeSession`, `drain`, and all five `httpLifecycle` close/failure sites.
- **`sessionServer.ts`** — rate-limit check wired into `CallTool` handler, between auth and dedup.
- **`auditLog.ts`** — `rate_limited` added as a valid `AuditOutcome`.
- **`mcpServer.ts`** (shared types) — `MCP_DEDUP_ALLOWLIST` widened from 4 → 8 entries (adds `git.commit`, `git.push`, `forge.openIssue`, `github.openPR`), safe now that the args-hash collision guard from #8429 is in place.
- **`McpAuditLogViewer.tsx`** — `rate_limited` rendered in the audit-log viewer.

## Testing

- Pure `consumeToken` unit tests: capacity enforcement, refill, cap at max, backward-clock handling, min `retryAfter` floor.
- `SessionStore` wrapper tests: per-session/per-tool isolation, tier exhaustion, `clearRateLimitState`, drain + `revokeSession` teardown paths.
- Handler integration tests: `MCP_RATE_LIMITED` error shape + `retryAfter` + `retriable` flag, audit written before return, runs before dedup, auth precedes rate-limit, grant-authorized calls still rate-limited, dedup cache-hit still charges token.
- Dedup allowlist widening verified.
- All verify gates pass: typecheck, channels, ipc, help, lint:ratchet, format, build.