### PR TITLE
perf(panel-store): batch activity writes and short-circuit same-state agent updates

### DIFF
--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -480,6 +480,8 @@ export interface TerminalInstance {
   stateChangeTrigger?: AgentStateChangeTrigger;
   stateChangeConfidence?: number;
   waitingReason?: WaitingReason;
+  /** Error code or message from agent state transitions (e.g., "ECONNRESET", "EPIPE") */
+  error?: string;
   /** Extracted session cost in dollars from the last completed agent run */
   sessionCost?: number;
   /** Extracted session token count from the last completed agent run */

--- a/src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts
@@ -119,6 +119,114 @@ describe("updateAgentState store action (#3217)", () => {
 
     expect(usePanelStore.getState().panelsById).toBe(before);
   });
+
+  // #8592: same-state re-delivery must not bump `lastStateChange` and must
+  // preserve `panelsById` reference (so subscribers don't fire).
+  it("preserves panelsById ref and lastStateChange when re-delivered with same state", () => {
+    const seededTerminal = {
+      ...baseTerminal,
+      agentState: "working" as const,
+      lastStateChange: 12345,
+    };
+    usePanelStore.setState({
+      panelsById: { [seededTerminal.id]: seededTerminal },
+      panelIds: [seededTerminal.id],
+    });
+
+    const before = usePanelStore.getState().panelsById;
+    const terminalBefore = before[seededTerminal.id];
+
+    usePanelStore.getState().updateAgentState(seededTerminal.id, "working");
+
+    const after = usePanelStore.getState().panelsById;
+    expect(after).toBe(before);
+    expect(after[seededTerminal.id]).toBe(terminalBefore);
+    expect(after[seededTerminal.id]!.lastStateChange).toBe(12345);
+  });
+
+  it("preserves panelsById ref when re-delivered waiting with the same waitingReason", () => {
+    const seededTerminal = {
+      ...baseTerminal,
+      agentState: "waiting" as const,
+      waitingReason: "prompt" as const,
+      lastStateChange: 9999,
+    };
+    usePanelStore.setState({
+      panelsById: { [seededTerminal.id]: seededTerminal },
+      panelIds: [seededTerminal.id],
+    });
+
+    const before = usePanelStore.getState().panelsById;
+
+    usePanelStore
+      .getState()
+      .updateAgentState(
+        seededTerminal.id,
+        "waiting",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "prompt"
+      );
+
+    const after = usePanelStore.getState().panelsById;
+    expect(after).toBe(before);
+    expect(after[seededTerminal.id]!.lastStateChange).toBe(9999);
+  });
+
+  it("writes when waiting is re-delivered with a different waitingReason", () => {
+    const seededTerminal = {
+      ...baseTerminal,
+      agentState: "waiting" as const,
+      waitingReason: "prompt" as const,
+      lastStateChange: 100,
+    };
+    usePanelStore.setState({
+      panelsById: { [seededTerminal.id]: seededTerminal },
+      panelIds: [seededTerminal.id],
+    });
+
+    const before = usePanelStore.getState().panelsById;
+
+    usePanelStore
+      .getState()
+      .updateAgentState(
+        seededTerminal.id,
+        "waiting",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "question"
+      );
+
+    const after = usePanelStore.getState().panelsById;
+    expect(after).not.toBe(before);
+    expect(after[seededTerminal.id]!.waitingReason).toBe("question");
+    expect(after[seededTerminal.id]!.lastStateChange).not.toBe(100);
+  });
+
+  it("writes when the error message differs even though agentState is unchanged", () => {
+    const seededTerminal = {
+      ...baseTerminal,
+      agentState: "exited" as const,
+      error: "ECONNRESET",
+      lastStateChange: 500,
+    };
+    usePanelStore.setState({
+      panelsById: { [seededTerminal.id]: seededTerminal },
+      panelIds: [seededTerminal.id],
+    });
+
+    const before = usePanelStore.getState().panelsById;
+
+    usePanelStore.getState().updateAgentState(seededTerminal.id, "exited", "EPIPE");
+
+    const after = usePanelStore.getState().panelsById;
+    expect(after).not.toBe(before);
+    expect(after[seededTerminal.id]!.error).toBe("EPIPE");
+  });
 });
 
 describe("setupTerminalStoreListeners directing guard (#3217)", () => {

--- a/src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts
@@ -207,6 +207,57 @@ describe("updateAgentState store action (#3217)", () => {
     expect(after[seededTerminal.id]!.lastStateChange).not.toBe(100);
   });
 
+  // #8592: TerminalAgentStateController.onEnterPressed() writes the optimistic
+  // `agentState:"working"` with no trigger, and the backend confirmation arrives
+  // with `trigger:"input"`. The guard must let that trigger transition through,
+  // otherwise HybridInputBar never sees `agentHasLifecycleEvent === true`.
+  it("writes through a backend trigger confirmation after an optimistic same-state write", () => {
+    const seededTerminal = {
+      ...baseTerminal,
+      agentState: "working" as const,
+      stateChangeTrigger: undefined,
+      lastStateChange: 200,
+    };
+    usePanelStore.setState({
+      panelsById: { [seededTerminal.id]: seededTerminal },
+      panelIds: [seededTerminal.id],
+    });
+
+    const before = usePanelStore.getState().panelsById;
+
+    usePanelStore
+      .getState()
+      .updateAgentState(seededTerminal.id, "working", undefined, 1500, "input", 0.9);
+
+    const after = usePanelStore.getState().panelsById;
+    expect(after).not.toBe(before);
+    expect(after[seededTerminal.id]!.stateChangeTrigger).toBe("input");
+    expect(after[seededTerminal.id]!.lastStateChange).toBe(1500);
+  });
+
+  it("preserves panelsById ref when re-delivered same state + same trigger", () => {
+    const seededTerminal = {
+      ...baseTerminal,
+      agentState: "working" as const,
+      stateChangeTrigger: "input" as const,
+      lastStateChange: 300,
+    };
+    usePanelStore.setState({
+      panelsById: { [seededTerminal.id]: seededTerminal },
+      panelIds: [seededTerminal.id],
+    });
+
+    const before = usePanelStore.getState().panelsById;
+
+    usePanelStore
+      .getState()
+      .updateAgentState(seededTerminal.id, "working", undefined, undefined, "input", 0.9);
+
+    const after = usePanelStore.getState().panelsById;
+    expect(after).toBe(before);
+    expect(after[seededTerminal.id]!.lastStateChange).toBe(300);
+  });
+
   it("writes when the error message differs even though agentState is unchanged", () => {
     const seededTerminal = {
       ...baseTerminal,

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -191,12 +191,18 @@ export const createCorePanelActions = (
       // when no user-visible field changed. `lastStateChange` gates the
       // window-blur badge filter (useTerminalSelectors) and the elapsed-time
       // header display (TerminalHeaderContent) — bumping it on duplicate
-      // events would falsely reset both. See #8592.
+      // events would falsely reset both. `stateChangeTrigger` is included
+      // because the optimistic controller path (TerminalAgentStateController
+      // onEnterPressed) writes `agentState:"working"` with no trigger, then the
+      // backend confirmation arrives with `trigger:"input"`; without comparing
+      // trigger here the confirmation would be suppressed and HybridInputBar
+      // would never see `agentHasLifecycleEvent === true`. See #8592.
       const nextWaitingReason = agentState === "waiting" ? waitingReason : undefined;
       if (
         terminal.agentState === agentState &&
         terminal.error === error &&
-        terminal.waitingReason === nextWaitingReason
+        terminal.waitingReason === nextWaitingReason &&
+        terminal.stateChangeTrigger === trigger
       ) {
         return state;
       }

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -187,6 +187,20 @@ export const createCorePanelActions = (
         return state;
       }
 
+      // Equality short-circuit: skip the write (and crucially `lastStateChange`)
+      // when no user-visible field changed. `lastStateChange` gates the
+      // window-blur badge filter (useTerminalSelectors) and the elapsed-time
+      // header display (TerminalHeaderContent) — bumping it on duplicate
+      // events would falsely reset both. See #8592.
+      const nextWaitingReason = agentState === "waiting" ? waitingReason : undefined;
+      if (
+        terminal.agentState === agentState &&
+        terminal.error === error &&
+        terminal.waitingReason === nextWaitingReason
+      ) {
+        return state;
+      }
+
       return {
         panelsById: {
           ...state.panelsById,
@@ -197,7 +211,7 @@ export const createCorePanelActions = (
             lastStateChange: lastStateChange ?? Date.now(),
             stateChangeTrigger: trigger,
             stateChangeConfidence: confidence,
-            waitingReason: agentState === "waiting" ? waitingReason : undefined,
+            waitingReason: nextWaitingReason,
             sessionCost:
               (agentState === "completed" || agentState === "exited") && sessionCost != null
                 ? sessionCost


### PR DESCRIPTION
## Summary

- Under multi-agent load, the panel store was triggering far more Zustand subscriptions than necessary — each RAF flush issued N individual `set()` calls, and `updateAgentState` wrote through even when nothing changed.
- Added `batchUpdateActivity` to `PanelRegistrySlice`: collapses the N per-frame activity writes into a single `set()` call with lazy `panelsById` allocation, returning state unchanged when every entry is a no-op so no subscribers fire at all.
- Added an equality short-circuit to `updateAgentState` comparing `agentState`, `error`, `waitingReason`, and `stateChangeTrigger` before writing. `stateChangeTrigger` is included in the predicate so the optimistic-controller → backend-confirmation path still writes through correctly.

Resolves #8592

## Changes

- `src/store/slices/panelRegistry/core.ts` — `batchUpdateActivity` slice method; equality guard in `updateAgentState`
- `src/store/slices/panelRegistry/types.ts` — `batchUpdateActivity` signature
- `src/store/listeners/panel/activity.ts` — RAF flush now issues one store call instead of N
- `shared/types/panel.ts` — declared `error?: string` on `TerminalInstance` (latent gap, now formal)
- `src/store/slices/panelRegistry/__tests__/batchUpdateActivity.test.ts` — 6 new cases
- `src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts` — 6 new cases

## Testing

81 targeted tests, 262 panel-region tests, 68 controller tests — all passing. Typecheck and lint clean.