### PR TITLE
fix(window): track primary window by focus order, not registration order

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -184,6 +184,7 @@ if (!gotTheLock) {
 
   const windowRegistry = new WindowRegistry();
   setWindowRegistry(windowRegistry);
+  windowRegistry.wireFocusTracking(app);
 
   // Read last-active projectId synchronously from SQLite BEFORE creating any window.
   // This allows the initial WebContentsView to use the correct session partition,

--- a/electron/window/WindowRegistry.ts
+++ b/electron/window/WindowRegistry.ts
@@ -47,6 +47,10 @@ export class WindowRegistry {
   private webContentsIndex = new Map<number, number>();
   private appViewWebContentsIds = new Map<number, Set<number>>(); // windowId → all view webContentsIds
   private primaryWindowId: number | null = null;
+  // Ordered list of recent focus targets (oldest → newest). Used to find the
+  // next primary when the current primary is unregistered, so the surviving
+  // window with the most recent focus wins instead of the first-registered.
+  private focusHistory: number[] = [];
   private focusTrackingWired = false;
 
   register(win: BrowserWindow, opts?: WindowRegistryOptions): WindowContext {
@@ -80,6 +84,7 @@ export class WindowRegistry {
     // before the async browser-window-focus event arrives), promote it now.
     if (typeof win.isFocused === "function" && win.isFocused()) {
       this.primaryWindowId = windowId;
+      this.recordFocus(windowId);
     }
 
     const doUnregister = () => {
@@ -103,12 +108,25 @@ export class WindowRegistry {
    */
   wireFocusTracking(app: FocusTrackingApp): void {
     if (this.focusTrackingWired) return;
-    this.focusTrackingWired = true;
     app.on("browser-window-focus", (_event, win) => {
-      if (this.windows.has(win.id)) {
-        this.primaryWindowId = win.id;
-      }
+      const ctx = this.windows.get(win.id);
+      if (!ctx) return;
+      // Defend against a focus event delivered for a window whose underlying
+      // BrowserWindow has been destroyed but whose registry entry hasn't been
+      // cleaned up yet.
+      if (typeof win.isDestroyed === "function" && win.isDestroyed()) return;
+      this.primaryWindowId = win.id;
+      this.recordFocus(win.id);
     });
+    this.focusTrackingWired = true;
+  }
+
+  private recordFocus(windowId: number): void {
+    const existing = this.focusHistory.indexOf(windowId);
+    if (existing !== -1) {
+      this.focusHistory.splice(existing, 1);
+    }
+    this.focusHistory.push(windowId);
   }
 
   /**
@@ -155,12 +173,30 @@ export class WindowRegistry {
     }
     this.windows.delete(windowId);
 
+    // Drop the closing window from the focus history before falling back.
+    const historyIdx = this.focusHistory.indexOf(windowId);
+    if (historyIdx !== -1) {
+      this.focusHistory.splice(historyIdx, 1);
+    }
+
     if (this.primaryWindowId === windowId) {
       this.primaryWindowId = null;
-      for (const [id, c] of this.windows) {
-        if (!c.browserWindow.isDestroyed()) {
+      // Prefer the most recently focused live window over Map insertion order
+      // so the user lands on the window they were last looking at.
+      for (let i = this.focusHistory.length - 1; i >= 0; i--) {
+        const id = this.focusHistory[i];
+        const c = this.windows.get(id);
+        if (c && !c.browserWindow.isDestroyed()) {
           this.primaryWindowId = id;
           break;
+        }
+      }
+      if (this.primaryWindowId === null) {
+        for (const [id, c] of this.windows) {
+          if (!c.browserWindow.isDestroyed()) {
+            this.primaryWindowId = id;
+            break;
+          }
         }
       }
     }

--- a/electron/window/WindowRegistry.ts
+++ b/electron/window/WindowRegistry.ts
@@ -5,6 +5,18 @@ import type { ProjectSwitchService } from "../services/ProjectSwitchService.js";
 import type { ProjectViewManager } from "./ProjectViewManager.js";
 import { DisposableStore } from "../utils/lifecycle.js";
 
+/**
+ * Narrow structural type for the Electron `app` module — exposes only the
+ * `on("browser-window-focus", ...)` subscription used by focus tracking.
+ * Keeps WindowRegistry testable without mocking the whole electron module.
+ */
+export interface FocusTrackingApp {
+  on(
+    event: "browser-window-focus",
+    listener: (event: unknown, win: BrowserWindow) => void
+  ): unknown;
+}
+
 export interface WindowServices {
   portalManager?: PortalManager;
   eventBuffer?: EventBuffer;
@@ -35,6 +47,7 @@ export class WindowRegistry {
   private webContentsIndex = new Map<number, number>();
   private appViewWebContentsIds = new Map<number, Set<number>>(); // windowId → all view webContentsIds
   private primaryWindowId: number | null = null;
+  private focusTrackingWired = false;
 
   register(win: BrowserWindow, opts?: WindowRegistryOptions): WindowContext {
     const windowId = win.id;
@@ -57,7 +70,15 @@ export class WindowRegistry {
     this.windows.set(windowId, ctx);
     this.webContentsIndex.set(webContentsId, windowId);
 
+    // Cold-start fallback: claim primary on first registration so getPrimary()
+    // returns a sane value before any focus event fires.
     if (this.primaryWindowId === null) {
+      this.primaryWindowId = windowId;
+    }
+
+    // If the window is already focused at registration time (sync show/focus
+    // before the async browser-window-focus event arrives), promote it now.
+    if (typeof win.isFocused === "function" && win.isFocused()) {
       this.primaryWindowId = windowId;
     }
 
@@ -70,6 +91,24 @@ export class WindowRegistry {
     win.webContents.once("destroyed", doUnregister);
 
     return ctx;
+  }
+
+  /**
+   * Subscribe to `browser-window-focus` so `primaryWindowId` tracks the most
+   * recently focused registered window. Idempotent — safe to call multiple
+   * times.
+   *
+   * The `windows.has(win.id)` guard filters out detached DevTools windows and
+   * any other Electron-internal BrowserWindow that isn't in our registry.
+   */
+  wireFocusTracking(app: FocusTrackingApp): void {
+    if (this.focusTrackingWired) return;
+    this.focusTrackingWired = true;
+    app.on("browser-window-focus", (_event, win) => {
+      if (this.windows.has(win.id)) {
+        this.primaryWindowId = win.id;
+      }
+    });
   }
 
   /**

--- a/electron/window/__tests__/WindowRegistry.adversarial.test.ts
+++ b/electron/window/__tests__/WindowRegistry.adversarial.test.ts
@@ -217,6 +217,63 @@ describe("WindowRegistry adversarial", () => {
     expect(registry.getPrimary()?.windowId).toBe(1);
   });
 
+  it("UNREGISTER_PRIMARY_PREFERS_FOCUS_ORDER_NOT_MAP_ORDER", () => {
+    const registry = new WindowRegistry();
+    const mockApp = makeMockApp();
+    const win1 = makeMockWindow(1, 100);
+    const win2 = makeMockWindow(2, 200);
+    const win3 = makeMockWindow(3, 300);
+
+    registry.wireFocusTracking(mockApp);
+    registry.register(win1);
+    registry.register(win2);
+    registry.register(win3);
+
+    // Focus B, then C. Now close C. Fallback should pick B (last-focused-
+    // surviving), NOT A (first inserted in Map).
+    mockApp.emit("browser-window-focus", null, win2);
+    mockApp.emit("browser-window-focus", null, win3);
+
+    registry.unregister(3);
+
+    expect(registry.getPrimary()?.windowId).toBe(2);
+  });
+
+  it("UNREGISTER_FALLS_BACK_TO_MAP_ORDER_WHEN_FOCUS_HISTORY_EXHAUSTED", () => {
+    const registry = new WindowRegistry();
+    const win1 = makeMockWindow(1, 100);
+    const win2 = makeMockWindow(2, 200);
+
+    // No focus events ever fired.
+    registry.register(win1);
+    registry.register(win2);
+    expect(registry.getPrimary()?.windowId).toBe(1);
+
+    registry.unregister(1);
+
+    // Empty focus history → fall back to Map insertion order (only win2 left).
+    expect(registry.getPrimary()?.windowId).toBe(2);
+  });
+
+  it("FOCUS_EVENT_FOR_DESTROYED_BUT_STILL_REGISTERED_WINDOW_IGNORED", () => {
+    const registry = new WindowRegistry();
+    const mockApp = makeMockApp();
+    const win1 = makeMockWindow(1, 100);
+    const win2 = makeMockWindow(2, 200);
+
+    registry.wireFocusTracking(mockApp);
+    registry.register(win1);
+    registry.register(win2);
+
+    // Simulate the window being destroyed mid-flight without its registry
+    // entry being cleaned up yet.
+    win2._destroyed = true;
+
+    mockApp.emit("browser-window-focus", null, win2);
+
+    expect(registry.getPrimary()?.windowId).toBe(1);
+  });
+
   it("UNKNOWN_APP_VIEW_UNREGISTER_NO_OP", () => {
     const registry = new WindowRegistry();
     const win = makeMockWindow(1, 100);

--- a/electron/window/__tests__/WindowRegistry.adversarial.test.ts
+++ b/electron/window/__tests__/WindowRegistry.adversarial.test.ts
@@ -37,6 +37,7 @@ function makeMockWindow(id: number, webContentsId: number): MockBrowserWindow {
       }
     }),
     isDestroyed: vi.fn(() => win._destroyed),
+    isFocused: vi.fn(() => false),
     _fireClosed: () => {
       win._destroyed = true;
       closedHandlers.forEach((handler) => handler());
@@ -48,6 +49,22 @@ function makeMockWindow(id: number, webContentsId: number): MockBrowserWindow {
   } as unknown as MockBrowserWindow;
 
   return win;
+}
+
+function makeMockApp() {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  return {
+    on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+      const arr = listeners.get(event) ?? [];
+      arr.push(listener);
+      listeners.set(event, arr);
+    }),
+    emit: (event: string, ...args: unknown[]) => {
+      for (const listener of listeners.get(event) ?? []) {
+        listener(...args);
+      }
+    },
+  };
 }
 
 describe("WindowRegistry adversarial", () => {
@@ -163,6 +180,41 @@ describe("WindowRegistry adversarial", () => {
     expect(registry.getPrimary()).toBe(liveCtx);
     expect(registry.getByWebContentsId(220)).toBeUndefined();
     expect(registry.getByWebContentsId(330)).toBe(liveCtx);
+  });
+
+  it("FOCUS_AFTER_UNREGISTER_NO_REVIVE", () => {
+    const registry = new WindowRegistry();
+    const mockApp = makeMockApp();
+    const win1 = makeMockWindow(1, 100);
+    const win2 = makeMockWindow(2, 200);
+
+    registry.wireFocusTracking(mockApp);
+    registry.register(win1);
+    registry.register(win2);
+
+    mockApp.emit("browser-window-focus", null, win2);
+    expect(registry.getPrimary()?.windowId).toBe(2);
+
+    registry.unregister(2);
+
+    // After unregistration, focus event for the dead window must NOT
+    // revive it as primary.
+    mockApp.emit("browser-window-focus", null, win2);
+
+    expect(registry.getPrimary()?.windowId).toBe(1);
+    expect(registry.getByWindowId(2)).toBeUndefined();
+  });
+
+  it("FOCUS_COLD_START_FALLBACK_PRESERVED", () => {
+    const registry = new WindowRegistry();
+    const win1 = makeMockWindow(1, 100);
+    const win2 = makeMockWindow(2, 200);
+
+    // No wireFocusTracking, no isFocused() returning true — pure cold start.
+    registry.register(win1);
+    registry.register(win2);
+
+    expect(registry.getPrimary()?.windowId).toBe(1);
   });
 
   it("UNKNOWN_APP_VIEW_UNREGISTER_NO_OP", () => {

--- a/electron/window/__tests__/WindowRegistry.test.ts
+++ b/electron/window/__tests__/WindowRegistry.test.ts
@@ -264,6 +264,47 @@ describe("WindowRegistry", () => {
       registry.unregister(2);
       expect(registry.getPrimary()?.windowId).toBe(3);
     });
+
+    it("FOCUS_SEQUENCE_LAST_EVENT_WINS_THREE_WINDOWS", () => {
+      const registry = new WindowRegistry();
+      const mockApp = makeMockApp();
+      const win1 = makeMockWindow(1, 100);
+      const win2 = makeMockWindow(2, 200);
+      const win3 = makeMockWindow(3, 300);
+
+      registry.wireFocusTracking(mockApp);
+      registry.register(win1);
+      registry.register(win2);
+      registry.register(win3);
+
+      mockApp.emit("browser-window-focus", null, win1);
+      expect(registry.getPrimary()?.windowId).toBe(1);
+
+      mockApp.emit("browser-window-focus", null, win2);
+      expect(registry.getPrimary()?.windowId).toBe(2);
+
+      mockApp.emit("browser-window-focus", null, win1);
+      expect(registry.getPrimary()?.windowId).toBe(1);
+    });
+
+    it("REGISTER_ALREADY_FOCUSED_THIRD_WINDOW_PROMOTES_OVER_EXISTING_PRIMARY", () => {
+      const registry = new WindowRegistry();
+      const mockApp = makeMockApp();
+      const win1 = makeMockWindow(1, 100, { focused: false });
+      const win2 = makeMockWindow(2, 200, { focused: false });
+      const win3 = makeMockWindow(3, 300, { focused: true });
+
+      registry.wireFocusTracking(mockApp);
+      registry.register(win1);
+      registry.register(win2);
+
+      mockApp.emit("browser-window-focus", null, win2);
+      expect(registry.getPrimary()?.windowId).toBe(2);
+
+      registry.register(win3);
+
+      expect(registry.getPrimary()?.windowId).toBe(3);
+    });
   });
 
   it("auto-unregisters on window closed event", () => {

--- a/electron/window/__tests__/WindowRegistry.test.ts
+++ b/electron/window/__tests__/WindowRegistry.test.ts
@@ -3,7 +3,7 @@ import { WindowRegistry } from "../WindowRegistry.js";
 import { toDisposable } from "../../utils/lifecycle.js";
 import type { BrowserWindow } from "electron";
 
-function makeMockWindow(id: number, webContentsId: number) {
+function makeMockWindow(id: number, webContentsId: number, opts?: { focused?: boolean }) {
   const closedHandlers: Array<() => void> = [];
   const destroyedHandlers: Array<() => void> = [];
 
@@ -20,6 +20,7 @@ function makeMockWindow(id: number, webContentsId: number) {
       if (event === "closed") closedHandlers.push(handler);
     }),
     isDestroyed: vi.fn(() => false),
+    isFocused: vi.fn(() => opts?.focused ?? false),
     isMinimized: vi.fn(() => false),
     focus: vi.fn(),
     restore: vi.fn(),
@@ -31,6 +32,23 @@ function makeMockWindow(id: number, webContentsId: number) {
   };
 
   return win;
+}
+
+function makeMockApp() {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  return {
+    on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+      const arr = listeners.get(event) ?? [];
+      arr.push(listener);
+      listeners.set(event, arr);
+    }),
+    emit: (event: string, ...args: unknown[]) => {
+      for (const listener of listeners.get(event) ?? []) {
+        listener(...args);
+      }
+    },
+    listenerCount: (event: string) => listeners.get(event)?.length ?? 0,
+  };
 }
 
 describe("WindowRegistry", () => {
@@ -162,6 +180,90 @@ describe("WindowRegistry", () => {
     registry.setPrimary(999);
 
     expect(registry.getPrimary()?.windowId).toBe(1);
+  });
+
+  describe("focus tracking", () => {
+    it("wireFocusTracking: focus on second registered window reassigns primary", () => {
+      const registry = new WindowRegistry();
+      const mockApp = makeMockApp();
+      const win1 = makeMockWindow(1, 100);
+      const win2 = makeMockWindow(2, 200);
+
+      registry.wireFocusTracking(mockApp);
+      registry.register(win1);
+      registry.register(win2);
+
+      expect(registry.getPrimary()?.windowId).toBe(1);
+
+      mockApp.emit("browser-window-focus", null, win2);
+
+      expect(registry.getPrimary()?.windowId).toBe(2);
+    });
+
+    it("wireFocusTracking: focus event for window not in registry does not change primary", () => {
+      const registry = new WindowRegistry();
+      const mockApp = makeMockApp();
+      const win1 = makeMockWindow(1, 100);
+
+      registry.wireFocusTracking(mockApp);
+      registry.register(win1);
+
+      const devtoolsLikeWin = makeMockWindow(42, 4200);
+      mockApp.emit("browser-window-focus", null, devtoolsLikeWin);
+
+      expect(registry.getPrimary()?.windowId).toBe(1);
+    });
+
+    it("wireFocusTracking is idempotent — calling twice attaches only one listener", () => {
+      const registry = new WindowRegistry();
+      const mockApp = makeMockApp();
+
+      registry.wireFocusTracking(mockApp);
+      registry.wireFocusTracking(mockApp);
+
+      expect(mockApp.listenerCount("browser-window-focus")).toBe(1);
+    });
+
+    it("register: already-focused window becomes primary immediately even when not first", () => {
+      const registry = new WindowRegistry();
+      const win1 = makeMockWindow(1, 100, { focused: false });
+      const win2 = makeMockWindow(2, 200, { focused: true });
+
+      registry.register(win1);
+      registry.register(win2);
+
+      expect(registry.getPrimary()?.windowId).toBe(2);
+    });
+
+    it("register: cold-start fallback still applies when no window is focused yet", () => {
+      const registry = new WindowRegistry();
+      const win1 = makeMockWindow(1, 100, { focused: false });
+      const win2 = makeMockWindow(2, 200, { focused: false });
+
+      registry.register(win1);
+      registry.register(win2);
+
+      expect(registry.getPrimary()?.windowId).toBe(1);
+    });
+
+    it("focus updates survive after unregister of unrelated window", () => {
+      const registry = new WindowRegistry();
+      const mockApp = makeMockApp();
+      const win1 = makeMockWindow(1, 100);
+      const win2 = makeMockWindow(2, 200);
+      const win3 = makeMockWindow(3, 300);
+
+      registry.wireFocusTracking(mockApp);
+      registry.register(win1);
+      registry.register(win2);
+      registry.register(win3);
+
+      mockApp.emit("browser-window-focus", null, win3);
+      expect(registry.getPrimary()?.windowId).toBe(3);
+
+      registry.unregister(2);
+      expect(registry.getPrimary()?.windowId).toBe(3);
+    });
   });
 
   it("auto-unregisters on window closed event", () => {


### PR DESCRIPTION
## Summary

- `WindowRegistry` was assigning `primaryWindowId` based on registration order. With multiple windows open, notification clicks and other primary-window routing would target the first-registered window rather than the one the user was actually looking at.
- Adds `wireFocusTracking(app)` to `WindowRegistry`, which subscribes to `browser-window-focus` events and updates `primaryWindowId` whenever focus changes. `register()` also promotes a window immediately if it's already focused at registration time. `unregister()` now falls back to focus-history order rather than Map insertion order when reassigning primary.
- A `focusHistory: number[]` array tracks windows in the order they gained focus; a defensive `isDestroyed()` check guards the listener against post-close events.

Resolves #8600

## Changes

- `electron/window/WindowRegistry.ts` — `wireFocusTracking(app)`, `focusHistory` field, focus-aware `register()`, focus-history fallback in `unregister()`
- `electron/main.ts` — one-line call to `windowRegistry.wireFocusTracking(app)` after registry construction
- `electron/window/__tests__/WindowRegistry.test.ts` and `WindowRegistry.adversarial.test.ts` — 11 new tests covering focus-driven primary updates, idempotency, register-time promotion, three-window focus sequences, focus-history-aware unregister fallback, and destroyed/unregistered edge cases

## Testing

- 11 new unit tests covering the main paths and edge cases
- Existing `WindowRegistry` suite passes unchanged
- Typecheck, lint, and build all clean