### PR TITLE
fix(crash-guard): close slow-flap blind spot in decay window

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -413,7 +413,6 @@ if (!gotTheLock) {
         }
       }
       await createWindow(undefined, lastActiveProjectId ?? undefined);
-      getCrashLoopGuard().startStabilityTimer();
     } catch (error) {
       console.error("[MAIN] Startup failed:", error);
       // Startup crashes hard-exit without running before-quit, which means

--- a/electron/services/CrashLoopGuardService.ts
+++ b/electron/services/CrashLoopGuardService.ts
@@ -6,8 +6,13 @@ import { resilientAtomicWriteFileSync } from "../utils/fs.js";
 const STATE_FILENAME = "crash-loop-state.json";
 const CRASH_THRESHOLD = 3;
 const HARD_STOP_THRESHOLD = 5;
-const STABILITY_TIMEOUT_MS = 5 * 60 * 1000;
-const RAPID_CRASH_WINDOW_MS = 300_000;
+// Sliding-window decay for the crash counter. Lazy-evaluated at boot and at
+// crash-record-time — no setTimeout, no proactive reset. A wider window
+// (compared to the prior 5-minute rapid-crash setting) closes the slow-flap
+// blind spot where a crash every 6+ minutes accumulated no strikes because
+// each entry expired before the next crash. Exported so the alignment test
+// (`crashGuardAlignment.test.ts`) can assert the three guards share one value.
+export const CRASH_WINDOW_MS = 30 * 60 * 1000;
 
 // Grace window before a leftover `.tmp` from `resilientAtomicWriteFileSync` is
 // swept. Matches the precedent in `terminalSessionPersistence.ts` — long enough
@@ -56,7 +61,6 @@ export class CrashLoopGuardService {
   private statePath: string;
   private safeMode = false;
   private relaunchAllowed = true;
-  private stabilityTimer: ReturnType<typeof setTimeout> | null = null;
   private initialized = false;
   private crashCount = 0;
   private lastCrashAt: number | undefined;
@@ -82,7 +86,7 @@ export class CrashLoopGuardService {
     const now = Date.now();
 
     if (!state.cleanExit) {
-      const recentLaunches = state.launches.filter((ts) => now - ts < RAPID_CRASH_WINDOW_MS);
+      const recentLaunches = state.launches.filter((ts) => now - ts < CRASH_WINDOW_MS);
       state.crashes = recentLaunches.length;
     } else {
       state.crashes = 0;
@@ -151,9 +155,8 @@ export class CrashLoopGuardService {
   }
 
   /**
-   * User-initiated reset: cancel the stability timer first so it can't
-   * fire between our write and exit and clobber the fresh state, then
-   * atomically clear the state file and reset in-memory flags.
+   * User-initiated reset: atomically clear the state file and reset in-memory
+   * flags.
    *
    * Throws if the disk write fails. The caller (IPC handler) must propagate
    * the failure so the renderer can re-enable the restart button — silently
@@ -161,10 +164,6 @@ export class CrashLoopGuardService {
    * boot the user straight back into safe mode after relaunch.
    */
   resetForNormalBoot(): void {
-    if (this.stabilityTimer) {
-      clearTimeout(this.stabilityTimer);
-      this.stabilityTimer = null;
-    }
     this.writeState(freshState());
     this.safeMode = false;
     this.relaunchAllowed = true;
@@ -182,27 +181,9 @@ export class CrashLoopGuardService {
     }
   }
 
-  startStabilityTimer(): void {
-    if (this.stabilityTimer) return;
-    this.stabilityTimer = setTimeout(() => {
-      this.stabilityTimer = null;
-      try {
-        const state = freshState();
-        this.writeState(state);
-        this.safeMode = false;
-        this.relaunchAllowed = true;
-        console.log("[CrashLoopGuard] Stability timer fired — crash counter reset");
-      } catch (err) {
-        console.error("[CrashLoopGuard] Failed to reset crash counter:", err);
-      }
-    }, STABILITY_TIMEOUT_MS);
-  }
-
   dispose(): void {
-    if (this.stabilityTimer) {
-      clearTimeout(this.stabilityTimer);
-      this.stabilityTimer = null;
-    }
+    // No resources held — kept for API stability with callers that pair
+    // initialize()/dispose() out of habit.
   }
 
   private readState(): CrashLoopState {
@@ -360,7 +341,7 @@ export function isSafeModeActive(userDataPath?: string): boolean {
     ) {
       if (parsed.cleanExit) return false;
       const now = Date.now();
-      const recentLaunches = parsed.launches.filter((ts) => now - ts < RAPID_CRASH_WINDOW_MS);
+      const recentLaunches = parsed.launches.filter((ts) => now - ts < CRASH_WINDOW_MS);
       return recentLaunches.length >= CRASH_THRESHOLD;
     }
     return false;

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -32,13 +32,14 @@ const RESTART_CAP_BASE_MS = 1_000;
 const RESTART_CAP_MAX_MS = 10_000;
 
 // Time-windowed crash-loop guard. Mirrors the constants in PtyHostLifecycle
-// (and CrashLoopGuardService) so the workspace-host follows the same policy:
-// three crashes within five minutes trip the cap, and a five-minute stretch
-// of clean running decays the window back to empty. Duplicated rather than
-// imported because the guards operate at independent layers.
+// and CrashLoopGuardService so the three guards follow the same policy: three
+// crashes within the window trip the cap, and crashes spread further apart
+// decay out lazily at crash-record-time. Duplicated rather than imported
+// because the guards operate at independent layers. The alignment test
+// (`crashGuardAlignment.test.ts`) asserts the three values stay in lockstep
+// so the next person tuning one is forced to consider the others.
 const CRASH_THRESHOLD = 3;
-const RAPID_CRASH_WINDOW_MS = 300_000;
-const STABILITY_TIMEOUT_MS = 300_000;
+export const CRASH_WINDOW_MS = 30 * 60 * 1000;
 
 export class WorkspaceHostProcess extends EventEmitter {
   private child: UtilityProcess | null = null;
@@ -52,18 +53,11 @@ export class WorkspaceHostProcess extends EventEmitter {
   private restartTimer: NodeJS.Timeout | null = null;
   private disposeTimer: NodeJS.Timeout | null = null;
   /**
-   * Sliding window of recent crash timestamps. Trimmed to entries within
-   * `RAPID_CRASH_WINDOW_MS` on each crash; cleared when the stability timer
-   * fires after a successful `ready`. Three crashes within the window trip
-   * the cap and emit `host-crash`.
+   * Sliding window of recent crash timestamps. Lazy-pruned to entries within
+   * `CRASH_WINDOW_MS` on each crash — no proactive reset, no setTimeout.
+   * Three crashes within the window trip the cap and emit `host-crash`.
    */
   private crashTimestamps: number[] = [];
-  /**
-   * Stability timer started on every `ready`. When it fires after
-   * `STABILITY_TIMEOUT_MS` of clean running, the crash window is cleared.
-   * Cleared on crash, `manualRestart()`, and `dispose()`.
-   */
-  private stabilityTimer: NodeJS.Timeout | null = null;
   /**
    * Authoritative crash reason captured from `app.on("child-process-gone")`.
    * Consumed by the next `exit` handler via `setImmediate` deferral, since the
@@ -282,11 +276,10 @@ export class WorkspaceHostProcess extends EventEmitter {
 
   /**
    * Restart the host after its auto-restart budget has been exhausted.
-   * Clears the crash window and pending stability timer so future crashes
-   * get a fresh budget, respawns the child, and emits `"restarted"` so
-   * `WorkspaceClient` can re-broker ports and reload the project — the
-   * auto-restart path emits this from its `setTimeout` callback which
-   * `manualRestart()` bypasses.
+   * Clears the crash window so future crashes get a fresh budget, respawns
+   * the child, and emits `"restarted"` so `WorkspaceClient` can re-broker
+   * ports and reload the project — the auto-restart path emits this from its
+   * `setTimeout` callback which `manualRestart()` bypasses.
    */
   manualRestart(): void {
     if (this.isDisposed) {
@@ -307,10 +300,6 @@ export class WorkspaceHostProcess extends EventEmitter {
     }
 
     this.crashTimestamps = [];
-    if (this.stabilityTimer) {
-      clearTimeout(this.stabilityTimer);
-      this.stabilityTimer = null;
-    }
 
     console.log(`[WorkspaceHost:${this.serviceName}] Manual restart initiated`);
     this.startHost();
@@ -336,10 +325,6 @@ export class WorkspaceHostProcess extends EventEmitter {
     if (this.restartTimer) {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;
-    }
-    if (this.stabilityTimer) {
-      clearTimeout(this.stabilityTimer);
-      this.stabilityTimer = null;
     }
     if (this.handshakeTimeout) {
       clearTimeout(this.handshakeTimeout);
@@ -570,15 +555,6 @@ export class WorkspaceHostProcess extends EventEmitter {
       this.isInitialized = false;
       this.child = null;
 
-      // Cancel any stability timer the prior `ready` armed. If it stayed
-      // alive, it could fire moments after a crash and wipe `crashTimestamps`
-      // even though the host never ran cleanly for the full window —
-      // defeating the three-crash guard for crash-ready-crash-ready patterns.
-      if (this.stabilityTimer) {
-        clearTimeout(this.stabilityTimer);
-        this.stabilityTimer = null;
-      }
-
       this.broker.clear(
         new BrokerError("HOST_EXITED", "Workspace Host crashed", {
           projectScopeId: this.projectPath,
@@ -628,13 +604,11 @@ export class WorkspaceHostProcess extends EventEmitter {
         // would orphan that host.
         if (this.child !== null) return;
 
-        // Time-windowed sliding crash counter. Trim entries older than the
-        // window, then append the current crash. Three crashes within five
-        // minutes trip the cap; crashes spread further apart decay out.
+        // Time-windowed sliding crash counter. Lazy-prune entries older than
+        // the window, then append the current crash. Three crashes within the
+        // window trip the cap; crashes spread further apart decay out.
         const crashAt = Date.now();
-        this.crashTimestamps = this.crashTimestamps.filter(
-          (t) => crashAt - t < RAPID_CRASH_WINDOW_MS
-        );
+        this.crashTimestamps = this.crashTimestamps.filter((t) => crashAt - t < CRASH_WINDOW_MS);
         this.crashTimestamps.push(crashAt);
 
         if (this.crashTimestamps.length < CRASH_THRESHOLD) {
@@ -661,7 +635,7 @@ export class WorkspaceHostProcess extends EventEmitter {
           this.restartTimer.unref?.();
         } else {
           console.error(
-            `[WorkspaceHost:${this.serviceName}] Max restart attempts reached (${CRASH_THRESHOLD} crashes in ${RAPID_CRASH_WINDOW_MS}ms), giving up`
+            `[WorkspaceHost:${this.serviceName}] Max restart attempts reached (${CRASH_THRESHOLD} crashes in ${CRASH_WINDOW_MS}ms), giving up`
           );
           this.emit("host-crash", reportedCode);
         }
@@ -736,23 +710,6 @@ export class WorkspaceHostProcess extends EventEmitter {
     app.on("child-process-gone", handler);
   }
 
-  /**
-   * Start (or restart) the stability timer. When it fires after
-   * `STABILITY_TIMEOUT_MS` of clean running, the crash window is cleared so
-   * subsequent crashes start fresh. Unref'd so the timer never pins the
-   * Electron event loop alive after `app.quit`.
-   */
-  private startStabilityTimer(): void {
-    if (this.stabilityTimer) {
-      clearTimeout(this.stabilityTimer);
-    }
-    this.stabilityTimer = setTimeout(() => {
-      this.stabilityTimer = null;
-      this.crashTimestamps = [];
-    }, STABILITY_TIMEOUT_MS);
-    this.stabilityTimer.unref?.();
-  }
-
   private handleHostEvent(event: WorkspaceHostEvent): void {
     try {
       this.processHostEvent(event);
@@ -777,13 +734,12 @@ export class WorkspaceHostProcess extends EventEmitter {
       case "ready": {
         if (!this.child) return;
         this.isInitialized = true;
-        // Start (or restart) the stability timer. We deliberately do NOT
-        // clear `crashTimestamps` here — clearing on ready would defeat the
-        // sliding window for a crash-ready-crash-ready loop, where each
-        // fresh ready would wipe the history right before the next crash.
-        // The window is only cleared when the timer fires after a full
-        // stable interval. This is the fix for #8553.
-        this.startStabilityTimer();
+        // Do NOT clear `crashTimestamps` here — clearing on ready would
+        // defeat the sliding window for a crash-ready-crash-ready loop,
+        // where each fresh ready would wipe the history right before the
+        // next crash. The window decays lazily at crash-record-time in the
+        // `exit` handler. This is the fix for #8553 (preserved) and #8683
+        // (no proactive reset timer).
 
         const token = GitHubAuth.getToken();
         if (token) {

--- a/electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts
@@ -95,12 +95,16 @@ describe("CrashLoopGuardService adversarial", () => {
     expect(stateAfterFailure).toEqual(stateBeforeFailure);
   });
 
-  it("counts only launches strictly inside the rapid-crash window boundary", () => {
+  it("counts only launches strictly inside the crash-window boundary", () => {
     const now = Date.now();
+    const window = 30 * 60_000;
+    // One launch exactly at the window edge (excluded by strict `<`), one
+    // 1ms inside (included). Stale `crashes: 9` is ignored — derived from
+    // the filtered launches array, not trusted from disk.
     writeStateFile(statePath, {
       version: 1,
       crashes: 9,
-      launches: [now - 300_000, now - 299_999],
+      launches: [now - window, now - (window - 1)],
       cleanExit: false,
       lastReset: now - 5_000,
     });
@@ -113,23 +117,41 @@ describe("CrashLoopGuardService adversarial", () => {
     expect(readStateFile(statePath).crashes).toBe(1);
   });
 
-  it("keeps clean-exit state fresh when markCleanExit wins before the stability timer fires", () => {
+  it("markCleanExit writes a clean state independent of any prior timer (regression #8683)", () => {
     const guard = new CrashLoopGuardService();
     guard.initialize();
-    guard.startStabilityTimer();
     guard.markCleanExit();
 
-    vi.advanceTimersByTime(5 * 60 * 1000);
+    // Advance well past the prior stability-timer deadline — there should
+    // be no timer to fire, no late write that could clobber the clean state.
+    vi.advanceTimersByTime(30 * 60 * 1000);
 
     const parsed = readStateFile(statePath);
     expect(parsed).toMatchObject({
       version: 1,
-      crashes: 0,
       cleanExit: true,
-      launches: [],
     });
     expect(guard.isSafeMode()).toBe(false);
     expect(guard.shouldRelaunch()).toBe(true);
+  });
+
+  it("slow flap of four 6-minute-spaced crashes accumulates safe mode (regression #8683)", () => {
+    const start = new Date("2026-04-13T12:00:00.000Z").getTime();
+
+    // Three prior unclean boots, then a fourth that reads the prior three
+    // as crashes-from-disk and trips safe mode. Under the prior 5-min
+    // rapid window those earlier entries had decayed and the fourth boot
+    // would have stayed normal.
+    for (let i = 0; i < 3; i++) {
+      vi.setSystemTime(start + i * 6 * 60_000);
+      new CrashLoopGuardService().initialize();
+    }
+
+    vi.setSystemTime(start + 3 * 6 * 60_000);
+    const guard = new CrashLoopGuardService();
+    guard.initialize();
+    expect(guard.isSafeMode()).toBe(true);
+    expect(guard.getCrashCount()).toBe(3);
   });
 
   it("replaces partially valid persisted state with a fully valid shape", () => {
@@ -248,21 +270,23 @@ describe("CrashLoopGuardService adversarial", () => {
     );
   });
 
-  it("does not keep relaunch disabled after old launches roll out of the hard-stop window", () => {
+  it("does not keep relaunch disabled after old launches roll out of the crash window", () => {
     const now = Date.now();
+    // Four launches outside the 30-min window (decayed) plus two inside —
+    // safe mode and relaunch should reflect only the recent two.
     writeStateFile(statePath, {
       version: 1,
       crashes: 5,
       launches: [
-        now - 320_000,
-        now - 310_000,
-        now - 305_000,
-        now - 301_000,
+        now - 35 * 60_000,
+        now - 34 * 60_000,
+        now - 33 * 60_000,
+        now - 31 * 60_000,
         now - 1_000,
         now - 500,
       ],
       cleanExit: false,
-      lastReset: now - 120_000,
+      lastReset: now - 2 * 60_000,
     });
 
     const guard = new CrashLoopGuardService();

--- a/electron/services/__tests__/CrashLoopGuardService.test.ts
+++ b/electron/services/__tests__/CrashLoopGuardService.test.ts
@@ -90,21 +90,42 @@ describe("isSafeModeActive", () => {
     expect(isSafeModeActive(tmpDir)).toBe(false);
   });
 
-  it("returns false when launches are outside the rapid crash window", () => {
+  it("returns false when launches are outside the crash window", () => {
     const now = Date.now();
+    // 31, 35, 40 minutes ago — all outside the 30-min window
     fs.writeFileSync(
       statePath,
       JSON.stringify({
         version: 1,
         crashes: 3,
-        launches: [now - 400000, now - 370000, now - 340000],
+        launches: [now - 31 * 60_000, now - 35 * 60_000, now - 40 * 60_000],
         cleanExit: false,
-        lastReset: now - 300000,
+        lastReset: now - 30 * 60_000,
       }),
       "utf8"
     );
 
     expect(isSafeModeActive(tmpDir)).toBe(false);
+  });
+
+  it("returns true for three slow-flap launches inside the wider window", () => {
+    const now = Date.now();
+    // Slow flap: crashes every 6 minutes — under the old 5-min window this
+    // accumulated 0 strikes (each entry expired before the next crash).
+    // With the 30-min window, three entries within ~18 minutes accumulate.
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({
+        version: 1,
+        crashes: 3,
+        launches: [now - 12 * 60_000, now - 6 * 60_000, now - 1_000],
+        cleanExit: false,
+        lastReset: now - 30 * 60_000,
+      }),
+      "utf8"
+    );
+
+    expect(isSafeModeActive(tmpDir)).toBe(true);
   });
 
   it("returns false on corrupted state file", () => {
@@ -228,26 +249,6 @@ describe("CrashLoopGuardService", () => {
     guard4.initialize();
 
     expect(guard4.isSafeMode()).toBe(false);
-  });
-
-  it("resets counter after stability timer fires", () => {
-    // Simulate 2 crashes
-    for (let i = 0; i < 2; i++) {
-      const guard = new CrashLoopGuardService();
-      guard.initialize();
-    }
-
-    const guard = new CrashLoopGuardService();
-    guard.initialize();
-    guard.startStabilityTimer();
-
-    vi.advanceTimersByTime(5 * 60 * 1000);
-
-    const state = readState();
-    expect(state.crashes).toBe(0);
-    expect(state.cleanExit).toBe(true);
-
-    guard.dispose();
   });
 
   it("handles corrupted state file gracefully", () => {
@@ -412,58 +413,43 @@ describe("CrashLoopGuardService", () => {
     });
   });
 
-  it("only counts crashes within the rapid crash window", () => {
+  it("only counts crashes within the crash window", () => {
     const now = Date.now();
 
-    // Write state with old launches (outside 300s window)
+    // Write state with launches well outside the 30-min window
     writeState({
       version: 1,
       crashes: 3,
-      launches: [now - 400000, now - 370000, now - 340000],
+      launches: [now - 40 * 60_000, now - 35 * 60_000, now - 31 * 60_000],
       cleanExit: false,
-      lastReset: now - 300000,
+      lastReset: now - 30 * 60_000,
     });
 
     const guard = new CrashLoopGuardService();
     guard.initialize();
 
-    // Old launches are outside the 300s window, so crashes should be 0
     expect(guard.isSafeMode()).toBe(false);
   });
 
-  it("dispose clears stability timer", () => {
-    const guard = new CrashLoopGuardService();
-    guard.initialize();
-    guard.startStabilityTimer();
-    guard.dispose();
-
-    // Timer should not fire
-    const stateBefore = readState();
-    vi.advanceTimersByTime(5 * 60 * 1000);
-    const stateAfter = readState();
-
-    expect(stateAfter.crashes).toBe(stateBefore.crashes);
-  });
-
-  it("stability timer resets in-memory flags after hard stop", () => {
-    // Reach hard-stop state (5 crashes)
-    for (let i = 0; i < 5; i++) {
+  it("accumulates slow-flap launches across the wider window (regression #8683)", () => {
+    // Four unclean launches spaced 6 minutes apart — the fourth boot reads
+    // three prior in-window launches and enters safe mode. Under the prior
+    // 5-min rapid window with the stability-timer reset, this slow flap
+    // silently accumulated zero strikes; with the 30-min lazy-decay window
+    // it correctly trips at the third strike.
+    const start = Date.now();
+    for (let i = 0; i < 3; i++) {
+      vi.setSystemTime(start + i * 6 * 60_000);
       const guard = new CrashLoopGuardService();
       guard.initialize();
+      expect(guard.isSafeMode()).toBe(false);
     }
 
-    const guard = new CrashLoopGuardService();
-    guard.initialize();
-    expect(guard.isSafeMode()).toBe(true);
-    expect(guard.shouldRelaunch()).toBe(false);
-
-    guard.startStabilityTimer();
-    vi.advanceTimersByTime(5 * 60 * 1000);
-
-    expect(guard.isSafeMode()).toBe(false);
-    expect(guard.shouldRelaunch()).toBe(true);
-
-    guard.dispose();
+    vi.setSystemTime(start + 3 * 6 * 60_000);
+    const fourth = new CrashLoopGuardService();
+    fourth.initialize();
+    expect(fourth.isSafeMode()).toBe(true);
+    expect(fourth.shouldRelaunch()).toBe(true);
   });
 
   it("initialize is idempotent — second call is a no-op", () => {
@@ -473,20 +459,6 @@ describe("CrashLoopGuardService", () => {
 
     const state = readState();
     expect(state.launches).toHaveLength(1);
-  });
-
-  it("startStabilityTimer is idempotent", () => {
-    const guard = new CrashLoopGuardService();
-    guard.initialize();
-    guard.startStabilityTimer();
-    guard.startStabilityTimer();
-
-    vi.advanceTimersByTime(5 * 60 * 1000);
-
-    const state = readState();
-    expect(state.crashes).toBe(0);
-
-    guard.dispose();
   });
 
   describe("crash metadata", () => {
@@ -598,29 +570,6 @@ describe("CrashLoopGuardService", () => {
 
       expect(guard.isSafeMode()).toBe(false);
       expect(guard.getLastCrashTimestamp()).toBeUndefined();
-    });
-
-    it("cancels the stability timer so it can't clobber the fresh state", () => {
-      for (let i = 0; i < 3; i++) {
-        const guard = new CrashLoopGuardService();
-        guard.initialize();
-      }
-      const guard = new CrashLoopGuardService();
-      guard.initialize();
-      guard.startStabilityTimer();
-
-      guard.resetForNormalBoot();
-
-      // Advancing past the 5-minute timeout must not re-fire the timer
-      // (which would also write fresh state, but more importantly must
-      // not throw on a torn-down service).
-      vi.advanceTimersByTime(6 * 60 * 1000);
-
-      const state = readState();
-      expect(state.crashes).toBe(0);
-      expect(state.cleanExit).toBe(true);
-
-      guard.dispose();
     });
   });
 });

--- a/electron/services/__tests__/WorkspaceHostProcess.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.test.ts
@@ -659,7 +659,7 @@ describe("WorkspaceHostProcess crash window", () => {
     host.dispose();
   });
 
-  it("stability timer clears the crash window after a quiet interval", async () => {
+  it("crash window persists through long quiet intervals (regression #8683)", async () => {
     const { WorkspaceHostProcess } = await loadModule();
     const host = new WorkspaceHostProcess("/tmp/project", {
       maxRestartAttempts: 3,
@@ -673,43 +673,15 @@ describe("WorkspaceHostProcess crash window", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect((host as any).crashTimestamps).toHaveLength(1);
 
-    // Auto-restart fires and host comes up; ready arms a fresh stability timer
+    // Auto-restart fires and host comes up
     host.waitForReady().catch(() => {});
     await vi.advanceTimersByTimeAsync(2_001);
     const child2 = mockChildren[1] as MockUtilityChild;
     child2.emit("message", { type: "ready" });
 
-    // Crash entry must survive immediately after ready
-    expect((host as any).crashTimestamps).toHaveLength(1);
-
-    // After STABILITY_TIMEOUT_MS of clean running, the window is cleared
-    await vi.advanceTimersByTimeAsync(300_000);
-    expect((host as any).crashTimestamps).toHaveLength(0);
-
-    host.dispose();
-  });
-
-  it("stability timer from a prior ready is cancelled on crash", async () => {
-    const { WorkspaceHostProcess } = await loadModule();
-    const host = new WorkspaceHostProcess("/tmp/project", {
-      maxRestartAttempts: 3,
-      healthCheckIntervalMs: 30000,
-    } as any);
-    host.waitForReady().catch(() => {});
-
-    const child = mockChildren[0] as MockUtilityChild;
-    child.emit("message", { type: "ready" });
-
-    // Run almost to the stability deadline, then crash. The stability timer
-    // is now ~100ms from firing; if it weren't cancelled it would wipe the
-    // crash window AFTER the crash, defeating the three-strike guard.
-    await vi.advanceTimersByTimeAsync(299_900);
-    child.emit("exit", 1);
-    await vi.advanceTimersByTimeAsync(0);
-    expect((host as any).crashTimestamps).toHaveLength(1);
-
-    // Advance past the stale deadline — the crash entry must survive
-    await vi.advanceTimersByTimeAsync(1_000);
+    // 10 minutes of clean running — the crash entry must persist (there
+    // is no proactive reset timer any more).
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
     expect((host as any).crashTimestamps).toHaveLength(1);
 
     host.dispose();
@@ -730,21 +702,59 @@ describe("WorkspaceHostProcess crash window", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect((host as any).crashTimestamps).toHaveLength(1);
 
-    // Restart fires; advance well past the window (6 minutes)
+    // Restart fires; advance well past the 30-min window (31 minutes)
     host.waitForReady().catch(() => {});
     await vi.advanceTimersByTimeAsync(2_001);
     const child2 = mockChildren[1] as MockUtilityChild;
     child2.emit("message", { type: "ready" });
-    // Advance well past the 5-min window — the stability timer fires at
-    // exactly 5min, which clears the window. After this point, any new
-    // crash starts fresh.
-    await vi.advanceTimersByTimeAsync(360_000);
-    expect((host as any).crashTimestamps).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(31 * 60_000);
 
-    // A subsequent crash gets a fresh budget
+    // A subsequent crash gets a fresh budget — the lazy filter at
+    // crash-record-time drops the stale entry.
     child2.emit("exit", 1);
     await vi.advanceTimersByTimeAsync(0);
     expect((host as any).crashTimestamps).toHaveLength(1);
+
+    host.dispose();
+  });
+
+  it("slow flap of 6-minute-cadence crashes trips host-crash (regression #8683)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const crashSpy = vi.fn();
+    host.on("host-crash", crashSpy);
+
+    // Crash 1
+    const child1 = mockChildren[0] as MockUtilityChild;
+    child1.emit("message", { type: "ready" });
+    child1.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).crashTimestamps).toHaveLength(1);
+
+    // Wait 6 minutes (just outside the prior 5-min rapid window), then crash
+    await vi.advanceTimersByTimeAsync(6 * 60_000);
+    const child2 = mockChildren[1] as MockUtilityChild;
+    host.waitForReady().catch(() => {});
+    child2.emit("message", { type: "ready" });
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).crashTimestamps).toHaveLength(2);
+    expect(crashSpy).not.toHaveBeenCalled();
+
+    // Another 6 minutes, then crash 3 — threshold reached
+    await vi.advanceTimersByTimeAsync(6 * 60_000);
+    const child3 = mockChildren[2] as MockUtilityChild;
+    host.waitForReady().catch(() => {});
+    child3.emit("message", { type: "ready" });
+    child3.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).crashTimestamps).toHaveLength(3);
+    expect(crashSpy).toHaveBeenCalledWith(1);
 
     host.dispose();
   });

--- a/electron/services/__tests__/crashGuardAlignment.test.ts
+++ b/electron/services/__tests__/crashGuardAlignment.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The three crash-loop guards intentionally duplicate their decay-window
+// constant rather than sharing a module — they operate at independent layers
+// (disk-persisted app-level vs. in-memory utility-process) and must remain
+// decoupled. This alignment test is the failure mechanism the source comments
+// promise: any future tuning of one constant fails this test until the other
+// two are updated to match. If the desired policy genuinely diverges, this
+// test should be deleted in the same PR that introduces the divergence.
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp" },
+  utilityProcess: { fork: () => undefined },
+  UtilityProcess: class {},
+  MessagePortMain: class {},
+}));
+
+vi.mock("../../utils/fs.js", () => ({ resilientAtomicWriteFileSync: () => undefined }));
+
+vi.mock("../github/GitHubAuth.js", () => ({ GitHubAuth: { getToken: () => null } }));
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: () => ({
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  }),
+}));
+
+describe("crash-loop guard alignment", () => {
+  it("the three guards share a single CRASH_WINDOW_MS value", async () => {
+    const [guard, ptyLifecycle, workspaceHost] = await Promise.all([
+      import("../CrashLoopGuardService.js"),
+      import("../pty/PtyHostLifecycle.js"),
+      import("../WorkspaceHostProcess.js"),
+    ]);
+
+    expect(guard.CRASH_WINDOW_MS).toBe(ptyLifecycle.CRASH_WINDOW_MS);
+    expect(ptyLifecycle.CRASH_WINDOW_MS).toBe(workspaceHost.CRASH_WINDOW_MS);
+    // Sanity check the policy itself — three rapid crashes (~few seconds
+    // apart) still trip the cap, and a 6-minute-cadence slow flap (the #8683
+    // blind spot) does too. Bumping below 18 minutes would let chronic
+    // 6-min-cadence crashers slip through again; bumping above 1 hour would
+    // make the boot-time decay surprising. Update intentionally.
+    expect(guard.CRASH_WINDOW_MS).toBeGreaterThanOrEqual(18 * 60_000);
+    expect(guard.CRASH_WINDOW_MS).toBeLessThanOrEqual(60 * 60_000);
+  });
+});

--- a/electron/services/pty/PtyHostLifecycle.ts
+++ b/electron/services/pty/PtyHostLifecycle.ts
@@ -105,15 +105,16 @@ const RESTART_CAP_BASE_MS = 1_000;
 const RESTART_CAP_MAX_MS = 10_000;
 
 // Time-windowed crash-loop guard. Mirrors the constants in
-// `CrashLoopGuardService` so the pty-host follows the same policy as the main
-// process: three crashes within five minutes trip the cap, and a five-minute
-// stretch of clean running decays the window back to empty. Constants are
-// duplicated rather than imported because the two guards operate at different
-// layers (disk-persisted app-level vs. in-memory pty-host) and shouldn't be
-// coupled.
+// `CrashLoopGuardService` and `WorkspaceHostProcess` so the three guards
+// follow the same policy: three crashes within the window trip the cap, and
+// crashes spread further apart decay out lazily at crash-record-time.
+// Constants are duplicated rather than imported because the guards operate at
+// different layers (disk-persisted app-level vs. in-memory utility-process)
+// and shouldn't be coupled. The alignment test
+// (`crashGuardAlignment.test.ts`) asserts the three values stay in lockstep
+// so the next person tuning one is forced to consider the others.
 const CRASH_THRESHOLD = 3;
-const RAPID_CRASH_WINDOW_MS = 300_000;
-const STABILITY_TIMEOUT_MS = 300_000;
+export const CRASH_WINDOW_MS = 30 * 60 * 1000;
 
 export interface PtyHostLifecycleConfig {
   memoryLimitMb: number;
@@ -170,19 +171,13 @@ export class PtyHostLifecycle {
   /** Public for test access — read by `isReady()` on PtyClient and the watchdog tick. */
   isInitialized = false;
   /**
-   * Sliding window of recent crash timestamps. Trimmed to entries within
-   * `RAPID_CRASH_WINDOW_MS` on each crash; cleared when the stability timer
-   * fires after a successful `markReady()`. Public for test access.
+   * Sliding window of recent crash timestamps. Lazy-pruned to entries within
+   * `CRASH_WINDOW_MS` on each crash — no proactive reset, no setTimeout.
+   * Public for test access.
    */
   crashTimestamps: number[] = [];
   /** Active restart timer; cleared on dispose / start / manualRestart. */
   restartTimer: NodeJS.Timeout | null = null;
-  /**
-   * Stability timer started on every `markReady()`. When it fires after
-   * `STABILITY_TIMEOUT_MS` of clean running, the crash window is cleared.
-   * Cleared by `manualRestart()` and `dispose()`.
-   */
-  private stabilityTimer: NodeJS.Timeout | null = null;
   /** Force-kill backstop timer scheduled by dispose(); cleared if dispose runs again. */
   private disposeTimer: NodeJS.Timeout | null = null;
   /**
@@ -227,12 +222,10 @@ export class PtyHostLifecycle {
   markReady(): boolean {
     if (!this.child) return false;
     this.isInitialized = true;
-    // Start (or restart) the stability timer. Note we deliberately do NOT
-    // clear `crashTimestamps` here — clearing on ready would defeat the
-    // sliding window for a crash-ready-crash-ready loop, where each fresh
+    // Do NOT clear `crashTimestamps` here — clearing on ready would defeat
+    // the sliding window for a crash-ready-crash-ready loop, where each fresh
     // ready would wipe the history right before the next crash. The window
-    // is only cleared when the timer fires after a full stable interval.
-    this.startStabilityTimer();
+    // decays lazily at crash-record-time in `handleExit()`.
     if (this.readyResolve) {
       this.readyResolve();
       this.readyResolve = null;
@@ -248,8 +241,8 @@ export class PtyHostLifecycle {
 
   /**
    * User-initiated restart (e.g., from the renderer). Clears the crash window
-   * and cancels any pending stability timer so the new cycle starts with a
-   * fresh budget. No-ops if already disposed or already running.
+   * so the new cycle starts with a fresh budget. No-ops if already disposed
+   * or already running.
    */
   manualRestart(): void {
     if (this.callbacks.isDisposed()) {
@@ -268,10 +261,6 @@ export class PtyHostLifecycle {
     }
 
     this.crashTimestamps = [];
-    if (this.stabilityTimer) {
-      clearTimeout(this.stabilityTimer);
-      this.stabilityTimer = null;
-    }
     this.callbacks.onBeforeRestart();
     this.callbacks.logInfo("[PtyClient] Manual restart initiated");
     this.start();
@@ -389,11 +378,6 @@ export class PtyHostLifecycle {
       this.restartTimer = null;
     }
 
-    if (this.stabilityTimer) {
-      clearTimeout(this.stabilityTimer);
-      this.stabilityTimer = null;
-    }
-
     if (this.disposeTimer) {
       clearTimeout(this.disposeTimer);
       this.disposeTimer = null;
@@ -461,15 +445,6 @@ export class PtyHostLifecycle {
     this.isInitialized = false;
     this.child = null; // Prevent posting to dead process
 
-    // Cancel any stability timer the prior `markReady()` armed. If it stayed
-    // alive, it could fire moments after a crash and wipe `crashTimestamps`
-    // even though the host never ran cleanly for the full window — defeating
-    // the three-crash guard for crash-ready-crash-ready patterns.
-    if (this.stabilityTimer) {
-      clearTimeout(this.stabilityTimer);
-      this.stabilityTimer = null;
-    }
-
     if (this.callbacks.isDisposed()) {
       // Expected shutdown - drop any buffered reason so it can't leak.
       this.pendingChildProcessGoneReason = null;
@@ -534,13 +509,11 @@ export class PtyHostLifecycle {
       // window, don't schedule a second auto-restart — it would orphan that host.
       if (this.child !== null) return;
 
-      // Time-windowed sliding crash counter. Trim entries older than the
-      // window, then append the current crash. Three crashes within five
-      // minutes trip the cap; crashes spread further apart decay out.
+      // Time-windowed sliding crash counter. Lazy-prune entries older than
+      // the window, then append the current crash. Three crashes within the
+      // window trip the cap; crashes spread further apart decay out.
       const crashAt = Date.now();
-      this.crashTimestamps = this.crashTimestamps.filter(
-        (t) => crashAt - t < RAPID_CRASH_WINDOW_MS
-      );
+      this.crashTimestamps = this.crashTimestamps.filter((t) => crashAt - t < CRASH_WINDOW_MS);
       this.crashTimestamps.push(crashAt);
 
       if (this.crashTimestamps.length < CRASH_THRESHOLD) {
@@ -563,28 +536,11 @@ export class PtyHostLifecycle {
         this.restartTimer.unref?.();
       } else {
         console.error(
-          `[PtyClient] Max restart attempts reached (${CRASH_THRESHOLD} crashes in ${RAPID_CRASH_WINDOW_MS}ms), giving up`
+          `[PtyClient] Max restart attempts reached (${CRASH_THRESHOLD} crashes in ${CRASH_WINDOW_MS}ms), giving up`
         );
         this.callbacks.onMaxRestartsReached(reportedCode);
       }
     });
-  }
-
-  /**
-   * Start (or restart) the stability timer. When it fires after
-   * `STABILITY_TIMEOUT_MS` of clean running, the crash window is cleared so
-   * subsequent crashes start fresh. Unref'd so the timer never pins the
-   * Electron event loop alive after `app.quit`.
-   */
-  private startStabilityTimer(): void {
-    if (this.stabilityTimer) {
-      clearTimeout(this.stabilityTimer);
-    }
-    this.stabilityTimer = setTimeout(() => {
-      this.stabilityTimer = null;
-      this.crashTimestamps = [];
-    }, STABILITY_TIMEOUT_MS);
-    this.stabilityTimer.unref?.();
   }
 
   private installHostLogForwarding(): void {

--- a/electron/services/pty/__tests__/PtyHostLifecycle.test.ts
+++ b/electron/services/pty/__tests__/PtyHostLifecycle.test.ts
@@ -488,16 +488,14 @@ describe("PtyHostLifecycle", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(lifecycle.crashTimestamps).toHaveLength(1);
 
-    // Fire the restart timer and advance well past the 5-minute window.
-    // Use advanceTimersToNextTimerAsync to drain whatever restart delay was
-    // scheduled with jitter, then advance past the window for the next crash.
+    // Fire the restart timer, then advance well past the 30-minute window.
     const child2 = createMockChild();
     shared.forkMock.mockReturnValueOnce(child2);
     await vi.advanceTimersByTimeAsync(4_001);
     lifecycle.waitForReady().catch(() => undefined);
 
-    // Advance 6 minutes — the first crash timestamp is now outside the window
-    await vi.advanceTimersByTimeAsync(360_000);
+    // Advance 31 minutes — the first crash timestamp is now outside the window
+    await vi.advanceTimersByTimeAsync(31 * 60_000);
 
     // Crash 2: filter drops the stale timestamp, length becomes 1 again
     child2.emit("exit", 1);
@@ -506,7 +504,7 @@ describe("PtyHostLifecycle", () => {
     expect(callbacks.log.onMaxRestartsCalls).toHaveLength(0);
   });
 
-  it("stability timer clears the crash window after a quiet interval", async () => {
+  it("crash window persists through long quiet intervals and decays lazily (regression #8683)", async () => {
     const { lifecycle, callbacks } = makeLifecycle();
     lifecycle.start();
     lifecycle.markReady();
@@ -516,27 +514,64 @@ describe("PtyHostLifecycle", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(lifecycle.crashTimestamps).toHaveLength(1);
 
-    // Restart fires, host comes up, markReady starts a fresh stability timer
+    // Restart fires, host comes up. The crash entry must survive ready and
+    // long quiet intervals — there is no proactive reset timer any more.
     const child2 = createMockChild();
     shared.forkMock.mockReturnValueOnce(child2);
     await vi.advanceTimersByTimeAsync(4_001);
     lifecycle.waitForReady().catch(() => undefined);
     lifecycle.markReady();
 
-    // Window still has the crash recorded immediately after ready (this is
-    // critical — clearing on ready would defeat the sliding window).
     expect(lifecycle.crashTimestamps).toHaveLength(1);
 
-    // After STABILITY_TIMEOUT_MS of clean running, the timer fires and clears
-    // the history.
-    await vi.advanceTimersByTimeAsync(300_000);
-    expect(lifecycle.crashTimestamps).toHaveLength(0);
+    // 10 minutes of clean running — the prior crash is still within the
+    // 30-min window and remains counted.
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
 
-    // A subsequent crash gets a fresh budget and does not trip the cap.
+    // The next crash accumulates rather than getting a fresh budget.
     child2.emit("exit", 1);
     await vi.advanceTimersByTimeAsync(0);
-    expect(lifecycle.crashTimestamps).toHaveLength(1);
+    expect(lifecycle.crashTimestamps).toHaveLength(2);
     expect(callbacks.log.onMaxRestartsCalls).toHaveLength(0);
+  });
+
+  it("slow flap of 6-minute-cadence crashes trips the cap (regression #8683)", async () => {
+    const { lifecycle, callbacks } = makeLifecycle();
+    lifecycle.start();
+    lifecycle.markReady();
+
+    // Crash 1
+    mockChild.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
+
+    // Wait 6 minutes (well past the prior 5-min rapid window), restart, then
+    // crash again. Under the old guard the prior timestamp had already
+    // expired and the count would not accumulate.
+    const child2 = createMockChild();
+    shared.forkMock.mockReturnValueOnce(child2);
+    await vi.advanceTimersByTimeAsync(6 * 60_000);
+    lifecycle.waitForReady().catch(() => undefined);
+    lifecycle.markReady();
+
+    // Crash 2 — still inside the 30-min window
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(2);
+    expect(callbacks.log.onMaxRestartsCalls).toHaveLength(0);
+
+    // Another 6 minutes, then crash 3 — threshold reached.
+    const child3 = createMockChild();
+    shared.forkMock.mockReturnValueOnce(child3);
+    await vi.advanceTimersByTimeAsync(6 * 60_000);
+    lifecycle.waitForReady().catch(() => undefined);
+    lifecycle.markReady();
+
+    child3.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(3);
+    expect(callbacks.log.onMaxRestartsCalls).toEqual([1]);
   });
 
   it("manualRestart no-ops when child is still alive", () => {
@@ -605,55 +640,6 @@ describe("PtyHostLifecycle", () => {
     expect(lifecycle.restartTimer).toBeNull();
     // The new host gets a fresh three-crash budget; the prior crashes don't
     // contribute to the next threshold check.
-    expect(callbacks.log.onMaxRestartsCalls).toHaveLength(0);
-  });
-
-  it("manualRestart cancels a pending stability timer", async () => {
-    const { lifecycle } = makeLifecycle();
-    lifecycle.start();
-    // markReady starts the stability timer.
-    lifecycle.markReady();
-
-    // Record one crash so the window is non-empty before the host exits again.
-    mockChild.emit("exit", 1);
-    await vi.advanceTimersByTimeAsync(0);
-    expect(lifecycle.crashTimestamps).toHaveLength(1);
-
-    // manualRestart clears both the window and any pending stability timer.
-    const child2 = createMockChild();
-    shared.forkMock.mockReturnValueOnce(child2);
-    lifecycle.manualRestart();
-    lifecycle.waitForReady().catch(() => undefined);
-    expect(lifecycle.crashTimestamps).toHaveLength(0);
-
-    // Record a new crash AFTER the manual restart, then advance past the
-    // original stability deadline. If the old timer had survived, it would
-    // fire here and wipe the freshly recorded crash. Asserting the entry
-    // survives proves the old timer was cancelled.
-    child2.emit("exit", 1);
-    await vi.advanceTimersByTimeAsync(0);
-    expect(lifecycle.crashTimestamps).toHaveLength(1);
-    await vi.advanceTimersByTimeAsync(300_001);
-    expect(lifecycle.crashTimestamps).toHaveLength(1);
-  });
-
-  it("stability timer from a prior ready is cancelled on crash", async () => {
-    const { lifecycle, callbacks } = makeLifecycle();
-    lifecycle.start();
-    lifecycle.markReady();
-
-    // Run almost to the stability deadline, then crash. The stability timer
-    // is now ~100ms from firing; if it weren't cancelled it would wipe the
-    // crash window after the crash, defeating the three-strike guard for any
-    // crash-near-ready pattern.
-    await vi.advanceTimersByTimeAsync(299_900);
-    mockChild.emit("exit", 1);
-    await vi.advanceTimersByTimeAsync(0);
-    expect(lifecycle.crashTimestamps).toHaveLength(1);
-
-    // Advance past the stale deadline — the crash entry must survive.
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(lifecycle.crashTimestamps).toHaveLength(1);
     expect(callbacks.log.onMaxRestartsCalls).toHaveLength(0);
   });
 
@@ -775,16 +761,16 @@ describe("PtyHostLifecycle timer hygiene", () => {
     }
   });
 
-  it("stability timer is unref'd so it never pins the event loop", () => {
+  it("markReady does not schedule any background timer (regression #8683)", () => {
     const { lifecycle } = makeLifecycle();
     lifecycle.start();
 
     const { unrefSpies, restore } = instrumentSetTimeoutUnref();
     try {
-      // markReady() schedules the stability setTimeout.
+      // markReady() must NOT schedule a stability timer — its absence is the
+      // core of #8683. The crash window decays lazily at crash-record-time.
       lifecycle.markReady();
-      expect(unrefSpies).toHaveLength(1);
-      expect(unrefSpies[0]).toHaveBeenCalledTimes(1);
+      expect(unrefSpies).toHaveLength(0);
     } finally {
       restore();
     }


### PR DESCRIPTION
## Summary

The three crash-loop guards (`CrashLoopGuardService`, `PtyHostLifecycle`, `WorkspaceHostProcess`) had a 5-minute stability timer that fully reset the crash counter on a single tick. A crash cadence just outside that window — 6+ minutes between unclean launches — accumulated zero strikes despite being chronic instability. Closes #8683.

Two coordinated changes across all three guards:

- **Delete the proactive stability-timer reset.** The per-crash filter (`crashTimestamps.filter(t => now - t < CRASH_WINDOW_MS)`) already implements lazy decay at crash-record-time. The `setTimeout`-driven wholesale reset was both redundant and the cause of the blind spot.
- **Widen the decay window from 5 minutes to 30 minutes** (`CRASH_WINDOW_MS = 30 * 60 * 1000`). With the prior 5-minute window, removing the timer alone wouldn't have helped — a 6-minute cadence still expires each entry before the next crash lands. The 30-minute window keeps three 6-minute-spaced strikes inside the window and trips the cap at strike 3.

The constants stay duplicated across the three files per the existing layered-independence design. A new alignment test (`crashGuardAlignment.test.ts`) imports `CRASH_WINDOW_MS` from each guard and asserts the three values match — the test-on-misalignment mechanism the issue called for so future tuning forces consideration of all three.

`GpuCrashMonitorService` is excluded from the alignment set (its inline-decay shape is intentional and predates this fix).

## Test plan

- [x] `npx vitest run electron/services/__tests__/CrashLoopGuardService.test.ts electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts electron/services/__tests__/crashGuardAlignment.test.ts electron/services/__tests__/WorkspaceHostProcess.test.ts electron/services/pty/__tests__/PtyHostLifecycle.test.ts` — 111 tests pass
- [x] New slow-flap regression coverage:
  - `CrashLoopGuardService` — four 6-minute-cadence boots accumulate to safe mode (was: zero strikes under the prior window)
  - `PtyHostLifecycle` — three 6-minute-cadence crashes emit `onMaxRestartsReached`
  - `WorkspaceHostProcess` — three 6-minute-cadence crashes emit `host-crash`
- [x] `npm run check` clean (typecheck + lint + format)
- [x] Production build succeeds