### PR TITLE
fix(lifecycle): harden main-process shutdown backup and exit-code paths

### DIFF
--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -4,6 +4,7 @@ const appMock = vi.hoisted(() => ({
   isPackaged: false as boolean,
   on: vi.fn(),
   quit: vi.fn(),
+  exit: vi.fn(),
 }));
 
 const browserWindowMock = vi.hoisted(() => ({
@@ -26,8 +27,10 @@ vi.mock("../../menu.js", () => ({
 }));
 
 const setSignalShutdownMock = vi.fn();
+const setSafetyBeltTimerMock = vi.fn();
 vi.mock("../signalShutdownState.js", () => ({
   setSignalShutdown: setSignalShutdownMock,
+  setSafetyBeltTimer: setSafetyBeltTimerMock,
 }));
 
 const isWindowRecreatingMock = vi.fn(() => false);
@@ -37,7 +40,7 @@ vi.mock("../windowRecreationState.js", () => ({
 
 import type { AppLifecycleOptions } from "../appLifecycle.js";
 import { handleDirectoryOpen } from "../../menu.js";
-import { CLEANUP_TIMEOUT_MS } from "../shutdownConfig.js";
+import { SAFETY_BELT_TIMEOUT_MS } from "../shutdownConfig.js";
 
 function makeOpts(overrides?: Partial<AppLifecycleOptions>): AppLifecycleOptions {
   return {
@@ -93,7 +96,7 @@ describe("registerAppLifecycleHandlers – signal handling", () => {
     expect(processOnSpy.mock.calls.some(([sig]: string[]) => sig === "SIGHUP")).toBe(false);
   });
 
-  it("signal handler calls setSignalShutdown, schedules timeout, and calls app.quit", async () => {
+  it("signal handler calls setSignalShutdown, schedules safety-belt timer, and calls app.quit", async () => {
     const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
     registerAppLifecycleHandlers(makeOpts());
 
@@ -104,14 +107,39 @@ describe("registerAppLifecycleHandlers – signal handling", () => {
 
     expect(setSignalShutdownMock).toHaveBeenCalledOnce();
     expect(appMock.quit).toHaveBeenCalledOnce();
+    // Belt handle must be stored so shutdown.ts can cancel it on clean exit.
+    // Without this, a slow closeTelemetry() could let the belt fire after
+    // app.exit(0) and clobber the exit code with a wrong-direction exit(1).
+    expect(setSafetyBeltTimerMock).toHaveBeenCalledWith(expect.anything());
 
-    // Belt must outlast CLEANUP_TIMEOUT_MS plus telemetry-drain buffer so it
-    // doesn't fire mid-cleanup. Advancing to (CLEANUP_TIMEOUT_MS + 3000 - 1)
+    // Belt must outlast the full cleanup chain: CLEANUP_TIMEOUT_MS + 3000ms
+    // buffer + 2500ms closeTelemetry budget. Advancing to (SAFETY_BELT_TIMEOUT_MS - 1)
     // confirms the belt hasn't fired prematurely.
-    vi.advanceTimersByTime(CLEANUP_TIMEOUT_MS + 3000 - 1);
+    vi.advanceTimersByTime(SAFETY_BELT_TIMEOUT_MS - 1);
+    expect(appMock.exit).not.toHaveBeenCalled();
     expect(processExitSpy).not.toHaveBeenCalled();
     vi.advanceTimersByTime(1);
-    expect(processExitSpy).toHaveBeenCalledWith(0);
+    // Belt fires app.exit(1) — dirty exit signals supervisors correctly and
+    // runs Electron's native teardown. Never process.exit(0).
+    expect(appMock.exit).toHaveBeenCalledWith(1);
+    expect(processExitSpy).not.toHaveBeenCalledWith(0);
+  });
+
+  it("safety-belt nulls the stored handle when it fires", async () => {
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    registerAppLifecycleHandlers(makeOpts());
+
+    const sigTermCall = processOnSpy.mock.calls.find(([sig]: string[]) => sig === "SIGTERM");
+    const handler = sigTermCall![1] as () => void;
+
+    handler();
+    setSafetyBeltTimerMock.mockClear();
+
+    vi.advanceTimersByTime(SAFETY_BELT_TIMEOUT_MS);
+
+    // Belt fired → handle cleared so a late clearSafetyBeltTimer() from
+    // shutdown.ts is a no-op rather than canceling an already-fired timer.
+    expect(setSafetyBeltTimerMock).toHaveBeenCalledWith(null);
   });
 
   it("rapid second signal within 2s force-exits with status 1", async () => {

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -26,6 +26,7 @@ vi.mock("../../services/ProjectStore.js", () => ({
 
 const crashRecoveryMock = vi.hoisted(() => ({
   cleanupOnExit: vi.fn(),
+  takeBackup: vi.fn(),
 }));
 
 vi.mock("../../services/CrashRecoveryService.js", () => ({
@@ -78,6 +79,7 @@ vi.mock("../../ipc/utils.js", () => ({
 
 const signalShutdownMock = vi.hoisted(() => ({
   isSignalShutdown: vi.fn(() => false),
+  clearSafetyBeltTimer: vi.fn(),
 }));
 
 vi.mock("../signalShutdownState.js", () => signalShutdownMock);
@@ -875,6 +877,102 @@ describe("registerShutdownHandler", () => {
       );
 
       warnSpy.mockRestore();
+    });
+  });
+
+  describe("eager backup at quit-intent (issue #8699)", () => {
+    it("snapshots backup at quit-intent before the cleanup chain runs", async () => {
+      const order: string[] = [];
+      crashRecoveryMock.takeBackup.mockImplementationOnce(() => {
+        order.push("eager-backup");
+      });
+      mcpServerMock.stop.mockImplementationOnce(async () => {
+        order.push("cleanup-chain");
+      });
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+
+      expect(crashRecoveryMock.takeBackup).toHaveBeenCalled();
+      // Eager backup must run before any async cleanup so a hard-timeout exit
+      // can never skip the post-quit-intent snapshot.
+      const eagerIdx = order.indexOf("eager-backup");
+      const chainIdx = order.indexOf("cleanup-chain");
+      expect(eagerIdx).toBeGreaterThanOrEqual(0);
+      expect(chainIdx).toBeGreaterThanOrEqual(0);
+      expect(eagerIdx).toBeLessThan(chainIdx);
+    });
+
+    it("skips eager backup in smoke test mode", async () => {
+      isSmokeTestMock.value = true;
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+      expect(crashRecoveryMock.takeBackup).not.toHaveBeenCalled();
+    });
+
+    it("continues shutdown when eager takeBackup throws", async () => {
+      crashRecoveryMock.takeBackup.mockImplementationOnce(() => {
+        throw new Error("eager backup boom");
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[MAIN] Eager takeBackup at quit-intent failed:",
+        expect.any(Error)
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("safety-belt timer cancellation (issue #8699)", () => {
+    it("clears safety-belt timer before app.exit(0) on clean shutdown", async () => {
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+
+      expect(signalShutdownMock.clearSafetyBeltTimer).toHaveBeenCalled();
+      // Order matters: belt MUST be cancelled before app.exit, otherwise a
+      // slow closeTelemetry() above could let the belt fire after exit(0)
+      // and clobber the exit code with exit(1).
+      const exitOrder = appMock.exit.mock.invocationCallOrder[0];
+      const clearOrders = signalShutdownMock.clearSafetyBeltTimer.mock.invocationCallOrder;
+      const lastClearOrder = clearOrders[clearOrders.length - 1];
+      expect(lastClearOrder).toBeLessThan(exitOrder);
+    });
+
+    it("clears safety-belt timer before app.exit(1) on hard timeout", async () => {
+      vi.useFakeTimers();
+      mcpServerMock.stop.mockReturnValue(new Promise(() => {}));
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.runAllTimersAsync();
+
+      expect(appMock.exit).toHaveBeenCalledWith(1);
+      expect(signalShutdownMock.clearSafetyBeltTimer).toHaveBeenCalled();
+      const exitOrder = appMock.exit.mock.invocationCallOrder[0];
+      const clearOrders = signalShutdownMock.clearSafetyBeltTimer.mock.invocationCallOrder;
+      const lastClearOrder = clearOrders[clearOrders.length - 1];
+      expect(lastClearOrder).toBeLessThan(exitOrder);
+
+      consoleSpy.mockRestore();
+      vi.useRealTimers();
     });
   });
 });

--- a/electron/lifecycle/__tests__/signalShutdownState.test.ts
+++ b/electron/lifecycle/__tests__/signalShutdownState.test.ts
@@ -29,7 +29,7 @@ describe("signalShutdownState", () => {
         await import("../signalShutdownState.js");
 
       const callback = vi.fn();
-      const handle = setTimeout(callback, 1000);
+      const handle = setTimeout(callback, 1000) as unknown as ReturnType<typeof setTimeout>;
       setSafetyBeltTimer(handle);
 
       clearSafetyBeltTimer();
@@ -58,7 +58,7 @@ describe("signalShutdownState", () => {
         await import("../signalShutdownState.js");
 
       const callback = vi.fn();
-      const handle = setTimeout(callback, 1000);
+      const handle = setTimeout(callback, 1000) as unknown as ReturnType<typeof setTimeout>;
       setSafetyBeltTimer(handle);
 
       // Simulate the belt firing and nulling itself — subsequent clear is no-op.

--- a/electron/lifecycle/__tests__/signalShutdownState.test.ts
+++ b/electron/lifecycle/__tests__/signalShutdownState.test.ts
@@ -15,4 +15,60 @@ describe("signalShutdownState", () => {
     setSignalShutdown();
     expect(isSignalShutdown()).toBe(true);
   });
+
+  describe("safety-belt timer", () => {
+    it("clearSafetyBeltTimer is a no-op when no timer is set", async () => {
+      const { clearSafetyBeltTimer } = await import("../signalShutdownState.js");
+      // No throw, no side effect — the module starts with the handle null.
+      expect(() => clearSafetyBeltTimer()).not.toThrow();
+    });
+
+    it("clearSafetyBeltTimer cancels a stored timer so it does not fire", async () => {
+      vi.useFakeTimers();
+      const { setSafetyBeltTimer, clearSafetyBeltTimer } =
+        await import("../signalShutdownState.js");
+
+      const callback = vi.fn();
+      const handle = setTimeout(callback, 1000);
+      setSafetyBeltTimer(handle);
+
+      clearSafetyBeltTimer();
+      vi.advanceTimersByTime(2000);
+
+      expect(callback).not.toHaveBeenCalled();
+      vi.useRealTimers();
+    });
+
+    it("clearSafetyBeltTimer is idempotent — second call is a no-op", async () => {
+      vi.useFakeTimers();
+      const { setSafetyBeltTimer, clearSafetyBeltTimer } =
+        await import("../signalShutdownState.js");
+
+      const handle = setTimeout(() => {}, 1000);
+      setSafetyBeltTimer(handle);
+      clearSafetyBeltTimer();
+      // Second clear must not throw or attempt to clear a null handle.
+      expect(() => clearSafetyBeltTimer()).not.toThrow();
+      vi.useRealTimers();
+    });
+
+    it("setSafetyBeltTimer(null) clears the stored handle without canceling", async () => {
+      vi.useFakeTimers();
+      const { setSafetyBeltTimer, clearSafetyBeltTimer } =
+        await import("../signalShutdownState.js");
+
+      const callback = vi.fn();
+      const handle = setTimeout(callback, 1000);
+      setSafetyBeltTimer(handle);
+
+      // Simulate the belt firing and nulling itself — subsequent clear is no-op.
+      setSafetyBeltTimer(null);
+      clearSafetyBeltTimer();
+
+      vi.advanceTimersByTime(2000);
+      // Callback still fires because we nulled the reference without clearing.
+      expect(callback).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+  });
 });

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -3,9 +3,9 @@ import type { CliAvailabilityService } from "../services/CliAvailabilityService.
 import type { WindowRegistry } from "../window/WindowRegistry.js";
 import { handleDirectoryOpen } from "../menu.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
-import { setSignalShutdown } from "./signalShutdownState.js";
+import { setSignalShutdown, setSafetyBeltTimer } from "./signalShutdownState.js";
 import { isWindowRecreating } from "./windowRecreationState.js";
-import { CLEANUP_TIMEOUT_MS } from "./shutdownConfig.js";
+import { SAFETY_BELT_TIMEOUT_MS } from "./shutdownConfig.js";
 
 let pendingCliPath: string | null = null;
 
@@ -51,10 +51,16 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
   // for the same reason: closing the dev terminal sends SIGHUP and would
   // otherwise terminate the process without the markCleanExit call.
   //
-  // The safety-belt timer must outlast `CLEANUP_TIMEOUT_MS` so it doesn't fire
-  // mid-cleanup; the 3000ms buffer covers `closeTelemetry()` which can take up
-  // to ~2500ms in the worst case (Sentry init-wait cap 500ms + close timeout
-  // 2000ms — see TelemetryService.ts) and runs after the cleanup race resolves.
+  // The safety-belt timer must outlast the full graceful-shutdown chain so it
+  // doesn't fire mid-cleanup. `SAFETY_BELT_TIMEOUT_MS` budgets the 10s cleanup
+  // race plus a 3000ms historical buffer plus 2500ms for closeTelemetry()
+  // (Sentry init-wait cap 500ms + close timeout 2000ms — see TelemetryService.ts).
+  // The handle is captured and stored in signalShutdownState.ts so shutdown.ts
+  // can `clearSafetyBeltTimer()` it before its own `app.exit()` calls; without
+  // that, a slow closeTelemetry() could let the belt fire after a normal exit
+  // and report the wrong exit code to systemd/nodemon. The belt fires
+  // `app.exit(1)` (dirty exit) — never `process.exit(0)` — so process
+  // supervisors get the correct signal and Electron's native teardown still runs.
   // A second signal within 2000ms force-exits with status 1 — escape hatch
   // when shutdown stalls. After that window, repeat signals are ignored
   // (cleanup is already in progress).
@@ -74,7 +80,12 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
     }
     firstSignalTime = Date.now();
     setSignalShutdown();
-    setTimeout(() => process.exit(0), CLEANUP_TIMEOUT_MS + 3000).unref();
+    const handle = setTimeout(() => {
+      setSafetyBeltTimer(null);
+      app.exit(1);
+    }, SAFETY_BELT_TIMEOUT_MS);
+    handle.unref();
+    setSafetyBeltTimer(handle);
     app.quit();
   };
   process.on("SIGTERM", signalHandler);

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -44,7 +44,7 @@ import {
 import { closeSharedDb } from "../services/persistence/db.js";
 import { closeTelemetry } from "../services/TelemetryService.js";
 import { isSmokeTest } from "../setup/environment.js";
-import { isSignalShutdown } from "./signalShutdownState.js";
+import { isSignalShutdown, clearSafetyBeltTimer } from "./signalShutdownState.js";
 import { CLEANUP_TIMEOUT_MS } from "./shutdownConfig.js";
 
 export { CLEANUP_TIMEOUT_MS };
@@ -112,6 +112,18 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
     }
 
     isQuitting = true;
+
+    // Eager snapshot at quit-intent so the next launch has a post-quit-intent
+    // backup regardless of which branch of the cleanup race wins. Without this,
+    // a hard-timeout dirty exit skips cleanupOnExit() entirely and leaves the
+    // user with whatever the 60s backup timer last captured. takeBackup() is
+    // synchronous and best-effort (swallows its own errors), so it cannot
+    // block or fail the shutdown chain.
+    try {
+      getCrashRecoveryService().takeBackup();
+    } catch (err) {
+      console.warn("[MAIN] Eager takeBackup at quit-intent failed:", err);
+    }
 
     console.log("[MAIN] Starting graceful shutdown...");
     const { drainRateLimitQueues } = await import("../ipc/utils.js");
@@ -404,6 +416,11 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         } catch (err) {
           console.warn("[MAIN] closeTelemetry failed:", err);
         }
+        // Cancel the signal-handler safety-belt before exiting cleanly so a slow
+        // closeTelemetry() above can't let the belt fire after app.exit(0) and
+        // clobber the exit code (signal handlers in appLifecycle.ts schedule
+        // SAFETY_BELT_TIMEOUT_MS to app.exit(1) on the dirty path).
+        clearSafetyBeltTimer();
         app.exit(0);
       })
       .catch(async (error) => {
@@ -418,6 +435,7 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         } catch (err) {
           console.warn("[MAIN] closeTelemetry failed:", err);
         }
+        clearSafetyBeltTimer();
         app.exit(1);
       });
   });

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -411,16 +411,17 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         } catch (err) {
           console.warn("[MAIN] CrashLoopGuard.markCleanExit failed:", err);
         }
+        // Defuse the signal-handler safety-belt the moment we've committed to a
+        // clean exit. closeTelemetry below has a 2500ms internal cap, but
+        // clearing first eliminates the dependency on that cap holding — if a
+        // future refactor extends the telemetry budget, the belt won't be able
+        // to fire after app.exit(0) and clobber the exit code with exit(1).
+        clearSafetyBeltTimer();
         try {
           await closeTelemetry();
         } catch (err) {
           console.warn("[MAIN] closeTelemetry failed:", err);
         }
-        // Cancel the signal-handler safety-belt before exiting cleanly so a slow
-        // closeTelemetry() above can't let the belt fire after app.exit(0) and
-        // clobber the exit code (signal handlers in appLifecycle.ts schedule
-        // SAFETY_BELT_TIMEOUT_MS to app.exit(1) on the dirty path).
-        clearSafetyBeltTimer();
         app.exit(0);
       })
       .catch(async (error) => {
@@ -430,12 +431,14 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         console.error("[MAIN] Error during cleanup:", error);
         // Intentionally do NOT clean up the marker on the error/timeout path —
         // leaving running.lock on disk is the dirty-exit signal for next launch.
+        // Defuse the belt before telemetry flush for the same reason as the
+        // clean branch above.
+        clearSafetyBeltTimer();
         try {
           await closeTelemetry();
         } catch (err) {
           console.warn("[MAIN] closeTelemetry failed:", err);
         }
-        clearSafetyBeltTimer();
         app.exit(1);
       });
   });

--- a/electron/lifecycle/shutdownConfig.ts
+++ b/electron/lifecycle/shutdownConfig.ts
@@ -2,3 +2,10 @@
 // signal-handler in appLifecycle.ts (and tests) can import it without pulling
 // in the full shutdown.ts service graph (ProjectStore, TelemetryService, etc).
 export const CLEANUP_TIMEOUT_MS = 10_000;
+
+// Safety-belt timer for the signal handler. Must outlast the full cleanup chain:
+// CLEANUP_TIMEOUT_MS (graceful cleanup race) + 3000ms historical buffer + 2500ms
+// worst-case closeTelemetry() (Sentry init-wait cap 500ms + close timeout 2000ms,
+// see TelemetryService.ts). Without the telemetry budget the belt could fire
+// mid-`await closeTelemetry()` and clobber the intended app.exit(1) on the dirty path.
+export const SAFETY_BELT_TIMEOUT_MS = CLEANUP_TIMEOUT_MS + 3_000 + 2_500;

--- a/electron/lifecycle/signalShutdownState.ts
+++ b/electron/lifecycle/signalShutdownState.ts
@@ -4,3 +4,20 @@ export const isSignalShutdown = (): boolean => _isSignalShutdown;
 export const setSignalShutdown = (): void => {
   _isSignalShutdown = true;
 };
+
+// Safety-belt timer handle, set by the signal handler in appLifecycle.ts and
+// cleared by the shutdown.ts before-quit handler before every app.exit() call.
+// Held here (not in appLifecycle.ts) so shutdown.ts can cancel it without
+// importing appLifecycle.ts — those modules cross-import would be a cycle.
+let _safetyBeltTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const setSafetyBeltTimer = (handle: ReturnType<typeof setTimeout> | null): void => {
+  _safetyBeltTimer = handle;
+};
+
+export const clearSafetyBeltTimer = (): void => {
+  if (_safetyBeltTimer !== null) {
+    clearTimeout(_safetyBeltTimer);
+    _safetyBeltTimer = null;
+  }
+};

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -23,6 +23,12 @@ const CRASHES_DIR = "crashes";
 const BACKUP_DIR = "backups";
 const BACKUP_FILENAME = "session-state.json";
 const CRASHED_BACKUP_PREFIX = "session-state.crashed-";
+// Previous-generation backup, kept as a Firefox-style rolling pair so a
+// corrupt write (truncated, partial, or unparseable) doesn't destroy the only
+// recovery snapshot. takeBackup() rotates current → previous before writing
+// new current; restoreBackup()/readBackupInfo() fall back to previous when
+// current is missing or fails to parse.
+const PREVIOUS_BACKUP_FILENAME = "session-state.previous.json";
 const BACKUP_INTERVAL_MS = 60_000;
 const DEBOUNCE_BACKUP_MS = 1_500;
 const BLUR_BACKUP_DEBOUNCE_MS = 100;
@@ -49,6 +55,7 @@ export class CrashRecoveryService {
   private markerPath: string;
   private crashesDir: string;
   private backupPath: string;
+  private previousBackupPath: string;
   private sessionStartMs: number;
   private pendingCrash: PendingCrash | null = null;
   private backupTimer: ReturnType<typeof setInterval> | null = null;
@@ -71,6 +78,7 @@ export class CrashRecoveryService {
     this.markerPath = path.join(this.userData, MARKER_FILENAME);
     this.crashesDir = path.join(this.userData, CRASHES_DIR);
     this.backupPath = path.join(this.userData, BACKUP_DIR, BACKUP_FILENAME);
+    this.previousBackupPath = path.join(this.userData, BACKUP_DIR, PREVIOUS_BACKUP_FILENAME);
     this.sessionStartMs = Date.now();
   }
 
@@ -259,10 +267,28 @@ export class CrashRecoveryService {
       const backupDir = path.join(this.userData, BACKUP_DIR);
       fs.mkdirSync(backupDir, { recursive: true });
 
+      // Rotate current → previous BEFORE writing new current. If a future
+      // write produces corrupt JSON, the previous-generation file still holds
+      // the last good snapshot. Rotation is best-effort: a rename failure on
+      // Windows under transient lock contention is non-fatal — we proceed with
+      // the write and the previous file just isn't refreshed this cycle.
+      this.rotateBackup();
+
       const snapshot = this.captureSessionSnapshot();
       resilientAtomicWriteFileSync(this.backupPath, JSON.stringify(snapshot, null, 2), "utf-8");
     } catch (err) {
       console.error("[CrashRecovery] Failed to take backup:", err);
+    }
+  }
+
+  private rotateBackup(): void {
+    if (!fs.existsSync(this.backupPath)) return;
+    try {
+      resilientRenameSync(this.backupPath, this.previousBackupPath);
+    } catch (err) {
+      // Rotation is best-effort; the new write below will still proceed and
+      // overwrite the (possibly stale) previous file on the next cycle.
+      console.warn("[CrashRecovery] Backup rotation rename failed:", err);
     }
   }
 
@@ -272,11 +298,20 @@ export class CrashRecoveryService {
       // timestamped crashed-* path. Read from that path so the current
       // session's backup tick can recreate session-state.json without
       // clobbering the pre-crash snapshot. Fall back to the live path for
-      // explicit user-driven restores in a non-crash session.
+      // explicit user-driven restores in a non-crash session, then to the
+      // rotated previous-generation file when the current file is corrupt
+      // or missing.
+      let snapshot: SessionSnapshot | null = null;
       const sourcePath = this.crashedBackupPath ?? this.backupPath;
-      if (!fs.existsSync(sourcePath)) return false;
-      const raw = fs.readFileSync(sourcePath, "utf8");
-      let snapshot = JSON.parse(raw) as SessionSnapshot;
+      snapshot = this.readBackupFile(sourcePath);
+      if (!snapshot && sourcePath !== this.previousBackupPath) {
+        const previous = this.readBackupFile(this.previousBackupPath);
+        if (previous) {
+          console.log("[CrashRecovery] Current backup unreadable; using previous generation");
+          snapshot = previous;
+        }
+      }
+      if (!snapshot) return false;
 
       if (panelIds !== undefined && panelIds.length > 0 && snapshot.appState) {
         // Filter onto a shallow copy so we don't mutate the parsed snapshot.
@@ -919,13 +954,38 @@ export class CrashRecoveryService {
     return this.buildCrashEntry();
   }
 
-  private readBackupInfo(): { exists: boolean; timestamp?: number } {
+  private readBackupInfo(): { exists: boolean; timestamp?: number; path?: string } {
+    // Prefer current; fall back to previous so the rotation pair is fully
+    // observable. `path` lets callers (consumeMarker, extractPanelSummaries)
+    // read from the file that readBackupInfo determined as usable.
     try {
-      if (!fs.existsSync(this.backupPath)) return { exists: false };
-      const stat = fs.statSync(this.backupPath);
-      return { exists: true, timestamp: stat.mtimeMs };
+      if (fs.existsSync(this.backupPath)) {
+        const stat = fs.statSync(this.backupPath);
+        return { exists: true, timestamp: stat.mtimeMs, path: this.backupPath };
+      }
     } catch {
-      return { exists: false };
+      // fall through to previous
+    }
+    try {
+      if (fs.existsSync(this.previousBackupPath)) {
+        const stat = fs.statSync(this.previousBackupPath);
+        return { exists: true, timestamp: stat.mtimeMs, path: this.previousBackupPath };
+      }
+    } catch {
+      // ignore
+    }
+    return { exists: false };
+  }
+
+  private readBackupFile(filePath: string): SessionSnapshot | null {
+    try {
+      if (!fs.existsSync(filePath)) return null;
+      const raw = fs.readFileSync(filePath, "utf8");
+      const parsed = JSON.parse(raw) as SessionSnapshot;
+      if (!hasRestorableSnapshotContent(parsed)) return null;
+      return parsed;
+    } catch {
+      return null;
     }
   }
 

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -72,6 +72,11 @@ export class CrashRecoveryService {
   // current session's backup tick cannot overwrite it. Null when there was
   // no pre-crash backup or after the file has been consumed/cleaned up.
   private crashedBackupPath: string | null = null;
+  // In-memory snapshot captured during consumeMarker() so restoreBackup() and
+  // getBackupPanelCount() can serve the pre-crash state even if the on-disk
+  // files are deleted, rotated, or overwritten between marker consumption and
+  // the user resolving the recovery dialog.
+  private cachedBackupSnapshot: SessionSnapshot | null = null;
 
   constructor() {
     this.userData = app.getPath("userData");
@@ -294,21 +299,22 @@ export class CrashRecoveryService {
 
   restoreBackup(panelIds?: string[]): boolean {
     try {
-      // After a crash, consumeMarker() renames the live backup file to a
-      // timestamped crashed-* path. Read from that path so the current
-      // session's backup tick can recreate session-state.json without
-      // clobbering the pre-crash snapshot. Fall back to the live path for
-      // explicit user-driven restores in a non-crash session, then to the
-      // rotated previous-generation file when the current file is corrupt
-      // or missing.
-      let snapshot: SessionSnapshot | null = null;
-      const sourcePath = this.crashedBackupPath ?? this.backupPath;
-      snapshot = this.readBackupFile(sourcePath);
-      if (!snapshot && sourcePath !== this.previousBackupPath) {
-        const previous = this.readBackupFile(this.previousBackupPath);
-        if (previous) {
-          console.log("[CrashRecovery] Current backup unreadable; using previous generation");
-          snapshot = previous;
+      // Prefer the snapshot cached by consumeMarker — startBackupTimer can
+      // overwrite the on-disk backup files between marker consumption and
+      // the user clicking restore, and the renamed crashed-* file could be
+      // unlinked concurrently. The cache holds the parsed pre-crash snapshot.
+      // Fall back current → previous on disk for explicit user-driven
+      // restores in a non-crash session (no cache populated).
+      let snapshot: SessionSnapshot | null = this.cachedBackupSnapshot;
+      if (!snapshot) {
+        const sourcePath = this.crashedBackupPath ?? this.backupPath;
+        snapshot = this.readBackupFile(sourcePath);
+        if (!snapshot && sourcePath !== this.previousBackupPath) {
+          const previous = this.readBackupFile(this.previousBackupPath);
+          if (previous) {
+            console.log("[CrashRecovery] Current backup unreadable; using previous generation");
+            snapshot = previous;
+          }
         }
       }
       if (!snapshot) return false;
@@ -430,10 +436,34 @@ export class CrashRecoveryService {
 
       this.deleteMarker();
 
+      // Gate hasBackup on parseability: a renamed crashed-* file that fails
+      // to parse (corrupted write, partial flush) shouldn't surface a
+      // restore option that would silently fail. Verify the crashed-* file
+      // parses; if not, fall back to the rotated previous-generation file
+      // (rotated by takeBackup before the crash). Cache the parsed snapshot
+      // so the recovery dialog and getBackupPanelCount survive concurrent
+      // file deletions/overwrites between marker consumption and resolve.
       let backupTimestamp: number | undefined;
-      if (this.crashedBackupPath !== null) {
+      let parseableBackupPath: string | null = null;
+      const fromCrashed = this.crashedBackupPath
+        ? this.readBackupFile(this.crashedBackupPath)
+        : null;
+      if (fromCrashed) {
+        this.cachedBackupSnapshot = fromCrashed;
+        parseableBackupPath = this.crashedBackupPath;
+      } else {
+        // Crashed file unparseable or missing — drop the pointer so the
+        // restoreBackup path doesn't try a known-bad read.
+        this.crashedBackupPath = null;
+        const fromPrevious = this.readBackupFile(this.previousBackupPath);
+        if (fromPrevious) {
+          this.cachedBackupSnapshot = fromPrevious;
+          parseableBackupPath = this.previousBackupPath;
+        }
+      }
+      if (parseableBackupPath) {
         try {
-          backupTimestamp = fs.statSync(this.crashedBackupPath).mtimeMs;
+          backupTimestamp = fs.statSync(parseableBackupPath).mtimeMs;
         } catch {
           // best-effort: backup timestamp is informational only
         }
@@ -459,13 +489,14 @@ export class CrashRecoveryService {
           }
         }
       }
-      const panels =
-        this.crashedBackupPath !== null ? this.extractPanelSummaries(entry.timestamp) : undefined;
+      const panels = parseableBackupPath
+        ? this.extractPanelSummaries(entry.timestamp, parseableBackupPath)
+        : undefined;
 
       return {
         logPath: logPath ?? path.join(this.crashesDir, `crash-${entry.id}.json`),
         entry,
-        hasBackup: this.crashedBackupPath !== null,
+        hasBackup: parseableBackupPath !== null,
         backupTimestamp,
         panels,
       };
@@ -554,6 +585,10 @@ export class CrashRecoveryService {
   }
 
   private unlinkCrashedBackup(): void {
+    // Always clear the in-memory cache too — keeping it around after the
+    // recovery decision is resolved would let a stale pre-crash snapshot
+    // surface from getBackupPanelCount or a follow-up restoreBackup call.
+    this.cachedBackupSnapshot = null;
     if (!this.crashedBackupPath) return;
     try {
       fs.unlinkSync(this.crashedBackupPath);
@@ -617,15 +652,17 @@ export class CrashRecoveryService {
     return annotation;
   }
 
-  private extractPanelSummaries(crashTimestamp: number): PanelSummary[] {
+  private extractPanelSummaries(crashTimestamp: number, sourcePath: string): PanelSummary[] {
     try {
-      // Reads the renamed crashed-* file populated by consumeMarker. The
-      // current session's backup tick can recreate session-state.json freely
-      // — it can't overwrite the renamed file, so panel summaries here and
-      // restoreBackup later see the same pre-crash snapshot.
-      if (!this.crashedBackupPath || !fs.existsSync(this.crashedBackupPath)) return [];
-      const raw = fs.readFileSync(this.crashedBackupPath, "utf8");
-      const snapshot = JSON.parse(raw) as SessionSnapshot;
+      // Prefer the cached snapshot resolved by consumeMarker so concurrent
+      // file deletion or backup-tick overwrites can't drop pre-crash panels.
+      // Fall back to disk only when the cache wasn't populated.
+      let snapshot: SessionSnapshot | null = this.cachedBackupSnapshot;
+      if (!snapshot) {
+        if (!fs.existsSync(sourcePath)) return [];
+        const raw = fs.readFileSync(sourcePath, "utf8");
+        snapshot = JSON.parse(raw) as SessionSnapshot;
+      }
       if (!snapshot.appState) return [];
 
       const appState = snapshot.appState as Record<string, unknown>;
@@ -958,21 +995,29 @@ export class CrashRecoveryService {
     // Prefer current; fall back to previous so the rotation pair is fully
     // observable. `path` lets callers (consumeMarker, extractPanelSummaries)
     // read from the file that readBackupInfo determined as usable.
-    try {
-      if (fs.existsSync(this.backupPath)) {
+    // Parseability is verified before reporting `exists: true` — a stat-able
+    // but corrupt current would otherwise mislead the recovery UI into showing
+    // a timestamp that points to an unrestorable file while restore silently
+    // uses previous. The probe (readBackupFile) reads the whole file; this is
+    // acceptable because readBackupInfo is only called during marker consumption
+    // (startup) and when the user opens the recovery dialog.
+    const currentParseable = this.readBackupFile(this.backupPath) !== null;
+    if (currentParseable) {
+      try {
         const stat = fs.statSync(this.backupPath);
         return { exists: true, timestamp: stat.mtimeMs, path: this.backupPath };
+      } catch {
+        // fall through to previous
       }
-    } catch {
-      // fall through to previous
     }
-    try {
-      if (fs.existsSync(this.previousBackupPath)) {
+    const previousParseable = this.readBackupFile(this.previousBackupPath) !== null;
+    if (previousParseable) {
+      try {
         const stat = fs.statSync(this.previousBackupPath);
         return { exists: true, timestamp: stat.mtimeMs, path: this.previousBackupPath };
+      } catch {
+        // ignore
       }
-    } catch {
-      // ignore
     }
     return { exists: false };
   }

--- a/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
@@ -464,8 +464,13 @@ describe("CrashRecoveryService adversarial", () => {
 
     const pending = service.getPendingCrash();
     expect(pending).not.toBeNull();
-    expect(pending?.hasBackup).toBe(true);
-    expect(pending?.panels).toEqual([]);
+    // With backup rotation (#8699): a corrupt current with no usable previous
+    // reports hasBackup=false so the recovery UI doesn't offer a restore that
+    // would silently fail. The safety invariant remains: the app doesn't brick
+    // (pending is non-null, panels are an empty array, restoreBackup returns
+    // false rather than throwing).
+    expect(pending?.hasBackup).toBe(false);
+    expect(pending?.panels).toBeUndefined();
     expect(service.restoreBackup()).toBe(false);
   });
 

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -656,6 +656,211 @@ describe("CrashRecoveryService", () => {
     });
   });
 
+  describe("backup rotation (rolling pair)", () => {
+    it("rotates current → previous before writing new current", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      const currentPath = path.join(backupDir, "session-state.json");
+      const previousPath = path.join(backupDir, "session-state.previous.json");
+      const firstSnapshot = {
+        capturedAt: 1_000,
+        appState: { sidebarWidth: 100, terminals: [{ id: "t1", kind: "terminal" }] },
+      };
+      fs.writeFileSync(currentPath, JSON.stringify(firstSnapshot));
+
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "appState") return { sidebarWidth: 200, terminals: [] };
+        return { autoRestoreOnCrash: false };
+      });
+      windowStatesStoreMock.get.mockReturnValue({});
+
+      const svc = makeService();
+      svc.initialize();
+      svc.takeBackup();
+
+      // After rotation, previous contains the original snapshot and current
+      // contains the freshly written one.
+      expect(fs.existsSync(previousPath)).toBe(true);
+      const rotated = JSON.parse(fs.readFileSync(previousPath, "utf8"));
+      expect(rotated.capturedAt).toBe(1_000);
+      const fresh = JSON.parse(fs.readFileSync(currentPath, "utf8"));
+      expect(fresh.appState.sidebarWidth).toBe(200);
+    });
+
+    it("does not rotate when no current backup exists yet", () => {
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "appState") return { sidebarWidth: 100, terminals: [] };
+        return { autoRestoreOnCrash: false };
+      });
+      windowStatesStoreMock.get.mockReturnValue({});
+
+      const svc = makeService();
+      svc.initialize();
+      svc.takeBackup();
+
+      const previousPath = path.join(userData, "backups", "session-state.previous.json");
+      expect(fs.existsSync(previousPath)).toBe(false);
+      // resilientRenameSync must not have been called when there is no source file.
+      expect(utilsMock.resilientRenameSync).not.toHaveBeenCalled();
+    });
+
+    it("still writes new current when rotation rename throws (best-effort)", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      const currentPath = path.join(backupDir, "session-state.json");
+      fs.writeFileSync(
+        currentPath,
+        JSON.stringify({ capturedAt: 1_000, appState: { terminals: [] } })
+      );
+
+      utilsMock.resilientRenameSync.mockImplementationOnce(() => {
+        throw new Error("EPERM: rename failed");
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "appState") return { sidebarWidth: 999, terminals: [] };
+        return { autoRestoreOnCrash: false };
+      });
+      windowStatesStoreMock.get.mockReturnValue({});
+
+      const svc = makeService();
+      svc.initialize();
+      svc.takeBackup();
+
+      // Rotation failed but the new current was written anyway.
+      const fresh = JSON.parse(fs.readFileSync(currentPath, "utf8"));
+      expect(fresh.appState.sidebarWidth).toBe(999);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[CrashRecovery] Backup rotation rename failed:",
+        expect.any(Error)
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("restoreBackup falls back to previous when current is missing", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      const previousSnapshot = {
+        capturedAt: Date.now() - 60_000,
+        appState: { sidebarWidth: 777, terminals: [{ id: "t-prev", kind: "terminal" }] },
+      };
+      fs.writeFileSync(
+        path.join(backupDir, "session-state.previous.json"),
+        JSON.stringify(previousSnapshot)
+      );
+
+      storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
+
+      const svc = makeService();
+      svc.initialize();
+      const result = svc.restoreBackup();
+
+      expect(result).toBe(true);
+      expect(storeMock.set).toHaveBeenCalledWith("appState", previousSnapshot.appState);
+    });
+
+    it("restoreBackup falls back to previous when current is corrupt", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      fs.writeFileSync(path.join(backupDir, "session-state.json"), "{ this is not json");
+      const previousSnapshot = {
+        capturedAt: Date.now() - 60_000,
+        appState: { sidebarWidth: 555, terminals: [] },
+      };
+      fs.writeFileSync(
+        path.join(backupDir, "session-state.previous.json"),
+        JSON.stringify(previousSnapshot)
+      );
+
+      storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
+
+      const svc = makeService();
+      svc.initialize();
+      const result = svc.restoreBackup();
+
+      expect(result).toBe(true);
+      expect(storeMock.set).toHaveBeenCalledWith("appState", previousSnapshot.appState);
+    });
+
+    it("restoreBackup returns false when both current and previous are corrupt", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      fs.writeFileSync(path.join(backupDir, "session-state.json"), "not json");
+      fs.writeFileSync(path.join(backupDir, "session-state.previous.json"), "also not json");
+
+      storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
+
+      const svc = makeService();
+      svc.initialize();
+      storeMock.set.mockClear();
+      const result = svc.restoreBackup();
+
+      expect(result).toBe(false);
+      expect(storeMock.set).not.toHaveBeenCalled();
+    });
+
+    it("readBackupInfo (via getLastBackupTimestamp) falls back to previous when current is missing", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      const previousPath = path.join(backupDir, "session-state.previous.json");
+      fs.writeFileSync(
+        previousPath,
+        JSON.stringify({ capturedAt: Date.now(), appState: { terminals: [] } })
+      );
+
+      const svc = makeService();
+      svc.initialize();
+
+      const ts = svc.getLastBackupTimestamp();
+      const stat = fs.statSync(previousPath);
+      expect(ts).toBe(stat.mtimeMs);
+    });
+
+    it("consumeMarker caches previous-generation snapshot when current is corrupt", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      fs.writeFileSync(path.join(backupDir, "session-state.json"), "corrupt");
+      const previousSnapshot = {
+        capturedAt: Date.now() - 30_000,
+        appState: { sidebarWidth: 321, terminals: [{ id: "p1", kind: "terminal" }] },
+      };
+      fs.writeFileSync(
+        path.join(backupDir, "session-state.previous.json"),
+        JSON.stringify(previousSnapshot)
+      );
+
+      const markerPath = path.join(userData, "running.lock");
+      fs.writeFileSync(
+        markerPath,
+        JSON.stringify({
+          sessionStartMs: Date.now() - 5000,
+          appVersion: "1.0.0",
+          platform: "darwin",
+        })
+      );
+
+      storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.hasBackup).toBe(true);
+      expect(pending!.panels).toBeDefined();
+      expect(pending!.panels![0]).toMatchObject({ id: "p1", kind: "terminal" });
+
+      // Cached snapshot ensures restoreBackup applies the previous-generation
+      // appState even if the backup files are deleted under it.
+      fs.unlinkSync(path.join(backupDir, "session-state.json"));
+      fs.unlinkSync(path.join(backupDir, "session-state.previous.json"));
+      const restored = svc.restoreBackup();
+      expect(restored).toBe(true);
+      expect(storeMock.set).toHaveBeenCalledWith("appState", previousSnapshot.appState);
+    });
+  });
+
   describe("panel summaries", () => {
     it("populates panels from backup when crash is detected", () => {
       // Set up backup with terminals

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -817,6 +817,72 @@ describe("CrashRecoveryService", () => {
       expect(ts).toBe(stat.mtimeMs);
     });
 
+    it("readBackupInfo skips corrupt current and reports previous timestamp", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      // Corrupt current — exists on disk but unparseable.
+      const currentPath = path.join(backupDir, "session-state.json");
+      fs.writeFileSync(currentPath, "{ corrupt");
+      // Valid previous.
+      const previousPath = path.join(backupDir, "session-state.previous.json");
+      fs.writeFileSync(
+        previousPath,
+        JSON.stringify({ capturedAt: Date.now() - 30_000, appState: { terminals: [] } })
+      );
+
+      const svc = makeService();
+      svc.initialize();
+
+      // Without the parseability gate, getLastBackupTimestamp would return the
+      // corrupt current's mtimeMs and mislead the UI into showing a backup
+      // exists at a timestamp it can't actually restore from.
+      const ts = svc.getLastBackupTimestamp();
+      const previousStat = fs.statSync(previousPath);
+      expect(ts).toBe(previousStat.mtimeMs);
+    });
+
+    it("rolling pair stays a pair across multiple takeBackup calls (no chain accumulation)", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      const currentPath = path.join(backupDir, "session-state.json");
+      const previousPath = path.join(backupDir, "session-state.previous.json");
+
+      // First write to set the baseline (no previous yet).
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "appState") return { sidebarWidth: 1, terminals: [] };
+        return { autoRestoreOnCrash: false };
+      });
+      windowStatesStoreMock.get.mockReturnValue({});
+
+      const svc = makeService();
+      svc.initialize();
+      svc.takeBackup();
+
+      // Change state and write again — previous now holds gen-1, current holds gen-2.
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "appState") return { sidebarWidth: 2, terminals: [] };
+        return { autoRestoreOnCrash: false };
+      });
+      svc.takeBackup();
+
+      // Change state and write a third time — previous now holds gen-2, current holds gen-3.
+      // Critically: gen-1 must be gone (no `.previous.previous.json` accumulation).
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "appState") return { sidebarWidth: 3, terminals: [] };
+        return { autoRestoreOnCrash: false };
+      });
+      svc.takeBackup();
+
+      const current = JSON.parse(fs.readFileSync(currentPath, "utf8"));
+      const previous = JSON.parse(fs.readFileSync(previousPath, "utf8"));
+      expect(current.appState.sidebarWidth).toBe(3);
+      expect(previous.appState.sidebarWidth).toBe(2);
+      // No third-generation file ever created — the directory must hold at
+      // most two backup files (plus crash logs in a sibling dir).
+      const backupFiles = fs.readdirSync(backupDir).filter((f) => f.endsWith(".json"));
+      expect(backupFiles.sort()).toEqual(["session-state.json", "session-state.previous.json"]);
+    });
+
     it("consumeMarker caches previous-generation snapshot when current is corrupt", () => {
       const backupDir = path.join(userData, "backups");
       fs.mkdirSync(backupDir, { recursive: true });


### PR DESCRIPTION
Closes #8699. This PR hardens Daintree's main-process shutdown across three gaps.

## Keep a rolling pair of backup files in `CrashRecoveryService`

`takeBackup()` now rotates the current backup file to `session-state.previous.json` before writing the new current. The restore path, `readBackupInfo()`, and the `consumeMarker()` cache populate all fall back current → previous when the current file is missing or unparseable. A corrupt write can no longer destroy the only recoverable snapshot.

`readBackupInfo()` only reports `hasBackup: true` when at least one generation parses; the recovery UI no longer offers a restore that would silently fail against a stat-able-but-unparseable file.

## Eagerly snapshot the backup at quit-intent

The `before-quit` handler in `shutdown.ts` now calls `getCrashRecoveryService().takeBackup()` synchronously right after `isQuitting = true`, before the async cleanup chain runs. A hard-timeout exit that skips `cleanupOnExit()` still leaves a post-quit-intent snapshot on disk for the next launch.

## Capture the safety-belt timer and fix its exit code

The signal handler in `appLifecycle.ts` used to schedule `setTimeout(() => process.exit(0), ...).unref()` with the handle discarded. That meant:

1. The handle couldn't be cancelled on a clean exit, so a slow `closeTelemetry()` could let the belt fire after `app.exit(0)` and clobber the exit code with the wrong value.
2. The wrong-direction exit code (`process.exit(0)` instead of `app.exit(1)`) misreported clean-vs-dirty to systemd, nodemon, and other process supervisors, and bypassed Electron's native teardown.

Now the handle is captured and stored in `signalShutdownState.ts`. The belt fires `app.exit(1)` (dirty) and `shutdown.ts` calls `clearSafetyBeltTimer()` immediately before every `app.exit()` on both branches. Defusing the belt before `await closeTelemetry()` (rather than after) eliminates the fragility around the telemetry-flush budget.

`SAFETY_BELT_TIMEOUT_MS` in `shutdownConfig.ts` budgets the full 10s cleanup race, plus a 3s buffer, plus 2.5s for `closeTelemetry()` (Sentry init-wait 500ms + close timeout 2000ms).

## Files

- `electron/lifecycle/shutdownConfig.ts`
- `electron/lifecycle/signalShutdownState.ts`
- `electron/lifecycle/appLifecycle.ts`
- `electron/lifecycle/shutdown.ts`
- `electron/services/CrashRecoveryService.ts`

## Tests

- `electron/services/__tests__/CrashRecoveryService.test.ts` — rotation order, no-rotation on first launch, rename failure is best-effort, fallback to previous on missing/corrupt current, both-corrupt returns false, `readBackupInfo` parseability gate, rolling pair stays a pair across multiple writes, `consumeMarker` caches previous-generation snapshot when current is corrupt.
- `electron/services/__tests__/CrashRecoveryService.adversarial.test.ts` — updated `MARKER_PLUS_BAD_BACKUP_DOES_NOT_BRICK` to assert the new `hasBackup: false` behaviour when the only backup file is corrupt.
- `electron/lifecycle/__tests__/shutdown.test.ts` — eager-backup ordering, smoke-test skip, eager-backup throw is non-fatal, `clearSafetyBeltTimer` called before `app.exit(0)` on clean shutdown and before `app.exit(1)` on hard timeout.
- `electron/lifecycle/__tests__/appLifecycle.test.ts` — safety-belt fires `app.exit(1)` (not `process.exit(0)`), handle is stored via `setSafetyBeltTimer`, fires at `SAFETY_BELT_TIMEOUT_MS`, nulls the handle on fire.
- `electron/lifecycle/__tests__/signalShutdownState.test.ts` — `clearSafetyBeltTimer` is idempotent, cancels a stored timer, and is a no-op when no timer is set.

## Test plan

- [x] `npx vitest run` on all four touched test files (133 tests pass)
- [x] `npx tsc --noEmit -p tsconfig.json` clean
- [x] `npm run check` (typecheck, lint, format, IPC, generated docs) clean; lint ratchet drops 122 warnings