### PR TITLE
perf(hydration): run independent hydration steps concurrently (#8619)

### DIFF
--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -809,6 +809,47 @@ describe("hydrateAppState", () => {
     expect(projectClientMock.getTabGroups).toHaveBeenCalledWith("project-1");
   });
 
+  it("dispatches getForProject concurrently with draft-input restore", async () => {
+    // Hold draft-input resolution so we can observe the IPC ordering. Without
+    // the parallelisation, getForProject would be blocked behind this await.
+    let releaseDrafts: () => void = () => {};
+    const draftsDeferred = new Promise<Record<string, string>>((resolve) => {
+      releaseDrafts = () => resolve({});
+    });
+    projectClientMock.getDraftInputs.mockReturnValue(draftsDeferred);
+
+    appClientMock.hydrate.mockResolvedValue({
+      appState: {
+        terminals: [],
+        activeWorktreeId: null,
+        sidebarWidth: 350,
+      },
+      terminalConfig,
+      project,
+      agentSettings,
+    });
+    terminalClientMock.getForProject.mockResolvedValue([]);
+
+    const hydrationPromise = hydrateAppState({
+      addPanel: vi.fn(),
+      setActiveWorktree: vi.fn(),
+      loadRecipes: vi.fn().mockResolvedValue(undefined),
+      openDiagnosticsDock: vi.fn(),
+    });
+
+    // Flush microtasks so the prefetch fan-out runs. getForProject should have
+    // been dispatched even though getDraftInputs is still pending.
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>((resolve) => queueMicrotask(resolve));
+    }
+
+    expect(terminalClientMock.getForProject).toHaveBeenCalledWith("project-1");
+    expect(projectClientMock.getDraftInputs).toHaveBeenCalledWith("project-1");
+
+    releaseDrafts();
+    await hydrationPromise;
+  });
+
   it("defers non-critical snapshot restoration to lazy scroll during project-switch", async () => {
     // Track managed terminals per ID so we can simulate scroll events
     const managedTerminals = new Map<string, ReturnType<typeof makeMockManagedTerminal>>();

--- a/src/utils/stateHydration/__tests__/bootstrapGuard.test.ts
+++ b/src/utils/stateHydration/__tests__/bootstrapGuard.test.ts
@@ -54,7 +54,9 @@ describe("ensureHydrationBootstrap", () => {
     await ensureHydrationBootstrap();
 
     expect(loadOverridesMock).toHaveBeenCalledTimes(2);
-    expect(initializeMock).toHaveBeenCalledTimes(1);
+    // initialize() runs concurrently with loadOverrides() via Promise.all,
+    // so it fires on the failing first attempt too: 1 (failed call) + 1 (retry).
+    expect(initializeMock).toHaveBeenCalledTimes(2);
   });
 
   it("propagates initialize() rejections and clears the singleton", async () => {

--- a/src/utils/stateHydration/bootstrapGuard.ts
+++ b/src/utils/stateHydration/bootstrapGuard.ts
@@ -5,13 +5,15 @@ let hydrationBootstrapPromise: Promise<void> | null = null;
 
 export async function ensureHydrationBootstrap(): Promise<void> {
   if (!hydrationBootstrapPromise) {
-    hydrationBootstrapPromise = (async () => {
-      await keybindingService.loadOverrides();
-      await useUserAgentRegistryStore.getState().initialize();
-    })().catch((error) => {
-      hydrationBootstrapPromise = null;
-      throw error;
-    });
+    hydrationBootstrapPromise = Promise.all([
+      keybindingService.loadOverrides(),
+      useUserAgentRegistryStore.getState().initialize(),
+    ])
+      .then(() => undefined)
+      .catch((error) => {
+        hydrationBootstrapPromise = null;
+        throw error;
+      });
   }
 
   await hydrationBootstrapPromise;

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -18,6 +18,7 @@ import { PERF_MARKS } from "@shared/perf/marks";
 import {
   markRendererPerformance,
   withRendererSpan,
+  startRendererSpan,
   isRendererPerfCaptureEnabled,
   RENDERER_T0,
 } from "@/utils/performance";
@@ -270,13 +271,21 @@ export async function hydrateAppState(
     // synchronous hydration work. The result is consumed inside the panel-restore
     // block below; any rejection is captured and re-thrown there so the existing
     // outer try/catch still logs and skips terminal restore.
+    //
+    // Perf span is split into startRendererSpan + manual finishGetForProject so
+    // the `:end` mark only fires once `checkCurrent()` has confirmed the run is
+    // still current. Wrapping the in-flight promise in `withRendererSpan` would
+    // emit `:end` after `hydrateAppState`'s `finally` flushes the buffer when a
+    // mid-flight supersede happens, polluting the next run's marks with the
+    // wrong `switchId`.
     let terminalFetchError: unknown = null;
+    const finishGetForProjectSpan = currentProjectId
+      ? startRendererSpan(PERF_MARKS.HYDRATE_GET_TERMINALS, {
+          switchId: _switchId ?? null,
+        })
+      : null;
     const getForProjectPromise: Promise<BackendTerminalInfo[]> = currentProjectId
-      ? withRendererSpan(
-          PERF_MARKS.HYDRATE_GET_TERMINALS,
-          () => terminalClient.getForProject(currentProjectId),
-          { switchId: _switchId ?? null }
-        ).catch((error: unknown) => {
+      ? terminalClient.getForProject(currentProjectId).catch((error: unknown) => {
           terminalFetchError = error;
           return [];
         })
@@ -299,8 +308,9 @@ export async function hydrateAppState(
     if (currentProjectId) {
       try {
         const backendTerminals = await getForProjectPromise;
-        if (terminalFetchError) throw terminalFetchError;
         if (!checkCurrent()) return;
+        finishGetForProjectSpan?.();
+        if (terminalFetchError) throw terminalFetchError;
 
         logHydrationInfo(
           `Found ${backendTerminals.length} running terminals for project ${currentProjectId}`

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -9,6 +9,7 @@ import type {
   TerminalReconnectError,
   TabGroup,
 } from "@/types";
+import type { BackendTerminalInfo } from "@shared/types/ipc/terminal";
 import type { ActionFrecencyEntry } from "@shared/types/actions";
 import { panelPersistence } from "@/store/persistence/panelPersistence";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -264,6 +265,23 @@ export async function hydrateAppState(
         })
       : null;
 
+    // Start the backend-terminal lookup alongside the other prefetch promises so
+    // its IPC round-trip overlaps with draft-input restore and the rest of the
+    // synchronous hydration work. The result is consumed inside the panel-restore
+    // block below; any rejection is captured and re-thrown there so the existing
+    // outer try/catch still logs and skips terminal restore.
+    let terminalFetchError: unknown = null;
+    const getForProjectPromise: Promise<BackendTerminalInfo[]> = currentProjectId
+      ? withRendererSpan(
+          PERF_MARKS.HYDRATE_GET_TERMINALS,
+          () => terminalClient.getForProject(currentProjectId),
+          { switchId: _switchId ?? null }
+        ).catch((error: unknown) => {
+          terminalFetchError = error;
+          return [];
+        })
+      : Promise.resolve([]);
+
     // Restore hybrid input bar draft inputs BEFORE terminal panels are created,
     // so HybridInputBar components pick up drafts from the store at mount time.
     if (currentProjectId) {
@@ -280,11 +298,8 @@ export async function hydrateAppState(
 
     if (currentProjectId) {
       try {
-        const backendTerminals = await withRendererSpan(
-          PERF_MARKS.HYDRATE_GET_TERMINALS,
-          () => terminalClient.getForProject(currentProjectId),
-          { switchId: _switchId ?? null }
-        );
+        const backendTerminals = await getForProjectPromise;
+        if (terminalFetchError) throw terminalFetchError;
         if (!checkCurrent()) return;
 
         logHydrationInfo(


### PR DESCRIPTION
## Summary

- Two spots in the renderer hydration path were awaiting independent IPC calls in series. Both are now parallelised.
- In `bootstrapGuard.ts`, `keybinding-overrides` and `user-agent-registry` were loaded sequentially — now run with `Promise.all`.
- In `hydrateAppState` (`index.ts`), `terminalClient.getForProject` was awaited mid-function after `appClient.hydrate` and the draft-input restore. It only needs `currentProjectId`, which is known well before that point, so it's now hoisted into the existing prefetch fan-out alongside `worktreesPromise`, `tabGroupsPromise`, `terminalSizesPromise`, `draftInputsPromise`, and `projectPresetsPromise`.

Resolves #8619

## Changes

- `bootstrapGuard.ts` — serial awaits replaced with `Promise.all`
- `index.ts` (`hydrateAppState`) — `terminalClient.getForProject` hoisted into the parallel prefetch fan-out
- Follow-up review fix: `getForProject` perf span now uses `startRendererSpan` + a manual `finishGetForProjectSpan()` call gated on `checkCurrent()`, preventing stale `:end` marks from contaminating the next hydration run when a project switch supersedes
- Tests updated to cover the concurrent fan-out behaviour

## Testing

- Unit tests updated and passing for both `bootstrapGuard` and `hydrateAppState`
- Existing hydration ordering invariants (crash-recovery gate resolves before hydration; `setStartupQuietPeriod` stays tied to hydration completion) verified through the test suite