### PR TITLE
fix(terminal): surface scrollback restore failures as inline warning banner

### DIFF
--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -48,6 +48,7 @@ export type {
   PanelTitleMode,
   TerminalRestartError,
   TerminalReconnectError,
+  TerminalScrollbackRestoreError,
   TerminalRuntimeStatus,
   PersistableFlowStatus,
   TerminalSpawnSource,

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -170,6 +170,16 @@ export interface TerminalReconnectError {
   };
 }
 
+/** Structured error state for scrollback restore failures (issue #8535) */
+export interface TerminalScrollbackRestoreError {
+  /** Human-readable error message */
+  message: string;
+  /** Error classification: write timeout, parse error from xterm, or other */
+  type: "timeout" | "parse" | "error";
+  /** Timestamp when error occurred (milliseconds since epoch) */
+  timestamp: number;
+}
+
 /** Exit behavior for panels/terminals after process exits */
 export type PanelExitBehavior = "keep" | "trash" | "remove" | "restart";
 
@@ -252,6 +262,8 @@ export interface PtyPanelData extends BasePanelData {
   restartError?: TerminalRestartError;
   /** Reconnection failure error - set when reconnection fails during project switch */
   reconnectError?: TerminalReconnectError;
+  /** Scrollback restore failure - set when deferred scrollback replay fails */
+  scrollbackRestoreError?: TerminalScrollbackRestoreError;
   /** Flow control status - indicates if terminal is paused/suspended due to backpressure or safety policy.
    *  Excludes `data-loss` (transient pulse only — never persisted as state). */
   flowStatus?: PersistableFlowStatus;
@@ -487,6 +499,8 @@ export interface TerminalInstance {
   reconnectError?: TerminalReconnectError;
   /** Error that occurred when spawning the PTY process */
   spawnError?: import("./pty-host.js").SpawnError;
+  /** Error that occurred during deferred scrollback restore (issue #8535) */
+  scrollbackRestoreError?: TerminalScrollbackRestoreError;
   flowStatus?: PersistableFlowStatus;
   runtimeStatus?: TerminalRuntimeStatus;
   flowStatusTimestamp?: number;

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -86,6 +86,7 @@ export function gridPanelPropsAreEqual(prev: GridPanelProps, next: GridPanelProp
       a.restartError !== b.restartError ||
       a.reconnectError !== b.reconnectError ||
       a.spawnError !== b.spawnError ||
+      a.scrollbackRestoreError !== b.scrollbackRestoreError ||
       a.detectedProcessId !== b.detectedProcessId ||
       a.browserUrl !== b.browserUrl ||
       a.isRestarting !== b.isRestarting ||

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -89,6 +89,7 @@ export function gridTabGroupPropsAreEqual(
           a.restartError !== b.restartError ||
           a.reconnectError !== b.reconnectError ||
           a.spawnError !== b.spawnError ||
+          a.scrollbackRestoreError !== b.scrollbackRestoreError ||
           a.detectedProcessId !== b.detectedProcessId ||
           a.agentLaunchFlags !== b.agentLaunchFlags ||
           a.browserUrl !== b.browserUrl ||

--- a/src/components/Terminal/ScrollbackRestoreErrorBanner.tsx
+++ b/src/components/Terminal/ScrollbackRestoreErrorBanner.tsx
@@ -1,0 +1,79 @@
+import { Clock, FileX2, History, RotateCcw } from "lucide-react";
+import { InlineStatusBanner } from "./InlineStatusBanner";
+import { boundedErrorText } from "@/utils/errorText";
+import type { TerminalScrollbackRestoreError } from "@/types";
+
+export interface ScrollbackRestoreErrorBannerProps {
+  terminalId: string;
+  error: TerminalScrollbackRestoreError;
+  onDismiss: (id: string) => void;
+  onRestart: (id: string) => void;
+  isRestarting?: boolean;
+  className?: string;
+}
+
+function getErrorIcon(type: TerminalScrollbackRestoreError["type"]) {
+  switch (type) {
+    case "timeout":
+      return Clock;
+    case "parse":
+      return FileX2;
+    default:
+      return History;
+  }
+}
+
+function getErrorTitle(type: TerminalScrollbackRestoreError["type"]): string {
+  switch (type) {
+    case "timeout":
+      return "Scrollback restore timed out";
+    case "parse":
+      return "Scrollback contents couldn't be replayed";
+    default:
+      return "Scrollback restore failed";
+  }
+}
+
+function getErrorDescription(type: TerminalScrollbackRestoreError["type"], message: string): string {
+  const detail = boundedErrorText(message);
+  switch (type) {
+    case "timeout":
+      return `Replay didn't finish in time. The terminal still works, but its earlier output isn't visible. ${detail}`;
+    case "parse":
+      return `The saved buffer couldn't be parsed. The terminal still works, but its earlier output isn't visible. ${detail}`;
+    default:
+      return `The terminal still works, but its earlier output isn't visible. ${detail}`;
+  }
+}
+
+export function ScrollbackRestoreErrorBanner({
+  terminalId,
+  error,
+  onDismiss,
+  onRestart,
+  isRestarting = false,
+  className,
+}: ScrollbackRestoreErrorBannerProps) {
+  return (
+    <InlineStatusBanner
+      icon={getErrorIcon(error.type)}
+      title={getErrorTitle(error.type)}
+      description={getErrorDescription(error.type, error.message)}
+      severity="warning"
+      actions={[
+        {
+          id: "reset",
+          label: "Reset terminal",
+          icon: RotateCcw,
+          variant: "primary",
+          onClick: () => onRestart(terminalId),
+          title: "Restart the terminal",
+          ariaLabel: "Reset terminal",
+          loading: isRestarting,
+        },
+      ]}
+      onClose={() => onDismiss(terminalId)}
+      className={className}
+    />
+  );
+}

--- a/src/components/Terminal/ScrollbackRestoreErrorBanner.tsx
+++ b/src/components/Terminal/ScrollbackRestoreErrorBanner.tsx
@@ -35,14 +35,17 @@ function getErrorTitle(type: TerminalScrollbackRestoreError["type"]): string {
 }
 
 function getErrorDescription(type: TerminalScrollbackRestoreError["type"], message: string): string {
-  const detail = boundedErrorText(message);
+  // The terminal itself is still operational — only the replayed buffer is
+  // missing — so lead with that reassurance. The raw message is only useful
+  // for the generic "error" case, where the title doesn't already convey
+  // the cause; for "timeout" and "parse" the title is sufficient.
   switch (type) {
     case "timeout":
-      return `Replay didn't finish in time. The terminal still works, but its earlier output isn't visible. ${detail}`;
+      return "Replay didn't finish in time. The terminal still works — only its earlier output is missing.";
     case "parse":
-      return `The saved buffer couldn't be parsed. The terminal still works, but its earlier output isn't visible. ${detail}`;
+      return "The saved buffer couldn't be replayed. The terminal still works — only its earlier output is missing.";
     default:
-      return `The terminal still works, but its earlier output isn't visible. ${detail}`;
+      return `${boundedErrorText(message)} The terminal still works — only its earlier output is missing.`;
   }
 }
 

--- a/src/components/Terminal/ScrollbackRestoreErrorBanner.tsx
+++ b/src/components/Terminal/ScrollbackRestoreErrorBanner.tsx
@@ -34,7 +34,10 @@ function getErrorTitle(type: TerminalScrollbackRestoreError["type"]): string {
   }
 }
 
-function getErrorDescription(type: TerminalScrollbackRestoreError["type"], message: string): string {
+function getErrorDescription(
+  type: TerminalScrollbackRestoreError["type"],
+  message: string
+): string {
   // The terminal itself is still operational — only the replayed buffer is
   // missing — so lead with that reassurance. The raw message is only useful
   // for the generic "error" case, where the title doesn't already convey

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -325,9 +325,7 @@ function TerminalPaneComponent({
   const removePanel = usePanelStore((state) => state.removePanel);
   const backendStatus = usePanelStore((state) => state.backendStatus);
   const clearReconnectError = usePanelStore((state) => state.clearReconnectError);
-  const clearScrollbackRestoreError = usePanelStore(
-    (state) => state.clearScrollbackRestoreError
-  );
+  const clearScrollbackRestoreError = usePanelStore((state) => state.clearScrollbackRestoreError);
 
   const cliDetails = useCliAvailabilityStore((state) => state.details);
   const getPanelCliDetail = (): AgentCliDetail | undefined => {

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -14,6 +14,7 @@ import type {
   TerminalRestartError,
   SpawnError,
   TerminalReconnectError,
+  TerminalScrollbackRestoreError,
   PersistableFlowStatus,
 } from "@/types";
 import { cn } from "@/lib/utils";
@@ -29,6 +30,7 @@ import { getRestartBannerVariant } from "./restartStatus";
 import { TerminalErrorBanner } from "./TerminalErrorBanner";
 import { SpawnErrorBanner } from "./SpawnErrorBanner";
 import { ReconnectErrorBanner } from "./ReconnectErrorBanner";
+import { ScrollbackRestoreErrorBanner } from "./ScrollbackRestoreErrorBanner";
 import { UpdateCwdDialog } from "./UpdateCwdDialog";
 import { ErrorBanner } from "../Errors/ErrorBanner";
 import { AgentCompletionBanner } from "./AgentCompletionBanner";
@@ -217,6 +219,7 @@ export interface TerminalPaneProps {
   restartError?: TerminalRestartError;
   reconnectError?: TerminalReconnectError;
   spawnError?: SpawnError;
+  scrollbackRestoreError?: TerminalScrollbackRestoreError;
   gridPanelCount?: number;
   detectedProcessId?: string;
   // Group-level ambient state: highest-urgency state across all tabs, for container border styling
@@ -262,6 +265,7 @@ function TerminalPaneComponent({
   restartError,
   reconnectError,
   spawnError,
+  scrollbackRestoreError,
   gridPanelCount,
   detectedProcessId,
   ambientAgentState,
@@ -321,6 +325,9 @@ function TerminalPaneComponent({
   const removePanel = usePanelStore((state) => state.removePanel);
   const backendStatus = usePanelStore((state) => state.backendStatus);
   const clearReconnectError = usePanelStore((state) => state.clearReconnectError);
+  const clearScrollbackRestoreError = usePanelStore(
+    (state) => state.clearScrollbackRestoreError
+  );
 
   const cliDetails = useCliAvailabilityStore((state) => state.details);
   const getPanelCliDetail = (): AgentCliDetail | undefined => {
@@ -783,6 +790,10 @@ function TerminalPaneComponent({
     clearReconnectError(id);
   };
 
+  const handleDismissScrollbackRestoreError = () => {
+    clearScrollbackRestoreError(id);
+  };
+
   useEffect(() => {
     terminalInstanceService.setFocused(id, isFocused);
 
@@ -1005,6 +1016,10 @@ function TerminalPaneComponent({
   const showRestartError = Boolean(restartError);
   const showSpawnError = Boolean(spawnError) && !showRestartError;
   const showReconnectError = Boolean(reconnectError) && !showRestartError && !showSpawnError;
+  // Scrollback restore is independent of PTY launch state (spawn/reconnect),
+  // so it can co-exist with those banners. Only restartError, which already
+  // implies a destroyed-and-respawning PTY, suppresses it.
+  const showScrollbackRestoreError = Boolean(scrollbackRestoreError) && !showRestartError;
   const showRestartStatus = restartBannerVariant.type !== "none";
 
   return (
@@ -1129,6 +1144,18 @@ function TerminalPaneComponent({
             terminalId={id}
             error={reconnectError}
             onDismiss={handleDismissReconnectError}
+            onRestart={handleRestart}
+            isRestarting={isRestarting}
+          />
+        )}
+      </BannerSlot>
+
+      <BannerSlot visible={showScrollbackRestoreError}>
+        {scrollbackRestoreError && (
+          <ScrollbackRestoreErrorBanner
+            terminalId={id}
+            error={scrollbackRestoreError}
+            onDismiss={handleDismissScrollbackRestoreError}
             onRestart={handleRestart}
             isRestarting={isRestarting}
           />

--- a/src/services/terminal/TerminalRestoreController.ts
+++ b/src/services/terminal/TerminalRestoreController.ts
@@ -177,6 +177,11 @@ export class TerminalRestoreController {
     };
 
     const writePromise = managed.writeChain.then(task).catch((err) => {
+      // Fires when writeChain itself was already poisoned (a prior link
+      // rejected). `task` never ran, so its own catch never set the error
+      // channel — surface it here so the scheduler still sees a real
+      // failure instead of silently marking the restore "done".
+      managed.lastScrollbackRestoreError = classifyRestoreError(err);
       logError(`Write chain error for ${id}`, err);
       return false;
     });

--- a/src/services/terminal/TerminalRestoreController.ts
+++ b/src/services/terminal/TerminalRestoreController.ts
@@ -2,6 +2,24 @@ import { terminalClient } from "@/clients";
 import type { ManagedTerminal } from "./types";
 import { INCREMENTAL_RESTORE_CONFIG } from "./types";
 import { logWarn, logError } from "@/utils/logger";
+import type { TerminalScrollbackRestoreError } from "@shared/types/panel";
+
+function classifyRestoreError(error: unknown): TerminalScrollbackRestoreError {
+  const timestamp = Date.now();
+  if (error instanceof Error) {
+    if (error.message === "Write timeout") {
+      return { type: "timeout", message: error.message, timestamp };
+    }
+    // xterm.js parser throws plain Error with messages starting with "Parser"
+    // or containing "parse"; fall through to generic "error" otherwise. Keep
+    // the message verbatim so the banner shows the underlying cause.
+    if (/pars/i.test(error.message)) {
+      return { type: "parse", message: error.message, timestamp };
+    }
+    return { type: "error", message: error.message, timestamp };
+  }
+  return { type: "error", message: String(error), timestamp };
+}
 
 export interface RestoreControllerDeps {
   getInstance: (id: string) => ManagedTerminal | undefined;
@@ -30,6 +48,7 @@ export class TerminalRestoreController {
 
       const restoreGeneration = ++managed.restoreGeneration;
       managed.isSerializedRestoreInProgress = true;
+      managed.lastScrollbackRestoreError = undefined;
 
       const scrollBackOffset = managed.isUserScrolledBack
         ? managed.terminal.buffer.active.baseY - managed.terminal.buffer.active.viewportY
@@ -56,6 +75,7 @@ export class TerminalRestoreController {
       return true;
     } catch (error) {
       managed.isSerializedRestoreInProgress = false;
+      managed.lastScrollbackRestoreError = classifyRestoreError(error);
       logError(`Failed to restore terminal ${id}`, error);
       return false;
     }
@@ -70,6 +90,7 @@ export class TerminalRestoreController {
 
     const restoreGeneration = ++managed.restoreGeneration;
     managed.isSerializedRestoreInProgress = true;
+    managed.lastScrollbackRestoreError = undefined;
 
     const task = async (): Promise<boolean> => {
       const scrollBackOffset = managed.isUserScrolledBack
@@ -126,6 +147,11 @@ export class TerminalRestoreController {
 
         return true;
       } catch (error) {
+        // Real failure during chunked replay (write timeout, xterm parse
+        // error). Stash the classified error on `managed` so the scheduler
+        // can surface it to the panel store; the stale-generation early
+        // returns above bypass this catch and remain silent. See #8535.
+        managed.lastScrollbackRestoreError = classifyRestoreError(error);
         logError(`Incremental restore failed for ${id}`, error);
         return false;
       } finally {
@@ -182,6 +208,7 @@ export class TerminalRestoreController {
 
     const restoreGeneration = managed.restoreGeneration;
     managed.isSerializedRestoreInProgress = true;
+    managed.lastScrollbackRestoreError = undefined;
 
     try {
       const serializedState = await terminalClient.getSerializedState(id);
@@ -201,6 +228,7 @@ export class TerminalRestoreController {
       return result;
     } catch (error) {
       managed.isSerializedRestoreInProgress = false;
+      managed.lastScrollbackRestoreError = classifyRestoreError(error);
       logError(`Failed to fetch state for terminal ${id}`, error);
       return false;
     }

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -6,6 +6,7 @@ import { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 
 import { TerminalRefreshTier, PanelKind, AgentState } from "@/types";
+import type { TerminalScrollbackRestoreError } from "@shared/types/panel";
 
 export type RefreshTierProvider = () => TerminalRefreshTier;
 
@@ -138,6 +139,12 @@ export interface ManagedTerminal {
   // Deferred scrollback restore state — prevents double-restore and tracks lifecycle
   scrollbackRestoreState: "none" | "pending" | "in-progress" | "done";
   scrollbackRestoreDisposable?: { dispose: () => void };
+  // Out-of-band failure channel set by TerminalRestoreController catch blocks
+  // when the deferred restore replay fails (write timeout, parse error). The
+  // scheduler reads this after fetchAndRestore() resolves to surface the
+  // failure to the panel store. Cleared at the start of each restore attempt
+  // and on the success path. See issue #8535.
+  lastScrollbackRestoreError?: TerminalScrollbackRestoreError;
 
   // Alternate screen buffer state (tracked via xterm.js onBufferChange).
   // Used to adapt UI (remove padding) and resize strategy for TUI applications.

--- a/src/store/slices/panelRegistry/browser.ts
+++ b/src/store/slices/panelRegistry/browser.ts
@@ -33,6 +33,8 @@ export const createBrowserActions = (
   | "clearSpawnError"
   | "setReconnectError"
   | "clearReconnectError"
+  | "setScrollbackRestoreError"
+  | "clearScrollbackRestoreError"
 > => ({
   setBrowserUrl: (id, url) => {
     set((state) => {
@@ -289,6 +291,38 @@ export const createBrowserActions = (
         panelsById: {
           ...state.panelsById,
           [id]: { ...terminal, reconnectError: undefined, runtimeStatus: undefined },
+        },
+      };
+    });
+  },
+
+  // Scrollback restore is a one-shot lifecycle event — no debounce. Severity
+  // is "warning" not "error", so we deliberately do NOT flip runtimeStatus;
+  // the terminal is still operational, only the replayed history is missing.
+  setScrollbackRestoreError: (id, error) => {
+    set((state) => {
+      const terminal = state.panelsById[id];
+      if (!terminal) return state;
+
+      return {
+        panelsById: {
+          ...state.panelsById,
+          [id]: { ...terminal, scrollbackRestoreError: error },
+        },
+      };
+    });
+  },
+
+  clearScrollbackRestoreError: (id) => {
+    set((state) => {
+      const terminal = state.panelsById[id];
+      if (!terminal) return state;
+      if (terminal.scrollbackRestoreError === undefined) return state;
+
+      return {
+        panelsById: {
+          ...state.panelsById,
+          [id]: { ...terminal, scrollbackRestoreError: undefined },
         },
       };
     });

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -193,6 +193,7 @@ export const createRestartActions = (
         restartError: undefined,
         reconnectError: undefined,
         spawnError: undefined,
+        scrollbackRestoreError: undefined,
         isRestarting: true,
       }))
     );
@@ -562,7 +563,13 @@ export const createRestartActions = (
   },
 
   clearTerminalError: (id) => {
-    set((state) => updateTerminal(state, id, (t) => ({ ...t, restartError: undefined })));
+    set((state) =>
+      updateTerminal(state, id, (t) => ({
+        ...t,
+        restartError: undefined,
+        scrollbackRestoreError: undefined,
+      }))
+    );
   },
 
   updateTerminalCwd: (id, cwd) => {

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -7,6 +7,7 @@ import type {
   TerminalRuntimeStatus,
   SpawnError,
   TerminalReconnectError,
+  TerminalScrollbackRestoreError,
   TabGroup,
   TabGroupLocation,
   BrowserHistory,
@@ -186,6 +187,8 @@ export interface PanelRegistrySlice {
   clearSpawnError: (id: string) => void;
   setReconnectError: (id: string, error: TerminalReconnectError) => void;
   clearReconnectError: (id: string) => void;
+  setScrollbackRestoreError: (id: string, error: TerminalScrollbackRestoreError) => void;
+  clearScrollbackRestoreError: (id: string) => void;
 
   // Tab grouping methods - TabGroup is the single source of truth
   /** Get all panels in a group, ordered by group's panelIds array. Location param is deprecated. */

--- a/src/utils/__tests__/panelProps.test.ts
+++ b/src/utils/__tests__/panelProps.test.ts
@@ -23,6 +23,7 @@ function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstan
     restartError: undefined,
     reconnectError: undefined,
     spawnError: undefined,
+    scrollbackRestoreError: undefined,
     detectedProcessId: undefined,
     browserUrl: undefined,
     ...overrides,

--- a/src/utils/panelProps.ts
+++ b/src/utils/panelProps.ts
@@ -96,6 +96,7 @@ export function buildPanelProps({
     restartError: terminal.restartError,
     reconnectError: terminal.reconnectError,
     spawnError: terminal.spawnError,
+    scrollbackRestoreError: terminal.scrollbackRestoreError,
     detectedProcessId: terminal.detectedProcessId,
 
     // Extension state

--- a/src/utils/stateHydration/__tests__/scrollbackRestoreScheduler.test.ts
+++ b/src/utils/stateHydration/__tests__/scrollbackRestoreScheduler.test.ts
@@ -129,7 +129,7 @@ describe("scheduleScrollbackRestore — background mode", () => {
     expect(setScrollbackRestoreErrorMock).not.toHaveBeenCalled();
   });
 
-  it("doRestore bails when isCurrent returns false (no fetch, state stays pending)", async () => {
+  it("doRestore bails when isCurrent returns false and resets state to 'none' so retry remains possible (#8535 regression)", async () => {
     const managed = fakeManaged("none");
     getMock.mockReturnValue(managed);
 
@@ -142,10 +142,13 @@ describe("scheduleScrollbackRestore — background mode", () => {
     await getScheduledDoRestore()();
 
     expect(fetchAndRestoreMock).not.toHaveBeenCalled();
-    expect(managed.scrollbackRestoreState).toBe("pending");
+    // Without the reset, the scheduler's entry guard
+    // (state !== "none" → continue) would permanently strand the terminal
+    // after the user navigates away and back.
+    expect(managed.scrollbackRestoreState).toBe("none");
   });
 
-  it("doRestore bails when terminal instance is replaced (LRU swap detection)", async () => {
+  it("doRestore bails when terminal instance is replaced (LRU swap detection) and resets state to 'none'", async () => {
     const original = fakeManaged("none");
     getMock.mockReturnValueOnce(original); // initial schedule call
 
@@ -162,7 +165,34 @@ describe("scheduleScrollbackRestore — background mode", () => {
     await getScheduledDoRestore()();
 
     expect(fetchAndRestoreMock).not.toHaveBeenCalled();
-    expect(original.scrollbackRestoreState).toBe("pending");
+    expect(original.scrollbackRestoreState).toBe("none");
+  });
+
+  it("after isCurrent() bail, a subsequent scheduleScrollbackRestore call picks the terminal up again", async () => {
+    const managed = fakeManaged("none");
+    getMock.mockReturnValue(managed);
+
+    // First call: isCurrent → false. doRestore bails and resets state.
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "x", location: "grid" }],
+      () => false,
+      "background"
+    );
+    await getScheduledDoRestore(0)();
+    expect(managed.scrollbackRestoreState).toBe("none");
+
+    // Second call (user navigated back): isCurrent → true. The entry guard
+    // now passes because state was reset. fetchAndRestore should run.
+    fetchAndRestoreMock.mockResolvedValue(undefined);
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "x", location: "grid" }],
+      () => true,
+      "background"
+    );
+    expect(scheduleBackgroundFetchAndRestoreMock).toHaveBeenCalledTimes(2);
+    await getScheduledDoRestore(1)();
+    expect(fetchAndRestoreMock).toHaveBeenCalledWith("t1");
+    expect(managed.scrollbackRestoreState).toBe("done");
   });
 
   it("doRestore bails when scrollbackRestoreState diverged from 'pending' (mid-flight cancel)", async () => {

--- a/src/utils/stateHydration/__tests__/scrollbackRestoreScheduler.test.ts
+++ b/src/utils/stateHydration/__tests__/scrollbackRestoreScheduler.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { TerminalScrollbackRestoreError } from "@shared/types/panel";
 
 vi.mock("@/utils/logger", () => ({
   logWarn: vi.fn(),
@@ -12,6 +13,16 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     get: (id: string) => getMock(id),
     fetchAndRestore: (id: string) => fetchAndRestoreMock(id),
+  },
+}));
+
+const setScrollbackRestoreErrorMock = vi.fn();
+
+vi.mock("@/store", () => ({
+  usePanelStore: {
+    getState: () => ({
+      setScrollbackRestoreError: setScrollbackRestoreErrorMock,
+    }),
   },
 }));
 
@@ -41,6 +52,7 @@ interface FakeManaged {
   hostElement?: HTMLElement | null;
   listeners: Array<() => void>;
   scrollbackRestoreDisposable?: { dispose: () => void };
+  lastScrollbackRestoreError?: TerminalScrollbackRestoreError;
 }
 
 function fakeManaged(state: FakeManaged["scrollbackRestoreState"] = "none"): FakeManaged {
@@ -55,6 +67,7 @@ beforeEach(() => {
   getMock.mockReset();
   scheduleBackgroundFetchAndRestoreMock.mockReset();
   registerLazyScrollRestoreMock.mockReset();
+  setScrollbackRestoreErrorMock.mockReset();
 });
 
 afterEach(() => {
@@ -113,6 +126,7 @@ describe("scheduleScrollbackRestore — background mode", () => {
 
     expect(fetchAndRestoreMock).toHaveBeenCalledWith("t1");
     expect(managed.scrollbackRestoreState).toBe("done");
+    expect(setScrollbackRestoreErrorMock).not.toHaveBeenCalled();
   });
 
   it("doRestore bails when isCurrent returns false (no fetch, state stays pending)", async () => {
@@ -169,7 +183,7 @@ describe("scheduleScrollbackRestore — background mode", () => {
     expect(fetchAndRestoreMock).not.toHaveBeenCalled();
   });
 
-  it("resets state to 'none' on fetchAndRestore failure (so it can be retried)", async () => {
+  it("resets state to 'none' on fetchAndRestore rejection (IPC error path)", async () => {
     const managed = fakeManaged("none");
     getMock.mockReturnValue(managed);
     fetchAndRestoreMock.mockRejectedValue(new Error("nope"));
@@ -182,6 +196,69 @@ describe("scheduleScrollbackRestore — background mode", () => {
 
     await getScheduledDoRestore()();
 
+    expect(managed.scrollbackRestoreState).toBe("none");
+    expect(setScrollbackRestoreErrorMock).toHaveBeenCalledWith(
+      "t1",
+      expect.objectContaining({ type: "error", message: "nope" })
+    );
+  });
+
+  it("surfaces lastScrollbackRestoreError to the panel store when fetchAndRestore returns silently after a replay failure (#8535)", async () => {
+    const managed = fakeManaged("none");
+    getMock.mockReturnValue(managed);
+    // Simulate the controller swallowing a write timeout: fetchAndRestore
+    // resolves (returns false internally) but stashes a classified error on
+    // managed.lastScrollbackRestoreError.
+    fetchAndRestoreMock.mockImplementation(async () => {
+      managed.lastScrollbackRestoreError = {
+        type: "timeout",
+        message: "Write timeout",
+        timestamp: 123,
+      };
+      return false;
+    });
+
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "x", location: "grid" }],
+      () => true,
+      "background"
+    );
+
+    await getScheduledDoRestore()();
+
+    expect(managed.scrollbackRestoreState).toBe("none");
+    expect(setScrollbackRestoreErrorMock).toHaveBeenCalledWith("t1", {
+      type: "timeout",
+      message: "Write timeout",
+      timestamp: 123,
+    });
+  });
+
+  it("does not emit to panel store if isCurrent flips to false before the failure handler reads it", async () => {
+    const managed = fakeManaged("none");
+    getMock.mockReturnValue(managed);
+    let currentFlag = true;
+    fetchAndRestoreMock.mockImplementation(async () => {
+      managed.lastScrollbackRestoreError = {
+        type: "parse",
+        message: "boom",
+        timestamp: 1,
+      };
+      // Simulate a project switch happening during the IPC await window.
+      currentFlag = false;
+      return false;
+    });
+
+    scheduleScrollbackRestore(
+      [{ terminalId: "t1", label: "x", location: "grid" }],
+      () => currentFlag,
+      "background"
+    );
+
+    await getScheduledDoRestore()();
+
+    expect(setScrollbackRestoreErrorMock).not.toHaveBeenCalled();
+    // State still resets so a future restore can retry.
     expect(managed.scrollbackRestoreState).toBe("none");
   });
 });

--- a/src/utils/stateHydration/scrollbackRestoreScheduler.ts
+++ b/src/utils/stateHydration/scrollbackRestoreScheduler.ts
@@ -66,9 +66,7 @@ export function scheduleScrollbackRestore(
         if (restoreError) {
           managed.scrollbackRestoreState = "none";
           if (isCurrent()) {
-            usePanelStore
-              .getState()
-              .setScrollbackRestoreError(task.terminalId, restoreError);
+            usePanelStore.getState().setScrollbackRestoreError(task.terminalId, restoreError);
           }
           logWarn(`Scrollback restore failed for ${task.label}`, { error: restoreError });
         } else {

--- a/src/utils/stateHydration/scrollbackRestoreScheduler.ts
+++ b/src/utils/stateHydration/scrollbackRestoreScheduler.ts
@@ -1,10 +1,20 @@
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { usePanelStore } from "@/store";
 import { logWarn } from "@/utils/logger";
+import type { TerminalScrollbackRestoreError } from "@shared/types/panel";
 import {
   type TerminalRestoreTask,
   registerLazyScrollRestore,
   scheduleBackgroundFetchAndRestore,
 } from "./batchScheduler";
+
+function classifySchedulerError(error: unknown): TerminalScrollbackRestoreError {
+  const timestamp = Date.now();
+  if (error instanceof Error) {
+    return { type: "error", message: error.message, timestamp };
+  }
+  return { type: "error", message: String(error), timestamp };
+}
 
 export function scheduleScrollbackRestore(
   tasks: TerminalRestoreTask[],
@@ -26,9 +36,36 @@ export function scheduleScrollbackRestore(
       managed.scrollbackRestoreState = "in-progress";
       try {
         await terminalInstanceService.fetchAndRestore(task.terminalId);
-        managed.scrollbackRestoreState = "done";
+
+        // fetchAndRestore swallows write-timeout / parse errors internally
+        // and returns false; the controller stashes the classified error on
+        // `managed.lastScrollbackRestoreError`. Emit it to the panel store
+        // so the user sees an inline banner instead of a silent blank
+        // terminal. Gated on isCurrent() so a project switch that aborts
+        // restore mid-flight does not surface a spurious banner.
+        const restoreError = managed.lastScrollbackRestoreError;
+        if (restoreError) {
+          managed.scrollbackRestoreState = "none";
+          if (isCurrent()) {
+            usePanelStore
+              .getState()
+              .setScrollbackRestoreError(task.terminalId, restoreError);
+          }
+          logWarn(`Scrollback restore failed for ${task.label}`, { error: restoreError });
+        } else {
+          managed.scrollbackRestoreState = "done";
+        }
       } catch (error) {
+        // IPC-level failure from terminalClient.getSerializedState (the
+        // controller's own catch returns false rather than rethrowing for
+        // replay failures, so reaching here means something below
+        // fetchAndRestore escaped — e.g. an unmocked test rejection).
         managed.scrollbackRestoreState = "none";
+        if (isCurrent()) {
+          usePanelStore
+            .getState()
+            .setScrollbackRestoreError(task.terminalId, classifySchedulerError(error));
+        }
         logWarn(`Scrollback restore failed for ${task.label}`, { error });
       }
     };

--- a/src/utils/stateHydration/scrollbackRestoreScheduler.ts
+++ b/src/utils/stateHydration/scrollbackRestoreScheduler.ts
@@ -28,9 +28,28 @@ export function scheduleScrollbackRestore(
     managed.scrollbackRestoreState = "pending";
 
     const doRestore = async () => {
-      if (!isCurrent()) return;
+      // On bail paths where state is still "pending" (we never started),
+      // reset to "none" so a subsequent scheduleScrollbackRestore call —
+      // e.g. after the user navigates back into a project view — picks the
+      // terminal up again. Without this reset, a project switch mid-flight
+      // permanently strands the terminal in "pending" and scrollback is
+      // never restored. The "state !== 'pending'" bail below is left alone:
+      // there, external code (destroy/done) already set a deliberate state.
+      const resetIfStillPending = () => {
+        if (managed.scrollbackRestoreState === "pending") {
+          managed.scrollbackRestoreState = "none";
+        }
+      };
+
+      if (!isCurrent()) {
+        resetIfStillPending();
+        return;
+      }
       const current = terminalInstanceService.get(task.terminalId);
-      if (!current || current !== managed) return;
+      if (!current || current !== managed) {
+        resetIfStillPending();
+        return;
+      }
       if (managed.scrollbackRestoreState !== "pending") return;
 
       managed.scrollbackRestoreState = "in-progress";


### PR DESCRIPTION
## Summary

When a scrollback restore fails, users were left with a blank terminal and nothing to explain why. This was a silent failure — the error went to the console and the terminal state was stranded in `pending` forever.

This PR surfaces those failures as a Tier-3 inline warning banner with a "Reset terminal" CTA, so the user knows what happened and has a clear recovery path.

Resolves #8535

## Changes

- New `TerminalScrollbackRestoreError` type covering `timeout`, `parse`, and `error` cases, plus `setScrollbackRestoreError` / `clearScrollbackRestoreError` store setters
- `lastScrollbackRestoreError` field on `ManagedTerminal`; the restore controller catches and classifies failures into this field
- Scheduler reads `lastScrollbackRestoreError` after `fetchAndRestore` and emits to the panel store gated on `isCurrent()` — project-switch aborts don't surface spurious banners
- Scrollback state reset to `"none"` on `isCurrent()` / LRU-swap bail, so navigating back to a project re-triggers restore instead of stranding it in `"pending"` forever
- New `ScrollbackRestoreErrorBanner` component wired into `TerminalPane`'s banner stack; banner severity is `warning` since the terminal itself still works (only replayed history is missing)
- "Reset terminal" CTA binds to `restartTerminal`, which already handles clearing the error state

## Testing

Scheduler tests extended with 8 new cases covering timeout, parse-error, and generic-error classification, `isCurrent()` gate, and bail-path state reset (16 tests total). Type-check, build, lint, and format all clean.