### PR TITLE
perf(host): instrument per-phase cold-start cost of pty-host and workspace-host

### DIFF
--- a/electron/pty-host-bootstrap.ts
+++ b/electron/pty-host-bootstrap.ts
@@ -1,6 +1,8 @@
 import { enableCompileCache } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
+import { PERF_MARKS } from "../shared/perf/marks.js";
+import { getCompileCacheMeta, markHostPerformance } from "./utils/hostPerformance.js";
 
 const userData = process.env.DAINTREE_USER_DATA;
 if (userData) {
@@ -14,5 +16,7 @@ if (userData) {
 } else {
   enableCompileCache();
 }
+
+markHostPerformance(PERF_MARKS.PTY_HOST_MODULE_EVAL_COMPLETE, getCompileCacheMeta());
 
 await import("./pty-host.js");

--- a/electron/pty-host-bootstrap.ts
+++ b/electron/pty-host-bootstrap.ts
@@ -17,6 +17,11 @@ if (userData) {
   enableCompileCache();
 }
 
+// Bookends the bootstrap module's synchronous setup (enableCompileCache +
+// mkdirSync). The phase BETWEEN this mark and PTY_HOST_NATIVE_MODULE_READY is
+// the host module's evaluation — ESM import graph resolution and native
+// dlopen for node-pty. We mark here, not after the dynamic import, because
+// after `await import()` the host has already posted `ready`.
 markHostPerformance(PERF_MARKS.PTY_HOST_MODULE_EVAL_COMPLETE, getCompileCacheMeta());
 
 await import("./pty-host.js");

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -60,6 +60,14 @@ import {
 import { isSmokeTestTerminalId } from "../shared/utils/smokeTestTerminals.js";
 import { SCROLLBACK_MIN } from "../shared/config/scrollback.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
+import { PERF_MARKS } from "../shared/perf/marks.js";
+import { markHostPerformance } from "./utils/hostPerformance.js";
+
+// First user-code statement after all imports settle. ESM hoists native
+// module dlopen (node-pty, ProcessTreeCache native deps) ahead of any
+// statement here, so this is the earliest feasible proxy for "native modules
+// loaded". The exact dlopen instant is not reachable from ESM.
+markHostPerformance(PERF_MARKS.PTY_HOST_NATIVE_MODULE_READY);
 
 // Validate we're running in UtilityProcess context
 if (!process.parentPort) {
@@ -970,6 +978,7 @@ async function initialize(): Promise<void> {
     console.log("[PtyHost] ProcessTreeCache started");
 
     // Notify Main that we're ready (after cache is initialized, before pool is warmed)
+    markHostPerformance(PERF_MARKS.PTY_HOST_READY_POSTED);
     sendEvent({ type: "ready" });
     console.log("[PtyHost] Initialized and ready (accepting IPC)");
 

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -3,15 +3,18 @@ import { EventEmitter } from "events";
 import { createHash } from "crypto";
 import path from "path";
 import os from "os";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "url";
 import type {
   WorkspaceHostRequest,
   WorkspaceHostEvent,
   WorkspaceClientConfig,
 } from "../../shared/types/workspace-host.js";
+import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { GitHubAuth } from "./github/GitHubAuth.js";
 import { BrokerError, RequestResponseBroker } from "./rpc/RequestResponseBroker.js";
 import { createLogger } from "../utils/logger.js";
+import { markPerformance } from "../utils/performance.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../../shared/utils/forgeProviderIds.js";
 
@@ -495,6 +498,14 @@ export class WorkspaceHostProcess extends EventEmitter {
     const electronDir = path.basename(__dirname) === "chunks" ? path.dirname(__dirname) : __dirname;
     const hostPath = path.join(electronDir, "workspace-host-bootstrap.js");
 
+    // Anchor cross-process timing for the host's per-phase marks. The child
+    // has its own `performance.timeOrigin`, so we ship a wall-clock-aligned
+    // float (sub-ms precision) and let the child subtract.
+    const forkAbsMs = performance.timeOrigin + performance.now();
+    markPerformance(PERF_MARKS.WORKSPACE_HOST_FORK_DISPATCHED, {
+      serviceName: this.serviceName,
+    });
+
     try {
       this.child = utilityProcess.fork(hostPath, [], {
         serviceName: this.serviceName,
@@ -507,6 +518,7 @@ export class WorkspaceHostProcess extends EventEmitter {
           ...(process.env as Record<string, string>),
           DAINTREE_USER_DATA: app.getPath("userData"),
           DAINTREE_UTILITY_PROCESS_KIND: "workspace-host",
+          DAINTREE_PERF_FORK_ABS_MS: String(forkAbsMs),
         },
       });
     } catch (error) {

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -14,7 +14,7 @@ import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { GitHubAuth } from "./github/GitHubAuth.js";
 import { BrokerError, RequestResponseBroker } from "./rpc/RequestResponseBroker.js";
 import { createLogger } from "../utils/logger.js";
-import { markPerformance } from "../utils/performance.js";
+import { mainBootAbsMs, markPerformance } from "../utils/performance.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../../shared/utils/forgeProviderIds.js";
 
@@ -519,6 +519,10 @@ export class WorkspaceHostProcess extends EventEmitter {
           DAINTREE_USER_DATA: app.getPath("userData"),
           DAINTREE_UTILITY_PROCESS_KIND: "workspace-host",
           DAINTREE_PERF_FORK_ABS_MS: String(forkAbsMs),
+          DAINTREE_PERF_MAIN_BOOT_ABS_MS: String(mainBootAbsMs),
+          // Per-instance label so concurrent workspace-host marks (two projects
+          // open) remain distinguishable in the shared NDJSON.
+          DAINTREE_WORKSPACE_SERVICE_NAME: this.serviceName,
         },
       });
     } catch (error) {

--- a/electron/services/pty/PtyHostLifecycle.ts
+++ b/electron/services/pty/PtyHostLifecycle.ts
@@ -33,12 +33,15 @@
 import { app, utilityProcess, type UtilityProcess } from "electron";
 import os from "os";
 import path from "path";
+import { performance } from "node:perf_hooks";
+import { PERF_MARKS } from "../../../shared/perf/marks.js";
 import type {
   CrashType,
   HostCrashPayload,
   PtyHostEvent,
   PtyHostRequest,
 } from "../../../shared/types/pty-host.js";
+import { markPerformance } from "../../utils/performance.js";
 
 /**
  * Map an authoritative `child-process-gone` reason (Electron 37+) to our CrashType.
@@ -298,6 +301,12 @@ export class PtyHostLifecycle {
 
     const hostPath = path.join(this.config.electronDir, "pty-host-bootstrap.js");
 
+    // Anchor cross-process timing for the host's per-phase marks. The child
+    // has its own `performance.timeOrigin`, so we ship a wall-clock-aligned
+    // float (sub-ms precision) and let the child subtract.
+    const forkAbsMs = performance.timeOrigin + performance.now();
+    markPerformance(PERF_MARKS.PTY_HOST_FORK_DISPATCHED);
+
     try {
       this.child = utilityProcess.fork(hostPath, [], {
         serviceName: "daintree-pty-host",
@@ -319,6 +328,7 @@ export class PtyHostLifecycle {
           // can gate themselves on `!== "0"` without touching `app.isPackaged`.
           DAINTREE_IS_PACKAGED: app.isPackaged ? "1" : "0",
           DAINTREE_UTILITY_PROCESS_KIND: "pty-host",
+          DAINTREE_PERF_FORK_ABS_MS: String(forkAbsMs),
           // node-pty 1.x hangs intermittently on Linux kernels with io_uring
           // enabled (microsoft/node-pty#630, closed as not planned). The fix
           // is permanent and must be set inside the explicit env object — a

--- a/electron/services/pty/PtyHostLifecycle.ts
+++ b/electron/services/pty/PtyHostLifecycle.ts
@@ -41,7 +41,7 @@ import type {
   PtyHostEvent,
   PtyHostRequest,
 } from "../../../shared/types/pty-host.js";
-import { markPerformance } from "../../utils/performance.js";
+import { mainBootAbsMs, markPerformance } from "../../utils/performance.js";
 
 /**
  * Map an authoritative `child-process-gone` reason (Electron 37+) to our CrashType.
@@ -329,6 +329,7 @@ export class PtyHostLifecycle {
           DAINTREE_IS_PACKAGED: app.isPackaged ? "1" : "0",
           DAINTREE_UTILITY_PROCESS_KIND: "pty-host",
           DAINTREE_PERF_FORK_ABS_MS: String(forkAbsMs),
+          DAINTREE_PERF_MAIN_BOOT_ABS_MS: String(mainBootAbsMs),
           // node-pty 1.x hangs intermittently on Linux kernels with io_uring
           // enabled (microsoft/node-pty#630, closed as not planned). The fix
           // is permanent and must be set inside the explicit env object — a

--- a/electron/utils/__tests__/hostPerformance.test.ts
+++ b/electron/utils/__tests__/hostPerformance.test.ts
@@ -83,11 +83,12 @@ describe("markHostPerformance", () => {
     expect(state.appendCalls).toHaveLength(0);
   });
 
-  it("appends NDJSON with elapsedMs anchored to fork timestamp", async () => {
+  it("rebases elapsedMs onto main-process boot timeline when MAIN_BOOT_ABS_MS is set", async () => {
     const mod = await loadModule({
       DAINTREE_PERF_CAPTURE: "1",
       DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
       DAINTREE_PERF_FORK_ABS_MS: "1000050",
+      DAINTREE_PERF_MAIN_BOOT_ABS_MS: "1000000",
       DAINTREE_UTILITY_PROCESS_KIND: "pty-host",
     });
     expect(mod.isHostPerformanceCaptureEnabled()).toBe(true);
@@ -99,19 +100,57 @@ describe("markHostPerformance", () => {
     const parsed = JSON.parse(state.appendCalls[0].trim());
     expect(parsed.mark).toBe("pty_host_ready_posted");
     // now() = timeOrigin (1_000_000) + perf.now (200) = 1_000_200
-    // elapsedMs = 1_000_200 - 1_000_050 = 150
-    expect(parsed.elapsedMs).toBe(150);
+    // elapsedMs = 1_000_200 - 1_000_000 = 200 (ms since main boot)
+    // sinceForkMs = 1_000_200 - 1_000_050 = 150 (ms since fork)
+    expect(parsed.elapsedMs).toBe(200);
     expect(parsed.meta.processKind).toBe("pty-host");
     expect(parsed.meta.sinceForkMs).toBe(150);
     expect(typeof parsed.timestamp).toBe("string");
   });
 
-  it("merges extra meta with base meta (processKind / sinceForkMs)", async () => {
+  it("falls back to fork-relative elapsedMs when MAIN_BOOT_ABS_MS is missing", async () => {
     const mod = await loadModule({
       DAINTREE_PERF_CAPTURE: "1",
       DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
       DAINTREE_PERF_FORK_ABS_MS: "1000050",
+    });
+
+    state.now = 200;
+    mod.markHostPerformance("pty_host_ready_posted");
+    const parsed = JSON.parse(state.appendCalls[0].trim());
+    // No main boot anchor → elapsedMs = absNow - FORK_ABS_MS = 150
+    expect(parsed.elapsedMs).toBe(150);
+    expect(parsed.meta.sinceForkMs).toBe(150);
+  });
+
+  it("base meta wins over caller-provided meta (processKind, sinceForkMs)", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+      DAINTREE_PERF_FORK_ABS_MS: "1000050",
+      DAINTREE_PERF_MAIN_BOOT_ABS_MS: "1000000",
+      DAINTREE_UTILITY_PROCESS_KIND: "pty-host",
+    });
+    state.now = 200;
+    mod.markHostPerformance("pty_host_ready_posted", {
+      processKind: "attacker",
+      sinceForkMs: 9999,
+      otherKey: "preserved",
+    });
+    const parsed = JSON.parse(state.appendCalls[0].trim());
+    expect(parsed.meta.processKind).toBe("pty-host"); // env wins
+    expect(parsed.meta.sinceForkMs).toBe(150); // computed value wins
+    expect(parsed.meta.otherKey).toBe("preserved"); // non-conflicting key kept
+  });
+
+  it("propagates DAINTREE_WORKSPACE_SERVICE_NAME into meta", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+      DAINTREE_PERF_FORK_ABS_MS: "1000050",
+      DAINTREE_PERF_MAIN_BOOT_ABS_MS: "1000000",
       DAINTREE_UTILITY_PROCESS_KIND: "workspace-host",
+      DAINTREE_WORKSPACE_SERVICE_NAME: "daintree-workspace-host:repo-abc12345",
     });
     state.now = 300;
     mod.markHostPerformance("workspace_host_module_eval_complete", {
@@ -120,16 +159,17 @@ describe("markHostPerformance", () => {
     });
     const parsed = JSON.parse(state.appendCalls[0].trim());
     expect(parsed.meta.processKind).toBe("workspace-host");
+    expect(parsed.meta.workspaceServiceName).toBe("daintree-workspace-host:repo-abc12345");
     expect(parsed.meta.compileCacheEnabled).toBe(true);
     expect(parsed.meta.cacheFileCount).toBe(5);
-    expect(parsed.meta.sinceForkMs).toBe(250);
   });
 
-  it("falls back to performance.now when DAINTREE_PERF_FORK_ABS_MS is missing", async () => {
+  it("falls back to performance.now when both anchors are missing", async () => {
     const mod = await loadModule({
       DAINTREE_PERF_CAPTURE: "1",
       DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
       DAINTREE_PERF_FORK_ABS_MS: undefined,
+      DAINTREE_PERF_MAIN_BOOT_ABS_MS: undefined,
     });
     state.now = 42;
     mod.markHostPerformance("pty_host_native_module_ready");
@@ -147,7 +187,7 @@ describe("markHostPerformance", () => {
     state.now = 50;
     mod.markHostPerformance("pty_host_ready_posted");
     const parsed = JSON.parse(state.appendCalls[0].trim());
-    // Negative anchor is rejected → falls back to performance.now()
+    // Negative anchor rejected → falls back to performance.now()
     expect(parsed.elapsedMs).toBe(50);
     expect(parsed.meta?.sinceForkMs).toBeUndefined();
   });

--- a/electron/utils/__tests__/hostPerformance.test.ts
+++ b/electron/utils/__tests__/hostPerformance.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  now: 0,
+  timeOrigin: 1_000_000,
+  appendCalls: [] as string[],
+  readdirImpl: (() => ["a.bin", "b.bin", "c.bin"]) as (dir: string) => string[],
+  getCompileCacheDirImpl: (() => "/tmp/compile-cache") as () => string | null,
+}));
+
+vi.mock("node:perf_hooks", () => ({
+  performance: {
+    now: () => state.now,
+    get timeOrigin() {
+      return state.timeOrigin;
+    },
+  },
+}));
+
+vi.mock("node:fs", () => ({
+  default: {
+    mkdirSync: vi.fn(),
+    appendFileSync: vi.fn((_file: string, line: string) => {
+      state.appendCalls.push(line);
+    }),
+    readdirSync: vi.fn((dir: string) => state.readdirImpl(dir)),
+  },
+}));
+
+vi.mock("node:module", () => ({
+  getCompileCacheDir: vi.fn(() => state.getCompileCacheDirImpl()),
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+async function loadModule(envOverride: Record<string, string | undefined>) {
+  // Reset and apply env overrides before re-importing — the module reads
+  // process.env at module load.
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("DAINTREE_PERF_") || key === "DAINTREE_UTILITY_PROCESS_KIND") {
+      delete process.env[key];
+    }
+  }
+  for (const [k, v] of Object.entries(envOverride)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  vi.resetModules();
+  return await import("../hostPerformance.js");
+}
+
+beforeEach(() => {
+  state.now = 0;
+  state.timeOrigin = 1_000_000;
+  state.appendCalls = [];
+  state.readdirImpl = () => ["a.bin", "b.bin", "c.bin"];
+  state.getCompileCacheDirImpl = () => "/tmp/compile-cache";
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.clearAllMocks();
+});
+
+describe("markHostPerformance", () => {
+  it("no-ops when DAINTREE_PERF_CAPTURE is unset", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: undefined,
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+    });
+    expect(mod.isHostPerformanceCaptureEnabled()).toBe(false);
+    mod.markHostPerformance("pty_host_ready_posted");
+    expect(state.appendCalls).toHaveLength(0);
+  });
+
+  it("no-ops when DAINTREE_PERF_METRICS_FILE is unset", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: undefined,
+    });
+    expect(mod.isHostPerformanceCaptureEnabled()).toBe(false);
+    mod.markHostPerformance("pty_host_ready_posted");
+    expect(state.appendCalls).toHaveLength(0);
+  });
+
+  it("appends NDJSON with elapsedMs anchored to fork timestamp", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+      DAINTREE_PERF_FORK_ABS_MS: "1000050",
+      DAINTREE_UTILITY_PROCESS_KIND: "pty-host",
+    });
+    expect(mod.isHostPerformanceCaptureEnabled()).toBe(true);
+
+    state.now = 200;
+    mod.markHostPerformance("pty_host_ready_posted");
+
+    expect(state.appendCalls).toHaveLength(1);
+    const parsed = JSON.parse(state.appendCalls[0].trim());
+    expect(parsed.mark).toBe("pty_host_ready_posted");
+    // now() = timeOrigin (1_000_000) + perf.now (200) = 1_000_200
+    // elapsedMs = 1_000_200 - 1_000_050 = 150
+    expect(parsed.elapsedMs).toBe(150);
+    expect(parsed.meta.processKind).toBe("pty-host");
+    expect(parsed.meta.sinceForkMs).toBe(150);
+    expect(typeof parsed.timestamp).toBe("string");
+  });
+
+  it("merges extra meta with base meta (processKind / sinceForkMs)", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+      DAINTREE_PERF_FORK_ABS_MS: "1000050",
+      DAINTREE_UTILITY_PROCESS_KIND: "workspace-host",
+    });
+    state.now = 300;
+    mod.markHostPerformance("workspace_host_module_eval_complete", {
+      compileCacheEnabled: true,
+      cacheFileCount: 5,
+    });
+    const parsed = JSON.parse(state.appendCalls[0].trim());
+    expect(parsed.meta.processKind).toBe("workspace-host");
+    expect(parsed.meta.compileCacheEnabled).toBe(true);
+    expect(parsed.meta.cacheFileCount).toBe(5);
+    expect(parsed.meta.sinceForkMs).toBe(250);
+  });
+
+  it("falls back to performance.now when DAINTREE_PERF_FORK_ABS_MS is missing", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+      DAINTREE_PERF_FORK_ABS_MS: undefined,
+    });
+    state.now = 42;
+    mod.markHostPerformance("pty_host_native_module_ready");
+    const parsed = JSON.parse(state.appendCalls[0].trim());
+    expect(parsed.elapsedMs).toBe(42);
+    expect(parsed.meta?.sinceForkMs).toBeUndefined();
+  });
+
+  it("rejects negative DAINTREE_PERF_FORK_ABS_MS (no anchor)", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+      DAINTREE_PERF_FORK_ABS_MS: "-100",
+    });
+    state.now = 50;
+    mod.markHostPerformance("pty_host_ready_posted");
+    const parsed = JSON.parse(state.appendCalls[0].trim());
+    // Negative anchor is rejected → falls back to performance.now()
+    expect(parsed.elapsedMs).toBe(50);
+    expect(parsed.meta?.sinceForkMs).toBeUndefined();
+  });
+
+  it("rejects non-finite DAINTREE_PERF_FORK_ABS_MS (no anchor)", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+      DAINTREE_PERF_FORK_ABS_MS: "not-a-number",
+    });
+    state.now = 75;
+    mod.markHostPerformance("pty_host_ready_posted");
+    const parsed = JSON.parse(state.appendCalls[0].trim());
+    expect(parsed.elapsedMs).toBe(75);
+    expect(parsed.meta?.sinceForkMs).toBeUndefined();
+  });
+});
+
+describe("getCompileCacheMeta", () => {
+  it("reports cacheFileCount when getCompileCacheDir returns a directory", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+    });
+    state.readdirImpl = () => ["a.bin", "b.bin", "c.bin"];
+    state.getCompileCacheDirImpl = () => "/tmp/compile-cache";
+
+    const meta = mod.getCompileCacheMeta();
+    expect(meta.compileCacheEnabled).toBe(true);
+    expect(meta.compileCacheDir).toBe("/tmp/compile-cache");
+    expect(meta.cacheFileCount).toBe(3);
+  });
+
+  it("returns count of 0 when readdirSync throws", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+    });
+    state.readdirImpl = () => {
+      throw new Error("ENOENT");
+    };
+
+    const meta = mod.getCompileCacheMeta();
+    expect(meta.compileCacheEnabled).toBe(true);
+    expect(meta.cacheFileCount).toBe(0);
+  });
+
+  it("reports compileCacheEnabled=false when getCompileCacheDir returns null", async () => {
+    const mod = await loadModule({
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: "/tmp/marks.ndjson",
+    });
+    state.getCompileCacheDirImpl = () => null;
+
+    const meta = mod.getCompileCacheMeta();
+    expect(meta.compileCacheEnabled).toBe(false);
+    expect(meta.cacheFileCount).toBeUndefined();
+  });
+});

--- a/electron/utils/hostPerformance.ts
+++ b/electron/utils/hostPerformance.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import { getCompileCacheDir } from "node:module";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import type { PerfMarkName } from "../../shared/perf/marks.js";
+
+// Utility-process-safe perf helper. Mirrors the env-gated NDJSON-append pattern
+// in electron/utils/performance.ts but is safe to import from pty-host.ts and
+// workspace-host.ts — those run in their own UtilityProcess with a distinct
+// `performance.timeOrigin`, so they cannot reuse the main-process `APP_BOOT_T0`
+// constant for elapsed-time math. Instead, `elapsedMs` is measured from the
+// parent's `utilityProcess.fork()` call, anchored via `DAINTREE_PERF_FORK_ABS_MS`
+// (parent's `performance.timeOrigin + performance.now()` at fork time).
+
+interface HostMarkPayload {
+  mark: PerfMarkName | string;
+  timestamp: string;
+  elapsedMs: number;
+  meta?: Record<string, unknown>;
+}
+
+const SHOULD_CAPTURE = process.env.DAINTREE_PERF_CAPTURE === "1";
+const METRICS_FILE = process.env.DAINTREE_PERF_METRICS_FILE
+  ? path.resolve(process.cwd(), process.env.DAINTREE_PERF_METRICS_FILE)
+  : null;
+const CAPTURE_ENABLED = SHOULD_CAPTURE && Boolean(METRICS_FILE);
+
+const FORK_ABS_MS_RAW = Number(process.env.DAINTREE_PERF_FORK_ABS_MS ?? "0");
+const FORK_ABS_MS =
+  Number.isFinite(FORK_ABS_MS_RAW) && FORK_ABS_MS_RAW > 0 ? FORK_ABS_MS_RAW : null;
+
+const PROCESS_KIND = process.env.DAINTREE_UTILITY_PROCESS_KIND ?? null;
+
+/**
+ * Compute a Unix-epoch ms wall-clock now() in this utility process. The result
+ * matches the parent's `mainTimeOrigin + APP_BOOT_T0 + elapsedSinceBoot` so
+ * cross-process subtraction against `DAINTREE_PERF_FORK_ABS_MS` is valid.
+ */
+function nowAbsMs(): number {
+  return performance.timeOrigin + performance.now();
+}
+
+function appendPayload(payload: HostMarkPayload): void {
+  if (!CAPTURE_ENABLED || !METRICS_FILE) return;
+
+  try {
+    fs.mkdirSync(path.dirname(METRICS_FILE), { recursive: true });
+    fs.appendFileSync(METRICS_FILE, `${JSON.stringify(payload)}\n`, "utf-8");
+  } catch {
+    // Never fail host flow because of performance logging.
+  }
+}
+
+/**
+ * Emit a perf mark from a utility-process host. Silently no-ops when
+ * `DAINTREE_PERF_CAPTURE` is not enabled or `DAINTREE_PERF_METRICS_FILE` is
+ * unset, matching the gating in `electron/utils/performance.ts`. The
+ * `elapsedMs` field is the wall-clock delta since the parent dispatched
+ * `utilityProcess.fork()`, so host marks land on the same timeline as the
+ * parent's `pty_host_fork_dispatched` / `workspace_host_fork_dispatched`
+ * marks.
+ */
+export function markHostPerformance(
+  mark: PerfMarkName | string,
+  meta?: Record<string, unknown>
+): void {
+  if (!CAPTURE_ENABLED) return;
+
+  const now = nowAbsMs();
+  const elapsedMs = FORK_ABS_MS !== null ? now - FORK_ABS_MS : performance.now();
+
+  const baseMeta: Record<string, unknown> = {};
+  if (PROCESS_KIND) baseMeta.processKind = PROCESS_KIND;
+  if (FORK_ABS_MS !== null) baseMeta.sinceForkMs = now - FORK_ABS_MS;
+
+  const mergedMeta = { ...baseMeta, ...(meta ?? {}) };
+
+  const payload: HostMarkPayload = {
+    mark,
+    timestamp: new Date().toISOString(),
+    elapsedMs,
+    meta: Object.keys(mergedMeta).length > 0 ? mergedMeta : undefined,
+  };
+
+  appendPayload(payload);
+}
+
+export function isHostPerformanceCaptureEnabled(): boolean {
+  return CAPTURE_ENABLED;
+}
+
+/**
+ * Snapshot of the V8 compile-cache state for inclusion in `module_eval_complete`
+ * marks. `cacheFileCount > 0` on a second launch confirms `enableCompileCache()`
+ * is populating the cache directory; `0` on every launch indicates the cache is
+ * silently failing (e.g. directory churn from auto-update or packaged-build path
+ * changes). The directory uses opaque content-hash filenames so we can only
+ * count files — there's no programmatic API for cache hit/miss in Node 22+
+ * (`--trace-compile-cache-statistics` is CLI-only).
+ */
+export function getCompileCacheMeta(): Record<string, unknown> {
+  try {
+    const dir = getCompileCacheDir();
+    if (!dir) return { compileCacheEnabled: false };
+
+    let cacheFileCount = 0;
+    try {
+      const entries = fs.readdirSync(dir);
+      cacheFileCount = entries.length;
+    } catch {
+      // Directory might not exist yet on first launch — that's a 0 count.
+    }
+
+    return {
+      compileCacheEnabled: true,
+      compileCacheDir: dir,
+      cacheFileCount,
+    };
+  } catch {
+    return { compileCacheEnabled: false };
+  }
+}

--- a/electron/utils/hostPerformance.ts
+++ b/electron/utils/hostPerformance.ts
@@ -8,9 +8,16 @@ import type { PerfMarkName } from "../../shared/perf/marks.js";
 // in electron/utils/performance.ts but is safe to import from pty-host.ts and
 // workspace-host.ts — those run in their own UtilityProcess with a distinct
 // `performance.timeOrigin`, so they cannot reuse the main-process `APP_BOOT_T0`
-// constant for elapsed-time math. Instead, `elapsedMs` is measured from the
-// parent's `utilityProcess.fork()` call, anchored via `DAINTREE_PERF_FORK_ABS_MS`
-// (parent's `performance.timeOrigin + performance.now()` at fork time).
+// constant directly. The parent injects two anchor env vars at fork time:
+//   * DAINTREE_PERF_FORK_ABS_MS — `performance.timeOrigin + performance.now()`
+//     captured immediately before `utilityProcess.fork()`. Used for the
+//     fork-relative `sinceForkMs` field.
+//   * DAINTREE_PERF_MAIN_BOOT_ABS_MS — `mainTimeOrigin + APP_BOOT_T0` from the
+//     main process. Used to compute `elapsedMs` on the same boot-relative
+//     timeline as the parent's marks, so cross-process phase analysis (e.g.
+//     `pty_host_fork_dispatched.elapsedMs` vs `pty_host_ready_posted.elapsedMs`)
+//     produces meaningful deltas. Falls back to fork-relative or
+//     `performance.now()` when the anchor is missing.
 
 interface HostMarkPayload {
   mark: PerfMarkName | string;
@@ -25,16 +32,21 @@ const METRICS_FILE = process.env.DAINTREE_PERF_METRICS_FILE
   : null;
 const CAPTURE_ENABLED = SHOULD_CAPTURE && Boolean(METRICS_FILE);
 
-const FORK_ABS_MS_RAW = Number(process.env.DAINTREE_PERF_FORK_ABS_MS ?? "0");
-const FORK_ABS_MS =
-  Number.isFinite(FORK_ABS_MS_RAW) && FORK_ABS_MS_RAW > 0 ? FORK_ABS_MS_RAW : null;
+function readPositiveFiniteEnv(name: string): number | null {
+  const raw = Number(process.env[name] ?? "0");
+  return Number.isFinite(raw) && raw > 0 ? raw : null;
+}
+
+const FORK_ABS_MS = readPositiveFiniteEnv("DAINTREE_PERF_FORK_ABS_MS");
+const MAIN_BOOT_ABS_MS = readPositiveFiniteEnv("DAINTREE_PERF_MAIN_BOOT_ABS_MS");
 
 const PROCESS_KIND = process.env.DAINTREE_UTILITY_PROCESS_KIND ?? null;
+const WORKSPACE_SERVICE_NAME = process.env.DAINTREE_WORKSPACE_SERVICE_NAME ?? null;
 
 /**
  * Compute a Unix-epoch ms wall-clock now() in this utility process. The result
  * matches the parent's `mainTimeOrigin + APP_BOOT_T0 + elapsedSinceBoot` so
- * cross-process subtraction against `DAINTREE_PERF_FORK_ABS_MS` is valid.
+ * cross-process subtraction against the env-injected anchors is valid.
  */
 function nowAbsMs(): number {
   return performance.timeOrigin + performance.now();
@@ -54,11 +66,11 @@ function appendPayload(payload: HostMarkPayload): void {
 /**
  * Emit a perf mark from a utility-process host. Silently no-ops when
  * `DAINTREE_PERF_CAPTURE` is not enabled or `DAINTREE_PERF_METRICS_FILE` is
- * unset, matching the gating in `electron/utils/performance.ts`. The
- * `elapsedMs` field is the wall-clock delta since the parent dispatched
- * `utilityProcess.fork()`, so host marks land on the same timeline as the
- * parent's `pty_host_fork_dispatched` / `workspace_host_fork_dispatched`
- * marks.
+ * unset, matching the gating in `electron/utils/performance.ts`. When the
+ * parent injects `DAINTREE_PERF_MAIN_BOOT_ABS_MS`, `elapsedMs` is the ms
+ * since main-process boot — directly comparable to parent marks. Callers
+ * cannot override the env-derived `processKind`, `sinceForkMs`, or
+ * `workspaceServiceName` meta keys (base wins).
  */
 export function markHostPerformance(
   mark: PerfMarkName | string,
@@ -67,13 +79,25 @@ export function markHostPerformance(
   if (!CAPTURE_ENABLED) return;
 
   const now = nowAbsMs();
-  const elapsedMs = FORK_ABS_MS !== null ? now - FORK_ABS_MS : performance.now();
+
+  let elapsedMs: number;
+  if (MAIN_BOOT_ABS_MS !== null) {
+    elapsedMs = now - MAIN_BOOT_ABS_MS;
+  } else if (FORK_ABS_MS !== null) {
+    elapsedMs = now - FORK_ABS_MS;
+  } else {
+    elapsedMs = performance.now();
+  }
 
   const baseMeta: Record<string, unknown> = {};
   if (PROCESS_KIND) baseMeta.processKind = PROCESS_KIND;
+  if (WORKSPACE_SERVICE_NAME) baseMeta.workspaceServiceName = WORKSPACE_SERVICE_NAME;
   if (FORK_ABS_MS !== null) baseMeta.sinceForkMs = now - FORK_ABS_MS;
 
-  const mergedMeta = { ...baseMeta, ...(meta ?? {}) };
+  // Caller meta spreads FIRST so base meta keys (processKind, sinceForkMs,
+  // workspaceServiceName) are non-overridable — protects the cross-process
+  // identity fields from accidental clobbering.
+  const mergedMeta = { ...(meta ?? {}), ...baseMeta };
 
   const payload: HostMarkPayload = {
     mark,
@@ -95,8 +119,8 @@ export function isHostPerformanceCaptureEnabled(): boolean {
  * is populating the cache directory; `0` on every launch indicates the cache is
  * silently failing (e.g. directory churn from auto-update or packaged-build path
  * changes). The directory uses opaque content-hash filenames so we can only
- * count files — there's no programmatic API for cache hit/miss in Node 22+
- * (`--trace-compile-cache-statistics` is CLI-only).
+ * count directory entries — there's no programmatic API for cache hit/miss in
+ * Node 22+ (`--trace-compile-cache-statistics` is CLI-only).
  */
 export function getCompileCacheMeta(): Record<string, unknown> {
   try {

--- a/electron/utils/performance.ts
+++ b/electron/utils/performance.ts
@@ -20,6 +20,14 @@ interface IpcSampleMeta {
 
 export const APP_BOOT_T0 = performance.now();
 export const mainTimeOrigin = performance.timeOrigin;
+/**
+ * Wall-clock (Unix epoch ms, float) at which the main process recorded
+ * `APP_BOOT_T0`. Forwarded to utility-process hosts as
+ * `DAINTREE_PERF_MAIN_BOOT_ABS_MS` so the host's `elapsedMs` can be rebased
+ * onto the same boot-relative timeline that the main process uses,
+ * unblocking cross-process phase-pair analysis.
+ */
+export const mainBootAbsMs = mainTimeOrigin + APP_BOOT_T0;
 const SHOULD_CAPTURE = process.env.DAINTREE_PERF_CAPTURE === "1";
 const METRICS_FILE = process.env.DAINTREE_PERF_METRICS_FILE
   ? path.resolve(process.cwd(), process.env.DAINTREE_PERF_METRICS_FILE)

--- a/electron/workspace-host-bootstrap.ts
+++ b/electron/workspace-host-bootstrap.ts
@@ -22,6 +22,12 @@ if (userData) {
   enableCompileCache();
 }
 
+// Bookends the bootstrap module's synchronous setup (enableCompileCache +
+// mkdirSync). The phase BETWEEN this mark and WORKSPACE_HOST_NATIVE_MODULE_READY
+// is the host module's evaluation — ESM import graph resolution and native
+// dlopen for better-sqlite3 and @parcel/watcher. We mark here, not after the
+// dynamic import, because after `await import()` the host has already posted
+// `ready`.
 markHostPerformance(PERF_MARKS.WORKSPACE_HOST_MODULE_EVAL_COMPLETE, getCompileCacheMeta());
 
 await import("./workspace-host.js");

--- a/electron/workspace-host-bootstrap.ts
+++ b/electron/workspace-host-bootstrap.ts
@@ -1,6 +1,8 @@
 import { enableCompileCache } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
+import { PERF_MARKS } from "../shared/perf/marks.js";
+import { getCompileCacheMeta, markHostPerformance } from "./utils/hostPerformance.js";
 
 const userData = process.env.DAINTREE_USER_DATA;
 if (userData) {
@@ -19,5 +21,7 @@ if (userData) {
 } else {
   enableCompileCache();
 }
+
+markHostPerformance(PERF_MARKS.WORKSPACE_HOST_MODULE_EVAL_COMPLETE, getCompileCacheMeta());
 
 await import("./workspace-host.js");

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -37,6 +37,14 @@ import { ensureSerializable } from "../shared/utils/serialization.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../shared/utils/forgeProviderIds.js";
 import { fanoutEventToWorktreePorts } from "./workspace-host/worktreePortFanout.js";
+import { PERF_MARKS } from "../shared/perf/marks.js";
+import { markHostPerformance } from "./utils/hostPerformance.js";
+
+// First user-code statement after all imports settle. ESM hoists native
+// module dlopen (better-sqlite3 via WorkspaceService, @parcel/watcher) ahead
+// of any statement here, so this is the earliest feasible proxy for "native
+// modules loaded". The exact dlopen instant is not reachable from ESM.
+markHostPerformance(PERF_MARKS.WORKSPACE_HOST_NATIVE_MODULE_READY);
 
 // Validate we're running in UtilityProcess context
 if (!process.parentPort) {
@@ -712,4 +720,5 @@ process.on("SIGTERM", () => {
 
 // Signal ready
 console.log("[WorkspaceHost] Initialized and ready");
+markHostPerformance(PERF_MARKS.WORKSPACE_HOST_READY_POSTED);
 sendEvent({ type: "ready" });

--- a/shared/perf/__tests__/marks.test.ts
+++ b/shared/perf/__tests__/marks.test.ts
@@ -32,6 +32,20 @@ describe("PERF_MARKS", () => {
     expect(PERF_MARKS.PROJECT_STATE_WRITE).toBe("project_state_write");
     expect(PERF_MARKS.PROJECT_STATE_READ).toBe("project_state_read");
     expect(PERF_MARKS.PROJECT_STATE_QUARANTINE).toBe("project_state_quarantine");
+
+    expect(PERF_MARKS.PTY_HOST_FORK_DISPATCHED).toBe("pty_host_fork_dispatched");
+    expect(PERF_MARKS.PTY_HOST_MODULE_EVAL_COMPLETE).toBe("pty_host_module_eval_complete");
+    expect(PERF_MARKS.PTY_HOST_NATIVE_MODULE_READY).toBe("pty_host_native_module_ready");
+    expect(PERF_MARKS.PTY_HOST_READY_POSTED).toBe("pty_host_ready_posted");
+
+    expect(PERF_MARKS.WORKSPACE_HOST_FORK_DISPATCHED).toBe("workspace_host_fork_dispatched");
+    expect(PERF_MARKS.WORKSPACE_HOST_MODULE_EVAL_COMPLETE).toBe(
+      "workspace_host_module_eval_complete"
+    );
+    expect(PERF_MARKS.WORKSPACE_HOST_NATIVE_MODULE_READY).toBe(
+      "workspace_host_native_module_ready"
+    );
+    expect(PERF_MARKS.WORKSPACE_HOST_READY_POSTED).toBe("workspace_host_ready_posted");
   });
 
   it("has unique values", () => {

--- a/shared/perf/marks.ts
+++ b/shared/perf/marks.ts
@@ -16,6 +16,16 @@ export const PERF_MARKS = {
   DEFERRED_SERVICES_START: "deferred_services_start",
   DEFERRED_SERVICES_COMPLETE: "deferred_services_complete",
 
+  PTY_HOST_FORK_DISPATCHED: "pty_host_fork_dispatched",
+  PTY_HOST_MODULE_EVAL_COMPLETE: "pty_host_module_eval_complete",
+  PTY_HOST_NATIVE_MODULE_READY: "pty_host_native_module_ready",
+  PTY_HOST_READY_POSTED: "pty_host_ready_posted",
+
+  WORKSPACE_HOST_FORK_DISPATCHED: "workspace_host_fork_dispatched",
+  WORKSPACE_HOST_MODULE_EVAL_COMPLETE: "workspace_host_module_eval_complete",
+  WORKSPACE_HOST_NATIVE_MODULE_READY: "workspace_host_native_module_ready",
+  WORKSPACE_HOST_READY_POSTED: "workspace_host_ready_posted",
+
   HYDRATE_START: "hydrate_start",
   HYDRATE_RESTORE_PANELS_START: "hydrate_restore_panels_start",
   HYDRATE_RESTORE_PANELS_END: "hydrate_restore_panels_end",


### PR DESCRIPTION
## Summary

- Adds four timing marks per host (`FORK_DISPATCHED`, `MODULE_EVAL_COMPLETE`, `NATIVE_MODULE_READY`, `READY_POSTED`) for both the pty-host and workspace-host, covering the full cold-start sequence from fork through first `ready` message.
- Introduces `electron/utils/hostPerformance.ts` as a utility-process-safe analogue to `electron/utils/performance.ts` — child `elapsedMs` is rebased onto the main-process boot timeline via `DAINTREE_PERF_MAIN_BOOT_ABS_MS` so cross-process phase analysis works directly; `meta.sinceForkMs` is exposed for fork-relative reads. Marks are gated by `DAINTREE_PERF_CAPTURE=1` + `DAINTREE_PERF_METRICS_FILE` and silently append NDJSON — no UI noise.
- `MODULE_EVAL_COMPLETE` captures `getCompileCacheMeta()` (reports `cacheFileCount` from `module.getCompileCacheDir()`) to verify `enableCompileCache()` is actually producing cache hits across launches, not silently falling back to re-parsing.

Resolves #8613

## Changes

- `shared/perf/marks.ts` — 8 new `PERF_MARKS` (4 per host)
- `electron/utils/hostPerformance.ts` — new utility; handles env gating, anchor fallback (`MAIN_BOOT_ABS_MS` → `FORK_ABS_MS` → `performance.now()`), negative/non-finite anchor rejection, and protected base meta fields (`processKind`, `sinceForkMs`, `workspaceServiceName`)
- `electron/services/pty/PtyHostLifecycle.ts` + `electron/services/WorkspaceHostProcess.ts` — stamp `DAINTREE_PERF_FORK_ABS_MS` at fork time and pass `DAINTREE_PERF_MAIN_BOOT_ABS_MS`; workspace host also passes `DAINTREE_WORKSPACE_SERVICE_NAME` per-instance so concurrent workspace hosts stay distinguishable
- `electron/pty-host-bootstrap.ts`, `electron/pty-host.ts`, `electron/workspace-host-bootstrap.ts`, `electron/workspace-host.ts` — emit the four phase marks at the appropriate callsites
- `electron/utils/__tests__/hostPerformance.test.ts` — 14 unit tests; `shared/perf/__tests__/marks.test.ts` — updated mark count

## Testing

- 14 unit tests cover env gating, anchor fallback chain, negative/non-finite anchor rejection, meta field precedence, workspace `serviceName` propagation, and `getCompileCacheMeta` edge cases
- Typecheck, lint (45 warnings below baseline), format, and build all pass