### PR TITLE
perf(app-protocol): add caching headers so V8 code cache persists

### DIFF
--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -3,7 +3,12 @@ import { getWindowForWebContents, getAppWebContents } from "../window/webContent
 import path from "path";
 import fs from "fs/promises";
 import { pathToFileURL } from "url";
-import { resolveAppUrlToDistPath, getMimeType, buildHeaders } from "../utils/appProtocol.js";
+import {
+  resolveAppUrlToDistPath,
+  getMimeType,
+  buildHeaders,
+  isNotModified,
+} from "../utils/appProtocol.js";
 import {
   classifyPartition,
   getDaintreeAppCSP,
@@ -45,6 +50,29 @@ function createAppProtocolHandler(distPath: string) {
       });
     }
 
+    // V8 code cache in Chromium 146 won't persist bytecode without both a
+    // non-`no-store` Cache-Control AND a validator header. We stat the file
+    // first so the validator and the 304 shortcut are both available — without
+    // the 304 path every reload returns a fresh 200 that invalidates the
+    // bytecode entry. See issue #8624.
+    let stats: Awaited<ReturnType<typeof fs.stat>>;
+    try {
+      stats = await fs.stat(filePath);
+    } catch {
+      return new Response("Not Found", {
+        status: 404,
+        headers: buildHeaders("text/plain"),
+      });
+    }
+
+    const ifModifiedSince = request.headers.get("If-Modified-Since");
+    if (isNotModified(ifModifiedSince, stats.mtime)) {
+      return new Response(null, {
+        status: 304,
+        headers: buildHeaders(getMimeType(filePath), { stats, filePath }),
+      });
+    }
+
     try {
       const fileUrl = pathToFileURL(filePath).toString();
       const response = await net.fetch(fileUrl);
@@ -57,7 +85,7 @@ function createAppProtocolHandler(distPath: string) {
       }
 
       const mimeType = getMimeType(filePath);
-      const headers = buildHeaders(mimeType);
+      const headers = buildHeaders(mimeType, { stats, filePath });
       const buffer = await response.arrayBuffer();
 
       return new Response(buffer, {

--- a/electron/utils/__tests__/appProtocol.test.ts
+++ b/electron/utils/__tests__/appProtocol.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from "vitest";
 import path from "node:path";
-import { resolveAppUrlToDistPath, getMimeType, buildHeaders } from "../appProtocol.js";
+import {
+  resolveAppUrlToDistPath,
+  getMimeType,
+  buildHeaders,
+  isImmutableAppAsset,
+  isNotModified,
+  toHttpDate,
+} from "../appProtocol.js";
 import { DAINTREE_APP_PERMISSIONS_POLICY } from "../../../shared/config/permissionsPolicy.js";
 
 describe("appProtocol utilities", () => {
@@ -54,6 +61,165 @@ describe("appProtocol utilities", () => {
     it("should accept any MIME type", () => {
       const headers = buildHeaders("application/json");
       expect(headers["Content-Type"]).toBe("application/json");
+    });
+
+    it("emits a revalidating Cache-Control by default (never no-store)", () => {
+      const headers = buildHeaders("text/html");
+      expect(headers["Cache-Control"]).toBe("no-cache, must-revalidate");
+      expect(headers["Cache-Control"]).not.toContain("no-store");
+    });
+
+    it("omits Last-Modified when no stats are provided", () => {
+      const headers = buildHeaders("text/html");
+      expect(headers["Last-Modified"]).toBeUndefined();
+    });
+
+    it("emits Last-Modified in RFC 7231 GMT format when stats are provided", () => {
+      const mtime = new Date("2025-06-03T12:34:56.789Z");
+      const headers = buildHeaders("text/html", {
+        stats: { mtime },
+        filePath: "index.html",
+      });
+      expect(headers["Last-Modified"]).toBe("Tue, 03 Jun 2025 12:34:56 GMT");
+    });
+
+    it("emits an immutable Cache-Control for content-hashed Vite assets", () => {
+      const headers = buildHeaders("text/javascript", {
+        stats: { mtime: new Date() },
+        filePath: path.join("dist", "assets", "app-a1b2c3d4.js"),
+      });
+      expect(headers["Cache-Control"]).toBe("public, max-age=31536000, immutable");
+    });
+
+    it("emits an immutable Cache-Control for content-hashed CSS", () => {
+      const headers = buildHeaders("text/css", {
+        stats: { mtime: new Date() },
+        filePath: "dist/assets/styles-A1b2C3d4.css",
+      });
+      expect(headers["Cache-Control"]).toBe("public, max-age=31536000, immutable");
+    });
+
+    it("emits a revalidating Cache-Control for index.html (not content-hashed)", () => {
+      const headers = buildHeaders("text/html", {
+        stats: { mtime: new Date() },
+        filePath: "dist/index.html",
+      });
+      expect(headers["Cache-Control"]).toBe("no-cache, must-revalidate");
+    });
+
+    it("emits a revalidating Cache-Control for unhashed files in dist root", () => {
+      const headers = buildHeaders("text/javascript", {
+        stats: { mtime: new Date() },
+        filePath: "dist/sw.js",
+      });
+      expect(headers["Cache-Control"]).toBe("no-cache, must-revalidate");
+    });
+
+    it("preserves the full security header set on every variant", () => {
+      const variants = [
+        buildHeaders("text/plain"),
+        buildHeaders("text/html", { stats: { mtime: new Date() }, filePath: "index.html" }),
+        buildHeaders("text/javascript", {
+          stats: { mtime: new Date() },
+          filePath: "dist/assets/app-12345678.js",
+        }),
+      ];
+      for (const headers of variants) {
+        expect(headers["Cross-Origin-Opener-Policy"]).toBe("same-origin");
+        expect(headers["Cross-Origin-Embedder-Policy"]).toBe("credentialless");
+        expect(headers["Permissions-Policy"]).toBe(DAINTREE_APP_PERMISSIONS_POLICY);
+        expect(headers["X-Content-Type-Options"]).toBe("nosniff");
+        expect(headers["Cross-Origin-Resource-Policy"]).toBe("same-origin");
+        expect(headers["Cache-Control"]).not.toContain("no-store");
+      }
+    });
+  });
+
+  describe("isImmutableAppAsset", () => {
+    it("matches Vite content-hashed JS chunks under assets/", () => {
+      expect(isImmutableAppAsset("dist/assets/app-a1b2c3d4.js")).toBe(true);
+      expect(isImmutableAppAsset("dist/assets/vendor-react-12345678.js")).toBe(true);
+      expect(isImmutableAppAsset("dist/assets/index-aBcDeFgH.mjs")).toBe(true);
+    });
+
+    it("matches Vite content-hashed CSS chunks under assets/", () => {
+      expect(isImmutableAppAsset("dist/assets/index-12345678.css")).toBe(true);
+    });
+
+    it("matches base64url hash characters (underscore, hyphen)", () => {
+      expect(isImmutableAppAsset("dist/assets/app-aB_d-FgH.js")).toBe(true);
+    });
+
+    it("matches longer hashes (>=8 chars)", () => {
+      expect(isImmutableAppAsset("dist/assets/app-a1b2c3d4e5f6.js")).toBe(true);
+    });
+
+    it("matches Windows-style backslash paths", () => {
+      expect(isImmutableAppAsset("dist\\assets\\app-a1b2c3d4.js")).toBe(true);
+    });
+
+    it("does not match index.html at the dist root", () => {
+      expect(isImmutableAppAsset("dist/index.html")).toBe(false);
+    });
+
+    it("does not match unhashed files in assets/", () => {
+      expect(isImmutableAppAsset("dist/assets/app.js")).toBe(false);
+      expect(isImmutableAppAsset("dist/assets/logo.svg")).toBe(false);
+    });
+
+    it("does not match files with a too-short hash", () => {
+      expect(isImmutableAppAsset("dist/assets/app-abc12.js")).toBe(false);
+    });
+
+    it("does not match files outside the assets/ directory", () => {
+      expect(isImmutableAppAsset("dist/sw-12345678.js")).toBe(false);
+      expect(isImmutableAppAsset("dist/nested/file-12345678.js")).toBe(false);
+    });
+
+    it("does not match nested paths under assets/ (Vite output is flat)", () => {
+      expect(isImmutableAppAsset("dist/assets/sub/file-12345678.js")).toBe(false);
+    });
+  });
+
+  describe("toHttpDate", () => {
+    it("formats dates in RFC 7231 IMF-fixdate (second precision, GMT)", () => {
+      expect(toHttpDate(new Date("2025-01-01T00:00:00Z"))).toBe("Wed, 01 Jan 2025 00:00:00 GMT");
+      expect(toHttpDate(new Date("2025-06-03T12:34:56.789Z"))).toBe(
+        "Tue, 03 Jun 2025 12:34:56 GMT"
+      );
+    });
+  });
+
+  describe("isNotModified", () => {
+    const mtime = new Date("2025-06-03T12:34:56.000Z");
+
+    it("returns false when the header is null", () => {
+      expect(isNotModified(null, mtime)).toBe(false);
+    });
+
+    it("returns false when the header is malformed", () => {
+      expect(isNotModified("not-a-date", mtime)).toBe(false);
+    });
+
+    it("returns true when the client date equals mtime", () => {
+      expect(isNotModified("Tue, 03 Jun 2025 12:34:56 GMT", mtime)).toBe(true);
+    });
+
+    it("returns true when the client date is newer than mtime", () => {
+      expect(isNotModified("Wed, 04 Jun 2025 00:00:00 GMT", mtime)).toBe(true);
+    });
+
+    it("returns false when mtime is newer than the client date", () => {
+      expect(isNotModified("Tue, 03 Jun 2025 12:34:55 GMT", mtime)).toBe(false);
+    });
+
+    it("normalizes sub-second mtime to seconds (matches header second-precision)", () => {
+      const subSecondMtime = new Date("2025-06-03T12:34:56.700Z");
+      expect(isNotModified("Tue, 03 Jun 2025 12:34:56 GMT", subSecondMtime)).toBe(true);
+    });
+
+    it("returns false on an empty string header", () => {
+      expect(isNotModified("", mtime)).toBe(false);
     });
   });
 

--- a/electron/utils/__tests__/appProtocol.test.ts
+++ b/electron/utils/__tests__/appProtocol.test.ts
@@ -23,6 +23,7 @@ describe("appProtocol utilities", () => {
       expect(getMimeType("module.wasm")).toBe("application/wasm");
       expect(getMimeType("photo.webp")).toBe("image/webp");
       expect(getMimeType("image.bmp")).toBe("image/bmp");
+      expect(getMimeType("hero.avif")).toBe("image/avif");
     });
 
     it("should return default MIME type for unknown extensions", () => {
@@ -115,6 +116,24 @@ describe("appProtocol utilities", () => {
       expect(headers["Cache-Control"]).toBe("no-cache, must-revalidate");
     });
 
+    it("always emits Last-Modified when stats are provided (304 path contract)", () => {
+      const mtime = new Date("2025-06-03T12:34:56Z");
+      const variants = [
+        buildHeaders("text/html", { stats: { mtime }, filePath: "index.html" }),
+        buildHeaders("text/javascript", {
+          stats: { mtime },
+          filePath: "dist/assets/app-12345678.js",
+        }),
+        buildHeaders("text/css", {
+          stats: { mtime },
+          filePath: "dist/assets/styles-12345678.css",
+        }),
+      ];
+      for (const headers of variants) {
+        expect(headers["Last-Modified"]).toBe("Tue, 03 Jun 2025 12:34:56 GMT");
+      }
+    });
+
     it("preserves the full security header set on every variant", () => {
       const variants = [
         buildHeaders("text/plain"),
@@ -144,6 +163,10 @@ describe("appProtocol utilities", () => {
 
     it("matches Vite content-hashed CSS chunks under assets/", () => {
       expect(isImmutableAppAsset("dist/assets/index-12345678.css")).toBe(true);
+    });
+
+    it("matches content-hashed AVIF images (paired with image/avif MIME)", () => {
+      expect(isImmutableAppAsset("dist/assets/hero-a1b2c3d4.avif")).toBe(true);
     });
 
     it("matches base64url hash characters (underscore, hyphen)", () => {

--- a/electron/utils/appProtocol.ts
+++ b/electron/utils/appProtocol.ts
@@ -40,6 +40,7 @@ const MIME_TYPES: Record<string, string> = {
   ".svg": "image/svg+xml",
   ".ico": "image/x-icon",
   ".webp": "image/webp",
+  ".avif": "image/avif",
   ".bmp": "image/bmp",
   ".woff": "font/woff",
   ".woff2": "font/woff2",

--- a/electron/utils/appProtocol.ts
+++ b/electron/utils/appProtocol.ts
@@ -9,7 +9,24 @@ export interface AppProtocolHeaders extends Record<string, string> {
   "Permissions-Policy": string;
   "X-Content-Type-Options": string;
   "Cross-Origin-Resource-Policy": string;
+  "Cache-Control": string;
 }
+
+export interface BuildHeadersOptions {
+  stats?: { mtime: Date };
+  filePath?: string;
+}
+
+const ONE_YEAR_SECONDS = 31_536_000;
+const IMMUTABLE_DIRECTIVE = `public, max-age=${ONE_YEAR_SECONDS}, immutable`;
+const REVALIDATE_DIRECTIVE = "no-cache, must-revalidate";
+
+// Vite content-hashed assets live under `assets/` as `<name>-<hash>.<ext>`. The
+// hash is 8+ URL-safe characters — covers Vite's default 8-char hex and
+// rolldown's 8-char xxHash base64url. Files outside `assets/` (e.g.
+// `index.html`) are not fingerprinted and must revalidate.
+const IMMUTABLE_ASSET_RE =
+  /(?:^|[/\\])assets[/\\][^/\\]+-[A-Za-z0-9_-]{8,}\.(?:js|mjs|css|map|woff2?|ttf|otf|eot|png|svg|webp|gif|jpe?g|ico|bmp|wasm|avif)$/i;
 
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html",
@@ -39,15 +56,53 @@ export function getMimeType(filePath: string): string {
   return MIME_TYPES[ext] || "application/octet-stream";
 }
 
-export function buildHeaders(mimeType: string): AppProtocolHeaders {
-  return {
+export function isImmutableAppAsset(filePath: string): boolean {
+  return IMMUTABLE_ASSET_RE.test(filePath);
+}
+
+export function toHttpDate(date: Date): string {
+  return date.toUTCString();
+}
+
+// Returns true when the client's If-Modified-Since timestamp is at or after the
+// file's mtime — the server should respond 304. HTTP dates have whole-second
+// precision; we floor both sides to seconds to avoid false 200s from sub-second
+// filesystem mtimes (e.g. 12:34:56.700 vs the 12:34:56 header).
+export function isNotModified(headerValue: string | null, mtime: Date): boolean {
+  if (!headerValue) return false;
+  const parsedMs = Date.parse(headerValue);
+  if (Number.isNaN(parsedMs)) return false;
+  const mtimeSec = Math.floor(mtime.getTime() / 1000);
+  const parsedSec = Math.floor(parsedMs / 1000);
+  return mtimeSec <= parsedSec;
+}
+
+export function buildHeaders(
+  mimeType: string,
+  options: BuildHeadersOptions = {}
+): AppProtocolHeaders {
+  const { stats, filePath } = options;
+  // V8 code cache persistence in Chromium requires both a non-`no-store`
+  // Cache-Control AND a validator header (Last-Modified or ETag). Without
+  // either, the renderer recompiles every cold launch. See issue #8624.
+  const cacheControl =
+    filePath && isImmutableAppAsset(filePath) ? IMMUTABLE_DIRECTIVE : REVALIDATE_DIRECTIVE;
+
+  const headers: AppProtocolHeaders = {
     "Content-Type": mimeType,
     "Cross-Origin-Opener-Policy": "same-origin",
     "Cross-Origin-Embedder-Policy": "credentialless",
     "Permissions-Policy": DAINTREE_APP_PERMISSIONS_POLICY,
     "X-Content-Type-Options": "nosniff",
     "Cross-Origin-Resource-Policy": "same-origin",
+    "Cache-Control": cacheControl,
   };
+
+  if (stats) {
+    headers["Last-Modified"] = toHttpDate(stats.mtime);
+  }
+
+  return headers;
 }
 
 export function resolveAppUrlToDistPath(


### PR DESCRIPTION
## Summary

- `app://` custom protocol handler wasn't emitting any caching headers, so Chromium never wrote the V8 code cache to disk -- it was compiled from scratch on every cold launch
- Adds `Cache-Control`, `Last-Modified`, and `304` conditional response support to the `app://` handler; content-hashed Vite assets (`*-[hash].js` / `.css` / `.avif` etc.) get `immutable`, `index.html` and other unhashed files get `no-cache,must-revalidate`
- `daintree-file://` handler is left untouched -- it already carries `no-store`, which is correct for mutable user files

Resolves #8624

## Changes

- `electron/utils/appProtocol.ts` -- `buildHeaders()` now emits `Cache-Control` and `Last-Modified`; handler returns `304` on a matching `If-Modified-Since`
- `electron/setup/protocols.ts` -- wires the updated header builder through the protocol registration path
- `electron/utils/__tests__/appProtocol.test.ts` -- covers immutable vs revalidate path selection, `304` short-circuit, and `avif` MIME pairing

## Testing

Unit tests added for all new cache-header paths. The win is observable at runtime: after the fix, `<userData>/Partitions/daintree/Code Cache/js/` populates on first launch and is reused on the second, with a measurable drop in `RENDERER_READY` / `HYDRATE_*` perf marks on launch 2+.