### PR TITLE
refactor(ipc): convert gitClone raw ipcMain.handle to defineIpcNamespace

### DIFF
--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -7,13 +7,9 @@ import {
   type ChildProcessWithoutNullStreams,
 } from "child_process";
 import { CHANNELS } from "../../channels.js";
+import { defineIpcNamespace, op } from "../../define.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
-import {
-  broadcastToRenderer,
-  sendToRenderer,
-  typedHandle,
-  typedHandleWithContext,
-} from "../../utils.js";
+import { broadcastToRenderer, sendToRenderer } from "../../utils.js";
 import { createAuthenticatedGit } from "../../../utils/hardenedGit.js";
 import { parseGitHubRepoUrl } from "../../../services/github/index.js";
 import type {
@@ -241,8 +237,6 @@ function killCloneProcessTree(pid: number | undefined): void {
 }
 
 export function registerGitCloneHandlers(): () => void {
-  const handlers: Array<() => void> = [];
-
   // Track every in-flight clone so cancel aborts each one independently.
   // Electron's ipcMain.handle permits concurrent invocations from multiple
   // senders; sharing a single controller would let a later clone overwrite an
@@ -454,7 +448,6 @@ export function registerGitCloneHandlers(): () => void {
       activeControllers.delete(localController);
     }
   };
-  handlers.push(typedHandleWithContext(CHANNELS.PROJECT_CLONE_REPO, handleProjectCloneRepo));
 
   const handleProjectCloneCancel = async (): Promise<void> => {
     // Cancel every in-flight clone. The renderer's clone dialog is the only
@@ -464,7 +457,12 @@ export function registerGitCloneHandlers(): () => void {
       controller.abort();
     }
   };
-  handlers.push(typedHandle(CHANNELS.PROJECT_CLONE_CANCEL, handleProjectCloneCancel));
 
-  return () => handlers.forEach((cleanup) => cleanup());
+  return defineIpcNamespace({
+    name: "gitClone",
+    ops: {
+      cloneRepo: op(CHANNELS.PROJECT_CLONE_REPO, handleProjectCloneRepo, { withContext: true }),
+      cancelClone: op(CHANNELS.PROJECT_CLONE_CANCEL, handleProjectCloneCancel),
+    },
+  }).register();
 }

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -314,6 +314,14 @@ export interface GeneratedIpcInvokeMap {
     args: [payload: import("../portal.js").PortalShowNewTabMenuPayload];
     result: void;
   };
+  "project:clone-cancel": {
+    args: [];
+    result: void;
+  };
+  "project:clone-repo": {
+    args: [options: import("./gitClone.js").CloneRepoOptions];
+    result: import("./gitClone.js").CloneRepoResult;
+  };
   "scratch:create": {
     args: [name?: string | undefined];
     result: import("../scratch.js").Scratch;


### PR DESCRIPTION
## Summary

- Converts `gitClone.ts` from raw `ipcMain.handle` calls to `defineIpcNamespace({ name: "gitClone", ops: { cloneRepo, cancelClone } })` — the main conversion target from issue #8570
- `accessibility.ts` was already fully migrated (no change needed); `plugin.ts` has one intentional raw `ipcMain.handle` for `plugin:invoke` that can't be expressed through `IpcInvokeMap` due to variadic `...args: unknown[]` and senderFrame URL trust checking — both files are documented inline
- The mutable `activeControllers` Set is kept inside the factory for per-call isolation rather than as a module-level global

Resolves #8570

## Changes

- `electron/ipc/handlers/projectCrud/gitClone.ts` — wrapped in `defineIpcNamespace`; `project:clone-repo` and `project:clone-cancel` channels were already in `IpcInvokeMap` so no map edits were needed
- `shared/types/ipc/generated.ts` — regenerated; namespace scan now picks up both channels
- No changes to `accessibility.ts` or `plugin.ts` (both have inline comments explaining the status)

## Testing

- 16/16 passing in both `gitClone` test suites
- Full verify pipeline clean: typecheck, channel drift check, IPC map gen, help prompts, lint ratchet, format, build