### PR TITLE
feat(worktree): make linked forge data the source of truth (#8452)

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -891,6 +891,8 @@ class PullRequestService {
               issueNumber: this.candidates.get(worktreeId)?.issueNumber,
               branchName: lookupBranchByWorktreeId.get(worktreeId),
               providerId: detectedPR.providerId,
+              owner: repo.owner,
+              repo: repo.repo,
               timestamp: Date.now(),
             });
           }
@@ -993,6 +995,8 @@ class PullRequestService {
                   issueTitle: issue.title,
                   branchName: lookupBranch,
                   providerId,
+                  owner: repo.owner,
+                  repo: repo.repo,
                   timestamp: Date.now(),
                 });
               } else {
@@ -1059,6 +1063,8 @@ class PullRequestService {
             issueNumber,
             branchName: lookupBranch,
             providerId,
+            owner: repo.owner,
+            repo: repo.repo,
             timestamp: Date.now(),
           });
         }
@@ -1176,6 +1182,8 @@ class PullRequestService {
               issueNumber: this.candidates.get(worktreeId)?.issueNumber,
               branchName: this.candidates.get(worktreeId)?.branchName,
               providerId: pr.providerId,
+              owner: repo.owner,
+              repo: repo.repo,
               ciStatus: pr._ciStatus,
               timestamp: Date.now(),
             });

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -163,8 +163,52 @@ describe("PullRequestService", () => {
       prState: "open",
       prTitle: "Add new feature",
       providerId: "daintree.github.github",
+      // #8452: the canonical repo identity must ride the event from the
+      // resolved repoRef, not be synthesized downstream with empty strings.
+      owner: "testowner",
+      repo: "testrepo",
     });
     expect(detected[0].issueNumber).toBeUndefined();
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
+  it("emits sys:issue:detected carrying the canonical owner/repo (#8452)", async () => {
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+    const mockImpl = mockForgeProviderResolved();
+    mockImpl.getIssue = vi.fn().mockResolvedValue({
+      number: 88,
+      title: "Widget request",
+      state: "open",
+      rawState: "OPEN",
+      url: "https://github.com/o/r/issues/88",
+      rawData: null,
+    });
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const issues: DaintreeEventMap["sys:issue:detected"][] = [];
+    const unsubscribe = events.on("sys:issue:detected", (payload) => issues.push(payload));
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/widget", issueNumber: 88 })
+    );
+
+    await pullRequestService.refresh();
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      worktreeId: "wt-1",
+      issueNumber: 88,
+      issueTitle: "Widget request",
+      providerId: "daintree.github.github",
+      owner: "testowner",
+      repo: "testrepo",
+    });
 
     unsubscribe();
     pullRequestService.destroy();

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -450,7 +450,11 @@ export type DaintreeEventMap = {
     /** Branch the lookup was initiated against; receivers drop the overlay if the worktree's branch has changed. */
     branchName?: string;
     /** Provider that resolved the PR (e.g. `"daintree.github.github"`). */
-    providerId?: string;
+    providerId: string;
+    /** Canonical repository owner the PR/issue belongs to. */
+    owner: string;
+    /** Canonical repository name the PR/issue belongs to. */
+    repo: string;
     /** Provider-agnostic CI status (forge format). */
     ciStatus?: import("../../shared/types/forge.js").CIStatus;
     timestamp: number;
@@ -476,7 +480,11 @@ export type DaintreeEventMap = {
     /** Branch the lookup was initiated against; receivers drop the overlay if the worktree's branch has changed. */
     branchName?: string;
     /** Provider that resolved the issue (e.g. `"daintree.github.github"`). */
-    providerId?: string;
+    providerId: string;
+    /** Canonical repository owner the issue belongs to. */
+    owner: string;
+    /** Canonical repository name the issue belongs to. */
+    repo: string;
     timestamp: number;
   };
 

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -124,6 +124,13 @@ export class WorkspaceHostEventRouter {
         break;
 
       case "pr-detected": {
+        // `linked` is the source of truth (#8452) — derive the canonical
+        // provider/owner/repo from it rather than reintroducing empty
+        // strings on this second hop (workspace-host → router → bus).
+        const linkedRef = event.linked?.pr?.ref ?? event.linked?.issue?.ref;
+        const providerId = event.linked?.providerId ?? event.providerId ?? "";
+        const owner = linkedRef?.owner ?? "";
+        const repo = linkedRef?.repo ?? "";
         const prPayload = {
           worktreeId: event.worktreeId,
           prNumber: event.prNumber,
@@ -135,7 +142,7 @@ export class WorkspaceHostEventRouter {
           issueTitle: event.issueTitle,
           timestamp: Date.now(),
         };
-        events.emit("sys:pr:detected", prPayload);
+        events.emit("sys:pr:detected", { ...prPayload, providerId, owner, repo });
         sendToEntryWindows(entry, CHANNELS.PR_DETECTED, prPayload);
         break;
       }
@@ -151,6 +158,13 @@ export class WorkspaceHostEventRouter {
       }
 
       case "issue-detected": {
+        // `linked` is the source of truth (#8452) — derive the canonical
+        // provider/owner/repo from it rather than reintroducing empty
+        // strings on this second hop (workspace-host → router → bus).
+        const linkedRef = event.linked?.issue?.ref ?? event.linked?.pr?.ref;
+        const providerId = event.linked?.providerId ?? event.providerId ?? "";
+        const owner = linkedRef?.owner ?? "";
+        const repo = linkedRef?.repo ?? "";
         const issuePayload = {
           worktreeId: event.worktreeId,
           issueNumber: event.issueNumber,
@@ -158,6 +172,9 @@ export class WorkspaceHostEventRouter {
         };
         events.emit("sys:issue:detected", {
           ...issuePayload,
+          providerId,
+          owner,
+          repo,
           timestamp: Date.now(),
         });
         sendToEntryWindows(entry, CHANNELS.ISSUE_DETECTED, issuePayload);

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -369,4 +369,79 @@ describe("WorkspaceHostEventRouter", () => {
       expect(events.emit).toHaveBeenCalledWith("sys:worktree:update", event.worktree);
     });
   });
+
+  describe("linked is the source of truth on re-emit (#8452)", () => {
+    it("derives canonical providerId/owner/repo from linked on sys:pr:detected", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(entry, {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 1234,
+        prUrl: "https://gitlab.acme.com/acme-corp/my-project/-/merge_requests/1234",
+        prState: "open",
+        prTitle: "Add widget",
+        providerId: "acme.gitlab",
+        linked: {
+          providerId: "acme.gitlab",
+          pr: {
+            ref: {
+              providerId: "acme.gitlab",
+              owner: "acme-corp",
+              repo: "my-project",
+              number: 1234,
+              rawData: null,
+            },
+            url: "https://gitlab.acme.com/acme-corp/my-project/-/merge_requests/1234",
+            state: "open",
+          },
+        },
+      });
+
+      expect(events.emit).toHaveBeenCalledWith(
+        "sys:pr:detected",
+        expect.objectContaining({
+          worktreeId: "wt-1",
+          prNumber: 1234,
+          providerId: "acme.gitlab",
+          owner: "acme-corp",
+          repo: "my-project",
+        })
+      );
+    });
+
+    it("derives canonical providerId/owner/repo from linked on sys:issue:detected", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(entry, {
+        type: "issue-detected",
+        worktreeId: "wt-2",
+        issueNumber: 88,
+        issueTitle: "Widget request",
+        providerId: "acme.gitlab",
+        linked: {
+          providerId: "acme.gitlab",
+          issue: {
+            ref: {
+              providerId: "acme.gitlab",
+              owner: "acme-corp",
+              repo: "my-project",
+              number: 88,
+              rawData: null,
+            },
+            title: "Widget request",
+          },
+        },
+      });
+
+      expect(events.emit).toHaveBeenCalledWith(
+        "sys:issue:detected",
+        expect.objectContaining({
+          worktreeId: "wt-2",
+          issueNumber: 88,
+          providerId: "acme.gitlab",
+          owner: "acme-corp",
+          repo: "my-project",
+        })
+      );
+    });
+  });
 });

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -38,7 +38,11 @@ export interface PRIntegrationCallbacks {
       /** Branch the lookup was initiated against — used by the renderer to drop stale overlays. */
       branchName?: string;
       /** Provider that resolved the PR (e.g. `"daintree.github.github"`). */
-      providerId?: string;
+      providerId: string;
+      /** Canonical repository owner the PR/issue belongs to. */
+      owner: string;
+      /** Canonical repository name the PR/issue belongs to. */
+      repo: string;
       /** Provider-agnostic CI status (forge format). */
       ciStatus?: import("../../shared/types/forge.js").CIStatus;
     }
@@ -53,7 +57,11 @@ export interface PRIntegrationCallbacks {
       /** Branch the lookup was initiated against — used by the renderer to drop stale overlays. */
       branchName?: string;
       /** Provider that resolved the issue (e.g. `"daintree.github.github"`). */
-      providerId?: string;
+      providerId: string;
+      /** Canonical repository owner the issue belongs to. */
+      owner: string;
+      /** Canonical repository name the issue belongs to. */
+      repo: string;
     }
   ): void;
   onIssueNotFound(worktreeId: string, issueNumber: number): void;
@@ -107,6 +115,8 @@ export class PRIntegrationService {
           issueLastUpdatedAt: data.issueTitle !== undefined ? Date.now() : undefined,
           branchName: data.branchName,
           providerId: data.providerId,
+          owner: data.owner,
+          repo: data.repo,
           ciStatus: data.ciStatus,
         });
       })
@@ -120,6 +130,8 @@ export class PRIntegrationService {
           issueLastUpdatedAt: Date.now(),
           branchName: data.branchName,
           providerId: data.providerId,
+          owner: data.owner,
+          repo: data.repo,
         });
       })
     );

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -296,6 +296,10 @@ export class WorkspaceService {
           return;
         }
 
+        // Keep the private flat issue number in lockstep so the
+        // onIssueNotFound guard (`monitor.issueNumber !== issueNumber`)
+        // matches forge-resolved issues, not just branch-parsed ones.
+        monitor.setIssueNumber(data.issueNumber);
         monitor.setIssueTitle(data.issueTitle);
         if (data.issueLastUpdatedAt !== undefined) {
           monitor.setIssueLastUpdatedAt(data.issueLastUpdatedAt);

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -17,6 +17,12 @@ import type {
   CreateWorktreeOptions,
   BranchInfo,
 } from "../../shared/types/workspace-host.js";
+import type {
+  PluginWorktreeLinked,
+  PluginWorktreeLinkedIssue,
+  PluginWorktreeLinkedPR,
+} from "../../shared/types/plugin.js";
+import type { CIStatus } from "../../shared/types/forge.js";
 import { invalidateGitStatusCache } from "../utils/git.js";
 import { detectWslPath, getDefaultWslDistro } from "../utils/wsl.js";
 import {
@@ -189,6 +195,31 @@ export class WorkspaceService {
           return;
         }
 
+        // `linked` is the source of truth — built from the canonical
+        // provider/owner/repo carried by the detection event. Flat fields are
+        // derived compatibility values written alongside it.
+        const existingIssue = monitor.getSnapshot().linked?.issue;
+        const linked = this.composeLinked({
+          providerId: data.providerId,
+          owner: data.owner,
+          repo: data.repo,
+          pr: {
+            number: data.prNumber,
+            title: data.prTitle,
+            url: data.prUrl,
+            state: data.prState,
+            ciStatus: data.ciStatus,
+          },
+          issue:
+            data.issueNumber && data.issueTitle
+              ? { number: data.issueNumber, title: data.issueTitle }
+              : undefined,
+        });
+        // Preserve an earlier issue linkage this PR event didn't carry.
+        const finalLinked: PluginWorktreeLinked =
+          !linked.issue && existingIssue ? { ...linked, issue: existingIssue } : linked;
+
+        monitor.setLinked(finalLinked);
         monitor.setPRInfo({
           prNumber: data.prNumber,
           prUrl: data.prUrl,
@@ -199,49 +230,6 @@ export class WorkspaceService {
           prLastUpdatedAt: data.prLastUpdatedAt,
           issueLastUpdatedAt: data.issueLastUpdatedAt,
         });
-
-        // Populate provider-agnostic linked projection alongside legacy fields.
-        // Preserve any existing linked.issue so that an earlier issue-detected
-        // event isn't wiped when the PR is resolved afterwards.
-        const existingLinked = monitor.getSnapshot().linked;
-        const existingIssue = existingLinked?.issue;
-        const issueData =
-          data.issueNumber && data.issueTitle
-            ? {
-                issue: {
-                  ref: {
-                    providerId: data.providerId!,
-                    owner: "",
-                    repo: "",
-                    number: data.issueNumber,
-                    rawData: null,
-                  },
-                  title: data.issueTitle,
-                },
-              }
-            : existingIssue
-              ? { issue: existingIssue }
-              : {};
-
-        if (data.providerId) {
-          monitor.setLinked({
-            providerId: data.providerId,
-            pr: {
-              ref: {
-                providerId: data.providerId,
-                owner: "",
-                repo: "",
-                number: data.prNumber,
-                rawData: null,
-              },
-              title: data.prTitle,
-              url: data.prUrl,
-              state: data.prState,
-              ...(data.ciStatus ? { ciStatus: data.ciStatus } : {}),
-            },
-            ...issueData,
-          });
-        }
 
         if (monitor.hasInitialStatus) {
           this.emitUpdate(monitor);
@@ -261,25 +249,7 @@ export class WorkspaceService {
           issueLastUpdatedAt: data.issueLastUpdatedAt,
           branchName: data.branchName,
           providerId: data.providerId,
-          linked: data.providerId
-            ? {
-                providerId: data.providerId,
-                pr: {
-                  ref: {
-                    providerId: data.providerId,
-                    owner: "",
-                    repo: "",
-                    number: data.prNumber,
-                    rawData: null,
-                  },
-                  title: data.prTitle,
-                  url: data.prUrl,
-                  state: data.prState,
-                  ...(data.ciStatus ? { ciStatus: data.ciStatus } : {}),
-                },
-                ...issueData,
-              }
-            : undefined,
+          linked: finalLinked,
         });
       },
       onPRCleared: (worktreeId, data) => {
@@ -331,26 +301,21 @@ export class WorkspaceService {
           monitor.setIssueLastUpdatedAt(data.issueLastUpdatedAt);
         }
 
-        // Update linked.issue if we have provider info
-        if (data.providerId) {
-          const snapshot = monitor.getSnapshot();
-          const existingLinked = snapshot.linked ?? null;
-          monitor.setLinked({
-            providerId: data.providerId,
-            issue: {
-              ref: {
-                providerId: data.providerId,
-                owner: "",
-                repo: "",
-                number: data.issueNumber,
-                rawData: null,
-              },
-              title: data.issueTitle,
-            },
-            // Preserve existing PR linkage if present
-            ...(existingLinked?.pr ? { pr: existingLinked.pr } : {}),
-          });
-        }
+        // `linked` is the source of truth — built from the canonical
+        // provider/owner/repo carried by the detection event.
+        const existingPr = monitor.getSnapshot().linked?.pr;
+        const linked = this.composeLinked({
+          providerId: data.providerId,
+          owner: data.owner,
+          repo: data.repo,
+          issue: { number: data.issueNumber, title: data.issueTitle },
+        });
+        // Preserve existing PR linkage if present.
+        const finalLinked: PluginWorktreeLinked = existingPr
+          ? { ...linked, pr: existingPr }
+          : linked;
+
+        monitor.setLinked(finalLinked);
 
         if (monitor.hasInitialStatus) {
           this.emitUpdate(monitor);
@@ -364,6 +329,7 @@ export class WorkspaceService {
           issueLastUpdatedAt: data.issueLastUpdatedAt,
           branchName: data.branchName,
           providerId: data.providerId,
+          linked: finalLinked,
         });
       },
       onIssueNotFound: (worktreeId, issueNumber) => {
@@ -892,6 +858,50 @@ export class WorkspaceService {
       seq: this.nextSeq(),
     });
     events.emit("sys:worktree:update", snapshot);
+  }
+
+  /**
+   * Build the provider-agnostic `linked` projection from canonical
+   * provider/owner/repo carried by detection events. This is the single
+   * construction point — callers must never synthesize a {@link ResourceRef}
+   * with empty `owner`/`repo` (the #8452 anti-pattern).
+   */
+  private composeLinked(params: {
+    providerId: string;
+    owner: string;
+    repo: string;
+    pr?: {
+      number: number;
+      title?: string;
+      url: string;
+      state: "open" | "merged" | "closed";
+      ciStatus?: CIStatus;
+    };
+    issue?: { number: number; title?: string };
+  }): PluginWorktreeLinked {
+    const { providerId, owner, repo } = params;
+    const linked: {
+      providerId: string;
+      pr?: PluginWorktreeLinkedPR;
+      issue?: PluginWorktreeLinkedIssue;
+    } = { providerId };
+
+    if (params.pr) {
+      linked.pr = {
+        ref: { providerId, owner, repo, number: params.pr.number, rawData: null },
+        title: params.pr.title,
+        url: params.pr.url,
+        state: params.pr.state,
+        ...(params.pr.ciStatus ? { ciStatus: params.pr.ciStatus } : {}),
+      };
+    }
+    if (params.issue) {
+      linked.issue = {
+        ref: { providerId, owner, repo, number: params.issue.number, rawData: null },
+        title: params.issue.title,
+      };
+    }
+    return linked;
   }
 
   private emitUpdate(monitor: WorktreeMonitor): void {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1000,6 +1000,26 @@ export class WorktreeMonitor {
       resourceStatus = { provider: this._resourceProvider };
     }
 
+    // `linked` is the source of truth (#8452). When present, the legacy flat
+    // fields are derived from it; the private flat fields only serve the
+    // legacy/branch-parse path where `_linked` was never populated.
+    const linkedPr = this._linked?.pr;
+    const linkedIssue = this._linked?.issue;
+    const linkedPrState: "open" | "merged" | "closed" | undefined = linkedPr
+      ? linkedPr.state === "declined"
+        ? "closed"
+        : linkedPr.state
+      : undefined;
+    const linkedPrCiStatus: GitHubPRCIStatus | undefined = linkedPr?.ciStatus
+      ? linkedPr.ciStatus.state === "success"
+        ? "SUCCESS"
+        : linkedPr.ciStatus.state === "failure"
+          ? "FAILURE"
+          : linkedPr.ciStatus.state === "pending"
+            ? "PENDING"
+            : undefined
+      : undefined;
+
     const snapshot: WorktreeSnapshot = {
       id: this.id,
       path: this.path,
@@ -1016,13 +1036,13 @@ export class WorktreeMonitor {
       createdAt: this._createdAt,
       aiNote: this.aiNote,
       aiNoteTimestamp: this.aiNoteTimestamp,
-      issueNumber: this._issueNumber,
-      prNumber: this.prNumber,
-      prUrl: this.prUrl,
-      prState: this.prState,
-      prCiStatus: this.prCiStatus,
-      prTitle: this.prTitle,
-      issueTitle: this.issueTitle,
+      issueNumber: linkedIssue?.ref.number ?? this._issueNumber,
+      prNumber: linkedPr?.ref.number ?? this.prNumber,
+      prUrl: linkedPr?.url ?? this.prUrl,
+      prState: linkedPr ? linkedPrState : this.prState,
+      prCiStatus: linkedPr ? linkedPrCiStatus : this.prCiStatus,
+      prTitle: linkedPr ? linkedPr.title : this.prTitle,
+      issueTitle: linkedIssue ? linkedIssue.title : this.issueTitle,
       prLastUpdatedAt: this.prLastUpdatedAt,
       issueLastUpdatedAt: this.issueLastUpdatedAt,
       worktreeChanges: this.worktreeChanges,

--- a/electron/workspace-host/__tests__/PRIntegrationService.test.ts
+++ b/electron/workspace-host/__tests__/PRIntegrationService.test.ts
@@ -111,6 +111,62 @@ describe("PRIntegrationService", () => {
     expect(updateCalls[1][1]).toMatchObject({ worktreeId: "wt-linked", isMainWorktree: false });
   });
 
+  describe("forwards canonical owner/repo (#8452)", () => {
+    it("threads owner/repo from a non-GitHub sys:pr:detected event to onPRDetected", async () => {
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+      await service.initialize("/repo", () => []);
+
+      eventBus.emit("sys:pr:detected", {
+        worktreeId: "wt-1",
+        prNumber: 1234,
+        prUrl: "https://gitlab.acme.com/acme-corp/my-project/-/merge_requests/1234",
+        prState: "open",
+        prTitle: "Add widget",
+        branchName: "feature/widget",
+        providerId: "acme.gitlab",
+        owner: "acme-corp",
+        repo: "my-project",
+        timestamp: Date.now(),
+      });
+
+      expect(callbacks.onPRDetected).toHaveBeenCalledWith(
+        "wt-1",
+        expect.objectContaining({
+          providerId: "acme.gitlab",
+          owner: "acme-corp",
+          repo: "my-project",
+          prNumber: 1234,
+        })
+      );
+    });
+
+    it("threads owner/repo from a non-GitHub sys:issue:detected event to onIssueDetected", async () => {
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+      await service.initialize("/repo", () => []);
+
+      eventBus.emit("sys:issue:detected", {
+        worktreeId: "wt-2",
+        issueNumber: 88,
+        issueTitle: "Widget request",
+        branchName: "feature/widget",
+        providerId: "acme.gitlab",
+        owner: "acme-corp",
+        repo: "my-project",
+        timestamp: Date.now(),
+      });
+
+      expect(callbacks.onIssueDetected).toHaveBeenCalledWith(
+        "wt-2",
+        expect.objectContaining({
+          providerId: "acme.gitlab",
+          owner: "acme-corp",
+          repo: "my-project",
+          issueNumber: 88,
+        })
+      );
+    });
+  });
+
   describe("getStatus", () => {
     it("maps PullRequestService status to PRServiceStatus shape", () => {
       prServiceMock.getStatus = vi.fn(() => ({

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -510,7 +510,14 @@ describe("WorktreeMonitor", () => {
           title: "Add widget",
           url: "https://gitlab.acme.com/acme-corp/my-project/-/merge_requests/1234",
           state: "open",
-          ciStatus: { state: "failure" },
+          ciStatus: {
+            state: "failure",
+            total: 3,
+            passed: 1,
+            failed: 2,
+            pending: 0,
+            rawData: null,
+          },
         },
         issue: {
           ref: {

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -494,6 +494,106 @@ describe("WorktreeMonitor", () => {
     expect(monitor.getSnapshot().prCiStatus).toBeUndefined();
   });
 
+  describe("linked is the source of truth (#8452)", () => {
+    it("derives flat fields from a non-GitHub linked projection", () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      monitor.setLinked({
+        providerId: "acme.gitlab",
+        pr: {
+          ref: {
+            providerId: "acme.gitlab",
+            owner: "acme-corp",
+            repo: "my-project",
+            number: 1234,
+            rawData: null,
+          },
+          title: "Add widget",
+          url: "https://gitlab.acme.com/acme-corp/my-project/-/merge_requests/1234",
+          state: "open",
+          ciStatus: { state: "failure" },
+        },
+        issue: {
+          ref: {
+            providerId: "acme.gitlab",
+            owner: "acme-corp",
+            repo: "my-project",
+            number: 88,
+            rawData: null,
+          },
+          title: "Widget request",
+        },
+      });
+
+      const snapshot = monitor.getSnapshot();
+      // Flat fields are derived from linked, not collapsed to GitHub defaults.
+      expect(snapshot.prNumber).toBe(1234);
+      expect(snapshot.prUrl).toBe(
+        "https://gitlab.acme.com/acme-corp/my-project/-/merge_requests/1234"
+      );
+      expect(snapshot.prState).toBe("open");
+      expect(snapshot.prTitle).toBe("Add widget");
+      expect(snapshot.prCiStatus).toBe("FAILURE");
+      expect(snapshot.issueNumber).toBe(88);
+      expect(snapshot.issueTitle).toBe("Widget request");
+      // The canonical owner/repo survive on the linked projection itself.
+      expect(snapshot.linked?.pr?.ref.owner).toBe("acme-corp");
+      expect(snapshot.linked?.pr?.ref.repo).toBe("my-project");
+    });
+
+    it("maps the declined PR state down to closed for the flat field", () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      monitor.setLinked({
+        providerId: "acme.bitbucket",
+        pr: {
+          ref: {
+            providerId: "acme.bitbucket",
+            owner: "acme-corp",
+            repo: "my-project",
+            number: 5,
+            rawData: null,
+          },
+          url: "u",
+          state: "declined",
+        },
+      });
+      expect(monitor.getSnapshot().prState).toBe("closed");
+    });
+
+    it("falls back to legacy flat fields when linked is null", () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      monitor.setPRInfo({ prNumber: 42, prUrl: "url", prState: "open", prTitle: "Legacy" });
+      const snapshot = monitor.getSnapshot();
+      expect(snapshot.linked).toBeNull();
+      expect(snapshot.prNumber).toBe(42);
+      expect(snapshot.prTitle).toBe("Legacy");
+    });
+
+    it("clearLinked reverts flat-field derivation to the legacy fields", () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      monitor.setPRInfo({ prNumber: 7, prUrl: "legacy-url", prState: "merged" });
+      monitor.setLinked({
+        providerId: "acme.gitlab",
+        pr: {
+          ref: {
+            providerId: "acme.gitlab",
+            owner: "acme-corp",
+            repo: "my-project",
+            number: 999,
+            rawData: null,
+          },
+          url: "linked-url",
+          state: "open",
+        },
+      });
+      expect(monitor.getSnapshot().prNumber).toBe(999);
+
+      monitor.clearLinked();
+      const snapshot = monitor.getSnapshot();
+      expect(snapshot.prNumber).toBe(7);
+      expect(snapshot.prUrl).toBe("legacy-url");
+    });
+  });
+
   it("hasInitialStatus is false before start", () => {
     const callbacks = makeCallbacks();
     const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -544,6 +544,8 @@ export type WorkspaceHostEvent =
       branchName?: string;
       /** Provider that resolved the issue (e.g. `"daintree.github.github"`). */
       providerId?: string;
+      /** Provider-agnostic linked projection (dual-shipped alongside legacy fields during migration). */
+      linked?: PluginWorktreeLinked | null;
     }
   | {
       type: "issue-not-found";

--- a/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
+++ b/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
@@ -253,12 +253,26 @@ describe("toPluginWorktreeSnapshot — linked is the source of truth (#8452)", (
             },
             url: "u",
             state: "open",
-            ciStatus: { state: "failure" },
+            ciStatus: {
+              state: "failure",
+              total: 3,
+              passed: 1,
+              failed: 2,
+              pending: 0,
+              rawData: null,
+            },
           },
         },
       })
     );
-    expect(out.linked?.pr?.ciStatus).toEqual({ state: "failure" });
+    expect(out.linked?.pr?.ciStatus).toEqual({
+      state: "failure",
+      total: 3,
+      passed: 1,
+      failed: 2,
+      pending: 0,
+      rawData: null,
+    });
   });
 
   it("deep-clones rather than freezing the host's live linked reference", () => {

--- a/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
+++ b/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
@@ -183,3 +183,113 @@ describe("toPluginWorktreeSnapshot — linked projection", () => {
     expect(out.lastActivityTimestamp).toBeNull();
   });
 });
+
+describe("toPluginWorktreeSnapshot — linked is the source of truth (#8452)", () => {
+  it("passes a non-GitHub linked projection through without collapsing to defaults", () => {
+    const out = toPluginWorktreeSnapshot(
+      makeSnapshot({
+        // Flat fields are the legacy GitHub-shaped derivation; they must NOT
+        // override the canonical linked payload.
+        prNumber: 42,
+        prUrl: "https://github.com/o/r/pull/42",
+        prState: "open",
+        issueNumber: 7,
+        linked: {
+          providerId: "acme.gitlab",
+          pr: {
+            ref: {
+              providerId: "acme.gitlab",
+              owner: "acme-corp",
+              repo: "my-project",
+              number: 1234,
+              rawData: null,
+            },
+            title: "Add widget",
+            url: "https://gitlab.acme.com/acme-corp/my-project/-/merge_requests/1234",
+            state: "open",
+          },
+          issue: {
+            ref: {
+              providerId: "acme.gitlab",
+              owner: "acme-corp",
+              repo: "my-project",
+              number: 88,
+              rawData: null,
+            },
+            title: "Widget request",
+          },
+        },
+      })
+    );
+
+    expect(out.linked?.providerId).toBe("acme.gitlab");
+    expect(out.linked?.pr?.ref).toEqual({
+      providerId: "acme.gitlab",
+      owner: "acme-corp",
+      repo: "my-project",
+      number: 1234,
+      rawData: null,
+    });
+    expect(out.linked?.pr?.url).toBe(
+      "https://gitlab.acme.com/acme-corp/my-project/-/merge_requests/1234"
+    );
+    expect(out.linked?.issue?.ref.owner).toBe("acme-corp");
+    expect(out.linked?.issue?.ref.repo).toBe("my-project");
+    expect(out.linked?.issue?.ref.number).toBe(88);
+  });
+
+  it("preserves a forge CI status when passing linked through", () => {
+    const out = toPluginWorktreeSnapshot(
+      makeSnapshot({
+        linked: {
+          providerId: "acme.gitlab",
+          pr: {
+            ref: {
+              providerId: "acme.gitlab",
+              owner: "acme-corp",
+              repo: "my-project",
+              number: 5,
+              rawData: null,
+            },
+            url: "u",
+            state: "open",
+            ciStatus: { state: "failure" },
+          },
+        },
+      })
+    );
+    expect(out.linked?.pr?.ciStatus).toEqual({ state: "failure" });
+  });
+
+  it("deep-clones rather than freezing the host's live linked reference", () => {
+    const liveLinked = {
+      providerId: "acme.gitlab",
+      pr: {
+        ref: {
+          providerId: "acme.gitlab",
+          owner: "acme-corp",
+          repo: "my-project",
+          number: 9,
+          rawData: null,
+        },
+        url: "u",
+        state: "open" as const,
+      },
+    };
+    const out = toPluginWorktreeSnapshot(makeSnapshot({ linked: liveLinked }));
+
+    // Projection is frozen…
+    expect(Object.isFrozen(out.linked)).toBe(true);
+    expect(Object.isFrozen(out.linked?.pr)).toBe(true);
+    expect(Object.isFrozen(out.linked?.pr?.ref)).toBe(true);
+    // …but the host's original object is untouched and still mutable.
+    expect(Object.isFrozen(liveLinked)).toBe(false);
+    expect(Object.isFrozen(liveLinked.pr)).toBe(false);
+    expect(Object.isFrozen(liveLinked.pr.ref)).toBe(false);
+    expect(out.linked).not.toBe(liveLinked);
+  });
+
+  it("returns null only when linked is null AND no flat fields are present", () => {
+    expect(toPluginWorktreeSnapshot(makeSnapshot({ linked: null })).linked).toBeNull();
+  });
+});

--- a/shared/utils/pluginWorktreeSnapshot.ts
+++ b/shared/utils/pluginWorktreeSnapshot.ts
@@ -34,17 +34,19 @@ export function toPluginWorktreeSnapshot(snapshot: WorktreeSnapshot): PluginWork
 }
 
 /**
- * Synthesize the provider-agnostic `linked` projection from the internal
- * snapshot's flat GitHub-shaped fields. Returns `null` when neither an issue
- * nor a PR is linked. Provider id is hardcoded to `"github"` because the only
- * forge currently writing these fields is the built-in GitHub integration.
- *
- * TODO(forge-abstraction): when `PRIntegrationService` is rewritten against
- * the {@link ForgeProviderImpl} contract, the synthesized {@link ResourceRef}
- * will be replaced with one carrying populated `owner`/`repo` — they're empty
- * here because `WorktreeSnapshot` does not currently carry repo identity.
+ * Project the worktree's linked forge resources for plugins. `snapshot.linked`
+ * is the source of truth (#8452): when present it is passed through verbatim
+ * (deep-cloned then frozen so the host's live `_linked` reference is never
+ * mutated). Only legacy snapshots that never populated `linked` fall back to
+ * synthesizing it from the flat GitHub-shaped fields, where the provider id is
+ * hardcoded to `"github"` and `owner`/`repo` are empty because those snapshots
+ * predate canonical repo identity on the payload.
  */
 function buildLinkedProjection(snapshot: WorktreeSnapshot): PluginWorktreeLinked | null {
+  if (snapshot.linked != null) {
+    return freezeLinked(snapshot.linked);
+  }
+
   const hasPR = typeof snapshot.prNumber === "number";
   const hasIssue = typeof snapshot.issueNumber === "number";
   if (!hasPR && !hasIssue) return null;
@@ -91,4 +93,36 @@ function buildLinkedProjection(snapshot: WorktreeSnapshot): PluginWorktreeLinked
   }
 
   return Object.freeze(linked);
+}
+
+/**
+ * Deep-clone then freeze a host-provided `linked` projection. Cloning is
+ * mandatory: freezing the live `WorktreeMonitor._linked` reference directly
+ * would make the host's own internal state immutable and break subsequent
+ * `setLinked()` merges.
+ */
+function freezeLinked(linked: PluginWorktreeLinked): PluginWorktreeLinked {
+  const cloned: {
+    providerId: string;
+    issue?: PluginWorktreeLinkedIssue;
+    pr?: PluginWorktreeLinkedPR;
+  } = { providerId: linked.providerId };
+
+  if (linked.issue) {
+    cloned.issue = Object.freeze({
+      ref: Object.freeze({ ...linked.issue.ref }),
+      title: linked.issue.title,
+    });
+  }
+  if (linked.pr) {
+    cloned.pr = Object.freeze({
+      ref: Object.freeze({ ...linked.pr.ref }),
+      title: linked.pr.title,
+      url: linked.pr.url,
+      state: linked.pr.state,
+      ...(linked.pr.ciStatus ? { ciStatus: linked.pr.ciStatus } : {}),
+    });
+  }
+
+  return Object.freeze(cloned);
 }

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -64,6 +64,7 @@ interface IssueDetectedEvent {
   issueLastUpdatedAt?: number;
   branchName?: string;
   providerId?: string;
+  linked?: PluginWorktreeLinked | null;
 }
 
 interface IssueNotFoundEvent {
@@ -442,30 +443,17 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         const existing = worktrees.get(event.worktreeId);
         if (!existing) return;
         if (!branchesMatch(event.branchName, existing.branch)) return;
+        // `linked` is the source of truth — pass through the host-built
+        // projection (carrying canonical providerId/owner/repo) rather than
+        // re-synthesizing it with empty owner/repo (#8452). Full-replace, so
+        // the host's preserved PR linkage isn't lost.
         store.getState().applyUpdate(
           {
             ...existing,
             issueNumber: event.issueNumber,
             issueTitle: event.issueTitle,
             issueLastUpdatedAt: event.issueLastUpdatedAt ?? existing.issueLastUpdatedAt,
-            ...(event.providerId
-              ? {
-                  linked: {
-                    providerId: event.providerId,
-                    issue: {
-                      ref: {
-                        providerId: event.providerId,
-                        owner: "",
-                        repo: "",
-                        number: event.issueNumber,
-                        rawData: null,
-                      },
-                      title: event.issueTitle,
-                    },
-                    ...(existing.linked?.pr ? { pr: existing.linked.pr } : {}),
-                  },
-                }
-              : {}),
+            linked: event.linked ?? existing.linked,
           },
           overlayVersion(store.getState().version)
         );

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -467,12 +467,18 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         const existing = worktrees.get(event.worktreeId);
         if (!existing) return;
         if (existing.issueNumber !== event.issueNumber) return;
+        // `linked` is the source of truth (#8452): clearing the issue must
+        // drop linked.issue too, mirroring the host's onIssueNotFound and the
+        // pr-cleared handler above. Preserve any PR linkage that's present.
         store.getState().applyUpdate(
           {
             ...existing,
             issueNumber: undefined,
             issueTitle: undefined,
             issueLastUpdatedAt: undefined,
+            linked: existing.linked?.pr
+              ? { providerId: existing.linked.providerId, pr: existing.linked.pr }
+              : null,
           },
           overlayVersion(store.getState().version)
         );

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -1034,6 +1034,57 @@ describe("WorktreeStoreProvider issue-detected handler", () => {
     expect(wt?.linked?.pr?.ref.number).toBe(1234);
     expect(wt?.linked?.issue?.ref.number).toBe(88);
   });
+
+  it("issue-not-found clears linked.issue but preserves linked.pr (#8452)", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(
+        makeWorktree("wt-1", {
+          branch: "feature/widget",
+          issueNumber: 88,
+          issueTitle: "Widget request",
+          linked: {
+            providerId: "acme.gitlab",
+            issue: {
+              ref: {
+                providerId: "acme.gitlab",
+                owner: "acme-corp",
+                repo: "my-project",
+                number: 88,
+                rawData: null,
+              },
+              title: "Widget request",
+            },
+            pr: {
+              ref: {
+                providerId: "acme.gitlab",
+                owner: "acme-corp",
+                repo: "my-project",
+                number: 1234,
+                rawData: null,
+              },
+              url: "https://gitlab.acme.com/acme-corp/my-project/-/merge_requests/1234",
+              state: "open",
+            },
+          },
+        }),
+        nextV()
+      );
+    });
+
+    act(() => {
+      emit("issue-not-found", {
+        type: "issue-not-found",
+        worktreeId: "wt-1",
+        issueNumber: 88,
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBeUndefined();
+    expect(wt?.linked?.issue).toBeUndefined();
+    expect(wt?.linked?.pr?.ref.number).toBe(1234);
+  });
 });
 
 describe("WorktreeStoreProvider manual issue associations (#8079)", () => {

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -950,6 +950,90 @@ describe("WorktreeStoreProvider issue-detected handler", () => {
 
     expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBe(200);
   });
+
+  it("passes a non-GitHub linked projection through without collapsing to defaults (#8452)", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1", { branch: "feature/widget" }), nextV());
+    });
+
+    act(() => {
+      emit("issue-detected", {
+        type: "issue-detected",
+        worktreeId: "wt-1",
+        issueNumber: 88,
+        issueTitle: "Widget request",
+        branchName: "feature/widget",
+        providerId: "acme.gitlab",
+        linked: {
+          providerId: "acme.gitlab",
+          issue: {
+            ref: {
+              providerId: "acme.gitlab",
+              owner: "acme-corp",
+              repo: "my-project",
+              number: 88,
+              rawData: null,
+            },
+            title: "Widget request",
+          },
+        },
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBe(88);
+    expect(wt?.linked?.providerId).toBe("acme.gitlab");
+    expect(wt?.linked?.issue?.ref.owner).toBe("acme-corp");
+    expect(wt?.linked?.issue?.ref.repo).toBe("my-project");
+    expect(wt?.linked?.issue?.ref.number).toBe(88);
+  });
+
+  it("preserves an existing PR linkage carried in the host-built issue linked payload", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1", { branch: "feature/widget" }), nextV());
+    });
+
+    act(() => {
+      emit("issue-detected", {
+        type: "issue-detected",
+        worktreeId: "wt-1",
+        issueNumber: 88,
+        issueTitle: "Widget request",
+        branchName: "feature/widget",
+        providerId: "acme.gitlab",
+        linked: {
+          providerId: "acme.gitlab",
+          issue: {
+            ref: {
+              providerId: "acme.gitlab",
+              owner: "acme-corp",
+              repo: "my-project",
+              number: 88,
+              rawData: null,
+            },
+            title: "Widget request",
+          },
+          pr: {
+            ref: {
+              providerId: "acme.gitlab",
+              owner: "acme-corp",
+              repo: "my-project",
+              number: 1234,
+              rawData: null,
+            },
+            url: "https://gitlab.acme.com/acme-corp/my-project/-/merge_requests/1234",
+            state: "open",
+          },
+        },
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.linked?.pr?.ref.number).toBe(1234);
+    expect(wt?.linked?.issue?.ref.number).toBe(88);
+  });
 });
 
 describe("WorktreeStoreProvider manual issue associations (#8079)", () => {


### PR DESCRIPTION
## Summary

Closes #8452. Depends on #8451 (merged).

Worktree state carried two parallel representations of linked forge resources: legacy GitHub-shaped flat fields (`issueNumber`, `prNumber`, `prUrl`, `prState`, `prCiStatus`, `issueTitle`, `prTitle`) and a provider-agnostic `linked` object. The flow was backwards — `linked` was synthesized *downstream* from the flat fields, often with a hard-coded `providerId: "github"` and empty `owner`/`repo`.

This inverts the flow. `linked` (`PluginWorktreeLinked`, carrying canonical `providerId`/`owner`/`repo`/`number`/`title`/`url`/`state`/`ci`) is now the primary internal payload; the flat fields are derived backward-compat values during migration.

## Root cause

`PullRequestService` already held the real `owner`/`repo` in `this.repoRef`, but the `sys:pr:detected` / `sys:issue:detected` events didn't carry them — so every downstream `ResourceRef` construction (4+ sites) fell back to empty strings.

## Changes

- **`events.ts`** — `owner`/`repo` (and `providerId`) are now required on `sys:pr:detected` / `sys:issue:detected`, surfacing every stale construction site at compile time.
- **`PullRequestService.ts`** — threads `repo.owner`/`repo.repo` at all four emit sites.
- **`PRIntegrationService.ts`** — forwards `owner`/`repo` through the detection callbacks.
- **`WorkspaceService.ts`** — a single `composeLinked()` helper is the sole `ResourceRef` construction point; `onPRDetected`/`onIssueDetected` build `linked` first (canonical identity), then derive flat fields; the `issue-detected` host event now ships `linked`.
- **`WorktreeMonitor.ts`** — `getSnapshot()` derives flat fields from `_linked` when present (declined→closed PR state, forge CI → GitHub-shaped rollup), falling back to the legacy private fields only when `_linked` is null (preserves branch-name issue extraction).
- **`WorkspaceHostEventRouter.ts`** — the second hop (workspace-host → bus) derives canonical identity from `event.linked` instead of reintroducing empty strings.
- **`WorktreeStoreContext.tsx`** — passes the host-built `linked` through; `issue-not-found` clears `linked.issue` while preserving `linked.pr`.
- **`pluginWorktreeSnapshot.ts`** — passes `snapshot.linked` through (deep-cloned then frozen so the host's live `_linked` is never mutated); flat-field synthesis with `providerId:"github"` is now the legacy-only fallback.

## Tests

Fake-provider coverage (non-GitHub `acme.gitlab` `acme-corp/my-project`) proves a non-GitHub `providerId`/`owner`/`repo`/issue/PR survives workspace-host → router → renderer → plugin snapshot without collapsing to GitHub defaults. Extended 6 existing test files (no new files); 205 targeted tests green; `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
