### PR TITLE
fix(perf): correct cold-start harness reporting (#8612)

### DIFF
--- a/scripts/perf/__tests__/coldStartAggregate.test.ts
+++ b/scripts/perf/__tests__/coldStartAggregate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { aggregate, type RunData } from "../lib/coldStartAggregate";
+import { aggregate, normalizeLoafSourceURL, type RunData } from "../lib/coldStartAggregate";
 import { PERF_MARKS } from "../../../shared/perf/marks";
 
 function makeRun(overrides: Partial<RunData>): RunData {
@@ -276,5 +276,159 @@ describe("cold-start aggregate", () => {
     // Degraded run's APP_BOOT_START is not visited for marks/osToAppBoot.
     expect(agg.osToAppBoot).toBeNull();
     expect(agg.marks[PERF_MARKS.RENDERER_READY]).toBeDefined();
+  });
+});
+
+describe("normalizeLoafSourceURL", () => {
+  it("strips 8-char lowercase hex Vite hash suffix before .js", () => {
+    expect(normalizeLoafSourceURL("app://./assets/vendor-xterm-BcD3kf9a.js")).toBe(
+      "app://./assets/vendor-xterm.js"
+    );
+    expect(normalizeLoafSourceURL("app://./assets/index-a1b2c3d4.js")).toBe(
+      "app://./assets/index.js"
+    );
+  });
+
+  it("strips hashes that include uppercase hex chars (case-insensitive)", () => {
+    expect(normalizeLoafSourceURL("app://./assets/vendor-react-ABCDEF12.js")).toBe(
+      "app://./assets/vendor-react.js"
+    );
+  });
+
+  it("strips hashes from .css chunks too", () => {
+    expect(normalizeLoafSourceURL("app://./assets/styles-deadbeef.css")).toBe(
+      "app://./assets/styles.css"
+    );
+  });
+
+  it("preserves query strings while stripping the hash", () => {
+    expect(normalizeLoafSourceURL("app://./assets/index-a1b2c3d4.js?v=1")).toBe(
+      "app://./assets/index.js?v=1"
+    );
+  });
+
+  it("does not modify URLs without a recognizable 8-char hash", () => {
+    // Short fake hash (3 chars) — does not match the 8-char pattern, passes through.
+    expect(normalizeLoafSourceURL("app://./assets/vendor-react-abc.js")).toBe(
+      "app://./assets/vendor-react-abc.js"
+    );
+    // No hash at all.
+    expect(normalizeLoafSourceURL("app://./assets/index.js")).toBe("app://./assets/index.js");
+    // Unknown sentinel.
+    expect(normalizeLoafSourceURL("<unknown>")).toBe("<unknown>");
+    // Empty string passes through.
+    expect(normalizeLoafSourceURL("")).toBe("");
+  });
+
+  it("only strips the trailing hash, not hash-like substrings elsewhere in the path", () => {
+    expect(normalizeLoafSourceURL("app://./assets/abcdef12/index.js")).toBe(
+      "app://./assets/abcdef12/index.js"
+    );
+  });
+});
+
+describe("LoAF aggregation with build-hash normalization", () => {
+  it("merges chunks from different builds with same logical name", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          {
+            mark: "renderer_long_animation_frame",
+            timestamp: "t",
+            elapsedMs: 100,
+            meta: {
+              blockingDurationMs: 50,
+              topScripts: [{ sourceURL: "app://./assets/vendor-xterm-BcD3kf9a.js" }],
+            },
+          },
+          {
+            mark: "renderer_long_animation_frame",
+            timestamp: "t",
+            elapsedMs: 200,
+            meta: {
+              blockingDurationMs: 70,
+              topScripts: [{ sourceURL: "app://./assets/vendor-xterm-Ef5g6h7i.js" }],
+            },
+          },
+        ],
+      }),
+    ]);
+
+    expect(Object.keys(agg.loaf)).toEqual(["app://./assets/vendor-xterm.js"]);
+    expect(agg.loaf["app://./assets/vendor-xterm.js"].frames).toBe(2);
+    expect(agg.loaf["app://./assets/vendor-xterm.js"].totalBlockingMs).toBe(120);
+  });
+});
+
+describe("event_loop_lag aggregation", () => {
+  it("aggregates lagMs samples into samples/p50/p95/mean/max/total", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          { mark: "event_loop_lag", timestamp: "t", elapsedMs: 6000, meta: { lagMs: 120 } },
+          { mark: "event_loop_lag", timestamp: "t", elapsedMs: 7000, meta: { lagMs: 250 } },
+          { mark: "event_loop_lag", timestamp: "t", elapsedMs: 8000, meta: { lagMs: 180 } },
+        ],
+      }),
+    ]);
+
+    expect(agg.eventLoopLag).not.toBeNull();
+    expect(agg.eventLoopLag!.samples).toBe(3);
+    expect(agg.eventLoopLag!.maxMs).toBe(250);
+    expect(agg.eventLoopLag!.totalAccumulatedMs).toBe(550);
+    expect(agg.eventLoopLag!.meanMs).toBeCloseTo(550 / 3, 3);
+  });
+
+  it("returns null eventLoopLag when no samples are present", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          { mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 },
+          { mark: PERF_MARKS.RENDERER_READY, timestamp: "t", elapsedMs: 500 },
+        ],
+      }),
+    ]);
+
+    expect(agg.eventLoopLag).toBeNull();
+  });
+
+  it("skips event_loop_lag records with malformed meta.lagMs", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          { mark: "event_loop_lag", timestamp: "t", elapsedMs: 6000, meta: { lagMs: Number.NaN } },
+          {
+            mark: "event_loop_lag",
+            timestamp: "t",
+            elapsedMs: 7000,
+            meta: { lagMs: Number.POSITIVE_INFINITY },
+          },
+          { mark: "event_loop_lag", timestamp: "t", elapsedMs: 8000, meta: { lagMs: "200" } },
+          { mark: "event_loop_lag", timestamp: "t", elapsedMs: 9000, meta: {} },
+          { mark: "event_loop_lag", timestamp: "t", elapsedMs: 10000, meta: { lagMs: 150 } },
+          { mark: "event_loop_lag", timestamp: "t", elapsedMs: 11000, meta: { lagMs: -5 } },
+        ],
+      }),
+    ]);
+
+    expect(agg.eventLoopLag).not.toBeNull();
+    expect(agg.eventLoopLag!.samples).toBe(1);
+    expect(agg.eventLoopLag!.maxMs).toBe(150);
+  });
+
+  it("excludes event_loop_lag from the generic marks bucket", () => {
+    // Without the dedicated bucket, the generic markElapsed loop would record
+    // event_loop_lag.elapsedMs (since-boot timestamp) into agg.marks — which
+    // tells us nothing about lag severity. Confirm we suppress it.
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          { mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 },
+          { mark: "event_loop_lag", timestamp: "t", elapsedMs: 6000, meta: { lagMs: 150 } },
+        ],
+      }),
+    ]);
+
+    expect(agg.marks["event_loop_lag"]).toBeUndefined();
   });
 });

--- a/scripts/perf/__tests__/coldStartAggregate.test.ts
+++ b/scripts/perf/__tests__/coldStartAggregate.test.ts
@@ -416,6 +416,75 @@ describe("event_loop_lag aggregation", () => {
     expect(agg.eventLoopLag!.maxMs).toBe(150);
   });
 
+  it("rejects negative blockingDurationMs without poisoning totals", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          {
+            mark: "renderer_long_animation_frame",
+            timestamp: "t",
+            elapsedMs: 100,
+            meta: {
+              blockingDurationMs: -100,
+              topScripts: [{ sourceURL: "app://./assets/x.js" }],
+            },
+          },
+          {
+            mark: "renderer_long_animation_frame",
+            timestamp: "t",
+            elapsedMs: 200,
+            meta: {
+              blockingDurationMs: 50,
+              topScripts: [{ sourceURL: "app://./assets/x.js" }],
+            },
+          },
+        ],
+      }),
+    ]);
+
+    expect(agg.loaf["app://./assets/x.js"].totalBlockingMs).toBe(50);
+    expect(agg.loaf["app://./assets/x.js"].totalBlockingMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("skips marks with non-finite or negative elapsedMs so they don't poison p50/p95", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          // Cast through unknown so we can simulate malformed NDJSON.
+          {
+            mark: PERF_MARKS.HYDRATE_COMPLETE,
+            timestamp: "t",
+            elapsedMs: Number.NaN as unknown as number,
+          },
+          {
+            mark: PERF_MARKS.HYDRATE_COMPLETE,
+            timestamp: "t",
+            elapsedMs: 500,
+          },
+        ],
+      }),
+      makeRun({
+        marks: [
+          {
+            mark: PERF_MARKS.HYDRATE_COMPLETE,
+            timestamp: "t",
+            elapsedMs: -50,
+          },
+          {
+            mark: PERF_MARKS.HYDRATE_COMPLETE,
+            timestamp: "t",
+            elapsedMs: 700,
+          },
+        ],
+      }),
+    ]);
+
+    const stats = agg.marks[PERF_MARKS.HYDRATE_COMPLETE];
+    expect(stats.runs).toBe(2);
+    expect(Number.isFinite(stats.meanMs)).toBe(true);
+    expect(stats.meanMs).toBe(600);
+  });
+
   it("excludes event_loop_lag from the generic marks bucket", () => {
     // Without the dedicated bucket, the generic markElapsed loop would record
     // event_loop_lag.elapsedMs (since-boot timestamp) into agg.marks — which

--- a/scripts/perf/__tests__/parseBootDuration.test.ts
+++ b/scripts/perf/__tests__/parseBootDuration.test.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parseBootDuration } from "../lib/packagedLaunch";
+import { PERF_MARKS } from "../../../shared/perf/marks";
+
+interface MarkLine {
+  mark: string;
+  timestamp: string;
+  elapsedMs: number;
+  meta?: Record<string, unknown>;
+}
+
+function writeNdjson(lines: MarkLine[]): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "perf-boot-"));
+  const file = path.join(dir, "perf-metrics.ndjson");
+  fs.writeFileSync(file, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  return file;
+}
+
+describe("parseBootDuration", () => {
+  const tmpFiles: string[] = [];
+
+  beforeEach(() => {
+    tmpFiles.length = 0;
+  });
+
+  afterEach(() => {
+    for (const file of tmpFiles) {
+      try {
+        fs.rmSync(path.dirname(file), { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    }
+  });
+
+  it("uses RENDERER_FIRST_INTERACTIVE elapsedMs minus APP_BOOT_START elapsedMs as the headline duration", () => {
+    const file = writeNdjson([
+      { mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 },
+      { mark: PERF_MARKS.RENDERER_READY, timestamp: "t", elapsedMs: 800 },
+      { mark: PERF_MARKS.RENDERER_FIRST_INTERACTIVE, timestamp: "t", elapsedMs: 1200 },
+    ]);
+    tmpFiles.push(file);
+
+    const result = parseBootDuration(file);
+
+    expect(result.durationMs).toBe(1200);
+    expect(result.metrics.rendererReadyMs).toBe(800);
+    expect(result.degraded).toBeUndefined();
+  });
+
+  it("falls back to RENDERER_READY with a degraded note when FIRST_INTERACTIVE is missing", () => {
+    const file = writeNdjson([
+      { mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 },
+      { mark: PERF_MARKS.RENDERER_READY, timestamp: "t", elapsedMs: 800 },
+    ]);
+    tmpFiles.push(file);
+
+    const result = parseBootDuration(file);
+
+    expect(result.durationMs).toBe(800);
+    expect(result.degraded).toContain("FIRST_INTERACTIVE");
+    expect(result.metrics.rendererReadyMs).toBe(800);
+  });
+
+  it("returns -1 when both RENDERER_READY and RENDERER_FIRST_INTERACTIVE are missing", () => {
+    const file = writeNdjson([{ mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 }]);
+    tmpFiles.push(file);
+
+    const result = parseBootDuration(file);
+
+    expect(result.durationMs).toBe(-1);
+  });
+
+  it("returns -1 when APP_BOOT_START is missing", () => {
+    const file = writeNdjson([
+      { mark: PERF_MARKS.RENDERER_READY, timestamp: "t", elapsedMs: 800 },
+      { mark: PERF_MARKS.RENDERER_FIRST_INTERACTIVE, timestamp: "t", elapsedMs: 1200 },
+    ]);
+    tmpFiles.push(file);
+
+    const result = parseBootDuration(file);
+
+    expect(result.durationMs).toBe(-1);
+  });
+
+  it("returns -1 when the ndjson file does not exist", () => {
+    const result = parseBootDuration(path.join(os.tmpdir(), "definitely-missing-perf.ndjson"));
+    expect(result.durationMs).toBe(-1);
+  });
+
+  it("populates serviceInitMs and hydrateMs metrics when those phase marks exist", () => {
+    const file = writeNdjson([
+      { mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 },
+      { mark: PERF_MARKS.SERVICE_INIT_START, timestamp: "t", elapsedMs: 100 },
+      { mark: PERF_MARKS.SERVICE_INIT_COMPLETE, timestamp: "t", elapsedMs: 400 },
+      { mark: PERF_MARKS.HYDRATE_START, timestamp: "t", elapsedMs: 500 },
+      { mark: PERF_MARKS.HYDRATE_COMPLETE, timestamp: "t", elapsedMs: 900 },
+      { mark: PERF_MARKS.RENDERER_FIRST_INTERACTIVE, timestamp: "t", elapsedMs: 1200 },
+    ]);
+    tmpFiles.push(file);
+
+    const result = parseBootDuration(file);
+
+    expect(result.metrics.serviceInitMs).toBe(300);
+    expect(result.metrics.hydrateMs).toBe(400);
+    expect(result.durationMs).toBe(1200);
+  });
+});

--- a/scripts/perf/__tests__/parseBootDuration.test.ts
+++ b/scripts/perf/__tests__/parseBootDuration.test.ts
@@ -91,6 +91,22 @@ describe("parseBootDuration", () => {
     expect(result.durationMs).toBe(-1);
   });
 
+  it("uses the first occurrence of a duplicate mark (first-wins), matching aggregate semantics", () => {
+    // RENDERER_FIRST_INTERACTIVE has an idempotency guard in the renderer,
+    // but if it somehow appeared twice we must take the first value to stay
+    // consistent with aggregate()'s firstByMark policy.
+    const file = writeNdjson([
+      { mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 },
+      { mark: PERF_MARKS.RENDERER_FIRST_INTERACTIVE, timestamp: "t", elapsedMs: 1200 },
+      { mark: PERF_MARKS.RENDERER_FIRST_INTERACTIVE, timestamp: "t", elapsedMs: 9000 },
+    ]);
+    tmpFiles.push(file);
+
+    const result = parseBootDuration(file);
+
+    expect(result.durationMs).toBe(1200);
+  });
+
   it("populates serviceInitMs and hydrateMs metrics when those phase marks exist", () => {
     const file = writeNdjson([
       { mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 },

--- a/scripts/perf/cold-start.ts
+++ b/scripts/perf/cold-start.ts
@@ -14,6 +14,17 @@ import {
   type RunData,
 } from "./lib/coldStartAggregate";
 
+// p95 from a tiny sample interpolates between rank n-2 and rank n-1, which is
+// effectively the maximum. With n=5 the rank is 3.8 (80% of max + 20% of #4):
+// statistically meaningless. Suppress the p95 cell in the text report until we
+// have enough samples for the interpolation to land between non-extreme ranks.
+// The raw value is still emitted in --json output for machine consumers.
+const MIN_SAMPLES_FOR_P95 = 20;
+
+function formatP95(stats: { runs: number; p95Ms: number }): string {
+  return stats.runs < MIN_SAMPLES_FOR_P95 ? "n/a (<20 runs)" : formatMs(stats.p95Ms);
+}
+
 interface JsonOutput {
   runs: Array<{
     index: number;
@@ -103,7 +114,7 @@ function renderTextReport(
       phase: label,
       runs: String(stats.runs),
       p50: formatMs(stats.p50Ms),
-      p95: formatMs(stats.p95Ms),
+      p95: formatP95(stats),
       mean: formatMs(stats.meanMs),
       stdDev: formatMs(stats.stdDevMs),
     }));
@@ -120,7 +131,7 @@ function renderTextReport(
       mark: name,
       runs: String(stats.runs),
       p50: formatMs(stats.p50Ms),
-      p95: formatMs(stats.p95Ms),
+      p95: formatP95(stats),
       mean: formatMs(stats.meanMs),
     }));
 
@@ -136,7 +147,7 @@ function renderTextReport(
       channel,
       samples: String(stats.samples),
       p50: formatMs(stats.p50Ms),
-      p95: formatMs(stats.p95Ms),
+      p95: formatP95(stats),
       mean: formatMs(stats.meanMs),
       errors: stats.errorCount > 0 ? String(stats.errorCount) : "",
     }));
@@ -158,7 +169,7 @@ function renderTextReport(
       source: sourceURL,
       frames: String(stats.frames),
       p50: formatMs(stats.p50BlockingMs),
-      p95: formatMs(stats.p95BlockingMs),
+      p95: stats.frames < MIN_SAMPLES_FOR_P95 ? "n/a (<20 frames)" : formatMs(stats.p95BlockingMs),
       total: formatMs(stats.totalBlockingMs),
       warn:
         stats.p95BlockingMs > LOAF_SOURCE_P95_WARN_MS ||
@@ -219,15 +230,19 @@ function renderTextReport(
     const warnMs = OS_TO_APP_BOOT_WARN_MS[platform];
     const exceeds = warnMs !== undefined && agg.osToAppBoot.p95Ms > warnMs;
     const warnLabel = warnMs !== undefined ? `warn p95 > ${warnMs}ms` : "no warn threshold";
+    const osBootRunsCount = agg.osToAppBoot.runs;
     lines.push(`OS-to-app-boot wall-clock — ${platform} (${warnLabel}, warn-only)`);
     lines.push(
       formatTable(
         [
           {
             metric: "os_to_app_boot",
-            runs: String(agg.osToAppBoot.runs),
+            runs: String(osBootRunsCount),
             p50: formatMs(agg.osToAppBoot.p50Ms),
-            p95: formatMs(agg.osToAppBoot.p95Ms),
+            p95:
+              osBootRunsCount < MIN_SAMPLES_FOR_P95
+                ? "n/a (<20 runs)"
+                : formatMs(agg.osToAppBoot.p95Ms),
             mean: formatMs(agg.osToAppBoot.meanMs),
             max: formatMs(agg.osToAppBoot.maxMs),
             warn: exceeds ? "⚠" : "",
@@ -242,6 +257,36 @@ function renderTextReport(
         `::warning::os_to_app_boot_ms p95 ${agg.osToAppBoot.p95Ms}ms exceeds warn-only threshold ${warnMs}ms on ${platform}`
       );
     }
+  }
+
+  if (agg.eventLoopLag) {
+    const lagSamples = agg.eventLoopLag.samples;
+    lines.push(
+      "Event-loop lag (samples emitted only when lag ≥ 100ms after the 5s startup-suppression window)"
+    );
+    lines.push(
+      formatTable(
+        [
+          {
+            metric: "event_loop_lag",
+            samples: String(lagSamples),
+            p50: formatMs(agg.eventLoopLag.p50Ms),
+            p95:
+              lagSamples < MIN_SAMPLES_FOR_P95
+                ? "n/a (<20 samples)"
+                : formatMs(agg.eventLoopLag.p95Ms),
+            mean: formatMs(agg.eventLoopLag.meanMs),
+            max: formatMs(agg.eventLoopLag.maxMs),
+            total: formatMs(agg.eventLoopLag.totalAccumulatedMs),
+          },
+        ],
+        ["metric", "samples", "p50", "p95", "mean", "max", "total"]
+      )
+    );
+    lines.push("");
+  } else {
+    lines.push("Event-loop lag: no samples captured (no stalls ≥ 100ms past startup window)");
+    lines.push("");
   }
 
   return lines.join("\n");
@@ -333,13 +378,15 @@ Requires a packaged binary under release/. Build one first with:
     try {
       const result = await launchPackagedAndMeasure(executablePath, i, { projectRoot });
       const marks = parseNdjson(result.ndjsonPath);
-      const degraded = Boolean(result.notes);
+      // Only true-degraded runs (wall-clock fallback) are excluded from
+      // mark/phase aggregates. A run that fell back from FI → RR still has
+      // valid marks; its `notes` is set but `degraded` is false.
       results.push({
         index: i,
         durationMs: result.durationMs,
         notes: result.notes,
         marks,
-        degraded,
+        degraded: Boolean(result.degraded),
       });
 
       if (!asJson) {

--- a/scripts/perf/lib/coldStartAggregate.ts
+++ b/scripts/perf/lib/coldStartAggregate.ts
@@ -187,9 +187,13 @@ export function aggregate(runs: RunData[]): Aggregate {
         const sourceURL = normalizeLoafSourceURL(rawSourceURL);
         // `typeof NaN === "number"` is true, so a malformed mark could poison
         // mean/percentile stats. `Number.isFinite` excludes NaN and ±Infinity.
+        // Negatives are clamped to 0 — a real LoAF entry cannot block for a
+        // negative duration; a negative value means malformed meta.
         const rawBlocking = record.meta?.blockingDurationMs;
         const blockingMs =
-          typeof rawBlocking === "number" && Number.isFinite(rawBlocking) ? rawBlocking : 0;
+          typeof rawBlocking === "number" && Number.isFinite(rawBlocking) && rawBlocking >= 0
+            ? rawBlocking
+            : 0;
         const list = loafBySource.get(sourceURL) ?? [];
         list.push(blockingMs);
         loafBySource.set(sourceURL, list);
@@ -213,6 +217,16 @@ export function aggregate(runs: RunData[]): Aggregate {
       }
 
       if (!firstByMark.has(record.mark)) {
+        // Skip malformed records: elapsedMs must be a finite non-negative
+        // number to participate in p50/p95 stats. A null/NaN/string from a
+        // mid-write would otherwise poison the bucket.
+        if (
+          typeof record.elapsedMs !== "number" ||
+          !Number.isFinite(record.elapsedMs) ||
+          record.elapsedMs < 0
+        ) {
+          continue;
+        }
         firstByMark.set(record.mark, record);
         const list = markElapsed.get(record.mark) ?? [];
         list.push(record.elapsedMs);

--- a/scripts/perf/lib/coldStartAggregate.ts
+++ b/scripts/perf/lib/coldStartAggregate.ts
@@ -55,6 +55,15 @@ export interface OsToAppBootStats {
   maxMs: number;
 }
 
+export interface EventLoopLagStats {
+  samples: number;
+  p50Ms: number;
+  p95Ms: number;
+  meanMs: number;
+  maxMs: number;
+  totalAccumulatedMs: number;
+}
+
 export interface Aggregate {
   marks: Record<string, MarkStats>;
   phaseDurations: Record<string, MarkStats>;
@@ -62,11 +71,30 @@ export interface Aggregate {
   loaf: Record<string, LoafSourceStats>;
   cls: ClsStats | null;
   osToAppBoot: OsToAppBootStats | null;
+  eventLoopLag: EventLoopLagStats | null;
+}
+
+// Vite/Rolldown default chunkFileNames is `[name]-[hash].js`. The hash is 8
+// chars by default and uses one of the supported alphabets — `base64`
+// (URL-safe: A-Z, a-z, 0-9, _, -), `base36` (a-z, 0-9), or `hex` (a-f, 0-9).
+// We accept the union so we don't have to special-case the build mode. The
+// lookahead anchors at the file extension so we only ever strip the trailing
+// hash, never a hash-shaped substring elsewhere in the path. Query strings
+// are preserved. Without normalization, every rebuild rotates the LoAF
+// source key and prevents build-to-build comparison.
+const LOAF_VITE_HASH_RE = /-[A-Za-z0-9_-]{8}(?=\.(?:js|css)(?:\?.*)?$)/;
+
+export function normalizeLoafSourceURL(sourceURL: string): string {
+  if (!sourceURL) return sourceURL;
+  return sourceURL.replace(LOAF_VITE_HASH_RE, "");
 }
 
 export const PHASE_PAIRS: Array<[string, string, string]> = [
-  [PERF_MARKS.APP_BOOT_START, PERF_MARKS.RENDERER_READY, "boot → renderer_ready"],
+  // Headline metric: boot → first_interactive. This is what users perceive as
+  // "the app is usable". renderer_ready (DOM did-finish-load, pre-hydration)
+  // is kept as a sub-phase signal to distinguish hydration cost.
   [PERF_MARKS.APP_BOOT_START, PERF_MARKS.RENDERER_FIRST_INTERACTIVE, "boot → first_interactive"],
+  [PERF_MARKS.APP_BOOT_START, PERF_MARKS.RENDERER_READY, "boot → renderer_ready (pre-hydration)"],
   [PERF_MARKS.SERVICE_INIT_START, PERF_MARKS.SERVICE_INIT_COMPLETE, "service_init"],
   [PERF_MARKS.HYDRATE_START, PERF_MARKS.HYDRATE_COMPLETE, "hydrate"],
   [
@@ -111,6 +139,7 @@ export function aggregate(runs: RunData[]): Aggregate {
   const loafBySource = new Map<string, number[]>();
   const clsValuesPerRun: number[] = [];
   const osToAppBootValues: number[] = [];
+  const eventLoopLagValues: number[] = [];
 
   for (const run of successful) {
     for (const record of run.marks) {
@@ -134,16 +163,28 @@ export function aggregate(runs: RunData[]): Aggregate {
     for (const record of run.marks) {
       if (record.mark === "ipc_request_sample") continue;
 
+      // event_loop_lag carries the lag amount in meta.lagMs (not elapsedMs).
+      // We bucket the lag values directly and skip the generic markElapsed
+      // path, since elapsedMs-since-boot tells us nothing about lag severity.
+      if (record.mark === "event_loop_lag") {
+        const rawLag = record.meta?.lagMs;
+        if (typeof rawLag === "number" && Number.isFinite(rawLag) && rawLag >= 0) {
+          eventLoopLagValues.push(rawLag);
+        }
+        continue;
+      }
+
       // LoAF marks attribute blocking time to the top script's source URL.
       // Boot-window marks are captured (the suppression in longTaskMonitor
       // suppresses logWarn only, not mark emission), so this is full coverage.
       if (record.mark === "renderer_long_animation_frame") {
         const topScripts = record.meta?.topScripts;
         const top = Array.isArray(topScripts) && topScripts.length > 0 ? topScripts[0] : null;
-        const sourceURL =
+        const rawSourceURL =
           top && typeof (top as Record<string, unknown>).sourceURL === "string"
             ? ((top as Record<string, unknown>).sourceURL as string) || "<unknown>"
             : "<unknown>";
+        const sourceURL = normalizeLoafSourceURL(rawSourceURL);
         // `typeof NaN === "number"` is true, so a malformed mark could poison
         // mean/percentile stats. `Number.isFinite` excludes NaN and ±Infinity.
         const rawBlocking = record.meta?.blockingDurationMs;
@@ -253,5 +294,17 @@ export function aggregate(runs: RunData[]): Aggregate {
         }
       : null;
 
-  return { marks, phaseDurations, ipc, loaf, cls, osToAppBoot };
+  const eventLoopLag: EventLoopLagStats | null =
+    eventLoopLagValues.length > 0
+      ? {
+          samples: eventLoopLagValues.length,
+          p50Ms: round(percentile(eventLoopLagValues, 50)),
+          p95Ms: round(percentile(eventLoopLagValues, 95)),
+          meanMs: round(mean(eventLoopLagValues)),
+          maxMs: round(Math.max(...eventLoopLagValues)),
+          totalAccumulatedMs: round(eventLoopLagValues.reduce((a, b) => a + b, 0)),
+        }
+      : null;
+
+  return { marks, phaseDurations, ipc, loaf, cls, osToAppBoot, eventLoopLag };
 }

--- a/scripts/perf/lib/packagedLaunch.ts
+++ b/scripts/perf/lib/packagedLaunch.ts
@@ -122,21 +122,29 @@ async function waitForNdjsonMark(
 ): Promise<MarkRecord | null> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
+    if (!fs.existsSync(ndjsonPath)) {
+      await new Promise((r) => setTimeout(r, 100));
+      continue;
+    }
+    let lines: string[] = [];
     try {
-      if (!fs.existsSync(ndjsonPath)) {
-        await new Promise((r) => setTimeout(r, 100));
-        continue;
-      }
-      const lines = fs.readFileSync(ndjsonPath, "utf-8").trim().split("\n");
-      for (const line of lines) {
-        if (!line) continue;
+      lines = fs.readFileSync(ndjsonPath, "utf-8").trim().split("\n");
+    } catch {
+      // File read raced with a write — try again on the next poll.
+    }
+    // Per-line try/catch so a single malformed line (e.g. a truncated
+    // mid-write) doesn't cause us to skip the rest of the buffer for this
+    // poll tick.
+    for (const line of lines) {
+      if (!line) continue;
+      try {
         const record = JSON.parse(line) as MarkRecord;
         if (record.mark === targetMark) {
           return record;
         }
+      } catch {
+        // Skip malformed line
       }
-    } catch {
-      // File may be mid-write
     }
     await new Promise((r) => setTimeout(r, 100));
   }
@@ -159,7 +167,13 @@ export function parseBootDuration(ndjsonPath: string): {
     if (!line) continue;
     try {
       const record = JSON.parse(line) as MarkRecord;
-      marks.set(record.mark, record);
+      // First-wins matches the aggregate() policy in coldStartAggregate.ts.
+      // Marks are append-only in NDJSON; the first occurrence is the
+      // canonical one. Later duplicates (idempotency-guard breakage,
+      // re-emission during teardown) should not silently shift the value.
+      if (!marks.has(record.mark)) {
+        marks.set(record.mark, record);
+      }
     } catch {
       // Skip malformed lines
     }

--- a/scripts/perf/lib/packagedLaunch.ts
+++ b/scripts/perf/lib/packagedLaunch.ts
@@ -10,6 +10,11 @@ export interface PackagedLaunchResult {
   metrics: Record<string, number>;
   ndjsonPath: string;
   notes?: string;
+  // True only when the headline durationMs came from a wall-clock fallback
+  // (RENDERER_READY mark missing entirely). An RR-fallback (FI missing but
+  // RR present) is annotated via `notes` but the marks are still aggregatable
+  // and `degraded` stays false.
+  degraded?: boolean;
 }
 
 interface MarkRecord {
@@ -138,9 +143,10 @@ async function waitForNdjsonMark(
   return null;
 }
 
-function parseBootDuration(ndjsonPath: string): {
+export function parseBootDuration(ndjsonPath: string): {
   durationMs: number;
   metrics: Record<string, number>;
+  degraded?: string;
 } {
   if (!fs.existsSync(ndjsonPath)) {
     return { durationMs: -1, metrics: {} };
@@ -160,16 +166,20 @@ function parseBootDuration(ndjsonPath: string): {
   }
 
   const bootStart = marks.get(PERF_MARKS.APP_BOOT_START);
-  const rendererReady = marks.get(PERF_MARKS.RENDERER_READY);
-
-  if (!bootStart || !rendererReady) {
+  if (!bootStart) {
     return { durationMs: -1, metrics: {} };
   }
 
-  const durationMs = rendererReady.elapsedMs - bootStart.elapsedMs;
+  // RENDERER_FIRST_INTERACTIVE fires post-hydration after 2x rAF + the
+  // notifyFirstInteractive IPC round-trip. That is what users perceive as
+  // "interactive". RENDERER_READY only signals did-finish-load (DOM ready,
+  // pre-hydration) and is reserved as a degraded fallback. See #8612.
+  const firstInteractive = marks.get(PERF_MARKS.RENDERER_FIRST_INTERACTIVE);
+  const rendererReady = marks.get(PERF_MARKS.RENDERER_READY);
+
   const metrics: Record<string, number> = {};
 
-  // Extract key phase durations
+  // Extract key phase durations regardless of which terminal mark we use.
   const serviceInitStart = marks.get(PERF_MARKS.SERVICE_INIT_START);
   const serviceInitComplete = marks.get(PERF_MARKS.SERVICE_INIT_COMPLETE);
   if (serviceInitStart && serviceInitComplete) {
@@ -182,7 +192,24 @@ function parseBootDuration(ndjsonPath: string): {
     metrics.hydrateMs = hydrateComplete.elapsedMs - hydrateStart.elapsedMs;
   }
 
-  return { durationMs, metrics };
+  if (rendererReady) {
+    metrics.rendererReadyMs = rendererReady.elapsedMs - bootStart.elapsedMs;
+  }
+
+  if (firstInteractive) {
+    return { durationMs: firstInteractive.elapsedMs - bootStart.elapsedMs, metrics };
+  }
+
+  if (rendererReady) {
+    return {
+      durationMs: rendererReady.elapsedMs - bootStart.elapsedMs,
+      metrics,
+      degraded:
+        "RENDERER_FIRST_INTERACTIVE mark not captured — falling back to RENDERER_READY (pre-hydration)",
+    };
+  }
+
+  return { durationMs: -1, metrics };
 }
 
 export async function launchPackagedAndMeasure(
@@ -241,10 +268,15 @@ export async function launchPackagedAndMeasure(
 
     await waitForNdjsonMark(ndjsonPath, PERF_MARKS.RENDERER_READY, timeoutMs);
 
-    // Allow a brief settling period for any remaining marks to flush
-    await new Promise((r) => setTimeout(r, 500));
+    // After RENDERER_READY arrives, wait for RENDERER_FIRST_INTERACTIVE — the
+    // post-hydration interactive signal. It typically arrives within 100ms of
+    // RENDERER_READY (2x rAF + IPC round-trip) but CI runners under CPU
+    // contention can push it past 500ms, so a deterministic mark wait is
+    // safer than a fixed sleep. 5s is generous; if it doesn't arrive,
+    // parseBootDuration falls back to RENDERER_READY with a degraded note.
+    await waitForNdjsonMark(ndjsonPath, PERF_MARKS.RENDERER_FIRST_INTERACTIVE, 5_000);
 
-    const { durationMs, metrics } = parseBootDuration(ndjsonPath);
+    const { durationMs, metrics, degraded } = parseBootDuration(ndjsonPath);
     const wallClockMs = performance.now() - startMs;
 
     if (durationMs < 0) {
@@ -254,10 +286,11 @@ export async function launchPackagedAndMeasure(
         metrics,
         ndjsonPath,
         notes: "RENDERER_READY mark not captured — using wall-clock fallback",
+        degraded: true,
       };
     }
 
-    return { durationMs, metrics, ndjsonPath };
+    return { durationMs, metrics, ndjsonPath, notes: degraded };
   } finally {
     if (app) {
       try {

--- a/scripts/perf/scenarios/startup.ts
+++ b/scripts/perf/scenarios/startup.ts
@@ -14,8 +14,9 @@ const HEAVY_LAYOUT_SERIALIZED = JSON.stringify(HEAVY_LAYOUT);
 export const startupScenarios: PerfScenario[] = [
   {
     id: "PERF-001",
-    name: "Cold Start - Empty Project",
-    description: "Approximate cold startup bootstrap path with minimal persisted state.",
+    name: "Startup Simulation - Empty Project",
+    description:
+      "In-process hydration of a near-empty layout (NOT a real binary launch — see PERF-004 for real cold start).",
     tier: "fast",
     modes: ["smoke", "ci", "nightly"],
     iterations: { smoke: 10, ci: 20, nightly: 30 },
@@ -38,8 +39,9 @@ export const startupScenarios: PerfScenario[] = [
   },
   {
     id: "PERF-002",
-    name: "Cold Start - Heavy Persisted Layout",
-    description: "Deserialize and hydrate a high-density panel/tab-group workspace state.",
+    name: "Startup Simulation - Heavy Layout",
+    description:
+      "In-process deserialize + hydration of a high-density panel/tab-group workspace (NOT a real binary launch — see PERF-004).",
     tier: "heavy",
     modes: ["ci", "nightly"],
     iterations: { ci: 8, nightly: 12 },
@@ -93,7 +95,7 @@ export const startupScenarios: PerfScenario[] = [
     id: "PERF-004",
     name: "Real Cold Start - Packaged Binary",
     description:
-      "Launch the packaged Electron binary via Playwright, capture APP_BOOT_START to RENDERER_READY via NDJSON pipeline.",
+      "Launch the packaged Electron binary via Playwright, capture APP_BOOT_START to RENDERER_FIRST_INTERACTIVE via NDJSON pipeline.",
     tier: "heavy",
     modes: ["nightly"],
     iterations: { nightly: 30 },


### PR DESCRIPTION
## Summary

- The harness was reporting `RENDERER_READY` (skeleton paint) as the headline boot duration instead of `RENDERER_FIRST_INTERACTIVE` (post-hydration). That's the whole point of the measurement, so this was the most load-bearing fix.
- A hard 500ms sleep after `RENDERER_READY` meant `RENDERER_FIRST_INTERACTIVE` could silently disappear if hydration ran long. Replaced with a deterministic `waitForNdjsonMark` call with a 5s sub-timeout.
- `event_loop_lag` marks were being collected and discarded. They're now aggregated (samples/p50/p95/mean/max/total) and rendered in their own section.
- LoAF source URLs included Vite build hashes, so the same code landed under a different key every build. Hashes are now stripped before bucketing, making the LoAF table actually comparable across runs.
- `p95` was displayed from as few as 5 samples (statistically it's just the max). It's now suppressed below n=20 in the text report; the raw value is still in JSON.
- `PERF-001`/`002` were labelled "Cold Start" but never launched the binary. Renamed to "Startup Simulation" so the report isn't misleading.

Resolves #8612

## Changes

- `scripts/perf/lib/packagedLaunch.ts` — `parseBootDuration` prefers `RENDERER_FIRST_INTERACTIVE` with `RENDERER_READY` fallback; `waitForNdjsonMark` replaces the 500ms sleep; added explicit `degraded: boolean` field to `PackagedLaunchResult`
- `scripts/perf/lib/coldStartAggregate.ts` — `EventLoopLagStats` type and aggregation; `normalizeLoafSourceURL` (Vite hash regex); hardened mark/LoAF input validation (non-finite/negative values rejected)
- `scripts/perf/cold-start.ts` — `MIN_SAMPLES_FOR_P95=20` gate via `formatP95()`; new `event_loop_lag` section; reads `result.degraded` explicitly
- `scripts/perf/scenarios/startup.ts` — renamed PERF-001/002; updated PERF-004 description
- `scripts/perf/__tests__/coldStartAggregate.test.ts` — 13 new tests (normalizeLoafSourceURL, build-hash merging, event_loop_lag, defensive guards, edge cases)
- `scripts/perf/__tests__/parseBootDuration.test.ts` (new) — 7 tests covering FI headline, RR fallback, both-missing, boot-missing, metrics population, first-wins deduplication

## Testing

- 54/54 perf tests pass (`npx vitest run scripts/perf`)
- Typecheck, lint, and format clean

To verify locally: run `npm run perf:cold-start -- --runs 5` and confirm `durationMs` reflects `RENDERER_FIRST_INTERACTIVE`, p95 column shows `n/a (<20 runs)`, the `event_loop_lag` section renders, and LoAF source URLs don't include hash suffixes.