### PR TITLE
perf(app): lazy-load recovery components to shrink initial chunk

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -280,6 +280,9 @@ function preloadSafeModeBanner() {
 const LazySafeModeBanner = lazy(() =>
   preloadSafeModeBanner().then((m) => ({ default: m.SafeModeBanner }))
 );
+// Fetch eagerly: `safeMode` is set synchronously during hydration, so the
+// first post-hydration render can suspend before the idle preload fires.
+void preloadSafeModeBanner();
 
 function preloadRestoreConfirmationBanner() {
   return import("./components/Recovery/RestoreConfirmationBanner");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,12 +44,6 @@ import { useSoundPlaybackListener } from "./hooks/useSoundPlaybackListener";
 import { useHeldShortcutReveal } from "./hooks/useHeldShortcutReveal";
 import { notifyViewPainted, removeStartupSkeleton } from "./utils/removeStartupSkeleton";
 import { useCrashRecoveryGate } from "./hooks/app/useCrashRecoveryGate";
-import { CrashRecoveryDialog } from "./components/Recovery/CrashRecoveryDialog";
-import { SafeModeBanner } from "./components/Recovery/SafeModeBanner";
-import { CloudSyncBanner } from "./components/Recovery/CloudSyncBanner";
-import { GitHubTokenBanner } from "./components/Recovery/GitHubTokenBanner";
-import { HostCrashBanner } from "./components/Recovery/HostCrashBanner";
-import { RestoreConfirmationBanner } from "./components/Recovery/RestoreConfirmationBanner";
 import {
   useAppHydration,
   useProjectSwitchRehydration,
@@ -273,6 +267,48 @@ const LazyGitPullRebaseConfirmDialog = lazy(() =>
   }))
 );
 
+function preloadCrashRecoveryDialog() {
+  return import("./components/Recovery/CrashRecoveryDialog");
+}
+const LazyCrashRecoveryDialog = lazy(() =>
+  preloadCrashRecoveryDialog().then((m) => ({ default: m.CrashRecoveryDialog }))
+);
+
+function preloadSafeModeBanner() {
+  return import("./components/Recovery/SafeModeBanner");
+}
+const LazySafeModeBanner = lazy(() =>
+  preloadSafeModeBanner().then((m) => ({ default: m.SafeModeBanner }))
+);
+
+function preloadRestoreConfirmationBanner() {
+  return import("./components/Recovery/RestoreConfirmationBanner");
+}
+const LazyRestoreConfirmationBanner = lazy(() =>
+  preloadRestoreConfirmationBanner().then((m) => ({ default: m.RestoreConfirmationBanner }))
+);
+
+function preloadGitHubTokenBanner() {
+  return import("./components/Recovery/GitHubTokenBanner");
+}
+const LazyGitHubTokenBanner = lazy(() =>
+  preloadGitHubTokenBanner().then((m) => ({ default: m.GitHubTokenBanner }))
+);
+
+function preloadCloudSyncBanner() {
+  return import("./components/Recovery/CloudSyncBanner");
+}
+const LazyCloudSyncBanner = lazy(() =>
+  preloadCloudSyncBanner().then((m) => ({ default: m.CloudSyncBanner }))
+);
+
+function preloadHostCrashBanner() {
+  return import("./components/Recovery/HostCrashBanner");
+}
+const LazyHostCrashBanner = lazy(() =>
+  preloadHostCrashBanner().then((m) => ({ default: m.HostCrashBanner }))
+);
+
 import { Toaster } from "./components/ui/toaster";
 import { ShortcutHint } from "./components/ui/ShortcutHint";
 import { ReEntrySummary } from "./components/ui/ReEntrySummary";
@@ -288,7 +324,6 @@ import {
   usePreferencesStore,
 } from "./store";
 import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore";
-import "@github-renderer/index";
 import { useShallow } from "zustand/react/shallow";
 import { LazyMotion, MotionConfig } from "framer-motion";
 import { useMacroFocusStore } from "./store/macroFocusStore";
@@ -511,6 +546,12 @@ function App() {
       void preloadSendToAgentPalette();
       void preloadQuickCreatePalette();
       void preloadLogLevelPalette();
+      void preloadSafeModeBanner();
+      void preloadRestoreConfirmationBanner();
+      void preloadGitHubTokenBanner();
+      void preloadCloudSyncBanner();
+      void preloadHostCrashBanner();
+      import("@github-renderer/index").catch(() => {});
       import("@fontsource/jetbrains-mono/latin-500.css").catch(() => {});
       import("@fontsource/jetbrains-mono/latin-600.css").catch(() => {});
     };
@@ -643,12 +684,14 @@ function App() {
   if (crashState.status === "pending") {
     return (
       <div className="h-screen w-screen bg-daintree-bg">
-        <CrashRecoveryDialog
-          crash={crashState.crash}
-          config={crashState.config}
-          onResolve={resolveCrash}
-          onUpdateConfig={updateCrashConfig}
-        />
+        <Suspense fallback={null}>
+          <LazyCrashRecoveryDialog
+            crash={crashState.crash}
+            config={crashState.config}
+            onResolve={resolveCrash}
+            onUpdateConfig={updateCrashConfig}
+          />
+        </Suspense>
       </div>
     );
   }
@@ -695,11 +738,23 @@ function App() {
             disableHoverableContent
           >
             <E2EFaultInjector />
-            {isSafeMode && <SafeModeBanner />}
-            <RestoreConfirmationBanner />
-            <GitHubTokenBanner />
-            <CloudSyncBanner />
-            <HostCrashBanner />
+            {isSafeMode && (
+              <Suspense fallback={null}>
+                <LazySafeModeBanner />
+              </Suspense>
+            )}
+            <Suspense fallback={null}>
+              <LazyRestoreConfirmationBanner />
+            </Suspense>
+            <Suspense fallback={null}>
+              <LazyGitHubTokenBanner />
+            </Suspense>
+            <Suspense fallback={null}>
+              <LazyCloudSyncBanner />
+            </Suspense>
+            <Suspense fallback={null}>
+              <LazyHostCrashBanner />
+            </Suspense>
             <DndProvider>
               <VoiceRecordingAnnouncer />
               <AccessibilityAnnouncer />

--- a/src/hooks/app/useCrashRecoveryGate.ts
+++ b/src/hooks/app/useCrashRecoveryGate.ts
@@ -46,6 +46,10 @@ export function useCrashRecoveryGate(): {
           return;
         }
 
+        // Kick off the CrashRecoveryDialog chunk fetch before the next render
+        // commits the Suspense boundary, so the dialog appears without a blank
+        // fallback. The promise is cached, so the lazy() consumer reuses it.
+        void import("@/components/Recovery/CrashRecoveryDialog");
         setState({ status: "pending", crash: pending, config });
       })
       .catch(() => {


### PR DESCRIPTION
## Summary

- Lazy-loads 6 recovery UI components (`CrashRecoveryDialog`, `SafeModeBanner`, `RestoreConfirmationBanner`, `GitHubTokenBanner`, `CloudSyncBanner`, `HostCrashBanner`) and defers the `@github-renderer` side-effect import to reduce the initial `App.tsx` chunk.
- `CrashRecoveryDialog` is eagerly preloaded inside the IPC resolver in `useCrashRecoveryGate`, before state transitions to `'pending'`, so the cold-start crash recovery path never hits a blank Suspense fallback.
- `SafeModeBanner` is preloaded at module level because `safeMode` is set synchronously during hydration — the first post-hydration render can suspend before the idle preload fires.

Resolves #8627

## Changes

- `src/App.tsx` — converted 6 components to `React.lazy`, each with its own `<Suspense fallback={null}>` boundary matching the existing pattern used by ~25 other lazy dialogs in the file; deferred `@github-renderer/index` registration into the existing `isStateLoaded` idle preload block.
- `src/hooks/app/useCrashRecoveryGate.ts` — added eager preload of `CrashRecoveryDialog` inside the IPC resolver so the component is in-flight before the state machine transitions.

## Testing

- Normal boot: no banners render, no Suspense fallback flashes.
- Safe mode boot: `SafeModeBanner` appears without delay.
- Post-crash boot: `CrashRecoveryDialog` appears without blank screen.
- `BulkCreateWorktreeDialog` and `IssueSelector` still work via the deferred `@github-renderer/index` registration.