### PR TITLE
fix(terminal): coalesce WebGL context-loss bursts into one breaker tick

### DIFF
--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -131,6 +131,9 @@ export class TerminalWebGLManager {
   // To preserve case 1 while neutralising case 2, recordContextLoss is fed
   // through scheduleContextLossFlush: per-frame burst coalescing means one
   // GPU event = one breaker tick regardless of how many pool entries fired.
+  // Timestamps are taken at flush time (next rAF), not at event-dispatch time;
+  // this matters only if rAF is suppressed for longer than LOSS_WINDOW_MS (e.g.
+  // a fully backgrounded renderer), which is not a path we render WebGL on.
   private static readonly LOSS_THRESHOLD = 3;
   private static readonly LOSS_WINDOW_MS = 60_000;
 

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -118,8 +118,19 @@ export class TerminalWebGLManager {
 
   // Circuit breaker: if N genuine context-loss events occur within W ms,
   // disable WebGL for the rest of the session to avoid strobing reacquisition
-  // on systems with persistent GPU faults (e.g. M-series Macs on external
-  // displays at fractional scaling).
+  // on systems with persistent GPU faults. Two recurrence paths to keep in
+  // mind when tuning these constants:
+  //   1. M-series Macs on external displays at fractional scaling — repeated
+  //      per-context faults spaced over seconds; each loss is a distinct GPU
+  //      event and must each count toward the threshold (issue #6163).
+  //   2. Chromium 146 D3D11on12 memory pressure (and equivalent bulk
+  //      GL_OUT_OF_MEMORY paths) — the GPU process drops every active context
+  //      via a single IPC, dispatching webglcontextlost synchronously to N
+  //      pool entries in the same animation frame. Counting each of those as
+  //      a separate breaker event would trip the threshold from one GPU event.
+  // To preserve case 1 while neutralising case 2, recordContextLoss is fed
+  // through scheduleContextLossFlush: per-frame burst coalescing means one
+  // GPU event = one breaker tick regardless of how many pool entries fired.
   private static readonly LOSS_THRESHOLD = 3;
   private static readonly LOSS_WINDOW_MS = 60_000;
 
@@ -141,6 +152,12 @@ export class TerminalWebGLManager {
   private hasLoggedSoftwareSkip = false;
   private lossTimestamps: number[] = [];
   private hasLoggedBreakerTrip = false;
+  // Burst coalescer for context-loss events: a bulk GPU-process eviction can
+  // synchronously fire webglcontextlost on every pool entry within one frame.
+  // pendingLossCount accumulates raw notifications; flushContextLoss records
+  // exactly one breaker tick per frame regardless of how many fired.
+  private pendingLossCount = 0;
+  private lossCoalesceRafId: number | null = null;
   // Pool-pressure diagnostics (Tier 0 — silent log). Eviction at a full pool is
   // expected behaviour in 20–30 terminal tiled fleets and falls back seamlessly
   // to the DOM renderer, so this is observable-only, not user-facing. Rate
@@ -286,6 +303,15 @@ export class TerminalWebGLManager {
     }
     this.atlasResyncRafId = null;
     this.atlasResyncPending.clear();
+    if (this.lossCoalesceRafId !== null) {
+      try {
+        cancelAnimationFrame(this.lossCoalesceRafId);
+      } catch {
+        // ignore
+      }
+    }
+    this.lossCoalesceRafId = null;
+    this.pendingLossCount = 0;
     for (const id of [...this.pool.keys()]) {
       this.doRelease(id);
     }
@@ -372,6 +398,26 @@ export class TerminalWebGLManager {
     }
   };
 
+  // Coalesce a burst of webglcontextlost events (one per active pool entry on
+  // a bulk GPU eviction — see LOSS_THRESHOLD comment) into one breaker tick.
+  private scheduleContextLossFlush(): void {
+    this.pendingLossCount += 1;
+    if (this.lossCoalesceRafId !== null) return;
+    const rafId = requestAnimationFrame(this.flushContextLoss);
+    // If flushContextLoss ran synchronously (test shim), pendingLossCount is
+    // already 0 and there is no rAF handle to retain.
+    if (this.pendingLossCount > 0) {
+      this.lossCoalesceRafId = rafId;
+    }
+  }
+
+  private flushContextLoss = (): void => {
+    this.lossCoalesceRafId = null;
+    if (this.pendingLossCount === 0) return;
+    this.pendingLossCount = 0;
+    this.recordContextLoss();
+  };
+
   private reacquireContext(id: string, entry: WebGLEntry): void {
     if (this.pool.get(id) !== entry) return;
     const managed = entry.managed;
@@ -410,7 +456,7 @@ export class TerminalWebGLManager {
       clDisposable = addon.onContextLoss(() => {
         if (this.pool.get(id)?.addon === ownAddon) {
           // record before release; pool entry still valid here
-          this.recordContextLoss();
+          this.scheduleContextLossFlush();
           this.releaseContext(id);
         }
       });
@@ -442,7 +488,7 @@ export class TerminalWebGLManager {
       if (element) {
         const captureHandler = (): void => {
           if (this.pool.get(id)?.addon !== ownAddon) return;
-          this.recordContextLoss();
+          this.scheduleContextLossFlush();
           this.releaseContext(id);
           try {
             if (managed.isOpened && managed.terminal.rows > 0) {

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -903,6 +903,7 @@ describe("TerminalWebGLManager", () => {
     });
 
     it("dispose cancels a pending loss flush before it records a tick", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const handlers = captureContextLossHandlers();
 
       const m1 = makeManagedTerminal();
@@ -918,15 +919,13 @@ describe("TerminalWebGLManager", () => {
       handlers[2]!();
 
       manager.dispose();
-      // The queued rAF callback must be a no-op — pendingLossCount cleared and
-      // the rAF id cancelled, so flushing the queue records no breaker ticks.
-      flushRafFrame();
+      // dispose must cancel the queued flush — not just zero pendingLossCount.
+      // If the rAF survived, flushRafFrame would still find an entry. The
+      // distinction matters: a future change that drops cancelAnimationFrame
+      // but keeps the count reset would silently leak rAF callbacks, and only
+      // this empty-queue assertion catches it.
+      expect(flushRafFrame()).toBe(false);
 
-      // Fresh manager should still acquire — the disposed manager's state is
-      // local to that instance, but a stray flush on the queue must not have
-      // tripped any console.warn breaker log either.
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      flushRafFrame();
       const breakerWarnings = warnSpy.mock.calls.filter(
         (args) => typeof args[0] === "string" && args[0].includes("circuit breaker")
       );
@@ -1786,6 +1785,9 @@ describe("TerminalWebGLManager", () => {
       manager.ensureContext("t2", m2);
       manager.ensureContext("t3", m3);
 
+      // Sync rAF here — three distinct events each flush inline as one tick
+      // apiece, matching production where each DOM event arrives in its own
+      // frame on a persistent-fault display (issue #6163 path).
       (m1.terminal.element as HTMLElement).dispatchEvent(new Event("webglcontextlost"));
       (m2.terminal.element as HTMLElement).dispatchEvent(new Event("webglcontextlost"));
       (m3.terminal.element as HTMLElement).dispatchEvent(new Event("webglcontextlost"));
@@ -1795,6 +1797,37 @@ describe("TerminalWebGLManager", () => {
       manager.ensureContext("t4", m4);
       expect(WebglAddonMock.mock.calls.length).toBe(before);
       expect(manager.isActive("t4")).toBe(false);
+    });
+
+    it("coalesces a same-frame DOM-event burst across pool entries (#8541)", () => {
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      const m3 = makeManagedTerminal();
+      const m4 = makeManagedTerminal();
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+      manager.ensureContext("t3", m3);
+      manager.ensureContext("t4", m4);
+
+      // Queued rAF — mirrors the production path where Chromium dispatches
+      // webglcontextlost synchronously to every pool entry within one frame
+      // on a bulk GPU eviction. Must coalesce to one tick, well below the
+      // 3-loss threshold, so a new ensure still attaches.
+      rafMode = "queued";
+      (m1.terminal.element as HTMLElement).dispatchEvent(new Event("webglcontextlost"));
+      (m2.terminal.element as HTMLElement).dispatchEvent(new Event("webglcontextlost"));
+      (m3.terminal.element as HTMLElement).dispatchEvent(new Event("webglcontextlost"));
+      (m4.terminal.element as HTMLElement).dispatchEvent(new Event("webglcontextlost"));
+
+      expect(flushRafFrame()).toBe(true);
+      expect(flushRafFrame()).toBe(false);
+
+      rafMode = "sync";
+      const before = WebglAddonMock.mock.calls.length;
+      const m5 = makeManagedTerminal();
+      manager.ensureContext("t5", m5);
+      expect(WebglAddonMock.mock.calls.length).toBe(before + 1);
+      expect(manager.isActive("t5")).toBe(true);
     });
 
     it("does not re-fire after release (handler is removed)", () => {

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -839,6 +839,101 @@ describe("TerminalWebGLManager", () => {
       warnSpy.mockRestore();
     });
 
+    it("coalesces a same-frame loss burst across pool entries into one breaker tick", () => {
+      const handlers = captureContextLossHandlers();
+
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      const m3 = makeManagedTerminal();
+      const m4 = makeManagedTerminal();
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+      manager.ensureContext("t3", m3);
+      manager.ensureContext("t4", m4);
+
+      // Bulk GPU eviction (e.g. Chromium 146 D3D11on12 memory pressure) fires
+      // webglcontextlost on every pool entry within one animation frame. Queue
+      // the rAF so the burst collapses into a single breaker tick.
+      rafMode = "queued";
+      handlers[0]!();
+      handlers[1]!();
+      handlers[2]!();
+      handlers[3]!();
+
+      expect(flushRafFrame()).toBe(true);
+      // The burst collapsed to one frame — nothing else queued.
+      expect(flushRafFrame()).toBe(false);
+
+      // One coalesced tick — far below LOSS_THRESHOLD, so the breaker must NOT
+      // have tripped and a new ensure must still attach. Flip rAF back to sync
+      // so the drain runs inline (matching how this suite's other tests work).
+      rafMode = "sync";
+      const before = WebglAddonMock.mock.calls.length;
+      const m5 = makeManagedTerminal();
+      manager.ensureContext("t5", m5);
+      expect(WebglAddonMock.mock.calls.length).toBe(before + 1);
+      expect(manager.isActive("t5")).toBe(true);
+    });
+
+    it("still trips on LOSS_THRESHOLD bursts across distinct frames", () => {
+      const handlers = captureContextLossHandlers();
+
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      const m3 = makeManagedTerminal();
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+      manager.ensureContext("t3", m3);
+
+      // Three genuinely distinct GPU events — one per frame — must each tick
+      // the breaker so the issue #6163 persistent-fault path still trips.
+      rafMode = "queued";
+      handlers[0]!();
+      flushRafFrame();
+      handlers[1]!();
+      flushRafFrame();
+      handlers[2]!();
+      flushRafFrame();
+
+      const before = WebglAddonMock.mock.calls.length;
+      const m4 = makeManagedTerminal();
+      manager.ensureContext("t4", m4);
+      expect(WebglAddonMock.mock.calls.length).toBe(before);
+      expect(manager.isActive("t4")).toBe(false);
+    });
+
+    it("dispose cancels a pending loss flush before it records a tick", () => {
+      const handlers = captureContextLossHandlers();
+
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      const m3 = makeManagedTerminal();
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+      manager.ensureContext("t3", m3);
+
+      rafMode = "queued";
+      handlers[0]!();
+      handlers[1]!();
+      handlers[2]!();
+
+      manager.dispose();
+      // The queued rAF callback must be a no-op — pendingLossCount cleared and
+      // the rAF id cancelled, so flushing the queue records no breaker ticks.
+      flushRafFrame();
+
+      // Fresh manager should still acquire — the disposed manager's state is
+      // local to that instance, but a stray flush on the queue must not have
+      // tripped any console.warn breaker log either.
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      flushRafFrame();
+      const breakerWarnings = warnSpy.mock.calls.filter(
+        (args) => typeof args[0] === "string" && args[0].includes("circuit breaker")
+      );
+      expect(breakerWarnings).toHaveLength(0);
+      warnSpy.mockRestore();
+    });
+
     it("logs the breaker-trip warning only once", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const handlers = captureContextLossHandlers();


### PR DESCRIPTION
## Summary

- Under memory pressure, Chromium 146 emits one `webglcontextlost` event per pool entry synchronously in the same animation frame, so a single GPU eviction was counting as multiple independent faults and incorrectly tripping the 3-loss/60s circuit breaker.
- Adds a per-rAF coalescer (`scheduleContextLossFlush` / `flushContextLoss`) modelled on the existing `scheduleAtlasResync` pattern. Both the addon `onContextLoss` and the capture-phase `webglcontextlost` handlers route through it — a burst in one animation frame counts as one breaker tick; genuine faults across separate frames still trip the breaker.
- `dispose()` cancels any pending coalescer rAF. The `LOSS_THRESHOLD` comment block is updated to document both the M-series fractional-scaling path (#6163) and the new bulk-loss path.

Resolves #8541

## Changes

- `src/services/terminal/TerminalWebGLManager.ts` — `scheduleContextLossFlush`, `flushContextLoss`, and `pendingLossCount` added; `recordContextLoss` calls replaced with coalescer calls in both loss handlers; `dispose()` updated to cancel the pending rAF
- `src/services/terminal/__tests__/TerminalWebGLManager.test.ts` — 4 new tests: burst coalescing via `onContextLoss`, distinct-frame trips still work, `dispose()` cancels pending rAF, capture-phase same-frame burst coalescing

## Testing

84 tests pass in `TerminalWebGLManager.test.ts`, 801 pass across `src/services/terminal/__tests__/`. `npm run check` clean; lint warning count improved by 1.