### PR TITLE
fix(resource-profile): graduate fleet-size signal and add system-memory pressure

### DIFF
--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -29,6 +29,7 @@ import { ACTIVE_AGENT_STATES, type AgentState } from "../../shared/types/agent.j
 type ActiveAgentTerminalLike = {
   agentState?: AgentState;
   isTrashed?: boolean;
+  hasPty?: boolean;
   detectedAgentId?: string;
   launchAgentId?: string;
   everDetectedAgent?: boolean;
@@ -117,6 +118,10 @@ export class ResourceProfileService {
   private tickCount = 0;
   private disposed = false;
   private cachedActiveAgentCount = 0;
+  // Monotonic counter; bumped on every start() and refreshFleetState() invocation
+  // so that promises from a previous lifecycle (or out-of-order responses within
+  // one lifecycle) can be detected and dropped without contaminating the cache.
+  private refreshGeneration = 0;
   private thermalState: "unknown" | "nominal" | "fair" | "serious" | "critical" = "unknown";
   private speedLimit = 100;
   private isOnBattery = false;
@@ -197,6 +202,14 @@ export class ResourceProfileService {
     this.tickCount = 0;
     this.candidateProfile = null;
     this.candidateFirstSeenAt = null;
+    // Zero the fleet-count cache so a stop → start cycle does not inherit
+    // pressure from a previous lifecycle's fleet. The first refresh below
+    // re-populates from the live PTY host.
+    this.cachedActiveAgentCount = 0;
+    // Bump the generation so any in-flight promise from the previous lifecycle
+    // (or any earlier refresh in this lifecycle) will see a stale generation
+    // in its .then() and drop its result.
+    this.refreshGeneration += 1;
 
     logInfo("resource-profile-service-started", { profile: this.currentProfile });
 
@@ -424,14 +437,23 @@ export class ResourceProfileService {
     const ptyClient = this.deps.getPtyClient();
     if (!ptyClient) return;
 
+    // Capture the generation at request time. Any later refresh (or a stop →
+    // start cycle) bumps the counter, so when our .then() runs we can detect
+    // that a fresher request is in flight and drop our stale result.
+    this.refreshGeneration += 1;
+    const generation = this.refreshGeneration;
+
     ptyClient
       .getAllTerminalsAsync()
       .then((terminals) => {
         if (this.disposed) return;
+        if (generation !== this.refreshGeneration) return;
         this.cachedActiveAgentCount = this.countActiveAgentTerminals(terminals);
       })
       .catch(() => {
-        // non-critical — use last known count
+        // PtyClient.getAllTerminalsAsync absorbs IPC failures and resolves
+        // with []; this branch only fires for an unexpected throw inside the
+        // .then() above. Leave the cache untouched in that case.
       });
   }
 
@@ -439,6 +461,11 @@ export class ResourceProfileService {
     let count = 0;
     for (const t of terminals) {
       if (t.isTrashed) continue;
+      // Orphaned terminals whose PTY process exited still carry stale agent
+      // metadata. Mirrors ProjectStatsService's per-project active-agent
+      // counter — without this, a fleet that exited without being trashed
+      // would keep the score pinned to `efficiency` forever.
+      if (t.hasPty === false) continue;
       if (!t.agentState || !ACTIVE_AGENT_STATES.has(t.agentState)) continue;
       // Only count terminals with an agent identity. `detectedAgentId` is the
       // strongest signal (runtime-detected). A non-empty `launchAgentId` is

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -20,6 +20,19 @@ import {
   type ResourceProfile,
   type ResourceProfilePayload,
 } from "../../shared/types/resourceProfile.js";
+import { ACTIVE_AGENT_STATES, type AgentState } from "../../shared/types/agent.js";
+
+/**
+ * Subset of PtyClient's TerminalInfoResponse used by the active-agent filter.
+ * Declared structurally so we don't depend on a non-exported interface.
+ */
+type ActiveAgentTerminalLike = {
+  agentState?: AgentState;
+  isTrashed?: boolean;
+  detectedAgentId?: string;
+  launchAgentId?: string;
+  everDetectedAgent?: boolean;
+};
 
 const EVAL_INTERVAL_MS = 30_000;
 const DOWNGRADE_HOLD_MS = 30_000;
@@ -69,7 +82,23 @@ const LAG_PRESSURE_MAX_MS = 120_000; // 2-minute hard cap on stuck latch
 // stops false "efficiency" drops when the app has plenty of headroom.
 const HIGH_FRACTION = 0.15;
 const LOW_FRACTION = 0.08;
-const WORKTREE_COUNT_HIGH = 8;
+
+// Fleet-size signal (live agent terminals in working/waiting/directing states).
+// Each running agent's resident memory is ~200–500 MB, so a graduated curve
+// reflects that fleet size scales pressure roughly linearly. A flat +1 was
+// indistinguishable across 8, 16, and 24 agents — those have wildly different
+// memory footprints and the service must react accordingly.
+const FLEET_COUNT_HIGH = 8;
+const FLEET_COUNT_VERY_HIGH = 16;
+const FLEET_COUNT_CRITICAL = 24;
+
+// System-available memory thresholds expressed as fractions of total RAM so
+// devices with very different physical memory behave consistently. On macOS
+// "available" = free + purgeable; elsewhere it's free alone. The score scales
+// alongside the app-private signal to catch the case where the OS as a whole
+// is starved by other processes even when this app's footprint is modest.
+const SYS_AVAILABLE_HIGH_FRACTION = 0.2;
+const SYS_AVAILABLE_LOW_FRACTION = 0.1;
 
 export interface ResourceProfileDeps {
   getPtyClient: () => PtyClient | null;
@@ -87,12 +116,14 @@ export class ResourceProfileService {
   private evalCleanup: (() => void) | null = null;
   private tickCount = 0;
   private disposed = false;
-  private cachedWorktreeCount = 0;
+  private cachedActiveAgentCount = 0;
   private thermalState: "unknown" | "nominal" | "fair" | "serious" | "critical" = "unknown";
   private speedLimit = 100;
   private isOnBattery = false;
   private readonly memoryThresholdHighMb: number;
   private readonly memoryThresholdLowMb: number;
+  private readonly sysMemThresholdHighMb: number;
+  private readonly sysMemThresholdLowMb: number;
   private lagInterval: NodeJS.Timeout | null = null;
   private lagHistogram: IntervalHistogram | null = null;
   private lagPreviousElu: EventLoopUtilization | null = null;
@@ -106,6 +137,8 @@ export class ResourceProfileService {
     const totalRamMb = os.totalmem() / 1024 / 1024;
     this.memoryThresholdHighMb = totalRamMb * HIGH_FRACTION;
     this.memoryThresholdLowMb = totalRamMb * LOW_FRACTION;
+    this.sysMemThresholdHighMb = totalRamMb * SYS_AVAILABLE_HIGH_FRACTION;
+    this.sysMemThresholdLowMb = totalRamMb * SYS_AVAILABLE_LOW_FRACTION;
   }
 
   private onThermalStateChange = (details: { state: string }): void => {
@@ -154,10 +187,6 @@ export class ResourceProfileService {
     this.isOnBattery = false;
   };
 
-  setWorktreeCount(count: number): void {
-    this.cachedWorktreeCount = count;
-  }
-
   getProfile(): ResourceProfile {
     return this.currentProfile;
   }
@@ -171,7 +200,7 @@ export class ResourceProfileService {
 
     logInfo("resource-profile-service-started", { profile: this.currentProfile });
 
-    this.refreshWorktreeCount();
+    this.refreshFleetState();
 
     powerMonitor.on("thermal-state-change", this.onThermalStateChange);
     powerMonitor.on("speed-limit-change", this.onSpeedLimitChange);
@@ -186,7 +215,7 @@ export class ResourceProfileService {
     powerMonitor.on("on-ac", this.onAcPower);
 
     this.evalCleanup = setAlignedInterval(() => {
-      this.refreshWorktreeCount();
+      this.refreshFleetState();
       this.evaluate();
     }, EVAL_INTERVAL_MS);
 
@@ -386,22 +415,68 @@ export class ResourceProfileService {
     }
   }
 
-  private refreshWorktreeCount(): void {
+  private refreshFleetState(): void {
     if (this.disposed) return;
     // Under sustained event-loop saturation, skip the only optional async work
-    // in this service. Cached count is used until pressure clears.
+    // in this service. Cached counts are used until pressure clears.
     if (this.lagEscalatedActive) return;
-    const workspaceClient = this.deps.getWorkspaceClient();
-    if (!workspaceClient) return;
-    workspaceClient
-      .getAllStatesAsync()
-      .then((states) => {
+
+    const ptyClient = this.deps.getPtyClient();
+    if (!ptyClient) return;
+
+    ptyClient
+      .getAllTerminalsAsync()
+      .then((terminals) => {
         if (this.disposed) return;
-        this.cachedWorktreeCount = states.length;
+        this.cachedActiveAgentCount = this.countActiveAgentTerminals(terminals);
       })
       .catch(() => {
         // non-critical — use last known count
       });
+  }
+
+  private countActiveAgentTerminals(terminals: ActiveAgentTerminalLike[]): number {
+    let count = 0;
+    for (const t of terminals) {
+      if (t.isTrashed) continue;
+      if (!t.agentState || !ACTIVE_AGENT_STATES.has(t.agentState)) continue;
+      // Only count terminals with an agent identity. `detectedAgentId` is the
+      // strongest signal (runtime-detected). A non-empty `launchAgentId` is
+      // accepted only before runtime detection has ever fired — once
+      // `everDetectedAgent` is true, missing `detectedAgentId` means the agent
+      // exited and we should not double-count the residual shell.
+      const hasIdentity =
+        Boolean(t.detectedAgentId) || (Boolean(t.launchAgentId) && t.everDetectedAgent !== true);
+      if (!hasIdentity) continue;
+      count += 1;
+    }
+    return count;
+  }
+
+  /**
+   * Read system-wide available memory in MB. Mirrors
+   * ProjectViewManager.getAvailableMemoryMb(): on macOS "available" =
+   * free + purgeable, because Darwin holds reclaimable pages as purgeable
+   * rather than free. On Windows/Linux, `free` alone is accurate. Returns
+   * null when the Chromium API is unavailable (e.g., under test mocks).
+   */
+  private getAvailableSystemMemoryMb(): number | null {
+    try {
+      const getInfo = (
+        process as {
+          getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
+        }
+      ).getSystemMemoryInfo;
+      if (typeof getInfo !== "function") return null;
+      const info = getInfo.call(process);
+      const freeKb = typeof info.free === "number" ? info.free : 0;
+      const purgeableKb = typeof info.purgeable === "number" ? info.purgeable : 0;
+      const availableKb = freeKb + purgeableKb;
+      if (availableKb <= 0) return null;
+      return availableKb / 1024;
+    } catch {
+      return null;
+    }
   }
 
   stop(): void {
@@ -500,10 +575,33 @@ export class ResourceProfileService {
     if (this.speedLimit < 50) pressureScore += 2;
     else if (this.speedLimit < 100) pressureScore += 1;
 
-    // Worktree count signal
-    const worktreeCount = this.cachedWorktreeCount;
-    if (worktreeCount >= WORKTREE_COUNT_HIGH) {
+    // Fleet-size signal (graduated). Counts live agent terminals filtered
+    // through ACTIVE_AGENT_STATES rather than worktrees: an idle worktree
+    // costs negligible incremental memory, but each running agent runtime
+    // (Claude, Gemini, Codex) is hundreds of MB. With a flat +1 at 8, a 24-
+    // agent fleet scored identically to an 8-worktree project and could
+    // never reach `efficiency` from fleet size alone.
+    const agentCount = this.cachedActiveAgentCount;
+    if (agentCount >= FLEET_COUNT_CRITICAL) {
+      pressureScore += 3;
+    } else if (agentCount >= FLEET_COUNT_VERY_HIGH) {
+      pressureScore += 2;
+    } else if (agentCount >= FLEET_COUNT_HIGH) {
       pressureScore += 1;
+    }
+
+    // System-available memory signal. The app-private signal above only sees
+    // this process's footprint; if another app on the box is hoarding RAM
+    // and the OS is paging, we want to back off even when our own memory
+    // looks fine. Mirrors the (free + purgeable) pattern ProjectViewManager
+    // already uses for cached-view eviction.
+    const sysAvailMb = this.getAvailableSystemMemoryMb();
+    if (sysAvailMb !== null) {
+      if (sysAvailMb < this.sysMemThresholdLowMb) {
+        pressureScore += 2;
+      } else if (sysAvailMb < this.sysMemThresholdHighMb) {
+        pressureScore += 1;
+      }
     }
 
     if (pressureScore >= 3) return "efficiency";

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -1109,24 +1109,111 @@ describe("ResourceProfileService adversarial", () => {
       service.stop();
     });
 
-    it("retains last-known agent count when getAllTerminalsAsync rejects", async () => {
+    it("resets fleet count to 0 when PtyClient returns [] under IPC failure", async () => {
+      // Documents the real production behavior: PtyClient.getAllTerminalsAsync
+      // catches its own IPC failures and resolves [], so the service's cache
+      // resets to 0. The 90s upgrade hold prevents transient drops from
+      // immediately upgrading the profile.
       const { deps, pty } = createDeps();
       pty.getAllTerminalsAsync.mockResolvedValueOnce(makeActiveAgentTerminals(24));
       const service = new ResourceProfileService(deps);
       service.start();
       await flushAsync();
+      expect(
+        (service as unknown as { cachedActiveAgentCount: number }).cachedActiveAgentCount
+      ).toBe(24);
 
-      // Subsequent refreshes fail.
-      pty.getAllTerminalsAsync.mockRejectedValue(new Error("ipc down"));
+      // Subsequent refreshes fail in the PtyClient layer — surfaced as [].
+      pty.getAllTerminalsAsync.mockResolvedValue([]);
+
+      vi.advanceTimersByTime(30_000);
+      await flushAsync();
+      expect(
+        (service as unknown as { cachedActiveAgentCount: number }).cachedActiveAgentCount
+      ).toBe(0);
+
+      service.stop();
+    });
+
+    it("excludes terminals with hasPty=false from the active-agent count", async () => {
+      const { deps, pty } = createDeps();
+      // 24 terminals that look 'live' by every other signal but their PTY exited.
+      // ProjectStatsService applies the same hasPty filter; without it the
+      // service would lock to efficiency indefinitely on a fleet that exited
+      // without being trashed.
+      pty.getAllTerminalsAsync.mockResolvedValue(
+        Array.from({ length: 24 }, (_, i) => ({
+          id: `orphan-${i}`,
+          agentState: "working",
+          detectedAgentId: "claude",
+          hasPty: false,
+        }))
+      );
+      const service = new ResourceProfileService(deps);
+      service.start();
+      await flushAsync();
 
       mockGetAppMetrics.mockReturnValue([makeMetric(200)]);
       mockIsOnBatteryPower.mockReturnValue(false);
 
-      // Should still drive to efficiency because the 24-count was already cached.
-      vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
-      await flushAsync();
-      expect(service.getProfile()).toBe("efficiency");
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("performance");
 
+      service.stop();
+    });
+
+    it("ignores a stale getAllTerminalsAsync result from a previous lifecycle", async () => {
+      const pendingTerminals = deferred<Array<Record<string, unknown>>>();
+      const { deps, pty } = createDeps();
+      // The very first call (during the first start()) is the slow one.
+      pty.getAllTerminalsAsync.mockReturnValueOnce(pendingTerminals.promise);
+      // Calls after that resolve immediately with [] (fresh lifecycle: no fleet).
+      pty.getAllTerminalsAsync.mockResolvedValue([]);
+
+      const service = new ResourceProfileService(deps);
+      service.start();
+      service.stop();
+      service.start();
+      // Drain the fresh-lifecycle refresh to set cachedActiveAgentCount = 0.
+      await flushAsync();
+
+      // The slow promise from lifecycle #1 finally resolves with a huge fleet.
+      // Without the generation guard, this would write 24 into the new
+      // lifecycle's cache.
+      pendingTerminals.resolve(makeActiveAgentTerminals(24));
+      await pendingTerminals.promise;
+      await flushAsync();
+
+      const internals = service as unknown as { cachedActiveAgentCount: number };
+      expect(internals.cachedActiveAgentCount).toBe(0);
+
+      service.stop();
+    });
+
+    it("zeros cachedActiveAgentCount on restart even if the prior refresh succeeded", async () => {
+      const { deps, pty } = createDeps();
+      pty.getAllTerminalsAsync.mockResolvedValueOnce(makeActiveAgentTerminals(24));
+      const service = new ResourceProfileService(deps);
+      service.start();
+      await flushAsync();
+      expect(
+        (service as unknown as { cachedActiveAgentCount: number }).cachedActiveAgentCount
+      ).toBe(24);
+
+      // Stop, then keep the next refresh deferred so it can't immediately
+      // overwrite the cache. The restart itself must reset the count.
+      service.stop();
+      const pending = deferred<Array<Record<string, unknown>>>();
+      pty.getAllTerminalsAsync.mockReturnValue(pending.promise);
+
+      service.start();
+      // No flushAsync — the new refresh hasn't resolved yet. The reset must
+      // come from start() itself, not from the refresh result.
+      expect(
+        (service as unknown as { cachedActiveAgentCount: number }).cachedActiveAgentCount
+      ).toBe(0);
+
+      pending.resolve([]);
       service.stop();
     });
   });

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -76,11 +76,31 @@ const mockPowerMonitorRemoveListener = powerMonitor.removeListener as unknown as
 
 interface MockPtyClient {
   setResourceProfile: Mock;
+  getAllTerminalsAsync: Mock;
 }
 
 interface MockWorkspaceClient {
   updateMonitorConfig: Mock;
   getAllStatesAsync: Mock;
+}
+
+function makeActiveAgentTerminals(count: number): Array<Record<string, unknown>> {
+  const terminals: Array<Record<string, unknown>> = [];
+  for (let i = 0; i < count; i += 1) {
+    terminals.push({
+      id: `t-${i}`,
+      agentState: "working",
+      detectedAgentId: "claude",
+      isTrashed: false,
+    });
+  }
+  return terminals;
+}
+
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) {
+    await Promise.resolve();
+  }
 }
 
 interface MockHibernationService {
@@ -132,6 +152,7 @@ function createDeps(overrides?: Partial<ResourceProfileDeps>): {
 } {
   const pty: MockPtyClient = {
     setResourceProfile: vi.fn(),
+    getAllTerminalsAsync: vi.fn().mockResolvedValue([]),
   };
   const workspace: MockWorkspaceClient = {
     updateMonitorConfig: vi.fn(),
@@ -228,31 +249,21 @@ describe("ResourceProfileService adversarial", () => {
     service.stop();
   });
 
-  it("ignores an in-flight getAllStatesAsync resolution after stop", async () => {
-    const pendingStates = deferred<Array<{ id: string }>>();
-    const { deps, workspace } = createDeps();
-    workspace.getAllStatesAsync.mockReturnValueOnce(pendingStates.promise);
+  it("ignores an in-flight getAllTerminalsAsync resolution after stop", async () => {
+    const pendingTerminals = deferred<Array<Record<string, unknown>>>();
+    const { deps, pty } = createDeps();
+    pty.getAllTerminalsAsync.mockReturnValueOnce(pendingTerminals.promise);
 
     const service = new ResourceProfileService(deps);
     service.start();
     service.stop();
 
-    pendingStates.resolve([
-      { id: "wt-1" },
-      { id: "wt-2" },
-      { id: "wt-3" },
-      { id: "wt-4" },
-      { id: "wt-5" },
-      { id: "wt-6" },
-      { id: "wt-7" },
-      { id: "wt-8" },
-      { id: "wt-9" },
-    ]);
-    await pendingStates.promise;
+    pendingTerminals.resolve(makeActiveAgentTerminals(20));
+    await pendingTerminals.promise;
     await Promise.resolve();
 
-    const internals = service as unknown as { cachedWorktreeCount: number };
-    expect(internals.cachedWorktreeCount).toBe(0);
+    const internals = service as unknown as { cachedActiveAgentCount: number };
+    expect(internals.cachedActiveAgentCount).toBe(0);
   });
 
   it("clears pending evaluation timers on stop", () => {
@@ -274,18 +285,20 @@ describe("ResourceProfileService adversarial", () => {
     expect(broadcastToRenderer).not.toHaveBeenCalled();
   });
 
-  it("prefers the most constrained profile when memory and worktree pressure spike together", () => {
-    const { deps } = createDeps();
+  it("prefers the most constrained profile when memory and fleet pressure spike together", async () => {
+    const { deps, pty } = createDeps();
+    pty.getAllTerminalsAsync.mockResolvedValue(makeActiveAgentTerminals(9));
     const service = new ResourceProfileService(deps);
 
-    service.setWorktreeCount(9);
     service.start();
+    await flushAsync();
 
     mockGetAppMetrics.mockReturnValue([makeMetric(1300)]);
     mockIsOnBatteryPower.mockReturnValue(false);
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
 
+    // HIGH memory (+2) + 9 agents (+1 at FLEET_COUNT_HIGH) = 3 => efficiency
     expect(service.getProfile()).toBe("efficiency");
     service.stop();
   });
@@ -331,15 +344,16 @@ describe("ResourceProfileService adversarial", () => {
     service.stop();
   });
 
-  it("thermal and speed-limit signals combine with worktree count for efficiency", () => {
-    const { deps } = createDeps();
+  it("thermal and speed-limit signals combine with active-agent count for efficiency", async () => {
+    const { deps, pty } = createDeps();
+    pty.getAllTerminalsAsync.mockResolvedValue(makeActiveAgentTerminals(9));
     const service = new ResourceProfileService(deps);
 
-    service.setWorktreeCount(9);
     mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
+    await flushAsync();
 
-    // Low memory (0) + battery (+1) + thermal serious (+1) + worktrees (+1) = 3 => efficiency
+    // Low memory (0) + battery (+1) + thermal serious (+1) + 9 agents (+1) = 3 => efficiency
     mockGetAppMetrics.mockReturnValue([makeMetric(200)]);
     (service as unknown as { thermalState: string }).thermalState = "serious";
 
@@ -672,13 +686,13 @@ describe("ResourceProfileService adversarial", () => {
       service.stop();
     });
 
-    it("escalation skips refreshWorktreeCount", async () => {
-      const { deps, workspace } = createDeps();
+    it("escalation skips refreshFleetState", async () => {
+      const { deps, pty } = createDeps();
       const service = new ResourceProfileService(deps);
       service.start();
 
-      // start() invokes refreshWorktreeCount once unconditionally.
-      const initialCalls = workspace.getAllStatesAsync.mock.calls.length;
+      // start() invokes refreshFleetState once unconditionally.
+      const initialCalls = pty.getAllTerminalsAsync.mock.calls.length;
 
       // Enter degraded.
       setLag(300, 0.85);
@@ -690,9 +704,9 @@ describe("ResourceProfileService adversarial", () => {
       vi.advanceTimersByTime(5_000);
       expect((service as unknown as { lagEscalatedActive: boolean }).lagEscalatedActive).toBe(true);
 
-      // The next 30s eval should NOT call refreshWorktreeCount.
+      // The next 30s eval should NOT call refreshFleetState (no new IPC fetch).
       vi.advanceTimersByTime(30_000);
-      expect(workspace.getAllStatesAsync).toHaveBeenCalledTimes(initialCalls);
+      expect(pty.getAllTerminalsAsync).toHaveBeenCalledTimes(initialCalls);
 
       service.stop();
     });
@@ -1013,6 +1027,107 @@ describe("ResourceProfileService adversarial", () => {
       };
       expect(internals.lagInterval).toBeNull();
       expect(internals.lagHistogram).toBeNull();
+    });
+  });
+
+  describe("active-agent count filtering", () => {
+    it("counts terminals across all ACTIVE_AGENT_STATES (working, waiting, directing)", async () => {
+      const { deps, pty } = createDeps();
+      pty.getAllTerminalsAsync.mockResolvedValue([
+        { id: "a", agentState: "working", detectedAgentId: "claude" },
+        { id: "b", agentState: "waiting", detectedAgentId: "gemini" },
+        { id: "c", agentState: "directing", detectedAgentId: "claude" },
+        { id: "d", agentState: "working", detectedAgentId: "codex" },
+        { id: "e", agentState: "waiting", detectedAgentId: "claude" },
+        { id: "f", agentState: "directing", detectedAgentId: "claude" },
+        { id: "g", agentState: "working", detectedAgentId: "claude" },
+        { id: "h", agentState: "working", detectedAgentId: "claude" },
+      ]);
+      const service = new ResourceProfileService(deps);
+      service.start();
+      await flushAsync();
+
+      // 8 active agents → +1; no other pressure → balanced
+      mockGetAppMetrics.mockReturnValue([makeMetric(200)]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("balanced");
+
+      service.stop();
+    });
+
+    it("accepts launchAgentId before runtime detection ever fired", async () => {
+      const { deps, pty } = createDeps();
+      // Cold-launched agents before first state-machine detection. Identity
+      // comes from launchAgentId; everDetectedAgent is undefined (false-ish).
+      pty.getAllTerminalsAsync.mockResolvedValue(
+        Array.from({ length: 24 }, (_, i) => ({
+          id: `launch-${i}`,
+          agentState: "working",
+          launchAgentId: "claude",
+        }))
+      );
+      const service = new ResourceProfileService(deps);
+      service.start();
+      await flushAsync();
+
+      // 24 agents alone (+3) → efficiency
+      mockGetAppMetrics.mockReturnValue([makeMetric(200)]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      service.stop();
+    });
+
+    it("excludes terminals whose agent exited (everDetectedAgent=true, no detectedAgentId)", async () => {
+      const { deps, pty } = createDeps();
+      // Residual shell after agent exit: everDetectedAgent sticky, detectedAgentId cleared.
+      // These would falsely inflate the fleet count if not filtered.
+      pty.getAllTerminalsAsync.mockResolvedValue(
+        Array.from({ length: 24 }, (_, i) => ({
+          id: `exit-${i}`,
+          agentState: "working",
+          launchAgentId: "claude",
+          everDetectedAgent: true,
+          // no detectedAgentId
+        }))
+      );
+      const service = new ResourceProfileService(deps);
+      service.start();
+      await flushAsync();
+
+      mockGetAppMetrics.mockReturnValue([makeMetric(200)]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      // Zero qualifying agents → performance (after upgrade hold)
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("performance");
+
+      service.stop();
+    });
+
+    it("retains last-known agent count when getAllTerminalsAsync rejects", async () => {
+      const { deps, pty } = createDeps();
+      pty.getAllTerminalsAsync.mockResolvedValueOnce(makeActiveAgentTerminals(24));
+      const service = new ResourceProfileService(deps);
+      service.start();
+      await flushAsync();
+
+      // Subsequent refreshes fail.
+      pty.getAllTerminalsAsync.mockRejectedValue(new Error("ipc down"));
+
+      mockGetAppMetrics.mockReturnValue([makeMetric(200)]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      // Should still drive to efficiency because the 24-count was already cached.
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+      await flushAsync();
+      expect(service.getProfile()).toBe("efficiency");
+
+      service.stop();
     });
   });
 });

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -76,10 +76,34 @@ function makeMetric(type: string, privateMb: number): Electron.ProcessMetric {
 
 interface MockPtyClient {
   setResourceProfile: Mock;
+  getAllTerminalsAsync: Mock;
 }
 interface MockWorkspaceClient {
   updateMonitorConfig: Mock;
   getAllStatesAsync: Mock;
+}
+
+function makeActiveAgentTerminals(count: number): Array<Record<string, unknown>> {
+  const terminals: Array<Record<string, unknown>> = [];
+  for (let i = 0; i < count; i += 1) {
+    terminals.push({
+      id: `t-${i}`,
+      agentState: "working",
+      detectedAgentId: "claude",
+      isTrashed: false,
+    });
+  }
+  return terminals;
+}
+
+async function flushAsync(): Promise<void> {
+  // The fleet refresh fires fire-and-forget promises inside the eval timer.
+  // After advancing fake timers we need to drain the microtask queue so the
+  // `.then(...)` writers commit `cachedActiveAgentCount` before computeTargetProfile
+  // runs on the next tick.
+  for (let i = 0; i < 5; i += 1) {
+    await Promise.resolve();
+  }
 }
 interface MockHibernationService {
   setMemoryPressureThresholdMs: Mock;
@@ -96,6 +120,7 @@ interface MockProjectStatsService {
 function createDeps(overrides?: Partial<ResourceProfileDeps>): ResourceProfileDeps {
   const mockPtyClient: MockPtyClient = {
     setResourceProfile: vi.fn(),
+    getAllTerminalsAsync: vi.fn().mockResolvedValue([]),
   };
   const mockWorkspaceClient: MockWorkspaceClient = {
     updateMonitorConfig: vi.fn(),
@@ -663,18 +688,109 @@ describe("ResourceProfileService", () => {
     service.stop();
   });
 
-  it("high worktree count contributes to pressure", () => {
+  it("high active-agent count contributes to pressure", async () => {
     const deps = createDeps();
+    const mockPty = deps.getPtyClient() as unknown as MockPtyClient;
+    mockPty.getAllTerminalsAsync.mockResolvedValue(makeActiveAgentTerminals(10));
     const service = new ResourceProfileService(deps);
-    service.setWorktreeCount(10);
     mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
+    await flushAsync();
 
-    // Low memory (0) + battery (+1) + worktrees (+1) = 2 => balanced
+    // Low memory (0) + battery (+1) + 10 agents (+1 at FLEET_COUNT_HIGH=8) = 2 => balanced
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
     expect(service.getProfile()).toBe("balanced");
+
+    service.stop();
+  });
+
+  it("16 active agents alone reach balanced from performance", async () => {
+    const deps = createDeps();
+    const mockPty = deps.getPtyClient() as unknown as MockPtyClient;
+    mockPty.getAllTerminalsAsync.mockResolvedValue(makeActiveAgentTerminals(16));
+    const service = new ResourceProfileService(deps);
+    service.start();
+    await flushAsync();
+
+    // Low memory (0) + no battery (0) + 16 agents (+2 at FLEET_COUNT_VERY_HIGH=16) = 2 => balanced
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("balanced");
+
+    service.stop();
+  });
+
+  it("24 active agents alone drive to efficiency", async () => {
+    const deps = createDeps();
+    const mockPty = deps.getPtyClient() as unknown as MockPtyClient;
+    mockPty.getAllTerminalsAsync.mockResolvedValue(makeActiveAgentTerminals(24));
+    const service = new ResourceProfileService(deps);
+    service.start();
+    await flushAsync();
+
+    // Low memory (0) + no battery (0) + 24 agents (+3 at FLEET_COUNT_CRITICAL=24) = 3 => efficiency.
+    // This is the core fix: fleet size alone could never reach efficiency under the
+    // old flat +1 worktree-count signal.
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    service.stop();
+  });
+
+  it("7 active agents (below FLEET_COUNT_HIGH) contribute zero pressure", async () => {
+    const deps = createDeps();
+    const mockPty = deps.getPtyClient() as unknown as MockPtyClient;
+    mockPty.getAllTerminalsAsync.mockResolvedValue(makeActiveAgentTerminals(7));
+    const service = new ResourceProfileService(deps);
+    service.start();
+    await flushAsync();
+
+    // Low memory (0) + no battery (0) + 7 agents (0) = 0 => performance (after upgrade hold)
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("performance");
+
+    service.stop();
+  });
+
+  it("trashed and idle terminals are excluded from the active-agent count", async () => {
+    const deps = createDeps();
+    const mockPty = deps.getPtyClient() as unknown as MockPtyClient;
+    // 24 entries total but only 7 qualify as live agents: the rest are either
+    // trashed, idle/completed, or lack an agent identity.
+    const mix: Array<Record<string, unknown>> = [];
+    for (let i = 0; i < 7; i += 1) {
+      mix.push({ id: `live-${i}`, agentState: "working", detectedAgentId: "claude" });
+    }
+    for (let i = 0; i < 8; i += 1) {
+      mix.push({ id: `trash-${i}`, agentState: "working", detectedAgentId: "claude", isTrashed: true });
+    }
+    for (let i = 0; i < 5; i += 1) {
+      mix.push({ id: `idle-${i}`, agentState: "idle", detectedAgentId: "claude" });
+    }
+    for (let i = 0; i < 4; i += 1) {
+      mix.push({ id: `noid-${i}`, agentState: "working" }); // no agent identity
+    }
+    mockPty.getAllTerminalsAsync.mockResolvedValue(mix);
+    const service = new ResourceProfileService(deps);
+    service.start();
+    await flushAsync();
+
+    // Only 7 live agents (below FLEET_COUNT_HIGH=8) — fleet score 0.
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("performance");
 
     service.stop();
   });
@@ -919,18 +1035,20 @@ describe("ResourceProfileService", () => {
     expect(mockPowerMonitorRemoveListener).toHaveBeenCalledWith("on-ac", expect.any(Function));
   });
 
-  it("scales thresholds down on low-RAM devices so 500 MB usage is detected", () => {
+  it("scales thresholds down on low-RAM devices so 500 MB usage is detected", async () => {
     // 4 GB machine: HIGH = 614 MB, LOW = 328 MB.
     // 500 MB of privateBytes must score LOW (+1), not HIGH (+2). To discriminate,
-    // pair with 10 worktrees (+1). LOW + worktrees = 2 → balanced;
-    // HIGH + worktrees = 3 → efficiency. The "balanced" assertion only passes
+    // pair with 10 active agents (+1). LOW + agents = 2 → balanced;
+    // HIGH + agents = 3 → efficiency. The "balanced" assertion only passes
     // if the 500 MB reading was scored as LOW.
     vi.spyOn(os, "totalmem").mockReturnValue(4 * 1024 * 1024 * 1024);
 
     const deps = createDeps();
+    const mockPty = deps.getPtyClient() as unknown as MockPtyClient;
+    mockPty.getAllTerminalsAsync.mockResolvedValue(makeActiveAgentTerminals(10));
     const service = new ResourceProfileService(deps);
-    service.setWorktreeCount(10);
     service.start();
+    await flushAsync();
 
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 500)]);
     mockIsOnBatteryPower.mockReturnValue(false);
@@ -1041,5 +1159,189 @@ describe("ResourceProfileService", () => {
     expect(mockIsOnBatteryPower).toHaveBeenCalledTimes(1);
 
     service.stop();
+  });
+
+  describe("system available memory signal", () => {
+    // The Electron-augmented `process.getSystemMemoryInfo` lives on the real
+    // process global, so we attach a stub directly and restore it after each
+    // test. `vi.stubGlobal('process', ...)` would obliterate Node internals.
+    let originalGetSystemMemoryInfo: unknown;
+
+    beforeEach(() => {
+      originalGetSystemMemoryInfo = (process as { getSystemMemoryInfo?: unknown })
+        .getSystemMemoryInfo;
+    });
+
+    afterEach(() => {
+      if (originalGetSystemMemoryInfo === undefined) {
+        delete (process as { getSystemMemoryInfo?: unknown }).getSystemMemoryInfo;
+      } else {
+        (process as { getSystemMemoryInfo?: unknown }).getSystemMemoryInfo =
+          originalGetSystemMemoryInfo;
+      }
+    });
+
+    function stubSystemMemory(freeKb: number, purgeableKb: number, totalKb: number): void {
+      (process as { getSystemMemoryInfo?: unknown }).getSystemMemoryInfo = vi.fn(() => ({
+        free: freeKb,
+        purgeable: purgeableKb,
+        total: totalKb,
+      }));
+    }
+
+    it("system available memory below 10% of total adds +2 to pressure", () => {
+      // 8 GB total. 10% = 819 MB. Stub free+purgeable = 500 MB (well below LOW threshold).
+      // Free 300 MB + purgeable 200 MB = 500 MB available.
+      stubSystemMemory(300 * 1024, 200 * 1024, EIGHT_GB / 1024);
+
+      const deps = createDeps();
+      const service = new ResourceProfileService(deps);
+      mockIsOnBatteryPower.mockReturnValue(true);
+      service.start();
+
+      // Low app memory (0) + battery (+1) + sys mem <10% (+2) = 3 => efficiency
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      service.stop();
+    });
+
+    it("system available memory between 10–20% of total adds +1 to pressure", () => {
+      // 8 GB total. HIGH threshold (20%) = 1638 MB; LOW (10%) = 819 MB.
+      // Stub free 1000 MB + purgeable 0 = 1000 MB (between LOW and HIGH).
+      stubSystemMemory(1000 * 1024, 0, EIGHT_GB / 1024);
+
+      const deps = createDeps();
+      const service = new ResourceProfileService(deps);
+      mockIsOnBatteryPower.mockReturnValue(true);
+      service.start();
+
+      // Low app memory (0) + battery (+1) + sys mem 12% (+1) = 2 => balanced
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("balanced");
+
+      service.stop();
+    });
+
+    it("system available memory above 20% does not contribute", () => {
+      // Free 3 GB on 8 GB total = 37% available.
+      stubSystemMemory(3 * 1024 * 1024, 0, EIGHT_GB / 1024);
+
+      const deps = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // Low memory (0) + no battery (0) + sys mem fine (0) = 0 => performance
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("performance");
+
+      service.stop();
+    });
+
+    it("includes purgeable memory in the 'available' calculation", () => {
+      // 8 GB total. Free alone = 200 MB (well below 10% / 819 MB).
+      // With purgeable = 4 GB folded in, available = 4.2 GB (above 20% / 1638 MB).
+      // Asserting "performance" only passes if purgeable was added — without it
+      // the score would jump to +2 (sys mem critical).
+      stubSystemMemory(200 * 1024, 4 * 1024 * 1024, EIGHT_GB / 1024);
+
+      const deps = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("performance");
+
+      service.stop();
+    });
+
+    it("treats missing purgeable field as 0", () => {
+      // Non-macOS shape: only free is reported. Free = 500 MB on 8 GB = 6% available.
+      (process as { getSystemMemoryInfo?: unknown }).getSystemMemoryInfo = vi.fn(() => ({
+        free: 500 * 1024,
+        total: EIGHT_GB / 1024,
+      }));
+
+      const deps = createDeps();
+      const service = new ResourceProfileService(deps);
+      mockIsOnBatteryPower.mockReturnValue(true);
+      service.start();
+
+      // sys mem <10% (+2) + battery (+1) = 3 => efficiency
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      service.stop();
+    });
+
+    it("contributes nothing when process.getSystemMemoryInfo is absent", () => {
+      // Default state: no stub. Removed defensively in case the test runner
+      // happens to expose it.
+      delete (process as { getSystemMemoryInfo?: unknown }).getSystemMemoryInfo;
+
+      const deps = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("performance");
+
+      service.stop();
+    });
+
+    it("swallows errors from getSystemMemoryInfo", () => {
+      (process as { getSystemMemoryInfo?: unknown }).getSystemMemoryInfo = vi.fn(() => {
+        throw new Error("simulated native failure");
+      });
+
+      const deps = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // Should not throw; sys mem signal contributes 0.
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      expect(() =>
+        vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000)
+      ).not.toThrow();
+      expect(service.getProfile()).toBe("performance");
+
+      service.stop();
+    });
+
+    it("treats non-positive available memory as no signal", () => {
+      // Edge case: API returns zero/negative free which would otherwise create
+      // a false positive. The helper should return null and the signal should
+      // not contribute, mirroring ProjectViewManager.
+      stubSystemMemory(0, 0, EIGHT_GB / 1024);
+
+      const deps = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("performance");
+
+      service.stop();
+    });
   });
 });

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -706,6 +706,25 @@ describe("ResourceProfileService", () => {
     service.stop();
   });
 
+  it("exactly 8 active agents alone (FLEET_COUNT_HIGH boundary) reach balanced", async () => {
+    const deps = createDeps();
+    const mockPty = deps.getPtyClient() as unknown as MockPtyClient;
+    mockPty.getAllTerminalsAsync.mockResolvedValue(makeActiveAgentTerminals(8));
+    const service = new ResourceProfileService(deps);
+    service.start();
+    await flushAsync();
+
+    // Discriminating: with no other pressure, score 0 → "performance" after
+    // upgrade hold. Adding 8 agents pulls the score to +1 → blocks performance.
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("balanced");
+
+    service.stop();
+  });
+
   it("16 active agents alone reach balanced from performance", async () => {
     const deps = createDeps();
     const mockPty = deps.getPtyClient() as unknown as MockPtyClient;

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -791,7 +791,12 @@ describe("ResourceProfileService", () => {
       mix.push({ id: `live-${i}`, agentState: "working", detectedAgentId: "claude" });
     }
     for (let i = 0; i < 8; i += 1) {
-      mix.push({ id: `trash-${i}`, agentState: "working", detectedAgentId: "claude", isTrashed: true });
+      mix.push({
+        id: `trash-${i}`,
+        agentState: "working",
+        detectedAgentId: "claude",
+        isTrashed: true,
+      });
     }
     for (let i = 0; i < 5; i += 1) {
       mix.push({ id: `idle-${i}`, agentState: "idle", detectedAgentId: "claude" });


### PR DESCRIPTION
## Summary

- Fleet size now gives a graduated signal: 8+ active agents adds +1 to the pressure score, 16+ adds +2, 24+ adds +3. The previous flat +1 was indistinguishable across fleet sizes, so a 24-agent fleet scored the same as an 8-worktree machine.
- System available memory is now folded into the score via `process.getSystemMemoryInfo()` (free + purgeable on macOS, free elsewhere, matching `ProjectViewManager`). Below 20% of total RAM adds +1; below 10% adds +2.
- Active agent count is now read directly from `PtyClient.getAllTerminalsAsync()` filtered by `ACTIVE_AGENT_STATES`, `hasPty`, and agent identity, replacing the worktree-count IPC round-trip.

Resolves #8623

## Changes

- `computeTargetProfile` in `ResourceProfileService` now applies graduated fleet-size pressure and system-memory pressure to the score.
- `refreshWorktreeCount` renamed to `refreshFleetState`; a `refreshGeneration` counter guards against stale-promise races and out-of-order responses.
- Removed the now-unused `setWorktreeCount` / `cachedWorktreeCount` surface and the workspace IPC dependency from this service.

## Testing

96 tests pass (primary suite + adversarial). Coverage includes: fleet boundary cases (7/8/16/24 agents), identity filtering, trashed/idle/`hasPty=false` exclusion, generation-guard race, restart cache reset, and 4 system-memory edge paths (absent API, throwing API, missing `purgeable`, non-positive available memory).