### PR TITLE
refactor(hooks): replace useDeferredLoading raw delay with gate wrappers

### DIFF
--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -345,7 +345,7 @@ export function registerGitCloneHandlers(): () => void {
       // No "starting" event here on purpose: emitting one would populate the
       // renderer's progress list immediately and defeat the Doherty gate that
       // suppresses the connecting placeholder for sub-400ms clones. The
-      // renderer owns that phase via `isCloning` + `useDeferredLoading`.
+      // renderer owns that phase via `isCloning` + `useDohertyGate`.
 
       if (useGhPath && ghTarget) {
         await cloneWithGh(

--- a/plugins/builtin/github/renderer/components/GitHubDropdownSkeletons.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubDropdownSkeletons.tsx
@@ -1,7 +1,6 @@
 import { Search, ExternalLink, Plus, Filter } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useDeferredLoading } from "@/hooks/useDeferredLoading";
-import { UI_SKELETON_GATE_MS } from "@/lib/animationUtils";
+import { useSkeletonGate } from "@/hooks/useDeferredLoading";
 
 export const RESOURCE_ITEM_HEIGHT_PX = 68;
 export const COMMIT_ITEM_HEIGHT_PX = 64;
@@ -27,7 +26,7 @@ export function GitHubResourceListSkeleton({
   type = "issue",
 }: ResourceListSkeletonProps) {
   const renderCount = normalizeCount(count);
-  const showImmediate = useDeferredLoading(Boolean(immediate), UI_SKELETON_GATE_MS);
+  const showImmediate = useSkeletonGate(Boolean(immediate));
   const pulseClass = showImmediate ? "animate-pulse-immediate" : "animate-pulse-delayed";
 
   const stateTabs =
@@ -160,7 +159,7 @@ export function GitHubResourceRowsSkeleton({ count, immediate }: SkeletonProps) 
 
 export function CommitListSkeleton({ count, immediate }: SkeletonProps) {
   const renderCount = normalizeCount(count);
-  const showImmediate = useDeferredLoading(Boolean(immediate), UI_SKELETON_GATE_MS);
+  const showImmediate = useSkeletonGate(Boolean(immediate));
   const pulseClass = showImmediate ? "animate-pulse-immediate" : "animate-pulse-delayed";
 
   return (

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -36,8 +36,7 @@ import { useProjectStore } from "@/store";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { useFindInPage } from "@/hooks/useFindInPage";
-import { useDeferredLoading } from "@/hooks/useDeferredLoading";
-import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { logError } from "@/utils/logger";
 
 export interface BrowserPaneProps extends BasePanelProps {
@@ -145,7 +144,7 @@ export function BrowserPane({
 
   const [isLoading, setIsLoading] = useState(true);
   // Doherty 400ms gate: skip loading affordances on fast loads to prevent flicker.
-  const showLoadingOverlay = useDeferredLoading(isLoading, UI_DOHERTY_THRESHOLD);
+  const showLoadingOverlay = useDohertyGate(isLoading);
   const [loadError, setLoadError] = useState<LoadError | null>(null);
   const [blockedNav, setBlockedNav] = useState<{
     url: string;

--- a/src/components/DevPreview/DevPreviewLoadingState.tsx
+++ b/src/components/DevPreview/DevPreviewLoadingState.tsx
@@ -1,5 +1,4 @@
-import { useDeferredLoading } from "@/hooks/useDeferredLoading";
-import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { SkeletonHint } from "@/components/ui/Skeleton";
 
 interface DevPreviewLoadingStateProps {
@@ -20,7 +19,7 @@ function SkeletonBone({ className }: { className?: string }) {
 }
 
 function FullSkeleton({ phaseLabel, isLoading }: { phaseLabel: string; isLoading: boolean }) {
-  const showPhaseLabel = useDeferredLoading(isLoading, UI_DOHERTY_THRESHOLD);
+  const showPhaseLabel = useDohertyGate(isLoading);
 
   return (
     <div className="relative flex flex-col items-center justify-center h-full bg-daintree-bg px-6">
@@ -67,7 +66,7 @@ function OverlaySkeleton({
   isLoading: boolean;
   onCancel?: () => void;
 }) {
-  const showOverlay = useDeferredLoading(isLoading, UI_DOHERTY_THRESHOLD);
+  const showOverlay = useDohertyGate(isLoading);
 
   if (!showOverlay) return null;
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -50,8 +50,7 @@ import { actionService } from "@/services/ActionService";
 import { useWebviewThrottle } from "@/hooks/useWebviewThrottle";
 import { useHasBeenVisible } from "@/hooks/useHasBeenVisible";
 import { useWebviewEviction } from "@/hooks/useWebviewEviction";
-import { useDeferredLoading } from "@/hooks/useDeferredLoading";
-import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { useWebviewDialog } from "@/hooks/useWebviewDialog";
 import { WebviewDialog } from "../Browser/WebviewDialog";
 import { FindBar } from "../Browser/FindBar";
@@ -358,7 +357,7 @@ export function DevPreviewPane({
     previousIsEvictedRef.current = isEvicted;
   }, [isEvicted, hasBeenVisible]);
 
-  const showRecoverySpinner = useDeferredLoading(isRecoveringFromEviction, UI_DOHERTY_THRESHOLD);
+  const showRecoverySpinner = useDohertyGate(isRecoveringFromEviction);
 
   useEffect(() => {
     const webview = webviewElement;

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -50,11 +50,10 @@ import { useToolbarOverflow } from "@/hooks/useToolbarOverflow";
 import { useWorktreeActions } from "@/hooks/useWorktreeActions";
 import {
   useAriaKeyshortcuts,
-  useDeferredLoading,
+  useDohertyGate,
   useKeybindingDisplay,
   useShortcutHintHover,
 } from "@/hooks";
-import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
 import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
 import { useProjectStore } from "@/store/projectStore";
@@ -254,7 +253,7 @@ export function Toolbar({
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [treeCopied, setTreeCopied] = useState(false);
   const [isCopyingTree, setIsCopyingTree] = useState(false);
-  const showCopyingSpinner = useDeferredLoading(isCopyingTree, UI_DOHERTY_THRESHOLD);
+  const showCopyingSpinner = useDohertyGate(isCopyingTree);
   const [copyFeedback, setCopyFeedback] = useState<string>("");
   const treeCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 

--- a/src/components/Layout/VoiceRecordingToolbarButton.tsx
+++ b/src/components/Layout/VoiceRecordingToolbarButton.tsx
@@ -11,8 +11,7 @@ import {
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import { cn } from "@/lib/utils";
 import { useAriaKeyshortcuts, useKeybindingDisplay } from "@/hooks";
-import { useDeferredLoading } from "@/hooks/useDeferredLoading";
-import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 import { useVoiceRecordingStore } from "@/store/voiceRecordingStore";
 import { voiceRecordingService } from "@/services/VoiceRecordingService";
@@ -66,7 +65,7 @@ export function VoiceRecordingToolbarButton({
 
   // Doherty gate — under 400ms of "connecting" should never paint the orbit;
   // it would flash before the recording state arrives.
-  const showConnecting = useDeferredLoading(isConnecting, UI_DOHERTY_THRESHOLD);
+  const showConnecting = useDohertyGate(isConnecting);
   // Gate the orbit on isActive too — protects against a transient teardown
   // race where status briefly stays "recording"/"finishing" while
   // activeTarget has already been cleared, which would otherwise leave the

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -165,18 +165,12 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
   });
 
   describe("copy-tree button polish — issue #8179", () => {
-    it("imports useDeferredLoading from @/hooks", () => {
-      expect(source).toMatch(/useDeferredLoading[\s\S]*?from "@\/hooks"/);
+    it("imports useDohertyGate from @/hooks", () => {
+      expect(source).toMatch(/useDohertyGate[\s\S]*?from "@\/hooks"/);
     });
 
-    it("imports UI_DOHERTY_THRESHOLD from @/lib/animationUtils", () => {
-      expect(source).toContain('import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils"');
-    });
-
-    it("derives showCopyingSpinner via useDeferredLoading at the Doherty threshold", () => {
-      expect(source).toContain(
-        "const showCopyingSpinner = useDeferredLoading(isCopyingTree, UI_DOHERTY_THRESHOLD);"
-      );
+    it("derives showCopyingSpinner via useDohertyGate at the Doherty threshold", () => {
+      expect(source).toContain("const showCopyingSpinner = useDohertyGate(isCopyingTree);");
     });
 
     it("renders the spinner glyph gated on showCopyingSpinner, not raw isCopyingTree", () => {

--- a/src/components/Layout/__tests__/VoiceRecordingToolbarButton.test.ts
+++ b/src/components/Layout/__tests__/VoiceRecordingToolbarButton.test.ts
@@ -61,16 +61,15 @@ describe("VoiceRecordingToolbarButton polish — issue #8176", () => {
   });
 
   describe("Doherty anti-flicker gate", () => {
-    it("imports useDeferredLoading and UI_DOHERTY_THRESHOLD", () => {
+    it("imports useDohertyGate from the deferred-loading hook module", () => {
+      expect(source).toContain("useDohertyGate");
       expect(source).toContain('from "@/hooks/useDeferredLoading"');
-      expect(source).toContain('from "@/lib/animationUtils"');
-      expect(source).toContain("UI_DOHERTY_THRESHOLD");
     });
 
     it("gates the connecting-state orbit reveal behind the 400ms Doherty threshold", () => {
       // Sub-400ms connections must never paint the orbit ring — the
       // placeholder stays visible throughout.
-      expect(source).toMatch(/useDeferredLoading\(isConnecting,\s*UI_DOHERTY_THRESHOLD\)/);
+      expect(source).toMatch(/useDohertyGate\(isConnecting\)/);
     });
   });
 

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -7,8 +7,7 @@ import { FolderGit2 } from "@/components/icons";
 import { InlineStatusBanner, type BannerAction } from "@/components/Terminal/InlineStatusBanner";
 import { projectClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
-import { useDeferredLoading } from "@/hooks";
-import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { useDohertyGate } from "@/hooks";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { validateFolderName } from "@shared/utils/folderName";
 import { isGitHubRemoteUrl } from "@shared/utils/githubUrl";
@@ -207,10 +206,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   // Doherty gate: don't flash the progress box / spinner for a sub-400ms gap
   // before the first git progress event — only reveal it if the wait exceeds
   // the threshold. Once real progress arrives the box stays up regardless.
-  const showConnecting = useDeferredLoading(
-    isCloning && progressEvents.length === 0,
-    UI_DOHERTY_THRESHOLD
-  );
+  const showConnecting = useDohertyGate(isCloning && progressEvents.length === 0);
   const showProgress = showConnecting || progressEvents.length > 0;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -8,8 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/Spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useKeybindingDisplay } from "@/hooks/useKeybinding";
-import { useProjectSwitcherPalette, useDeferredLoading } from "@/hooks";
-import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { useProjectSwitcherPalette, useDohertyGate } from "@/hooks";
 import { actionService } from "@/services/ActionService";
 import { ProjectSwitcherPalette } from "./ProjectSwitcherPalette";
 import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
@@ -34,7 +33,7 @@ export function ProjectSwitcher() {
   const projects = useProjectStore((state) => state.projects);
   const currentProject = useProjectStore((state) => state.currentProject);
   const isLoading = useProjectStore((state) => state.isLoading);
-  const showLoadingSpinner = useDeferredLoading(isLoading, UI_DOHERTY_THRESHOLD);
+  const showLoadingSpinner = useDohertyGate(isLoading);
   const projectSwitcher = useProjectSwitcherPalette();
   const projectSwitcherShortcut = useKeybindingDisplay("project.switcherPalette");
   const isDropdownOpen = projectSwitcher.isOpen && projectSwitcher.mode === "dropdown";

--- a/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcher.loading.test.tsx
@@ -35,7 +35,7 @@ vi.mock("@/hooks", async () => {
     "@/hooks/useDeferredLoading"
   );
   return {
-    useDeferredLoading: deferred.useDeferredLoading,
+    useDohertyGate: deferred.useDohertyGate,
     useProjectSwitcherPalette: () => ({
       isOpen: false,
       mode: "dropdown",
@@ -126,10 +126,10 @@ function setStore(patch: Partial<ProjectStoreState>) {
   Object.assign(projectStoreState, patch);
 }
 
-// The spinner is gated behind useDeferredLoading(isLoading, 400) so a
-// sub-threshold isLoading flip never flashes on warm-cache project state.
-// Advancing 400ms of fake timers inside act() simulates a load that
-// genuinely crosses the Doherty threshold.
+// The spinner is gated behind useDohertyGate(isLoading) so a sub-threshold
+// isLoading flip never flashes on warm-cache project state. Advancing 400ms
+// of fake timers inside act() simulates a load that genuinely crosses the
+// Doherty threshold.
 const DEFER_MS = 400;
 
 function advanceDeferGate() {
@@ -265,7 +265,7 @@ describe("ProjectSwitcher loading affordance", () => {
     expect(trigger.querySelector(".animate-spin")).not.toBeNull();
     expect(trigger.querySelector(".lucide-chevrons-up-down")).toBeNull();
 
-    // Clearing is instant — useDeferredLoading drops the loader the moment
+    // Clearing is instant — useDohertyGate drops the loader the moment
     // isPending goes false, with no timer to advance.
     setStore({ isLoading: false });
     rerender(<ProjectSwitcher />);

--- a/src/components/Recovery/HostCrashBanner.tsx
+++ b/src/components/Recovery/HostCrashBanner.tsx
@@ -5,8 +5,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { actionService } from "@/services/ActionService";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { logError } from "@/utils/logger";
-import { useDeferredLoading } from "@/hooks/useDeferredLoading";
-import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { HOST_CRASH_RECOVERING_COPY, getHostCrashBannerCopy } from "./recoveryCopy";
 
 function SpinnerIcon({ className, style }: { className?: string; style?: CSSProperties }) {
@@ -23,7 +22,7 @@ export function HostCrashBanner() {
   const backendStatus = usePanelStore((s) => s.backendStatus);
   const lastCrashType = usePanelStore((s) => s.lastCrashType);
   const [isRestarting, setIsRestarting] = useState(false);
-  const recoveringShown = useDeferredLoading(backendStatus === "recovering", UI_DOHERTY_THRESHOLD);
+  const recoveringShown = useDohertyGate(backendStatus === "recovering");
 
   if (backendStatus === "connected") return null;
 

--- a/src/components/Settings/ForgeIntegrationsTab.tsx
+++ b/src/components/Settings/ForgeIntegrationsTab.tsx
@@ -10,8 +10,7 @@ import { SettingsSection } from "./SettingsSection";
 import { SettingsSelect, type SettingsSelectOption } from "./SettingsSelect";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useProjectStore } from "@/store";
-import { useDeferredLoading } from "@/hooks";
-import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { useDohertyGate } from "@/hooks";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
 import { logError } from "@/utils/logger";
@@ -74,7 +73,7 @@ export function ForgeIntegrationsTab() {
   }, [remotes]);
   // Defer the "Loading remotes…" text past the Doherty threshold so fast IPC
   // resolutions don't flash a loading state for sub-400ms work.
-  const showRemotesLoading = useDeferredLoading(remotesLoading, UI_DOHERTY_THRESHOLD);
+  const showRemotesLoading = useDohertyGate(remotesLoading);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
+++ b/src/components/Settings/__tests__/ForgeIntegrationsTab.test.tsx
@@ -276,12 +276,9 @@ describe("ForgeIntegrationsTab source guards", () => {
     source = await fs.readFile(path.resolve(__dirname, "../ForgeIntegrationsTab.tsx"), "utf-8");
   });
 
-  it("gates the remotes loading text on useDeferredLoading + UI_DOHERTY_THRESHOLD", () => {
-    expect(source).toContain("useDeferredLoading");
-    expect(source).toContain("UI_DOHERTY_THRESHOLD");
-    expect(source).toMatch(
-      /showRemotesLoading\s*=\s*useDeferredLoading\(\s*remotesLoading\s*,\s*UI_DOHERTY_THRESHOLD\s*\)/
-    );
+  it("gates the remotes loading text on useDohertyGate", () => {
+    expect(source).toContain("useDohertyGate");
+    expect(source).toMatch(/showRemotesLoading\s*=\s*useDohertyGate\(\s*remotesLoading\s*\)/);
     expect(source).toMatch(/loading=\{showRemotesLoading\}/);
     expect(source).not.toMatch(/loading=\{remotesLoading\}/);
   });

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -22,10 +22,9 @@ import {
   useWorktreeActions,
   useAriaKeyshortcuts,
   useKeybindingDisplay,
-  useDeferredLoading,
+  useDohertyGate,
   useResizeObserverRaf,
 } from "@/hooks";
-import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { WorktreeSidebarSearchBar, QuickStateFilterBar } from "@/components/Worktree";
 import { getBuiltinView } from "@/registry/builtinRendererRegistry";
@@ -369,11 +368,11 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     Date.now() - reconnectingAt >= RECONNECT_ESCALATE_MS;
   const deferredWorktrees = useDeferredValue(worktrees);
   const [isRefreshing, startRefreshTransition] = useTransition();
-  const showRefreshSpinner = useDeferredLoading(isRefreshing, UI_DOHERTY_THRESHOLD);
+  const showRefreshSpinner = useDohertyGate(isRefreshing);
   // Gate the "Reconnecting…" indicator behind the Doherty threshold so routine
   // sub-400ms port replacements don't flash the spinner. A real host crash
   // takes 2–4s to recover, well past the threshold.
-  const showReconnecting = useDeferredLoading(isReconnecting, UI_DOHERTY_THRESHOLD);
+  const showReconnecting = useDohertyGate(isReconnecting);
   const currentProject = useProjectStore((state) => state.currentProject);
   const worktreeLoadError = useProjectStore((state) => state.worktreeLoadError);
   useProjectSettings();

--- a/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
@@ -69,12 +69,9 @@ describe("SidebarContent header reveal — issue #6964", () => {
     expect(source).toContain("motion-reduce:transition-none");
   });
 
-  it("gates the refresh spinner on useDeferredLoading + UI_DOHERTY_THRESHOLD to avoid sub-threshold flashes", () => {
-    expect(source).toContain("useDeferredLoading");
-    expect(source).toContain("UI_DOHERTY_THRESHOLD");
-    expect(source).toMatch(
-      /showRefreshSpinner\s*=\s*useDeferredLoading\(\s*isRefreshing\s*,\s*UI_DOHERTY_THRESHOLD\s*\)/
-    );
+  it("gates the refresh spinner on useDohertyGate to avoid sub-threshold flashes", () => {
+    expect(source).toContain("useDohertyGate");
+    expect(source).toMatch(/showRefreshSpinner\s*=\s*useDohertyGate\(\s*isRefreshing\s*\)/);
     expect(source).toMatch(/showRefreshSpinner\s*\?\s*"animate-spin"/);
     expect(source).not.toMatch(/isRefreshing\s*\?\s*"animate-spin"/);
   });

--- a/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
@@ -11,13 +11,11 @@ describe("SidebarContent reconnecting indicator — issue #8074", () => {
     source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
   });
 
-  it("gates the reconnecting indicator behind useDeferredLoading with UI_DOHERTY_THRESHOLD", () => {
+  it("gates the reconnecting indicator behind useDohertyGate", () => {
     // Doherty Threshold (400ms): routine sub-second port replacements must not
     // flash a spinner. The reconnecting state mirrors the existing
     // showRefreshSpinner pattern on the same component.
-    expect(source).toMatch(
-      /const showReconnecting = useDeferredLoading\(isReconnecting, UI_DOHERTY_THRESHOLD\)/
-    );
+    expect(source).toMatch(/const showReconnecting = useDohertyGate\(isReconnecting\)/);
   });
 
   it("renders the Reconnecting… span behind showReconnecting, not raw isReconnecting", () => {

--- a/src/components/Worktree/WorktreeCard/IssueBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/IssueBadge.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { CircleDot, Clock, CloudOff } from "lucide-react";
-import { useDeferredLoading } from "@/hooks/useDeferredLoading";
-import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { useIssueTooltip } from "@/hooks/useGitHubTooltip";
 import { useGitHubBadgeTooltip } from "./hooks/useGitHubBadgeTooltip";
@@ -58,7 +57,7 @@ export function IssueBadge({
   // the store, so this gate only fires on genuine issue-number transitions.
   const prevIssueNumber = useRef<number | undefined>(undefined);
   const isColdTitleGap = !issueTitle && issueNumber !== prevIssueNumber.current;
-  const showColdFallback = useDeferredLoading(isColdTitleGap, UI_DOHERTY_THRESHOLD);
+  const showColdFallback = useDohertyGate(isColdTitleGap);
   useEffect(() => {
     prevIssueNumber.current = issueNumber;
   }, [issueNumber]);

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -2,8 +2,7 @@ import { useCallback, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { actionService } from "@/services/ActionService";
-import { useDeferredLoading } from "@/hooks/useDeferredLoading";
-import { UI_SKELETON_GATE_MS } from "@/lib/animationUtils";
+import { useSkeletonGate } from "@/hooks/useDeferredLoading";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
 
 interface UpstreamSyncBadgeProps {
@@ -41,7 +40,7 @@ export function UpstreamSyncBadge({
 }: UpstreamSyncBadgeProps) {
   const hasAhead = aheadCount !== undefined && aheadCount > 0;
   const hasBehind = behindCount !== undefined && behindCount > 0;
-  const showPulse = useDeferredLoading(isFetchInFlight, UI_SKELETON_GATE_MS);
+  const showPulse = useSkeletonGate(isFetchInFlight);
 
   const isStale = useMemo(() => {
     if (lastFetchedAt == null || fetchIntervalMs == null) return false;

--- a/src/hooks/__tests__/useDeferredLoading.test.tsx
+++ b/src/hooks/__tests__/useDeferredLoading.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import { useDeferredLoading } from "../useDeferredLoading";
+import { useDeferredLoading, useDohertyGate, useSkeletonGate } from "../useDeferredLoading";
 
 describe("useDeferredLoading", () => {
   afterEach(() => {
@@ -78,23 +78,6 @@ describe("useDeferredLoading", () => {
     expect(result.current).toBe(false);
   });
 
-  it("uses a default delay of 200ms when not specified", () => {
-    vi.useFakeTimers();
-    const { result } = renderHook(({ isPending }) => useDeferredLoading(isPending), {
-      initialProps: { isPending: true },
-    });
-
-    act(() => {
-      vi.advanceTimersByTime(199);
-    });
-    expect(result.current).toBe(false);
-
-    act(() => {
-      vi.advanceTimersByTime(1);
-    });
-    expect(result.current).toBe(true);
-  });
-
   it("shows the loader immediately when delay is 0", () => {
     const { result } = renderHook(() => useDeferredLoading(true, 0));
     expect(result.current).toBe(true);
@@ -160,6 +143,66 @@ describe("useDeferredLoading", () => {
 
     act(() => {
       vi.advanceTimersByTime(50);
+    });
+    expect(result.current).toBe(true);
+  });
+});
+
+describe("useDohertyGate", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not flip to true before the 400ms Doherty threshold elapses", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(({ isPending }) => useDohertyGate(isPending), {
+      initialProps: { isPending: true },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(399);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("flips to true after the 400ms Doherty threshold elapses while still pending", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(({ isPending }) => useDohertyGate(isPending), {
+      initialProps: { isPending: true },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(result.current).toBe(true);
+  });
+});
+
+describe("useSkeletonGate", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not flip to true before the 200ms skeleton gate elapses", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(({ isPending }) => useSkeletonGate(isPending), {
+      initialProps: { isPending: true },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("flips to true after the 200ms skeleton gate elapses while still pending", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(({ isPending }) => useSkeletonGate(isPending), {
+      initialProps: { isPending: true },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
     });
     expect(result.current).toBe(true);
   });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -113,7 +113,7 @@ export type { UseUnsavedChangesOptions } from "./useUnsavedChanges";
 
 export { useDebounce } from "./useDebounce";
 
-export { useDeferredLoading } from "./useDeferredLoading";
+export { useDeferredLoading, useDohertyGate, useSkeletonGate } from "./useDeferredLoading";
 
 export { useTabLoad } from "./useTabLoad";
 export type { UseTabLoadOptions, UseTabLoadResult } from "./useTabLoad";

--- a/src/hooks/useDeferredLoading.ts
+++ b/src/hooks/useDeferredLoading.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
 
-export function useDeferredLoading(isPending: boolean, delay = 200): boolean {
+import { UI_DOHERTY_THRESHOLD, UI_SKELETON_GATE_MS } from "@/lib/animationUtils";
+
+export function useDeferredLoading(isPending: boolean, delay: number): boolean {
   const [showLoader, setShowLoader] = useState(isPending && delay <= 0);
 
   useEffect(() => {
@@ -17,4 +19,12 @@ export function useDeferredLoading(isPending: boolean, delay = 200): boolean {
   }, [isPending, delay]);
 
   return showLoader;
+}
+
+export function useDohertyGate(isPending: boolean): boolean {
+  return useDeferredLoading(isPending, UI_DOHERTY_THRESHOLD);
+}
+
+export function useSkeletonGate(isPending: boolean): boolean {
+  return useDeferredLoading(isPending, UI_SKELETON_GATE_MS);
 }

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -53,7 +53,7 @@ export const UI_DOHERTY_THRESHOLD = 400;
 
 /** UX anti-flicker gate for skeleton components using the `immediate` prop.
  *  Sub-200ms work should show no pulse — warm-cache Suspense falls through this.
- *  Keep in sync with the `useDeferredLoading` default delay (200ms).
+ *  Consumed by `useSkeletonGate` in `src/hooks/useDeferredLoading.ts`.
  *  Not an animation token — a perceptual floor, same family as Doherty. */
 export const UI_SKELETON_GATE_MS = 200;
 


### PR DESCRIPTION
## Summary

- Adds `useDohertyGate` and `useSkeletonGate` wrapper hooks that bake in `UI_DOHERTY_THRESHOLD` (400ms) and `UI_SKELETON_GATE_MS` (200ms) respectively, replacing raw magic numbers at call sites
- Makes the base `useDeferredLoading` delay argument required to close the silent-default footgun (was `= 200`)
- Migrates all 15 call sites across `src/` and `plugins/`

Resolves #8654

## Changes

- `src/hooks/useDeferredLoading.ts` — delay param now required; exports `useDohertyGate` and `useSkeletonGate`
- `src/hooks/index.ts` — barrel updated to export both new hooks
- `src/lib/animationUtils.ts` — removed stale comment referencing the old default
- 12 `src/` call sites migrated to `useDohertyGate`, 1 to `useSkeletonGate`
- `plugins/.../GitHubDropdownSkeletons.tsx` — 2 call sites migrated to `useSkeletonGate`
- `src/hooks/__tests__/useDeferredLoading.test.tsx` — removed default-delay test, added 4 threshold tests for the two new wrappers
- 5 source-regex tests updated to match the new hook names

## Testing

All targeted tests pass (101 unit + 15 hook tests). Typecheck, lint, format, and build all clean.