### PR TITLE
feat(plugins): add fileDecorationProviders contribution point (#8511)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -742,6 +742,7 @@ export const CHANNELS = {
   PLUGIN_ACTIONS_UNREGISTER: "plugin:actions-unregister",
   PLUGIN_PANEL_KINDS_GET: "plugin:panel-kinds-get",
   PLUGIN_FORGE_PROVIDERS_GET: "plugin:forge-providers-get",
+  PLUGIN_FILE_DECORATIONS_GET: "plugin:file-decorations-get",
 
   // Config reload channels
   APP_RELOAD_CONFIG: "app:reload-config",

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -620,6 +620,68 @@ describe("PLUGIN_FILE_DECORATIONS_GET handler", () => {
     const handler = getHandler();
     expect(await handler({}, "s:1", ["a.ts"])).toEqual({});
   });
+
+  it("treats an empty-string field as absent so a later provider can fill it", async () => {
+    mockGetFileDecorationImpls.mockReturnValue([
+      {
+        pluginId: "p.first",
+        contributionId: "d",
+        impl: { provideDecorations: vi.fn().mockResolvedValue({ "a.ts": { badge: "" } }) },
+      },
+      {
+        pluginId: "p.second",
+        contributionId: "d",
+        impl: { provideDecorations: vi.fn().mockResolvedValue({ "a.ts": { badge: "7" } }) },
+      },
+    ]);
+    const handler = getHandler();
+    expect(await handler({}, "s:1", ["a.ts"])).toEqual({ "a.ts": { badge: "7" } });
+  });
+
+  it("drops decorations for paths the caller did not request", async () => {
+    mockGetFileDecorationImpls.mockReturnValue([
+      {
+        pluginId: "p",
+        contributionId: "d",
+        impl: {
+          provideDecorations: vi.fn().mockResolvedValue({
+            "requested.ts": { badge: "1" },
+            "not-requested.ts": { badge: "9" },
+          }),
+        },
+      },
+    ]);
+    const handler = getHandler();
+    expect(await handler({}, "s:1", ["requested.ts"])).toEqual({
+      "requested.ts": { badge: "1" },
+    });
+  });
+
+  it("skips a provider that never settles and still returns the healthy one", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetFileDecorationImpls.mockReturnValue([
+        {
+          pluginId: "p.hang",
+          contributionId: "d",
+          impl: { provideDecorations: vi.fn().mockReturnValue(new Promise(() => {})) },
+        },
+        {
+          pluginId: "p.good",
+          contributionId: "d",
+          impl: {
+            provideDecorations: vi.fn().mockResolvedValue({ "a.ts": { badge: "4" } }),
+          },
+        },
+      ]);
+      const handler = getHandler();
+      const promise = handler({}, "s:1", ["a.ts"]) as Promise<unknown>;
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(await promise).toEqual({ "a.ts": { badge: "4" } });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("registerPluginHandler", () => {

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -37,6 +37,11 @@ vi.mock("../../../services/forgeProviderRegistry.js", () => ({
   getRegisteredForgeProviders: (...args: unknown[]) => mockGetRegisteredForgeProviders(...args),
 }));
 
+const mockGetFileDecorationImpls = vi.fn();
+vi.mock("../../../services/fileDecorationRegistry.js", () => ({
+  getFileDecorationImpls: (...args: unknown[]) => mockGetFileDecorationImpls(...args),
+}));
+
 const mockIpcMainHandle = vi.fn();
 const mockIpcMainRemoveHandler = vi.fn();
 vi.mock("electron", () => ({
@@ -56,6 +61,7 @@ beforeEach(() => {
   mockGetPluginMenuItems.mockReturnValue([]);
   mockListPluginActions.mockReturnValue([]);
   mockGetRegisteredForgeProviders.mockReturnValue([]);
+  mockGetFileDecorationImpls.mockReturnValue([]);
   _resetIpcGuardForTesting();
   markIpcSecurityReady();
 });
@@ -63,7 +69,7 @@ beforeEach(() => {
 describe("registerPluginHandlers", () => {
   it("registers handlers for all plugin channels", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(10);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(11);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:invoke", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:toolbar-buttons", expect.any(Function));
@@ -81,6 +87,10 @@ describe("registerPluginHandlers", () => {
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:panel-kinds-get", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith(
       "plugin:forge-providers-get",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:file-decorations-get",
       expect.any(Function)
     );
   });
@@ -517,6 +527,98 @@ describe("PLUGIN_FORGE_PROVIDERS_GET handler", () => {
     const handler = getHandler();
     const result = await handler({});
     expect(result).toEqual([]);
+  });
+});
+
+describe("PLUGIN_FILE_DECORATIONS_GET handler", () => {
+  function getHandler() {
+    registerPluginHandlers();
+    return mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:file-decorations-get"
+    )![1] as (...args: unknown[]) => unknown;
+  }
+
+  it("returns {} when no impl matches the scope", async () => {
+    mockGetFileDecorationImpls.mockReturnValue([]);
+    const handler = getHandler();
+    expect(await handler({}, "worktree-diff:/r", ["a.ts"])).toEqual({});
+  });
+
+  it("returns {} for empty scope or empty paths without calling the registry", async () => {
+    const handler = getHandler();
+    expect(await handler({}, "", ["a.ts"])).toEqual({});
+    expect(await handler({}, "worktree-diff:/r", [])).toEqual({});
+    expect(mockGetFileDecorationImpls).not.toHaveBeenCalled();
+  });
+
+  it("merges providers first-writer-wins per field, in load order", async () => {
+    const first = {
+      pluginId: "p.one",
+      contributionId: "d",
+      impl: {
+        provideDecorations: vi.fn().mockResolvedValue({
+          "a.ts": { badge: "1", color: "text-status-warning" },
+        }),
+      },
+    };
+    const second = {
+      pluginId: "p.two",
+      contributionId: "d",
+      impl: {
+        provideDecorations: vi.fn().mockResolvedValue({
+          "a.ts": { badge: "9", tooltip: "from second" },
+          "b.ts": { badge: "2" },
+        }),
+      },
+    };
+    mockGetFileDecorationImpls.mockReturnValue([first, second]);
+    const handler = getHandler();
+    const result = await handler({}, "worktree-diff:/r", ["a.ts", "b.ts"]);
+    expect(result).toEqual({
+      "a.ts": { badge: "1", color: "text-status-warning", tooltip: "from second" },
+      "b.ts": { badge: "2" },
+    });
+  });
+
+  it("deduplicates requested paths before invoking impls", async () => {
+    const provide = vi.fn().mockResolvedValue({});
+    mockGetFileDecorationImpls.mockReturnValue([
+      { pluginId: "p", contributionId: "d", impl: { provideDecorations: provide } },
+    ]);
+    const handler = getHandler();
+    await handler({}, "s:1", ["a.ts", "a.ts", "b.ts"]);
+    expect(provide).toHaveBeenCalledWith("s:1", ["a.ts", "b.ts"]);
+  });
+
+  it("skips a rejecting provider without dropping a healthy one's results", async () => {
+    mockGetFileDecorationImpls.mockReturnValue([
+      {
+        pluginId: "p.bad",
+        contributionId: "d",
+        impl: { provideDecorations: vi.fn().mockRejectedValue(new Error("boom")) },
+      },
+      {
+        pluginId: "p.good",
+        contributionId: "d",
+        impl: {
+          provideDecorations: vi.fn().mockResolvedValue({ "a.ts": { badge: "3" } }),
+        },
+      },
+    ]);
+    const handler = getHandler();
+    expect(await handler({}, "s:1", ["a.ts"])).toEqual({ "a.ts": { badge: "3" } });
+  });
+
+  it("omits paths whose merged decoration has no fields", async () => {
+    mockGetFileDecorationImpls.mockReturnValue([
+      {
+        pluginId: "p",
+        contributionId: "d",
+        impl: { provideDecorations: vi.fn().mockResolvedValue({ "a.ts": {} }) },
+      },
+    ]);
+    const handler = getHandler();
+    expect(await handler({}, "s:1", ["a.ts"])).toEqual({});
   });
 });
 

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -55,6 +55,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "plugin:actions-changed": "external",
   "plugin:panel-kinds-changed": "external",
   "plugin:toolbar-buttons-changed": "external",
+  "plugin:decorations-changed": "external",
   "terminal:exit": "external",
   "terminal:spawn-result": "external",
 } as const satisfies Record<keyof IpcEventBusMap, "bus" | "external">;

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -15,6 +15,7 @@ export const PLUGIN_METHOD_CHANNELS = {
   unregisterAction: "plugin:actions-unregister",
   getPanelKinds: "plugin:panel-kinds-get",
   getForgeProviders: "plugin:forge-providers-get",
+  getDecorations: "plugin:file-decorations-get",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof PLUGIN_METHOD_CHANNELS;

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -107,13 +107,35 @@ async function handleForgeProvidersGet(): Promise<RegisteredForgeProvider[]> {
 }
 
 /**
+ * Per-provider budget for a single `provideDecorations` call. A provider that
+ * never settles its promise would otherwise hang the whole IPC invocation
+ * (and the renderer's pull) indefinitely — `Promise.allSettled` only handles
+ * rejection, not a promise that simply never resolves. On expiry the slow
+ * provider is treated like a rejecting one (skipped + logged); healthy
+ * providers for the same scope are unaffected.
+ */
+const DECORATION_PROVIDER_TIMEOUT_MS = 3000;
+
+const DECORATION_TIMEOUT = Symbol("decoration-timeout");
+
+/**
+ * A non-empty string is "present" for merge purposes. Empty string counts as
+ * absent so it can't block a later provider from supplying a real value.
+ */
+function presentString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
  * Resolve per-file decorations for `scope` over the given `paths` by invoking
  * every plugin impl whose declared scopes match. Results merge with
  * first-writer-wins semantics per field (badge/tooltip/color independently):
- * the first provider in plugin load order that returns a non-undefined value
- * for a field on a path keeps it. The host treats every decoration opaquely —
- * it never inspects what a badge means. A provider that throws or rejects is
- * skipped (logged) so one bad plugin can't blank the whole row.
+ * the first provider in plugin load order that returns a non-empty value for a
+ * field on a path keeps it. The host treats every decoration opaquely — it
+ * never inspects what a badge means. A provider that throws, rejects, or
+ * exceeds {@link DECORATION_PROVIDER_TIMEOUT_MS} is skipped (logged) so one
+ * bad plugin can't blank or stall the whole row. Only the requested paths are
+ * returned — a provider that decorates unrequested paths can't leak them.
  */
 async function handleFileDecorationsGet(
   scope: string,
@@ -125,38 +147,57 @@ async function handleFileDecorationsGet(
     ...new Set(paths.filter((p): p is string => typeof p === "string" && p.length > 0)),
   ];
   if (cleanPaths.length === 0) return {};
+  const requested = new Set(cleanPaths);
 
   const impls = getFileDecorationImpls(scope);
   if (impls.length === 0) return {};
 
   const merged: Record<string, FileDecoration> = {};
   const results = await Promise.allSettled(
-    impls.map(({ impl }) => impl.provideDecorations(scope, cleanPaths))
+    impls.map(({ impl }) =>
+      Promise.race([
+        impl.provideDecorations(scope, cleanPaths),
+        new Promise<typeof DECORATION_TIMEOUT>((resolve) =>
+          setTimeout(() => resolve(DECORATION_TIMEOUT), DECORATION_PROVIDER_TIMEOUT_MS)
+        ),
+      ])
+    )
   );
 
   for (let i = 0; i < results.length; i++) {
     const r = results[i];
-    if (r.status !== "fulfilled" || !r.value || typeof r.value !== "object") {
-      if (r.status === "rejected") {
-        const { pluginId, contributionId } = impls[i];
-        console.warn(
-          `[Plugin] fileDecorationProvider "${pluginId}.${contributionId}" failed for scope "${scope}":`,
-          r.reason
-        );
-      }
+    const { pluginId, contributionId } = impls[i];
+    if (r.status === "rejected") {
+      console.warn(
+        `[Plugin] fileDecorationProvider "${pluginId}.${contributionId}" failed for scope "${scope}":`,
+        r.reason
+      );
       continue;
     }
+    if (r.value === DECORATION_TIMEOUT) {
+      console.warn(
+        `[Plugin] fileDecorationProvider "${pluginId}.${contributionId}" timed out after ${DECORATION_PROVIDER_TIMEOUT_MS}ms for scope "${scope}"`
+      );
+      continue;
+    }
+    if (!r.value || typeof r.value !== "object") continue;
     for (const [path, decoration] of Object.entries(r.value)) {
+      // Enforce the requested-paths contract at the host boundary so a
+      // misbehaving provider can't widen the result set.
+      if (!requested.has(path)) continue;
       if (!decoration || typeof decoration !== "object") continue;
       const target = merged[path] ?? (merged[path] = {});
-      if (target.badge === undefined && typeof decoration.badge === "string") {
-        target.badge = decoration.badge;
+      if (target.badge === undefined) {
+        const badge = presentString(decoration.badge);
+        if (badge !== undefined) target.badge = badge;
       }
-      if (target.tooltip === undefined && typeof decoration.tooltip === "string") {
-        target.tooltip = decoration.tooltip;
+      if (target.tooltip === undefined) {
+        const tooltip = presentString(decoration.tooltip);
+        if (tooltip !== undefined) target.tooltip = tooltip;
       }
-      if (target.color === undefined && typeof decoration.color === "string") {
-        target.color = decoration.color;
+      if (target.color === undefined) {
+        const color = presentString(decoration.color);
+        if (color !== undefined) target.color = color;
       }
     }
   }

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -16,6 +16,8 @@ import {
   getRegisteredForgeProviders,
   type RegisteredForgeProvider,
 } from "../../services/forgeProviderRegistry.js";
+import { getFileDecorationImpls } from "../../services/fileDecorationRegistry.js";
+import type { FileDecoration } from "../../../shared/types/forge.js";
 import { isTrustedRendererUrl } from "../../../shared/utils/trustedRenderer.js";
 import type {
   LoadedPluginInfo,
@@ -104,6 +106,76 @@ async function handleForgeProvidersGet(): Promise<RegisteredForgeProvider[]> {
   return getRegisteredForgeProviders();
 }
 
+/**
+ * Resolve per-file decorations for `scope` over the given `paths` by invoking
+ * every plugin impl whose declared scopes match. Results merge with
+ * first-writer-wins semantics per field (badge/tooltip/color independently):
+ * the first provider in plugin load order that returns a non-undefined value
+ * for a field on a path keeps it. The host treats every decoration opaquely —
+ * it never inspects what a badge means. A provider that throws or rejects is
+ * skipped (logged) so one bad plugin can't blank the whole row.
+ */
+async function handleFileDecorationsGet(
+  scope: string,
+  paths: string[]
+): Promise<Record<string, FileDecoration>> {
+  if (typeof scope !== "string" || scope.length === 0) return {};
+  if (!Array.isArray(paths) || paths.length === 0) return {};
+  const cleanPaths = [
+    ...new Set(paths.filter((p): p is string => typeof p === "string" && p.length > 0)),
+  ];
+  if (cleanPaths.length === 0) return {};
+
+  const impls = getFileDecorationImpls(scope);
+  if (impls.length === 0) return {};
+
+  const merged: Record<string, FileDecoration> = {};
+  const results = await Promise.allSettled(
+    impls.map(({ impl }) => impl.provideDecorations(scope, cleanPaths))
+  );
+
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (r.status !== "fulfilled" || !r.value || typeof r.value !== "object") {
+      if (r.status === "rejected") {
+        const { pluginId, contributionId } = impls[i];
+        console.warn(
+          `[Plugin] fileDecorationProvider "${pluginId}.${contributionId}" failed for scope "${scope}":`,
+          r.reason
+        );
+      }
+      continue;
+    }
+    for (const [path, decoration] of Object.entries(r.value)) {
+      if (!decoration || typeof decoration !== "object") continue;
+      const target = merged[path] ?? (merged[path] = {});
+      if (target.badge === undefined && typeof decoration.badge === "string") {
+        target.badge = decoration.badge;
+      }
+      if (target.tooltip === undefined && typeof decoration.tooltip === "string") {
+        target.tooltip = decoration.tooltip;
+      }
+      if (target.color === undefined && typeof decoration.color === "string") {
+        target.color = decoration.color;
+      }
+    }
+  }
+
+  // Drop paths that ended up with no fields (a provider returned an entry but
+  // every field was empty) so the renderer's "decorated?" check stays cheap.
+  for (const [path, decoration] of Object.entries(merged)) {
+    if (
+      decoration.badge === undefined &&
+      decoration.tooltip === undefined &&
+      decoration.color === undefined
+    ) {
+      delete merged[path];
+    }
+  }
+
+  return merged;
+}
+
 export const pluginNamespace = defineIpcNamespace({
   name: "plugin",
   ops: {
@@ -116,6 +188,7 @@ export const pluginNamespace = defineIpcNamespace({
     unregisterAction: op(PLUGIN_METHOD_CHANNELS.unregisterAction, handleActionsUnregister),
     getPanelKinds: op(PLUGIN_METHOD_CHANNELS.getPanelKinds, handlePanelKindsGet),
     getForgeProviders: op(PLUGIN_METHOD_CHANNELS.getForgeProviders, handleForgeProvidersGet),
+    getDecorations: op(PLUGIN_METHOD_CHANNELS.getDecorations, handleFileDecorationsGet),
   },
 });
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2573,6 +2573,8 @@ const api: ElectronAPI = {
     onToolbarButtonsChanged: (
       callback: (payload: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void
     ) => _eventBusOn("plugin:toolbar-buttons-changed", callback),
+    onDecorationsChanged: (callback: (payload: { scope: string; paths?: string[] }) => void) =>
+      _eventBusOn("plugin:decorations-changed", callback),
   },
 
   crashRecovery: {

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -10,7 +10,10 @@ import type {
   McpServerContribution,
   PluginPermission,
 } from "../../shared/types/plugin.js";
-import type { ForgeProviderContribution } from "../../shared/types/forge.js";
+import type {
+  FileDecorationContribution,
+  ForgeProviderContribution,
+} from "../../shared/types/forge.js";
 
 const SAFE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
@@ -96,6 +99,19 @@ export const ForgeProviderContributionSchema = z.object({
   viewRefs: z.array(z.string().min(1)).optional(),
 });
 
+/**
+ * `fileDecorationProviders` manifest entry. Declares which scopes a plugin's
+ * decoration provider handles so the host can route renderer pulls without
+ * the plugin's code having run yet. Strict so unknown fields from plugin
+ * authors are rejected loudly rather than silently ignored.
+ */
+export const FileDecorationContributionSchema = z
+  .object({
+    id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
+    scopes: z.array(z.string().min(1)).min(1),
+  })
+  .strict();
+
 export const PluginPermissionSchema = z.enum(BUILT_IN_PLUGIN_PERMISSIONS);
 
 export const PluginManifestSchema = z
@@ -128,6 +144,7 @@ export const PluginManifestSchema = z
         views: z.array(ViewContributionSchema).default([]),
         mcpServers: z.array(McpServerContributionSchema).default([]),
         forgeProviders: z.array(ForgeProviderContributionSchema).default([]),
+        fileDecorationProviders: z.array(FileDecorationContributionSchema).default([]),
       })
       .default({
         panels: [],
@@ -136,6 +153,7 @@ export const PluginManifestSchema = z
         views: [],
         mcpServers: [],
         forgeProviders: [],
+        fileDecorationProviders: [],
       }),
   })
   .strict();
@@ -149,4 +167,4 @@ export type {
   McpServerContribution,
   PluginPermission,
 };
-export type { ForgeProviderContribution };
+export type { ForgeProviderContribution, FileDecorationContribution };

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -41,6 +41,7 @@ import {
 import {
   registerFileDecorationProviderImpl,
   registerFileDecorationProviders,
+  scopeMatchesPattern,
   unregisterFileDecorationProviderImpl,
   unregisterFileDecorationProviderImpls,
   unregisterFileDecorationProviders,
@@ -702,6 +703,22 @@ export class PluginService {
             `Plugin "${pluginId}" invalidateFileDecorations: scope must be a non-empty string`
           );
         }
+        // A plugin may only invalidate scopes it actually declared in
+        // `contributes.fileDecorationProviders`. Without this a plugin could
+        // force unrelated renderer views to re-pull. Mirrors the
+        // registration-time declared-id guard so the manifest stays the
+        // single source of truth for what a plugin owns.
+        const declaredScopes = this.plugins
+          .get(pluginId)
+          ?.manifest.contributes.fileDecorationProviders.flatMap((c) => c.scopes);
+        if (
+          !declaredScopes ||
+          !declaredScopes.some((pattern) => scopeMatchesPattern(scope, pattern))
+        ) {
+          throw new Error(
+            `Plugin "${pluginId}" invalidateFileDecorations: scope "${scope}" is not covered by any declared contributes.fileDecorationProviders[].scopes`
+          );
+        }
         const narrowed =
           Array.isArray(paths) && paths.length > 0
             ? paths.filter((p): p is string => typeof p === "string" && p.length > 0)
@@ -893,9 +910,25 @@ export class PluginService {
     // re-bind that didn't refresh the disposer slot). The bulk call is
     // idempotent — already-cleared keys are silent no-ops.
     unregisterForgeProviderImpls(pluginId);
+    // Capture the unloaded plugin's declared decoration scopes before clearing
+    // the registry so we can tell any renderer that was showing them to
+    // re-pull (it will now resolve no impl and clear). Without this, stale
+    // decorations from a runtime-unloaded plugin would linger until the next
+    // scope/path change or remount.
+    const decorationScopes = this.plugins
+      .get(pluginId)
+      ?.manifest.contributes.fileDecorationProviders.flatMap((c) => c.scopes);
     unregisterFileDecorationProviders(pluginId);
     unregisterFileDecorationProviderImpls(pluginId);
     this.plugins.delete(pluginId);
+    if (decorationScopes && decorationScopes.length > 0) {
+      for (const scope of new Set(decorationScopes)) {
+        broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+          name: "plugin:decorations-changed",
+          payload: { scope },
+        });
+      }
+    }
   }
 
   private flushPluginEventCleanups(pluginId: string): void {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -38,6 +38,13 @@ import {
   unregisterForgeProviderImpls,
   unregisterForgeProviders,
 } from "./forgeProviderRegistry.js";
+import {
+  registerFileDecorationProviderImpl,
+  registerFileDecorationProviders,
+  unregisterFileDecorationProviderImpl,
+  unregisterFileDecorationProviderImpls,
+  unregisterFileDecorationProviders,
+} from "./fileDecorationRegistry.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
@@ -437,6 +444,10 @@ export class PluginService {
       registerForgeProviders(manifest.name, manifest.contributes.forgeProviders);
     }
 
+    if (manifest.contributes.fileDecorationProviders.length > 0) {
+      registerFileDecorationProviders(manifest.name, manifest.contributes.fileDecorationProviders);
+    }
+
     // Insert the plugin into the registry BEFORE importing its main module so
     // synchronous host-API calls made during module evaluation (e.g., a plugin
     // that calls host.registerAction/registerHandler at import time) see the
@@ -622,6 +633,84 @@ export class PluginService {
         list.push(dispose);
         return dispose;
       },
+      registerFileDecorationProvider: (descriptor, impl) => {
+        if (revoked) {
+          throw new Error(
+            `Plugin "${pluginId}" host revoked: registerFileDecorationProvider called after activate() returned or timed out`
+          );
+        }
+        if (!descriptor || typeof descriptor !== "object") {
+          throw new Error(
+            `Plugin "${pluginId}" registerFileDecorationProvider: descriptor must be an object`
+          );
+        }
+        if (typeof descriptor.id !== "string" || descriptor.id.length === 0) {
+          throw new Error(
+            `Plugin "${pluginId}" registerFileDecorationProvider: descriptor.id must be a non-empty string`
+          );
+        }
+        if (!impl || typeof impl !== "object" || typeof impl.provideDecorations !== "function") {
+          throw new Error(
+            `Plugin "${pluginId}" registerFileDecorationProvider: impl must expose provideDecorations()`
+          );
+        }
+        // Reject ids not declared in `contributes.fileDecorationProviders` for
+        // the same reason as forge providers: an undeclared id is unreachable
+        // through the eager scope-routing table, so the binding would be a
+        // silent orphan. Fail loud at registration instead.
+        const contributionId = descriptor.id;
+        const plugin = this.plugins.get(pluginId);
+        const declared = plugin?.manifest.contributes.fileDecorationProviders.some(
+          (c) => c.id === contributionId
+        );
+        if (!declared) {
+          throw new Error(
+            `Plugin "${pluginId}" registerFileDecorationProvider: descriptor.id "${contributionId}" is not declared in contributes.fileDecorationProviders`
+          );
+        }
+
+        registerFileDecorationProviderImpl(pluginId, contributionId, impl);
+
+        let disposed = false;
+        const dispose = (): void => {
+          if (disposed) return;
+          disposed = true;
+          unregisterFileDecorationProviderImpl(pluginId, contributionId, impl);
+          const list = this.pluginEventCleanups.get(pluginId);
+          if (!list) return;
+          const idx = list.indexOf(dispose);
+          if (idx >= 0) list.splice(idx, 1);
+          if (list.length === 0) this.pluginEventCleanups.delete(pluginId);
+        };
+
+        let list = this.pluginEventCleanups.get(pluginId);
+        if (!list) {
+          list = [];
+          this.pluginEventCleanups.set(pluginId, list);
+        }
+        list.push(dispose);
+        return dispose;
+      },
+      // NOT revoke-guarded: called from the plugin's own post-activation
+      // subscription callbacks (worktree changes, polling timers). The
+      // liveness guard is plugin membership, not the activation window — once
+      // the plugin unloads this becomes a silent no-op.
+      invalidateFileDecorations: (scope, paths) => {
+        if (!this.plugins.has(pluginId)) return;
+        if (typeof scope !== "string" || scope.length === 0) {
+          throw new Error(
+            `Plugin "${pluginId}" invalidateFileDecorations: scope must be a non-empty string`
+          );
+        }
+        const narrowed =
+          Array.isArray(paths) && paths.length > 0
+            ? paths.filter((p): p is string => typeof p === "string" && p.length > 0)
+            : undefined;
+        broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+          name: "plugin:decorations-changed",
+          payload: { scope, ...(narrowed && narrowed.length > 0 ? { paths: narrowed } : {}) },
+        });
+      },
     };
     return {
       host,
@@ -804,6 +893,8 @@ export class PluginService {
     // re-bind that didn't refresh the disposer slot). The bulk call is
     // idempotent — already-cleared keys are silent no-ops.
     unregisterForgeProviderImpls(pluginId);
+    unregisterFileDecorationProviders(pluginId);
+    unregisterFileDecorationProviderImpls(pluginId);
     this.plugins.delete(pluginId);
   }
 

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -61,6 +61,13 @@ import {
   getRegisteredForgeProviders,
   listMatchingProviders,
 } from "../forgeProviderRegistry.js";
+import {
+  clearFileDecorationImplRegistry,
+  clearFileDecorationRegistry,
+  getFileDecorationImpls,
+  getRegisteredFileDecorationProviders,
+} from "../fileDecorationRegistry.js";
+import { broadcastToRenderer } from "../../ipc/utils.js";
 
 function makeCtx(pluginId: string, overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
   return {
@@ -84,6 +91,7 @@ type PluginManifestShape = {
     views?: unknown[];
     mcpServers?: unknown[];
     forgeProviders?: unknown[];
+    fileDecorationProviders?: unknown[];
   };
 };
 
@@ -129,6 +137,8 @@ afterEach(async () => {
     clearToolbarButtonRegistry();
     clearPluginMenuRegistry();
     clearForgeProviderRegistry();
+    clearFileDecorationRegistry();
+    clearFileDecorationImplRegistry();
     storeState.clear();
     for (const key of globalMarkers) {
       delete (globalThis as Record<string, unknown>)[key];
@@ -443,6 +453,130 @@ describe("PluginService integration — forge provider contributions", () => {
     expect(getRegisteredForgeProviders()).toHaveLength(2);
     expect(listMatchingProviders("https://primary.example/repo")).toHaveLength(1);
     expect(listMatchingProviders("https://secondary.example/repo")).toHaveLength(1);
+  });
+});
+
+describe("PluginService integration — file decoration provider contributions", () => {
+  it("registers a manifest fileDecorationProviders entry and unregisters it on unload", async () => {
+    await writePlugin("acme.decor-plugin", {
+      name: "acme.decor-plugin",
+      version: "1.0.0",
+      contributes: {
+        fileDecorationProviders: [{ id: "badges", scopes: ["my-scope:*"] }],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    const registered = getRegisteredFileDecorationProviders();
+    expect(registered).toEqual([
+      {
+        pluginId: "acme.decor-plugin",
+        contribution: { id: "badges", scopes: ["my-scope:*"] },
+      },
+    ]);
+
+    service.unloadPlugin("acme.decor-plugin");
+    expect(getRegisteredFileDecorationProviders()).toEqual([]);
+  });
+
+  it("serves a non-GitHub plugin's decorations opaquely and broadcasts invalidation", async () => {
+    // This is the acceptance proof: the host wires through a fake plugin's
+    // decorations with zero knowledge of what they represent (no review
+    // threads, no GitHub) and rebroadcasts its invalidation signal.
+    const pluginDir = await writePlugin("acme.decor-plugin", {
+      name: "acme.decor-plugin",
+      version: "1.0.0",
+    });
+    const mainFile = `decor-${randomUUID()}.mjs`;
+    await fs.writeFile(
+      path.join(pluginDir, mainFile),
+      `export function activate(host) {
+  const dispose = host.registerFileDecorationProvider({ id: "badges" }, {
+    async provideDecorations(scope, paths) {
+      const out = {};
+      for (const p of paths) out[p] = { badge: "★", tooltip: "fake:" + scope };
+      return out;
+    },
+  });
+  host.invalidateFileDecorations("my-scope:/x", ["a.ts"]);
+  return dispose;
+}
+`
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.decor-plugin",
+        version: "1.0.0",
+        main: mainFile,
+        contributes: {
+          fileDecorationProviders: [{ id: "badges", scopes: ["my-scope:*"] }],
+        },
+      })
+    );
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    const impls = getFileDecorationImpls("my-scope:/x");
+    expect(impls).toHaveLength(1);
+    expect(impls[0]).toMatchObject({
+      pluginId: "acme.decor-plugin",
+      contributionId: "badges",
+    });
+
+    const decorations = await impls[0].impl.provideDecorations("my-scope:/x", ["a.ts", "b.ts"]);
+    expect(decorations).toEqual({
+      "a.ts": { badge: "★", tooltip: "fake:my-scope:/x" },
+      "b.ts": { badge: "★", tooltip: "fake:my-scope:/x" },
+    });
+
+    expect(vi.mocked(broadcastToRenderer)).toHaveBeenCalledWith("events:push", {
+      name: "plugin:decorations-changed",
+      payload: { scope: "my-scope:/x", paths: ["a.ts"] },
+    });
+
+    service.unloadPlugin("acme.decor-plugin");
+    expect(getFileDecorationImpls("my-scope:/x")).toEqual([]);
+  });
+
+  it("rejects registering a provider id not declared in the manifest", async () => {
+    const pluginDir = await writePlugin("acme.bad-decor", {
+      name: "acme.bad-decor",
+      version: "1.0.0",
+    });
+    const markerKey = makeMarkerKey();
+    const mainFile = `decor-${randomUUID()}.mjs`;
+    await fs.writeFile(
+      path.join(pluginDir, mainFile),
+      `export function activate(host) {
+  try {
+    host.registerFileDecorationProvider({ id: "undeclared" }, { async provideDecorations() { return {}; } });
+  } catch (err) {
+    globalThis[${JSON.stringify(markerKey)}] = String(err && err.message);
+  }
+}
+`
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.bad-decor",
+        version: "1.0.0",
+        main: mainFile,
+        contributes: {
+          fileDecorationProviders: [{ id: "declared", scopes: ["s:*"] }],
+        },
+      })
+    );
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    expect(String(readMarker(markerKey))).toContain("is not declared in contributes");
+    expect(getFileDecorationImpls("s:/x")).toEqual([]);
   });
 });
 

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -578,6 +578,114 @@ describe("PluginService integration — file decoration provider contributions",
     expect(String(readMarker(markerKey))).toContain("is not declared in contributes");
     expect(getFileDecorationImpls("s:/x")).toEqual([]);
   });
+
+  it("rejects invalidating a scope not covered by declared scopes", async () => {
+    const pluginDir = await writePlugin("acme.scope-guard", {
+      name: "acme.scope-guard",
+      version: "1.0.0",
+    });
+    const markerKey = makeMarkerKey();
+    const mainFile = `decor-${randomUUID()}.mjs`;
+    await fs.writeFile(
+      path.join(pluginDir, mainFile),
+      `export function activate(host) {
+  try {
+    host.invalidateFileDecorations("other:/x");
+  } catch (err) {
+    globalThis[${JSON.stringify(markerKey)}] = String(err && err.message);
+  }
+}
+`
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.scope-guard",
+        version: "1.0.0",
+        main: mainFile,
+        contributes: {
+          fileDecorationProviders: [{ id: "d", scopes: ["allowed:*"] }],
+        },
+      })
+    );
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    expect(String(readMarker(markerKey))).toContain("is not covered by any declared");
+  });
+
+  it("broadcasts a decorations-changed event for each declared scope on unload", async () => {
+    await writePlugin("acme.unload-decor", {
+      name: "acme.unload-decor",
+      version: "1.0.0",
+      contributes: {
+        fileDecorationProviders: [{ id: "d", scopes: ["scope-a:*", "scope-b:*"] }],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+    vi.mocked(broadcastToRenderer).mockClear();
+
+    service.unloadPlugin("acme.unload-decor");
+
+    const decorationBroadcasts = vi
+      .mocked(broadcastToRenderer)
+      .mock.calls.filter(
+        (c) =>
+          c[0] === "events:push" &&
+          (c[1] as { name?: string }).name === "plugin:decorations-changed"
+      )
+      .map((c) => (c[1] as { payload: { scope: string } }).payload.scope);
+    expect(new Set(decorationBroadcasts)).toEqual(new Set(["scope-a:*", "scope-b:*"]));
+    expect(getFileDecorationImpls("scope-a:/x")).toEqual([]);
+  });
+
+  it("invalidateFileDecorations is a silent no-op after the plugin unloads", async () => {
+    const pluginDir = await writePlugin("acme.post-unload", {
+      name: "acme.post-unload",
+      version: "1.0.0",
+    });
+    const mainFile = `decor-${randomUUID()}.mjs`;
+    // Stash the host so the test can call invalidate AFTER unload — the true
+    // post-activation path the no-op guard protects.
+    await fs.writeFile(
+      path.join(pluginDir, mainFile),
+      `export function activate(host) {
+  globalThis.__postUnloadHost = host;
+}
+`
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.post-unload",
+        version: "1.0.0",
+        main: mainFile,
+        contributes: {
+          fileDecorationProviders: [{ id: "d", scopes: ["live:*"] }],
+        },
+      })
+    );
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+    const host = (globalThis as Record<string, unknown>).__postUnloadHost as {
+      invalidateFileDecorations: (scope: string) => void;
+    };
+    service.unloadPlugin("acme.post-unload");
+    vi.mocked(broadcastToRenderer).mockClear();
+
+    expect(() => host.invalidateFileDecorations("live:/x")).not.toThrow();
+    const after = vi
+      .mocked(broadcastToRenderer)
+      .mock.calls.filter(
+        (c) => (c[1] as { name?: string } | undefined)?.name === "plugin:decorations-changed"
+      );
+    expect(after).toEqual([]);
+    delete (globalThis as Record<string, unknown>).__postUnloadHost;
+  });
 });
 
 describe("PluginService integration — main entry execution", () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -380,6 +380,67 @@ describe("PluginManifestSchema forgeProviders contribution", () => {
   });
 });
 
+describe("PluginManifestSchema fileDecorationProviders contribution", () => {
+  const validBase = { name: "acme.decor", version: "1.0.0" };
+
+  it("defaults contributes.fileDecorationProviders to [] when contributes is absent", () => {
+    const result = PluginManifestSchema.safeParse(validBase);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.fileDecorationProviders).toEqual([]);
+    }
+  });
+
+  it("defaults to [] when contributes is an empty object", () => {
+    const result = PluginManifestSchema.safeParse({ ...validBase, contributes: {} });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.fileDecorationProviders).toEqual([]);
+    }
+  });
+
+  it("accepts a valid fileDecorationProviders entry", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: {
+        fileDecorationProviders: [{ id: "worktree-diff-review", scopes: ["worktree-diff:*"] }],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.fileDecorationProviders).toEqual([
+        { id: "worktree-diff-review", scopes: ["worktree-diff:*"] },
+      ]);
+    }
+  });
+
+  it("rejects an entry with an empty scopes array", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: { fileDecorationProviders: [{ id: "d", scopes: [] }] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an entry missing required fields", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: { fileDecorationProviders: [{ id: "d" }] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown keys on the entry (strict schema)", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: {
+        fileDecorationProviders: [{ id: "d", scopes: ["s:*"], extra: true }],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("PluginService", () => {
   it("returns empty list when plugins directory does not exist", async () => {
     const service = new PluginService(path.join(tmpDir, "nonexistent"));

--- a/electron/services/__tests__/fileDecorationRegistry.test.ts
+++ b/electron/services/__tests__/fileDecorationRegistry.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { FileDecoration, FileDecorationProviderImpl } from "../../../shared/types/forge.js";
+import {
+  clearFileDecorationImplRegistry,
+  clearFileDecorationRegistry,
+  getFileDecorationImpls,
+  getRegisteredFileDecorationProviders,
+  registerFileDecorationProviderImpl,
+  registerFileDecorationProviders,
+  unregisterFileDecorationProviderImpl,
+  unregisterFileDecorationProviderImpls,
+  unregisterFileDecorationProviders,
+} from "../fileDecorationRegistry.js";
+
+beforeEach(() => {
+  clearFileDecorationRegistry();
+  clearFileDecorationImplRegistry();
+});
+
+function makeImpl(badge: string): FileDecorationProviderImpl {
+  return {
+    async provideDecorations(_scope, paths): Promise<Record<string, FileDecoration>> {
+      const out: Record<string, FileDecoration> = {};
+      for (const p of paths) out[p] = { badge };
+      return out;
+    },
+  };
+}
+
+describe("fileDecorationRegistry", () => {
+  it("registers manifest descriptors eagerly and lists them", () => {
+    registerFileDecorationProviders("acme.plugin", [{ id: "decor", scopes: ["worktree-diff:*"] }]);
+    const listed = getRegisteredFileDecorationProviders();
+    expect(listed).toEqual([
+      { pluginId: "acme.plugin", contribution: { id: "decor", scopes: ["worktree-diff:*"] } },
+    ]);
+  });
+
+  it("freezes stored contributions so callers can't mutate the registry", () => {
+    registerFileDecorationProviders("acme.plugin", [{ id: "decor", scopes: ["worktree-diff:*"] }]);
+    const [{ contribution }] = getRegisteredFileDecorationProviders();
+    expect(() => {
+      (contribution.scopes as string[]).push("x:*");
+    }).toThrow();
+  });
+
+  it("returns no impls until one is bound (descriptor present, impl lazy)", () => {
+    registerFileDecorationProviders("acme.plugin", [{ id: "decor", scopes: ["worktree-diff:*"] }]);
+    expect(getFileDecorationImpls("worktree-diff:/repo")).toEqual([]);
+
+    const impl = makeImpl("1");
+    registerFileDecorationProviderImpl("acme.plugin", "decor", impl);
+    const resolved = getFileDecorationImpls("worktree-diff:/repo");
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]).toMatchObject({ pluginId: "acme.plugin", contributionId: "decor" });
+    expect(resolved[0].impl).toBe(impl);
+  });
+
+  it("matches exact scopes, prefix wildcards, and the bare wildcard", () => {
+    registerFileDecorationProviders("p.exact", [{ id: "a", scopes: ["worktree-diff:/x"] }]);
+    registerFileDecorationProviders("p.prefix", [{ id: "b", scopes: ["worktree-diff:*"] }]);
+    registerFileDecorationProviders("p.any", [{ id: "c", scopes: ["*"] }]);
+    registerFileDecorationProviderImpl("p.exact", "a", makeImpl("a"));
+    registerFileDecorationProviderImpl("p.prefix", "b", makeImpl("b"));
+    registerFileDecorationProviderImpl("p.any", "c", makeImpl("c"));
+
+    const exact = getFileDecorationImpls("worktree-diff:/x").map((r) => r.pluginId);
+    expect(new Set(exact)).toEqual(new Set(["p.exact", "p.prefix", "p.any"]));
+
+    const other = getFileDecorationImpls("worktree-diff:/y").map((r) => r.pluginId);
+    expect(new Set(other)).toEqual(new Set(["p.prefix", "p.any"]));
+
+    const unrelated = getFileDecorationImpls("lint:/x").map((r) => r.pluginId);
+    expect(unrelated).toEqual(["p.any"]);
+  });
+
+  it("ignores empty scope input", () => {
+    registerFileDecorationProviders("p", [{ id: "a", scopes: ["*"] }]);
+    registerFileDecorationProviderImpl("p", "a", makeImpl("a"));
+    expect(getFileDecorationImpls("")).toEqual([]);
+  });
+
+  it("unregisterFileDecorationProviderImpl is identity-guarded", () => {
+    registerFileDecorationProviders("p", [{ id: "a", scopes: ["*"] }]);
+    const first = makeImpl("1");
+    const second = makeImpl("2");
+    registerFileDecorationProviderImpl("p", "a", first);
+    registerFileDecorationProviderImpl("p", "a", second); // overwrite
+
+    // Stale disposer for `first` must not remove the active `second`.
+    unregisterFileDecorationProviderImpl("p", "a", first);
+    expect(getFileDecorationImpls("x")[0]?.impl).toBe(second);
+
+    unregisterFileDecorationProviderImpl("p", "a", second);
+    expect(getFileDecorationImpls("x")).toEqual([]);
+  });
+
+  it("bulk-unregisters all impls and descriptors for a plugin on unload", () => {
+    registerFileDecorationProviders("p", [
+      { id: "a", scopes: ["*"] },
+      { id: "b", scopes: ["*"] },
+    ]);
+    registerFileDecorationProviderImpl("p", "a", makeImpl("a"));
+    registerFileDecorationProviderImpl("p", "b", makeImpl("b"));
+
+    unregisterFileDecorationProviderImpls("p");
+    expect(getFileDecorationImpls("x")).toEqual([]);
+
+    unregisterFileDecorationProviders("p");
+    expect(getRegisteredFileDecorationProviders()).toEqual([]);
+  });
+
+  it("empty contributions array clears the descriptor entry", () => {
+    registerFileDecorationProviders("p", [{ id: "a", scopes: ["*"] }]);
+    registerFileDecorationProviders("p", []);
+    expect(getRegisteredFileDecorationProviders()).toEqual([]);
+  });
+});

--- a/electron/services/fileDecorationRegistry.ts
+++ b/electron/services/fileDecorationRegistry.ts
@@ -1,0 +1,176 @@
+import type {
+  FileDecorationContribution,
+  FileDecorationProviderImpl,
+  RegisteredFileDecorationProvider,
+} from "../../shared/types/forge.js";
+
+export type { RegisteredFileDecorationProvider } from "../../shared/types/forge.js";
+
+/**
+ * Host-side registry of `fileDecorationProviders` contributions, keyed by
+ * pluginId. Mirrors the two-map structure of `forgeProviderRegistry.ts`:
+ * descriptors register eagerly from each plugin's manifest during
+ * `loadPlugin` (so scope routing is decidable before any plugin code runs),
+ * while the runtime {@link FileDecorationProviderImpl} binds lazily during
+ * `activate()` via `host.registerFileDecorationProvider`.
+ *
+ * The host treats decorations opaquely — it never inspects what a decoration
+ * represents (review threads, lint state, …). That meaning belongs entirely
+ * to the contributing plugin.
+ */
+const PLUGIN_FILE_DECORATION_PROVIDERS = new Map<string, FileDecorationContribution[]>();
+
+/**
+ * Runtime impls bound via `host.registerFileDecorationProvider`. Keyed by the
+ * canonical id `{pluginId}.{contributionId}` so a scope lookup resolves an
+ * impl without joining two maps. Separate from
+ * {@link PLUGIN_FILE_DECORATION_PROVIDERS} because descriptors register
+ * eagerly from the manifest while impls bind lazily during `activate()` —
+ * callers must treat a missing impl as "not yet bound", not an error.
+ */
+const PLUGIN_FILE_DECORATION_IMPLS = new Map<string, FileDecorationProviderImpl>();
+
+function buildImplKey(pluginId: string, contributionId: string): string {
+  return `${pluginId}.${contributionId}`;
+}
+
+function freezeContribution(c: FileDecorationContribution): FileDecorationContribution {
+  return Object.freeze({
+    ...c,
+    scopes: Object.freeze([...c.scopes]) as unknown as string[],
+  });
+}
+
+export function registerFileDecorationProviders(
+  pluginId: string,
+  contributions: FileDecorationContribution[]
+): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  if (!Array.isArray(contributions) || contributions.length === 0) {
+    PLUGIN_FILE_DECORATION_PROVIDERS.delete(pluginId);
+    return;
+  }
+  PLUGIN_FILE_DECORATION_PROVIDERS.set(pluginId, contributions.map(freezeContribution));
+}
+
+export function unregisterFileDecorationProviders(pluginId: string): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  PLUGIN_FILE_DECORATION_PROVIDERS.delete(pluginId);
+}
+
+export function clearFileDecorationRegistry(): void {
+  PLUGIN_FILE_DECORATION_PROVIDERS.clear();
+}
+
+/**
+ * Bind a runtime {@link FileDecorationProviderImpl} to a descriptor declared
+ * by `contributes.fileDecorationProviders`. Re-binding the same key
+ * overwrites — a plugin that re-registers from a deferred callback picks up
+ * the new impl on the next decoration pull.
+ */
+export function registerFileDecorationProviderImpl(
+  pluginId: string,
+  contributionId: string,
+  impl: FileDecorationProviderImpl
+): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  if (typeof contributionId !== "string" || contributionId.length === 0) return;
+  if (impl === null || typeof impl !== "object") return;
+  PLUGIN_FILE_DECORATION_IMPLS.set(buildImplKey(pluginId, contributionId), impl);
+}
+
+/**
+ * Unbind a single runtime impl. Silent no-op if the key was never bound.
+ * Pass `expected` to make the removal conditional — the entry is deleted only
+ * if it currently references that exact impl, so a stale disposer (from a
+ * prior binding that was overwritten) cannot remove the active impl.
+ */
+export function unregisterFileDecorationProviderImpl(
+  pluginId: string,
+  contributionId: string,
+  expected?: FileDecorationProviderImpl
+): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  if (typeof contributionId !== "string" || contributionId.length === 0) return;
+  const key = buildImplKey(pluginId, contributionId);
+  if (expected !== undefined) {
+    const current = PLUGIN_FILE_DECORATION_IMPLS.get(key);
+    if (current !== expected) return;
+  }
+  PLUGIN_FILE_DECORATION_IMPLS.delete(key);
+}
+
+/**
+ * Unbind every impl owned by the given plugin. Fires from `unloadPlugin`
+ * alongside descriptor cleanup. Idempotent.
+ */
+export function unregisterFileDecorationProviderImpls(pluginId: string): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  const prefix = `${pluginId}.`;
+  for (const key of [...PLUGIN_FILE_DECORATION_IMPLS.keys()]) {
+    if (key.startsWith(prefix)) {
+      PLUGIN_FILE_DECORATION_IMPLS.delete(key);
+    }
+  }
+}
+
+/** Test-isolation helper paralleling {@link clearFileDecorationRegistry}. */
+export function clearFileDecorationImplRegistry(): void {
+  PLUGIN_FILE_DECORATION_IMPLS.clear();
+}
+
+/**
+ * Match a runtime scope string against a declared scope pattern. Supports
+ * exact equality and a single trailing `*` wildcard on a `prefix:*` form
+ * (e.g. `worktree-diff:*` matches `worktree-diff:/abs/path`). A bare `*`
+ * matches any scope. No regex — the pattern space is intentionally tiny so
+ * the contract stays obvious to plugin authors.
+ */
+function scopeMatchesPattern(scope: string, pattern: string): boolean {
+  if (pattern === "*") return true;
+  if (pattern.endsWith("*")) {
+    return scope.startsWith(pattern.slice(0, -1));
+  }
+  return scope === pattern;
+}
+
+/**
+ * Resolve the bound impls whose declared scopes match `scope`, in plugin
+ * load order (stable per boot). Returns the contribution id and pluginId
+ * alongside each impl so the IPC handler can attribute results. Descriptors
+ * without a bound impl are skipped — the plugin's `activate()` may not have
+ * run yet, or it unloaded; callers treat that as "no decorations".
+ */
+export function getFileDecorationImpls(scope: string): Array<{
+  pluginId: string;
+  contributionId: string;
+  impl: FileDecorationProviderImpl;
+}> {
+  const result: Array<{
+    pluginId: string;
+    contributionId: string;
+    impl: FileDecorationProviderImpl;
+  }> = [];
+  if (typeof scope !== "string" || scope.length === 0) return result;
+  for (const [pluginId, contributions] of PLUGIN_FILE_DECORATION_PROVIDERS) {
+    for (const contribution of contributions) {
+      if (!contribution.scopes.some((p) => scopeMatchesPattern(scope, p))) continue;
+      const impl = PLUGIN_FILE_DECORATION_IMPLS.get(buildImplKey(pluginId, contribution.id));
+      if (impl) {
+        result.push({ pluginId, contributionId: contribution.id, impl });
+      }
+    }
+  }
+  return result;
+}
+
+/** Flattened snapshot of all registered descriptors (manifest-level). */
+export function getRegisteredFileDecorationProviders(): RegisteredFileDecorationProvider[] {
+  const result: RegisteredFileDecorationProvider[] = [];
+  for (const [pluginId, contributions] of PLUGIN_FILE_DECORATION_PROVIDERS) {
+    for (const contribution of contributions) {
+      result.push({ pluginId, contribution });
+    }
+  }
+  return result;
+}

--- a/electron/services/fileDecorationRegistry.ts
+++ b/electron/services/fileDecorationRegistry.ts
@@ -126,7 +126,7 @@ export function clearFileDecorationImplRegistry(): void {
  * matches any scope. No regex — the pattern space is intentionally tiny so
  * the contract stays obvious to plugin authors.
  */
-function scopeMatchesPattern(scope: string, pattern: string): boolean {
+export function scopeMatchesPattern(scope: string, pattern: string): boolean {
   if (pattern === "*") return true;
   if (pattern.endsWith("*")) {
     return scope.startsWith(pattern.slice(0, -1));

--- a/plugins/builtin/github/main/index.ts
+++ b/plugins/builtin/github/main/index.ts
@@ -1,17 +1,29 @@
 import type { PluginHostApi } from "../../../../shared/types/plugin.js";
 import { githubForgeProvider } from "./forgeProvider.js";
+import { registerReviewDecorationProvider } from "./reviewDecorationProvider.js";
 
 /**
  * Plugin activation entry point — called by `PluginService` after manifest
- * validation. Registers the `github` forge provider declared in `plugin.json`.
- * The descriptor id MUST match `contributes.forgeProviders[].id` or
- * `host.registerForgeProvider` throws.
+ * validation. Registers the `github` forge provider plus the
+ * `worktree-diff-review` file-decoration provider, both declared in
+ * `plugin.json`. The descriptor ids MUST match the manifest contributions or
+ * the host throws. Returns a disposer that tears down both.
  */
 export function activate(host: PluginHostApi): () => void {
-  return host.registerForgeProvider({ id: "github" }, githubForgeProvider);
+  const disposeForge = host.registerForgeProvider({ id: "github" }, githubForgeProvider);
+  const disposeDecorations = registerReviewDecorationProvider(host);
+  return () => {
+    disposeForge();
+    disposeDecorations();
+  };
 }
 
 export { githubForgeProvider } from "./forgeProvider.js";
+
+export {
+  createReviewDecorationProvider,
+  registerReviewDecorationProvider,
+} from "./reviewDecorationProvider.js";
 
 export {
   GitHubAuth,

--- a/plugins/builtin/github/main/reviewDecorationProvider.ts
+++ b/plugins/builtin/github/main/reviewDecorationProvider.ts
@@ -1,0 +1,74 @@
+import type { FileDecoration, FileDecorationProviderImpl } from "../../../../shared/types/forge.js";
+import type { PluginHostApi } from "../../../../shared/types/plugin.js";
+import { getPRReviewThreads } from "./GitHubPRs.js";
+
+const SCOPE_PREFIX = "worktree-diff:";
+
+/**
+ * Built-in GitHub `fileDecorationProvider` for the `worktree-diff:*` scope.
+ *
+ * Replaces the renderer's old direct `getPRReviewThreads` coupling in
+ * `ReviewHubContent`: the host now pulls decorations generically and never
+ * learns what a review thread is. The scope string carries the worktree path
+ * (`worktree-diff:/abs/path`); the provider resolves that worktree's linked
+ * PR number from the host's worktree snapshots, fetches unresolved review
+ * thread counts, and maps each to a badge/tooltip/color decoration.
+ */
+export function createReviewDecorationProvider(host: PluginHostApi): FileDecorationProviderImpl {
+  return {
+    async provideDecorations(scope, paths) {
+      if (!scope.startsWith(SCOPE_PREFIX)) return {};
+      const worktreePath = scope.slice(SCOPE_PREFIX.length);
+      if (worktreePath.length === 0 || paths.length === 0) return {};
+
+      const worktrees = await host.getWorktrees();
+      const worktree = worktrees.find((w) => w.path === worktreePath);
+      const prNumber = worktree?.linked?.pr?.ref.number;
+      if (typeof prNumber !== "number") return {};
+
+      const counts = await getPRReviewThreads(worktreePath, prNumber);
+      const wanted = new Set(paths);
+      const out: Record<string, FileDecoration> = {};
+      for (const [path, count] of Object.entries(counts)) {
+        if (count > 0 && wanted.has(path)) {
+          out[path] = {
+            badge: String(count),
+            tooltip: `${count} unresolved review comment${count !== 1 ? "s" : ""}`,
+            color: "text-status-warning",
+          };
+        }
+      }
+      return out;
+    },
+  };
+}
+
+/**
+ * Wire the provider plus a worktree-change subscription that invalidates the
+ * affected scopes so an open Review Hub re-pulls when PR linkage changes.
+ * Returns a disposer covering both.
+ */
+export function registerReviewDecorationProvider(host: PluginHostApi): () => void {
+  const disposeProvider = host.registerFileDecorationProvider(
+    { id: "worktree-diff-review" },
+    createReviewDecorationProvider(host)
+  );
+
+  // `onDidChangeWorktrees` fires after `activate()` resolves; that is exactly
+  // why `invalidateFileDecorations` is not revoke-guarded on the host side.
+  const disposeWatch = host.onDidChangeWorktrees((snapshots) => {
+    for (const wt of snapshots) {
+      if (wt.linked?.pr) {
+        host.invalidateFileDecorations(`${SCOPE_PREFIX}${wt.path}`);
+      }
+    }
+  });
+
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    disposeProvider();
+    disposeWatch();
+  };
+}

--- a/plugins/builtin/github/plugin.json
+++ b/plugins/builtin/github/plugin.json
@@ -24,6 +24,12 @@
           "releases"
         ]
       }
+    ],
+    "fileDecorationProviders": [
+      {
+        "id": "worktree-diff-review",
+        "scopes": ["worktree-diff:*"]
+      }
     ]
   }
 }

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -460,3 +460,76 @@ export interface ResolvedForgeProvider {
   entry: ForgeProviderEntry | null;
   resolvedVia: ForgeProviderResolutionVia | null;
 }
+
+/**
+ * Per-file decoration a plugin attaches to a path within a named scope.
+ * Modelled on VS Code's `FileDecoration`. The host renders this opaquely —
+ * it never inspects what the decoration represents (review threads, lint
+ * errors, sync state, …); that meaning is entirely the plugin's.
+ *
+ * `color` is a raw string passed straight to `className` on the renderer
+ * side, matching the existing plugin-contributed color convention
+ * ({@link ForgeProviderContribution} has no color, but `PanelContribution`
+ * and `ToolbarButtonContribution` already pass raw color/token strings).
+ * Plugins are responsible for using a valid design-system semantic token.
+ */
+export interface FileDecoration {
+  /** Short badge text — keep to ≤2 visible chars per the VS Code convention. */
+  badge?: string;
+  /** Hover tooltip describing what the decoration means. */
+  tooltip?: string;
+  /** Opaque color token/class passed through to `className` by the host. */
+  color?: string;
+}
+
+/**
+ * Runtime contract a plugin implements and binds via
+ * `host.registerFileDecorationProvider`. The host invokes
+ * {@link provideDecorations} on demand (renderer pull) and never caches the
+ * result — invalidation is signalled separately via
+ * `host.invalidateFileDecorations`.
+ *
+ * `scope` is a runtime string (e.g. `worktree-diff:/abs/worktree/path`); the
+ * provider decides how to interpret it. `paths` is the set of file paths the
+ * caller currently cares about — the provider should return a map containing
+ * only the paths it has a decoration for (omitted paths render undecorated).
+ */
+export interface FileDecorationProviderImpl {
+  provideDecorations(scope: string, paths: string[]): Promise<Record<string, FileDecoration>>;
+}
+
+/**
+ * `fileDecorationProviders` manifest entry. Eager (manifest-driven)
+ * registration lets the host know which plugin owns which scopes before any
+ * plugin code runs; the implementation handler binds lazily during
+ * `activate()` via `host.registerFileDecorationProvider`.
+ *
+ * `scopes` are exact strings or `prefix:*` wildcards (e.g. `worktree-diff:*`)
+ * — the host matches a runtime scope against these to decide which providers
+ * to invoke. At least one scope pattern is required.
+ */
+export interface FileDecorationContribution {
+  /** Namespaced at runtime as `{pluginId}.{id}`; must match the descriptor passed to `registerFileDecorationProvider`. */
+  id: string;
+  /** Exact scope strings or `prefix:*` wildcards this provider handles. */
+  scopes: string[];
+}
+
+/**
+ * Passed to `host.registerFileDecorationProvider` alongside the impl. Mirrors
+ * the manifest entry; only `id` is required since `scopes` are already
+ * declared statically in `plugin.json`.
+ */
+export interface FileDecorationProviderDescriptor {
+  id: string;
+  scopes?: string[];
+}
+
+/**
+ * Registry-surface shape for a `fileDecorationProviders` contribution, paired
+ * with the `pluginId` that registered it.
+ */
+export interface RegisteredFileDecorationProvider {
+  pluginId: string;
+  contribution: FileDecorationContribution;
+}

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1547,6 +1547,23 @@ export interface ElectronAPI {
     getPanelKinds(): Promise<import("../../config/panelKindRegistry.js").PanelKindConfig[]>;
     /** Pull the current set of registered forge providers (pluginId + manifest contribution). */
     getForgeProviders(): Promise<import("../forge.js").RegisteredForgeProvider[]>;
+    /**
+     * Pull merged per-file decorations for `scope` over `paths` from every
+     * matching plugin provider. Returns a map of path → decoration; paths
+     * with no decoration are omitted.
+     */
+    getDecorations(
+      scope: string,
+      paths: string[]
+    ): Promise<Record<string, import("../forge.js").FileDecoration>>;
+    /**
+     * Subscribe to file-decoration invalidations. The callback fires with the
+     * changed scope (and optionally the narrowed paths) — it carries no
+     * decoration data; re-pull via {@link getDecorations}. Returns a cleanup.
+     */
+    onDecorationsChanged(
+      callback: (payload: { scope: string; paths?: string[] }) => void
+    ): () => void;
     /** Subscribe to plugin panel kind registry changes. Returns a cleanup. */
     onPanelKindsChanged(
       callback: (payload: {

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -230,6 +230,10 @@ export interface GeneratedIpcInvokeMap {
     args: [pluginId: string, actionId: string];
     result: void;
   };
+  "plugin:file-decorations-get": {
+    args: [scope: string, paths: string[]];
+    result: Record<string, import("../forge.js").FileDecoration>;
+  };
   "plugin:forge-providers-get": {
     args: [];
     result: import("../forge.js").RegisteredForgeProvider[];

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2437,6 +2437,14 @@ export interface IpcEventMap {
     complete: boolean;
   };
 
+  // Plugin file-decoration invalidation (main → renderer). Carries only the
+  // changed scope (optionally narrowed to `paths`) — never decoration data.
+  // The renderer re-pulls fresh decorations via `plugin:file-decorations-get`.
+  "plugin:decorations-changed": {
+    scope: string;
+    paths?: string[];
+  };
+
   // Resource profile change (main → renderer)
   "resource:profile-changed": import("../resourceProfile.js").ResourceProfilePayload;
 
@@ -2511,6 +2519,8 @@ export type IpcEventBusMap = Pick<
   | "plugin:panel-kinds-changed"
   // Plugin toolbar button registry (global broadcast)
   | "plugin:toolbar-buttons-changed"
+  // Plugin file-decoration invalidation (global broadcast)
+  | "plugin:decorations-changed"
   // Terminal lifecycle (non-data) — exit, spawn-result, backend crash/ready
   | "terminal:exit"
   | "terminal:backend-crashed"

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1,4 +1,7 @@
 import type {
+  FileDecorationContribution,
+  FileDecorationProviderDescriptor,
+  FileDecorationProviderImpl,
   ForgeProviderContribution,
   ForgeProviderDescriptor,
   ForgeProviderImpl,
@@ -100,6 +103,7 @@ export interface PluginManifest {
     views: ViewContribution[];
     mcpServers: McpServerContribution[];
     forgeProviders: ForgeProviderContribution[];
+    fileDecorationProviders: FileDecorationContribution[];
   };
 }
 
@@ -227,6 +231,32 @@ export interface PluginHostApi {
    * later invoked.
    */
   registerForgeProvider(descriptor: ForgeProviderDescriptor, impl: ForgeProviderImpl): () => void;
+  /**
+   * Bind a runtime {@link FileDecorationProviderImpl} to a descriptor declared
+   * in `contributes.fileDecorationProviders`. The descriptor's `id` is
+   * namespaced at runtime as `{pluginId}.{descriptor.id}` and must match an
+   * entry in the manifest — an undeclared id is rejected so the impl cannot
+   * drift away from the manifest-driven scope-routing table. Returns a
+   * disposer that unbinds the single implementation; all bindings are
+   * automatically removed when the plugin is unloaded. Must be called during
+   * `activate()` — the host is revoked once activation resolves or times out.
+   * Calling this twice with the same `descriptor.id` overwrites the prior
+   * binding; the older disposer becomes inert.
+   */
+  registerFileDecorationProvider(
+    descriptor: FileDecorationProviderDescriptor,
+    impl: FileDecorationProviderImpl
+  ): () => void;
+  /**
+   * Signal that decorations for `scope` (optionally narrowed to `paths`) have
+   * changed and any renderer showing them should re-pull. Unlike the
+   * `register*` methods this is NOT revoke-guarded: it is called from the
+   * plugin's own subscription callbacks (worktree changes, polling timers)
+   * which fire long after `activate()` resolves, and must remain callable for
+   * the plugin's whole lifetime. It becomes a silent no-op once the plugin is
+   * unloaded.
+   */
+  invalidateFileDecorations(scope: string, paths?: string[]): void;
 }
 
 export type PluginActivate = (

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -55,6 +55,7 @@ import {
 import { EmptyState } from "@/components/ui/EmptyState";
 import { debounce } from "@/utils/debounce";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
+import { useFileDecorations } from "@/hooks/useFileDecorations";
 import { useShallow } from "zustand/react/shallow";
 // eslint-disable-next-line no-restricted-imports
 import { githubClient } from "@/clients/githubClient";
@@ -249,8 +250,6 @@ export function ReviewHubContent({
   const [selectedBaseBranchFile, setSelectedBaseBranchFile] = useState<CrossWorktreeFile | null>(
     null
   );
-  const [reviewThreadCounts, setReviewThreadCounts] = useState<Record<string, number> | null>(null);
-  const reviewThreadsRequestRef = useRef(0);
   const [selectedPaths, setSelectedPaths] = useState<Set<string>>(() => new Set());
   const [selectionSection, setSelectionSection] = useState<FileStageRowSection | null>(null);
   const refreshIdRef = useRef(0);
@@ -389,6 +388,21 @@ export function ReviewHubContent({
       return null;
     })
   );
+
+  // Per-file review-thread badges now come from the generic plugin
+  // file-decoration system (the built-in GitHub plugin contributes the
+  // `worktree-diff:*` provider) rather than a direct `getPRReviewThreads`
+  // call here. The scope is empty (→ no-op, no IPC) unless the base-branch
+  // diff is showing for a worktree with a linked PR.
+  const decorationScope =
+    isOpen && diffMode === "base-branch" && worktreePR?.prNumber && worktreePath
+      ? `worktree-diff:${worktreePath}`
+      : "";
+  const decorationPaths = useMemo(
+    () => sortedBaseBranchFiles?.map((f) => f.path) ?? [],
+    [sortedBaseBranchFiles]
+  );
+  const reviewDecorations = useFileDecorations(decorationScope, decorationPaths);
 
   const behindCount = useWorktreeStore((state) => {
     for (const wt of state.worktrees.values()) {
@@ -530,7 +544,6 @@ export function ReviewHubContent({
       refreshIdRef.current++;
       bgRefreshIdRef.current++;
       baseBranchRequestRef.current++;
-      reviewThreadsRequestRef.current++;
       setStatus(null);
       setLoadError(null);
       setActionError(null);
@@ -542,7 +555,6 @@ export function ReviewHubContent({
       setBaseBranchFiles(null);
       setBaseBranchError(null);
       setSelectedBaseBranchFile(null);
-      setReviewThreadCounts(null);
       setForcePushDialogOpen(false);
       setPullRebasing(false);
       isPullRebasingRef.current = false;
@@ -598,38 +610,12 @@ export function ReviewHubContent({
   useEffect(() => {
     if (diffMode === "base-branch" && status?.currentBranch === mainBranch) {
       baseBranchRequestRef.current++;
-      reviewThreadsRequestRef.current++;
       setDiffMode("working-tree");
       setBaseBranchFiles(null);
       setBaseBranchError(null);
       setSelectedBaseBranchFile(null);
-      setReviewThreadCounts(null);
     }
   }, [status?.currentBranch, mainBranch, diffMode]);
-
-  useEffect(() => {
-    if (!isOpen || diffMode !== "base-branch" || !worktreePR?.prNumber || !worktreePath) {
-      if (diffMode !== "base-branch") {
-        setReviewThreadCounts(null);
-      }
-      return;
-    }
-
-    const requestId = ++reviewThreadsRequestRef.current;
-
-    void (async () => {
-      try {
-        const counts = await githubClient.getPRReviewThreads(worktreePath, worktreePR.prNumber!);
-        if (reviewThreadsRequestRef.current === requestId) {
-          setReviewThreadCounts(counts);
-        }
-      } catch {
-        if (reviewThreadsRequestRef.current === requestId) {
-          setReviewThreadCounts(null);
-        }
-      }
-    })();
-  }, [isOpen, diffMode, worktreePR?.prNumber, worktreePath]);
 
   useEffect(() => {
     if (!status || !selectionSection) return;
@@ -1510,7 +1496,12 @@ export function ReviewHubContent({
                       key={`${file.status}:${file.path}`}
                       file={file}
                       onClick={() => setSelectedBaseBranchFile(file)}
-                      unresolvedCount={reviewThreadCounts?.[file.path]}
+                      unresolvedCount={(() => {
+                        const badge = reviewDecorations[file.path]?.badge;
+                        if (badge === undefined) return undefined;
+                        const n = Number.parseInt(badge, 10);
+                        return Number.isNaN(n) ? undefined : n;
+                      })()}
                       onBadgeClick={
                         worktreePR?.prUrl
                           ? () =>

--- a/src/hooks/__tests__/useFileDecorations.test.ts
+++ b/src/hooks/__tests__/useFileDecorations.test.ts
@@ -101,6 +101,48 @@ describe("useFileDecorations", () => {
     expect(getDecorationsMock).toHaveBeenCalledTimes(1);
   });
 
+  it("re-pulls on a wildcard payload scope (plugin-unload broadcast)", async () => {
+    let listener: ((p: { scope: string; paths?: string[] }) => void) | undefined;
+    onDecorationsChangedMock.mockImplementation((cb: typeof listener) => {
+      listener = cb;
+      return () => {};
+    });
+    getDecorationsMock.mockResolvedValueOnce({ "a.ts": { badge: "1" } });
+    const useFileDecorations = await load();
+    const { result } = renderHook(() => useFileDecorations("worktree-diff:/r", ["a.ts"]));
+    await waitFor(() => expect(result.current).toEqual({ "a.ts": { badge: "1" } }));
+
+    getDecorationsMock.mockResolvedValueOnce({});
+    act(() => listener?.({ scope: "worktree-diff:*" }));
+    await waitFor(() => expect(result.current).toEqual({}));
+  });
+
+  it("ignores a stale fetch that resolves after a newer one", async () => {
+    let listener: ((p: { scope: string; paths?: string[] }) => void) | undefined;
+    onDecorationsChangedMock.mockImplementation((cb: typeof listener) => {
+      listener = cb;
+      return () => {};
+    });
+    let resolveFirst: ((v: Record<string, FileDecoration>) => void) | undefined;
+    getDecorationsMock.mockReturnValueOnce(
+      new Promise<Record<string, FileDecoration>>((res) => {
+        resolveFirst = res;
+      })
+    );
+    const useFileDecorations = await load();
+    const { result } = renderHook(() => useFileDecorations("s:1", ["a.ts"]));
+
+    // Second fetch (from invalidation) resolves first with the fresh value.
+    getDecorationsMock.mockResolvedValueOnce({ "a.ts": { badge: "new" } });
+    act(() => listener?.({ scope: "s:1" }));
+    await waitFor(() => expect(result.current).toEqual({ "a.ts": { badge: "new" } }));
+
+    // The stale first fetch resolves late — it must NOT clobber the fresh value.
+    act(() => resolveFirst?.({ "a.ts": { badge: "stale" } }));
+    await Promise.resolve();
+    expect(result.current).toEqual({ "a.ts": { badge: "new" } });
+  });
+
   it("ignores invalidation whose narrowed paths don't intersect visible paths", async () => {
     let listener: ((p: { scope: string; paths?: string[] }) => void) | undefined;
     onDecorationsChangedMock.mockImplementation((cb: typeof listener) => {

--- a/src/hooks/__tests__/useFileDecorations.test.ts
+++ b/src/hooks/__tests__/useFileDecorations.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { FileDecoration } from "@shared/types/forge";
+
+const { getDecorationsMock, onDecorationsChangedMock } = vi.hoisted(() => ({
+  getDecorationsMock: vi.fn(),
+  onDecorationsChangedMock: vi.fn(),
+}));
+
+vi.mock("@/utils/logger", () => ({ logWarn: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as unknown as { window: unknown }).window = Object.assign(globalThis.window ?? {}, {
+    electron: {
+      plugin: {
+        getDecorations: getDecorationsMock,
+        onDecorationsChanged: onDecorationsChangedMock,
+      },
+    },
+  });
+  getDecorationsMock.mockResolvedValue({});
+  onDecorationsChangedMock.mockReturnValue(() => {});
+});
+
+async function load() {
+  const { useFileDecorations } = await import("../useFileDecorations");
+  return useFileDecorations;
+}
+
+describe("useFileDecorations", () => {
+  it("pulls decorations on mount for the given scope and paths", async () => {
+    const decos: Record<string, FileDecoration> = { "a.ts": { badge: "2" } };
+    getDecorationsMock.mockResolvedValue(decos);
+    const useFileDecorations = await load();
+
+    const { result } = renderHook(() => useFileDecorations("worktree-diff:/r", ["a.ts", "b.ts"]));
+
+    await waitFor(() => {
+      expect(result.current).toEqual(decos);
+    });
+    expect(getDecorationsMock).toHaveBeenCalledWith("worktree-diff:/r", ["a.ts", "b.ts"]);
+  });
+
+  it("returns a stable empty object and skips IPC when scope is empty", async () => {
+    const useFileDecorations = await load();
+    const { result, rerender } = renderHook(
+      ({ s }: { s: string }) => useFileDecorations(s, ["a.ts"]),
+      { initialProps: { s: "" } }
+    );
+    const first = result.current;
+    rerender({ s: "" });
+    expect(result.current).toBe(first);
+    expect(getDecorationsMock).not.toHaveBeenCalled();
+  });
+
+  it("skips IPC when there are no paths", async () => {
+    const useFileDecorations = await load();
+    renderHook(() => useFileDecorations("s:1", []));
+    expect(getDecorationsMock).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates and sorts paths before fetching", async () => {
+    const useFileDecorations = await load();
+    renderHook(() => useFileDecorations("s:1", ["b.ts", "a.ts", "b.ts"]));
+    await waitFor(() => {
+      expect(getDecorationsMock).toHaveBeenCalledWith("s:1", ["a.ts", "b.ts"]);
+    });
+  });
+
+  it("re-pulls when a matching invalidation event fires", async () => {
+    let listener: ((p: { scope: string; paths?: string[] }) => void) | undefined;
+    onDecorationsChangedMock.mockImplementation((cb: typeof listener) => {
+      listener = cb;
+      return () => {};
+    });
+    getDecorationsMock.mockResolvedValueOnce({ "a.ts": { badge: "1" } });
+    const useFileDecorations = await load();
+
+    const { result } = renderHook(() => useFileDecorations("s:1", ["a.ts"]));
+    await waitFor(() => expect(result.current).toEqual({ "a.ts": { badge: "1" } }));
+
+    getDecorationsMock.mockResolvedValueOnce({ "a.ts": { badge: "5" } });
+    act(() => listener?.({ scope: "s:1" }));
+    await waitFor(() => expect(result.current).toEqual({ "a.ts": { badge: "5" } }));
+  });
+
+  it("ignores invalidation for a different scope", async () => {
+    let listener: ((p: { scope: string; paths?: string[] }) => void) | undefined;
+    onDecorationsChangedMock.mockImplementation((cb: typeof listener) => {
+      listener = cb;
+      return () => {};
+    });
+    const useFileDecorations = await load();
+    renderHook(() => useFileDecorations("s:1", ["a.ts"]));
+    await waitFor(() => expect(getDecorationsMock).toHaveBeenCalledTimes(1));
+
+    act(() => listener?.({ scope: "other:scope" }));
+    // No additional fetch for the unrelated scope.
+    expect(getDecorationsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores invalidation whose narrowed paths don't intersect visible paths", async () => {
+    let listener: ((p: { scope: string; paths?: string[] }) => void) | undefined;
+    onDecorationsChangedMock.mockImplementation((cb: typeof listener) => {
+      listener = cb;
+      return () => {};
+    });
+    const useFileDecorations = await load();
+    renderHook(() => useFileDecorations("s:1", ["a.ts"]));
+    await waitFor(() => expect(getDecorationsMock).toHaveBeenCalledTimes(1));
+
+    act(() => listener?.({ scope: "s:1", paths: ["unrelated.ts"] }));
+    expect(getDecorationsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useFileDecorations.ts
+++ b/src/hooks/useFileDecorations.ts
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { FileDecoration } from "@shared/types/forge";
+import { logWarn } from "@/utils/logger";
+
+/**
+ * Stable empty result. Returning the same object identity when there are no
+ * decorations keeps consumers' `useMemo`/`useEffect` deps from thrashing.
+ */
+const EMPTY: Readonly<Record<string, FileDecoration>> = Object.freeze({});
+
+/**
+ * Subscribe to plugin-contributed file decorations for `scope` over `paths`.
+ *
+ * The host knows nothing about what a decoration means — a plugin (e.g. the
+ * built-in GitHub plugin for `worktree-diff:*`) supplies badge/tooltip/color
+ * per path; this hook just renders whatever it gets.
+ *
+ * Data flow mirrors `usePluginPanelKinds`: pull on mount and whenever
+ * `scope`/`paths` change, plus a lightweight push subscription
+ * (`plugin:decorations-changed`) that re-pulls when a matching scope is
+ * invalidated. The push payload carries only keys, never decoration data, so
+ * the renderer always fetches fresh values for exactly the visible paths.
+ * Pull-on-mount is the safety net for cached `WebContentsView`s that missed a
+ * broadcast.
+ */
+export function useFileDecorations(scope: string, paths: string[]): Record<string, FileDecoration> {
+  // Deduplicate + stabilize so an array with identical contents but a new
+  // identity does not retrigger the fetch effect every render.
+  const cleanPaths = useMemo(() => {
+    const seen = new Set<string>();
+    for (const p of paths) {
+      if (typeof p === "string" && p.length > 0) seen.add(p);
+    }
+    return [...seen].sort();
+  }, [paths]);
+  const pathsKey = cleanPaths.join("\n");
+
+  const [decorations, setDecorations] = useState<Record<string, FileDecoration>>(EMPTY);
+
+  // Keep the latest path set readable from the subscription callback without
+  // making it a dependency (the callback is registered once per scope).
+  const pathsRef = useRef<string[]>(cleanPaths);
+  pathsRef.current = cleanPaths;
+
+  useEffect(() => {
+    const electron = typeof window !== "undefined" ? window.electron : undefined;
+    if (!electron?.plugin || scope.length === 0) {
+      setDecorations(EMPTY);
+      return;
+    }
+    if (pathsRef.current.length === 0) {
+      setDecorations(EMPTY);
+      return;
+    }
+
+    let disposed = false;
+    let requestId = 0;
+
+    const fetchDecorations = (): void => {
+      const current = ++requestId;
+      const requested = pathsRef.current;
+      if (requested.length === 0) {
+        setDecorations(EMPTY);
+        return;
+      }
+      void electron.plugin
+        .getDecorations(scope, requested)
+        .then((result) => {
+          if (disposed || current !== requestId) return;
+          setDecorations(result && Object.keys(result).length > 0 ? result : EMPTY);
+        })
+        .catch((err: unknown) => {
+          if (disposed || current !== requestId) return;
+          logWarn("[FileDecorations] Failed to fetch decorations", {
+            scope,
+            error: err,
+          });
+          setDecorations(EMPTY);
+        });
+    };
+
+    fetchDecorations();
+
+    const cleanup = electron.plugin.onDecorationsChanged((payload) => {
+      if (payload.scope !== scope) return;
+      // No path narrowing, or the invalidated paths intersect what we show →
+      // re-pull. An empty intersection means nothing visible changed.
+      if (payload.paths && payload.paths.length > 0) {
+        const visible = new Set(pathsRef.current);
+        if (!payload.paths.some((p) => visible.has(p))) return;
+      }
+      fetchDecorations();
+    });
+
+    return () => {
+      disposed = true;
+      cleanup();
+    };
+    // `pathsKey` is the stable trigger (the deduped+sorted join). `cleanPaths`
+    // itself is intentionally NOT a dep — it gets a fresh identity every
+    // render (its memo depends on the caller's array identity), so including
+    // it would re-run this effect every render and let a later stale fetch
+    // overwrite a fresh result. The current path set is read off `pathsRef`.
+  }, [scope, pathsKey]);
+
+  return decorations;
+}

--- a/src/hooks/useFileDecorations.ts
+++ b/src/hooks/useFileDecorations.ts
@@ -9,6 +9,19 @@ import { logWarn } from "@/utils/logger";
 const EMPTY: Readonly<Record<string, FileDecoration>> = Object.freeze({});
 
 /**
+ * An invalidation payload scope may be a concrete scope (from a plugin's
+ * `invalidateFileDecorations`, which equals this hook's scope) or a declared
+ * pattern (`prefix:*` / `*`, broadcast when a plugin unloads). Match both with
+ * the same tiny rule the host registry uses so an unload-time wildcard still
+ * triggers a re-pull. Exact equality is the `pattern === scope` branch.
+ */
+function payloadScopeMatches(payloadScope: string, scope: string): boolean {
+  if (payloadScope === "*") return true;
+  if (payloadScope.endsWith("*")) return scope.startsWith(payloadScope.slice(0, -1));
+  return payloadScope === scope;
+}
+
+/**
  * Subscribe to plugin-contributed file decorations for `scope` over `paths`.
  *
  * The host knows nothing about what a decoration means — a plugin (e.g. the
@@ -33,7 +46,9 @@ export function useFileDecorations(scope: string, paths: string[]): Record<strin
     }
     return [...seen].sort();
   }, [paths]);
-  const pathsKey = cleanPaths.join("\n");
+  // NUL join: the one byte that cannot appear in a POSIX path, so the key is
+  // unambiguous even for filenames containing newlines.
+  const pathsKey = cleanPaths.join("\0");
 
   const [decorations, setDecorations] = useState<Record<string, FileDecoration>>(EMPTY);
 
@@ -82,7 +97,7 @@ export function useFileDecorations(scope: string, paths: string[]): Record<strin
     fetchDecorations();
 
     const cleanup = electron.plugin.onDecorationsChanged((payload) => {
-      if (payload.scope !== scope) return;
+      if (!payloadScopeMatches(payload.scope, scope)) return;
       // No path narrowing, or the invalidated paths intersect what we show →
       // re-pull. An empty intersection means nothing visible changed.
       if (payload.paths && payload.paths.length > 0) {


### PR DESCRIPTION
## Summary

- Adds `fileDecorationProviders` as a new plugin contribution point, modeled closely on VS Code's `FileDecorationProvider` API.
- IPC is pull-on-demand (`plugin:file-decorations-get`) with a lightweight invalidation broadcast (`plugin:decorations-changed`) that sends only changed keys — not full decoration data.
- The built-in GitHub plugin contributes a `worktree-diff-review` decoration provider; `ReviewHubContent` is migrated off direct `getPRReviewThreads` coupling to consume it through the new system.

Resolves #8511

## Changes

- **Host registry** (`electron/services/fileDecorationRegistry.ts`): two-map registry mirroring the `forgeProviderRegistry` pattern. Per-provider 3s timeout, first-writer-wins per-field merge (`badge`, `color`, `tooltip`), requested-path filtering, and scope-guarded invalidation on provider unload.
- **IPC** (`electron/ipc/handlers/plugin.ts`, `channels.ts`, `plugin.preload.ts`): `plugin:file-decorations-get` handler + `plugin:decorations-changed` invalidation broadcast wired into the event bus.
- **Renderer hook** (`src/hooks/useFileDecorations.ts`): `useFileDecorations` subscribes to invalidation events and pulls fresh decorations on demand.
- **GitHub plugin** (`plugins/builtin/github/main/reviewDecorationProvider.ts`): contributes a `worktree-diff-review` provider; `ReviewHubContent` updated to consume decorations via the hook.
- **Types** (`shared/types/forge.ts`, `shared/types/plugin.ts`, `shared/types/ipc/`): `FileDecoration`, `FileDecorationProvider`, `FileDecorationMap` added; IPC maps updated.

## Testing

- Unit tests for `fileDecorationRegistry` covering timeout, merge semantics, path filtering, and invalidation on unload.
- `useFileDecorations` hook tests covering subscription, pull-on-demand, and stale-key cleanup.
- Integration test (`PluginService.integration.test.ts`) registers a fake non-GitHub plugin with a decoration provider and verifies the host serves decorations opaquely.
- All 244 unit tests pass; typecheck, lint, and build clean.