### PR TITLE
perf(cold-start): defer log prune and scratch init off critical path

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -68,12 +68,7 @@ import { getIdleTerminalNotificationService } from "./services/IdleTerminalNotif
 import { preAgentSnapshotService } from "./services/PreAgentSnapshotService.js";
 import { isSmokeTest, kickOffEarlyPathRefresh } from "./setup/environment.js";
 import { store } from "./store.js";
-import {
-  pruneOldLogs,
-  initializeLogger,
-  registerLoggerTransport,
-  setLogLevelOverrides,
-} from "./utils/logger.js";
+import { initializeLogger, registerLoggerTransport, setLogLevelOverrides } from "./utils/logger.js";
 import { broadcastToRenderer } from "./ipc/utils.js";
 import { registerCommands } from "./services/commands/index.js";
 import {
@@ -146,14 +141,6 @@ if (!gotTheLock) {
   console.log("[MAIN] Another instance is already running. Quitting...");
   app.quit();
 } else {
-  // Prune old log files based on retention setting
-  {
-    const retentionDays = store.get("privacy")?.logRetentionDays ?? 30;
-    if (retentionDays > 0) {
-      pruneOldLogs(app.getPath("userData"), retentionDays);
-    }
-  }
-
   initializeLogger(app.getPath("userData"));
 
   // Seed per-module level overrides from persisted store so main-process

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -4,9 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // imported module captures our mock. Names recorded here drive the
 // task-ordering assertions below.
 const registeredTaskNames: string[] = [];
+const registeredTaskRuns = new Map<string, () => unknown>();
 const setMcpRegistry = vi.fn();
 let migrationCurrentVersion = 1;
 let migrationShouldThrow = false;
+let mockLogRetentionDays: number | undefined = 30;
+const { pruneOldLogs } = vi.hoisted(() => ({ pruneOldLogs: vi.fn() }));
 
 vi.mock("../../utils/performance.js", () => ({
   markPerformance: vi.fn(),
@@ -31,8 +34,21 @@ vi.mock("../../services/StoreMigrations.js", () => ({
 
 vi.mock("../../store.js", () => ({
   store: {
-    get: vi.fn(() => ({})),
+    get: vi.fn((key: string) => {
+      if (key === "privacy") {
+        return mockLogRetentionDays === undefined ? {} : { logRetentionDays: mockLogRetentionDays };
+      }
+      return {};
+    }),
   },
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  pruneOldLogs,
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
 }));
 
 vi.mock("../../services/TelemetryService.js", () => ({
@@ -162,13 +178,14 @@ vi.mock("../../services/HelpSessionService.js", () => ({
 vi.mock("../deferredInitQueue.js", () => ({
   registerDeferredTask: vi.fn((task: { name: string; run: () => unknown }) => {
     registeredTaskNames.push(task.name);
+    registeredTaskRuns.set(task.name, task.run);
   }),
   finalizeDeferredRegistration: vi.fn(),
   resetDeferredQueue: vi.fn(),
 }));
 
 vi.mock("electron", () => ({
-  app: { exit: vi.fn() },
+  app: { exit: vi.fn(), getPath: vi.fn(() => "/tmp/userData") },
   dialog: { showErrorBox: vi.fn() },
   session: { defaultSession: { clearCache: vi.fn(), clearStorageData: vi.fn() } },
 }));
@@ -181,12 +198,15 @@ import { app } from "electron";
 describe("initGlobalServices task ordering", () => {
   beforeEach(() => {
     registeredTaskNames.length = 0;
+    registeredTaskRuns.clear();
     // mockReset (not mockClear) so mockImplementation set in one test doesn't
     // leak into the next — keeps tests independent as the suite grows.
     setMcpRegistry.mockReset();
+    pruneOldLogs.mockReset();
     (app.exit as ReturnType<typeof vi.fn>).mockReset();
     migrationCurrentVersion = 1;
     migrationShouldThrow = false;
+    mockLogRetentionDays = 30;
     setGlobalServicesInitialized(false);
   });
 
@@ -295,6 +315,49 @@ describe("initGlobalServices task ordering", () => {
 
     expect(registeredTaskNames).toContain("ccr-config");
     expect(registeredTaskNames).toContain("plugin-service");
+  });
+
+  it("registers prune-old-logs as a deferred task so it doesn't block cold start (#8622)", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    expect(registeredTaskNames).toContain("prune-old-logs");
+  });
+
+  it("prune-old-logs task invokes pruneOldLogs with retentionDays from privacy settings", async () => {
+    mockLogRetentionDays = 14;
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("prune-old-logs");
+    expect(run).toBeDefined();
+    run?.();
+
+    expect(pruneOldLogs).toHaveBeenCalledWith("/tmp/userData", 14);
+  });
+
+  it("prune-old-logs task skips pruning when retentionDays is 0", async () => {
+    mockLogRetentionDays = 0;
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("prune-old-logs");
+    expect(run).toBeDefined();
+    run?.();
+
+    expect(pruneOldLogs).not.toHaveBeenCalled();
+  });
+
+  it("prune-old-logs task defaults retentionDays to 30 when privacy setting is missing", async () => {
+    mockLogRetentionDays = undefined;
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("prune-old-logs");
+    expect(run).toBeDefined();
+    run?.();
+
+    expect(pruneOldLogs).toHaveBeenCalledWith("/tmp/userData", 30);
   });
 
   it("returns 'ok' on the happy path", async () => {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -35,6 +35,7 @@ import {
 import { startAppMetricsMonitor } from "../services/ProcessMemoryMonitor.js";
 
 import { startDiskSpaceMonitor } from "../services/DiskSpaceMonitor.js";
+import { pruneOldLogs } from "../utils/logger.js";
 import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { CHANNELS } from "../ipc/channels.js";
@@ -702,6 +703,16 @@ export async function initGlobalServices(
   registerDeferredTask({
     name: "session-eviction",
     run: () => evictStaleSessionFiles(),
+  });
+
+  registerDeferredTask({
+    name: "prune-old-logs",
+    run: () => {
+      const retentionDays = store.get("privacy")?.logRetentionDays ?? 30;
+      if (retentionDays > 0) {
+        pruneOldLogs(app.getPath("userData"), retentionDays);
+      }
+    },
   });
 
   return "ok";

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -708,6 +708,12 @@ export async function initGlobalServices(
   registerDeferredTask({
     name: "prune-old-logs",
     run: () => {
+      // Deferred (post first-interactive) so the synchronous fs scan doesn't
+      // block cold start. Note: `userData/debug/*.log` files have their mtimes
+      // refreshed by `clearDebugLogs` during `initializeLogger` (pre-deferral),
+      // so debug stubs effectively survive each prune cycle. They're empty
+      // (0 bytes) so the accumulation is harmless; `userData/logs/` is still
+      // pruned correctly because its files are appended-to, not truncated.
       const retentionDays = store.get("privacy")?.logRetentionDays ?? 30;
       if (retentionDays > 0) {
         pruneOldLogs(app.getPath("userData"), retentionDays);

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -276,22 +276,22 @@ export async function setupWindowServices(
   // Workspace client is always "ready" — per-project hosts start on-demand via loadProject()
   const workspaceReady = true;
 
+  // Scratch store init is not needed for first interaction — fire-and-forget
+  // so it doesn't gate critical-path readiness. createScratch() does its own
+  // recursive mkdir, so the root dir doesn't have to exist before IPC handlers
+  // register.
+  scratchStore.initialize().catch((err) => {
+    console.warn("[MAIN] Scratch store init failed:", err);
+  });
+
   try {
     const results = await Promise.allSettled([
       getPtyClient()!.waitForReady(),
       projectStore.initialize(),
-      scratchStore.initialize(),
     ]);
 
     ptyReady = results[0].status === "fulfilled";
     const projectStoreReady = results[1].status === "fulfilled";
-    const scratchStoreReady = results[2].status === "fulfilled";
-    if (!scratchStoreReady) {
-      console.warn(
-        "[MAIN] Scratch store init failed:",
-        results[2].status === "rejected" ? results[2].reason : "unknown"
-      );
-    }
 
     if (ptyReady && workspaceReady && projectStoreReady) {
       console.log("[MAIN] All critical services ready");


### PR DESCRIPTION
## Summary

- `pruneOldLogs()` was running synchronously before `app.whenReady()`, blocking window creation. It now runs after the app is interactive, so the cost (which scales with accumulated log files on long-lived installs) doesn't hit cold start.
- `scratchStore.initialize()` was awaited in the critical-path `Promise.allSettled` block alongside `ptyClient.waitForReady()` and `projectStore.initialize()`. Nothing on the `app:hydrate` / first-interactive path reads scratch state, so there's no reason to gate first-interactive on it. It now fires without being awaited.
- Error handling is preserved in both cases — neither deferral introduces unhandled rejections.

Resolves #8622

## Changes

- `electron/main.ts` — move `pruneOldLogs()` call to after `app.whenReady()`
- `electron/window/windowServices.ts` — remove `scratchStore.initialize()` from the awaited `Promise.allSettled`
- `electron/window/globalServicesInit.ts` — fire scratch init with a `.catch` handler so errors surface without blocking
- `electron/window/globalServicesInit/__tests__/globalServicesInit.order.test.ts` — test coverage for init ordering and non-blocking scratch behaviour

## Testing

Unit tests added covering the deferred init order. Verified cold-start path still hydrates correctly with scratch state arriving after first-interactive.