### PR TITLE
feat(fleet): confirm broadcasts on the resolved fan-out, not the source draft

### DIFF
--- a/docs/architecture/destructive-action-safeguards.md
+++ b/docs/architecture/destructive-action-safeguards.md
@@ -114,6 +114,7 @@ Columns:
 | `fleet.recallNamedFleet` | safe | n/a | n/a | reversible (re-arm) | armed set | D0 | Leave | — |
 | `fleet.deleteNamedFleet` | **confirm** (updated #8023) | yes (`ConfirmDialog` hoisted to `FleetArmingRibbon`, outside the dropdown tree) | Boolean via dispatch | local-irreversible (settings entry gone) | one saved fleet | D1 | Done (#8023) — confirm state lifted above the Radix `DropdownMenu` so the dialog survives the menu closing (#2828) | — |
 | `fleet.retryFailures` | safe | n/a | n/a | local-undo (just re-fires the last broadcast) | failed broadcast targets | D0 | Leave | — |
+| `fleet.broadcast` (Enter-broadcast / `tryFleetBroadcastFromEditor`) | **confirm** (updated #8689) | yes (`ConfirmDialog` via `fleetBroadcastConfirmStore` + `FleetArmingRibbon`) — renders resolved per-target commands after recipe-variable substitution, surfaces the destructive substring + character offset, allows per-target opt-out, and re-evaluates the byte-threshold against the resolved fan-out rather than only the source draft | n/a (bypass — direct confirm-store call, not `ActionService`) | shared-state (sends a command to N PTYs; already-dispatched IPC writes cannot be revoked) | N armed panes | D2 | Done (#8689) — same silent-fallback class as #7880: confirm gate must show the actual bytes each pane will receive, not just a category label and target count | — |
 
 ### Project / window
 
@@ -198,6 +199,7 @@ Direct `window.electron.*` IPC calls that skip `ActionService`. These are the hi
 | `src/hooks/useDevServer.ts:299` | `devPreview.restart` (dev-preview restart button) | **No** — hook invokes IPC directly; sibling UI issue migrates to the `devPreview.restart` action |
 | `src/components/Recovery/SafeModeBanner.tsx` | `app.resetAndRelaunch` (safe-mode restart) | **Yes** — `ConfirmDialog` with destructive variant + `logs.openFile` recovery (#8685) |
 | `public/recovery-renderer.js` | `recovery:reset-and-reload` (emergency recovery page) | **Yes** — inline vanilla-JS Disclosure confirm with panel count + backup timestamp preview; React is unavailable on this surface (#8697) |
+| `src/components/Fleet/fleetEnterBroadcast.ts` | `fleet.broadcast` (Enter-broadcast → `executeFleetBroadcast` → `terminalClient.submit`) | **Yes** — `ConfirmDialog` via `fleetBroadcastConfirmStore` + `FleetArmingRibbon` with per-target resolved-payload preview, destructive-substring callout, and per-target opt-out (#8689) |
 
 ## Maintenance
 

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -522,6 +522,15 @@ export function FleetArmingRibbon(): ReactElement | null {
         onConfirm={confirmPendingBroadcast}
         onClose={cancelPendingBroadcast}
       >
+        {pendingBroadcast?.destructiveMatch ? (
+          <div
+            data-testid="fleet-broadcast-destructive-callout"
+            className="mb-2 rounded border border-category-rose-border bg-category-rose-subtle px-2 py-1.5 text-[11px] text-category-rose-text"
+          >
+            Destructive command detected:{" "}
+            <code className="font-mono">{pendingBroadcast.destructiveMatch.substring}</code>
+          </div>
+        ) : null}
         <ul
           data-testid="fleet-divergence-preview-list"
           className="max-h-[280px] overflow-y-auto rounded border border-daintree-border bg-tint/[0.03]"

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -9,6 +9,7 @@ import {
   FLEET_LARGE_PASTE_BYTE_THRESHOLD,
   buildFleetBroadcastRecipeContext,
   getFleetBroadcastByteLength,
+  getFleetBroadcastDestructiveMatch,
   getFleetBroadcastWarnings,
   needsFleetBroadcastConfirmation,
   resolveFleetBroadcastTargetIds,
@@ -213,6 +214,65 @@ describe("needsFleetBroadcastConfirmation", () => {
   });
   it("returns false for short, single-line, safe text", () => {
     expect(needsFleetBroadcastConfirmation("run the test")).toBe(false);
+  });
+
+  describe("resolved-payload variant", () => {
+    it("confirms when any resolved payload exceeds the byte threshold even if the source draft is safe", () => {
+      const safeDraft = "cd {{worktree_path}}";
+      const longResolved = `cd ${"/very/long/path/".repeat(40)}`;
+      expect(getFleetBroadcastByteLength(longResolved)).toBeGreaterThan(
+        FLEET_CONFIRM_BYTE_THRESHOLD
+      );
+      expect(needsFleetBroadcastConfirmation(safeDraft, [longResolved])).toBe(true);
+      expect(needsFleetBroadcastConfirmation(safeDraft, ["safe"])).toBe(false);
+    });
+
+    it("confirms when any resolved payload contains a destructive pattern surfaced by substitution", () => {
+      const safeDraft = "cleanup {{worktree_path}}";
+      // Variable expansion could introduce `rm -rf` not present in the draft.
+      expect(needsFleetBroadcastConfirmation(safeDraft, ["cleanup", "rm -rf /tmp/scratch"])).toBe(
+        true
+      );
+    });
+
+    it("returns false when source draft is safe and all resolved payloads are safe", () => {
+      expect(
+        needsFleetBroadcastConfirmation("status {{branch_name}}", ["status main", "status develop"])
+      ).toBe(false);
+    });
+
+    it("source-level warnings still take precedence over an empty resolved list", () => {
+      expect(needsFleetBroadcastConfirmation("rm -rf .", [])).toBe(true);
+    });
+  });
+});
+
+describe("getFleetBroadcastDestructiveMatch", () => {
+  it("returns substring and index for a destructive draft", () => {
+    const match = getFleetBroadcastDestructiveMatch("rm -rf node_modules");
+    expect(match).not.toBeNull();
+    expect(match!.index).toBe(0);
+    expect(match!.substring.toLowerCase()).toContain("rm -rf");
+  });
+
+  it("returns the offset for a destructive command embedded in the draft", () => {
+    const draft = "echo 'cleanup' && rm -rf /tmp/scratch";
+    const match = getFleetBroadcastDestructiveMatch(draft);
+    expect(match).not.toBeNull();
+    expect(match!.index).toBe(draft.indexOf("rm -rf"));
+    expect(match!.substring.toLowerCase()).toContain("rm");
+  });
+
+  it("returns null for safe text", () => {
+    expect(getFleetBroadcastDestructiveMatch("echo hello")).toBeNull();
+    expect(getFleetBroadcastDestructiveMatch("npm test")).toBeNull();
+  });
+
+  it("does not depend on regex lastIndex — repeated calls are stable", () => {
+    const draft = "rm -rf node_modules";
+    const first = getFleetBroadcastDestructiveMatch(draft);
+    const second = getFleetBroadcastDestructiveMatch(draft);
+    expect(first).toEqual(second);
   });
 });
 

--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -325,6 +325,29 @@ describe("tryFleetBroadcastFromEditor — confirmation gate", () => {
     await flush();
     expect(submitMock).toHaveBeenCalled();
   });
+
+  it("drops targets that became ineligible while the confirm dialog was open", async () => {
+    arm(["a", "b", "c"]);
+    tryFleetBroadcastFromEditor("a", "rm -rf /tmp", vi.fn());
+    expect(useFleetBroadcastConfirmStore.getState().pending).not.toBeNull();
+
+    // Pane B is trashed between confirm-request and confirm-submit.
+    usePanelStore.setState({
+      panelsById: {
+        a: makeAgent("a"),
+        b: { ...makeAgent("b"), location: "trash" } as TerminalInstance,
+        c: makeAgent("c"),
+      },
+      panelIds: ["a", "b", "c"],
+    });
+
+    resolveFleetBroadcastConfirmation();
+    await flush();
+    await flush();
+
+    const submittedIds = submitMock.mock.calls.map((call) => call[0]).sort();
+    expect(submittedIds).toEqual(["a", "c"]);
+  });
 });
 
 describe("cancelActiveBroadcast", () => {

--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -292,6 +292,41 @@ describe("tryFleetBroadcastFromEditor — permanent failure auto-disarm (#8706)"
   });
 });
 
+describe("tryFleetBroadcastFromEditor — confirmation gate", () => {
+  it("opens the confirm gate with destructiveMatch snapshot for destructive drafts", () => {
+    arm(["a", "b"]);
+    const consumed = tryFleetBroadcastFromEditor("a", "rm -rf /tmp", vi.fn());
+    expect(consumed).toBe(true);
+    const pending = useFleetBroadcastConfirmStore.getState().pending;
+    expect(pending).not.toBeNull();
+    expect(pending!.destructiveMatch).not.toBeNull();
+    expect(pending!.destructiveMatch!.substring.toLowerCase()).toContain("rm");
+    // Nothing has dispatched yet — submit only fires after confirmation.
+    expect(submitMock).not.toHaveBeenCalled();
+  });
+
+  it("confirming dispatches to every armed target", async () => {
+    arm(["a", "b", "c"]);
+    tryFleetBroadcastFromEditor("a", "rm -rf /tmp", vi.fn());
+    expect(useFleetBroadcastConfirmStore.getState().pending).not.toBeNull();
+
+    resolveFleetBroadcastConfirmation();
+    await flush();
+    await flush();
+
+    const submittedIds = submitMock.mock.calls.map((call) => call[0]).sort();
+    expect(submittedIds).toEqual(["a", "b", "c"]);
+  });
+
+  it("skips the confirm gate for short, single-line, safe text", async () => {
+    arm(["a", "b"]);
+    tryFleetBroadcastFromEditor("a", "npm test", vi.fn());
+    expect(useFleetBroadcastConfirmStore.getState().pending).toBeNull();
+    await flush();
+    expect(submitMock).toHaveBeenCalled();
+  });
+});
+
 describe("cancelActiveBroadcast", () => {
   it("aborts the in-flight controller so the run finalizes as cancelled", async () => {
     arm(["a", "b", "c"]);

--- a/src/components/Fleet/fleetBroadcast.ts
+++ b/src/components/Fleet/fleetBroadcast.ts
@@ -100,6 +100,16 @@ export interface FleetBroadcastWarnings {
   destructive: boolean;
 }
 
+/**
+ * Position and substring of the first destructive match in a payload, used
+ * by the confirm gate to point the user at the actual command instead of
+ * showing only a category label ("destructive command detected").
+ */
+export interface FleetBroadcastDestructiveMatch {
+  substring: string;
+  index: number;
+}
+
 export function getFleetBroadcastByteLength(text: string): number {
   if (typeof TextEncoder !== "undefined") {
     return new TextEncoder().encode(text).length;
@@ -116,9 +126,41 @@ export function getFleetBroadcastWarnings(text: string): FleetBroadcastWarnings 
   };
 }
 
-export function needsFleetBroadcastConfirmation(text: string): boolean {
+/**
+ * `FLEET_DESTRUCTIVE_RE` has no `/g` or `/y` flag, so module-level `.exec()`
+ * is safe to call without resetting `lastIndex`. Returns `null` for safe
+ * text; the caller decides display truncation.
+ */
+export function getFleetBroadcastDestructiveMatch(
+  text: string
+): FleetBroadcastDestructiveMatch | null {
+  const match = FLEET_DESTRUCTIVE_RE.exec(text);
+  if (match === null) return null;
+  return { substring: match[0], index: match.index };
+}
+
+/**
+ * Confirmation gate. The optional `resolvedPayloads` argument lets the
+ * caller surface the *resolved fan-out* (after recipe-variable substitution)
+ * so a draft that's under-threshold but expands per-target to over-threshold
+ * still triggers confirm. Any single non-excluded resolved payload above
+ * the threshold is the meaningful danger signal — not the aggregate.
+ *
+ * Resolved payloads are passed as `string[]` (not `FleetTargetPreview[]`)
+ * to avoid a circular import with `fleetExecution.ts`.
+ */
+export function needsFleetBroadcastConfirmation(
+  text: string,
+  resolvedPayloads?: readonly string[]
+): boolean {
   const w = getFleetBroadcastWarnings(text);
-  return w.multiline || w.overByteLimit || w.destructive;
+  if (w.multiline || w.overByteLimit || w.destructive) return true;
+  if (!resolvedPayloads) return false;
+  for (const payload of resolvedPayloads) {
+    if (getFleetBroadcastByteLength(payload) > FLEET_CONFIRM_BYTE_THRESHOLD) return true;
+    if (FLEET_DESTRUCTIVE_RE.test(payload)) return true;
+  }
+  return false;
 }
 
 /**

--- a/src/components/Fleet/fleetEnterBroadcast.ts
+++ b/src/components/Fleet/fleetEnterBroadcast.ts
@@ -18,6 +18,7 @@ import {
 import {
   buildFleetTargetPreviews,
   executeFleetBroadcast,
+  filterEligibleIds,
   type FleetExecutionResult,
   type FleetTargetPreview,
 } from "./fleetExecution";
@@ -174,7 +175,13 @@ export function tryFleetBroadcastFromEditor(
     livePreviews.length > 0 ? livePreviews : buildFleetTargetPreviews(text);
 
   const reasons = describeWarnings(text);
-  const destructiveMatch = getFleetBroadcastDestructiveMatch(text);
+  // Surface the destructive match from the source draft when possible
+  // (gives the user the offset inside their typed text). When the draft
+  // itself is safe but a resolved payload introduces a destructive
+  // pattern via variable expansion, fall back to the first non-excluded
+  // resolved match so the dialog can still explain the gate.
+  const destructiveMatch =
+    getFleetBroadcastDestructiveMatch(text) ?? findFirstResolvedDestructiveMatch(previews);
 
   // Resolved-payload gate: recipe-variable expansion can push a safe-
   // looking draft past the 512-byte threshold or surface a destructive
@@ -232,9 +239,16 @@ export function tryFleetBroadcastFromEditor(
     const controller = new AbortController();
     activeBroadcastController = controller;
     try {
+      // Re-check eligibility at dispatch time. Panes that disarmed,
+      // trashed, or lost their PTY between confirm-request and confirm-
+      // submit must not still receive bytes just because the snapshot
+      // marked them eligible. `effectiveTargets` already filtered against
+      // `resolveFleetBroadcastTargetIds()`; re-run the panel-eligibility
+      // filter so disposed PTYs are dropped too.
+      const eligibleTargets = filterEligibleIds(effectiveTargets);
       const result = await executeFleetBroadcast(
         text,
-        effectiveTargets,
+        eligibleTargets,
         overridesArg,
         controller.signal
       );
@@ -274,7 +288,7 @@ export function tryFleetBroadcastFromEditor(
         // A successful broadcast clears any stale failure dot on these
         // targets — the partial-failure state from a prior attempt is
         // now resolved.
-        for (const id of effectiveTargets) useFleetFailureStore.getState().dismissId(id);
+        for (const id of eligibleTargets) useFleetFailureStore.getState().dismissId(id);
       } else if (result.successCount > 0) {
         // Partial cancel — dispatched batches that succeeded should clear
         // their old failure dots; targets in skipped batches stay as-is.
@@ -320,4 +334,15 @@ export function tryFleetBroadcastFromEditor(
 
   void doSend();
   return true;
+}
+
+function findFirstResolvedDestructiveMatch(
+  previews: FleetTargetPreview[]
+): ReturnType<typeof getFleetBroadcastDestructiveMatch> {
+  for (const preview of previews) {
+    if (preview.excluded) continue;
+    const match = getFleetBroadcastDestructiveMatch(preview.resolvedPayload);
+    if (match !== null) return match;
+  }
+  return null;
 }

--- a/src/components/Fleet/fleetEnterBroadcast.ts
+++ b/src/components/Fleet/fleetEnterBroadcast.ts
@@ -9,7 +9,12 @@ import { useFleetResolutionPreviewStore } from "@/store/fleetResolutionPreviewSt
 import { useFleetTargetOverridesStore } from "@/store/fleetTargetOverridesStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { logWarn } from "@/utils/logger";
-import { getFleetBroadcastWarnings, resolveFleetBroadcastTargetIds } from "./fleetBroadcast";
+import {
+  getFleetBroadcastDestructiveMatch,
+  getFleetBroadcastWarnings,
+  needsFleetBroadcastConfirmation,
+  resolveFleetBroadcastTargetIds,
+} from "./fleetBroadcast";
 import {
   buildFleetTargetPreviews,
   executeFleetBroadcast,
@@ -118,6 +123,12 @@ function buildDivergenceTargets(
  * variables) route through a confirm dialog before dispatch so the user
  * sees the actual per-target content — the silent-fallback comment that
  * used to live here is gone because we no longer silently fall back.
+ *
+ * Recipe-variable expansion can also push a safe-looking draft past the
+ * 512-byte threshold or surface a destructive substring not in the source
+ * draft. `needsFleetBroadcastConfirmation` re-checks the resolved per-
+ * target payloads so the confirm gate sees what each pane will actually
+ * receive, not just the source text.
  */
 export function tryFleetBroadcastFromEditor(
   terminalId: string,
@@ -163,6 +174,14 @@ export function tryFleetBroadcastFromEditor(
     livePreviews.length > 0 ? livePreviews : buildFleetTargetPreviews(text);
 
   const reasons = describeWarnings(text);
+  const destructiveMatch = getFleetBroadcastDestructiveMatch(text);
+
+  // Resolved-payload gate: recipe-variable expansion can push a safe-
+  // looking draft past the 512-byte threshold or surface a destructive
+  // substring per-target. Re-check against the resolved fan-out so the
+  // confirm reflects what each pane will actually receive.
+  const resolvedPayloads = previews.filter((p) => !p.excluded).map((p) => p.resolvedPayload);
+  const requiresWarningConfirm = needsFleetBroadcastConfirmation(text, resolvedPayloads);
 
   // Divergence is scoped to live armed targets: a stale override for a
   // terminal that has since disarmed must not force a spurious confirm
@@ -285,7 +304,7 @@ export function tryFleetBroadcastFromEditor(
     }
   };
 
-  if (reasons.length > 0 || divergent) {
+  if (requiresWarningConfirm || divergent) {
     void requestFleetBroadcastConfirmation({
       text,
       warningReasons: reasons,
@@ -294,6 +313,7 @@ export function tryFleetBroadcastFromEditor(
             targets: buildDivergenceTargets(previews, initialOverrides, initialSkipped),
           }
         : undefined,
+      destructiveMatch,
     }).then(doSend);
     return true;
   }

--- a/src/components/Fleet/fleetExecution.ts
+++ b/src/components/Fleet/fleetExecution.ts
@@ -106,7 +106,13 @@ function detectUnresolved(text: string, ctx: RecipeContext): string[] {
   return unresolved;
 }
 
-function filterEligibleIds(ids: string[]): string[] {
+/**
+ * Drop ids whose backing panel is no longer fleet-eligible (trashed,
+ * backgrounded, no PTY, etc.). Exported so the Enter-broadcast confirm
+ * path can re-check eligibility at dispatch time — a pane that went
+ * away while the confirm dialog was open must not still receive bytes.
+ */
+export function filterEligibleIds(ids: string[]): string[] {
   const { panelsById } = usePanelStore.getState();
   return ids.filter((id) => isTerminalFleetEligible(panelsById[id]));
 }

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -39,6 +39,13 @@ type ConfirmDialogBaseProps = {
   cancelLabel?: string;
   onConfirm: () => void | Promise<void>;
   isConfirmLoading?: boolean;
+  /**
+   * Disable the primary action while the dialog stays open — for gates
+   * that depend on the body's own state (e.g. all options excluded).
+   * Stacks with the typed-name gate; the button stays disabled if
+   * either gate fails.
+   */
+  confirmDisabled?: boolean;
   zIndex?: DialogZIndex;
   initialFocus?: DialogInitialFocus;
 };
@@ -64,6 +71,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
     cancelLabel = "Cancel",
     onConfirm,
     isConfirmLoading = false,
+    confirmDisabled = false,
     variant,
     zIndex,
     initialFocus,
@@ -120,6 +128,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
 
   const handleConfirm = () => {
     if (hasTypedNameGate && !isTypedMatched) return;
+    if (confirmDisabled) return;
     return onConfirm();
   };
 
@@ -162,7 +171,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
           label: confirmLabel,
           onClick: handleConfirm,
           loading: isConfirmLoading,
-          disabled: hasTypedNameGate && !isTypedMatched,
+          disabled: (hasTypedNameGate && !isTypedMatched) || confirmDisabled,
           intent: variant === "destructive" ? "destructive" : "default",
         }}
       />

--- a/src/store/__tests__/fleetBroadcastConfirmStore.test.ts
+++ b/src/store/__tests__/fleetBroadcastConfirmStore.test.ts
@@ -193,6 +193,24 @@ describe("fleetBroadcastConfirmStore", () => {
       expect(firstResolved).toBe(false);
       expect(secondResolved).toBe(true);
     });
+
+    it("a new request replaces the destructiveMatch without bleed", () => {
+      requestFleetBroadcastConfirmation({
+        text: "rm -rf /old",
+        warningReasons: ["destructive"],
+        destructiveMatch: { substring: "rm -rf ", index: 0 },
+      }).catch(() => {});
+
+      requestFleetBroadcastConfirmation({
+        text: "echo new",
+        warningReasons: ["multi-line"],
+        destructiveMatch: null,
+      }).catch(() => {});
+
+      const { pending } = useFleetBroadcastConfirmStore.getState();
+      expect(pending!.text).toBe("echo new");
+      expect(pending!.destructiveMatch).toBeNull();
+    });
   });
 
   describe("resolveFleetBroadcastConfirmation when nothing pending", () => {

--- a/src/store/__tests__/fleetBroadcastConfirmStore.test.ts
+++ b/src/store/__tests__/fleetBroadcastConfirmStore.test.ts
@@ -39,8 +39,9 @@ describe("fleetBroadcastConfirmStore", () => {
       expect(parsed.text).toBe("rm -rf /");
       expect(parsed.warningReasons).toEqual(["destructive"]);
       // Guard against regression: onConfirm must not exist on pending.
-      // `divergence` is optional (omitted when absent serializes to undefined,
-      // which JSON.stringify drops) — guard sorts on whatever keys survive.
+      // `divergence` and `destructiveMatch` are optional (omitted when
+      // absent serializes to undefined, which JSON.stringify drops) —
+      // guard sorts on whatever keys survive.
       expect(Object.keys(parsed).sort()).toEqual(["requestId", "text", "warningReasons"].sort());
     });
 
@@ -74,6 +75,16 @@ describe("fleetBroadcastConfirmStore", () => {
       const { pending } = useFleetBroadcastConfirmStore.getState();
       expect(pending!.divergence?.targets).toHaveLength(2);
       expect(pending!.divergence?.targets[1]!.unresolvedVars).toEqual(["branch_name"]);
+    });
+
+    it("carries destructiveMatch when provided", () => {
+      requestFleetBroadcastConfirmation({
+        text: "rm -rf /",
+        warningReasons: ["destructive"],
+        destructiveMatch: { substring: "rm -rf ", index: 0 },
+      }).catch(() => {});
+      const { pending } = useFleetBroadcastConfirmStore.getState();
+      expect(pending!.destructiveMatch).toEqual({ substring: "rm -rf ", index: 0 });
     });
   });
 

--- a/src/store/fleetBroadcastConfirmStore.ts
+++ b/src/store/fleetBroadcastConfirmStore.ts
@@ -1,4 +1,7 @@
 import { create } from "zustand";
+import type { FleetBroadcastDestructiveMatch } from "@/components/Fleet/fleetBroadcast";
+
+export type { FleetBroadcastDestructiveMatch };
 
 /**
  * Frozen per-target snapshot rendered in the divergence confirm dialog.
@@ -38,6 +41,16 @@ export interface PendingFleetBroadcastTarget {
  * Lives outside ribbon-local state so any caller (paste handler, input bar,
  * future scriptable broadcasts) can request a confirm without a callback
  * prop chain.
+ *
+ * `divergence.targets` is a request-time snapshot of resolved per-target
+ * payloads + per-target overrides/skips. The confirm UI reads only this
+ * snapshot — never the live `fleetResolutionPreviewStore`, which rebuilds
+ * on every keystroke and would otherwise show stale data after the dialog
+ * opens.
+ *
+ * `destructiveMatch` points at the first destructive substring + its
+ * character offset so the confirm UI can show the user the actual command
+ * rather than an abstract category label.
  */
 export interface PendingFleetBroadcast {
   requestId: string;
@@ -52,6 +65,12 @@ export interface PendingFleetBroadcast {
   divergence?: {
     targets: PendingFleetBroadcastTarget[];
   };
+  /**
+   * First destructive substring + position in the source draft, or null
+   * when no destructive pattern matched. Lets the confirm UI point at the
+   * actual command rather than only a category label.
+   */
+  destructiveMatch?: FleetBroadcastDestructiveMatch | null;
 }
 
 interface FleetBroadcastConfirmState {


### PR DESCRIPTION
## Summary

- The fleet broadcast confirm gate was showing a category label and target count — not the actual resolved per-target content. Same silent-fallback class as #7880: the user was approving a description of what would happen, not the bytes that would actually reach each pane.
- The confirm surface is now a `ConfirmDialog` that shows the resolved payload for every armed target, lets the user opt individual panes out before sending, names the blast radius in the CTA, and checks the byte threshold against resolved per-target size rather than the source draft.
- `PendingFleetBroadcast` now carries a request-time snapshot of `FleetTargetPreview[]`; the dispatched broadcast uses those snapshotted payloads as `perTargetOverrides` so live worktree-state mutations between confirm-request and confirm-submit can't silently change the bytes the user confirmed.

Resolves #8689

## Changes

**User-visible**
- `ConfirmDialog` replaces the inline ribbon strip for destructive/oversized broadcasts
- Per-target resolved payload preview — recipe variables (`{{worktreePath}}`, `{{branchName}}`, `{{issueNumber}}`) substituted; destructive substring and character offset shown inline ("Matched `rm -rf` at char 1")
- Per-target opt-out via checkbox; unchecked panes are excluded from the fan-out
- Dynamic CTA: "Send to N panes" reflects the current selection; button disables if all targets are unchecked
- Byte threshold now evaluated against resolved per-target size, not the source draft length

**Architecture**
- `PendingFleetBroadcast` carries a `resolvedPreviews: FleetTargetPreview[]` snapshot taken at confirm-request time
- `resolveFleetBroadcastConfirmation` resolves its Promise with the user-selected target IDs, not just a boolean
- Dispatch passes `perTargetOverrides` built from the snapshot, so late worktree-state mutations are ignored
- `filterEligibleIds` re-runs at dispatch time — panes that go ineligible while the dialog is open are dropped silently

**Docs**
- `docs/architecture/destructive-action-safeguards.md`: `fleet.broadcast` added as a D2 row; Known bypasses section updated with the direct-IPC call site in `FleetArmingRibbon`

## Testing

All 147 fleet/store tests pass. New coverage includes:

- `getFleetBroadcastDestructiveMatch` — destructive substring extraction and offset reporting
- Resolved-payload variant of `needsFleetBroadcastConfirmation` — threshold evaluated against per-target resolved size
- Dialog opt-out reducing the CTA count
- All-excluded state disabling the confirm button
- Stale-eligibility drop — pane going ineligible between confirm-request and dispatch is excluded
- Supersede preview-bleed protection — a new broadcast request doesn't leak preview state from the previous one

**Manual test plan**
- [ ] Arm 3+ worktrees, send a broadcast containing `rm -rf` — confirm dialog opens, each target shows its resolved payload with the destructive match highlighted
- [ ] Uncheck one target, verify CTA reads "Send to N-1 panes" and that target receives nothing
- [ ] Uncheck all targets, verify confirm button is disabled
- [ ] Trigger a broadcast that exceeds 512 bytes after variable substitution but not before — confirm gate opens (previously it wouldn't)
- [ ] Open the confirm dialog, switch to a different worktree so one pane goes ineligible, submit — verify the ineligible pane is skipped and the others receive the snapshotted payload
- [ ] Cancel the dialog, verify no broadcast is sent