### PR TITLE
refactor(motion): make anti-flicker threshold a single CSS/TS source of truth

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -661,6 +661,11 @@ code.hljs {
   --terminal-animation-duration: 50ms;
   --focus-transition-duration: 150ms;
   --focus-transition-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  /* Anti-flicker (Doherty) gate — single source of truth for the 400ms
+   * perceptual floor below which loading affordances should stay hidden.
+   * Mirror of UI_DOHERTY_THRESHOLD in src/lib/animationUtils.ts; the contract
+   * test in src/lib/__tests__/animationUtils.test.ts enforces parity. */
+  --anti-flicker-delay: 400ms;
   --background: var(--theme-surface-canvas);
   --foreground: var(--theme-text-primary);
   --card: var(--theme-surface-panel);
@@ -1124,7 +1129,7 @@ body,
 .animate-pulse-delayed {
   opacity: 0;
   animation: pulse-delayed 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-  animation-delay: 400ms;
+  animation-delay: var(--anti-flicker-delay);
   will-change: opacity;
 }
 
@@ -1143,11 +1148,13 @@ body,
  * (typical for ~258 actions on fast hardware), the dim never starts. On a
  * genuinely overloaded render the surface fades to half opacity as a "still
  * working" cue.
- * Keep in sync with UI_DOHERTY_THRESHOLD in src/lib/animationUtils.ts. */
+ * The 400ms gate lives in the --anti-flicker-delay token in :root above; the
+ * UI_DOHERTY_THRESHOLD constant in src/lib/animationUtils.ts mirrors it for
+ * JS consumers. */
 .palette-results-stale,
 .surface-stale {
   opacity: 0.5;
-  transition: opacity 150ms ease-out 400ms;
+  transition: opacity 150ms ease-out var(--anti-flicker-delay);
 }
 
 /* Opt-in shimmer sweep for skeleton bones. Layered on top of the opacity pulse;

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -167,7 +167,8 @@ describe("--anti-flicker-delay CSS contract", () => {
   it("token value matches UI_DOHERTY_THRESHOLD", () => {
     const match = css.match(/--anti-flicker-delay\s*:\s*(\d+)ms/);
     expect(match).not.toBeNull();
-    const ms = Number.parseInt(match![1], 10);
+    if (!match?.[1]) return;
+    const ms = Number.parseInt(match[1], 10);
     expect(ms).toBe(UI_DOHERTY_THRESHOLD);
   });
 

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   DURATION_75,
@@ -18,6 +20,7 @@ import {
   PANEL_RESTORE_DURATION,
   TERMINAL_ANIMATION_DURATION,
   UI_ANIMATION_DURATION,
+  UI_DOHERTY_THRESHOLD,
   UI_ENTER_DURATION,
   UI_EXIT_DURATION,
   UI_ENTER_EASING,
@@ -137,5 +140,35 @@ describe("spring easing constants", () => {
   it("uses asymmetric durations with exit faster than enter", () => {
     expect(UI_EXIT_DURATION).toBeLessThan(UI_ENTER_DURATION);
     expect(UI_EXIT_DURATION / UI_ENTER_DURATION).toBe(0.6);
+  });
+});
+
+describe("--anti-flicker-delay CSS contract", () => {
+  // Read the source CSS once. Asserting authored intent in src/index.css —
+  // the build pipeline (Tailwind, autoprefixer) doesn't affect these regexes.
+  const css = readFileSync(resolve(__dirname, "../../index.css"), "utf8");
+
+  it("declares --anti-flicker-delay in :root", () => {
+    expect(css).toMatch(/--anti-flicker-delay\s*:\s*\d+ms/);
+  });
+
+  it("token value matches UI_DOHERTY_THRESHOLD", () => {
+    const match = css.match(/--anti-flicker-delay\s*:\s*(\d+)ms/);
+    expect(match).not.toBeNull();
+    const ms = Number.parseInt(match![1], 10);
+    expect(ms).toBe(UI_DOHERTY_THRESHOLD);
+  });
+
+  it(".animate-pulse-delayed references the token (not a bare literal)", () => {
+    expect(css).toMatch(
+      /\.animate-pulse-delayed\s*\{[\s\S]*?animation-delay:\s*var\(--anti-flicker-delay\)/
+    );
+    expect(css).not.toMatch(/\.animate-pulse-delayed\s*\{[\s\S]*?animation-delay:\s*\d+ms/);
+  });
+
+  it(".palette-results-stale / .surface-stale transition references the token", () => {
+    expect(css).toMatch(
+      /\.palette-results-stale,\s*\.surface-stale\s*\{[\s\S]*?transition:\s*opacity\s+150ms\s+ease-out\s+var\(--anti-flicker-delay\)/
+    );
   });
 });

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -148,8 +148,20 @@ describe("--anti-flicker-delay CSS contract", () => {
   // the build pipeline (Tailwind, autoprefixer) doesn't affect these regexes.
   const css = readFileSync(resolve(__dirname, "../../index.css"), "utf8");
 
-  it("declares --anti-flicker-delay in :root", () => {
-    expect(css).toMatch(/--anti-flicker-delay\s*:\s*\d+ms/);
+  it("declares --anti-flicker-delay inside the :root block", () => {
+    // Scope matters: a stray declaration in a narrower selector would let
+    // var() fall through to its initial value for consumers outside that
+    // scope. Anchor the property to the :root block so the test fails if it
+    // ever migrates out.
+    expect(css).toMatch(/:root\s*\{[^}]*--anti-flicker-delay\s*:\s*\d+ms/);
+  });
+
+  it("declares --anti-flicker-delay exactly once", () => {
+    // A second declaration in a media query or duplicate :root would let the
+    // cascade resolve to a different value while the first-match parity test
+    // below still passes — guard against that.
+    const declarations = css.match(/--anti-flicker-delay\s*:/g) ?? [];
+    expect(declarations.length).toBe(1);
   });
 
   it("token value matches UI_DOHERTY_THRESHOLD", () => {

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -47,7 +47,8 @@ export const UI_PALETTE_EXIT_DURATION = DURATION_100;
 /** UX anti-flicker gate: sub-400ms work should show nothing (Doherty threshold).
  *  Used by palette loading bar and stale-result dimming to prevent flashes on
  *  fast renders. Not an animation token — a perceptual floor.
- *  Keep in sync with .palette-results-stale transition-delay in src/index.css. */
+ *  CSS counterpart: `--anti-flicker-delay` in src/index.css `:root`. The
+ *  drift-contract test in animationUtils.test.ts enforces parity. */
 export const UI_DOHERTY_THRESHOLD = 400;
 
 /** UX anti-flicker gate for skeleton components using the `immediate` prop.


### PR DESCRIPTION
## Summary

- The 400ms Doherty anti-flicker threshold was duplicated across `src/index.css` (two rule sites: `.animate-pulse-delayed` and `.palette-results-stale` / `.surface-stale`) and `UI_DOHERTY_THRESHOLD` in `src/lib/animationUtils.ts`, kept in sync only by comments
- Adds `--anti-flicker-delay: 400ms` to the `:root` animation-vars cluster as the single CSS source of truth, and updates both CSS rule sites to use `var(--anti-flicker-delay)` instead of bare `400ms` literals
- Adds a drift-contract test that parses `index.css` and asserts: (1) the token is declared once in `:root`, (2) its value matches `UI_DOHERTY_THRESHOLD`, and (3) both CSS rule sites reference `var()` rather than a hardcoded literal

The `UI_DOHERTY_THRESHOLD` TS constant stays — it's still needed for JS consumers (`useDeferredLoading`, inline styles). The test enforces parity between the two representations so any future drift fails the build instead of relying on a comment.

Resolves #8657

## Why `:root` and not `@theme`?

Tailwind v4 auto-generates utility classes for tokens declared in `@theme`. A `--duration-*` or `--anti-flicker-*` token in `@theme` would produce a spurious `duration-*` utility class for what is purely a perceptual-floor constant, not a utility. `:root` keeps it accessible via `var()` without polluting the utility namespace.

## Changes

- `src/index.css` — adds `--anti-flicker-delay: 400ms` to `:root`, replaces both `400ms` animation-delay literals with `var(--anti-flicker-delay)`
- `src/lib/animationUtils.ts` — adds a `"keep in sync with --anti-flicker-delay"` note (TS constant unchanged)
- `src/lib/__tests__/animationUtils.test.ts` — 4 new contract assertions covering declaration, value parity, and both CSS rule sites

## Testing

- `npx vitest run src/lib/__tests__/animationUtils.test.ts` — 18 tests pass (4 new contract cases)
- `npm run check` — all 8 checks pass