### PR TITLE
refactor(rpc): unify request/response correlation behind RequestResponseBroker

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -19,6 +19,7 @@ import type { ActionContext } from "../shared/types/actions.js";
 import type { PushProgressEvent } from "../shared/types/ipc/gitPush.js";
 import type { HelpAssistantTier } from "../shared/types/ipc/maps.js";
 import { CHANNELS } from "./ipc/channels.js";
+import { BrokerError, RequestResponseBroker } from "./services/rpc/RequestResponseBroker.js";
 import { buildClipboardPreloadBindings } from "./ipc/handlers/clipboard.preload.js";
 import { buildSlashCommandsPreloadBindings } from "./ipc/handlers/slashCommands.preload.js";
 import { buildGlobalEnvPreloadBindings } from "./ipc/handlers/globalEnv.preload.js";
@@ -224,16 +225,33 @@ ipcRenderer.on("terminal-port", (event, payload: { token: string }) => {
 
 type WorktreePortEventCallback = (data: unknown) => void;
 
+/**
+ * Encode a {@link BrokerError} into a plain `Error` whose message carries the
+ * `code` discriminant in a structured prefix. Electron's contextBridge strips
+ * ALL custom Error properties (including `name` and `code`) when an error
+ * crosses preload→renderer, so the prefix is the only reliable carrier.
+ * The renderer-side `isClientBrokerError` guard
+ * (`src/utils/clientBrokerError.ts`) decodes the prefix back into a `code`
+ * field on the caught error.
+ *
+ * Format: `[BrokerError|<code>] <original message>`
+ */
+function encodeBrokerError(err: BrokerError): Error {
+  const encoded = `[BrokerError|${err.code}] ${err.message}`;
+  const out = new Error(encoded);
+  // Same-realm properties (don't survive contextBridge but useful for tests
+  // and any in-preload consumer before crossing the boundary).
+  out.name = "BrokerError";
+  (out as Error & { code: BrokerError["code"] }).code = err.code;
+  return out;
+}
+
 class WorktreePortClient {
   private port: MessagePort | null = null;
-  private pending = new Map<
-    string,
-    {
-      resolve: (value: unknown) => void;
-      reject: (error: Error) => void;
-      timeout: ReturnType<typeof setTimeout>;
-    }
-  >();
+  private broker = new RequestResponseBroker({
+    idPrefix: "worktree",
+    defaultTimeoutMs: 10000,
+  });
   private eventListeners = new Map<string, Set<WorktreePortEventCallback>>();
   private readyCallbacks: Array<() => void> = [];
   private disconnectedCallbacks: Array<() => void> = [];
@@ -269,15 +287,11 @@ class WorktreePortClient {
       if (!data) return;
 
       // Response to a request
-      if (data.id && this.pending.has(data.id)) {
-        const entry = this.pending.get(data.id)!;
-        clearTimeout(entry.timeout);
-        this.pending.delete(data.id);
-
+      if (data.id && this.broker.has(data.id)) {
         if (data.error != null) {
-          entry.reject(new Error(String(data.error)));
+          this.broker.reject(data.id, new Error(String(data.error)));
         } else {
-          entry.resolve(data.result);
+          this.broker.resolve(data.id, data.result);
         }
         return;
       }
@@ -318,12 +332,9 @@ class WorktreePortClient {
       // ignore
     }
 
-    // Reject all pending requests
-    for (const [, entry] of this.pending) {
-      clearTimeout(entry.timeout);
-      entry.reject(new Error("Worktree port replaced"));
-    }
-    this.pending.clear();
+    // Clear pending BEFORE nulling state — preserves the invariant that no
+    // request can be registered after clearance but before the null check.
+    this.broker.clear(encodeBrokerError(new BrokerError("APP_SHUTDOWN", "Worktree port replaced")));
 
     this.port = null;
     this._isReady = false;
@@ -348,11 +359,9 @@ class WorktreePortClient {
       // ignore
     }
 
-    for (const [, entry] of this.pending) {
-      clearTimeout(entry.timeout);
-      entry.reject(new Error("Worktree port disconnected"));
-    }
-    this.pending.clear();
+    this.broker.clear(
+      encodeBrokerError(new BrokerError("HOST_EXITED", "Worktree port disconnected"))
+    );
 
     this.port = null;
     this._isReady = false;
@@ -371,32 +380,36 @@ class WorktreePortClient {
     payload?: WorktreePortPayload<K>,
     timeoutMs?: number
   ): Promise<WorktreePortResult<K>> {
-    return new Promise<WorktreePortResult<K>>((resolve, reject) => {
-      if (!this.port) {
-        reject(new Error("Worktree port not ready"));
-        return;
+    if (!this.port) {
+      return Promise.reject(new Error("Worktree port not ready"));
+    }
+
+    const id = this.broker.generateId();
+    // Resolve the per-action timeout (#8551): create/delete-worktree,
+    // resource-action, and run-lifecycle-setup legitimately run longer than
+    // the 10s default. The broker's own getEffectiveTimeout only validates a
+    // single defaultTimeoutMs, so the per-action table must be applied here.
+    const effectiveTimeout = resolveWorktreePortTimeout(action, timeoutMs);
+    const promise = this.broker.register<WorktreePortResult<K>>(id, {
+      method: String(action),
+      timeoutMs: effectiveTimeout,
+    });
+
+    try {
+      this.port.postMessage({ id, action, payload: payload ?? {} });
+    } catch (error) {
+      this.broker.reject(id, error instanceof Error ? error : new Error(String(error)));
+    }
+
+    // Encode BrokerError rejections (TIMEOUT, HOST_EXITED, APP_SHUTDOWN) so
+    // the renderer can decode the discriminant via `isClientBrokerError`.
+    // contextBridge strips own Error properties, so the prefix is the only
+    // reliable carrier across the realm boundary.
+    return promise.catch((err: unknown) => {
+      if (err instanceof BrokerError) {
+        throw encodeBrokerError(err);
       }
-
-      const id = crypto.randomUUID();
-      const effectiveTimeout = resolveWorktreePortTimeout(action, timeoutMs);
-      const timeout = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`Worktree port request timed out: ${String(action)}`));
-      }, effectiveTimeout);
-
-      this.pending.set(id, {
-        resolve: resolve as (value: unknown) => void,
-        reject,
-        timeout,
-      });
-
-      try {
-        this.port.postMessage({ id, action, payload: payload ?? {} });
-      } catch (error) {
-        clearTimeout(timeout);
-        this.pending.delete(id);
-        reject(error instanceof Error ? error : new Error(String(error)));
-      }
+      throw err;
     });
   }
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -19,7 +19,11 @@ import type { ActionContext } from "../shared/types/actions.js";
 import type { PushProgressEvent } from "../shared/types/ipc/gitPush.js";
 import type { HelpAssistantTier } from "../shared/types/ipc/maps.js";
 import { CHANNELS } from "./ipc/channels.js";
-import { BrokerError, RequestResponseBroker } from "./services/rpc/RequestResponseBroker.js";
+import {
+  BrokerError,
+  RequestResponseBroker,
+  encodeBrokerError,
+} from "./services/rpc/RequestResponseBroker.js";
 import { buildClipboardPreloadBindings } from "./ipc/handlers/clipboard.preload.js";
 import { buildSlashCommandsPreloadBindings } from "./ipc/handlers/slashCommands.preload.js";
 import { buildGlobalEnvPreloadBindings } from "./ipc/handlers/globalEnv.preload.js";
@@ -225,27 +229,6 @@ ipcRenderer.on("terminal-port", (event, payload: { token: string }) => {
 
 type WorktreePortEventCallback = (data: unknown) => void;
 
-/**
- * Encode a {@link BrokerError} into a plain `Error` whose message carries the
- * `code` discriminant in a structured prefix. Electron's contextBridge strips
- * ALL custom Error properties (including `name` and `code`) when an error
- * crosses preload→renderer, so the prefix is the only reliable carrier.
- * The renderer-side `isClientBrokerError` guard
- * (`src/utils/clientBrokerError.ts`) decodes the prefix back into a `code`
- * field on the caught error.
- *
- * Format: `[BrokerError|<code>] <original message>`
- */
-function encodeBrokerError(err: BrokerError): Error {
-  const encoded = `[BrokerError|${err.code}] ${err.message}`;
-  const out = new Error(encoded);
-  // Same-realm properties (don't survive contextBridge but useful for tests
-  // and any in-preload consumer before crossing the boundary).
-  out.name = "BrokerError";
-  (out as Error & { code: BrokerError["code"] }).code = err.code;
-  return out;
-}
-
 class WorktreePortClient {
   private port: MessagePort | null = null;
   private broker = new RequestResponseBroker({
@@ -334,7 +317,10 @@ class WorktreePortClient {
 
     // Clear pending BEFORE nulling state — preserves the invariant that no
     // request can be registered after clearance but before the null check.
-    this.broker.clear(encodeBrokerError(new BrokerError("APP_SHUTDOWN", "Worktree port replaced")));
+    // Port replacement is a transient/recoverable condition (host restart,
+    // project switch within window), not app shutdown — surface HOST_EXITED
+    // so callers can retry rather than treating it as terminal.
+    this.broker.clear(encodeBrokerError(new BrokerError("HOST_EXITED", "Worktree port replaced")));
 
     this.port = null;
     this._isReady = false;
@@ -381,7 +367,9 @@ class WorktreePortClient {
     timeoutMs?: number
   ): Promise<WorktreePortResult<K>> {
     if (!this.port) {
-      return Promise.reject(new Error("Worktree port not ready"));
+      return Promise.reject(
+        encodeBrokerError(new BrokerError("HOST_EXITED", "Worktree port not ready"))
+      );
     }
 
     const id = this.broker.generateId();

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -819,10 +819,13 @@ export class PtyClient extends EventEmitter {
     return promise.catch((error: unknown) => {
       // Sending a kill to a host that isn't there only mutates local bookkeeping.
       // Skip whenever the host is known to be gone — either because the broker
-      // clear told us (typed BrokerError), or because we notice it ourselves
-      // (null child or disposed client, e.g. restart pending, max restarts
-      // exhausted, or app quit arriving during the 5s timeout window).
-      if (error instanceof BrokerError || !this.lifecycle.child || this.isDisposed) {
+      // clear told us via a typed BrokerError (HOST_EXITED / APP_SHUTDOWN), or
+      // because we notice it ourselves (null child or disposed client, e.g.
+      // restart pending, max restarts exhausted, or app quit arriving during
+      // the 5s timeout window). TIMEOUT is excluded: a per-request timeout
+      // with a live host should still escalate to a forced kill.
+      const isHostGoneBrokerError = error instanceof BrokerError && error.code !== "TIMEOUT";
+      if (isHostGoneBrokerError || !this.lifecycle.child || this.isDisposed) {
         return null;
       }
       this.kill(id, "graceful-kill-timeout");

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -10,7 +10,7 @@ import type {
   WorkspaceClientConfig,
 } from "../../shared/types/workspace-host.js";
 import { GitHubAuth } from "./github/GitHubAuth.js";
-import { BrokerError } from "./rpc/RequestResponseBroker.js";
+import { BrokerError, RequestResponseBroker } from "./rpc/RequestResponseBroker.js";
 import { createLogger } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../../shared/utils/forgeProviderIds.js";
@@ -77,15 +77,12 @@ export class WorkspaceHostProcess extends EventEmitter {
   private missedHeartbeats = 0;
   private readonly MAX_MISSED_HEARTBEATS = 3;
 
-  private pendingRequests = new Map<
-    string,
-    {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      resolve: (value: any) => void;
-      reject: (error: Error) => void;
-      timeout: NodeJS.Timeout;
-    }
-  >();
+  private broker = new RequestResponseBroker({
+    idPrefix: "workspace",
+    // Slow git ops (project-pulse, file-diff, create-worktree) need the legacy
+    // 30s ceiling; collapsing to the broker's 5s default would break them.
+    defaultTimeoutMs: 30000,
+  });
 
   private readyPromise: Promise<void>;
   private readyResolve: (() => void) | null = null;
@@ -136,7 +133,7 @@ export class WorkspaceHostProcess extends EventEmitter {
   }
 
   generateRequestId(): string {
-    return `req-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+    return this.broker.generateId();
   }
 
   send(request: WorkspaceHostRequest): boolean {
@@ -187,38 +184,39 @@ export class WorkspaceHostProcess extends EventEmitter {
       );
     }
 
-    return new Promise((resolve, reject) => {
-      const existing = this.pendingRequests.get(request.requestId);
-      if (existing) {
-        clearTimeout(existing.timeout);
-        existing.reject(new Error(`Duplicate request ID: ${request.requestId}`));
-        this.pendingRequests.delete(request.requestId);
-      }
+    const promise = this.broker.register<T>(request.requestId, {
+      method: request.type,
+      timeoutMs,
+    });
 
-      const timeout = setTimeout(() => {
-        if (this.pendingRequests.has(request.requestId)) {
-          this.pendingRequests.delete(request.requestId);
-          reject(
-            new BrokerError("TIMEOUT", "Request timeout", {
-              projectScopeId: this.projectPath,
-            })
-          );
-        }
-      }, timeoutMs);
-
-      this.pendingRequests.set(request.requestId, { resolve, reject, timeout });
-      try {
-        if (!this.child) {
-          throw new BrokerError("HOST_EXITED", "Workspace Host not running", {
-            projectScopeId: this.projectPath,
-          });
-        }
-        this.child.postMessage(request);
-      } catch (error) {
-        clearTimeout(timeout);
-        this.pendingRequests.delete(request.requestId);
-        reject(error instanceof Error ? error : new Error(String(error)));
+    try {
+      if (!this.child) {
+        throw new BrokerError("HOST_EXITED", "Workspace Host not running", {
+          projectScopeId: this.projectPath,
+        });
       }
+      this.child.postMessage(request);
+    } catch (error) {
+      this.broker.reject(
+        request.requestId,
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+
+    // The broker emits plain BrokerError("TIMEOUT", ...) on timeout; callers
+    // here have always seen projectScopeId on the rejection, so wrap to preserve
+    // that contract without re-running the timer.
+    return promise.catch((err: unknown) => {
+      if (
+        err instanceof BrokerError &&
+        err.code === "TIMEOUT" &&
+        err.projectScopeId === undefined
+      ) {
+        throw new BrokerError("TIMEOUT", "Request timeout", {
+          projectScopeId: this.projectPath,
+        });
+      }
+      throw err;
     });
   }
 
@@ -360,15 +358,11 @@ export class WorkspaceHostProcess extends EventEmitter {
       this.readyResolve = null;
     }
 
-    for (const [, { reject, timeout }] of this.pendingRequests) {
-      clearTimeout(timeout);
-      reject(
-        new BrokerError("APP_SHUTDOWN", "WorkspaceHostProcess disposed", {
-          projectScopeId: this.projectPath,
-        })
-      );
-    }
-    this.pendingRequests.clear();
+    this.broker.clear(
+      new BrokerError("APP_SHUTDOWN", "WorkspaceHostProcess disposed", {
+        projectScopeId: this.projectPath,
+      })
+    );
 
     if (this.child) {
       this.send({ type: "dispose" });
@@ -567,15 +561,11 @@ export class WorkspaceHostProcess extends EventEmitter {
         this.stabilityTimer = null;
       }
 
-      for (const [, { reject, timeout }] of this.pendingRequests) {
-        clearTimeout(timeout);
-        reject(
-          new BrokerError("HOST_EXITED", "Workspace Host crashed", {
-            projectScopeId: this.projectPath,
-          })
-        );
-      }
-      this.pendingRequests.clear();
+      this.broker.clear(
+        new BrokerError("HOST_EXITED", "Workspace Host crashed", {
+          projectScopeId: this.projectPath,
+        })
+      );
 
       if (this.readyReject) {
         this.readyReject(
@@ -753,14 +743,10 @@ export class WorkspaceHostProcess extends EventEmitter {
 
       const requestId = (event as { requestId?: string })?.requestId;
       if (requestId) {
-        const pending = this.pendingRequests.get(requestId);
-        if (pending) {
-          clearTimeout(pending.timeout);
-          this.pendingRequests.delete(requestId);
-          pending.reject(
-            error instanceof Error ? error : new Error(`Event processing failed: ${eventType}`)
-          );
-        }
+        this.broker.reject(
+          requestId,
+          error instanceof Error ? error : new Error(`Event processing failed: ${eventType}`)
+        );
       }
     }
   }
@@ -815,12 +801,7 @@ export class WorkspaceHostProcess extends EventEmitter {
       case "error":
         console.error(`[WorkspaceHost:${this.serviceName}] Host error:`, event.error);
         if (event.requestId) {
-          const pending = this.pendingRequests.get(event.requestId);
-          if (pending) {
-            clearTimeout(pending.timeout);
-            this.pendingRequests.delete(event.requestId);
-            pending.reject(new Error(event.error));
-          }
+          this.broker.reject(event.requestId, new Error(event.error));
         }
         break;
 
@@ -907,15 +888,10 @@ export class WorkspaceHostProcess extends EventEmitter {
     success?: boolean;
     error?: string;
   }): void {
-    const pending = this.pendingRequests.get(event.requestId);
-    if (pending) {
-      clearTimeout(pending.timeout);
-      this.pendingRequests.delete(event.requestId);
-      if (event.success === false || event.error) {
-        pending.reject(new Error(event.error || "Operation failed"));
-      } else {
-        pending.resolve(event);
-      }
+    if (event.success === false || event.error) {
+      this.broker.reject(event.requestId, new Error(event.error || "Operation failed"));
+    } else {
+      this.broker.resolve(event.requestId, event);
     }
   }
 

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -360,10 +360,11 @@ describe("PtyClient adversarial", () => {
 
   it("GRACEFUL_KILL_SKIPS_KILL_WHEN_TIMEOUT_FIRES_AFTER_HOST_GONE", async () => {
     // When the host exits and the restart timer hasn't yet refilled `child`,
-    // a subsequent gracefulKill will time out with a plain Error('Request
-    // timeout: …') — not a BrokerError. Without the null-child guard, the
-    // catch would fall through to this.kill() and mutate local state on a
-    // dead client.
+    // a subsequent gracefulKill will time out with a BrokerError("TIMEOUT").
+    // gracefulKill excludes TIMEOUT from its host-gone short-circuit (a live
+    // host that timed out still needs a forced kill), so without the
+    // null-child guard the catch would fall through to this.kill() and
+    // mutate local state on a dead client.
     const client = createReadyClient();
     const privateAccess = client as unknown as PtyClientPrivateAccess;
     // Neutralize the auto-restart so `child` stays null for the duration of
@@ -396,8 +397,10 @@ describe("PtyClient adversarial", () => {
 
     await expect(promise).resolves.toBeNull();
 
-    // On timeout (non-BrokerError rejection) with a live host, gracefulKill
-    // must still send a kill message and remove the trashed PID.
+    // On timeout (BrokerError TIMEOUT) with a live host, gracefulKill must
+    // still send a kill message and remove the trashed PID — TIMEOUT is
+    // distinct from the host-gone broker clear reasons (HOST_EXITED /
+    // APP_SHUTDOWN).
     expect(shared.tracker.removeTrashed).toHaveBeenCalledWith("t1");
     const killCall = mockChild.postMessage.mock.calls.find(
       (call: unknown[]) => (call[0] as { type?: string })?.type === "kill"

--- a/electron/services/rpc/RequestResponseBroker.ts
+++ b/electron/services/rpc/RequestResponseBroker.ts
@@ -29,7 +29,9 @@ export class BrokerError extends Error {
 export interface PendingRequest<T = unknown> {
   resolve: (value: T) => void;
   reject: (error: Error) => void;
-  timeout: NodeJS.Timeout;
+  // ReturnType<typeof setTimeout> rather than NodeJS.Timeout so the broker
+  // typechecks under preload's DOM lib (no @types/node) as well as main.
+  timeout: ReturnType<typeof setTimeout>;
   createdAt: number;
   method?: string;
 }
@@ -106,7 +108,7 @@ export class RequestResponseBroker {
         } catch {
           // onTimeout is a best-effort callback and must not block timeout rejection.
         }
-        pending.reject(new Error(`Request timeout: ${requestId}`));
+        pending.reject(new BrokerError("TIMEOUT", `Request timeout: ${requestId}`));
       }, effectiveTimeout);
 
       this.pendingRequests.set(requestId, {

--- a/electron/services/rpc/RequestResponseBroker.ts
+++ b/electron/services/rpc/RequestResponseBroker.ts
@@ -216,3 +216,25 @@ function normalizeRegisterArg(arg?: number | RegisterOptions): {
   if (typeof arg === "number") return { timeoutMs: arg };
   return { method: arg.method, timeoutMs: arg.timeoutMs };
 }
+
+/**
+ * Encode a {@link BrokerError} into a plain `Error` whose message carries the
+ * `code` discriminant in a structured prefix. Electron's contextBridge strips
+ * ALL custom Error properties (including `name` and `code`) when an error
+ * crosses preload→renderer, so the prefix is the only reliable carrier.
+ * The renderer-side `isClientBrokerError` guard
+ * (`src/utils/clientBrokerError.ts`) decodes the prefix back into a `code`
+ * field on the caught error. Mirrors the pattern used by `_reconstructAppError`
+ * in `electron/preload.cts` for the parallel `AppError` boundary problem.
+ *
+ * Format: `[BrokerError|<code>] <original message>`
+ */
+export function encodeBrokerError(err: BrokerError): Error {
+  const encoded = `[BrokerError|${err.code}] ${err.message}`;
+  const out = new Error(encoded);
+  // Same-realm properties (don't survive contextBridge but useful for tests
+  // and any in-preload consumer before crossing the boundary).
+  out.name = "BrokerError";
+  (out as Error & { code: BrokerError["code"] }).code = err.code;
+  return out;
+}

--- a/electron/services/rpc/__tests__/RequestResponseBroker.test.ts
+++ b/electron/services/rpc/__tests__/RequestResponseBroker.test.ts
@@ -47,7 +47,10 @@ describe("RequestResponseBroker", () => {
     const promise = broker.register("req-timeout");
 
     vi.advanceTimersByTime(11);
-    await expect(promise).rejects.toThrow("Request timeout: req-timeout");
+    const err = await promise.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(BrokerError);
+    expect((err as BrokerError).code).toBe("TIMEOUT");
+    expect((err as BrokerError).message).toBe("Request timeout: req-timeout");
     expect(onTimeout).toHaveBeenCalledWith("req-timeout", undefined);
     expect(broker.size).toBe(0);
   });

--- a/electron/services/rpc/index.ts
+++ b/electron/services/rpc/index.ts
@@ -1,4 +1,4 @@
-export { RequestResponseBroker, BrokerError } from "./RequestResponseBroker.js";
+export { RequestResponseBroker, BrokerError, encodeBrokerError } from "./RequestResponseBroker.js";
 export type {
   PendingRequest,
   BrokerOptions,

--- a/src/utils/__tests__/clientBrokerError.test.ts
+++ b/src/utils/__tests__/clientBrokerError.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { ClientBrokerError, isClientBrokerError } from "../clientBrokerError";
+
+describe("isClientBrokerError", () => {
+  it.each(["HOST_EXITED", "APP_SHUTDOWN", "TIMEOUT"] as const)(
+    "decodes prefix-encoded %s and restores code/name/message",
+    (code) => {
+      const err = new Error(`[BrokerError|${code}] underlying message`);
+      expect(isClientBrokerError(err)).toBe(true);
+      expect(err.name).toBe("BrokerError");
+      expect((err as Error & { code: string }).code).toBe(code);
+      expect(err.message).toBe("underlying message");
+    }
+  );
+
+  it("returns false for a plain Error without the prefix", () => {
+    const err = new Error("nothing to see here");
+    expect(isClientBrokerError(err)).toBe(false);
+    expect(err.message).toBe("nothing to see here");
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isClientBrokerError(null)).toBe(false);
+    expect(isClientBrokerError(undefined)).toBe(false);
+    expect(isClientBrokerError("string error")).toBe(false);
+    expect(isClientBrokerError({ message: "fake" })).toBe(false);
+  });
+
+  it("returns false for prefix with unknown code", () => {
+    const err = new Error("[BrokerError|MYSTERY_CODE] something");
+    expect(isClientBrokerError(err)).toBe(false);
+    // Side effects should not have fired
+    expect(err.message).toBe("[BrokerError|MYSTERY_CODE] something");
+  });
+
+  it("returns false for malformed prefix (lowercase code)", () => {
+    const err = new Error("[BrokerError|host_exited] foo");
+    expect(isClientBrokerError(err)).toBe(false);
+  });
+
+  it("decodes multi-line messages (regex /s flag)", () => {
+    const err = new Error("[BrokerError|TIMEOUT] line one\nline two");
+    expect(isClientBrokerError(err)).toBe(true);
+    expect((err as Error & { code: string }).code).toBe("TIMEOUT");
+    expect(err.message).toBe("line one\nline two");
+  });
+
+  it("recognises same-realm ClientBrokerError without a prefix", () => {
+    const err = new ClientBrokerError("HOST_EXITED", "fell over");
+    expect(isClientBrokerError(err)).toBe(true);
+    expect(err.code).toBe("HOST_EXITED");
+    expect(err.message).toBe("fell over");
+  });
+});

--- a/src/utils/__tests__/clientBrokerError.test.ts
+++ b/src/utils/__tests__/clientBrokerError.test.ts
@@ -12,6 +12,7 @@ describe("isClientBrokerError", () => {
       const err = new Error(`[BrokerError|${code}] underlying message`);
       expect(isClientBrokerError(err)).toBe(true);
       expect(err.name).toBe("BrokerError");
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- code property added by isClientBrokerError
       expect((err as Error & { code: string }).code).toBe(code);
       expect(err.message).toBe("underlying message");
     }
@@ -45,6 +46,7 @@ describe("isClientBrokerError", () => {
   it("decodes multi-line messages (regex /s flag)", () => {
     const err = new Error("[BrokerError|TIMEOUT] line one\nline two");
     expect(isClientBrokerError(err)).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- code property added by isClientBrokerError
     expect((err as Error & { code: string }).code).toBe("TIMEOUT");
     expect(err.message).toBe("line one\nline two");
   });
@@ -65,6 +67,7 @@ describe("isClientBrokerError", () => {
     (code) => {
       const encoded = encodeBrokerError(new BrokerError(code, "carrier message"));
       expect(isClientBrokerError(encoded)).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- code property added by isClientBrokerError
       expect((encoded as Error & { code: string }).code).toBe(code);
       expect(encoded.message).toBe("carrier message");
     }

--- a/src/utils/__tests__/clientBrokerError.test.ts
+++ b/src/utils/__tests__/clientBrokerError.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import {
+  BrokerError,
+  encodeBrokerError,
+} from "../../../electron/services/rpc/RequestResponseBroker";
 import { ClientBrokerError, isClientBrokerError } from "../clientBrokerError";
 
 describe("isClientBrokerError", () => {
@@ -51,4 +55,18 @@ describe("isClientBrokerError", () => {
     expect(err.code).toBe("HOST_EXITED");
     expect(err.message).toBe("fell over");
   });
+
+  // Guards against format drift between encoder and decoder. The encoder lives
+  // in preload (electron/services/rpc), the decoder in src/utils — they're
+  // tested separately and would silently lose each other on a prefix change
+  // unless we roundtrip here.
+  it.each(["HOST_EXITED", "APP_SHUTDOWN", "TIMEOUT"] as const)(
+    "roundtrips encodeBrokerError -> isClientBrokerError for %s",
+    (code) => {
+      const encoded = encodeBrokerError(new BrokerError(code, "carrier message"));
+      expect(isClientBrokerError(encoded)).toBe(true);
+      expect((encoded as Error & { code: string }).code).toBe(code);
+      expect(encoded.message).toBe("carrier message");
+    }
+  );
 });

--- a/src/utils/clientBrokerError.ts
+++ b/src/utils/clientBrokerError.ts
@@ -1,0 +1,74 @@
+/**
+ * Renderer-side mirror of `BrokerError` (electron/services/rpc/RequestResponseBroker).
+ *
+ * The `RequestResponseBroker` lives in the main / preload realm. When it
+ * rejects a request that crosses the contextBridge boundary (worktree port
+ * disconnect, host exit, app shutdown, request timeout), Electron's structured
+ * clone strips all custom Error properties — including `name` and `code`.
+ * The preload encodes the discriminant into the message prefix
+ * `[BrokerError|<code>] <original message>`. This guard decodes that prefix
+ * so renderer callers can pattern-match on `code` instead of substring-matching
+ * `e.message`.
+ *
+ * `instanceof ClientBrokerError` is unreliable across realm boundaries — use
+ * `isClientBrokerError`.
+ */
+
+export type BrokerErrorCode = "HOST_EXITED" | "APP_SHUTDOWN" | "TIMEOUT";
+
+export class ClientBrokerError extends Error {
+  readonly code: BrokerErrorCode;
+
+  constructor(code: BrokerErrorCode, message: string) {
+    super(message);
+    this.name = "BrokerError";
+    this.code = code;
+    Object.setPrototypeOf(this, ClientBrokerError.prototype);
+  }
+}
+
+const VALID_CODES: ReadonlySet<BrokerErrorCode> = new Set([
+  "HOST_EXITED",
+  "APP_SHUTDOWN",
+  "TIMEOUT",
+]);
+
+const ENCODED_BROKER_ERROR_PATTERN = /^\[BrokerError\|([A-Z_]+)\] (.*)$/s;
+
+function isBrokerErrorCode(value: string): value is BrokerErrorCode {
+  return (VALID_CODES as ReadonlySet<string>).has(value);
+}
+
+/**
+ * Realm-safe guard. Decodes the `[BrokerError|<code>] message` prefix that
+ * the preload injects when a broker rejection crosses the contextBridge.
+ * As a side effect, restores `name`, `code`, and the cleaned `message` on
+ * the caught error so callers can read them directly.
+ *
+ * Falls back to duck-typing on `name === "BrokerError" && code is BrokerErrorCode`
+ * for errors originating inside the renderer realm.
+ */
+export function isClientBrokerError(e: unknown): e is Error & { code: BrokerErrorCode } {
+  if (!(e instanceof Error)) return false;
+
+  // Preferred path: decode the prefix the preload injected.
+  const match = ENCODED_BROKER_ERROR_PATTERN.exec(e.message);
+  if (match) {
+    const rawCode = match[1];
+    const originalMessage = match[2];
+    if (rawCode === undefined || !isBrokerErrorCode(rawCode)) return false;
+    const target = e as Error & { code?: string };
+    target.name = "BrokerError";
+    target.code = rawCode;
+    e.message = originalMessage ?? e.message;
+    return true;
+  }
+
+  // Same-realm fallback (no contextBridge crossing).
+  const candidate = e as { code?: unknown };
+  return (
+    e.name === "BrokerError" &&
+    typeof candidate.code === "string" &&
+    isBrokerErrorCode(candidate.code)
+  );
+}

--- a/src/utils/clientBrokerError.ts
+++ b/src/utils/clientBrokerError.ts
@@ -65,6 +65,7 @@ export function isClientBrokerError(e: unknown): e is Error & { code: BrokerErro
   }
 
   // Same-realm fallback (no contextBridge crossing).
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- type narrowed by guard checks below
   const candidate = e as { code?: unknown };
   return (
     e.name === "BrokerError" &&


### PR DESCRIPTION
## Summary

- Both `WorkspaceHostProcess` and the preload layer had hand-rolled `pending` Maps for tracking in-flight requests — this PR replaces both with a shared `RequestResponseBroker`
- Fixes the `PendingRequest.timeout` type for preload compatibility, emits `BrokerError("TIMEOUT")` on timeout, and adds an `encodeBrokerError` helper that produces a `[BrokerError|CODE] msg` prefix string that survives `contextBridge` structured clone
- Adds `ClientBrokerError` + `isClientBrokerError` on the renderer side to decode that prefix back into a typed `code` field, mirroring the `clientAppError` pattern

Resolves #8554

## Changes

- `electron/services/rpc/RequestResponseBroker.ts` — fix timeout type, emit `BrokerError("TIMEOUT")`, export `encodeBrokerError`
- `electron/services/rpc/index.ts` — re-export `encodeBrokerError`
- `electron/services/WorkspaceHostProcess.ts` — replace hand-rolled pending Map with broker (`defaultTimeoutMs: 30000`, `idPrefix: "workspace"`); all dispose/exit/error paths use `broker.clear`/`broker.reject`
- `electron/preload.cts` — replace `WorktreePortClient` pending Map with broker; encode all `BrokerError` rejections via `encodeBrokerError`; port replacement uses `HOST_EXITED` (transient) not `APP_SHUTDOWN`
- `src/utils/clientBrokerError.ts` (new) — `ClientBrokerError` + `isClientBrokerError`
- `src/utils/__tests__/clientBrokerError.test.ts` (new) — 10 tests including roundtrip with `encodeBrokerError`

## Testing

Unit tests cover the full encode/decode roundtrip, `isClientBrokerError` type guard, and edge cases like malformed prefixes and unknown codes. Existing `RequestResponseBroker` tests updated for the new timeout error shape.