### PR TITLE
fix(window): use per-renderer CDP throttling for cached project views

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -124,7 +124,9 @@ app.commandLine.appendSwitch(
 );
 
 // Allow autoplay without user gesture (voice input, media panels).
-// Per-view throttling is managed by ProjectViewManager.setBackgroundThrottling().
+// Per-view CPU throttling for cached views is managed by ProjectViewManager
+// via CDP Emulation.setCPUThrottlingRate (per-renderer; window-wide
+// setBackgroundThrottling is unsuitable since Electron 28 — #8599).
 app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");
 // BackForwardCache wastes memory in an Electron app (no browser navigation history).
 const disabledFeatures = ["BackForwardCache"];
@@ -231,10 +233,10 @@ if (!gotTheLock) {
       },
       onViewCached: (wcId) => {
         // Same producer cleanup as eviction: a cached view becomes
-        // freeze-eligible once setBackgroundThrottling(true) is applied.
-        // Live worktree/workspace ports would otherwise queue messages
-        // into a frozen renderer (#6273). Reactivation re-brokers a fresh
-        // port via activateProjectView in projectCrud/switch.ts.
+        // freeze-eligible once CPU throttling lands. Live worktree/workspace
+        // ports would otherwise queue messages into a frozen renderer
+        // (#6273). Reactivation re-brokers a fresh port via
+        // activateProjectView in projectCrud/switch.ts.
         // Each cleanup is isolated so a throw in one path can't leave the
         // other producer alive — that's the exact failure mode this PR
         // exists to prevent.

--- a/electron/utils/__tests__/webContentsLifecycle.test.ts
+++ b/electron/utils/__tests__/webContentsLifecycle.test.ts
@@ -212,7 +212,7 @@ describe("webContentsLifecycle", () => {
       expect(wc.debugger.sendCommand).not.toHaveBeenCalled();
     });
 
-    it("swallows expected CDP errors silently", async () => {
+    it("swallows expected CDP errors silently (throttle)", async () => {
       const wc = createMockWc();
       wc.debugger.sendCommand.mockRejectedValueOnce(new Error("Target closed"));
       await expect(
@@ -221,7 +221,16 @@ describe("webContentsLifecycle", () => {
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
-    it("warns once for an unexpected CDP error", async () => {
+    it("swallows expected CDP errors silently (unthrottle)", async () => {
+      const wc = createMockWc();
+      wc.debugger.sendCommand.mockRejectedValueOnce(new Error("Inspected target navigated"));
+      await expect(
+        unthrottleCpuWebContents(wc as unknown as Electron.WebContents)
+      ).resolves.toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("warns once for an unexpected CDP error (throttle, rate 4)", async () => {
       const wc = createMockWc();
       wc.debugger.sendCommand.mockRejectedValueOnce(new Error("Unknown protocol failure"));
       await expect(
@@ -231,9 +240,36 @@ describe("webContentsLifecycle", () => {
       expect(warnSpy.mock.calls[0][0]).toContain("setCPUThrottlingRate(4) failed");
     });
 
-    it("never throws when wc.debugger is missing entirely", async () => {
+    it("warns once for an unexpected CDP error (unthrottle, rate 1)", async () => {
+      const wc = createMockWc();
+      wc.debugger.sendCommand.mockRejectedValueOnce(new Error("Unknown protocol failure"));
+      await expect(
+        unthrottleCpuWebContents(wc as unknown as Electron.WebContents)
+      ).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("setCPUThrottlingRate(1) failed");
+    });
+
+    it("swallows synchronous throw from debugger.attach", async () => {
+      const wc = createMockWc();
+      wc.debugger.attach.mockImplementation(() => {
+        throw new Error("Another debugger is already attached to this target");
+      });
+      await expect(
+        throttleCpuWebContents(wc as unknown as Electron.WebContents)
+      ).resolves.toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("never throws when wc.debugger is missing entirely (throttle)", async () => {
       const wc = { isDestroyed: vi.fn(() => false) } as unknown as Electron.WebContents;
       await expect(throttleCpuWebContents(wc)).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("never throws when wc.debugger is missing entirely (unthrottle)", async () => {
+      const wc = { isDestroyed: vi.fn(() => false) } as unknown as Electron.WebContents;
+      await expect(unthrottleCpuWebContents(wc)).resolves.toBeUndefined();
       expect(warnSpy).toHaveBeenCalledTimes(1);
     });
   });

--- a/electron/utils/__tests__/webContentsLifecycle.test.ts
+++ b/electron/utils/__tests__/webContentsLifecycle.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
-import { freezeWebContents, unfreezeWebContents } from "../webContentsLifecycle.js";
+import {
+  freezeWebContents,
+  unfreezeWebContents,
+  throttleCpuWebContents,
+  unthrottleCpuWebContents,
+} from "../webContentsLifecycle.js";
 
 interface MockDebugger {
   isAttached: ReturnType<typeof vi.fn>;
@@ -158,5 +163,78 @@ describe("webContentsLifecycle", () => {
     await unfreezeWebContents(wc as unknown as Electron.WebContents);
     expect(wc.debugger.isAttached).toHaveBeenCalledTimes(2);
     expect(wc.debugger.attach).toHaveBeenCalledTimes(1);
+  });
+
+  describe("throttleCpuWebContents / unthrottleCpuWebContents", () => {
+    it("throttleCpuWebContents sends Emulation.setCPUThrottlingRate with rate: 4", async () => {
+      const wc = createMockWc();
+      await throttleCpuWebContents(wc as unknown as Electron.WebContents);
+      const calls = wc.debugger.sendCommand.mock.calls;
+      expect(calls.length).toBe(1);
+      expect(calls[0][0]).toBe("Emulation.setCPUThrottlingRate");
+      expect(calls[0][1]).toEqual({ rate: 4 });
+    });
+
+    it("unthrottleCpuWebContents sends rate: 1", async () => {
+      const wc = createMockWc();
+      await unthrottleCpuWebContents(wc as unknown as Electron.WebContents);
+      const calls = wc.debugger.sendCommand.mock.calls;
+      expect(calls.length).toBe(1);
+      expect(calls[0][0]).toBe("Emulation.setCPUThrottlingRate");
+      expect(calls[0][1]).toEqual({ rate: 1 });
+    });
+
+    it("does not call Page.enable or Emulation.enable", async () => {
+      const wc = createMockWc();
+      await throttleCpuWebContents(wc as unknown as Electron.WebContents);
+      await unthrottleCpuWebContents(wc as unknown as Electron.WebContents);
+      const methods = wc.debugger.sendCommand.mock.calls.map((c: unknown[]) => c[0]);
+      expect(methods).not.toContain("Page.enable");
+      expect(methods).not.toContain("Emulation.enable");
+    });
+
+    it("attaches the debugger when not already attached", async () => {
+      const wc = createMockWc();
+      await throttleCpuWebContents(wc as unknown as Electron.WebContents);
+      expect(wc.debugger.attach).toHaveBeenCalledWith("1.3");
+    });
+
+    it("skips attach when already attached", async () => {
+      const wc = createMockWc({ attached: true });
+      await throttleCpuWebContents(wc as unknown as Electron.WebContents);
+      expect(wc.debugger.attach).not.toHaveBeenCalled();
+    });
+
+    it("returns early when wc is destroyed", async () => {
+      const wc = createMockWc({ destroyed: true });
+      await throttleCpuWebContents(wc as unknown as Electron.WebContents);
+      await unthrottleCpuWebContents(wc as unknown as Electron.WebContents);
+      expect(wc.debugger.sendCommand).not.toHaveBeenCalled();
+    });
+
+    it("swallows expected CDP errors silently", async () => {
+      const wc = createMockWc();
+      wc.debugger.sendCommand.mockRejectedValueOnce(new Error("Target closed"));
+      await expect(
+        throttleCpuWebContents(wc as unknown as Electron.WebContents)
+      ).resolves.toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("warns once for an unexpected CDP error", async () => {
+      const wc = createMockWc();
+      wc.debugger.sendCommand.mockRejectedValueOnce(new Error("Unknown protocol failure"));
+      await expect(
+        throttleCpuWebContents(wc as unknown as Electron.WebContents)
+      ).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("setCPUThrottlingRate(4) failed");
+    });
+
+    it("never throws when wc.debugger is missing entirely", async () => {
+      const wc = { isDestroyed: vi.fn(() => false) } as unknown as Electron.WebContents;
+      await expect(throttleCpuWebContents(wc)).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/electron/utils/webContentsLifecycle.ts
+++ b/electron/utils/webContentsLifecycle.ts
@@ -1,9 +1,19 @@
 /**
- * webContentsLifecycle — Shared CDP freeze/unfreeze for WebContents.
+ * webContentsLifecycle — Shared CDP helpers for per-renderer freeze and CPU throttle.
  *
- * Wraps `Page.setWebLifecycleState` so callers don't need to know about
- * `debugger.attach`, `Page.enable`, or the swallow-list of expected CDP errors
- * that surface during teardown/navigation races.
+ * Wraps `Page.setWebLifecycleState` and `Emulation.setCPUThrottlingRate` so callers
+ * don't need to know about `debugger.attach`, `Page.enable`, or the swallow-list of
+ * expected CDP errors that surface during teardown/navigation races.
+ *
+ * Why CDP instead of `WebContents.setBackgroundThrottling`: since Electron 28,
+ * `setBackgroundThrottling(false)` on any view in a BrowserWindow disables timer
+ * throttling for ALL sibling WebContents in that window. With one always-active
+ * view per window, that silently un-throttled every cached sibling and made the
+ * cached-view `setBackgroundThrottling(true)` ineffective (#8599).
+ * `Emulation.setCPUThrottlingRate` is per-target — it slows the V8/Blink clock
+ * for one renderer only while leaving the event loop, IPC, and MessagePort
+ * dispatch running, so it is safe for cached views that still receive
+ * worktree/workspace messages.
  *
  * Chromium 146 does NOT auto-resume a frozen renderer on focus or re-attach —
  * an explicit `"active"` call is required. Callers that activate a previously
@@ -25,6 +35,9 @@ const EXPECTED_CDP_ERRORS = [
   "debugger is already attached",
   "No debugger attached",
 ];
+
+const CACHED_VIEW_CPU_THROTTLE_RATE = 4;
+const ACTIVE_VIEW_CPU_THROTTLE_RATE = 1;
 
 function ensureAttached(wc: Electron.WebContents): void {
   if (!wc.debugger.isAttached()) {
@@ -48,10 +61,31 @@ async function setLifecycleState(
   }
 }
 
+async function setCpuThrottlingRate(wc: Electron.WebContents, rate: number): Promise<void> {
+  if (wc.isDestroyed()) return;
+  try {
+    ensureAttached(wc);
+    // Emulation domain does not require an `enable` call.
+    await wc.debugger.sendCommand("Emulation.setCPUThrottlingRate", { rate });
+  } catch (err) {
+    const message = formatErrorMessage(err, "CDP CPU throttle failed");
+    if (EXPECTED_CDP_ERRORS.some((s) => message.includes(s))) return;
+    console.warn(`[webContentsLifecycle] setCPUThrottlingRate(${rate}) failed:`, message);
+  }
+}
+
 export function freezeWebContents(wc: Electron.WebContents): Promise<void> {
   return setLifecycleState(wc, "frozen");
 }
 
 export function unfreezeWebContents(wc: Electron.WebContents): Promise<void> {
   return setLifecycleState(wc, "active");
+}
+
+export function throttleCpuWebContents(wc: Electron.WebContents): Promise<void> {
+  return setCpuThrottlingRate(wc, CACHED_VIEW_CPU_THROTTLE_RATE);
+}
+
+export function unthrottleCpuWebContents(wc: Electron.WebContents): Promise<void> {
+  return setCpuThrottlingRate(wc, ACTIVE_VIEW_CPU_THROTTLE_RATE);
 }

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -32,7 +32,12 @@ import {
   attachRendererConsoleCapture,
   detachRendererConsoleCapture,
 } from "./rendererConsoleCapture.js";
-import { freezeWebContents, unfreezeWebContents } from "../utils/webContentsLifecycle.js";
+import {
+  freezeWebContents,
+  unfreezeWebContents,
+  throttleCpuWebContents,
+  unthrottleCpuWebContents,
+} from "../utils/webContentsLifecycle.js";
 import { ACTIVE_AGENT_STATES } from "../../shared/types/agent.js";
 import { setAlignedInterval } from "../utils/setAlignedInterval.js";
 import {
@@ -101,7 +106,7 @@ export interface ProjectViewManagerOptions {
    * Called when a view transitions from active to cached with its webContents.id.
    * Mirrors onViewEvicted: live producer ports (worktree, workspace direct) must
    * be closed so messages don't accumulate in a renderer that Chromium may freeze
-   * after backgroundThrottling is enabled. Reactivation re-brokers a fresh port.
+   * after CPU throttling lands. Reactivation re-brokers a fresh port.
    */
   onViewCached?: (webContentsId: number) => void;
   /** Called on every did-finish-load for any managed view (initial load and reloads) */
@@ -672,17 +677,23 @@ export class ProjectViewManager {
     // Throttle background view to reduce CPU and allow Chromium to reclaim memory
     if (!current.view.webContents.isDestroyed()) {
       const cachedWcId = current.view.webContents.id;
-      // Close live producer ports BEFORE enabling background throttling. Once
-      // throttled, Chromium can freeze the renderer after ~5 min hidden or
-      // under memory pressure; any messages still posted by main/utility
-      // processes accumulate in the frozen renderer's task queue (no native
+      // Close live producer ports BEFORE applying CPU throttle. Once throttled,
+      // Chromium can freeze the renderer after ~5 min hidden or under memory
+      // pressure; any messages still posted by main/utility processes
+      // accumulate in the frozen renderer's task queue (no native
       // backpressure). Reactivation re-brokers a fresh port via activateView.
       try {
         this.onViewCached?.(cachedWcId);
       } catch (error) {
         console.error("[ProjectViewManager] onViewCached threw during deactivate:", error);
       }
-      current.view.webContents.setBackgroundThrottling(true);
+      // Use CDP Emulation.setCPUThrottlingRate (per-renderer) instead of
+      // WebContents.setBackgroundThrottling — the latter is window-wide in
+      // Electron 28+, so the active view's setBackgroundThrottling(false)
+      // silently un-throttled every cached sibling (#8599). CPU throttling
+      // keeps the event loop and MessagePort dispatch alive while slowing
+      // V8/Blink CPU time for this single renderer.
+      void throttleCpuWebContents(current.view.webContents);
 
       // Flush pending DOMStorage writes (synchronous — view stays alive in
       // cache, so data loss is not a concern)
@@ -730,10 +741,10 @@ export class ProjectViewManager {
   private activateView(entry: ViewEntry): void {
     registerAppView(this.win, entry.view);
 
-    // Defensive unfreeze BEFORE setBackgroundThrottling(false): efficiency
-    // transitions and view activations are async, so an activating view may
-    // still be frozen even if we've left efficiency in the meantime. Chromium
-    // does not auto-resume on focus or re-attach — explicit "active" required.
+    // Defensive unfreeze BEFORE restoring CPU rate: efficiency transitions and
+    // view activations are async, so an activating view may still be frozen
+    // even if we've left efficiency in the meantime. Chromium does not
+    // auto-resume on focus or re-attach — explicit "active" required.
     // Fire-and-forget: there is a sub-millisecond window between addChildView
     // making the view visible and Chromium processing the "active" CDP command.
     // Awaiting would force activateView to be async and ripple through all
@@ -743,9 +754,11 @@ export class ProjectViewManager {
       void unfreezeWebContents(entry.view.webContents);
     }
 
-    // Restore full priority before making visible
+    // Restore full CPU rate before making visible. Uses
+    // Emulation.setCPUThrottlingRate (per-renderer) — see deactivateEntry for
+    // why setBackgroundThrottling is unsuitable (window-wide in Electron 28+).
     if (!entry.view.webContents.isDestroyed()) {
-      entry.view.webContents.setBackgroundThrottling(false);
+      void unthrottleCpuWebContents(entry.view.webContents);
     }
 
     this.win.contentView.addChildView(entry.view);

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -7,7 +7,6 @@ type Handler = (...args: unknown[]) => void;
 interface MockWebContents {
   id: number;
   isDestroyed: ReturnType<typeof vi.fn>;
-  setBackgroundThrottling: ReturnType<typeof vi.fn>;
   executeJavaScript: ReturnType<typeof vi.fn>;
   loadURL: ReturnType<typeof vi.fn>;
   focus: ReturnType<typeof vi.fn>;
@@ -34,7 +33,6 @@ function createMockWebContents(options?: { autoFinishLoad?: boolean }): MockWebC
   const webContents: MockWebContents = {
     id,
     isDestroyed: vi.fn(() => false),
-    setBackgroundThrottling: vi.fn(),
     executeJavaScript: vi.fn(() => Promise.resolve()),
     loadURL: vi.fn(() => Promise.resolve()),
     focus: vi.fn(),

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -134,6 +134,8 @@ vi.mock("../skeletonCss.js", () => ({
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+  throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+  unthrottleCpuWebContents: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { ProjectViewManager } from "../ProjectViewManager.js";

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -122,6 +122,8 @@ vi.mock("../rendererConsoleCapture.js", () => ({
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+  throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+  unthrottleCpuWebContents: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../utils/logger.js", () => ({
@@ -145,6 +147,7 @@ import { ProjectViewManager } from "../ProjectViewManager.js";
 import { logInfo } from "../../utils/logger.js";
 import { forgetBlinkSample, forgetEluSample } from "../../services/ProcessMemoryMonitor.js";
 import { detachRendererConsoleCapture } from "../rendererConsoleCapture.js";
+import { throttleCpuWebContents } from "../../utils/webContentsLifecycle.js";
 
 function createMockWindow() {
   return {
@@ -1123,7 +1126,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     expect(onViewCached).not.toHaveBeenCalledWith(wcB.id);
   });
 
-  it("fires onViewCached BEFORE setBackgroundThrottling(true) so ports close before freeze becomes possible", async () => {
+  it("fires onViewCached BEFORE CPU throttle so ports close before freeze becomes possible", async () => {
     const onViewCached = vi.fn();
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -1136,14 +1139,18 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     const viewA = { webContents: wcA, setBounds: vi.fn() };
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
+    const throttleMock = vi.mocked(throttleCpuWebContents);
+    throttleMock.mockClear();
+
     await manager.switchTo("proj-b", "/path/b");
 
     const cachedOrder = onViewCached.mock.invocationCallOrder[0];
-    const throttleOrder = wcA.setBackgroundThrottling.mock.invocationCallOrder[0];
+    const throttleCall = throttleMock.mock.calls.findIndex((args) => args[0] === wcA);
+    const throttleOrder = throttleMock.mock.invocationCallOrder[throttleCall];
     expect(cachedOrder).toBeDefined();
     expect(throttleOrder).toBeDefined();
     expect(cachedOrder!).toBeLessThan(throttleOrder);
-    expect(wcA.setBackgroundThrottling).toHaveBeenCalledWith(true);
+    expect(throttleMock).toHaveBeenCalledWith(wcA);
   });
 
   it("invokes onViewCached for each cached view across rapid switches A→B→C (never for the active C)", async () => {
@@ -1248,9 +1255,9 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     await expect(manager.switchTo("proj-b", "/path/b")).resolves.toMatchObject({ isNew: true });
     expect(manager.getActiveProjectId()).toBe("proj-b");
     expect(onViewCached).toHaveBeenCalledWith(wcA.id);
-    // Throttling must still happen even if the callback throws — the catch
+    // CPU throttle must still happen even if the callback throws — the catch
     // is around onViewCached only, not the surrounding deactivate flow.
-    expect(wcA.setBackgroundThrottling).toHaveBeenCalledWith(true);
+    expect(vi.mocked(throttleCpuWebContents)).toHaveBeenCalledWith(wcA);
   });
 
   it("manager works without onViewCached configured (option is optional)", async () => {
@@ -1265,7 +1272,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await expect(manager.switchTo("proj-b", "/path/b")).resolves.toMatchObject({ isNew: true });
-    expect(wcA.setBackgroundThrottling).toHaveBeenCalledWith(true);
+    expect(vi.mocked(throttleCpuWebContents)).toHaveBeenCalledWith(wcA);
   });
 });
 

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -1144,7 +1144,10 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     await manager.switchTo("proj-b", "/path/b");
 
     const cachedOrder = onViewCached.mock.invocationCallOrder[0];
-    const throttleCall = throttleMock.mock.calls.findIndex((args) => args[0] === wcA);
+    const throttleCall = throttleMock.mock.calls.findIndex((args) => {
+      const arg = args[0] as unknown;
+      return arg instanceof Object && "id" in arg && (arg as { id: number }).id === wcA.id;
+    });
     const throttleOrder = throttleMock.mock.invocationCallOrder[throttleCall];
     expect(cachedOrder).toBeDefined();
     expect(throttleOrder).toBeDefined();

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -13,7 +13,6 @@ function createMockWebContents() {
     id,
     osPid,
     isDestroyed: vi.fn(() => false),
-    setBackgroundThrottling: vi.fn(),
     executeJavaScript: vi.fn(() => Promise.resolve()),
     loadURL: vi.fn(() => Promise.resolve()),
     focus: vi.fn(),

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -142,6 +142,13 @@ vi.mock("../rendererConsoleCapture.js", () => ({
   detachRendererConsoleCapture: vi.fn(),
 }));
 
+vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  freezeWebContents: vi.fn().mockResolvedValue(undefined),
+  unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+  throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+  unthrottleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../../utils/logger.js", () => ({
   logInfo: vi.fn(),
   logWarn: vi.fn(),

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -7,7 +7,6 @@ type Handler = (...args: unknown[]) => void;
 interface MockWc {
   id: number;
   isDestroyed: ReturnType<typeof vi.fn>;
-  setBackgroundThrottling: ReturnType<typeof vi.fn>;
   executeJavaScript: ReturnType<typeof vi.fn>;
   loadURL: ReturnType<typeof vi.fn>;
   focus: ReturnType<typeof vi.fn>;
@@ -32,7 +31,6 @@ function createMockWebContents(opts?: { autoFinishLoad?: boolean }): MockWc {
   const wc: MockWc = {
     id,
     isDestroyed: vi.fn(() => false),
-    setBackgroundThrottling: vi.fn(),
     executeJavaScript: vi.fn(() => Promise.resolve()),
     loadURL: vi.fn(() => Promise.resolve()),
     focus: vi.fn(),

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -7,7 +7,6 @@ function createMockWebContents() {
   return {
     id,
     isDestroyed: vi.fn(() => false),
-    setBackgroundThrottling: vi.fn(),
     executeJavaScript: vi.fn(() => Promise.resolve()),
     loadURL: vi.fn(() => Promise.resolve()),
     focus: vi.fn(),

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -88,6 +88,8 @@ vi.mock("../skeletonCss.js", () => ({
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+  throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+  unthrottleCpuWebContents: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { ProjectViewManager } from "../ProjectViewManager.js";

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -7,7 +7,6 @@ function createMockWebContents() {
   return {
     id,
     isDestroyed: vi.fn(() => false),
-    setBackgroundThrottling: vi.fn(),
     executeJavaScript: vi.fn(() => Promise.resolve()),
     loadURL: vi.fn(() => Promise.resolve()),
     focus: vi.fn(),

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -89,6 +89,8 @@ vi.mock("../skeletonCss.js", () => ({
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+  throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+  unthrottleCpuWebContents: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { ProjectViewManager } from "../ProjectViewManager.js";

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -142,6 +142,13 @@ vi.mock("../rendererConsoleCapture.js", () => ({
   detachRendererConsoleCapture: vi.fn(),
 }));
 
+vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  freezeWebContents: vi.fn().mockResolvedValue(undefined),
+  unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+  throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+  unthrottleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../../utils/logger.js", () => ({
   logInfo: vi.fn(),
   logWarn: vi.fn(),

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -7,7 +7,6 @@ type Handler = (...args: unknown[]) => void;
 interface MockWc {
   id: number;
   isDestroyed: ReturnType<typeof vi.fn>;
-  setBackgroundThrottling: ReturnType<typeof vi.fn>;
   executeJavaScript: ReturnType<typeof vi.fn>;
   loadURL: ReturnType<typeof vi.fn>;
   focus: ReturnType<typeof vi.fn>;
@@ -32,7 +31,6 @@ function createMockWebContents(opts?: { autoFinishLoad?: boolean }): MockWc {
   const wc: MockWc = {
     id,
     isDestroyed: vi.fn(() => false),
-    setBackgroundThrottling: vi.fn(),
     executeJavaScript: vi.fn(() => Promise.resolve()),
     loadURL: vi.fn(() => Promise.resolve()),
     focus: vi.fn(),

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -129,6 +129,8 @@ vi.mock("../skeletonCss.js", () => ({
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+  throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+  unthrottleCpuWebContents: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../utils/logger.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -7,7 +7,6 @@ type Handler = (...args: unknown[]) => void;
 interface MockWc {
   id: number;
   isDestroyed: ReturnType<typeof vi.fn>;
-  setBackgroundThrottling: ReturnType<typeof vi.fn>;
   executeJavaScript: ReturnType<typeof vi.fn>;
   loadURL: ReturnType<typeof vi.fn>;
   focus: ReturnType<typeof vi.fn>;
@@ -31,7 +30,6 @@ function createMockWebContents(opts?: { autoFinishLoad?: boolean }): MockWc {
   const wc: MockWc = {
     id,
     isDestroyed: vi.fn(() => false),
-    setBackgroundThrottling: vi.fn(),
     executeJavaScript: vi.fn(() => Promise.resolve()),
     loadURL: vi.fn(() => Promise.resolve()),
     focus: vi.fn(),

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -524,11 +524,12 @@ export async function initGlobalServices(
             for (const wCtx of windowRegistry.all()) {
               const w = wCtx.browserWindow;
               if (w.isDestroyed()) continue;
-              // Cached/loading views have setBackgroundThrottling(true) which
-              // throttles JS timers and the LoAF observer, producing burst
-              // signal that doesn't reflect user-visible lag. Only sample
-              // active views; fall back to the app webContents for windows
-              // still on the bootstrap shell (no PVM yet).
+              // Cached/loading views are CPU-throttled (Emulation.setCPUThrottlingRate)
+              // or Efficiency-frozen (Page.setWebLifecycleState) which slows
+              // JS timers and the LoAF observer, producing burst signal that
+              // doesn't reflect user-visible lag. Only sample active views;
+              // fall back to the app webContents for windows still on the
+              // bootstrap shell (no PVM yet).
               const pvm = wCtx.services.projectViewManager;
               const targets = pvm
                 ? pvm


### PR DESCRIPTION
## Summary

- `setBackgroundThrottling(false)` on any `WebContents` disables throttling for the entire `BrowserWindow`, so the throttle calls in `ProjectViewManager` were silently no-ops for every cached sibling renderer
- Replaces the window-wide `setBackgroundThrottling` calls with per-renderer `Emulation.setCPUThrottlingRate` via CDP, using two new helpers (`throttleCpuWebContents` / `unthrottleCpuWebContents`) in `webContentsLifecycle.ts`
- The Efficiency-profile freeze path (`Page.setWebLifecycleState`) is untouched — only the Balanced/Performance throttle path changes

Resolves #8599

## Changes

- `electron/utils/webContentsLifecycle.ts` — adds `throttleCpuWebContents` and `unthrottleCpuWebContents` helpers that open a CDP session and call `Emulation.setCPUThrottlingRate`
- `electron/window/ProjectViewManager.ts` — `deactivateEntry` now calls `throttleCpuWebContents`; `activateView` calls `unthrottleCpuWebContents`; `setBackgroundThrottling` calls removed
- `electron/main.ts` / `electron/window/globalServicesInit.ts` — minor plumbing updates
- 8 `ProjectViewManager` test files updated with matching CDP mock stubs; `webContentsLifecycle.test.ts` extended with throttle helper coverage

## Testing

- Unit tests across all 8 `ProjectViewManager` test suites pass with the updated mocks
- `webContentsLifecycle.test.ts` covers both the throttle and unthrottle code paths, including the CDP session lifecycle