### PR TITLE
fix(ipc): preserve GitOperationError metadata across contextBridge

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -521,6 +521,45 @@ function _reconstructAppError(serialized: {
   return error;
 }
 
+/**
+ * Reconstruct `GitOperationError` thrown in the main process. Same realm-
+ * boundary stripping as `_reconstructAppError`: contextBridge clones the Error
+ * and discards `gitReason`, `leaseSha`, and `branchName`. The renderer decodes
+ * this prefix via `isClientGitError` (`src/utils/clientGitError.ts`).
+ *
+ * Optional fields use a fixed three-slot positional layout so the renderer
+ * regex always matches; absent fields are empty between the pipes. `leaseSha`
+ * is hex (URL-safe) but encoded for consistency with `branchName`, which can
+ * contain `/` and other ref characters.
+ *
+ * Format: `[GitError|<reason>|<urlencoded leaseSha>|<urlencoded branchName>] <original message>`
+ */
+function _reconstructGitError(serialized: {
+  name: string;
+  message: string;
+  gitReason?: string;
+  leaseSha?: string;
+  branchName?: string;
+}): Error {
+  const reason = serialized.gitReason ?? "unknown";
+  const leaseShaPart = encodeURIComponent(serialized.leaseSha ?? "");
+  const branchNamePart = encodeURIComponent(serialized.branchName ?? "");
+  const encoded = `[GitError|${reason}|${leaseShaPart}|${branchNamePart}] ${serialized.message}`;
+  const error = new Error(encoded);
+  // Standard properties — set for callers in the same realm. They don't
+  // survive the contextBridge crossing; the message prefix is the source
+  // of truth on the renderer side.
+  error.name = "GitOperationError";
+  (error as Error & { gitReason: string }).gitReason = reason;
+  if (serialized.leaseSha !== undefined) {
+    (error as Error & { leaseSha: string }).leaseSha = serialized.leaseSha;
+  }
+  if (serialized.branchName !== undefined) {
+    (error as Error & { branchName: string }).branchName = serialized.branchName;
+  }
+  return error;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches ipcRenderer.invoke return type
 async function _unwrappingInvoke(channel: string, ...args: unknown[]): Promise<any> {
   const response = await ipcRenderer.invoke(channel, ...args);
@@ -529,6 +568,9 @@ async function _unwrappingInvoke(channel: string, ...args: unknown[]): Promise<a
       const serialized = response.error;
       if (serialized.name === "AppError" && typeof serialized.code === "string") {
         throw _reconstructAppError(serialized);
+      }
+      if (serialized.name === "GitOperationError" && typeof serialized.gitReason === "string") {
+        throw _reconstructGitError(serialized);
       }
       throw deserializeError(serialized);
     }

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -14,6 +14,7 @@ import { validateFolderName } from "@shared/utils/folderName";
 import { isGitHubRemoteUrl } from "@shared/utils/githubUrl";
 import type { CloneRepoProgressEvent } from "@shared/types/ipc/gitClone";
 import type { GitOperationReason } from "@shared/types/ipc/errors";
+import { isClientGitError } from "@/utils/clientGitError";
 
 interface CloneError {
   message: string;
@@ -168,11 +169,12 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
       // CANCELLED is the user aborting via the cancel button — not a failure.
       const code = (err as { code?: string })?.code;
       if (code !== "CANCELLED") {
-        // `gitReason` is reattached duck-typed across the IPC realm boundary
-        // (see `deserializeError` in shared/utils/ipcErrorSerialization.ts);
-        // `instanceof GitOperationError` would fail here.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- intentional duck-type read across IPC realm
-        const gitReason = (err as { gitReason?: GitOperationReason })?.gitReason;
+        // Decode the preload-injected `[GitError|...]` message prefix so we
+        // can branch on `gitReason`. contextBridge strips own Error properties
+        // when the preload's reconstructed error crosses to the renderer, so
+        // the prefix is the only reliable carrier; `isClientGitError` decodes
+        // it and reattaches `gitReason` onto the error.
+        const gitReason = isClientGitError(err) ? err.gitReason : undefined;
         setError({
           message: formatErrorMessage(err, "Failed to clone repository"),
           gitReason,

--- a/src/components/Worktree/ReviewHub/__tests__/reviewHubUtils.test.ts
+++ b/src/components/Worktree/ReviewHub/__tests__/reviewHubUtils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { readGitErrorFields } from "../reviewHubUtils";
+
+describe("readGitErrorFields", () => {
+  it("decodes the preload's prefix when no own properties survive (post-contextBridge)", () => {
+    // Simulates the renderer side of the bridge: only `message` and `stack`
+    // crossed, custom Error properties were stripped. The doc comment claim
+    // before #8567 said the properties survived — they did not. The fix is
+    // that the prefix on `message` carries the discriminant.
+    const err = new Error(
+      "[GitError|push-rejected-outdated|deadbeef|feature%2Fmy-branch] rejected"
+    );
+    expect(readGitErrorFields(err)).toEqual({
+      gitReason: "push-rejected-outdated",
+      leaseSha: "deadbeef",
+      branchName: "feature/my-branch",
+    });
+  });
+
+  it("returns gitReason but no leaseSha/branchName when the slots are empty", () => {
+    const err = new Error("[GitError|auth-failed||] auth refused");
+    expect(readGitErrorFields(err)).toEqual({
+      gitReason: "auth-failed",
+      leaseSha: undefined,
+      branchName: undefined,
+    });
+  });
+
+  it("reads same-realm errors that already carry the fields as own properties", () => {
+    // A test mock or main-process-side throw in the same realm — the properties
+    // survive and isClientGitError's fallback recognises them.
+    const err = Object.assign(new Error("rejected"), {
+      name: "GitOperationError",
+      gitReason: "push-rejected-outdated",
+      leaseSha: "abc123",
+      branchName: "main",
+    });
+    expect(readGitErrorFields(err)).toEqual({
+      gitReason: "push-rejected-outdated",
+      leaseSha: "abc123",
+      branchName: "main",
+    });
+  });
+
+  it("returns empty object for non-Error inputs", () => {
+    expect(readGitErrorFields(null)).toEqual({});
+    expect(readGitErrorFields(undefined)).toEqual({});
+    expect(readGitErrorFields("oops")).toEqual({});
+    expect(readGitErrorFields(42)).toEqual({});
+  });
+
+  it("returns empty object for a plain Error with no prefix and no own properties", () => {
+    const err = new Error("just a message");
+    expect(readGitErrorFields(err)).toEqual({
+      gitReason: undefined,
+      leaseSha: undefined,
+      branchName: undefined,
+    });
+  });
+});

--- a/src/components/Worktree/ReviewHub/__tests__/reviewHubUtils.test.ts
+++ b/src/components/Worktree/ReviewHub/__tests__/reviewHubUtils.test.ts
@@ -47,6 +47,10 @@ describe("readGitErrorFields", () => {
     expect(readGitErrorFields(undefined)).toEqual({});
     expect(readGitErrorFields("oops")).toEqual({});
     expect(readGitErrorFields(42)).toEqual({});
+    // Plain object with the right shape — still not an Error instance.
+    // Tightening to instanceof Error keeps the surface area to actual thrown
+    // errors and prevents accidental coercion of unrelated payloads.
+    expect(readGitErrorFields({ gitReason: "push-rejected-outdated", leaseSha: "x" })).toEqual({});
   });
 
   it("returns empty object for a plain Error with no prefix and no own properties", () => {

--- a/src/components/Worktree/ReviewHub/reviewHubUtils.ts
+++ b/src/components/Worktree/ReviewHub/reviewHubUtils.ts
@@ -1,6 +1,7 @@
 import type { GitStatus, StagingFileEntry } from "@shared/types";
 import type { GitOperationReason } from "@shared/types/ipc/errors";
 import { getGitRecoveryHint } from "@shared/utils/gitOperationErrors";
+import { isClientGitError } from "@/utils/clientGitError";
 
 export type DiffMode = "working-tree" | "base-branch";
 
@@ -140,9 +141,13 @@ export const PUSH_BANNER_CONFIGS: Record<GitOperationReason, PushBannerConfig> =
 /**
  * Pulls the divergence-recovery fields off a thrown value. `GitOperationError`
  * promotes `gitReason`/`leaseSha`/`branchName` to top-level fields on the
- * serialized error envelope (`SerializedError`), and the preload's
- * `_unwrappingInvoke` reattaches them onto the reconstructed Error before it
- * reaches the renderer. Each field is runtime-checked before use.
+ * serialized error envelope (`SerializedError`), but Electron's contextBridge
+ * strips own Error properties when the preload's reconstructed error crosses
+ * the preload→renderer realm. The preload encodes the discriminant fields
+ * into a `[GitError|<reason>|<leaseSha>|<branchName>]` message prefix;
+ * {@link isClientGitError} decodes it and side-effects the fields back onto
+ * the error. Same-realm throws (renderer tests, no contextBridge crossing)
+ * fall through to the duck-typed reads below.
  */
 export function readGitErrorFields(err: unknown): {
   gitReason?: GitOperationReason;
@@ -150,6 +155,7 @@ export function readGitErrorFields(err: unknown): {
   branchName?: string;
 } {
   if (typeof err !== "object" || err === null) return {};
+  isClientGitError(err);
   const gitReason = Reflect.get(err, "gitReason");
   const leaseSha = Reflect.get(err, "leaseSha");
   const branchName = Reflect.get(err, "branchName");

--- a/src/components/Worktree/ReviewHub/reviewHubUtils.ts
+++ b/src/components/Worktree/ReviewHub/reviewHubUtils.ts
@@ -154,7 +154,7 @@ export function readGitErrorFields(err: unknown): {
   leaseSha?: string;
   branchName?: string;
 } {
-  if (typeof err !== "object" || err === null) return {};
+  if (!(err instanceof Error)) return {};
   isClientGitError(err);
   const gitReason = Reflect.get(err, "gitReason");
   const leaseSha = Reflect.get(err, "leaseSha");

--- a/src/utils/__tests__/clientGitError.test.ts
+++ b/src/utils/__tests__/clientGitError.test.ts
@@ -69,6 +69,13 @@ describe("isClientGitError", () => {
     expect(err.message).toBe("[GitError|PUSH_REJECTED||] something");
   });
 
+  it("returns false for a reason containing underscores or digits (regex boundary)", () => {
+    const errUnderscore = new Error("[GitError|push_rejected||] msg");
+    expect(isClientGitError(errUnderscore)).toBe(false);
+    const errDigits = new Error("[GitError|reason42||] msg");
+    expect(isClientGitError(errDigits)).toBe(false);
+  });
+
   it("recognises a same-realm ClientGitError without a prefix", () => {
     const err = new ClientGitError("auth-failed", "fell over", undefined, undefined);
     expect(isClientGitError(err)).toBe(true);

--- a/src/utils/__tests__/clientGitError.test.ts
+++ b/src/utils/__tests__/clientGitError.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { ClientGitError, isClientGitError } from "../clientGitError";
+
+describe("isClientGitError", () => {
+  it("decodes prefix-encoded errors and restores name/gitReason/message", () => {
+    const err = new Error("[GitError|push-rejected-outdated|deadbeef|main] rejected");
+    expect(isClientGitError(err)).toBe(true);
+    expect(err.name).toBe("GitOperationError");
+    expect((err as Error & { gitReason: string }).gitReason).toBe("push-rejected-outdated");
+    expect((err as Error & { leaseSha?: string }).leaseSha).toBe("deadbeef");
+    expect((err as Error & { branchName?: string }).branchName).toBe("main");
+    expect(err.message).toBe("rejected");
+  });
+
+  it("decodes branch names containing slashes (urlencoded as %2F)", () => {
+    const err = new Error("[GitError|push-rejected-outdated|abc123|feature%2Fmy-branch] rejection");
+    expect(isClientGitError(err)).toBe(true);
+    expect((err as Error & { branchName?: string }).branchName).toBe("feature/my-branch");
+    expect(err.message).toBe("rejection");
+  });
+
+  it("decodes branch names containing pipes and brackets (urlencoded)", () => {
+    const branch = "weird|name]with[chars";
+    const encoded = encodeURIComponent(branch);
+    const err = new Error(`[GitError|auth-failed||${encoded}] auth error`);
+    expect(isClientGitError(err)).toBe(true);
+    expect((err as Error & { branchName?: string }).branchName).toBe(branch);
+    expect(err.message).toBe("auth error");
+  });
+
+  it("treats empty leaseSha / branchName slots as undefined", () => {
+    const err = new Error("[GitError|auth-failed||] auth refused");
+    expect(isClientGitError(err)).toBe(true);
+    expect((err as Error & { gitReason: string }).gitReason).toBe("auth-failed");
+    expect((err as Error & { leaseSha?: string }).leaseSha).toBeUndefined();
+    expect((err as Error & { branchName?: string }).branchName).toBeUndefined();
+    expect(err.message).toBe("auth refused");
+  });
+
+  it("treats only one optional slot present", () => {
+    const err = new Error("[GitError|push-rejected-outdated|sha123|] no branch");
+    expect(isClientGitError(err)).toBe(true);
+    expect((err as Error & { leaseSha?: string }).leaseSha).toBe("sha123");
+    expect((err as Error & { branchName?: string }).branchName).toBeUndefined();
+  });
+
+  it("decodes multi-line messages (regex /s flag)", () => {
+    const err = new Error("[GitError|hook-rejected||] line one\nline two");
+    expect(isClientGitError(err)).toBe(true);
+    expect(err.message).toBe("line one\nline two");
+  });
+
+  it("returns false for a plain Error without the prefix", () => {
+    const err = new Error("nothing to see here");
+    expect(isClientGitError(err)).toBe(false);
+    expect(err.message).toBe("nothing to see here");
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isClientGitError(null)).toBe(false);
+    expect(isClientGitError(undefined)).toBe(false);
+    expect(isClientGitError("string error")).toBe(false);
+    expect(isClientGitError({ message: "fake" })).toBe(false);
+  });
+
+  it("returns false for a malformed prefix (uppercase reason)", () => {
+    const err = new Error("[GitError|PUSH_REJECTED||] something");
+    expect(isClientGitError(err)).toBe(false);
+    expect(err.message).toBe("[GitError|PUSH_REJECTED||] something");
+  });
+
+  it("recognises a same-realm ClientGitError without a prefix", () => {
+    const err = new ClientGitError("auth-failed", "fell over", undefined, undefined);
+    expect(isClientGitError(err)).toBe(true);
+    expect(err.gitReason).toBe("auth-failed");
+    expect(err.message).toBe("fell over");
+  });
+
+  it("recognises a duck-typed same-realm error (name + gitReason)", () => {
+    const err = Object.assign(new Error("fell over"), {
+      name: "GitOperationError",
+      gitReason: "auth-failed",
+    });
+    expect(isClientGitError(err)).toBe(true);
+  });
+
+  it("is idempotent — second call uses the same-realm fallback after the prefix is stripped", () => {
+    const err = new Error("[GitError|auth-failed|sha|branch] original");
+    expect(isClientGitError(err)).toBe(true);
+    expect(err.message).toBe("original");
+    // Second call no longer sees the prefix but the side-effects make the
+    // same-realm fallback succeed.
+    expect(isClientGitError(err)).toBe(true);
+    expect(err.message).toBe("original");
+    expect((err as Error & { gitReason: string }).gitReason).toBe("auth-failed");
+  });
+
+  it("tolerates malformed percent-encoding without throwing", () => {
+    const err = new Error("[GitError|auth-failed|%GG|main] msg");
+    expect(() => isClientGitError(err)).not.toThrow();
+    expect(isClientGitError(err)).toBe(true);
+    // Falls back to the raw encoded string when decodeURIComponent throws.
+    expect((err as Error & { leaseSha?: string }).leaseSha).toBe("%GG");
+  });
+});

--- a/src/utils/clientGitError.ts
+++ b/src/utils/clientGitError.ts
@@ -1,0 +1,101 @@
+import type { GitOperationReason } from "../../shared/types/ipc/errors";
+
+/**
+ * Renderer-side mirror of the main-process `GitOperationError`. Reconstructed
+ * by the preload's `_unwrappingInvoke` when an IPC handler throws a
+ * `GitOperationError`, so callers can branch on the discriminated `gitReason`
+ * (and the divergence-recovery `leaseSha`/`branchName`) instead of substring-
+ * matching `e.message`.
+ *
+ * `instanceof ClientGitError` is unreliable across the contextBridge realm
+ * boundary — use the {@link isClientGitError} guard, which decodes the
+ * `[GitError|<reason>|<urlencoded leaseSha>|<urlencoded branchName>] message`
+ * prefix that the preload sets on `e.message`. Electron's contextBridge strips
+ * ALL custom properties on Error instances (including own `name`) when an
+ * error crosses the preload→renderer realm, so the prefix is the only reliable
+ * carrier for the discriminant fields.
+ */
+export class ClientGitError extends Error {
+  readonly gitReason: GitOperationReason;
+  readonly leaseSha?: string;
+  readonly branchName?: string;
+
+  constructor(
+    gitReason: GitOperationReason,
+    message: string,
+    leaseSha?: string,
+    branchName?: string
+  ) {
+    super(message);
+    this.name = "GitOperationError";
+    this.gitReason = gitReason;
+    if (leaseSha !== undefined) this.leaseSha = leaseSha;
+    if (branchName !== undefined) this.branchName = branchName;
+    Object.setPrototypeOf(this, ClientGitError.prototype);
+  }
+}
+
+// Matches the prefix injected by the preload's `_reconstructGitError`.
+// Group 1: gitReason (lowercase kebab — `GitOperationReason` union).
+// Group 2: urlencoded leaseSha (may be empty when absent).
+// Group 3: urlencoded branchName (may be empty when absent).
+// Group 4: the original human-readable message after the closing `]`.
+// Encoded fields contain no literal `|` or `]` (encodeURIComponent escapes
+// them as `%7C`/`%5D`), so the positional character classes are safe.
+const ENCODED_GIT_ERROR_PATTERN = /^\[GitError\|([a-z-]+)\|([^|]*)\|([^\]]*)\] (.*)$/s;
+
+function decodeOptional(encoded: string): string | undefined {
+  if (encoded === "") return undefined;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
+}
+
+/**
+ * Realm-safe guard. Decodes the `[GitError|<reason>|<leaseSha>|<branchName>]`
+ * prefix that the preload sets when an IPC handler throws a
+ * `GitOperationError`, and as a side effect attaches `name`, `gitReason`,
+ * `leaseSha`, `branchName`, and the cleaned `message` back onto the error so
+ * callers can read them directly.
+ *
+ * Idempotent — after the first call the prefix is stripped from `e.message`,
+ * so a second call goes through the same-realm fallback and returns the same
+ * result.
+ *
+ * Falls back to duck-typing on `name === "GitOperationError" && typeof gitReason === "string"`
+ * for errors that originate inside the renderer realm (where contextBridge is
+ * not in the path and own properties survive).
+ */
+export function isClientGitError(
+  e: unknown
+): e is Error & { gitReason: GitOperationReason; leaseSha?: string; branchName?: string } {
+  if (!(e instanceof Error)) return false;
+
+  const match = ENCODED_GIT_ERROR_PATTERN.exec(e.message);
+  if (match) {
+    const [, reason, encodedLeaseSha, encodedBranchName, originalMessage] = match;
+    const target = e as Error & {
+      gitReason?: string;
+      leaseSha?: string;
+      branchName?: string;
+    };
+    target.name = "GitOperationError";
+    // GitOperationReason is a closed union; the cast narrows the runtime
+    // string (validated by the regex character class) for downstream consumers.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    target.gitReason = reason as GitOperationReason;
+    const leaseSha = decodeOptional(encodedLeaseSha ?? "");
+    const branchName = decodeOptional(encodedBranchName ?? "");
+    if (leaseSha !== undefined) target.leaseSha = leaseSha;
+    if (branchName !== undefined) target.branchName = branchName;
+    e.message = originalMessage ?? e.message;
+    return true;
+  }
+
+  // Same-realm fallback (no contextBridge crossing).
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- type narrowed by guard checks below
+  const candidate = e as { gitReason?: unknown };
+  return e.name === "GitOperationError" && typeof candidate.gitReason === "string";
+}

--- a/src/utils/clientGitError.ts
+++ b/src/utils/clientGitError.ts
@@ -42,6 +42,11 @@ export class ClientGitError extends Error {
 // Group 4: the original human-readable message after the closing `]`.
 // Encoded fields contain no literal `|` or `]` (encodeURIComponent escapes
 // them as `%7C`/`%5D`), so the positional character classes are safe.
+// `[a-z-]+` constrains the reason group to the lowercase-kebab shape of every
+// `GitOperationReason` union member. A future reason with underscores or
+// digits would fail to decode; the consumer-side `?? "unknown"` fallback
+// (see `readGitErrorFields` callers + `PUSH_BANNER_CONFIGS.unknown`) catches
+// that, but adding the new shape here must remain a coordinated change.
 const ENCODED_GIT_ERROR_PATTERN = /^\[GitError\|([a-z-]+)\|([^|]*)\|([^\]]*)\] (.*)$/s;
 
 function decodeOptional(encoded: string): string | undefined {


### PR DESCRIPTION
## Summary

- `GitOperationError`'s `gitReason`, `leaseSha`, and `branchName` fields were silently dropped when crossing the `contextBridge` boundary — Electron strips own-properties off `Error` objects, leaving only `message` and `stack`. Without `leaseSha`, the force-push-with-lease recovery path in the Review Hub either didn't render or degraded to a plain force push.
- Fixed by encoding those three fields as a structured prefix in `_reconstructGitError` (`electron/preload.cts`), mirroring the existing `AppError` and `BrokerError` boundary patterns. A new `ClientGitError` class and `isClientGitError` guard in `src/utils/clientGitError.ts` decode the prefix back and side-effect the fields onto the error instance.
- Updated `readGitErrorFields` (ReviewHub) and the `CloneRepoDialog` catch handler to call `isClientGitError` before reading the discriminant fields, and fixed the misleading doc comments that claimed the fields were already reattached.

Resolves #8567

## Changes

- `electron/preload.cts` — `_reconstructGitError` encodes `gitReason`/`leaseSha`/`branchName` as a `[GitOperationError|...]` message prefix
- `src/utils/clientGitError.ts` — new `ClientGitError` class + `isClientGitError` guard (mirrors `clientAppError` / `clientBrokerError`)
- `src/components/Worktree/ReviewHub/reviewHubUtils.ts` — `readGitErrorFields` calls `isClientGitError`; doc comment corrected
- `src/components/Project/CloneRepoDialog.tsx` — catch handler calls `isClientGitError` before reading fields

## Testing

23 unit specs added in `src/utils/__tests__/clientGitError.test.ts` and `src/components/Worktree/ReviewHub/__tests__/reviewHubUtils.test.ts`, covering: prefix encode/decode, URL-encoded branch names with `/`, empty optional slots, multi-line messages, regex boundary cases (underscores/digits/uppercase rejected), idempotency, and same-realm fallback (plain `GitOperationError` passing directly without the boundary prefix).