### PR TITLE
fix(worktree-port): harden MessagePort transport against silent failures

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -76,6 +76,7 @@ import type {
   WorktreePortRequestArgs,
   WorktreePortResult,
 } from "../shared/types/worktree-port.js";
+import { resolveWorktreePortTimeout } from "./utils/worktreePortTimeouts.js";
 import type {
   AgentStateChangePayload,
   AgentDetectedPayload,
@@ -368,7 +369,7 @@ class WorktreePortClient {
   request<K extends WorktreePortAction>(
     action: K,
     payload?: WorktreePortPayload<K>,
-    timeoutMs = 10000
+    timeoutMs?: number
   ): Promise<WorktreePortResult<K>> {
     return new Promise<WorktreePortResult<K>>((resolve, reject) => {
       if (!this.port) {
@@ -377,10 +378,11 @@ class WorktreePortClient {
       }
 
       const id = crypto.randomUUID();
+      const effectiveTimeout = resolveWorktreePortTimeout(action, timeoutMs);
       const timeout = setTimeout(() => {
         this.pending.delete(id);
         reject(new Error(`Worktree port request timed out: ${String(action)}`));
-      }, timeoutMs);
+      }, effectiveTimeout);
 
       this.pending.set(id, {
         resolve: resolve as (value: unknown) => void,

--- a/electron/utils/__tests__/worktreePortTimeouts.test.ts
+++ b/electron/utils/__tests__/worktreePortTimeouts.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_WORKTREE_PORT_TIMEOUT_MS,
+  WORKTREE_PORT_TIMEOUTS_MS,
+  resolveWorktreePortTimeout,
+} from "../worktreePortTimeouts.js";
+
+describe("resolveWorktreePortTimeout", () => {
+  it("returns the default for fast actions not in the table", () => {
+    expect(resolveWorktreePortTimeout("get-all-states")).toBe(DEFAULT_WORKTREE_PORT_TIMEOUT_MS);
+    expect(resolveWorktreePortTimeout("set-active")).toBe(DEFAULT_WORKTREE_PORT_TIMEOUT_MS);
+    expect(resolveWorktreePortTimeout("refresh")).toBe(DEFAULT_WORKTREE_PORT_TIMEOUT_MS);
+    expect(resolveWorktreePortTimeout("list-branches")).toBe(DEFAULT_WORKTREE_PORT_TIMEOUT_MS);
+    expect(resolveWorktreePortTimeout("get-recent-branches")).toBe(
+      DEFAULT_WORKTREE_PORT_TIMEOUT_MS
+    );
+    expect(resolveWorktreePortTimeout("refresh-prs")).toBe(DEFAULT_WORKTREE_PORT_TIMEOUT_MS);
+    expect(resolveWorktreePortTimeout("has-resource-config")).toBe(
+      DEFAULT_WORKTREE_PORT_TIMEOUT_MS
+    );
+    expect(resolveWorktreePortTimeout("switch-worktree-environment")).toBe(
+      DEFAULT_WORKTREE_PORT_TIMEOUT_MS
+    );
+  });
+
+  it("returns the table value for long-running actions", () => {
+    expect(resolveWorktreePortTimeout("create-worktree")).toBe(5 * 60_000);
+    expect(resolveWorktreePortTimeout("delete-worktree")).toBe(5 * 60_000);
+    expect(resolveWorktreePortTimeout("resource-action")).toBe(10 * 60_000);
+    expect(resolveWorktreePortTimeout("run-lifecycle-setup")).toBe(10 * 60_000);
+  });
+
+  it("respects an explicit positive finite override", () => {
+    expect(resolveWorktreePortTimeout("create-worktree", 1234)).toBe(1234);
+    expect(resolveWorktreePortTimeout("get-all-states", 5000)).toBe(5000);
+  });
+
+  it("ignores undefined override and falls back to table/default", () => {
+    expect(resolveWorktreePortTimeout("create-worktree", undefined)).toBe(5 * 60_000);
+    expect(resolveWorktreePortTimeout("get-all-states", undefined)).toBe(
+      DEFAULT_WORKTREE_PORT_TIMEOUT_MS
+    );
+  });
+
+  it("rejects Infinity, NaN, zero, and negative overrides — falls back to table/default", () => {
+    expect(resolveWorktreePortTimeout("create-worktree", Infinity)).toBe(5 * 60_000);
+    expect(resolveWorktreePortTimeout("create-worktree", -Infinity)).toBe(5 * 60_000);
+    expect(resolveWorktreePortTimeout("create-worktree", Number.NaN)).toBe(5 * 60_000);
+    expect(resolveWorktreePortTimeout("create-worktree", 0)).toBe(5 * 60_000);
+    expect(resolveWorktreePortTimeout("create-worktree", -100)).toBe(5 * 60_000);
+
+    expect(resolveWorktreePortTimeout("get-all-states", Infinity)).toBe(
+      DEFAULT_WORKTREE_PORT_TIMEOUT_MS
+    );
+    expect(resolveWorktreePortTimeout("get-all-states", 0)).toBe(DEFAULT_WORKTREE_PORT_TIMEOUT_MS);
+  });
+
+  it("table only lists the four long-running actions", () => {
+    expect(Object.keys(WORKTREE_PORT_TIMEOUTS_MS).sort()).toEqual([
+      "create-worktree",
+      "delete-worktree",
+      "resource-action",
+      "run-lifecycle-setup",
+    ]);
+  });
+});

--- a/electron/utils/__tests__/worktreePortTimeouts.test.ts
+++ b/electron/utils/__tests__/worktreePortTimeouts.test.ts
@@ -26,9 +26,29 @@ describe("resolveWorktreePortTimeout", () => {
 
   it("returns the table value for long-running actions", () => {
     expect(resolveWorktreePortTimeout("create-worktree")).toBe(5 * 60_000);
-    expect(resolveWorktreePortTimeout("delete-worktree")).toBe(5 * 60_000);
-    expect(resolveWorktreePortTimeout("resource-action")).toBe(10 * 60_000);
-    expect(resolveWorktreePortTimeout("run-lifecycle-setup")).toBe(10 * 60_000);
+    expect(resolveWorktreePortTimeout("delete-worktree")).toBe(10 * 60_000);
+    expect(resolveWorktreePortTimeout("resource-action")).toBe(15 * 60_000);
+    expect(resolveWorktreePortTimeout("run-lifecycle-setup")).toBe(15 * 60_000);
+  });
+
+  it("delete-worktree timeout exceeds the host worst case", () => {
+    // Host runs resource-teardown (300s) + regular teardown (120s) sequentially.
+    // The renderer ceiling must exceed that sum so it never errors on a delete
+    // that is still completing successfully on the host.
+    const HOST_DELETE_WORST_CASE_MS = (300 + 120) * 1000;
+    expect(resolveWorktreePortTimeout("delete-worktree")).toBeGreaterThan(
+      HOST_DELETE_WORST_CASE_MS
+    );
+  });
+
+  it("resource-action timeout exceeds the default host per-action ceilings", () => {
+    // ResourceActionExecutor.DEFAULT_TIMEOUT_MS tops out at 300s for
+    // provision/teardown. User configs can exceed this but have no schema cap;
+    // 15 min covers all realistic cloud provision/teardown workflows.
+    const HOST_RESOURCE_DEFAULT_MAX_MS = 300_000;
+    expect(resolveWorktreePortTimeout("resource-action")).toBeGreaterThan(
+      HOST_RESOURCE_DEFAULT_MAX_MS
+    );
   });
 
   it("respects an explicit positive finite override", () => {

--- a/electron/utils/worktreePortTimeouts.ts
+++ b/electron/utils/worktreePortTimeouts.ts
@@ -15,12 +15,25 @@ export const DEFAULT_WORKTREE_PORT_TIMEOUT_MS = 10_000;
  * renderer stuck on a hung utility process that never crashes (so the port
  * `close` event never fires). The `close` event is the fast-failure signal;
  * these timeouts are the deadlock backstop.
+ *
+ * Values must exceed the host-side worst case so the renderer is never the
+ * limiting factor. As of writing:
+ *   - delete-worktree: host runs resource-teardown (300s, hardcoded in
+ *     WorktreeLifecycleService.runTeardown) then regular teardown (120s),
+ *     sequentially → 7 min worst case. Renderer gets 10 min headroom.
+ *   - resource-action: per-action defaults are 300s
+ *     (ResourceActionExecutor.DEFAULT_TIMEOUT_MS); user configs in
+ *     `.daintree/config.json` may extend this without an enforced ceiling.
+ *     15 min covers all realistic cloud provision/teardown workflows.
+ *   - run-lifecycle-setup: arbitrary user-defined setup scripts.
+ *   - create-worktree: git worktree add + branch creation on slow
+ *     filesystems / large repos.
  */
 export const WORKTREE_PORT_TIMEOUTS_MS: Partial<Record<WorktreePortAction, number>> = {
-  "create-worktree": 5 * 60_000, // git worktree add + branch creation
-  "delete-worktree": 5 * 60_000, // git worktree remove + optional branch delete
-  "resource-action": 10 * 60_000, // cloud provision/teardown can run for minutes
-  "run-lifecycle-setup": 10 * 60_000, // arbitrary user-defined setup scripts
+  "create-worktree": 5 * 60_000,
+  "delete-worktree": 10 * 60_000,
+  "resource-action": 15 * 60_000,
+  "run-lifecycle-setup": 15 * 60_000,
 };
 
 /**

--- a/electron/utils/worktreePortTimeouts.ts
+++ b/electron/utils/worktreePortTimeouts.ts
@@ -1,0 +1,41 @@
+import type { WorktreePortAction } from "../../shared/types/worktree-port.js";
+
+/**
+ * Default deadline for short, bounded worktree-port actions (status snapshots,
+ * git list/log queries, env switches). 10 seconds is generous for fast paths
+ * that should never block on user-perceptible work.
+ */
+export const DEFAULT_WORKTREE_PORT_TIMEOUT_MS = 10_000;
+
+/**
+ * Per-action deadlines for actions that legitimately run longer than the
+ * default. The previous fixed 10s ceiling fired spurious "timed out" errors
+ * on operations that were still completing successfully on the host (issue
+ * #8551, gap 2). Keep these finite — an `Infinity` timeout would leave the
+ * renderer stuck on a hung utility process that never crashes (so the port
+ * `close` event never fires). The `close` event is the fast-failure signal;
+ * these timeouts are the deadlock backstop.
+ */
+export const WORKTREE_PORT_TIMEOUTS_MS: Partial<Record<WorktreePortAction, number>> = {
+  "create-worktree": 5 * 60_000, // git worktree add + branch creation
+  "delete-worktree": 5 * 60_000, // git worktree remove + optional branch delete
+  "resource-action": 10 * 60_000, // cloud provision/teardown can run for minutes
+  "run-lifecycle-setup": 10 * 60_000, // arbitrary user-defined setup scripts
+};
+
+/**
+ * Resolve the effective timeout for a worktree-port request.
+ *
+ * - An explicit `override` wins when it is a positive finite number. Invalid
+ *   overrides (NaN, Infinity, ≤0) silently fall through to the table; the
+ *   only caller is internal preload code, not user input, so a hard reject
+ *   would just convert a misuse into a harder-to-debug Promise rejection.
+ * - Otherwise the per-action table is consulted.
+ * - Otherwise the default applies.
+ */
+export function resolveWorktreePortTimeout(action: WorktreePortAction, override?: number): number {
+  if (override != null && Number.isFinite(override) && override > 0) {
+    return override;
+  }
+  return WORKTREE_PORT_TIMEOUTS_MS[action] ?? DEFAULT_WORKTREE_PORT_TIMEOUT_MS;
+}

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -36,6 +36,7 @@ import { gitHubRateLimitService } from "./services/github/index.js";
 import { ensureSerializable } from "../shared/utils/serialization.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../shared/utils/forgeProviderIds.js";
+import { fanoutEventToWorktreePorts } from "./workspace-host/worktreePortFanout.js";
 
 // Validate we're running in UtilityProcess context
 if (!process.parentPort) {
@@ -70,13 +71,7 @@ const DIRECT_RENDERER_EVENTS = new Set([
 ]);
 
 function sendToWorktreePorts(event: WorkspaceHostEvent): void {
-  for (let i = worktreePorts.length - 1; i >= 0; i--) {
-    try {
-      worktreePorts[i].postMessage({ type: "event", event });
-    } catch {
-      worktreePorts.splice(i, 1);
-    }
-  }
+  fanoutEventToWorktreePorts(worktreePorts, event);
 }
 
 async function handleWorktreePortRequest(

--- a/electron/workspace-host/__tests__/worktreePortFanout.test.ts
+++ b/electron/workspace-host/__tests__/worktreePortFanout.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { fanoutEventToPorts, type FanoutPort } from "../worktreePortFanout.js";
+
+function makePort(throwOnPost = false): FanoutPort & {
+  postMessage: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+} {
+  return {
+    postMessage: vi.fn(() => {
+      if (throwOnPost) throw new Error("DataCloneError: not serializable");
+    }),
+    close: vi.fn(),
+  };
+}
+
+describe("fanoutEventToPorts", () => {
+  it("delivers the event to every port when none throw", () => {
+    const a = makePort();
+    const b = makePort();
+    const ports = [a, b];
+    const logger = { error: vi.fn() };
+
+    fanoutEventToPorts(ports, { type: "worktree-update", x: 1 }, logger);
+
+    expect(a.postMessage).toHaveBeenCalledWith({
+      type: "event",
+      event: { type: "worktree-update", x: 1 },
+    });
+    expect(b.postMessage).toHaveBeenCalledWith({
+      type: "event",
+      event: { type: "worktree-update", x: 1 },
+    });
+    expect(a.close).not.toHaveBeenCalled();
+    expect(b.close).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(ports).toEqual([a, b]);
+  });
+
+  it("removes the failing port AND calls close() so the renderer can recover", () => {
+    const good = makePort();
+    const bad = makePort(true);
+    const ports = [good, bad];
+    const logger = { error: vi.fn() };
+
+    fanoutEventToPorts(ports, { type: "worktree-update" }, logger);
+
+    expect(bad.postMessage).toHaveBeenCalledTimes(1);
+    expect(bad.close).toHaveBeenCalledTimes(1);
+    expect(ports).toEqual([good]);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error.mock.calls[0][0]).toContain("postMessage failed, closing port");
+  });
+
+  it("still delivers to the remaining ports when one throws (reverse iteration)", () => {
+    const earlyBad = makePort(true);
+    const middleGood = makePort();
+    const lateBad = makePort(true);
+    const ports = [earlyBad, middleGood, lateBad];
+    const logger = { error: vi.fn() };
+
+    fanoutEventToPorts(ports, { type: "pr-detected" }, logger);
+
+    expect(middleGood.postMessage).toHaveBeenCalledWith({
+      type: "event",
+      event: { type: "pr-detected" },
+    });
+    expect(earlyBad.close).toHaveBeenCalledTimes(1);
+    expect(lateBad.close).toHaveBeenCalledTimes(1);
+    expect(ports).toEqual([middleGood]);
+    expect(logger.error).toHaveBeenCalledTimes(2);
+  });
+
+  it("splices the port before calling close() so a re-entrant close listener finds idx === -1", () => {
+    const bad = makePort(true);
+    const ports = [bad];
+    const observedDuringClose: FanoutPort[][] = [];
+    bad.close = vi.fn(() => {
+      observedDuringClose.push([...ports]);
+    });
+
+    fanoutEventToPorts(ports, { type: "worktree-update" }, { error: vi.fn() });
+
+    expect(observedDuringClose).toEqual([[]]);
+    expect(ports).toEqual([]);
+  });
+
+  it("swallows errors thrown by close() itself", () => {
+    const bad = makePort(true);
+    bad.close = vi.fn(() => {
+      throw new Error("port already closed");
+    });
+    const ports = [bad];
+    const logger = { error: vi.fn() };
+
+    expect(() => fanoutEventToPorts(ports, { type: "worktree-update" }, logger)).not.toThrow();
+
+    expect(ports).toEqual([]);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/workspace-host/__tests__/worktreePortFanout.test.ts
+++ b/electron/workspace-host/__tests__/worktreePortFanout.test.ts
@@ -2,15 +2,17 @@ import { describe, expect, it, vi } from "vitest";
 
 import { fanoutEventToPorts, type FanoutPort } from "../worktreePortFanout.js";
 
-function makePort(throwOnPost = false): FanoutPort & {
-  postMessage: ReturnType<typeof vi.fn>;
-  close: ReturnType<typeof vi.fn>;
-} {
+function makePort(throwOnPost = false) {
+  const postMessage = vi.fn(() => {
+    if (throwOnPost) throw new Error("DataCloneError: not serializable");
+  });
+  const close = vi.fn(() => {});
   return {
-    postMessage: vi.fn(() => {
-      if (throwOnPost) throw new Error("DataCloneError: not serializable");
-    }),
-    close: vi.fn(),
+    postMessage,
+    close,
+  } as FanoutPort & {
+    postMessage: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
   };
 }
 

--- a/electron/workspace-host/__tests__/worktreePortFanout.test.ts
+++ b/electron/workspace-host/__tests__/worktreePortFanout.test.ts
@@ -85,6 +85,45 @@ describe("fanoutEventToPorts", () => {
     expect(ports).toEqual([]);
   });
 
+  it("handles alternating good/bad ports without skipping any good port (reverse iteration)", () => {
+    const good1 = makePort();
+    const bad1 = makePort(true);
+    const good2 = makePort();
+    const bad2 = makePort(true);
+    const good3 = makePort();
+    const ports = [good1, bad1, good2, bad2, good3];
+    const logger = { error: vi.fn() };
+
+    fanoutEventToPorts(ports, { type: "worktree-update" }, logger);
+
+    expect(good1.postMessage).toHaveBeenCalledTimes(1);
+    expect(good2.postMessage).toHaveBeenCalledTimes(1);
+    expect(good3.postMessage).toHaveBeenCalledTimes(1);
+    expect(bad1.close).toHaveBeenCalledTimes(1);
+    expect(bad2.close).toHaveBeenCalledTimes(1);
+    expect(ports).toEqual([good1, good2, good3]);
+    expect(logger.error).toHaveBeenCalledTimes(2);
+  });
+
+  it("closes ALL renderer ports when the event itself is non-serializable", () => {
+    // Simulates the DataCloneError fan-out fail mode — every port throws on
+    // the same event. All ports must be removed and closed so the renderers'
+    // close-event recovery paths can re-broker fresh ports.
+    const a = makePort(true);
+    const b = makePort(true);
+    const c = makePort(true);
+    const ports = [a, b, c];
+    const logger = { error: vi.fn() };
+
+    fanoutEventToPorts(ports, { fn: () => undefined }, logger);
+
+    expect(a.close).toHaveBeenCalledTimes(1);
+    expect(b.close).toHaveBeenCalledTimes(1);
+    expect(c.close).toHaveBeenCalledTimes(1);
+    expect(ports).toEqual([]);
+    expect(logger.error).toHaveBeenCalledTimes(3);
+  });
+
   it("swallows errors thrown by close() itself", () => {
     const bad = makePort(true);
     bad.close = vi.fn(() => {

--- a/electron/workspace-host/worktreePortFanout.ts
+++ b/electron/workspace-host/worktreePortFanout.ts
@@ -1,0 +1,56 @@
+import type { MessagePort } from "node:worker_threads";
+
+// Surface used by `fanoutEventToPorts`. Kept narrow so tests can mock it
+// without dragging in `node:worker_threads` types.
+export interface FanoutPort {
+  postMessage(message: unknown): void;
+  close(): void;
+}
+
+export interface FanoutLogger {
+  error(...args: unknown[]): void;
+}
+
+/**
+ * Fan an event out to every active worktree MessagePort.
+ *
+ * When `postMessage` throws (e.g. `DataCloneError` on a non-cloneable value,
+ * or a closed channel), the port is removed from `ports` AND closed. The
+ * close is the load-bearing change vs. the previous silent-drop behaviour:
+ * the renderer-side `WorktreePortClient` only learns the channel is gone
+ * via the `close` event, which triggers `_handlePortClose` and the broker
+ * re-attach recovery path. Without the explicit `close()` the renderer would
+ * wait for GC to reclaim the host-side port — non-deterministic and
+ * effectively never under load.
+ *
+ * Order matters: splice BEFORE close. `close()` fires the `close` event on
+ * both sides; the local listener installed by `attachWorktreePort` does its
+ * own `indexOf`/`splice`, so removing the port first means that listener
+ * sees `idx === -1` and no-ops instead of racing the reverse-iteration loop.
+ */
+export function fanoutEventToPorts<TPort extends FanoutPort, TEvent>(
+  ports: TPort[],
+  event: TEvent,
+  logger: FanoutLogger = console
+): void {
+  for (let i = ports.length - 1; i >= 0; i--) {
+    try {
+      ports[i].postMessage({ type: "event", event });
+    } catch (error) {
+      const failedPort = ports[i];
+      ports.splice(i, 1);
+      try {
+        failedPort.close();
+      } catch {
+        // Port may already be closed; the splice is what matters.
+      }
+      logger.error("[WorkspaceHost] sendToWorktreePorts: postMessage failed, closing port:", error);
+    }
+  }
+}
+
+// Convenience overload pinned to the `node:worker_threads` MessagePort type
+// for the production call site. Re-uses the generic implementation above.
+export function fanoutEventToWorktreePorts<TEvent>(ports: MessagePort[], event: TEvent): void {
+  fanoutEventToPorts(ports as unknown as FanoutPort[], event);
+}


### PR DESCRIPTION
## Summary

Two silent failure modes in the worktree `MessagePort` transport. Both could leave the renderer hanging with no indication of what was happening.

Resolves #8551

## Changes

**Gap 1: dead port cleanup on send failure**

When a port send failed, the dead port was silently left in the active list. The fix splices it out, calls `port.close()` to trigger the renderer's `_handlePortClose` recovery path, and logs via `console.error`. Splice happens before `close()` — the existing close listener at `workspace-host.ts:238-241` would otherwise fire during `close()` and attempt a second splice on the now-shifted array.

**Gap 2: per-action timeouts in `WorktreePortClient.request()`**

Every worktree IPC action was capped at 10 seconds regardless of what the operation actually does. A new timeout table in `worktreePortTimeouts.ts` resolves per-action:

| Action | Timeout | Reason |
|---|---|---|
| `create-worktree` | 5 min | Git clone can be slow |
| `delete-worktree` | 10 min | Exceeds 7-min host worst case |
| `resource-action` | 15 min | User-configured; uncapped on host side |
| `run-lifecycle-setup` | 15 min | Setup scripts can be long-running |
| All other actions | 10 s | Fast IPC — should never take longer |

Invalid overrides (`Infinity`, `NaN`, `<= 0`) fall back to the table or the 10s default. The renderer can never deadlock waiting on a hung host.

**Extraction + tests**

Logic pulled into two pure helpers — `electron/workspace-host/worktreePortFanout.ts` and `electron/utils/worktreePortTimeouts.ts` — each with its own unit test file (15 tests total covering the happy path, invalid-override guards, and the splice-before-close ordering).

## Testing

- 15 new unit tests across the two helper modules
- Typecheck, lint, and build all pass