### PR TITLE
fix(terminal): pass shift+click through and capture drag on unfocused panes

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -755,7 +755,7 @@ function TerminalPaneComponent({
     // pointerdown still lets drag motion leak into PTY mouse-reporting modes
     // (DECSET 1002/1003) as escape sequences.
     try {
-      e.currentTarget.setPointerCapture(e.nativeEvent.pointerId);
+      e.currentTarget.setPointerCapture(e.pointerId);
     } catch {
       // Element was detached (e.g. LRU view eviction). Safe to ignore.
     }

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -737,6 +737,7 @@ function TerminalPaneComponent({
       location,
       isFocused,
       isCursorPointer: xtermElement.classList.contains("xterm-cursor-pointer"),
+      isShiftKey: e.shiftKey,
     });
 
     if (!shouldSuppress) {
@@ -749,9 +750,21 @@ function TerminalPaneComponent({
     e.preventDefault();
     e.stopPropagation();
 
+    // Capture the pointer so follow-on pointermove/pointerup events route to
+    // this wrapper instead of xterm's canvas. Without this, suppressing only
+    // pointerdown still lets drag motion leak into PTY mouse-reporting modes
+    // (DECSET 1002/1003) as escape sequences.
+    try {
+      e.currentTarget.setPointerCapture(e.nativeEvent.pointerId);
+    } catch {
+      // Element was detached (e.g. LRU view eviction). Safe to ignore.
+    }
+
     setFocused(id);
     requestAnimationFrame(() => terminalInstanceService.focus(id));
   };
+
+  const handleXtermPointerNoop = () => {};
 
   const handleRestart = () => {
     restartTerminal(id);
@@ -1146,6 +1159,8 @@ function TerminalPaneComponent({
                   (isBackendDisconnected || isBackendRecovering) && "pointer-events-none opacity-50"
                 )}
                 onPointerDownCapture={handleXtermPointerDownCapture}
+                onPointerMove={handleXtermPointerNoop}
+                onPointerUp={handleXtermPointerNoop}
               >
                 <Suspense fallback={null}>
                   <XtermAdapter

--- a/src/components/Terminal/__tests__/focusClickSuppression.test.ts
+++ b/src/components/Terminal/__tests__/focusClickSuppression.test.ts
@@ -8,6 +8,7 @@ describe("shouldSuppressUnfocusedClick", () => {
         location: "grid",
         isFocused: false,
         isCursorPointer: false,
+        isShiftKey: false,
       })
     ).toBe(true);
   });
@@ -18,6 +19,7 @@ describe("shouldSuppressUnfocusedClick", () => {
         location: "grid",
         isFocused: true,
         isCursorPointer: false,
+        isShiftKey: false,
       })
     ).toBe(false);
   });
@@ -28,6 +30,7 @@ describe("shouldSuppressUnfocusedClick", () => {
         location: "dock",
         isFocused: false,
         isCursorPointer: false,
+        isShiftKey: false,
       })
     ).toBe(false);
   });
@@ -38,6 +41,18 @@ describe("shouldSuppressUnfocusedClick", () => {
         location: "grid",
         isFocused: false,
         isCursorPointer: true,
+        isShiftKey: false,
+      })
+    ).toBe(false);
+  });
+
+  it("passes through shift+click on unfocused grid pane — xterm uses shift to bypass PTY mouse reporting", () => {
+    expect(
+      shouldSuppressUnfocusedClick({
+        location: "grid",
+        isFocused: false,
+        isCursorPointer: false,
+        isShiftKey: true,
       })
     ).toBe(false);
   });

--- a/src/components/Terminal/__tests__/terminalFocus.test.ts
+++ b/src/components/Terminal/__tests__/terminalFocus.test.ts
@@ -149,4 +149,15 @@ describe("shouldSuppressUnfocusedClick", () => {
       })
     ).toBe(false);
   });
+
+  it("does not suppress shift+click — xterm uses shift to bypass PTY mouse reporting for native selection", () => {
+    expect(
+      shouldSuppressUnfocusedClick({
+        location: "grid",
+        isFocused: false,
+        isCursorPointer: false,
+        isShiftKey: true,
+      })
+    ).toBe(false);
+  });
 });

--- a/src/components/Terminal/__tests__/terminalFocus.test.ts
+++ b/src/components/Terminal/__tests__/terminalFocus.test.ts
@@ -112,6 +112,7 @@ describe("shouldSuppressUnfocusedClick", () => {
         location: "grid",
         isFocused: false,
         isCursorPointer: false,
+        isShiftKey: false,
       })
     ).toBe(true);
   });
@@ -122,6 +123,7 @@ describe("shouldSuppressUnfocusedClick", () => {
         location: "grid",
         isFocused: true,
         isCursorPointer: false,
+        isShiftKey: false,
       })
     ).toBe(false);
   });
@@ -132,6 +134,7 @@ describe("shouldSuppressUnfocusedClick", () => {
         location: "grid",
         isFocused: false,
         isCursorPointer: true,
+        isShiftKey: false,
       })
     ).toBe(false);
   });
@@ -142,6 +145,7 @@ describe("shouldSuppressUnfocusedClick", () => {
         location: "dock",
         isFocused: false,
         isCursorPointer: false,
+        isShiftKey: false,
       })
     ).toBe(false);
   });

--- a/src/components/Terminal/terminalFocus.ts
+++ b/src/components/Terminal/terminalFocus.ts
@@ -50,16 +50,21 @@ export function getTerminalFocusTarget(options: {
  * that the user is just trying to activate.
  *
  * Intentionally narrow: only applies to the unfocused grid case, only for
- * non-pointer (non-link) cells. The redirect to hybrid input vs xterm is *not*
- * decided here — callers consult `getTerminalFocusTarget` separately.
+ * non-pointer (non-link) cells, and never for shift+click — xterm's
+ * SelectionService treats shift as the override gesture to bypass PTY mouse
+ * reporting and force native text selection, so the event must reach xterm.
+ * The redirect to hybrid input vs xterm is *not* decided here — callers
+ * consult `getTerminalFocusTarget` separately.
  */
 export function shouldSuppressUnfocusedClick(options: {
   location: string;
   isFocused: boolean;
   isCursorPointer: boolean;
+  isShiftKey: boolean;
 }): boolean {
   if (options.location !== "grid") return false;
   if (options.isFocused) return false;
   if (options.isCursorPointer) return false;
+  if (options.isShiftKey) return false;
   return true;
 }


### PR DESCRIPTION
## Summary

Two bugs in the unfocused terminal pane click suppression, both on the same `handleXtermPointerDownCapture` surface.

**Shift+click swallowed.** The suppression predicate didn't consult `shiftKey`, so xterm never saw the shift+click it needs to bypass PTY mouse reporting and start a native text selection. Fix threads `e.shiftKey` through `shouldSuppressUnfocusedClick` so those clicks pass straight through.

**Click-and-drag leaks pointer events.** In DECSET 1002/1003 mouse-tracking modes (vim with `set mouse=a`, tmux with `mouse on`, btop), a click-and-drag-to-activate gesture was leaking `pointermove` escape sequences to the PTY after the suppressed `pointerdown`. Fix calls `e.currentTarget.setPointerCapture(e.pointerId)` in the suppressed branch so follow-on pointer events are captured rather than routed to the terminal.

Resolves #8531

## Changes

- `terminalFocus.ts` — added required `isShiftKey: boolean` to `shouldSuppressUnfocusedClick` options; returns `false` when set so shift+click passes through
- `TerminalPane.tsx` — threads `e.shiftKey` to the predicate; calls `setPointerCapture` (try-caught for LRU view eviction) after suppressing; adds no-op `onPointerMove`/`onPointerUp` on the wrapper div for React synthetic event routing
- `focusClickSuppression.test.ts` and `terminalFocus.test.ts` — five cases each, including new shift+click pass-through coverage

## Testing

- 18/18 targeted unit tests pass (`focusClickSuppression.test.ts`, `terminalFocus.test.ts`)
- All 5 `npm run check` gates pass (typecheck, channels, IPC, help, lint:ratchet, format)