### PR TITLE
fix(panel): close memo comparator field drift causing stale panel chrome

### DIFF
--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -122,7 +122,11 @@ export function gridPanelPropsAreEqual(prev: GridPanelProps, next: GridPanelProp
         !terminalChromeDescriptorsEqual(pt.chrome, nt.chrome) ||
         pt.kind !== nt.kind ||
         pt.agentState !== nt.agentState ||
-        pt.isActive !== nt.isActive
+        pt.isActive !== nt.isActive ||
+        pt.presetColor !== nt.presetColor ||
+        pt.isUsingFallback !== nt.isUsingFallback ||
+        pt.fallbackTooltip !== nt.fallbackTooltip ||
+        pt.hasDangerousFlags !== nt.hasDangerousFlags
       ) {
         return false;
       }

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -45,7 +45,9 @@ export interface GridPanelProps {
  * Skips callback props (onTabClick, onTabClose, onTabRename, onAddTab,
  * onTabReorder) because ContentGrid passes inline closures that change every
  * render. Compares terminal fields used by buildPanelProps and ErrorBoundary
- * resetKeys — if buildPanelProps gains new terminal fields, update this list.
+ * resetKeys. The drift-coverage test in gridPanelPropsAreEqual.test.ts
+ * Proxies buildPanelProps and asserts each accessed terminal.* field is
+ * caught here, so this list fails CI if it falls behind panelProps.ts.
  */
 export function gridPanelPropsAreEqual(prev: GridPanelProps, next: GridPanelProps): boolean {
   // Scalar props
@@ -93,7 +95,13 @@ export function gridPanelPropsAreEqual(prev: GridPanelProps, next: GridPanelProp
       a.runtimeStatus !== b.runtimeStatus ||
       a.isInputLocked !== b.isInputLocked ||
       a.extensionState !== b.extensionState ||
-      a.pluginId !== b.pluginId
+      a.pluginId !== b.pluginId ||
+      a.exitCode !== b.exitCode ||
+      a.agentPresetColor !== b.agentPresetColor ||
+      a.agentPresetId !== b.agentPresetId ||
+      a.agentLaunchFlags !== b.agentLaunchFlags ||
+      a.browserHistory !== b.browserHistory ||
+      a.browserZoom !== b.browserZoom
     ) {
       return false;
     }

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -105,7 +105,9 @@ export function gridTabGroupPropsAreEqual(
           a.extensionState !== b.extensionState ||
           a.pluginId !== b.pluginId ||
           a.browserHistory !== b.browserHistory ||
-          a.browserZoom !== b.browserZoom
+          a.browserZoom !== b.browserZoom ||
+          a.isUsingFallback !== b.isUsingFallback ||
+          a.originalPresetId !== b.originalPresetId
         ) {
           return false;
         }

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -28,7 +28,10 @@ export interface GridTabGroupProps {
  * Compares panel rendering fields used by the tabs useMemo, isGroupFocused,
  * and getGroupAmbientAgentState. Skips callback props (none on this component).
  * The group.activeTabId is NOT compared because the component subscribes to it
- * via Zustand store selector instead.
+ * via Zustand store selector instead. The drift-coverage test in
+ * gridTabGroupPropsAreEqual.test.ts Proxies buildPanelProps and asserts each
+ * accessed terminal.* field is caught here, so this list fails CI if it falls
+ * behind panelProps.ts.
  */
 export function gridTabGroupPropsAreEqual(
   prev: GridTabGroupProps,
@@ -95,7 +98,14 @@ export function gridTabGroupPropsAreEqual(
           a.browserUrl !== b.browserUrl ||
           a.isRestarting !== b.isRestarting ||
           a.runtimeStatus !== b.runtimeStatus ||
-          a.isInputLocked !== b.isInputLocked
+          a.isInputLocked !== b.isInputLocked ||
+          a.exitCode !== b.exitCode ||
+          a.agentPresetColor !== b.agentPresetColor ||
+          a.agentPresetId !== b.agentPresetId ||
+          a.extensionState !== b.extensionState ||
+          a.pluginId !== b.pluginId ||
+          a.browserHistory !== b.browserHistory ||
+          a.browserZoom !== b.browserZoom
         ) {
           return false;
         }

--- a/src/components/Terminal/__tests__/gridPanelPropsAreEqual.test.ts
+++ b/src/components/Terminal/__tests__/gridPanelPropsAreEqual.test.ts
@@ -294,6 +294,52 @@ describe("gridPanelPropsAreEqual", () => {
     expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
   });
 
+  it("returns false when tab presetColor changes", () => {
+    const prev = baseProps({ tabs: [{ ...baseTab, presetColor: "#ff00ff" }] });
+    const next = baseProps({ tabs: [{ ...baseTab, presetColor: "#00ffff" }] });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when tab isUsingFallback changes", () => {
+    const prev = baseProps({ tabs: [{ ...baseTab, isUsingFallback: false }] });
+    const next = baseProps({ tabs: [{ ...baseTab, isUsingFallback: true }] });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when tab fallbackTooltip changes", () => {
+    const prev = baseProps({ tabs: [{ ...baseTab, fallbackTooltip: undefined }] });
+    const next = baseProps({
+      tabs: [{ ...baseTab, fallbackTooltip: 'Using fallback "x" — "y" unavailable' }],
+    });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when tab hasDangerousFlags changes", () => {
+    const prev = baseProps({ tabs: [{ ...baseTab, hasDangerousFlags: false }] });
+    const next = baseProps({ tabs: [{ ...baseTab, hasDangerousFlags: true }] });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when tab chrome.hasExited changes (post-exit spinner suppression)", () => {
+    // Race: exitCode/runtimeStatus fires before agentState:"exited" arrives.
+    // Without hasExited in the descriptor equality, the stale working spinner
+    // survives the re-render gate.
+    const liveChrome = deriveTerminalChrome({
+      kind: "terminal",
+      launchAgentId: "claude",
+      agentState: "working",
+    });
+    const exitedChrome = deriveTerminalChrome({
+      kind: "terminal",
+      launchAgentId: "claude",
+      agentState: "working",
+      exitCode: 0,
+    });
+    const prev = baseProps({ tabs: [{ ...baseTab, chrome: liveChrome }] });
+    const next = baseProps({ tabs: [{ ...baseTab, chrome: exitedChrome }] });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
   describe("drift coverage", () => {
     // Wraps a terminal in a Proxy that records every property read, then drives
     // buildPanelProps so the Proxy captures the full terminal.* surface

--- a/src/components/Terminal/__tests__/gridPanelPropsAreEqual.test.ts
+++ b/src/components/Terminal/__tests__/gridPanelPropsAreEqual.test.ts
@@ -3,6 +3,7 @@ import { gridPanelPropsAreEqual, type GridPanelProps } from "../GridPanel";
 import type { TerminalInstance } from "@/store";
 import type { TabInfo } from "@/components/Panel/TabButton";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { buildPanelProps } from "@/utils/panelProps";
 
 const noop = () => {};
 
@@ -225,4 +226,129 @@ describe("gridPanelPropsAreEqual", () => {
     const next = baseProps({ titleOverride: "wt-a — Claude" });
     expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
   });
+
+  it("returns false when terminal.exitCode changes", () => {
+    const prev = baseProps({
+      terminal: { ...baseTerminal, exitCode: undefined } as TerminalInstance,
+    });
+    const next = baseProps({ terminal: { ...baseTerminal, exitCode: 137 } as TerminalInstance });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when terminal.agentPresetColor changes", () => {
+    const prev = baseProps({
+      terminal: { ...baseTerminal, agentPresetColor: "#ff00ff" } as TerminalInstance,
+    });
+    const next = baseProps({
+      terminal: { ...baseTerminal, agentPresetColor: "#00ffff" } as TerminalInstance,
+    });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when terminal.agentPresetId changes", () => {
+    const prev = baseProps({
+      terminal: { ...baseTerminal, agentPresetId: "preset-a" } as TerminalInstance,
+    });
+    const next = baseProps({
+      terminal: { ...baseTerminal, agentPresetId: "preset-b" } as TerminalInstance,
+    });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when terminal.agentLaunchFlags changes reference", () => {
+    const prev = baseProps({
+      terminal: { ...baseTerminal, agentLaunchFlags: ["--print"] } as TerminalInstance,
+    });
+    const next = baseProps({
+      terminal: {
+        ...baseTerminal,
+        agentLaunchFlags: ["--print", "--dangerously-skip-permissions"],
+      } as TerminalInstance,
+    });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when terminal.browserHistory changes reference", () => {
+    const prev = baseProps({
+      terminal: {
+        ...baseTerminal,
+        browserHistory: { entries: [], currentIndex: -1 },
+      } as TerminalInstance,
+    });
+    const next = baseProps({
+      terminal: {
+        ...baseTerminal,
+        browserHistory: { entries: [{ url: "http://x" }], currentIndex: 0 },
+      } as TerminalInstance,
+    });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when terminal.browserZoom changes", () => {
+    const prev = baseProps({
+      terminal: { ...baseTerminal, browserZoom: 1.0 } as TerminalInstance,
+    });
+    const next = baseProps({
+      terminal: { ...baseTerminal, browserZoom: 1.25 } as TerminalInstance,
+    });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  describe("drift coverage", () => {
+    // Wraps a terminal in a Proxy that records every property read, then drives
+    // buildPanelProps so the Proxy captures the full terminal.* surface
+    // (including transitive reads inside deriveTerminalChrome). For each
+    // recorded key, mutating it must force the comparator to return false.
+    // Fails automatically when buildPanelProps gains a new terminal.* field
+    // that the comparator does not check.
+    it("catches every terminal.* field buildPanelProps reads", () => {
+      const reads = new Set<string>();
+      const fixture: TerminalInstance = {
+        ...baseTerminal,
+        agentState: "idle",
+        runtimeStatus: "running",
+        agentLaunchFlags: ["--print"],
+        browserHistory: { entries: [], currentIndex: -1 },
+        browserZoom: 1.0,
+      } as TerminalInstance;
+
+      const proxy = new Proxy(fixture, {
+        get(target, prop, receiver) {
+          if (typeof prop === "string") reads.add(prop);
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+
+      buildPanelProps({
+        terminal: proxy,
+        isFocused: false,
+        overrides: { onFocus: noop, onClose: noop },
+      });
+
+      const observed = [...reads];
+      expect(observed.length).toBeGreaterThan(0);
+
+      for (const key of observed) {
+        const prev = baseProps({ terminal: fixture });
+        const next = baseProps({
+          terminal: mutateTerminalField(fixture, key),
+        });
+        expect(
+          gridPanelPropsAreEqual(prev, next),
+          `gridPanelPropsAreEqual must return false when terminal.${key} changes`
+        ).toBe(false);
+      }
+    });
+  });
 });
+
+function mutateTerminalField(terminal: TerminalInstance, key: string): TerminalInstance {
+  const current = (terminal as Record<string, unknown>)[key];
+  let mutated: unknown;
+  if (typeof current === "string") mutated = `${current}__drift`;
+  else if (typeof current === "number") mutated = current + 1;
+  else if (typeof current === "boolean") mutated = !current;
+  else if (Array.isArray(current)) mutated = [...current, "__drift"];
+  else mutated = { __drift: true };
+  return { ...terminal, [key]: mutated } as TerminalInstance;
+}

--- a/src/components/Terminal/__tests__/gridPanelPropsAreEqual.test.ts
+++ b/src/components/Terminal/__tests__/gridPanelPropsAreEqual.test.ts
@@ -272,13 +272,13 @@ describe("gridPanelPropsAreEqual", () => {
     const prev = baseProps({
       terminal: {
         ...baseTerminal,
-        browserHistory: { entries: [], currentIndex: -1 },
+        browserHistory: { past: [], present: "http://a", future: [] },
       } as TerminalInstance,
     });
     const next = baseProps({
       terminal: {
         ...baseTerminal,
-        browserHistory: { entries: [{ url: "http://x" }], currentIndex: 0 },
+        browserHistory: { past: ["http://a"], present: "http://x", future: [] },
       } as TerminalInstance,
     });
     expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
@@ -354,7 +354,7 @@ describe("gridPanelPropsAreEqual", () => {
         agentState: "idle",
         runtimeStatus: "running",
         agentLaunchFlags: ["--print"],
-        browserHistory: { entries: [], currentIndex: -1 },
+        browserHistory: { past: [], present: "http://a", future: [] },
         browserZoom: 1.0,
       } as TerminalInstance;
 
@@ -389,7 +389,7 @@ describe("gridPanelPropsAreEqual", () => {
 });
 
 function mutateTerminalField(terminal: TerminalInstance, key: string): TerminalInstance {
-  const current = (terminal as Record<string, unknown>)[key];
+  const current = (terminal as unknown as Record<string, unknown>)[key];
   let mutated: unknown;
   if (typeof current === "string") mutated = `${current}__drift`;
   else if (typeof current === "number") mutated = current + 1;

--- a/src/components/Terminal/__tests__/gridTabGroupPropsAreEqual.test.ts
+++ b/src/components/Terminal/__tests__/gridTabGroupPropsAreEqual.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from "vitest";
 import { gridTabGroupPropsAreEqual, type GridTabGroupProps } from "../GridTabGroup";
 import type { TerminalInstance } from "@/store";
 import type { TabGroup } from "@/types";
+import { buildPanelProps } from "@/utils/panelProps";
+
+const noop = () => {};
 
 const baseGroup: TabGroup = {
   id: "g-1",
@@ -165,4 +168,139 @@ describe("gridTabGroupPropsAreEqual", () => {
     const next = baseProps({ group: { ...baseGroup, worktreeId: "wt-2" } });
     expect(gridTabGroupPropsAreEqual(prev, next)).toBe(false);
   });
+
+  it("returns false when panel exitCode changes", () => {
+    const prev = baseProps({ panels: [basePanel, basePanel2] });
+    const next = baseProps({
+      panels: [{ ...basePanel, exitCode: 137 } as TerminalInstance, basePanel2],
+    });
+    expect(gridTabGroupPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when panel agentPresetColor changes", () => {
+    const prev = baseProps({
+      panels: [{ ...basePanel, agentPresetColor: "#ff00ff" } as TerminalInstance, basePanel2],
+    });
+    const next = baseProps({
+      panels: [{ ...basePanel, agentPresetColor: "#00ffff" } as TerminalInstance, basePanel2],
+    });
+    expect(gridTabGroupPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when panel agentPresetId changes", () => {
+    const prev = baseProps({
+      panels: [{ ...basePanel, agentPresetId: "preset-a" } as TerminalInstance, basePanel2],
+    });
+    const next = baseProps({
+      panels: [{ ...basePanel, agentPresetId: "preset-b" } as TerminalInstance, basePanel2],
+    });
+    expect(gridTabGroupPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when panel pluginId changes", () => {
+    const prev = baseProps({
+      panels: [{ ...basePanel, pluginId: undefined } as TerminalInstance, basePanel2],
+    });
+    const next = baseProps({
+      panels: [{ ...basePanel, pluginId: "my-plugin" } as TerminalInstance, basePanel2],
+    });
+    expect(gridTabGroupPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when panel extensionState changes reference", () => {
+    const prev = baseProps({
+      panels: [{ ...basePanel, extensionState: { kind: "a" } } as TerminalInstance, basePanel2],
+    });
+    const next = baseProps({
+      panels: [{ ...basePanel, extensionState: { kind: "b" } } as TerminalInstance, basePanel2],
+    });
+    expect(gridTabGroupPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when panel browserHistory changes reference", () => {
+    const prev = baseProps({
+      panels: [
+        { ...basePanel, browserHistory: { entries: [], currentIndex: -1 } } as TerminalInstance,
+        basePanel2,
+      ],
+    });
+    const next = baseProps({
+      panels: [
+        {
+          ...basePanel,
+          browserHistory: { entries: [{ url: "http://x" }], currentIndex: 0 },
+        } as TerminalInstance,
+        basePanel2,
+      ],
+    });
+    expect(gridTabGroupPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when panel browserZoom changes", () => {
+    const prev = baseProps({
+      panels: [{ ...basePanel, browserZoom: 1.0 } as TerminalInstance, basePanel2],
+    });
+    const next = baseProps({
+      panels: [{ ...basePanel, browserZoom: 1.25 } as TerminalInstance, basePanel2],
+    });
+    expect(gridTabGroupPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  describe("drift coverage", () => {
+    // Wraps a panel in a Proxy that records every property read, then drives
+    // buildPanelProps so the Proxy captures the full terminal.* surface
+    // (including transitive reads inside deriveTerminalChrome). For each
+    // recorded key, mutating it must force the comparator to return false.
+    // Fails automatically when buildPanelProps gains a new terminal.* field
+    // that the comparator does not check.
+    it("catches every terminal.* field buildPanelProps reads", () => {
+      const reads = new Set<string>();
+      const fixture: TerminalInstance = {
+        ...basePanel,
+        agentState: "idle",
+        runtimeStatus: "running",
+        agentLaunchFlags: ["--print"],
+        browserHistory: { entries: [], currentIndex: -1 },
+        browserZoom: 1.0,
+      } as TerminalInstance;
+
+      const proxy = new Proxy(fixture, {
+        get(target, prop, receiver) {
+          if (typeof prop === "string") reads.add(prop);
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+
+      buildPanelProps({
+        terminal: proxy,
+        isFocused: false,
+        overrides: { onFocus: noop, onClose: noop },
+      });
+
+      const observed = [...reads];
+      expect(observed.length).toBeGreaterThan(0);
+
+      for (const key of observed) {
+        const prev = baseProps({ panels: [fixture, basePanel2] });
+        const next = baseProps({
+          panels: [mutateTerminalField(fixture, key), basePanel2],
+        });
+        expect(
+          gridTabGroupPropsAreEqual(prev, next),
+          `gridTabGroupPropsAreEqual must return false when panel.${key} changes`
+        ).toBe(false);
+      }
+    });
+  });
 });
+
+function mutateTerminalField(terminal: TerminalInstance, key: string): TerminalInstance {
+  const current = (terminal as Record<string, unknown>)[key];
+  let mutated: unknown;
+  if (typeof current === "string") mutated = `${current}__drift`;
+  else if (typeof current === "number") mutated = current + 1;
+  else if (typeof current === "boolean") mutated = !current;
+  else if (Array.isArray(current)) mutated = [...current, "__drift"];
+  else mutated = { __drift: true };
+  return { ...terminal, [key]: mutated } as TerminalInstance;
+}

--- a/src/components/Terminal/__tests__/gridTabGroupPropsAreEqual.test.ts
+++ b/src/components/Terminal/__tests__/gridTabGroupPropsAreEqual.test.ts
@@ -220,7 +220,10 @@ describe("gridTabGroupPropsAreEqual", () => {
   it("returns false when panel browserHistory changes reference", () => {
     const prev = baseProps({
       panels: [
-        { ...basePanel, browserHistory: { entries: [], currentIndex: -1 } } as TerminalInstance,
+        {
+          ...basePanel,
+          browserHistory: { past: [], present: "http://a", future: [] },
+        } as TerminalInstance,
         basePanel2,
       ],
     });
@@ -228,7 +231,7 @@ describe("gridTabGroupPropsAreEqual", () => {
       panels: [
         {
           ...basePanel,
-          browserHistory: { entries: [{ url: "http://x" }], currentIndex: 0 },
+          browserHistory: { past: ["http://a"], present: "http://x", future: [] },
         } as TerminalInstance,
         basePanel2,
       ],
@@ -289,7 +292,7 @@ describe("gridTabGroupPropsAreEqual", () => {
         agentState: "idle",
         runtimeStatus: "running",
         agentLaunchFlags: ["--print"],
-        browserHistory: { entries: [], currentIndex: -1 },
+        browserHistory: { past: [], present: "http://a", future: [] },
         browserZoom: 1.0,
       } as TerminalInstance;
 
@@ -324,7 +327,7 @@ describe("gridTabGroupPropsAreEqual", () => {
 });
 
 function mutateTerminalField(terminal: TerminalInstance, key: string): TerminalInstance {
-  const current = (terminal as Record<string, unknown>)[key];
+  const current = (terminal as unknown as Record<string, unknown>)[key];
   let mutated: unknown;
   if (typeof current === "string") mutated = `${current}__drift`;
   else if (typeof current === "number") mutated = current + 1;

--- a/src/components/Terminal/__tests__/gridTabGroupPropsAreEqual.test.ts
+++ b/src/components/Terminal/__tests__/gridTabGroupPropsAreEqual.test.ts
@@ -246,6 +246,35 @@ describe("gridTabGroupPropsAreEqual", () => {
     expect(gridTabGroupPropsAreEqual(prev, next)).toBe(false);
   });
 
+  it("returns false when panel isUsingFallback changes", () => {
+    const prev = baseProps({
+      panels: [{ ...basePanel, isUsingFallback: false } as TerminalInstance, basePanel2],
+    });
+    const next = baseProps({
+      panels: [
+        { ...basePanel, isUsingFallback: true, originalPresetId: "preset-a" } as TerminalInstance,
+        basePanel2,
+      ],
+    });
+    expect(gridTabGroupPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when panel originalPresetId changes", () => {
+    const prev = baseProps({
+      panels: [
+        { ...basePanel, isUsingFallback: true, originalPresetId: "preset-a" } as TerminalInstance,
+        basePanel2,
+      ],
+    });
+    const next = baseProps({
+      panels: [
+        { ...basePanel, isUsingFallback: true, originalPresetId: "preset-b" } as TerminalInstance,
+        basePanel2,
+      ],
+    });
+    expect(gridTabGroupPropsAreEqual(prev, next)).toBe(false);
+  });
+
   describe("drift coverage", () => {
     // Wraps a panel in a Proxy that records every property read, then drives
     // buildPanelProps so the Proxy captures the full terminal.* surface

--- a/src/utils/__tests__/terminalChrome.test.ts
+++ b/src/utils/__tests__/terminalChrome.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   deriveTerminalChrome,
   deriveTerminalRuntimeIdentity,
+  terminalChromeDescriptorsEqual,
   terminalRuntimeIdentitiesEqual,
 } from "../terminalChrome";
 
@@ -227,5 +228,50 @@ describe("terminalRuntimeIdentitiesEqual", () => {
 
     expect(terminalRuntimeIdentitiesEqual(left, right)).toBe(true);
     expect(terminalRuntimeIdentitiesEqual(left, other)).toBe(false);
+  });
+});
+
+describe("terminalChromeDescriptorsEqual", () => {
+  it("detects hasExited differences (post-exit spinner suppression)", () => {
+    // Race: exitCode arrives before agentState transitions to "exited". Both
+    // descriptors share identity fields; only hasExited diverges. The equality
+    // check must catch this or the memo gate keeps the working spinner alive
+    // after the process has died.
+    const live = deriveTerminalChrome({
+      kind: "terminal",
+      launchAgentId: "claude",
+      agentState: "working",
+    });
+    const exited = deriveTerminalChrome({
+      kind: "terminal",
+      launchAgentId: "claude",
+      agentState: "working",
+      exitCode: 0,
+    });
+
+    expect(live.hasExited).toBe(false);
+    expect(exited.hasExited).toBe(true);
+    expect(terminalChromeDescriptorsEqual(live, exited)).toBe(false);
+  });
+
+  it("returns true for two equivalent descriptors", () => {
+    const a = deriveTerminalChrome({ kind: "terminal", launchAgentId: "claude" });
+    const b = deriveTerminalChrome({ kind: "terminal", launchAgentId: "claude" });
+    expect(terminalChromeDescriptorsEqual(a, b)).toBe(true);
+  });
+
+  it("returns true for identical references", () => {
+    const a = deriveTerminalChrome({ kind: "browser" });
+    expect(terminalChromeDescriptorsEqual(a, a)).toBe(true);
+  });
+
+  it("returns false when one side is undefined", () => {
+    const a = deriveTerminalChrome({ kind: "terminal" });
+    expect(terminalChromeDescriptorsEqual(a, undefined)).toBe(false);
+    expect(terminalChromeDescriptorsEqual(undefined, a)).toBe(false);
+  });
+
+  it("returns true when both sides are undefined", () => {
+    expect(terminalChromeDescriptorsEqual(undefined, undefined)).toBe(true);
   });
 });

--- a/src/utils/terminalChrome.ts
+++ b/src/utils/terminalChrome.ts
@@ -180,7 +180,8 @@ export function terminalChromeDescriptorsEqual(
     left.isAgent === right.isAgent &&
     left.agentId === right.agentId &&
     left.processId === right.processId &&
-    left.runtimeKind === right.runtimeKind
+    left.runtimeKind === right.runtimeKind &&
+    left.hasExited === right.hasExited
   );
 }
 


### PR DESCRIPTION
## Summary

- `gridPanelPropsAreEqual` and `gridTabGroupPropsAreEqual` were missing fields that `buildPanelProps` reads — `exitCode`, `agentPresetColor`, `agentPresetId`, `agentLaunchFlags`, `browserHistory`, `browserZoom` — so changes to those fields didn't trigger re-renders and panel chrome went stale until something else forced one
- Three adjacent bugs found and fixed: `terminalChromeDescriptorsEqual` missing `hasExited` (post-exit spinner-suppression race), the tabs loop in `gridPanelPropsAreEqual` missing `presetColor`/`isUsingFallback`/`fallbackTooltip`/`hasDangerousFlags`, and `gridTabGroupPropsAreEqual` missing `isUsingFallback`/`originalPresetId`
- Added a Proxy-based drift test that records every field `buildPanelProps` reads at runtime and asserts each one forces the comparator to return false — fails automatically when `panelProps.ts` grows new field reads without a matching comparator update

Resolves #8588

## Changes

- `GridPanel.tsx` — added missing terminal fields to `gridPanelPropsAreEqual` and its per-tab loop
- `GridTabGroup.tsx` — added missing fields to `gridTabGroupPropsAreEqual` per-panel loop
- `terminalChrome.ts` — added `hasExited` to `terminalChromeDescriptorsEqual`
- `gridPanelPropsAreEqual.test.ts` — new Proxy-based coverage test across all `buildPanelProps` field reads
- `gridTabGroupPropsAreEqual.test.ts` — same drift-coverage approach for the tab-group comparator
- `terminalChrome.test.ts` — coverage for the `hasExited` fix

## Testing

All 90 tests in the touched files pass. Typecheck, lint, and format clean.