### PR TITLE
chore(terminal): demote scrollback-reduced warning to log

### DIFF
--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -747,7 +747,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
           icon={HardDrive}
           title="Scrollback history"
           id="terminal-scrollback"
-          description="Base scrollback applies to agent terminals. Shells and dev servers use reduced limits automatically."
+          description="Base scrollback applies to agent terminals. Shells and dev servers use reduced limits automatically. Background terminals may temporarily reduce scrollback under memory pressure."
           badge="New Terminals"
         >
           <div className="grid grid-cols-4 gap-3" role="radiogroup" aria-label="Scrollback presets">

--- a/src/services/terminal/TerminalScrollbackController.ts
+++ b/src/services/terminal/TerminalScrollbackController.ts
@@ -3,6 +3,7 @@ import { useScrollbackStore } from "@/store/scrollbackStore";
 import { usePerformanceModeStore } from "@/store/performanceModeStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { getScrollbackForType, PERFORMANCE_MODE_SCROLLBACK } from "@/utils/scrollbackConfig";
+import { logInfo } from "@/utils/logger";
 
 function getValidScrollbackBase(value: number | undefined): number | undefined {
   if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
@@ -45,9 +46,14 @@ export function reduceScrollback(
   managed.lastScrollbackReduceAt = Date.now();
 
   if (scrollbackUsed > targetLines) {
-    managed.terminal.write(
-      `\r\n\x1b[33m[Daintree] Scrollback reduced to ${targetLines} lines due to memory pressure. Older history is no longer available.\x1b[0m\r\n`
-    );
+    logInfo("Terminal scrollback reduced under memory pressure", {
+      targetLines,
+      scrollbackUsed,
+      previousScrollback: currentScrollback,
+      rows: managed.terminal.rows,
+      kind: managed.kind,
+      force: options.force === true,
+    });
   }
 }
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { logInfo } from "@/utils/logger";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -59,6 +60,13 @@ vi.mock("@/store/performanceModeStore", () => ({
 const mockProjectSettingsStore: { settings: Record<string, unknown> | null } = { settings: null };
 vi.mock("@/store/projectSettingsStore", () => ({
   useProjectSettingsStore: { getState: () => mockProjectSettingsStore },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
 }));
 
 type ScrollbackTestService = {
@@ -164,7 +172,7 @@ describe("TerminalInstanceService - Scrollback", () => {
       expect(managed.terminal.options.scrollback).toBe(300);
     });
 
-    it("reduces scrollback and writes notice when scrollback content exceeds target", () => {
+    it("reduces scrollback and logs info without writing to terminal when content exceeds target", () => {
       const managed = makeMockManaged();
       // 3000 total - 24 viewport = 2976 scrollback lines > 500 target
       managed.terminal.buffer.active.length = 3000;
@@ -173,11 +181,20 @@ describe("TerminalInstanceService - Scrollback", () => {
       service.reduceScrollback("t1", 500);
 
       expect(managed.terminal.options.scrollback).toBe(500);
-      expect(managed.writtenData).toHaveLength(1);
-      expect(managed.writtenData[0]).toContain("Scrollback reduced to 500 lines");
+      expect(managed.writtenData).toHaveLength(0);
+      expect(logInfo).toHaveBeenCalledTimes(1);
+      expect(logInfo).toHaveBeenCalledWith(
+        "Terminal scrollback reduced under memory pressure",
+        expect.objectContaining({
+          targetLines: 500,
+          scrollbackUsed: 2976,
+          previousScrollback: 5000,
+          rows: 24,
+        })
+      );
     });
 
-    it("reduces scrollback without notice when scrollback content is within target", () => {
+    it("reduces scrollback without logging when scrollback content is within target", () => {
       const managed = makeMockManaged();
       // 100 total - 24 viewport = 76 scrollback lines < 500 target
       managed.terminal.buffer.active.length = 100;
@@ -187,6 +204,7 @@ describe("TerminalInstanceService - Scrollback", () => {
 
       expect(managed.terminal.options.scrollback).toBe(500);
       expect(managed.writtenData).toHaveLength(0);
+      expect(logInfo).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalScrollbackController.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.adversarial.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { reduceScrollback, restoreScrollback } from "../TerminalScrollbackController";
 import type { ManagedTerminal } from "../types";
+import { logInfo } from "@/utils/logger";
 
 const mockState = vi.hoisted(() => ({
   scrollbackStore: { scrollbackLines: 5000 },
@@ -20,6 +21,13 @@ vi.mock("@/store/performanceModeStore", () => ({
 
 vi.mock("@/store/projectSettingsStore", () => ({
   useProjectSettingsStore: { getState: () => mockState.projectSettingsStore },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
 }));
 
 function createManagedTerminal(
@@ -52,6 +60,7 @@ describe("TerminalScrollbackController adversarial", () => {
     mockState.scrollbackStore.scrollbackLines = 5000;
     mockState.performanceModeStore.performanceMode = false;
     mockState.projectSettingsStore.settings = null;
+    vi.mocked(logInfo).mockClear();
   });
 
   it("INVALID_PROJECT_OVERRIDE_NAN", () => {
@@ -97,9 +106,10 @@ describe("TerminalScrollbackController adversarial", () => {
 
     expect(managed.terminal.options.scrollback).toBe(500);
     expect(managed.terminal.write).not.toHaveBeenCalled();
+    expect(logInfo).not.toHaveBeenCalled();
   });
 
-  it("HUGE_BUFFER_REDUCTION_ONE_NOTICE", () => {
+  it("HUGE_BUFFER_REDUCTION_LOGS_ONCE_NO_TERMINAL_WRITE", () => {
     const managed = createManagedTerminal({}, {
       options: { scrollback: 2_000_000 },
       buffer: { active: { length: 5_000_000 } },
@@ -108,9 +118,16 @@ describe("TerminalScrollbackController adversarial", () => {
     reduceScrollback(managed, 500);
 
     expect(managed.terminal.options.scrollback).toBe(500);
-    expect(managed.terminal.write).toHaveBeenCalledTimes(1);
-    expect(managed.terminal.write).toHaveBeenCalledWith(
-      expect.stringContaining("Scrollback reduced to 500 lines")
+    expect(managed.terminal.write).not.toHaveBeenCalled();
+    expect(logInfo).toHaveBeenCalledTimes(1);
+    expect(logInfo).toHaveBeenCalledWith(
+      "Terminal scrollback reduced under memory pressure",
+      expect.objectContaining({
+        targetLines: 500,
+        scrollbackUsed: 4_999_976,
+        previousScrollback: 2_000_000,
+        rows: 24,
+      })
     );
   });
 

--- a/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { reduceScrollback, restoreScrollback } from "../TerminalScrollbackController";
 import type { ManagedTerminal } from "../types";
+import { logInfo } from "@/utils/logger";
 
 const mockScrollbackStore = { scrollbackLines: 5000 };
 vi.mock("@/store/scrollbackStore", () => ({
@@ -15,6 +16,13 @@ vi.mock("@/store/performanceModeStore", () => ({
 const mockProjectSettingsStore: { settings: Record<string, unknown> | null } = { settings: null };
 vi.mock("@/store/projectSettingsStore", () => ({
   useProjectSettingsStore: { getState: () => mockProjectSettingsStore },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
 }));
 
 function getWrittenData(managed: ManagedTerminal): string[] {
@@ -46,6 +54,7 @@ describe("TerminalScrollbackController", () => {
     mockScrollbackStore.scrollbackLines = 5000;
     mockPerformanceModeStore.performanceMode = false;
     mockProjectSettingsStore.settings = null;
+    vi.mocked(logInfo).mockClear();
   });
 
   describe("reduceScrollback", () => {
@@ -81,7 +90,7 @@ describe("TerminalScrollbackController", () => {
       expect(managed.terminal.options.scrollback).toBe(300);
     });
 
-    it("reduces scrollback and writes notice when scrollback content exceeds target", () => {
+    it("reduces scrollback and logs info without polluting the terminal when content exceeds target", () => {
       const managed = makeMockManaged();
       Object.defineProperty(managed.terminal.buffer.active, "length", {
         value: 3000,
@@ -90,11 +99,20 @@ describe("TerminalScrollbackController", () => {
       reduceScrollback(managed, 500);
 
       expect(managed.terminal.options.scrollback).toBe(500);
-      expect(getWrittenData(managed)).toHaveLength(1);
-      expect(getWrittenData(managed)[0]).toContain("Scrollback reduced to 500 lines");
+      expect(getWrittenData(managed)).toHaveLength(0);
+      expect(logInfo).toHaveBeenCalledTimes(1);
+      expect(logInfo).toHaveBeenCalledWith(
+        "Terminal scrollback reduced under memory pressure",
+        expect.objectContaining({
+          targetLines: 500,
+          scrollbackUsed: 2976,
+          previousScrollback: 5000,
+          rows: 24,
+        })
+      );
     });
 
-    it("reduces scrollback without notice when scrollback content is within target", () => {
+    it("reduces scrollback without logging when scrollback content is within target", () => {
       const managed = makeMockManaged();
       Object.defineProperty(managed.terminal.buffer.active, "length", {
         value: 100,
@@ -104,6 +122,7 @@ describe("TerminalScrollbackController", () => {
 
       expect(managed.terminal.options.scrollback).toBe(500);
       expect(getWrittenData(managed)).toHaveLength(0);
+      expect(logInfo).not.toHaveBeenCalled();
     });
 
     describe("cooldown gate", () => {


### PR DESCRIPTION
## Summary

- When background terminals had scrollback reduced under memory pressure, the warning was written directly into the terminal buffer — which meant it showed up in agent transcripts via copy-tree and context injection, looking like program output
- Demoted to `logInfo` (via `@/utils/logger`) so the signal stays out of the buffer entirely
- Added a short explanatory sentence to the Scrollback section in `TerminalSettingsTab.tsx` so the behaviour is still discoverable for curious users

Resolves #8529

## Changes

- `TerminalScrollbackController.ts` — replace buffer write with `logInfo` call
- `TerminalSettingsTab.tsx` — note that background terminals may temporarily reduce scrollback under memory pressure
- Updated tests in `TerminalScrollbackController.test.ts`, `TerminalScrollbackController.adversarial.test.ts`, and `TerminalInstanceService.scrollback.test.ts` to match the new signal path

## Testing

- Existing scrollback controller unit tests updated and passing — the reduction policy and guard conditions (`!isFocused`, `!isUserScrolledBack`, `!isAltBuffer`, `!hasSelection()`) and the 2s cooldown are unchanged
- Adversarial test suite updated to confirm no buffer writes occur on reduction