### PR TITLE
perf(resource-profile): only clamp cached view limit when memory contributed

### DIFF
--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -137,6 +137,12 @@ export class ResourceProfileService {
   private lagEnterTicks = 0;
   private lagExitWindow: boolean[] = [];
   private lagPressureStartedAt: number | null = null;
+  // Memory sub-score captured from the most recent computeTargetProfile() run.
+  // Gates the setCachedViewLimit(1) clamp on efficiency entry so non-memory
+  // efficiency triggers (battery + thermal/CPU + worktrees) don't pay the
+  // cost of destroying cached WebContentsViews. sampleLag() bypasses
+  // computeTargetProfile() and must zero this before calling applyProfile().
+  private lastMemoryScore = 0;
 
   constructor(private deps: ResourceProfileDeps) {
     const totalRamMb = os.totalmem() / 1024 / 1024;
@@ -402,6 +408,11 @@ export class ResourceProfileService {
         utilization: Math.round(utilization * 100) / 100,
       });
       if (this.currentProfile !== "efficiency") {
+        // Severe-spike lag entry bypasses computeTargetProfile(), so
+        // lastMemoryScore holds whatever the previous eval recorded (stale).
+        // The trigger here is CPU/event-loop, not memory — zero it so the
+        // setCachedViewLimit(1) clamp in applyProfile() stays off.
+        this.lastMemoryScore = 0;
         this.applyProfile("efficiency");
       }
       return;
@@ -420,6 +431,11 @@ export class ResourceProfileService {
           utilization: Math.round(utilization * 100) / 100,
         });
         if (this.currentProfile !== "efficiency") {
+          // Lag-triggered efficiency entry bypasses computeTargetProfile(), so
+          // lastMemoryScore holds whatever the previous eval recorded (stale).
+          // The trigger here is CPU/event-loop, not memory — zero it so the
+          // setCachedViewLimit(1) clamp in applyProfile() stays off.
+          this.lastMemoryScore = 0;
           this.applyProfile("efficiency");
         }
       }
@@ -530,6 +546,7 @@ export class ResourceProfileService {
     }
     this.lagPreviousElu = null;
     this.clearLagPressure();
+    this.lastMemoryScore = 0;
     this.thermalState = "unknown";
     this.isOnBattery = false;
     this.speedLimit = 100;
@@ -571,6 +588,7 @@ export class ResourceProfileService {
 
   private computeTargetProfile(): ResourceProfile {
     let pressureScore = 0;
+    let memoryScore = 0;
 
     // Memory signal
     try {
@@ -581,13 +599,15 @@ export class ResourceProfileService {
       }
 
       if (totalPrivateMb > this.memoryThresholdHighMb) {
-        pressureScore += 2;
+        memoryScore = 2;
       } else if (totalPrivateMb > this.memoryThresholdLowMb) {
-        pressureScore += 1;
+        memoryScore = 1;
       }
     } catch {
-      // Skip memory signal on error
+      // Skip memory signal on error — memoryScore stays 0 (correct: no measurement, no clamp)
     }
+    pressureScore += memoryScore;
+    this.lastMemoryScore = memoryScore;
 
     // Battery signal (cached from startup + transition events)
     if (this.isOnBattery) {
@@ -711,10 +731,17 @@ export class ResourceProfileService {
       // isolation applies per-PVM: a failure on one window must not skip the
       // remaining windows in the iteration.
       if (profile === "efficiency") {
-        try {
-          pvm.setCachedViewLimit(1);
-        } catch {
-          // non-critical
+        // Only destroy cached WebContentsViews when memory actually contributed
+        // to entering efficiency. Battery + thermal/CPU-only triggers are
+        // handled by setEfficiencyFreeze(true) alone, and evictStaleViews()
+        // has its own lowMemoryFreeThresholdMb floor that clamps to 1 when
+        // free RAM really is low (independent of profile).
+        if (this.lastMemoryScore > 0) {
+          try {
+            pvm.setCachedViewLimit(1);
+          } catch {
+            // non-critical
+          }
         }
         try {
           // Freeze cached project views' renderers via CDP under efficiency to

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -984,6 +984,54 @@ describe("ResourceProfileService adversarial", () => {
       service.stop();
     });
 
+    it("lag-only efficiency entry still unfreezes and restores limit on exit", () => {
+      // Lag enters efficiency without clamping (no memory contribution). On
+      // exit, the always-unconditional restore branch must still fire so
+      // renderers don't stay frozen and the user-configured limit is reasserted
+      // (even though entry never clamped — PVM's own evictStaleViews floor may
+      // have clamped during the efficiency window).
+      const pvm = {
+        setCachedViewLimit: vi.fn(),
+        setLowMemoryFreeThresholdMb: vi.fn(),
+        setEfficiencyFreeze: vi.fn(),
+      };
+      const { deps } = createDeps({
+        getProjectViewManager: () =>
+          pvm as unknown as ReturnType<ResourceProfileDeps["getProjectViewManager"]>,
+        getUserCachedViewLimit: () => 4,
+      });
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      mockGetAppMetrics.mockReturnValue([]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("efficiency");
+      expect(pvm.setCachedViewLimit).not.toHaveBeenCalled();
+      expect(pvm.setEfficiencyFreeze).toHaveBeenLastCalledWith(true);
+
+      // Recover from lag.
+      setLag(50, 0.1);
+      for (let i = 0; i < 9; i++) {
+        vi.advanceTimersByTime(5_000);
+      }
+
+      // Drive normal scoring back up.
+      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(30_000);
+      expect(service.getProfile()).toBe("performance");
+
+      expect(pvm.setEfficiencyFreeze).toHaveBeenLastCalledWith(false);
+      expect(pvm.setCachedViewLimit).toHaveBeenLastCalledWith(4);
+
+      service.stop();
+    });
+
     it("getCurrentThermalState throwing does not crash start", () => {
       vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
       mockGetCurrentThermalState.mockImplementation(() => {

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -400,6 +400,87 @@ describe("ResourceProfileService adversarial", () => {
       service.stop();
     });
 
+    it("lag-triggered efficiency entry does not clamp cached view limit", () => {
+      // Lag triggers efficiency directly from sampleLag(), bypassing
+      // computeTargetProfile(). Memory is not the trigger, so the
+      // setCachedViewLimit(1) clamp must NOT fire — only setEfficiencyFreeze(true)
+      // should run (freezing the renderers suppresses the CPU wake-ups that
+      // lag pressure is actually about).
+      const pvm = {
+        setCachedViewLimit: vi.fn(),
+        setLowMemoryFreeThresholdMb: vi.fn(),
+        setEfficiencyFreeze: vi.fn(),
+      };
+      const { deps } = createDeps({
+        getProjectViewManager: () =>
+          pvm as unknown as ReturnType<ResourceProfileDeps["getProjectViewManager"]>,
+      });
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      mockGetAppMetrics.mockReturnValue([]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      expect(pvm.setCachedViewLimit).not.toHaveBeenCalled();
+      expect(pvm.setEfficiencyFreeze).toHaveBeenCalledWith(true);
+
+      service.stop();
+    });
+
+    it("lag-triggered efficiency entry clears stale memory score from prior eval", () => {
+      // A prior memory-pressure eval may have set lastMemoryScore to 2. If lag
+      // then triggers a fresh efficiency entry (the prior entry was reset by an
+      // intervening recovery), the lag path must zero the stale score so the
+      // clamp does NOT fire. Without the zero, the lag path would inherit the
+      // last memory measurement (up to 30s old) and clamp incorrectly.
+      const pvm = {
+        setCachedViewLimit: vi.fn(),
+        setLowMemoryFreeThresholdMb: vi.fn(),
+        setEfficiencyFreeze: vi.fn(),
+      };
+      const { deps } = createDeps({
+        getProjectViewManager: () =>
+          pvm as unknown as ReturnType<ResourceProfileDeps["getProjectViewManager"]>,
+        getUserCachedViewLimit: () => 3,
+      });
+      const service = new ResourceProfileService(deps);
+      mockIsOnBatteryPower.mockReturnValue(true);
+      service.start();
+
+      // Drive into efficiency via memory + battery — sets lastMemoryScore = 2.
+      mockGetAppMetrics.mockReturnValue([makeMetric(1300)]);
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("efficiency");
+      expect(pvm.setCachedViewLimit).toHaveBeenLastCalledWith(1);
+
+      // Recover to balanced. Memory drops, battery off.
+      const onAcHandler = mockPowerMonitorOn.mock.calls.find(
+        (call: string[]) => call[0] === "on-ac"
+      )?.[1] as (() => void) | undefined;
+      mockGetAppMetrics.mockReturnValue([makeMetric(200)]);
+      onAcHandler!();
+      vi.advanceTimersByTime(30_000 * 4);
+      expect(service.getProfile()).not.toBe("efficiency");
+      pvm.setCachedViewLimit.mockClear();
+
+      // Now drive efficiency via lag only. Memory is still low (no contribution).
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      // The lag entry must not have reused the stale memory score.
+      expect(pvm.setCachedViewLimit).not.toHaveBeenCalled();
+      expect(pvm.setEfficiencyFreeze).toHaveBeenLastCalledWith(true);
+
+      service.stop();
+    });
+
     it("does not enter degraded mode on an isolated lag spike", () => {
       const { deps } = createDeps();
       const service = new ResourceProfileService(deps);

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -372,6 +372,85 @@ describe("ResourceProfileService", () => {
     service.stop();
   });
 
+  it("does not clamp cached view limit when efficiency is triggered by non-memory signals", () => {
+    // Battery (+1) + thermal critical (+2) + zero memory = score 3 → efficiency.
+    // No memory contribution, so setCachedViewLimit(1) MUST NOT fire — it would
+    // destroy cached WebContentsViews (each 100–500 MB) for no memory benefit.
+    // setEfficiencyFreeze(true) still fires because freeze suppresses CPU/timer
+    // wake-ups, which IS what the thermal+battery trigger needs.
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    (service as unknown as { thermalState: string }).thermalState = "critical";
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+    expect(pvm.setCachedViewLimit).not.toHaveBeenCalled();
+    expect(pvm.setEfficiencyFreeze).toHaveBeenCalledWith(true);
+
+    service.stop();
+  });
+
+  it("clamps cached view limit when efficiency is triggered with LOW memory pressure", () => {
+    // Battery (+1) + thermal serious (+1) + LOW memory (+1) = score 3 → efficiency.
+    // Memory contributed (+1), so the clamp DOES fire even at LOW tier.
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
+    (service as unknown as { thermalState: string }).thermalState = "serious";
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+    expect(pvm.setCachedViewLimit).toHaveBeenCalledWith(1);
+
+    service.stop();
+  });
+
+  it("still restores user cached view limit on exit after a non-memory efficiency entry", () => {
+    // Enter efficiency via battery + thermal critical (no memory), so entry does
+    // NOT clamp. On exit, the restore call must still fire — the user-configured
+    // limit might have changed mid-efficiency, and PVM's own evictStaleViews
+    // floor could have clamped while we were inside.
+    const deps = createDeps({ getUserCachedViewLimit: () => 3 });
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+
+    const onAcHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-ac"
+    )?.[1] as (() => void) | undefined;
+
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    (service as unknown as { thermalState: string }).thermalState = "critical";
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+    expect(pvm.setCachedViewLimit).not.toHaveBeenCalled();
+
+    // Clear thermal + battery — back to balanced.
+    (service as unknown as { thermalState: string }).thermalState = "nominal";
+    onAcHandler!();
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    vi.advanceTimersByTime(30_000 * 4);
+
+    expect(service.getProfile()).not.toBe("efficiency");
+    expect(pvm.setCachedViewLimit).toHaveBeenLastCalledWith(3);
+    expect(pvm.setEfficiencyFreeze).toHaveBeenLastCalledWith(false);
+
+    service.stop();
+  });
+
   it("enables and disables setEfficiencyFreeze across an efficiency → balanced cycle", () => {
     const deps = createDeps({ getUserCachedViewLimit: () => 2 });
     const service = new ResourceProfileService(deps);

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -481,6 +481,30 @@ describe("ResourceProfileService", () => {
     service.stop();
   });
 
+  it("still freezes when setCachedViewLimit throws on the entry path", () => {
+    // Split try/catch on entry mirrors the exit path: a throw from
+    // setCachedViewLimit(1) (e.g. an onViewEvicted callback failing inside
+    // evictStaleViews) must not block setEfficiencyFreeze(true) — leaving
+    // efficiency unfrozen defeats the CPU/timer-wake suppression that
+    // efficiency is supposed to provide.
+    const deps = createDeps();
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+
+    pvm.setCachedViewLimit.mockImplementationOnce(() => {
+      throw new Error("simulated eviction failure");
+    });
+
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+    expect(pvm.setEfficiencyFreeze).toHaveBeenCalledWith(true);
+
+    service.stop();
+  });
+
   it("still unfreezes when setCachedViewLimit throws on the exit path", () => {
     const deps = createDeps({ getUserCachedViewLimit: () => 2 });
     const pvm = deps.getAllProjectViewManagers()[0] as unknown as MockProjectViewManager;


### PR DESCRIPTION
## Summary

- `ResourceProfileService` was calling `setCachedViewLimit(1)` unconditionally on efficiency entry, destroying cached `WebContentsViews` renderer processes even when efficiency was triggered purely by battery, thermal, or CPU signals with no memory pressure at all
- Fix gates the view limit clamp on a captured memory sub-score: only clamp when memory actually contributed to crossing the efficiency threshold; `setEfficiencyFreeze(true)` and the exit path remain unconditional
- `sampleLag()` now zeros the score before calling `applyProfile()` to prevent stale score carryover from a previous evaluation

Resolves #8603

## Changes

- `electron/services/ResourceProfileService.ts`: capture `memoryScore` before the profile is applied; only call `setCachedViewLimit(1)` when `memoryScore > 0`; zero the score in `sampleLag()` before dispatching to `applyProfile()`
- `electron/services/__tests__/ResourceProfileService.test.ts`: new cases covering lag-only efficiency entry (view limit not clamped) and entry-throw resilience
- `electron/services/__tests__/ResourceProfileService.adversarial.test.ts`: extended adversarial suite covering the same entry/exit paths

## Testing

- Existing unit suite passes
- New test: efficiency entered via lag-only signals does not call `setCachedViewLimit` 
- New test: throwing inside an entry handler does not corrupt profile state