### PR TITLE
feat(forge): forge-agnostic commit-author avatar provider system

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -154,6 +154,7 @@ export const CHANNELS = {
   GITHUB_GET_TOKEN_HEALTH: "github:get-token-health",
   GITHUB_REPO_STATS_AND_PAGE_UPDATED: "github:repo-stats-and-page-updated",
   GITHUB_GET_FIRST_PAGE_CACHE: "github:get-first-page-cache",
+  GITHUB_RESOLVE_AUTHOR_AVATAR: "github:resolve-author-avatar",
 
   APP_GET_STATE: "app:get-state",
   APP_SET_STATE: "app:set-state",

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -18,6 +18,7 @@ import {
   gitHubRateLimitService,
   gitHubTokenHealthService,
   fetchRateLimitDetails,
+  resolveAuthorAvatar,
   setTokenAndSync,
   clearTokenAndSync,
 } from "../../services/github/index.js";
@@ -48,6 +49,13 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     return fetchRateLimitDetails();
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_RATE_LIMIT_DETAILS, handleGetRateLimitDetails));
+
+  const handleResolveAuthorAvatar = async (email: string): Promise<string | null> => {
+    checkRateLimit(CHANNELS.GITHUB_RESOLVE_AUTHOR_AVATAR, 30, 60_000);
+    if (typeof email !== "string" || !email.trim()) return null;
+    return resolveAuthorAvatar(email.trim().toLowerCase());
+  };
+  handlers.push(typedHandle(CHANNELS.GITHUB_RESOLVE_AUTHOR_AVATAR, handleResolveAuthorAvatar));
 
   const handleGitHubGetRepoStats = async (
     cwd: string,

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1591,6 +1591,9 @@ const api: ElectronAPI = {
 
     listRemotes: (cwd: string) => _unwrappingInvoke(CHANNELS.GITHUB_LIST_REMOTES, cwd),
 
+    resolveAuthorAvatar: (email: string) =>
+      _unwrappingInvoke(CHANNELS.GITHUB_RESOLVE_AUTHOR_AVATAR, email),
+
     onPRDetected: (callback: (data: PRDetectedPayload) => void) =>
       _typedOn(CHANNELS.PR_DETECTED, callback),
 

--- a/plugins/builtin/github/main/GitHubProfilePicture.ts
+++ b/plugins/builtin/github/main/GitHubProfilePicture.ts
@@ -1,0 +1,135 @@
+import { Cache } from "../../../../electron/utils/cache.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../../shared/utils/forgeProviderIds.js";
+import type { ProfilePictureProvider } from "../../../../shared/types/profilePictureProvider.js";
+import { GitHubAuth, GITHUB_API_TIMEOUT_MS, rateLimitAwareFetch } from "./GitHubAuth.js";
+import { GitHubRateLimitError } from "./GitHubRateLimitService.js";
+
+/**
+ * GitHub {@link ProfilePictureProvider} — resolves a commit-author email to
+ * the author's GitHub avatar URL via the Search Users API (#8514).
+ *
+ * `in:email` only matches users whose email is *public* on their GitHub
+ * profile, so `null` is the common, expected result — callers fall through
+ * to the next avatar tier (Gravatar → initials).
+ *
+ * A TTL cache plus a singleflight map keep the Search API's tight 30 req/min
+ * authenticated bucket safe even when a project has many worktree cards
+ * sharing one committer:
+ *
+ * - `avatarCache` stores resolved URLs *and* genuine `null` misses. Caching
+ *   the miss is deliberate — most emails have no public profile and we must
+ *   not re-hit the API for them every render.
+ * - `inflight` deduplicates concurrent lookups for the same email so 10 cards
+ *   mounting at once issue a single HTTP request, not 10.
+ *
+ * Transient outcomes (no token yet, rate-limited, network/5xx error) resolve
+ * to `null` for the caller but are deliberately *not* cached, so the very
+ * next render retries instead of being pinned to a generic identicon for the
+ * full 3-hour TTL.
+ */
+
+/** A few hours — profile pictures change rarely and the cache is per-process. */
+const AVATAR_CACHE_TTL = 3 * 60 * 60 * 1000;
+const AVATAR_CACHE_MAX_SIZE = 500;
+
+const avatarCache = new Cache<string, string | null>({
+  maxSize: AVATAR_CACHE_MAX_SIZE,
+  defaultTTL: AVATAR_CACHE_TTL,
+});
+
+const inflight = new Map<string, Promise<string | null>>();
+
+/** Sentinel: a transient failure — return `null` to the caller, don't cache. */
+const TRANSIENT = Symbol("transient");
+type FetchOutcome = string | null | typeof TRANSIENT;
+
+interface SearchUsersResponse {
+  items?: Array<{ avatar_url?: unknown }>;
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+async function fetchAvatarByEmail(email: string, signal?: AbortSignal): Promise<FetchOutcome> {
+  const token = GitHubAuth.getToken();
+  // The unauthenticated Search limit (10 req/min) is too tight to be useful.
+  // Without a token we don't open a socket — and we treat it as transient so
+  // a token configured later resolves on the next render.
+  if (!token) return TRANSIENT;
+
+  try {
+    const url = `https://api.github.com/search/users?q=${encodeURIComponent(email)}+in:email`;
+    const response = await rateLimitAwareFetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github.v3+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "Daintree-Electron",
+      },
+      signal: signal ?? AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      // 422 is GitHub's "the query itself can't match" — a genuine, stable
+      // miss worth caching. 403/429/5xx are transient and must not be.
+      return response.status === 422 ? null : TRANSIENT;
+    }
+
+    const body = (await response.json()) as SearchUsersResponse;
+    const avatarUrl = body.items?.[0]?.avatar_url;
+    return typeof avatarUrl === "string" && avatarUrl.length > 0 ? avatarUrl : null;
+  } catch (error) {
+    // Rate-limit, network, and abort errors stay inside the provider — the
+    // caller only ever sees a resolved URL or `null`, never backoff state.
+    if (error instanceof GitHubRateLimitError) return TRANSIENT;
+    return TRANSIENT;
+  }
+}
+
+async function resolveByEmail(email: string, signal?: AbortSignal): Promise<string | null> {
+  const key = normalizeEmail(email);
+  if (key.length === 0) return null;
+
+  const cached = avatarCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const pending = inflight.get(key);
+  if (pending) return pending;
+
+  const request = fetchAvatarByEmail(key, signal)
+    .then((outcome) => {
+      if (outcome === TRANSIENT) return null;
+      // A request aborted by the caller's unmount must not poison the cache —
+      // the next mount should retry rather than read a forced `null`.
+      if (signal?.aborted) return null;
+      avatarCache.set(key, outcome);
+      return outcome;
+    })
+    .finally(() => {
+      // Drop the entry so a failed/aborted/transient lookup is retryable.
+      inflight.delete(key);
+    });
+
+  inflight.set(key, request);
+  return request;
+}
+
+export const gitHubProfilePictureProvider: ProfilePictureProvider = {
+  providerId: BUILTIN_GITHUB_PROVIDER_ID,
+  resolveByEmail,
+};
+
+/**
+ * IPC-facing entry point — `electron/ipc/handlers/github.ts` calls this.
+ * Returns `string | null`; `undefined`-while-loading is the renderer hook's
+ * abstraction, not part of the provider contract.
+ */
+export function resolveAuthorAvatar(email: string): Promise<string | null> {
+  return resolveByEmail(email);
+}
+
+/** Test-only — reset the module-level caches between unit tests. */
+export function _resetGitHubProfilePictureCachesForTests(): void {
+  avatarCache.clear();
+  inflight.clear();
+}

--- a/plugins/builtin/github/main/GitHubProfilePicture.ts
+++ b/plugins/builtin/github/main/GitHubProfilePicture.ts
@@ -67,7 +67,12 @@ async function fetchAvatarByEmail(email: string, signal?: AbortSignal): Promise<
         "X-GitHub-Api-Version": "2022-11-28",
         "User-Agent": "Daintree-Electron",
       },
-      signal: signal ?? AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+      // Compose the caller's abort signal with the API timeout so neither is
+      // silently dropped — a caller-provided signal must not disable the
+      // timeout, and vice versa.
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(GITHUB_API_TIMEOUT_MS)])
+        : AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
     });
     if (!response.ok) {
       // 422 is GitHub's "the query itself can't match" — a genuine, stable
@@ -98,10 +103,13 @@ async function resolveByEmail(email: string, signal?: AbortSignal): Promise<stri
 
   const request = fetchAvatarByEmail(key, signal)
     .then((outcome) => {
+      // A genuine outcome means the HTTP call completed — cache it regardless
+      // of the initiating caller's signal. The singleflight promise is shared
+      // by every concurrent caller, so keying the cache write off the *first*
+      // caller's abort would deny a successful result to all the others and
+      // leave the cache empty. An aborted in-flight fetch never reaches here:
+      // its AbortError is caught and mapped to TRANSIENT (uncached, retryable).
       if (outcome === TRANSIENT) return null;
-      // A request aborted by the caller's unmount must not poison the cache —
-      // the next mount should retry rather than read a forced `null`.
-      if (signal?.aborted) return null;
       avatarCache.set(key, outcome);
       return outcome;
     })

--- a/plugins/builtin/github/main/__tests__/GitHubProfilePicture.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubProfilePicture.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockToken: string | null = "test-token";
+
+vi.mock("../GitHubAuth.js", () => ({
+  GitHubAuth: {
+    getToken: vi.fn(() => mockToken),
+  },
+  GITHUB_API_TIMEOUT_MS: 5000,
+  rateLimitAwareFetch: (input: RequestInfo | URL, init?: RequestInit) =>
+    globalThis.fetch(input, init),
+}));
+
+vi.mock("../GitHubRateLimitService.js", () => ({
+  GitHubRateLimitError: class GitHubRateLimitError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "GitHubRateLimitError";
+    }
+  },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import {
+  gitHubProfilePictureProvider,
+  resolveAuthorAvatar,
+  _resetGitHubProfilePictureCachesForTests,
+} from "../GitHubProfilePicture.js";
+import { GitHubRateLimitError } from "../GitHubRateLimitService.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../../../shared/utils/forgeProviderIds.js";
+
+function okResponse(items: Array<{ avatar_url?: unknown }>) {
+  return { ok: true, status: 200, json: async () => ({ items }) };
+}
+
+describe("GitHubProfilePicture", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToken = "test-token";
+    _resetGitHubProfilePictureCachesForTests();
+  });
+
+  it("exposes the canonical GitHub provider id", () => {
+    expect(gitHubProfilePictureProvider.providerId).toBe(BUILTIN_GITHUB_PROVIDER_ID);
+  });
+
+  it("resolves the first user's avatar_url for a public email", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([{ avatar_url: "https://avatars.example/u/1" }]));
+    const url = await resolveAuthorAvatar("dev@example.com");
+    expect(url).toBe("https://avatars.example/u/1");
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("search/users?q=");
+    expect(calledUrl).toContain("dev%40example.com");
+    expect(calledUrl).toContain("+in:email");
+  });
+
+  it("returns null when no profile matches the email", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([]));
+    expect(await resolveAuthorAvatar("nobody@example.com")).toBeNull();
+  });
+
+  it("returns null without opening a socket when there is no token", async () => {
+    mockToken = null;
+    expect(await resolveAuthorAvatar("dev@example.com")).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("treats a 422 as a genuine cached miss", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 422, json: async () => ({}) });
+    expect(await resolveAuthorAvatar("dev@example.com")).toBeNull();
+    expect(await resolveAuthorAvatar("dev@example.com")).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a 403 as transient and does not cache it", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 403, json: async () => ({}) });
+    expect(await resolveAuthorAvatar("dev@example.com")).toBeNull();
+    mockFetch.mockResolvedValueOnce(okResponse([{ avatar_url: "https://avatars.example/late" }]));
+    expect(await resolveAuthorAvatar("dev@example.com")).toBe("https://avatars.example/late");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null (not a throw) on rate-limit errors", async () => {
+    mockFetch.mockRejectedValueOnce(new GitHubRateLimitError("secondary limit"));
+    await expect(resolveAuthorAvatar("dev@example.com")).resolves.toBeNull();
+  });
+
+  it("caches resolved URLs — a second lookup does not hit the network", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([{ avatar_url: "https://avatars.example/u/2" }]));
+    expect(await resolveAuthorAvatar("dev@example.com")).toBe("https://avatars.example/u/2");
+    expect(await resolveAuthorAvatar("DEV@example.com")).toBe("https://avatars.example/u/2");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches null misses so repeated lookups don't re-hit the API", async () => {
+    mockFetch.mockResolvedValueOnce(okResponse([]));
+    expect(await resolveAuthorAvatar("nobody@example.com")).toBeNull();
+    expect(await resolveAuthorAvatar("nobody@example.com")).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("singleflights concurrent lookups for the same email into one request", async () => {
+    let resolveFetch: (v: unknown) => void = () => {};
+    mockFetch.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveFetch = res;
+      })
+    );
+
+    const calls = Array.from({ length: 10 }, () => resolveAuthorAvatar("shared@example.com"));
+    resolveFetch(okResponse([{ avatar_url: "https://avatars.example/shared" }]));
+    const results = await Promise.all(calls);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(new Set(results)).toEqual(new Set(["https://avatars.example/shared"]));
+  });
+
+  it("returns null for an empty email without a request", async () => {
+    expect(await resolveAuthorAvatar("   ")).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("retries after a failed lookup (inflight entry is cleared)", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network"));
+    expect(await resolveAuthorAvatar("flaky@example.com")).toBeNull();
+    mockFetch.mockResolvedValueOnce(
+      okResponse([{ avatar_url: "https://avatars.example/recovered" }])
+    );
+    expect(await resolveAuthorAvatar("flaky@example.com")).toBe(
+      "https://avatars.example/recovered"
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/builtin/github/main/__tests__/GitHubProfilePicture.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubProfilePicture.test.ts
@@ -83,7 +83,7 @@ describe("GitHubProfilePicture", () => {
   });
 
   it("returns null (not a throw) on rate-limit errors", async () => {
-    mockFetch.mockRejectedValueOnce(new GitHubRateLimitError("secondary limit"));
+    mockFetch.mockRejectedValueOnce(new GitHubRateLimitError("secondary", Date.now() + 60000));
     await expect(resolveAuthorAvatar("dev@example.com")).resolves.toBeNull();
   });
 

--- a/plugins/builtin/github/main/__tests__/GitHubProfilePicture.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubProfilePicture.test.ts
@@ -122,6 +122,84 @@ describe("GitHubProfilePicture", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("retries once a token becomes available (no-token is not cached)", async () => {
+    mockToken = null;
+    expect(await resolveAuthorAvatar("dev@example.com")).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    mockToken = "test-token";
+    mockFetch.mockResolvedValueOnce(
+      okResponse([{ avatar_url: "https://avatars.example/after-token" }])
+    );
+    expect(await resolveAuthorAvatar("dev@example.com")).toBe(
+      "https://avatars.example/after-token"
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("singleflights a TRANSIENT failure: all callers get null, then a retry succeeds", async () => {
+    let resolveFetch: (v: unknown) => void = () => {};
+    mockFetch.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveFetch = res;
+      })
+    );
+
+    const calls = Array.from({ length: 10 }, () => resolveAuthorAvatar("burst@example.com"));
+    resolveFetch({ ok: false, status: 403, json: async () => ({}) });
+    const results = await Promise.all(calls);
+    expect(results).toEqual(Array(10).fill(null));
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // inflight was cleared and 403 wasn't cached — a later lookup retries.
+    mockFetch.mockResolvedValueOnce(
+      okResponse([{ avatar_url: "https://avatars.example/recovered" }])
+    );
+    expect(await resolveAuthorAvatar("burst@example.com")).toBe(
+      "https://avatars.example/recovered"
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches a successful response even when the initiating caller aborts", async () => {
+    const controller = new AbortController();
+    let resolveFetch: (v: unknown) => void = () => {};
+    mockFetch.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveFetch = res;
+      })
+    );
+
+    const first = gitHubProfilePictureProvider.resolveByEmail(
+      "abort@example.com",
+      controller.signal
+    );
+    const second = resolveAuthorAvatar("abort@example.com");
+
+    controller.abort();
+    resolveFetch(okResponse([{ avatar_url: "https://avatars.example/shared-win" }]));
+
+    expect(await first).toBe("https://avatars.example/shared-win");
+    expect(await second).toBe("https://avatars.example/shared-win");
+    // Cached — a third lookup does not hit the network.
+    expect(await resolveAuthorAvatar("abort@example.com")).toBe(
+      "https://avatars.example/shared-win"
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["items null", { items: null }],
+    ["empty object item", { items: [{}] }],
+    ["empty string avatar_url", { items: [{ avatar_url: "" }] }],
+    ["non-string avatar_url", { items: [{ avatar_url: 42 }] }],
+  ])("treats a malformed body (%s) as a cached genuine miss", async (_label, body) => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => body });
+    expect(await resolveAuthorAvatar("malformed@example.com")).toBeNull();
+    expect(await resolveAuthorAvatar("malformed@example.com")).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
   it("retries after a failed lookup (inflight entry is cleared)", async () => {
     mockFetch.mockRejectedValueOnce(new Error("network"));
     expect(await resolveAuthorAvatar("flaky@example.com")).toBeNull();

--- a/plugins/builtin/github/main/index.ts
+++ b/plugins/builtin/github/main/index.ts
@@ -136,3 +136,6 @@ export { fetchRateLimitDetails } from "./GitHubRateLimitApi.js";
 
 // Remotes
 export { listGitHubRemotes } from "./GitHubRemotes.js";
+
+// Profile pictures (forge-agnostic avatar resolution)
+export { resolveAuthorAvatar, gitHubProfilePictureProvider } from "./GitHubProfilePicture.js";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -725,6 +725,7 @@ export interface ElectronAPI {
     getPRReviewThreads(cwd: string, prNumber: number): Promise<Record<string, number>>;
     /** @deprecated Use `project.listRemotes` instead (#8456). */
     listRemotes(cwd: string): Promise<import("./github.js").RemoteInfo[]>;
+    resolveAuthorAvatar(email: string): Promise<string | null>;
     onPRDetected(callback: (data: PRDetectedPayload) => void): () => void;
     onPRCleared(callback: (data: PRClearedPayload) => void): () => void;
     onIssueDetected(callback: (data: IssueDetectedPayload) => void): () => void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1953,6 +1953,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [];
     result: GitHubRateLimitDetails | null;
   };
+  "github:resolve-author-avatar": {
+    args: [email: string];
+    result: string | null;
+  };
 
   // Per-service connectivity channels
   "connectivity:get-state": {

--- a/shared/types/profilePictureProvider.ts
+++ b/shared/types/profilePictureProvider.ts
@@ -1,0 +1,36 @@
+/**
+ * Forge-agnostic profile-picture resolution.
+ *
+ * A `ProfilePictureProvider` maps a commit-author email to that author's
+ * avatar URL on a specific forge (GitHub first; GitLab, Bitbucket, Codeberg,
+ * and any future forge follow the same shape). It is the source-of-truth tier
+ * above Gravatar in the committer-chip avatar fallback chain (#8514).
+ *
+ * The contract is deliberately thin: implementations own their own caching,
+ * rate-limit handling, and network-error recovery. Callers only ever see
+ * `string | null` — a resolved URL, or `null` when no profile matches the
+ * email (including the rate-limited / unauthenticated cases, which resolve to
+ * `null` rather than surfacing backoff state).
+ *
+ * Type-only module — zero runtime behavior — so the renderer, main process,
+ * and the workspace-host UtilityProcess can all import it without dragging a
+ * provider implementation across a process boundary. Concrete providers live
+ * in the main process next to their forge's auth/request infrastructure.
+ */
+export interface ProfilePictureProvider {
+  /**
+   * Canonical forge provider id this implementation serves — matches the
+   * `{pluginId}.{contributionId}` ids from `shared/utils/forgeProviderIds.ts`
+   * (e.g. {@link BUILTIN_GITHUB_PROVIDER_ID}). The consumer hook uses this to
+   * route an author email to the right forge.
+   */
+  readonly providerId: string;
+
+  /**
+   * Resolve an avatar URL for `email`. Returns the URL on success, or `null`
+   * when no profile matches, the request was rate-limited, or auth is
+   * unavailable — never throws for those cases. `signal` aborts an in-flight
+   * lookup when the caller unmounts.
+   */
+  resolveByEmail(email: string, signal?: AbortSignal): Promise<string | null>;
+}

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { WorktreeDetails } from "../WorktreeDetails";
 import { CommitChip } from "./CommitChip";
 import { Spinner } from "@/components/ui/Spinner";
+import { useForgeAuthorAvatar } from "@/hooks/useForgeAuthorAvatar";
 import {
   Activity,
   AlertTriangle,
@@ -98,6 +99,14 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
   } = props;
   const detailsId = `worktree-${worktree.id}-details`;
   const detailsPanelId = `worktree-${worktree.id}-details-panel`;
+
+  // Forge-resolved committer avatar (#8514). Resolves to a real GitHub
+  // profile picture when the email is public; `undefined` while loading or on
+  // miss, so the existing Gravatar tier transparently takes over.
+  const forgeAuthorAvatarUrl = useForgeAuthorAvatar({
+    email: worktree.worktreeChanges?.lastCommitAuthor?.email,
+    linkedProviderId: worktree.linked?.providerId,
+  });
 
   const changedFileCount = worktree.worktreeChanges?.changedFileCount ?? 0;
   const [countScope, animate] = useAnimate<HTMLSpanElement>();
@@ -425,6 +434,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                       lastCommitTimestampMs={worktree.worktreeChanges.lastCommitTimestampMs}
                       author={worktree.worktreeChanges.lastCommitAuthor}
                       commitMessage={worktree.worktreeChanges.lastCommitMessage}
+                      forgeAvatarUrl={forgeAuthorAvatarUrl}
                     />
                   )}
               </div>

--- a/src/hooks/__tests__/useForgeAuthorAvatar.test.tsx
+++ b/src/hooks/__tests__/useForgeAuthorAvatar.test.tsx
@@ -80,6 +80,21 @@ describe("useForgeAuthorAvatar", () => {
     expect(result.current).toBeUndefined();
   });
 
+  it("clears the avatar when the forge changes from GitHub to non-GitHub", async () => {
+    resolveAuthorAvatar.mockResolvedValue("https://avatars.example/u/1");
+    const { result, rerender } = renderHook(
+      ({ provider }) =>
+        useForgeAuthorAvatar({ email: "dev@example.com", linkedProviderId: provider }),
+      { initialProps: { provider: BUILTIN_GITHUB_PROVIDER_ID as string } }
+    );
+    await waitFor(() => expect(result.current).toBe("https://avatars.example/u/1"));
+
+    resolveAuthorAvatar.mockClear();
+    rerender({ provider: "gitlab.gitlab" });
+    expect(result.current).toBeUndefined();
+    expect(resolveAuthorAvatar).not.toHaveBeenCalled();
+  });
+
   it("does not apply a stale response after the email changes", async () => {
     let resolveFirst: (v: string) => void = () => {};
     resolveAuthorAvatar.mockImplementationOnce(

--- a/src/hooks/__tests__/useForgeAuthorAvatar.test.tsx
+++ b/src/hooks/__tests__/useForgeAuthorAvatar.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useForgeAuthorAvatar } from "../useForgeAuthorAvatar";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
+
+const resolveAuthorAvatar = vi.fn();
+
+beforeEach(() => {
+  resolveAuthorAvatar.mockReset();
+  (globalThis as { window: Window }).window.electron = {
+    github: { resolveAuthorAvatar },
+  } as unknown as Window["electron"];
+});
+
+describe("useForgeAuthorAvatar", () => {
+  it("returns undefined while loading, then the resolved URL", async () => {
+    resolveAuthorAvatar.mockResolvedValue("https://avatars.example/u/1");
+    const { result } = renderHook(() =>
+      useForgeAuthorAvatar({
+        email: "dev@example.com",
+        linkedProviderId: BUILTIN_GITHUB_PROVIDER_ID,
+      })
+    );
+    expect(result.current).toBeUndefined();
+    await waitFor(() => expect(result.current).toBe("https://avatars.example/u/1"));
+    expect(resolveAuthorAvatar).toHaveBeenCalledWith("dev@example.com");
+  });
+
+  it("does not call the provider for a non-GitHub forge", () => {
+    renderHook(() =>
+      useForgeAuthorAvatar({ email: "dev@example.com", linkedProviderId: "gitlab.gitlab" })
+    );
+    expect(resolveAuthorAvatar).not.toHaveBeenCalled();
+  });
+
+  it("does not call the provider when there is no linked provider", () => {
+    renderHook(() =>
+      useForgeAuthorAvatar({ email: "dev@example.com", linkedProviderId: undefined })
+    );
+    expect(resolveAuthorAvatar).not.toHaveBeenCalled();
+  });
+
+  it("does not call the provider for an empty email", () => {
+    renderHook(() =>
+      useForgeAuthorAvatar({ email: "   ", linkedProviderId: BUILTIN_GITHUB_PROVIDER_ID })
+    );
+    expect(resolveAuthorAvatar).not.toHaveBeenCalled();
+  });
+
+  it("normalizes a legacy provider id before routing", async () => {
+    resolveAuthorAvatar.mockResolvedValue("https://avatars.example/legacy");
+    const { result } = renderHook(() =>
+      useForgeAuthorAvatar({ email: "dev@example.com", linkedProviderId: "github" })
+    );
+    await waitFor(() => expect(result.current).toBe("https://avatars.example/legacy"));
+  });
+
+  it("stays undefined when the provider resolves null", async () => {
+    resolveAuthorAvatar.mockResolvedValue(null);
+    const { result } = renderHook(() =>
+      useForgeAuthorAvatar({
+        email: "nobody@example.com",
+        linkedProviderId: BUILTIN_GITHUB_PROVIDER_ID,
+      })
+    );
+    await waitFor(() => expect(resolveAuthorAvatar).toHaveBeenCalled());
+    expect(result.current).toBeUndefined();
+  });
+
+  it("swallows provider rejection and stays undefined", async () => {
+    resolveAuthorAvatar.mockRejectedValue(new Error("ipc failed"));
+    const { result } = renderHook(() =>
+      useForgeAuthorAvatar({
+        email: "dev@example.com",
+        linkedProviderId: BUILTIN_GITHUB_PROVIDER_ID,
+      })
+    );
+    await waitFor(() => expect(resolveAuthorAvatar).toHaveBeenCalled());
+    expect(result.current).toBeUndefined();
+  });
+
+  it("does not apply a stale response after the email changes", async () => {
+    let resolveFirst: (v: string) => void = () => {};
+    resolveAuthorAvatar.mockImplementationOnce(
+      () =>
+        new Promise<string>((res) => {
+          resolveFirst = res;
+        })
+    );
+    resolveAuthorAvatar.mockResolvedValueOnce("https://avatars.example/second");
+
+    const { result, rerender } = renderHook(
+      ({ email }) => useForgeAuthorAvatar({ email, linkedProviderId: BUILTIN_GITHUB_PROVIDER_ID }),
+      { initialProps: { email: "first@example.com" } }
+    );
+
+    rerender({ email: "second@example.com" });
+    await waitFor(() => expect(result.current).toBe("https://avatars.example/second"));
+
+    // The first lookup resolves late — its cleanup-cancelled callback must not
+    // clobber the second email's avatar.
+    resolveFirst("https://avatars.example/first");
+    await Promise.resolve();
+    expect(result.current).toBe("https://avatars.example/second");
+  });
+});

--- a/src/hooks/useForgeAuthorAvatar.ts
+++ b/src/hooks/useForgeAuthorAvatar.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { BUILTIN_GITHUB_PROVIDER_ID, normalizeProviderId } from "@shared/utils/forgeProviderIds";
+
+/**
+ * Resolve a commit author's forge avatar URL for the committer chip (#8514).
+ *
+ * Routes `email` to the forge identified by `linkedProviderId`, asks the
+ * main-process provider to resolve it, and returns the URL — or `undefined`
+ * while loading, on failure, or when no profile matches. `undefined` (not
+ * `null`) is the loading/empty signal so it slots straight into the chip's
+ * `forgeAvatarUrl?: string` prop and lets the existing Gravatar tier take over
+ * with no extra branching at the call site.
+ *
+ * Network resolution, caching, and rate-limit handling all live behind the
+ * IPC boundary in the provider — the hook never blocks render and never sees
+ * backoff state.
+ */
+export function useForgeAuthorAvatar({
+  email,
+  linkedProviderId,
+}: {
+  email: string | undefined;
+  linkedProviderId: string | undefined;
+}): string | undefined {
+  const [avatarUrl, setAvatarUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    setAvatarUrl(undefined);
+
+    const trimmedEmail = email?.trim();
+    if (!trimmedEmail) return;
+
+    // Only GitHub has a provider today. A worktree linked to a different
+    // forge falls straight through to Gravatar until that provider ships —
+    // adding one is a new registry entry, no change here.
+    if (normalizeProviderId(linkedProviderId) !== BUILTIN_GITHUB_PROVIDER_ID) return;
+
+    let cancelled = false;
+    window.electron.github
+      .resolveAuthorAvatar(trimmedEmail)
+      .then((url) => {
+        if (!cancelled) setAvatarUrl(url ?? undefined);
+      })
+      .catch(() => {
+        // Provider failures fall through to the next avatar tier silently.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [email, linkedProviderId]);
+
+  return avatarUrl;
+}


### PR DESCRIPTION
## Summary

Adds a forge-agnostic profile-picture provider system so the worktree committer chip can show a real GitHub avatar (the load-bearing identity signal) instead of a generic Gravatar identicon, with Gravatar demoted to fallback. Closes #8514.

## What's in it

- **`ProfilePictureProvider` interface** (`shared/types/profilePictureProvider.ts`) — type-only, forge-agnostic: `{ providerId, resolveByEmail(email, signal?) => Promise<string | null> }`. Importable from main, renderer, and the workspace-host.
- **GitHub implementation** (`plugins/builtin/github/main/GitHubProfilePicture.ts`) — resolves avatars via `GET /search/users?q={email}+in:email`, reusing the existing `rateLimitAwareFetch` / token / rate-limit infrastructure. Key behaviors:
  - 3-hour process-scoped TTL+LRU cache (not persisted to disk).
  - Singleflight in-flight dedup so N worktree cards sharing one committer issue **one** Search API request, not N (the Search bucket is only 30 req/min authenticated).
  - `TRANSIENT`-vs-genuine-miss split: no-token / rate-limited / network / 5xx resolve to `null` for the caller but are **not** cached (retryable next render), while genuine misses (empty `items`, 422, malformed body) are cached.
  - Caller `AbortSignal` composed with the API timeout via `AbortSignal.any`; a successful response is cached even if the initiating caller aborts (the singleflight promise is shared).
- **IPC plumbing** — `github:resolve-author-avatar` channel + typed `IpcInvokeMap` entry + rate-limited handler + preload + `api.ts` type.
- **`useForgeAuthorAvatar` hook** (`src/hooks/useForgeAuthorAvatar.ts`) — returns the URL or `undefined` while loading/on failure; stale-closure `cancelled` guard; normalizes the linked provider id and gates on `BUILTIN_GITHUB_PROVIDER_ID`.
- **Consumer wiring** — the worktree committer `Avatar` now prefers the forge URL and falls back to Gravatar. (#8513's `CommitterChip` isn't on this branch yet; the rebase at merge time reconciles it.)

## Extensibility

Adding GitLab / Bitbucket / Codeberg is a new provider file + registry entry — no change to the consumer hook.

## Testing

28 unit tests (`GitHubProfilePicture.test.ts`, `useForgeAuthorAvatar.test.tsx`) covering cache hit/miss, singleflight (success + transient), abort-during-singleflight, no-token retry, malformed bodies, rate-limit, and the hook's provider-gating / stale-closure paths. `npm run check` clean (typecheck, lint ratchet at baseline, format, channel drift, IPC codegen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
