### PR TITLE
fix(gpu-crash): no-op first-strike on non-Linux, atomic flag writes

### DIFF
--- a/electron/services/GpuCrashMonitorService.ts
+++ b/electron/services/GpuCrashMonitorService.ts
@@ -2,6 +2,7 @@ import { app } from "electron";
 import fs from "node:fs";
 import path from "node:path";
 import { store } from "../store.js";
+import { resilientAtomicWriteFileSync } from "../utils/fs.js";
 import { createLogger } from "../utils/logger.js";
 import { closeTelemetry } from "./TelemetryService.js";
 import { getCrashLoopGuard } from "./CrashLoopGuardService.js";
@@ -26,7 +27,11 @@ export function isGpuDisabledByFlag(userDataPath: string): boolean {
 }
 
 export function writeGpuDisabledFlag(userDataPath: string): void {
-  fs.writeFileSync(path.join(userDataPath, GPU_DISABLED_FLAG), String(Date.now()), "utf8");
+  resilientAtomicWriteFileSync(
+    path.join(userDataPath, GPU_DISABLED_FLAG),
+    String(Date.now()),
+    "utf8"
+  );
 }
 
 export function clearGpuDisabledFlag(userDataPath: string): void {
@@ -58,7 +63,11 @@ export function isGpuAngleFallbackApplied(userDataPath: string): boolean {
 }
 
 export function writeGpuAngleFallbackFlag(userDataPath: string): void {
-  fs.writeFileSync(path.join(userDataPath, GPU_ANGLE_FALLBACK_FLAG), String(Date.now()), "utf8");
+  resilientAtomicWriteFileSync(
+    path.join(userDataPath, GPU_ANGLE_FALLBACK_FLAG),
+    String(Date.now()),
+    "utf8"
+  );
 }
 
 export function clearGpuAngleFallbackFlag(userDataPath: string): void {
@@ -120,6 +129,17 @@ class GpuCrashMonitorService {
       // hardware where Vulkan itself crashes — in that case the strikes
       // accumulate normally toward the nuclear path below.
       if (effectiveCount === 1 && !alreadyHasAngleFallback) {
+        // The ANGLE/Vulkan switches are only applied on Linux+Wayland (see
+        // `electron/setup/environment.ts`). On macOS/Windows the relaunch
+        // would be a no-op — let the strike accumulate toward the nuclear
+        // path instead of burning a session restart for no behavior change.
+        if (process.platform !== "linux") {
+          logger.info("gpu-crash-soft-fallback-skip-nonlinux", {
+            platform: process.platform,
+            crashCount: effectiveCount,
+          });
+          return;
+        }
         try {
           writeGpuAngleFallbackFlag(userDataPath);
         } catch (err) {

--- a/electron/services/__tests__/GpuCrashMonitorService.test.ts
+++ b/electron/services/__tests__/GpuCrashMonitorService.test.ts
@@ -68,6 +68,7 @@ import {
 
 describe("GpuCrashMonitorService", () => {
   let tmpDir: string;
+  let originalPlatform: NodeJS.Platform;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -75,12 +76,18 @@ describe("GpuCrashMonitorService", () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gpu-crash-test-"));
     appMock.getPath.mockReturnValue(tmpDir);
     crashLoopGuardMock.shouldRelaunch.mockReturnValue(true);
+    // Default to linux so existing first-strike tests exercise the soft
+    // fallback path. The "non-Linux first-strike no-op" describe overrides
+    // this per-test.
+    originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
     fs.rmSync(tmpDir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
@@ -381,8 +388,15 @@ describe("GpuCrashMonitorService", () => {
     });
 
     it("does NOT relaunch when ANGLE flag write fails (prevents per-session loop)", async () => {
-      const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
-        throw new Error("EROFS: read-only filesystem");
+      vi.doMock("../../utils/fs.js", async () => {
+        const actual =
+          await vi.importActual<typeof import("../../utils/fs.js")>("../../utils/fs.js");
+        return {
+          ...actual,
+          resilientAtomicWriteFileSync: vi.fn(() => {
+            throw new Error("EROFS: read-only filesystem");
+          }),
+        };
       });
       try {
         await loadAndInit();
@@ -397,14 +411,21 @@ describe("GpuCrashMonitorService", () => {
           expect.objectContaining({ path: "angle-fallback" })
         );
       } finally {
-        writeSpy.mockRestore();
+        vi.doUnmock("../../utils/fs.js");
       }
     });
 
     it("does NOT relaunch when nuclear disable flag write fails", async () => {
       writeGpuAngleFallbackFlag(tmpDir);
-      const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
-        throw new Error("EROFS: read-only filesystem");
+      vi.doMock("../../utils/fs.js", async () => {
+        const actual =
+          await vi.importActual<typeof import("../../utils/fs.js")>("../../utils/fs.js");
+        return {
+          ...actual,
+          resilientAtomicWriteFileSync: vi.fn(() => {
+            throw new Error("EROFS: read-only filesystem");
+          }),
+        };
       });
       try {
         await loadAndInit();
@@ -421,7 +442,7 @@ describe("GpuCrashMonitorService", () => {
           expect.objectContaining({ path: "disable" })
         );
       } finally {
-        writeSpy.mockRestore();
+        vi.doUnmock("../../utils/fs.js");
       }
     });
 
@@ -455,6 +476,77 @@ describe("GpuCrashMonitorService", () => {
       mod.initializeGpuCrashMonitor();
       const listenerCount = (appListeners["child-process-gone"] ?? []).length;
       expect(listenerCount).toBe(1);
+    });
+
+    describe("non-Linux first-strike no-op", () => {
+      function withPlatform(platform: NodeJS.Platform, fn: () => Promise<void>): Promise<void> {
+        const original = process.platform;
+        Object.defineProperty(process, "platform", { value: platform, configurable: true });
+        return fn().finally(() => {
+          Object.defineProperty(process, "platform", { value: original, configurable: true });
+        });
+      }
+
+      it("darwin: first crash does not write ANGLE flag, does not relaunch", async () => {
+        await withPlatform("darwin", async () => {
+          await loadAndInit();
+          emitGpuCrash();
+          await new Promise((r) => setImmediate(r));
+          expect(appMock.relaunch).not.toHaveBeenCalled();
+          expect(appMock.exit).not.toHaveBeenCalled();
+          expect(isGpuAngleFallbackByFlag(tmpDir)).toBe(false);
+          expect(loggerMethods.info).toHaveBeenCalledWith(
+            "gpu-crash-soft-fallback-skip-nonlinux",
+            expect.objectContaining({ platform: "darwin", crashCount: 1 })
+          );
+        });
+      });
+
+      it("win32: first crash does not write ANGLE flag, does not relaunch", async () => {
+        await withPlatform("win32", async () => {
+          await loadAndInit();
+          emitGpuCrash();
+          await new Promise((r) => setImmediate(r));
+          expect(appMock.relaunch).not.toHaveBeenCalled();
+          expect(appMock.exit).not.toHaveBeenCalled();
+          expect(isGpuAngleFallbackByFlag(tmpDir)).toBe(false);
+          expect(loggerMethods.info).toHaveBeenCalledWith(
+            "gpu-crash-soft-fallback-skip-nonlinux",
+            expect.objectContaining({ platform: "win32", crashCount: 1 })
+          );
+        });
+      });
+
+      it("darwin: strikes still accumulate to nuclear disable across crashes", async () => {
+        await withPlatform("darwin", async () => {
+          await loadAndInit();
+          emitGpuCrash();
+          emitGpuCrash();
+          emitGpuCrash();
+          await vi.waitFor(() => {
+            expect(appMock.exit).toHaveBeenCalledWith(0);
+          });
+          expect(appMock.relaunch).toHaveBeenCalledTimes(1);
+          expect(isGpuDisabledByFlag(tmpDir)).toBe(true);
+          expect(storeMock.set).toHaveBeenCalledWith("gpu", {
+            hardwareAccelerationDisabled: true,
+          });
+        });
+      });
+
+      it("win32: strikes still accumulate to nuclear disable across crashes", async () => {
+        await withPlatform("win32", async () => {
+          await loadAndInit();
+          emitGpuCrash();
+          emitGpuCrash();
+          emitGpuCrash();
+          await vi.waitFor(() => {
+            expect(appMock.exit).toHaveBeenCalledWith(0);
+          });
+          expect(appMock.relaunch).toHaveBeenCalledTimes(1);
+          expect(isGpuDisabledByFlag(tmpDir)).toBe(true);
+        });
+      });
     });
 
     describe("crash-loop guard integration", () => {

--- a/electron/services/__tests__/GpuCrashMonitorService.test.ts
+++ b/electron/services/__tests__/GpuCrashMonitorService.test.ts
@@ -487,33 +487,63 @@ describe("GpuCrashMonitorService", () => {
         });
       }
 
+      async function trackAtomicWriter(): Promise<ReturnType<typeof vi.fn>> {
+        const writeSpy = vi.fn();
+        vi.doMock("../../utils/fs.js", async () => {
+          const actual =
+            await vi.importActual<typeof import("../../utils/fs.js")>("../../utils/fs.js");
+          return {
+            ...actual,
+            resilientAtomicWriteFileSync: (
+              ...args: Parameters<typeof actual.resilientAtomicWriteFileSync>
+            ) => {
+              writeSpy(...args);
+              return actual.resilientAtomicWriteFileSync(...args);
+            },
+          };
+        });
+        return writeSpy;
+      }
+
       it("darwin: first crash does not write ANGLE flag, does not relaunch", async () => {
         await withPlatform("darwin", async () => {
-          await loadAndInit();
-          emitGpuCrash();
-          await new Promise((r) => setImmediate(r));
-          expect(appMock.relaunch).not.toHaveBeenCalled();
-          expect(appMock.exit).not.toHaveBeenCalled();
-          expect(isGpuAngleFallbackByFlag(tmpDir)).toBe(false);
-          expect(loggerMethods.info).toHaveBeenCalledWith(
-            "gpu-crash-soft-fallback-skip-nonlinux",
-            expect.objectContaining({ platform: "darwin", crashCount: 1 })
-          );
+          const writeSpy = await trackAtomicWriter();
+          try {
+            await loadAndInit();
+            emitGpuCrash();
+            await new Promise((r) => setImmediate(r));
+            expect(appMock.relaunch).not.toHaveBeenCalled();
+            expect(appMock.exit).not.toHaveBeenCalled();
+            expect(isGpuAngleFallbackByFlag(tmpDir)).toBe(false);
+            expect(writeSpy).not.toHaveBeenCalled();
+            expect(loggerMethods.info).toHaveBeenCalledWith(
+              "gpu-crash-soft-fallback-skip-nonlinux",
+              expect.objectContaining({ platform: "darwin", crashCount: 1 })
+            );
+          } finally {
+            vi.doUnmock("../../utils/fs.js");
+          }
         });
       });
 
       it("win32: first crash does not write ANGLE flag, does not relaunch", async () => {
         await withPlatform("win32", async () => {
-          await loadAndInit();
-          emitGpuCrash();
-          await new Promise((r) => setImmediate(r));
-          expect(appMock.relaunch).not.toHaveBeenCalled();
-          expect(appMock.exit).not.toHaveBeenCalled();
-          expect(isGpuAngleFallbackByFlag(tmpDir)).toBe(false);
-          expect(loggerMethods.info).toHaveBeenCalledWith(
-            "gpu-crash-soft-fallback-skip-nonlinux",
-            expect.objectContaining({ platform: "win32", crashCount: 1 })
-          );
+          const writeSpy = await trackAtomicWriter();
+          try {
+            await loadAndInit();
+            emitGpuCrash();
+            await new Promise((r) => setImmediate(r));
+            expect(appMock.relaunch).not.toHaveBeenCalled();
+            expect(appMock.exit).not.toHaveBeenCalled();
+            expect(isGpuAngleFallbackByFlag(tmpDir)).toBe(false);
+            expect(writeSpy).not.toHaveBeenCalled();
+            expect(loggerMethods.info).toHaveBeenCalledWith(
+              "gpu-crash-soft-fallback-skip-nonlinux",
+              expect.objectContaining({ platform: "win32", crashCount: 1 })
+            );
+          } finally {
+            vi.doUnmock("../../utils/fs.js");
+          }
         });
       });
 


### PR DESCRIPTION
## Summary

- Adds a platform guard to the first-strike branch in `GpuCrashMonitorService`: on non-Linux platforms the relaunch is skipped entirely, since the ANGLE/Vulkan switches in `environment.ts` only activate under Linux + Wayland. Crashes still count toward the nuclear-disable threshold cross-platform.
- Swaps raw `fs.writeFileSync` calls in `writeGpuDisabledFlag` and `writeGpuAngleFallbackFlag` for `resilientAtomicWriteFileSync`, preventing zero-byte partial writes from being read as truthy by `fs.existsSync` on the next launch.

Resolves #8671

## Changes

- `GpuCrashMonitorService.ts` — platform guard on first-strike path; atomic writes for both flag functions
- `GpuCrashMonitorService.test.ts` — pin `process.platform` to `linux` in `beforeEach`; four new non-Linux no-op tests; write-failure tests rewritten with `vi.doMock` since the destructured `writeFileSync` inside `resilientAtomicWriteFileSync` isn't intercepted by spying on `fs.writeFileSync`

## Testing

42 tests passing. Typecheck, lint, format, and build all clean.