### PR TITLE
perf(window): switch project-view eviction to pure LRU

### DIFF
--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -1170,10 +1170,11 @@ export class ProjectViewManager {
     }
 
     // Build pid → privateBytes index from the synchronous app.getAppMetrics()
-    // snapshot. Joined per-view via `webContents.getOSProcessId()` so eviction
-    // can prefer the largest renderer first instead of pure LRU. Views without
-    // a measured pid (process not yet spawned, or metrics missing) sort below
-    // measured ones via the 0 fallback, preserving LRU as the final tiebreak.
+    // snapshot. Joined per-view via `webContents.getOSProcessId()` so the
+    // eviction log line can record each evicted view's footprint. Memory size
+    // does not drive eviction order — the largest renderer is typically the
+    // project the user has been working in, so size-first ordering destroys
+    // the most valuable view. Eviction is pure LRU (see #8602).
     const memoryByPid = new Map<number, number>();
     try {
       for (const proc of app.getAppMetrics()) {
@@ -1183,7 +1184,8 @@ export class ProjectViewManager {
         }
       }
     } catch {
-      // app.getAppMetrics() throwing is non-fatal — fall back to pure LRU below.
+      // app.getAppMetrics() throwing is non-fatal — memoryKb is simply omitted
+      // from the eviction log line below.
     }
     const memoryFor = (entry: ViewEntry): number => {
       const wc = entry.view.webContents;
@@ -1197,14 +1199,10 @@ export class ProjectViewManager {
 
     const evictable = Array.from(this.views.entries())
       .filter(([id]) => id !== this.activeProjectId)
-      // Largest privateBytes first; LRU (oldest first) as tiebreaker so the
-      // existing limit-change/lru ordering still holds when memory data is
-      // unavailable for both candidates.
-      .sort(([, a], [, b]) => {
-        const memDelta = memoryFor(b) - memoryFor(a);
-        if (memDelta !== 0) return memDelta;
-        return a.lastUsed - b.lastUsed;
-      });
+      // Oldest lastUsed first — pure LRU. Sequential switchTo calls stamp
+      // distinct millisecond timestamps so equal-lastUsed ties don't arise
+      // in practice; Array.sort stability handles them deterministically.
+      .sort(([, a], [, b]) => a.lastUsed - b.lastUsed);
 
     // Partition: evict views without active agents first, only fall back to
     // active-agent views when safe candidates are exhausted. This keeps memory

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -389,6 +389,34 @@ describe("ProjectViewManager — eviction safety", () => {
     expect(wcB.close).not.toHaveBeenCalled();
   });
 
+  it("switching back to a cached view refreshes its LRU stamp", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      cachedProjectViews: 3,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    // Re-visit proj-a from cache — its lastUsed must be refreshed so it is
+    // no longer the oldest candidate. Without this, the next overflow would
+    // wrongly target proj-a.
+    await managerWithLimit.switchTo("proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-d", "/path/d");
+
+    const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+    expect(remaining).not.toContain("proj-b");
+    expect(remaining).toContain("proj-a");
+    expect(remaining).toContain("proj-c");
+    expect(remaining).toContain("proj-d");
+  });
+
   it("falls back to LRU when no candidate has measured memory", async () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -442,7 +470,7 @@ describe("ProjectViewManager — eviction safety", () => {
     expect(remaining).toContain("proj-c");
   });
 
-  it("active-agent views are still evicted last regardless of memory rank", async () => {
+  it("active-agent views are still evicted last regardless of LRU rank", async () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
@@ -566,6 +594,15 @@ describe("ProjectViewManager — eviction safety", () => {
     expect(remaining).toContain("proj-d");
     expect(remaining).not.toContain("proj-a");
     expect(remaining).not.toContain("proj-b");
+
+    // Lock in eviction sequence (not just membership): proj-a evicts before
+    // proj-b, matching LRU order. Without this, a reverse-order regression
+    // would still produce the same survivor set and silently pass.
+    const evictionCalls = vi
+      .mocked(logInfo)
+      .mock.calls.filter(([event]) => event === "projectview.eviction")
+      .map(([, ctx]) => (ctx as { projectId: string }).projectId);
+    expect(evictionCalls).toEqual(["proj-a", "proj-b"]);
   });
 
   it("calls forgetBlinkSample with the evicted webContents id", async () => {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -354,9 +354,9 @@ describe("ProjectViewManager — eviction safety", () => {
     );
   });
 
-  // ── Memory-sorted eviction (issue #6272) ──
+  // ── LRU eviction with memory logging (issue #8602) ──
 
-  it("evicts the largest-privateBytes cached view first, not the LRU one", async () => {
+  it("evicts the LRU cached view first, not the largest renderer", async () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
@@ -369,8 +369,9 @@ describe("ProjectViewManager — eviction safety", () => {
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
 
-    // proj-a (oldest LRU) is small; proj-b is the heaviest cached renderer.
-    // Memory-sorted eviction should target proj-b even though proj-a is older.
+    // proj-a is the LRU view but small; proj-b is the heaviest cached renderer
+    // and more recent. Under #8602, size must not promote proj-b ahead of the
+    // LRU pick — proj-a is evicted, the large/recently-used proj-b survives.
     const wcBEntry = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b");
     const wcB = wcBEntry?.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
     mockGetAppMetrics.mockReturnValue([
@@ -381,11 +382,11 @@ describe("ProjectViewManager — eviction safety", () => {
     await managerWithLimit.switchTo("proj-c", "/path/c");
 
     const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
-    expect(remaining).toContain("proj-a");
+    expect(remaining).not.toContain("proj-a");
+    expect(remaining).toContain("proj-b");
     expect(remaining).toContain("proj-c");
-    expect(remaining).not.toContain("proj-b");
-    expect(wcA.close).not.toHaveBeenCalled();
-    expect(wcB.close).toHaveBeenCalled();
+    expect(wcA.close).toHaveBeenCalled();
+    expect(wcB.close).not.toHaveBeenCalled();
   });
 
   it("falls back to LRU when no candidate has measured memory", async () => {
@@ -413,7 +414,7 @@ describe("ProjectViewManager — eviction safety", () => {
     expect(wcA.close).toHaveBeenCalled();
   });
 
-  it("missing-metric views sort below measured ones (LRU as the deeper fallback)", async () => {
+  it("evicts the LRU view even when only some candidates have measured memory", async () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
@@ -426,9 +427,9 @@ describe("ProjectViewManager — eviction safety", () => {
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
 
-    // Only proj-a has a measured pid. proj-b is unmeasured and should sort
-    // *below* proj-a despite being newer; proj-a (the only measured candidate)
-    // wins eviction priority.
+    // Only proj-a has a measured pid; proj-b is unmeasured. Memory data does
+    // not influence the sort — proj-a is the LRU pick and wins eviction
+    // priority regardless of which side has metrics.
     mockGetAppMetrics.mockReturnValue([
       { pid: wcA.osPid, memory: { privateBytes: 600 * 1024 } },
     ] as unknown as Electron.ProcessMetric[]);
@@ -528,7 +529,7 @@ describe("ProjectViewManager — eviction safety", () => {
     expect(remaining).toContain("proj-c");
   });
 
-  it("evicts in descending privateBytes order when limit shrinks past multiple views", async () => {
+  it("evicts in LRU order when limit shrinks past multiple views", async () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
@@ -548,8 +549,10 @@ describe("ProjectViewManager — eviction safety", () => {
     const wcC = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-c")?.view
       .webContents as unknown as ReturnType<typeof createMockWebContents>;
 
-    // proj-d is active. Among the cached three (a, b, c), expect c (900) to
-    // evict before a (800), with b (100) surviving once limit drops to 2.
+    // proj-d is active. Among the cached three (a, b, c), LRU order is
+    // a → b → c (a was backgrounded first, c most recently). With the limit
+    // dropping to 2, the two oldest (a, b) evict and proj-c survives,
+    // regardless of their memory footprint.
     mockGetAppMetrics.mockReturnValue([
       { pid: wcA.osPid, memory: { privateBytes: 800 * 1024 } },
       { pid: wcB.osPid, memory: { privateBytes: 100 * 1024 } },
@@ -559,10 +562,10 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.setCachedViewLimit(2);
 
     const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
-    expect(remaining).toContain("proj-b");
+    expect(remaining).toContain("proj-c");
     expect(remaining).toContain("proj-d");
     expect(remaining).not.toContain("proj-a");
-    expect(remaining).not.toContain("proj-c");
+    expect(remaining).not.toContain("proj-b");
   });
 
   it("calls forgetBlinkSample with the evicted webContents id", async () => {


### PR DESCRIPTION
Closes #8602.

## Summary

- `ProjectViewManager.evictStaleViews` ranks cached views by `lastUsed` (oldest first) instead of `privateBytes` (largest first). Sequential `switchTo` calls stamp distinct ms timestamps so equal-`lastUsed` ties don't arise in practice; `Array.sort` stability handles them deterministically.
- All memory plumbing (`memoryByPid`, `memoryFor`, `app.getAppMetrics`, `memoryKb` log field) is retained — `memoryKb` still appears on `projectview.eviction` events for observability.
- The `lowMemoryOverride` (`effectiveMax = 1`) path and the active-agent partition (`safeToEvict` / `activeAgentFallback`) are untouched and now LRU-ordered within each partition.

## Why

Each cached `WebContentsView` is a full Chromium renderer (100–500 MB). The largest renderer is typically the project the user has been working in most, so size-first eviction was destroying the most valuable cached view and forcing a cold start on the project the user cares about most. The `CLAUDE.md` architecture notes already described eviction as LRU; the code now matches.

## Tests

- Updated three existing tests in `electron/window/__tests__/ProjectViewManager.eviction.test.ts` to assert LRU semantics (two assertion flips, one description rewrite).
- Added `"switching back to a cached view refreshes its LRU stamp"` — regression test for hot-cache-hit recency (without the refresh at `activateView`, an old view would wrongly remain the next eviction target).
- Locked in eviction sequence (not just survivor set) in the multi-eviction test via ordered `logInfo("projectview.eviction", ...)` assertions, so a reverse-order regression can't silently pass.
- Active-agent guard test renamed from \"regardless of memory rank\" to \"regardless of LRU rank\".

## Test plan

- [x] `npx vitest run electron/window/__tests__/ProjectViewManager.eviction.test.ts` — 50/50 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint:ratchet` — clean (warnings dropped by 45)
- [x] `npm run format:check` — clean