### PR TITLE
perf(panel-store): batch activity + flow-status writes into one rAF setState (#8589)

### DIFF
--- a/src/store/listeners/panel/__tests__/panelStatusBuffer.test.ts
+++ b/src/store/listeners/panel/__tests__/panelStatusBuffer.test.ts
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePanelStore } from "@/store/panelStore";
+import {
+  cancelPanelStatusBuffer,
+  enqueueActivityUpdate,
+  enqueueFlowStatusUpdate,
+  flushPanelStatusBuffer,
+} from "@/store/panelStatusBuffer";
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    setAgentState: vi.fn(),
+    injectDataLossMarker: vi.fn(),
+    wake: vi.fn(),
+  },
+}));
+
+interface FakeRaf {
+  callbacks: FrameRequestCallback[];
+  flushAll(): void;
+}
+
+function installFakeRaf(): FakeRaf {
+  const callbacks: FrameRequestCallback[] = [];
+  let nextHandle = 1;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    callbacks.push(cb);
+    return nextHandle++;
+  }) as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+  return {
+    callbacks,
+    flushAll() {
+      while (callbacks.length > 0) {
+        const cb = callbacks.shift()!;
+        cb(performance.now());
+      }
+    },
+  };
+}
+
+function seedPanel(id: string, overrides: Record<string, unknown> = {}): void {
+  usePanelStore.setState((state) => ({
+    panelsById: {
+      ...state.panelsById,
+      [id]: {
+        id,
+        kind: "terminal",
+        title: id,
+        cwd: "/tmp",
+        cols: 80,
+        rows: 24,
+        location: "grid" as const,
+        isVisible: true,
+        ...overrides,
+      },
+    },
+    panelIds: state.panelIds.includes(id) ? state.panelIds : [...state.panelIds, id],
+  }));
+}
+
+let raf: FakeRaf;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  raf = installFakeRaf();
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+  cancelPanelStatusBuffer();
+});
+
+afterEach(() => {
+  cancelPanelStatusBuffer();
+});
+
+describe("panelStatusBuffer — activity batching", () => {
+  it("collapses N activity updates across distinct terminals into one setState per frame", () => {
+    for (let i = 0; i < 10; i++) {
+      seedPanel(`term-${i}`);
+    }
+    const setSpy = vi.spyOn(usePanelStore, "setState");
+    setSpy.mockClear();
+
+    for (let i = 0; i < 10; i++) {
+      enqueueActivityUpdate(`term-${i}`, `Working ${i}`, "working", "interactive", 1000 + i, "cmd");
+    }
+
+    expect(setSpy).not.toHaveBeenCalled();
+    raf.flushAll();
+    expect(setSpy).toHaveBeenCalledTimes(1);
+
+    const state = usePanelStore.getState();
+    for (let i = 0; i < 10; i++) {
+      const t = state.panelsById[`term-${i}`];
+      expect(t?.activityHeadline).toBe(`Working ${i}`);
+      expect(t?.activityStatus).toBe("working");
+      expect(t?.activityType).toBe("interactive");
+      expect(t?.activityTimestamp).toBe(1000 + i);
+      expect(t?.lastCommand).toBe("cmd");
+    }
+  });
+
+  it("last-write-wins within a frame for the same terminal", () => {
+    seedPanel("term-1");
+    enqueueActivityUpdate("term-1", "First", "working", "interactive", 100, "a");
+    enqueueActivityUpdate("term-1", "Second", "waiting", "interactive", 200, "b");
+    raf.flushAll();
+    const t = usePanelStore.getState().panelsById["term-1"];
+    expect(t?.activityHeadline).toBe("Second");
+    expect(t?.activityStatus).toBe("waiting");
+    expect(t?.activityTimestamp).toBe(200);
+    expect(t?.lastCommand).toBe("b");
+  });
+
+  it("skips writing when all activity fields are unchanged", () => {
+    seedPanel("term-1", {
+      activityHeadline: "Stable",
+      activityStatus: "working",
+      activityType: "interactive",
+      activityTimestamp: 100,
+      lastCommand: "cmd",
+    });
+    const setSpy = vi.spyOn(usePanelStore, "setState");
+    enqueueActivityUpdate("term-1", "Stable", "working", "interactive", 100, "cmd");
+    raf.flushAll();
+    // setState is still called once (the fold runs), but the returned object
+    // reflects no terminal change. Assert via state equality, not call count.
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const t = usePanelStore.getState().panelsById["term-1"];
+    expect(t?.activityHeadline).toBe("Stable");
+  });
+
+  it("drops patches for terminals that no longer exist", () => {
+    enqueueActivityUpdate("ghost", "Phantom", "working", "interactive", 100, undefined);
+    raf.flushAll();
+    expect(usePanelStore.getState().panelsById["ghost"]).toBeUndefined();
+  });
+});
+
+describe("panelStatusBuffer — flow-status batching", () => {
+  it("collapses N flow-status updates into one setState per frame and derives runtimeStatus", () => {
+    for (let i = 0; i < 5; i++) {
+      seedPanel(`term-${i}`, { isVisible: true, runtimeStatus: "running" });
+    }
+    const setSpy = vi.spyOn(usePanelStore, "setState");
+
+    for (let i = 0; i < 5; i++) {
+      enqueueFlowStatusUpdate(`term-${i}`, "suspended", 1000 + i);
+    }
+
+    raf.flushAll();
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const state = usePanelStore.getState();
+    for (let i = 0; i < 5; i++) {
+      const t = state.panelsById[`term-${i}`];
+      expect(t?.flowStatus).toBe("suspended");
+      expect(t?.flowStatusTimestamp).toBe(1000 + i);
+      // deriveRuntimeStatus(isVisible=true, flowStatus="suspended", "running") -> "suspended"
+      expect(t?.runtimeStatus).toBe("suspended");
+    }
+  });
+
+  it("derives runtimeStatus from current isVisible (not a stale closure)", () => {
+    seedPanel("term-1", { isVisible: false, runtimeStatus: "background" });
+    // Enqueue with flowStatus that would normally win; visibility is false,
+    // and deriveRuntimeStatus returns the flowStatus first if non-running.
+    enqueueFlowStatusUpdate("term-1", "suspended", 100);
+    raf.flushAll();
+    const t = usePanelStore.getState().panelsById["term-1"];
+    expect(t?.flowStatus).toBe("suspended");
+    expect(t?.runtimeStatus).toBe("suspended");
+  });
+
+  it("rejects out-of-order flow-status timestamps inside the fold", () => {
+    seedPanel("term-1", {
+      flowStatus: "running",
+      flowStatusTimestamp: 500,
+      runtimeStatus: "running",
+      isVisible: true,
+    });
+    enqueueFlowStatusUpdate("term-1", "suspended", 400);
+    raf.flushAll();
+    const t = usePanelStore.getState().panelsById["term-1"];
+    expect(t?.flowStatus).toBe("running");
+    expect(t?.flowStatusTimestamp).toBe(500);
+  });
+
+  it("last-write-wins within a frame for the same terminal", () => {
+    seedPanel("term-1", { isVisible: true });
+    enqueueFlowStatusUpdate("term-1", "suspended", 100);
+    enqueueFlowStatusUpdate("term-1", "paused-backpressure", 200);
+    raf.flushAll();
+    const t = usePanelStore.getState().panelsById["term-1"];
+    expect(t?.flowStatus).toBe("paused-backpressure");
+    expect(t?.flowStatusTimestamp).toBe(200);
+  });
+});
+
+describe("panelStatusBuffer — combined flush", () => {
+  it("activity + flow-status patches in the same frame produce one setState call", () => {
+    seedPanel("term-1", { isVisible: true });
+    seedPanel("term-2", { isVisible: true });
+    const setSpy = vi.spyOn(usePanelStore, "setState");
+
+    enqueueActivityUpdate("term-1", "Doing", "working", "interactive", 100, undefined);
+    enqueueFlowStatusUpdate("term-2", "suspended", 100);
+
+    raf.flushAll();
+    expect(setSpy).toHaveBeenCalledTimes(1);
+
+    const state = usePanelStore.getState();
+    expect(state.panelsById["term-1"]?.activityHeadline).toBe("Doing");
+    expect(state.panelsById["term-2"]?.flowStatus).toBe("suspended");
+  });
+});
+
+describe("panelStatusBuffer — lifecycle", () => {
+  it("cancelPanelStatusBuffer is idempotent and clears pending patches", () => {
+    seedPanel("term-1");
+    enqueueActivityUpdate("term-1", "Pending", "working", "interactive", 100, undefined);
+    cancelPanelStatusBuffer();
+    cancelPanelStatusBuffer();
+    raf.flushAll();
+    const t = usePanelStore.getState().panelsById["term-1"];
+    expect(t?.activityHeadline).toBeUndefined();
+  });
+
+  it("enqueue after cancel schedules a fresh RAF", () => {
+    seedPanel("term-1");
+    enqueueActivityUpdate("term-1", "First", "working", "interactive", 100, undefined);
+    cancelPanelStatusBuffer();
+    enqueueActivityUpdate("term-1", "Second", "working", "interactive", 200, undefined);
+    raf.flushAll();
+    const t = usePanelStore.getState().panelsById["term-1"];
+    expect(t?.activityHeadline).toBe("Second");
+  });
+
+  it("manual flushPanelStatusBuffer is a no-op when buffers are empty", () => {
+    const setSpy = vi.spyOn(usePanelStore, "setState");
+    flushPanelStatusBuffer();
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-uses a single RAF handle for many enqueues in the same tick", () => {
+    seedPanel("term-1");
+    seedPanel("term-2");
+
+    enqueueActivityUpdate("term-1", "A", "working", "interactive", 100, undefined);
+    enqueueActivityUpdate("term-2", "B", "working", "interactive", 100, undefined);
+    enqueueFlowStatusUpdate("term-1", "suspended", 100);
+
+    expect(raf.callbacks).toHaveLength(1);
+  });
+});

--- a/src/store/listeners/panel/__tests__/panelStatusBuffer.test.ts
+++ b/src/store/listeners/panel/__tests__/panelStatusBuffer.test.ts
@@ -161,14 +161,36 @@ describe("panelStatusBuffer — flow-status batching", () => {
   });
 
   it("derives runtimeStatus from current isVisible (not a stale closure)", () => {
-    seedPanel("term-1", { isVisible: false, runtimeStatus: "background" });
-    // Enqueue with flowStatus that would normally win; visibility is false,
-    // and deriveRuntimeStatus returns the flowStatus first if non-running.
+    // Lock in stale-closure proof: enqueue while panel is visible, mutate
+    // isVisible -> false BEFORE the RAF flush. The fold must observe the
+    // post-mutation `isVisible: false` from the state snapshot, which makes
+    // deriveRuntimeStatus(false, "running") return "background".
+    seedPanel("term-1", { isVisible: true, runtimeStatus: "running" });
+    enqueueFlowStatusUpdate("term-1", "running", 100);
+    usePanelStore.setState((s) => ({
+      panelsById: {
+        ...s.panelsById,
+        "term-1": { ...s.panelsById["term-1"]!, isVisible: false },
+      },
+    }));
+    raf.flushAll();
+    const t = usePanelStore.getState().panelsById["term-1"];
+    expect(t?.flowStatus).toBe("running");
+    expect(t?.runtimeStatus).toBe("background");
+  });
+
+  it("rejects in-buffer reordering: later-arriving older event must not displace newer in-buffer event", () => {
+    // Locks in the fix for the critical review finding: IPC can deliver
+    // events out of order within a frame (backpressure, multi-source). The
+    // buffer must guard at enqueue time, not only via the fold's
+    // persisted-store guard which can't see other in-buffer patches.
+    seedPanel("term-1", { isVisible: true });
+    enqueueFlowStatusUpdate("term-1", "running", 200);
     enqueueFlowStatusUpdate("term-1", "suspended", 100);
     raf.flushAll();
     const t = usePanelStore.getState().panelsById["term-1"];
-    expect(t?.flowStatus).toBe("suspended");
-    expect(t?.runtimeStatus).toBe("suspended");
+    expect(t?.flowStatus).toBe("running");
+    expect(t?.flowStatusTimestamp).toBe(200);
   });
 
   it("rejects out-of-order flow-status timestamps inside the fold", () => {
@@ -211,6 +233,23 @@ describe("panelStatusBuffer — combined flush", () => {
     const state = usePanelStore.getState();
     expect(state.panelsById["term-1"]?.activityHeadline).toBe("Doing");
     expect(state.panelsById["term-2"]?.flowStatus).toBe("suspended");
+  });
+
+  it("same terminal: activity + flow-status patches do not clobber each other", () => {
+    // The fold iterates activity first, then flow-status. Both must compose
+    // into a single merged terminal record; the flow-status pass reads from
+    // the activity-merged draft, not the original state snapshot.
+    seedPanel("term-1", { isVisible: true, runtimeStatus: "running" });
+    enqueueActivityUpdate("term-1", "Compiling", "working", "interactive", 100, "npm run dev");
+    enqueueFlowStatusUpdate("term-1", "suspended", 100);
+    raf.flushAll();
+    const t = usePanelStore.getState().panelsById["term-1"];
+    expect(t?.activityHeadline).toBe("Compiling");
+    expect(t?.activityStatus).toBe("working");
+    expect(t?.lastCommand).toBe("npm run dev");
+    expect(t?.flowStatus).toBe("suspended");
+    expect(t?.flowStatusTimestamp).toBe(100);
+    expect(t?.runtimeStatus).toBe("suspended");
   });
 });
 

--- a/src/store/listeners/panel/activity.ts
+++ b/src/store/listeners/panel/activity.ts
@@ -1,48 +1,24 @@
 import type { TerminalActivityPayload } from "@shared/types";
 import { terminalRegistryController } from "@/controllers";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
-import { usePanelStore } from "@/store/panelStore";
-
-const activityBuffer = new Map<string, TerminalActivityPayload>();
-let activityRafId: number | null = null;
-
-function flushActivityBuffer(): void {
-  activityRafId = null;
-  if (activityBuffer.size === 0) return;
-  const panelStore = usePanelStore.getState();
-  for (const data of activityBuffer.values()) {
-    panelStore.updateActivity(
-      data.terminalId,
-      data.headline,
-      data.status,
-      data.type,
-      data.timestamp,
-      data.lastCommand
-    );
-  }
-  activityBuffer.clear();
-}
-
-function cancelActivityBuffer(): void {
-  if (activityRafId !== null && typeof cancelAnimationFrame !== "undefined") {
-    cancelAnimationFrame(activityRafId);
-  }
-  activityRafId = null;
-  activityBuffer.clear();
-}
+import { enqueueActivityUpdate, cancelPanelStatusBuffer } from "@/store/panelStatusBuffer";
 
 export function setupActivityListeners(): DisposableStore {
   const d = new DisposableStore();
 
-  d.add(toDisposable(cancelActivityBuffer));
+  d.add(toDisposable(cancelPanelStatusBuffer));
 
   d.add(
     toDisposable(
       terminalRegistryController.onActivity((data: TerminalActivityPayload) => {
-        activityBuffer.set(data.terminalId, data);
-        if (activityRafId === null) {
-          activityRafId = requestAnimationFrame(flushActivityBuffer);
-        }
+        enqueueActivityUpdate(
+          data.terminalId,
+          data.headline,
+          data.status,
+          data.type,
+          data.timestamp,
+          data.lastCommand
+        );
       })
     )
   );

--- a/src/store/listeners/panel/activity.ts
+++ b/src/store/listeners/panel/activity.ts
@@ -1,12 +1,10 @@
 import type { TerminalActivityPayload } from "@shared/types";
 import { terminalRegistryController } from "@/controllers";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
-import { enqueueActivityUpdate, cancelPanelStatusBuffer } from "@/store/panelStatusBuffer";
+import { enqueueActivityUpdate } from "@/store/panelStatusBuffer";
 
 export function setupActivityListeners(): DisposableStore {
   const d = new DisposableStore();
-
-  d.add(toDisposable(cancelPanelStatusBuffer));
 
   d.add(
     toDisposable(

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -7,6 +7,7 @@ import { isAgentTerminal } from "@/utils/terminalType";
 import { logInfo, logError } from "@/utils/logger";
 import { isTerminalRestarting } from "@/store/restartExitSuppression";
 import { usePanelStore, type PanelGridState } from "@/store/panelStore";
+import { enqueueFlowStatusUpdate, cancelPanelStatusBuffer } from "@/store/panelStatusBuffer";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
 import { getMergedPresets } from "@/config/agents";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
@@ -168,6 +169,7 @@ export function setupLifecycleListeners(): DisposableStore {
   const d = new DisposableStore();
 
   d.add(toDisposable(() => fallbackInFlight.clear()));
+  d.add(toDisposable(cancelPanelStatusBuffer));
 
   d.add(
     toDisposable(
@@ -346,7 +348,7 @@ export function setupLifecycleListeners(): DisposableStore {
           terminalInstanceService.injectDataLossMarker(id, droppedBytes ?? 0);
           return;
         }
-        usePanelStore.getState().updateFlowStatus(id, status, timestamp);
+        enqueueFlowStatusUpdate(id, status, timestamp);
         if (status === "suspended" || status === "paused-backpressure") {
           terminalInstanceService.wake(id);
         }

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -7,7 +7,7 @@ import { isAgentTerminal } from "@/utils/terminalType";
 import { logInfo, logError } from "@/utils/logger";
 import { isTerminalRestarting } from "@/store/restartExitSuppression";
 import { usePanelStore, type PanelGridState } from "@/store/panelStore";
-import { enqueueFlowStatusUpdate, cancelPanelStatusBuffer } from "@/store/panelStatusBuffer";
+import { enqueueFlowStatusUpdate } from "@/store/panelStatusBuffer";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
 import { getMergedPresets } from "@/config/agents";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
@@ -169,7 +169,6 @@ export function setupLifecycleListeners(): DisposableStore {
   const d = new DisposableStore();
 
   d.add(toDisposable(() => fallbackInFlight.clear()));
-  d.add(toDisposable(cancelPanelStatusBuffer));
 
   d.add(
     toDisposable(

--- a/src/store/panelStatusBuffer.ts
+++ b/src/store/panelStatusBuffer.ts
@@ -1,0 +1,152 @@
+import type { TerminalActivityPayload } from "@shared/types";
+import type { PersistableFlowStatus } from "@shared/types";
+import { usePanelStore } from "@/store/panelStore";
+import { deriveRuntimeStatus } from "@/store/slices/panelRegistry/helpers";
+
+// Shared RAF-flushed buffer for high-frequency panel-status writes. Listeners
+// in src/store/listeners/panel/ (activity, lifecycle onStatus) enqueue patches
+// here instead of calling the per-call setState methods on usePanelStore. One
+// shared rAF coalesces all enqueued patches into a single setState — collapsing
+// N subscriber notifications per frame into 1, which is the dominant perf win
+// because Zustand 5 fires its notify loop synchronously per setState call.
+//
+// Agent-state writes from `identity.ts` deliberately stay direct (not routed
+// through this buffer): processQueue reads live store state on the same tick
+// as the write, so deferring the write by a frame would break dispatch
+// ordering. See issue #8589 for the perf-vs-correctness trade-off.
+
+type ActivityPatch = Pick<
+  TerminalActivityPayload,
+  "headline" | "status" | "type" | "timestamp" | "lastCommand"
+>;
+
+interface FlowStatusPatch {
+  status: PersistableFlowStatus;
+  timestamp: number;
+}
+
+const activityBuffer = new Map<string, ActivityPatch>();
+const flowStatusBuffer = new Map<string, FlowStatusPatch>();
+let rafId: number | null = null;
+
+function schedule(): void {
+  if (rafId !== null) return;
+  if (typeof requestAnimationFrame === "undefined") {
+    // Non-DOM environments (some test contexts) — flush synchronously to keep
+    // semantics observable without a polyfill.
+    flushPanelStatusBuffer();
+    return;
+  }
+  rafId = requestAnimationFrame(flushPanelStatusBuffer);
+}
+
+export function enqueueActivityUpdate(
+  terminalId: string,
+  headline: string,
+  status: TerminalActivityPayload["status"],
+  type: TerminalActivityPayload["type"],
+  timestamp: number,
+  lastCommand: string | undefined
+): void {
+  activityBuffer.set(terminalId, { headline, status, type, timestamp, lastCommand });
+  schedule();
+}
+
+export function enqueueFlowStatusUpdate(
+  terminalId: string,
+  status: PersistableFlowStatus,
+  timestamp: number
+): void {
+  // Last write wins per terminal per frame. The slice's stale-timestamp guard
+  // is reproduced inside the fold against live store state, so accepting the
+  // latest enqueued patch here is correct: an older event still in-buffer is
+  // already superseded by the newer one we are about to set.
+  flowStatusBuffer.set(terminalId, { status, timestamp });
+  schedule();
+}
+
+export function flushPanelStatusBuffer(): void {
+  rafId = null;
+  if (activityBuffer.size === 0 && flowStatusBuffer.size === 0) return;
+
+  // Snapshot and clear before the setState updater runs. Clearing first lets
+  // re-entrant enqueues during subscriber callbacks land in a fresh frame
+  // rather than being silently dropped by a later iteration of this fold.
+  const activity = activityBuffer.size > 0 ? new Map(activityBuffer) : null;
+  const flow = flowStatusBuffer.size > 0 ? new Map(flowStatusBuffer) : null;
+  activityBuffer.clear();
+  flowStatusBuffer.clear();
+
+  usePanelStore.setState((state) => {
+    const nextById = { ...state.panelsById };
+    let changed = false;
+
+    if (activity) {
+      for (const [id, patch] of activity) {
+        const terminal = nextById[id];
+        if (!terminal) continue;
+        if (
+          terminal.activityHeadline === patch.headline &&
+          terminal.activityStatus === patch.status &&
+          terminal.activityType === patch.type &&
+          terminal.activityTimestamp === patch.timestamp &&
+          terminal.lastCommand === patch.lastCommand
+        ) {
+          continue;
+        }
+        nextById[id] = {
+          ...terminal,
+          activityHeadline: patch.headline,
+          activityStatus: patch.status,
+          activityType: patch.type,
+          activityTimestamp: patch.timestamp,
+          lastCommand: patch.lastCommand,
+        };
+        changed = true;
+      }
+    }
+
+    if (flow) {
+      for (const [id, patch] of flow) {
+        const terminal = nextById[id];
+        if (!terminal) continue;
+
+        const prevTs = terminal.flowStatusTimestamp;
+        if (prevTs !== undefined && patch.timestamp < prevTs) continue;
+
+        if (
+          terminal.flowStatus === patch.status &&
+          terminal.flowStatusTimestamp === patch.timestamp
+        ) {
+          continue;
+        }
+
+        const runtimeStatus = deriveRuntimeStatus(
+          terminal.isVisible,
+          patch.status,
+          terminal.runtimeStatus
+        );
+
+        nextById[id] = {
+          ...terminal,
+          flowStatus: patch.status,
+          flowStatusTimestamp: patch.timestamp,
+          runtimeStatus,
+        };
+        changed = true;
+      }
+    }
+
+    if (!changed) return state;
+    return { panelsById: nextById };
+  });
+}
+
+export function cancelPanelStatusBuffer(): void {
+  if (rafId !== null && typeof cancelAnimationFrame !== "undefined") {
+    cancelAnimationFrame(rafId);
+  }
+  rafId = null;
+  activityBuffer.clear();
+  flowStatusBuffer.clear();
+}

--- a/src/store/panelStatusBuffer.ts
+++ b/src/store/panelStatusBuffer.ts
@@ -57,10 +57,14 @@ export function enqueueFlowStatusUpdate(
   status: PersistableFlowStatus,
   timestamp: number
 ): void {
-  // Last write wins per terminal per frame. The slice's stale-timestamp guard
-  // is reproduced inside the fold against live store state, so accepting the
-  // latest enqueued patch here is correct: an older event still in-buffer is
-  // already superseded by the newer one we are about to set.
+  // Guard against in-buffer reordering: IPC can deliver events out of
+  // chronological order within a single frame (backpressure, multi-source
+  // emission, reconnect). Without this guard, a later-arriving `t=100`
+  // event would clobber an in-buffer `t=200` event and then pass the
+  // fold's persisted-store guard because nothing else has been committed
+  // yet for this terminal.
+  const existing = flowStatusBuffer.get(terminalId);
+  if (existing && timestamp < existing.timestamp) return;
   flowStatusBuffer.set(terminalId, { status, timestamp });
   schedule();
 }

--- a/src/store/panelStoreListeners.ts
+++ b/src/store/panelStoreListeners.ts
@@ -1,5 +1,6 @@
-import { DisposableStore } from "@/utils/disposable";
+import { DisposableStore, toDisposable } from "@/utils/disposable";
 import { clearAllRestartGuards } from "./restartExitSuppression";
+import { cancelPanelStatusBuffer } from "./panelStatusBuffer";
 import { setupIdentityListeners } from "./listeners/panel/identity";
 import { setupLifecycleListeners } from "./listeners/panel/lifecycle";
 import { setupActivityListeners } from "./listeners/panel/activity";
@@ -25,6 +26,11 @@ export function setupTerminalStoreListeners() {
 
   const disposables = new DisposableStore();
   store = disposables;
+
+  // Owns the shared RAF buffer's teardown. Sub-listeners (activity, lifecycle
+  // onStatus) only enqueue patches; the buffer is a module-level singleton
+  // and must outlive any single sub-store, so cancellation lives here.
+  disposables.add(toDisposable(cancelPanelStatusBuffer));
 
   disposables.add(setupIdentityListeners());
   disposables.add(setupLifecycleListeners());


### PR DESCRIPTION
## Summary

- Zustand 5 fires synchronous notifications on every `setState` call — with 3–10 agents running, each emitting activity or flow-status events, the renderer was doing one store write per event per frame, triggering redundant selector executions across the board
- Adds `src/store/panelStatusBuffer.ts`: a shared `requestAnimationFrame` buffer that folds all activity and flow-status writes into a single `setState` per frame, collapsing the per-frame write count to one regardless of agent count
- Agent-state writes in `identity.ts` are deliberately kept direct — they drive a processing queue that depends on observing every transition in order, and fire side-effects (review-inbox notifications, changed-file snapshots) that can't be coalesced

Resolves #8589

## Changes

- `src/store/panelStatusBuffer.ts` — new shared buffer with `enqueueActivityUpdate`, `enqueueFlowStatusUpdate`, and `cancelPanelStatusBuffer`; out-of-order flow-status events are rejected (later-arriving older timestamps discarded)
- `src/store/listeners/panel/activity.ts` — refactored to delegate through `enqueueActivityUpdate` instead of writing the store directly per-terminal
- `src/store/listeners/panel/lifecycle.ts` — `onStatus` routes through `enqueueFlowStatusUpdate` instead of calling `updateFlowStatus` directly
- `src/store/panelStoreListeners.ts` — `cancelPanelStatusBuffer` registration centralised here on teardown

## Testing

13 new unit tests in `src/store/listeners/panel/__tests__/panelStatusBuffer.test.ts` covering: single-frame batching, multi-producer coalescing, out-of-order rejection, cancel/cleanup, and RAF scheduling. Existing listener tests stay green.