### PR TITLE
fix(projectview): cold project switch paint-gate flash fix

### DIFF
--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -238,15 +238,27 @@ export class ResourceProfileService {
       this.evaluate();
     }, EVAL_INTERVAL_MS);
 
-    // Push the initial profile's low-memory floor so the feature is armed on
-    // launch even when the service stays on its default profile (`balanced`)
-    // and applyProfile() never runs. Fan out to every window's PVM so
+    // Push the initial profile's PVM settings so they are armed on launch
+    // even when the service stays on its default profile (`balanced`) and
+    // applyProfile() never runs. Fan out to every window's PVM so
     // multi-window sessions are armed alongside the original window.
+    // Paint-gate values are no-ops at default but pushed for symmetry so the
+    // profile config remains the single source of truth — drift in the PVM
+    // defaults stops mattering.
+    const initialConfig = RESOURCE_PROFILE_CONFIGS[this.currentProfile];
     for (const pvm of this.deps.getAllProjectViewManagers()) {
       try {
-        pvm.setLowMemoryFreeThresholdMb(
-          RESOURCE_PROFILE_CONFIGS[this.currentProfile].lowMemoryFreeThresholdMb
-        );
+        pvm.setLowMemoryFreeThresholdMb(initialConfig.lowMemoryFreeThresholdMb);
+      } catch {
+        // non-critical
+      }
+      try {
+        pvm.setPaintGateTimeoutMs(initialConfig.paintGateTimeoutMs);
+      } catch {
+        // non-critical
+      }
+      try {
+        pvm.setPaintGateHardTimeoutMs(initialConfig.paintGateHardTimeoutMs);
       } catch {
         // non-critical
       }
@@ -773,6 +785,22 @@ export class ResourceProfileService {
       // it, without mutating the user-configured `maxCachedViews`.
       try {
         pvm.setLowMemoryFreeThresholdMb(config.lowMemoryFreeThresholdMb);
+      } catch {
+        // non-critical
+      }
+
+      // Push per-profile paint-gate timeouts. Cold starts run measurably
+      // slower under efficiency (memory/thermal/battery pressure), so the
+      // soft warning bound stretches from 3s to 5s and the hard fall-through
+      // bound from 8s to 12s. Each setter wrapped in its own try/catch so a
+      // throw from one doesn't skip the other.
+      try {
+        pvm.setPaintGateTimeoutMs(config.paintGateTimeoutMs);
+      } catch {
+        // non-critical
+      }
+      try {
+        pvm.setPaintGateHardTimeoutMs(config.paintGateHardTimeoutMs);
       } catch {
         // non-critical
       }

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -132,6 +132,8 @@ interface MockProjectViewManager {
   setCachedViewLimit: Mock;
   setLowMemoryFreeThresholdMb: Mock;
   setEfficiencyFreeze: Mock;
+  setPaintGateTimeoutMs: Mock;
+  setPaintGateHardTimeoutMs: Mock;
 }
 interface MockProjectStatsService {
   updatePollInterval: Mock;
@@ -153,6 +155,8 @@ function createDeps(overrides?: Partial<ResourceProfileDeps>): ResourceProfileDe
     setCachedViewLimit: vi.fn(),
     setLowMemoryFreeThresholdMb: vi.fn(),
     setEfficiencyFreeze: vi.fn(),
+    setPaintGateTimeoutMs: vi.fn(),
+    setPaintGateHardTimeoutMs: vi.fn(),
   };
   const mockProjectStatsService: MockProjectStatsService = {
     updatePollInterval: vi.fn(),
@@ -687,6 +691,80 @@ describe("ResourceProfileService", () => {
       RESOURCE_PROFILE_CONFIGS.balanced.lowMemoryFreeThresholdMb
     );
     expect(pvm.setLowMemoryFreeThresholdMb).toHaveBeenCalledTimes(1);
+
+    service.stop();
+  });
+
+  it("pushes the balanced profile's paint-gate timeouts on start()", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+
+    service.start();
+
+    expect(pvm.setPaintGateTimeoutMs).toHaveBeenCalledWith(
+      RESOURCE_PROFILE_CONFIGS.balanced.paintGateTimeoutMs
+    );
+    expect(pvm.setPaintGateHardTimeoutMs).toHaveBeenCalledWith(
+      RESOURCE_PROFILE_CONFIGS.balanced.paintGateHardTimeoutMs
+    );
+
+    service.stop();
+  });
+
+  it("pushes efficiency paint-gate timeouts on transition into efficiency", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+    expect(pvm.setPaintGateTimeoutMs).toHaveBeenLastCalledWith(
+      RESOURCE_PROFILE_CONFIGS.efficiency.paintGateTimeoutMs
+    );
+    expect(pvm.setPaintGateHardTimeoutMs).toHaveBeenLastCalledWith(
+      RESOURCE_PROFILE_CONFIGS.efficiency.paintGateHardTimeoutMs
+    );
+
+    service.stop();
+  });
+
+  it("restores balanced paint-gate timeouts on upgrade from efficiency", () => {
+    const deps = createDeps({ getUserCachedViewLimit: () => 3 });
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+
+    const onAcHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-ac"
+    )?.[1] as (() => void) | undefined;
+
+    // Drive into efficiency
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+    expect(pvm.setPaintGateTimeoutMs).toHaveBeenLastCalledWith(
+      RESOURCE_PROFILE_CONFIGS.efficiency.paintGateTimeoutMs
+    );
+
+    // Relieve to balanced
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
+    onAcHandler!();
+    vi.advanceTimersByTime(30_000 * 4);
+
+    expect(service.getProfile()).toBe("balanced");
+    expect(pvm.setPaintGateTimeoutMs).toHaveBeenLastCalledWith(
+      RESOURCE_PROFILE_CONFIGS.balanced.paintGateTimeoutMs
+    );
+    expect(pvm.setPaintGateHardTimeoutMs).toHaveBeenLastCalledWith(
+      RESOURCE_PROFILE_CONFIGS.balanced.paintGateHardTimeoutMs
+    );
 
     service.stop();
   });

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -56,13 +56,19 @@ const CRASH_LOOP_THRESHOLD = 3;
 // after we've decided to leave efficiency is the worst-of-both-worlds.
 const EFFICIENCY_FREEZE_DEBOUNCE_MS = 500;
 /**
- * Maximum time to wait for the incoming view's renderer to signal
- * `APP_VIEW_PAINTED` before unconditionally tearing down the outgoing
- * view. Three seconds keeps a slow renderer from leaving the outgoing
- * view attached indefinitely on a stuck or crashed cold start, while
- * comfortably covering the realistic worst case (~1s on cold disk).
+ * Soft paint-gate timeout (ms). At this point the gate logs that the
+ * incoming view is taking longer than the typical cold start, but the
+ * outgoing view stays attached so the user never sees an unfinished
+ * frame. Crossing this bound is observable but never user-visible.
  */
-const PAINT_GATE_TIMEOUT_MS = 3_000;
+const DEFAULT_PAINT_GATE_TIMEOUT_MS = 3_000;
+/**
+ * Hard paint-gate timeout (ms). Last-resort ceiling — assumes the
+ * incoming renderer is stuck or crashed and forcibly detaches the
+ * outgoing view. Generous enough that legitimately slow cold starts
+ * (low memory, thermal throttling) finish via the signal path instead.
+ */
+const DEFAULT_PAINT_GATE_HARD_TIMEOUT_MS = 8_000;
 /**
  * Period between renderer-memory samples for cached (non-active) views. 30 s
  * matches `ProcessMemoryMonitor` and keeps the synchronous `app.getAppMetrics()`
@@ -73,6 +79,8 @@ const CACHED_VIEW_MEMORY_SAMPLE_INTERVAL_MS = 30_000;
 
 type ViewState = "loading" | "active" | "cached";
 
+type PaintGateOutcome = "signal" | "hard-timeout" | "cancelled";
+
 interface PaintGate {
   webContentsId: number;
   /**
@@ -80,8 +88,21 @@ interface PaintGate {
    * wait. Resize events must reach it too so visible bounds stay in sync.
    */
   outgoingEntry: ViewEntry | null;
-  timeout: ReturnType<typeof setTimeout>;
-  resolve: (reason: "signal" | "timeout" | "cancelled") => void;
+  /**
+   * Soft timer — fires `onSoftTimeout` but does NOT resolve the gate. The
+   * outgoing view stays attached so the soft tail is invisible to the user.
+   */
+  softTimeout: ReturnType<typeof setTimeout>;
+  /**
+   * Hard timer — resolves the gate as `"hard-timeout"`, signalling the
+   * caller to detach the outgoing view as a last resort.
+   */
+  hardTimeout: ReturnType<typeof setTimeout>;
+  /**
+   * Settle the gate. Clears both timers, clears `pendingPaintGate`, and
+   * resolves the outer promise. Idempotent — repeat calls no-op.
+   */
+  resolve: (reason: PaintGateOutcome) => void;
 }
 
 type EvictionReason = "lru" | "pressure" | "limit-change";
@@ -116,11 +137,19 @@ export interface ProjectViewManagerOptions {
   /** Number of project views to keep cached in memory (1–5, default: 1) */
   cachedProjectViews?: number;
   /**
-   * Override the paint-gate fallback timeout (default 3000 ms). Lower values
-   * are useful in tests so the cold-start swap proceeds without waiting on
-   * a real renderer paint signal.
+   * Override the soft paint-gate timeout (default 3000 ms). Crossing this
+   * bound only logs `projectview.paintgate.softtimeout` — the outgoing view
+   * stays attached. Lower values are useful in tests to exercise the
+   * soft-timeout warning path without forcing a real cold start.
    */
   paintGateTimeoutMs?: number;
+  /**
+   * Override the hard paint-gate timeout (default 8000 ms). At this bound
+   * the outgoing view is forcibly detached as a last resort. Lower values
+   * are useful in tests to drive both the hard-timeout warning and the
+   * fall-through deactivation deterministically.
+   */
+  paintGateHardTimeoutMs?: number;
 }
 
 export class ProjectViewManager {
@@ -143,7 +172,8 @@ export class ProjectViewManager {
   private efficiencyFreezeEnabled = false;
   private efficiencyFreezeTimer: NodeJS.Timeout | null = null;
   private pendingPaintGate: PaintGate | null = null;
-  private paintGateTimeoutMs = PAINT_GATE_TIMEOUT_MS;
+  private paintGateTimeoutMs = DEFAULT_PAINT_GATE_TIMEOUT_MS;
+  private paintGateHardTimeoutMs = DEFAULT_PAINT_GATE_HARD_TIMEOUT_MS;
   // One-shot focus intent consumed by the next switchTo for this projectId.
   // Lives on the instance (not module) so multi-window does not cross-leak.
   // Cleared after delivery or discard so a later unrelated switch can't
@@ -169,6 +199,9 @@ export class ProjectViewManager {
     }
     if (opts.paintGateTimeoutMs != null) {
       this.paintGateTimeoutMs = Math.max(0, opts.paintGateTimeoutMs);
+    }
+    if (opts.paintGateHardTimeoutMs != null) {
+      this.paintGateHardTimeoutMs = Math.max(0, opts.paintGateHardTimeoutMs);
     }
 
     // Single resize handler that always updates the active view's bounds.
@@ -362,7 +395,15 @@ export class ProjectViewManager {
     // `did-finish-load`) is captured instead of dropped. The renderer fires
     // `APP_VIEW_PAINTED` once per V8 context and never retries — without
     // pre-arming, every fast cold switch would fall through to the timeout.
-    const paintGatePromise = this.waitForPaint(view.webContents.id, previousEntry);
+    const softMs = this.paintGateTimeoutMs;
+    const paintGatePromise = this.waitForPaint(view.webContents.id, previousEntry, () => {
+      // Soft timeout: outgoing stays attached, gate keeps waiting. Logging
+      // only — the user never sees an unfinished frame on the soft path.
+      logWarn("projectview.paintgate.softtimeout", {
+        projectId,
+        waitedMs: softMs,
+      });
+    });
 
     let visibleAt: number;
     try {
@@ -371,18 +412,22 @@ export class ProjectViewManager {
 
       // Wait for the renderer to confirm React has committed its first
       // structural paint (sent via `APP_VIEW_PAINTED` after a double-rAF in
-      // `notifyViewPainted`). Bounded by `PAINT_GATE_TIMEOUT_MS` so a stuck
-      // renderer cannot leave the outgoing view attached forever.
+      // `notifyViewPainted`). Two-phase: the soft timeout above is observable
+      // but never user-visible; only the hard timeout below detaches the
+      // outgoing view as a last resort when the renderer is stuck or crashed.
       const gateResult = await paintGatePromise;
       visibleAt = performance.now();
-      if (gateResult === "timeout") {
-        logWarn("projectview.paintgate.timeout", {
+      if (gateResult === "hard-timeout") {
+        logWarn("projectview.paintgate.hardtimeout", {
           projectId,
-          waitedMs: this.paintGateTimeoutMs,
+          waitedMs: this.paintGateHardTimeoutMs,
         });
       }
 
-      // Paint signal received (or timed out) — safe to detach the outgoing view.
+      // Paint signal received (or hard timeout reached) — detach the
+      // outgoing view. On hard timeout the incoming frame may be blank,
+      // but the renderer has had its full grace period and holding the
+      // outgoing view longer can't recover a stuck renderer.
       if (previousEntry && this.activeProjectId === projectId) {
         this.deactivateEntry(previousEntry);
       }
@@ -395,12 +440,13 @@ export class ProjectViewManager {
       });
 
       // Deliver pending focus intent only when the renderer has confirmed
-      // first paint. On timeout the renderer may be stuck or unresponsive —
-      // dropping the intent is safer than firing into a partially-mounted
-      // view (the subscriber is registered before `notifyViewPainted`, but
-      // a paint-gate timeout means we have no positive evidence of that).
-      // The intent is always consumed (cleared) regardless of outcome to
-      // prevent a later unrelated switch from picking up a stale focus.
+      // first paint. On hard timeout the renderer may be stuck or
+      // unresponsive — dropping the intent is safer than firing into a
+      // partially-mounted view (the subscriber is registered before
+      // `notifyViewPainted`, but a hard timeout means we have no positive
+      // evidence of that). The intent is always consumed (cleared)
+      // regardless of outcome to prevent a later unrelated switch from
+      // picking up a stale focus.
       const coldIntent = this.consumePendingFocusIntent(projectId);
       if (coldIntent && gateResult === "signal") {
         this.deliverFocusIntent(view, coldIntent);
@@ -411,7 +457,7 @@ export class ProjectViewManager {
       // previous app-view registration (`registerAppView` was overwritten to
       // point at the failed view), and let the still-attached outgoing view
       // resume as the active view.
-      this.clearPaintGate("cancelled");
+      this.clearPaintGate();
       // Discard any pending focus intent for the failed projectId so a later
       // unrelated switch can't pick it up.
       this.consumePendingFocusIntent(projectId);
@@ -445,31 +491,59 @@ export class ProjectViewManager {
 
   /**
    * Resolve when the renderer with `webContentsId` posts `APP_VIEW_PAINTED`
-   * via {@link signalViewPainted}, or when `PAINT_GATE_TIMEOUT_MS` elapses,
-   * or when a superseding switch cancels the gate. Only one paint gate is
-   * tracked at a time — opening a new gate cancels any prior pending one.
+   * via {@link signalViewPainted}, when the hard timeout elapses, or when a
+   * superseding switch cancels the gate. Only one paint gate is tracked at
+   * a time — opening a new gate cancels any prior pending one.
+   *
+   * Two-phase timing:
+   *   - Soft (`paintGateTimeoutMs`): fires `onSoftTimeout` for observability.
+   *     The gate stays open and the outgoing view stays attached.
+   *   - Hard (`paintGateHardTimeoutMs`): resolves the gate as
+   *     `"hard-timeout"`, prompting the caller to detach the outgoing view.
+   *
+   * Both timer values are captured at gate creation. A later
+   * `setPaintGateTimeoutMs` / `setPaintGateHardTimeoutMs` call updates the
+   * fields but does NOT retime an in-flight gate.
    */
   private waitForPaint(
     webContentsId: number,
-    outgoingEntry: ViewEntry | null
-  ): Promise<"signal" | "timeout" | "cancelled"> {
+    outgoingEntry: ViewEntry | null,
+    onSoftTimeout?: () => void
+  ): Promise<PaintGateOutcome> {
     // Cancel any prior gate from a previous switch attempt. Should not
     // normally occur (switchChain serializes), but guards against re-entry
     // from rollback paths.
-    this.clearPaintGate("cancelled");
+    this.clearPaintGate();
 
-    return new Promise((resolveOuter) => {
+    const softMs = this.paintGateTimeoutMs;
+    // Guarantee hard >= soft at gate-creation time so the soft callback
+    // always fires before the hard fall-through, regardless of how the two
+    // setters are ordered by the resource-profile push.
+    const hardMs = Math.max(this.paintGateHardTimeoutMs, softMs);
+
+    return new Promise<PaintGateOutcome>((resolveOuter) => {
+      let settled = false;
       const gate: PaintGate = {
         webContentsId,
         outgoingEntry,
-        timeout: setTimeout(() => {
-          if (this.pendingPaintGate === gate) {
-            this.pendingPaintGate = null;
-            resolveOuter("timeout");
+        softTimeout: setTimeout(() => {
+          // Soft tail: log only. Keep waiting for either the paint signal
+          // or the hard timeout — DO NOT resolve.
+          if (this.pendingPaintGate !== gate) return;
+          try {
+            onSoftTimeout?.();
+          } catch (err) {
+            console.error("[ProjectViewManager] paint-gate soft callback threw:", err);
           }
-        }, this.paintGateTimeoutMs),
+        }, softMs),
+        hardTimeout: setTimeout(() => {
+          gate.resolve("hard-timeout");
+        }, hardMs),
         resolve: (reason) => {
-          clearTimeout(gate.timeout);
+          if (settled) return;
+          settled = true;
+          clearTimeout(gate.softTimeout);
+          clearTimeout(gate.hardTimeout);
           if (this.pendingPaintGate === gate) {
             this.pendingPaintGate = null;
           }
@@ -480,12 +554,10 @@ export class ProjectViewManager {
     });
   }
 
-  private clearPaintGate(reason: "signal" | "timeout" | "cancelled"): void {
+  private clearPaintGate(): void {
     const gate = this.pendingPaintGate;
     if (!gate) return;
-    this.pendingPaintGate = null;
-    clearTimeout(gate.timeout);
-    gate.resolve(reason);
+    gate.resolve("cancelled");
   }
 
   /**
@@ -551,6 +623,26 @@ export class ProjectViewManager {
     const safe = Number.isFinite(n) ? n : 1;
     this.maxCachedViews = Math.max(1, Math.min(5, safe));
     this.evictStaleViews("limit-change");
+  }
+
+  /**
+   * Set the soft paint-gate timeout (ms). Does NOT retime an in-flight
+   * gate — the value is captured at gate creation. Called by
+   * `ResourceProfileService` to push per-profile timing.
+   */
+  setPaintGateTimeoutMs(ms: number): void {
+    if (!Number.isFinite(ms) || ms < 0) return;
+    this.paintGateTimeoutMs = ms;
+  }
+
+  /**
+   * Set the hard paint-gate timeout (ms). Does NOT retime an in-flight
+   * gate — the value is captured at gate creation. Called by
+   * `ResourceProfileService` to push per-profile timing.
+   */
+  setPaintGateHardTimeoutMs(ms: number): void {
+    if (!Number.isFinite(ms) || ms < 0) return;
+    this.paintGateHardTimeoutMs = ms;
   }
 
   /**
@@ -644,7 +736,7 @@ export class ProjectViewManager {
     }
     this.efficiencyFreezeEnabled = false;
 
-    this.clearPaintGate("cancelled");
+    this.clearPaintGate();
     for (const projectId of Array.from(this.views.keys())) {
       this.cleanupEntry(projectId);
     }

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -395,7 +395,12 @@ export class ProjectViewManager {
     // `did-finish-load`) is captured instead of dropped. The renderer fires
     // `APP_VIEW_PAINTED` once per V8 context and never retries — without
     // pre-arming, every fast cold switch would fall through to the timeout.
+    //
+    // Capture both bounds at call time so the warning logs reflect the
+    // value actually used by the in-flight gate even if the setters fire
+    // a profile push between gate creation and log emission.
     const softMs = this.paintGateTimeoutMs;
+    const hardMs = Math.max(this.paintGateHardTimeoutMs, softMs);
     const paintGatePromise = this.waitForPaint(view.webContents.id, previousEntry, () => {
       // Soft timeout: outgoing stays attached, gate keeps waiting. Logging
       // only — the user never sees an unfinished frame on the soft path.
@@ -420,7 +425,7 @@ export class ProjectViewManager {
       if (gateResult === "hard-timeout") {
         logWarn("projectview.paintgate.hardtimeout", {
           projectId,
-          waitedMs: this.paintGateHardTimeoutMs,
+          waitedMs: hardMs,
         });
       }
 
@@ -1302,8 +1307,16 @@ export class ProjectViewManager {
       return memoryByPid.get(pid) ?? 0;
     };
 
+    // Outgoing view of an open paint gate is still on-screen and serving as
+    // the anti-flash bridge — treat it as non-evictable, same as the active
+    // view. Without this, a setCachedViewLimit(1) call landing mid-gate
+    // (e.g. an efficiency-profile transition firing during a slow cold
+    // start) would evict the outgoing view and expose the unpainted
+    // incoming frame, re-creating the exact flash this gate prevents.
+    const gateOutgoingProjectId = this.pendingPaintGate?.outgoingEntry?.projectId ?? null;
+
     const evictable = Array.from(this.views.entries())
-      .filter(([id]) => id !== this.activeProjectId)
+      .filter(([id]) => id !== this.activeProjectId && id !== gateOutgoingProjectId)
       // Oldest lastUsed first — pure LRU. Sequential switchTo calls stamp
       // distinct millisecond timestamps so equal-lastUsed ties don't arise
       // in practice; Array.sort stability handles them deterministically.

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -170,6 +170,7 @@ describe("ProjectViewManager adversarial", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
     });
 
@@ -202,6 +203,7 @@ describe("ProjectViewManager adversarial", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -235,6 +237,7 @@ describe("ProjectViewManager adversarial", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
     });
 

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -179,6 +179,7 @@ describe("ProjectViewManager — eviction safety", () => {
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
     });
   });
@@ -223,6 +224,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -256,6 +258,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -289,6 +292,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -322,6 +326,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
     });
 
@@ -362,6 +367,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -423,6 +429,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -448,6 +455,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -476,6 +484,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -512,6 +521,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -537,6 +547,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -563,6 +574,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 4,
     });
 
@@ -611,6 +623,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -628,6 +641,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -660,6 +674,7 @@ describe("ProjectViewManager — telemetry", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -692,6 +707,7 @@ describe("ProjectViewManager — telemetry", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
     });
 
@@ -734,6 +750,7 @@ describe("ProjectViewManager — telemetry", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -769,6 +786,7 @@ describe("ProjectViewManager — telemetry", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -803,6 +821,7 @@ describe("ProjectViewManager — telemetry", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -829,6 +848,7 @@ describe("ProjectViewManager — telemetry", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -1105,6 +1125,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
       onViewCached,
     });
@@ -1130,6 +1151,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
       onViewCached,
     });
@@ -1160,6 +1182,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
       onViewCached,
     });
@@ -1186,6 +1209,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
       onViewCached,
     });
@@ -1203,6 +1227,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
       onViewCached,
     });
@@ -1221,6 +1246,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
       onViewCached,
     });
@@ -1246,6 +1272,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
       onViewCached,
     });
@@ -1266,6 +1293,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
     });
 
@@ -1305,6 +1333,7 @@ describe("ProjectViewManager — listener cleanup", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -1359,6 +1388,7 @@ describe("ProjectViewManager — listener cleanup", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -1394,6 +1424,7 @@ describe("ProjectViewManager — listener cleanup", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
       onViewReady,
     });
@@ -1431,6 +1462,7 @@ describe("ProjectViewManager — listener cleanup", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 
@@ -1455,6 +1487,7 @@ describe("ProjectViewManager — listener cleanup", () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
     });
 
@@ -1527,6 +1560,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
     });
   });
@@ -1684,6 +1718,8 @@ describe("ProjectViewManager — low-memory eviction", () => {
     const managerWithLimit = new ProjectViewManager(win as never, {
       dirname: "/test",
       cachedProjectViews: 2,
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
     });
     managerWithLimit.setLowMemoryFreeThresholdMb(768);
 
@@ -1774,6 +1810,8 @@ describe("ProjectViewManager — low-memory eviction", () => {
       dirname: "/test",
       cachedProjectViews: 4,
       onViewEvicted,
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
     });
     stubSystemMemoryInfo({ free: 64 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
     pressureManager.setLowMemoryFreeThresholdMb(768);

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -201,6 +201,7 @@ describe("ProjectViewManager — pending focus intent", () => {
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 50,
+      paintGateHardTimeoutMs: 150,
       cachedProjectViews: 3,
     });
 
@@ -233,7 +234,7 @@ describe("ProjectViewManager — pending focus intent", () => {
     expect(focusSends[0][1]).toEqual({ intent: "focus-next-waiting" });
   });
 
-  it("does not deliver focus intent when paint gate times out", async () => {
+  it("does not deliver focus intent when paint gate hard timeout fires", async () => {
     vi.useFakeTimers();
     try {
       const slowWc = createMockWebContents();
@@ -243,8 +244,9 @@ describe("ProjectViewManager — pending focus intent", () => {
       const switchPromise = manager.switchTo("proj-b", "/path/b");
       await vi.advanceTimersByTimeAsync(0);
 
-      // Advance past the paint gate timeout.
-      await vi.advanceTimersByTimeAsync(60);
+      // Past hard bound (150 ms). The soft bound at 50 ms only warns —
+      // intent is dropped on hard fall-through, not on soft warning.
+      await vi.advanceTimersByTimeAsync(200);
       await switchPromise;
 
       const focusSends = slowWc.send.mock.calls.filter(

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -123,6 +123,7 @@ describe("ProjectViewManager — efficiency freeze", () => {
       dirname: "/test",
       cachedProjectViews: 3,
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
     });
     // Stub the paint gate to resolve immediately — this suite uses fake timers
     // so the gate's setTimeout cannot fire on its own.

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -120,6 +120,7 @@ describe("ProjectViewManager — GC on deactivate", () => {
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
       cachedProjectViews: 2,
     });
 

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -345,6 +345,42 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     }
   });
 
+  it("setCachedViewLimit(1) during the paint gate does NOT evict the outgoing view", async () => {
+    // Regression: a profile transition to efficiency mid-cold-start can
+    // call setCachedViewLimit(1) while the paint gate is open. Without
+    // the gate-aware eviction guard the outgoing view would be evicted
+    // and expose the blank incoming frame — the exact flash this gate
+    // is meant to prevent.
+    const slowWc = createMockWebContents();
+    wcQueue.push(slowWc);
+
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Pre-flight: outgoing (proj-a) attached, gate pending.
+    expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+
+    // Squeeze the cache while the gate is open. This call is the normal
+    // efficiency-transition behaviour from ResourceProfileService.
+    manager.setCachedViewLimit(1);
+
+    // Outgoing must NOT be evicted by the limit-change pass — it's still
+    // the visible anti-flash bridge until the gate resolves.
+    expect(initialWc.close).not.toHaveBeenCalled();
+    expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+
+    // Release the gate. The outgoing view is now detached (gate release)
+    // and may be evicted (post-switch LRU pass with the new max=1). The
+    // critical guarantee is that the detach order — gate release first,
+    // eviction second — keeps the swap seamless even when both fire on
+    // the same trailing-edge.
+    manager.signalViewPainted(slowWc.id);
+    await switchPromise;
+
+    expect(manager.getActiveProjectId()).toBe("proj-b");
+  });
+
   it("paint-gate timeout setters do not retime an in-flight gate", async () => {
     vi.useFakeTimers();
     try {

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -202,11 +202,14 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     vi.mocked(logWarn).mockClear();
 
     win = createMockWindow();
-    // Use a small, non-zero timeout so tests can observe both the signal
-    // path (resolves before timeout) and the timeout path (advances past it).
+    // Use small, non-zero timeouts so tests can observe each phase:
+    //  - soft (50 ms) fires the warning but keeps the outgoing view attached
+    //  - hard (150 ms) is the last-resort fall-through that detaches
+    // Both must be set explicitly because the PVM defaults are 3 s / 8 s.
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 50,
+      paintGateHardTimeoutMs: 150,
       cachedProjectViews: 3,
     });
 
@@ -247,7 +250,46 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     expect(manager.getActiveProjectId()).toBe("proj-b");
   });
 
-  it("falls through paint gate after timeout when signal never arrives", async () => {
+  it("soft timeout warns but does NOT detach the outgoing view", async () => {
+    vi.useFakeTimers();
+    try {
+      const slowWc = createMockWebContents();
+      wcQueue.push(slowWc);
+
+      const switchPromise = manager.switchTo("proj-b", "/path/b");
+
+      // Flush microtasks so did-finish-load fires and waitForPaint is armed.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+
+      // Cross the soft bound (50 ms) — warning logged, gate still open.
+      await vi.advanceTimersByTimeAsync(60);
+      expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+      expect(
+        vi
+          .mocked(logWarn)
+          .mock.calls.filter(([event]) => event === "projectview.paintgate.softtimeout")
+      ).toHaveLength(1);
+
+      // Signal eventually arrives between soft and hard — outgoing released
+      // cleanly. No hard-timeout warning. (Hard bound is 150 ms; soft fired
+      // at 50 ms; we are at ~60 ms.)
+      manager.signalViewPainted(slowWc.id);
+      await switchPromise;
+
+      expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
+      expect(manager.getActiveProjectId()).toBe("proj-b");
+      expect(
+        vi
+          .mocked(logWarn)
+          .mock.calls.filter(([event]) => event === "projectview.paintgate.hardtimeout")
+      ).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls through paint gate at hard timeout when signal never arrives", async () => {
     vi.useFakeTimers();
     try {
       const slowWc = createMockWebContents();
@@ -258,18 +300,78 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
       // Flush microtasks so did-finish-load fires and waitForPaint is armed.
       await vi.advanceTimersByTimeAsync(0);
 
-      // Outgoing still attached, gate pending.
+      // Cross the soft bound (50 ms) — outgoing still attached.
+      await vi.advanceTimersByTimeAsync(60);
       expect(win.contentView.removeChildView).not.toHaveBeenCalled();
 
-      // Advance past the paint gate timeout (50ms).
-      await vi.advanceTimersByTimeAsync(60);
+      // Cross the hard bound (150 ms total) — outgoing now detached.
+      await vi.advanceTimersByTimeAsync(100);
       await switchPromise;
 
       expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
       expect(manager.getActiveProjectId()).toBe("proj-b");
       expect(
-        vi.mocked(logWarn).mock.calls.filter(([event]) => event === "projectview.paintgate.timeout")
+        vi
+          .mocked(logWarn)
+          .mock.calls.filter(([event]) => event === "projectview.paintgate.softtimeout")
       ).toHaveLength(1);
+      expect(
+        vi
+          .mocked(logWarn)
+          .mock.calls.filter(([event]) => event === "projectview.paintgate.hardtimeout")
+      ).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("hard timeout drops the pending focus intent", async () => {
+    vi.useFakeTimers();
+    try {
+      const slowWc = createMockWebContents();
+      wcQueue.push(slowWc);
+
+      manager.setPendingFocusIntent("proj-b", "focus-next-waiting");
+
+      const switchPromise = manager.switchTo("proj-b", "/path/b");
+      await vi.advanceTimersByTimeAsync(0);
+      // Past hard bound — fall-through, intent dropped.
+      await vi.advanceTimersByTimeAsync(200);
+      await switchPromise;
+
+      expect(slowWc.send).not.toHaveBeenCalledWith("project:focus-on-activate", expect.anything());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("paint-gate timeout setters do not retime an in-flight gate", async () => {
+    vi.useFakeTimers();
+    try {
+      const slowWc = createMockWebContents();
+      wcQueue.push(slowWc);
+
+      const switchPromise = manager.switchTo("proj-b", "/path/b");
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Bump both bounds way up mid-flight — must NOT delay the active gate
+      // (captured at gate creation). The 50 ms / 150 ms bounds from beforeEach
+      // still apply.
+      manager.setPaintGateTimeoutMs(10_000);
+      manager.setPaintGateHardTimeoutMs(20_000);
+
+      // Cross the original soft bound — warning fires using captured value.
+      await vi.advanceTimersByTimeAsync(60);
+      expect(
+        vi
+          .mocked(logWarn)
+          .mock.calls.filter(([event]) => event === "projectview.paintgate.softtimeout")
+      ).toHaveLength(1);
+
+      // Cross the original hard bound — fall-through fires using captured value.
+      await vi.advanceTimersByTimeAsync(100);
+      await switchPromise;
+      expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -189,6 +189,7 @@ describe("ProjectViewManager — switch failure rollback", () => {
       dirname: "/test",
       cachedProjectViews: 3,
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
     });
 
     initialWc = createMockWebContents();
@@ -287,6 +288,7 @@ describe("ProjectViewManager — switch failure rollback", () => {
     const freshManager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
     });
 
     const failWc = createMockWebContents({ autoFinishLoad: false });

--- a/shared/types/resourceProfile.ts
+++ b/shared/types/resourceProfile.ts
@@ -31,6 +31,24 @@ export interface ResourceProfileConfig {
    * platforms it is free alone.
    */
   lowMemoryFreeThresholdMb: number | null;
+  /**
+   * Cold-start paint-gate SOFT timeout (ms). Bounds the wait for the incoming
+   * project view's renderer to emit `APP_VIEW_PAINTED`. Crossing this bound
+   * does NOT detach the outgoing view — it only logs a warning so the gate
+   * tail is observable; the outgoing view stays attached until either the
+   * paint signal arrives or the hard timeout fires. Tuned per profile because
+   * cold starts run measurably slower under memory/thermal/battery pressure
+   * (efficiency).
+   */
+  paintGateTimeoutMs: number;
+  /**
+   * Cold-start paint-gate HARD timeout (ms). Last-resort ceiling that
+   * deactivates the outgoing view even without a paint signal — assumes the
+   * incoming renderer is stuck or crashed. Should be comfortably above
+   * `paintGateTimeoutMs` so legitimately slow cold starts complete via the
+   * signal path instead of falling through.
+   */
+  paintGateHardTimeoutMs: number;
 }
 
 export interface ResourceProfilePayload {
@@ -64,6 +82,8 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     lowMemoryFreeThresholdMb: null,
     fetchIntervalActiveMs: 20_000,
     fetchIntervalBackgroundMs: 3 * 60_000,
+    paintGateTimeoutMs: 3_000,
+    paintGateHardTimeoutMs: 8_000,
   },
   balanced: {
     pollIntervalActive: 2000,
@@ -76,6 +96,8 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     lowMemoryFreeThresholdMb: 768,
     fetchIntervalActiveMs: 30_000,
     fetchIntervalBackgroundMs: 5 * 60_000,
+    paintGateTimeoutMs: 3_000,
+    paintGateHardTimeoutMs: 8_000,
   },
   efficiency: {
     pollIntervalActive: 4000,
@@ -88,5 +110,10 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     lowMemoryFreeThresholdMb: 1024,
     fetchIntervalActiveMs: 45_000,
     fetchIntervalBackgroundMs: 10 * 60_000,
+    // Cold starts under memory/thermal/battery pressure routinely run slower
+    // than the perf/balanced 3s soft bound — bumping to 5s keeps the
+    // anti-flash hand-off without false-timeout warning spam.
+    paintGateTimeoutMs: 5_000,
+    paintGateHardTimeoutMs: 12_000,
   },
 };


### PR DESCRIPTION
## Summary

- Replaces the single unconditional paint-gate timeout with a two-phase gate: a soft warning fires at the original 3-second threshold, and the hard fall-through only triggers at a configurable outer deadline driven by `ResourceProfileService`. That means blank frames can't be revealed on a slow machine that would have timed out early.
- Guards the outgoing `WebContentsView` against LRU eviction while the paint gate is active, closing the race where mid-gate eviction left nothing to show if the incoming view then hit its hard deadline.

Resolves #8606

## Changes

- `electron/window/ProjectViewManager.ts` — two-phase paint gate logic; soft-warn + hard fall-through; eviction guard on the outgoing view keyed to gate state
- `electron/services/ResourceProfileService.ts` — exposes per-profile `paintGateHardDeadlineMs` so the outer timeout scales with memory pressure and resource profile
- `shared/types/resourceProfile.ts` — adds `paintGateHardDeadlineMs` to the profile type
- Test coverage updated across `ProjectViewManager.paintGate.test.ts`, `ProjectViewManager.eviction.test.ts`, and `ResourceProfileService.test.ts`

## Testing

- `ProjectViewManager.paintGate` test suite covers the soft-warn path, hard fall-through path, and the gate clearing correctly on success
- `ProjectViewManager.eviction` tests confirm the outgoing view survives LRU pressure while the gate is open and is released once it resolves
- `ResourceProfileService` tests verify the hard deadline scales with each profile tier