### PR TITLE
fix(window): keep global services alive across last-window-close

### DIFF
--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -110,6 +110,115 @@ vi.mock("../../setup/environment.js", () => ({
   },
 }));
 
+const hibernationMock = vi.hoisted(() => ({ stop: vi.fn() }));
+vi.mock("../../services/HibernationService.js", () => ({
+  getHibernationService: vi.fn(() => hibernationMock),
+}));
+
+const idleTerminalMock = vi.hoisted(() => ({ stop: vi.fn() }));
+vi.mock("../../services/IdleTerminalNotificationService.js", () => ({
+  getIdleTerminalNotificationService: vi.fn(() => idleTerminalMock),
+}));
+
+const systemSleepMock = vi.hoisted(() => ({ dispose: vi.fn() }));
+vi.mock("../../services/SystemSleepService.js", () => ({
+  getSystemSleepService: vi.fn(() => systemSleepMock),
+}));
+
+const ghTokenHealthMock = vi.hoisted(() => ({ dispose: vi.fn() }));
+vi.mock("../../services/github/GitHubTokenHealthService.js", () => ({
+  gitHubTokenHealthService: ghTokenHealthMock,
+}));
+
+const agentConnectivityMock = vi.hoisted(() => ({ dispose: vi.fn() }));
+const connectivityRegistryMock = vi.hoisted(() => ({ dispose: vi.fn() }));
+vi.mock("../../services/connectivity/index.js", () => ({
+  agentConnectivityService: agentConnectivityMock,
+  getServiceConnectivityRegistry: vi.fn(() => connectivityRegistryMock),
+}));
+
+const notificationServiceMock = vi.hoisted(() => ({ dispose: vi.fn() }));
+vi.mock("../../services/NotificationService.js", () => ({
+  notificationService: notificationServiceMock,
+}));
+
+const preAgentSnapshotMock = vi.hoisted(() => ({ dispose: vi.fn() }));
+vi.mock("../../services/PreAgentSnapshotService.js", () => ({
+  preAgentSnapshotService: preAgentSnapshotMock,
+}));
+
+const pluginServiceMock = vi.hoisted(() => ({ setWorkspaceClient: vi.fn() }));
+vi.mock("../../services/PluginService.js", () => ({
+  pluginService: pluginServiceMock,
+}));
+
+const ccrConfigMock = vi.hoisted(() => ({ stopWatching: vi.fn(() => Promise.resolve()) }));
+const resourceProfileMock = vi.hoisted(() => ({ stop: vi.fn() }));
+const worktreePortBrokerMock = vi.hoisted(() => ({ dispose: vi.fn() }));
+const mainProcessWatchdogMock = vi.hoisted(() => ({ dispose: vi.fn() }));
+const agentNotificationMock = vi.hoisted(() => ({ dispose: vi.fn() }));
+const autoUpdaterMock = vi.hoisted(() => ({ dispose: vi.fn() }));
+const windowsStoreNotifierMock = vi.hoisted(() => ({ dispose: vi.fn() }));
+
+const serviceRefsMock = vi.hoisted(() => {
+  let ccr: { stopWatching: () => Promise<void> } | null = null;
+  let resourceProfile: { stop: () => void } | null = null;
+  let worktreePortBroker: { dispose: () => void } | null = null;
+  let watchdog: { dispose: () => void } | null = null;
+  let agentNotification: { dispose: () => void } | null = null;
+  let autoUpdater: { dispose: () => void } | null = null;
+  let windowsStoreNotifier: { dispose: () => void } | null = null;
+  return {
+    setInitialState: (state: {
+      ccr?: typeof ccr;
+      resourceProfile?: typeof resourceProfile;
+      worktreePortBroker?: typeof worktreePortBroker;
+      watchdog?: typeof watchdog;
+      agentNotification?: typeof agentNotification;
+      autoUpdater?: typeof autoUpdater;
+      windowsStoreNotifier?: typeof windowsStoreNotifier;
+    }) => {
+      ccr = state.ccr ?? null;
+      resourceProfile = state.resourceProfile ?? null;
+      worktreePortBroker = state.worktreePortBroker ?? null;
+      watchdog = state.watchdog ?? null;
+      agentNotification = state.agentNotification ?? null;
+      autoUpdater = state.autoUpdater ?? null;
+      windowsStoreNotifier = state.windowsStoreNotifier ?? null;
+    },
+    getCcrConfigService: vi.fn(() => ccr),
+    setCcrConfigService: vi.fn((v: typeof ccr) => {
+      ccr = v;
+    }),
+    getResourceProfileService: vi.fn(() => resourceProfile),
+    setResourceProfileService: vi.fn((v: typeof resourceProfile) => {
+      resourceProfile = v;
+    }),
+    getWorktreePortBrokerRef: vi.fn(() => worktreePortBroker),
+    setWorktreePortBrokerRef: vi.fn((v: typeof worktreePortBroker) => {
+      worktreePortBroker = v;
+    }),
+    getMainProcessWatchdogClientRef: vi.fn(() => watchdog),
+    setMainProcessWatchdogClientRef: vi.fn((v: typeof watchdog) => {
+      watchdog = v;
+    }),
+    getAgentNotificationServiceRef: vi.fn(() => agentNotification),
+    setAgentNotificationServiceRef: vi.fn((v: typeof agentNotification) => {
+      agentNotification = v;
+    }),
+    getAutoUpdaterServiceRef: vi.fn(() => autoUpdater),
+    setAutoUpdaterServiceRef: vi.fn((v: typeof autoUpdater) => {
+      autoUpdater = v;
+    }),
+    getWindowsStoreNotifierServiceRef: vi.fn(() => windowsStoreNotifier),
+    setWindowsStoreNotifierServiceRef: vi.fn((v: typeof windowsStoreNotifier) => {
+      windowsStoreNotifier = v;
+    }),
+  };
+});
+
+vi.mock("../../window/serviceRefs.js", () => serviceRefsMock);
+
 import type { ShutdownDeps } from "../shutdown.js";
 
 function makeDeps(overrides?: Partial<ShutdownDeps>): ShutdownDeps {
@@ -146,6 +255,8 @@ describe("registerShutdownHandler", () => {
     signalShutdownMock.isSignalShutdown.mockReturnValue(false);
     quitWarningMock.getActiveAgentCount.mockReturnValue(0);
     quitWarningMock.showQuitWarning.mockResolvedValue(true);
+    ccrConfigMock.stopWatching.mockResolvedValue(undefined);
+    serviceRefsMock.setInitialState({});
   });
 
   async function setup(overrides?: Partial<ShutdownDeps>) {
@@ -566,6 +677,124 @@ describe("registerShutdownHandler", () => {
       );
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  // The global services below used to be torn down by the `win.on("closed")`
+  // handler in electron/window/windowServices.ts when the last window closed.
+  // Issue #8604: on macOS, last-window-close does NOT quit the app, so a dock
+  // reactivation could race the async teardown. They now live in `before-quit`
+  // so they are disposed exactly once at app quit time.
+  describe("global service disposal moved from last-window-close (issue #8604)", () => {
+    it("disposes hibernation, idle-terminal, system-sleep, and connectivity services", async () => {
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+
+      expect(hibernationMock.stop).toHaveBeenCalledTimes(1);
+      expect(idleTerminalMock.stop).toHaveBeenCalledTimes(1);
+      expect(systemSleepMock.dispose).toHaveBeenCalledTimes(1);
+      expect(ghTokenHealthMock.dispose).toHaveBeenCalledTimes(1);
+      expect(agentConnectivityMock.dispose).toHaveBeenCalledTimes(1);
+      expect(connectivityRegistryMock.dispose).toHaveBeenCalledTimes(1);
+      expect(notificationServiceMock.dispose).toHaveBeenCalledTimes(1);
+      expect(preAgentSnapshotMock.dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it("disposes optional refs only when present and nulls them after", async () => {
+      serviceRefsMock.setInitialState({
+        ccr: ccrConfigMock,
+        resourceProfile: resourceProfileMock,
+        worktreePortBroker: worktreePortBrokerMock,
+        watchdog: mainProcessWatchdogMock,
+        agentNotification: agentNotificationMock,
+        autoUpdater: autoUpdaterMock,
+        windowsStoreNotifier: windowsStoreNotifierMock,
+      });
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+
+      expect(ccrConfigMock.stopWatching).toHaveBeenCalledTimes(1);
+      expect(resourceProfileMock.stop).toHaveBeenCalledTimes(1);
+      expect(worktreePortBrokerMock.dispose).toHaveBeenCalledTimes(1);
+      expect(mainProcessWatchdogMock.dispose).toHaveBeenCalledTimes(1);
+      expect(agentNotificationMock.dispose).toHaveBeenCalledTimes(1);
+      expect(autoUpdaterMock.dispose).toHaveBeenCalledTimes(1);
+      expect(windowsStoreNotifierMock.dispose).toHaveBeenCalledTimes(1);
+
+      // Refs nulled so any late callbacks no-op.
+      expect(serviceRefsMock.setCcrConfigService).toHaveBeenCalledWith(null);
+      expect(serviceRefsMock.setResourceProfileService).toHaveBeenCalledWith(null);
+      expect(serviceRefsMock.setWorktreePortBrokerRef).toHaveBeenCalledWith(null);
+      expect(serviceRefsMock.setMainProcessWatchdogClientRef).toHaveBeenCalledWith(null);
+      expect(serviceRefsMock.setAgentNotificationServiceRef).toHaveBeenCalledWith(null);
+      expect(serviceRefsMock.setAutoUpdaterServiceRef).toHaveBeenCalledWith(null);
+      expect(serviceRefsMock.setWindowsStoreNotifierServiceRef).toHaveBeenCalledWith(null);
+    });
+
+    it("clears PluginService's WorkspaceClient reference during shutdown", async () => {
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+
+      expect(pluginServiceMock.setWorkspaceClient).toHaveBeenCalledWith(null);
+    });
+
+    it("still exits cleanly when a moved disposal throws", async () => {
+      hibernationMock.stop.mockImplementationOnce(() => {
+        throw new Error("hibernation boom");
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[MAIN] HibernationService.stop failed:",
+        expect.any(Error)
+      );
+      // Sibling disposals still run.
+      expect(idleTerminalMock.stop).toHaveBeenCalled();
+      expect(notificationServiceMock.dispose).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it("still exits cleanly when ccrConfigService.stopWatching rejects", async () => {
+      serviceRefsMock.setInitialState({ ccr: ccrConfigMock });
+      ccrConfigMock.stopWatching.mockRejectedValueOnce(new Error("ccr boom"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[MAIN] CcrConfigService.stopWatching failed:",
+        expect.any(Error)
+      );
+      // Ref still cleared after the failed stop.
+      expect(serviceRefsMock.setCcrConfigService).toHaveBeenCalledWith(null);
+
+      warnSpy.mockRestore();
     });
   });
 });

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -198,6 +198,7 @@ const serviceRefsMock = vi.hoisted(() => {
     setWorktreePortBrokerRef: vi.fn((v: typeof worktreePortBroker) => {
       worktreePortBroker = v;
     }),
+    setWorkspaceClientRef: vi.fn(),
     getMainProcessWatchdogClientRef: vi.fn(() => watchdog),
     setMainProcessWatchdogClientRef: vi.fn((v: typeof watchdog) => {
       watchdog = v;
@@ -793,6 +794,85 @@ describe("registerShutdownHandler", () => {
       );
       // Ref still cleared after the failed stop.
       expect(serviceRefsMock.setCcrConfigService).toHaveBeenCalledWith(null);
+
+      warnSpy.mockRestore();
+    });
+
+    it("stops CCR watcher and clears PluginService before WorkspaceClient disposal", async () => {
+      const order: string[] = [];
+      serviceRefsMock.setInitialState({ ccr: ccrConfigMock });
+
+      ccrConfigMock.stopWatching.mockImplementationOnce(async () => {
+        order.push("ccr:stop");
+      });
+      pluginServiceMock.setWorkspaceClient.mockImplementationOnce(() => {
+        order.push("plugin:setWorkspaceClient(null)");
+      });
+      const workspaceDispose = vi.fn(async () => {
+        order.push("workspace:dispose");
+      });
+
+      const { beforeQuitCb } = await setup({
+        getWorkspaceClient: () => ({ dispose: workspaceDispose }) as never,
+      });
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+
+      // CCR + plugin unwiring must complete before workspaceClient.dispose()
+      // runs; otherwise a file-change callback could fire into a disposing client.
+      const ccrIdx = order.indexOf("ccr:stop");
+      const pluginIdx = order.indexOf("plugin:setWorkspaceClient(null)");
+      const workspaceIdx = order.indexOf("workspace:dispose");
+      expect(ccrIdx).toBeGreaterThanOrEqual(0);
+      expect(pluginIdx).toBeGreaterThanOrEqual(0);
+      expect(workspaceIdx).toBeGreaterThanOrEqual(0);
+      expect(ccrIdx).toBeLessThan(workspaceIdx);
+      expect(pluginIdx).toBeLessThan(workspaceIdx);
+    });
+
+    it("nulls workspaceClientRef after disposeWorkspaceClient runs", async () => {
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+
+      expect(serviceRefsMock.setWorkspaceClientRef).toHaveBeenCalledWith(null);
+    });
+
+    it("still tears down PTY/workspace/watchdog when an earlier optional-ref dispose throws", async () => {
+      serviceRefsMock.setInitialState({
+        autoUpdater: autoUpdaterMock,
+        worktreePortBroker: worktreePortBrokerMock,
+        watchdog: mainProcessWatchdogMock,
+      });
+      autoUpdaterMock.dispose.mockImplementationOnce(() => {
+        throw new Error("auto-updater boom");
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+
+      // The throwing optional-ref dispose must not strand the rest of the
+      // sync block — the WorktreePortBroker, watchdog, and ref-nullers all
+      // sit after it in source order.
+      expect(worktreePortBrokerMock.dispose).toHaveBeenCalled();
+      expect(mainProcessWatchdogMock.dispose).toHaveBeenCalled();
+      expect(serviceRefsMock.setAutoUpdaterServiceRef).toHaveBeenCalledWith(null);
+      expect(serviceRefsMock.setWorkspaceClientRef).toHaveBeenCalledWith(null);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[MAIN] AutoUpdaterService.dispose failed:",
+        expect.any(Error)
+      );
 
       warnSpy.mockRestore();
     });

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -31,6 +31,7 @@ import {
   setResourceProfileService,
   getWorktreePortBrokerRef,
   setWorktreePortBrokerRef,
+  setWorkspaceClientRef,
   getMainProcessWatchdogClientRef,
   setMainProcessWatchdogClientRef,
   getAgentNotificationServiceRef,
@@ -155,7 +156,31 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
     let exitCalled = false;
     let hardTimer: ReturnType<typeof setTimeout> | undefined;
 
-    const cleanupPromise = gracefulShutdownPromise
+    // Stop the CCR config watcher and unwire PluginService's WorkspaceClient
+    // reference before the Promise.all that disposes the WorkspaceClient.
+    // Running these sequentially guarantees no file-change callback can fire
+    // into a half-disposed WorkspaceClient during the await. Both wrap their
+    // own failures so a single throw can't strand the rest of shutdown.
+    const preDisposePromise = gracefulShutdownPromise.then(async () => {
+      const ccr = getCcrConfigService();
+      if (ccr) {
+        try {
+          await ccr.stopWatching();
+        } catch (err) {
+          console.warn("[MAIN] CcrConfigService.stopWatching failed:", err);
+        }
+        setCcrConfigService(null);
+      }
+      try {
+        const { pluginService } = await import("../services/PluginService.js");
+        pluginService.setWorkspaceClient(null);
+      } catch {
+        // Module load errors during teardown are non-fatal (PluginService may
+        // never have been loaded if shutdown fired before first-interactive).
+      }
+    });
+
+    const cleanupPromise = preDisposePromise
       .then(() =>
         Promise.all([
           workspaceClient ? workspaceClient.dispose() : Promise.resolve(),
@@ -170,32 +195,21 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
           import("../services/HelpSessionService.js")
             .then(({ helpSessionService }) => helpSessionService.revokeAll())
             .catch(() => {}),
-          // CCR config watcher is async — stop before nulling the PluginService
-          // WorkspaceClient ref to keep file-change callbacks from racing teardown.
-          (async () => {
-            const ccr = getCcrConfigService();
-            if (!ccr) return;
-            try {
-              await ccr.stopWatching();
-            } catch (err) {
-              console.warn("[MAIN] CcrConfigService.stopWatching failed:", err);
-            }
-            setCcrConfigService(null);
-          })(),
-          // Drop PluginService's WorkspaceClient reference so plugin event
-          // handlers can't fire into the disposed instance during late
-          // teardown. Dynamically imported to match the lazy load pattern used
-          // when the WorkspaceClient was wired in (see windowServices.ts).
-          import("../services/PluginService.js")
-            .then(({ pluginService }) => pluginService.setWorkspaceClient(null))
-            .catch(() => {}),
           new Promise<void>((resolve) => {
             // Global singletons that previously tore down on last-window-close
             // (electron/window/windowServices.ts) live here now so they cover
             // the macOS dock-reactivate path without racing a new window's
-            // re-init. Order: stop monitors and timers, then dispose clients,
-            // then null refs so any late callbacks no-op.
-            getResourceProfileService()?.stop();
+            // re-init. Every dispose() wraps in try/catch so one failure can't
+            // strand later cleanup (PTY/workspace/watchdog/DB) — matching the
+            // pattern already used for closeSharedDb downstream.
+            // Order: stop monitors and timers, then connectivity, then
+            // notifiers, then port broker (before WorkspaceClient is killed),
+            // then PTY/workspace/watchdog.
+            try {
+              getResourceProfileService()?.stop();
+            } catch (err) {
+              console.warn("[MAIN] ResourceProfileService.stop failed:", err);
+            }
             setResourceProfileService(null);
 
             try {
@@ -235,34 +249,77 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
             } catch (err) {
               console.warn("[MAIN] notificationService.dispose failed:", err);
             }
-            getAgentNotificationServiceRef()?.dispose();
+            try {
+              getAgentNotificationServiceRef()?.dispose();
+            } catch (err) {
+              console.warn("[MAIN] AgentNotificationService.dispose failed:", err);
+            }
             setAgentNotificationServiceRef(null);
             try {
               preAgentSnapshotService.dispose();
             } catch (err) {
               console.warn("[MAIN] preAgentSnapshotService.dispose failed:", err);
             }
-            getAutoUpdaterServiceRef()?.dispose();
+            try {
+              getAutoUpdaterServiceRef()?.dispose();
+            } catch (err) {
+              console.warn("[MAIN] AutoUpdaterService.dispose failed:", err);
+            }
             setAutoUpdaterServiceRef(null);
-            getWindowsStoreNotifierServiceRef()?.dispose();
+            try {
+              getWindowsStoreNotifierServiceRef()?.dispose();
+            } catch (err) {
+              console.warn("[MAIN] WindowsStoreNotifierService.dispose failed:", err);
+            }
             setWindowsStoreNotifierServiceRef(null);
 
-            // Port broker holds a WorkspaceClient reference — dispose before
-            // the WorkspaceClient module-level singleton is killed below.
-            getWorktreePortBrokerRef()?.dispose();
+            try {
+              getWorktreePortBrokerRef()?.dispose();
+            } catch (err) {
+              console.warn("[MAIN] WorktreePortBroker.dispose failed:", err);
+            }
             setWorktreePortBrokerRef(null);
 
-            disposePowerSaveBlockerService();
-            disposeAgentAvailabilityStore();
+            try {
+              disposePowerSaveBlockerService();
+            } catch (err) {
+              console.warn("[MAIN] disposePowerSaveBlockerService failed:", err);
+            }
+            try {
+              disposeAgentAvailabilityStore();
+            } catch (err) {
+              console.warn("[MAIN] disposeAgentAvailabilityStore failed:", err);
+            }
             if (ptyClient) {
-              ptyClient.dispose();
+              try {
+                ptyClient.dispose();
+              } catch (err) {
+                console.warn("[MAIN] PtyClient.dispose failed:", err);
+              }
               deps.setPtyClient(null);
             }
-            disposePtyClient();
-            disposeWorkspaceClient();
-            getMainProcessWatchdogClientRef()?.dispose();
+            try {
+              disposePtyClient();
+            } catch (err) {
+              console.warn("[MAIN] disposePtyClient failed:", err);
+            }
+            try {
+              disposeWorkspaceClient();
+            } catch (err) {
+              console.warn("[MAIN] disposeWorkspaceClient failed:", err);
+            }
+            setWorkspaceClientRef(null);
+            try {
+              getMainProcessWatchdogClientRef()?.dispose();
+            } catch (err) {
+              console.warn("[MAIN] MainProcessWatchdogClient.dispose failed:", err);
+            }
             setMainProcessWatchdogClientRef(null);
-            disposeMainProcessWatchdog();
+            try {
+              disposeMainProcessWatchdog();
+            } catch (err) {
+              console.warn("[MAIN] disposeMainProcessWatchdog failed:", err);
+            }
             resolve();
           }),
         ])

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -14,6 +14,32 @@ import { disposeMainProcessWatchdog } from "../services/MainProcessWatchdogClien
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { getCrashLoopGuard } from "../services/CrashLoopGuardService.js";
 import { getDatabaseMaintenanceService } from "../services/DatabaseMaintenanceService.js";
+import { getHibernationService } from "../services/HibernationService.js";
+import { getIdleTerminalNotificationService } from "../services/IdleTerminalNotificationService.js";
+import { getSystemSleepService } from "../services/SystemSleepService.js";
+import { gitHubTokenHealthService } from "../services/github/GitHubTokenHealthService.js";
+import {
+  agentConnectivityService,
+  getServiceConnectivityRegistry,
+} from "../services/connectivity/index.js";
+import { notificationService } from "../services/NotificationService.js";
+import { preAgentSnapshotService } from "../services/PreAgentSnapshotService.js";
+import {
+  getCcrConfigService,
+  setCcrConfigService,
+  getResourceProfileService,
+  setResourceProfileService,
+  getWorktreePortBrokerRef,
+  setWorktreePortBrokerRef,
+  getMainProcessWatchdogClientRef,
+  setMainProcessWatchdogClientRef,
+  getAgentNotificationServiceRef,
+  setAgentNotificationServiceRef,
+  getAutoUpdaterServiceRef,
+  setAutoUpdaterServiceRef,
+  getWindowsStoreNotifierServiceRef,
+  setWindowsStoreNotifierServiceRef,
+} from "../window/serviceRefs.js";
 import { closeSharedDb } from "../services/persistence/db.js";
 import { closeTelemetry } from "../services/TelemetryService.js";
 import { isSmokeTest } from "../setup/environment.js";
@@ -144,7 +170,88 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
           import("../services/HelpSessionService.js")
             .then(({ helpSessionService }) => helpSessionService.revokeAll())
             .catch(() => {}),
+          // CCR config watcher is async — stop before nulling the PluginService
+          // WorkspaceClient ref to keep file-change callbacks from racing teardown.
+          (async () => {
+            const ccr = getCcrConfigService();
+            if (!ccr) return;
+            try {
+              await ccr.stopWatching();
+            } catch (err) {
+              console.warn("[MAIN] CcrConfigService.stopWatching failed:", err);
+            }
+            setCcrConfigService(null);
+          })(),
+          // Drop PluginService's WorkspaceClient reference so plugin event
+          // handlers can't fire into the disposed instance during late
+          // teardown. Dynamically imported to match the lazy load pattern used
+          // when the WorkspaceClient was wired in (see windowServices.ts).
+          import("../services/PluginService.js")
+            .then(({ pluginService }) => pluginService.setWorkspaceClient(null))
+            .catch(() => {}),
           new Promise<void>((resolve) => {
+            // Global singletons that previously tore down on last-window-close
+            // (electron/window/windowServices.ts) live here now so they cover
+            // the macOS dock-reactivate path without racing a new window's
+            // re-init. Order: stop monitors and timers, then dispose clients,
+            // then null refs so any late callbacks no-op.
+            getResourceProfileService()?.stop();
+            setResourceProfileService(null);
+
+            try {
+              getHibernationService().stop();
+            } catch (err) {
+              console.warn("[MAIN] HibernationService.stop failed:", err);
+            }
+            try {
+              getIdleTerminalNotificationService().stop();
+            } catch (err) {
+              console.warn("[MAIN] IdleTerminalNotificationService.stop failed:", err);
+            }
+            try {
+              getSystemSleepService().dispose();
+            } catch (err) {
+              console.warn("[MAIN] SystemSleepService.dispose failed:", err);
+            }
+
+            try {
+              gitHubTokenHealthService.dispose();
+            } catch (err) {
+              console.warn("[MAIN] gitHubTokenHealthService.dispose failed:", err);
+            }
+            try {
+              agentConnectivityService.dispose();
+            } catch (err) {
+              console.warn("[MAIN] agentConnectivityService.dispose failed:", err);
+            }
+            try {
+              getServiceConnectivityRegistry().dispose();
+            } catch (err) {
+              console.warn("[MAIN] ServiceConnectivityRegistry.dispose failed:", err);
+            }
+
+            try {
+              notificationService.dispose();
+            } catch (err) {
+              console.warn("[MAIN] notificationService.dispose failed:", err);
+            }
+            getAgentNotificationServiceRef()?.dispose();
+            setAgentNotificationServiceRef(null);
+            try {
+              preAgentSnapshotService.dispose();
+            } catch (err) {
+              console.warn("[MAIN] preAgentSnapshotService.dispose failed:", err);
+            }
+            getAutoUpdaterServiceRef()?.dispose();
+            setAutoUpdaterServiceRef(null);
+            getWindowsStoreNotifierServiceRef()?.dispose();
+            setWindowsStoreNotifierServiceRef(null);
+
+            // Port broker holds a WorkspaceClient reference — dispose before
+            // the WorkspaceClient module-level singleton is killed below.
+            getWorktreePortBrokerRef()?.dispose();
+            setWorktreePortBrokerRef(null);
+
             disposePowerSaveBlockerService();
             disposeAgentAvailabilityStore();
             if (ptyClient) {
@@ -153,6 +260,8 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
             }
             disposePtyClient();
             disposeWorkspaceClient();
+            getMainProcessWatchdogClientRef()?.dispose();
+            setMainProcessWatchdogClientRef(null);
             disposeMainProcessWatchdog();
             resolve();
           }),

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -4,33 +4,14 @@ import { registerIpcHandlers, sendToRenderer } from "../ipc/handlers.js";
 import { getAppWebContents } from "./webContentsRegistry.js";
 import { distributePortsToView } from "./portDistribution.js";
 import { registerErrorHandlers, flushPendingErrors } from "../ipc/errorHandlers.js";
-import { disposePtyClient } from "../services/PtyClient.js";
-import { disposeMainProcessWatchdog } from "../services/MainProcessWatchdogClient.js";
-import { getWorkspaceClient, disposeWorkspaceClient } from "../services/WorkspaceClient.js";
+import { getWorkspaceClient } from "../services/WorkspaceClient.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { handleDirectoryOpen } from "../menu.js";
 import { projectStore } from "../services/ProjectStore.js";
 import { scratchStore } from "../services/ScratchStore.js";
-import { gitHubTokenHealthService } from "../services/github/GitHubTokenHealthService.js";
-import {
-  agentConnectivityService,
-  getServiceConnectivityRegistry,
-} from "../services/connectivity/index.js";
-import { notificationService } from "../services/NotificationService.js";
-import { preAgentSnapshotService } from "../services/PreAgentSnapshotService.js";
-import {
-  initializeAgentAvailabilityStore,
-  disposeAgentAvailabilityStore,
-} from "../services/AgentAvailabilityStore.js";
-import {
-  initializePowerSaveBlockerService,
-  disposePowerSaveBlockerService,
-} from "../services/PowerSaveBlockerService.js";
+import { initializeAgentAvailabilityStore } from "../services/AgentAvailabilityStore.js";
+import { initializePowerSaveBlockerService } from "../services/PowerSaveBlockerService.js";
 import { runSmokeFunctionalChecks } from "../services/smokeTest.js";
-import { getHibernationService } from "../services/HibernationService.js";
-import { getSystemSleepService } from "../services/SystemSleepService.js";
-import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
-import { getIdleTerminalNotificationService } from "../services/IdleTerminalNotificationService.js";
 import { markPerformance } from "../utils/performance.js";
 import { getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
@@ -43,42 +24,19 @@ import { initGlobalServices } from "./globalServicesInit.js";
 import { initPerWindowServices } from "./perWindowInit.js";
 import {
   getPtyClient,
-  setPtyClientRef,
-  getMainProcessWatchdogClientRef,
-  setMainProcessWatchdogClientRef,
   getWorkspaceClientRef,
   setWorkspaceClientRef,
   getWorktreePortBrokerRef,
   setWorktreePortBrokerRef,
   getCliAvailabilityServiceRef,
-  getCleanupIpcHandlers,
-  setCleanupIpcHandlers,
   getCleanupErrorHandlers,
   setCleanupErrorHandlers,
-  getStopEventLoopLagMonitor,
-  setStopEventLoopLagMonitor,
-  getStopProcessMemoryMonitor,
-  setStopProcessMemoryMonitor,
-  getStopAppMetricsMonitor,
-  setStopAppMetricsMonitor,
-  getStopDiskSpaceMonitor,
-  setStopDiskSpaceMonitor,
-  getResourceProfileService,
-  setResourceProfileService,
-  getCcrConfigService,
-  setCcrConfigService,
-  getAutoUpdaterServiceRef,
-  setAutoUpdaterServiceRef,
-  getWindowsStoreNotifierServiceRef,
-  setWindowsStoreNotifierServiceRef,
-  getAgentNotificationServiceRef,
-  setAgentNotificationServiceRef,
+  setCleanupIpcHandlers,
   getProcessArgvCliHandled,
   setProcessArgvCliHandled,
   getIpcHandlersRegistered,
   setIpcHandlersRegistered,
   getGlobalServicesInitialized,
-  setGlobalServicesInitialized,
 } from "./serviceRefs.js";
 
 // Re-export the public getters/setters so existing import paths in main.ts,
@@ -518,121 +476,24 @@ export async function setupWindowServices(
     );
   }
 
-  // ── Last-window-close: dispose global services ──
+  // ── Last-window-close: reset per-window deferred queue ──
+  //
   // Per-window cleanup is handled by ctx.cleanup (run by WindowRegistry.unregister).
-  // This handler only disposes global singletons when the last window closes.
-  win.on("closed", async () => {
+  // Global services (PtyClient, WorkspaceClient, monitors, watchers, notifiers, etc.)
+  // are kept alive for app lifetime — they are torn down only in `before-quit`
+  // (electron/lifecycle/shutdown.ts). On macOS, closing all windows does NOT quit
+  // the app; reactivating from the dock must re-open a window without racing an
+  // in-flight async teardown of the global singletons. Keeping globals alive
+  // makes the dock-reactivation path a no-op past `initGlobalServices()`.
+  //
+  // We still reset the deferred init queue so a future window can re-register
+  // per-window-context deferred tasks. The `globalServicesInitialized` guard
+  // stays true, so `initGlobalServices()` itself does NOT re-run.
+  win.on("closed", () => {
     if (windowRegistry && windowRegistry.size > 0) {
-      // Other windows still open — do not dispose global services
+      // Other windows still open — nothing to do at this level.
       return;
     }
-
-    // Last window closed — dispose global services.
-    // Stop the CCR config watcher first, before any guard resets or IPC teardown.
-    // Awaiting here blocks a new window from racing into the init block (which would
-    // restart the singleton watcher) and finding this handler about to null the ref.
-    const ccrConfigService = getCcrConfigService();
-    if (ccrConfigService) {
-      await ccrConfigService.stopWatching();
-      setCcrConfigService(null);
-    }
-
-    const stopELL = getStopEventLoopLagMonitor();
-    if (stopELL) {
-      stopELL();
-      setStopEventLoopLagMonitor(null);
-    }
-    const stopPM = getStopProcessMemoryMonitor();
-    if (stopPM) {
-      stopPM();
-      setStopProcessMemoryMonitor(null);
-    }
-    const stopAM = getStopAppMetricsMonitor();
-    if (stopAM) {
-      stopAM();
-      setStopAppMetricsMonitor(null);
-    }
-    const stopDS = getStopDiskSpaceMonitor();
-    if (stopDS) {
-      stopDS();
-      setStopDiskSpaceMonitor(null);
-    }
-    const rps = getResourceProfileService();
-    if (rps) {
-      rps.stop();
-      setResourceProfileService(null);
-    }
-
-    const wpb = getWorktreePortBrokerRef();
-    if (wpb) wpb.dispose();
-    setWorktreePortBrokerRef(null);
-    const ws = getWorkspaceClientRef();
-    if (ws) ws.dispose();
-    setWorkspaceClientRef(null);
-    disposeWorkspaceClient();
-
-    // Drop PluginService's WorkspaceClient reference so plugin event handlers
-    // can't fire into the disposed instance during late teardown.
-    try {
-      const { pluginService } = await import("../services/PluginService.js");
-      pluginService.setWorkspaceClient(null);
-    } catch {
-      // module load errors during teardown are non-fatal
-    }
-
-    disposePowerSaveBlockerService();
-    disposeAgentAvailabilityStore();
-
-    const pty = getPtyClient();
-    if (pty) pty.dispose();
-    setPtyClientRef(null);
-    disposePtyClient();
-
-    const watchdog = getMainProcessWatchdogClientRef();
-    if (watchdog) watchdog.dispose();
-    setMainProcessWatchdogClientRef(null);
-    disposeMainProcessWatchdog();
-
-    // Clean up IPC handlers and reset guards so next window re-registers fresh
-    const cleanupIpc = getCleanupIpcHandlers();
-    if (cleanupIpc) {
-      cleanupIpc();
-      setCleanupIpcHandlers(null);
-    }
-    const cleanupErr = getCleanupErrorHandlers();
-    if (cleanupErr) {
-      cleanupErr();
-      setCleanupErrorHandlers(null);
-    }
-    setIpcHandlersRegistered(false);
-    // Reset the global init guard so the next window re-runs
-    // initGlobalServices() from a clean slate.
-    setGlobalServicesInitialized(false);
     resetDeferredQueue();
-
-    getHibernationService().stop();
-    getIdleTerminalNotificationService().stop();
-    getCrashRecoveryService().stopBackupTimer();
-    getSystemSleepService().dispose();
-    gitHubTokenHealthService.dispose();
-    agentConnectivityService.dispose();
-    getServiceConnectivityRegistry().dispose();
-    notificationService.dispose();
-    const ans = getAgentNotificationServiceRef();
-    if (ans) {
-      ans.dispose();
-      setAgentNotificationServiceRef(null);
-    }
-    preAgentSnapshotService.dispose();
-    const aus = getAutoUpdaterServiceRef();
-    if (aus) {
-      aus.dispose();
-      setAutoUpdaterServiceRef(null);
-    }
-    const wsns = getWindowsStoreNotifierServiceRef();
-    if (wsns) {
-      wsns.dispose();
-      setWindowsStoreNotifierServiceRef(null);
-    }
   });
 }


### PR DESCRIPTION
## Summary

- `win.on('closed')` in `windowServices.ts` was disposing all global singletons and resetting `globalServicesInitialized` to `false` on last-window-close. On macOS, last-window-close doesn't trigger `app.quit()`, so a dock reactivation could call `setupWindowServices()` while async teardown was still in flight, racing the new window's `initGlobalServices()` over the singleton refs.
- Fix strips the `closed` handler down to just `resetDeferredQueue()`. All service disposals are moved to `before-quit` in `electron/lifecycle/shutdown.ts`, where they run exactly once per app lifetime.
- `CcrConfigService.stopWatching()` and `PluginService.setWorkspaceClient(null)` are serialized ahead of the main `Promise.all` so no file-change callback can fire into a half-disposed `WorkspaceClient`. Every disposal is wrapped in `try/catch` so a single failure can't strand the rest of shutdown.

Resolves #8604

## Changes

- `electron/window/windowServices.ts` — gut the `closed` handler; global services now stay alive until `before-quit`
- `electron/lifecycle/shutdown.ts` — absorb all displaced disposals: `HibernationService`, `IdleTerminalNotificationService`, `SystemSleepService`, `gitHubTokenHealthService`, `agentConnectivityService`, `ServiceConnectivityRegistry`, `NotificationService`, optional ref services, `preAgentSnapshotService`, `ResourceProfileService`, `WorktreePortBroker`, `MainProcessWatchdogClient`, CCR watcher, and `PluginService` workspace client teardown
- `electron/lifecycle/__tests__/shutdown.test.ts` — 9 new tests covering moved disposals, CCR+Plugin sequencing before workspace dispose, `workspaceClientRef` nulled post-shutdown, and error isolation

## Testing

- Typecheck, lint, and format pass clean
- New unit tests cover every moved disposal site and the CCR/Plugin pre-dispose sequencing
- macOS: the re-init race on dock reactivation is eliminated; services persist until `app.quit()`
- Windows/Linux: `window-all-closed` → `app.quit()` → `before-quit` path is unchanged; disposals fire exactly once as before