### PR TITLE
fix(recovery): coordinate global recovery banners with stacked precedence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -275,22 +275,15 @@ const LazyCrashRecoveryDialog = lazy(() =>
   preloadCrashRecoveryDialog().then((m) => ({ default: m.CrashRecoveryDialog }))
 );
 
-function preloadSafeModeBanner() {
-  return import("./components/Recovery/SafeModeBanner");
+function preloadRecoveryBannerCoordinator() {
+  return import("./components/Recovery/RecoveryBannerCoordinator");
 }
-const LazySafeModeBanner = lazy(() =>
-  preloadSafeModeBanner().then((m) => ({ default: m.SafeModeBanner }))
+const LazyRecoveryBannerCoordinator = lazy(() =>
+  preloadRecoveryBannerCoordinator().then((m) => ({ default: m.RecoveryBannerCoordinator }))
 );
 // Fetch eagerly: `safeMode` is set synchronously during hydration, so the
 // first post-hydration render can suspend before the idle preload fires.
-void preloadSafeModeBanner();
-
-function preloadRestoreConfirmationBanner() {
-  return import("./components/Recovery/RestoreConfirmationBanner");
-}
-const LazyRestoreConfirmationBanner = lazy(() =>
-  preloadRestoreConfirmationBanner().then((m) => ({ default: m.RestoreConfirmationBanner }))
-);
+void preloadRecoveryBannerCoordinator();
 
 function preloadGitHubTokenBanner() {
   return import("./components/Recovery/GitHubTokenBanner");
@@ -304,20 +297,6 @@ function preloadCloudSyncBanner() {
 }
 const LazyCloudSyncBanner = lazy(() =>
   preloadCloudSyncBanner().then((m) => ({ default: m.CloudSyncBanner }))
-);
-
-function preloadHostCrashBanner() {
-  return import("./components/Recovery/HostCrashBanner");
-}
-const LazyHostCrashBanner = lazy(() =>
-  preloadHostCrashBanner().then((m) => ({ default: m.HostCrashBanner }))
-);
-
-function preloadWatchdogDisabledBanner() {
-  return import("./components/Recovery/WatchdogDisabledBanner");
-}
-const LazyWatchdogDisabledBanner = lazy(() =>
-  preloadWatchdogDisabledBanner().then((m) => ({ default: m.WatchdogDisabledBanner }))
 );
 
 import { Toaster } from "./components/ui/toaster";
@@ -338,7 +317,6 @@ import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore"
 import { useShallow } from "zustand/react/shallow";
 import { LazyMotion, MotionConfig } from "framer-motion";
 import { useMacroFocusStore } from "./store/macroFocusStore";
-import { useSafeModeStore } from "./store/safeModeStore";
 import type { BuiltInPanelKind } from "./types";
 import { actionService } from "./services/ActionService";
 import { voiceRecordingService } from "./services/VoiceRecordingService";
@@ -569,12 +547,9 @@ function App() {
       void preloadSendToAgentPalette();
       void preloadQuickCreatePalette();
       void preloadLogLevelPalette();
-      void preloadSafeModeBanner();
-      void preloadRestoreConfirmationBanner();
+      void preloadRecoveryBannerCoordinator();
       void preloadGitHubTokenBanner();
       void preloadCloudSyncBanner();
-      void preloadHostCrashBanner();
-      void preloadWatchdogDisabledBanner();
       import("@github-renderer/index").catch(() => {});
       import("@fontsource/jetbrains-mono/latin-500.css").catch(() => {});
       import("@fontsource/jetbrains-mono/latin-600.css").catch(() => {});
@@ -698,7 +673,6 @@ function App() {
 
   useFileDropGuard();
 
-  const isSafeMode = useSafeModeStore((s) => s.safeMode);
   const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
 
   if (!isElectronAvailable()) {
@@ -768,25 +742,14 @@ function App() {
             disableHoverableContent
           >
             <E2EFaultInjector />
-            {isSafeMode && (
-              <Suspense fallback={null}>
-                <LazySafeModeBanner />
-              </Suspense>
-            )}
             <Suspense fallback={null}>
-              <LazyRestoreConfirmationBanner />
+              <LazyRecoveryBannerCoordinator />
             </Suspense>
             <Suspense fallback={null}>
               <LazyGitHubTokenBanner />
             </Suspense>
             <Suspense fallback={null}>
               <LazyCloudSyncBanner />
-            </Suspense>
-            <Suspense fallback={null}>
-              <LazyHostCrashBanner />
-            </Suspense>
-            <Suspense fallback={null}>
-              <LazyWatchdogDisabledBanner />
             </Suspense>
             <DndProvider>
               <VoiceRecordingAnnouncer />

--- a/src/components/Recovery/RecoveryBannerCoordinator.tsx
+++ b/src/components/Recovery/RecoveryBannerCoordinator.tsx
@@ -1,0 +1,19 @@
+import { HostCrashBanner } from "./HostCrashBanner";
+import { WatchdogDisabledBanner } from "./WatchdogDisabledBanner";
+import { SafeModeBanner } from "./SafeModeBanner";
+import { RestoreConfirmationBanner } from "./RestoreConfirmationBanner";
+import { useRecoveryPriority } from "./useRecoveryPriority";
+
+// Renders the highest-priority active global recovery banner. Suppressed
+// banners are unmounted (not CSS-hidden) so any mount-driven effects — most
+// notably RestoreConfirmationBanner's auto-dismiss timer — only run while the
+// banner is actually visible to the user.
+export function RecoveryBannerCoordinator() {
+  const slot = useRecoveryPriority();
+
+  if (slot === "host-crash") return <HostCrashBanner />;
+  if (slot === "watchdog-disabled") return <WatchdogDisabledBanner />;
+  if (slot === "safe-mode") return <SafeModeBanner />;
+  if (slot === "restore-confirmation") return <RestoreConfirmationBanner />;
+  return null;
+}

--- a/src/components/Recovery/__tests__/RecoveryBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/RecoveryBannerCoordinator.test.tsx
@@ -169,18 +169,102 @@ describe("RecoveryBannerCoordinator", () => {
     expect(useRestoreConfirmationStore.getState().visible).toBe(false);
   });
 
-  it("switches from restore to safe mode when safe mode activates", () => {
+  it("switches from restore to safe mode reactively via store subscription", async () => {
     useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
-    const { rerender } = render(<RecoveryBannerCoordinator />);
+    render(<RecoveryBannerCoordinator />);
     expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
 
     act(() => {
       useSafeModeStore.setState({ safeMode: true, dismissed: false });
     });
 
-    rerender(<RecoveryBannerCoordinator />);
-
-    expect(screen.getByText("Safe mode — panels weren't restored")).toBeTruthy();
+    expect(await screen.findByText("Safe mode — panels weren't restored")).toBeTruthy();
     expect(screen.queryByText(/Session recovered after unexpected exit/)).toBeNull();
+  });
+
+  it("does not auto-dismiss the restore banner while suppressed by safe mode", () => {
+    vi.useFakeTimers();
+    useSafeModeStore.setState({ safeMode: true, dismissed: false });
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
+
+    render(<RecoveryBannerCoordinator />);
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(useRestoreConfirmationStore.getState().visible).toBe(true);
+  });
+
+  it("drains the stack: host-crash -> safe-mode -> restore with a fresh timer each step", () => {
+    vi.useFakeTimers();
+    usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "UNKNOWN_CRASH" });
+    useSafeModeStore.setState({ safeMode: true, dismissed: false });
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
+
+    render(<RecoveryBannerCoordinator />);
+
+    expect(screen.getByText("Terminal service crashed")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(useRestoreConfirmationStore.getState().visible).toBe(true);
+
+    act(() => {
+      usePanelStore.setState({ backendStatus: "connected", lastCrashType: null });
+    });
+    expect(screen.getByText("Safe mode — panels weren't restored")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(useRestoreConfirmationStore.getState().visible).toBe(true);
+
+    act(() => {
+      useSafeModeStore.setState({ dismissed: true });
+    });
+    expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(useRestoreConfirmationStore.getState().visible).toBe(false);
+  });
+
+  it("does not auto-dismiss a suspect-count restore after promotion", () => {
+    vi.useFakeTimers();
+    usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "UNKNOWN_CRASH" });
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 2, crashCount: 1 });
+
+    render(<RecoveryBannerCoordinator />);
+
+    act(() => {
+      usePanelStore.setState({ backendStatus: "connected", lastCrashType: null });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(useRestoreConfirmationStore.getState().visible).toBe(true);
+  });
+
+  it("documents Doherty-gated recovering behavior: nothing shown for <400ms, then host-crash recovering banner", () => {
+    vi.useFakeTimers();
+    usePanelStore.setState({ backendStatus: "recovering" });
+    useSafeModeStore.setState({ safeMode: true, dismissed: false });
+
+    const { container } = render(<RecoveryBannerCoordinator />);
+
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText("Safe mode — panels weren't restored")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(screen.getByText("Terminal service restarting")).toBeTruthy();
+    expect(screen.queryByText("Safe mode — panels weren't restored")).toBeNull();
   });
 });

--- a/src/components/Recovery/__tests__/RecoveryBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/RecoveryBannerCoordinator.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, act } from "@testing-library/react";
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: vi.fn().mockResolvedValue({ ok: true, result: undefined }),
+  },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+import { RecoveryBannerCoordinator } from "../RecoveryBannerCoordinator";
+import { usePanelStore } from "@/store/panelStore";
+import { useSafeModeStore } from "@/store/safeModeStore";
+import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+function resetStores() {
+  usePanelStore.setState({ backendStatus: "connected", lastCrashType: null });
+  useSafeModeStore.setState({
+    safeMode: false,
+    dismissed: false,
+    crashCount: undefined,
+    skippedPanelCount: undefined,
+    lastCrashAt: undefined,
+  });
+  useRestoreConfirmationStore.setState({ visible: false, suspectCount: 0, crashCount: 0 });
+}
+
+beforeEach(() => {
+  resetStores();
+  cleanup();
+});
+
+afterEach(() => {
+  if (vi.isFakeTimers()) {
+    vi.useRealTimers();
+  }
+});
+
+describe("RecoveryBannerCoordinator", () => {
+  it("renders nothing when no recovery state is active", () => {
+    const { container } = render(<RecoveryBannerCoordinator />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders only the host crash banner when all three states are active", () => {
+    usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "UNKNOWN_CRASH" });
+    useSafeModeStore.setState({ safeMode: true, dismissed: false });
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
+
+    render(<RecoveryBannerCoordinator />);
+
+    expect(screen.getByText("Terminal service crashed")).toBeTruthy();
+    expect(screen.queryByText("Safe mode — panels weren't restored")).toBeNull();
+    expect(screen.queryByText(/Session recovered after unexpected exit/)).toBeNull();
+  });
+
+  it("renders the host crash banner when backend is disconnected", () => {
+    usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "OUT_OF_MEMORY" });
+
+    render(<RecoveryBannerCoordinator />);
+
+    expect(screen.getByText("Terminal service ran out of memory")).toBeTruthy();
+  });
+
+  it("treats recovering backend as host-crash priority", () => {
+    vi.useFakeTimers();
+    usePanelStore.setState({ backendStatus: "recovering" });
+    useSafeModeStore.setState({ safeMode: true, dismissed: false });
+
+    render(<RecoveryBannerCoordinator />);
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(screen.getByText("Terminal service restarting")).toBeTruthy();
+    expect(screen.queryByText("Safe mode — panels weren't restored")).toBeNull();
+  });
+
+  it("renders the safe mode banner when host is connected and safe mode is active", () => {
+    useSafeModeStore.setState({ safeMode: true, dismissed: false });
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
+
+    render(<RecoveryBannerCoordinator />);
+
+    expect(screen.getByText("Safe mode — panels weren't restored")).toBeTruthy();
+    expect(screen.queryByText(/Session recovered after unexpected exit/)).toBeNull();
+  });
+
+  it("renders the restore confirmation when only restore is active", () => {
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
+
+    render(<RecoveryBannerCoordinator />);
+
+    expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
+  });
+
+  it("treats a dismissed safe mode as inactive and promotes restore", () => {
+    useSafeModeStore.setState({ safeMode: true, dismissed: true });
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
+
+    render(<RecoveryBannerCoordinator />);
+
+    expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
+    expect(screen.queryByText("Safe mode — panels weren't restored")).toBeNull();
+  });
+
+  it("does not auto-dismiss the restore banner while suppressed by a higher-priority banner", () => {
+    vi.useFakeTimers();
+    usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "UNKNOWN_CRASH" });
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
+
+    render(<RecoveryBannerCoordinator />);
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(useRestoreConfirmationStore.getState().visible).toBe(true);
+  });
+
+  it("starts the restore auto-dismiss timer fresh after promotion from suppressed", () => {
+    vi.useFakeTimers();
+    usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "UNKNOWN_CRASH" });
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
+
+    render(<RecoveryBannerCoordinator />);
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(useRestoreConfirmationStore.getState().visible).toBe(true);
+
+    act(() => {
+      usePanelStore.setState({ backendStatus: "connected", lastCrashType: null });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(9_999);
+    });
+    expect(useRestoreConfirmationStore.getState().visible).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(useRestoreConfirmationStore.getState().visible).toBe(false);
+  });
+
+  it("switches from restore to safe mode when safe mode activates", () => {
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
+    const { rerender } = render(<RecoveryBannerCoordinator />);
+    expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
+
+    act(() => {
+      useSafeModeStore.setState({ safeMode: true, dismissed: false });
+    });
+
+    rerender(<RecoveryBannerCoordinator />);
+
+    expect(screen.getByText("Safe mode — panels weren't restored")).toBeTruthy();
+    expect(screen.queryByText(/Session recovered after unexpected exit/)).toBeNull();
+  });
+});

--- a/src/components/Recovery/useRecoveryPriority.ts
+++ b/src/components/Recovery/useRecoveryPriority.ts
@@ -1,0 +1,35 @@
+import { usePanelStore } from "@/store/panelStore";
+import { useSafeModeStore } from "@/store/safeModeStore";
+import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
+
+export type RecoveryBannerSlot =
+  | "host-crash"
+  | "watchdog-disabled"
+  | "safe-mode"
+  | "restore-confirmation"
+  | null;
+
+// Precedence (highest first):
+//   host-crash         — backend is unusable right now (#8678 motivator)
+//   watchdog-disabled  — deadlock detector is gone; protection layer down (#8674)
+//   safe-mode          — panels weren't restored after a crash loop
+//   restore-confirmation — informational "session recovered" toast-banner
+// Watchdog sits below host-crash because a live host failure is more urgent
+// than a downed monitor, and above safe-mode because the watchdog protects
+// against the next crash whereas safe-mode is a consequence of the previous
+// one. A non-connected backendStatus always wins the slot — HostCrashBanner's
+// internal 400ms Doherty gate produces a brief empty slot rather than a
+// flicker through to a lower-priority banner.
+export function useRecoveryPriority(): RecoveryBannerSlot {
+  const backendStatus = usePanelStore((s) => s.backendStatus);
+  const watchdogStatus = usePanelStore((s) => s.watchdogStatus);
+  const safeMode = useSafeModeStore((s) => s.safeMode);
+  const safeModeDismissed = useSafeModeStore((s) => s.dismissed);
+  const restoreVisible = useRestoreConfirmationStore((s) => s.visible);
+
+  if (backendStatus !== "connected") return "host-crash";
+  if (watchdogStatus === "disabled") return "watchdog-disabled";
+  if (safeMode && !safeModeDismissed) return "safe-mode";
+  if (restoreVisible) return "restore-confirmation";
+  return null;
+}

--- a/src/components/Recovery/useRecoveryPriority.ts
+++ b/src/components/Recovery/useRecoveryPriority.ts
@@ -17,9 +17,12 @@ export type RecoveryBannerSlot =
 // Watchdog sits below host-crash because a live host failure is more urgent
 // than a downed monitor, and above safe-mode because the watchdog protects
 // against the next crash whereas safe-mode is a consequence of the previous
-// one. A non-connected backendStatus always wins the slot — HostCrashBanner's
-// internal 400ms Doherty gate produces a brief empty slot rather than a
-// flicker through to a lower-priority banner.
+// one. Any non-connected backend state — `"disconnected"` or `"recovering"` —
+// wins the slot. HostCrashBanner internally gates the `"recovering"` variant
+// behind the 400ms Doherty threshold and renders nothing under it; during
+// that gate the coordinator shows nothing rather than flashing the
+// lower-priority banner back in, matching the Doherty anti-flicker pattern
+// used elsewhere in the app.
 export function useRecoveryPriority(): RecoveryBannerSlot {
   const backendStatus = usePanelStore((s) => s.backendStatus);
   const watchdogStatus = usePanelStore((s) => s.watchdogStatus);


### PR DESCRIPTION
## Summary

Replaces the three sibling recovery banners (`HostCrashBanner`, `SafeModeBanner`, `RestoreConfirmationBanner`) with a single coordinator that renders the highest-priority active banner. Closes #8678.

- New `RecoveryBannerCoordinator` and `useRecoveryPriority` hook in `src/components/Recovery/` enforce the precedence `HostCrash > SafeMode > RestoreConfirmation`. Suppressed banners are unmounted (not CSS-hidden), so `RestoreConfirmationBanner`'s 10-second auto-dismiss timer (`InlineStatusBanner` `autoDismissAfter`) only counts down while the banner is actually on screen.
- `src/App.tsx` collapses three lazy banner slots, three preloads, and the `isSafeMode` renderer-only guard into a single eager-preloaded `<Suspense fallback={null}><LazyRecoveryBannerCoordinator /></Suspense>`. `GitHubTokenBanner` and `CloudSyncBanner` stay outside the coordinator as separate siblings (different signal class).
- A code comment in `useRecoveryPriority` documents the intentional Doherty-gated behavior: any non-connected backend state wins the slot, and `HostCrashBanner`'s internal 400ms recovering gate produces a brief empty slot rather than a flicker.

## Test plan

- [x] `npx vitest run src/components/Recovery/__tests__/RecoveryBannerCoordinator.test.tsx` (14 tests)
- [x] Full Recovery suite (`src/components/Recovery/__tests__/`) — 7 files, 102 tests
- [x] `npm run check` — typecheck, channels/IPC validators, lint ratchet (warnings decreased by 122), prettier
- [ ] Manual: trigger overlapping recovery states and confirm only one banner shows, suppressed restore timer does not auto-dismiss
- [ ] Multi-window: confirm precedence holds per project view (each `WebContentsView` has its own React tree and store instances)

### Coordinator test coverage

- Renders nothing when all stores idle
- Host crash wins when all three states are active
- Recovering backend takes host-crash priority
- Safe mode wins over restore when host connected
- Restore renders alone when only restore is active
- Dismissed safe mode promotes restore
- Restore auto-dismiss timer does **not** fire while suppressed by host-crash
- Restore auto-dismiss timer does **not** fire while suppressed by safe-mode
- Timer starts fresh after promotion from suppressed
- Reactive store transition (no manual rerender) restore -> safe-mode
- Three-stage stack drain: host-crash -> safe-mode -> restore with a fresh timer per slot (issue motivation)
- `suspectCount > 0` restore does not auto-dismiss after promotion
- Doherty-gated recovering: nothing shown for <400ms, then recovering banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)