### PR TITLE
perf(actions): defer ActionService JSON schema compilation to first use (#8614)

### DIFF
--- a/src/hooks/useActionRegistry.ts
+++ b/src/hooks/useActionRegistry.ts
@@ -10,6 +10,7 @@ import { useProjectStore } from "@/store/projectStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import { startRendererSpan } from "@/utils/performance";
 
 export type { ActionCallbacks };
 
@@ -65,9 +66,16 @@ export function useActionRegistry(options: ActionCallbacks): void {
 
     const actionFactories = createActionDefinitions(callbackProxy);
 
-    for (const createAction of actionFactories.values()) {
-      const action = createAction();
-      actionService.register(action);
+    const endSpan = startRendererSpan("action_registry:register", {
+      actionCount: actionFactories.size,
+    });
+    try {
+      for (const createAction of actionFactories.values()) {
+        const action = createAction();
+        actionService.register(action);
+      }
+    } finally {
+      endSpan();
     }
 
     actionService.setContextProvider((): ActionContext => {
@@ -106,7 +114,7 @@ export function useActionRegistry(options: ActionCallbacks): void {
     if (validatedRef.current) return;
     validatedRef.current = true;
     safeFireAndForget(
-      window.electron.plugin.validateActionIds(actionService.list().map((entry) => entry.id)),
+      window.electron.plugin.validateActionIds(Array.from(actionService.listIds())),
       { context: "Validating plugin action IDs" }
     );
   }, []);

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -163,17 +163,24 @@ export interface LastDispatchedAction {
 }
 
 /**
- * Cached fields from {@link ActionService.toManifestEntry} that depend solely
- * on the action definition (not on the runtime context). Computed once at
- * `register()` time and reused on every `list()` / `get()` call.
+ * Cached JSON Schemas derived from an action definition. Computed lazily on the
+ * first {@link ActionService.toManifestEntry} call that needs them, because
+ * `z.toJSONSchema()` is sync-CPU and ~308 built-in actions otherwise compile
+ * during cold start before any consumer needs the manifest (issue #8614).
  */
-type CachedManifestPartials = {
+type CachedSchemas = {
   inputSchema: Record<string, unknown> | undefined;
   outputSchema: Record<string, unknown> | undefined;
-  requiresArgs: boolean;
 };
 
-function computeManifestPartials(definition: AnyActionDefinition): CachedManifestPartials {
+function computeRequiresArgs(definition: AnyActionDefinition): boolean {
+  return definition.argsSchema
+    ? !definition.argsSchema.safeParse(undefined).success &&
+        !definition.argsSchema.safeParse({}).success
+    : rawSchemaRequiresArgs(definition.rawInputSchema);
+}
+
+function computeSchemas(definition: AnyActionDefinition): CachedSchemas {
   return {
     inputSchema: definition.argsSchema
       ? zodSchemaToJsonSchema(definition.argsSchema)
@@ -184,16 +191,19 @@ function computeManifestPartials(definition: AnyActionDefinition): CachedManifes
         : definition.mcpOutputSchema
           ? definition.rawOutputSchema
           : undefined,
-    requiresArgs: definition.argsSchema
-      ? !definition.argsSchema.safeParse(undefined).success &&
-        !definition.argsSchema.safeParse({}).success
-      : rawSchemaRequiresArgs(definition.rawInputSchema),
   };
 }
 
 export class ActionService {
   private registry = new Map<ActionId, AnyActionDefinition>();
-  private manifestPartialCache = new Map<ActionId, CachedManifestPartials>();
+  private requiresArgsCache = new Map<ActionId, boolean>();
+  /**
+   * Lazily-filled JSON schema cache. Populated on first `toManifestEntry()` for
+   * a given id; `.has(id)` distinguishes "not computed yet" from "computed but
+   * the schema is intentionally undefined" (the input/output fields can both
+   * be undefined for actions without schemas).
+   */
+  private schemaCache = new Map<ActionId, CachedSchemas>();
   private contextProvider: (() => ActionContext) | null = null;
   /**
    * Last eligible {actionId, args} captured after a successful dispatch from a
@@ -213,12 +223,15 @@ export class ActionService {
     // a warning before the throw would be spurious noise.
     validateActionDefinition(definition);
     const typed = definition as AnyActionDefinition;
-    // Compute partials before mutating the registry: if a custom validator
-    // inside computeManifestPartials throws, we don't want has() to start
-    // returning true for a half-registered action.
-    const partials = computeManifestPartials(typed);
+    // Compute requiresArgs before mutating the registry: if argsSchema.safeParse
+    // throws, we don't want has() to start returning true for a half-registered
+    // action. JSON-schema compilation is intentionally deferred to first
+    // toManifestEntry() call (issue #8614) — bulk-compiling 308 schemas at
+    // startup would block ~150-300ms of frame budget for data no consumer
+    // needs until the action palette or MCP manifest is first opened.
+    const requiresArgs = computeRequiresArgs(typed);
     this.registry.set(definition.id, typed);
-    this.manifestPartialCache.set(definition.id, partials);
+    this.requiresArgsCache.set(definition.id, requiresArgs);
   }
 
   /** Whether an action id is present in the registry. */
@@ -229,7 +242,17 @@ export class ActionService {
   /** Remove an action from the registry. Silent no-op if unknown — safe for unload cleanup. */
   unregister(id: ActionId): void {
     this.registry.delete(id);
-    this.manifestPartialCache.delete(id);
+    this.requiresArgsCache.delete(id);
+    this.schemaCache.delete(id);
+  }
+
+  /**
+   * Iterate registered action ids without materializing manifest entries. Avoids
+   * the JSON-schema compilation that `list()` triggers — use this when only
+   * ids are needed (e.g. plugin id validation at startup).
+   */
+  listIds(): IterableIterator<ActionId> {
+    return this.registry.keys();
   }
 
   setContextProvider(provider: (() => ActionContext) | null): void {
@@ -428,14 +451,22 @@ export class ActionService {
       }
     }
 
-    // Defensive: register() populates the cache, so a miss should only happen
-    // if a test bypasses register() and writes to the registry directly.
-    // Compute on the fly rather than throwing, matching getActionContext()'s
-    // graceful-degradation pattern.
-    let cached = this.manifestPartialCache.get(definition.id);
-    if (!cached) {
-      cached = computeManifestPartials(definition);
-      this.manifestPartialCache.set(definition.id, cached);
+    // requiresArgs is populated by register(); the defensive fallback covers
+    // tests that bypass register() and write to the registry directly,
+    // matching getActionContext()'s graceful-degradation pattern.
+    let requiresArgs = this.requiresArgsCache.get(definition.id);
+    if (requiresArgs === undefined) {
+      requiresArgs = computeRequiresArgs(definition);
+      this.requiresArgsCache.set(definition.id, requiresArgs);
+    }
+
+    // JSON schemas are deferred from register-time to first-use (issue #8614).
+    // Use .has() rather than truthy-check so an action whose schemas are both
+    // intentionally undefined isn't recomputed on every call.
+    let schemas = this.schemaCache.get(definition.id);
+    if (!this.schemaCache.has(definition.id)) {
+      schemas = computeSchemas(definition);
+      this.schemaCache.set(definition.id, schemas);
     }
 
     // Shallow-copy the cached schemas so that if a downstream consumer
@@ -455,11 +486,11 @@ export class ActionService {
         danger: definition.danger,
         category: definition.category,
       }),
-      inputSchema: cached.inputSchema ? { ...cached.inputSchema } : undefined,
-      outputSchema: cached.outputSchema ? { ...cached.outputSchema } : undefined,
+      inputSchema: schemas?.inputSchema ? { ...schemas.inputSchema } : undefined,
+      outputSchema: schemas?.outputSchema ? { ...schemas.outputSchema } : undefined,
       enabled,
       disabledReason,
-      requiresArgs: cached.requiresArgs,
+      requiresArgs,
       keywords: definition.keywords?.slice(),
       ...(definition.mcpAnnotations ? { mcpAnnotations: { ...definition.mcpAnnotations } } : {}),
       ...(definition.mcpVisibility ? { mcpVisibility: definition.mcpVisibility } : {}),

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -1790,6 +1790,115 @@ describe("ActionService", () => {
     });
   });
 
+  describe("lazy schema compilation (issue #8614)", () => {
+    /**
+     * The schemaCache is private; we read it via the same-file `unknown` cast
+     * because ESM module-namespace freezing prevents `vi.spyOn(z, "toJSONSchema")`.
+     * Cache state is the most direct observable signal that compilation has or
+     * has not run.
+     */
+    function getSchemaCache(s: ActionService): Map<string, unknown> {
+      return (s as unknown as { schemaCache: Map<string, unknown> }).schemaCache;
+    }
+
+    function getRequiresArgsCache(s: ActionService): Map<string, boolean> {
+      return (s as unknown as { requiresArgsCache: Map<string, boolean> }).requiresArgsCache;
+    }
+
+    function registerSchemaAction(id = "actions.list" as ActionId): void {
+      service.register({
+        id,
+        title: "Test",
+        description:
+          "Test action for validating ActionService lazy JSON schema compilation behavior under issue #8614.",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        argsSchema: z.object({ name: z.string() }),
+        run: vi.fn().mockResolvedValue(undefined),
+      });
+    }
+
+    it("does not populate schemaCache during register()", () => {
+      registerSchemaAction();
+      expect(getSchemaCache(service).size).toBe(0);
+    });
+
+    it("populates requiresArgsCache eagerly during register()", () => {
+      registerSchemaAction();
+      expect(getRequiresArgsCache(service).get("actions.list" as ActionId)).toBe(true);
+    });
+
+    it("listIds() returns registered ids without populating schemaCache", () => {
+      registerSchemaAction("actions.list" as ActionId);
+      service.register({
+        id: "actions.get" as ActionId,
+        title: "T",
+        description:
+          "Test action for validating ActionService lazy JSON schema compilation behavior under issue #8614.",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const ids = Array.from(service.listIds());
+      expect(ids).toEqual(["actions.list", "actions.get"]);
+      expect(getSchemaCache(service).size).toBe(0);
+    });
+
+    it("populates schemaCache on first list() call", () => {
+      registerSchemaAction();
+      expect(getSchemaCache(service).size).toBe(0);
+      service.list();
+      expect(getSchemaCache(service).size).toBe(1);
+    });
+
+    it("populates schemaCache on first get() call", () => {
+      registerSchemaAction();
+      expect(getSchemaCache(service).size).toBe(0);
+      service.get("actions.list" as ActionId);
+      expect(getSchemaCache(service).size).toBe(1);
+    });
+
+    it("caches no-argsSchema actions on first read so repeated calls do not recompute", () => {
+      service.register({
+        id: "actions.list" as ActionId,
+        title: "T",
+        description:
+          "Test action for validating ActionService lazy JSON schema compilation behavior under issue #8614.",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: vi.fn().mockResolvedValue(undefined),
+      });
+
+      service.list();
+      const cache = getSchemaCache(service);
+      // Without argsSchema, inputSchema is undefined — but the entry must exist
+      // in the cache so .has() short-circuits subsequent recomputation.
+      expect(cache.has("actions.list" as ActionId)).toBe(true);
+      const cachedAfterFirst = cache.get("actions.list" as ActionId);
+      service.list();
+      service.get("actions.list" as ActionId);
+      expect(cache.get("actions.list" as ActionId)).toBe(cachedAfterFirst);
+    });
+
+    it("unregister() clears both requiresArgsCache and schemaCache", () => {
+      registerSchemaAction();
+      service.list();
+      expect(getSchemaCache(service).size).toBe(1);
+      expect(getRequiresArgsCache(service).size).toBe(1);
+
+      service.unregister("actions.list" as ActionId);
+      expect(getSchemaCache(service).size).toBe(0);
+      expect(getRequiresArgsCache(service).size).toBe(0);
+    });
+  });
+
   describe("dispatch error boundaries (issue #7284)", () => {
     let warnSpy: ReturnType<typeof vi.spyOn>;
 


### PR DESCRIPTION
## Summary

- `ActionService` was calling `z.toJSONSchema()` for all ~308 built-in actions synchronously during the startup `useActionRegistry` effect, blocking ~150-300ms of frame budget for data no consumer needs until the action palette or MCP manifest is first opened.
- Split the single cache into `requiresArgsCache` (eager — needed by the palette hot-path filter) and `schemaCache` (lazy — populated on first `list()` or `get()` call via a `.has()` check that handles `undefined`-schema actions cleanly).
- Added `listIds()` iterator so `useActionRegistry`'s plugin-id validation loop never forces all schemas to materialize at startup. Wrapped the registration loop in `startRendererSpan('action_registry:register')` for measurement.

Resolves #8614

## Changes

- `src/services/ActionService.ts` — split cache, lazy schema compilation, `listIds()` method, registration span
- `src/hooks/useActionRegistry.ts` — switch plugin-id validation to `listIds()` instead of `list()`
- `src/services/__tests__/ActionService.test.ts` — 7 new tests covering lazy compilation, `requiresArgsCache` eagerness, and `listIds()` behaviour

## Testing

All 9 CI checks passed (typecheck, channels, ipc, ipc-renderer, ipc-handwritten, help, lint-ratchet, format, build). 91 unit tests passing. Lint warnings decreased by 45.