### PR TITLE
feat(terminal): make hibernation idle-aware and memory-pressure adaptive

### DIFF
--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -35,6 +35,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "window:fullscreen-change": "external",
   "window:reclaim-memory": "external",
   "window:destroy-hidden-webviews": "external",
+  "window:accelerate-hibernation": "external",
   "window:disk-space-status": "external",
   "window:sample-blink-memory": "external",
   "window:sample-renderer-elu": "external",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -939,6 +939,9 @@ const api: ElectronAPI = {
 
     onReclaimMemory: (callback: () => void) =>
       _eventBusOn("window:reclaim-memory", () => callback()),
+
+    onAccelerateHibernation: (callback: (data: { level: 1 | 2 }) => void) =>
+      _eventBusOn("window:accelerate-hibernation", callback),
   },
 
   // Files API

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -182,6 +182,17 @@ export interface MemoryPressureActions {
   hibernateIdleProjects: () => Promise<void>;
   trimPtyHostState?: () => void;
   /**
+   * Optional accelerator that compresses the per-terminal hibernation timer
+   * under memory pressure. Tier 1 fires at the same point as
+   * `destroyHiddenWebviews(1)`; tier 2 fires alongside `hibernateIdleProjects`.
+   * Fan-out implementations should push a `window:accelerate-hibernation`
+   * event to every live renderer — the renderer-side handler in
+   * `setupResourceListeners` calls `terminalInstanceService.accelerateHibernation`.
+   * Optional so legacy callers and test fixtures with partial action objects
+   * keep compiling.
+   */
+  accelerateTerminalHibernation?: (level: 1 | 2) => void;
+  /**
    * Optional Blink memory sampler. If wired, called once per poll BEFORE
    * pressure evaluation so renderer samples land alongside the metrics
    * snapshot. Implementations should fan a `window:sample-blink-memory`
@@ -384,6 +395,11 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
           } catch {
             /* non-critical */
           }
+          try {
+            actions.accelerateTerminalHibernation?.(1);
+          } catch {
+            /* non-critical */
+          }
 
           if (
             consecutivePressureCount >= PRESSURE_COUNT_TIER2 &&
@@ -395,6 +411,11 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
             });
             await actions.destroyHiddenWebviews(2);
             await actions.hibernateIdleProjects();
+            try {
+              actions.accelerateTerminalHibernation?.(2);
+            } catch {
+              /* non-critical */
+            }
             lastTier2At = Date.now();
           }
         } catch (err) {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -474,6 +474,26 @@ export async function initGlobalServices(
           hibernateIdleProjects: async () => {
             await getHibernationService().hibernateUnderMemoryPressure();
           },
+          accelerateTerminalHibernation: (level: 1 | 2) => {
+            // Fan the per-window push event so every renderer compresses
+            // its hibernation timer. Mirrors the destroyHiddenWebviews
+            // fanout pattern above — broadcastToRenderer is not used
+            // because the renderer's TerminalInstanceService is window-
+            // scoped (xterm instances live in a single project view), so
+            // there's nothing to gain from a global broadcast.
+            if (!windowRegistry) return;
+            for (const wCtx of windowRegistry.all()) {
+              if (wCtx.browserWindow.isDestroyed()) continue;
+              try {
+                sendToRenderer(wCtx.browserWindow, CHANNELS.EVENTS_PUSH, {
+                  name: "window:accelerate-hibernation",
+                  payload: { level },
+                });
+              } catch {
+                /* non-critical */
+              }
+            }
+          },
           trimPtyHostState: () => {
             getPtyClient()?.trimState(SCROLLBACK_BACKGROUND);
           },

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -310,6 +310,7 @@ export interface ElectronAPI {
     onRestoreScrollback(callback: (data: { terminalIds: string[] }) => void): () => void;
     restartService(): Promise<void>;
     onReclaimMemory(callback: () => void): () => void;
+    onAccelerateHibernation(callback: (data: { level: 1 | 2 }) => void): () => void;
   };
   files: {
     search(payload: FileSearchPayload): Promise<FileSearchResult>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2332,6 +2332,12 @@ export interface IpcEventMap {
   "window:fullscreen-change": boolean;
   "window:reclaim-memory": { reason: string };
   "window:destroy-hidden-webviews": { tier: 1 | 2 };
+  // Per-window push event fired by `ProcessMemoryMonitor` mitigation tiers
+  // 1 and 2. The renderer compresses every BACKGROUND-tier terminal's
+  // hibernation timer to a much shorter delay (5s / 0s) so idle agent
+  // panes release memory immediately under OS pressure instead of waiting
+  // for the fixed 30s window. Renderer handler in `setupResourceListeners`.
+  "window:accelerate-hibernation": { level: 1 | 2 };
   // Main asks renderers to report process.getBlinkMemoryInfo() so
   // ProcessMemoryMonitor can see the Blink (DOM/CSS/inter-frame) memory tier
   // that V8 heap stats miss. Renderer replies via SYSTEM_REPORT_BLINK_MEMORY.
@@ -2549,6 +2555,7 @@ export type IpcEventBusMap = Pick<
   | "window:fullscreen-change"
   | "window:reclaim-memory"
   | "window:destroy-hidden-webviews"
+  | "window:accelerate-hibernation"
   | "window:disk-space-status"
   | "window:sample-blink-memory"
   | "window:sample-renderer-elu"

--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -1,8 +1,9 @@
 import { Terminal } from "@xterm/xterm";
 import { TerminalRefreshTier } from "@/types";
-import { HIBERNATION_DELAY_MS, type ManagedTerminal } from "./types";
+import { AGENT_IDLE_SILENCE_MS, HIBERNATION_DELAY_MS, type ManagedTerminal } from "./types";
 import { setupTerminalAddons } from "./TerminalAddonManager";
 import { TerminalParserHandler } from "./TerminalParserHandler";
+import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
 import { logDebug, logError } from "@/utils/logger";
 import {
   installTerminalBoundListeners,
@@ -30,20 +31,24 @@ export class TerminalHibernationManager {
 
   hibernate(id: string): void {
     const managed = this.deps.getInstance(id);
-    if (
-      !managed ||
-      managed.isHibernated ||
-      (managed.runtimeAgentId &&
-        managed.canonicalAgentState !== "completed" &&
-        managed.canonicalAgentState !== "exited")
-    )
-      return;
+    if (!managed || managed.isHibernated) return;
+    // Single source of truth for "is this terminal safe to tear down right
+    // now?" — shared with the eligibility predicate so the scheduled-timer
+    // path and the direct (memory-pressure accelerated) path stay in
+    // lockstep. The predicate adds a tier check on top; hibernate() itself
+    // is permissive about tier because callers (memory-pressure accelerator)
+    // may want to force teardown regardless of the renderer-policy tier.
+    if (!this.isSafeToHibernate(managed)) return;
 
     logDebug(`[TIS.hibernate] Hibernating terminal ${id}`);
 
     if (managed.hibernationTimer) {
       clearTimeout(managed.hibernationTimer);
       managed.hibernationTimer = undefined;
+    }
+    if (managed.hibernationEligibilityTimer) {
+      clearTimeout(managed.hibernationEligibilityTimer);
+      managed.hibernationEligibilityTimer = undefined;
     }
     // Cancel any in-flight visibility-driven hide-dwell — hibernation is
     // authoritative and routes through onTerminalDestroyed (bypassing
@@ -198,18 +203,46 @@ export class TerminalHibernationManager {
   }
 
   /**
-   * Eligibility for the auto-hibernation timer: only BACKGROUND-tier
-   * terminals that are either non-agent, completed, or exited. An agent
-   * terminal in working/waiting/etc. state must keep rendering even when
-   * hidden — hibernating it would lose live activity tracking.
+   * Safety check shared between the scheduled-timer eligibility predicate
+   * and the direct hibernate() guard. Returns true if the terminal can be
+   * torn down without losing in-flight activity. Tier-agnostic — the
+   * eligibility predicate composes this with a BACKGROUND tier check.
+   *
+   * Rules:
+   * - Non-agent terminals: always safe.
+   * - Agents in resting states (`idle`/`completed`/`exited`, or undefined
+   *   state for legacy paths that never assigned canonicalAgentState):
+   *   always safe. `idle` is not in ACTIVE_AGENT_STATES — it represents
+   *   the agent itself reporting it has nothing to do.
+   * - Agents in active states (`working`/`waiting`/`directing`): safe
+   *   only if no writes are in flight AND the last rendered output is
+   *   either non-existent or at least AGENT_IDLE_SILENCE_MS old. The
+   *   "never wrote" case is treated as safe because silence is by
+   *   definition infinite if no write has ever been recorded.
    */
-  isHibernationEligible(tier: TerminalRefreshTier, managed: ManagedTerminal): boolean {
+  private isSafeToHibernate(managed: ManagedTerminal, now: number = Date.now()): boolean {
+    if (!managed.runtimeAgentId) return true;
+    const state = managed.canonicalAgentState;
+    if (state === undefined || !ACTIVE_AGENT_STATES.has(state)) return true;
+    if ((managed.pendingWrites ?? 0) > 0) return false;
+    if (managed.lastWriteAt === undefined) return true;
+    return now - managed.lastWriteAt >= AGENT_IDLE_SILENCE_MS;
+  }
+
+  /**
+   * Eligibility for the auto-hibernation timer: BACKGROUND-tier terminals
+   * that pass the shared safety check. An agent terminal in an active state
+   * (working/waiting/directing) becomes eligible after AGENT_IDLE_SILENCE_MS
+   * of output silence so a long-parked agent doesn't permanently strand
+   * memory the way the original "active agent → never hibernate" rule did.
+   */
+  isHibernationEligible(
+    tier: TerminalRefreshTier,
+    managed: ManagedTerminal,
+    now: number = Date.now()
+  ): boolean {
     if (tier !== TerminalRefreshTier.BACKGROUND) return false;
-    return (
-      !managed.runtimeAgentId ||
-      managed.canonicalAgentState === "completed" ||
-      managed.canonicalAgentState === "exited"
-    );
+    return this.isSafeToHibernate(managed, now);
   }
 
   /**
@@ -218,9 +251,53 @@ export class TerminalHibernationManager {
    * don't have to coordinate. The fire path re-checks visibility and
    * hibernation state because the user may have revealed the terminal
    * between schedule and fire.
+   *
+   * `delayMs` defaults to HIBERNATION_DELAY_MS. The memory-pressure
+   * accelerator passes a shorter value (5s for tier 1, 0ms for tier 2) so
+   * the existing schedule path is reused under load instead of a parallel
+   * mechanism. If the terminal is not yet idle-eligible because its last
+   * write is too recent, an eligibility re-check timer is armed instead
+   * — when that fires, scheduleHibernation re-runs and either arms the
+   * normal timer or no-ops if the terminal has since become active.
    */
-  scheduleHibernation(id: string, managed: ManagedTerminal): void {
+  scheduleHibernation(
+    id: string,
+    managed: ManagedTerminal,
+    delayMs: number = HIBERNATION_DELAY_MS
+  ): void {
     if (managed.hibernationTimer || managed.isHibernated) return;
+
+    // Active-state agent that is silent but not yet past the idle window:
+    // arm a single delayed re-check at the exact moment eligibility flips.
+    // This is the "arm once" pattern from lesson #4974 — do not re-arm on
+    // every write, since that would create unbounded deferral. The next
+    // write will naturally re-trigger scheduleHibernation via the renderer
+    // policy if the tier is still BACKGROUND.
+    if (
+      managed.runtimeAgentId &&
+      managed.canonicalAgentState !== undefined &&
+      ACTIVE_AGENT_STATES.has(managed.canonicalAgentState) &&
+      (managed.pendingWrites ?? 0) === 0 &&
+      managed.lastWriteAt !== undefined
+    ) {
+      const now = Date.now();
+      const elapsed = now - managed.lastWriteAt;
+      if (elapsed < AGENT_IDLE_SILENCE_MS) {
+        if (managed.hibernationEligibilityTimer) return;
+        const wait = AGENT_IDLE_SILENCE_MS - elapsed;
+        managed.hibernationEligibilityTimer = setTimeout(() => {
+          // Re-fetch in callback — the closed-over ref could be stale if
+          // the instance was destroyed/re-created (#4850 pattern).
+          const current = this.deps.getInstance(id);
+          if (!current) return;
+          current.hibernationEligibilityTimer = undefined;
+          if (current.isHibernated || current.isVisible) return;
+          this.scheduleHibernation(id, current, delayMs);
+        }, wait);
+        return;
+      }
+    }
+
     managed.hibernationTimer = setTimeout(() => {
       managed.hibernationTimer = undefined;
       const current = this.deps.getInstance(id);
@@ -228,16 +305,22 @@ export class TerminalHibernationManager {
       // fire should not be hibernated — the user is looking at it.
       if (!current || current.isVisible || current.isHibernated) return;
       this.hibernate(id);
-    }, HIBERNATION_DELAY_MS);
+    }, delayMs);
   }
 
   /**
    * Cancel a pending hibernation timer. Safe to call when no timer is armed.
+   * Also clears the eligibility re-check timer so a terminal that left
+   * BACKGROUND tier doesn't have a stale callback fire later and re-arm.
    */
   cancelHibernation(managed: ManagedTerminal): void {
     if (managed.hibernationTimer) {
       clearTimeout(managed.hibernationTimer);
       managed.hibernationTimer = undefined;
+    }
+    if (managed.hibernationEligibilityTimer) {
+      clearTimeout(managed.hibernationEligibilityTimer);
+      managed.hibernationEligibilityTimer = undefined;
     }
   }
 }

--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -265,7 +265,8 @@ export class TerminalHibernationManager {
     managed: ManagedTerminal,
     delayMs: number = HIBERNATION_DELAY_MS
   ): void {
-    if (managed.hibernationTimer || managed.isHibernated) return;
+    if (managed.hibernationTimer || managed.hibernationEligibilityTimer || managed.isHibernated)
+      return;
 
     // Active-state agent that is silent but not yet past the idle window:
     // arm a single delayed re-check at the exact moment eligibility flips.
@@ -283,7 +284,8 @@ export class TerminalHibernationManager {
       const now = Date.now();
       const elapsed = now - managed.lastWriteAt;
       if (elapsed < AGENT_IDLE_SILENCE_MS) {
-        if (managed.hibernationEligibilityTimer) return;
+        // Outer idempotency guard already catches a re-arm attempt while
+        // hibernationEligibilityTimer is pending.
         const wait = AGENT_IDLE_SILENCE_MS - elapsed;
         managed.hibernationEligibilityTimer = setTimeout(() => {
           // Re-fetch in callback — the closed-over ref could be stale if

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -159,7 +159,16 @@ class TerminalInstanceService {
       onResumeFlush: (id) => this.dataBuffer.resumeFlush(id),
       applyDeferredResize: (id) => this.resizeController.applyDeferredResize(id),
       onTierApplied: (id, tier, managed) => {
-        if (this.isHibernationEligible(tier, managed) && !managed.isVisible) {
+        // Enter scheduleHibernation whenever the terminal is BACKGROUND and
+        // offscreen, even if it's not eligible right now. scheduleHibernation
+        // owns the decision: arm the regular 30s timer if eligible now, or
+        // arm a one-shot eligibility re-check for active-state agents that
+        // are silent but inside the AGENT_IDLE_SILENCE_MS window. Gating
+        // here on isHibernationEligible (as the original did) makes the
+        // re-check unreachable — a recently-active agent that drops to
+        // BACKGROUND would be permanently exempt, the exact regression
+        // this feature was built to fix.
+        if (tier === TerminalRefreshTier.BACKGROUND && !managed.isVisible) {
           this.scheduleHibernation(id, managed);
         } else {
           this.cancelHibernation(managed);
@@ -646,10 +655,13 @@ class TerminalInstanceService {
           this.webGLManager.releaseContext(id);
         }, WEBGL_HIDE_DWELL_MS);
 
-        // If we're already in a hibernation-eligible tier, onTierApplied
-        // won't fire to start the timer — do it here instead.
+        // If we're already in BACKGROUND tier, onTierApplied won't fire to
+        // start the timer — do it here instead. Pass to scheduleHibernation
+        // even when not eligible right now (active-state agent with recent
+        // writes); the function arms either the regular timer or a one-shot
+        // eligibility re-check that fires when the silence window expires.
         const tier = managed.lastAppliedTier ?? managed.getRefreshTier?.();
-        if (tier !== undefined && this.isHibernationEligible(tier, managed)) {
+        if (tier === TerminalRefreshTier.BACKGROUND) {
           this.scheduleHibernation(id, managed);
         }
       }
@@ -1880,10 +1892,6 @@ class TerminalInstanceService {
     this.hibernationManager.unhibernate(id);
   }
 
-  private isHibernationEligible(tier: TerminalRefreshTier, managed: ManagedTerminal): boolean {
-    return this.hibernationManager.isHibernationEligible(tier, managed);
-  }
-
   private scheduleHibernation(id: string, managed: ManagedTerminal, delayMs?: number): void {
     this.hibernationManager.scheduleHibernation(id, managed, delayMs);
   }
@@ -1969,6 +1977,10 @@ class TerminalInstanceService {
     if (managed.hibernationTimer) {
       clearTimeout(managed.hibernationTimer);
       managed.hibernationTimer = undefined;
+    }
+    if (managed.hibernationEligibilityTimer) {
+      clearTimeout(managed.hibernationEligibilityTimer);
+      managed.hibernationEligibilityTimer = undefined;
     }
     if (managed.tierChangeTimer !== undefined) {
       clearTimeout(managed.tierChangeTimer);

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -10,6 +10,8 @@ import {
   PostCompleteHook,
   isWebGLEligibleTier,
   WRITE_BURST_DECAY_MS,
+  HIBERNATION_DELAY_PRESSURE_TIER1_MS,
+  HIBERNATION_DELAY_PRESSURE_TIER2_MS,
 } from "./types";
 import {
   setupTerminalAddons,
@@ -1882,12 +1884,46 @@ class TerminalInstanceService {
     return this.hibernationManager.isHibernationEligible(tier, managed);
   }
 
-  private scheduleHibernation(id: string, managed: ManagedTerminal): void {
-    this.hibernationManager.scheduleHibernation(id, managed);
+  private scheduleHibernation(id: string, managed: ManagedTerminal, delayMs?: number): void {
+    this.hibernationManager.scheduleHibernation(id, managed, delayMs);
   }
 
   private cancelHibernation(managed: ManagedTerminal): void {
     this.hibernationManager.cancelHibernation(managed);
+  }
+
+  /**
+   * Memory-pressure accelerator. Sweep every BACKGROUND-tier instance and
+   * re-arm its hibernation timer with a shorter delay so idle terminals
+   * release memory immediately under OS pressure instead of waiting for the
+   * fixed 30s window.
+   *
+   * - Level 1 (mild pressure): HIBERNATION_DELAY_PRESSURE_TIER1_MS (5s).
+   *   Enough headroom for a write burst to drain and to absorb tab-flip
+   *   oscillation, but ~6x faster than the normal window.
+   * - Level 2 (sustained pressure): HIBERNATION_DELAY_PRESSURE_TIER2_MS (0).
+   *   Fire immediately; the `hibernate()` safety guard still blocks
+   *   actively-writing or recently-active agent terminals.
+   *
+   * Skips visible terminals (the user is looking at them) and terminals that
+   * are not currently in BACKGROUND tier (those are protected by the
+   * renderer policy). Already-hibernated terminals are skipped.
+   */
+  accelerateHibernation(level: 1 | 2): void {
+    const delayMs =
+      level === 1 ? HIBERNATION_DELAY_PRESSURE_TIER1_MS : HIBERNATION_DELAY_PRESSURE_TIER2_MS;
+    for (const [id, managed] of this.instances.entries()) {
+      if (managed.isHibernated) continue;
+      if (managed.isVisible) continue;
+      if (managed.lastAppliedTier !== TerminalRefreshTier.BACKGROUND) continue;
+      // Cancel the existing 30s timer so we don't race two pending
+      // hibernations against each other. The new schedule re-runs the
+      // eligibility check, so active-agent terminals with recent writes
+      // still wait out their silence window (their eligibility re-check
+      // timer takes over from here).
+      this.cancelHibernation(managed);
+      this.scheduleHibernation(id, managed, delayMs);
+    }
   }
 
   destroy(id: string): void {

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TerminalHibernationManager, HibernationManagerDeps } from "../TerminalHibernationManager";
 import type { ManagedTerminal } from "../types";
+import { AGENT_IDLE_SILENCE_MS } from "../types";
 import { TerminalRefreshTier } from "../../../../shared/types/panel";
 
 const { freshTerminalOpenMock, freshTerminalOnWriteParsed } = vi.hoisted(() => ({
@@ -205,20 +206,58 @@ describe("TerminalHibernationManager", () => {
       expect(deps.destroyRestoreState).not.toHaveBeenCalled();
     });
 
-    it("should no-op for working agent terminal", () => {
+    it("should no-op for recently-active working agent terminal", () => {
       managed.launchAgentId = "claude";
       managed.runtimeAgentId = "claude";
       managed.canonicalAgentState = "working";
+      // Recently rendered output → inside the silence window, must not tear
+      // down. The plain "working" state alone isn't enough to block anymore
+      // — silence is the load-bearing signal.
+      managed.lastWriteAt = Date.now() - 1000;
       manager.hibernate("t1");
       expect(managed.isHibernated).toBeFalsy();
     });
 
-    it("should no-op for waiting agent terminal", () => {
+    it("should no-op for recently-active waiting agent terminal", () => {
       managed.launchAgentId = "claude";
       managed.runtimeAgentId = "claude";
       managed.canonicalAgentState = "waiting";
+      managed.lastWriteAt = Date.now() - 1000;
       manager.hibernate("t1");
       expect(managed.isHibernated).toBeFalsy();
+    });
+
+    it("should no-op when an active agent has writes in flight", () => {
+      managed.launchAgentId = "claude";
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      // lastWriteAt far enough in the past to clear the silence window, but
+      // pendingWrites > 0 means xterm is still flushing a burst — must not
+      // tear down mid-write.
+      managed.lastWriteAt = Date.now() - AGENT_IDLE_SILENCE_MS - 5000;
+      managed.pendingWrites = 2;
+      manager.hibernate("t1");
+      expect(managed.isHibernated).toBeFalsy();
+    });
+
+    it("should hibernate a working agent that has been silent past AGENT_IDLE_SILENCE_MS", () => {
+      managed.launchAgentId = "claude";
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.pendingWrites = 0;
+      managed.lastWriteAt = Date.now() - AGENT_IDLE_SILENCE_MS - 1000;
+      manager.hibernate("t1");
+      expect(managed.isHibernated).toBe(true);
+    });
+
+    it("should hibernate an idle agent immediately (no silence window required)", () => {
+      managed.launchAgentId = "claude";
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "idle";
+      // No lastWriteAt set — `idle` is a resting state, treated like
+      // completed/exited, so the silence window doesn't apply.
+      manager.hibernate("t1");
+      expect(managed.isHibernated).toBe(true);
     });
 
     it("should hibernate completed agent terminal", () => {
@@ -454,13 +493,25 @@ describe("TerminalHibernationManager", () => {
       expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed)).toBe(true);
     });
 
-    it("rejects BACKGROUND while an agent is still working/waiting", () => {
+    it("rejects BACKGROUND while a recently-active agent is still working/waiting/directing", () => {
+      const now = Date.now();
       managed.runtimeAgentId = "claude";
+      managed.lastWriteAt = now - 1000;
+
       managed.canonicalAgentState = "working";
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed)).toBe(false);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, now)).toBe(
+        false
+      );
 
       managed.canonicalAgentState = "waiting";
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed)).toBe(false);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, now)).toBe(
+        false
+      );
+
+      managed.canonicalAgentState = "directing";
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, now)).toBe(
+        false
+      );
     });
 
     it("accepts BACKGROUND once an agent has completed or exited", () => {
@@ -469,6 +520,58 @@ describe("TerminalHibernationManager", () => {
       expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed)).toBe(true);
 
       managed.canonicalAgentState = "exited";
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed)).toBe(true);
+    });
+
+    it("treats `idle` as immediately eligible — no silence window required", () => {
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "idle";
+      // No lastWriteAt: `idle` is a resting state, not in ACTIVE_AGENT_STATES,
+      // so the silence guard doesn't apply.
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed)).toBe(true);
+    });
+
+    it("accepts BACKGROUND for a working agent that has been silent past AGENT_IDLE_SILENCE_MS", () => {
+      const now = Date.now();
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.lastWriteAt = now - AGENT_IDLE_SILENCE_MS;
+      managed.pendingWrites = 0;
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, now)).toBe(
+        true
+      );
+    });
+
+    it("rejects BACKGROUND one millisecond shy of the silence boundary", () => {
+      const now = Date.now();
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "waiting";
+      managed.lastWriteAt = now - AGENT_IDLE_SILENCE_MS + 1;
+      managed.pendingWrites = 0;
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, now)).toBe(
+        false
+      );
+    });
+
+    it("rejects BACKGROUND when an idle-eligible active agent still has pending writes", () => {
+      const now = Date.now();
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.lastWriteAt = now - AGENT_IDLE_SILENCE_MS - 10_000;
+      managed.pendingWrites = 1;
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, now)).toBe(
+        false
+      );
+    });
+
+    it("accepts BACKGROUND for an active agent that has no recorded lastWriteAt", () => {
+      // A just-spawned agent that has never written anything reports
+      // infinite silence by definition — eligible. The next write will
+      // stamp lastWriteAt and may flip the state back to ineligible.
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "waiting";
+      managed.pendingWrites = 0;
+      managed.lastWriteAt = undefined;
       expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed)).toBe(true);
     });
   });
@@ -536,6 +639,110 @@ describe("TerminalHibernationManager", () => {
     it("cancelHibernation is safe when no timer is armed", () => {
       managed.hibernationTimer = undefined;
       expect(() => manager.cancelHibernation(managed)).not.toThrow();
+    });
+
+    it("honors the optional delayMs override", () => {
+      managed.runtimeAgentId = undefined;
+      managed.isVisible = false;
+
+      manager.scheduleHibernation("t1", managed, 5_000);
+      expect(managed.hibernationTimer).toBeDefined();
+
+      // Standard 30s should NOT be enough — we set 5s.
+      vi.advanceTimersByTime(4_999);
+      expect(managed.isHibernated).toBe(false);
+
+      vi.advanceTimersByTime(2);
+      expect(managed.isHibernated).toBe(true);
+    });
+
+    it("arms an eligibility re-check (not the hibernation timer) for a still-silent active agent", () => {
+      vi.setSystemTime(0);
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.isVisible = false;
+      managed.pendingWrites = 0;
+      managed.lastWriteAt = 0; // wrote at t=0, silence window not yet reached
+
+      manager.scheduleHibernation("t1", managed);
+
+      // No hibernation timer yet — re-check timer is armed instead.
+      expect(managed.hibernationTimer).toBeUndefined();
+      expect(managed.hibernationEligibilityTimer).toBeDefined();
+
+      // Advance to just before eligibility flips.
+      vi.advanceTimersByTime(AGENT_IDLE_SILENCE_MS - 1);
+      expect(managed.hibernationTimer).toBeUndefined();
+      expect(managed.isHibernated).toBe(false);
+
+      // Cross the silence boundary — re-check fires, schedules the
+      // normal 30s timer, then advance through that to hibernate.
+      vi.advanceTimersByTime(1);
+      expect(managed.hibernationEligibilityTimer).toBeUndefined();
+      expect(managed.hibernationTimer).toBeDefined();
+
+      vi.advanceTimersByTime(30_000);
+      expect(managed.isHibernated).toBe(true);
+
+      vi.setSystemTime(new Date());
+    });
+
+    it("re-check bails if the terminal became visible before eligibility flipped", () => {
+      vi.setSystemTime(0);
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.isVisible = false;
+      managed.pendingWrites = 0;
+      managed.lastWriteAt = 0;
+
+      manager.scheduleHibernation("t1", managed);
+      expect(managed.hibernationEligibilityTimer).toBeDefined();
+
+      managed.isVisible = true;
+      vi.advanceTimersByTime(AGENT_IDLE_SILENCE_MS);
+
+      // Eligibility re-check ran, bailed because terminal is visible.
+      expect(managed.hibernationTimer).toBeUndefined();
+      expect(managed.isHibernated).toBe(false);
+
+      vi.setSystemTime(new Date());
+    });
+
+    it("cancelHibernation clears the eligibility re-check timer too", () => {
+      vi.setSystemTime(0);
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "waiting";
+      managed.isVisible = false;
+      managed.pendingWrites = 0;
+      managed.lastWriteAt = 0;
+
+      manager.scheduleHibernation("t1", managed);
+      expect(managed.hibernationEligibilityTimer).toBeDefined();
+
+      manager.cancelHibernation(managed);
+      expect(managed.hibernationEligibilityTimer).toBeUndefined();
+
+      // Past the window, nothing should fire.
+      vi.advanceTimersByTime(AGENT_IDLE_SILENCE_MS + 1000);
+      expect(managed.hibernationTimer).toBeUndefined();
+      expect(managed.isHibernated).toBe(false);
+
+      vi.setSystemTime(new Date());
+    });
+
+    it("arms the regular hibernation timer immediately when an active agent is already past the silence window", () => {
+      vi.setSystemTime(AGENT_IDLE_SILENCE_MS + 10_000);
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.isVisible = false;
+      managed.pendingWrites = 0;
+      managed.lastWriteAt = 0; // ancient
+
+      manager.scheduleHibernation("t1", managed);
+      expect(managed.hibernationEligibilityTimer).toBeUndefined();
+      expect(managed.hibernationTimer).toBeDefined();
+
+      vi.setSystemTime(new Date());
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { TerminalRefreshTier } from "../../../../shared/types/panel";
-import { HIBERNATION_DELAY_MS } from "../types";
+import { AGENT_IDLE_SILENCE_MS, HIBERNATION_DELAY_MS } from "../types";
 
 const mockTerminalClient = {
   onData: vi.fn(() => vi.fn()),
@@ -160,6 +160,7 @@ function makeMockManaged(overrides: Record<string, unknown> = {}) {
     deferredOutput: [] as Array<string | Uint8Array>,
     isHibernated: false,
     hibernationTimer: undefined as ReturnType<typeof setTimeout> | undefined,
+    hibernationEligibilityTimer: undefined as ReturnType<typeof setTimeout> | undefined,
     isInputLocked: false,
     ipcListenerCount: 0,
     ...overrides,
@@ -455,6 +456,93 @@ describe("TerminalInstanceService - Hibernation", () => {
       expect(managed.hibernationTimer).toBeUndefined();
     });
 
+    it("arms the eligibility re-check timer for a recently-active agent dropping to BACKGROUND", () => {
+      // Regression guard for the issue that motivated this feature: a
+      // recently-active working agent backgrounded by tier transition must
+      // arm the silence-window re-check (not the regular timer, not
+      // nothing). Without this re-check, the agent would be permanently
+      // exempt from hibernation, leaking memory indefinitely.
+      const startTime = Date.now();
+      vi.setSystemTime(startTime);
+      const managed = makeMockManaged({
+        lastAppliedTier: TerminalRefreshTier.FOCUSED,
+        isVisible: false,
+        kind: "terminal",
+        launchAgentId: "claude",
+        canonicalAgentState: "working",
+        lastWriteAt: startTime - 1000,
+        pendingWrites: 0,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.applyRendererPolicy("t1", TerminalRefreshTier.BACKGROUND);
+      vi.advanceTimersByTime(600); // past hysteresis
+
+      expect(managed.hibernationTimer).toBeUndefined();
+      expect(managed.hibernationEligibilityTimer).toBeDefined();
+
+      vi.setSystemTime(new Date());
+    });
+
+    it("hibernates a recently-active agent after silence window + regular delay elapses", () => {
+      const startTime = Date.now();
+      vi.setSystemTime(startTime);
+      const managed = makeMockManaged({
+        lastAppliedTier: TerminalRefreshTier.FOCUSED,
+        isVisible: false,
+        kind: "terminal",
+        launchAgentId: "claude",
+        canonicalAgentState: "working",
+        lastWriteAt: startTime - 1000,
+        pendingWrites: 0,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.applyRendererPolicy("t1", TerminalRefreshTier.BACKGROUND);
+      vi.advanceTimersByTime(600); // past hysteresis
+
+      // Cross the silence window (re-check fires, schedules regular timer).
+      vi.advanceTimersByTime(AGENT_IDLE_SILENCE_MS);
+      expect(managed.hibernationTimer).toBeDefined();
+
+      // Cross the regular 30s delay.
+      vi.advanceTimersByTime(HIBERNATION_DELAY_MS);
+      expect(managed.isHibernated).toBe(true);
+
+      vi.setSystemTime(new Date());
+    });
+
+    it("clears the eligibility re-check timer when tier upgrades out of BACKGROUND", () => {
+      const startTime = Date.now();
+      vi.setSystemTime(startTime);
+      const managed = makeMockManaged({
+        lastAppliedTier: TerminalRefreshTier.FOCUSED,
+        isVisible: false,
+        kind: "terminal",
+        launchAgentId: "claude",
+        canonicalAgentState: "working",
+        lastWriteAt: startTime - 1000,
+        pendingWrites: 0,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.applyRendererPolicy("t1", TerminalRefreshTier.BACKGROUND);
+      vi.advanceTimersByTime(600);
+      expect(managed.hibernationEligibilityTimer).toBeDefined();
+
+      // User comes back: tier upgrades to FOCUSED before silence window
+      // expires. The re-check must be cancelled, otherwise it would fire
+      // 5 minutes later and the callback's stale managed-ref might still
+      // arm a regular timer despite the terminal being visible.
+      service.applyRendererPolicy("t1", TerminalRefreshTier.FOCUSED);
+      expect(managed.hibernationEligibilityTimer).toBeUndefined();
+
+      vi.advanceTimersByTime(AGENT_IDLE_SILENCE_MS + HIBERNATION_DELAY_MS);
+      expect(managed.isHibernated).toBeFalsy();
+
+      vi.setSystemTime(new Date());
+    });
+
     it("should start hibernation timer for offscreen completed agent terminals in BACKGROUND", () => {
       const managed = makeMockManaged({
         lastAppliedTier: TerminalRefreshTier.FOCUSED,
@@ -644,6 +732,33 @@ describe("TerminalInstanceService - Hibernation", () => {
 
       // Timer should have been cleared (no lingering setTimeout)
       expect(managed.hibernationTimer).toBeUndefined();
+    });
+
+    it("should clear the eligibility re-check timer on destroy", () => {
+      // Without this cleanup, the re-check could run for up to 5 minutes
+      // post-destroy. The callback's getInstance(id) guard prevents
+      // mutation of a recreated terminal, but the leak itself is the bug.
+      const startTime = Date.now();
+      vi.setSystemTime(startTime);
+      const managed = makeMockManaged({
+        lastAppliedTier: TerminalRefreshTier.FOCUSED,
+        isVisible: false,
+        kind: "terminal",
+        launchAgentId: "claude",
+        canonicalAgentState: "working",
+        lastWriteAt: startTime - 1000,
+        pendingWrites: 0,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.applyRendererPolicy("t1", TerminalRefreshTier.BACKGROUND);
+      vi.advanceTimersByTime(600);
+      expect(managed.hibernationEligibilityTimer).toBeDefined();
+
+      service.destroy("t1");
+      expect(managed.hibernationEligibilityTimer).toBeUndefined();
+
+      vi.setSystemTime(new Date());
     });
   });
 
@@ -930,6 +1045,51 @@ describe("TerminalInstanceService - Hibernation", () => {
 
       // Must NOT have hibernated — silence window unmet.
       expect(managed.isHibernated).toBeFalsy();
+    });
+
+    it("arms the eligibility re-check (not the regular timer) when accelerating a recently-active agent", () => {
+      const startTime = Date.now();
+      vi.setSystemTime(startTime);
+      const managed = makeMockManaged({
+        isVisible: false,
+        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+        launchAgentId: "claude",
+        canonicalAgentState: "working",
+        lastWriteAt: startTime - 1000,
+        pendingWrites: 0,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.accelerateHibernation(1);
+
+      // accelerateHibernation cancels any existing timer and calls
+      // scheduleHibernation with a shorter delay — but for a silent-but-
+      // not-yet-idle agent that means arming the eligibility re-check,
+      // not the regular timer. The accelerated delay is delivered to
+      // the second scheduleHibernation call from inside the re-check.
+      expect(managed.hibernationTimer).toBeUndefined();
+      expect(managed.hibernationEligibilityTimer).toBeDefined();
+
+      vi.setSystemTime(new Date());
+    });
+
+    it("replaces an existing regular timer with the accelerated delay", () => {
+      const managed = makeMockManaged({
+        isVisible: false,
+        lastAppliedTier: TerminalRefreshTier.FOCUSED,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.applyRendererPolicy("t1", TerminalRefreshTier.BACKGROUND);
+      vi.advanceTimersByTime(600); // past hysteresis — regular timer armed
+      expect(managed.hibernationTimer).toBeDefined();
+
+      service.accelerateHibernation(1);
+
+      // Tier 1 = 5s; the original 30s timer must have been cancelled and
+      // replaced — otherwise the 5s acceleration is a no-op.
+      vi.advanceTimersByTime(5_001);
+      expect(managed.isHibernated).toBe(true);
     });
 
     it("does not hibernate a non-BACKGROUND terminal even with idle agent state", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -81,6 +81,7 @@ type HibernationTestService = {
   resetRenderer: (id: string) => void;
   setVisible: (id: string, visible: boolean) => void;
   setInputLocked: (id: string, locked: boolean) => void;
+  accelerateHibernation: (level: 1 | 2) => void;
 };
 
 function makeMockManaged(overrides: Record<string, unknown> = {}) {
@@ -247,11 +248,16 @@ describe("TerminalInstanceService - Hibernation", () => {
       expect(service.isHibernated("t1")).toBe(true);
     });
 
-    it("should never hibernate active agent terminals", () => {
+    it("should never hibernate recently-active working agent terminals", () => {
+      // The eligibility check now uses lastWriteAt as the load-bearing
+      // signal; the plain "working" state alone is no longer permanent
+      // immunity. A recent write proves the agent is still live.
       const managed = makeMockManaged({
         kind: "terminal",
         launchAgentId: "claude",
         canonicalAgentState: "working",
+        lastWriteAt: Date.now() - 1000,
+        pendingWrites: 0,
       });
       service.instances.set("t1", managed as unknown as Record<string, unknown>);
 
@@ -261,11 +267,13 @@ describe("TerminalInstanceService - Hibernation", () => {
       expect(managed.terminal.dispose).not.toHaveBeenCalled();
     });
 
-    it("should never hibernate waiting agent terminals", () => {
+    it("should never hibernate recently-active waiting agent terminals", () => {
       const managed = makeMockManaged({
         kind: "terminal",
         launchAgentId: "claude",
         canonicalAgentState: "waiting",
+        lastWriteAt: Date.now() - 1000,
+        pendingWrites: 0,
       });
       service.instances.set("t1", managed as unknown as Record<string, unknown>);
 
@@ -425,13 +433,19 @@ describe("TerminalInstanceService - Hibernation", () => {
       expect(managed.isHibernated).toBe(true);
     });
 
-    it("should NOT start hibernation timer for active agent terminals", () => {
+    it("should NOT start hibernation timer for recently-active agent terminals", () => {
+      // With idle-aware eligibility, an active-state agent is only excluded
+      // while its silence window is unmet. Setting a recent lastWriteAt
+      // pins this terminal inside that window so the regular timer must
+      // not fire — though the eligibility re-check timer is allowed.
       const managed = makeMockManaged({
         lastAppliedTier: TerminalRefreshTier.FOCUSED,
         isVisible: false,
         kind: "terminal",
         launchAgentId: "claude",
         canonicalAgentState: "working",
+        lastWriteAt: Date.now() - 1000,
+        pendingWrites: 0,
       });
       service.instances.set("t1", managed as unknown as Record<string, unknown>);
 
@@ -814,6 +828,126 @@ describe("TerminalInstanceService - Hibernation", () => {
       service.hibernate("t1");
       service.unhibernate("t1");
       expect(managed.listeners.length).toBe(afterFirstCycle);
+    });
+  });
+
+  describe("accelerateHibernation() under memory pressure", () => {
+    it("compresses a BACKGROUND offscreen terminal's hibernation timer at tier 1", () => {
+      const managed = makeMockManaged({
+        isVisible: false,
+        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.accelerateHibernation(1);
+
+      expect(managed.hibernationTimer).toBeDefined();
+
+      // Standard 30s window must NOT apply — tier 1 is 5s.
+      vi.advanceTimersByTime(4_999);
+      expect(managed.isHibernated).toBe(false);
+
+      vi.advanceTimersByTime(2);
+      expect(managed.isHibernated).toBe(true);
+    });
+
+    it("hibernates a BACKGROUND offscreen terminal immediately at tier 2", () => {
+      const managed = makeMockManaged({
+        isVisible: false,
+        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.accelerateHibernation(2);
+
+      // Tier 2 schedules with delay 0 — flush the macrotask queue.
+      vi.advanceTimersByTime(0);
+      expect(managed.isHibernated).toBe(true);
+    });
+
+    it("ignores terminals that are not in BACKGROUND tier", () => {
+      const managed = makeMockManaged({
+        isVisible: false,
+        lastAppliedTier: TerminalRefreshTier.VISIBLE,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.accelerateHibernation(2);
+      vi.advanceTimersByTime(10_000);
+
+      expect(managed.hibernationTimer).toBeUndefined();
+      expect(managed.isHibernated).toBeFalsy();
+    });
+
+    it("ignores visible terminals even in BACKGROUND tier", () => {
+      // A non-focused split-view terminal can be BACKGROUND-tier and still
+      // on screen. Tearing it down under memory pressure would visibly
+      // collapse the user's view — never do this.
+      const managed = makeMockManaged({
+        isVisible: true,
+        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.accelerateHibernation(2);
+      vi.advanceTimersByTime(10_000);
+
+      expect(managed.hibernationTimer).toBeUndefined();
+      expect(managed.isHibernated).toBeFalsy();
+    });
+
+    it("skips terminals that are already hibernated", () => {
+      const managed = makeMockManaged({
+        isVisible: false,
+        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+        isHibernated: true,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.accelerateHibernation(2);
+      vi.advanceTimersByTime(10_000);
+
+      // Already-hibernated terminals stay hibernated; no new timer.
+      expect(managed.hibernationTimer).toBeUndefined();
+    });
+
+    it("does not tear down a recently-active agent terminal at tier 2", () => {
+      // Tier 2 fires immediately, but the hibernate() safety guard still
+      // protects an agent that has recent output — the silence window must
+      // pass first. The pending re-check timer takes over.
+      const managed = makeMockManaged({
+        isVisible: false,
+        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+        launchAgentId: "claude",
+        canonicalAgentState: "working",
+        lastWriteAt: Date.now() - 1000, // very recent write
+        pendingWrites: 0,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.accelerateHibernation(2);
+      vi.advanceTimersByTime(0);
+
+      // Must NOT have hibernated — silence window unmet.
+      expect(managed.isHibernated).toBeFalsy();
+    });
+
+    it("does not hibernate a non-BACKGROUND terminal even with idle agent state", () => {
+      const managed = makeMockManaged({
+        isVisible: false,
+        lastAppliedTier: TerminalRefreshTier.FOCUSED,
+        launchAgentId: "claude",
+        canonicalAgentState: "idle",
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.accelerateHibernation(2);
+      vi.advanceTimersByTime(10_000);
+
+      // The renderer policy owns when to hibernate based on tier; the
+      // accelerator only compresses the timer for already-BACKGROUND
+      // terminals. A FOCUSED idle agent is still on the user's screen.
+      expect(managed.isHibernated).toBeFalsy();
     });
   });
 });

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -166,6 +166,13 @@ export interface ManagedTerminal {
   // Hibernation: xterm.js Terminal instance disposed to free memory
   isHibernated?: boolean;
   hibernationTimer?: ReturnType<typeof setTimeout>;
+  // Delayed re-check for active-state agent terminals (working/waiting/directing)
+  // that are not yet idle-eligible because their last write was too recent.
+  // Armed once at `lastWriteAt + AGENT_IDLE_SILENCE_MS - now`; on fire it
+  // re-calls scheduleHibernation, which arms the regular hibernationTimer if
+  // the terminal is now eligible. Cleared by cancelHibernation, hibernate, and
+  // tier upgrade alongside hibernationTimer.
+  hibernationEligibilityTimer?: ReturnType<typeof setTimeout>;
   ipcListenerCount: number;
 
   // Visibility-driven WebGL restore debounce. Show path waits ~100ms before
@@ -214,6 +221,27 @@ export const SCROLLBACK_REDUCE_COOLDOWN_MS = 2000;
 export const WRITE_BURST_RECENCY_MS = 2000;
 
 export const HIBERNATION_DELAY_MS = 30_000;
+
+// Silence window after which an agent terminal in an ACTIVE_AGENT_STATE
+// (working/waiting/directing) becomes hibernation-eligible despite a live
+// runtimeAgentId. The fixed permanent exemption used to strand idle agent
+// terminals that had been parked for hours with no output — 5 minutes is the
+// shortest window where it's plausible the agent or downstream tool is truly
+// dormant (long enough to outlast bursty prompt round-trips and long tool
+// invocations, short enough to recover the memory before the user notices).
+// "idle"/"completed"/"exited" are not gated by this — they're treated as
+// resting states and qualify for the normal HIBERNATION_DELAY_MS timer.
+export const AGENT_IDLE_SILENCE_MS = 5 * 60 * 1000;
+
+// Accelerated hibernation delays under OS memory pressure. Tier 1 (mild
+// pressure) drops the BACKGROUND→hibernate delay from HIBERNATION_DELAY_MS to
+// 5 seconds — still enough headroom for an in-flight write burst to drain
+// (WRITE_BURST_RECENCY_MS = 2s) and to absorb tab-flip oscillation. Tier 2
+// (sustained pressure) forces immediate hibernation; pendingWrites/agent-state
+// guards in `hibernate()` still apply so an actively-writing terminal can't be
+// torn down mid-burst.
+export const HIBERNATION_DELAY_PRESSURE_TIER1_MS = 5_000;
+export const HIBERNATION_DELAY_PRESSURE_TIER2_MS = 0;
 
 export const INCREMENTAL_RESTORE_CONFIG = {
   chunkBytes: 32768,

--- a/src/store/__tests__/panelStore.processDetectionListeners.test.ts
+++ b/src/store/__tests__/panelStore.processDetectionListeners.test.ts
@@ -199,6 +199,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     cleanup: vi.fn(),
     applyAgentPromotion: applyAgentPromotionMock,
     clearAgentPromotion: clearAgentPromotionMock,
+    accelerateHibernation: vi.fn(),
   },
 }));
 
@@ -209,6 +210,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     onResourceMetrics: vi.fn(() => vi.fn()),
     onReclaimMemory: vi.fn(() => vi.fn()),
     onFdLeakWarning: vi.fn(() => vi.fn()),
+    onAccelerateHibernation: vi.fn(() => vi.fn()),
   },
   terminalConfig: {
     get: vi.fn().mockResolvedValue({}),

--- a/src/store/listeners/panel/resource.ts
+++ b/src/store/listeners/panel/resource.ts
@@ -28,6 +28,19 @@ export function setupResourceListeners(): DisposableStore {
     )
   );
 
+  // Memory pressure: accelerate hibernation of every BACKGROUND-tier terminal
+  // so idle agent panes release memory immediately under OS pressure instead
+  // of waiting out the fixed 30s window. Tier 1 compresses the delay to 5s;
+  // tier 2 fires immediately. The hibernate() safety guard still blocks
+  // actively-writing or recently-active agent terminals.
+  d.add(
+    toDisposable(
+      window.electron.terminal.onAccelerateHibernation(({ level }) => {
+        terminalInstanceService.accelerateHibernation(level);
+      })
+    )
+  );
+
   // Flush pending terminal persistence on window close to prevent data loss
   const beforeUnloadHandler = () => {
     flushPanelPersistence();


### PR DESCRIPTION
## Summary

- Terminals in `working`, `waiting`, or `directing` agent states are no longer permanently exempt from hibernation. After `AGENT_IDLE_SILENCE_MS` (5 min) of output silence with no pending writes, they become eligible — a new `hibernationEligibilityTimer` arms a one-shot re-check at exactly the right moment so a recently-active agent that drops to BACKGROUND doesn't strand memory indefinitely.
- `idle` joins `completed`/`exited` as a resting state that qualifies immediately, matching what the state names imply.
- Memory pressure now accelerates per-terminal hibernation. A new `window:accelerate-hibernation` push event flows from `ProcessMemoryMonitor` through the IPC event bus to `TerminalInstanceService.accelerateHibernation()`, which sweeps BACKGROUND offscreen instances and re-arms them with a compressed delay at tier-1 (5s) and tier-2 (immediate) mitigations.

Closes #8534

## Changes

- `TerminalHibernationManager` — idle-recency check via `lastWriteAt`, one-shot `hibernationEligibilityTimer`, expanded eligibility to include `idle` state
- `TerminalInstanceService` — `accelerateHibernation(level)` sweep with compressed delay; `hibernate()` safety guard still protects mid-burst writes
- `ProcessMemoryMonitor` + `MemoryPressureActions` — fan `accelerateTerminalHibernation` to every live `BrowserWindow`
- IPC plumbing — `window:accelerate-hibernation` in `IpcEventBusMap` + `EVENT_BUS_BRIDGED_MANIFEST`, preload, `setupResourceListeners`
- `types.ts` — `hibernationEligibilityTimer` field on `ManagedTerminal`

## Testing

- `TerminalHibernationManager.test.ts` + adversarial suite + `TerminalInstanceService.hibernation.test.ts`: 105 pass
- `ProcessMemoryMonitor.test.ts`: 69 pass
- `npm run typecheck`: clean
- `npm run check`: all 7 checks pass, `lint:ratchet` improved by 1

Constraints: hibernation transitions stay Tier 0 silent (no toasts, no notify calls); `runtimeAgentId` survives hibernation cycles so agent-state detection is unaffected; no new external dependencies.