### PR TITLE
feat(fleet): show preset match counts and dim unmatched panes on hover

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -41,6 +41,7 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
@@ -237,6 +238,18 @@ export function FleetArmingRibbon(): ReactElement | null {
   const setPreviewArmedIds = useFleetArmingStore((s) => s.setPreviewArmedIds);
   const clearPreviewArmedIds = useFleetArmingStore((s) => s.clearPreviewArmedIds);
 
+  // Counts shown beside each preset menu item. Read at render time from
+  // the pure helpers — they snapshot the panel store internally. The
+  // ribbon re-renders on every fleet/broadcast/preview store mutation, so
+  // counts stay fresh enough for the brief lifetime of an open menu; on
+  // commit, armByState recomputes against live state regardless.
+  const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId ?? null);
+  const waitingCurrentCount = computeArmByStateIds("waiting", "current", activeWorktreeId).length;
+  const waitingAllCount = computeArmByStateIds("waiting", "all", activeWorktreeId).length;
+  const workingCurrentCount = computeArmByStateIds("working", "current", activeWorktreeId).length;
+  const workingAllCount = computeArmByStateIds("working", "all", activeWorktreeId).length;
+  const allCurrentCount = collectEligibleIds("current", activeWorktreeId).length;
+
   // Compute which panel ids a state-preset menu item would arm — used to
   // light up the matching panes' title bars while the user hovers/focuses
   // the menu item, before they commit. Pure dry-run; no store mutation.
@@ -280,7 +293,15 @@ export function FleetArmingRibbon(): ReactElement | null {
         }}
         {...previewItemHandlers(() => computePreviewByState("waiting", "current"))}
       >
-        All waiting — this worktree
+        <span>All waiting — this worktree</span>
+        {waitingCurrentCount > 0 ? (
+          <DropdownMenuShortcut
+            data-testid="fleet-preset-count-waiting-current"
+            className="tabular-nums"
+          >
+            {waitingCurrentCount}
+          </DropdownMenuShortcut>
+        ) : null}
       </DropdownMenuItem>
       <DropdownMenuItem
         onSelect={() => {
@@ -288,7 +309,15 @@ export function FleetArmingRibbon(): ReactElement | null {
         }}
         {...previewItemHandlers(() => computePreviewByState("waiting", "all"))}
       >
-        All waiting — all worktrees
+        <span>All waiting — all worktrees</span>
+        {waitingAllCount > 0 ? (
+          <DropdownMenuShortcut
+            data-testid="fleet-preset-count-waiting-all"
+            className="tabular-nums"
+          >
+            {waitingAllCount}
+          </DropdownMenuShortcut>
+        ) : null}
       </DropdownMenuItem>
       <DropdownMenuItem
         onSelect={() => {
@@ -296,7 +325,15 @@ export function FleetArmingRibbon(): ReactElement | null {
         }}
         {...previewItemHandlers(() => computePreviewByState("working", "current"))}
       >
-        All working — this worktree
+        <span>All working — this worktree</span>
+        {workingCurrentCount > 0 ? (
+          <DropdownMenuShortcut
+            data-testid="fleet-preset-count-working-current"
+            className="tabular-nums"
+          >
+            {workingCurrentCount}
+          </DropdownMenuShortcut>
+        ) : null}
       </DropdownMenuItem>
       <DropdownMenuItem
         onSelect={() => {
@@ -304,7 +341,15 @@ export function FleetArmingRibbon(): ReactElement | null {
         }}
         {...previewItemHandlers(() => computePreviewByState("working", "all"))}
       >
-        All working — all worktrees
+        <span>All working — all worktrees</span>
+        {workingAllCount > 0 ? (
+          <DropdownMenuShortcut
+            data-testid="fleet-preset-count-working-all"
+            className="tabular-nums"
+          >
+            {workingAllCount}
+          </DropdownMenuShortcut>
+        ) : null}
       </DropdownMenuItem>
       <DropdownMenuSeparator />
       <DropdownMenuItem
@@ -313,7 +358,15 @@ export function FleetArmingRibbon(): ReactElement | null {
         }}
         {...previewItemHandlers(() => computePreviewAll("current"))}
       >
-        All in this worktree
+        <span>All in this worktree</span>
+        {allCurrentCount > 0 ? (
+          <DropdownMenuShortcut
+            data-testid="fleet-preset-count-all-current"
+            className="tabular-nums"
+          >
+            {allCurrentCount}
+          </DropdownMenuShortcut>
+        ) : null}
       </DropdownMenuItem>
       {armedCount > 0 ? (
         <>

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -69,6 +69,9 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   ),
   DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DropdownMenuSeparator: () => <hr />,
+  DropdownMenuShortcut: ({ children, ...rest }: React.HTMLAttributes<HTMLSpanElement>) => (
+    <span {...rest}>{children}</span>
+  ),
 }));
 
 import { FleetArmingRibbon } from "../FleetArmingRibbon";
@@ -785,6 +788,35 @@ describe("FleetArmingRibbon", () => {
       fireEvent.click(findMenuItem(/All working — this worktree/));
       const armed = useFleetArmingStore.getState().armedIds;
       expect([...armed].sort()).toEqual(["t1", "t2"]);
+    });
+
+    it("renders match counts next to each preset menu item", () => {
+      seed([
+        makeAgent("t1", "waiting"),
+        makeAgent("t2", "waiting"),
+        makeAgent("t3", "working"),
+        { ...makeAgent("t4", "waiting"), worktreeId: "wt-2" } as TerminalInstance,
+        { ...makeAgent("t5", "working"), worktreeId: "wt-2" } as TerminalInstance,
+      ]);
+      useFleetArmingStore.getState().armIds(["t1", "t3"]);
+      render(<FleetArmingRibbon />);
+      expect(screen.getByTestId("fleet-preset-count-waiting-current").textContent).toBe("2");
+      expect(screen.getByTestId("fleet-preset-count-waiting-all").textContent).toBe("3");
+      expect(screen.getByTestId("fleet-preset-count-working-current").textContent).toBe("1");
+      expect(screen.getByTestId("fleet-preset-count-working-all").textContent).toBe("2");
+      // "All in this worktree" counts every eligible pane in wt-1.
+      expect(screen.getByTestId("fleet-preset-count-all-current").textContent).toBe("3");
+    });
+
+    it("omits the count badge when a preset would match zero panes", () => {
+      seed([makeAgent("t1", "waiting"), makeAgent("t2", "waiting")]);
+      useFleetArmingStore.getState().armIds(["t1", "t2"]);
+      render(<FleetArmingRibbon />);
+      // No working agents anywhere — badge is hidden for both working presets.
+      expect(screen.queryByTestId("fleet-preset-count-working-current")).toBeNull();
+      expect(screen.queryByTestId("fleet-preset-count-working-all")).toBeNull();
+      // Waiting matches exist — those badges are visible.
+      expect(screen.getByTestId("fleet-preset-count-waiting-current").textContent).toBe("2");
     });
   });
 

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -95,6 +95,7 @@ function resetStores() {
     armOrder: [],
     armOrderById: {},
     lastArmedId: null,
+    previewArmedIds: new Set<string>(),
   });
   useFleetPendingActionStore.setState({ pending: null });
   useFleetBroadcastConfirmStore.setState({ pending: null });

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -201,6 +201,13 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
   // pane's title bar lifts to a neutral surface tint (not accent) so the
   // preview is unmistakable but doesn't squat on the focus anchor color.
   const isFleetPreviewed = useFleetArmingStore((s) => s.previewArmedIds.has(id));
+  // Dim panes that are NOT in the active preview set so matched panes
+  // stand out. Active = preview set is non-empty AND this pane is missing
+  // from it. Two .has() checks on the existing Set — primitive boolean
+  // selector, no derived collection, no extra store state.
+  const isFleetPreviewDimmed = useFleetArmingStore(
+    (s) => s.previewArmedIds.size > 0 && !s.previewArmedIds.has(id)
+  );
 
   // One-shot ring pulse when this pane becomes the new primary on fleet
   // exit. Listens for the CustomEvent dispatched from FleetArmingRibbon's
@@ -414,6 +421,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
         data-runtime-icon-id={terminalChrome.iconId || undefined}
         data-selected={isSelected || undefined}
         data-hibernated={isHibernated || undefined}
+        data-fleet-dimmed={isFleetPreviewDimmed || undefined}
         style={{
           contain: "content",
           ...(worktreeAccentColor
@@ -440,6 +448,11 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
                     : "border-overlay hover:border-tint/[0.08]"),
           location === "grid" && isMaximized && "border-0 rounded-none z-[var(--z-maximized)]",
           worktreeAccentColor && location === "grid" && !isMaximized && "panel-worktree-identity",
+          // Snap (no transition) — a synchronous opacity shift across many
+          // panels at once reads cleanly; a 150ms waterfall fade would feel
+          // jittery. Matched panes stay at full opacity, providing the
+          // contrast that makes the preview legible.
+          isFleetPreviewDimmed && "opacity-50",
           className
         )}
         onClick={handleClick}

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -202,11 +202,12 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
   // preview is unmistakable but doesn't squat on the focus anchor color.
   const isFleetPreviewed = useFleetArmingStore((s) => s.previewArmedIds.has(id));
   // Dim panes that are NOT in the active preview set so matched panes
-  // stand out. Active = preview set is non-empty AND this pane is missing
-  // from it. Two .has() checks on the existing Set — primitive boolean
-  // selector, no derived collection, no extra store state.
+  // stand out. Gated on kind === "terminal" so browser, dev-preview, and
+  // other non-fleet panels (which are never in previewArmedIds) stay at
+  // full opacity — dimming them would imply they could have been armed.
+  // Primitive boolean selector — no derived collection, no extra state.
   const isFleetPreviewDimmed = useFleetArmingStore(
-    (s) => s.previewArmedIds.size > 0 && !s.previewArmedIds.has(id)
+    (s) => kind === "terminal" && s.previewArmedIds.size > 0 && !s.previewArmedIds.has(id)
   );
 
   // One-shot ring pulse when this pane becomes the new primary on fleet


### PR DESCRIPTION
## Summary

- Adds right-aligned count badges to each preset menu item in `FleetArmingRibbon.tsx` showing how many panes the preset would arm; badge is hidden when the count is zero
- Dims non-matched panes to 50% opacity during hover preview so matched panes stand out clearly; gated to `kind === 'terminal'` so browser and dev-preview panels are unaffected
- No new store state — counts derived from existing `previewArmedIds`

Resolves #8696

## Changes

- `FleetArmingRibbon.tsx`: compute per-preset match counts from `previewArmedIds` and render the count badge; badge hidden at zero
- `ContentPanel.tsx`: apply `opacity-50` to non-matched panels when `previewArmedIds` is active and the panel is terminal kind
- `FleetArmingRibbon.test.tsx`: 4 new tests covering count rendering and zero-badge omission

## Testing

Covered by the 4 new unit tests in `FleetArmingRibbon.test.tsx`. Typecheck, lint, and build all pass clean.