### PR TITLE
chore(zod): migrate off deprecated ZodError.format() and .flatten()

### DIFF
--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -4,6 +4,7 @@ import os from "os";
 import path from "path";
 import { chmod, mkdir, writeFile } from "fs/promises";
 import { pathToFileURL } from "url";
+import { z } from "zod";
 import { CHANNELS } from "../channels.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import {
@@ -222,7 +223,10 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     const parseResult = CopyTreeGeneratePayloadSchema.safeParse(payload);
     if (!parseResult.success) {
-      console.error(`[${traceId}] Invalid CopyTree generate payload:`, parseResult.error.format());
+      console.error(
+        `[${traceId}] Invalid CopyTree generate payload:`,
+        z.prettifyError(parseResult.error)
+      );
       return {
         content: "",
         fileCount: 0,
@@ -284,7 +288,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     if (!parseResult.success) {
       console.error(
         `[${traceId}] Invalid CopyTree generate-and-copy-file payload:`,
-        parseResult.error.format()
+        z.prettifyError(parseResult.error)
       );
       return {
         content: "",
@@ -432,7 +436,10 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     const parseResult = CopyTreeInjectPayloadSchema.safeParse(payload);
     if (!parseResult.success) {
-      console.error(`[${traceId}] Invalid CopyTree inject payload:`, parseResult.error.format());
+      console.error(
+        `[${traceId}] Invalid CopyTree inject payload:`,
+        z.prettifyError(parseResult.error)
+      );
       return {
         content: "",
         fileCount: 0,
@@ -624,7 +631,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     if (!parseResult.success) {
       console.error(
         `[${traceId}] Invalid CopyTree test-config payload:`,
-        parseResult.error.format()
+        z.prettifyError(parseResult.error)
       );
       return {
         includedFiles: 0,

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -105,10 +105,7 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
     try {
       const parseResult = TerminalResizePayloadSchema.safeParse(payload);
       if (!parseResult.success) {
-        console.error(
-          "[IPC] Invalid terminal resize payload:",
-          z.prettifyError(parseResult.error)
-        );
+        console.error("[IPC] Invalid terminal resize payload:", z.prettifyError(parseResult.error));
         return;
       }
 

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -3,6 +3,7 @@
  */
 
 import { ipcMain } from "electron";
+import { z } from "zod";
 import { CHANNELS } from "../../channels.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { TerminalResizePayload } from "../../../types/index.js";
@@ -104,7 +105,10 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
     try {
       const parseResult = TerminalResizePayloadSchema.safeParse(payload);
       if (!parseResult.success) {
-        console.error("[IPC] Invalid terminal resize payload:", parseResult.error.format());
+        console.error(
+          "[IPC] Invalid terminal resize payload:",
+          z.prettifyError(parseResult.error)
+        );
         return;
       }
 

--- a/electron/ipc/utils.ts
+++ b/electron/ipc/utils.ts
@@ -36,7 +36,7 @@ function parseIpcPayload<S extends z.ZodTypeAny>(
 ): z.output<S> {
   const parsed = schema.safeParse(payload);
   if (!parsed.success) {
-    console.error(`[IPC] Validation failed for ${channel}:`, parsed.error.flatten());
+    console.error(`[IPC] Validation failed for ${channel}:`, z.prettifyError(parsed.error));
     throw new ValidationError(channel);
   }
   return parsed.data;

--- a/electron/schemas/external.ts
+++ b/electron/schemas/external.ts
@@ -86,7 +86,7 @@ export function safeParse<T>(schema: z.ZodSchema<T>, value: unknown, context?: s
   const result = schema.safeParse(value);
   if (!result.success) {
     const prefix = context ? `[${context}] ` : "";
-    console.warn(`${prefix}Validation failed:`, result.error.format());
+    console.warn(`${prefix}Validation failed:`, z.prettifyError(result.error));
     return null;
   }
   return result.data;

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -262,7 +262,7 @@ export function filterValidTerminalEntries<T>(
           ? entry.id
           : `index-${i}`;
 
-      const flattened = result.error.flatten();
+      const flattened = z.flattenError(result.error);
       // Log both field errors and form errors for better diagnostics
       const errorDetails =
         Object.keys(flattened.fieldErrors).length > 0
@@ -552,7 +552,7 @@ export function sanitizeTabGroups(
           ? group.id
           : `index-${i}`;
 
-      const flattened = result.error.flatten();
+      const flattened = z.flattenError(result.error);
       const errorDetails =
         Object.keys(flattened.fieldErrors).length > 0
           ? flattened.fieldErrors

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -7,6 +7,7 @@ import {
 import type { AgentPreset } from "../../shared/config/agentRegistry.js";
 import path from "path";
 import fs from "fs/promises";
+import { z } from "zod";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { UTF8_BOM } from "./projectStorePaths.js";
 import { safeRecipeFilename } from "../utils/recipeFilename.js";
@@ -287,7 +288,7 @@ export class ProjectIdentityFiles {
         if (!result.success) {
           console.warn(
             `[ProjectIdentityFiles] Skipping invalid recipe: ${entry.name}`,
-            result.error.flatten()
+            z.prettifyError(result.error)
           );
           continue;
         }

--- a/electron/services/pty/AgentStateService.ts
+++ b/electron/services/pty/AgentStateService.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { events } from "../events.js";
 import { nextAgentState, getStateChangeTimestamp, type AgentEvent } from "../AgentStateMachine.js";
 // AgentState type used implicitly via TerminalInfo.agentState
@@ -224,7 +225,7 @@ export class AgentStateService {
     if (!validatedStateChange.success) {
       console.error(
         "[AgentStateService] Invalid agent:state-changed payload:",
-        validatedStateChange.error.format()
+        z.prettifyError(validatedStateChange.error)
       );
       return false;
     }
@@ -306,7 +307,7 @@ export class AgentStateService {
     } else {
       console.error(
         "[AgentStateService] Invalid agent:completed payload:",
-        validatedCompleted.error.format()
+        z.prettifyError(validatedCompleted.error)
       );
     }
   }
@@ -331,7 +332,7 @@ export class AgentStateService {
     } else {
       console.error(
         "[AgentStateService] Invalid agent:killed payload:",
-        validatedKilled.error.format()
+        z.prettifyError(validatedKilled.error)
       );
     }
   }

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { z } from "zod";
 import type * as pty from "node-pty";
 import type { Terminal as HeadlessTerminalType } from "@xterm/headless";
 import headless from "@xterm/headless";
@@ -483,7 +484,7 @@ export class TerminalProcess {
       } else {
         console.error(
           "[TerminalProcess] Invalid agent:spawned payload:",
-          validatedSpawned.error.format()
+          z.prettifyError(validatedSpawned.error)
         );
       }
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -201,6 +201,18 @@ export default tseslint.config(
           message:
             "Pass __html through createTrustedHTML(value) from @/lib/trustedTypesPolicy instead of a raw string. See #6392.",
         },
+        {
+          // why: ZodError.flatten() and .format() instance methods are
+          // deprecated in Zod 4 and slated for removal in Zod 5. Anchored on
+          // an object named `error` / `err` (single-hop bare ident or tail
+          // of a chain like `result.error.flatten()`) so this does not
+          // collide with Array.prototype.flat() or String.prototype.format.
+          // See #8566.
+          selector:
+            "CallExpression[callee.type='MemberExpression'][callee.property.name=/^(flatten|format)$/]:matches([callee.object.property.name=/^(error|err)$/], [callee.object.name=/^(error|err)$/])",
+          message:
+            "Use z.flattenError(err) (shape-consuming) or z.prettifyError(err) (log-only) instead of deprecated ZodError instance methods .flatten() / .format(). See #8566.",
+        },
       ],
     },
   },
@@ -281,6 +293,18 @@ export default tseslint.config(
             "BinaryExpression[operator=/^(!==|===)$/]:matches([left.name='kind'], [left.property.name='kind'])[right.type='Literal'][right.value=/^(terminal|browser|dev-preview)$/]",
           message:
             "Don't compare panel.kind against string literals. Use registry helpers (panelKindHasPty, panelKindCanRestart) or sanctioned type guards (isPtyPanel, isBrowserPanel, isDevPreviewPanel) from @shared/types/panel. See #7672.",
+        },
+        {
+          // why: ZodError.flatten() and .format() instance methods are
+          // deprecated in Zod 4 and slated for removal in Zod 5. Anchored on
+          // an object named `error` / `err` (single-hop bare ident or tail
+          // of a chain like `result.error.flatten()`) so this does not
+          // collide with Array.prototype.flat() or String.prototype.format.
+          // See #8566.
+          selector:
+            "CallExpression[callee.type='MemberExpression'][callee.property.name=/^(flatten|format)$/]:matches([callee.object.property.name=/^(error|err)$/], [callee.object.name=/^(error|err)$/])",
+          message:
+            "Use z.flattenError(err) (shape-consuming) or z.prettifyError(err) (log-only) instead of deprecated ZodError instance methods .flatten() / .format(). See #8566.",
         },
       ],
     },
@@ -457,6 +481,18 @@ export default tseslint.config(
             "CallExpression[callee.object.name='actionService'][callee.property.name='dispatch'] Property[key.name='source'][value.value='context-menu']",
           message:
             'Don\'t hardcode source:"context-menu" in actionService.dispatch calls. Derive it from React Context via useMenuActionSource() from @/components/ui/menu-source. Suppress with // eslint-disable-next-line no-restricted-syntax -- context-menu-source: ok when the dispatch lives outside a ContextMenu/DropdownMenu Root. See #8322.',
+        },
+        {
+          // why: ZodError.flatten() and .format() instance methods are
+          // deprecated in Zod 4 and slated for removal in Zod 5. Anchored on
+          // an object named `error` / `err` (single-hop bare ident or tail
+          // of a chain like `result.error.flatten()`) so this does not
+          // collide with Array.prototype.flat() or String.prototype.format.
+          // See #8566.
+          selector:
+            "CallExpression[callee.type='MemberExpression'][callee.property.name=/^(flatten|format)$/]:matches([callee.object.property.name=/^(error|err)$/], [callee.object.name=/^(error|err)$/])",
+          message:
+            "Use z.flattenError(err) (shape-consuming) or z.prettifyError(err) (log-only) instead of deprecated ZodError instance methods .flatten() / .format(). See #8566.",
         },
       ],
     },

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -285,7 +285,7 @@ export class ActionService {
         const error: ActionError = {
           code: "VALIDATION_ERROR",
           message: `Invalid arguments for action "${actionId}"`,
-          details: validation.error.format(),
+          details: z.prettifyError(validation.error),
         };
         return { ok: false, error };
       }


### PR DESCRIPTION
## Summary

- Replaces all 15 deprecated `ZodError` instance method calls (`.format()` / `.flatten()`) with the Zod 4 top-level equivalents, ahead of their removal in Zod 5
- 13 log-only sites use `z.prettifyError()` — cleaner output than the nested object `.format()` produced
- 2 shape-consuming sites in `electron/schemas/ipc.ts` (`filterValidTerminalEntries`, `sanitizeTabGroups`) use `z.flattenError()` to preserve the `fieldErrors`/`formErrors` contract downstream callers depend on

Resolves #8566

## Changes

- 13 call sites migrated to `z.prettifyError()`
- 2 call sites migrated to `z.flattenError()` (`electron/schemas/ipc.ts`)
- 5 files gained a new `import { z } from "zod"` (`copyTree.ts`, `terminal/io.ts`, `ProjectIdentityFiles.ts`, `AgentStateService.ts`, `TerminalProcess.ts`)
- `eslint.config.js` — added `no-restricted-syntax` guards on all 3 blocks (electron, src, shared) to prevent regression; messages point to the correct replacements

## Testing

- `npm run check` passes (typecheck, lint, format)
- `vitest` for `electron/schemas` and `ActionService` passes
- Build succeeds