### PR TITLE
fix(mcp): decay session tier elevation back to baseline after TTL

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -91,6 +91,20 @@ export class McpServerService {
       {
         emitGrantLifecycle: (sessionId, payload) => this.emitGrantLifecycle(sessionId, payload),
         dropAbuseState: (sessionId) => abusePolicy.dropSession(sessionId),
+        onTierDecayed: (sessionId) => {
+          // Tier just decayed to the workbench baseline (#8462). Push a
+          // tools/list_changed so the model re-fetches the now-narrowed
+          // manifest instead of calling a tool it no longer has. The
+          // session map is the freshness check — a transport closing
+          // between the lookup and the send rejects harmlessly.
+          const session =
+            this.sessionStore.httpSessions.get(sessionId) ??
+            this.sessionStore.sessions.get(sessionId);
+          session?.server.sendToolListChanged().catch(() => {
+            // Transport already closing/closed — the model will see the
+            // narrowed surface on its next list call regardless.
+          });
+        },
       }
     );
 

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -56,6 +56,8 @@ function fakeDeps(overrides?: Partial<HttpLifecycleDeps>): HttpLifecycleDeps {
       createHttpIdleTimer: vi.fn(() => setTimeout(() => {}, 1_000_000)),
       resetIdleTimer: vi.fn(),
       resetHttpIdleTimer: vi.fn(),
+      armTierElevationTimer: vi.fn(),
+      clearElevationTimer: vi.fn(),
       revokeSession: vi.fn(() => false),
     },
     auditService: {

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -264,6 +264,13 @@ describe("HttpLifecycle", () => {
 
       expect(result).toEqual({ sessionId: "sess-1", tier: "system" });
       expect(deps.sessionStore.sessionTierMap.get("sess-1")).toBe("system");
+      // The elevation must arm the decay timer with the pre-elevation tier
+      // as the baseline (#8462) — otherwise the elevation is unbounded.
+      expect(deps.sessionStore.armTierElevationTimer).toHaveBeenCalledWith(
+        "sess-1",
+        "system",
+        "workbench"
+      );
     });
 
     it("refuses downgrades silently and keeps current tier", () => {

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1411,6 +1411,7 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     const sessionStore = fakeSessionStore("workbench");
     sessionStore.sessions.set("s", {
       transport: {} as never,
+      server: {} as never,
       idleTimer: setTimeout(() => {}, 1_000_000),
     });
     const resetIdle = sessionStore.resetIdleTimer as ReturnType<typeof vi.fn>;
@@ -1538,6 +1539,7 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     const sessionStore = fakeSessionStore("workbench");
     sessionStore.sessions.set("s", {
       transport: {} as never,
+      server: {} as never,
       idleTimer: setTimeout(() => {}, 1_000_000),
     });
     const resetIdle = sessionStore.resetIdleTimer as ReturnType<typeof vi.fn>;

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MCP_SSE_IDLE_TIMEOUT_MS, type McpSseSession, type McpHttpSession } from "../shared.js";
+import {
+  MCP_SSE_IDLE_TIMEOUT_MS,
+  MCP_TIER_ELEVATION_TTL_MS,
+  type McpSseSession,
+  type McpHttpSession,
+} from "../shared.js";
 
 // Mutable test state controlled per-test.
 let mockAwakeTimeSince = 0;
@@ -18,6 +23,9 @@ function fakeSseSession(): McpSseSession {
     transport: {
       close: vi.fn().mockResolvedValue(undefined),
     } as unknown as McpSseSession["transport"],
+    server: {
+      sendToolListChanged: vi.fn().mockResolvedValue(undefined),
+    } as unknown as McpSseSession["server"],
     idleTimer: setTimeout(() => {}, 1_000_000),
   };
 }
@@ -555,5 +563,165 @@ describe("SessionStore dropAbuseState wiring (#8467)", () => {
   it("does not fire dropAbuseState when revokeSession returns false (unknown session)", () => {
     expect(store.revokeSession("ghost")).toBe(false);
     expect(dropAbuseSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("SessionStore tier-elevation decay (#8462)", () => {
+  let store: SessionStore;
+  let decayed: string[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setAwakeTime(0);
+    decayed = [];
+    store = new SessionStore(() => {}, {
+      onTierDecayed: (sessionId) => {
+        decayed.push(sessionId);
+      },
+    });
+  });
+
+  afterEach(() => {
+    store.grantCache.dispose();
+    store.drain();
+    vi.useRealTimers();
+  });
+
+  it("decays an elevated session back to workbench after the TTL and fires onTierDecayed", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "action");
+    store.armTierElevationTimer("s", "action");
+
+    setAwakeTime(MCP_TIER_ELEVATION_TTL_MS);
+    vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS + 1);
+
+    expect(store.getTier("s")).toBe("workbench");
+    expect(decayed).toEqual(["s"]);
+  });
+
+  it("does not arm a timer for the workbench baseline (nothing to decay)", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "workbench");
+    store.armTierElevationTimer("s", "workbench");
+
+    setAwakeTime(MCP_TIER_ELEVATION_TTL_MS);
+    vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS + 1);
+
+    expect(decayed).toEqual([]);
+  });
+
+  it("re-arming refreshes the window from now (repeat Always allow)", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "action");
+    store.armTierElevationTimer("s", "action");
+
+    // Halfway through the window the user re-approves — window resets.
+    setAwakeTime(MCP_TIER_ELEVATION_TTL_MS / 2);
+    vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS / 2);
+    store.armTierElevationTimer("s", "action");
+
+    // Original deadline passes — must NOT have decayed (window was reset).
+    setAwakeTime(MCP_TIER_ELEVATION_TTL_MS / 2 + 1);
+    vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS / 2 + 1);
+    expect(store.getTier("s")).toBe("action");
+
+    // Full fresh window elapsed from the re-arm — now it decays.
+    setAwakeTime(MCP_TIER_ELEVATION_TTL_MS + 1);
+    vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS);
+    expect(store.getTier("s")).toBe("workbench");
+  });
+
+  it("does not count suspended time against the window (awake-time corrected)", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "system");
+    store.armTierElevationTimer("s", "system");
+
+    // Wall clock advances a full TTL but the machine was asleep — zero
+    // awake time elapsed, so the elevation must survive.
+    setAwakeTime(0);
+    vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS + 1);
+
+    expect(store.getTier("s")).toBe("system");
+    expect(decayed).toEqual([]);
+  });
+
+  it("recomputeIdleTimers does not prematurely decay when awake time is below the TTL (suspend correction)", () => {
+    store.httpSessions.set("h", fakeHttpSession());
+    store.sessionTierMap.set("h", "action");
+    clearTimeout(store.httpSessions.get("h")!.idleTimer);
+    store.httpSessions.get("h")!.idleTimer = store.createHttpIdleTimer("h");
+    store.armTierElevationTimer("h", "action");
+
+    // Long wall-clock sleep but ~no awake time elapsed — the wake recompute
+    // must keep both the idle and elevation windows armed, not collapse them.
+    setAwakeTime(0);
+    store.recomputeIdleTimers();
+
+    expect(store.getTier("h")).toBe("action");
+    expect(store.httpSessions.has("h")).toBe(true);
+    expect(decayed).toEqual([]);
+  });
+
+  it("does not wipe a tier the user re-approved between arm and fire (stale-token guard, #2243)", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "action");
+    store.armTierElevationTimer("s", "action");
+
+    // Simulate a re-elevation to a different tier just before the original
+    // timer fires: the live tier no longer matches the captured token.
+    store.sessionTierMap.set("s", "system");
+
+    setAwakeTime(MCP_TIER_ELEVATION_TTL_MS);
+    vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS + 1);
+
+    // The original timer's decay must be a no-op — the re-approval stands.
+    expect(store.getTier("s")).toBe("system");
+    expect(decayed).toEqual([]);
+  });
+
+  it("is a safe no-op when the session was torn down before the timer fires (#3728)", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "action");
+    store.armTierElevationTimer("s", "action");
+
+    store.revokeSession("s");
+
+    setAwakeTime(MCP_TIER_ELEVATION_TTL_MS);
+    expect(() => vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS + 1)).not.toThrow();
+    expect(decayed).toEqual([]);
+  });
+
+  it("clears elevation state on revokeSession, drain, and clearElevationTimer", () => {
+    store.sessions.set("s1", fakeSseSession());
+    store.armTierElevationTimer("s1", "action");
+    store.revokeSession("s1");
+
+    store.httpSessions.set("h1", fakeHttpSession());
+    store.armTierElevationTimer("h1", "action");
+    store.clearElevationTimer("h1");
+
+    store.sessions.set("s2", fakeSseSession());
+    store.armTierElevationTimer("s2", "action");
+    store.drain();
+
+    // No armed timer survives — advancing past the TTL decays nothing.
+    setAwakeTime(MCP_TIER_ELEVATION_TTL_MS);
+    vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS + 1);
+    expect(decayed).toEqual([]);
+  });
+
+  it("idle expiry beating elevation decay leaves the decay a no-op", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "action");
+    clearTimeout(store.sessions.get("s")!.idleTimer);
+    store.sessions.get("s")!.idleTimer = store.createIdleTimer("s");
+    store.armTierElevationTimer("s", "action");
+
+    // Both windows are equal; the idle reaper collects the session first.
+    setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS);
+    vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS + 1);
+
+    expect(store.sessions.has("s")).toBe(false);
+    expect(decayed).toEqual([]);
   });
 });

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -587,10 +587,10 @@ describe("SessionStore tier-elevation decay (#8462)", () => {
     vi.useRealTimers();
   });
 
-  it("decays an elevated session back to workbench after the TTL and fires onTierDecayed", () => {
+  it("decays a workbench-baseline session back to workbench after the TTL and fires onTierDecayed", () => {
     store.sessions.set("s", fakeSseSession());
     store.sessionTierMap.set("s", "action");
-    store.armTierElevationTimer("s", "action");
+    store.armTierElevationTimer("s", "action", "workbench");
 
     setAwakeTime(MCP_TIER_ELEVATION_TTL_MS);
     vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS + 1);
@@ -599,10 +599,44 @@ describe("SessionStore tier-elevation decay (#8462)", () => {
     expect(decayed).toEqual(["s"]);
   });
 
-  it("does not arm a timer for the workbench baseline (nothing to decay)", () => {
+  it("decays to the session's token baseline, not hardcoded workbench", () => {
+    // A help-session bearer configured with `tier: "action"` connects at
+    // the action baseline, then gets elevated to system. After the window
+    // it must fall back to action — dropping to workbench would strip
+    // tools the user legitimately held from handshake.
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "action");
+    store.armTierElevationTimer("s", "system", "action");
+    store.sessionTierMap.set("s", "system");
+
+    setAwakeTime(MCP_TIER_ELEVATION_TTL_MS);
+    vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS + 1);
+
+    expect(store.getTier("s")).toBe("action");
+    expect(decayed).toEqual(["s"]);
+  });
+
+  it("a chained elevation decays all the way to the original baseline", () => {
+    // workbench → action → system: the second arm must preserve the
+    // workbench baseline captured by the first, not decay to action.
     store.sessions.set("s", fakeSseSession());
     store.sessionTierMap.set("s", "workbench");
-    store.armTierElevationTimer("s", "workbench");
+    store.armTierElevationTimer("s", "action", "workbench");
+    store.sessionTierMap.set("s", "action");
+    store.armTierElevationTimer("s", "system", "action");
+    store.sessionTierMap.set("s", "system");
+
+    setAwakeTime(MCP_TIER_ELEVATION_TTL_MS);
+    vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS + 1);
+
+    expect(store.getTier("s")).toBe("workbench");
+    expect(decayed).toEqual(["s"]);
+  });
+
+  it("does not arm a timer when the requested tier equals the baseline (nothing to decay)", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "workbench");
+    store.armTierElevationTimer("s", "workbench", "workbench");
 
     setAwakeTime(MCP_TIER_ELEVATION_TTL_MS);
     vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS + 1);
@@ -610,15 +644,35 @@ describe("SessionStore tier-elevation decay (#8462)", () => {
     expect(decayed).toEqual([]);
   });
 
+  it("drops stale denial-suppression counters on decay so the banner re-triggers", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "action");
+    store.armTierElevationTimer("s", "action", "workbench");
+
+    // Tool was denied enough times before the elevation that the banner
+    // is now suppressed for it.
+    store.grantCache.incrementDenial("s", "worktree.delete");
+    store.grantCache.incrementDenial("s", "worktree.delete");
+    store.grantCache.incrementDenial("s", "worktree.delete");
+    expect(store.grantCache.shouldSuppressBanner("s", "worktree.delete")).toBe(true);
+
+    setAwakeTime(MCP_TIER_ELEVATION_TTL_MS);
+    vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS + 1);
+
+    expect(store.getTier("s")).toBe("workbench");
+    // Post-decay the next out-of-baseline call must surface the banner.
+    expect(store.grantCache.shouldSuppressBanner("s", "worktree.delete")).toBe(false);
+  });
+
   it("re-arming refreshes the window from now (repeat Always allow)", () => {
     store.sessions.set("s", fakeSseSession());
     store.sessionTierMap.set("s", "action");
-    store.armTierElevationTimer("s", "action");
+    store.armTierElevationTimer("s", "action", "workbench");
 
     // Halfway through the window the user re-approves — window resets.
     setAwakeTime(MCP_TIER_ELEVATION_TTL_MS / 2);
     vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS / 2);
-    store.armTierElevationTimer("s", "action");
+    store.armTierElevationTimer("s", "action", "workbench");
 
     // Original deadline passes — must NOT have decayed (window was reset).
     setAwakeTime(MCP_TIER_ELEVATION_TTL_MS / 2 + 1);
@@ -634,7 +688,7 @@ describe("SessionStore tier-elevation decay (#8462)", () => {
   it("does not count suspended time against the window (awake-time corrected)", () => {
     store.sessions.set("s", fakeSseSession());
     store.sessionTierMap.set("s", "system");
-    store.armTierElevationTimer("s", "system");
+    store.armTierElevationTimer("s", "system", "workbench");
 
     // Wall clock advances a full TTL but the machine was asleep — zero
     // awake time elapsed, so the elevation must survive.
@@ -650,7 +704,7 @@ describe("SessionStore tier-elevation decay (#8462)", () => {
     store.sessionTierMap.set("h", "action");
     clearTimeout(store.httpSessions.get("h")!.idleTimer);
     store.httpSessions.get("h")!.idleTimer = store.createHttpIdleTimer("h");
-    store.armTierElevationTimer("h", "action");
+    store.armTierElevationTimer("h", "action", "workbench");
 
     // Long wall-clock sleep but ~no awake time elapsed — the wake recompute
     // must keep both the idle and elevation windows armed, not collapse them.
@@ -665,7 +719,7 @@ describe("SessionStore tier-elevation decay (#8462)", () => {
   it("does not wipe a tier the user re-approved between arm and fire (stale-token guard, #2243)", () => {
     store.sessions.set("s", fakeSseSession());
     store.sessionTierMap.set("s", "action");
-    store.armTierElevationTimer("s", "action");
+    store.armTierElevationTimer("s", "action", "workbench");
 
     // Simulate a re-elevation to a different tier just before the original
     // timer fires: the live tier no longer matches the captured token.
@@ -682,7 +736,7 @@ describe("SessionStore tier-elevation decay (#8462)", () => {
   it("is a safe no-op when the session was torn down before the timer fires (#3728)", () => {
     store.sessions.set("s", fakeSseSession());
     store.sessionTierMap.set("s", "action");
-    store.armTierElevationTimer("s", "action");
+    store.armTierElevationTimer("s", "action", "workbench");
 
     store.revokeSession("s");
 
@@ -693,15 +747,15 @@ describe("SessionStore tier-elevation decay (#8462)", () => {
 
   it("clears elevation state on revokeSession, drain, and clearElevationTimer", () => {
     store.sessions.set("s1", fakeSseSession());
-    store.armTierElevationTimer("s1", "action");
+    store.armTierElevationTimer("s1", "action", "workbench");
     store.revokeSession("s1");
 
     store.httpSessions.set("h1", fakeHttpSession());
-    store.armTierElevationTimer("h1", "action");
+    store.armTierElevationTimer("h1", "action", "workbench");
     store.clearElevationTimer("h1");
 
     store.sessions.set("s2", fakeSseSession());
-    store.armTierElevationTimer("s2", "action");
+    store.armTierElevationTimer("s2", "action", "workbench");
     store.drain();
 
     // No armed timer survives — advancing past the TTL decays nothing.
@@ -715,7 +769,7 @@ describe("SessionStore tier-elevation decay (#8462)", () => {
     store.sessionTierMap.set("s", "action");
     clearTimeout(store.sessions.get("s")!.idleTimer);
     store.sessions.get("s")!.idleTimer = store.createIdleTimer("s");
-    store.armTierElevationTimer("s", "action");
+    store.armTierElevationTimer("s", "action", "workbench");
 
     // Both windows are equal; the idle reaper collects the session first.
     setAwakeTime(MCP_SSE_IDLE_TIMEOUT_MS);

--- a/electron/services/mcp-server/grantCache.ts
+++ b/electron/services/mcp-server/grantCache.ts
@@ -231,6 +231,22 @@ export class GrantCache {
   }
 
   /**
+   * Drop only the consecutive-denial suppression counters for a session,
+   * leaving any active per-tool grants intact. Used by the tier-decay path
+   * (#8462): a decayed session must re-show the tier-mismatch banner on its
+   * next out-of-baseline call rather than have it silently suppressed by
+   * denials accrued before the elevation. Grants are an orthogonal per-tool
+   * approval (#8442) with their own TTL and must survive the decay, so this
+   * is deliberately narrower than {@link clearSessionState}.
+   */
+  clearDenialCounts(sessionId: string): void {
+    const prefix = `${sessionId}:`;
+    for (const k of [...this.denialCounts.keys()]) {
+      if (k.startsWith(prefix)) this.denialCounts.delete(k);
+    }
+  }
+
+  /**
    * True when the current denial for the pair should suppress the renderer
    * banner. The audit record is still written; this controls only the UI
    * surface. The check uses the post-increment count: with threshold = 2

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -950,10 +950,12 @@ export class HttpLifecycle {
     }
     this.deps.sessionStore.sessionTierMap.set(sessionId, tier);
     // Bound the renderer-approved elevation: after MCP_TIER_ELEVATION_TTL_MS
-    // of awake time the session silently decays back to `workbench` so a
-    // stale "Always allow" can't outlive the user's intent (#8462). Each
-    // accepted approval refreshes the window from now.
-    this.deps.sessionStore.armTierElevationTimer(sessionId, tier);
+    // of awake time the session silently decays back to its token-resolved
+    // baseline (`current`, the pre-elevation tier) so a stale "Always allow"
+    // can't outlive the user's intent (#8462). Each accepted approval
+    // refreshes the window from now; a chained re-elevation preserves the
+    // original baseline.
+    this.deps.sessionStore.armTierElevationTimer(sessionId, tier, current);
     return { sessionId, tier };
   }
 

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -578,13 +578,14 @@ export class HttpLifecycle {
       const server = createSessionServer(sessionId, deps);
 
       const idleTimer = this.deps.sessionStore.createIdleTimer(sessionId);
-      this.deps.sessionStore.sessions.set(sessionId, { transport, idleTimer });
+      this.deps.sessionStore.sessions.set(sessionId, { transport, server, idleTimer });
       transport.onclose = () => {
         const session = this.deps.sessionStore.sessions.get(sessionId);
         if (session) {
           clearTimeout(session.idleTimer);
           this.deps.sessionStore.sessions.delete(sessionId);
         }
+        this.deps.sessionStore.clearElevationTimer(sessionId);
         this.deps.sessionStore.sessionTierMap.delete(sessionId);
         // Revoke before deleting the WebContents pin so the lifecycle
         // emitter can still find the pinned renderer for the
@@ -605,6 +606,7 @@ export class HttpLifecycle {
       } catch (err) {
         clearTimeout(idleTimer);
         this.deps.sessionStore.sessions.delete(sessionId);
+        this.deps.sessionStore.clearElevationTimer(sessionId);
         this.deps.sessionStore.sessionTierMap.delete(sessionId);
         // Same pin-before-clear ordering — the connect failure path
         // mirrors normal close cleanup.
@@ -716,6 +718,7 @@ export class HttpLifecycle {
         clearTimeout(session.idleTimer);
         this.deps.sessionStore.httpSessions.delete(id);
       }
+      this.deps.sessionStore.clearElevationTimer(id);
       this.deps.sessionStore.sessionTierMap.delete(id);
       // Pin-before-revoke ordering identical to the SSE path above —
       // see `transport.onclose` in the GET /sse branch.
@@ -740,6 +743,7 @@ export class HttpLifecycle {
           clearTimeout(session.idleTimer);
           this.deps.sessionStore.httpSessions.delete(id);
         }
+        this.deps.sessionStore.clearElevationTimer(id);
         this.deps.sessionStore.sessionTierMap.delete(id);
         this.deps.sessionStore.grantCache.revokeSession(id, "session-ended");
         this.deps.sessionStore.sessionWebContentsMap.delete(id);
@@ -749,6 +753,7 @@ export class HttpLifecycle {
         this.deps.abusePolicy.dropSession(id);
         cleanupResourceSubscriptions(id, this.deps.sessionStore);
       } else {
+        this.deps.sessionStore.clearElevationTimer(newSessionId);
         this.deps.sessionStore.sessionTierMap.delete(newSessionId);
         this.deps.sessionStore.grantCache.revokeSession(newSessionId, "session-ended");
         this.deps.sessionStore.sessionWebContentsMap.delete(newSessionId);
@@ -944,6 +949,11 @@ export class HttpLifecycle {
       return { sessionId, tier: current };
     }
     this.deps.sessionStore.sessionTierMap.set(sessionId, tier);
+    // Bound the renderer-approved elevation: after MCP_TIER_ELEVATION_TTL_MS
+    // of awake time the session silently decays back to `workbench` so a
+    // stale "Always allow" can't outlive the user's intent (#8462). Each
+    // accepted approval refreshes the window from now.
+    this.deps.sessionStore.armTierElevationTimer(sessionId, tier);
     return { sessionId, tier };
   }
 

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -159,7 +159,11 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     { name: "Daintree", version: app.getVersion() },
     {
       capabilities: {
-        tools: {},
+        // `listChanged: true` is required for clients to process the
+        // `notifications/tools/list_changed` we send when a session's tier
+        // elevates or decays (#8462). Must be declared at construction —
+        // the SDK rejects post-connect capability registration in ^1.20+.
+        tools: { listChanged: true },
         resources: { subscribe: true, listChanged: false },
         prompts: {},
       },

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -1,6 +1,10 @@
 import type { ActionContext } from "../../../shared/types/actions.js";
 import type { McpTier, McpSseSession, McpHttpSession, RateLimitConfig } from "./shared.js";
-import { MCP_SSE_IDLE_TIMEOUT_MS, rateLimitConfigForTool } from "./shared.js";
+import {
+  MCP_SSE_IDLE_TIMEOUT_MS,
+  MCP_TIER_ELEVATION_TTL_MS,
+  rateLimitConfigForTool,
+} from "./shared.js";
 import type { DedupCacheEntry, DedupInFlightEntry } from "./sessionDedup.js";
 import { GrantCache, type GrantLifecycleEmitter } from "./grantCache.js";
 import { getSystemSleepService } from "../SystemSleepService.js";
@@ -23,6 +27,15 @@ export interface SessionStoreOptions {
    * fixtures construct without one.
    */
   dropAbuseState?: (sessionId: string) => void;
+  /**
+   * Fired when a session's renderer-approved tier elevation expires and the
+   * session is silently decayed back to the `workbench` baseline (#8462).
+   * `httpLifecycle` wires this to `server.sendToolListChanged()` on the
+   * decayed session so the model's tool manifest reflects the narrowed
+   * surface immediately. Optional so bare test fixtures construct without
+   * one (decay still mutates the tier map; only the notification is skipped).
+   */
+  onTierDecayed?: (sessionId: string) => void;
 }
 
 /**
@@ -104,8 +117,22 @@ export class SessionStore {
   private readonly idleStartedAt = new Map<string, number>();
   private readonly httpIdleStartedAt = new Map<string, number>();
 
+  // Tier-elevation decay timers, keyed by sessionId (unique across SSE and
+  // HTTP). A renderer-approved "Always allow" elevation is bounded to
+  // MCP_TIER_ELEVATION_TTL_MS; on expiry the session silently decays to the
+  // `workbench` baseline (#8462). `tierElevationStartedAt` drives the same
+  // awake-time correction as the idle reaper; `tierElevationToken` records
+  // the tier captured when the timer was armed so a fresh re-elevation
+  // between arm and fire is never wiped (#2243 stale-token guard). Stored
+  // off the session object (unlike `idleTimer`) so the four inline cleanup
+  // paths in `httpLifecycle` can tear it down via `clearElevationTimer`.
+  private readonly tierElevationTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly tierElevationStartedAt = new Map<string, number>();
+  private readonly tierElevationToken = new Map<string, McpTier>();
+
   private readonly cleanupResourceSubscriptionsFn: (sessionId: string) => void;
   private readonly dropAbuseStateFn: (sessionId: string) => void;
+  private readonly onTierDecayedFn: (sessionId: string) => void;
 
   constructor(
     cleanupResourceSubscriptions: (sessionId: string) => void,
@@ -113,6 +140,7 @@ export class SessionStore {
   ) {
     this.cleanupResourceSubscriptionsFn = cleanupResourceSubscriptions;
     this.dropAbuseStateFn = options.dropAbuseState ?? (() => {});
+    this.onTierDecayedFn = options.onTierDecayed ?? (() => {});
     this.grantCache = new GrantCache({ emit: options.emitGrantLifecycle });
   }
 
@@ -165,6 +193,7 @@ export class SessionStore {
     this.clearDedupState(sessionId);
     this.clearRateLimitState(sessionId);
     this.idleStartedAt.delete(sessionId);
+    this.clearElevationTimer(sessionId);
     this.dropAbuseStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
     session.transport.close().catch(() => {
@@ -218,6 +247,7 @@ export class SessionStore {
     this.clearDedupState(sessionId);
     this.clearRateLimitState(sessionId);
     this.httpIdleStartedAt.delete(sessionId);
+    this.clearElevationTimer(sessionId);
     this.dropAbuseStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
     session.transport.close().catch(() => {
@@ -309,6 +339,109 @@ export class SessionStore {
         // SystemSleepService may not be initialized; keep existing timer.
       }
     }
+
+    // Recompute tier-elevation timers in lockstep with the idle reaper so a
+    // long suspend doesn't either prematurely decay a session (sleep time
+    // must not count) or leave a stale elevation parked indefinitely after
+    // wake. If idle expiry above already collected the session, the
+    // session-existence guard makes this a no-op cleanup. Snapshot to avoid
+    // mutation-during-iteration from `decayTier`.
+    const elevationEntries = Array.from(this.tierElevationStartedAt.entries());
+    for (const [sessionId, startedAt] of elevationEntries) {
+      if (!this.sessions.has(sessionId) && !this.httpSessions.has(sessionId)) {
+        this.clearElevationTimer(sessionId);
+        continue;
+      }
+      try {
+        const awakeElapsed = getSystemSleepService().getAwakeTimeSince(startedAt);
+        if (awakeElapsed >= MCP_TIER_ELEVATION_TTL_MS) {
+          this.decayTier(sessionId);
+        } else {
+          clearTimeout(this.tierElevationTimers.get(sessionId));
+          const remaining = Math.max(1, MCP_TIER_ELEVATION_TTL_MS - awakeElapsed);
+          this.scheduleTierElevationCheck(sessionId, remaining);
+        }
+      } catch {
+        // SystemSleepService may not be initialized; keep existing timer.
+      }
+    }
+  }
+
+  /**
+   * Arm (or refresh) the decay timer for a renderer-approved tier
+   * elevation. Idempotent: clearing first makes a repeat "Always allow"
+   * correctly reset the window from now. `workbench` is the baseline — there
+   * is nothing to decay, so any pending timer is just cleared. Call this
+   * from `setSessionTier` after the promote-only guard accepts the change.
+   */
+  armTierElevationTimer(sessionId: string, tier: McpTier): void {
+    this.clearElevationTimer(sessionId);
+    if (tier === "workbench") return;
+    this.tierElevationStartedAt.set(sessionId, Date.now());
+    this.tierElevationToken.set(sessionId, tier);
+    this.scheduleTierElevationCheck(sessionId, MCP_TIER_ELEVATION_TTL_MS);
+  }
+
+  private scheduleTierElevationCheck(sessionId: string, delayMs: number): void {
+    const timer = setTimeout(() => this.checkAndDecayTier(sessionId), delayMs);
+    timer.unref?.();
+    this.tierElevationTimers.set(sessionId, timer);
+  }
+
+  private checkAndDecayTier(sessionId: string): void {
+    // Guard #1 (#3728): the session may have been reaped/closed between arm
+    // and fire — its teardown path already dropped the elevation state.
+    if (!this.sessions.has(sessionId) && !this.httpSessions.has(sessionId)) {
+      this.clearElevationTimer(sessionId);
+      return;
+    }
+    const startedAt = this.tierElevationStartedAt.get(sessionId);
+    if (startedAt === undefined) return;
+    try {
+      const awakeElapsed = getSystemSleepService().getAwakeTimeSince(startedAt);
+      if (awakeElapsed < MCP_TIER_ELEVATION_TTL_MS) {
+        // Suspend time is excluded by getAwakeTimeSince, so re-arm against
+        // the remaining awake budget without resetting startedAt/token —
+        // the original deadline is preserved across sleep/wake.
+        const remaining = Math.max(1, MCP_TIER_ELEVATION_TTL_MS - awakeElapsed);
+        clearTimeout(this.tierElevationTimers.get(sessionId));
+        this.scheduleTierElevationCheck(sessionId, remaining);
+        return;
+      }
+    } catch {
+      // SystemSleepService not initialized — fall through to decay.
+    }
+    this.decayTier(sessionId);
+  }
+
+  private decayTier(sessionId: string): void {
+    const token = this.tierElevationToken.get(sessionId);
+    const current = this.sessionTierMap.get(sessionId);
+    this.clearElevationTimer(sessionId);
+    // Guard #1: session gone — nothing to decay, nobody to notify.
+    if (!this.sessions.has(sessionId) && !this.httpSessions.has(sessionId)) return;
+    // Guard #2 (#2243): a fresh "Always allow" re-elevated this session
+    // between arm and fire — its own timer owns the new window now; never
+    // wipe a tier the user just re-approved.
+    if (current === undefined || current !== token) return;
+    if (current === "workbench") return;
+    this.sessionTierMap.set(sessionId, "workbench");
+    this.onTierDecayedFn(sessionId);
+  }
+
+  /**
+   * Tear down a session's tier-elevation timer and bookkeeping. Public so
+   * the inline cleanup paths in `httpLifecycle` (SSE/HTTP `transport.onclose`
+   * and the two connect-failure catch blocks) can clear it without routing
+   * through the private session-expiry helpers (#4851: every setTimeout must
+   * be cleared in every exit path).
+   */
+  clearElevationTimer(sessionId: string): void {
+    const timer = this.tierElevationTimers.get(sessionId);
+    if (timer !== undefined) clearTimeout(timer);
+    this.tierElevationTimers.delete(sessionId);
+    this.tierElevationStartedAt.delete(sessionId);
+    this.tierElevationToken.delete(sessionId);
   }
 
   getTier(sessionId: string): McpTier {
@@ -343,6 +476,7 @@ export class SessionStore {
     this.sessionContextMap.delete(sessionId);
     this.clearDedupState(sessionId);
     this.clearRateLimitState(sessionId);
+    this.clearElevationTimer(sessionId);
     this.dropAbuseStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
     return true;
@@ -381,6 +515,12 @@ export class SessionStore {
     }
     this.httpSessions.clear();
     this.httpIdleStartedAt.clear();
+    for (const timer of this.tierElevationTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.tierElevationTimers.clear();
+    this.tierElevationStartedAt.clear();
+    this.tierElevationToken.clear();
     this.sessionTierMap.clear();
     this.sessionWebContentsMap.clear();
     this.sessionContextMap.clear();

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -129,6 +129,14 @@ export class SessionStore {
   private readonly tierElevationTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly tierElevationStartedAt = new Map<string, number>();
   private readonly tierElevationToken = new Map<string, McpTier>();
+  // The session's token-resolved baseline tier captured at the first
+  // elevation in a chain. Decay reverts here, NOT to a hardcoded
+  // `workbench` — a help-session bearer can hold a configured baseline of
+  // `action`/`system` (`HelpAssistantTier`), and dropping it to `workbench`
+  // would strip tools the user legitimately had from handshake. Preserved
+  // across chained re-elevations (workbench→action→system still decays all
+  // the way to workbench).
+  private readonly tierElevationBaseline = new Map<string, McpTier>();
 
   private readonly cleanupResourceSubscriptionsFn: (sessionId: string) => void;
   private readonly dropAbuseStateFn: (sessionId: string) => void;
@@ -369,16 +377,23 @@ export class SessionStore {
 
   /**
    * Arm (or refresh) the decay timer for a renderer-approved tier
-   * elevation. Idempotent: clearing first makes a repeat "Always allow"
-   * correctly reset the window from now. `workbench` is the baseline — there
-   * is nothing to decay, so any pending timer is just cleared. Call this
-   * from `setSessionTier` after the promote-only guard accepts the change.
+   * elevation. `baselineTier` is the session's pre-elevation tier (the
+   * token-resolved handshake tier) — decay reverts here, not to a hardcoded
+   * `workbench`. Idempotent: clearing first makes a repeat "Always allow"
+   * reset the window from now. A baseline captured by an earlier elevation
+   * in the same chain is preserved (workbench→action→system still decays
+   * all the way to workbench). When the requested tier equals the effective
+   * baseline the session isn't actually elevated, so any pending timer is
+   * just cleared. Call this from `setSessionTier` after the promote-only
+   * guard accepts the change.
    */
-  armTierElevationTimer(sessionId: string, tier: McpTier): void {
+  armTierElevationTimer(sessionId: string, tier: McpTier, baselineTier: McpTier): void {
+    const baseline = this.tierElevationBaseline.get(sessionId) ?? baselineTier;
     this.clearElevationTimer(sessionId);
-    if (tier === "workbench") return;
+    if (tier === baseline) return;
     this.tierElevationStartedAt.set(sessionId, Date.now());
     this.tierElevationToken.set(sessionId, tier);
+    this.tierElevationBaseline.set(sessionId, baseline);
     this.scheduleTierElevationCheck(sessionId, MCP_TIER_ELEVATION_TTL_MS);
   }
 
@@ -416,6 +431,7 @@ export class SessionStore {
 
   private decayTier(sessionId: string): void {
     const token = this.tierElevationToken.get(sessionId);
+    const baseline = this.tierElevationBaseline.get(sessionId) ?? "workbench";
     const current = this.sessionTierMap.get(sessionId);
     this.clearElevationTimer(sessionId);
     // Guard #1: session gone — nothing to decay, nobody to notify.
@@ -424,8 +440,15 @@ export class SessionStore {
     // between arm and fire — its own timer owns the new window now; never
     // wipe a tier the user just re-approved.
     if (current === undefined || current !== token) return;
-    if (current === "workbench") return;
-    this.sessionTierMap.set(sessionId, "workbench");
+    // Already at/below the token baseline — nothing to roll back.
+    if (current === baseline) return;
+    this.sessionTierMap.set(sessionId, baseline);
+    // Drop stale denial-suppression counters so the first post-decay
+    // out-of-baseline call re-triggers the tier-mismatch banner instead of
+    // being silently suppressed by denials accrued before the elevation
+    // (the #8462 acceptance criterion). Per-tool grants survive — they are
+    // an orthogonal explicit approval (#8442).
+    this.grantCache.clearDenialCounts(sessionId);
     this.onTierDecayedFn(sessionId);
   }
 
@@ -442,6 +465,7 @@ export class SessionStore {
     this.tierElevationTimers.delete(sessionId);
     this.tierElevationStartedAt.delete(sessionId);
     this.tierElevationToken.delete(sessionId);
+    this.tierElevationBaseline.delete(sessionId);
   }
 
   getTier(sessionId: string): McpTier {
@@ -521,6 +545,7 @@ export class SessionStore {
     this.tierElevationTimers.clear();
     this.tierElevationStartedAt.clear();
     this.tierElevationToken.clear();
+    this.tierElevationBaseline.clear();
     this.sessionTierMap.clear();
     this.sessionWebContentsMap.clear();
     this.sessionContextMap.clear();

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -68,6 +68,20 @@ export const MAX_PORT_RETRIES = 10;
 export const MCP_SSE_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
+ * Lifetime of a renderer-approved session-tier elevation ("Always allow"
+ * via {@link minimumPermittingTier}). After this window the session silently
+ * decays back to the `workbench` baseline so a stale "Always allow" can't
+ * outlive the user's intent across hibernate/wake and project switches
+ * (#8462). The next out-of-baseline tool call re-triggers the tier-mismatch
+ * banner — there is no separate decay notification. The window is awake-time
+ * corrected via {@link SystemSleepService.getAwakeTimeSince} so suspend time
+ * doesn't count against it, exactly like the idle reaper. Intentionally
+ * equal to {@link MCP_SSE_IDLE_TIMEOUT_MS}: a tier can never silently apply
+ * to a session the idle reaper has already collected.
+ */
+export const MCP_TIER_ELEVATION_TTL_MS = 30 * 60 * 1000;
+
+/**
  * Sliding-TTL window for per-tool grants minted via "Approve once". A grant
  * issued for `(sessionId, toolId)` permits that exact tool for this session
  * for the duration, and any successful dispatch through the grant refreshes
@@ -696,6 +710,12 @@ export interface DispatchEnvelope {
 
 export interface McpSseSession {
   transport: import("@modelcontextprotocol/sdk/server/sse.js").SSEServerTransport;
+  // The per-session `Server` instance. Stored so the tier-decay path can
+  // call `sendToolListChanged()` on this exact session when its elevation
+  // window expires (#8462) — `McpHttpSession` already carries it for the
+  // same reason; the SSE path previously let the reference go out of scope
+  // after `server.connect(transport)`.
+  server: import("@modelcontextprotocol/sdk/server/index.js").Server;
   idleTimer: ReturnType<typeof setTimeout>;
 }
 


### PR DESCRIPTION
## Summary

- Renderer-approved \"Always allow\" tier elevations were stored indefinitely in `sessionTierMap` with no expiry, surviving hibernate/wake cycles and project switches — the model manifest would keep showing a wider tool surface than it should.
- Adds `MCP_TIER_ELEVATION_TTL_MS` (30 min, awake-time corrected via `SystemSleepService.getAwakeTimeSince`). After the TTL, the session silently decays to its token-resolved baseline tier — not hardcoded workbench, so help-session bearers holding a configured action/system baseline are unaffected. Chained elevations preserve the original baseline.
- On decay: `tools.listChanged` broadcast so the model manifest narrows immediately; `GrantCache.clearDenialCounts` resets stale denial-suppression counters so the next out-of-baseline call re-shows the tier-mismatch banner (the #8462 acceptance criterion).

Resolves #8462

## Changes

- `sessionStore.ts` — `armTierElevationTimer` / `decayTier` mirror the idle-timer pattern: suspend correction, re-arm loop, stale-token guard (#2243 — a re-elevation between arm and fire is never wiped), session-existence guard (#3728). Elevation timers cleared in every teardown path: `expireSse/HttpSession`, `revokeSession`, `drain`, `recomputeIdleTimers`, and the four inline cleanup paths in `httpLifecycle` (#4851).
- `shared.ts` — exports `MCP_TIER_ELEVATION_TTL_MS`.
- `sessionServer.ts` — stores the per-session `Server` reference on `McpSseSession` (HTTP already had it) so `decayTier` can push `sendToolListChanged`.
- `McpServerService.ts` — declares `tools.listChanged: true` in capabilities.
- `grantCache.ts` — adds scoped `clearDenialCounts(sessionId)` (per-tool grants are orthogonal to #8442 and survive).

Scope is mechanism-only; the renderer tier-mismatch banner UI is unchanged.

## Testing

15 new unit test cases in `sessionStore.test.ts` covering: decay to token baseline, chained elevation preserving original baseline, re-arm on fresh elevation, suspend correction, stale-token guard, denial-counter reset, teardown clearing, and idle-beats-decay ordering. All 144 mcp-server unit tests pass. `npm run check` clean (typecheck, lint ratchet no new warnings, format, build).