### PR TITLE
fix(IssuePicker): drop stale fetch responses and dim list during refetch

### DIFF
--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -134,6 +134,9 @@ export function IssuePickerDialog({
     }, 300);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
+      // Invalidate any in-flight fetch the moment the user's input changes,
+      // so a slow response from the prior query can't land under the new one.
+      fetchIdRef.current++;
     };
   }, [search, stateFilter, isOpen, fetchIssues]);
 
@@ -142,6 +145,9 @@ export function IssuePickerDialog({
       setSearch("");
       setStateFilter("open");
       setFetchedQuery("");
+      setIssues([]);
+      setError(null);
+      setIsPending(true);
       setSelectedIndex(0);
       setTimeout(() => inputRef.current?.focus(), 100);
     }

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -83,30 +83,39 @@ export function IssuePickerDialog({
   const [search, setSearch] = useState("");
   const [stateFilter, setStateFilter] = useState<StateFilter>("open");
   const [issues, setIssues] = useState<GitHubIssue[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const [fetchedQuery, setFetchedQuery] = useState("");
+  const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fetchIdRef = useRef(0);
 
   const fetchIssues = useCallback(
     async (searchTerm: string, state: StateFilter) => {
-      setIsLoading(true);
-      setError(null);
+      const trimmed = searchTerm.trim();
+      const id = ++fetchIdRef.current;
+      setIsPending(true);
       try {
         const result = await githubClient.listIssues({
           cwd: worktree.path,
-          search: searchTerm.trim() || undefined,
+          search: trimmed || undefined,
           state,
         });
+        if (id !== fetchIdRef.current) return;
         setIssues(result.items);
+        setFetchedQuery(trimmed);
         setSelectedIndex(0);
+        setError(null);
+        setIsPending(false);
       } catch (e) {
+        if (id !== fetchIdRef.current) return;
         setError(formatErrorMessage(e, "Failed to load issues"));
         setIssues([]);
-      } finally {
-        setIsLoading(false);
+        setFetchedQuery(trimmed);
+        setSelectedIndex(0);
+        setIsPending(false);
       }
     },
     [worktree.path]
@@ -132,6 +141,7 @@ export function IssuePickerDialog({
     if (isOpen) {
       setSearch("");
       setStateFilter("open");
+      setFetchedQuery("");
       setSelectedIndex(0);
       setTimeout(() => inputRef.current?.focus(), 100);
     }
@@ -218,7 +228,7 @@ export function IssuePickerDialog({
       </div>
 
       <div className="flex-1 overflow-y-auto min-h-0 px-6 pb-4">
-        {isLoading && issues.length === 0 ? (
+        {isPending && issues.length === 0 ? (
           <Skeleton label="Loading issues" className="space-y-1">
             {Array.from({ length: 6 }).map((_, i) => (
               <div
@@ -236,11 +246,11 @@ export function IssuePickerDialog({
         ) : error ? (
           <div className="text-center py-8 text-sm text-status-error">{error}</div>
         ) : issues.length === 0 ? (
-          search.trim() ? (
+          fetchedQuery ? (
             <EmptyState
               variant="filtered-empty"
               scale="popover"
-              title={`No matches for "${search.trim()}"`}
+              title={`No matches for "${fetchedQuery}"`}
               action={
                 <button
                   type="button"
@@ -255,7 +265,13 @@ export function IssuePickerDialog({
             <EmptyState variant="zero-data" scale="popover" title="No issues found" />
           )
         ) : (
-          <div ref={listRef} className="space-y-1" role="listbox">
+          <div
+            ref={listRef}
+            className={cn("space-y-1", isPending && "surface-stale")}
+            role="listbox"
+            data-stale={isPending ? "true" : undefined}
+            aria-busy={isPending || undefined}
+          >
             {issues.map((issue, index) => (
               <IssueOptionRow
                 key={issue.number}

--- a/src/components/Worktree/__tests__/IssuePickerDialog.test.tsx
+++ b/src/components/Worktree/__tests__/IssuePickerDialog.test.tsx
@@ -2,7 +2,8 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, afterEach, beforeAll, vi } from "vitest";
-import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { act, render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import type { GitHubIssue } from "@shared/types/github";
 import type { WorktreeState } from "@/types";
 import { IssuePickerDialog } from "../IssuePickerDialog";
 
@@ -20,6 +21,14 @@ vi.mock("@/clients", () => ({
   githubClient: {
     listIssues: listIssuesMock,
   },
+}));
+
+vi.mock("@/components/ui/TruncatedTooltip", () => ({
+  TruncatedTooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/useTruncationDetection", () => ({
+  useTruncationDetection: () => ({ ref: () => {}, isTruncated: false }),
 }));
 
 vi.mock("@/components/ui/AppDialog", () => {
@@ -109,5 +118,159 @@ describe("IssuePickerDialog empty states", () => {
       expect(screen.getByText(/boom|Failed to load issues/)).toBeTruthy();
     });
     expect(screen.queryByRole("status")).toBeNull();
+  });
+});
+
+function makeIssue(number: number, title: string): GitHubIssue {
+  return {
+    number,
+    title,
+    url: `https://example.test/${number}`,
+    state: "OPEN",
+    updatedAt: "2026-01-01T00:00:00Z",
+    author: { login: "tester", avatarUrl: "" },
+    assignees: [],
+    commentCount: 0,
+  };
+}
+
+describe("IssuePickerDialog stale behavior", () => {
+  it("dims the listbox and marks it aria-busy during an in-flight refetch", async () => {
+    vi.useFakeTimers();
+    try {
+      const issueA = makeIssue(1, "Issue A");
+      const issueB = makeIssue(2, "Issue B");
+
+      let resolveSlow: ((value: { items: GitHubIssue[] }) => void) | undefined;
+      const slowPromise = new Promise<{ items: GitHubIssue[] }>((r) => {
+        resolveSlow = r;
+      });
+
+      listIssuesMock
+        .mockResolvedValueOnce({ items: [issueA] })
+        .mockResolvedValueOnce({ items: [issueA] })
+        .mockReturnValueOnce(slowPromise);
+
+      renderDialog();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(screen.getByText("Issue A")).toBeTruthy();
+
+      fireEvent.change(screen.getByPlaceholderText("Search issues by title or number..."), {
+        target: { value: "x" },
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      const listbox = screen.getByRole("listbox");
+      expect(listbox.classList.contains("surface-stale")).toBe(true);
+      expect(listbox.getAttribute("data-stale")).toBe("true");
+      expect(listbox.getAttribute("aria-busy")).toBe("true");
+
+      await act(async () => {
+        resolveSlow?.({ items: [issueB] });
+        await vi.runAllTimersAsync();
+      });
+
+      const finalListbox = screen.getByRole("listbox");
+      expect(finalListbox.classList.contains("surface-stale")).toBe(false);
+      expect(finalListbox.hasAttribute("data-stale")).toBe(false);
+      expect(finalListbox.hasAttribute("aria-busy")).toBe(false);
+      expect(screen.getByText("Issue B")).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drops a stale response when a newer fetch already committed", async () => {
+    vi.useFakeTimers();
+    try {
+      const initial = makeIssue(1, "Initial");
+      const issueX = makeIssue(2, "Issue X");
+      const issueY = makeIssue(3, "Issue Y");
+
+      let resolveX: ((value: { items: GitHubIssue[] }) => void) | undefined;
+      const xPromise = new Promise<{ items: GitHubIssue[] }>((r) => {
+        resolveX = r;
+      });
+
+      listIssuesMock
+        .mockResolvedValueOnce({ items: [initial] })
+        .mockResolvedValueOnce({ items: [initial] })
+        .mockReturnValueOnce(xPromise)
+        .mockResolvedValueOnce({ items: [issueY] });
+
+      renderDialog();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(screen.getByText("Initial")).toBeTruthy();
+
+      fireEvent.change(screen.getByPlaceholderText("Search issues by title or number..."), {
+        target: { value: "x" },
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      fireEvent.change(screen.getByPlaceholderText("Search issues by title or number..."), {
+        target: { value: "y" },
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(screen.getByText("Issue Y")).toBeTruthy();
+      expect(screen.queryByText("Issue X")).toBeNull();
+
+      await act(async () => {
+        resolveX?.({ items: [issueX] });
+        await vi.runAllTimersAsync();
+      });
+
+      expect(screen.queryByText("Issue X")).toBeNull();
+      expect(screen.getByText("Issue Y")).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("binds the empty-state title to the committed query, not the live input", async () => {
+    vi.useFakeTimers();
+    try {
+      listIssuesMock.mockResolvedValue({ items: [] });
+
+      renderDialog();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(screen.getByRole("status").textContent).toContain("No issues found");
+
+      fireEvent.change(screen.getByPlaceholderText("Search issues by title or number..."), {
+        target: { value: "foo" },
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(screen.getByRole("status").textContent).toContain('No matches for "foo"');
+
+      fireEvent.change(screen.getByPlaceholderText("Search issues by title or number..."), {
+        target: { value: "foobar" },
+      });
+
+      expect(screen.getByRole("status").textContent).toContain('No matches for "foo"');
+      expect(screen.getByRole("status").textContent).not.toContain("foobar");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/components/Worktree/__tests__/IssuePickerDialog.test.tsx
+++ b/src/components/Worktree/__tests__/IssuePickerDialog.test.tsx
@@ -242,6 +242,112 @@ describe("IssuePickerDialog stale behavior", () => {
     }
   });
 
+  it("does not show prior-session results when the dialog reopens", async () => {
+    vi.useFakeTimers();
+    try {
+      const issueA = makeIssue(1, "Issue A");
+
+      let resolveSecond: ((value: { items: GitHubIssue[] }) => void) | undefined;
+      const secondOpenPromise = new Promise<{ items: GitHubIssue[] }>((r) => {
+        resolveSecond = r;
+      });
+
+      listIssuesMock
+        .mockResolvedValueOnce({ items: [issueA] })
+        .mockResolvedValueOnce({ items: [issueA] })
+        .mockReturnValueOnce(secondOpenPromise)
+        .mockReturnValueOnce(secondOpenPromise);
+
+      const { rerender } = render(
+        <IssuePickerDialog
+          isOpen
+          onClose={() => {}}
+          worktree={worktree}
+          onAttach={() => {}}
+          onDetach={() => {}}
+        />
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(screen.getByText("Issue A")).toBeTruthy();
+
+      rerender(
+        <IssuePickerDialog
+          isOpen={false}
+          onClose={() => {}}
+          worktree={worktree}
+          onAttach={() => {}}
+          onDetach={() => {}}
+        />
+      );
+
+      rerender(
+        <IssuePickerDialog
+          isOpen
+          onClose={() => {}}
+          worktree={worktree}
+          onAttach={() => {}}
+          onDetach={() => {}}
+        />
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(screen.queryByText("Issue A")).toBeNull();
+      expect(screen.queryByRole("listbox")).toBeNull();
+
+      resolveSecond?.({ items: [] });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drops a slow response when the user has already typed past it", async () => {
+    vi.useFakeTimers();
+    try {
+      const stale = makeIssue(1, "Stale foo result");
+
+      let resolveFoo: ((value: { items: GitHubIssue[] }) => void) | undefined;
+      const fooPromise = new Promise<{ items: GitHubIssue[] }>((r) => {
+        resolveFoo = r;
+      });
+
+      listIssuesMock
+        .mockResolvedValueOnce({ items: [] })
+        .mockResolvedValueOnce({ items: [] })
+        .mockReturnValueOnce(fooPromise);
+
+      renderDialog();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      const input = screen.getByPlaceholderText("Search issues by title or number...");
+
+      fireEvent.change(input, { target: { value: "foo" } });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      fireEvent.change(input, { target: { value: "foobar" } });
+
+      await act(async () => {
+        resolveFoo?.({ items: [stale] });
+        await Promise.resolve();
+      });
+
+      expect(screen.queryByText("Stale foo result")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("binds the empty-state title to the committed query, not the live input", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary

- Adds a monotonic generation counter (`fetchIdRef`) that increments on fetch start and in the debounce-effect cleanup, so any `listIssues` response from a prior query is dropped — including ones that slip through the debounce gap when the user changes search/filter mid-flight
- Tracks `fetchedQuery` atomically alongside results, so `No matches for "{...}"` always names the query the visible results were actually run for, not the live input
- Applies `surface-stale` / `data-stale` / `aria-busy` to the listbox while a refetch is in flight (mirrors `SearchablePalette`; CSS owns the 400ms Doherty anti-flicker gate), and resets `issues`, `error`, and `isPending` on open so a reopen never flashes prior-session results

Resolves #8647

## Changes

- `IssuePickerDialog.tsx` — generation counter, `fetchedQuery` state, dim-during-refetch, reopen reset
- `IssuePickerDialog.test.tsx` — 9 tests total (4 existing + 5 new): dim-during-refetch, stale-response-dropped, `fetchedQuery` binding, reopen-no-stale, slow-response-dropped-during-debounce-gap

## Testing

All 9 unit tests pass. `npm run check` clean (0 errors; lint warnings down 121 from baseline).