### PR TITLE
fix(crash-recovery): eliminate marker-consumption race and attribute crash cause

### DIFF
--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import type {
+  CrashCause,
   CrashLogEntry,
   CrashRecoveryConfig,
   PanelSummary,
@@ -13,17 +14,22 @@ import { store, windowStatesStore } from "../store.js";
 import { isGpuDisabledByFlag } from "./GpuCrashMonitorService.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
 import { getActionBreadcrumbService } from "./ActionBreadcrumbService.js";
-import { resilientAtomicWriteFileSync } from "../utils/fs.js";
+import { resilientAtomicWriteFileSync, resilientRenameSync } from "../utils/fs.js";
 
 const MAX_CRASH_LOGS = 10;
 const MARKER_FILENAME = "running.lock";
 const CRASHES_DIR = "crashes";
 const BACKUP_DIR = "backups";
 const BACKUP_FILENAME = "session-state.json";
+const CRASHED_BACKUP_PREFIX = "session-state.crashed-";
 const BACKUP_INTERVAL_MS = 60_000;
 const DEBOUNCE_BACKUP_MS = 1_500;
 const BLUR_BACKUP_DEBOUNCE_MS = 100;
 const SUSPECT_WINDOW_MS = 30_000;
+// If the heartbeat field in the marker is older than this on next launch, the
+// previous session was almost certainly killed externally (SIGKILL, OOM killer,
+// force-quit) before its backup tick could refresh the stamp.
+const HEARTBEAT_STALE_THRESHOLD_MS = 120_000;
 
 export class CrashRecoveryService {
   private userData: string;
@@ -41,7 +47,11 @@ export class CrashRecoveryService {
   private removeFocusListener: (() => void) | null = null;
   private crashRecorded = false;
   private pendingPanelFilter: string[] | null = null;
-  private cachedBackupSnapshot: SessionSnapshot | null = null;
+  // Path of the renamed crashed-session backup file from the previous launch.
+  // Populated in consumeMarker() when the live backup is moved aside so the
+  // current session's backup tick cannot overwrite it. Null when there was
+  // no pre-crash backup or after the file has been consumed/cleaned up.
+  private crashedBackupPath: string | null = null;
 
   constructor() {
     this.userData = app.getPath("userData");
@@ -102,8 +112,10 @@ export class CrashRecoveryService {
   startBackupTimer(): void {
     if (this.backupTimer) return;
     this.takeBackup();
+    this.updateMarkerHeartbeat();
     this.backupTimer = setInterval(() => {
       this.takeBackup();
+      this.updateMarkerHeartbeat();
     }, BACKUP_INTERVAL_MS);
     this.registerSleepListeners();
     this.registerBlurListener();
@@ -126,6 +138,10 @@ export class CrashRecoveryService {
     this.unregisterSleepListeners();
     try {
       this.removeSuspendListener = getSystemSleepService().onSuspend(() => {
+        // Stamp the suspend start time so a power loss during sleep can be
+        // attributed to "suspended-then-lost" on the next launch instead of
+        // looking like a generic crash with a stale heartbeat.
+        this.stampSuspend(Date.now());
         if (this.backupTimer) {
           clearInterval(this.backupTimer);
           this.backupTimer = null;
@@ -136,6 +152,7 @@ export class CrashRecoveryService {
         }
       });
       this.removeWakeListener = getSystemSleepService().onWake(() => {
+        this.clearSuspend();
         this.startBackupTimer();
       });
     } catch {
@@ -226,23 +243,21 @@ export class CrashRecoveryService {
 
   restoreBackup(panelIds?: string[]): boolean {
     try {
-      // Use cached snapshot if available (backup file may have been overwritten
-      // by startBackupTimer between consumeMarker and user clicking restore)
-      let snapshot: SessionSnapshot;
-      if (this.cachedBackupSnapshot) {
-        snapshot = this.cachedBackupSnapshot;
-      } else {
-        if (!fs.existsSync(this.backupPath)) return false;
-        const raw = fs.readFileSync(this.backupPath, "utf8");
-        snapshot = JSON.parse(raw) as SessionSnapshot;
-      }
+      // After a crash, consumeMarker() renames the live backup file to a
+      // timestamped crashed-* path. Read from that path so the current
+      // session's backup tick can recreate session-state.json without
+      // clobbering the pre-crash snapshot. Fall back to the live path for
+      // explicit user-driven restores in a non-crash session.
+      const sourcePath = this.crashedBackupPath ?? this.backupPath;
+      if (!fs.existsSync(sourcePath)) return false;
+      const raw = fs.readFileSync(sourcePath, "utf8");
+      let snapshot = JSON.parse(raw) as SessionSnapshot;
 
       if (panelIds !== undefined && panelIds.length > 0 && snapshot.appState) {
-        // Filter onto a shallow copy so we don't mutate cachedBackupSnapshot.
+        // Filter onto a shallow copy so we don't mutate the parsed snapshot.
         // If applySessionSnapshot below throws and the user retries the
-        // restore (with or without a different filter), the cache must
-        // still hold the full pre-crash terminal list — mutating it in
-        // place permanently drops panels from any retry path.
+        // restore (with or without a different filter), re-reading from
+        // the crashed-* file gives the full pre-crash terminal list again.
         const appState = { ...(snapshot.appState as Record<string, unknown>) };
         if (Array.isArray(appState.terminals)) {
           const idSet = new Set(panelIds);
@@ -258,7 +273,7 @@ export class CrashRecoveryService {
       }
 
       this.applySessionSnapshot(snapshot);
-      this.cachedBackupSnapshot = null;
+      this.unlinkCrashedBackup();
       console.log(
         "[CrashRecovery] Session restored from backup" +
           (panelIds && panelIds.length > 0 ? ` (${panelIds.length} panels selected)` : "")
@@ -289,7 +304,7 @@ export class CrashRecoveryService {
         hasSeenWelcome: true,
         panelGridConfig: { strategy: "automatic" as const, value: 3 },
       });
-      this.cachedBackupSnapshot = null;
+      this.unlinkCrashedBackup();
       console.log("[CrashRecovery] Reset to fresh state");
     } catch (err) {
       console.error("[CrashRecovery] Failed to reset to fresh:", err);
@@ -301,9 +316,10 @@ export class CrashRecoveryService {
     if (!this.crashRecorded) {
       this.takeBackup();
       this.deleteMarker();
+      this.cleanupOrphanedCrashedBackups();
       console.log("[CrashRecovery] Clean exit — marker removed");
     }
-    this.cachedBackupSnapshot = null;
+    this.unlinkCrashedBackup();
   }
 
   private consumeMarker(): PendingCrash | null {
@@ -327,29 +343,32 @@ export class CrashRecoveryService {
 
       this.deleteMarker();
 
-      const backupInfo = this.readBackupInfo();
+      // Move the live backup aside before any other code path (notably
+      // startBackupTimer in this new session) can overwrite it. The renamed
+      // file becomes the durable source of truth for restoreBackup and
+      // extractPanelSummaries — no in-memory cache, no race.
+      this.crashedBackupPath = this.preserveBackupForRecovery(marker.sessionStartMs);
 
-      // Cache the backup snapshot early so buildCrashEntryFromMarker can
-      // read panel data, and restoreBackup() can use it even if
-      // startBackupTimer() overwrites the backup file before the user resolves.
-      if (backupInfo.exists) {
+      let backupTimestamp: number | undefined;
+      if (this.crashedBackupPath !== null) {
         try {
-          const raw = fs.readFileSync(this.backupPath, "utf8");
-          this.cachedBackupSnapshot = JSON.parse(raw) as SessionSnapshot;
+          backupTimestamp = fs.statSync(this.crashedBackupPath).mtimeMs;
         } catch {
-          // If read fails, restoreBackup will fall back to reading from disk
+          // best-effort: backup timestamp is informational only
         }
       }
 
       const logPath = marker.crashLogPath ?? null;
       const entry = logPath ? this.readCrashLog(logPath) : this.buildCrashEntryFromMarker(marker);
-      const panels = backupInfo.exists ? this.extractPanelSummaries(entry.timestamp) : undefined;
+      entry.crashCause = this.classifyCrashCause(marker);
+      const panels =
+        this.crashedBackupPath !== null ? this.extractPanelSummaries(entry.timestamp) : undefined;
 
       return {
         logPath: logPath ?? path.join(this.crashesDir, `crash-${entry.id}.json`),
         entry,
-        hasBackup: backupInfo.exists,
-        backupTimestamp: backupInfo.timestamp,
+        hasBackup: this.crashedBackupPath !== null,
+        backupTimestamp,
         panels,
       };
     } catch (err) {
@@ -359,21 +378,97 @@ export class CrashRecoveryService {
     }
   }
 
+  /**
+   * Renames `session-state.json` to a timestamped `session-state.crashed-*.json`
+   * so the new session's backup tick cannot clobber it.
+   *
+   * On Windows the rename can transiently fail under antivirus or search-indexer
+   * locks (EPERM/EBUSY/EACCES). `resilientRenameSync` retries for up to 500ms;
+   * if it still fails we fall back to a copy-then-unlink path so the pre-crash
+   * snapshot is never silently lost.
+   *
+   * Returns the path of the renamed (or copied) file, or null if no live
+   * backup existed.
+   */
+  private preserveBackupForRecovery(markerSessionStartMs: number): string | null {
+    if (!fs.existsSync(this.backupPath)) return null;
+
+    const crashedBackupPath = path.join(
+      this.userData,
+      BACKUP_DIR,
+      `${CRASHED_BACKUP_PREFIX}${markerSessionStartMs}.json`
+    );
+
+    try {
+      resilientRenameSync(this.backupPath, crashedBackupPath);
+      return crashedBackupPath;
+    } catch (renameErr) {
+      try {
+        const content = fs.readFileSync(this.backupPath, "utf-8");
+        resilientAtomicWriteFileSync(crashedBackupPath, content, "utf-8");
+        try {
+          fs.unlinkSync(this.backupPath);
+        } catch {
+          // The duplicate at crashedBackupPath is the durable copy. If the
+          // original still can't be unlinked, the next backup tick will
+          // overwrite it — we won't keep reading stale content.
+        }
+        return crashedBackupPath;
+      } catch (copyErr) {
+        console.error(
+          "[CrashRecovery] Failed to preserve crash backup via rename or copy:",
+          renameErr,
+          copyErr
+        );
+        return null;
+      }
+    }
+  }
+
+  /**
+   * Best-effort unlink of any leftover `session-state.crashed-*.json` files in
+   * the backup directory. Called on clean exit so a force-quit during a future
+   * pending-crash dialog can't leak crashed-backup files indefinitely (the
+   * orphan-cleanup pattern from #3762).
+   */
+  private cleanupOrphanedCrashedBackups(): void {
+    try {
+      const backupDir = path.join(this.userData, BACKUP_DIR);
+      if (!fs.existsSync(backupDir)) return;
+      const files = fs
+        .readdirSync(backupDir)
+        .filter((f) => f.startsWith(CRASHED_BACKUP_PREFIX) && f.endsWith(".json"));
+      for (const file of files) {
+        try {
+          fs.unlinkSync(path.join(backupDir, file));
+        } catch {
+          // best-effort
+        }
+      }
+    } catch {
+      // best-effort
+    }
+  }
+
+  private unlinkCrashedBackup(): void {
+    if (!this.crashedBackupPath) return;
+    try {
+      fs.unlinkSync(this.crashedBackupPath);
+    } catch {
+      // File may already be gone (multiple cleanup paths can race); ignore.
+    }
+    this.crashedBackupPath = null;
+  }
+
   private extractPanelSummaries(crashTimestamp: number): PanelSummary[] {
     try {
-      // Prefer the snapshot cached by consumeMarker — startBackupTimer can
-      // overwrite this.backupPath on disk between marker consumption and
-      // here, which would silently swap pre-crash panels for an empty
-      // post-crash session. Fall back to disk only when the cache failed
-      // to populate (read or parse error in consumeMarker's try block).
-      let snapshot: SessionSnapshot;
-      if (this.cachedBackupSnapshot) {
-        snapshot = this.cachedBackupSnapshot;
-      } else {
-        if (!fs.existsSync(this.backupPath)) return [];
-        const raw = fs.readFileSync(this.backupPath, "utf8");
-        snapshot = JSON.parse(raw) as SessionSnapshot;
-      }
+      // Reads the renamed crashed-* file populated by consumeMarker. The
+      // current session's backup tick can recreate session-state.json freely
+      // — it can't overwrite the renamed file, so panel summaries here and
+      // restoreBackup later see the same pre-crash snapshot.
+      if (!this.crashedBackupPath || !fs.existsSync(this.crashedBackupPath)) return [];
+      const raw = fs.readFileSync(this.crashedBackupPath, "utf8");
+      const snapshot = JSON.parse(raw) as SessionSnapshot;
       if (!snapshot.appState) return [];
 
       const appState = snapshot.appState as Record<string, unknown>;
@@ -406,6 +501,10 @@ export class CrashRecoveryService {
         appVersion: app.getVersion(),
         platform: process.platform,
         isPackaged: app.isPackaged,
+        // Initialize the heartbeat to sessionStartMs so a launch that crashes
+        // before the first backup tick can still be classified as such — an
+        // undefined heartbeat would suppress external-kill detection entirely.
+        lastHeartbeatMs: this.sessionStartMs,
         crashLogPath: crashEntry
           ? path.join(this.crashesDir, `crash-${crashEntry.id}.json`)
           : undefined,
@@ -414,6 +513,43 @@ export class CrashRecoveryService {
     } catch (err) {
       console.error("[CrashRecovery] Failed to write marker:", err);
     }
+  }
+
+  /**
+   * Read-modify-write the marker so existing fields (crashLogPath,
+   * lastSuspendStart) are preserved. The in-memory approach used previously
+   * for the backup snapshot caused the very race this service is rewriting
+   * to eliminate — we keep the marker as a single source of truth on disk.
+   */
+  private mutateMarker(mutate: (marker: MarkerFile) => void): void {
+    try {
+      if (!fs.existsSync(this.markerPath)) return;
+      const raw = fs.readFileSync(this.markerPath, "utf8");
+      const marker = JSON.parse(raw) as MarkerFile;
+      if (!isValidMarker(marker)) return;
+      mutate(marker);
+      resilientAtomicWriteFileSync(this.markerPath, JSON.stringify(marker), "utf-8");
+    } catch (err) {
+      console.warn("[CrashRecovery] Failed to mutate marker:", err);
+    }
+  }
+
+  private updateMarkerHeartbeat(): void {
+    this.mutateMarker((marker) => {
+      marker.lastHeartbeatMs = Date.now();
+    });
+  }
+
+  private stampSuspend(suspendStartMs: number): void {
+    this.mutateMarker((marker) => {
+      marker.lastSuspendStart = suspendStartMs;
+    });
+  }
+
+  private clearSuspend(): void {
+    this.mutateMarker((marker) => {
+      delete marker.lastSuspendStart;
+    });
   }
 
   private deleteMarker(): void {
@@ -465,10 +601,104 @@ export class CrashRecoveryService {
     };
 
     this.enrichWithEnvironmentMetadata(entry);
-    const backupAppState = this.cachedBackupSnapshot?.appState;
-    this.enrichWithPanelData(entry, backupAppState);
+    this.enrichWithPanelData(entry, this.readCrashedBackupAppState());
 
     return entry;
+  }
+
+  private readCrashedBackupAppState(): unknown {
+    if (!this.crashedBackupPath) return undefined;
+    try {
+      if (!fs.existsSync(this.crashedBackupPath)) return undefined;
+      const raw = fs.readFileSync(this.crashedBackupPath, "utf-8");
+      const snapshot = JSON.parse(raw) as SessionSnapshot;
+      return snapshot.appState;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Best-effort classification of why the previous session ended.
+   *
+   * Priority order matters: stronger signals override weaker ones. A
+   * crashLogPath (set by recordCrash on uncaughtException) is the strongest
+   * signal because it was written by our own code; we trust it. Crashpad
+   * minidumps come from the OS-level handler and prove a native fault.
+   * Suspend/heartbeat/uptime are heuristics that distinguish power loss
+   * from external kills.
+   */
+  private classifyCrashCause(marker: MarkerFile): CrashCause {
+    if (marker.crashLogPath) return "uncaught-exception";
+    if (this.hasRecentCrashpadDump(marker.sessionStartMs)) return "native-crash";
+    if (typeof marker.lastSuspendStart === "number") return "suspended-then-lost";
+    if (this.didSystemReboot(marker.sessionStartMs)) return "power-loss";
+    if (this.isHeartbeatStale(marker.lastHeartbeatMs)) return "external-kill";
+    return "unknown";
+  }
+
+  /**
+   * Scans Electron's Crashpad directories for `.dmp` files written after the
+   * previous session started. Crashpad writes minidumps synchronously before
+   * the process terminates, so a newer dump file is definitive evidence the
+   * crash was a native fault (segfault, OOM, GPU process crash, etc.) rather
+   * than a JS exception or external kill.
+   */
+  private hasRecentCrashpadDump(sessionStartMs: number): boolean {
+    let dumpsDir: string;
+    try {
+      dumpsDir = app.getPath("crashDumps");
+    } catch {
+      return false;
+    }
+    // Crashpad shards dumps across these three subdirectories depending on
+    // their lifecycle. A dump can appear in any of them at next launch.
+    const subdirs = ["new", "pending", "completed"];
+    for (const subdir of subdirs) {
+      const fullPath = path.join(dumpsDir, subdir);
+      try {
+        if (!fs.existsSync(fullPath)) continue;
+        const files = fs.readdirSync(fullPath);
+        for (const file of files) {
+          if (!file.endsWith(".dmp")) continue;
+          try {
+            const stat = fs.statSync(path.join(fullPath, file));
+            if (stat.mtimeMs > sessionStartMs) return true;
+          } catch {
+            // best-effort
+          }
+        }
+      } catch {
+        // best-effort
+      }
+    }
+    return false;
+  }
+
+  /**
+   * True only when `os.uptime()` is shorter than the wall-clock time since
+   * the previous session started — a definitive reboot signal. Reliable
+   * positively only: sleep pauses uptime on macOS/Linux and Windows Fast
+   * Startup hibernation does not reset it, so the absence of this signal
+   * does NOT prove the system did not reboot.
+   */
+  private didSystemReboot(sessionStartMs: number, nowMs: number = Date.now()): boolean {
+    try {
+      const uptimeMs = os.uptime() * 1000;
+      const elapsedMs = nowMs - sessionStartMs;
+      if (elapsedMs <= 0) return false;
+      return uptimeMs < elapsedMs;
+    } catch {
+      return false;
+    }
+  }
+
+  private isHeartbeatStale(
+    lastHeartbeatMs: number | undefined,
+    nowMs: number = Date.now()
+  ): boolean {
+    if (typeof lastHeartbeatMs !== "number") return false;
+    return nowMs - lastHeartbeatMs > HEARTBEAT_STALE_THRESHOLD_MS;
   }
 
   private enrichWithRecentActions(entry: CrashLogEntry): void {
@@ -622,6 +852,19 @@ interface MarkerFile {
   platform: string;
   crashLogPath?: string;
   isPackaged?: boolean;
+  /**
+   * Wall-clock timestamp of the most recent backup-tick liveness write.
+   * Refreshed every BACKUP_INTERVAL_MS while the app is running. Compared
+   * at next launch against the staleness threshold to detect external
+   * kills (heartbeat older than threshold AND system did not reboot).
+   */
+  lastHeartbeatMs?: number;
+  /**
+   * Set on powerMonitor "suspend", cleared on "resume". A non-null value
+   * at next launch means the system slept and never made it through the
+   * resume callback — usually a power loss during sleep.
+   */
+  lastSuspendStart?: number;
 }
 
 interface SessionSnapshot {

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -260,10 +260,17 @@ export class CrashRecoveryService {
         // the crashed-* file gives the full pre-crash terminal list again.
         const appState = { ...(snapshot.appState as Record<string, unknown>) };
         if (Array.isArray(appState.terminals)) {
+          const originalTerminals = appState.terminals as Array<{ id: string }>;
           const idSet = new Set(panelIds);
-          appState.terminals = (appState.terminals as Array<{ id: string }>).filter((t) =>
-            idSet.has(t.id)
-          );
+          const filtered = originalTerminals.filter((t) => idSet.has(t.id));
+          // Stale or typo'd panel IDs would otherwise empty the filter and
+          // succeed-then-unlink the crashed-* file, dropping the recovery
+          // source the user might still want. Return false so they can
+          // retry with the correct IDs or no filter at all.
+          if (filtered.length === 0 && originalTerminals.length > 0) {
+            return false;
+          }
+          appState.terminals = filtered;
         }
         snapshot = { ...snapshot, appState };
       }
@@ -341,13 +348,15 @@ export class CrashRecoveryService {
         return null;
       }
 
-      this.deleteMarker();
-
-      // Move the live backup aside before any other code path (notably
-      // startBackupTimer in this new session) can overwrite it. The renamed
-      // file becomes the durable source of truth for restoreBackup and
-      // extractPanelSummaries — no in-memory cache, no race.
+      // Move the live backup aside BEFORE deleting the marker. A kill
+      // between the two operations would otherwise wipe the marker (and
+      // skip crash detection on the next launch) while session-state.json
+      // is still present and recoverable. preserveBackupForRecovery is
+      // idempotent — if a crashed-{sessionStartMs}.json already exists
+      // from a partially-completed prior attempt it is reused.
       this.crashedBackupPath = this.preserveBackupForRecovery(marker.sessionStartMs);
+
+      this.deleteMarker();
 
       let backupTimestamp: number | undefined;
       if (this.crashedBackupPath !== null) {
@@ -391,13 +400,18 @@ export class CrashRecoveryService {
    * backup existed.
    */
   private preserveBackupForRecovery(markerSessionStartMs: number): string | null {
-    if (!fs.existsSync(this.backupPath)) return null;
-
     const crashedBackupPath = path.join(
       this.userData,
       BACKUP_DIR,
       `${CRASHED_BACKUP_PREFIX}${markerSessionStartMs}.json`
     );
+
+    // Idempotency: if a prior consumeMarker run completed the rename but
+    // was killed before deleteMarker, the destination is already on disk
+    // and the live backup is gone. Reuse the existing crashed-* file.
+    if (fs.existsSync(crashedBackupPath)) return crashedBackupPath;
+
+    if (!fs.existsSync(this.backupPath)) return null;
 
     try {
       resilientRenameSync(this.backupPath, crashedBackupPath);
@@ -475,20 +489,29 @@ export class CrashRecoveryService {
       const terminals = appState.terminals;
       if (!Array.isArray(terminals)) return [];
 
-      return terminals.map((t: Record<string, unknown>) => ({
-        id: String(t.id ?? ""),
-        kind: String(t.kind ?? "terminal"),
-        title: String(t.title ?? ""),
-        cwd: t.cwd ? String(t.cwd) : undefined,
-        worktreeId: t.worktreeId ? String(t.worktreeId) : undefined,
-        location: (t.location === "dock" ? "dock" : "grid") as "grid" | "dock",
-        isSuspect:
-          typeof t.createdAt === "number"
-            ? Math.abs(crashTimestamp - t.createdAt) < SUSPECT_WINDOW_MS
-            : false,
-        agentState: coerceAgentState(t.agentState),
-        lastStateChange: typeof t.lastStateChange === "number" ? t.lastStateChange : undefined,
-      }));
+      // Per-item guard so one malformed entry (null, primitive, missing
+      // fields) cannot drop the entire panel list. Returning fewer
+      // summaries is acceptable; returning none when some were valid is not.
+      const summaries: PanelSummary[] = [];
+      for (const entry of terminals) {
+        if (typeof entry !== "object" || entry === null) continue;
+        const t = entry as Record<string, unknown>;
+        summaries.push({
+          id: String(t.id ?? ""),
+          kind: String(t.kind ?? "terminal"),
+          title: String(t.title ?? ""),
+          cwd: t.cwd ? String(t.cwd) : undefined,
+          worktreeId: t.worktreeId ? String(t.worktreeId) : undefined,
+          location: (t.location === "dock" ? "dock" : "grid") as "grid" | "dock",
+          isSuspect:
+            typeof t.createdAt === "number"
+              ? Math.abs(crashTimestamp - t.createdAt) < SUSPECT_WINDOW_MS
+              : false,
+          agentState: coerceAgentState(t.agentState),
+          lastStateChange: typeof t.lastStateChange === "number" ? t.lastStateChange : undefined,
+        });
+      }
+      return summaries;
     } catch {
       return [];
     }

--- a/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
@@ -28,6 +28,7 @@ const browserWindowMock = vi.hoisted(() => ({
 
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
+  resilientRenameSync: vi.fn(),
 }));
 
 vi.mock("../../utils/fs.js", () => utilsMock);
@@ -95,6 +96,9 @@ describe("CrashRecoveryService adversarial", () => {
         fs.writeFileSync(fp, data, enc ?? "utf-8");
       }
     );
+    utilsMock.resilientRenameSync.mockImplementation((src: string, dest: string) => {
+      fs.renameSync(src, dest);
+    });
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -132,7 +136,11 @@ describe("CrashRecoveryService adversarial", () => {
     expect(storeMock.set).not.toHaveBeenCalled();
   });
 
-  it("CACHED_PRE_CRASH_SNAPSHOT_WINS", () => {
+  it("RENAMED_BACKUP_SURVIVES_TIMER_OVERWRITE", () => {
+    // Issue #8681: consumeMarker renames the live backup to a timestamped
+    // crashed-* path so the new session's backup tick can write a fresh
+    // session-state.json without clobbering the pre-crash snapshot. The
+    // renamed file is the durable cache — no in-memory state to drift.
     writeBackup(tmpDir, {
       capturedAt: Date.now(),
       appState: {
@@ -147,6 +155,8 @@ describe("CrashRecoveryService adversarial", () => {
     const service = makeService();
     service.initialize();
 
+    // Simulate the backup timer recreating session-state.json with the empty
+    // current session after the marker has been consumed.
     writeBackup(tmpDir, {
       capturedAt: Date.now(),
       appState: {
@@ -163,13 +173,11 @@ describe("CrashRecoveryService adversarial", () => {
     });
   });
 
-  it("PANEL_SUMMARIES_USE_CACHED_SNAPSHOT", () => {
-    // Bug #7113: extractPanelSummaries used to re-read backupPath from disk
-    // even though consumeMarker had already populated cachedBackupSnapshot
-    // for exactly this purpose. If anything overwrote the file between those
-    // reads (concurrent backup, external process, racy test fixtures), the
-    // pending crash's panel summaries diverged from the snapshot restoreBackup
-    // would later use. Both paths must see the same cached snapshot.
+  it("PANEL_SUMMARIES_READ_RENAMED_FILE_NOT_LIVE_PATH", () => {
+    // Issue #8681: extractPanelSummaries must read from the renamed
+    // crashed-* file, not from session-state.json — otherwise a concurrent
+    // overwrite (backup tick, external process) would silently swap
+    // pre-crash panels for the empty post-crash session.
     writeBackup(tmpDir, {
       capturedAt: Date.now(),
       appState: {
@@ -178,41 +186,50 @@ describe("CrashRecoveryService adversarial", () => {
     });
     writeMarker(tmpDir);
 
-    const realRead = fs.readFileSync.bind(fs);
-    let backupReadCount = 0;
-    const readSpy = vi.spyOn(fs, "readFileSync").mockImplementation(((
-      target: fs.PathOrFileDescriptor,
-      options?: unknown
-    ) => {
-      if (typeof target === "string" && target.endsWith("session-state.json")) {
-        backupReadCount++;
-        if (backupReadCount > 1) {
-          // Any *re-read* of the backup must come back with overwritten
-          // content. If production code re-reads the file here, the
-          // panels assertion below will see empty terminals.
-          return JSON.stringify({
-            capturedAt: Date.now(),
-            appState: { terminals: [] },
-          });
-        }
-      }
-      return (realRead as (...a: unknown[]) => string | Buffer)(target, options);
-    }) as typeof fs.readFileSync);
-
     const service = makeService();
     service.initialize();
 
-    expect(backupReadCount).toBe(1);
+    // Overwrite the live path right after consumeMarker. Panel summaries
+    // were captured during initialize and stored on PendingCrash; they
+    // must still reflect the pre-crash terminals.
+    writeBackup(tmpDir, {
+      capturedAt: Date.now(),
+      appState: { terminals: [] },
+    });
+
     const pending = service.getPendingCrash();
     expect(pending).not.toBeNull();
     expect(pending!.panels).toBeDefined();
     expect(pending!.panels!.length).toBe(1);
-    expect(pending!.panels![0]).toMatchObject({
-      id: "agent-1",
-      title: "Pre-Crash",
+    expect(pending!.panels![0]).toMatchObject({ id: "agent-1", title: "Pre-Crash" });
+  });
+
+  it("RENAME_FAILURE_FALLS_BACK_TO_COPY_PLUS_UNLINK", () => {
+    // Windows antivirus and search indexers can hold session-state.json
+    // open long enough that resilientRenameSync exhausts its 500ms retry
+    // budget. The fallback copies content to the crashed-* path and
+    // unlinks the original so the pre-crash snapshot is never lost.
+    writeBackup(tmpDir, {
+      capturedAt: Date.now(),
+      appState: {
+        terminals: [{ id: "agent-1", kind: "terminal", title: "Lock-Bypass" }],
+      },
+    });
+    writeMarker(tmpDir);
+
+    utilsMock.resilientRenameSync.mockImplementationOnce(() => {
+      const err = new Error("EBUSY: resource busy or locked") as NodeJS.ErrnoException;
+      err.code = "EBUSY";
+      throw err;
     });
 
-    readSpy.mockRestore();
+    const service = makeService();
+    service.initialize();
+
+    expect(service.restoreBackup()).toBe(true);
+    expect(storeMock.set).toHaveBeenCalledWith("appState", {
+      terminals: [{ id: "agent-1", kind: "terminal", title: "Lock-Bypass" }],
+    });
   });
 
   it("FILTERED_RESTORE_DOES_NOT_NARROW_CACHE_ON_FAILURE", () => {

--- a/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
@@ -204,6 +204,108 @@ describe("CrashRecoveryService adversarial", () => {
     expect(pending!.panels![0]).toMatchObject({ id: "agent-1", title: "Pre-Crash" });
   });
 
+  it("PRESERVE_BEFORE_DELETE_MARKER_AVOIDS_LOST_CRASH_DETECTION", () => {
+    // Issue #8681 review finding: if deleteMarker fires before the backup
+    // is preserved, a kill between the two leaves no marker on disk and
+    // the next launch silently skips crash detection. Order must be:
+    // preserve first, then delete. Simulate the kill-after-preserve case
+    // by leaving the crashed-* file from a "prior attempt" on disk; the
+    // second consumeMarker pass must reuse it idempotently.
+    const sessionStartMs = Date.now() - 5_000;
+    fs.writeFileSync(
+      path.join(tmpDir, "running.lock"),
+      JSON.stringify({
+        sessionStartMs,
+        appVersion: "1.0.0",
+        platform: "darwin",
+      })
+    );
+
+    // Pre-existing crashed-* file from a previous (killed) consumeMarker
+    // attempt. session-state.json is absent — already renamed last time.
+    const backupDir = path.join(tmpDir, "backups");
+    fs.mkdirSync(backupDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(backupDir, `session-state.crashed-${sessionStartMs}.json`),
+      JSON.stringify({
+        capturedAt: Date.now(),
+        appState: { terminals: [{ id: "agent-1", kind: "terminal", title: "Survived" }] },
+      })
+    );
+
+    const service = makeService();
+    service.initialize();
+
+    const pending = service.getPendingCrash();
+    expect(pending).not.toBeNull();
+    expect(pending!.hasBackup).toBe(true);
+    expect(pending!.panels!.length).toBe(1);
+    expect(pending!.panels![0]).toMatchObject({ id: "agent-1", title: "Survived" });
+    expect(service.restoreBackup()).toBe(true);
+    expect(storeMock.set).toHaveBeenCalledWith("appState", {
+      terminals: [{ id: "agent-1", kind: "terminal", title: "Survived" }],
+    });
+  });
+
+  it("FILTER_WITH_NO_MATCHES_KEEPS_RECOVERY_SOURCE_FOR_RETRY", () => {
+    // Stale or typo'd panel IDs would otherwise empty the filter, succeed
+    // restoreBackup, and unlink the crashed-* file — silently dropping
+    // the recovery source. Return false instead so a follow-up restore
+    // (without the bad filter) still finds the snapshot.
+    writeBackup(tmpDir, {
+      capturedAt: Date.now(),
+      appState: {
+        terminals: [
+          { id: "a", kind: "terminal", title: "Alpha" },
+          { id: "b", kind: "terminal", title: "Bravo" },
+        ],
+      },
+    });
+    writeMarker(tmpDir);
+
+    const service = makeService();
+    service.initialize();
+
+    expect(service.restoreBackup(["nonexistent"])).toBe(false);
+    expect(storeMock.set).not.toHaveBeenCalled();
+
+    // Retry with no filter — must still see both panels.
+    expect(service.restoreBackup()).toBe(true);
+    expect(storeMock.set).toHaveBeenCalledWith("appState", {
+      terminals: [
+        { id: "a", kind: "terminal", title: "Alpha" },
+        { id: "b", kind: "terminal", title: "Bravo" },
+      ],
+    });
+  });
+
+  it("NULL_TERMINAL_IN_BACKUP_DOES_NOT_DROP_VALID_PANELS", () => {
+    // Issue #8681 review finding: one malformed terminal entry must not
+    // drop all panel summaries. Per-item guard yields the valid subset.
+    writeBackup(tmpDir, {
+      capturedAt: Date.now(),
+      appState: {
+        terminals: [
+          { id: "t1", kind: "terminal", title: "Alpha" },
+          null,
+          "garbage",
+          { id: "t2", kind: "terminal", title: "Bravo" },
+        ],
+      },
+    });
+    writeMarker(tmpDir);
+
+    const service = makeService();
+    service.initialize();
+
+    const pending = service.getPendingCrash();
+    expect(pending).not.toBeNull();
+    expect(pending!.panels).toBeDefined();
+    expect(pending!.panels!.length).toBe(2);
+    expect(pending!.panels![0]).toMatchObject({ id: "t1", title: "Alpha" });
+    expect(pending!.panels![1]).toMatchObject({ id: "t2", title: "Bravo" });
+  });
+
   it("RENAME_FAILURE_FALLS_BACK_TO_COPY_PLUS_UNLINK", () => {
     // Windows antivirus and search indexers can hold session-state.json
     // open long enough that resilientRenameSync exhausts its 500ms retry

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -31,6 +31,7 @@ const appMock = vi.hoisted(() => {
 
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFileSync: vi.fn(),
+  resilientRenameSync: vi.fn(),
 }));
 
 vi.mock("../../utils/fs.js", () => utilsMock);
@@ -93,6 +94,9 @@ describe("CrashRecoveryService", () => {
         fs.writeFileSync(fp, data, enc ?? "utf-8");
       }
     );
+    utilsMock.resilientRenameSync.mockImplementation((src: string, dest: string) => {
+      fs.renameSync(src, dest);
+    });
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -931,7 +935,7 @@ describe("CrashRecoveryService", () => {
       expect(storeMock.set.mock.calls[0][0]).toBe("appState");
     });
 
-    it("clears cached backup snapshot so restoreBackup has no stale reference", () => {
+    it("removes the renamed crashed-backup file so restoreBackup has no source", () => {
       const markerPath = path.join(userData, "running.lock");
       fs.writeFileSync(
         markerPath,
@@ -955,13 +959,18 @@ describe("CrashRecoveryService", () => {
       const svc = makeService();
       svc.initialize();
 
-      // Delete backup file so restoreBackup can only succeed via cache
-      fs.unlinkSync(path.join(backupDir, "session-state.json"));
-
+      // After initialize the live backup has been renamed to
+      // session-state.crashed-*.json. resetToFresh must unlink it so the
+      // user can't restore stale state by accident after explicitly
+      // choosing a fresh start.
       storeMock.set.mockClear();
       svc.resetToFresh();
 
       expect(svc.restoreBackup()).toBe(false);
+      const remaining = fs
+        .readdirSync(backupDir)
+        .filter((f) => f.startsWith("session-state.crashed-"));
+      expect(remaining).toEqual([]);
     });
   });
 
@@ -992,7 +1001,7 @@ describe("CrashRecoveryService", () => {
       expect(fs.existsSync(markerPath)).toBe(true);
     });
 
-    it("clears cached backup snapshot even when crashRecorded prevents backup/marker cleanup", () => {
+    it("unlinks crashed-backup file on cleanupOnExit even when crashRecorded skips marker cleanup", () => {
       const markerPath = path.join(userData, "running.lock");
       fs.writeFileSync(
         markerPath,
@@ -1016,14 +1025,12 @@ describe("CrashRecoveryService", () => {
       const svc = makeService();
       svc.initialize();
 
-      // Record crash so cleanupOnExit skips takeBackup/deleteMarker
       svc.recordCrash(new Error("test crash"));
-
-      // Delete backup file so restoreBackup can only succeed via cache
-      fs.unlinkSync(path.join(backupDir, "session-state.json"));
-
       svc.cleanupOnExit();
 
+      // The crashed-* file is unlinked regardless of crashRecorded so a
+      // re-run during the dying process doesn't restore stale state. The
+      // crashed-* file is owned by this service instance only.
       expect(svc.restoreBackup()).toBe(false);
     });
   });
@@ -1074,6 +1081,241 @@ describe("CrashRecoveryService", () => {
         expect.any(String),
         "utf-8"
       );
+    });
+
+    it("routes consumeMarker backup rename through resilientRenameSync", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(backupDir, "session-state.json"),
+        JSON.stringify({ capturedAt: Date.now(), appState: { terminals: [] } })
+      );
+      const markerSessionStart = Date.now() - 5000;
+      fs.writeFileSync(
+        path.join(userData, "running.lock"),
+        JSON.stringify({
+          sessionStartMs: markerSessionStart,
+          appVersion: "1.0.0",
+          platform: "darwin",
+        })
+      );
+
+      const svc = makeService();
+      svc.initialize();
+
+      const expectedDest = path.join(backupDir, `session-state.crashed-${markerSessionStart}.json`);
+      expect(utilsMock.resilientRenameSync).toHaveBeenCalledWith(
+        path.join(backupDir, "session-state.json"),
+        expectedDest
+      );
+      expect(fs.existsSync(expectedDest)).toBe(true);
+      expect(fs.existsSync(path.join(backupDir, "session-state.json"))).toBe(false);
+    });
+  });
+
+  describe("crash cause classification", () => {
+    function osUptimeSpy(returnValue: number): ReturnType<typeof vi.spyOn> {
+      return vi.spyOn(os, "uptime").mockReturnValue(returnValue);
+    }
+
+    it("returns 'uncaught-exception' when marker has crashLogPath", () => {
+      const crashDir = path.join(userData, "crashes");
+      fs.mkdirSync(crashDir, { recursive: true });
+      const crashLogPath = path.join(crashDir, "crash-abc.json");
+      fs.writeFileSync(
+        crashLogPath,
+        JSON.stringify({
+          id: "abc",
+          timestamp: Date.now(),
+          appVersion: "1.0.0",
+          platform: "darwin",
+          osVersion: "22.0",
+          arch: "x64",
+        })
+      );
+
+      fs.writeFileSync(
+        path.join(userData, "running.lock"),
+        JSON.stringify({
+          sessionStartMs: Date.now() - 5_000,
+          appVersion: "1.0.0",
+          platform: "darwin",
+          crashLogPath,
+        })
+      );
+
+      const svc = makeService();
+      svc.initialize();
+
+      expect(svc.getPendingCrash()!.entry.crashCause).toBe("uncaught-exception");
+    });
+
+    it("returns 'suspended-then-lost' when marker has lastSuspendStart", () => {
+      const uptime = osUptimeSpy(10_000);
+      try {
+        fs.writeFileSync(
+          path.join(userData, "running.lock"),
+          JSON.stringify({
+            sessionStartMs: Date.now() - 5_000,
+            appVersion: "1.0.0",
+            platform: "darwin",
+            lastSuspendStart: Date.now() - 4_000,
+            lastHeartbeatMs: Date.now() - 4_500,
+          })
+        );
+
+        const svc = makeService();
+        svc.initialize();
+
+        expect(svc.getPendingCrash()!.entry.crashCause).toBe("suspended-then-lost");
+      } finally {
+        uptime.mockRestore();
+      }
+    });
+
+    it("returns 'power-loss' when os.uptime is shorter than elapsed wall time", () => {
+      // sessionStart = 5min ago, but uptime is only 10 seconds — definitive reboot
+      const uptime = osUptimeSpy(10);
+      try {
+        fs.writeFileSync(
+          path.join(userData, "running.lock"),
+          JSON.stringify({
+            sessionStartMs: Date.now() - 5 * 60 * 1000,
+            appVersion: "1.0.0",
+            platform: "darwin",
+            lastHeartbeatMs: Date.now() - 60_000,
+          })
+        );
+
+        const svc = makeService();
+        svc.initialize();
+
+        expect(svc.getPendingCrash()!.entry.crashCause).toBe("power-loss");
+      } finally {
+        uptime.mockRestore();
+      }
+    });
+
+    it("returns 'external-kill' when heartbeat stale but system did not reboot", () => {
+      // uptime far exceeds elapsed wall time → no reboot. Heartbeat is 5min
+      // stale → external kill (SIGKILL, OOM killer, force-quit).
+      const uptime = osUptimeSpy(24 * 60 * 60);
+      try {
+        fs.writeFileSync(
+          path.join(userData, "running.lock"),
+          JSON.stringify({
+            sessionStartMs: Date.now() - 10 * 60 * 1000,
+            appVersion: "1.0.0",
+            platform: "darwin",
+            lastHeartbeatMs: Date.now() - 5 * 60 * 1000,
+          })
+        );
+
+        const svc = makeService();
+        svc.initialize();
+
+        expect(svc.getPendingCrash()!.entry.crashCause).toBe("external-kill");
+      } finally {
+        uptime.mockRestore();
+      }
+    });
+
+    it("returns 'unknown' when no attribution signal fires", () => {
+      const uptime = osUptimeSpy(24 * 60 * 60);
+      try {
+        const now = Date.now();
+        fs.writeFileSync(
+          path.join(userData, "running.lock"),
+          JSON.stringify({
+            sessionStartMs: now - 10_000,
+            appVersion: "1.0.0",
+            platform: "darwin",
+            // Fresh heartbeat → not stale. No suspend stamp. uptime >> elapsed.
+            lastHeartbeatMs: now - 5_000,
+          })
+        );
+
+        const svc = makeService();
+        svc.initialize();
+
+        expect(svc.getPendingCrash()!.entry.crashCause).toBe("unknown");
+      } finally {
+        uptime.mockRestore();
+      }
+    });
+
+    it("returns 'native-crash' when a Crashpad .dmp newer than sessionStart exists", () => {
+      const dumpsDir = path.join(userData, "crashpad-dumps");
+      const completedDir = path.join(dumpsDir, "completed");
+      fs.mkdirSync(completedDir, { recursive: true });
+      const dumpPath = path.join(completedDir, "abc-xyz.dmp");
+      fs.writeFileSync(dumpPath, "fake-minidump");
+      const sessionStartMs = Date.now() - 60_000;
+      // Backdate the dump's mtime so it's between sessionStart and now.
+      const dumpMtime = new Date(sessionStartMs + 5_000);
+      fs.utimesSync(dumpPath, dumpMtime, dumpMtime);
+
+      const getPathMock = appMock.getPath as ReturnType<typeof vi.fn>;
+      getPathMock.mockImplementation((key: string) => {
+        if (key === "crashDumps") return dumpsDir;
+        return userData;
+      });
+
+      try {
+        fs.writeFileSync(
+          path.join(userData, "running.lock"),
+          JSON.stringify({
+            sessionStartMs,
+            appVersion: "1.0.0",
+            platform: "darwin",
+            lastHeartbeatMs: Date.now() - 30_000,
+          })
+        );
+
+        const svc = makeService();
+        svc.initialize();
+
+        expect(svc.getPendingCrash()!.entry.crashCause).toBe("native-crash");
+      } finally {
+        getPathMock.mockReturnValue(userData);
+      }
+    });
+  });
+
+  describe("heartbeat and suspend stamping", () => {
+    it("writes lastHeartbeatMs on initialize", () => {
+      const before = Date.now();
+      const svc = makeService();
+      svc.initialize();
+      const after = Date.now();
+
+      const marker = JSON.parse(fs.readFileSync(path.join(userData, "running.lock"), "utf8"));
+      expect(typeof marker.lastHeartbeatMs).toBe("number");
+      expect(marker.lastHeartbeatMs).toBeGreaterThanOrEqual(before);
+      expect(marker.lastHeartbeatMs).toBeLessThanOrEqual(after);
+    });
+
+    it("refreshes lastHeartbeatMs on each backup-timer tick", () => {
+      vi.useFakeTimers();
+      try {
+        const svc = makeService();
+        svc.initialize();
+        svc.startBackupTimer();
+
+        const firstMarker = JSON.parse(
+          fs.readFileSync(path.join(userData, "running.lock"), "utf8")
+        );
+        const firstHeartbeat = firstMarker.lastHeartbeatMs;
+
+        vi.advanceTimersByTime(60_000);
+
+        const secondMarker = JSON.parse(
+          fs.readFileSync(path.join(userData, "running.lock"), "utf8")
+        );
+        expect(secondMarker.lastHeartbeatMs).toBeGreaterThan(firstHeartbeat);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/shared/types/ipc/crashRecovery.ts
+++ b/shared/types/ipc/crashRecovery.ts
@@ -16,6 +16,29 @@ export interface ActionBreadcrumb {
   confirmed?: boolean;
 }
 
+/**
+ * Best-effort attribution of why the previous session ended.
+ *
+ * - "uncaught-exception": JS uncaughtException fired and recordCrash wrote a crash log.
+ * - "native-crash": Crashpad minidump newer than sessionStartMs was found in the dumps dir.
+ * - "suspended-then-lost": Marker showed an in-flight suspend stamp at next launch.
+ * - "power-loss": os.uptime() at next launch is shorter than wall-clock time since
+ *   sessionStartMs, meaning the system rebooted. Reliable in the positive direction
+ *   only — sleep pauses uptime, so the absence of this signal does not prove a reboot
+ *   did not happen.
+ * - "external-kill": Marker heartbeat is older than the staleness threshold while
+ *   os.uptime() shows no reboot, indicating the process was killed without a chance
+ *   to clean up (SIGKILL, OOM killer, force-quit).
+ * - "unknown": None of the signals above fired.
+ */
+export type CrashCause =
+  | "uncaught-exception"
+  | "native-crash"
+  | "suspended-then-lost"
+  | "power-loss"
+  | "external-kill"
+  | "unknown";
+
 export interface CrashLogEntry {
   id: string;
   timestamp: number;
@@ -43,6 +66,7 @@ export interface CrashLogEntry {
   gpuAccelerationDisabled?: boolean;
   processUptime?: number;
   recentActions?: ActionBreadcrumb[];
+  crashCause?: CrashCause;
 }
 
 export interface PanelSummary {


### PR DESCRIPTION
## Summary

- Replaces the snapshot-based marker approach with an idempotent `rename-to-crashed-*` pattern, eliminating the race where a marker could be consumed before backup. Falls back to copy-then-unlink on `EBUSY`/`EPERM`.
- Adds `lastHeartbeatMs` (refreshed every 60s) and `lastSuspendStart` (stamped on `powerMonitor` suspend, cleared on resume) to the marker file, enabling accurate crash cause attribution via a new `CrashCause` union (`uncaught-exception` | `native-crash` | `suspended-then-lost` | `power-loss` | `external-kill` | `unknown`).
- Fixes the ordering bug where `deleteMarker` ran before the backup was preserved, which could silently drop crash detection on a kill between the two operations.

Resolves #8681

## Changes

- `CrashRecoveryService.ts`: `consumeMarker` now renames to a timestamped `crashed-*` file (idempotent, EBUSY/EPERM fallback). Adds `classifyCrashCause`, `hasRecentCrashpadDump` (scans Crashpad `new/pending/completed` for `.dmp` files), `didSystemReboot` (`os.uptime < elapsed`), and `isHeartbeatStale` (>120s). Reorders preserve-before-delete.
- `shared/types/ipc/crashRecovery.ts`: adds `CrashCause` union type and `CrashLogEntry.crashCause`.
- `CrashRecoveryService.test.ts` / `CrashRecoveryService.adversarial.test.ts`: adds `resilientRenameSync` mock, updates obsolete tests, adds 9 new tests covering cause classification (6), heartbeat staleness (2), and rename routing (1).

## Testing

80 tests passing (up from 71). Covers the rename-vs-fallback routing, preserve-before-delete ordering, each `CrashCause` classification branch, heartbeat staleness threshold, `null`-terminal guard, and filter-with-no-matches degenerate case.