### PR TITLE
perf(terminal): batch grid resizes into single read/write pass

### DIFF
--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -635,47 +635,20 @@ export function useContentGridContext({
         GRID_TRANSITION_DURATION_MS
       );
     }
-    const cancelRef = { cancelled: false };
     const timeoutId = window.setTimeout(() => {
       if (isDraggingRef.current) return;
-      let index = 0;
-      const processNext = () => {
-        if (cancelRef.cancelled || index >= ids.length) return;
-        if (isDraggingRef.current) return;
-        const id = ids[index++]!;
-        const managed = terminalInstanceService.get(id);
-        if (managed?.hostElement.isConnected) {
-          terminalInstanceService.fit(id);
-        }
-        requestAnimationFrame(processNext);
-      };
-      processNext();
+      terminalInstanceService.batchResize(ids);
     }, GRID_FIT_DELAY_MS);
     return () => {
-      cancelRef.cancelled = true;
       clearTimeout(timeoutId);
     };
   }, [isFleetScopeRender, fleetPanels, fleetGridCols, layoutConfig.strategy]);
 
-  const startBatchFit = useEffectEvent((cancelRef: { cancelled: boolean }) => {
+  const startBatchFit = useEffectEvent(() => {
     const ids = gridTerminals.map((t) => t.id);
     return window.setTimeout(() => {
       if (isDraggingRef.current) return;
-
-      let index = 0;
-      const processNext = () => {
-        if (cancelRef.cancelled || index >= ids.length) return;
-        if (isDraggingRef.current) return;
-
-        const id = ids[index++]!;
-        const managed = terminalInstanceService.get(id);
-
-        if (managed?.hostElement.isConnected) {
-          terminalInstanceService.fit(id);
-        }
-        requestAnimationFrame(processNext);
-      };
-      processNext();
+      terminalInstanceService.batchResize(ids);
     }, GRID_FIT_DELAY_MS);
   });
   const prevGridColsRef = useRef(gridCols);
@@ -698,11 +671,9 @@ export function useContentGridContext({
       }
     }
 
-    const cancelRef = { cancelled: false };
-    const timeoutId = startBatchFit(cancelRef);
+    const timeoutId = startBatchFit();
 
     return () => {
-      cancelRef.cancelled = true;
       clearTimeout(timeoutId);
     };
   }, [gridCols, panelIds, isProjectSwitching, layoutConfig.strategy, showPlaceholder]);

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -693,8 +693,14 @@ class TerminalInstanceService {
       for (const id of panelIds) {
         if (!this.instances.has(id)) continue;
         this.resizeController.lockResize(id, false);
-        this.resizeController.fit(id);
       }
+      // ResizeObserver doesn't retroactively fire when a lock releases, so a
+      // corrective pass is required to pick up the post-transition geometry.
+      // batchResize runs the read-all / write-all pass in a single task —
+      // safe to call inline since locks above release synchronously (#8597).
+      // The grid hook (useContentGridContext) also schedules a batch ~50ms
+      // later when grid deps change; the resize() dedup guard absorbs that.
+      this.batchResize(panelIds);
     }, durationMs);
   }
 
@@ -1427,6 +1433,55 @@ class TerminalInstanceService {
     options: { immediate?: boolean } = {}
   ): { cols: number; rows: number } | null {
     return this.resizeController.resize(id, width, height, options);
+  }
+
+  /**
+   * Resize a set of panels in a single read-all / write-all pass (#8597).
+   *
+   * The previous grid-fit batch chained one `fit()` per requestAnimationFrame,
+   * which (a) spread the visual settle across N frames and (b) interleaved
+   * `fitAddon.fit()`'s `getComputedStyle` read with the per-panel xterm write
+   * for every panel — classic layout thrash. Here we phase the work: phase 1
+   * reads `getBoundingClientRect()` for every eligible panel up front (cheap
+   * thanks to per-panel `contain: layout style`), phase 2 calls
+   * `resizeController.resize()` for each collected rect. `resize()` computes
+   * cols/rows from cached cell metrics without touching the DOM, so the write
+   * phase performs no further layout reads. The whole pass completes in a
+   * single task.
+   *
+   * Eligibility guards mirror the per-panel checks the old chained-fit loop
+   * relied on: instance must exist, host element must be connected and
+   * visible (xterm's `fit()` path checks `checkVisibility()`, but `resize()`
+   * does not, so we apply it here), and the panel must not be resize-locked.
+   * Caller is responsible for the `isDragging` guard since the React ref
+   * holding that state is owned by the grid hook.
+   */
+  batchResize(ids: string[]): void {
+    if (ids.length === 0) return;
+
+    type Pending = { id: string; width: number; height: number };
+    const seen = new Set<string>();
+    const pending: Pending[] = [];
+
+    for (const id of ids) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+
+      const managed = this.instances.get(id);
+      if (!managed) continue;
+      if (!managed.hostElement.isConnected) continue;
+      if (!managed.hostElement.checkVisibility()) continue;
+      if (this.resizeController.isResizeLocked(id)) continue;
+
+      const rect = managed.hostElement.getBoundingClientRect();
+      if (rect.width < 50 || rect.height < 50) continue;
+
+      pending.push({ id, width: rect.width, height: rect.height });
+    }
+
+    for (const { id, width, height } of pending) {
+      this.resizeController.resize(id, width, height);
+    }
   }
 
   scrollToBottom(id: string): void {

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -428,6 +428,11 @@ export class TerminalResizeController {
       const current = this.deps.getInstance(id);
       if (current) {
         current.resizeDebounceTimer = undefined;
+        // Mirror the applyResize guard: if a new lock landed between the
+        // debounce schedule and fire, a fresh layout transition is in flight
+        // and we must not write mid-transition. The lock release path will
+        // requeue via batchResize when it ends.
+        if (this.isResizeLocked(id)) return;
         this.deps.dataBuffer.flushForTerminal(id);
         this.deps.dataBuffer.resetForTerminal(id);
         this.resizeTerminal(current, cols, rows);

--- a/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
@@ -52,11 +52,7 @@ type BatchTestService = {
   batchResize: (ids: string[]) => void;
   suppressResizesDuringLayoutTransition: (ids: string[], durationMs: number) => void;
   resizeController: {
-    resize: (
-      id: string,
-      width: number,
-      height: number
-    ) => { cols: number; rows: number } | null;
+    resize: (id: string, width: number, height: number) => { cols: number; rows: number } | null;
     fit: (id: string) => unknown;
     lockResize: (id: string, locked: boolean, customTtlMs?: number) => void;
     isResizeLocked: (id: string) => boolean;
@@ -150,9 +146,10 @@ describe("TerminalInstanceService batchResize", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.useFakeTimers();
-    ({ terminalInstanceService: service } = (await import(
-      "../TerminalInstanceService"
-    )) as unknown as { terminalInstanceService: BatchTestService });
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: BatchTestService;
+      });
     service.instances.clear();
   });
 
@@ -293,9 +290,10 @@ describe("TerminalInstanceService suppressResizesDuringLayoutTransition", () => 
   beforeEach(async () => {
     vi.resetModules();
     vi.useFakeTimers();
-    ({ terminalInstanceService: service } = (await import(
-      "../TerminalInstanceService"
-    )) as unknown as { terminalInstanceService: BatchTestService });
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: BatchTestService;
+      });
     service.instances.clear();
   });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
@@ -1,0 +1,340 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ManagedTerminal } from "../types";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    resize: vi.fn(),
+    onData: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    write: vi.fn(),
+    setActivityTier: vi.fn(),
+    wake: vi.fn(),
+    getSerializedState: vi.fn(),
+    getSharedBuffers: vi.fn(async () => ({
+      visualBuffers: [],
+      signalBuffer: null,
+    })),
+    acknowledgeData: vi.fn(),
+    acknowledgePortData: vi.fn(),
+  },
+  systemClient: { openExternal: vi.fn() },
+  appClient: { getHydrationState: vi.fn() },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+    onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+  })),
+}));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(() => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: { dispose: vi.fn() },
+    searchAddon: {},
+    fileLinksDisposable: { dispose: vi.fn() },
+    webLinksAddon: { dispose: vi.fn() },
+  })),
+  createImageAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+type BatchTestService = {
+  instances: Map<string, ManagedTerminal>;
+  batchResize: (ids: string[]) => void;
+  suppressResizesDuringLayoutTransition: (ids: string[], durationMs: number) => void;
+  resizeController: {
+    resize: (
+      id: string,
+      width: number,
+      height: number
+    ) => { cols: number; rows: number } | null;
+    fit: (id: string) => unknown;
+    lockResize: (id: string, locked: boolean, customTtlMs?: number) => void;
+    isResizeLocked: (id: string) => boolean;
+  };
+};
+
+interface ManagedFixture {
+  id: string;
+  visible?: boolean;
+  connected?: boolean;
+  rect?: { width: number; height: number };
+}
+
+function makeManaged(fixture: ManagedFixture): ManagedTerminal {
+  const hostElement = document.createElement("div");
+  const termEl = document.createElement("div");
+  hostElement.appendChild(termEl);
+
+  const width = fixture.rect?.width ?? 800;
+  const height = fixture.rect?.height ?? 600;
+  hostElement.getBoundingClientRect = vi.fn(() => ({
+    width,
+    height,
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  })) as unknown as HTMLElement["getBoundingClientRect"];
+
+  const visible = fixture.visible ?? true;
+  hostElement.checkVisibility = vi.fn(() => visible);
+
+  if (fixture.connected !== false) {
+    document.body.appendChild(hostElement);
+  }
+
+  return {
+    terminal: {
+      element: termEl,
+      modes: { synchronizedOutputMode: false },
+    } as unknown as ManagedTerminal["terminal"],
+    type: "terminal",
+    kind: "terminal",
+    hostElement,
+    isOpened: true,
+    isVisible: true,
+    isFocused: false,
+    isHibernated: false,
+    isAttaching: false,
+    isUserScrolledBack: false,
+    isAltBuffer: false,
+    lastActiveTime: Date.now(),
+    lastWidth: 0,
+    lastHeight: 0,
+    lastAttachAt: 0,
+    lastDetachAt: 0,
+    lastReflowAt: 0,
+    latestCols: 80,
+    latestRows: 24,
+    latestWasAtBottom: true,
+    listeners: [],
+    exitSubscribers: new Set(),
+    agentStateSubscribers: new Set(),
+    altBufferListeners: new Set(),
+    writeChain: Promise.resolve(),
+    restoreGeneration: 0,
+    isSerializedRestoreInProgress: false,
+    deferredOutput: [],
+    scrollbackRestoreState: "none",
+    attachGeneration: 0,
+    attachRevealToken: 0,
+    keyHandlerInstalled: false,
+    ipcListenerCount: 0,
+    getRefreshTier: () => 0 as unknown as ManagedTerminal["lastAppliedTier"] as never,
+    fitAddon: { fit: vi.fn() } as unknown as ManagedTerminal["fitAddon"],
+    serializeAddon: { serialize: vi.fn() } as unknown as ManagedTerminal["serializeAddon"],
+    imageAddon: null,
+    searchAddon: {} as ManagedTerminal["searchAddon"],
+    fileLinksDisposable: null,
+    webLinksAddon: null,
+    hoveredLink: null,
+  } as ManagedTerminal;
+}
+
+describe("TerminalInstanceService batchResize", () => {
+  let service: BatchTestService;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    ({ terminalInstanceService: service } = (await import(
+      "../TerminalInstanceService"
+    )) as unknown as { terminalInstanceService: BatchTestService });
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    service.instances.clear();
+    document.body.innerHTML = "";
+  });
+
+  it("no-ops on an empty id list", () => {
+    const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
+    service.batchResize([]);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("calls resize for each eligible panel with its rect dimensions", () => {
+    const a = makeManaged({ id: "a", rect: { width: 800, height: 600 } });
+    const b = makeManaged({ id: "b", rect: { width: 400, height: 300 } });
+    service.instances.set("a", a);
+    service.instances.set("b", b);
+
+    const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
+
+    service.batchResize(["a", "b"]);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(1, "a", 800, 600);
+    expect(spy).toHaveBeenNthCalledWith(2, "b", 400, 300);
+  });
+
+  it("deduplicates repeated ids in the input list", () => {
+    const a = makeManaged({ id: "a" });
+    service.instances.set("a", a);
+    const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
+
+    service.batchResize(["a", "a", "a"]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips panels with no managed instance", () => {
+    const a = makeManaged({ id: "a" });
+    service.instances.set("a", a);
+    const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
+
+    service.batchResize(["a", "missing"]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("a", expect.any(Number), expect.any(Number));
+  });
+
+  it("skips disconnected panels", () => {
+    const a = makeManaged({ id: "a", connected: false });
+    service.instances.set("a", a);
+    const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
+
+    service.batchResize(["a"]);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("skips invisible panels (checkVisibility returns false)", () => {
+    const a = makeManaged({ id: "a", visible: false });
+    service.instances.set("a", a);
+    const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
+
+    service.batchResize(["a"]);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("skips resize-locked panels", () => {
+    const a = makeManaged({ id: "a" });
+    service.instances.set("a", a);
+    service.resizeController.lockResize("a", true);
+    const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
+
+    service.batchResize(["a"]);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("skips panels whose rect is below the 50px floor (0x0 init, hidden tabs)", () => {
+    const a = makeManaged({ id: "a", rect: { width: 0, height: 0 } });
+    const b = makeManaged({ id: "b", rect: { width: 30, height: 30 } });
+    service.instances.set("a", a);
+    service.instances.set("b", b);
+    const spy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
+
+    service.batchResize(["a", "b"]);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("reads all geometry before issuing any resize (read-all / write-all phasing)", () => {
+    const a = makeManaged({ id: "a" });
+    const b = makeManaged({ id: "b" });
+    service.instances.set("a", a);
+    service.instances.set("b", b);
+
+    const sequence: string[] = [];
+    const aRect = a.hostElement.getBoundingClientRect.bind(a.hostElement);
+    a.hostElement.getBoundingClientRect = vi.fn(() => {
+      sequence.push("read:a");
+      return aRect();
+    }) as unknown as HTMLElement["getBoundingClientRect"];
+    const bRect = b.hostElement.getBoundingClientRect.bind(b.hostElement);
+    b.hostElement.getBoundingClientRect = vi.fn(() => {
+      sequence.push("read:b");
+      return bRect();
+    }) as unknown as HTMLElement["getBoundingClientRect"];
+
+    vi.spyOn(service.resizeController, "resize").mockImplementation((id: string) => {
+      sequence.push(`write:${id}`);
+      return null;
+    });
+
+    service.batchResize(["a", "b"]);
+
+    expect(sequence).toEqual(["read:a", "read:b", "write:a", "write:b"]);
+  });
+
+  it("does NOT call resizeController.fit() — fit() forces layout reads we want to avoid", () => {
+    const a = makeManaged({ id: "a" });
+    service.instances.set("a", a);
+    const fitSpy = vi.spyOn(service.resizeController, "fit").mockReturnValue(null);
+    vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
+
+    service.batchResize(["a"]);
+
+    expect(fitSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("TerminalInstanceService suppressResizesDuringLayoutTransition", () => {
+  let service: BatchTestService;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    ({ terminalInstanceService: service } = (await import(
+      "../TerminalInstanceService"
+    )) as unknown as { terminalInstanceService: BatchTestService });
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    service.instances.clear();
+    document.body.innerHTML = "";
+  });
+
+  it("does not call fit() on unlock — the batchResize call replaces it (#8597)", () => {
+    const a = makeManaged({ id: "a" });
+    service.instances.set("a", a);
+    const fitSpy = vi.spyOn(service.resizeController, "fit").mockReturnValue(null);
+    vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
+
+    service.suppressResizesDuringLayoutTransition(["a"], 200);
+
+    // Fire the 200ms transition timer; batchResize runs synchronously inside.
+    vi.advanceTimersByTime(200);
+
+    expect(fitSpy).not.toHaveBeenCalled();
+  });
+
+  it("releases the resize lock and runs a batchResize after the transition", () => {
+    const a = makeManaged({ id: "a", rect: { width: 800, height: 600 } });
+    service.instances.set("a", a);
+    const resizeSpy = vi.spyOn(service.resizeController, "resize").mockReturnValue(null);
+
+    service.suppressResizesDuringLayoutTransition(["a"], 200);
+
+    // During the lock window, the panel is locked and the batch hasn't fired.
+    expect(service.resizeController.isResizeLocked("a")).toBe(true);
+    expect(resizeSpy).not.toHaveBeenCalled();
+
+    // Fire the 200ms transition timer; batchResize runs synchronously inside.
+    vi.advanceTimersByTime(200);
+
+    expect(service.resizeController.isResizeLocked("a")).toBe(false);
+    expect(resizeSpy).toHaveBeenCalledTimes(1);
+    expect(resizeSpy).toHaveBeenCalledWith("a", 800, 600);
+  });
+});


### PR DESCRIPTION
## Summary

- The panel grid was reflowing panels one frame at a time via two chained `requestAnimationFrame` loops — one for fleet-scope resizes and one for grid-scope. On a busy grid that meant N frames to resize N panels.
- Adds `TerminalInstanceService.batchResize(ids)`, which reads all element rects first and then writes all resizes in a single task, collapsing the per-panel frame cost to one pass regardless of grid size.
- Replaces both chained-rAF loops in `useContentGridContext.tsx` with single `setTimeout` calls invoking `batchResize`, and removes a duplicate `fit()` call that was running again in `suppressResizesDuringLayoutTransition`'s unlock callback.

Resolves #8597

## Changes

- `TerminalInstanceService` — new `batchResize(ids)` method: deduplicates IDs, checks eligibility (instance, connection, visibility, lock, 50px floor), reads all rects, then writes all resizes in one pass
- `useContentGridContext.tsx` — both chained-rAF loops replaced with `setTimeout(() => batchResize(...))` calls; the corrective pass after lock release now goes through `batchResize` inline rather than a separate `fit()` loop
- `TerminalResizeController` — `debounceResize` callback now checks `isResizeLocked` before running, closing a newly-reachable race where a new transition's lock could land between debounce schedule and fire
- 12 unit tests covering empty input, dedup, all eligibility guards, read-all-before-write phasing, no stray `fit()` invocations, and unlock behavior

## Testing

- 12 unit tests in `TerminalInstanceService.batchResize.test.ts`; all pass
- Rebased cleanly onto `develop` after recent Zod migration merges
- Typecheck and lint clean