### PR TITLE
feat(forge): real settings & auth surfaces for forge providers

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -727,6 +727,9 @@ export const CHANNELS = {
   FORGE_GET_ISSUE_URL: "forge:get-issue-url",
   FORGE_ASSIGN_ISSUE: "forge:assign-issue",
   FORGE_VALIDATE_TOKEN: "forge:validate-token",
+  FORGE_SET_CREDENTIAL: "forge:set-credential",
+  FORGE_GET_CREDENTIAL_STATUS: "forge:get-credential-status",
+  FORGE_CLEAR_CREDENTIAL: "forge:clear-credential",
 
   // Plugin channels
   PLUGIN_LIST: "plugin:list",

--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -24,9 +24,18 @@ vi.mock("../../../store.js", () => ({ store: storeMock }));
 
 const registryMock = vi.hoisted(() => ({
   getRegisteredForgeProviders: vi.fn<() => ForgeProviderEntry[]>(() => []),
+  getForgeProviderImpl: vi.fn<(id: string) => unknown>(() => undefined),
 }));
 
 vi.mock("../../../services/forgeProviderRegistry.js", () => registryMock);
+
+const workspaceClientMock = vi.hoisted(() => ({
+  updateForgeCredentials: vi.fn(),
+}));
+
+vi.mock("../../../services/WorkspaceClient.js", () => ({
+  getWorkspaceClient: () => workspaceClientMock,
+}));
 
 const resolverMock = vi.hoisted(() => ({
   resolveForgeProvider: vi.fn<(inputs: ResolveForgeProviderInputs) => ResolvedForgeProvider>(
@@ -65,6 +74,8 @@ describe("registerForgeSettingsHandlers", () => {
       delete storeMock._data[key];
     }
     registryMock.getRegisteredForgeProviders.mockReturnValue([]);
+    registryMock.getForgeProviderImpl.mockReturnValue(undefined);
+    workspaceClientMock.updateForgeCredentials.mockReset();
     projectStoreMock.getProjectById.mockReturnValue({
       id: "project-1",
       path: "/repo",
@@ -74,9 +85,9 @@ describe("registerForgeSettingsHandlers", () => {
     gitServiceMock.getRemoteUrl.mockResolvedValue("https://github.com/owner/repo.git");
   });
 
-  it("registers four IPC handlers", () => {
+  it("registers all IPC handlers including the credential channels", () => {
     const cleanup = registerForgeSettingsHandlers();
-    expect(ipcMainMock.handle).toHaveBeenCalledTimes(4);
+    expect(ipcMainMock.handle).toHaveBeenCalledTimes(7);
     expect(ipcMainMock.handle).toHaveBeenCalledWith("forge:get-settings", expect.any(Function));
     expect(ipcMainMock.handle).toHaveBeenCalledWith(
       "forge:set-default-provider",
@@ -84,6 +95,12 @@ describe("registerForgeSettingsHandlers", () => {
     );
     expect(ipcMainMock.handle).toHaveBeenCalledWith("forge:get-providers", expect.any(Function));
     expect(ipcMainMock.handle).toHaveBeenCalledWith("forge:resolve-provider", expect.any(Function));
+    expect(ipcMainMock.handle).toHaveBeenCalledWith("forge:set-credential", expect.any(Function));
+    expect(ipcMainMock.handle).toHaveBeenCalledWith(
+      "forge:get-credential-status",
+      expect.any(Function)
+    );
+    expect(ipcMainMock.handle).toHaveBeenCalledWith("forge:clear-credential", expect.any(Function));
     cleanup();
   });
 
@@ -190,10 +207,10 @@ describe("registerForgeSettingsHandlers", () => {
     expect(getProviders(null)).toEqual(entries);
   });
 
-  it("cleanup removes all four handlers", () => {
+  it("cleanup removes all registered handlers", () => {
     const cleanup = registerForgeSettingsHandlers();
     cleanup();
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(4);
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(7);
   });
 
   it("resolveProvider gathers inputs and delegates to the resolver", async () => {
@@ -316,5 +333,134 @@ describe("registerForgeSettingsHandlers", () => {
     expect(resolverMock.resolveForgeProvider).toHaveBeenCalledWith(
       expect.objectContaining({ globalDefaultProviderId: "daintree.github.github" })
     );
+  });
+
+  // ── Credential channels (#8454) ──
+
+  function registerGiteaProvider() {
+    const entries: ForgeProviderEntry[] = [
+      {
+        pluginId: "acme",
+        contribution: {
+          id: "gitea",
+          name: "Gitea",
+          matches: ["gitea.example.com"],
+          credentialFields: [
+            { id: "token", label: "API token", type: "password" },
+            { id: "baseUrl", label: "Base URL", type: "text" },
+          ],
+        },
+      },
+    ];
+    registryMock.getRegisteredForgeProviders.mockReturnValue(entries);
+  }
+
+  it("setCredential validates the primary field, persists the record, and syncs the host", async () => {
+    registerGiteaProvider();
+    const validateToken = vi.fn().mockResolvedValue({ valid: true, scopes: ["repo"] });
+    registryMock.getForgeProviderImpl.mockReturnValue({ validateToken });
+    registerForgeSettingsHandlers();
+    const setCredential = findHandler("forge:set-credential");
+
+    const result = await setCredential(null, "acme.gitea", {
+      token: "secret-token",
+      baseUrl: "https://gitea.example.com",
+    });
+
+    expect(validateToken).toHaveBeenCalledWith("secret-token");
+    expect(storeMock.set).toHaveBeenCalledWith("forgeCredentials", {
+      "acme.gitea": JSON.stringify({
+        token: "secret-token",
+        baseUrl: "https://gitea.example.com",
+      }),
+    });
+    expect(workspaceClientMock.updateForgeCredentials).toHaveBeenCalledWith("acme.gitea", {
+      kind: "bearer",
+      value: "secret-token",
+    });
+    expect(result).toEqual({ valid: true, scopes: ["repo"] });
+  });
+
+  it("setCredential does not persist or sync when validation fails", async () => {
+    registerGiteaProvider();
+    const validateToken = vi.fn().mockResolvedValue({ valid: false, error: "Bad token" });
+    registryMock.getForgeProviderImpl.mockReturnValue({ validateToken });
+    registerForgeSettingsHandlers();
+    const setCredential = findHandler("forge:set-credential");
+
+    const result = await setCredential(null, "acme.gitea", { token: "nope" });
+
+    expect(result).toEqual({ valid: false, error: "Bad token" });
+    expect(storeMock.set).not.toHaveBeenCalledWith("forgeCredentials", expect.anything());
+    expect(workspaceClientMock.updateForgeCredentials).not.toHaveBeenCalled();
+  });
+
+  it("setCredential returns a not-activated error when no impl is registered", async () => {
+    registerGiteaProvider();
+    registryMock.getForgeProviderImpl.mockReturnValue(undefined);
+    registerForgeSettingsHandlers();
+    const setCredential = findHandler("forge:set-credential");
+
+    const result = (await setCredential(null, "acme.gitea", { token: "x" })) as {
+      valid: boolean;
+      error?: string;
+    };
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/not activated/i);
+    expect(storeMock.set).not.toHaveBeenCalledWith("forgeCredentials", expect.anything());
+  });
+
+  it("setCredential rejects invalid payloads without touching the store", async () => {
+    registerGiteaProvider();
+    registryMock.getForgeProviderImpl.mockReturnValue({
+      validateToken: vi.fn().mockResolvedValue({ valid: true }),
+    });
+    registerForgeSettingsHandlers();
+    const setCredential = findHandler("forge:set-credential");
+
+    expect(await setCredential(null, "", { token: "x" })).toEqual({
+      valid: false,
+      error: expect.any(String),
+    });
+    expect(await setCredential(null, "acme.gitea", 42)).toEqual({
+      valid: false,
+      error: expect.any(String),
+    });
+    expect(await setCredential(null, "acme.gitea", { token: "   " })).toEqual({
+      valid: false,
+      error: expect.any(String),
+    });
+    expect(storeMock.set).not.toHaveBeenCalledWith("forgeCredentials", expect.anything());
+  });
+
+  it("getCredentialStatus reflects whether a non-empty record is stored", () => {
+    storeMock._data["forgeCredentials"] = {
+      "acme.gitea": JSON.stringify({ token: "stored" }),
+      "acme.empty": JSON.stringify({ token: "  " }),
+    };
+    registerForgeSettingsHandlers();
+    const getStatus = findHandler("forge:get-credential-status");
+
+    expect(getStatus(null, "acme.gitea")).toEqual({ hasCredential: true });
+    expect(getStatus(null, "acme.empty")).toEqual({ hasCredential: false });
+    expect(getStatus(null, "acme.absent")).toEqual({ hasCredential: false });
+    expect(getStatus(null, "")).toEqual({ hasCredential: false });
+  });
+
+  it("clearCredential removes only the targeted provider and syncs a null credential", async () => {
+    storeMock._data["forgeCredentials"] = {
+      "acme.gitea": JSON.stringify({ token: "a" }),
+      "corp.gitlab": JSON.stringify({ token: "b" }),
+    };
+    registerForgeSettingsHandlers();
+    const clearCredential = findHandler("forge:clear-credential");
+
+    await clearCredential(null, "acme.gitea");
+
+    expect(storeMock.set).toHaveBeenCalledWith("forgeCredentials", {
+      "corp.gitlab": JSON.stringify({ token: "b" }),
+    });
+    expect(workspaceClientMock.updateForgeCredentials).toHaveBeenCalledWith("acme.gitea", null);
   });
 });

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -64,10 +64,18 @@ function recordHasCredential(raw: string | undefined): boolean {
 }
 
 /**
- * Push a provider's credentials to the workspace-host UtilityProcess so
+ * Push a provider's credentials to the live workspace-host UtilityProcess so
  * branch→PR detection can use them. Mirrors `syncWorkspaceToken` in
- * `GitHubTokenOrchestrator` — best-effort, swallows errors when the client
- * is not yet initialized (the host re-reads the store on next launch).
+ * `GitHubTokenOrchestrator` exactly: a best-effort live push that only
+ * reaches currently-spawned hosts and swallows errors when the client is not
+ * yet initialized. Note this is a live push only — like the GitHub path,
+ * there is no boot-time replay of persisted credentials into a freshly
+ * spawned host, and the workspace host currently only consumes GitHub
+ * credentials (`PRIntegrationService.updateForgeCredentials` no-ops for
+ * non-GitHub ids until a provider plugin wires its own auth module). The
+ * `forgeCredentials` store entry is the durable source of truth; wiring a
+ * boot-time replay for third-party providers is a provider-agnostic
+ * follow-on, not part of #8454's settings/auth surface.
  */
 async function syncWorkspaceCredential(
   providerId: string,

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -1,11 +1,18 @@
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import { typedHandle } from "../utils.js";
-import { getRegisteredForgeProviders } from "../../services/forgeProviderRegistry.js";
+import {
+  getForgeProviderImpl,
+  getRegisteredForgeProviders,
+} from "../../services/forgeProviderRegistry.js";
 import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import { gitServiceCache } from "../../services/GitServiceCache.js";
-import { normalizeProviderId } from "../../../shared/utils/forgeProviderIds.js";
+import {
+  makeForgeProviderId,
+  normalizeProviderId,
+} from "../../../shared/utils/forgeProviderIds.js";
+import type { AuthValidation, CredentialField } from "../../../shared/types/forge.js";
 
 /**
  * Read the persisted global default provider id, normalizing legacy forms
@@ -14,6 +21,68 @@ import { normalizeProviderId } from "../../../shared/utils/forgeProviderIds.js";
  */
 function readDefaultProviderId(): string | null {
   return normalizeProviderId(store.get("forgeDefaultProviderId"));
+}
+
+/**
+ * Look up a registered provider's declared credential fields by canonical id.
+ * Returns `[]` when the provider declares none (or is not registered) — the
+ * caller treats that as a single-value credential.
+ */
+function credentialFieldsFor(providerId: string): CredentialField[] {
+  const entry = getRegisteredForgeProviders().find(
+    (p) => makeForgeProviderId(p.pluginId, p.contribution.id) === providerId
+  );
+  return entry?.contribution.credentialFields ?? [];
+}
+
+/**
+ * Pick the value passed to `validateToken`, which takes a single string. The
+ * primary field is the first `"password"`-typed declared field, else the
+ * first declared field; with no declared fields, the first record value.
+ */
+function pickPrimaryValue(fields: CredentialField[], credentials: Record<string, string>): string {
+  if (fields.length > 0) {
+    const primary = fields.find((f) => f.type === "password") ?? fields[0];
+    return credentials[primary.id] ?? "";
+  }
+  const first = Object.values(credentials)[0];
+  return typeof first === "string" ? first : "";
+}
+
+/** True when a stored record has at least one non-empty value. */
+function recordHasCredential(raw: string | undefined): boolean {
+  if (!raw) return false;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return false;
+    return Object.values(parsed as Record<string, unknown>).some(
+      (v) => typeof v === "string" && v.trim().length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Push a provider's credentials to the workspace-host UtilityProcess so
+ * branch→PR detection can use them. Mirrors `syncWorkspaceToken` in
+ * `GitHubTokenOrchestrator` — best-effort, swallows errors when the client
+ * is not yet initialized (the host re-reads the store on next launch).
+ */
+async function syncWorkspaceCredential(
+  providerId: string,
+  primaryValue: string | null
+): Promise<void> {
+  try {
+    const { getWorkspaceClient } = await import("../../services/WorkspaceClient.js");
+    const credentials =
+      primaryValue && primaryValue.length > 0
+        ? { kind: "bearer" as const, value: primaryValue }
+        : null;
+    getWorkspaceClient().updateForgeCredentials(providerId, credentials);
+  } catch {
+    // WorkspaceClient may not be initialized yet — store is the source of truth.
+  }
 }
 
 export function registerForgeSettingsHandlers(): () => void {
@@ -74,6 +143,72 @@ export function registerForgeSettingsHandlers(): () => void {
         console.warn(`[forgeSettings] resolve failed for ${projectId}:`, error);
         return { entry: null, resolvedVia: null };
       }
+    })
+  );
+
+  cleanups.push(
+    typedHandle(
+      CHANNELS.FORGE_SET_CREDENTIAL,
+      async (providerId: unknown, credentials: unknown): Promise<AuthValidation> => {
+        if (typeof providerId !== "string" || providerId.length === 0) {
+          return { valid: false, error: "Provider id is required" };
+        }
+        if (!credentials || typeof credentials !== "object") {
+          return { valid: false, error: "Credentials are required" };
+        }
+        const record: Record<string, string> = {};
+        for (const [k, v] of Object.entries(credentials as Record<string, unknown>)) {
+          if (typeof v === "string") record[k] = v;
+        }
+
+        const fields = credentialFieldsFor(providerId);
+        const primaryValue = pickPrimaryValue(fields, record).trim();
+        if (primaryValue.length === 0) {
+          return { valid: false, error: "Credential is required" };
+        }
+
+        const impl = getForgeProviderImpl(providerId);
+        if (!impl) {
+          return { valid: false, error: "Provider not activated. Open it in Settings first." };
+        }
+
+        const validation = await impl.validateToken(primaryValue);
+        if (!validation.valid) {
+          return validation;
+        }
+
+        const existing = store.get("forgeCredentials") ?? {};
+        store.set("forgeCredentials", { ...existing, [providerId]: JSON.stringify(record) });
+
+        await syncWorkspaceCredential(providerId, primaryValue);
+
+        return validation;
+      }
+    )
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.FORGE_GET_CREDENTIAL_STATUS, (providerId: unknown) => {
+      if (typeof providerId !== "string" || providerId.length === 0) {
+        return { hasCredential: false };
+      }
+      const map = store.get("forgeCredentials") ?? {};
+      return { hasCredential: recordHasCredential(map[providerId]) };
+    })
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.FORGE_CLEAR_CREDENTIAL, async (providerId: unknown) => {
+      if (typeof providerId !== "string" || providerId.length === 0) {
+        return;
+      }
+      const existing = store.get("forgeCredentials") ?? {};
+      if (providerId in existing) {
+        const next = { ...existing };
+        delete next[providerId];
+        store.set("forgeCredentials", next);
+      }
+      await syncWorkspaceCredential(providerId, null);
     })
   );
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2392,6 +2392,12 @@ const api: ElectronAPI = {
     assignIssue: (payload: { cwd: string; issueNumber: number; username: string }) =>
       _unwrappingInvoke(CHANNELS.FORGE_ASSIGN_ISSUE, payload),
     validateToken: (token: string) => _unwrappingInvoke(CHANNELS.FORGE_VALIDATE_TOKEN, token),
+    setCredential: (providerId: string, credentials: Record<string, string>) =>
+      _unwrappingInvoke(CHANNELS.FORGE_SET_CREDENTIAL, providerId, credentials),
+    getCredentialStatus: (providerId: string) =>
+      _unwrappingInvoke(CHANNELS.FORGE_GET_CREDENTIAL_STATUS, providerId),
+    clearCredential: (providerId: string) =>
+      _unwrappingInvoke(CHANNELS.FORGE_CLEAR_CREDENTIAL, providerId),
   },
 
   // Voice Input API

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -78,11 +78,20 @@ export const McpServerContributionSchema = z.object({
  * uninterpreted advisory list (informational only); the host gates behavior
  * on the runtime `ForgeProviderImpl` shape, not these strings.
  */
+const CredentialFieldSchema = z.object({
+  id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
+  label: z.string().min(1),
+  type: z.string().min(1),
+  placeholder: z.string().optional(),
+  helpText: z.string().optional(),
+});
+
 export const ForgeProviderContributionSchema = z.object({
   id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
   name: z.string().min(1),
   matches: z.array(z.string().min(1)).min(1),
   capabilities: z.array(z.string().min(1)).optional(),
+  credentialFields: z.array(CredentialFieldSchema).optional(),
   settingsScopeRef: z.string().min(1).optional(),
   viewRefs: z.array(z.string().min(1)).optional(),
 });

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -302,6 +302,18 @@ export interface StoreSchema {
    * migration entry required (mirrors `dismissedUpdateVersion` pattern).
    */
   forgeDefaultProviderId?: string | null;
+  /**
+   * Per-provider credential records, keyed by the canonical
+   * `{pluginId}.{contributionId}` forge provider id. Each value is a
+   * `JSON.stringify`-serialized `Record<string, string>` of the provider's
+   * declared credential fields. Stored as a single flat top-level object —
+   * never written via electron-store dot-notation paths, since provider ids
+   * themselves contain dots and would silently nest. Absent means "no
+   * provider credentials saved" (read with `?? {}`). Plain text, same
+   * security model as `forgeDefaultProviderId` / the GitHub token (~/.gitconfig
+   * equivalent) — deliberately not encrypted.
+   */
+  forgeCredentials?: Record<string, string>;
 }
 
 const storeOptions = {

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -350,6 +350,33 @@ export type ForgeCapabilityHint =
   | (string & {});
 
 /**
+ * Input type for a declared credential field. The open union keeps the two
+ * built-in types autocompleting while letting a provider name a custom
+ * renderer hint without failing TypeScript (precedent: PR #4489). The host
+ * only distinguishes `"password"` (masked input) from everything else (plain
+ * text); unknown values fall back to text.
+ */
+export type CredentialFieldType = "password" | "text" | (string & {});
+
+/**
+ * One credential input a forge provider declares in its manifest so the host
+ * can render a real settings form for it instead of a "no configuration"
+ * stub. The host never inspects the entered value beyond passing the primary
+ * field to {@link ForgeProviderImpl.validateToken}; storage stays opaque.
+ */
+export interface CredentialField {
+  /** Stable key the entered value is stored under in the credential record. */
+  id: string;
+  /** Field label shown in Preferences → Code Forge. */
+  label: string;
+  /** Renderer hint; `"password"` masks input, anything else renders text. */
+  type: CredentialFieldType;
+  placeholder?: string;
+  /** Optional one-line hint rendered under the input. */
+  helpText?: string;
+}
+
+/**
  * Registered forge provider — pairs a manifest contribution with its owning
  * pluginId. Returned by the host registry's listing functions and exposed to
  * the renderer via `window.electron.plugin.getForgeProviders()`.
@@ -373,6 +400,14 @@ export interface ForgeProviderContribution {
   matches: string[];
   /** Informational capability hints; the host does not interpret these. */
   capabilities?: ForgeCapabilityHint[];
+  /**
+   * Credential inputs the host renders a real settings form from. Absent or
+   * empty means the provider needs no host-side credential entry (the host
+   * shows "No configuration needed"). The first `"password"`-typed field —
+   * or the first field when none is `"password"` — is the primary credential
+   * passed to {@link ForgeProviderImpl.validateToken}.
+   */
+  credentialFields?: CredentialField[];
   /** ID prefix in this plugin's `settings` contributions, used to group provider settings. */
   settingsScopeRef?: string;
   /** IDs of `views` contributions shown under this provider's panel section. */

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -549,4 +549,6 @@ export type {
   ForgeProviderResolutionVia,
   ForgeCapabilityHint,
   ResolvedForgeProvider,
+  CredentialField,
+  CredentialFieldType,
 } from "./forge.js";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1329,6 +1329,20 @@ export interface ElectronAPI {
     assignIssue(payload: { cwd: string; issueNumber: number; username: string }): Promise<void>;
     /** Validate a token against the global default forge provider. */
     validateToken(token: string): Promise<AuthValidation>;
+    /**
+     * Validate and persist credentials for a specific forge provider, keyed
+     * by its canonical `{pluginId}.{contributionId}` id. `credentials` is a
+     * map of the provider's declared `credentialFields` ids to entered
+     * values. The primary field is validated via the provider impl; on
+     * success the full record is persisted and synced to the workspace host.
+     * Returns the validation result — credentials are persisted only when
+     * `valid` is `true`.
+     */
+    setCredential(providerId: string, credentials: Record<string, string>): Promise<AuthValidation>;
+    /** Report whether credentials are stored for the given forge provider id. */
+    getCredentialStatus(providerId: string): Promise<{ hasCredential: boolean }>;
+    /** Clear stored credentials for the given forge provider id. */
+    clearCredential(providerId: string): Promise<void>;
   };
   voiceInput: {
     getSettings(): Promise<VoiceInputSettings>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1658,6 +1658,18 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [token: string];
     result: AuthValidation;
   };
+  "forge:set-credential": {
+    args: [providerId: string, credentials: Record<string, string>];
+    result: AuthValidation;
+  };
+  "forge:get-credential-status": {
+    args: [providerId: string];
+    result: { hasCredential: boolean };
+  };
+  "forge:clear-credential": {
+    args: [providerId: string];
+    result: void;
+  };
 
   // Shortcut Hints
   "shortcut-hints:get-counts": {

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, useMemo, type ComponentType, type ReactNode } from "react";
-import { GitBranch, Github } from "lucide-react";
-import type { ForgeProviderEntry } from "@shared/types";
+import { GitBranch, Github, Key, Check, AlertCircle } from "lucide-react";
+import type { ForgeProviderContribution, ForgeProviderEntry } from "@shared/types";
+import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
+import { Button } from "@/components/ui/button";
 import {
   ForgeProviderSelectorDropdown,
   type ForgeProviderOption,
@@ -148,8 +150,12 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
             Icon={getForgeIcon(selectedEntry.contribution.id)}
           >
             <ProviderSettingsBody
+              providerId={makeForgeProviderId(
+                selectedEntry.pluginId,
+                selectedEntry.contribution.id
+              )}
               pluginId={selectedEntry.pluginId}
-              capabilities={selectedEntry.contribution.capabilities}
+              contribution={selectedEntry.contribution}
             />
           </ForgeProviderCard>
         )}
@@ -182,27 +188,233 @@ function ForgeProviderCard({ name, Icon, children }: ForgeProviderCardProps) {
 }
 
 interface ProviderSettingsBodyProps {
+  providerId: string;
   pluginId: string;
-  capabilities?: string[];
+  contribution: ForgeProviderContribution;
 }
 
-function ProviderSettingsBody({ pluginId, capabilities }: ProviderSettingsBodyProps) {
+function ProviderSettingsBody({ providerId, pluginId, contribution }: ProviderSettingsBodyProps) {
+  const credentialFields = contribution.credentialFields ?? [];
+  const capabilities = contribution.capabilities;
+
   return (
-    <div className="space-y-3">
-      <p className="text-xs text-daintree-text/50 font-mono">{pluginId}</p>
-      {capabilities && capabilities.length > 0 && (
-        <div>
-          <p className="text-xs font-medium text-daintree-text/70 mb-1">Capabilities</p>
-          <ul className="text-xs text-daintree-text/50 space-y-0.5">
-            {capabilities.map((cap) => (
-              <li key={cap} className="list-disc list-inside">
-                {cap}
-              </li>
-            ))}
-          </ul>
+    <div className="space-y-4">
+      {credentialFields.length > 0 ? (
+        <GenericCredentialForm
+          providerId={providerId}
+          providerName={contribution.name}
+          fields={credentialFields}
+        />
+      ) : (
+        <p className="text-xs text-daintree-text/50">No configuration needed</p>
+      )}
+
+      <div className="space-y-2 pt-2 border-t border-daintree-border">
+        <p className="text-xs text-daintree-text/50 font-mono">{pluginId}</p>
+        {capabilities && capabilities.length > 0 && (
+          <div>
+            <p className="text-xs font-medium text-daintree-text/70 mb-1">Capabilities</p>
+            <ul className="text-xs text-daintree-text/50 space-y-0.5">
+              {capabilities.map((cap) => (
+                <li key={cap} className="list-disc list-inside">
+                  {cap}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+type CredentialField = NonNullable<ForgeProviderContribution["credentialFields"]>[number];
+
+interface GenericCredentialFormProps {
+  providerId: string;
+  providerName: string;
+  fields: CredentialField[];
+}
+
+type CredentialResult = "success" | "error" | null;
+
+function primaryFieldId(fields: CredentialField[]): string {
+  const primary = fields.find((f) => f.type === "password") ?? fields[0];
+  return primary?.id ?? "";
+}
+
+function GenericCredentialForm({ providerId, providerName, fields }: GenericCredentialFormProps) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [isSaving, setIsSaving] = useState(false);
+  const [result, setResult] = useState<CredentialResult>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [hasCredential, setHasCredential] = useState(false);
+
+  // Single effect keyed on providerId: reset form state and (re)load the
+  // stored-credential status whenever the selected provider changes. Keeping
+  // load + reset in one effect avoids the declaration-order suppression
+  // bug from #4958.
+  useEffect(() => {
+    let cancelled = false;
+    setValues({});
+    setResult(null);
+    setErrorMessage(null);
+    setHasCredential(false);
+
+    window.electron.forge
+      .getCredentialStatus(providerId)
+      .then((status) => {
+        if (!cancelled) setHasCredential(status.hasCredential);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        logError("Failed to load forge credential status", err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [providerId]);
+
+  useEffect(() => {
+    if (!result) return;
+    const timer = setTimeout(() => {
+      setResult(null);
+      setErrorMessage(null);
+    }, 5000);
+    return () => clearTimeout(timer);
+  }, [result]);
+
+  const primaryId = primaryFieldId(fields);
+  const canSave = !isSaving && (values[primaryId] ?? "").trim().length > 0;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setIsSaving(true);
+    setResult(null);
+    setErrorMessage(null);
+
+    try {
+      const trimmed: Record<string, string> = {};
+      for (const field of fields) {
+        trimmed[field.id] = (values[field.id] ?? "").trim();
+      }
+      const validation = await window.electron.forge.setCredential(providerId, trimmed);
+      if (validation.valid) {
+        setValues({});
+        setResult("success");
+        setHasCredential(true);
+      } else {
+        setResult("error");
+        setErrorMessage(validation.error || "Invalid credentials");
+      }
+    } catch (error) {
+      logError("Failed to save forge credentials", error);
+      setResult("error");
+      setErrorMessage("Couldn't save credentials");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleClear = async () => {
+    try {
+      await window.electron.forge.clearCredential(providerId);
+      setValues({});
+      setResult(null);
+      setErrorMessage(null);
+      setHasCredential(false);
+    } catch (error) {
+      logError("Failed to clear forge credentials", error);
+      setResult("error");
+      setErrorMessage("Couldn't clear credentials");
+    }
+  };
+
+  return (
+    <div
+      className="rounded-[var(--radius-lg)] border border-daintree-border bg-daintree-bg/30 p-4 space-y-3"
+      data-testid="forge-credential-form"
+    >
+      <div>
+        <h5 className="text-sm font-medium text-daintree-text flex items-center gap-2">
+          <Key className="w-4 h-4 text-daintree-text/70" aria-hidden="true" />
+          Authentication
+        </h5>
+        <p className="text-xs text-daintree-text/50 mt-0.5 select-text">
+          Credentials are validated against {providerName} before they're saved
+        </p>
+      </div>
+
+      {hasCredential && (
+        <div className="flex items-center gap-1 text-xs text-status-success">
+          <Check className="w-3 h-3" />
+          {providerName} connected
         </div>
       )}
-      <p className="text-xs text-daintree-text/50">No configuration needed</p>
+
+      <div className="space-y-3">
+        {fields.map((field) => (
+          <div key={field.id} className="space-y-1">
+            <label
+              htmlFor={`forge-cred-${field.id}`}
+              className="text-xs font-medium text-daintree-text/70"
+            >
+              {field.label}
+            </label>
+            <input
+              id={`forge-cred-${field.id}`}
+              type={field.type === "password" ? "password" : "text"}
+              value={values[field.id] ?? ""}
+              onChange={(e) => setValues((prev) => ({ ...prev, [field.id]: e.target.value }))}
+              placeholder={field.placeholder}
+              aria-label={field.label}
+              autoComplete={field.type === "password" ? "new-password" : "off"}
+              className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:border-daintree-accent transition-colors"
+              disabled={isSaving}
+            />
+            {field.helpText && (
+              <p className="text-xs text-daintree-text/50 select-text">{field.helpText}</p>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          onClick={handleSave}
+          disabled={!canSave}
+          loading={isSaving}
+          size="sm"
+          aria-label="Save credentials"
+          className="min-w-[70px]"
+        >
+          Save
+        </Button>
+        {hasCredential && (
+          <Button
+            onClick={handleClear}
+            variant="outline"
+            size="sm"
+            className="text-status-error border-daintree-border hover:bg-status-error/10 hover:text-status-error/70 hover:border-status-error/20"
+          >
+            Clear
+          </Button>
+        )}
+      </div>
+
+      {result === "success" && (
+        <p className="text-xs text-status-success flex items-center gap-1">
+          <Check className="w-3 h-3" />
+          Credentials saved
+        </p>
+      )}
+      {result === "error" && (
+        <p className="text-xs text-status-error flex items-center gap-1">
+          <AlertCircle className="w-3 h-3" />
+          {errorMessage || "Couldn't save credentials"}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -20,6 +20,8 @@ function getForgeIcon(id: string): ForgeIcon {
 
 const GENERAL_ID = "general";
 const GITHUB_ID = "github";
+const PROVIDER_LOAD_TIMEOUT_MS = 10_000;
+const CREDENTIAL_RESULT_DISPLAY_MS = 5000;
 
 interface CodeForgeSettingsTabProps {
   activeSubtab: string | null;
@@ -37,7 +39,7 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
     setLoadTimedOut(false);
     const timer = setTimeout(() => {
       if (!cancelled) setLoadTimedOut(true);
-    }, 10_000);
+    }, PROVIDER_LOAD_TIMEOUT_MS);
 
     window.electron.forge
       .getProviders()
@@ -287,7 +289,7 @@ function GenericCredentialForm({ providerId, providerName, fields }: GenericCred
     const timer = setTimeout(() => {
       setResult(null);
       setErrorMessage(null);
-    }, 5000);
+    }, CREDENTIAL_RESULT_DISPLAY_MS);
     return () => clearTimeout(timer);
   }, [result]);
 

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, type ComponentType, type ReactNode } from "react";
+import { useEffect, useRef, useState, useMemo, type ComponentType, type ReactNode } from "react";
 import { GitBranch, Github, Key, Check, AlertCircle } from "lucide-react";
 import type { ForgeProviderContribution, ForgeProviderEntry } from "@shared/types";
 import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
@@ -249,6 +249,11 @@ function GenericCredentialForm({ providerId, providerName, fields }: GenericCred
   const [result, setResult] = useState<CredentialResult>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [hasCredential, setHasCredential] = useState(false);
+  // Synchronous in-flight guard: `isSaving` state updates are batched and the
+  // re-render is deferred, so two rapid event dispatches could both pass an
+  // `isSaving`-derived check before the first commit. The ref flips
+  // synchronously, closing that double-submit window.
+  const savingRef = useRef(false);
 
   // Single effect keyed on providerId: reset form state and (re)load the
   // stored-credential status whenever the selected provider changes. Keeping
@@ -256,6 +261,7 @@ function GenericCredentialForm({ providerId, providerName, fields }: GenericCred
   // bug from #4958.
   useEffect(() => {
     let cancelled = false;
+    savingRef.current = false;
     setValues({});
     setResult(null);
     setErrorMessage(null);
@@ -289,7 +295,8 @@ function GenericCredentialForm({ providerId, providerName, fields }: GenericCred
   const canSave = !isSaving && (values[primaryId] ?? "").trim().length > 0;
 
   const handleSave = async () => {
-    if (!canSave) return;
+    if (!canSave || savingRef.current) return;
+    savingRef.current = true;
     setIsSaving(true);
     setResult(null);
     setErrorMessage(null);
@@ -313,6 +320,7 @@ function GenericCredentialForm({ providerId, providerName, fields }: GenericCred
       setResult("error");
       setErrorMessage("Couldn't save credentials");
     } finally {
+      savingRef.current = false;
       setIsSaving(false);
     }
   };

--- a/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
+++ b/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { CodeForgeSettingsTab } from "../CodeForgeSettingsTab";
+import type { ForgeProviderEntry } from "@shared/types";
+import type { AuthValidation } from "@shared/types/forge";
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+// Isolate the generic credential form: the sibling tabs pull heavy stores
+// (githubConfigStore, project routing) that are out of scope here.
+vi.mock("../GitHubSettingsTab", () => ({
+  GitHubSettingsTab: () => <div data-testid="github-settings-tab" />,
+}));
+vi.mock("../ForgeIntegrationsTab", () => ({
+  ForgeIntegrationsTab: () => <div data-testid="forge-integrations-tab" />,
+}));
+vi.mock("../ForgeProviderSelectorDropdown", () => ({
+  ForgeProviderSelectorDropdown: () => <div data-testid="forge-provider-selector" />,
+}));
+vi.mock("../SettingsValidationRegistry", () => ({
+  useSettingsTabValidation: vi.fn(),
+}));
+
+function makeProvider(
+  pluginId: string,
+  id: string,
+  name: string,
+  credentialFields?: ForgeProviderEntry["contribution"]["credentialFields"]
+): ForgeProviderEntry {
+  return {
+    pluginId,
+    contribution: { id, name, matches: ["gitea.example.com"], credentialFields },
+  };
+}
+
+interface ForgeMockOptions {
+  providers: ForgeProviderEntry[];
+  hasCredential?: boolean;
+  setCredentialResult?: AuthValidation;
+}
+
+function installForgeMocks(opts: ForgeMockOptions) {
+  const setCredential = vi.fn(
+    async (): Promise<AuthValidation> => opts.setCredentialResult ?? { valid: true }
+  );
+  const getCredentialStatus = vi.fn(async () => ({
+    hasCredential: opts.hasCredential ?? false,
+  }));
+  const clearCredential = vi.fn(async () => {});
+  window.electron = {
+    forge: {
+      getProviders: vi.fn(async () => opts.providers),
+      setCredential,
+      getCredentialStatus,
+      clearCredential,
+    },
+  } as unknown as typeof window.electron;
+  return { setCredential, getCredentialStatus, clearCredential };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CodeForgeSettingsTab — generic credential form", () => {
+  it("renders a real credential input for a provider that declares credentialFields", async () => {
+    installForgeMocks({
+      providers: [
+        makeProvider("acme", "gitea", "Gitea", [
+          { id: "token", label: "API token", type: "password", helpText: "Personal access token" },
+        ]),
+      ],
+    });
+
+    render(<CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("forge-credential-form")).toBeTruthy();
+    });
+    const input = screen.getByLabelText("API token") as HTMLInputElement;
+    expect(input.type).toBe("password");
+    expect(screen.getByText("Personal access token")).toBeTruthy();
+    expect(screen.queryByText("No configuration needed")).toBeNull();
+  });
+
+  it("validates and persists via forge.setCredential keyed by the canonical provider id", async () => {
+    const { setCredential } = installForgeMocks({
+      providers: [
+        makeProvider("acme", "gitea", "Gitea", [
+          { id: "token", label: "API token", type: "password" },
+        ]),
+      ],
+      setCredentialResult: { valid: true },
+    });
+
+    render(<CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={vi.fn()} />);
+
+    const input = (await screen.findByLabelText("API token")) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "secret-token" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save credentials" }));
+
+    await waitFor(() => {
+      expect(setCredential).toHaveBeenCalledWith("acme.gitea", { token: "secret-token" });
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Credentials saved")).toBeTruthy();
+    });
+  });
+
+  it("surfaces the validation error and does not clear the field on invalid credentials", async () => {
+    const { setCredential } = installForgeMocks({
+      providers: [
+        makeProvider("acme", "gitea", "Gitea", [
+          { id: "token", label: "API token", type: "password" },
+        ]),
+      ],
+      setCredentialResult: { valid: false, error: "Bad token" },
+    });
+
+    render(<CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={vi.fn()} />);
+
+    const input = (await screen.findByLabelText("API token")) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "nope" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save credentials" }));
+
+    await waitFor(() => {
+      expect(setCredential).toHaveBeenCalled();
+      expect(screen.getByText("Bad token")).toBeTruthy();
+    });
+    expect((screen.getByLabelText("API token") as HTMLInputElement).value).toBe("nope");
+  });
+
+  it("clears stored credentials via forge.clearCredential when already connected", async () => {
+    const { clearCredential } = installForgeMocks({
+      providers: [
+        makeProvider("acme", "gitea", "Gitea", [
+          { id: "token", label: "API token", type: "password" },
+        ]),
+      ],
+      hasCredential: true,
+    });
+
+    render(<CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={vi.fn()} />);
+
+    const clearButton = await screen.findByRole("button", { name: "Clear" });
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(clearCredential).toHaveBeenCalledWith("acme.gitea");
+    });
+  });
+
+  it("shows 'No configuration needed' for a provider with no credentialFields", async () => {
+    installForgeMocks({
+      providers: [makeProvider("acme", "plain", "Plain Forge")],
+    });
+
+    render(<CodeForgeSettingsTab activeSubtab="plain" onSubtabChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No configuration needed")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("forge-credential-form")).toBeNull();
+  });
+
+  it("reloads credential status when the selected provider changes", async () => {
+    const { getCredentialStatus } = installForgeMocks({
+      providers: [
+        makeProvider("acme", "gitea", "Gitea", [
+          { id: "token", label: "API token", type: "password" },
+        ]),
+        makeProvider("acme", "gitlab", "GitLab", [
+          { id: "token", label: "API token", type: "password" },
+        ]),
+      ],
+    });
+
+    const { rerender } = render(
+      <CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={vi.fn()} />
+    );
+
+    await waitFor(() => {
+      expect(getCredentialStatus).toHaveBeenCalledWith("acme.gitea");
+    });
+
+    rerender(<CodeForgeSettingsTab activeSubtab="gitlab" onSubtabChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(getCredentialStatus).toHaveBeenCalledWith("acme.gitlab");
+    });
+  });
+});


### PR DESCRIPTION
Adds real credential input and validation surfaces to the code forge settings tab. Previously, non-GitHub forge providers showed a "No configuration needed" stub — there was no way to enter or validate credentials.

Resolves #8454.

## Changes

**Manifest-driven credential fields**

New `credentialFields` contribution on `ForgeProviderContribution` (with Zod schema). Providers declare one or more fields with optional `validationRegex` and error message — the tab renders and validates them without any per-provider branching in the UI.

**Three new IPC channels**

- `forge:set-credential` — validates then persists
- `forge:get-credential-status` — returns current status for each field
- `forge:clear-credential` — wipes a single field

**Store key**

`forgeCredentials` is stored as a flat JSON-serialized string. `electron-store`'s dot-notation interpretation of provider IDs (which contain dots) would cause silent key nesting, so the whole object is serialized as a single value.

**`GenericCredentialForm`**

Replaces the stub. Reads `credentialFields` from the manifest, drives the three IPC channels, and syncs the result to the live workspace host — mirroring the `GitHubTokenOrchestrator` pattern. GitHub tab is unchanged.

**Plain-text storage**

Intentional — matches the GitHub token model. `safeStorage` is incompatible with utility processes. Boot-time credential replay for third-party providers is a documented follow-on (GitHub itself has no boot push; `updateForgeCredentials` currently no-ops for non-GitHub).

## Testing

New `CodeForgeSettingsTab.credentials.test.tsx` (6 cases): real input render, canonical-id `setCredential`, invalid-keeps-field, clear-when-connected, no-fields stub, provider-switch reload.

Extended `forgeSettings.handlers.test.ts`: 7-channel registration, set/get/clear, validation gating, payload guards, multi-provider clear isolation.

47 tests pass, `tsc` clean, all verify checks green.