### PR TITLE
fix(workspace-host): replace restart counter with sliding-window crash guard

### DIFF
--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -23,6 +23,19 @@ const logWarn = (msg: string, ctx?: Record<string, unknown>) =>
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const RESTART_FLOOR_MS = 100;
+const RESTART_CAP_BASE_MS = 1_000;
+const RESTART_CAP_MAX_MS = 10_000;
+
+// Time-windowed crash-loop guard. Mirrors the constants in PtyHostLifecycle
+// (and CrashLoopGuardService) so the workspace-host follows the same policy:
+// three crashes within five minutes trip the cap, and a five-minute stretch
+// of clean running decays the window back to empty. Duplicated rather than
+// imported because the guards operate at independent layers.
+const CRASH_THRESHOLD = 3;
+const RAPID_CRASH_WINDOW_MS = 300_000;
+const STABILITY_TIMEOUT_MS = 300_000;
+
 export class WorkspaceHostProcess extends EventEmitter {
   private child: UtilityProcess | null = null;
   private config: Required<WorkspaceClientConfig>;
@@ -33,7 +46,29 @@ export class WorkspaceHostProcess extends EventEmitter {
 
   private healthCheckInterval: NodeJS.Timeout | null = null;
   private restartTimer: NodeJS.Timeout | null = null;
-  private restartAttempts = 0;
+  /**
+   * Sliding window of recent crash timestamps. Trimmed to entries within
+   * `RAPID_CRASH_WINDOW_MS` on each crash; cleared when the stability timer
+   * fires after a successful `ready`. Three crashes within the window trip
+   * the cap and emit `host-crash`.
+   */
+  private crashTimestamps: number[] = [];
+  /**
+   * Stability timer started on every `ready`. When it fires after
+   * `STABILITY_TIMEOUT_MS` of clean running, the crash window is cleared.
+   * Cleared on crash, `manualRestart()`, and `dispose()`.
+   */
+  private stabilityTimer: NodeJS.Timeout | null = null;
+  /**
+   * Authoritative crash reason captured from `app.on("child-process-gone")`.
+   * Consumed by the next `exit` handler via `setImmediate` deferral, since
+   * Electron 37-41 has a documented race where `exit` often fires before
+   * `child-process-gone` for utility-process crashes.
+   */
+  private pendingChildProcessGoneReason: { reason: string; exitCode: number } | null = null;
+  private childProcessGoneHandler:
+    | ((event: Electron.Event, details: Electron.Details) => void)
+    | null = null;
   private isHealthCheckPaused = false;
   private isWaitingForHandshake = false;
   private handshakeTimeout: NodeJS.Timeout | null = null;
@@ -81,6 +116,7 @@ export class WorkspaceHostProcess extends EventEmitter {
       this.readyReject = reject;
     });
 
+    this.registerChildProcessGoneListener();
     this.startHost();
   }
 
@@ -236,10 +272,11 @@ export class WorkspaceHostProcess extends EventEmitter {
 
   /**
    * Restart the host after its auto-restart budget has been exhausted.
-   * Resets `restartAttempts` so future crashes get a fresh budget, respawns
-   * the child, and emits `"restarted"` so `WorkspaceClient` can re-broker
-   * ports and reload the project — the auto-restart path emits this from
-   * its `setTimeout` callback which `manualRestart()` bypasses.
+   * Clears the crash window and pending stability timer so future crashes
+   * get a fresh budget, respawns the child, and emits `"restarted"` so
+   * `WorkspaceClient` can re-broker ports and reload the project — the
+   * auto-restart path emits this from its `setTimeout` callback which
+   * `manualRestart()` bypasses.
    */
   manualRestart(): void {
     if (this.isDisposed) {
@@ -259,7 +296,11 @@ export class WorkspaceHostProcess extends EventEmitter {
       this.restartTimer = null;
     }
 
-    this.restartAttempts = 0;
+    this.crashTimestamps = [];
+    if (this.stabilityTimer) {
+      clearTimeout(this.stabilityTimer);
+      this.stabilityTimer = null;
+    }
 
     console.log(`[WorkspaceHost:${this.serviceName}] Manual restart initiated`);
     this.startHost();
@@ -286,11 +327,21 @@ export class WorkspaceHostProcess extends EventEmitter {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;
     }
+    if (this.stabilityTimer) {
+      clearTimeout(this.stabilityTimer);
+      this.stabilityTimer = null;
+    }
     if (this.handshakeTimeout) {
       clearTimeout(this.handshakeTimeout);
       this.handshakeTimeout = null;
     }
     this.isWaitingForHandshake = false;
+
+    if (this.childProcessGoneHandler) {
+      app.off("child-process-gone", this.childProcessGoneHandler);
+      this.childProcessGoneHandler = null;
+    }
+    this.pendingChildProcessGoneReason = null;
 
     if (this.readyReject) {
       this.readyReject(
@@ -414,6 +465,12 @@ export class WorkspaceHostProcess extends EventEmitter {
       this.restartTimer = null;
     }
 
+    // Defensive: clear any stale crash reason from a prior host cycle. Under
+    // normal flow the `exit` handler's setImmediate consumes this, but a
+    // missed exit event (or out-of-band listener fire) would otherwise leak
+    // into the next crash.
+    this.pendingChildProcessGoneReason = null;
+
     if (this.readyReject && this.isInitialized) {
       this.readyReject(new Error("Workspace Host restarting"));
     }
@@ -484,6 +541,15 @@ export class WorkspaceHostProcess extends EventEmitter {
       this.isInitialized = false;
       this.child = null;
 
+      // Cancel any stability timer the prior `ready` armed. If it stayed
+      // alive, it could fire moments after a crash and wipe `crashTimestamps`
+      // even though the host never ran cleanly for the full window —
+      // defeating the three-crash guard for crash-ready-crash-ready patterns.
+      if (this.stabilityTimer) {
+        clearTimeout(this.stabilityTimer);
+        this.stabilityTimer = null;
+      }
+
       for (const [, { reject, timeout }] of this.pendingRequests) {
         clearTimeout(timeout);
         reject(
@@ -503,33 +569,77 @@ export class WorkspaceHostProcess extends EventEmitter {
         this.readyReject = null;
       }
 
-      if (this.isDisposed) return;
+      if (this.isDisposed) {
+        this.pendingChildProcessGoneReason = null;
+        return;
+      }
 
       // Fire the recovery signal before restart scheduling so the renderer can
       // reject in-flight requests immediately instead of waiting up to ~10s for
       // the per-request timeout.
       this.emit("host-recovering", code);
 
-      if (this.restartAttempts < this.config.maxRestartAttempts) {
-        this.restartAttempts++;
-        const cap = Math.min(1000 * Math.pow(2, this.restartAttempts), 10000);
-        const delay = 100 + Math.floor(Math.random() * Math.max(0, cap - 100));
-        console.log(
-          `[WorkspaceHost:${this.serviceName}] Restarting in ${delay}ms (attempt ${this.restartAttempts}/${this.config.maxRestartAttempts})`
-        );
+      // Electron 37-41 race: `exit` often fires before `child-process-gone`
+      // for utility-process crashes. Defer the restart decision by one event
+      // loop tick so the authoritative reason and exit code can arrive; fall
+      // back to the exit-code from the `exit` event when no reason was
+      // captured in time.
+      setImmediate(() => {
+        if (this.isDisposed) {
+          this.pendingChildProcessGoneReason = null;
+          return;
+        }
 
-        if (this.restartTimer) clearTimeout(this.restartTimer);
-        this.restartTimer = setTimeout(() => {
-          this.restartTimer = null;
-          this.startHost();
-          if (this.child !== null) {
-            this.emit("restarted");
-          }
-        }, delay);
-      } else {
-        console.error(`[WorkspaceHost:${this.serviceName}] Max restart attempts reached`);
-        this.emit("host-crash", code);
-      }
+        const gone = this.pendingChildProcessGoneReason;
+        this.pendingChildProcessGoneReason = null;
+        // Prefer the authoritative exit code from `child-process-gone` over
+        // the (sometimes unreliable) one from `exit` — Electron 40-41 has a
+        // known signed/unsigned mangling bug on Windows for the exit event.
+        const reportedCode = gone ? gone.exitCode : code;
+
+        // If `manualRestart()` or some other path already spawned a new host
+        // during the defer window, don't schedule a second auto-restart — it
+        // would orphan that host.
+        if (this.child !== null) return;
+
+        // Time-windowed sliding crash counter. Trim entries older than the
+        // window, then append the current crash. Three crashes within five
+        // minutes trip the cap; crashes spread further apart decay out.
+        const crashAt = Date.now();
+        this.crashTimestamps = this.crashTimestamps.filter(
+          (t) => crashAt - t < RAPID_CRASH_WINDOW_MS
+        );
+        this.crashTimestamps.push(crashAt);
+
+        if (this.crashTimestamps.length < CRASH_THRESHOLD) {
+          const windowAttempt = this.crashTimestamps.length;
+          const cap = Math.min(
+            RESTART_CAP_BASE_MS * Math.pow(2, windowAttempt),
+            RESTART_CAP_MAX_MS
+          );
+          const delay =
+            RESTART_FLOOR_MS + Math.floor(Math.random() * Math.max(0, cap - RESTART_FLOOR_MS));
+          console.log(
+            `[WorkspaceHost:${this.serviceName}] Restarting in ${delay}ms (attempt ${windowAttempt}/${CRASH_THRESHOLD - 1} in window)`
+          );
+
+          if (this.restartTimer) clearTimeout(this.restartTimer);
+          this.restartTimer = setTimeout(() => {
+            this.restartTimer = null;
+            if (this.isDisposed || this.child !== null) return;
+            this.startHost();
+            if (this.child !== null) {
+              this.emit("restarted");
+            }
+          }, delay);
+          this.restartTimer.unref?.();
+        } else {
+          console.error(
+            `[WorkspaceHost:${this.serviceName}] Max restart attempts reached (${CRASH_THRESHOLD} crashes in ${RAPID_CRASH_WINDOW_MS}ms), giving up`
+          );
+          this.emit("host-crash", reportedCode);
+        }
+      });
     });
 
     this.startHealthCheckInterval();
@@ -574,6 +684,49 @@ export class WorkspaceHostProcess extends EventEmitter {
     }, this.config.healthCheckIntervalMs);
   }
 
+  /**
+   * Register the `child-process-gone` listener once. Filtered to this host's
+   * unique per-instance `serviceName` (each WorkspaceHostProcess scopes its
+   * own host). The handler only records the reason; the `exit` handler
+   * consumes it via setImmediate.
+   */
+  private registerChildProcessGoneListener(): void {
+    if (this.childProcessGoneHandler) return;
+    const handler = (_event: Electron.Event, details: Electron.Details): void => {
+      if (this.isDisposed) return;
+      if (details.type !== "Utility") return;
+      // Electron 41 populates `name` from `serviceName` at runtime, but both
+      // fields are typed as optional. Accept either to stay resilient to
+      // future runtime changes or edge cases where only one is set.
+      const matchesHost =
+        details.name === this.serviceName || details.serviceName === this.serviceName;
+      if (!matchesHost) return;
+      this.pendingChildProcessGoneReason = {
+        reason: details.reason,
+        exitCode: details.exitCode,
+      };
+    };
+    this.childProcessGoneHandler = handler;
+    app.on("child-process-gone", handler);
+  }
+
+  /**
+   * Start (or restart) the stability timer. When it fires after
+   * `STABILITY_TIMEOUT_MS` of clean running, the crash window is cleared so
+   * subsequent crashes start fresh. Unref'd so the timer never pins the
+   * Electron event loop alive after `app.quit`.
+   */
+  private startStabilityTimer(): void {
+    if (this.stabilityTimer) {
+      clearTimeout(this.stabilityTimer);
+    }
+    this.stabilityTimer = setTimeout(() => {
+      this.stabilityTimer = null;
+      this.crashTimestamps = [];
+    }, STABILITY_TIMEOUT_MS);
+    this.stabilityTimer.unref?.();
+  }
+
   private handleHostEvent(event: WorkspaceHostEvent): void {
     try {
       this.processHostEvent(event);
@@ -602,7 +755,13 @@ export class WorkspaceHostProcess extends EventEmitter {
       case "ready": {
         if (!this.child) return;
         this.isInitialized = true;
-        this.restartAttempts = 0;
+        // Start (or restart) the stability timer. We deliberately do NOT
+        // clear `crashTimestamps` here — clearing on ready would defeat the
+        // sliding window for a crash-ready-crash-ready loop, where each
+        // fresh ready would wipe the history right before the next crash.
+        // The window is only cleared when the timer fires after a full
+        // stable interval. This is the fix for #8553.
+        this.startStabilityTimer();
 
         const token = GitHubAuth.getToken();
         if (token) {

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -1,5 +1,6 @@
 import { utilityProcess, UtilityProcess, app, MessagePortMain } from "electron";
 import { EventEmitter } from "events";
+import { createHash } from "crypto";
 import path from "path";
 import os from "os";
 import { fileURLToPath } from "url";
@@ -46,6 +47,7 @@ export class WorkspaceHostProcess extends EventEmitter {
 
   private healthCheckInterval: NodeJS.Timeout | null = null;
   private restartTimer: NodeJS.Timeout | null = null;
+  private disposeTimer: NodeJS.Timeout | null = null;
   /**
    * Sliding window of recent crash timestamps. Trimmed to entries within
    * `RAPID_CRASH_WINDOW_MS` on each crash; cleared when the stability timer
@@ -109,7 +111,12 @@ export class WorkspaceHostProcess extends EventEmitter {
       .basename(projectPath)
       .replace(/[^a-zA-Z0-9_-]/g, "-")
       .slice(0, 40);
-    this.serviceName = `daintree-workspace-host:${safeName}`;
+    // Hash the full path to disambiguate same-basename projects (e.g.
+    // `/workspaces/a/api` and `/workspaces/b/api`). Without this suffix the
+    // per-instance `child-process-gone` filter would match both hosts and
+    // cross-attribute crash reasons.
+    const pathHash = createHash("sha1").update(projectPath).digest("hex").slice(0, 8);
+    this.serviceName = `daintree-workspace-host:${safeName}-${pathHash}`;
 
     this.readyPromise = new Promise((resolve, reject) => {
       this.readyResolve = resolve;
@@ -365,7 +372,10 @@ export class WorkspaceHostProcess extends EventEmitter {
 
     if (this.child) {
       this.send({ type: "dispose" });
-      setTimeout(() => {
+      // Unref'd so the pending backstop never holds the Electron event loop
+      // alive after app.quit when the host has already cooperated.
+      this.disposeTimer = setTimeout(() => {
+        this.disposeTimer = null;
         if (this.child) {
           try {
             this.child.kill();
@@ -379,6 +389,7 @@ export class WorkspaceHostProcess extends EventEmitter {
           }
         }
       }, 1000);
+      this.disposeTimer.unref?.();
     }
 
     this.removeAllListeners();

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -491,6 +491,12 @@ export class WorkspaceHostProcess extends EventEmitter {
       this.readyResolve = resolve;
       this.readyReject = reject;
     });
+    // Attach a no-op handler so a fork failure (which rejects readyPromise
+    // synchronously inside the catch below) doesn't surface as an unhandled
+    // rejection on internal restart paths where no external caller is
+    // awaiting. Consumers calling waitForReady() still observe the rejection
+    // on their own chain because .catch returns a new branched promise.
+    this.readyPromise.catch(() => undefined);
 
     const electronDir = path.basename(__dirname) === "chunks" ? path.dirname(__dirname) : __dirname;
     const hostPath = path.join(electronDir, "workspace-host-bootstrap.js");

--- a/electron/services/__tests__/WorkspaceHostProcess.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.test.ts
@@ -3,11 +3,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "events";
 import { Readable } from "node:stream";
 
-const { forkMock, mockChildren, loggerCalls } = vi.hoisted(() => {
+const { forkMock, mockChildren, loggerCalls, appMock } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("events") as typeof import("events");
   const forkMock = vi.fn();
   const mockChildren: any[] = [];
   const loggerCalls: { level: "info" | "warn"; message: string }[] = [];
-  return { forkMock, mockChildren, loggerCalls };
+  const appEmitter = new EventEmitter();
+  const appMock = Object.assign(appEmitter, {
+    getPath: vi.fn(() => "/tmp/userData"),
+  });
+  return { forkMock, mockChildren, loggerCalls, appMock };
 });
 
 class MockUtilityChild extends EventEmitter {
@@ -29,9 +35,7 @@ vi.mock("electron", () => ({
   utilityProcess: {
     fork: forkMock,
   },
-  app: {
-    getPath: vi.fn(() => "/tmp/userData"),
-  },
+  app: appMock,
   UtilityProcess: class {},
   MessagePortMain: class {},
 }));
@@ -62,6 +66,7 @@ describe("WorkspaceHostProcess", () => {
     forkMock.mockReset();
     mockChildren.length = 0;
     loggerCalls.length = 0;
+    appMock.removeAllListeners();
     forkMock.mockImplementation(() => new MockUtilityChild());
   });
 
@@ -249,6 +254,7 @@ describe("WorkspaceHostProcess BrokerError contract", () => {
     forkMock.mockReset();
     mockChildren.length = 0;
     loggerCalls.length = 0;
+    appMock.removeAllListeners();
     forkMock.mockImplementation(() => new MockUtilityChild());
   });
 
@@ -442,7 +448,7 @@ describe("WorkspaceHostProcess BrokerError contract", () => {
   });
 
   it("restart delay has random jitter (full-jitter parity with PtyHostLifecycle)", async () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setImmediate", "Date"] });
     // Mock Math.random to control jitter
     const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
 
@@ -457,12 +463,15 @@ describe("WorkspaceHostProcess BrokerError contract", () => {
     child.emit("message", { type: "ready" });
     child.emit("exit", 1);
 
-    // restartAttempts = 1, cap = min(1000*2^1, 10000) = 2000
+    // After one crash: crashTimestamps.length=1, cap = min(1000*2^1, 10000) = 2000
     // delay = 100 + 0.5 * (2000 - 100) = 100 + 950 = 1050
     const restartSpy = vi.fn();
     host.on("restarted", restartSpy);
 
-    vi.advanceTimersByTime(1050);
+    // Flush the setImmediate that defers crash classification
+    await vi.advanceTimersByTimeAsync(0);
+    // Then advance through the restart delay
+    await vi.advanceTimersByTimeAsync(1050);
     expect(restartSpy).toHaveBeenCalledTimes(1);
 
     // Auto-restart created a new readyPromise; swallow its rejection on dispose
@@ -473,7 +482,7 @@ describe("WorkspaceHostProcess BrokerError contract", () => {
   });
 
   it("auto-restart does not emit 'restarted' when fork fails", async () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setImmediate", "Date"] });
     const { WorkspaceHostProcess } = await loadModule();
     const host = new WorkspaceHostProcess("/tmp/project", {
       maxRestartAttempts: 3,
@@ -496,9 +505,10 @@ describe("WorkspaceHostProcess BrokerError contract", () => {
 
     child.emit("exit", 1);
 
-    // Advance past the restart delay
+    // Flush setImmediate then advance past the restart delay
+    await vi.advanceTimersByTimeAsync(0);
     const cap = Math.min(1000 * Math.pow(2, 1), 10000); // 2000
-    vi.advanceTimersByTime(cap + 100);
+    await vi.advanceTimersByTimeAsync(cap + 100);
 
     expect(restartSpy).not.toHaveBeenCalled();
     expect(crashSpy).toHaveBeenCalled();
@@ -545,5 +555,362 @@ describe("WorkspaceHostProcess BrokerError contract", () => {
 
     host.dispose();
     vi.useRealTimers();
+  });
+});
+
+// ── Sliding-window crash guard (regression #8553) ──
+
+describe("WorkspaceHostProcess crash window", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    forkMock.mockReset();
+    mockChildren.length = 0;
+    loggerCalls.length = 0;
+    appMock.removeAllListeners();
+    forkMock.mockImplementation(() => new MockUtilityChild());
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setImmediate", "Date"] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("ready does NOT reset the crash window (regression #8553)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    // Crash 1
+    const child1 = mockChildren[0] as MockUtilityChild;
+    child1.emit("message", { type: "ready" });
+    child1.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).crashTimestamps).toHaveLength(1);
+
+    // Auto-restart fires
+    host.waitForReady().catch(() => {});
+    await vi.advanceTimersByTimeAsync(2_001);
+    const child2 = mockChildren[1] as MockUtilityChild;
+
+    // New host becomes ready — under the OLD bug, this would reset the
+    // crash counter to zero. Under the new sliding-window guard, the
+    // history must persist.
+    child2.emit("message", { type: "ready" });
+    expect((host as any).crashTimestamps).toHaveLength(1);
+
+    host.dispose();
+  });
+
+  it("emits host-crash on three crashes within the window (with intervening ready)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const crashSpy = vi.fn();
+    host.on("host-crash", crashSpy);
+
+    // Crash 1 — ready then crash
+    const child1 = mockChildren[0] as MockUtilityChild;
+    child1.emit("message", { type: "ready" });
+    child1.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(2_001);
+    expect((host as any).crashTimestamps).toHaveLength(1);
+    expect(crashSpy).not.toHaveBeenCalled();
+
+    // Crash 2 — ready then crash again (regression: this used to reset
+    // crashTimestamps to zero via the `ready` case)
+    const child2 = mockChildren[1] as MockUtilityChild;
+    host.waitForReady().catch(() => {});
+    child2.emit("message", { type: "ready" });
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(4_001);
+    expect((host as any).crashTimestamps).toHaveLength(2);
+    expect(crashSpy).not.toHaveBeenCalled();
+
+    // Crash 3 — threshold reached, no further restart, host-crash emitted
+    const child3 = mockChildren[2] as MockUtilityChild;
+    host.waitForReady().catch(() => {});
+    child3.emit("message", { type: "ready" });
+    child3.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).crashTimestamps).toHaveLength(3);
+    expect(crashSpy).toHaveBeenCalledWith(1);
+
+    host.dispose();
+  });
+
+  it("stability timer clears the crash window after a quiet interval", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const child1 = mockChildren[0] as MockUtilityChild;
+    child1.emit("message", { type: "ready" });
+    child1.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).crashTimestamps).toHaveLength(1);
+
+    // Auto-restart fires and host comes up; ready arms a fresh stability timer
+    host.waitForReady().catch(() => {});
+    await vi.advanceTimersByTimeAsync(2_001);
+    const child2 = mockChildren[1] as MockUtilityChild;
+    child2.emit("message", { type: "ready" });
+
+    // Crash entry must survive immediately after ready
+    expect((host as any).crashTimestamps).toHaveLength(1);
+
+    // After STABILITY_TIMEOUT_MS of clean running, the window is cleared
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect((host as any).crashTimestamps).toHaveLength(0);
+
+    host.dispose();
+  });
+
+  it("stability timer from a prior ready is cancelled on crash", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    // Run almost to the stability deadline, then crash. The stability timer
+    // is now ~100ms from firing; if it weren't cancelled it would wipe the
+    // crash window AFTER the crash, defeating the three-strike guard.
+    await vi.advanceTimersByTimeAsync(299_900);
+    child.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).crashTimestamps).toHaveLength(1);
+
+    // Advance past the stale deadline — the crash entry must survive
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect((host as any).crashTimestamps).toHaveLength(1);
+
+    host.dispose();
+  });
+
+  it("crashes spread beyond the window decay out", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    // Crash 1
+    const child1 = mockChildren[0] as MockUtilityChild;
+    child1.emit("message", { type: "ready" });
+    child1.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).crashTimestamps).toHaveLength(1);
+
+    // Restart fires; advance well past the window (6 minutes)
+    host.waitForReady().catch(() => {});
+    await vi.advanceTimersByTimeAsync(2_001);
+    const child2 = mockChildren[1] as MockUtilityChild;
+    child2.emit("message", { type: "ready" });
+    // Advance well past the 5-min window — the stability timer fires at
+    // exactly 5min, which clears the window. After this point, any new
+    // crash starts fresh.
+    await vi.advanceTimersByTimeAsync(360_000);
+    expect((host as any).crashTimestamps).toHaveLength(0);
+
+    // A subsequent crash gets a fresh budget
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).crashTimestamps).toHaveLength(1);
+
+    host.dispose();
+  });
+
+  it("manualRestart clears the crash window so a fresh budget is given", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    // Two rapid crashes — short of the threshold
+    const child1 = mockChildren[0] as MockUtilityChild;
+    child1.emit("message", { type: "ready" });
+    child1.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(2_001);
+    const child2 = mockChildren[1] as MockUtilityChild;
+    host.waitForReady().catch(() => {});
+    child2.emit("message", { type: "ready" });
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).crashTimestamps).toHaveLength(2);
+    expect((host as any).child).toBeNull();
+
+    // User intervenes with manualRestart — clears window + pending stability timer
+    host.manualRestart();
+    host.waitForReady().catch(() => {});
+    expect((host as any).crashTimestamps).toHaveLength(0);
+    expect((host as any).restartTimer).toBeNull();
+
+    host.dispose();
+  });
+
+  it("child-process-gone with matching serviceName captures reason", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    // Simulate Electron 37-41 race: child-process-gone arrives BEFORE exit
+    appMock.emit(
+      "child-process-gone",
+      {} as Electron.Event,
+      {
+        type: "Utility",
+        name: "daintree-workspace-host:project",
+        reason: "oom",
+        exitCode: 137,
+      } as Electron.Details
+    );
+
+    // The handler should have captured the reason
+    expect((host as any).pendingChildProcessGoneReason).toEqual({
+      reason: "oom",
+      exitCode: 137,
+    });
+
+    const crashSpy = vi.fn();
+    host.on("host-crash", crashSpy);
+
+    // To trigger host-crash on first exit, fill the crash window
+    (host as any).crashTimestamps = [Date.now() - 1000, Date.now() - 500];
+
+    child.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // host-crash uses the authoritative exitCode 137, not the exit event's 1
+    expect(crashSpy).toHaveBeenCalledWith(137);
+
+    host.dispose();
+  });
+
+  it("child-process-gone with non-matching serviceName is ignored", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    appMock.emit(
+      "child-process-gone",
+      {} as Electron.Event,
+      {
+        type: "Utility",
+        name: "daintree-workspace-host:some-other-project",
+        reason: "oom",
+        exitCode: 137,
+      } as Electron.Details
+    );
+
+    expect((host as any).pendingChildProcessGoneReason).toBeNull();
+
+    host.dispose();
+  });
+
+  it("child-process-gone with non-Utility type is ignored", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    appMock.emit(
+      "child-process-gone",
+      {} as Electron.Event,
+      {
+        type: "Tab",
+        name: "daintree-workspace-host:project",
+        reason: "crashed",
+        exitCode: 1,
+      } as unknown as Electron.Details
+    );
+
+    expect((host as any).pendingChildProcessGoneReason).toBeNull();
+
+    host.dispose();
+  });
+
+  it("dispose removes the child-process-gone listener", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    expect(appMock.listenerCount("child-process-gone")).toBe(1);
+
+    host.dispose();
+
+    expect(appMock.listenerCount("child-process-gone")).toBe(0);
+  });
+
+  it("each WorkspaceHostProcess instance registers its own listener (isolation across projects)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const hostA = new WorkspaceHostProcess("/tmp/projectA", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    hostA.waitForReady().catch(() => {});
+    const hostB = new WorkspaceHostProcess("/tmp/projectB", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    hostB.waitForReady().catch(() => {});
+
+    expect(appMock.listenerCount("child-process-gone")).toBe(2);
+
+    // Emit a gone event matching hostA's serviceName only
+    appMock.emit(
+      "child-process-gone",
+      {} as Electron.Event,
+      {
+        type: "Utility",
+        name: "daintree-workspace-host:projectA",
+        reason: "oom",
+        exitCode: 137,
+      } as Electron.Details
+    );
+
+    expect((hostA as any).pendingChildProcessGoneReason).toEqual({
+      reason: "oom",
+      exitCode: 137,
+    });
+    // hostB must NOT have captured the reason (cross-instance isolation)
+    expect((hostB as any).pendingChildProcessGoneReason).toBeNull();
+
+    hostA.dispose();
+    hostB.dispose();
   });
 });

--- a/electron/services/__tests__/WorkspaceHostProcess.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.test.ts
@@ -1,7 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "events";
+import { createHash } from "crypto";
 import { Readable } from "node:stream";
+
+function serviceNameFor(projectPath: string): string {
+  const safeName = projectPath
+    .split("/")
+    .pop()!
+    .replace(/[^a-zA-Z0-9_-]/g, "-")
+    .slice(0, 40);
+  const pathHash = createHash("sha1").update(projectPath).digest("hex").slice(0, 8);
+  return `daintree-workspace-host:${safeName}-${pathHash}`;
+}
 
 const { forkMock, mockChildren, loggerCalls, appMock } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -786,7 +797,7 @@ describe("WorkspaceHostProcess crash window", () => {
       {} as Electron.Event,
       {
         type: "Utility",
-        name: "daintree-workspace-host:project",
+        name: serviceNameFor("/tmp/project"),
         reason: "oom",
         exitCode: 137,
       } as Electron.Details
@@ -813,6 +824,48 @@ describe("WorkspaceHostProcess crash window", () => {
     host.dispose();
   });
 
+  it("uses child-process-gone reason when it arrives AFTER exit (named Electron 37-41 race)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    const crashSpy = vi.fn();
+    host.on("host-crash", crashSpy);
+
+    // Pre-fill the crash window so the next crash trips the cap.
+    (host as any).crashTimestamps = [Date.now() - 1000, Date.now() - 500];
+
+    // Exit fires first — sync teardown runs, but the deferred restart
+    // decision has NOT executed yet (setImmediate is queued).
+    child.emit("exit", 1);
+
+    // The authoritative reason arrives between exit and the setImmediate.
+    appMock.emit(
+      "child-process-gone",
+      {} as Electron.Event,
+      {
+        type: "Utility",
+        name: serviceNameFor("/tmp/project"),
+        reason: "oom",
+        exitCode: 137,
+      } as Electron.Details
+    );
+
+    // Flush setImmediate — the deferred handler must now consume the
+    // late-arriving reason instead of the exit-event's code.
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(crashSpy).toHaveBeenCalledWith(137);
+
+    host.dispose();
+  });
+
   it("child-process-gone with non-matching serviceName is ignored", async () => {
     const { WorkspaceHostProcess } = await loadModule();
     const host = new WorkspaceHostProcess("/tmp/project", {
@@ -826,7 +879,7 @@ describe("WorkspaceHostProcess crash window", () => {
       {} as Electron.Event,
       {
         type: "Utility",
-        name: "daintree-workspace-host:some-other-project",
+        name: serviceNameFor("/tmp/some-other-project"),
         reason: "oom",
         exitCode: 137,
       } as Electron.Details
@@ -850,13 +903,86 @@ describe("WorkspaceHostProcess crash window", () => {
       {} as Electron.Event,
       {
         type: "Tab",
-        name: "daintree-workspace-host:project",
+        name: serviceNameFor("/tmp/project"),
         reason: "crashed",
         exitCode: 1,
       } as unknown as Electron.Details
     );
 
     expect((host as any).pendingChildProcessGoneReason).toBeNull();
+
+    host.dispose();
+  });
+
+  it("same-basename projects do not cross-attribute crash reasons", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const hostA = new WorkspaceHostProcess("/workspaces/a/api", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    hostA.waitForReady().catch(() => {});
+    const hostB = new WorkspaceHostProcess("/workspaces/b/api", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    hostB.waitForReady().catch(() => {});
+
+    // The service names must be distinct despite identical basename.
+    expect(serviceNameFor("/workspaces/a/api")).not.toBe(serviceNameFor("/workspaces/b/api"));
+
+    // A gone event for hostA only — hostB must NOT capture it.
+    appMock.emit(
+      "child-process-gone",
+      {} as Electron.Event,
+      {
+        type: "Utility",
+        name: serviceNameFor("/workspaces/a/api"),
+        reason: "oom",
+        exitCode: 137,
+      } as Electron.Details
+    );
+
+    expect((hostA as any).pendingChildProcessGoneReason).toEqual({
+      reason: "oom",
+      exitCode: 137,
+    });
+    expect((hostB as any).pendingChildProcessGoneReason).toBeNull();
+
+    hostA.dispose();
+    hostB.dispose();
+  });
+
+  it("does NOT fork a fourth time after the crash threshold is reached", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    // Crash 1 → restart
+    mockChildren[0].emit("message", { type: "ready" });
+    mockChildren[0].emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(2_001);
+    expect(forkMock).toHaveBeenCalledTimes(2);
+
+    // Crash 2 → restart
+    host.waitForReady().catch(() => {});
+    mockChildren[1].emit("message", { type: "ready" });
+    mockChildren[1].emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(4_001);
+    expect(forkMock).toHaveBeenCalledTimes(3);
+
+    // Crash 3 → threshold tripped, NO further fork
+    host.waitForReady().catch(() => {});
+    mockChildren[2].emit("message", { type: "ready" });
+    mockChildren[2].emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    // Advance well past any possible restart-delay cap to prove no timer fires.
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(forkMock).toHaveBeenCalledTimes(3);
 
     host.dispose();
   });
@@ -897,7 +1023,7 @@ describe("WorkspaceHostProcess crash window", () => {
       {} as Electron.Event,
       {
         type: "Utility",
-        name: "daintree-workspace-host:projectA",
+        name: serviceNameFor("/tmp/projectA"),
         reason: "oom",
         exitCode: 137,
       } as Electron.Details


### PR DESCRIPTION
## Summary

- `WorkspaceHostProcess` had a cumulative restart counter that reset to zero on every `ready` state, so a crash-boot-crash loop never accumulated toward the cap and the host respawned indefinitely
- Replaces it with a sliding-window crash guard mirroring `PtyHostLifecycle` — crashes only count if they fall within the rolling time window, so tight loops trip the cap while occasional crashes in a stable host don't
- Adds a `child-process-gone` listener for authoritative crash detection and correct exit-code handling, matching how the PTY host works

Resolves #8553

## Changes

- `electron/services/WorkspaceHostProcess.ts` — sliding-window crash guard (`crashTimestamps[]` + window-based counter), `child-process-gone` listener, removed the `restartAttempts` reset on `ready`
- `electron/services/__tests__/WorkspaceHostProcess.test.ts` — 14 new unit tests covering sliding-window logic, stability decay, ready-state resets outside the window, and crash-loop detection

## Testing

14 new unit tests, all passing. Covers the core invariants: crashes outside the window don't count, crashes inside it do, and reaching the cap fires `host-crash` instead of respawning.