### PR TITLE
feat(fleet): show armed panel count on preset menu items

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -272,6 +272,8 @@ export function FleetArmingRibbon(): ReactElement | null {
   );
 
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId) ?? null;
+  usePanelStore((s) => s.panelIds);
+  usePanelStore((s) => s.panelsById);
 
   const presetCounts = {
     waitingCurrent: computeArmByStateIds("waiting", "current", activeWorktreeId).length,

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -271,6 +271,16 @@ export function FleetArmingRibbon(): ReactElement | null {
     [setPreviewArmedIds, clearPreviewArmedIds]
   );
 
+  const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId) ?? null;
+
+  const presetCounts = {
+    waitingCurrent: computeArmByStateIds("waiting", "current", activeWorktreeId).length,
+    waitingAll: computeArmByStateIds("waiting", "all", activeWorktreeId).length,
+    workingCurrent: computeArmByStateIds("working", "current", activeWorktreeId).length,
+    workingAll: computeArmByStateIds("working", "all", activeWorktreeId).length,
+    eligibleCurrent: collectEligibleIds("current", activeWorktreeId).length,
+  };
+
   const selectionMenuItems = (
     <>
       <DropdownMenuLabel>Select by state</DropdownMenuLabel>
@@ -281,6 +291,9 @@ export function FleetArmingRibbon(): ReactElement | null {
         {...previewItemHandlers(() => computePreviewByState("waiting", "current"))}
       >
         All waiting — this worktree
+        <span className="ml-auto text-[11px] tabular-nums text-daintree-text/50">
+          {presetCounts.waitingCurrent}
+        </span>
       </DropdownMenuItem>
       <DropdownMenuItem
         onSelect={() => {
@@ -289,6 +302,9 @@ export function FleetArmingRibbon(): ReactElement | null {
         {...previewItemHandlers(() => computePreviewByState("waiting", "all"))}
       >
         All waiting — all worktrees
+        <span className="ml-auto text-[11px] tabular-nums text-daintree-text/50">
+          {presetCounts.waitingAll}
+        </span>
       </DropdownMenuItem>
       <DropdownMenuItem
         onSelect={() => {
@@ -297,6 +313,9 @@ export function FleetArmingRibbon(): ReactElement | null {
         {...previewItemHandlers(() => computePreviewByState("working", "current"))}
       >
         All working — this worktree
+        <span className="ml-auto text-[11px] tabular-nums text-daintree-text/50">
+          {presetCounts.workingCurrent}
+        </span>
       </DropdownMenuItem>
       <DropdownMenuItem
         onSelect={() => {
@@ -305,6 +324,9 @@ export function FleetArmingRibbon(): ReactElement | null {
         {...previewItemHandlers(() => computePreviewByState("working", "all"))}
       >
         All working — all worktrees
+        <span className="ml-auto text-[11px] tabular-nums text-daintree-text/50">
+          {presetCounts.workingAll}
+        </span>
       </DropdownMenuItem>
       <DropdownMenuSeparator />
       <DropdownMenuItem
@@ -314,6 +336,9 @@ export function FleetArmingRibbon(): ReactElement | null {
         {...previewItemHandlers(() => computePreviewAll("current"))}
       >
         All in this worktree
+        <span className="ml-auto text-[11px] tabular-nums text-daintree-text/50">
+          {presetCounts.eligibleCurrent}
+        </span>
       </DropdownMenuItem>
       {armedCount > 0 ? (
         <>


### PR DESCRIPTION
## Summary
- Shows the number of panels each preset would arm directly in the dropdown menu, so users can confirm scope before committing.
- Subscribes the ribbon to the panel store so counts stay reactive as panels change.
- Uses the same `computeArmByStateIds` and `collectEligibleIds` functions already powering the hover preview — the count was already computed, just not surfaced.

Resolves #8688

## Changes
- Added panel store subscriptions in `FleetArmingRibbon` for reactive preset counts
- Computed `presetCounts` object with armed-count for each of the five presets
- Rendered count as a right-aligned muted label next to each preset label in the dropdown

## Testing
- Verified counts match the amber-tinted preview when hovering each preset
- Counts react correctly when panels are added/removed or change state
- "All in this worktree" count factors in idleness threshold correctly