### PR TITLE
feat(crash-recovery): default to silent restore, clarify opt-in

### DIFF
--- a/e2e/full/resilience/core-crash-recovery.spec.ts
+++ b/e2e/full/resilience/core-crash-recovery.spec.ts
@@ -9,6 +9,7 @@ import {
   mkdtempSync,
   mkdirSync,
   writeFileSync,
+  readFileSync,
   readdirSync,
   existsSync,
   rmSync,
@@ -41,6 +42,20 @@ interface CrashLogEntry {
   errorStack?: string;
 }
 
+function forceAutoRestoreOff(userDataDir: string): void {
+  const configPath = path.join(userDataDir, "config.json");
+  let config: Record<string, unknown> = {};
+  if (existsSync(configPath)) {
+    try {
+      config = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+    } catch {
+      config = {};
+    }
+  }
+  config.crashRecovery = { autoRestoreOnCrash: false };
+  writeFileSync(configPath, JSON.stringify(config));
+}
+
 function seedCrashData(userDataDir: string): void {
   const now = Date.now();
   const crashId = "e2e-test-crash";
@@ -49,6 +64,11 @@ function seedCrashData(userDataDir: string): void {
   const backupsDir = path.join(userDataDir, "backups");
   mkdirSync(crashesDir, { recursive: true });
   mkdirSync(backupsDir, { recursive: true });
+
+  // Opt out of auto-restore so the dialog appears for UI tests. The app
+  // defaults to silent restore — these specs exercise the explicit-recovery
+  // path that users only see when they've previously turned auto-restore off.
+  forceAutoRestoreOff(userDataDir);
 
   const crashLog: CrashLogEntry = {
     id: crashId,
@@ -207,17 +227,17 @@ test.describe.serial("Core: Crash Recovery", () => {
     await expect(details).not.toBeVisible();
   });
 
-  test("auto-restore checkbox toggles", async () => {
+  test("auto-restore switch toggles", async () => {
     const { window } = ctx;
-    const checkbox = window.locator(SEL.crashRecovery.autoRestoreCheckbox);
+    const switchEl = window.locator(SEL.crashRecovery.autoRestoreCheckbox);
 
-    await expect(checkbox).not.toBeChecked();
+    await expect(switchEl).not.toBeChecked();
 
-    await checkbox.click();
-    await expect(checkbox).toBeChecked();
+    await switchEl.click();
+    await expect(switchEl).toBeChecked();
 
-    await checkbox.click();
-    await expect(checkbox).not.toBeChecked();
+    await switchEl.click();
+    await expect(switchEl).not.toBeChecked();
   });
 
   test("start fresh dismisses dialog and shows main UI", async () => {
@@ -301,6 +321,11 @@ function seedCrashDataForRestore(
   const backupsDir = path.join(userDataDir, "backups");
   mkdirSync(crashesDir, { recursive: true });
   mkdirSync(backupsDir, { recursive: true });
+
+  // Opt out of auto-restore so the dialog appears for the panel-restoration
+  // specs. The app defaults to silent restore — this block covers the explicit
+  // recovery path users only see after turning auto-restore off.
+  forceAutoRestoreOff(userDataDir);
 
   const crashLog: CrashLogEntry = {
     id: crashId,

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -99,7 +99,7 @@ export class CrashRecoveryService {
     const stored = store.get("crashRecovery");
     return {
       autoRestoreOnCrash:
-        typeof stored?.autoRestoreOnCrash === "boolean" ? stored.autoRestoreOnCrash : false,
+        typeof stored?.autoRestoreOnCrash === "boolean" ? stored.autoRestoreOnCrash : true,
     };
   }
 

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -105,7 +105,13 @@ export class CrashRecoveryService {
 
   setConfig(patch: Partial<CrashRecoveryConfig>): CrashRecoveryConfig {
     const current = this.getConfig();
-    const updated = { ...current, ...patch };
+    const updated: CrashRecoveryConfig = { ...current };
+    // Drop non-boolean values so a stray `undefined` from a caller can't
+    // erase an explicit opt-out and let getConfig() silently fall back to
+    // the new `true` default.
+    if (typeof patch.autoRestoreOnCrash === "boolean") {
+      updated.autoRestoreOnCrash = patch.autoRestoreOnCrash;
+    }
     store.set("crashRecovery", updated);
     return updated;
   }

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -868,10 +868,10 @@ describe("CrashRecoveryService", () => {
       expect(svc.getConfig()).toEqual({ autoRestoreOnCrash: true });
     });
 
-    it("defaults to false for invalid stored value", () => {
+    it("defaults to true for invalid stored value", () => {
       storeMock.get.mockReturnValue({ autoRestoreOnCrash: "yes" });
       const svc = makeService();
-      expect(svc.getConfig().autoRestoreOnCrash).toBe(false);
+      expect(svc.getConfig().autoRestoreOnCrash).toBe(true);
     });
 
     it("setConfig persists to store", () => {

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -874,6 +874,12 @@ describe("CrashRecoveryService", () => {
       expect(svc.getConfig().autoRestoreOnCrash).toBe(true);
     });
 
+    it("defaults to true when stored value is undefined", () => {
+      storeMock.get.mockReturnValue(undefined);
+      const svc = makeService();
+      expect(svc.getConfig().autoRestoreOnCrash).toBe(true);
+    });
+
     it("setConfig persists to store", () => {
       storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
       const svc = makeService();
@@ -881,6 +887,17 @@ describe("CrashRecoveryService", () => {
 
       expect(result.autoRestoreOnCrash).toBe(true);
       expect(storeMock.set).toHaveBeenCalledWith("crashRecovery", { autoRestoreOnCrash: true });
+    });
+
+    it("setConfig ignores non-boolean autoRestoreOnCrash so an opt-out survives a malformed patch", () => {
+      storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
+      const svc = makeService();
+      const result = svc.setConfig({
+        autoRestoreOnCrash: undefined as unknown as boolean,
+      });
+
+      expect(result.autoRestoreOnCrash).toBe(false);
+      expect(storeMock.set).toHaveBeenCalledWith("crashRecovery", { autoRestoreOnCrash: false });
     });
   });
 

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -432,7 +432,7 @@ const storeOptions = {
       hardwareAccelerationDisabled: false,
     },
     crashRecovery: {
-      autoRestoreOnCrash: false,
+      autoRestoreOnCrash: true,
     },
     onboarding: {
       schemaVersion: 2,

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -16,6 +16,7 @@ import { AppDialog } from "../ui/AppDialog";
 import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { AnimatedLabel } from "../ui/AnimatedLabel";
+import { SettingsSwitch } from "../Settings/SettingsSwitch";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -437,21 +438,22 @@ export function CrashRecoveryDialog({
               </p>
             )
           ) : (
-            <label
-              className="flex items-center gap-2 cursor-pointer"
-              data-testid="auto-restore-label"
-            >
-              <input
-                type="checkbox"
+            <div className="flex items-center justify-between gap-3" data-testid="auto-restore-label">
+              <div className="text-left">
+                <div id="auto-restore-title" className="text-sm font-medium text-daintree-text">
+                  Restore automatically next time
+                </div>
+                <div className="text-xs text-daintree-text/60">
+                  Skips this dialog. Shows again if Daintree crashes twice in a row.
+                </div>
+              </div>
+              <SettingsSwitch
                 checked={config.autoRestoreOnCrash}
-                onChange={(e) => handleAutoRestore(e.target.checked)}
-                className="accent-daintree-accent h-4 w-4"
+                onCheckedChange={handleAutoRestore}
+                aria-labelledby="auto-restore-title"
                 data-testid="auto-restore-checkbox"
               />
-              <span className="text-xs text-daintree-text/60">
-                Always restore sessions automatically
-              </span>
-            </label>
+            </div>
           )}
         </AppDialog.Body>
       </AppDialog>

--- a/src/components/Settings/SettingsSwitch.tsx
+++ b/src/components/Settings/SettingsSwitch.tsx
@@ -28,6 +28,7 @@ interface SettingsSwitchProps {
   "aria-label"?: string;
   "aria-labelledby"?: string;
   "aria-describedby"?: string;
+  "data-testid"?: string;
   id?: string;
   name?: string;
   colorScheme?: ColorScheme;
@@ -41,6 +42,7 @@ export function SettingsSwitch({
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledby,
   "aria-describedby": ariaDescribedby,
+  "data-testid": dataTestId,
   id,
   name,
   colorScheme = "accent",
@@ -58,6 +60,7 @@ export function SettingsSwitch({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
       aria-describedby={ariaDescribedby}
+      data-testid={dataTestId}
       className={cn(
         "relative inline-flex items-center shrink-0 rounded-full transition-colors duration-200 ease-out",
         "w-11 h-6",

--- a/src/hooks/__tests__/useCrashRecoveryGate.test.tsx
+++ b/src/hooks/__tests__/useCrashRecoveryGate.test.tsx
@@ -201,6 +201,31 @@ describe("useCrashRecoveryGate", () => {
     expect(result.current.state.status).toBe("none");
   });
 
+  it("surfaces the dialog instead of silent-restoring when hasBackup is false", async () => {
+    const resolve = vi.fn(async () => {});
+    installElectronStub({ resolve });
+
+    const { result } = renderHook(() =>
+      useCrashRecoveryGate(
+        makeBoot({
+          settled: true,
+          result: makeBootResult({
+            crashPending: { ...mockCrash, hasBackup: false },
+            crashConfig: { autoRestoreOnCrash: true },
+          }),
+        })
+      )
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(result.current.state.status).toBe("pending");
+  });
+
   it("auto-restores with empty panelIds when no panels available", async () => {
     const resolve = vi.fn(async () => {});
     installElectronStub({ resolve });

--- a/src/hooks/app/useCrashRecoveryGate.ts
+++ b/src/hooks/app/useCrashRecoveryGate.ts
@@ -51,7 +51,10 @@ export function useCrashRecoveryGate(boot: AppBootState): {
       return;
     }
 
-    if (config.autoRestoreOnCrash && (pending.crashCount ?? 0) < 2) {
+    // Skip silent restore when there's nothing to restore — the auto-path
+    // hands an empty backup result to the user with no dialog, which is
+    // indistinguishable from data loss. Surface the recovery dialog instead.
+    if (config.autoRestoreOnCrash && (pending.crashCount ?? 0) < 2 && pending.hasBackup) {
       const suspectCount = (pending.panels ?? []).filter((p) => p.isSuspect).length;
       const crashCount = pending.crashCount ?? 0;
       const allPanelIds = (pending.panels ?? []).map((p) => p.id);


### PR DESCRIPTION
## Summary

- `autoRestoreOnCrash` defaulted to `false` in both `CrashRecoveryService.getConfig()` and the electron-store schema, so every new install hit the blocking recovery modal after any dirty exit (forced reboot, `kill -9`, etc.). The default should have been `true` all along.
- Silent auto-restore now requires `pending.hasBackup === true` before firing — previously it could silently proceed with nothing to restore.
- The opt-in checkbox in `CrashRecoveryDialog` is replaced with a `SettingsSwitch` carrying a proper title/subtitle that explains the crash-loop scenario (`crashCount >= 2`) that bypasses auto-restore.

Resolves #8677

## Changes

- `electron/services/CrashRecoveryService.ts` — flip `autoRestoreOnCrash` default `false` → `true` in `getConfig()` fallback; add `typeof` boolean guard in `setConfig()` to reject non-boolean patches.
- `electron/store.ts` — flip electron-store schema default `false` → `true`.
- `src/hooks/app/useCrashRecoveryGate.ts` — gate silent auto-restore on `pending.hasBackup` being truthy.
- `src/components/Recovery/CrashRecoveryDialog.tsx` — replace bare checkbox with `SettingsSwitch` ("Restore automatically next time" / "Skips this dialog. Shows again if Daintree crashes twice in a row.").
- `src/components/Settings/SettingsSwitch.tsx` — forward `data-testid` to `Switch.Root` for E2E selector stability.
- Tests — `CrashRecoveryService.test.ts` covers the new default and `setConfig()` type guard; `useCrashRecoveryGate.test.tsx` adds a regression for the `hasBackup: false` path; E2E spec adds `forceAutoRestoreOff` helper so existing dialog-flow tests still exercise the explicit-recovery path.

## Existing users

Users who previously saved `autoRestoreOnCrash: false` are unaffected. The `typeof` boolean guard in `setConfig()` means only stored boolean values are trusted; any non-boolean falls back to the new `true` default. Users with the old `false` persisted will keep seeing the dialog until they opt in.

## Testing

- 123/123 unit tests pass.
- `npm run check` clean (typecheck + lint ratchet + format + IPC + help drift).
- E2E `core-crash-recovery.spec.ts` updated and verified locally.