### PR TITLE
refactor(recovery): centralize banner copy in typed registries

### DIFF
--- a/src/components/Recovery/HostCrashBanner.tsx
+++ b/src/components/Recovery/HostCrashBanner.tsx
@@ -1,6 +1,5 @@
 import { useState, type CSSProperties } from "react";
 import { AlertTriangle, Loader2 } from "lucide-react";
-import type { CrashType } from "@shared/types/pty-host";
 import { cn } from "@/lib/utils";
 import { usePanelStore } from "@/store/panelStore";
 import { actionService } from "@/services/ActionService";
@@ -8,6 +7,7 @@ import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { logError } from "@/utils/logger";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { HOST_CRASH_RECOVERING_COPY, getHostCrashBannerCopy } from "./recoveryCopy";
 
 function SpinnerIcon({ className, style }: { className?: string; style?: CSSProperties }) {
   return (
@@ -17,42 +17,6 @@ function SpinnerIcon({ className, style }: { className?: string; style?: CSSProp
       aria-hidden="true"
     />
   );
-}
-
-interface CrashCopy {
-  title: string;
-  body: string;
-}
-
-function copyForCrash(crashType: CrashType | null): CrashCopy {
-  switch (crashType) {
-    case "OUT_OF_MEMORY":
-      return {
-        title: "Terminal service ran out of memory",
-        body: "The terminal backend exhausted memory and gave up after three auto-restart attempts. Close unused terminals before restarting.",
-      };
-    case "SIGNAL_TERMINATED":
-      return {
-        title: "Terminal service was terminated",
-        body: "The OS or a watchdog ended the terminal backend three times in a row. Restart the service to continue.",
-      };
-    case "ASSERTION_FAILURE":
-      return {
-        title: "Terminal service hit an assertion failure",
-        body: "The terminal backend crashed three times in a row. Restart the service to continue.",
-      };
-    case "CLEAN_EXIT":
-      return {
-        title: "Terminal service stopped unexpectedly",
-        body: "The terminal backend exited without an error but wasn't asked to. Restart the service to continue.",
-      };
-    case "UNKNOWN_CRASH":
-    default:
-      return {
-        title: "Terminal service crashed",
-        body: "The terminal backend stopped after three auto-restart attempts. Restart the service to continue.",
-      };
-  }
 }
 
 export function HostCrashBanner() {
@@ -69,8 +33,8 @@ export function HostCrashBanner() {
     return (
       <InlineStatusBanner
         icon={SpinnerIcon}
-        title="Terminal service restarting"
-        description="The terminal backend stopped and is restarting automatically."
+        title={HOST_CRASH_RECOVERING_COPY.title}
+        description={HOST_CRASH_RECOVERING_COPY.description}
         severity="warning"
         role="alert"
         animated={false}
@@ -79,7 +43,7 @@ export function HostCrashBanner() {
     );
   }
 
-  const { title, body } = copyForCrash(lastCrashType);
+  const { title, description } = getHostCrashBannerCopy(lastCrashType);
 
   const handleRestart = async () => {
     if (isRestarting) return;
@@ -97,7 +61,7 @@ export function HostCrashBanner() {
     <InlineStatusBanner
       icon={AlertTriangle}
       title={title}
-      description={body}
+      description={description}
       severity="error"
       role="alert"
       animated={false}

--- a/src/components/Recovery/RestoreConfirmationBanner.tsx
+++ b/src/components/Recovery/RestoreConfirmationBanner.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle } from "lucide-react";
 import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
+import { getRestoreConfirmationTitle } from "./recoveryCopy";
 
 const AUTO_DISMISS_MS = 10_000;
 
@@ -14,11 +15,7 @@ export function RestoreConfirmationBanner() {
   return (
     <InlineStatusBanner
       icon={AlertTriangle}
-      title={
-        suspectCount > 0
-          ? `Session recovered after unexpected exit — ${suspectCount} ${suspectCount === 1 ? "panel" : "panels"} created near the crash may be affected.`
-          : "Session recovered after unexpected exit."
-      }
+      title={getRestoreConfirmationTitle(suspectCount)}
       severity="warning"
       role="status"
       actions={[]}

--- a/src/components/Recovery/SafeModeBanner.tsx
+++ b/src/components/Recovery/SafeModeBanner.tsx
@@ -6,6 +6,7 @@ import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
+import { SAFE_MODE_BANNER_COPY } from "./recoveryCopy";
 
 function formatRelativeTime(timestamp: number): string {
   const diff = Date.now() - timestamp;
@@ -93,7 +94,7 @@ export function SafeModeBanner() {
     <>
       <InlineStatusBanner
         icon={AlertTriangle}
-        title="Safe mode — panels weren't restored"
+        title={SAFE_MODE_BANNER_COPY.title}
         severity="warning"
         role="status"
         trailingSlot={detailsPopover}

--- a/src/components/Recovery/__tests__/recoveryCopy.test.ts
+++ b/src/components/Recovery/__tests__/recoveryCopy.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import type { CrashType } from "@shared/types/pty-host";
+import {
+  HOST_CRASH_BANNER_COPY,
+  HOST_CRASH_RECOVERING_COPY,
+  SAFE_MODE_BANNER_COPY,
+  getHostCrashBannerCopy,
+  getRestoreConfirmationTitle,
+} from "../recoveryCopy";
+
+describe("HOST_CRASH_BANNER_COPY", () => {
+  const cases: Array<[CrashType, string, RegExp]> = [
+    [
+      "OUT_OF_MEMORY",
+      "Terminal service ran out of memory",
+      /exhausted memory.+Close unused terminals/,
+    ],
+    [
+      "SIGNAL_TERMINATED",
+      "Terminal service was terminated",
+      /OS or a watchdog.+Restart the service/,
+    ],
+    [
+      "ASSERTION_FAILURE",
+      "Terminal service hit an assertion failure",
+      /crashed three times in a row/,
+    ],
+    [
+      "CLEAN_EXIT",
+      "Terminal service stopped unexpectedly",
+      /exited without an error but wasn't asked to/,
+    ],
+    ["UNKNOWN_CRASH", "Terminal service crashed", /stopped after three auto-restart attempts/],
+  ];
+
+  it.each(cases)("maps %s to the expected title and description", (type, title, descRe) => {
+    expect(HOST_CRASH_BANNER_COPY[type].title).toBe(title);
+    expect(HOST_CRASH_BANNER_COPY[type].description).toMatch(descRe);
+  });
+
+  it("falls back to UNKNOWN_CRASH copy when crashType is null", () => {
+    expect(getHostCrashBannerCopy(null)).toBe(HOST_CRASH_BANNER_COPY.UNKNOWN_CRASH);
+  });
+
+  it("returns the matching entry for a non-null crashType", () => {
+    expect(getHostCrashBannerCopy("OUT_OF_MEMORY")).toBe(HOST_CRASH_BANNER_COPY.OUT_OF_MEMORY);
+  });
+});
+
+describe("HOST_CRASH_RECOVERING_COPY", () => {
+  it("matches the rendered recovering-banner strings byte-for-byte", () => {
+    expect(HOST_CRASH_RECOVERING_COPY.title).toBe("Terminal service restarting");
+    expect(HOST_CRASH_RECOVERING_COPY.description).toBe(
+      "The terminal backend stopped and is restarting automatically."
+    );
+  });
+});
+
+describe("SAFE_MODE_BANNER_COPY", () => {
+  it("matches the rendered safe-mode title byte-for-byte", () => {
+    expect(SAFE_MODE_BANNER_COPY.title).toBe("Safe mode — panels weren't restored");
+  });
+});
+
+describe("getRestoreConfirmationTitle", () => {
+  it("returns the static title when there are no suspect panels", () => {
+    expect(getRestoreConfirmationTitle(0)).toBe("Session recovered after unexpected exit.");
+  });
+
+  it("pluralises panel/panels by suspectCount", () => {
+    expect(getRestoreConfirmationTitle(1)).toBe(
+      "Session recovered after unexpected exit — 1 panel created near the crash may be affected."
+    );
+    expect(getRestoreConfirmationTitle(3)).toBe(
+      "Session recovered after unexpected exit — 3 panels created near the crash may be affected."
+    );
+  });
+});

--- a/src/components/Recovery/__tests__/recoveryCopy.test.ts
+++ b/src/components/Recovery/__tests__/recoveryCopy.test.ts
@@ -9,42 +9,49 @@ import {
 } from "../recoveryCopy";
 
 describe("HOST_CRASH_BANNER_COPY", () => {
-  const cases: Array<[CrashType, string, RegExp]> = [
+  const cases: Array<[CrashType, string, string]> = [
     [
       "OUT_OF_MEMORY",
       "Terminal service ran out of memory",
-      /exhausted memory.+Close unused terminals/,
+      "The terminal backend exhausted memory and gave up after three auto-restart attempts. Close unused terminals before restarting.",
     ],
     [
       "SIGNAL_TERMINATED",
       "Terminal service was terminated",
-      /OS or a watchdog.+Restart the service/,
+      "The OS or a watchdog ended the terminal backend three times in a row. Restart the service to continue.",
     ],
     [
       "ASSERTION_FAILURE",
       "Terminal service hit an assertion failure",
-      /crashed three times in a row/,
+      "The terminal backend crashed three times in a row. Restart the service to continue.",
     ],
     [
       "CLEAN_EXIT",
       "Terminal service stopped unexpectedly",
-      /exited without an error but wasn't asked to/,
+      "The terminal backend exited without an error but wasn't asked to. Restart the service to continue.",
     ],
-    ["UNKNOWN_CRASH", "Terminal service crashed", /stopped after three auto-restart attempts/],
+    [
+      "UNKNOWN_CRASH",
+      "Terminal service crashed",
+      "The terminal backend stopped after three auto-restart attempts. Restart the service to continue.",
+    ],
   ];
 
-  it.each(cases)("maps %s to the expected title and description", (type, title, descRe) => {
+  it.each(cases)("maps %s to the expected title and description", (type, title, description) => {
     expect(HOST_CRASH_BANNER_COPY[type].title).toBe(title);
-    expect(HOST_CRASH_BANNER_COPY[type].description).toMatch(descRe);
+    expect(HOST_CRASH_BANNER_COPY[type].description).toBe(description);
   });
 
   it("falls back to UNKNOWN_CRASH copy when crashType is null", () => {
     expect(getHostCrashBannerCopy(null)).toBe(HOST_CRASH_BANNER_COPY.UNKNOWN_CRASH);
   });
 
-  it("returns the matching entry for a non-null crashType", () => {
-    expect(getHostCrashBannerCopy("OUT_OF_MEMORY")).toBe(HOST_CRASH_BANNER_COPY.OUT_OF_MEMORY);
-  });
+  it.each(cases.map(([type]) => [type] as [CrashType]))(
+    "getHostCrashBannerCopy returns the matching entry for %s",
+    (type) => {
+      expect(getHostCrashBannerCopy(type)).toBe(HOST_CRASH_BANNER_COPY[type]);
+    }
+  );
 });
 
 describe("HOST_CRASH_RECOVERING_COPY", () => {
@@ -70,6 +77,9 @@ describe("getRestoreConfirmationTitle", () => {
   it("pluralises panel/panels by suspectCount", () => {
     expect(getRestoreConfirmationTitle(1)).toBe(
       "Session recovered after unexpected exit — 1 panel created near the crash may be affected."
+    );
+    expect(getRestoreConfirmationTitle(2)).toBe(
+      "Session recovered after unexpected exit — 2 panels created near the crash may be affected."
     );
     expect(getRestoreConfirmationTitle(3)).toBe(
       "Session recovered after unexpected exit — 3 panels created near the crash may be affected."

--- a/src/components/Recovery/recoveryCopy.ts
+++ b/src/components/Recovery/recoveryCopy.ts
@@ -1,0 +1,54 @@
+import type { CrashType } from "@shared/types/pty-host";
+
+export interface RecoveryBannerCopy {
+  title: string;
+  description: string;
+}
+
+export const HOST_CRASH_RECOVERING_COPY = {
+  title: "Terminal service restarting",
+  description: "The terminal backend stopped and is restarting automatically.",
+} as const satisfies RecoveryBannerCopy;
+
+export const HOST_CRASH_BANNER_COPY = {
+  OUT_OF_MEMORY: {
+    title: "Terminal service ran out of memory",
+    description:
+      "The terminal backend exhausted memory and gave up after three auto-restart attempts. Close unused terminals before restarting.",
+  },
+  SIGNAL_TERMINATED: {
+    title: "Terminal service was terminated",
+    description:
+      "The OS or a watchdog ended the terminal backend three times in a row. Restart the service to continue.",
+  },
+  ASSERTION_FAILURE: {
+    title: "Terminal service hit an assertion failure",
+    description:
+      "The terminal backend crashed three times in a row. Restart the service to continue.",
+  },
+  CLEAN_EXIT: {
+    title: "Terminal service stopped unexpectedly",
+    description:
+      "The terminal backend exited without an error but wasn't asked to. Restart the service to continue.",
+  },
+  UNKNOWN_CRASH: {
+    title: "Terminal service crashed",
+    description:
+      "The terminal backend stopped after three auto-restart attempts. Restart the service to continue.",
+  },
+} as const satisfies Record<CrashType, RecoveryBannerCopy>;
+
+export function getHostCrashBannerCopy(crashType: CrashType | null): RecoveryBannerCopy {
+  return HOST_CRASH_BANNER_COPY[crashType ?? "UNKNOWN_CRASH"];
+}
+
+export const SAFE_MODE_BANNER_COPY = {
+  title: "Safe mode — panels weren't restored",
+} as const;
+
+export function getRestoreConfirmationTitle(suspectCount: number): string {
+  if (suspectCount > 0) {
+    return `Session recovered after unexpected exit — ${suspectCount} ${suspectCount === 1 ? "panel" : "panels"} created near the crash may be affected.`;
+  }
+  return "Session recovered after unexpected exit.";
+}

--- a/src/components/Terminal/TerminalRestartStatusBanner.tsx
+++ b/src/components/Terminal/TerminalRestartStatusBanner.tsx
@@ -3,6 +3,7 @@ import { XCircle, Loader2, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { InlineStatusBanner } from "./InlineStatusBanner";
 import type { RestartBannerVariant } from "./restartStatus";
+import { RESTART_BANNER_COPY } from "./restartBannerCopy";
 
 export interface TerminalRestartStatusBannerProps {
   variant: RestartBannerVariant;
@@ -33,7 +34,7 @@ export function TerminalRestartStatusBanner({
       return (
         <InlineStatusBanner
           icon={SpinnerIcon}
-          title="Auto-restarting…"
+          title={RESTART_BANNER_COPY["auto-restarting"].title}
           severity="info"
           animated={false}
           role="status"
@@ -46,7 +47,7 @@ export function TerminalRestartStatusBanner({
       return (
         <InlineStatusBanner
           icon={XCircle}
-          title={`Session exited with code ${variant.exitCode}`}
+          title={RESTART_BANNER_COPY["exit-error"]({ exitCode: variant.exitCode }).title}
           severity="error"
           animated={false}
           actions={[

--- a/src/components/Terminal/__tests__/restartBannerCopy.test.ts
+++ b/src/components/Terminal/__tests__/restartBannerCopy.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { RESTART_BANNER_COPY } from "../restartBannerCopy";
+
+describe("RESTART_BANNER_COPY", () => {
+  it("renders the auto-restarting title with a Unicode ellipsis", () => {
+    expect(RESTART_BANNER_COPY["auto-restarting"].title).toBe("Auto-restarting…");
+  });
+
+  it("interpolates exitCode into the exit-error title", () => {
+    expect(RESTART_BANNER_COPY["exit-error"]({ exitCode: 1 }).title).toBe(
+      "Session exited with code 1"
+    );
+    expect(RESTART_BANNER_COPY["exit-error"]({ exitCode: 137 }).title).toBe(
+      "Session exited with code 137"
+    );
+  });
+});

--- a/src/components/Terminal/restartBannerCopy.ts
+++ b/src/components/Terminal/restartBannerCopy.ts
@@ -1,0 +1,9 @@
+export interface RestartBannerCopyMap {
+  "auto-restarting": { title: string };
+  "exit-error": (args: { exitCode: number }) => { title: string };
+}
+
+export const RESTART_BANNER_COPY: RestartBannerCopyMap = {
+  "auto-restarting": { title: "Auto-restarting…" },
+  "exit-error": ({ exitCode }) => ({ title: `Session exited with code ${exitCode}` }),
+};


### PR DESCRIPTION
Extracts recovery-banner copy from 4 inline locations into 2 collocated typed registries: `recoveryCopy.ts` for the 3 Recovery components, and `restartBannerCopy.ts` for `TerminalRestartStatusBanner`.

`HOST_CRASH_BANNER_COPY` uses `as const satisfies Record<CrashType, RecoveryBannerCopy>` for compile-time exhaustiveness — a missing `CrashType` variant is now a type error, not a silent gap.

Dynamic copy stays as functions: `getHostCrashBannerCopy` handles the null-safe fallback, `getRestoreConfirmationTitle` handles panel/panels pluralisation, and the `RESTART_BANNER_COPY` `"exit-error"` entry is a function taking `exitCode`. Rendered output is byte-identical.

Resolves #8680.

## Changes

- `recoveryCopy.ts` — typed registry for `HostCrashBanner`, `RestoreConfirmationBanner`, `SafeModeBanner`
- `restartBannerCopy.ts` — typed registry for `TerminalRestartStatusBanner`
- 4 modified components — inline copy replaced with registry lookups
- 2 test files — exact-string assertions for every entry, all 5 `CrashType` variants, and the `suspectCount` boundary

## Testing

79 tests pass. Unit tests cover all 5 `CrashType` variants and both sides of the `suspectCount` boundary. Typecheck, lint, format, and build all clean. No copy changes. No behavioural changes.