### PR TITLE
feat(worktree): collapse trailing row chips into single CommitChip

### DIFF
--- a/shared/config/csp.ts
+++ b/shared/config/csp.ts
@@ -11,6 +11,11 @@ const FRAME_LOCALHOST =
 
 const GITHUB_AVATARS = "https://avatars.githubusercontent.com";
 
+// Custom commit-author avatars. `getGravatarUrl()` requests
+// `https://www.gravatar.com/avatar/<hash>?d=404`; with `d=404` there is no
+// redirect to *.wp.com on a miss, so only this origin needs allowing.
+const GRAVATAR = "https://www.gravatar.com";
+
 // Named Trusted Types policy backing all DOM HTML-sink writes in the renderer.
 // 'allow-duplicates' is required so Vite HMR can re-evaluate the policy module
 // on hot reload without throwing 'Policy with name "<x>" already exists'.
@@ -45,7 +50,7 @@ export function getDaintreeAppProdCSP(): string {
     "script-src 'self' 'wasm-unsafe-eval'",
     "style-src 'self' 'unsafe-inline'",
     `connect-src 'self' ${FILE_SCHEMES}`,
-    `img-src 'self' ${GITHUB_AVATARS} ${FILE_SCHEMES} data: blob:`,
+    `img-src 'self' ${GITHUB_AVATARS} ${GRAVATAR} ${FILE_SCHEMES} data: blob:`,
     "font-src 'self' data:",
     "media-src 'self'",
     "worker-src 'self' blob:",
@@ -79,7 +84,7 @@ export function getDaintreeAppDevCSP(): string {
     `script-src 'self' ${origins} 'unsafe-inline' 'unsafe-eval'`,
     `style-src 'self' ${origins} 'unsafe-inline'`,
     `connect-src 'self' ${origins} ${wsOrigins} ${FILE_SCHEMES}`,
-    `img-src 'self' ${origins} ${GITHUB_AVATARS} ${FILE_SCHEMES} data: blob:`,
+    `img-src 'self' ${origins} ${GITHUB_AVATARS} ${GRAVATAR} ${FILE_SCHEMES} data: blob:`,
     `font-src 'self' ${origins} data:`,
     "media-src 'self'",
     "worker-src 'self' blob:",

--- a/src/components/Worktree/WorktreeCard/CommitChip.tsx
+++ b/src/components/Worktree/WorktreeCard/CommitChip.tsx
@@ -40,21 +40,20 @@ const MACHINE_EMAIL_TO_AGENT: Record<string, string> = {
   "noreply@anthropic.com": "claude",
 };
 
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 /**
  * Tier 1 — match the commit author against the agent registry. Returns the
  * branded icon component when the committer is a known AI agent (Claude,
- * Codex, Gemini, …), else null so the chain falls through. Matching is
- * deliberately conservative: an exact machine-email map, an email segment
- * equal to an agent id (≥4 chars, to avoid short-token collisions), or the
- * agent's display name as a standalone word in the author name.
+ * Codex, Gemini, …), else null so the chain falls through.
+ *
+ * Matching is intentionally email-only and conservative: an exact
+ * machine-email map, or an email segment that exactly equals an agent id
+ * (≥4 chars, to avoid short-token collisions). Author *name* is deliberately
+ * not matched — a human committing as "Claude Monet" must not be painted as
+ * an AI agent. Every documented real agent identity (Codex, Gemini CLI,
+ * Claude Code's co-author address) is covered by the email signal.
  */
 export function resolveCommitAgentIcon(author: CommitAuthor): ComponentType<AgentIconProps> | null {
   const email = author.email.trim().toLowerCase();
-  const name = author.name.trim().toLowerCase();
 
   const mapped = MACHINE_EMAIL_TO_AGENT[email];
   if (mapped && AGENT_REGISTRY[mapped]) return AGENT_REGISTRY[mapped].icon;
@@ -63,8 +62,6 @@ export function resolveCommitAgentIcon(author: CommitAuthor): ComponentType<Agen
   for (const agent of Object.values(AGENT_REGISTRY)) {
     const id = agent.id.toLowerCase();
     if (id.length >= 4 && segments.includes(id)) return agent.icon;
-    const display = agent.name.toLowerCase();
-    if (new RegExp(`\\b${escapeRegExp(display)}\\b`).test(name)) return agent.icon;
   }
   return null;
 }

--- a/src/components/Worktree/WorktreeCard/CommitChip.tsx
+++ b/src/components/Worktree/WorktreeCard/CommitChip.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useState, type ComponentType } from "react";
+import { cn } from "@/lib/utils";
+import { CAT_COLOR_CLASSES } from "@/config/categoryColors";
+import { AGENT_REGISTRY, type AgentIconProps } from "@/config/agents";
+import { getGravatarUrl, isBotAuthor } from "@/utils/gravatar";
+import { LiveTimeAgo } from "../LiveTimeAgo";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+export interface CommitAuthor {
+  name: string;
+  email: string;
+}
+
+export interface CommitChipProps {
+  /** Timestamp of the last commit. The chip's relative time always shows this. */
+  lastCommitTimestampMs: number;
+  /** Commit author. When absent the chip shows the time only (no avatar). */
+  author?: CommitAuthor | null;
+  /** Commit subject, shown on the first tooltip line. */
+  commitMessage?: string;
+  /**
+   * Reserved seat for the forge profile-picture provider issue. When present
+   * it is tried before Gravatar. This issue does not populate it.
+   */
+  forgeAvatarUrl?: string;
+  /**
+   * Reserved seat for the avatar freshness-ring issue. Accepted but unused
+   * here so the ring work layers on without changing this API.
+   */
+  lastActivityTimestamp?: number | null;
+}
+
+// CLI tools that commit under a fixed machine identity rather than the
+// human's git config. Maps the commit email to an agent registry id.
+const MACHINE_EMAIL_TO_AGENT: Record<string, string> = {
+  "noreply@codex.openai.com": "codex",
+  "codex@example.com": "codex",
+  "gemini-cli-agent@google.com": "gemini",
+  "claude-code@anthropic.com": "claude",
+  "noreply@anthropic.com": "claude",
+};
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Tier 1 — match the commit author against the agent registry. Returns the
+ * branded icon component when the committer is a known AI agent (Claude,
+ * Codex, Gemini, …), else null so the chain falls through. Matching is
+ * deliberately conservative: an exact machine-email map, an email segment
+ * equal to an agent id (≥4 chars, to avoid short-token collisions), or the
+ * agent's display name as a standalone word in the author name.
+ */
+export function resolveCommitAgentIcon(author: CommitAuthor): ComponentType<AgentIconProps> | null {
+  const email = author.email.trim().toLowerCase();
+  const name = author.name.trim().toLowerCase();
+
+  const mapped = MACHINE_EMAIL_TO_AGENT[email];
+  if (mapped && AGENT_REGISTRY[mapped]) return AGENT_REGISTRY[mapped].icon;
+
+  const segments = email.split(/[^a-z0-9]+/).filter(Boolean);
+  for (const agent of Object.values(AGENT_REGISTRY)) {
+    const id = agent.id.toLowerCase();
+    if (id.length >= 4 && segments.includes(id)) return agent.icon;
+    const display = agent.name.toLowerCase();
+    if (new RegExp(`\\b${escapeRegExp(display)}\\b`).test(name)) return agent.icon;
+  }
+  return null;
+}
+
+function djb2(input: string): number {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) | 0;
+  }
+  return hash;
+}
+
+function initialsOf(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase();
+  return (words[0]![0]! + words[words.length - 1]![0]!).toUpperCase();
+}
+
+function relativeCommitPhrase(diffMs: number): string {
+  const s = Math.floor(diffMs / 1000);
+  const m = Math.floor(s / 60);
+  const h = Math.floor(m / 60);
+  const d = Math.floor(h / 24);
+  if (s < 60) return "just now";
+  if (m < 60) return `${m} minute${m !== 1 ? "s" : ""} ago`;
+  if (h < 24) return `${h} hour${h !== 1 ? "s" : ""} ago`;
+  if (d < 7) return `${d} day${d !== 1 ? "s" : ""} ago`;
+  const w = Math.floor(d / 7);
+  return `${w} week${w !== 1 ? "s" : ""} ago`;
+}
+
+const AVATAR_SIZE = "h-4 w-4 shrink-0";
+
+/**
+ * Tier 4 — deterministic coloured initials. Background hue is hashed from the
+ * author email (falls back to name) so the same person keeps one colour
+ * everywhere. Decorative: the chip itself carries the accessible name.
+ */
+function InitialsAvatar({ author, square }: { author: CommitAuthor; square: boolean }) {
+  const key = (author.email.trim() || author.name.trim()).toLowerCase();
+  const color = CAT_COLOR_CLASSES[Math.abs(djb2(key)) % CAT_COLOR_CLASSES.length]!;
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        AVATAR_SIZE,
+        "flex items-center justify-center text-[8px] font-semibold leading-none",
+        square ? "rounded-md" : "rounded-full",
+        color
+      )}
+    >
+      {initialsOf(author.name)}
+    </span>
+  );
+}
+
+function CommitChipAvatar({
+  author,
+  forgeAvatarUrl,
+}: {
+  author: CommitAuthor;
+  forgeAvatarUrl?: string;
+}) {
+  const AgentIcon = resolveCommitAgentIcon(author);
+  const square = AgentIcon != null || isBotAuthor(author.name);
+
+  // Ordered image tiers tried before initials: forge picture, then a
+  // `d=404` Gravatar probe. Skip Gravatar when offline — the request would
+  // otherwise hang until the browser timeout before firing onError.
+  const offline = typeof navigator !== "undefined" && navigator.onLine === false;
+  const imgSources: string[] = [];
+  if (!AgentIcon) {
+    if (forgeAvatarUrl) imgSources.push(forgeAvatarUrl);
+    if (!offline && author.email.trim()) imgSources.push(getGravatarUrl(author.email, 32));
+  }
+
+  const [srcIndex, setSrcIndex] = useState(0);
+  const identityKey = `${author.email}|${author.name}|${forgeAvatarUrl ?? ""}`;
+  useEffect(() => {
+    setSrcIndex(0);
+  }, [identityKey]);
+
+  if (AgentIcon) {
+    return (
+      <span aria-hidden="true" className={cn(AVATAR_SIZE, "flex items-center justify-center")}>
+        <AgentIcon size={16} />
+      </span>
+    );
+  }
+
+  const src = imgSources[srcIndex];
+  if (src == null) {
+    return <InitialsAvatar author={author} square={square} />;
+  }
+
+  return (
+    <img
+      key={src}
+      src={src}
+      alt=""
+      aria-hidden="true"
+      onError={() => setSrcIndex((i) => i + 1)}
+      className={cn(AVATAR_SIZE, "object-cover", square ? "rounded-md" : "rounded-full")}
+    />
+  );
+}
+
+/**
+ * Single trailing chip for a worktree row: one identity avatar plus one
+ * relative time, both keyed to the last commit. Replaces the former
+ * avatar+commit-time / ActivityLight+activity-time pair that collapsed to a
+ * duplicated label on a clean tree. Self-contained so the forge-picture and
+ * freshness-ring work can layer on via the reserved props.
+ */
+export function CommitChip({
+  lastCommitTimestampMs,
+  author,
+  commitMessage,
+  forgeAvatarUrl,
+}: CommitChipProps) {
+  const relative = relativeCommitPhrase(Date.now() - lastCommitTimestampMs);
+  const absolute = new Date(lastCommitTimestampMs).toLocaleString();
+  const authorClause = author
+    ? `${author.name} · committed ${relative} (${absolute})`
+    : `Committed ${relative} (${absolute})`;
+  const accessibleName = author ? `Last commit by ${author.name}` : "Last commit";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className="relative z-10 ml-3 flex shrink-0 items-center gap-1 text-xs text-text-muted"
+          aria-label={accessibleName}
+        >
+          {author && <CommitChipAvatar author={author} forgeAvatarUrl={forgeAvatarUrl} />}
+          <LiveTimeAgo timestamp={lastCommitTimestampMs} noTooltip />
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        <div className="flex flex-col gap-0.5">
+          {commitMessage && <span className="font-medium">{`"${commitMessage}"`}</span>}
+          <span>{authorClause}</span>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -419,13 +419,14 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                     </span>
                   )}
 
-                {worktree.worktreeChanges?.lastCommitTimestampMs != null && (
-                  <CommitChip
-                    lastCommitTimestampMs={worktree.worktreeChanges.lastCommitTimestampMs}
-                    author={worktree.worktreeChanges.lastCommitAuthor}
-                    commitMessage={worktree.worktreeChanges.lastCommitMessage}
-                  />
-                )}
+                {worktree.worktreeChanges?.lastCommitTimestampMs != null &&
+                  Number.isFinite(worktree.worktreeChanges.lastCommitTimestampMs) && (
+                    <CommitChip
+                      lastCommitTimestampMs={worktree.worktreeChanges.lastCommitTimestampMs}
+                      author={worktree.worktreeChanges.lastCommitAuthor}
+                      commitMessage={worktree.worktreeChanges.lastCommitMessage}
+                    />
+                  )}
               </div>
 
               {showReviewHubButton && (

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -6,12 +6,9 @@ import type { ErrorRecord } from "@/store/errorStore";
 import { useAnimate, useReducedMotion } from "framer-motion";
 import { DURATION_200 } from "@/lib/animationUtils";
 import { cn } from "@/lib/utils";
-import { ActivityLight } from "../ActivityLight";
-import { LiveTimeAgo } from "../LiveTimeAgo";
 import { WorktreeDetails } from "../WorktreeDetails";
-import { Avatar } from "@/components/ui/Avatar";
+import { CommitChip } from "./CommitChip";
 import { Spinner } from "@/components/ui/Spinner";
-import { getGravatarUrl, isBotAuthor } from "@/utils/gravatar";
 import {
   Activity,
   AlertTriangle,
@@ -423,63 +420,12 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                   )}
 
                 {worktree.worktreeChanges?.lastCommitTimestampMs != null && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div className="relative z-10 ml-3 flex shrink-0 items-center gap-1 text-xs text-text-muted">
-                        {worktree.worktreeChanges?.lastCommitAuthor && (
-                          <Avatar
-                            src={getGravatarUrl(
-                              worktree.worktreeChanges.lastCommitAuthor.email,
-                              32
-                            )}
-                            alt={worktree.worktreeChanges.lastCommitAuthor.name}
-                            shape={
-                              isBotAuthor(worktree.worktreeChanges.lastCommitAuthor.name)
-                                ? "square"
-                                : "circle"
-                            }
-                            className="w-4 h-4"
-                          />
-                        )}
-                        <LiveTimeAgo
-                          timestamp={worktree.worktreeChanges.lastCommitTimestampMs}
-                          noTooltip
-                        />
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      {worktree.worktreeChanges?.lastCommitMessage
-                        ? `"${worktree.worktreeChanges.lastCommitMessage}"`
-                        : "Last commit"}
-                      {worktree.worktreeChanges?.lastCommitAuthor
-                        ? ` by ${worktree.worktreeChanges.lastCommitAuthor.name}`
-                        : ""}
-                    </TooltipContent>
-                  </Tooltip>
+                  <CommitChip
+                    lastCommitTimestampMs={worktree.worktreeChanges.lastCommitTimestampMs}
+                    author={worktree.worktreeChanges.lastCommitAuthor}
+                    commitMessage={worktree.worktreeChanges.lastCommitMessage}
+                  />
                 )}
-
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="relative z-10 ml-3 flex shrink-0 items-center gap-1.5 text-xs text-text-muted">
-                      {worktree.lastActivityTimestamp != null ? (
-                        <>
-                          <ActivityLight
-                            lastActivityTimestamp={worktree.lastActivityTimestamp}
-                            className="w-1.5 h-1.5"
-                          />
-                          <LiveTimeAgo timestamp={worktree.lastActivityTimestamp} noTooltip />
-                        </>
-                      ) : (
-                        <span>No activity</span>
-                      )}
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {worktree.lastActivityTimestamp != null
-                      ? `Last activity: ${new Date(worktree.lastActivityTimestamp).toLocaleString()}`
-                      : "No recent activity recorded"}
-                  </TooltipContent>
-                </Tooltip>
               </div>
 
               {showReviewHubButton && (

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -454,4 +454,54 @@ describe("WorktreeDetailsSection trailing commit chip", () => {
     expect(screen.queryByLabelText(/Last commit/)).toBeNull();
     expect(container.querySelector("img")).toBeNull();
   });
+
+  it("does not paint an agent icon for a human whose name contains 'Claude'", () => {
+    const worktree = {
+      ...baseWorktree,
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        lastCommitTimestampMs: Date.now() - 120_000,
+        lastCommitAuthor: { name: "Claude Monet", email: "cmonet@museum.fr" },
+      } as WorktreeChanges,
+    };
+    const { container } = renderSection({ worktree, hasChanges: false });
+
+    // No branded SVG icon — falls through to the Gravatar image instead.
+    expect(container.querySelector("svg")).toBeNull();
+    const avatarImg = Array.from(container.querySelectorAll("img")).find((el) =>
+      el.getAttribute("src")?.includes("gravatar.com")
+    );
+    expect(avatarImg).toBeTruthy();
+  });
+
+  it("omits the chip when lastCommitTimestampMs is NaN", () => {
+    const worktree = {
+      ...baseWorktree,
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        lastCommitTimestampMs: Number.NaN,
+        lastCommitAuthor: { name: "Jane Doe", email: "jane@example.com" },
+      } as WorktreeChanges,
+    };
+    const { container } = renderSection({ worktree, hasChanges: false });
+
+    expect(screen.queryByLabelText(/Last commit/)).toBeNull();
+    expect(container.textContent).not.toContain("NaN");
+  });
+
+  it("renders exactly one trailing chip when both commit and activity timestamps exist", () => {
+    const worktree = {
+      ...baseWorktree,
+      lastActivityTimestamp: Date.now() - 60_000,
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        lastCommitTimestampMs: Date.now() - 120_000,
+        lastCommitAuthor: { name: "Jane Doe", email: "jane@example.com" },
+      } as WorktreeChanges,
+    };
+    renderSection({ worktree, hasChanges: false });
+
+    expect(screen.getAllByLabelText(/Last commit/)).toHaveLength(1);
+    expect(screen.queryByText("No activity")).toBeNull();
+  });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -336,7 +336,7 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
   });
 });
 
-describe("WorktreeDetailsSection activity indicator", () => {
+describe("WorktreeDetailsSection trailing commit chip", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2025-06-15T12:00:00Z").getTime());
@@ -346,61 +346,7 @@ describe("WorktreeDetailsSection activity indicator", () => {
     vi.useRealTimers();
   });
 
-  it("renders 'No activity' placeholder when lastActivityTimestamp is null", () => {
-    const worktree: WorktreeState = { ...baseWorktree, lastActivityTimestamp: null };
-    renderSection({ worktree, hasChanges: false });
-    expect(screen.getByText("No activity")).toBeDefined();
-  });
-
-  it("renders the activity dot and time ago when timestamp is present", () => {
-    const worktree: WorktreeState = {
-      ...baseWorktree,
-      lastActivityTimestamp: Date.now(),
-    };
-    renderSection({ worktree, hasChanges: false });
-    expect(screen.queryByText("No activity")).toBeNull();
-    // LiveTimeAgo renders "now" for a just-now timestamp
-    expect(screen.getByText("now")).toBeDefined();
-  });
-
-  it("renders hollow ring and time label for decayed timestamp", () => {
-    const worktree: WorktreeState = {
-      ...baseWorktree,
-      lastActivityTimestamp: Date.now() - 120_000, // 2 minutes ago — past DECAY_DURATION (90s)
-    };
-    renderSection({ worktree, hasChanges: false });
-    expect(screen.queryByText("No activity")).toBeNull();
-    // LiveTimeAgo renders a time label like "2m"
-    expect(screen.getByText("2m")).toBeDefined();
-  });
-
-  it("collapsed view shows 'No activity' when expanded view shows worktree details without activity section", () => {
-    // The expanded view (WorktreeDetails) already gates the activity section
-    // on showTime && lastActivityTimestamp (line 81). Verify the collapsed
-    // view handles the null case distinctly.
-    const worktree: WorktreeState = { ...baseWorktree, lastActivityTimestamp: null };
-    renderSection({ worktree, hasChanges: false });
-    expect(screen.getByText("No activity")).toBeDefined();
-  });
-
-  it("null timestamp worktree does not render an ActivityLight dot", () => {
-    const worktree: WorktreeState = { ...baseWorktree, lastActivityTimestamp: null };
-    const { container } = renderSection({ worktree, hasChanges: false });
-    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
-  });
-});
-
-describe("WorktreeDetailsSection commit author chip", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2025-06-15T12:00:00Z").getTime());
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("renders avatar and time when lastCommitAuthor and timestamp present", () => {
+  it("renders a single avatar and commit time when author and timestamp present", () => {
     const worktree = {
       ...baseWorktree,
       worktreeChanges: {
@@ -417,10 +363,15 @@ describe("WorktreeDetailsSection commit author chip", () => {
       el.getAttribute("src")?.includes("gravatar.com")
     );
     expect(avatarImg).toBeTruthy();
+    // Gravatar uses the d=404 probe so generic identicons never paint.
+    expect(avatarImg!.getAttribute("src")).toContain("d=404");
+    expect(avatarImg!.getAttribute("src")).not.toContain("d=mp");
     expect(container.textContent).toContain("2m");
+    // Old duplicated activity chip is gone.
+    expect(screen.queryByText("No activity")).toBeNull();
   });
 
-  it("renders square avatar for bot author", () => {
+  it("renders a square avatar for a bot author", () => {
     const worktree = {
       ...baseWorktree,
       worktreeChanges: {
@@ -443,7 +394,7 @@ describe("WorktreeDetailsSection commit author chip", () => {
     expect(avatarImg!.className).not.toContain("rounded-full");
   });
 
-  it("renders LiveTimeAgo without avatar when timestamp present but author absent", () => {
+  it("renders the time without an avatar when the author is absent", () => {
     const worktree = {
       ...baseWorktree,
       worktreeChanges: {
@@ -453,8 +404,41 @@ describe("WorktreeDetailsSection commit author chip", () => {
     };
     const { container } = renderSection({ worktree, hasChanges: false });
 
-    // Should show time without an avatar
     expect(container.textContent).toContain("2m");
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("falls through to coloured initials when Gravatar 404s", () => {
+    const worktree = {
+      ...baseWorktree,
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        lastCommitTimestampMs: Date.now() - 120_000,
+        lastCommitAuthor: { name: "Jane Doe", email: "jane@example.com" },
+      } as WorktreeChanges,
+    };
+    const { container } = renderSection({ worktree, hasChanges: false });
+
+    const img = container.querySelector("img")!;
+    expect(img).toBeTruthy();
+    fireEvent.error(img);
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(screen.getByText("JD")).toBeDefined();
+  });
+
+  it("renders a branded agent icon for a known agent committer", () => {
+    const worktree = {
+      ...baseWorktree,
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        lastCommitTimestampMs: Date.now() - 120_000,
+        lastCommitAuthor: { name: "Codex", email: "noreply@codex.openai.com" },
+      } as WorktreeChanges,
+    };
+    const { container } = renderSection({ worktree, hasChanges: false });
+
+    expect(container.querySelector("svg")).toBeTruthy();
     const imgs = container.querySelectorAll("img");
     const gravatarImg = Array.from(imgs).find((el) =>
       el.getAttribute("src")?.includes("gravatar.com")
@@ -462,13 +446,12 @@ describe("WorktreeDetailsSection commit author chip", () => {
     expect(gravatarImg).toBeFalsy();
   });
 
-  it("omits commit chip when lastCommitTimestampMs is absent", () => {
+  it("omits the trailing chip entirely when lastCommitTimestampMs is absent", () => {
     const worktree = { ...baseWorktree, lastActivityTimestamp: Date.now() };
-    renderSection({ worktree, hasChanges: false });
+    const { container } = renderSection({ worktree, hasChanges: false });
 
-    // Activity indicator should be visible but no commit author chip
-    expect(screen.getByText("now")).toBeDefined();
-    // "No activity" should NOT appear since there is activity
     expect(screen.queryByText("No activity")).toBeNull();
+    expect(screen.queryByLabelText(/Last commit/)).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
   });
 });

--- a/src/config/categoryColors.ts
+++ b/src/config/categoryColors.ts
@@ -26,6 +26,28 @@ export const ACTION_CATEGORY_COLORS: Record<string, string> = {
 export const ACTION_CATEGORY_DEFAULT_COLOR = "bg-tint/[0.06] text-daintree-text/50";
 
 /**
+ * The 12 --color-cat-* hue tokens as complete Tailwind class literals.
+ * Listed in full here (not assembled from parts) so the JIT scanner keeps
+ * every variant; consumers index into this array via a deterministic hash to
+ * give an entity a stable colour (e.g. initials avatars). `/15` tint matches
+ * the action/event chip treatment so the palette stays visually consistent.
+ */
+export const CAT_COLOR_CLASSES: readonly string[] = [
+  "bg-cat-blue/15 text-cat-blue",
+  "bg-cat-purple/15 text-cat-purple",
+  "bg-cat-cyan/15 text-cat-cyan",
+  "bg-cat-green/15 text-cat-green",
+  "bg-cat-amber/15 text-cat-amber",
+  "bg-cat-orange/15 text-cat-orange",
+  "bg-cat-teal/15 text-cat-teal",
+  "bg-cat-indigo/15 text-cat-indigo",
+  "bg-cat-rose/15 text-cat-rose",
+  "bg-cat-pink/15 text-cat-pink",
+  "bg-cat-violet/15 text-cat-violet",
+  "bg-cat-slate/15 text-cat-slate",
+];
+
+/**
  * Event inspector category chip styles.
  * Uses the same --color-cat-* hue tokens as action palette, assigned independently
  * to the event domain (system events ≠ system actions).

--- a/src/utils/__tests__/gravatar.test.ts
+++ b/src/utils/__tests__/gravatar.test.ts
@@ -8,7 +8,7 @@ describe("getGravatarUrl", () => {
   it("returns a gravatar URL with the expected hash for a known email", () => {
     const url = getGravatarUrl("MyEmailAddress@example.com", 32);
     expect(url).toContain("https://www.gravatar.com/avatar/");
-    expect(url).toContain("?s=32&d=mp");
+    expect(url).toContain("?s=32&d=404");
     // SHA-256 of "myemailaddress@example.com"
     const hash = url.split("/").pop()!.split("?")[0];
     expect(hash).toBe("84059b07d4be67b806386c0aad8070a23f18836bbaae342275dc0a83414c32ee");
@@ -17,7 +17,7 @@ describe("getGravatarUrl", () => {
   it("returns fallback hash for empty email", () => {
     const url = getGravatarUrl("", 16);
     expect(url).toContain("00000000000000000000000000000000");
-    expect(url).toContain("?s=16&d=mp");
+    expect(url).toContain("?s=16&d=404");
   });
 
   it("trims whitespace and lowercases", () => {
@@ -28,7 +28,7 @@ describe("getGravatarUrl", () => {
 
   it("includes the size parameter", () => {
     const url = getGravatarUrl("a@b.com", 80);
-    expect(url).toContain("?s=80&d=mp");
+    expect(url).toContain("?s=80&d=404");
   });
 });
 

--- a/src/utils/gravatar.ts
+++ b/src/utils/gravatar.ts
@@ -155,11 +155,14 @@ function rr(x: number, n: number): number {
   return (x >>> n) | (x << (32 - n));
 }
 
+// `d=404` — Gravatar returns HTTP 404 (not a generic identicon) when the email
+// has no custom image, so the avatar chain can fall through to coloured
+// initials instead of ever painting a meaningless geometric placeholder.
 export function getGravatarUrl(email: string, size: number): string {
   const trimmed = email.trim().toLowerCase();
-  if (!trimmed) return `${GRAVATAR_BASE}/00000000000000000000000000000000?s=${size}&d=mp`;
+  if (!trimmed) return `${GRAVATAR_BASE}/00000000000000000000000000000000?s=${size}&d=404`;
   const hash = sha256hex(trimmed);
-  return `${GRAVATAR_BASE}/${hash}?s=${size}&d=mp`;
+  return `${GRAVATAR_BASE}/${hash}?s=${size}&d=404`;
 }
 
 export function isBotAuthor(name: string): boolean {


### PR DESCRIPTION
## Summary

- Collapses the two adjacent trailing chips in the worktree sidebar row (gravatar + commit time, `ActivityLight` + activity time) into a single `CommitChip` component. On clean trees these chips rendered identical labels (`4m · 4m`), which was structural noise, not signal.
- `CommitChip` uses tiered identity resolution: agent icon via email registry match → reserved `forgeAvatarUrl` seat → Gravatar with `d=404` probe (no generic identicons ever reach the UI) → deterministic coloured initials hashed from `author.email`. Single tooltip combining commit subject, author name, and exact datetime.
- `getGravatarUrl` now appends `d=404`. `CAT_COLOR_CLASSES` exported from `categoryColors.ts` for JIT-safe initials hue. `https://www.gravatar.com` added to renderer `img-src` CSP. `ActivityLight` removed from this row only — the component itself is untouched.

Resolves #8513

## Changes

- `src/components/Worktree/WorktreeCard/CommitChip.tsx` — new self-contained component with the tiered avatar and combined tooltip
- `src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx` — replaced the two trailing chips with `CommitChip`
- `src/config/categoryColors.ts` — export `CAT_COLOR_CLASSES` for JIT-safe Tailwind colour lookup
- `src/utils/gravatar.ts` — `getGravatarUrl` appends `d=404`; `d` param exposed via options
- `shared/config/csp.ts` — `https://www.gravatar.com` added to `img-src`
- `src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx` — updated assertions to match new chip structure
- `src/utils/__tests__/gravatar.test.ts` — updated to cover `d=404` default

## Testing

- 31 vitest tests covering `CommitChip` identity resolution tiers (agent match, forge URL seat, Gravatar probe, initials fallback, missing-author fallback), tooltip content, and aria contracts
- `npm run check` clean — no errors, no new warnings