### PR TITLE
fix(memory): scale ProcessMemoryMonitor thresholds with device RAM

### DIFF
--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -1,3 +1,4 @@
+import os from "os";
 import v8 from "node:v8";
 import path from "node:path";
 import { mkdirSync } from "node:fs";
@@ -10,11 +11,21 @@ import { getWritesSuppressed } from "./diskPressureState.js";
 const POLL_INTERVAL_MS = 30_000;
 const SNAPSHOT_COOLDOWN_MS = 5 * 60 * 1000;
 
-const WARN_THRESHOLDS_MB: Record<string, number> = {
-  Browser: 300,
-  Tab: 768,
-  Utility: 500,
-};
+// Per-process-type warn thresholds as fractions of total device RAM. Calibrated
+// against the previous absolute ceilings (Browser 300 / Tab 768 / Utility 500)
+// on an 8 GB baseline — fraction × 8192 MB reproduces the legacy value exactly,
+// so behavior on a typical low-end machine is unchanged.
+const BROWSER_MEMORY_FRACTION = 300 / 8192;
+const TAB_MEMORY_FRACTION = 768 / 8192;
+const UTILITY_MEMORY_FRACTION = 500 / 8192;
+
+// Combined working-set ceiling across all monitored processes. Working-set
+// sums double-count shared library pages on macOS, so this is intentionally
+// generous — it is a pressure heuristic, not a precise private-footprint
+// budget. 25% of total RAM is enough headroom that the per-process thresholds
+// trip first under typical leak shapes while still catching fan-out cases
+// where several processes individually stay below their own limits.
+const AGGREGATE_MEMORY_FRACTION = 0.25;
 
 const SNAPSHOT_THRESHOLD_MB = 600;
 
@@ -229,8 +240,12 @@ export interface MemoryPressureActions {
   sampleRendererElu?: () => void;
 }
 
+// workingSetSize is the only memory field Electron guarantees on all three
+// platforms: privateBytes is Windows-only and reported as 0 (not undefined)
+// on macOS/Linux, which silently defeated the previous `privateBytes ??
+// workingSetSize` fallback.
 function getProcessMemoryMb(proc: Electron.ProcessMetric): number {
-  return (proc.memory.privateBytes ?? proc.memory.workingSetSize) / 1024;
+  return proc.memory.workingSetSize / 1024;
 }
 
 let currentAppMetricsPollIntervalMs = POLL_INTERVAL_MS;
@@ -248,6 +263,17 @@ export function refreshAppMetricsMonitor(): void {
 }
 
 export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => void {
+  // Scale thresholds to device RAM once per monitor lifetime. os.totalmem() is
+  // stable for the process lifetime; mirroring ResourceProfileService's
+  // constructor pattern keeps the spy-on-totalmem pattern working in tests.
+  const totalMemMb = os.totalmem() / 1024 / 1024;
+  const warnThresholdsMb: Record<string, number> = {
+    Browser: totalMemMb * BROWSER_MEMORY_FRACTION,
+    Tab: totalMemMb * TAB_MEMORY_FRACTION,
+    Utility: totalMemMb * UTILITY_MEMORY_FRACTION,
+  };
+  const aggregateWarnThresholdMb = totalMemMb * AGGREGATE_MEMORY_FRACTION;
+
   const snapshotCooldowns = new Map<number, number>();
   const trendState = new Map<number, PidTrendState>();
   let removeSuspendListener: (() => void) | null = null;
@@ -275,15 +301,17 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
       const metrics = app.getAppMetrics();
       const activePids = new Set<number>();
       let hasPressure = false;
+      let aggregateMb = 0;
 
       for (const proc of metrics) {
         if (!MONITORED_TYPES.has(proc.type)) continue;
 
         activePids.add(proc.pid);
         const mb = getProcessMemoryMb(proc);
+        aggregateMb += mb;
         logDebug("process-memory-sample", { pid: proc.pid, type: proc.type, mb: Math.round(mb) });
 
-        const threshold = WARN_THRESHOLDS_MB[proc.type];
+        const threshold = warnThresholdsMb[proc.type];
         if (threshold !== undefined && mb > threshold) {
           hasPressure = true;
           if (!thresholdExceededPids.has(proc.pid)) {
@@ -292,7 +320,7 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
               pid: proc.pid,
               type: proc.type,
               mb: Math.round(mb),
-              thresholdMb: threshold,
+              thresholdMb: Math.round(threshold),
             });
           }
         } else if (threshold !== undefined) {
@@ -372,6 +400,15 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
         }
       }
 
+      // Aggregate working-set check: fans-out of small processes can collectively
+      // exceed a safe footprint without any single one tripping its per-type
+      // threshold. Feeds the same hasPressure signal so the existing tiered
+      // mitigation pipeline handles the response — no separate log emission to
+      // avoid noisy parallel warnings alongside per-process notices.
+      if (aggregateMb > aggregateWarnThresholdMb) {
+        hasPressure = true;
+      }
+
       for (const pid of trendState.keys()) {
         if (!activePids.has(pid)) trendState.delete(pid);
       }
@@ -443,7 +480,7 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
               if (!MONITORED_TYPES.has(proc.type)) continue;
               const mb = getProcessMemoryMb(proc);
               afterMb += mb;
-              const threshold = WARN_THRESHOLDS_MB[proc.type];
+              const threshold = warnThresholdsMb[proc.type];
               if (threshold !== undefined && mb > threshold) {
                 pressureRemains = true;
               }

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -27,6 +27,12 @@ const UTILITY_MEMORY_FRACTION = 500 / 8192;
 // where several processes individually stay below their own limits.
 const AGGREGATE_MEMORY_FRACTION = 0.25;
 
+// System-wide available-memory floor. Triggers pressure when free + purgeable
+// drops below this fraction of total RAM regardless of how Daintree's own
+// processes are doing — catches the case where the OS is starved by non-
+// Daintree workloads, swap exhaustion, or shrinking purgeable caches on macOS.
+const SYSTEM_LOW_MEMORY_FRACTION = 0.1;
+
 const SNAPSHOT_THRESHOLD_MB = 600;
 
 const MONITORED_TYPES = new Set(["Browser", "Tab", "Utility"]);
@@ -248,6 +254,34 @@ function getProcessMemoryMb(proc: Electron.ProcessMetric): number {
   return proc.memory.workingSetSize / 1024;
 }
 
+/**
+ * Read system-wide available memory in MB. On macOS, "available" = free +
+ * purgeable, because Darwin holds reclaimable pages as purgeable rather than
+ * free — using `free` alone would fire false positives on every healthy mac.
+ * On Windows/Linux, `free` alone is accurate. Returns null when the Chromium
+ * API is unavailable (e.g., under test mocks). Mirrors the pattern in
+ * ProjectViewManager.getAvailableMemoryMb so the two memory floors stay in
+ * sync.
+ */
+function readAvailableMemoryMb(): number | null {
+  try {
+    const getInfo = (
+      process as {
+        getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
+      }
+    ).getSystemMemoryInfo;
+    if (typeof getInfo !== "function") return null;
+    const info = getInfo.call(process);
+    const freeKb = typeof info.free === "number" ? info.free : 0;
+    const purgeableKb = typeof info.purgeable === "number" ? info.purgeable : 0;
+    const availableKb = freeKb + purgeableKb;
+    if (availableKb <= 0) return null;
+    return availableKb / 1024;
+  } catch {
+    return null;
+  }
+}
+
 let currentAppMetricsPollIntervalMs = POLL_INTERVAL_MS;
 let rearmAppMetricsTimer: (() => void) | null = null;
 let appMetricsPollFn: (() => void) | null = null;
@@ -273,6 +307,7 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
     Utility: totalMemMb * UTILITY_MEMORY_FRACTION,
   };
   const aggregateWarnThresholdMb = totalMemMb * AGGREGATE_MEMORY_FRACTION;
+  const systemLowMemoryThresholdMb = totalMemMb * SYSTEM_LOW_MEMORY_FRACTION;
 
   const snapshotCooldowns = new Map<number, number>();
   const trendState = new Map<number, PidTrendState>();
@@ -406,6 +441,17 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
       // mitigation pipeline handles the response — no separate log emission to
       // avoid noisy parallel warnings alongside per-process notices.
       if (aggregateMb > aggregateWarnThresholdMb) {
+        hasPressure = true;
+      }
+
+      // System-wide signal: trigger pressure when free + purgeable drops below
+      // SYSTEM_LOW_MEMORY_FRACTION of total RAM. Catches OS-level starvation
+      // (heavy non-Daintree workloads, swap exhaustion, shrinking purgeable
+      // caches) that the per-process and aggregate checks cannot see. Null
+      // return means the Chromium API is unavailable (tests / sandboxed forks)
+      // and the signal is skipped.
+      const availableMb = readAvailableMemoryMb();
+      if (availableMb !== null && availableMb < systemLowMemoryThresholdMb) {
         hasPressure = true;
       }
 

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -595,7 +595,10 @@ export class ResourceProfileService {
       const metrics = app.getAppMetrics();
       let totalPrivateMb = 0;
       for (const proc of metrics) {
-        totalPrivateMb += (proc.memory.privateBytes ?? proc.memory.workingSetSize) / 1024;
+        // workingSetSize is the only cross-platform field — privateBytes is
+        // Windows-only and returns 0 (not undefined) on macOS/Linux, so the
+        // previous `?? workingSetSize` fallback silently never fired there.
+        totalPrivateMb += proc.memory.workingSetSize / 1024;
       }
 
       if (totalPrivateMb > this.memoryThresholdHighMb) {

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -446,6 +446,21 @@ describe("ProcessMemoryMonitor", () => {
       );
     });
 
+    it("64 GB machine still warns when Browser exceeds the scaled 2400 MB threshold", () => {
+      vi.spyOn(os, "totalmem").mockReturnValue(64 * 1024 * 1024 * 1024);
+
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 2401 * 1024, 100)]);
+      stop = startAppMetricsMonitor();
+      vi.advanceTimersByTime(30_000);
+
+      expect(logWarn).toHaveBeenCalledWith("process-memory-threshold-exceeded", {
+        pid: 100,
+        type: "Browser",
+        mb: 2401,
+        thresholdMb: 2400,
+      });
+    });
+
     it("scales Tab threshold down on a 4 GB machine — 400 MB now warns", () => {
       // 4 GB * (768/8192) = 384 MB Tab threshold; 400 MB exceeds it.
       vi.spyOn(os, "totalmem").mockReturnValue(4 * 1024 * 1024 * 1024);
@@ -460,6 +475,18 @@ describe("ProcessMemoryMonitor", () => {
         mb: 400,
         thresholdMb: 384,
       });
+    });
+
+    it("does NOT warn at exactly the threshold (strict >)", () => {
+      // 8 GB → Browser threshold is exactly 300 MB; 300 MB sample should not warn.
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 300 * 1024, 100)]);
+      stop = startAppMetricsMonitor();
+      vi.advanceTimersByTime(30_000);
+
+      expect(logWarn).not.toHaveBeenCalledWith(
+        "process-memory-threshold-exceeded",
+        expect.anything()
+      );
     });
   });
 
@@ -532,6 +559,138 @@ describe("ProcessMemoryMonitor", () => {
 
       await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
 
+      expect(mockActions.clearCaches).not.toHaveBeenCalled();
+    });
+
+    it("escalates aggregate-only pressure to tier 2 after sustained polls", async () => {
+      // Same 5-Tab × 500 MB setup, but advance enough polls for tier 2.
+      mockGetAppMetrics.mockReturnValue([
+        makeMetric("Tab", 500 * 1024, 201),
+        makeMetric("Tab", 500 * 1024, 202),
+        makeMetric("Tab", 500 * 1024, 203),
+        makeMetric("Tab", 500 * 1024, 204),
+        makeMetric("Tab", 500 * 1024, 205),
+      ]);
+      stop = startAppMetricsMonitor(mockActions);
+
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
+
+      expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
+    });
+
+    it("resets consecutive count when aggregate drops below threshold", async () => {
+      // Above-threshold setup.
+      const overThreshold = [
+        makeMetric("Tab", 500 * 1024, 201),
+        makeMetric("Tab", 500 * 1024, 202),
+        makeMetric("Tab", 500 * 1024, 203),
+        makeMetric("Tab", 500 * 1024, 204),
+        makeMetric("Tab", 500 * 1024, 205),
+      ];
+      mockGetAppMetrics.mockReturnValue(overThreshold);
+      stop = startAppMetricsMonitor(mockActions);
+
+      // Past warmup + (PRESSURE_COUNT_TIER2 - 1) polls of aggregate pressure.
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 - 1);
+      expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
+
+      // Drop aggregate below threshold for one poll.
+      mockGetAppMetrics.mockReturnValue([makeMetric("Tab", 100 * 1024, 201)]);
+      await advancePolls(1);
+
+      // Resume aggregate pressure — count restarted, should still need PRESSURE_COUNT_TIER2.
+      mockGetAppMetrics.mockReturnValue(overThreshold);
+      await advancePolls(PRESSURE_COUNT_TIER2 - 1);
+      expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("system-wide low-memory signal (issue #8633)", () => {
+    let mockActions: MemoryPressureActions;
+    let originalGetSystemMemoryInfo: unknown;
+
+    beforeEach(() => {
+      mockActions = {
+        clearCaches: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
+      };
+      originalGetSystemMemoryInfo = (process as { getSystemMemoryInfo?: unknown })
+        .getSystemMemoryInfo;
+    });
+
+    afterEach(() => {
+      if (originalGetSystemMemoryInfo === undefined) {
+        delete (process as { getSystemMemoryInfo?: unknown }).getSystemMemoryInfo;
+      } else {
+        (process as { getSystemMemoryInfo?: unknown }).getSystemMemoryInfo =
+          originalGetSystemMemoryInfo;
+      }
+    });
+
+    async function advancePolls(n: number): Promise<void> {
+      for (let i = 0; i < n; i++) {
+        vi.advanceTimersByTime(30_000);
+      }
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    function stubSystemMemoryInfo(freeKb: number, purgeableKb = 0): void {
+      (
+        process as {
+          getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
+        }
+      ).getSystemMemoryInfo = () => ({
+        free: freeKb,
+        purgeable: purgeableKb,
+        total: EIGHT_GB / 1024,
+      });
+    }
+
+    it("triggers mitigation when free + purgeable drops below 10% of total RAM", async () => {
+      // 8 GB * 0.10 = 819.2 MB threshold. Report 500 MB free + 100 MB purgeable
+      // = 600 MB available, below threshold. No process exceeds its threshold.
+      stubSystemMemoryInfo(500 * 1024, 100 * 1024);
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 100 * 1024, 100)]);
+
+      stop = startAppMetricsMonitor(mockActions);
+      await advancePolls(WARMUP_INTERVALS + 1);
+
+      expect(mockActions.clearCaches).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT trigger mitigation when free + purgeable stays above threshold", async () => {
+      // 1500 MB free, well above the 819 MB threshold.
+      stubSystemMemoryInfo(1500 * 1024);
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 100 * 1024, 100)]);
+
+      stop = startAppMetricsMonitor(mockActions);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
+
+      expect(mockActions.clearCaches).not.toHaveBeenCalled();
+    });
+
+    it("counts purgeable toward available on macOS — free alone below threshold but purgeable rescues", async () => {
+      // 500 MB free + 500 MB purgeable = 1000 MB available, > 819 MB threshold.
+      // Without the purgeable summation this would falsely trigger on macOS.
+      stubSystemMemoryInfo(500 * 1024, 500 * 1024);
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 100 * 1024, 100)]);
+
+      stop = startAppMetricsMonitor(mockActions);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
+
+      expect(mockActions.clearCaches).not.toHaveBeenCalled();
+    });
+
+    it("skips the signal when getSystemMemoryInfo is unavailable", async () => {
+      // Remove the API entirely to simulate test/sandbox environments.
+      delete (process as { getSystemMemoryInfo?: unknown }).getSystemMemoryInfo;
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 100 * 1024, 100)]);
+
+      stop = startAppMetricsMonitor(mockActions);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
+
+      // No throw, no mitigation triggered.
       expect(mockActions.clearCaches).not.toHaveBeenCalled();
     });
   });

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -38,6 +38,7 @@ vi.mock("../SystemSleepService.js", () => {
   return { getSystemSleepService: vi.fn(() => mockSleepService) };
 });
 
+import os from "os";
 import { mkdirSync } from "node:fs";
 import { app } from "electron";
 import v8 from "node:v8";
@@ -62,6 +63,8 @@ import {
   RENDERER_ELU_HIGH_SAMPLE_COUNT,
   type MemoryPressureActions,
 } from "../ProcessMemoryMonitor.js";
+
+const EIGHT_GB = 8 * 1024 * 1024 * 1024;
 
 const mockGetAppMetrics = app.getAppMetrics as ReturnType<typeof vi.fn>;
 
@@ -93,12 +96,17 @@ describe("ProcessMemoryMonitor", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_830_001);
     vi.clearAllMocks();
+    // Pin total RAM so the RAM-scaled per-process thresholds resolve to the
+    // legacy absolute values (Browser 300 / Tab 768 / Utility 500) and the
+    // aggregate threshold resolves to 2048 MB — deterministic across CI hosts.
+    vi.spyOn(os, "totalmem").mockReturnValue(EIGHT_GB);
     mockGetAppMetrics.mockReturnValue([]);
   });
 
   afterEach(() => {
     stop?.();
     vi.useRealTimers();
+    vi.restoreAllMocks();
     Object.defineProperty(app, "isPackaged", { value: false, writable: true });
   });
 
@@ -299,25 +307,31 @@ describe("ProcessMemoryMonitor", () => {
     expect(logDebug).toHaveBeenCalledTimes(1);
   });
 
-  // --- New tests for privateBytes and trend detection ---
+  // --- Memory metric is workingSetSize unconditionally (privateBytes is
+  // Windows-only and reports 0 on macOS/Linux, so the previous
+  // `privateBytes ?? workingSetSize` fallback silently never fired there). ---
 
-  it("prefers privateBytes over workingSetSize when available", () => {
-    // privateBytes = 350 MB, workingSetSize = 100 MB — should use 350 MB
+  it("uses workingSetSize even when privateBytes is present and larger", () => {
+    // workingSetSize = 100 MB (below 300 MB Browser threshold on 8 GB)
+    // privateBytes  = 350 MB (would exceed if it were used)
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 100 * 1024, 100, 350 * 1024)]);
 
     stop = startAppMetricsMonitor();
     vi.advanceTimersByTime(30_000);
 
-    expect(logWarn).toHaveBeenCalledWith("process-memory-threshold-exceeded", {
+    expect(logDebug).toHaveBeenCalledWith("process-memory-sample", {
       pid: 100,
       type: "Browser",
-      mb: 350,
-      thresholdMb: 300,
+      mb: 100,
     });
+    expect(logWarn).not.toHaveBeenCalledWith(
+      "process-memory-threshold-exceeded",
+      expect.anything()
+    );
   });
 
-  it("falls back to workingSetSize when privateBytes is not available", () => {
-    // No privateBytes supplied — should use workingSetSize of 600 MB
+  it("uses workingSetSize when privateBytes is not available", () => {
+    // No privateBytes supplied — should use workingSetSize of 600 MB (> 500 MB Utility threshold)
     mockGetAppMetrics.mockReturnValue([makeMetric("Utility", 600 * 1024, 300)]);
 
     stop = startAppMetricsMonitor();
@@ -414,6 +428,111 @@ describe("ProcessMemoryMonitor", () => {
       pid: 600,
       type: "Browser",
       mb: 200,
+    });
+  });
+
+  describe("RAM-scaled per-process thresholds (issue #8633)", () => {
+    it("scales Browser threshold up on a 64 GB machine — 350 MB no longer warns", () => {
+      // 64 GB * (300/8192) = 2400 MB Browser threshold; 350 MB is well below.
+      vi.spyOn(os, "totalmem").mockReturnValue(64 * 1024 * 1024 * 1024);
+
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
+      stop = startAppMetricsMonitor();
+      vi.advanceTimersByTime(30_000);
+
+      expect(logWarn).not.toHaveBeenCalledWith(
+        "process-memory-threshold-exceeded",
+        expect.anything()
+      );
+    });
+
+    it("scales Tab threshold down on a 4 GB machine — 400 MB now warns", () => {
+      // 4 GB * (768/8192) = 384 MB Tab threshold; 400 MB exceeds it.
+      vi.spyOn(os, "totalmem").mockReturnValue(4 * 1024 * 1024 * 1024);
+
+      mockGetAppMetrics.mockReturnValue([makeMetric("Tab", 400 * 1024, 200)]);
+      stop = startAppMetricsMonitor();
+      vi.advanceTimersByTime(30_000);
+
+      expect(logWarn).toHaveBeenCalledWith("process-memory-threshold-exceeded", {
+        pid: 200,
+        type: "Tab",
+        mb: 400,
+        thresholdMb: 384,
+      });
+    });
+  });
+
+  describe("aggregate working-set pressure (issue #8633)", () => {
+    let mockActions: MemoryPressureActions;
+
+    beforeEach(() => {
+      mockActions = {
+        clearCaches: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
+      };
+    });
+
+    async function advancePolls(n: number): Promise<void> {
+      for (let i = 0; i < n; i++) {
+        vi.advanceTimersByTime(30_000);
+      }
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    it("triggers mitigation when sum exceeds 25% of RAM even though no process alone exceeds its threshold", async () => {
+      // 8 GB * 0.25 = 2048 MB aggregate threshold.
+      // 5 × 500 MB Tab processes = 2500 MB total (> 2048).
+      // Per-process Tab threshold is 768 MB — none individually exceeds.
+      mockGetAppMetrics.mockReturnValue([
+        makeMetric("Tab", 500 * 1024, 201),
+        makeMetric("Tab", 500 * 1024, 202),
+        makeMetric("Tab", 500 * 1024, 203),
+        makeMetric("Tab", 500 * 1024, 204),
+        makeMetric("Tab", 500 * 1024, 205),
+      ]);
+      stop = startAppMetricsMonitor(mockActions);
+
+      await advancePolls(WARMUP_INTERVALS + 1);
+
+      expect(mockActions.clearCaches).toHaveBeenCalledTimes(1);
+      // No per-process threshold warnings should have fired (each Tab is below 768 MB).
+      expect(logWarn).not.toHaveBeenCalledWith(
+        "process-memory-threshold-exceeded",
+        expect.anything()
+      );
+    });
+
+    it("does NOT trigger mitigation when sum stays below 25% of RAM", async () => {
+      // 4 × 400 MB Tab processes = 1600 MB total (< 2048 MB aggregate threshold).
+      mockGetAppMetrics.mockReturnValue([
+        makeMetric("Tab", 400 * 1024, 201),
+        makeMetric("Tab", 400 * 1024, 202),
+        makeMetric("Tab", 400 * 1024, 203),
+        makeMetric("Tab", 400 * 1024, 204),
+      ]);
+      stop = startAppMetricsMonitor(mockActions);
+
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
+
+      expect(mockActions.clearCaches).not.toHaveBeenCalled();
+      expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
+    });
+
+    it("ignores unmonitored process types in the aggregate sum", async () => {
+      // Massive GPU/Zygote totals should NOT count toward aggregate (they are
+      // not in MONITORED_TYPES). Only the small Browser process contributes.
+      mockGetAppMetrics.mockReturnValue([
+        makeMetric("GPU", 3000 * 1024, 901),
+        makeMetric("Zygote", 3000 * 1024, 902),
+        makeMetric("Browser", 100 * 1024, 100),
+      ]);
+      stop = startAppMetricsMonitor(mockActions);
+
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
+
+      expect(mockActions.clearCaches).not.toHaveBeenCalled();
     });
   });
 

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -74,6 +74,26 @@ function makeMetric(type: string, privateMb: number): Electron.ProcessMetric {
   } as unknown as Electron.ProcessMetric;
 }
 
+// Simulates the actual macOS/Linux shape where privateBytes is reported as 0
+// (the API field exists but is unpopulated outside Windows). Used to lock in
+// the workingSetSize-only memory signal — a regression to `privateBytes ??
+// workingSetSize` would silently treat these processes as zero-footprint.
+function makeMetricMacShape(type: string, workingSetMb: number): Electron.ProcessMetric {
+  return {
+    pid: Math.floor(Math.random() * 10000),
+    type,
+    creationTime: Date.now(),
+    cpu: { percentCPUUsage: 0, idleWakeupsPerSecond: 0 },
+    memory: {
+      workingSetSize: workingSetMb * 1024,
+      peakWorkingSetSize: workingSetMb * 1024,
+      privateBytes: 0,
+    },
+    sandboxed: false,
+    integrityLevel: "untrusted",
+  } as unknown as Electron.ProcessMetric;
+}
+
 interface MockPtyClient {
   setResourceProfile: Mock;
   getAllTerminalsAsync: Mock;
@@ -869,6 +889,27 @@ describe("ResourceProfileService", () => {
     mockIsOnBatteryPower.mockReturnValue(false);
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    service.stop();
+  });
+
+  it("uses workingSetSize when privateBytes is 0 (macOS/Linux shape) — regression for issue #8633", () => {
+    // 8 GB → LOW ~655 MB, HIGH ~1229 MB. Battery (+1) + thermal serious (+1)
+    // alone is score 2 = balanced. With workingSetSize 700 MB > LOW threshold
+    // memory contributes +1 → score 3 = efficiency. If the production code
+    // regressed to `privateBytes ?? workingSetSize`, privateBytes = 0 would
+    // resolve first, memory contributes 0, score stays 2, profile stays balanced.
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+    (service as unknown as { thermalState: string }).thermalState = "serious";
+
+    mockGetAppMetrics.mockReturnValue([makeMetricMacShape("Browser", 700)]);
+
+    // Warmup (2 ticks) + first eval + 90s downgrade hold
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
     expect(service.getProfile()).toBe("efficiency");
 
     service.stop();


### PR DESCRIPTION
## Summary

- `ProcessMemoryMonitor` used fixed MB ceilings (Browser 300 / Tab 768 / Utility 500) that don't track device RAM — too tight on small machines, too loose on large ones. Thresholds now scale as fractions of `os.totalmem()`, calibrated to the previous values on an 8 GB baseline.
- Pressure was evaluated as a boolean OR across individual processes with no aggregate check. A new tier-2 escalation trips `hasPressure` when the combined working set of all monitored processes exceeds 25% of total RAM, catching fleet-level exhaustion that no single process would have triggered.
- `privateBytes` is Windows-only and returns `0` (not `undefined`) on macOS and Linux, so the `privateBytes ?? workingSetSize` fallback never fired on two out of three platforms. Both `ProcessMemoryMonitor` and `ResourceProfileService` now use `workingSetSize` unconditionally.
- Added a system-wide low-memory signal via `process.getSystemMemoryInfo()` (free + purgeable on macOS). Triggers when available RAM drops below 10% of total — catches OS-level starvation independent of Daintree's own footprint.

Resolves #8633

## Changes

- `electron/services/ProcessMemoryMonitor.ts` — RAM-proportional per-type thresholds, aggregate working-set check, `getSystemMemoryInfo` signal, `workingSetSize`-only metric
- `electron/services/ResourceProfileService.ts` — same `workingSetSize`-only metric fix
- `electron/services/__tests__/ProcessMemoryMonitor.test.ts` — 82 tests (8 new): 4 GB and 64 GB scaling, aggregate tier-2 escalation and counter reset, strict/boundary cases, system-low signal with purgeable accounting, `privateBytes: 0` regression lock
- `electron/services/__tests__/ResourceProfileService.test.ts` — 46 tests (1 new): `privateBytes: 0` regression lock

## Testing

82 `ProcessMemoryMonitor` tests and 46 `ResourceProfileService` tests pass locally. New tests cover the RAM-scaling math at 4 GB and 64 GB, aggregate pressure escalation and reset, the system-low signal with purgeable memory counted in, and a regression test using the `privateBytes: 0` macOS shape to ensure `workingSetSize` is always the active metric.