### PR TITLE
feat(memory): close the memory-pressure mitigation loop

### DIFF
--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -437,6 +437,7 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
 
           let afterMb = 0;
           let pressureRemains = false;
+          let resampleFailed = false;
           try {
             for (const proc of app.getAppMetrics()) {
               if (!MONITORED_TYPES.has(proc.type)) continue;
@@ -448,17 +449,24 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
               }
             }
           } catch {
-            // Re-sample failed — assume pressure persists so the ladder
-            // doesn't silently stall mid-cycle.
+            // Re-sample failed — assume pressure persists and treat reclaim
+            // as zero so the gate falls through to escalation. Without
+            // forcing afterMb=beforeMb here, deltaMb would equal the full
+            // beforeMb, satisfying `deltaMb >= MIN_RECLAIMED_MB` and
+            // *suppressing* escalation, which is the opposite of the
+            // safe-side intent.
             pressureRemains = true;
+            resampleFailed = true;
+            afterMb = beforeMb;
           }
 
-          const deltaMb = Math.max(0, beforeMb - afterMb);
+          const deltaMb = resampleFailed ? 0 : Math.max(0, beforeMb - afterMb);
           logInfo("memory-pressure-tier1-reclaim", {
             beforeMb: Math.round(beforeMb),
             afterMb: Math.round(afterMb),
             deltaMb: Math.round(deltaMb),
             pressureRemains,
+            resampleFailed,
           });
 
           if (
@@ -466,6 +474,11 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
             deltaMb < MIN_RECLAIMED_MB &&
             Date.now() - lastTier2At >= MITIGATION_COOLDOWN_MS
           ) {
+            // Stamp the cooldown BEFORE the tier-2 actions so a thrown
+            // hibernateIdleProjects (after destroyHiddenWebviews succeeded)
+            // doesn't leave the cooldown unconsumed and let the next poll
+            // re-fire destroyHiddenWebviews(2).
+            lastTier2At = Date.now();
             logInfo("memory-pressure-tier2-mitigation", {
               pollCount,
               consecutivePressureCount,
@@ -478,7 +491,6 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
             } catch {
               /* non-critical */
             }
-            lastTier2At = Date.now();
           }
         } catch (err) {
           logWarn("memory-pressure-mitigation-failed", { error: String(err) });

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -30,6 +30,25 @@ export const WARMUP_INTERVALS = 5;
 export const PRESSURE_COUNT_TIER2 = 3;
 export const MITIGATION_COOLDOWN_MS = 10 * 60 * 1000;
 
+/**
+ * Settle window between applying a tier 1 mitigation step and re-sampling
+ * footprint via `app.getAppMetrics()`. Chromium PartitionAlloc returns freed
+ * pages to the OS via background `MemoryReclaimer` (`MADV_FREE` on
+ * macOS/Linux, Windows background trim), so privateBytes lags reclamation by
+ * a few seconds. 3s sits within the 2–5s window confirmed reliable on all
+ * three platforms while staying well under {@link POLL_INTERVAL_MS}.
+ */
+export const RECLAIM_SETTLE_MS = 3_000;
+
+/**
+ * Below this MB delta, tier 1 is considered to have reclaimed effectively
+ * nothing — if pressure also persists after the settle window, the ladder
+ * escalates to tier 2. Above this threshold tier 1 is judged to have worked
+ * (the pressure that prompted us may have legitimately re-arrived, but
+ * that's a different cycle and should not chain into immediate escalation).
+ */
+export const MIN_RECLAIMED_MB = 50;
+
 interface PidTrendState {
   startedAt: number;
   tickInBucket: number;
@@ -383,10 +402,23 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
       mitigationInFlight = true;
       void (async () => {
         try {
+          let beforeMb = 0;
+          try {
+            for (const proc of app.getAppMetrics()) {
+              if (!MONITORED_TYPES.has(proc.type)) continue;
+              beforeMb += getProcessMemoryMb(proc);
+            }
+          } catch {
+            // If pre-sample fails, beforeMb stays 0; delta will be 0 and we'll
+            // err on the side of escalating if pressure persists.
+          }
+
           logInfo("memory-pressure-tier1-mitigation", {
             pollCount,
             consecutivePressureCount,
+            beforeMb: Math.round(beforeMb),
           });
+
           await actions.clearCaches();
           await actions.destroyHiddenWebviews(1);
 
@@ -401,13 +433,43 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
             /* non-critical */
           }
 
+          await new Promise<void>((resolve) => setTimeout(resolve, RECLAIM_SETTLE_MS));
+
+          let afterMb = 0;
+          let pressureRemains = false;
+          try {
+            for (const proc of app.getAppMetrics()) {
+              if (!MONITORED_TYPES.has(proc.type)) continue;
+              const mb = getProcessMemoryMb(proc);
+              afterMb += mb;
+              const threshold = WARN_THRESHOLDS_MB[proc.type];
+              if (threshold !== undefined && mb > threshold) {
+                pressureRemains = true;
+              }
+            }
+          } catch {
+            // Re-sample failed — assume pressure persists so the ladder
+            // doesn't silently stall mid-cycle.
+            pressureRemains = true;
+          }
+
+          const deltaMb = Math.max(0, beforeMb - afterMb);
+          logInfo("memory-pressure-tier1-reclaim", {
+            beforeMb: Math.round(beforeMb),
+            afterMb: Math.round(afterMb),
+            deltaMb: Math.round(deltaMb),
+            pressureRemains,
+          });
+
           if (
-            consecutivePressureCount >= PRESSURE_COUNT_TIER2 &&
+            pressureRemains &&
+            deltaMb < MIN_RECLAIMED_MB &&
             Date.now() - lastTier2At >= MITIGATION_COOLDOWN_MS
           ) {
             logInfo("memory-pressure-tier2-mitigation", {
               pollCount,
               consecutivePressureCount,
+              deltaMb: Math.round(deltaMb),
             });
             await actions.destroyHiddenWebviews(2);
             await actions.hibernateIdleProjects();

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -693,6 +693,66 @@ describe("ProcessMemoryMonitor", () => {
 
       expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
     });
+
+    it("escalates to tier 2 when the post-settle re-sample throws", async () => {
+      // Regression: the post-settle catch block must produce deltaMb=0,
+      // not deltaMb=beforeMb, so the AND gate falls through to escalation.
+      // Without `afterMb = beforeMb` inside the catch, the large derived
+      // delta would suppress tier 2 even with pressureRemains=true.
+      let cleared = false;
+      mockGetAppMetrics.mockImplementation(() => {
+        if (cleared) {
+          throw new Error("getAppMetrics unavailable");
+        }
+        return [makeMetric("Browser", 350 * 1024, 100)];
+      });
+      mockActions.clearCaches = vi.fn().mockImplementation(async () => {
+        cleared = true;
+      });
+      stop = startAppMetricsMonitor(mockActions);
+
+      await advancePolls(WARMUP_INTERVALS + 1);
+
+      expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
+      expect(logInfo).toHaveBeenCalledWith(
+        "memory-pressure-tier1-reclaim",
+        expect.objectContaining({
+          pressureRemains: true,
+          resampleFailed: true,
+          deltaMb: 0,
+        })
+      );
+    });
+
+    it("consumes tier-2 cooldown even when hibernateIdleProjects throws", async () => {
+      // Regression: lastTier2At must be stamped before the tier-2 awaits.
+      // Otherwise a partial failure (destroyHiddenWebviews(2) succeeds,
+      // hibernateIdleProjects throws) leaves the cooldown unconsumed and the
+      // next pressure poll re-fires destroyHiddenWebviews(2).
+      arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 345 });
+      mockActions.hibernateIdleProjects = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("hibernate failed"))
+        .mockResolvedValue(undefined);
+
+      stop = startAppMetricsMonitor(mockActions);
+
+      await advancePolls(WARMUP_INTERVALS + 1);
+      // First cycle: tier-2 attempted, destroyHiddenWebviews(2) called,
+      // hibernate throws. Cooldown should still be consumed.
+      expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(2);
+      const destroyCallsAfterFirst = vi
+        .mocked(mockActions.destroyHiddenWebviews)
+        .mock.calls.filter((c) => c[0] === 2).length;
+      expect(destroyCallsAfterFirst).toBe(1);
+
+      // Second cycle within cooldown: no new tier-2 fire.
+      await advancePolls(3);
+      const destroyCallsAfterSecond = vi
+        .mocked(mockActions.destroyHiddenWebviews)
+        .mock.calls.filter((c) => c[0] === 2).length;
+      expect(destroyCallsAfterSecond).toBe(1);
+    });
   });
 
   describe("blink memory sampling (issue #6272)", () => {

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -49,6 +49,8 @@ import {
   WARMUP_INTERVALS,
   PRESSURE_COUNT_TIER2,
   MITIGATION_COOLDOWN_MS,
+  RECLAIM_SETTLE_MS,
+  MIN_RECLAIMED_MB,
   recordBlinkSample,
   forgetBlinkSample,
   getBlinkSamples,
@@ -426,11 +428,35 @@ describe("ProcessMemoryMonitor", () => {
       };
     });
 
+    // Helper that mocks getAppMetrics to return `beforeMb` until clearCaches
+    // is called, then returns `afterMb`. Lets each test express the
+    // closed-loop reclamation delta directly.
+    function arrangeClosedLoopMetrics(opts: {
+      beforeMb: number;
+      afterMb: number;
+      pid?: number;
+    }): void {
+      const { beforeMb, afterMb, pid = 100 } = opts;
+      let postMitigation = false;
+      mockGetAppMetrics.mockImplementation(() => {
+        const mb = postMitigation ? afterMb : beforeMb;
+        return [makeMetric("Browser", mb * 1024, pid, mb * 1024)];
+      });
+      mockActions.clearCaches = vi.fn().mockImplementation(async () => {
+        postMitigation = true;
+      });
+    }
+
+    // Advances `n` polls then drives the async mitigation IIFE through its
+    // {@link RECLAIM_SETTLE_MS} settle delay so the re-sample and tier-2
+    // decision run before assertions.
     async function advancePolls(n: number): Promise<void> {
       for (let i = 0; i < n; i++) {
         vi.advanceTimersByTime(30_000);
       }
-      await vi.advanceTimersByTimeAsync(0);
+      // Flush microtasks so the IIFE starts and reaches the settle await,
+      // then advance through the settle delay (also flushes microtasks).
+      await vi.advanceTimersByTimeAsync(RECLAIM_SETTLE_MS);
     }
 
     it("works without actions parameter (backward compat)", () => {
@@ -459,65 +485,106 @@ describe("ProcessMemoryMonitor", () => {
       expect(mockActions.clearCaches).toHaveBeenCalledTimes(1);
     });
 
-    it("does not call hibernateIdleProjects before sustained pressure threshold", async () => {
-      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
+    it("does not escalate to tier 2 when tier 1 reclaims above the minimum", async () => {
+      // Tier 1 frees 100 MB (well above MIN_RECLAIMED_MB), and the post-
+      // settle sample drops below the Browser pressure threshold — both
+      // halves of the AND gate should suppress escalation.
+      arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 250 });
       stop = startAppMetricsMonitor(mockActions);
 
-      // Warmup + pressure count less than tier2
-      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 - 1);
+      await advancePolls(WARMUP_INTERVALS + 1);
 
+      expect(mockActions.clearCaches).toHaveBeenCalledTimes(1);
       expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
+      expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalledWith(2);
     });
 
-    it("calls hibernateIdleProjects after sustained pressure threshold", async () => {
-      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
+    it("escalates to tier 2 when tier 1 reclaims insufficient memory and pressure remains", async () => {
+      // Tier 1 freed only 10 MB (< MIN_RECLAIMED_MB) and pressure persists.
+      arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 340 });
       stop = startAppMetricsMonitor(mockActions);
 
-      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
+      await advancePolls(WARMUP_INTERVALS + 1);
 
       expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
+      expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(2);
     });
 
-    it("resets consecutive pressure count when pressure subsides", async () => {
-      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
+    it("does NOT escalate to tier 2 when post-settle re-sample shows pressure cleared", async () => {
+      // Tier 1 freed only 5 MB (< MIN_RECLAIMED_MB) but pressure dropped
+      // below threshold after the settle window — pressureRemains is false,
+      // so the AND gate suppresses escalation even though delta is small.
+      arrangeClosedLoopMetrics({ beforeMb: 305, afterMb: 295 });
       stop = startAppMetricsMonitor(mockActions);
 
-      // Past warmup + 2 pressure polls
-      await advancePolls(WARMUP_INTERVALS + 2);
-
-      // Drop below threshold
-      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200 * 1024, 100)]);
-      await advancePolls(1);
-
-      // Resume pressure — should restart count from 0
-      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
-      await advancePolls(PRESSURE_COUNT_TIER2 - 1);
+      await advancePolls(WARMUP_INTERVALS + 1);
 
       expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
+      expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalledWith(2);
+    });
+
+    it("logs reclaim delta alongside before/after totals", async () => {
+      arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 250 });
+      stop = startAppMetricsMonitor(mockActions);
+
+      await advancePolls(WARMUP_INTERVALS + 1);
+
+      expect(logInfo).toHaveBeenCalledWith(
+        "memory-pressure-tier1-reclaim",
+        expect.objectContaining({
+          beforeMb: 350,
+          afterMb: 250,
+          deltaMb: 100,
+          pressureRemains: false,
+        })
+      );
+    });
+
+    it("re-samples app.getAppMetrics() only after the settle delay elapses", async () => {
+      arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 250 });
+      stop = startAppMetricsMonitor(mockActions);
+
+      // Advance to the first post-warmup poll and let the IIFE start, but
+      // stop short of the settle delay completing.
+      for (let i = 0; i < WARMUP_INTERVALS + 1; i++) {
+        vi.advanceTimersByTime(30_000);
+      }
+      // Let the IIFE run up to the settle await.
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The reclaim log fires only after the settle delay; nothing yet.
+      expect(logInfo).not.toHaveBeenCalledWith("memory-pressure-tier1-reclaim", expect.any(Object));
+
+      // Advance through the settle delay; now the IIFE completes.
+      await vi.advanceTimersByTimeAsync(RECLAIM_SETTLE_MS);
+
+      expect(logInfo).toHaveBeenCalledWith("memory-pressure-tier1-reclaim", expect.any(Object));
     });
 
     it("respects tier 2 cooldown — no re-trigger within cooldown period", async () => {
-      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
+      // Tier 1 reclaims very little, so tier 2 fires every cycle absent the
+      // cooldown.
+      arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 345 });
       stop = startAppMetricsMonitor(mockActions);
 
-      // Trigger tier 2
-      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
+      // Trigger tier 2 on the first post-warmup pressure poll.
+      await advancePolls(WARMUP_INTERVALS + 1);
       expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
 
-      // Continue pressure — should not trigger again within cooldown
-      await advancePolls(PRESSURE_COUNT_TIER2);
+      // Continue pressure — should not trigger again within cooldown.
+      await advancePolls(3);
       expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
     });
 
     it("allows tier 2 re-trigger after cooldown expires", async () => {
-      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
+      arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 345 });
       stop = startAppMetricsMonitor(mockActions);
 
-      // Trigger tier 2
-      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
+      // Trigger tier 2.
+      await advancePolls(WARMUP_INTERVALS + 1);
       expect(mockActions.hibernateIdleProjects).toHaveBeenCalledTimes(1);
 
-      // Advance past cooldown (keep pressure)
+      // Advance past cooldown (pressure remains, delta remains insufficient).
       const cooldownPolls = Math.ceil(MITIGATION_COOLDOWN_MS / 30_000);
       await advancePolls(cooldownPolls + 1);
 
@@ -525,10 +592,10 @@ describe("ProcessMemoryMonitor", () => {
     });
 
     it("logs tier 1 and tier 2 mitigation events", async () => {
-      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
+      arrangeClosedLoopMetrics({ beforeMb: 350, afterMb: 345 });
       stop = startAppMetricsMonitor(mockActions);
 
-      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
+      await advancePolls(WARMUP_INTERVALS + 1);
 
       expect(logInfo).toHaveBeenCalledWith("memory-pressure-tier1-mitigation", expect.any(Object));
       expect(logInfo).toHaveBeenCalledWith("memory-pressure-tier2-mitigation", expect.any(Object));
@@ -556,10 +623,12 @@ describe("ProcessMemoryMonitor", () => {
         ...mockActions,
         trimPtyHostState,
       };
+      // Default mockActions has clearCaches as a no-op resolver; reclaim
+      // delta stays at 0 so tier 2 should still fire here.
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
       stop = startAppMetricsMonitor(actionsWithTrim);
 
-      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
+      await advancePolls(WARMUP_INTERVALS + 1);
 
       expect(trimPtyHostState).toHaveBeenCalled();
       expect(actionsWithTrim.hibernateIdleProjects).toHaveBeenCalledTimes(1);
@@ -575,10 +644,11 @@ describe("ProcessMemoryMonitor", () => {
     });
 
     it("calls destroyHiddenWebviews(2) on tier 2 mitigation", async () => {
+      // Zero reclamation + pressure remains → tier 2 fires immediately.
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
       stop = startAppMetricsMonitor(mockActions);
 
-      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
+      await advancePolls(WARMUP_INTERVALS + 1);
 
       expect(mockActions.destroyHiddenWebviews).toHaveBeenCalledWith(2);
     });
@@ -595,7 +665,7 @@ describe("ProcessMemoryMonitor", () => {
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 350 * 1024, 100)]);
       stop = startAppMetricsMonitor(mockActions);
 
-      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2);
+      await advancePolls(WARMUP_INTERVALS + 1);
 
       const destroyIdx = callOrder.lastIndexOf("destroyHiddenWebviews");
       const hibernateIdx = callOrder.indexOf("hibernateIdleProjects");
@@ -609,6 +679,18 @@ describe("ProcessMemoryMonitor", () => {
       await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 5);
 
       expect(mockActions.clearCaches).not.toHaveBeenCalled();
+      expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
+    });
+
+    it("escalation gate honors MIN_RECLAIMED_MB at the boundary", async () => {
+      // Reclaim exactly equals MIN_RECLAIMED_MB → the gate `deltaMb <
+      // MIN_RECLAIMED_MB` is false, so no escalation even with pressure
+      // persisting.
+      arrangeClosedLoopMetrics({ beforeMb: 400, afterMb: 400 - MIN_RECLAIMED_MB });
+      stop = startAppMetricsMonitor(mockActions);
+
+      await advancePolls(WARMUP_INTERVALS + 1);
+
       expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
     });
   });

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -36,7 +36,6 @@ import { startAppMetricsMonitor } from "../services/ProcessMemoryMonitor.js";
 
 import { startDiskSpaceMonitor } from "../services/DiskSpaceMonitor.js";
 import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
-import { exposeGc } from "../setup/environment.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { sendToRenderer } from "../ipc/handlers.js";
@@ -421,11 +420,6 @@ export async function initGlobalServices(
               await session.defaultSession.clearStorageData({
                 storages: ["shadercache", "cachestorage"],
               });
-            } catch {
-              /* non-critical */
-            }
-            try {
-              exposeGc?.();
             } catch {
               /* non-critical */
             }


### PR DESCRIPTION
## Summary

- Makes the mitigation ladder in `ProcessMemoryMonitor` closed-loop: snapshots `privateBytes` before tier-1 actions, waits 3 s for OS reclamation to settle, re-measures, and only escalates to tier-2 if pressure remains **and** the delta is below 50 MB. The old blind consecutive-count gate is gone.
- Stamps the tier-2 cooldown before the awaits so a partial failure can't bypass it.
- Drops the forced `gc()` call on every cycle from `globalServicesInit` — V8 manages its own collection.

Resolves #8634

## Changes

- `electron/services/ProcessMemoryMonitor.ts` — added `RECLAIM_SETTLE_MS` (3000) and `MIN_RECLAIMED_MB` (50) constants; snapshot/settle/resample cycle replaces the consecutive-count gate; `memory-pressure-tier1-reclaim` log event records `{beforeMb, afterMb, deltaMb, pressureRemains, resampleFailed}`; resample failure forces `deltaMb = 0` so the ladder still escalates correctly; tier-2 cooldown stamped before any async work.
- `electron/window/globalServicesInit.ts` — removed `exposeGc?.()` call and its import from the `clearCaches` handler. The export in `environment.ts` is untouched.
- `electron/services/__tests__/ProcessMemoryMonitor.test.ts` — tests rewritten around the delta gate with an `arrangeClosedLoopMetrics` helper; new cases cover reclaim logging, settle timing, the 50 MB boundary, pressure-cleared short-circuit, post-sample-throw regression, and partial-tier2-failure cooldown bypass regression.

## Testing

74 `ProcessMemoryMonitor` unit tests pass, plus 10 `globalServicesInit.order` tests. Typecheck clean. Build succeeded.