### PR TITLE
chore(workspace-host): remove dead legacy workspace-port channel

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -218,82 +218,8 @@ ipcRenderer.on("terminal-port", (event, payload: { token: string }) => {
   }
 });
 
-// Direct MessagePort from workspace host for worktree/PR/issue events.
-// Events arrive as WorkspaceHostEvent objects and are re-emitted on ipcRenderer
-// so existing contextBridge-exposed listeners work transparently.
-let workspacePort: MessagePort | null = null;
-
-ipcRenderer.on("workspace-port", (event: Electron.IpcRendererEvent) => {
-  if (!event.ports || event.ports.length === 0) return;
-
-  if (workspacePort) {
-    try {
-      workspacePort.close();
-    } catch {
-      /* ignore */
-    }
-  }
-
-  workspacePort = event.ports[0];
-  workspacePort.onmessage = (msg: MessageEvent) => {
-    const data = msg.data;
-    if (!data?.type) return;
-
-    // Re-emit as ipcRenderer events so existing on*/subscribe handlers fire
-    const fakeEvent = {} as Electron.IpcRendererEvent;
-    switch (data.type) {
-      case "worktree-update":
-        ipcRenderer.emit(CHANNELS.EVENTS_PUSH, fakeEvent, {
-          name: "worktree:update",
-          payload: { worktree: data.worktree },
-        });
-        break;
-      case "worktree-removed":
-        ipcRenderer.emit(CHANNELS.WORKTREE_REMOVE, fakeEvent, {
-          worktreeId: data.worktreeId,
-        });
-        break;
-      case "pr-detected":
-        ipcRenderer.emit(CHANNELS.PR_DETECTED, fakeEvent, {
-          worktreeId: data.worktreeId,
-          prNumber: data.prNumber,
-          prUrl: data.prUrl,
-          prState: data.prState,
-          prCiStatus: data.prCiStatus,
-          prTitle: data.prTitle,
-          issueNumber: data.issueNumber,
-          issueTitle: data.issueTitle,
-          timestamp: Date.now(),
-        });
-        break;
-      case "pr-cleared":
-        ipcRenderer.emit(CHANNELS.PR_CLEARED, fakeEvent, {
-          worktreeId: data.worktreeId,
-          timestamp: Date.now(),
-        });
-        break;
-      case "issue-detected":
-        ipcRenderer.emit(CHANNELS.ISSUE_DETECTED, fakeEvent, {
-          worktreeId: data.worktreeId,
-          issueNumber: data.issueNumber,
-          issueTitle: data.issueTitle,
-        });
-        break;
-      case "issue-not-found":
-        ipcRenderer.emit(CHANNELS.ISSUE_NOT_FOUND, fakeEvent, {
-          worktreeId: data.worktreeId,
-          issueNumber: data.issueNumber,
-          timestamp: Date.now(),
-        });
-        break;
-    }
-  };
-  console.log("[Preload] Workspace direct port connected");
-});
-
 // ── Worktree Port Client (Phase 1) ──────────────────────────────────────────
 // New dedicated port for worktree data with request/response correlation.
-// Coexists with the legacy workspace-port above — both work independently.
 
 type WorktreePortEventCallback = (data: unknown) => void;
 

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -111,22 +111,6 @@ export class WorkspaceHostProcess extends EventEmitter {
   }
 
   /**
-   * Transfer a MessagePort to the workspace host for direct renderer communication.
-   * The host sends spontaneous events (worktree updates, PR events) through this port,
-   * bypassing the main-process IPC relay.
-   */
-  attachRendererPort(port: MessagePortMain): boolean {
-    if (!this.child || this.isDisposed) return false;
-    try {
-      this.child.postMessage({ type: "attach-renderer-port" }, [port]);
-      return true;
-    } catch (error) {
-      console.error(`[WorkspaceHost:${this.serviceName}] Failed to attach renderer port:`, error);
-      return false;
-    }
-  }
-
-  /**
    * Transfer a MessagePort for the new worktree port protocol (Phase 1).
    * Supports request/response correlation and scoped event delivery.
    */

--- a/electron/services/__tests__/WorkspaceClient.prewarm.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.prewarm.test.ts
@@ -53,7 +53,6 @@ const { mockHosts, MockWorkspaceHostProcess } = vi.hoisted(() => {
     dispose = vi.fn(() => {
       this._isDisposed = true;
     });
-    attachRendererPort = vi.fn(() => true);
 
     setLogLevelOverrides = vi.fn();
 
@@ -104,13 +103,8 @@ vi.mock("../WorkspaceHostProcess.js", () => ({
 }));
 
 vi.mock("electron", () => {
-  class MockMessageChannelMain {
-    port1 = { close: vi.fn() };
-    port2 = { close: vi.fn() };
-  }
   return {
     BrowserWindow: { getAllWindows: vi.fn(() => []) },
-    MessageChannelMain: MockMessageChannelMain,
   };
 });
 

--- a/electron/services/__tests__/WorkspaceClient.readiness.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.readiness.test.ts
@@ -96,8 +96,6 @@ const { mockHosts, MockWorkspaceHostProcess } = vi.hoisted(() => {
     getAllRequests(): Array<{ requestId: string; type: string; [key: string]: any }> {
       return this.sendWithResponse.mock.calls.map(([req]: any) => req);
     }
-
-    attachRendererPort = vi.fn(() => true);
   }
 
   return { mockHosts, MockWorkspaceHostProcess };
@@ -108,15 +106,10 @@ vi.mock("../WorkspaceHostProcess.js", () => ({
 }));
 
 vi.mock("electron", () => {
-  class MockMessageChannelMain {
-    port1 = { close: vi.fn() };
-    port2 = { close: vi.fn() };
-  }
   return {
     BrowserWindow: {
       getAllWindows: vi.fn(() => []),
     },
-    MessageChannelMain: MockMessageChannelMain,
   };
 });
 

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -95,8 +95,6 @@ const { mockHosts, MockWorkspaceHostProcess } = vi.hoisted(() => {
     getAllRequests(): Array<{ requestId: string; type: string; [key: string]: any }> {
       return this.sendWithResponse.mock.calls.map(([req]: any) => req);
     }
-
-    attachRendererPort = vi.fn(() => true);
   }
 
   return { mockHosts, MockWorkspaceHostProcess };
@@ -107,15 +105,10 @@ vi.mock("../WorkspaceHostProcess.js", () => ({
 }));
 
 vi.mock("electron", () => {
-  class MockMessageChannelMain {
-    port1 = { close: vi.fn() };
-    port2 = { close: vi.fn() };
-  }
   return {
     BrowserWindow: {
       getAllWindows: vi.fn(() => []),
     },
-    MessageChannelMain: MockMessageChannelMain,
   };
 });
 

--- a/electron/services/__tests__/helpers/stubWorkspaceHost.worker.mjs
+++ b/electron/services/__tests__/helpers/stubWorkspaceHost.worker.mjs
@@ -36,7 +36,6 @@ port.on("message", (raw) => {
 
     case "set-log-level-overrides":
     case "update-forge-credentials":
-    case "attach-renderer-port":
     case "attach-worktree-port":
     case "dispose":
     case "load-project":

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -1,4 +1,4 @@
-import { MessageChannelMain, type WebContents } from "electron";
+import { type WebContents } from "electron";
 import path from "path";
 import { WorkspaceHostProcess } from "../WorkspaceHostProcess.js";
 import { store } from "../../store.js";
@@ -403,22 +403,7 @@ export class WorkspaceHostPool {
       console.warn("[WorkspaceClient] No entry for window, cannot attach direct port");
       return;
     }
-    this.createDirectPortForEntry(entry, webContents);
-  }
-
-  private createDirectPortForEntry(entry: ProcessEntry, webContents: WebContents): void {
     if (webContents.isDestroyed()) return;
-
-    const { port1, port2 } = new MessageChannelMain();
-
-    const attached = entry.host.attachRendererPort(port1);
-    if (!attached) {
-      port1.close();
-      port2.close();
-      return;
-    }
-
-    webContents.postMessage("workspace-port", null, [port2]);
     entry.directPortViews.set(webContents.id, webContents);
   }
 
@@ -462,9 +447,7 @@ export class WorkspaceHostPool {
     for (const [wcId, wc] of entry.directPortViews) {
       if (wc.isDestroyed()) {
         entry.directPortViews.delete(wcId);
-        continue;
       }
-      this.createDirectPortForEntry(entry, wc);
     }
 
     this.emit("host-restarted", {

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -185,11 +185,11 @@ export async function setupWindowServices(
       if (isSmokeTest) console.error("[SMOKE] CHECK: Renderer did-finish-load — OK");
       markPerformance(PERF_MARKS.RENDERER_READY);
       createAndDistributePorts(win, ctx);
-      // Refresh workspace direct port on reload (preload context is reset).
-      // With early-renderer mode (default), workspaceClient may still be null
-      // on the first did-finish-load — the initial direct-port attach is
-      // performed by the loadProject() path below once the workspace host is
-      // ready.
+      // Re-register the renderer in directPortViews on reload so
+      // sendToEntryWindows continues routing host events to it. With
+      // early-renderer mode (default), workspaceClient may still be null on
+      // the first did-finish-load — the initial registration is performed by
+      // the loadProject() path below once the workspace host is ready.
       const workspaceClient = getWorkspaceClientRef();
       if (workspaceClient) {
         workspaceClient.attachDirectPort(win.id, appWc);
@@ -435,7 +435,8 @@ export async function setupWindowServices(
       await workspaceClient.loadProject(projectPathForWorktrees, win.id);
       console.log("[MAIN] Worktrees loaded");
 
-      // Attach direct MessagePort for workspace events (bypasses main-process relay)
+      // Register the renderer in directPortViews so sendToEntryWindows
+      // routes host events (worktree updates, PR detection, etc.) to it.
       const directPortTarget = opts.initialAppView?.webContents ?? getAppWebContents(win);
       if (directPortTarget && !directPortTarget.isDestroyed()) {
         workspaceClient.attachDirectPort(win.id, directPortTarget);

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -338,13 +338,6 @@ port.on("message", async (rawMsg: any) => {
 
   // Handle MessagePort transfers (worktree-specific port with request/response correlation)
   const transferredPorts = rawMsg?.ports || [];
-  // Legacy renderer ports are no longer used — worktreePorts replaced them.
-  // Accept and close the port silently to avoid "Unknown message type" warnings.
-  if (msg?.type === "attach-renderer-port" && transferredPorts.length > 0) {
-    transferredPorts[0].close();
-    return;
-  }
-
   if (msg?.type === "attach-worktree-port" && transferredPorts.length > 0) {
     attachWorktreePort(transferredPorts[0] as MessagePort);
     return;

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -394,8 +394,6 @@ export type WorkspaceHostRequest =
       envKey: string;
     }
   | { type: "has-resource-config"; requestId: string; rootPath: string }
-  // Direct renderer port attachment (port transferred via postMessage transfer list)
-  | { type: "attach-renderer-port" }
   // Forge credential propagation
   | { type: "update-forge-credentials"; providerId: string; credentials: Credentials | null }
   // Project environment variable propagation


### PR DESCRIPTION
## Summary

- The `workspace-port` IPC channel never delivered any data — the host closed the port immediately on receipt, so the renderer was attaching a handler to a port that was dead on arrival.
- Removes all the associated scaffolding: the renderer listener and its synthetic-event re-emission shim, the main-process port distribution, the host-side accept-and-close handler, dead test mocks, and stale shared types.
- Confirmed that live worktree event delivery is fully preserved via the main-process `EVENTS_PUSH` relay — the legacy channel had no part in it.

Resolves #8552.

## Changes

- `electron/preload.cts` — removed `workspace-port` MessagePort listener and re-emission shim
- `electron/workspace-host.ts` — removed `attach-renderer-port` case that closed the port immediately
- `electron/services/WorkspaceHostProcess.ts` — removed `attachRendererPort` method
- `electron/services/workspace-client/WorkspaceHostPool.ts` — removed `createDirectPortForEntry` helper and `MessageChannelMain` import; inlined the essential `directPortViews.set()` registration into `attachDirectPort`
- `electron/window/windowServices.ts` — removed dead port-distribution call and updated stale comments
- `shared/types/workspace-host.ts` — removed `attach-renderer-port` from `WorkspaceHostRequest` union
- Three `WorkspaceClient` test files — removed dead mocks (`attachRendererPort`, `MockMessageChannelMain`)
- `stubWorkspaceHost.worker.mjs` — removed dead `case "attach-renderer-port":` branch

Net: +8 / -144 lines across 10 files.

## Testing

- 69 `WorkspaceClient` tests pass
- `npm run check` (typecheck + lint + format) passes clean