### PR TITLE
feat(crash-recovery): annotate watchdog SIGKILL so deadlock kills aren't unknown (#8682)

### DIFF
--- a/electron/__tests__/watchdog-host-core.test.ts
+++ b/electron/__tests__/watchdog-host-core.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import {
+  buildWatchdogKillPayload,
   createWatchdog,
   parseMainPid,
+  writeWatchdogKillFlag,
   HEARTBEAT_INTERVAL_MS,
   MAX_MISSED,
+  WATCHDOG_KILL_FLAG_NAME,
 } from "../watchdog-host-core.js";
 
 describe("parseMainPid", () => {
@@ -195,5 +198,75 @@ describe("createWatchdog", () => {
 
   it("HEARTBEAT_INTERVAL_MS × MAX_MISSED gives the conservative ~15s threshold", () => {
     expect(HEARTBEAT_INTERVAL_MS * MAX_MISSED).toBe(15000);
+  });
+});
+
+describe("buildWatchdogKillPayload", () => {
+  it("captures missedBeats and mainPid plus a fresh killedAt timestamp", () => {
+    const before = Date.now();
+    const payload = buildWatchdogKillPayload(MAX_MISSED, 4242);
+    const after = Date.now();
+
+    expect(payload.missedBeats).toBe(MAX_MISSED);
+    expect(payload.mainPid).toBe(4242);
+    expect(payload.killedAt).toBeGreaterThanOrEqual(before);
+    expect(payload.killedAt).toBeLessThanOrEqual(after);
+  });
+
+  it("produces a JSON-serialisable object (the host writes it to disk)", () => {
+    const payload = buildWatchdogKillPayload(3, 1234);
+    const round = JSON.parse(JSON.stringify(payload));
+    expect(round).toEqual({
+      killedAt: payload.killedAt,
+      missedBeats: 3,
+      mainPid: 1234,
+    });
+  });
+
+  it("uses a stable flag filename (writer/reader must agree)", () => {
+    expect(WATCHDOG_KILL_FLAG_NAME).toBe("watchdog-kill.flag");
+  });
+});
+
+describe("writeWatchdogKillFlag", () => {
+  function makeDeps(overrides: Partial<{ throwOnWrite: boolean }> = {}) {
+    const writes: Array<{ path: string; data: string }> = [];
+    const deps = {
+      writeFileSync: vi.fn((p: string, data: string) => {
+        if (overrides.throwOnWrite) throw new Error("disk full");
+        writes.push({ path: p, data });
+      }),
+      joinPath: (userData: string, name: string) => `${userData}/${name}`,
+    };
+    return { deps, writes };
+  }
+
+  it("writes the flag at <userData>/watchdog-kill.flag with the expected payload", () => {
+    const { deps, writes } = makeDeps();
+    const ok = writeWatchdogKillFlag("/fake/userData", MAX_MISSED, 4242, deps);
+    expect(ok).toBe(true);
+    expect(writes).toHaveLength(1);
+    expect(writes[0].path).toBe(`/fake/userData/${WATCHDOG_KILL_FLAG_NAME}`);
+    const parsed = JSON.parse(writes[0].data);
+    expect(parsed.missedBeats).toBe(MAX_MISSED);
+    expect(parsed.mainPid).toBe(4242);
+    expect(typeof parsed.killedAt).toBe("number");
+  });
+
+  it("returns false and writes nothing when userData is null (env missing)", () => {
+    const { deps, writes } = makeDeps();
+    const ok = writeWatchdogKillFlag(null, 3, 4242, deps);
+    expect(ok).toBe(false);
+    expect(writes).toHaveLength(0);
+    expect(deps.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("returns false (and does NOT throw) when the write itself fails — fail-open", () => {
+    const { deps } = makeDeps({ throwOnWrite: true });
+    // The contract is: writeWatchdogKillFlag must never propagate. The caller
+    // immediately fires SIGKILL after this returns.
+    const ok = writeWatchdogKillFlag("/fake/userData", 3, 4242, deps);
+    expect(ok).toBe(false);
+    expect(deps.writeFileSync).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -15,6 +15,7 @@ import { isGpuDisabledByFlag } from "./GpuCrashMonitorService.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
 import { getActionBreadcrumbService } from "./ActionBreadcrumbService.js";
 import { resilientAtomicWriteFileSync, resilientRenameSync } from "../utils/fs.js";
+import { WATCHDOG_KILL_FLAG_NAME } from "../watchdog-host-core.js";
 
 const MAX_CRASH_LOGS = 10;
 const MARKER_FILENAME = "running.lock";
@@ -30,6 +31,18 @@ const SUSPECT_WINDOW_MS = 30_000;
 // previous session was almost certainly killed externally (SIGKILL, OOM killer,
 // force-quit) before its backup tick could refresh the stamp.
 const HEARTBEAT_STALE_THRESHOLD_MS = 120_000;
+// Negative margin on the watchdog flag's mtime check: filesystem mtime
+// resolution (HFS+, ext3) can be up to ~1s, and a flag written in the
+// current session will always be ≥ HEARTBEAT_INTERVAL_MS × MAX_MISSED (~15s)
+// after sessionStartMs. 5s of grace safely absorbs clock drift and fs jitter
+// without admitting any flag from a prior session.
+const WATCHDOG_GRACE_MS = 5_000;
+
+interface WatchdogKillAnnotation {
+  killedAt: number;
+  missedBeats: number;
+  mainPid: number;
+}
 
 export class CrashRecoveryService {
   private userData: string;
@@ -348,6 +361,11 @@ export class CrashRecoveryService {
         return null;
       }
 
+      // Read the watchdog kill flag BEFORE deleteMarker — the flag's mtime is
+      // validated against marker.sessionStartMs to reject stale flags from a
+      // prior session that survived an unlink failure.
+      const watchdogAnnotation = this.consumeWatchdogKillFlag(marker);
+
       // Move the live backup aside BEFORE deleting the marker. A kill
       // between the two operations would otherwise wipe the marker (and
       // skip crash detection on the next launch) while session-state.json
@@ -370,6 +388,12 @@ export class CrashRecoveryService {
       const logPath = marker.crashLogPath ?? null;
       const entry = logPath ? this.readCrashLog(logPath) : this.buildCrashEntryFromMarker(marker);
       entry.crashCause = this.classifyCrashCause(marker);
+      if (watchdogAnnotation) {
+        entry.cause = "watchdog-deadlock";
+        entry.watchdogKilledAt = watchdogAnnotation.killedAt;
+        entry.watchdogMissedBeats = watchdogAnnotation.missedBeats;
+        entry.watchdogMainPid = watchdogAnnotation.mainPid;
+      }
       const panels =
         this.crashedBackupPath !== null ? this.extractPanelSummaries(entry.timestamp) : undefined;
 
@@ -387,7 +411,6 @@ export class CrashRecoveryService {
     }
   }
 
-  /**
    * Renames `session-state.json` to a timestamped `session-state.crashed-*.json`
    * so the new session's backup tick cannot clobber it.
    *
@@ -472,6 +495,52 @@ export class CrashRecoveryService {
       // File may already be gone (multiple cleanup paths can race); ignore.
     }
     this.crashedBackupPath = null;
+  }
+
+  /**
+   * Read and consume the sidecar flag the watchdog writes synchronously
+   * before SIGKILLing main. Returns the annotation when the flag is fresh
+   * (mtime >= sessionStartMs - GRACE_MS), or null when missing/stale/malformed.
+   * The flag is unlinked unconditionally so a stale flag can't poison
+   * subsequent launches.
+   */
+  private consumeWatchdogKillFlag(marker: MarkerFile): WatchdogKillAnnotation | null {
+    const flagPath = path.join(this.userData, WATCHDOG_KILL_FLAG_NAME);
+    if (!fs.existsSync(flagPath)) return null;
+
+    let annotation: WatchdogKillAnnotation | null = null;
+    try {
+      const stat = fs.statSync(flagPath);
+      const isFresh = stat.mtimeMs >= marker.sessionStartMs - WATCHDOG_GRACE_MS;
+      if (isFresh) {
+        const raw = fs.readFileSync(flagPath, "utf8");
+        const parsed = JSON.parse(raw) as Partial<WatchdogKillAnnotation>;
+        if (
+          typeof parsed.killedAt === "number" &&
+          typeof parsed.missedBeats === "number" &&
+          typeof parsed.mainPid === "number"
+        ) {
+          annotation = {
+            killedAt: parsed.killedAt,
+            missedBeats: parsed.missedBeats,
+            mainPid: parsed.mainPid,
+          };
+        } else {
+          console.warn("[CrashRecovery] Malformed watchdog kill flag, ignoring");
+        }
+      }
+    } catch (err) {
+      console.warn("[CrashRecovery] Failed to read watchdog kill flag:", err);
+    }
+
+    try {
+      fs.unlinkSync(flagPath);
+    } catch {
+      // best-effort; a stuck flag will be re-evaluated next launch and the
+      // mtime guard will reject it if it doesn't match the new session.
+    }
+
+    return annotation;
   }
 
   private extractPanelSummaries(crashTimestamp: number): PanelSummary[] {

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -355,16 +355,23 @@ export class CrashRecoveryService {
         return null;
       }
 
-      if (!app.isPackaged && marker.isPackaged === false && !marker.crashLogPath) {
+      // Read the watchdog kill flag BEFORE the dev-mode discard branch — even
+      // an orphaned dev marker may have a fresh flag (real watchdog kill in
+      // dev). Consume it unconditionally so a stale flag can't linger across
+      // dev restarts. The mtime guard inside consumeWatchdogKillFlag ensures
+      // only a fresh flag is treated as an annotation.
+      const watchdogAnnotation = this.consumeWatchdogKillFlag(marker);
+
+      if (
+        !app.isPackaged &&
+        marker.isPackaged === false &&
+        !marker.crashLogPath &&
+        !watchdogAnnotation
+      ) {
         console.log("[CrashRecovery] Orphaned dev-mode marker — discarding (not a crash)");
         this.deleteMarker();
         return null;
       }
-
-      // Read the watchdog kill flag BEFORE deleteMarker — the flag's mtime is
-      // validated against marker.sessionStartMs to reject stale flags from a
-      // prior session that survived an unlink failure.
-      const watchdogAnnotation = this.consumeWatchdogKillFlag(marker);
 
       // Move the live backup aside BEFORE deleting the marker. A kill
       // between the two operations would otherwise wipe the marker (and
@@ -393,6 +400,17 @@ export class CrashRecoveryService {
         entry.watchdogKilledAt = watchdogAnnotation.killedAt;
         entry.watchdogMissedBeats = watchdogAnnotation.missedBeats;
         entry.watchdogMainPid = watchdogAnnotation.mainPid;
+        // Persist the annotation onto the on-disk crash log too, so a user
+        // who opens the JSON file directly (via the dialog's "open log file"
+        // affordance, or for support) sees the watchdog attribution. Failure
+        // is non-fatal — the in-memory entry is the source of truth.
+        if (logPath) {
+          try {
+            resilientAtomicWriteFileSync(logPath, JSON.stringify(entry, null, 2), "utf-8");
+          } catch (err) {
+            console.error("[CrashRecovery] Failed to persist watchdog annotation:", err);
+          }
+        }
       }
       const panels =
         this.crashedBackupPath !== null ? this.extractPanelSummaries(entry.timestamp) : undefined;
@@ -411,6 +429,7 @@ export class CrashRecoveryService {
     }
   }
 
+  /**
    * Renames `session-state.json` to a timestamped `session-state.crashed-*.json`
    * so the new session's backup tick cannot clobber it.
    *
@@ -515,10 +534,18 @@ export class CrashRecoveryService {
       if (isFresh) {
         const raw = fs.readFileSync(flagPath, "utf8");
         const parsed = JSON.parse(raw) as Partial<WatchdogKillAnnotation>;
+        // Defensive range checks: a corrupted flag with all-zero numbers
+        // would pass a bare `typeof === "number"` check and produce a
+        // misleading attribution. Real values from buildWatchdogKillPayload
+        // are always positive (killedAt = Date.now(), missedBeats >= 1,
+        // mainPid > 0).
         if (
           typeof parsed.killedAt === "number" &&
+          parsed.killedAt > 0 &&
           typeof parsed.missedBeats === "number" &&
-          typeof parsed.mainPid === "number"
+          parsed.missedBeats >= 1 &&
+          typeof parsed.mainPid === "number" &&
+          parsed.mainPid > 0
         ) {
           annotation = {
             killedAt: parsed.killedAt,

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -1641,5 +1641,141 @@ describe("CrashRecoveryService", () => {
       expect(pending!.entry.cause).toBe("watchdog-deadlock");
       expect(pending!.entry.watchdogMissedBeats).toBe(3);
     });
+
+    it("persists the annotation back onto the on-disk crash log file", () => {
+      const sessionStartMs = Date.now() - 20_000;
+      const crashDir = path.join(userData, "crashes");
+      fs.mkdirSync(crashDir, { recursive: true });
+      const crashLogPath = path.join(crashDir, "crash-disk-update.json");
+      fs.writeFileSync(
+        crashLogPath,
+        JSON.stringify({
+          id: "disk-update",
+          timestamp: Date.now() - 10_000,
+          appVersion: "1.0.0",
+          platform: "darwin",
+          osVersion: "23.0",
+          arch: "arm64",
+        })
+      );
+      fs.writeFileSync(
+        path.join(userData, "running.lock"),
+        JSON.stringify({
+          sessionStartMs,
+          appVersion: "1.0.0",
+          platform: "darwin",
+          crashLogPath,
+        })
+      );
+      const killedAt = sessionStartMs + 16_000;
+      writeWatchdogFlag({ killedAt, missedBeats: 3, mainPid: 4242 }, killedAt);
+
+      const svc = makeService();
+      svc.initialize();
+
+      const onDisk = JSON.parse(fs.readFileSync(crashLogPath, "utf8"));
+      expect(onDisk.cause).toBe("watchdog-deadlock");
+      expect(onDisk.watchdogKilledAt).toBe(killedAt);
+      expect(onDisk.watchdogMissedBeats).toBe(3);
+      expect(onDisk.watchdogMainPid).toBe(4242);
+    });
+
+    it("surfaces a dev-mode crash with a fresh watchdog flag (otherwise discarded as orphan)", () => {
+      const sessionStartMs = Date.now() - 20_000;
+      // Dev-mode orphan marker — no crashLogPath, isPackaged: false — that
+      // would normally be discarded. The fresh watchdog flag must promote it
+      // to a genuine watchdog-deadlock crash and the flag must be unlinked.
+      fs.writeFileSync(
+        path.join(userData, "running.lock"),
+        JSON.stringify({
+          sessionStartMs,
+          appVersion: "1.0.0",
+          platform: "darwin",
+          isPackaged: false,
+        })
+      );
+      const killedAt = sessionStartMs + 16_000;
+      const flagPath = writeWatchdogFlag({ killedAt, missedBeats: 3, mainPid: 4242 }, killedAt);
+
+      appMock.isPackaged = false;
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.cause).toBe("watchdog-deadlock");
+      expect(pending!.entry.watchdogMissedBeats).toBe(3);
+      expect(fs.existsSync(flagPath)).toBe(false);
+    });
+
+    it("unlinks a stale flag even when the dev-mode marker is discarded as orphaned", () => {
+      const sessionStartMs = Date.now() - 1000;
+      // Dev orphan marker + stale flag from a prior session — the orphan is
+      // correctly discarded but the stale flag must still be cleaned up so
+      // it doesn't poison the next launch.
+      fs.writeFileSync(
+        path.join(userData, "running.lock"),
+        JSON.stringify({
+          sessionStartMs,
+          appVersion: "1.0.0",
+          platform: "darwin",
+          isPackaged: false,
+        })
+      );
+      const staleMtime = sessionStartMs - 3_600_000;
+      const flagPath = writeWatchdogFlag(
+        { killedAt: staleMtime, missedBeats: 3, mainPid: 4242 },
+        staleMtime
+      );
+
+      appMock.isPackaged = false;
+      const svc = makeService();
+      svc.initialize();
+
+      expect(svc.getPendingCrash()).toBeNull();
+      expect(fs.existsSync(flagPath)).toBe(false);
+    });
+
+    it("rejects flag payloads with non-positive numeric values", () => {
+      const sessionStartMs = Date.now() - 20_000;
+      writeMarker(sessionStartMs);
+      const mtime = sessionStartMs + 16_000;
+      // All-zero numbers: pass `typeof === "number"` but are not real values
+      // produced by buildWatchdogKillPayload (killedAt = Date.now() > 0,
+      // missedBeats >= 1, mainPid > 0).
+      writeWatchdogFlag({ killedAt: 0, missedBeats: 0, mainPid: 0 }, mtime);
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending!.entry.cause).toBeUndefined();
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("accepts a flag at the exact inclusive mtime boundary (sessionStartMs - 5000)", () => {
+      const sessionStartMs = Date.now() - 20_000;
+      writeMarker(sessionStartMs);
+      const boundaryMtime = sessionStartMs - 5_000;
+      writeWatchdogFlag({ killedAt: boundaryMtime, missedBeats: 3, mainPid: 4242 }, boundaryMtime);
+
+      const svc = makeService();
+      svc.initialize();
+
+      expect(svc.getPendingCrash()!.entry.cause).toBe("watchdog-deadlock");
+    });
+
+    it("rejects a flag whose mtime is just outside the grace window", () => {
+      const sessionStartMs = Date.now() - 20_000;
+      writeMarker(sessionStartMs);
+      // 1ms before the inclusive boundary — should be rejected.
+      const outsideMtime = sessionStartMs - 5_001;
+      writeWatchdogFlag({ killedAt: outsideMtime, missedBeats: 3, mainPid: 4242 }, outsideMtime);
+
+      const svc = makeService();
+      svc.initialize();
+
+      expect(svc.getPendingCrash()!.entry.cause).toBeUndefined();
+    });
   });
 });

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -1469,4 +1469,177 @@ describe("CrashRecoveryService", () => {
       expect(spy).not.toHaveBeenCalled();
     });
   });
+
+  describe("watchdog attribution", () => {
+    function writeMarker(sessionStartMs: number): void {
+      fs.writeFileSync(
+        path.join(userData, "running.lock"),
+        JSON.stringify({
+          sessionStartMs,
+          appVersion: "1.0.0",
+          platform: "darwin",
+        })
+      );
+    }
+
+    function writeWatchdogFlag(payload: unknown, mtimeMs?: number): string {
+      const flagPath = path.join(userData, "watchdog-kill.flag");
+      fs.writeFileSync(flagPath, JSON.stringify(payload), "utf8");
+      if (typeof mtimeMs === "number") {
+        const t = new Date(mtimeMs);
+        fs.utimesSync(flagPath, t, t);
+      }
+      return flagPath;
+    }
+
+    it("annotates the crash entry when a fresh watchdog flag is present", () => {
+      const sessionStartMs = Date.now() - 20_000;
+      writeMarker(sessionStartMs);
+      const killedAt = sessionStartMs + 16_000;
+      writeWatchdogFlag({ killedAt, missedBeats: 3, mainPid: 4242 }, killedAt);
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.cause).toBe("watchdog-deadlock");
+      expect(pending!.entry.watchdogKilledAt).toBe(killedAt);
+      expect(pending!.entry.watchdogMissedBeats).toBe(3);
+      expect(pending!.entry.watchdogMainPid).toBe(4242);
+    });
+
+    it("consumes (unlinks) the flag regardless of attribution outcome", () => {
+      const sessionStartMs = Date.now() - 20_000;
+      writeMarker(sessionStartMs);
+      const flagPath = writeWatchdogFlag(
+        { killedAt: sessionStartMs + 16_000, missedBeats: 3, mainPid: 4242 },
+        sessionStartMs + 16_000
+      );
+
+      const svc = makeService();
+      svc.initialize();
+
+      expect(fs.existsSync(flagPath)).toBe(false);
+    });
+
+    it("leaves entry without cause when no watchdog flag is present", () => {
+      writeMarker(Date.now() - 5000);
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.cause).toBeUndefined();
+      expect(pending!.entry.watchdogKilledAt).toBeUndefined();
+    });
+
+    it("rejects a stale flag (mtime far earlier than current session) and still unlinks it", () => {
+      const sessionStartMs = Date.now() - 1000;
+      writeMarker(sessionStartMs);
+      // Stale flag: mtime is 1 hour before this session started — clearly
+      // a leftover from a previous run where unlink failed.
+      const staleMtime = sessionStartMs - 3_600_000;
+      const flagPath = writeWatchdogFlag(
+        { killedAt: staleMtime, missedBeats: 3, mainPid: 4242 },
+        staleMtime
+      );
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.cause).toBeUndefined();
+      // Flag is still cleaned up so it can't poison the next launch.
+      expect(fs.existsSync(flagPath)).toBe(false);
+    });
+
+    it("accepts a flag whose mtime is within the 5-second grace window before sessionStartMs", () => {
+      const sessionStartMs = Date.now() - 20_000;
+      writeMarker(sessionStartMs);
+      // 3 seconds before sessionStartMs is within the 5s grace — should still
+      // be treated as fresh (clock drift / fs mtime resolution).
+      const mtime = sessionStartMs - 3_000;
+      writeWatchdogFlag({ killedAt: mtime, missedBeats: 3, mainPid: 4242 }, mtime);
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending!.entry.cause).toBe("watchdog-deadlock");
+    });
+
+    it("ignores a malformed JSON flag, warns, and unlinks it", () => {
+      const sessionStartMs = Date.now() - 5_000;
+      writeMarker(sessionStartMs);
+      const flagPath = path.join(userData, "watchdog-kill.flag");
+      fs.writeFileSync(flagPath, "not valid json{{{", "utf8");
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.cause).toBeUndefined();
+      expect(fs.existsSync(flagPath)).toBe(false);
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("ignores a flag whose payload is the right shape but missing fields", () => {
+      const sessionStartMs = Date.now() - 20_000;
+      writeMarker(sessionStartMs);
+      // missedBeats omitted
+      writeWatchdogFlag(
+        { killedAt: sessionStartMs + 16_000, mainPid: 4242 },
+        sessionStartMs + 16_000
+      );
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending!.entry.cause).toBeUndefined();
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("annotates entries built from an existing crash log too", () => {
+      const sessionStartMs = Date.now() - 20_000;
+      const crashDir = path.join(userData, "crashes");
+      fs.mkdirSync(crashDir, { recursive: true });
+      const crashLogPath = path.join(crashDir, "crash-precrash.json");
+      fs.writeFileSync(
+        crashLogPath,
+        JSON.stringify({
+          id: "precrash",
+          timestamp: Date.now() - 10_000,
+          appVersion: "1.0.0",
+          platform: "darwin",
+          osVersion: "23.0",
+          arch: "arm64",
+          errorMessage: "pre-existing crash record",
+        })
+      );
+      fs.writeFileSync(
+        path.join(userData, "running.lock"),
+        JSON.stringify({
+          sessionStartMs,
+          appVersion: "1.0.0",
+          platform: "darwin",
+          crashLogPath,
+        })
+      );
+      const killedAt = sessionStartMs + 16_000;
+      writeWatchdogFlag({ killedAt, missedBeats: 3, mainPid: 4242 }, killedAt);
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending!.entry.errorMessage).toBe("pre-existing crash record");
+      expect(pending!.entry.cause).toBe("watchdog-deadlock");
+      expect(pending!.entry.watchdogMissedBeats).toBe(3);
+    });
+  });
 });

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -1753,11 +1753,16 @@ describe("CrashRecoveryService", () => {
       expect(console.warn).toHaveBeenCalled();
     });
 
-    it("accepts a flag at the exact inclusive mtime boundary (sessionStartMs - 5000)", () => {
+    it("accepts a flag just inside the inclusive grace window (sessionStartMs - 4900)", () => {
       const sessionStartMs = Date.now() - 20_000;
       writeMarker(sessionStartMs);
-      const boundaryMtime = sessionStartMs - 5_000;
-      writeWatchdogFlag({ killedAt: boundaryMtime, missedBeats: 3, mainPid: 4242 }, boundaryMtime);
+      // 100ms inside the 5s grace boundary — comfortably above filesystem
+      // mtime precision on Linux ext4 / macOS HFS+, so the test is reliable
+      // across CI platforms. The exact boundary (sessionStartMs - 5000) is
+      // unsafe to assert here because fs.utimesSync(Date) rounds through
+      // float seconds and the round-trip can land 1-2ms either side.
+      const insideMtime = sessionStartMs - 4_900;
+      writeWatchdogFlag({ killedAt: insideMtime, missedBeats: 3, mainPid: 4242 }, insideMtime);
 
       const svc = makeService();
       svc.initialize();
@@ -1765,11 +1770,12 @@ describe("CrashRecoveryService", () => {
       expect(svc.getPendingCrash()!.entry.cause).toBe("watchdog-deadlock");
     });
 
-    it("rejects a flag whose mtime is just outside the grace window", () => {
+    it("rejects a flag clearly outside the grace window", () => {
       const sessionStartMs = Date.now() - 20_000;
       writeMarker(sessionStartMs);
-      // 1ms before the inclusive boundary — should be rejected.
-      const outsideMtime = sessionStartMs - 5_001;
+      // 100ms outside the 5s grace — clearly stale, robust to fs mtime
+      // rounding on all platforms.
+      const outsideMtime = sessionStartMs - 5_100;
       writeWatchdogFlag({ killedAt: outsideMtime, missedBeats: 3, mainPid: 4242 }, outsideMtime);
 
       const svc = makeService();

--- a/electron/watchdog-host-core.ts
+++ b/electron/watchdog-host-core.ts
@@ -103,6 +103,61 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
   return { state, tick, handleMessage, disarm };
 }
 
+/** Name of the sidecar flag file the watchdog writes synchronously before
+ * SIGKILL. CrashRecoveryService reads + unlinks it on next launch to
+ * attribute the crash as a deadlock kill rather than "unknown". */
+export const WATCHDOG_KILL_FLAG_NAME = "watchdog-kill.flag";
+
+export interface WatchdogKillPayload {
+  killedAt: number;
+  missedBeats: number;
+  mainPid: number;
+}
+
+/** Pure builder for the flag-file payload. Extracted from watchdog-host.ts so
+ * the JSON shape can be tested without touching disk or the UtilityProcess
+ * runtime. The host wraps this in a try/catch synchronous write so the
+ * fail-open guarantee on the SIGKILL path is preserved. */
+export function buildWatchdogKillPayload(
+  missedBeats: number,
+  mainPid: number
+): WatchdogKillPayload {
+  return { killedAt: Date.now(), missedBeats, mainPid };
+}
+
+export interface WriteWatchdogKillFlagDeps {
+  /** Synchronous write. Defaults are injected by the host; tests inject
+   * a stub (including throw-cases) to verify fail-open behaviour. */
+  writeFileSync: (path: string, data: string) => void;
+  /** Path join shim — only needed so tests don't pull in node:path. */
+  joinPath: (userData: string, name: string) => string;
+}
+
+/** Write the sidecar flag the next-launch crash recovery reads to attribute
+ * SIGKILL-by-watchdog. Fail-open: any error is swallowed silently so the
+ * SIGKILL path is never delayed or aborted by a disk failure.
+ *
+ * Returns true on success, false on any failure (missing userData, write
+ * failure). Callers MUST treat the return value as advisory only — the
+ * SIGKILL must fire regardless.
+ */
+export function writeWatchdogKillFlag(
+  userData: string | null,
+  missedBeats: number,
+  mainPid: number,
+  deps: WriteWatchdogKillFlagDeps
+): boolean {
+  if (!userData) return false;
+  try {
+    const flagPath = deps.joinPath(userData, WATCHDOG_KILL_FLAG_NAME);
+    const payload = buildWatchdogKillPayload(missedBeats, mainPid);
+    deps.writeFileSync(flagPath, JSON.stringify(payload));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Parse the `--main-pid=<pid>` flag out of argv. Returns null if missing
  * or malformed — Chromium injects positional arguments into `process.argv`,
  * so the named flag is the only reliable transport. Strict parsing: rejects

--- a/electron/watchdog-host.ts
+++ b/electron/watchdog-host.ts
@@ -12,10 +12,13 @@
  * worse than missing a deadlock — every kill path is gated.
  */
 
+import fs from "node:fs";
+import path from "node:path";
 import { MessagePort } from "node:worker_threads";
 import {
   createWatchdog,
   parseMainPid,
+  writeWatchdogKillFlag,
   HEARTBEAT_INTERVAL_MS,
   MAX_MISSED,
   type WatchdogMessage,
@@ -59,6 +62,16 @@ function isMainAlive(pid: number): boolean {
   }
 }
 
+// userData path is passed through utilityProcess.fork({ env }) so the
+// watchdog can drop a sidecar flag file alongside the marker. Missing env =
+// silent no-op write (fail-open) — the SIGKILL still fires; CrashRecovery
+// just records the crash as "unknown" rather than "watchdog-deadlock".
+const userDataPath = process.env.DAINTREE_USER_DATA ?? null;
+const killFlagDeps = {
+  writeFileSync: (p: string, data: string) => fs.writeFileSync(p, data, "utf8"),
+  joinPath: (userData: string, name: string) => path.join(userData, name),
+};
+
 const watchdog = createWatchdog({
   killMain: () => {
     if (mainPid === null) return;
@@ -69,6 +82,9 @@ const watchdog = createWatchdog({
       return;
     }
     console.error(`[WatchdogHost] Sending SIGKILL to main PID ${mainPid}`);
+    // Annotation write is best-effort and must NEVER gate the kill. The
+    // helper swallows all errors internally; SIGKILL fires unconditionally.
+    writeWatchdogKillFlag(userDataPath, watchdog.state.missedBeats, mainPid, killFlagDeps);
     try {
       process.kill(mainPid, "SIGKILL");
     } catch (err) {

--- a/shared/types/ipc/crashRecovery.ts
+++ b/shared/types/ipc/crashRecovery.ts
@@ -67,6 +67,16 @@ export interface CrashLogEntry {
   processUptime?: number;
   recentActions?: ActionBreadcrumb[];
   crashCause?: CrashCause;
+  /**
+   * Precise sub-classification for watchdog-driven kills. Complements
+   * crashCause (which is heuristic-only): when the external watchdog
+   * SIGKILLs main after missed heartbeats, it writes a sidecar flag and
+   * this field is set on the entry. Absent = no watchdog signal.
+   */
+  cause?: "watchdog-deadlock";
+  watchdogKilledAt?: number;
+  watchdogMissedBeats?: number;
+  watchdogMainPid?: number;
 }
 
 export interface PanelSummary {

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -613,6 +613,20 @@ function buildClipboardText(crash: PendingCrash): string {
 
   lines.push(`- **Crashed at**: ${new Date(e.timestamp).toISOString()}`);
 
+  if (e.cause === "watchdog-deadlock") {
+    const causeParts: string[] = [`**Cause**: Watchdog deadlock (SIGKILL)`];
+    if (e.watchdogMissedBeats !== undefined) {
+      causeParts.push(`${e.watchdogMissedBeats} missed heartbeats`);
+    }
+    if (e.watchdogKilledAt !== undefined) {
+      causeParts.push(`killed at ${new Date(e.watchdogKilledAt).toISOString()}`);
+    }
+    if (e.watchdogMainPid !== undefined) {
+      causeParts.push(`main PID ${e.watchdogMainPid}`);
+    }
+    lines.push(`- ${causeParts.join(" — ")}`);
+  }
+
   if (e.errorMessage) {
     lines.push(``, `**Error:** ${e.errorMessage}`);
   }

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -614,4 +614,33 @@ describe("CrashRecoveryDialog", () => {
     setup({ crash: { hasBackup: false, backupTimestamp: undefined, panels: undefined } });
     expect(screen.getByText(/No backup available/)).toBeTruthy();
   });
+
+  it("clipboard surfaces watchdog deadlock cause when present", async () => {
+    setup({
+      crash: {
+        entry: {
+          id: "wd-123",
+          timestamp: 1700000000000,
+          appVersion: "1.0.0",
+          platform: "linux",
+          osVersion: "5.15.0",
+          arch: "x64",
+          cause: "watchdog-deadlock",
+          watchdogKilledAt: 1700000016000,
+          watchdogMissedBeats: 3,
+          watchdogMainPid: 4242,
+        },
+      },
+    });
+    fireEvent.click(screen.getByTestId("details-toggle"));
+    fireEvent.click(screen.getByTestId("report-button"));
+    fireEvent.click(screen.getByTestId("report-button"));
+
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalled());
+    const clipText = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as string;
+    expect(clipText).toContain("Watchdog deadlock");
+    expect(clipText).toContain("3 missed heartbeats");
+    expect(clipText).toContain("main PID 4242");
+  });
 });


### PR DESCRIPTION
## Summary

- Watchdog SIGKILL events were being classified as unknown crashes. The watchdog utility process now writes a synchronous JSON sidecar (`watchdog-kill.flag`) just before sending SIGKILL, recording `killedAt`, `missedBeats`, and `mainPid`.
- `CrashRecoveryService` consumes the flag during marker processing, validates `mtime` against `sessionStartMs` (5 s grace), and annotates the `CrashLogEntry` with `cause: "watchdog-deadlock"` plus the three watchdog fields. The annotation is persisted back to the on-disk crash log and surfaces in the bug-report clipboard output.
- Fail-open: write errors are silently swallowed and SIGKILL fires regardless. Dev-mode orphan markers with a fresh flag are now promoted to genuine `watchdog-deadlock` crashes instead of being discarded.

Resolves #8682

## Changes

- `shared/types/ipc/crashRecovery.ts` — 4 new optional fields on `CrashLogEntry` (`cause`, `watchdogKilledAt`, `watchdogMissedBeats`, `watchdogMainPid`)
- `electron/watchdog-host-core.ts` — `WATCHDOG_KILL_FLAG_NAME`, `buildWatchdogKillPayload`, `writeWatchdogKillFlag` (injected fs deps for testability)
- `electron/watchdog-host.ts` — calls `writeWatchdogKillFlag` with real fs deps, reads `DAINTREE_USER_DATA`
- `electron/services/CrashRecoveryService.ts` — `consumeWatchdogKillFlag`, annotation overlay, write-back to disk
- `src/components/Recovery/CrashRecoveryDialog.tsx` — surfaces `watchdog-deadlock` cause in clipboard output
- Tests: 7 unit tests for the host-core helpers, 11 for the `CrashRecoveryService` watchdog attribution path, clipboard test for `CrashRecoveryDialog`

## Testing

137 unit tests pass across the three affected test files. Typecheck, lint, format, IPC codegen drift, and ratchet all clean (ratchet decreased by 122 warnings).