### PR TITLE
fix(project): broadcast project:updated on switch so MRU ordering stays fresh

### DIFF
--- a/electron/ipc/__tests__/projectSwitchBroadcast.test.ts
+++ b/electron/ipc/__tests__/projectSwitchBroadcast.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const broadcastToRendererMock = vi.hoisted(() => vi.fn());
+const getProjectByIdMock = vi.hoisted(() => vi.fn<(id: string) => unknown>());
+
+vi.mock("../utils.js", () => ({
+  broadcastToRenderer: broadcastToRendererMock,
+}));
+
+vi.mock("../../services/ProjectStore.js", () => ({
+  projectStore: {
+    getProjectById: getProjectByIdMock,
+  },
+}));
+
+import { broadcastProjectSwitchUpdates } from "../projectSwitchBroadcast.js";
+import { CHANNELS } from "../channels.js";
+
+describe("broadcastProjectSwitchUpdates", () => {
+  beforeEach(() => {
+    broadcastToRendererMock.mockClear();
+    getProjectByIdMock.mockReset();
+  });
+
+  it("broadcasts both departing and activated rows on a real switch", () => {
+    const prevRow = { id: "prev", name: "Previous" };
+    const activeRow = { id: "active", name: "Active" };
+    getProjectByIdMock.mockImplementation((id: string) =>
+      id === "prev" ? prevRow : id === "active" ? activeRow : null
+    );
+
+    broadcastProjectSwitchUpdates("prev", "active");
+
+    expect(broadcastToRendererMock).toHaveBeenCalledTimes(2);
+    expect(broadcastToRendererMock).toHaveBeenNthCalledWith(1, CHANNELS.PROJECT_UPDATED, prevRow);
+    expect(broadcastToRendererMock).toHaveBeenNthCalledWith(2, CHANNELS.PROJECT_UPDATED, activeRow);
+  });
+
+  it("skips the departing broadcast when there was no previous project (cold start)", () => {
+    const activeRow = { id: "active", name: "Active" };
+    getProjectByIdMock.mockReturnValue(activeRow);
+
+    broadcastProjectSwitchUpdates(null, "active");
+
+    expect(broadcastToRendererMock).toHaveBeenCalledTimes(1);
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.PROJECT_UPDATED, activeRow);
+  });
+
+  it("skips the departing broadcast when re-activating the same project", () => {
+    const activeRow = { id: "same", name: "Same" };
+    getProjectByIdMock.mockReturnValue(activeRow);
+
+    broadcastProjectSwitchUpdates("same", "same");
+
+    expect(broadcastToRendererMock).toHaveBeenCalledTimes(1);
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.PROJECT_UPDATED, activeRow);
+  });
+
+  it("silently drops broadcasts when getProjectById returns null", () => {
+    getProjectByIdMock.mockReturnValue(null);
+
+    broadcastProjectSwitchUpdates("prev", "active");
+
+    expect(broadcastToRendererMock).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -53,6 +53,10 @@ vi.mock("../../../services/RunCommandDetector.js", () => ({
 const mockGetWindowForWebContents = vi.fn();
 vi.mock("../../../window/webContentsRegistry.js", () => ({
   getWindowForWebContents: (...args: unknown[]) => mockGetWindowForWebContents(...args),
+  // broadcastProjectSwitchUpdates → broadcastToRenderer → getAllAppWebContents.
+  // Returning [] keeps the broadcast a no-op in this suite; PROJECT_UPDATED
+  // delivery is covered by projectSwitchBroadcast.test.ts.
+  getAllAppWebContents: vi.fn(() => []),
 }));
 
 vi.mock("../../../window/portDistribution.js", () => ({

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -5,6 +5,7 @@ import { distributePortsToView } from "../../../window/portDistribution.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import { scratchStore } from "../../../services/ScratchStore.js";
 import { ProjectSwitchService } from "../../../services/ProjectSwitchService.js";
+import { broadcastProjectSwitchUpdates } from "../../projectSwitchBroadcast.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import {
   sanitizeTerminals,
@@ -179,12 +180,23 @@ async function activateProjectView(
     console.warn("[ProjectSwitch] Failed to clear active scratch:", err);
   }
 
+  // Capture the outgoing project id before the pointer flips so we can
+  // broadcast its bumped `lastOpened` to every cached view (#8561).
+  const previousProjectId = projectStore.getCurrentProjectId();
+
   // Update the main process global state
   await projectStore.setCurrentProject(projectId);
 
   if (options.markActive) {
     projectStore.updateProjectStatus(projectId, "active");
   }
+
+  // Push the persisted `lastOpened`/`status` updates to every renderer.
+  // `setCurrentProject` writes both the departing and activated rows inside a
+  // single transaction but does not emit IPC; without this broadcast, cached
+  // WebContentsView stores keep stale MRU timestamps and the next
+  // `Cmd+Alt+=` / project switcher pick targets the wrong project.
+  broadcastProjectSwitchUpdates(previousProjectId, projectId);
 
   // Reopen requires the workspace host to be resumed BEFORE loadProject so
   // the host is ready to accept worktree IPC from the newly-active view.

--- a/electron/ipc/projectSwitchBroadcast.ts
+++ b/electron/ipc/projectSwitchBroadcast.ts
@@ -1,0 +1,28 @@
+import { CHANNELS } from "./channels.js";
+import { broadcastToRenderer } from "./utils.js";
+import { projectStore } from "../services/ProjectStore.js";
+
+/**
+ * Broadcast `project:updated` for both the departing and newly-active project
+ * after `ProjectStore.setCurrentProject` commits.
+ *
+ * Why: `setCurrentProject` writes both rows inside a single SQLite transaction
+ * but does not emit IPC. Without this broadcast, cached WebContentsView
+ * renderer stores keep stale MRU timestamps and the next `Cmd+Alt+=` /
+ * project switcher pick targets the wrong project. See #8561.
+ *
+ * Reads each row back via `getProjectById` so the payload reflects the
+ * actual persisted state — under write suppression, `lastOpened` may be
+ * unchanged while `status` still flipped, and the broadcast must reflect that.
+ */
+export function broadcastProjectSwitchUpdates(
+  previousProjectId: string | null,
+  activeProjectId: string
+): void {
+  if (previousProjectId && previousProjectId !== activeProjectId) {
+    const prevRow = projectStore.getProjectById(previousProjectId);
+    if (prevRow) broadcastToRenderer(CHANNELS.PROJECT_UPDATED, prevRow);
+  }
+  const activeRow = projectStore.getProjectById(activeProjectId);
+  if (activeRow) broadcastToRenderer(CHANNELS.PROJECT_UPDATED, activeRow);
+}

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -1,6 +1,7 @@
 import { Menu, dialog, BrowserWindow, shell, app, webContents } from "electron";
 import { projectStore } from "./services/ProjectStore.js";
 import { CHANNELS } from "./ipc/channels.js";
+import { broadcastProjectSwitchUpdates } from "./ipc/projectSwitchBroadcast.js";
 import { getEffectiveRegistry } from "../shared/config/agentRegistry.js";
 import type { CliAvailabilityService } from "./services/CliAvailabilityService.js";
 import { isAgentInstalled } from "../shared/utils/agentAvailability.js";
@@ -575,7 +576,14 @@ export async function handleDirectoryOpen(
     const pvm = getProjectViewManager();
     if (pvm) {
       const { view, isNew } = await pvm.switchTo(project.id, project.path);
+      // Capture the outgoing project id before the pointer flips so we can
+      // broadcast its bumped `lastOpened` to every cached view (#8561).
+      const previousProjectId = projectStore.getCurrentProjectId();
       await projectStore.setCurrentProject(project.id);
+      // Mirror the IPC switch path: fan out `project:updated` for both
+      // departing and activated rows so cached views' MRU timestamps stay
+      // fresh; otherwise the next `Cmd+Alt+=` targets the wrong project.
+      broadcastProjectSwitchUpdates(previousProjectId, project.id);
 
       // Re-attach producer ports for cached-view reactivation. The IPC switch
       // handler (projectCrud/switch.ts:activateProjectView) does this in the

--- a/electron/services/ProjectSwitchService.ts
+++ b/electron/services/ProjectSwitchService.ts
@@ -7,6 +7,7 @@ import { gitServiceCache } from "./GitServiceCache.js";
 import { contextInjectionTracker } from "./ContextInjectionTracker.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
+import { broadcastProjectSwitchUpdates } from "../ipc/projectSwitchBroadcast.js";
 import { randomUUID } from "crypto";
 import { store } from "../store.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
@@ -78,6 +79,12 @@ export class ProjectSwitchService {
       // Apply portable project identity from .daintree/project.json if the user
       // hasn't customised the project name/emoji (still has defaults).
       await this.applyInRepoIdentity(project);
+
+      // Fan out the persisted `lastOpened`/`status` flips to every renderer,
+      // including LRU-cached project views. PROJECT_ON_SWITCH below only
+      // carries the active project; the departing project's bumped
+      // `lastOpened` would otherwise stay stale in cached stores (#8561).
+      broadcastProjectSwitchUpdates(previousProjectId, projectId);
 
       const updatedProject = projectStore.getProjectById(projectId);
       if (!updatedProject) {

--- a/electron/services/__tests__/ProjectSwitchService.test.ts
+++ b/electron/services/__tests__/ProjectSwitchService.test.ts
@@ -327,7 +327,13 @@ describe("ProjectSwitchService", () => {
 
     await service.switchProject("project-new");
 
-    const payload = sendToRendererMock.mock.calls[0][1];
+    // Use channel-aware lookup: broadcastProjectSwitchUpdates now fires
+    // PROJECT_UPDATED for the departing project before PROJECT_ON_SWITCH,
+    // so index 0 is no longer the switch payload.
+    const payload = sendToRendererMock.mock.calls.find(
+      (c: unknown[]) => c[0] === CHANNELS.PROJECT_ON_SWITCH
+    )?.[1];
+    expect(payload).toBeDefined();
     expect(payload.hydrateResult).toBeDefined();
     expect(payload.hydrateResult.settingsRecovery).toBeNull();
     expect(buildSwitchHydrateResultMock).toHaveBeenCalledWith("project-new");
@@ -339,7 +345,10 @@ describe("ProjectSwitchService", () => {
 
     await service.switchProject("project-new");
 
-    const payload = sendToRendererMock.mock.calls[0][1];
+    const payload = sendToRendererMock.mock.calls.find(
+      (c: unknown[]) => c[0] === CHANNELS.PROJECT_ON_SWITCH
+    )?.[1];
+    expect(payload).toBeDefined();
     expect(payload).not.toHaveProperty("hydrateResult");
     expect(payload.project).toMatchObject({ id: "project-new" });
     expect(payload.switchId).toBe("switch-id-1");

--- a/src/hooks/__tests__/useProjectMruSwitcher.test.tsx
+++ b/src/hooks/__tests__/useProjectMruSwitcher.test.tsx
@@ -166,14 +166,15 @@ describe("useProjectMruSwitcher", () => {
     expect(switchProjectMock).toHaveBeenCalledWith("p-recent");
   });
 
-  it("Cmd+Alt+Plus (Shift+Equal) switches forward through MRU", () => {
+  it("Cmd+Shift+Alt+= switches backward through MRU (Shift inverts direction)", () => {
     renderHook(() => useProjectMruSwitcher());
 
     act(() => {
       keyDown("Equal", { shiftKey: true });
     });
 
-    expect(switchProjectMock).toHaveBeenCalledWith("p-recent");
+    // Shift maps to "newer" → least-recently-opened non-current project
+    expect(switchProjectMock).toHaveBeenCalledWith("p-oldest");
   });
 
   it("numpad add switches forward and numpad subtract remains free", () => {

--- a/src/hooks/useProjectMruSwitcher.ts
+++ b/src/hooks/useProjectMruSwitcher.ts
@@ -28,7 +28,9 @@ function consumeEvent(event: KeyboardEvent): void {
 /**
  * Immediate MRU project switcher.
  *
- * Cmd+Alt+=/Plus switches down/forward in MRU order.
+ * `Cmd+Alt+=` cycles forward (most-recent non-current project).
+ * `Cmd+Shift+Alt+=` inverts direction and cycles backward (least-recent
+ * non-current project).
  *
  * Uses capture-phase window listeners so the event fires before xterm's
  * custom key handler and before `KeybindingService` dispatches the matching

--- a/src/hooks/useProjectMruSwitcher.ts
+++ b/src/hooks/useProjectMruSwitcher.ts
@@ -13,7 +13,9 @@ function isEditableTarget(target: EventTarget | null): boolean {
 }
 
 function getTriggerDirection(event: KeyboardEvent): ProjectMruCycleDirection | null {
-  if (event.code === "Equal" || event.code === "NumpadAdd") return "older";
+  if (event.code === "Equal" || event.code === "NumpadAdd") {
+    return event.shiftKey ? "newer" : "older";
+  }
   return null;
 }
 

--- a/src/lib/__tests__/projectMruSwitch.test.ts
+++ b/src/lib/__tests__/projectMruSwitch.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import type { Project } from "@shared/types";
+import { getProjectMruSwitchTarget } from "../projectMruSwitch";
+
+function make(id: string, lastOpened: number, name = id): Project {
+  return {
+    id,
+    path: `/repo/${id}`,
+    name,
+    emoji: "🌲",
+    lastOpened,
+  } as Project;
+}
+
+describe("getProjectMruSwitchTarget", () => {
+  it("returns null when no current project is set", () => {
+    const projects = [make("a", 100), make("b", 200)];
+    expect(getProjectMruSwitchTarget(projects, null, "older")).toBeNull();
+    expect(getProjectMruSwitchTarget(projects, undefined, "newer")).toBeNull();
+  });
+
+  it("returns null when the current project is not in the list", () => {
+    const projects = [make("a", 100), make("b", 200)];
+    expect(getProjectMruSwitchTarget(projects, "ghost", "older")).toBeNull();
+  });
+
+  it("returns null when only the current project exists", () => {
+    const projects = [make("a", 100)];
+    expect(getProjectMruSwitchTarget(projects, "a", "older")).toBeNull();
+    expect(getProjectMruSwitchTarget(projects, "a", "newer")).toBeNull();
+  });
+
+  it("returns the top non-current MRU entry for 'older'", () => {
+    // active is "a" (lastOpened: 300); the most-recent OTHER project is "b".
+    const projects = [make("a", 300), make("b", 200), make("c", 100)];
+    const target = getProjectMruSwitchTarget(projects, "a", "older");
+    expect(target?.id).toBe("b");
+  });
+
+  it("returns the bottom non-current MRU entry for 'newer'", () => {
+    const projects = [make("a", 300), make("b", 200), make("c", 100)];
+    const target = getProjectMruSwitchTarget(projects, "a", "newer");
+    expect(target?.id).toBe("c");
+  });
+
+  it("'older' selects the bumped previous project after a switch (Alt+Tab toggle)", () => {
+    // Simulates the post-switch state after setCurrentProject A→B: A was
+    // bumped to (now - 1), B to now. From B, 'older' must land on A again,
+    // not on the alphabetically-first stale project.
+    const now = 1_000_000;
+    const projects = [
+      make("a", now - 1, "Alpha"),
+      make("b", now, "Bravo"),
+      make("c", now - 50_000, "Charlie"),
+    ];
+    expect(getProjectMruSwitchTarget(projects, "b", "older")?.id).toBe("a");
+  });
+
+  it("breaks ties by name when lastOpened is equal", () => {
+    // Two projects share lastOpened; the name-sort tiebreak picks Alpha
+    // (matches getMruProjects behavior).
+    const projects = [make("a", 100, "Alpha"), make("b", 100, "Bravo"), make("c", 50, "Charlie")];
+    expect(getProjectMruSwitchTarget(projects, "c", "older")?.id).toBe("a");
+  });
+});

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -511,15 +511,12 @@ describe("KeybindingService", () => {
     expect(service.getBinding("terminal.new")?.combo).toBe("Cmd+Alt+T");
   });
 
-  it("binds project MRU plus by default and leaves minus unbound", () => {
+  it("binds project MRU plus (older) and shift+plus (newer) by default; minus stays unbound", () => {
     setPlatform("MacIntel");
     const service = new KeybindingService();
 
     expect(service.getBinding("project.mruCycleOlder")?.combo).toBe("Cmd+Alt+=");
-    expect(service.getBinding("project.mruCycleNewer")).toBeUndefined();
-    expect(
-      DEFAULT_KEYBINDINGS.filter((b) => b.actionId === "project.mruCycleOlder").map((b) => b.combo)
-    ).toContain("Cmd+Shift+Alt+=");
+    expect(service.getBinding("project.mruCycleNewer")?.combo).toBe("Cmd+Shift+Alt+=");
 
     const plus = createKeyboardEvent({
       key: "≠",
@@ -536,7 +533,7 @@ describe("KeybindingService", () => {
       altKey: true,
       shiftKey: true,
     });
-    expect(service.findMatchingAction(shiftedPlus)?.actionId).toBe("project.mruCycleOlder");
+    expect(service.findMatchingAction(shiftedPlus)?.actionId).toBe("project.mruCycleNewer");
 
     const minus = createKeyboardEvent({
       key: "–",

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -805,11 +805,11 @@ const CORE_KEYBINDINGS: KeybindingConfig[] = [
     category: "Project",
   },
   {
-    actionId: "project.mruCycleOlder",
+    actionId: "project.mruCycleNewer",
     combo: "Cmd+Shift+Alt+=",
     scope: "global",
     priority: 10,
-    description: "Switch project forward",
+    description: "Switch project backward",
     category: "Project",
   },
   {


### PR DESCRIPTION
## Summary

- Project switch operations never broadcast a `project:updated` event, so LRU-cached views kept stale `lastOpened` data. This made `Cmd+Alt+=` jump to the wrong project and the switcher palette highlight the wrong default.
- Adds the broadcast at all three switch entry points: `activateProjectView` in `switch.ts`, `ProjectSwitchService.performSwitch`, and the `handleDirectoryOpen` path in `menu.ts`.
- Fixes a duplicate keybinding where `Cmd+Shift+Alt+=` was bound to `project.mruCycleOlder` twice; the shifted binding now correctly targets `project.mruCycleNewer`. `useProjectMruSwitcher` also now checks `shiftKey` and returns the `"newer"` direction when held.

Resolves #8561

## Changes

- `electron/ipc/projectSwitchBroadcast.ts` (new) — shared helper that re-reads both the departing and incoming project rows after `setCurrentProject` commits and fans out `CHANNELS.PROJECT_UPDATED` to all cached views
- `electron/ipc/handlers/projectCrud/switch.ts`, `electron/services/ProjectSwitchService.ts`, `electron/menu.ts` — wired to the broadcast helper
- `src/services/defaultKeybindings.ts` — second `Cmd+Shift+Alt+=` binding changed from `project.mruCycleOlder` to `project.mruCycleNewer`
- `src/hooks/useProjectMruSwitcher.ts` — `getTriggerDirection` returns `"newer"` when `shiftKey` is held

## Testing

- New unit tests for `projectSwitchBroadcast` (4 cases covering both rows, write-suppressed path, and null previous project)
- New unit tests for `projectMruSwitch` logic (7 cases)
- Updated `KeybindingService.test.ts`, `project.switch.test.ts`, `ProjectSwitchService.test.ts`, and `useProjectMruSwitcher.test.tsx` to reflect the changes