### PR TITLE
refactor(ipc): migrate worktree and terminal namespaces to defineIpcNamespace

### DIFF
--- a/electron/ipc/handlers/terminal/artifacts.ts
+++ b/electron/ipc/handlers/terminal/artifacts.ts
@@ -6,35 +6,31 @@ import { dialog } from "electron";
 import os from "os";
 import path from "path";
 import { CHANNELS } from "../../channels.js";
-import type { HandlerDependencies } from "../../types.js";
-import { typedHandle, typedHandleWithContext } from "../../utils.js";
+import type { HandlerDependencies, IpcContext } from "../../types.js";
+import { defineIpcNamespace, op } from "../../define.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { AppError } from "../../../utils/errorTypes.js";
+import type {
+  SaveArtifactOptions,
+  SaveArtifactResult,
+  ApplyPatchOptions,
+  ApplyPatchResult,
+} from "../../../../shared/types/ipc/agent.js";
 
 export function registerArtifactHandlers(deps: HandlerDependencies): () => void {
   const mainWindow = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
-  const handlers: Array<() => void> = [];
 
   const handleArtifactSaveToFile = async (
-    options: unknown
-  ): Promise<{ filePath: string } | null> => {
-    if (
-      typeof options !== "object" ||
-      options === null ||
-      !("content" in options) ||
-      typeof (options as Record<string, unknown>).content !== "string"
-    ) {
+    options: SaveArtifactOptions
+  ): Promise<SaveArtifactResult | null> => {
+    if (typeof options !== "object" || options === null || typeof options.content !== "string") {
       throw new AppError({
         code: "VALIDATION",
         message: "Invalid saveToFile payload: missing or invalid content",
       });
     }
 
-    const { content, suggestedFilename, cwd } = options as {
-      content: string;
-      suggestedFilename?: string;
-      cwd?: string;
-    };
+    const { content, suggestedFilename, cwd } = options;
 
     if (content.length > 10 * 1024 * 1024) {
       throw new AppError({
@@ -90,19 +86,16 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
       });
     }
   };
-  handlers.push(typedHandle(CHANNELS.ARTIFACT_SAVE_TO_FILE, handleArtifactSaveToFile));
 
   const handleArtifactApplyPatch = async (
-    ctx: import("../../types.js").IpcContext,
-    options: unknown
-  ): Promise<{ modifiedFiles: string[] }> => {
+    ctx: IpcContext,
+    options: ApplyPatchOptions
+  ): Promise<ApplyPatchResult> => {
     if (
       typeof options !== "object" ||
       options === null ||
-      !("patchContent" in options) ||
-      !("cwd" in options) ||
-      typeof (options as Record<string, unknown>).patchContent !== "string" ||
-      typeof (options as Record<string, unknown>).cwd !== "string"
+      typeof options.patchContent !== "string" ||
+      typeof options.cwd !== "string"
     ) {
       throw new AppError({
         code: "VALIDATION",
@@ -110,7 +103,7 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
       });
     }
 
-    const { patchContent, cwd } = options as { patchContent: string; cwd: string };
+    const { patchContent, cwd } = options;
 
     if (patchContent.length > 5 * 1024 * 1024) {
       throw new AppError({
@@ -203,7 +196,15 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
       await fs.unlink(tmpPatchPath).catch(() => {});
     }
   };
-  handlers.push(typedHandleWithContext(CHANNELS.ARTIFACT_APPLY_PATCH, handleArtifactApplyPatch));
+  const namespace = defineIpcNamespace({
+    name: "artifacts",
+    ops: {
+      saveToFile: op(CHANNELS.ARTIFACT_SAVE_TO_FILE, handleArtifactSaveToFile),
+      applyPatch: op(CHANNELS.ARTIFACT_APPLY_PATCH, handleArtifactApplyPatch, {
+        withContext: true,
+      }),
+    },
+  });
 
-  return () => handlers.forEach((cleanup) => cleanup());
+  return namespace.register();
 }

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -9,7 +9,7 @@ import type { TerminalResizePayload } from "../../../types/index.js";
 import { TerminalResizePayloadSchema } from "../../../schemas/ipc.js";
 import type { PtyHostActivityTier } from "../../../../shared/types/pty-host.js";
 import { normalizeObservedTitle } from "../../../../shared/utils/isUselessTitle.js";
-import { typedHandle } from "../../utils.js";
+import { defineIpcNamespace, op } from "../../define.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { AppError } from "../../../utils/errorTypes.js";
 
@@ -88,7 +88,7 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
     ipcMain.removeListener(CHANNELS.TERMINAL_BROADCAST_WRITE, handleTerminalBroadcastWrite)
   );
 
-  const handleTerminalSubmit = async (id: string, text: string) => {
+  const handleTerminalSubmit = async (id: string, text: string): Promise<void> => {
     try {
       if (typeof id !== "string" || typeof text !== "string") {
         throw new Error("Invalid terminal submit parameters");
@@ -99,7 +99,6 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
       throw new Error(`Failed to submit to terminal: ${errorMessage}`);
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_SUBMIT, handleTerminalSubmit));
 
   const handleTerminalResize = (_event: Electron.IpcMainEvent, payload: TerminalResizePayload) => {
     try {
@@ -227,7 +226,15 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
       });
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_FORCE_RESUME, handleTerminalForceResume));
+
+  const namespace = defineIpcNamespace({
+    name: "terminalIo",
+    ops: {
+      submit: op(CHANNELS.TERMINAL_SUBMIT, handleTerminalSubmit),
+      forceResume: op(CHANNELS.TERMINAL_FORCE_RESUME, handleTerminalForceResume),
+    },
+  });
+  handlers.push(namespace.register());
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -6,12 +6,8 @@ import crypto from "crypto";
 import os from "os";
 import { z } from "zod";
 import { CHANNELS } from "../../channels.js";
-import {
-  waitForRateLimitSlot,
-  consumeRestoreQuota,
-  typedHandle,
-  typedHandleValidated,
-} from "../../utils.js";
+import { waitForRateLimitSlot, consumeRestoreQuota } from "../../utils.js";
+import { defineIpcNamespace, op, opValidated } from "../../define.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import { mcpServerService } from "../../../services/McpServerService.js";
 import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js";
@@ -40,7 +36,6 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
   if (!ptyClient) {
     return () => {};
   }
-  const handlers: Array<() => void> = [];
 
   const handleTerminalSpawn = async (
     validatedOptions: ValidatedTerminalSpawnOptions
@@ -448,11 +443,8 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       throw new Error(`Failed to spawn terminal: ${errorMessage}`);
     }
   };
-  handlers.push(
-    typedHandleValidated(CHANNELS.TERMINAL_SPAWN, TerminalSpawnOptionsSchema, handleTerminalSpawn)
-  );
 
-  const handleTerminalKill = async (id: string) => {
+  const handleTerminalKill = async (id: string): Promise<void> => {
     try {
       if (typeof id !== "string") {
         throw new Error("Invalid terminal ID: must be a string");
@@ -463,7 +455,6 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       throw new Error(`Failed to kill terminal: ${errorMessage}`);
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_KILL, handleTerminalKill));
 
   const handleTerminalGracefulKill = async (id: string): Promise<string | null> => {
     if (typeof id !== "string") {
@@ -471,9 +462,8 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     }
     return ptyClient.gracefulKill(id);
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_GRACEFUL_KILL, handleTerminalGracefulKill));
 
-  const handleTerminalTrash = async (id: string) => {
+  const handleTerminalTrash = async (id: string): Promise<void> => {
     try {
       if (typeof id !== "string") {
         throw new Error("Invalid terminal ID: must be a string");
@@ -484,7 +474,6 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       throw new Error(`Failed to trash terminal: ${errorMessage}`);
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_TRASH, handleTerminalTrash));
 
   const handleTerminalRestore = async (id: string): Promise<boolean> => {
     try {
@@ -497,24 +486,34 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       throw new Error(`Failed to restore terminal: ${errorMessage}`);
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_RESTORE, handleTerminalRestore));
 
-  const handleTerminalRestartService = async () => {
+  const handleTerminalRestartService = async (): Promise<void> => {
     ptyClient.manualRestart();
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_RESTART_SERVICE, handleTerminalRestartService));
 
   const handleAgentSessionList = async (payload: { worktreeId?: string }) => {
     const { app } = await import("electron");
     return listAgentSessions(payload?.worktreeId, app.getPath("userData"));
   };
-  handlers.push(typedHandle(CHANNELS.AGENT_SESSION_LIST, handleAgentSessionList));
 
-  const handleAgentSessionClear = async (payload: { worktreeId?: string }) => {
+  const handleAgentSessionClear = async (payload: { worktreeId?: string }): Promise<void> => {
     const { app } = await import("electron");
     await clearAgentSessions(payload?.worktreeId, app.getPath("userData"));
   };
-  handlers.push(typedHandle(CHANNELS.AGENT_SESSION_CLEAR, handleAgentSessionClear));
 
-  return () => handlers.forEach((cleanup) => cleanup());
+  const namespace = defineIpcNamespace({
+    name: "terminalLifecycle",
+    ops: {
+      spawn: opValidated(CHANNELS.TERMINAL_SPAWN, TerminalSpawnOptionsSchema, handleTerminalSpawn),
+      kill: op(CHANNELS.TERMINAL_KILL, handleTerminalKill),
+      gracefulKill: op(CHANNELS.TERMINAL_GRACEFUL_KILL, handleTerminalGracefulKill),
+      trash: op(CHANNELS.TERMINAL_TRASH, handleTerminalTrash),
+      restore: op(CHANNELS.TERMINAL_RESTORE, handleTerminalRestore),
+      restartService: op(CHANNELS.TERMINAL_RESTART_SERVICE, handleTerminalRestartService),
+      agentSessionList: op(CHANNELS.AGENT_SESSION_LIST, handleAgentSessionList),
+      agentSessionClear: op(CHANNELS.AGENT_SESSION_CLEAR, handleAgentSessionClear),
+    },
+  });
+
+  return namespace.register();
 }

--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -8,7 +8,7 @@ import type { HandlerDependencies } from "../../types.js";
 import { TerminalReplayHistoryPayloadSchema } from "../../../schemas/index.js";
 import { logDebug, logInfo, logWarn } from "../../../utils/logger.js";
 import { getAgentAvailabilityStore } from "../../../services/AgentAvailabilityStore.js";
-import { typedHandle, typedHandleValidated } from "../../utils.js";
+import { defineIpcNamespace, op, opValidated } from "../../define.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 
 type ValidatedReplayHistoryPayload = z.output<typeof TerminalReplayHistoryPayloadSchema>;
@@ -18,7 +18,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
   if (!ptyClient) {
     return () => {};
   }
-  const handlers: Array<() => void> = [];
 
   const handleTerminalWake = async (
     id: string
@@ -33,7 +32,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to wake terminal: ${errorMessage}`);
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_WAKE, handleTerminalWake));
 
   const handleTerminalGetSerializedState = async (terminalId: string): Promise<string | null> => {
     try {
@@ -54,9 +52,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to get serialized terminal state: ${errorMessage}`);
     }
   };
-  handlers.push(
-    typedHandle(CHANNELS.TERMINAL_GET_SERIALIZED_STATE, handleTerminalGetSerializedState)
-  );
 
   const handleTerminalGetSerializedStates = async (
     terminalIds: string[]
@@ -94,9 +89,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
 
     return Object.fromEntries(results);
   };
-  handlers.push(
-    typedHandle(CHANNELS.TERMINAL_GET_SERIALIZED_STATES, handleTerminalGetSerializedStates)
-  );
 
   const handleTerminalGetInfo = async (
     id: string
@@ -118,7 +110,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to get terminal info: ${errorMessage}`);
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_GET_INFO, handleTerminalGetInfo));
 
   const handleTerminalGetSharedBuffers = async (): Promise<{
     visualBuffers: SharedArrayBuffer[];
@@ -131,7 +122,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       return { visualBuffers: [], signalBuffer: null };
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_GET_SHARED_BUFFERS, handleTerminalGetSharedBuffers));
 
   const handleTerminalGetAnalysisBuffer = async (): Promise<SharedArrayBuffer | null> => {
     try {
@@ -141,9 +131,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       return null;
     }
   };
-  handlers.push(
-    typedHandle(CHANNELS.TERMINAL_GET_ANALYSIS_BUFFER, handleTerminalGetAnalysisBuffer)
-  );
 
   const handleTerminalReplayHistory = async ({
     terminalId,
@@ -159,13 +146,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to replay terminal history: ${errorMessage}`);
     }
   };
-  handlers.push(
-    typedHandleValidated(
-      CHANNELS.TERMINAL_REPLAY_HISTORY,
-      TerminalReplayHistoryPayloadSchema,
-      handleTerminalReplayHistory
-    )
-  );
 
   const handleTerminalGetForProject = async (
     projectId: string
@@ -231,7 +211,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to get terminals for project: ${errorMessage}`);
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_GET_FOR_PROJECT, handleTerminalGetForProject));
 
   const handleTerminalGetAvailable = async (): Promise<
     import("../../../../shared/types/ipc.js").BackendTerminalInfo[]
@@ -275,7 +254,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to get available terminals: ${errorMessage}`);
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_GET_AVAILABLE, handleTerminalGetAvailable));
 
   const handleTerminalGetByState = async (
     state: string
@@ -330,7 +308,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to get terminals by state: ${errorMessage}`);
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_GET_BY_STATE, handleTerminalGetByState));
 
   const handleTerminalGetAll = async (): Promise<
     import("../../../../shared/types/ipc.js").BackendTerminalInfo[]
@@ -374,7 +351,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to get all terminals: ${errorMessage}`);
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_GET_ALL, handleTerminalGetAll));
 
   const handleTerminalSearchSemanticBuffers = async (
     query: string,
@@ -398,9 +374,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       return [];
     }
   };
-  handlers.push(
-    typedHandle(CHANNELS.TERMINAL_SEARCH_SEMANTIC_BUFFERS, handleTerminalSearchSemanticBuffers)
-  );
 
   const handleTerminalReconnect = async (
     terminalId: string
@@ -453,7 +426,38 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to reconnect to terminal: ${errorMessage}`);
     }
   };
-  handlers.push(typedHandle(CHANNELS.TERMINAL_RECONNECT, handleTerminalReconnect));
 
-  return () => handlers.forEach((cleanup) => cleanup());
+  const namespace = defineIpcNamespace({
+    name: "terminalSnapshots",
+    ops: {
+      wake: op(CHANNELS.TERMINAL_WAKE, handleTerminalWake),
+      getSerializedState: op(
+        CHANNELS.TERMINAL_GET_SERIALIZED_STATE,
+        handleTerminalGetSerializedState
+      ),
+      getSerializedStates: op(
+        CHANNELS.TERMINAL_GET_SERIALIZED_STATES,
+        handleTerminalGetSerializedStates
+      ),
+      getInfo: op(CHANNELS.TERMINAL_GET_INFO, handleTerminalGetInfo),
+      getSharedBuffers: op(CHANNELS.TERMINAL_GET_SHARED_BUFFERS, handleTerminalGetSharedBuffers),
+      getAnalysisBuffer: op(CHANNELS.TERMINAL_GET_ANALYSIS_BUFFER, handleTerminalGetAnalysisBuffer),
+      replayHistory: opValidated(
+        CHANNELS.TERMINAL_REPLAY_HISTORY,
+        TerminalReplayHistoryPayloadSchema,
+        handleTerminalReplayHistory
+      ),
+      getForProject: op(CHANNELS.TERMINAL_GET_FOR_PROJECT, handleTerminalGetForProject),
+      getAvailable: op(CHANNELS.TERMINAL_GET_AVAILABLE, handleTerminalGetAvailable),
+      getByState: op(CHANNELS.TERMINAL_GET_BY_STATE, handleTerminalGetByState),
+      getAll: op(CHANNELS.TERMINAL_GET_ALL, handleTerminalGetAll),
+      searchSemanticBuffers: op(
+        CHANNELS.TERMINAL_SEARCH_SEMANTIC_BUFFERS,
+        handleTerminalSearchSemanticBuffers
+      ),
+      reconnect: op(CHANNELS.TERMINAL_RECONNECT, handleTerminalReconnect),
+    },
+  });
+
+  return namespace.register();
 }

--- a/electron/ipc/handlers/worktree/branches.ts
+++ b/electron/ipc/handlers/worktree/branches.ts
@@ -1,26 +1,26 @@
 import { CHANNELS } from "../../channels.js";
 import type { HandlerDependencies } from "../../types.js";
+import type { BranchInfo } from "../../../../shared/types/git.js";
 import { generateWorktreePath, validatePathPattern } from "../../../../shared/utils/pathPattern.js";
 import { resolveWorktreePattern } from "../../../utils/worktreePattern.js";
 import { gitServiceCache } from "../../../services/GitServiceCache.js";
-import { typedHandle } from "../../utils.js";
+import { defineIpcNamespace, op } from "../../define.js";
 
 export function registerWorktreeBranchHandlers(deps: HandlerDependencies): () => void {
-  const handlers: Array<() => void> = [];
-
-  const handleWorktreeListBranches = async (payload: { rootPath: string }) => {
+  const handleWorktreeListBranches = async (payload: {
+    rootPath: string;
+  }): Promise<BranchInfo[]> => {
     if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
     return await deps.worktreeService.listBranches(payload.rootPath);
   };
-  handlers.push(typedHandle(CHANNELS.WORKTREE_LIST_BRANCHES, handleWorktreeListBranches));
 
   const handleWorktreeFetchPRBranch = async (payload: {
     rootPath: string;
     prNumber: number;
     headRefName: string;
-  }) => {
+  }): Promise<void> => {
     if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
@@ -33,23 +33,21 @@ export function registerWorktreeBranchHandlers(deps: HandlerDependencies): () =>
     if (!payload.headRefName || typeof payload.headRefName !== "string") {
       throw new Error("headRefName is required");
     }
-    return await deps.worktreeService.fetchPRBranch(
+    await deps.worktreeService.fetchPRBranch(
       payload.rootPath,
       payload.prNumber,
       payload.headRefName
     );
   };
-  handlers.push(typedHandle(CHANNELS.WORKTREE_FETCH_PR_BRANCH, handleWorktreeFetchPRBranch));
 
-  const handleWorktreeGetRecentBranches = async (payload: { rootPath: string }) => {
+  const handleWorktreeGetRecentBranches = async (payload: {
+    rootPath: string;
+  }): Promise<string[]> => {
     if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
     return await deps.worktreeService.getRecentBranches(payload.rootPath);
   };
-  handlers.push(
-    typedHandle(CHANNELS.WORKTREE_GET_RECENT_BRANCHES, handleWorktreeGetRecentBranches)
-  );
 
   const handleWorktreeGetDefaultPath = async (payload: {
     rootPath: string;
@@ -81,7 +79,6 @@ export function registerWorktreeBranchHandlers(deps: HandlerDependencies): () =>
     const gitService = gitServiceCache.getGitService(rootPath);
     return gitService.findAvailablePath(initialPath);
   };
-  handlers.push(typedHandle(CHANNELS.WORKTREE_GET_DEFAULT_PATH, handleWorktreeGetDefaultPath));
 
   const handleWorktreeGetAvailableBranch = async (payload: {
     rootPath: string;
@@ -104,9 +101,20 @@ export function registerWorktreeBranchHandlers(deps: HandlerDependencies): () =>
     const gitService = gitServiceCache.getGitService(rootPath);
     return gitService.findAvailableBranchName(branchName);
   };
-  handlers.push(
-    typedHandle(CHANNELS.WORKTREE_GET_AVAILABLE_BRANCH, handleWorktreeGetAvailableBranch)
-  );
 
-  return () => handlers.forEach((cleanup) => cleanup());
+  const namespace = defineIpcNamespace({
+    name: "worktreeBranches",
+    ops: {
+      listBranches: op(CHANNELS.WORKTREE_LIST_BRANCHES, handleWorktreeListBranches),
+      fetchPRBranch: op(CHANNELS.WORKTREE_FETCH_PR_BRANCH, handleWorktreeFetchPRBranch),
+      getRecentBranches: op(CHANNELS.WORKTREE_GET_RECENT_BRANCHES, handleWorktreeGetRecentBranches),
+      getDefaultPath: op(CHANNELS.WORKTREE_GET_DEFAULT_PATH, handleWorktreeGetDefaultPath),
+      getAvailableBranch: op(
+        CHANNELS.WORKTREE_GET_AVAILABLE_BRANCH,
+        handleWorktreeGetAvailableBranch
+      ),
+    },
+  });
+
+  return namespace.register();
 }

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -5,6 +5,7 @@ import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 import type { WorktreeSetActivePayload, WorktreeDeletePayload } from "../../../types/index.js";
 import type { WorktreeState } from "../../../../shared/types/worktree.js";
+import type { CreateWorktreeOptions } from "../../../../shared/types/git.js";
 import { fileSearchService } from "../../../services/FileSearchService.js";
 import { getSoundService } from "../../../services/getSoundService.js";
 import type * as SoundServiceModule from "../../../services/SoundService.js";
@@ -50,7 +51,7 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
 
   const handleWorktreeCreate = async (payload: {
     rootPath: string;
-    options: { baseBranch: string; newBranch: string; path: string; fromRemote?: boolean };
+    options: CreateWorktreeOptions;
   }): Promise<string> => {
     if (
       !payload ||

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -8,6 +8,10 @@ import type { WorktreeState } from "../../../../shared/types/worktree.js";
 import { fileSearchService } from "../../../services/FileSearchService.js";
 import { getSoundService } from "../../../services/getSoundService.js";
 import type * as SoundServiceModule from "../../../services/SoundService.js";
+import { defineIpcNamespace, op } from "../../define.js";
+import { checkRateLimit, waitForRateLimitSlot } from "../../utils.js";
+import { validateBranchName } from "../../../../shared/utils/pathPattern.js";
+import { WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS } from "./constants.js";
 
 type SoundId = keyof typeof SoundServiceModule.SOUND_FILES;
 
@@ -16,35 +20,26 @@ function playSoundFireAndForget(id: SoundId): void {
     .then((svc) => svc.play(id))
     .catch((err) => console.error("[worktree.lifecycle] sound play failed:", err));
 }
-import {
-  checkRateLimit,
-  waitForRateLimitSlot,
-  typedHandle,
-  typedHandleWithContext,
-} from "../../utils.js";
-import { validateBranchName } from "../../../../shared/utils/pathPattern.js";
-import { WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS } from "./constants.js";
 
 export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): () => void {
-  const handlers: Array<() => void> = [];
-
   const handleWorktreeGetAll = async (ctx: IpcContext): Promise<WorktreeState[]> => {
     if (!deps.worktreeService) {
       return [];
     }
     return (await deps.worktreeService.getAllStatesAsync(ctx.senderWindow?.id)) as WorktreeState[];
   };
-  handlers.push(typedHandleWithContext(CHANNELS.WORKTREE_GET_ALL, handleWorktreeGetAll));
 
-  const handleWorktreeRefresh = async (worktreeId?: string) => {
+  const handleWorktreeRefresh = async (worktreeId?: string): Promise<void> => {
     if (!deps.worktreeService) {
       return;
     }
     await deps.worktreeService.refresh(worktreeId);
   };
-  handlers.push(typedHandle(CHANNELS.WORKTREE_REFRESH, handleWorktreeRefresh));
 
-  const handleWorktreeSetActive = async (ctx: IpcContext, payload: WorktreeSetActivePayload) => {
+  const handleWorktreeSetActive = async (
+    ctx: IpcContext,
+    payload: WorktreeSetActivePayload
+  ): Promise<void> => {
     if (!deps.worktreeService) {
       return;
     }
@@ -52,7 +47,6 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
       silent: true,
     });
   };
-  handlers.push(typedHandleWithContext(CHANNELS.WORKTREE_SET_ACTIVE, handleWorktreeSetActive));
 
   const handleWorktreeCreate = async (payload: {
     rootPath: string;
@@ -94,7 +88,6 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     }
     return worktreeId;
   };
-  handlers.push(typedHandle(CHANNELS.WORKTREE_CREATE, handleWorktreeCreate));
 
   const handleWorktreeRestartService = async (ctx: IpcContext): Promise<void> => {
     if (!deps.worktreeService) return;
@@ -107,9 +100,6 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     }
     deps.worktreeService.manualRestartForWindow(windowId);
   };
-  handlers.push(
-    typedHandleWithContext(CHANNELS.WORKTREE_RESTART_SERVICE, handleWorktreeRestartService)
-  );
 
   // Recovery path for a project switch whose worktree load threw (#8400).
   // The switch forward-fails to the new project, so the current project is
@@ -133,11 +123,11 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
       throw new Error(formatErrorMessage(error, "Failed to load worktrees"), { cause: error });
     }
   };
-  handlers.push(
-    typedHandleWithContext(CHANNELS.WORKTREE_RETRY_PROJECT_LOAD, handleWorktreeRetryProjectLoad)
-  );
 
-  const handleWorktreeDelete = async (ctx: IpcContext, payload: WorktreeDeletePayload) => {
+  const handleWorktreeDelete = async (
+    ctx: IpcContext,
+    payload: WorktreeDeletePayload
+  ): Promise<void> => {
     checkRateLimit(CHANNELS.WORKTREE_DELETE, 10, 10_000);
     if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
@@ -183,7 +173,23 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
       store.set("worktreeIssueMap", rest);
     }
   };
-  handlers.push(typedHandleWithContext(CHANNELS.WORKTREE_DELETE, handleWorktreeDelete));
 
-  return () => handlers.forEach((cleanup) => cleanup());
+  const namespace = defineIpcNamespace({
+    name: "worktreeLifecycle",
+    ops: {
+      getAll: op(CHANNELS.WORKTREE_GET_ALL, handleWorktreeGetAll, { withContext: true }),
+      refresh: op(CHANNELS.WORKTREE_REFRESH, handleWorktreeRefresh),
+      setActive: op(CHANNELS.WORKTREE_SET_ACTIVE, handleWorktreeSetActive, { withContext: true }),
+      create: op(CHANNELS.WORKTREE_CREATE, handleWorktreeCreate),
+      restartService: op(CHANNELS.WORKTREE_RESTART_SERVICE, handleWorktreeRestartService, {
+        withContext: true,
+      }),
+      retryProjectLoad: op(CHANNELS.WORKTREE_RETRY_PROJECT_LOAD, handleWorktreeRetryProjectLoad, {
+        withContext: true,
+      }),
+      delete: op(CHANNELS.WORKTREE_DELETE, handleWorktreeDelete, { withContext: true }),
+    },
+  });
+
+  return namespace.register();
 }

--- a/electron/ipc/handlers/worktree/pull-requests.ts
+++ b/electron/ipc/handlers/worktree/pull-requests.ts
@@ -6,26 +6,23 @@ import type {
   DetachIssuePayload,
   IssueAssociation,
 } from "../../../../shared/types/ipc/worktree.js";
-import { typedHandle } from "../../utils.js";
+import type { PRServiceStatus } from "../../../../shared/types/workspace-host.js";
+import { defineIpcNamespace, op } from "../../define.js";
 
 export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): () => void {
-  const handlers: Array<() => void> = [];
-
-  const handleWorktreePRRefresh = async () => {
+  const handleWorktreePRRefresh = async (): Promise<void> => {
     if (!deps.worktreeService) {
       return;
     }
     await deps.worktreeService.refreshPullRequests();
   };
-  handlers.push(typedHandle(CHANNELS.WORKTREE_PR_REFRESH, handleWorktreePRRefresh));
 
-  const handleWorktreePRStatus = async () => {
+  const handleWorktreePRStatus = async (): Promise<PRServiceStatus | null> => {
     if (!deps.worktreeService) {
       return null;
     }
     return await deps.worktreeService.getPRStatus();
   };
-  handlers.push(typedHandle(CHANNELS.WORKTREE_PR_STATUS, handleWorktreePRStatus));
 
   const handleWorktreeAttachIssue = async (payload: AttachIssuePayload): Promise<void> => {
     if (!payload || typeof payload !== "object") {
@@ -60,7 +57,6 @@ export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): 
     const currentMap = store.get("worktreeIssueMap") ?? {};
     store.set("worktreeIssueMap", { ...currentMap, [worktreeId]: association });
   };
-  handlers.push(typedHandle(CHANNELS.WORKTREE_ATTACH_ISSUE, handleWorktreeAttachIssue));
 
   const handleWorktreeDetachIssue = async (payload: DetachIssuePayload): Promise<void> => {
     if (!payload || typeof payload !== "object") {
@@ -77,7 +73,6 @@ export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): 
     const { [worktreeId]: _removed, ...rest } = currentMap;
     store.set("worktreeIssueMap", rest);
   };
-  handlers.push(typedHandle(CHANNELS.WORKTREE_DETACH_ISSUE, handleWorktreeDetachIssue));
 
   const handleWorktreeGetIssueAssociation = async (
     worktreeId: string
@@ -89,18 +84,30 @@ export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): 
     const currentMap = store.get("worktreeIssueMap") ?? {};
     return currentMap[worktreeId] ?? null;
   };
-  handlers.push(
-    typedHandle(CHANNELS.WORKTREE_GET_ISSUE_ASSOCIATION, handleWorktreeGetIssueAssociation)
-  );
 
   const handleWorktreeGetAllIssueAssociations = async (): Promise<
     Record<string, IssueAssociation>
   > => {
     return store.get("worktreeIssueMap") ?? {};
   };
-  handlers.push(
-    typedHandle(CHANNELS.WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS, handleWorktreeGetAllIssueAssociations)
-  );
 
-  return () => handlers.forEach((cleanup) => cleanup());
+  const namespace = defineIpcNamespace({
+    name: "worktreePullRequests",
+    ops: {
+      prRefresh: op(CHANNELS.WORKTREE_PR_REFRESH, handleWorktreePRRefresh),
+      prStatus: op(CHANNELS.WORKTREE_PR_STATUS, handleWorktreePRStatus),
+      attachIssue: op(CHANNELS.WORKTREE_ATTACH_ISSUE, handleWorktreeAttachIssue),
+      detachIssue: op(CHANNELS.WORKTREE_DETACH_ISSUE, handleWorktreeDetachIssue),
+      getIssueAssociation: op(
+        CHANNELS.WORKTREE_GET_ISSUE_ASSOCIATION,
+        handleWorktreeGetIssueAssociation
+      ),
+      getAllIssueAssociations: op(
+        CHANNELS.WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS,
+        handleWorktreeGetAllIssueAssociations
+      ),
+    },
+  });
+
+  return namespace.register();
 }

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -461,17 +461,7 @@ export interface GeneratedIpcInvokeMap {
     result: void;
   };
   "worktree:create": {
-    args: [
-      payload: {
-        rootPath: string;
-        options: {
-          baseBranch: string;
-          newBranch: string;
-          path: string;
-          fromRemote?: boolean | undefined;
-        };
-      },
-    ];
+    args: [payload: { rootPath: string; options: import("../git.js").CreateWorktreeOptions }];
     result: string;
   };
   "worktree:delete": {

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -8,6 +8,22 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: boolean;
   };
+  "agent-session:clear": {
+    args: [payload: { worktreeId?: string | undefined }];
+    result: void;
+  };
+  "agent-session:list": {
+    args: [payload: { worktreeId?: string | undefined }];
+    result: import("./agentSessionHistory.js").AgentSessionRecord[];
+  };
+  "artifact:apply-patch": {
+    args: [options: import("./agent.js").ApplyPatchOptions];
+    result: import("./agent.js").ApplyPatchResult;
+  };
+  "artifact:save-to-file": {
+    args: [options: import("./agent.js").SaveArtifactOptions];
+    result: import("./agent.js").SaveArtifactResult | null;
+  };
   "clipboard:read-selection": {
     args: [];
     result: { text: string };
@@ -332,5 +348,194 @@ export interface GeneratedIpcInvokeMap {
   "slash-commands:list": {
     args: [payload: import("../slashCommands.js").SlashCommandListRequest];
     result: import("../slashCommands.js").SlashCommand[];
+  };
+  "terminal:force-resume": {
+    args: [id: string];
+    result: void;
+  };
+  "terminal:get-all": {
+    args: [];
+    result: import("./terminal.js").BackendTerminalInfo[];
+  };
+  "terminal:get-analysis-buffer": {
+    args: [];
+    result: SharedArrayBuffer | null;
+  };
+  "terminal:get-available": {
+    args: [];
+    result: import("./terminal.js").BackendTerminalInfo[];
+  };
+  "terminal:get-by-state": {
+    args: [state: string];
+    result: import("./terminal.js").BackendTerminalInfo[];
+  };
+  "terminal:get-for-project": {
+    args: [projectId: string];
+    result: import("./terminal.js").BackendTerminalInfo[];
+  };
+  "terminal:get-info": {
+    args: [id: string];
+    result: import("./terminal.js").TerminalInfoPayload;
+  };
+  "terminal:get-serialized-state": {
+    args: [terminalId: string];
+    result: string | null;
+  };
+  "terminal:get-serialized-states": {
+    args: [terminalIds: string[]];
+    result: Record<string, string | null>;
+  };
+  "terminal:get-shared-buffers": {
+    args: [];
+    result: { visualBuffers: SharedArrayBuffer[]; signalBuffer: SharedArrayBuffer | null };
+  };
+  "terminal:graceful-kill": {
+    args: [id: string];
+    result: string | null;
+  };
+  "terminal:kill": {
+    args: [id: string];
+    result: void;
+  };
+  "terminal:reconnect": {
+    args: [terminalId: string];
+    result: import("./terminal.js").TerminalReconnectResult;
+  };
+  "terminal:replay-history": {
+    args: [__0: { terminalId: string; maxLines: number }];
+    result: { replayed: number };
+  };
+  "terminal:restart-service": {
+    args: [];
+    result: void;
+  };
+  "terminal:restore": {
+    args: [id: string];
+    result: boolean;
+  };
+  "terminal:search-semantic-buffers": {
+    args: [query: string, isRegex: boolean];
+    result: import("./terminal.js").SemanticSearchMatch[];
+  };
+  "terminal:spawn": {
+    args: [
+      validatedOptions: {
+        cols: number;
+        rows: number;
+        id?: string | undefined;
+        kind?: string | undefined;
+        launchAgentId?: string | undefined;
+        projectId?: string | undefined;
+        cwd?: string | undefined;
+        shell?: string | undefined;
+        command?: string | undefined;
+        env?: Record<string, string> | undefined;
+        title?: string | undefined;
+        titleMode?: "default" | "custom" | undefined;
+        restore?: boolean | undefined;
+        isEphemeral?: boolean | undefined;
+        agentLaunchFlags?: string[] | undefined;
+        agentModelId?: string | undefined;
+        worktreeId?: string | undefined;
+        agentPresetId?: string | undefined;
+        agentPresetColor?: string | undefined;
+        originalAgentPresetId?: string | undefined;
+      },
+    ];
+    result: string;
+  };
+  "terminal:submit": {
+    args: [id: string, text: string];
+    result: void;
+  };
+  "terminal:trash": {
+    args: [id: string];
+    result: void;
+  };
+  "terminal:wake": {
+    args: [id: string];
+    result: { state: string | null; warnings?: string[] | undefined };
+  };
+  "worktree:attach-issue": {
+    args: [payload: import("./worktree.js").AttachIssuePayload];
+    result: void;
+  };
+  "worktree:create": {
+    args: [
+      payload: {
+        rootPath: string;
+        options: {
+          baseBranch: string;
+          newBranch: string;
+          path: string;
+          fromRemote?: boolean | undefined;
+        };
+      },
+    ];
+    result: string;
+  };
+  "worktree:delete": {
+    args: [payload: import("./worktree.js").WorktreeDeletePayload];
+    result: void;
+  };
+  "worktree:detach-issue": {
+    args: [payload: import("./worktree.js").DetachIssuePayload];
+    result: void;
+  };
+  "worktree:fetch-pr-branch": {
+    args: [payload: { rootPath: string; prNumber: number; headRefName: string }];
+    result: void;
+  };
+  "worktree:get-all": {
+    args: [];
+    result: import("../worktree.js").WorktreeState[];
+  };
+  "worktree:get-all-issue-associations": {
+    args: [];
+    result: Record<string, import("./worktree.js").IssueAssociation>;
+  };
+  "worktree:get-available-branch": {
+    args: [payload: { rootPath: string; branchName: string }];
+    result: string;
+  };
+  "worktree:get-default-path": {
+    args: [payload: { rootPath: string; branchName: string }];
+    result: string;
+  };
+  "worktree:get-issue-association": {
+    args: [worktreeId: string];
+    result: import("./worktree.js").IssueAssociation | null;
+  };
+  "worktree:get-recent-branches": {
+    args: [payload: { rootPath: string }];
+    result: string[];
+  };
+  "worktree:list-branches": {
+    args: [payload: { rootPath: string }];
+    result: import("../git.js").BranchInfo[];
+  };
+  "worktree:pr-refresh": {
+    args: [];
+    result: void;
+  };
+  "worktree:pr-status": {
+    args: [];
+    result: import("../workspace-host.js").PRServiceStatus | null;
+  };
+  "worktree:refresh": {
+    args: [worktreeId?: string | undefined];
+    result: void;
+  };
+  "worktree:restart-service": {
+    args: [];
+    result: void;
+  };
+  "worktree:retry-project-load": {
+    args: [];
+    result: void;
+  };
+  "worktree:set-active": {
+    args: [payload: import("./worktree.js").WorktreeSetActivePayload];
+    result: void;
   };
 }

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1,5 +1,5 @@
 import type { StagingStatus } from "../git.js";
-import type { AgentId, AgentState } from "../agent.js";
+import type { AgentId } from "../agent.js";
 import type { VoiceInputStatus } from "../voice.js";
 import type { TabGroup } from "../panel.js";
 import type { WorktreeState } from "../worktree.js";
@@ -24,29 +24,9 @@ import type {
   VoiceInputSettings,
 } from "./api.js";
 
+import type { WorktreeConfig } from "./worktree.js";
+import type { TerminalActivityPayload } from "./terminal.js";
 import type {
-  WorktreeSetActivePayload,
-  WorktreeDeletePayload,
-  CreateWorktreeOptions,
-  BranchInfo,
-  WorktreeConfig,
-  AttachIssuePayload,
-  DetachIssuePayload,
-  IssueAssociation,
-} from "./worktree.js";
-import type {
-  TerminalSpawnOptions,
-  TerminalReconnectResult,
-  BackendTerminalInfo,
-  TerminalInfoPayload,
-  TerminalActivityPayload,
-  SemanticSearchMatch,
-} from "./terminal.js";
-import type {
-  SaveArtifactOptions,
-  SaveArtifactResult,
-  ApplyPatchOptions,
-  ApplyPatchResult,
   AgentStateChangePayload,
   AgentDetectedPayload,
   AgentExitedPayload,
@@ -173,7 +153,6 @@ import type {
 } from "./system.js";
 import type { CloneRepoOptions, CloneRepoResult } from "./gitClone.js";
 import type { AppAgentConfig } from "../appAgent.js";
-import type { AgentSessionRecord } from "./agentSessionHistory.js";
 import type { GeneratedIpcInvokeMap } from "./generated.js";
 import type {
   AuthValidation,
@@ -254,145 +233,6 @@ export interface MainProcessToastPayload {
 
 /** Maps IPC channels to their args/result types for type-safe invoke/handle */
 export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
-  // Worktree channels
-  "worktree:get-all": {
-    args: [];
-    result: WorktreeState[];
-  };
-  "worktree:refresh": {
-    args: [worktreeId?: string];
-    result: void;
-  };
-  "worktree:pr-refresh": {
-    args: [];
-    result: void;
-  };
-  "worktree:pr-status": {
-    args: [];
-    result: import("../workspace-host.js").PRServiceStatus | null;
-  };
-  "worktree:set-active": {
-    args: [payload: WorktreeSetActivePayload];
-    result: void;
-  };
-  "worktree:create": {
-    args: [payload: { rootPath: string; options: CreateWorktreeOptions }];
-    result: string;
-  };
-  "worktree:list-branches": {
-    args: [payload: { rootPath: string }];
-    result: BranchInfo[];
-  };
-  "worktree:get-recent-branches": {
-    args: [payload: { rootPath: string }];
-    result: string[];
-  };
-  "worktree:get-default-path": {
-    args: [payload: { rootPath: string; branchName: string }];
-    result: string;
-  };
-  "worktree:get-available-branch": {
-    args: [payload: { rootPath: string; branchName: string }];
-    result: string;
-  };
-  "worktree:delete": {
-    args: [payload: WorktreeDeletePayload];
-    result: void;
-  };
-  "worktree:attach-issue": {
-    args: [payload: AttachIssuePayload];
-    result: void;
-  };
-  "worktree:detach-issue": {
-    args: [payload: DetachIssuePayload];
-    result: void;
-  };
-  "worktree:get-issue-association": {
-    args: [worktreeId: string];
-    result: IssueAssociation | null;
-  };
-  "worktree:get-all-issue-associations": {
-    args: [];
-    result: Record<string, IssueAssociation>;
-  };
-  "worktree:restart-service": {
-    args: [];
-    result: void;
-  };
-  "worktree:retry-project-load": {
-    args: [];
-    result: void;
-  };
-
-  // Terminal channels
-  "terminal:spawn": {
-    args: [options: TerminalSpawnOptions];
-    result: string;
-  };
-  "terminal:submit": {
-    args: [id: string, text: string];
-    result: void;
-  };
-  "terminal:kill": {
-    args: [id: string];
-    result: void;
-  };
-  "terminal:trash": {
-    args: [id: string];
-    result: void;
-  };
-  "terminal:restore": {
-    args: [id: string];
-    result: boolean;
-  };
-  "terminal:wake": {
-    args: [id: string];
-    result: { state: string | null; warnings?: string[] };
-  };
-  "terminal:get-for-project": {
-    args: [projectId: string];
-    result: BackendTerminalInfo[];
-  };
-  "terminal:reconnect": {
-    args: [terminalId: string];
-    result: TerminalReconnectResult;
-  };
-  "terminal:replay-history": {
-    args: [payload: { terminalId: string; maxLines?: number }];
-    result: { replayed: number };
-  };
-  "terminal:get-serialized-state": {
-    args: [terminalId: string];
-    result: string | null;
-  };
-  "terminal:get-serialized-states": {
-    args: [terminalIds: string[]];
-    result: Record<string, string | null>;
-  };
-  "terminal:get-shared-buffers": {
-    args: [];
-    result: {
-      visualBuffers: SharedArrayBuffer[];
-      signalBuffer: SharedArrayBuffer | null;
-    };
-  };
-  "terminal:get-analysis-buffer": {
-    args: [];
-    result: SharedArrayBuffer | null;
-  };
-  "terminal:get-info": {
-    args: [id: string];
-    result: TerminalInfoPayload;
-  };
-  "terminal:force-resume": {
-    args: [id: string];
-    result: void;
-  };
-  "terminal:restart-service": {
-    args: [];
-    result: void;
-  };
-
   // Files channels
   "files:search": {
     args: [payload: FileSearchPayload];
@@ -408,16 +248,6 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
   "agent-help:get": {
     args: [request: AgentHelpRequest];
     result: AgentHelpResult;
-  };
-
-  // Artifact channels
-  "artifact:save-to-file": {
-    args: [options: SaveArtifactOptions];
-    result: SaveArtifactResult | null;
-  };
-  "artifact:apply-patch": {
-    args: [options: ApplyPatchOptions];
-    result: ApplyPatchResult;
   };
 
   // CopyTree channels
@@ -1887,16 +1717,6 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
   };
 
   // Demo mode channels (dev-only, gated by --demo-mode flag)
-  // Agent session history channels
-  "agent-session:list": {
-    args: [payload: { worktreeId?: string }];
-    result: AgentSessionRecord[];
-  };
-  "agent-session:clear": {
-    args: [payload: { worktreeId?: string }];
-    result: void;
-  };
-
   // App Agent channels
   "app-agent:get-config": {
     args: [];
@@ -2116,28 +1936,6 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     result: void;
   };
 
-  // Additional terminal snapshot channels
-  "terminal:get-all": {
-    args: [];
-    result: BackendTerminalInfo[];
-  };
-  "terminal:get-available": {
-    args: [];
-    result: BackendTerminalInfo[];
-  };
-  "terminal:get-by-state": {
-    args: [state: AgentState];
-    result: BackendTerminalInfo[];
-  };
-  "terminal:graceful-kill": {
-    args: [id: string];
-    result: string | null;
-  };
-  "terminal:search-semantic-buffers": {
-    args: [query: string, isRegex: boolean];
-    result: SemanticSearchMatch[];
-  };
-
   // Webview lifecycle / dialog / OAuth channels
   "webview:set-lifecycle-state": {
     args: [webContentsId: number, frozen: boolean];
@@ -2162,12 +1960,6 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
   };
   "webview:cancel-oauth-loopback": {
     args: [payload: { panelId: string }];
-    result: void;
-  };
-
-  // Additional worktree channels
-  "worktree:fetch-pr-branch": {
-    args: [payload: { rootPath: string; prNumber: number; headRefName: string }];
     result: void;
   };
 }


### PR DESCRIPTION
## Summary

- Migrates 43 IPC channels across the `worktree` (18), `terminal` (21), `artifacts` (2), and `agent-session` (2) namespaces from raw `typedHandle*` registration to `defineIpcNamespace` / `op` / `opValidated`
- The preload reshaping wrappers are intentionally untouched — the renderer API is positional while the wire payload is a named object, and the two shapes need to stay separate
- Channels now appear in the codegen-generated `shared/types/ipc/generated.ts` and have been removed from the hand-maintained `shared/types/ipc/maps.ts`

Resolves #8574

## Changes

- `electron/ipc/handlers/worktree/` — `lifecycle.ts`, `branches.ts`, `pull-requests.ts` migrated to `op`/`opValidated`
- `electron/ipc/handlers/terminal/` — `lifecycle.ts`, `snapshots.ts`, `artifacts.ts` migrated; `ipcMain.on` fire-and-forget channels in `io.ts` left as-is (out of scope for `defineIpcNamespace`)
- `shared/types/ipc/generated.ts` — 43 new entries added via codegen
- `shared/types/ipc/maps.ts` — corresponding hand-typed entries removed

## Testing

- `npm run typecheck` clean
- No new lint warnings (879 baseline preserved)
- IPC drift/coverage tests pass (3 tests)
- Terminal and worktree handler unit tests pass (105 tests)
- `npm run build` clean