### PR TITLE
refactor(ipc): type-check renderer IPC against IpcInvokeMap

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -560,9 +560,11 @@ function _reconstructGitError(serialized: {
   return error;
 }
 
-// Typed overload: when `channel` is a key of `IpcInvokeMap`, args and result are
-// statically enforced against the central IPC contract. Falls back to a loose
-// signature for the function-value pass-through used by `build*PreloadBindings`.
+// Typed overload: when `channel` is a key of `IpcInvokeMap` and the args match,
+// the result is statically enforced against the central IPC contract. Calls
+// that don't match the typed overload — including the function-value
+// pass-through to `build*PreloadBindings` — fall through to the loose
+// signature below and return `Promise<any>`.
 function _unwrappingInvoke<K extends Extract<keyof IpcInvokeMap, string>>(
   channel: K,
   ...args: IpcInvokeMap[K]["args"]

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -560,6 +560,15 @@ function _reconstructGitError(serialized: {
   return error;
 }
 
+// Typed overload: when `channel` is a key of `IpcInvokeMap`, args and result are
+// statically enforced against the central IPC contract. Falls back to a loose
+// signature for the function-value pass-through used by `build*PreloadBindings`.
+function _unwrappingInvoke<K extends Extract<keyof IpcInvokeMap, string>>(
+  channel: K,
+  ...args: IpcInvokeMap[K]["args"]
+): Promise<IpcInvokeMap[K]["result"]>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- fallback for function-value pass-through to build*PreloadBindings
+function _unwrappingInvoke(channel: string, ...args: unknown[]): Promise<any>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches ipcRenderer.invoke return type
 async function _unwrappingInvoke(channel: string, ...args: unknown[]): Promise<any> {
   const response = await ipcRenderer.invoke(channel, ...args);
@@ -577,13 +586,6 @@ async function _unwrappingInvoke(channel: string, ...args: unknown[]): Promise<a
     return response.data;
   }
   return response;
-}
-
-function _typedInvoke<K extends Extract<keyof IpcInvokeMap, string>>(
-  channel: K,
-  ...args: IpcInvokeMap[K]["args"]
-): Promise<IpcInvokeMap[K]["result"]> {
-  return _unwrappingInvoke(channel, ...args) as Promise<IpcInvokeMap[K]["result"]>;
 }
 
 function _typedOn<K extends Extract<keyof IpcEventMap, string>>(
@@ -974,7 +976,7 @@ const api: ElectronAPI = {
       editor: { id: string; customCommand?: string; customTemplate?: string };
       projectId?: string;
     }) =>
-      _typedInvoke(
+      _unwrappingInvoke(
         CHANNELS.EDITOR_SET_CONFIG,
         payload as import("../shared/types/editor.js").EditorSetConfigPayload
       ),

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -658,7 +658,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * (#7673). Idempotent: a no-op when the stored version is already ≥
      * the requested value.
      */
-    stampVersion(version: number): Promise<AgentSettings>;
+    stampVersion(version: number): Promise<Record<string, unknown>>;
   };
   userAgentRegistry: {
     get(): Promise<import("../userAgentRegistry.js").UserAgentRegistry>;

--- a/src/clients/agentSettingsClient.ts
+++ b/src/clients/agentSettingsClient.ts
@@ -13,7 +13,7 @@ export const agentSettingsClient = {
     return window.electron.agentSettings.reset(agentType);
   },
 
-  stampVersion: (version: number): Promise<AgentSettings> => {
+  stampVersion: (version: number): Promise<Record<string, unknown>> => {
     return window.electron.agentSettings.stampVersion(version);
   },
 } as const;


### PR DESCRIPTION
## Summary

- Adds a typed overload to `_unwrappingInvoke` in `electron/preload.cts` so calls using literal `CHANNELS.X` constants are statically enforced against `IpcInvokeMap` for result types. A fallback overload preserves the function-value pass-through used by `build*PreloadBindings`.
- Removes the now-redundant `_typedInvoke` helper and migrates its single call site to the overloaded `_unwrappingInvoke`.
- Fixes a drift site surfaced by the new overload: `agentSettings.stampVersion` was declared as `Promise<AgentSettings>` in `shared/types/ipc/api.ts` but the handler honestly returns `Record<string, unknown>` (matching `IpcInvokeMap`). The caller in `agentSettingsStore.ts` discards the result. Aligned `api.ts` and `src/clients/agentSettingsClient.ts` accordingly.

Resolves #8568

## Changes

- `electron/preload.cts` — typed overload on `_unwrappingInvoke`; `_typedInvoke` removed
- `shared/types/ipc/api.ts` — `stampVersion` return type corrected to `Record<string, unknown>`
- `src/clients/agentSettingsClient.ts` — aligned to match

## Testing

- `npm run typecheck` — pass
- `npm run check` (typecheck + check:channels + check:ipc + check:help + lint:ratchet + format:check) — pass
- `npm test electron/ipc` — 1180 tests pass
- `npm test src/store/__tests__/agentSettingsStore.adversarial.test.ts src/clients/__tests__` — 88 tests pass

No runtime behaviour changes — this is compile-time enforcement only.