### PR TITLE
feat(forge): generalize forge data APIs beyond open/assign/token

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -730,6 +730,11 @@ export const CHANNELS = {
   FORGE_SET_CREDENTIAL: "forge:set-credential",
   FORGE_GET_CREDENTIAL_STATUS: "forge:get-credential-status",
   FORGE_CLEAR_CREDENTIAL: "forge:clear-credential",
+  FORGE_LIST_ISSUES: "forge:list-issues",
+  FORGE_LIST_PRS: "forge:list-prs",
+  FORGE_GET_ISSUE: "forge:get-issue",
+  FORGE_GET_PR: "forge:get-pr",
+  FORGE_GET_REPO_METADATA: "forge:get-repo-metadata",
 
   // Plugin channels
   PLUGIN_LIST: "plugin:list",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -43,6 +43,7 @@ import { registerOnboardingHandlers } from "./handlers/onboarding.js";
 import { registerMilestonesHandlers } from "./handlers/milestones.js";
 import { registerShortcutHintsHandlers } from "./handlers/shortcutHints.js";
 import { registerForgeHandlers } from "./handlers/forge.js";
+import { registerForgeDataHandlers } from "./handlers/forgeData.js";
 import { registerForgeSettingsHandlers } from "./handlers/forgeSettings.js";
 import { registerVoiceInputHandlers } from "./handlers/voiceInput.js";
 import { registerMcpServerHandlers } from "./handlers/mcpServer.js";
@@ -145,6 +146,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerShortcutHintsHandlers());
     register(() => registerForgeSettingsHandlers());
     register(() => registerForgeHandlers());
+    register(() => registerForgeDataHandlers());
     register(() => registerVoiceInputHandlers(deps));
     register(() => registerMcpServerHandlers());
     register(() => registerHelpAssistantHandlers());

--- a/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  ForgeProviderImpl,
+  Issue,
+  PR,
+  Page,
+  RepoMetadata,
+  RepoRef,
+} from "../../../../shared/types/forge.js";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
+
+// A fake forge provider — deliberately NOT GitHub. Proves the data handlers
+// delegate through the normalized contract with no GitHub coupling.
+const fakeImpl = vi.hoisted(() => ({
+  listIssues: vi.fn(),
+  listPRs: vi.fn(),
+  getIssue: vi.fn(),
+  getPR: vi.fn(),
+  getRepoMetadata: vi.fn(),
+}));
+
+const repoRef: RepoRef = { host: "fake.test", owner: "acme", repo: "widgets", rawData: null };
+
+const resolveForCwdMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../forgeResolution.js", () => ({
+  resolveForCwd: resolveForCwdMock,
+}));
+
+import { registerForgeDataHandlers } from "../forgeData.js";
+
+function findHandler(channel: string): (...args: unknown[]) => unknown {
+  const entry = ipcMainMock.handle.mock.calls.find((c: unknown[]) => c[0] === channel);
+  if (!entry) throw new Error(`handler not registered for ${channel}`);
+  return entry[1] as (...args: unknown[]) => unknown;
+}
+
+const makeIssue = (n: number): Issue => ({
+  number: n,
+  title: `Issue ${n}`,
+  body: "",
+  state: "open",
+  rawState: "opened",
+  url: `https://fake.test/acme/widgets/issues/${n}`,
+  assignees: [],
+  labels: [],
+  createdAt: 0,
+  updatedAt: 0,
+  rawData: null,
+});
+
+const makePR = (n: number): PR => ({
+  number: n,
+  title: `PR ${n}`,
+  body: "",
+  state: "open",
+  rawState: "opened",
+  isDraft: false,
+  merged: false,
+  url: `https://fake.test/acme/widgets/pull/${n}`,
+  baseRef: "main",
+  headRef: `feat-${n}`,
+  createdAt: 0,
+  updatedAt: 0,
+  rawData: null,
+});
+
+describe("registerForgeDataHandlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveForCwdMock.mockResolvedValue({
+      namespaceId: "fake.provider",
+      repoRef,
+      impl: fakeImpl as unknown as ForgeProviderImpl,
+    });
+  });
+
+  it("registers five IPC handlers", () => {
+    const cleanup = registerForgeDataHandlers();
+    expect(ipcMainMock.handle).toHaveBeenCalledTimes(5);
+    expect(ipcMainMock.handle).toHaveBeenCalledWith("forge:list-issues", expect.any(Function));
+    expect(ipcMainMock.handle).toHaveBeenCalledWith("forge:list-prs", expect.any(Function));
+    expect(ipcMainMock.handle).toHaveBeenCalledWith("forge:get-issue", expect.any(Function));
+    expect(ipcMainMock.handle).toHaveBeenCalledWith("forge:get-pr", expect.any(Function));
+    expect(ipcMainMock.handle).toHaveBeenCalledWith(
+      "forge:get-repo-metadata",
+      expect.any(Function)
+    );
+    cleanup();
+  });
+
+  it("listIssues resolves the provider and returns its normalized page", async () => {
+    const page: Page<Issue> = {
+      items: [makeIssue(1), makeIssue(2)],
+      nextCursor: null,
+      hasMore: false,
+    };
+    fakeImpl.listIssues.mockResolvedValue(page);
+    registerForgeDataHandlers();
+
+    const result = await findHandler("forge:list-issues")(null, {
+      cwd: "/repo",
+      opts: { state: "open" },
+    });
+
+    expect(resolveForCwdMock).toHaveBeenCalledWith("/repo");
+    expect(fakeImpl.listIssues).toHaveBeenCalledWith(repoRef, { state: "open" });
+    expect(result).toEqual(page);
+  });
+
+  it("listIssues defaults opts to an empty object when omitted", async () => {
+    fakeImpl.listIssues.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
+    registerForgeDataHandlers();
+
+    await findHandler("forge:list-issues")(null, { cwd: "/repo" });
+
+    expect(fakeImpl.listIssues).toHaveBeenCalledWith(repoRef, {});
+  });
+
+  it("listPRs delegates to impl.listPRs", async () => {
+    const page: Page<PR> = { items: [makePR(7)], nextCursor: "c1", hasMore: true };
+    fakeImpl.listPRs.mockResolvedValue(page);
+    registerForgeDataHandlers();
+
+    const result = await findHandler("forge:list-prs")(null, { cwd: "/repo" });
+
+    expect(fakeImpl.listPRs).toHaveBeenCalledWith(repoRef, {});
+    expect(result).toEqual(page);
+  });
+
+  it("getIssue returns the issue", async () => {
+    fakeImpl.getIssue.mockResolvedValue(makeIssue(42));
+    registerForgeDataHandlers();
+
+    const result = await findHandler("forge:get-issue")(null, { cwd: "/repo", issueNumber: 42 });
+
+    expect(fakeImpl.getIssue).toHaveBeenCalledWith(repoRef, 42);
+    expect(result).toMatchObject({ number: 42 });
+  });
+
+  it("getIssue propagates a null result when the issue does not exist", async () => {
+    fakeImpl.getIssue.mockResolvedValue(null);
+    registerForgeDataHandlers();
+
+    const result = await findHandler("forge:get-issue")(null, { cwd: "/repo", issueNumber: 99 });
+
+    expect(result).toBeNull();
+  });
+
+  it("getPR delegates to impl.getPR", async () => {
+    fakeImpl.getPR.mockResolvedValue(makePR(5));
+    registerForgeDataHandlers();
+
+    const result = await findHandler("forge:get-pr")(null, { cwd: "/repo", prNumber: 5 });
+
+    expect(fakeImpl.getPR).toHaveBeenCalledWith(repoRef, 5);
+    expect(result).toMatchObject({ number: 5 });
+  });
+
+  it("getRepoMetadata delegates to impl.getRepoMetadata", async () => {
+    const meta: RepoMetadata = {
+      defaultBranch: "main",
+      isPrivate: false,
+      isFork: false,
+      isArchived: false,
+      rawData: null,
+    };
+    fakeImpl.getRepoMetadata.mockResolvedValue(meta);
+    registerForgeDataHandlers();
+
+    const result = await findHandler("forge:get-repo-metadata")(null, { cwd: "/repo" });
+
+    expect(fakeImpl.getRepoMetadata).toHaveBeenCalledWith(repoRef);
+    expect(result).toEqual(meta);
+  });
+
+  it("rejects an invalid cwd before resolving a provider", async () => {
+    registerForgeDataHandlers();
+    await expect(findHandler("forge:list-issues")(null, { cwd: "" })).rejects.toThrow(
+      "Invalid working directory"
+    );
+    expect(resolveForCwdMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-object payload", async () => {
+    registerForgeDataHandlers();
+    await expect(findHandler("forge:list-prs")(null, null)).rejects.toThrow("Invalid payload");
+  });
+
+  it("rejects a non-positive issue number", async () => {
+    registerForgeDataHandlers();
+    await expect(
+      findHandler("forge:get-issue")(null, { cwd: "/repo", issueNumber: 0 })
+    ).rejects.toThrow("Invalid issue number");
+  });
+
+  it("rejects a non-integer PR number", async () => {
+    registerForgeDataHandlers();
+    await expect(
+      findHandler("forge:get-pr")(null, { cwd: "/repo", prNumber: 1.5 })
+    ).rejects.toThrow("Invalid PR number");
+  });
+
+  it("propagates provider resolution failures (e.g. provider not activated)", async () => {
+    resolveForCwdMock.mockRejectedValue(
+      new Error("No forge provider registered for this repository")
+    );
+    registerForgeDataHandlers();
+    await expect(findHandler("forge:list-issues")(null, { cwd: "/repo" })).rejects.toThrow(
+      "No forge provider registered"
+    );
+  });
+});

--- a/electron/ipc/handlers/forge.ts
+++ b/electron/ipc/handlers/forge.ts
@@ -6,69 +6,11 @@ import {
   getForgeProviderImpl,
   getRegisteredForgeProviders,
 } from "../../services/forgeProviderRegistry.js";
-import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
-import { gitServiceCache } from "../../services/GitServiceCache.js";
-import type { RepoRef } from "../../../shared/types/forge.js";
+import { resolveForCwd, getImplForNamespace } from "./forgeResolution.js";
 import {
   makeForgeProviderId,
   normalizeProviderId,
 } from "../../../shared/utils/forgeProviderIds.js";
-
-interface ResolvedContext {
-  namespaceId: string;
-  repoRef: RepoRef;
-}
-
-async function resolveForCwd(cwd: string): Promise<ResolvedContext> {
-  if (typeof cwd !== "string" || !cwd) {
-    throw new Error("Invalid working directory");
-  }
-
-  const gitService = gitServiceCache.getGitService(cwd);
-  if (!gitService) {
-    throw new Error("Not a git repository");
-  }
-
-  const remoteUrl = await gitService.getRemoteUrl(cwd).catch(() => null);
-  if (!remoteUrl) {
-    throw new Error("No remote URL found for this repository");
-  }
-
-  const globalDefaultProviderId = normalizeProviderId(store.get("forgeDefaultProviderId"));
-
-  const resolved = resolveForgeProvider({
-    remoteUrl,
-    forgeProviderOverride: null,
-    globalDefaultProviderId,
-  });
-
-  if (!resolved.entry) {
-    throw new Error("No forge provider registered for this repository");
-  }
-
-  const namespaceId = makeForgeProviderId(resolved.entry.pluginId, resolved.entry.contribution.id);
-  const impl = getForgeProviderImpl(namespaceId);
-  if (!impl) {
-    throw new Error(
-      `Forge provider "${resolved.entry.contribution.id}" not activated. Activate it in Settings.`
-    );
-  }
-
-  const repoRef = impl.parseRemote(remoteUrl);
-  if (!repoRef) {
-    throw new Error("Could not parse repository identity from remote URL");
-  }
-
-  return { namespaceId, repoRef };
-}
-
-function getImplForNamespace(namespaceId: string) {
-  const impl = getForgeProviderImpl(namespaceId);
-  if (!impl) {
-    throw new Error(`Forge provider "${namespaceId}" not activated. Activate it in Settings.`);
-  }
-  return impl;
-}
 
 export function registerForgeHandlers(): () => void {
   const cleanups: Array<() => void> = [];

--- a/electron/ipc/handlers/forgeData.ts
+++ b/electron/ipc/handlers/forgeData.ts
@@ -1,0 +1,96 @@
+import { CHANNELS } from "../channels.js";
+import { typedHandle } from "../utils.js";
+import { resolveForCwd } from "./forgeResolution.js";
+import type { ListOptions } from "../../../shared/types/forge.js";
+
+/**
+ * Provider-agnostic forge *data* handlers (list/get queries). The sibling
+ * `forge.ts` owns side-effectful actions (open in browser, assign);
+ * `forgeSettings.ts` owns config CRUD. Splitting queries out keeps
+ * rate-limit/error handling for reads from tangling with the action surface.
+ *
+ * Every handler resolves `cwd → ForgeProviderImpl` via {@link resolveForCwd}
+ * and delegates to the normalized contract — the renderer never sees
+ * GitHub-shaped data through this path. Handlers throw on resolution or
+ * provider failure; the IPC envelope serializes the error (see #3769).
+ */
+
+function requirePositiveInt(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`Invalid ${label}`);
+  }
+  return value;
+}
+
+function requireCwd(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error("Invalid working directory");
+  }
+  return value;
+}
+
+export function registerForgeDataHandlers(): () => void {
+  const cleanups: Array<() => void> = [];
+
+  cleanups.push(
+    typedHandle(
+      CHANNELS.FORGE_LIST_ISSUES,
+      async (payload: { cwd: string; opts?: ListOptions }) => {
+        if (!payload || typeof payload !== "object") {
+          throw new Error("Invalid payload");
+        }
+        const cwd = requireCwd(payload.cwd);
+        const { impl, repoRef } = await resolveForCwd(cwd);
+        return impl.listIssues(repoRef, payload.opts ?? {});
+      }
+    )
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.FORGE_LIST_PRS, async (payload: { cwd: string; opts?: ListOptions }) => {
+      if (!payload || typeof payload !== "object") {
+        throw new Error("Invalid payload");
+      }
+      const cwd = requireCwd(payload.cwd);
+      const { impl, repoRef } = await resolveForCwd(cwd);
+      return impl.listPRs(repoRef, payload.opts ?? {});
+    })
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.FORGE_GET_ISSUE, async (payload: { cwd: string; issueNumber: number }) => {
+      if (!payload || typeof payload !== "object") {
+        throw new Error("Invalid payload");
+      }
+      const cwd = requireCwd(payload.cwd);
+      const issueNumber = requirePositiveInt(payload.issueNumber, "issue number");
+      const { impl, repoRef } = await resolveForCwd(cwd);
+      return impl.getIssue(repoRef, issueNumber);
+    })
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.FORGE_GET_PR, async (payload: { cwd: string; prNumber: number }) => {
+      if (!payload || typeof payload !== "object") {
+        throw new Error("Invalid payload");
+      }
+      const cwd = requireCwd(payload.cwd);
+      const prNumber = requirePositiveInt(payload.prNumber, "PR number");
+      const { impl, repoRef } = await resolveForCwd(cwd);
+      return impl.getPR(repoRef, prNumber);
+    })
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.FORGE_GET_REPO_METADATA, async (payload: { cwd: string }) => {
+      if (!payload || typeof payload !== "object") {
+        throw new Error("Invalid payload");
+      }
+      const cwd = requireCwd(payload.cwd);
+      const { impl, repoRef } = await resolveForCwd(cwd);
+      return impl.getRepoMetadata(repoRef);
+    })
+  );
+
+  return () => cleanups.forEach((c) => c());
+}

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -1,0 +1,76 @@
+import { store } from "../../store.js";
+import { getForgeProviderImpl } from "../../services/forgeProviderRegistry.js";
+import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
+import { gitServiceCache } from "../../services/GitServiceCache.js";
+import type { ForgeProviderImpl, RepoRef } from "../../../shared/types/forge.js";
+import {
+  makeForgeProviderId,
+  normalizeProviderId,
+} from "../../../shared/utils/forgeProviderIds.js";
+
+/**
+ * Shared `cwd → forge provider` resolution. Both the action handlers
+ * (`forge.ts` — open/assign) and the data handlers (`forgeData.ts` —
+ * list/get) resolve the same way: remote URL → registered provider →
+ * activated implementation → parsed {@link RepoRef}. Keeping one copy
+ * means the precedence chain can't drift between the two surfaces.
+ *
+ * `impl` is returned alongside so data handlers don't need a second
+ * registry lookup per call.
+ */
+export interface ResolvedForgeContext {
+  namespaceId: string;
+  repoRef: RepoRef;
+  impl: ForgeProviderImpl;
+}
+
+export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> {
+  if (typeof cwd !== "string" || !cwd) {
+    throw new Error("Invalid working directory");
+  }
+
+  const gitService = gitServiceCache.getGitService(cwd);
+  if (!gitService) {
+    throw new Error("Not a git repository");
+  }
+
+  const remoteUrl = await gitService.getRemoteUrl(cwd).catch(() => null);
+  if (!remoteUrl) {
+    throw new Error("No remote URL found for this repository");
+  }
+
+  const globalDefaultProviderId = normalizeProviderId(store.get("forgeDefaultProviderId"));
+
+  const resolved = resolveForgeProvider({
+    remoteUrl,
+    forgeProviderOverride: null,
+    globalDefaultProviderId,
+  });
+
+  if (!resolved.entry) {
+    throw new Error("No forge provider registered for this repository");
+  }
+
+  const namespaceId = makeForgeProviderId(resolved.entry.pluginId, resolved.entry.contribution.id);
+  const impl = getForgeProviderImpl(namespaceId);
+  if (!impl) {
+    throw new Error(
+      `Forge provider "${resolved.entry.contribution.id}" not activated. Activate it in Settings.`
+    );
+  }
+
+  const repoRef = impl.parseRemote(remoteUrl);
+  if (!repoRef) {
+    throw new Error("Could not parse repository identity from remote URL");
+  }
+
+  return { namespaceId, repoRef, impl };
+}
+
+export function getImplForNamespace(namespaceId: string): ForgeProviderImpl {
+  const impl = getForgeProviderImpl(namespaceId);
+  if (!impl) {
+    throw new Error(`Forge provider "${namespaceId}" not activated. Activate it in Settings.`);
+  }
+  return impl;
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2398,6 +2398,16 @@ const api: ElectronAPI = {
       _unwrappingInvoke(CHANNELS.FORGE_GET_CREDENTIAL_STATUS, providerId),
     clearCredential: (providerId: string) =>
       _unwrappingInvoke(CHANNELS.FORGE_CLEAR_CREDENTIAL, providerId),
+    listIssues: (payload: { cwd: string; opts?: unknown }) =>
+      _unwrappingInvoke(CHANNELS.FORGE_LIST_ISSUES, payload),
+    listPRs: (payload: { cwd: string; opts?: unknown }) =>
+      _unwrappingInvoke(CHANNELS.FORGE_LIST_PRS, payload),
+    getIssue: (payload: { cwd: string; issueNumber: number }) =>
+      _unwrappingInvoke(CHANNELS.FORGE_GET_ISSUE, payload),
+    getPR: (payload: { cwd: string; prNumber: number }) =>
+      _unwrappingInvoke(CHANNELS.FORGE_GET_PR, payload),
+    getRepoMetadata: (payload: { cwd: string }) =>
+      _unwrappingInvoke(CHANNELS.FORGE_GET_REPO_METADATA, payload),
   },
 
   // Voice Input API

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -22,7 +22,16 @@ import type { AgentSettings, AgentSettingsEntry } from "../agentSettings.js";
 import type { AgentPreset } from "../../config/agentRegistry.js";
 import type { VoiceInputStatus } from "../voice.js";
 export type { VoiceInputStatus };
-import type { AuthValidation, ForgeProviderEntry, ResolvedForgeProvider } from "../forge.js";
+import type {
+  AuthValidation,
+  ForgeProviderEntry,
+  ResolvedForgeProvider,
+  Issue,
+  PR,
+  Page,
+  RepoMetadata,
+  ListOptions,
+} from "../forge.js";
 import type { ResourceProfilePayload } from "../resourceProfile.js";
 import type {
   CreateWorktreeOptions,
@@ -1343,6 +1352,20 @@ export interface ElectronAPI {
     getCredentialStatus(providerId: string): Promise<{ hasCredential: boolean }>;
     /** Clear stored credentials for the given forge provider id. */
     clearCredential(providerId: string): Promise<void>;
+    /**
+     * List issues for the resolved forge provider. Provider-agnostic — returns
+     * normalized {@link Issue} rows, not GitHub-shaped types. Listing filters
+     * go through `opts`, never client-side across pages.
+     */
+    listIssues(payload: { cwd: string; opts?: ListOptions }): Promise<Page<Issue>>;
+    /** List pull/merge requests for the resolved forge provider. */
+    listPRs(payload: { cwd: string; opts?: ListOptions }): Promise<Page<PR>>;
+    /** Fetch a single normalized issue, or `null` when it doesn't exist. */
+    getIssue(payload: { cwd: string; issueNumber: number }): Promise<Issue | null>;
+    /** Fetch a single normalized PR, or `null` when it doesn't exist. */
+    getPR(payload: { cwd: string; prNumber: number }): Promise<PR | null>;
+    /** Fetch the normalized repository metadata roll-up. */
+    getRepoMetadata(payload: { cwd: string }): Promise<RepoMetadata>;
   };
   voiceInput: {
     getSettings(): Promise<VoiceInputSettings>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -175,7 +175,16 @@ import type { CloneRepoOptions, CloneRepoResult } from "./gitClone.js";
 import type { AppAgentConfig } from "../appAgent.js";
 import type { AgentSessionRecord } from "./agentSessionHistory.js";
 import type { GeneratedIpcInvokeMap } from "./generated.js";
-import type { AuthValidation, ForgeProviderEntry, ResolvedForgeProvider } from "../forge.js";
+import type {
+  AuthValidation,
+  ForgeProviderEntry,
+  ResolvedForgeProvider,
+  Issue,
+  PR,
+  Page,
+  RepoMetadata,
+  ListOptions,
+} from "../forge.js";
 
 export type ChecklistItemId =
   | "openedProject"
@@ -1669,6 +1678,26 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
   "forge:clear-credential": {
     args: [providerId: string];
     result: void;
+  };
+  "forge:list-issues": {
+    args: [payload: { cwd: string; opts?: ListOptions }];
+    result: Page<Issue>;
+  };
+  "forge:list-prs": {
+    args: [payload: { cwd: string; opts?: ListOptions }];
+    result: Page<PR>;
+  };
+  "forge:get-issue": {
+    args: [payload: { cwd: string; issueNumber: number }];
+    result: Issue | null;
+  };
+  "forge:get-pr": {
+    args: [payload: { cwd: string; prNumber: number }];
+    result: PR | null;
+  };
+  "forge:get-repo-metadata": {
+    args: [payload: { cwd: string }];
+    result: RepoMetadata;
   };
 
   // Shortcut Hints

--- a/src/clients/forgeClient.ts
+++ b/src/clients/forgeClient.ts
@@ -1,4 +1,11 @@
-import type { AuthValidation } from "@shared/types/forge";
+import type {
+  AuthValidation,
+  Issue,
+  PR,
+  Page,
+  RepoMetadata,
+  ListOptions,
+} from "@shared/types/forge";
 
 export const forgeClient = {
   openIssues: (cwd: string, query?: string, state?: string): Promise<void> => {
@@ -27,5 +34,25 @@ export const forgeClient = {
 
   validateToken: (token: string): Promise<AuthValidation> => {
     return window.electron.forge.validateToken(token);
+  },
+
+  listIssues: (cwd: string, opts?: ListOptions): Promise<Page<Issue>> => {
+    return window.electron.forge.listIssues({ cwd, opts });
+  },
+
+  listPRs: (cwd: string, opts?: ListOptions): Promise<Page<PR>> => {
+    return window.electron.forge.listPRs({ cwd, opts });
+  },
+
+  getIssue: (cwd: string, issueNumber: number): Promise<Issue | null> => {
+    return window.electron.forge.getIssue({ cwd, issueNumber });
+  },
+
+  getPR: (cwd: string, prNumber: number): Promise<PR | null> => {
+    return window.electron.forge.getPR({ cwd, prNumber });
+  },
+
+  getRepoMetadata: (cwd: string): Promise<RepoMetadata> => {
+    return window.electron.forge.getRepoMetadata({ cwd });
   },
 } as const;

--- a/src/hooks/__tests__/useForgeResourceListSWR.test.tsx
+++ b/src/hooks/__tests__/useForgeResourceListSWR.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useForgeResourceListSWR } from "../useForgeResourceListSWR";
+import { _resetForTests } from "@/lib/forgeResourceCache";
+import type { Issue, PR, Page } from "@shared/types/forge";
+
+// @vitest-environment jsdom
+
+const makeIssue = (n: number): Issue => ({
+  number: n,
+  title: `Issue ${n}`,
+  body: "",
+  state: "open",
+  rawState: "opened",
+  url: `https://fake.test/acme/widgets/issues/${n}`,
+  assignees: [],
+  labels: [],
+  createdAt: 0,
+  updatedAt: 0,
+  rawData: null,
+});
+
+const makePR = (n: number): PR => ({
+  number: n,
+  title: `PR ${n}`,
+  body: "",
+  state: "open",
+  rawState: "opened",
+  isDraft: false,
+  merged: false,
+  url: `https://fake.test/acme/widgets/pull/${n}`,
+  baseRef: "main",
+  headRef: `feat-${n}`,
+  createdAt: 0,
+  updatedAt: 0,
+  rawData: null,
+});
+
+// A GitHub IPC surface that throws on any access. If the forge data path
+// reaches around to `window.electron.github`, these tests fail loudly —
+// proving provider isolation.
+const githubTrap = new Proxy(
+  {},
+  {
+    get() {
+      throw new Error("window.electron.github must not be touched by the forge data path");
+    },
+  }
+);
+
+const listIssues = vi.fn<() => Promise<Page<Issue>>>();
+const listPRs = vi.fn<() => Promise<Page<PR>>>();
+
+describe("useForgeResourceListSWR (fake provider, no GitHub IPC)", () => {
+  beforeEach(() => {
+    _resetForTests();
+    listIssues.mockReset();
+    listPRs.mockReset();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).electron = {
+      forge: { listIssues, listPRs },
+      github: githubTrap,
+    };
+  });
+
+  it("renders an issue list sourced entirely from the forge IPC path", async () => {
+    listIssues.mockResolvedValue({
+      items: [makeIssue(1), makeIssue(2)],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    const { result } = renderHook(() =>
+      useForgeResourceListSWR({
+        cwd: "/repo",
+        providerId: "acme.gitea",
+        owner: "acme",
+        repo: "widgets",
+        type: "issue",
+        filterState: "open",
+        sortOrder: "created",
+      })
+    );
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data.map((i) => i.number)).toEqual([1, 2]);
+    expect(result.current.error).toBeNull();
+    expect(listIssues).toHaveBeenCalledWith({ cwd: "/repo", opts: {} });
+  });
+
+  it("renders a PR list without touching window.electron.github", async () => {
+    listPRs.mockResolvedValue({
+      items: [makePR(7)],
+      nextCursor: "c1",
+      hasMore: true,
+    });
+
+    const { result } = renderHook(() =>
+      useForgeResourceListSWR({
+        cwd: "/repo",
+        providerId: "acme.gitea",
+        owner: "acme",
+        repo: "widgets",
+        type: "pr",
+        filterState: "open",
+        sortOrder: "created",
+      })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data.map((p) => p.number)).toEqual([7]);
+    expect(result.current.hasMore).toBe(true);
+    expect(listPRs).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a provider error without crashing the list", async () => {
+    listIssues.mockRejectedValue(new Error("Rate limit exceeded"));
+
+    const { result } = renderHook(() =>
+      useForgeResourceListSWR({
+        cwd: "/repo",
+        providerId: "acme.gitea",
+        owner: "acme",
+        repo: "widgets",
+        type: "issue",
+        filterState: "open",
+        sortOrder: "created",
+      })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Rate limit exceeded");
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("serves cached rows immediately on a remount, then revalidates", async () => {
+    listIssues.mockResolvedValue({
+      items: [makeIssue(1)],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    const params = {
+      cwd: "/repo",
+      providerId: "acme.gitea",
+      owner: "acme",
+      repo: "widgets",
+      type: "issue" as const,
+      filterState: "open",
+      sortOrder: "created",
+    };
+
+    const first = renderHook(() => useForgeResourceListSWR(params));
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    first.unmount();
+
+    const second = renderHook(() => useForgeResourceListSWR(params));
+    // Cache hit — data is present synchronously, no loading skeleton.
+    expect(second.result.current.loading).toBe(false);
+    expect(second.result.current.data.map((i) => i.number)).toEqual([1]);
+    await waitFor(() => expect(second.result.current.refreshing).toBe(false));
+    expect(listIssues).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/__tests__/useForgeResourceListSWR.test.tsx
+++ b/src/hooks/__tests__/useForgeResourceListSWR.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { useForgeResourceListSWR } from "../useForgeResourceListSWR";
-import { _resetForTests } from "@/lib/forgeResourceCache";
+import { _resetForTests, nextGeneration } from "@/lib/forgeResourceCache";
 import type { Issue, PR, Page } from "@shared/types/forge";
 
 // @vitest-environment jsdom
@@ -56,11 +56,11 @@ describe("useForgeResourceListSWR (fake provider, no GitHub IPC)", () => {
     _resetForTests();
     listIssues.mockReset();
     listPRs.mockReset();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).electron = {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- test double: only the forge surface is exercised; github is a throwing trap proving isolation
+    window.electron = {
       forge: { listIssues, listPRs },
       github: githubTrap,
-    };
+    } as unknown as typeof window.electron;
   });
 
   it("renders an issue list sourced entirely from the forge IPC path", async () => {
@@ -165,5 +165,77 @@ describe("useForgeResourceListSWR (fake provider, no GitHub IPC)", () => {
     expect(second.result.current.data.map((i) => i.number)).toEqual([1]);
     await waitFor(() => expect(second.result.current.refreshing).toBe(false));
     expect(listIssues).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the previous repo's rows on a cache-key change", async () => {
+    listIssues.mockResolvedValueOnce({
+      items: [makeIssue(1), makeIssue(2)],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    const { result, rerender } = renderHook((props) => useForgeResourceListSWR(props), {
+      initialProps: {
+        cwd: "/repo-a",
+        providerId: "acme.gitea",
+        owner: "acme",
+        repo: "alpha",
+        type: "issue" as const,
+        filterState: "open",
+        sortOrder: "created",
+      },
+    });
+
+    await waitFor(() => expect(result.current.data.map((i) => i.number)).toEqual([1, 2]));
+
+    // Switch to a different repo; its fetch rejects. Stale alpha rows must
+    // not bleed through while loading or after the failure.
+    listIssues.mockRejectedValueOnce(new Error("nope"));
+    rerender({
+      cwd: "/repo-b",
+      providerId: "acme.gitea",
+      owner: "acme",
+      repo: "beta",
+      type: "issue" as const,
+      filterState: "open",
+      sortOrder: "created",
+    });
+
+    expect(result.current.data).toEqual([]);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual([]);
+    expect(result.current.error).toBe("nope");
+  });
+
+  it("does not strand loading when the generation map evicts its key", async () => {
+    let resolveFetch: (page: Page<Issue>) => void = () => {};
+    listIssues.mockImplementation(
+      () =>
+        new Promise<Page<Issue>>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const { result } = renderHook(() =>
+      useForgeResourceListSWR({
+        cwd: "/repo",
+        providerId: "acme.gitea",
+        owner: "acme",
+        repo: "widgets",
+        type: "issue",
+        filterState: "open",
+        sortOrder: "created",
+      })
+    );
+
+    expect(result.current.loading).toBe(true);
+
+    // Evict the hook's key from the bounded generation map by churning 20+
+    // unrelated keys, then let the original in-flight fetch resolve.
+    for (let i = 0; i < 25; i++) nextGeneration(`unrelated-${i}`);
+    resolveFetch({ items: [makeIssue(9)], nextCursor: null, hasMore: false });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data.map((i) => i.number)).toEqual([9]);
   });
 });

--- a/src/hooks/useForgeResourceListSWR.ts
+++ b/src/hooks/useForgeResourceListSWR.ts
@@ -90,6 +90,12 @@ export function useForgeResourceListSWR({
       setLoading(false);
       setRefreshing(true);
     } else {
+      // Cache miss after a key change (repo/provider/filter switch): drop the
+      // previous slot's rows so a consumer rendering `data` while `loading` is
+      // true never shows the wrong repo's issues, even if the new fetch fails.
+      setData([]);
+      setHasMore(false);
+      setLastUpdatedAt(null);
       setLoading(true);
       setRefreshing(false);
     }
@@ -107,13 +113,18 @@ export function useForgeResourceListSWR({
       opts = {};
     }
 
+    // Superseded only by a *strictly newer* generation (a later fetch or a
+    // `mutateCacheEntries` bump). A plain `!==` would also discard this
+    // response when the bounded generation map evicts our key back to 0,
+    // stranding the hook in a permanent loading state (#8455 review).
+    const isSuperseded = () => getGeneration(cacheKey) > generation;
+
     const fetchPage =
       type === "issue" ? forgeClient.listIssues(cwd, opts) : forgeClient.listPRs(cwd, opts);
 
     fetchPage
       .then((page) => {
-        // Discard if a newer fetch/mutation superseded this one.
-        if (cancelled || getGeneration(cacheKey) !== generation) return;
+        if (cancelled || isSuperseded()) return;
         const entry = {
           items: page.items,
           nextCursor: page.nextCursor,
@@ -127,7 +138,7 @@ export function useForgeResourceListSWR({
         setError(null);
       })
       .catch((err: unknown) => {
-        if (cancelled || getGeneration(cacheKey) !== generation) return;
+        if (cancelled || isSuperseded()) return;
         setError(
           formatErrorMessage(
             err,
@@ -136,7 +147,7 @@ export function useForgeResourceListSWR({
         );
       })
       .finally(() => {
-        if (cancelled || getGeneration(cacheKey) !== generation) return;
+        if (cancelled || isSuperseded()) return;
         setLoading(false);
         setRefreshing(false);
       });

--- a/src/hooks/useForgeResourceListSWR.ts
+++ b/src/hooks/useForgeResourceListSWR.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  buildCacheKey,
+  getCache,
+  setCache,
+  nextGeneration,
+  getGeneration,
+} from "@/lib/forgeResourceCache";
+import { forgeClient } from "@/clients/forgeClient";
+import type { Issue, PR, ListOptions } from "@shared/types/forge";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+/**
+ * Provider-agnostic stale-while-revalidate list hook. Consumes the normalized
+ * `forge:list-issues` / `forge:list-prs` IPC path via {@link forgeClient} — it
+ * never touches `window.electron.github`, so any forge provider can drive an
+ * issue/PR list with it.
+ *
+ * The GitHub plugin's `useGitHubResourceListSWR` stays as-is: it carries
+ * GitHub-shaped types and GitHub-specific retry/rate-limit/wake machinery that
+ * does not generalize. This hook is the lean, normalized counterpart — cache
+ * read, revalidate, generation-guarded stale-response discard.
+ */
+export interface UseForgeResourceListParams {
+  cwd: string;
+  /** Forge identity for the provider-scoped cache key. */
+  providerId: string;
+  owner: string;
+  repo: string;
+  type: "issue" | "pr";
+  filterState: string;
+  sortOrder: string;
+  opts?: ListOptions;
+}
+
+export interface UseForgeResourceListReturn {
+  data: (Issue | PR)[];
+  hasMore: boolean;
+  loading: boolean;
+  refreshing: boolean;
+  error: string | null;
+  lastUpdatedAt: number | null;
+  refresh: () => void;
+}
+
+export function useForgeResourceListSWR({
+  cwd,
+  providerId,
+  owner,
+  repo,
+  type,
+  filterState,
+  sortOrder,
+  opts,
+}: UseForgeResourceListParams): UseForgeResourceListReturn {
+  const cacheKey = useMemo(
+    () => buildCacheKey(providerId, owner, repo, type, filterState, sortOrder),
+    [providerId, owner, repo, type, filterState, sortOrder]
+  );
+
+  const cachedEntry = useMemo(() => getCache(cacheKey), [cacheKey]);
+
+  const [data, setData] = useState<(Issue | PR)[]>(() => cachedEntry?.items ?? []);
+  const [hasMore, setHasMore] = useState(() => cachedEntry?.hasMore ?? false);
+  const [loading, setLoading] = useState(() => !cachedEntry);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(
+    () => cachedEntry?.timestamp ?? null
+  );
+  const [reloadToken, setReloadToken] = useState(0);
+
+  // Serialized listing opts so an inline object literal doesn't retrigger the
+  // fetch effect every render.
+  const optsKey = useMemo(() => JSON.stringify(opts ?? {}), [opts]);
+
+  const refresh = useCallback(() => {
+    setReloadToken((t) => t + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const generation = nextGeneration(cacheKey);
+
+    const cached = getCache(cacheKey);
+    if (cached) {
+      setData(cached.items);
+      setHasMore(cached.hasMore);
+      setLastUpdatedAt(cached.timestamp);
+      setLoading(false);
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+      setRefreshing(false);
+    }
+    setError(null);
+
+    let opts: ListOptions;
+    try {
+      const parsed = JSON.parse(optsKey);
+      if (typeof parsed !== "object" || parsed === null) {
+        opts = {};
+      } else {
+        opts = parsed;
+      }
+    } catch {
+      opts = {};
+    }
+
+    const fetchPage =
+      type === "issue" ? forgeClient.listIssues(cwd, opts) : forgeClient.listPRs(cwd, opts);
+
+    fetchPage
+      .then((page) => {
+        // Discard if a newer fetch/mutation superseded this one.
+        if (cancelled || getGeneration(cacheKey) !== generation) return;
+        const entry = {
+          items: page.items,
+          nextCursor: page.nextCursor,
+          hasMore: page.hasMore,
+          timestamp: Date.now(),
+        };
+        setCache(cacheKey, entry);
+        setData(entry.items);
+        setHasMore(entry.hasMore);
+        setLastUpdatedAt(entry.timestamp);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if (cancelled || getGeneration(cacheKey) !== generation) return;
+        setError(
+          formatErrorMessage(
+            err,
+            type === "issue" ? "Couldn't load issues" : "Couldn't load pull requests"
+          )
+        );
+      })
+      .finally(() => {
+        if (cancelled || getGeneration(cacheKey) !== generation) return;
+        setLoading(false);
+        setRefreshing(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cacheKey, cwd, type, optsKey, reloadToken]);
+
+  return { data, hasMore, loading, refreshing, error, lastUpdatedAt, refresh };
+}

--- a/src/lib/__tests__/forgeResourceCache.test.ts
+++ b/src/lib/__tests__/forgeResourceCache.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  buildCacheKey,
+  getCache,
+  setCache,
+  nextGeneration,
+  getGeneration,
+  mutateCacheEntries,
+  _resetForTests,
+} from "../forgeResourceCache";
+import type { Issue } from "@shared/types/forge";
+
+const makeIssue = (n: number): Issue => ({
+  number: n,
+  title: `Issue #${n}`,
+  body: "",
+  state: "open",
+  rawState: "opened",
+  url: `https://fake.test/${n}`,
+  assignees: [],
+  labels: [],
+  createdAt: 0,
+  updatedAt: 0,
+  rawData: null,
+});
+
+const entry = (items: Issue[]) => ({
+  items,
+  nextCursor: null,
+  hasMore: false,
+  timestamp: 1,
+});
+
+describe("forgeResourceCache", () => {
+  beforeEach(() => {
+    _resetForTests();
+  });
+
+  describe("buildCacheKey", () => {
+    it("produces a deterministic provider-scoped key", () => {
+      expect(buildCacheKey("acme.gitea", "acme", "widgets", "issue", "open", "created")).toBe(
+        "acme.gitea:acme:widgets:issue:open:created"
+      );
+    });
+
+    it("different providers produce different keys for the same repo identity", () => {
+      const a = buildCacheKey("p.github", "acme", "widgets", "issue", "open", "created");
+      const b = buildCacheKey("q.gitea", "acme", "widgets", "issue", "open", "created");
+      expect(a).not.toBe(b);
+    });
+
+    it("different repos produce different keys", () => {
+      const a = buildCacheKey("p", "acme", "widgets", "issue", "open", "created");
+      const b = buildCacheKey("p", "acme", "gadgets", "issue", "open", "created");
+      expect(a).not.toBe(b);
+    });
+
+    it("type, filter, and sort each disambiguate the key", () => {
+      const base = buildCacheKey("p", "o", "r", "issue", "open", "created");
+      expect(base).not.toBe(buildCacheKey("p", "o", "r", "pr", "open", "created"));
+      expect(base).not.toBe(buildCacheKey("p", "o", "r", "issue", "closed", "created"));
+      expect(base).not.toBe(buildCacheKey("p", "o", "r", "issue", "open", "updated"));
+    });
+  });
+
+  describe("getCache / setCache", () => {
+    it("returns undefined for an unknown key", () => {
+      expect(getCache("missing")).toBeUndefined();
+    });
+
+    it("round-trips a cache entry", () => {
+      const e = entry([makeIssue(1)]);
+      setCache("k", e);
+      expect(getCache("k")).toEqual(e);
+    });
+
+    it("overwrites an existing entry", () => {
+      setCache("k", entry([makeIssue(1)]));
+      setCache("k", entry([makeIssue(2)]));
+      expect(getCache("k")?.items.map((i) => i.number)).toEqual([2]);
+    });
+  });
+
+  describe("generation counter", () => {
+    it("starts at 0 for an unknown key", () => {
+      expect(getGeneration("new")).toBe(0);
+    });
+
+    it("increments on each nextGeneration call", () => {
+      expect(nextGeneration("k")).toBe(1);
+      expect(nextGeneration("k")).toBe(2);
+    });
+
+    it("keeps independent counters per key", () => {
+      nextGeneration("a");
+      nextGeneration("a");
+      nextGeneration("b");
+      expect(getGeneration("a")).toBe(2);
+      expect(getGeneration("b")).toBe(1);
+    });
+
+    it("bounds the generation map so it cannot grow unbounded", () => {
+      for (let i = 0; i < 20; i++) nextGeneration(`g-${i}`);
+      expect(getGeneration("g-0")).toBe(1);
+      nextGeneration("g-20");
+      expect(getGeneration("g-0")).toBe(0);
+      expect(getGeneration("g-20")).toBe(1);
+    });
+  });
+
+  describe("TTL expiry", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("returns the entry before the 45s TTL elapses", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      setCache("k", entry([]));
+      vi.advanceTimersByTime(44 * 1000);
+      expect(getCache("k")).toBeDefined();
+    });
+
+    it("evicts the entry after the 45s TTL", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      setCache("k", entry([]));
+      vi.advanceTimersByTime(45 * 1000 + 1);
+      expect(getCache("k")).toBeUndefined();
+    });
+  });
+
+  describe("mutateCacheEntries", () => {
+    const seed = (
+      providerId: string,
+      owner: string,
+      repo: string,
+      type: string,
+      filter: string,
+      sort: string,
+      items: Issue[]
+    ): string => {
+      const key = buildCacheKey(providerId, owner, repo, type, filter, sort);
+      setCache(key, entry(items));
+      return key;
+    };
+
+    it("applies the transform across every (filter, sort) slot for the matching tuple", () => {
+      const openCreated = seed("p", "o", "r", "issue", "open", "created", [
+        makeIssue(1),
+        makeIssue(2),
+      ]);
+      const closedCreated = seed("p", "o", "r", "issue", "closed", "created", [makeIssue(3)]);
+      const openUpdated = seed("p", "o", "r", "issue", "open", "updated", [
+        makeIssue(1),
+        makeIssue(2),
+      ]);
+
+      mutateCacheEntries("p", "o", "r", "issue", (e) => ({
+        ...e,
+        items: e.items.filter((i) => i.number !== 2),
+      }));
+
+      expect(getCache(openCreated)?.items.map((i) => i.number)).toEqual([1]);
+      expect(getCache(closedCreated)?.items.map((i) => i.number)).toEqual([3]);
+      expect(getCache(openUpdated)?.items.map((i) => i.number)).toEqual([1]);
+    });
+
+    it("does not touch slots from a different provider for the same repo", () => {
+      const githubSlot = seed("gh", "o", "r", "issue", "open", "created", [makeIssue(1)]);
+      const giteaSlot = seed("gt", "o", "r", "issue", "open", "created", [makeIssue(1)]);
+
+      mutateCacheEntries("gh", "o", "r", "issue", (e) => ({ ...e, items: [] }));
+
+      expect(getCache(githubSlot)?.items).toEqual([]);
+      expect(getCache(giteaSlot)?.items.map((i) => i.number)).toEqual([1]);
+    });
+
+    it("does not touch slots from a different resource type", () => {
+      const issueSlot = seed("p", "o", "r", "issue", "open", "created", [makeIssue(1)]);
+      const prSlot = seed("p", "o", "r", "pr", "open", "created", [makeIssue(1)]);
+
+      mutateCacheEntries("p", "o", "r", "issue", (e) => ({ ...e, items: [] }));
+
+      expect(getCache(issueSlot)?.items).toEqual([]);
+      expect(getCache(prSlot)?.items.map((i) => i.number)).toEqual([1]);
+    });
+
+    it("bumps the generation counter only for changed slots", () => {
+      const changed = seed("p", "o", "r", "issue", "open", "created", [makeIssue(1)]);
+      const skipped = seed("p", "o", "r", "issue", "closed", "created", [makeIssue(3)]);
+      const changedBefore = getGeneration(changed);
+      const skippedBefore = getGeneration(skipped);
+
+      mutateCacheEntries("p", "o", "r", "issue", (e) =>
+        e.items.some((i) => i.number === 1) ? { ...e, items: [] } : null
+      );
+
+      expect(getGeneration(changed)).toBe(changedBefore + 1);
+      expect(getGeneration(skipped)).toBe(skippedBefore);
+    });
+
+    it("is a no-op on an empty cache", () => {
+      expect(() =>
+        mutateCacheEntries("p", "o", "r", "issue", (e) => ({ ...e, items: [] }))
+      ).not.toThrow();
+    });
+  });
+
+  describe("_resetForTests", () => {
+    it("clears both the cache and the generation map", () => {
+      setCache("k", entry([]));
+      nextGeneration("k");
+      _resetForTests();
+      expect(getCache("k")).toBeUndefined();
+      expect(getGeneration("k")).toBe(0);
+    });
+  });
+});

--- a/src/lib/forgeResourceCache.ts
+++ b/src/lib/forgeResourceCache.ts
@@ -1,0 +1,98 @@
+import type { Issue, PR } from "@shared/types/forge";
+import { TtlCache } from "@/utils/ttlCache";
+
+/**
+ * Provider-scoped renderer cache for normalized forge issue/PR lists. The
+ * GitHub-specific `githubResourceCache.ts` keys on `projectPath` and stores
+ * GitHub-shaped rows, so a second provider at the same path would collide and
+ * the rows wouldn't be provider-agnostic. This cache keys on
+ * `${providerId}:${owner}:${repo}` so each forge identity gets its own slots,
+ * and stores normalized {@link Issue}/{@link PR} rows.
+ *
+ * The 45s TTL is held strictly below the backend list-cache TTL (60s) so the
+ * renderer cache cannot stack on top of the backend cache and serve
+ * doubly-stale data (#4174). The generation map discards stale in-flight
+ * responses when a slot is refetched or mutated.
+ */
+export interface ForgeResourceCacheEntry {
+  items: (Issue | PR)[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  timestamp: number;
+}
+
+const CACHE_MAX_SIZE = 20;
+const CACHE_TTL_MS = 45 * 1000;
+
+const cache = new TtlCache<string, ForgeResourceCacheEntry>(CACHE_MAX_SIZE, CACHE_TTL_MS);
+const generationMap = new Map<string, number>();
+
+export function buildCacheKey(
+  providerId: string,
+  owner: string,
+  repo: string,
+  type: string,
+  filterState: string,
+  sortOrder: string
+): string {
+  return `${providerId}:${owner}:${repo}:${type}:${filterState}:${sortOrder}`;
+}
+
+export function getCache(key: string): ForgeResourceCacheEntry | undefined {
+  return cache.get(key);
+}
+
+export function setCache(key: string, entry: ForgeResourceCacheEntry): void {
+  cache.set(key, entry);
+}
+
+export function nextGeneration(key: string): number {
+  const gen = (generationMap.get(key) ?? 0) + 1;
+  if (!generationMap.has(key) && generationMap.size >= CACHE_MAX_SIZE) {
+    const oldest = generationMap.keys().next().value;
+    if (oldest !== undefined) generationMap.delete(oldest);
+  }
+  generationMap.set(key, gen);
+  return gen;
+}
+
+export function getGeneration(key: string): number {
+  return generationMap.get(key) ?? 0;
+}
+
+/**
+ * Apply a transform across every cached slot for a given
+ * (providerId, owner, repo, type) tuple, regardless of filter or sort. Use
+ * after a mutation (close, merge, reopen) so sibling filter slots don't serve
+ * stale rows on the next switch.
+ *
+ * The transform receives each entry plus the key remainder after the
+ * `${providerId}:${owner}:${repo}:${type}:` prefix (i.e.
+ * `${filterState}:${sortOrder}`). It returns either a new entry (write back +
+ * bump generation to discard any concurrent in-flight fetch for that slot) or
+ * null (leave untouched, no generation bump).
+ */
+export function mutateCacheEntries(
+  providerId: string,
+  owner: string,
+  repo: string,
+  type: string,
+  transform: (
+    entry: ForgeResourceCacheEntry,
+    keyRemainder: string
+  ) => ForgeResourceCacheEntry | null
+): void {
+  const prefix = `${providerId}:${owner}:${repo}:${type}:`;
+  for (const [key, entry] of cache.entries()) {
+    if (!key.startsWith(prefix)) continue;
+    const next = transform(entry, key.slice(prefix.length));
+    if (next === null) continue;
+    setCache(key, next);
+    nextGeneration(key);
+  }
+}
+
+export function _resetForTests(): void {
+  cache.clear();
+  generationMap.clear();
+}


### PR DESCRIPTION
## Summary

- Adds normalized forge data IPC endpoints (`forge:list-issues`, `forge:list-prs`, `forge:get-issue`, `forge:get-pr`, `forge:get-repo-metadata`) backed by provider resolution and `ForgeProviderImpl`. The renderer `forgeClient` now exposes `listIssues`, `listPRs`, `getIssue`, `getPR`, and `getRepoMetadata` — rich UI no longer needs to reach around to `window.electron.github`.
- Extracts `resolveForCwd` / `getImplForNamespace` into `electron/ipc/handlers/forgeResolution.ts` so the action handlers (`forge.ts`) and the new data handlers (`forgeData.ts`) resolve providers identically and can't drift. New `forgeData.ts` splits read-only query handlers from the side-effectful `forge.ts`.
- Adds provider-scoped `src/lib/forgeResourceCache.ts` keyed `${providerId}:${owner}:${repo}:${type}:${filterState}:${sortOrder}` (45s TTL, generation-guarded stale-discard, `mutateCacheEntries` invalidation). The existing `githubResourceCache.ts` is intentionally left untouched — a second provider can no longer collide with GitHub-keyed slots.
- Adds generic `src/hooks/useForgeResourceListSWR.ts` consuming normalized `Page<Issue>` / `Page<PR>`. The GitHub plugin's `useGitHubResourceListSWR` is intentionally left as-is — it carries GitHub-shaped types plus GitHub-specific retry/rate-limit/wake machinery that doesn't generalize.

Resolves #8455

## Changes

- `electron/ipc/handlers/forgeResolution.ts` — shared provider resolution (new)
- `electron/ipc/handlers/forgeData.ts` — read-only query handlers (new)
- `electron/ipc/handlers/forge.ts` — side-effectful handlers, now delegates resolution to shared module
- `electron/ipc/channels.ts`, `handlers.ts`, `electron/preload.cts` — new channel registrations
- `shared/types/ipc/api.ts`, `maps.ts` — normalized IPC types
- `src/clients/forgeClient.ts` — renderer client surface
- `src/lib/forgeResourceCache.ts` — provider-scoped cache (new)
- `src/hooks/useForgeResourceListSWR.ts` — generic SWR hook (new)

**Scope note:** `getRepoMetadata` is the only normalized surface added here. `getProjectHealth` and `getRepoStats` remain GitHub-only (no `ForgeProviderImpl` contract method, GitHub-specific `RepositoryStats` shape) — generalizing those is a separate follow-on. Existing GitHub UI consumers (`GitHubResourceList`, `GitHubStatsToolbarButton`) are not migrated in this PR; that depends on #8452 still being open. `useForgeResourceListSWR` also doesn't expose `loadMore`/`nextCursor` pagination yet — both are intentional follow-on.

## Testing

- 38 new tests across `forgeData.handlers.test.ts`, `forgeResourceCache.test.ts`, and `useForgeResourceListSWR.test.tsx`
- Fake non-GitHub provider proves the handlers and the list hook render issues/PRs with zero `window.electron.github` access (`github` is a throwing Proxy trap in the hook test)
- All checks green: typecheck, `check:channels`, `check:ipc`, `check:help`, lint ratchet (no new warnings), format