### PR TITLE
fix(grid): enforce min terminal width and surface overflow as status cards

### DIFF
--- a/src/components/Terminal/ContentGridDefault.tsx
+++ b/src/components/Terminal/ContentGridDefault.tsx
@@ -2,11 +2,12 @@ import React from "react";
 import { SortableContext, rectSortingStrategy } from "@dnd-kit/sortable";
 import { LayoutGroup } from "framer-motion";
 import { cn } from "@/lib/utils";
-import { MIN_TERMINAL_HEIGHT_PX } from "@/lib/terminalLayout";
+import { MIN_TERMINAL_HEIGHT_PX, MIN_TERMINAL_WIDTH_PX } from "@/lib/terminalLayout";
 import { GridNotificationBar } from "./GridNotificationBar";
 import { GridPanel } from "./GridPanel";
 import { GridTabGroup } from "./GridTabGroup";
 import { GridFullOverlay } from "./GridFullOverlay";
+import { OverflowStatusStrip } from "./OverflowStatusStrip";
 import {
   SortableTerminal,
   GRID_PLACEHOLDER_ID,
@@ -58,7 +59,7 @@ export function ContentGridDefault({
               )}
               style={{
                 display: "grid",
-                gridTemplateColumns: `repeat(${ctx.gridCols}, minmax(0, 1fr))`,
+                gridTemplateColumns: `repeat(${ctx.gridCols}, minmax(min(100%, ${MIN_TERMINAL_WIDTH_PX}px), 1fr))`,
                 gridAutoRows: `minmax(${MIN_TERMINAL_HEIGHT_PX}px, 1fr)`,
                 gap: "4px",
                 backgroundColor: "var(--color-grid-bg)",
@@ -89,7 +90,7 @@ export function ContentGridDefault({
                 </div>
               ) : (
                 <LayoutGroup id="main-grid">
-                  {ctx.tabGroups.map((group, index) => {
+                  {ctx.visibleTabGroups.map((group, index) => {
                     const groupPanels = ctx.getTabGroupPanels(group.id, "grid");
                     if (groupPanels.length === 0) return null;
 
@@ -152,7 +153,7 @@ export function ContentGridDefault({
                   })}
                   {ctx.showPlaceholder &&
                     ctx.placeholderInGrid &&
-                    ctx.placeholderIndex === ctx.tabGroups.length && (
+                    ctx.placeholderIndex === ctx.visibleTabGroups.length && (
                       <SortableGridPlaceholder key={GRID_PLACEHOLDER_ID} />
                     )}
                 </LayoutGroup>
@@ -163,6 +164,7 @@ export function ContentGridDefault({
 
         <GridFullOverlay maxTerminals={ctx.maxGridCapacity} show={ctx.showGridFullOverlay} />
       </div>
+      <OverflowStatusStrip groups={ctx.overflowTabGroups} />
     </div>
   );
 }

--- a/src/components/Terminal/ContentGridFleetScope.tsx
+++ b/src/components/Terminal/ContentGridFleetScope.tsx
@@ -1,6 +1,6 @@
 import { AnimatePresence, LayoutGroup, m } from "framer-motion";
 import { cn } from "@/lib/utils";
-import { MIN_TERMINAL_HEIGHT_PX } from "@/lib/terminalLayout";
+import { MIN_TERMINAL_HEIGHT_PX, MIN_TERMINAL_WIDTH_PX } from "@/lib/terminalLayout";
 import { GridNotificationBar } from "./GridNotificationBar";
 import { GridPanel } from "./GridPanel";
 import { GridShell } from "./GridShell";
@@ -43,7 +43,7 @@ export function ContentGridFleetScope({
           className="h-full bg-noise p-1"
           style={{
             display: "grid",
-            gridTemplateColumns: `repeat(${ctx.fleetGridCols}, minmax(0, 1fr))`,
+            gridTemplateColumns: `repeat(${ctx.fleetGridCols}, minmax(min(100%, ${MIN_TERMINAL_WIDTH_PX}px), 1fr))`,
             gridAutoRows: `minmax(${MIN_TERMINAL_HEIGHT_PX}px, 1fr)`,
             gap: "4px",
             backgroundColor: "var(--color-grid-bg)",

--- a/src/components/Terminal/OverflowStatusStrip.tsx
+++ b/src/components/Terminal/OverflowStatusStrip.tsx
@@ -49,6 +49,13 @@ export function OverflowStatusStrip({ groups, className }: OverflowStatusStripPr
     return ids;
   }, [groups]);
 
+  // Drop groups whose panels have all been removed from the store mid-render —
+  // otherwise the count header advertises agents that aren't actually painted.
+  const renderableGroups = useMemo(() => {
+    const byId = panelStoreApi.getState().panelsById;
+    return groups.filter((g) => g.panelIds.some((id) => byId[id]));
+  }, [groups]);
+
   useEffect(() => {
     for (const id of overflowPanelIds) {
       try {
@@ -69,7 +76,7 @@ export function OverflowStatusStrip({ groups, className }: OverflowStatusStripPr
     };
   }, [overflowPanelIds]);
 
-  if (groups.length === 0) return null;
+  if (renderableGroups.length === 0) return null;
 
   return (
     <div
@@ -82,12 +89,18 @@ export function OverflowStatusStrip({ groups, className }: OverflowStatusStripPr
     >
       <div className="flex items-center justify-between mb-1 px-0.5">
         <span className="text-[11px] uppercase tracking-wide text-daintree-text/50">
-          {groups.length} more {groups.length === 1 ? "agent" : "agents"}
+          {renderableGroups.length} more {renderableGroups.length === 1 ? "agent" : "agents"}
         </span>
         <span className="text-[11px] text-daintree-text/40">Click to move to dock</span>
       </div>
-      <div className="flex flex-wrap gap-1.5">
-        {groups.map((group) => (
+      {/*
+       * Cap the strip at ~30% viewport height so an extreme overflow set
+       * (capacity = 1 with many panels on a narrow window) can't push the
+       * `flex-1 min-h-0` grid above into near-zero height. Cards inside
+       * scroll vertically instead.
+       */}
+      <div className="flex flex-wrap gap-1.5 max-h-[30vh] overflow-y-auto">
+        {renderableGroups.map((group) => (
           <OverflowCard key={group.id} group={group} />
         ))}
       </div>

--- a/src/components/Terminal/OverflowStatusStrip.tsx
+++ b/src/components/Terminal/OverflowStatusStrip.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { getBaseTitle } from "@/lib/utils";
+import { panelStoreApi, type TerminalInstance } from "@/store";
+import { TerminalRefreshTier } from "@shared/types/panel";
+import type { TabGroup } from "@shared/types/panel";
+import { actionService } from "@/services/ActionService";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import {
+  getEffectiveStateIcon,
+  getEffectiveStateColor,
+  getEffectiveStateLabel,
+} from "@/components/Worktree/terminalStateConfig";
+import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
+import { deriveTerminalChrome } from "@/utils/terminalChrome";
+
+/**
+ * Compact status cards for panels that exceed the grid's screen-fit capacity.
+ *
+ * When the active worktree has more grid panels than fit at MIN_TERMINAL_WIDTH_PX
+ * × MIN_TERMINAL_HEIGHT_PX, the overflow set renders here as read-only cards
+ * surfacing agent state and current activity — never below readability — instead
+ * of squeezing every live terminal into the grid. See #8702.
+ *
+ * Clicking a card sends the panel to the dock via `terminal.moveToDock`, where
+ * the user can interact with the agent at full size. Swap-on-click (promotion
+ * back into the grid) is intentionally deferred — the promotion state machine
+ * adds reset paths that are out of scope for the MVP.
+ */
+export interface OverflowStatusStripProps {
+  groups: TabGroup[];
+  className?: string;
+}
+
+export function OverflowStatusStrip({ groups, className }: OverflowStatusStripProps) {
+  // Demote overflow panels to BACKGROUND so the analysis buffer keeps writing
+  // (state detection stays accurate) while visual streaming is suppressed.
+  // Restoring to VISIBLE on unmount lets the grid renderer show them at full
+  // refresh when capacity grows or panels move; the dock toggles BACKGROUND on
+  // its own when applicable.
+  const overflowPanelIds = useMemo(() => {
+    const ids: string[] = [];
+    const byId = panelStoreApi.getState().panelsById;
+    for (const group of groups) {
+      for (const panelId of group.panelIds) {
+        if (byId[panelId]) ids.push(panelId);
+      }
+    }
+    return ids;
+  }, [groups]);
+
+  useEffect(() => {
+    for (const id of overflowPanelIds) {
+      try {
+        terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.BACKGROUND);
+      } catch {
+        // Renderer may not have an instance yet — that's fine, the next
+        // mount will pick up the visible tier.
+      }
+    }
+    return () => {
+      for (const id of overflowPanelIds) {
+        try {
+          terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);
+        } catch {
+          // Ditto: a panel may have been removed before unmount completes.
+        }
+      }
+    };
+  }, [overflowPanelIds]);
+
+  if (groups.length === 0) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label="Overflow agents"
+      className={cn(
+        "shrink-0 border-t border-daintree-border/40 bg-daintree-bg/40 px-2 py-1.5",
+        className
+      )}
+    >
+      <div className="flex items-center justify-between mb-1 px-0.5">
+        <span className="text-[11px] uppercase tracking-wide text-daintree-text/50">
+          {groups.length} more {groups.length === 1 ? "agent" : "agents"}
+        </span>
+        <span className="text-[11px] text-daintree-text/40">Click to move to dock</span>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {groups.map((group) => (
+          <OverflowCard key={group.id} group={group} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface OverflowCardProps {
+  group: TabGroup;
+}
+
+function OverflowCard({ group }: OverflowCardProps) {
+  // Read the active panel for this group non-reactively. Cards live in the
+  // overflow strip — they don't need per-tick rerenders, but they should
+  // pick up the latest title/agent-state on each parent render.
+  const byId = panelStoreApi.getState().panelsById;
+  const activeId = group.panelIds.includes(group.activeTabId)
+    ? group.activeTabId
+    : (group.panelIds[0] ?? null);
+  const panel = activeId ? byId[activeId] : null;
+
+  if (!panel) return null;
+
+  return <OverflowCardContent panel={panel} groupSize={group.panelIds.length} />;
+}
+
+interface OverflowCardContentProps {
+  panel: TerminalInstance;
+  groupSize: number;
+}
+
+function OverflowCardContent({ panel, groupSize }: OverflowCardContentProps) {
+  const chrome = deriveTerminalChrome({
+    kind: panel.kind,
+    launchAgentId: panel.launchAgentId,
+    runtimeIdentity: panel.runtimeIdentity,
+    detectedAgentId: panel.detectedAgentId,
+    detectedProcessId: panel.detectedProcessId,
+    agentState: panel.agentState,
+    runtimeStatus: panel.runtimeStatus,
+    exitCode: panel.exitCode,
+  });
+  const displayAgentState = getTerminalAgentDisplayState(chrome, panel.agentState);
+  const StateIcon = displayAgentState ? getEffectiveStateIcon(displayAgentState) : null;
+  const stateColor = displayAgentState ? getEffectiveStateColor(displayAgentState) : null;
+  const stateLabel = displayAgentState ? getEffectiveStateLabel(displayAgentState) : null;
+  const title = getBaseTitle(panel.title);
+  const headline = panel.activityHeadline?.trim() || panel.lastCommand?.trim() || null;
+
+  return (
+    <button
+      type="button"
+      data-overflow-card=""
+      data-panel-id={panel.id}
+      style={{ contain: "layout style" }}
+      className={cn(
+        "group flex items-start gap-2 w-[220px] min-w-0 px-2 py-1.5 text-left",
+        "rounded-[var(--radius-md)] border border-daintree-border/40 bg-overlay-subtle/60",
+        "transition-colors duration-150 ease-out",
+        "hover:bg-overlay-subtle hover:border-daintree-border/60",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
+        "focus-visible:outline-offset-[-2px]"
+      )}
+      onClick={() => {
+        void actionService.dispatch(
+          "terminal.moveToDock",
+          { terminalId: panel.id },
+          { source: "user" }
+        );
+      }}
+      aria-label={
+        stateLabel
+          ? `${title} (${stateLabel}). Click to move to dock.`
+          : `${title}. Click to move to dock.`
+      }
+    >
+      {StateIcon ? (
+        <div className={cn("flex items-center justify-center shrink-0 mt-0.5", stateColor)}>
+          <StateIcon
+            className={cn(
+              "w-3.5 h-3.5",
+              displayAgentState === "working" && "animate-spin-slow",
+              "motion-reduce:animate-none"
+            )}
+            aria-hidden="true"
+          />
+        </div>
+      ) : (
+        <div className="w-3.5 h-3.5 shrink-0 mt-0.5" aria-hidden="true" />
+      )}
+      <div className="flex flex-col min-w-0 flex-1">
+        <span className="text-xs font-medium text-daintree-text truncate">
+          {title}
+          {groupSize > 1 ? (
+            <span className="ml-1 text-[11px] text-daintree-text/50 font-normal">
+              ({groupSize} tabs)
+            </span>
+          ) : null}
+        </span>
+        {headline ? (
+          <span className="text-[11px] text-daintree-text/60 truncate font-mono">{headline}</span>
+        ) : (
+          <span className="text-[11px] text-daintree-text/40 truncate">{stateLabel ?? "Idle"}</span>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/src/components/Terminal/__tests__/OverflowStatusStrip.test.tsx
+++ b/src/components/Terminal/__tests__/OverflowStatusStrip.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { TabGroup } from "@shared/types/panel";
+
+vi.mock("@/lib/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/utils")>();
+  return {
+    ...actual,
+    cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+  };
+});
+
+const { panelState, dispatchMock, applyRendererPolicyMock } = vi.hoisted(() => ({
+  panelState: { panelsById: {} as Record<string, unknown> },
+  dispatchMock: vi.fn(),
+  applyRendererPolicyMock: vi.fn(),
+}));
+
+vi.mock("@/store", () => ({
+  panelStoreApi: { getState: () => panelState },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: dispatchMock },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: { applyRendererPolicy: applyRendererPolicyMock },
+}));
+
+// Import after mocks
+import { OverflowStatusStrip } from "../OverflowStatusStrip";
+import { TerminalRefreshTier } from "@shared/types/panel";
+
+function makeGroup(id: string, panelIds: string[], activeTabId?: string): TabGroup {
+  return {
+    id,
+    panelIds,
+    activeTabId: activeTabId ?? panelIds[0] ?? "",
+    location: "grid",
+    worktreeId: "wt-1",
+  };
+}
+
+function makePanel(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    kind: "terminal" as const,
+    title: `Panel ${id}`,
+    location: "grid",
+    worktreeId: "wt-1",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  panelState.panelsById = {};
+  dispatchMock.mockClear();
+  applyRendererPolicyMock.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("OverflowStatusStrip", () => {
+  it("renders nothing when groups is empty", () => {
+    const { container } = render(<OverflowStatusStrip groups={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one card per overflow group", () => {
+    panelState.panelsById = {
+      "p-1": makePanel("p-1", { title: "Panel one" }),
+      "p-2": makePanel("p-2", { title: "Panel two" }),
+      "p-3": makePanel("p-3", { title: "Panel three" }),
+    };
+    const groups: TabGroup[] = [
+      makeGroup("g-1", ["p-1"]),
+      makeGroup("g-2", ["p-2"]),
+      makeGroup("g-3", ["p-3"]),
+    ];
+
+    render(<OverflowStatusStrip groups={groups} />);
+
+    const cards = screen.getAllByRole("button");
+    expect(cards).toHaveLength(3);
+    expect(screen.getByText("Panel one")).toBeTruthy();
+    expect(screen.getByText("Panel two")).toBeTruthy();
+    expect(screen.getByText("Panel three")).toBeTruthy();
+  });
+
+  it("shows the count header with correct pluralization", () => {
+    panelState.panelsById = {
+      "p-1": makePanel("p-1"),
+    };
+
+    const { rerender } = render(<OverflowStatusStrip groups={[makeGroup("g-1", ["p-1"])]} />);
+    expect(screen.getByText(/1 more agent$/)).toBeTruthy();
+
+    panelState.panelsById = {
+      "p-1": makePanel("p-1"),
+      "p-2": makePanel("p-2"),
+    };
+    rerender(
+      <OverflowStatusStrip groups={[makeGroup("g-1", ["p-1"]), makeGroup("g-2", ["p-2"])]} />
+    );
+    expect(screen.getByText(/2 more agents$/)).toBeTruthy();
+  });
+
+  it("dispatches terminal.moveToDock with the active panel id on click", () => {
+    panelState.panelsById = {
+      "p-active": makePanel("p-active", { title: "Active panel" }),
+      "p-other": makePanel("p-other"),
+    };
+    const group = makeGroup("g-tab", ["p-other", "p-active"], "p-active");
+
+    render(<OverflowStatusStrip groups={[group]} />);
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "terminal.moveToDock",
+      { terminalId: "p-active" },
+      { source: "user" }
+    );
+  });
+
+  it("shows the activity headline when present", () => {
+    panelState.panelsById = {
+      "p-1": makePanel("p-1", {
+        title: "Claude",
+        activityHeadline: "Refactoring grid layout",
+      }),
+    };
+
+    render(<OverflowStatusStrip groups={[makeGroup("g-1", ["p-1"])]} />);
+    expect(screen.getByText("Refactoring grid layout")).toBeTruthy();
+  });
+
+  it("falls back to lastCommand when activityHeadline is absent", () => {
+    panelState.panelsById = {
+      "p-1": makePanel("p-1", { lastCommand: "npm run build" }),
+    };
+
+    render(<OverflowStatusStrip groups={[makeGroup("g-1", ["p-1"])]} />);
+    expect(screen.getByText("npm run build")).toBeTruthy();
+  });
+
+  it("shows tab count when a group has multiple panels", () => {
+    panelState.panelsById = {
+      "p-1": makePanel("p-1", { title: "Multi" }),
+      "p-2": makePanel("p-2"),
+      "p-3": makePanel("p-3"),
+    };
+
+    render(<OverflowStatusStrip groups={[makeGroup("g-1", ["p-1", "p-2", "p-3"])]} />);
+    expect(screen.getByText("(3 tabs)")).toBeTruthy();
+  });
+
+  it("applies BACKGROUND tier to overflow panels on mount", () => {
+    panelState.panelsById = {
+      "p-1": makePanel("p-1"),
+      "p-2": makePanel("p-2"),
+    };
+
+    render(<OverflowStatusStrip groups={[makeGroup("g-1", ["p-1"]), makeGroup("g-2", ["p-2"])]} />);
+
+    expect(applyRendererPolicyMock).toHaveBeenCalledWith("p-1", TerminalRefreshTier.BACKGROUND);
+    expect(applyRendererPolicyMock).toHaveBeenCalledWith("p-2", TerminalRefreshTier.BACKGROUND);
+  });
+
+  it("restores VISIBLE tier on unmount so re-entry into the grid resumes streaming", () => {
+    panelState.panelsById = {
+      "p-1": makePanel("p-1"),
+    };
+
+    const { unmount } = render(<OverflowStatusStrip groups={[makeGroup("g-1", ["p-1"])]} />);
+    applyRendererPolicyMock.mockClear();
+    unmount();
+
+    expect(applyRendererPolicyMock).toHaveBeenCalledWith("p-1", TerminalRefreshTier.VISIBLE);
+  });
+
+  it("survives a panel disappearing between renders without throwing", () => {
+    panelState.panelsById = {
+      "p-1": makePanel("p-1"),
+    };
+
+    const { rerender } = render(<OverflowStatusStrip groups={[makeGroup("g-1", ["p-1"])]} />);
+
+    panelState.panelsById = {};
+    expect(() =>
+      rerender(<OverflowStatusStrip groups={[makeGroup("g-1", ["p-1"])]} />)
+    ).not.toThrow();
+  });
+});

--- a/src/components/Terminal/__tests__/OverflowStatusStrip.test.tsx
+++ b/src/components/Terminal/__tests__/OverflowStatusStrip.test.tsx
@@ -198,4 +198,28 @@ describe("OverflowStatusStrip", () => {
       rerender(<OverflowStatusStrip groups={[makeGroup("g-1", ["p-1"])]} />)
     ).not.toThrow();
   });
+
+  it("drops groups whose panels are all absent from the store so the count matches what renders", () => {
+    panelState.panelsById = {
+      "p-real": makePanel("p-real"),
+    };
+
+    render(
+      <OverflowStatusStrip
+        groups={[makeGroup("g-real", ["p-real"]), makeGroup("g-ghost", ["p-missing"])]}
+      />
+    );
+
+    // Header counts renderable groups, not the raw input list.
+    expect(screen.getByText(/1 more agent$/)).toBeTruthy();
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+  });
+
+  it("renders nothing when every group's panels are absent from the store", () => {
+    panelState.panelsById = {};
+    const { container } = render(
+      <OverflowStatusStrip groups={[makeGroup("g-1", ["p-missing"])]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
 });

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -56,6 +56,7 @@ import { actionService } from "@/services/ActionService";
 // mutated.
 const EMPTY_PANEL_IDS: string[] = [];
 const EMPTY_TERMINALS: TerminalInstance[] = [];
+const EMPTY_TAB_GROUPS: TabGroup[] = [];
 
 export function pixelSnapTransform({ x, y }: TransformProperties): string {
   const tx = typeof x === "number" ? x : parseFloat(x ?? "0") || 0;
@@ -76,6 +77,19 @@ export interface ContentGridContext {
   emptyContent?: React.ReactNode;
   gridTerminals: TerminalInstance[];
   tabGroups: TabGroup[];
+  /**
+   * Tab groups that fit in the grid at the readable minimum size, sliced from
+   * `tabGroups` by `maxGridCapacity`. Renderers iterate this list (not the raw
+   * `tabGroups`) so any panels above capacity are excluded from the grid and
+   * routed to the overflow status strip instead. See #8702.
+   */
+  visibleTabGroups: TabGroup[];
+  /**
+   * Tab groups that exceed the grid's screen-fit capacity and render as
+   * compact status cards below the grid. Empty when `tabGroups.length <=
+   * maxGridCapacity`. See #8702.
+   */
+  overflowTabGroups: TabGroup[];
   focusedId: string | null;
   maximizedId: string | null;
   maximizeTarget: ReturnType<typeof usePanelStore.getState>["maximizeTarget"];
@@ -325,7 +339,19 @@ export function useContentGridContext({
   const getMaxGridCapacity = useLayoutConfigStore((state) => state.getMaxGridCapacity);
 
   const maxGridCapacity = getMaxGridCapacity();
-  const isGridFull = tabGroups.length >= maxGridCapacity;
+  // Split the grid panels at the screen-fit capacity. Everything past the cap
+  // renders in the overflow status strip (#8702) so we never paint terminals
+  // narrower than MIN_TERMINAL_WIDTH_PX.
+  const visibleTabGroups = useMemo(
+    () => (tabGroups.length <= maxGridCapacity ? tabGroups : tabGroups.slice(0, maxGridCapacity)),
+    [tabGroups, maxGridCapacity]
+  );
+  const overflowTabGroups = useMemo(
+    () =>
+      tabGroups.length <= maxGridCapacity ? EMPTY_TAB_GROUPS : tabGroups.slice(maxGridCapacity),
+    [tabGroups, maxGridCapacity]
+  );
+  const isGridFull = visibleTabGroups.length >= maxGridCapacity;
 
   const { setNodeRef, isOver } = useDroppable({
     id: "grid-container",
@@ -347,10 +373,12 @@ export function useContentGridContext({
   }, [isDragging]);
 
   const placeholderInGrid =
-    placeholderIndex !== null && placeholderIndex >= 0 && placeholderIndex <= tabGroups.length;
+    placeholderIndex !== null &&
+    placeholderIndex >= 0 &&
+    placeholderIndex <= visibleTabGroups.length;
 
   const showPlaceholder = placeholderInGrid && sourceContainer === "dock" && !isGridFull;
-  const gridItemCount = tabGroups.length + (showPlaceholder ? 1 : 0);
+  const gridItemCount = visibleTabGroups.length + (showPlaceholder ? 1 : 0);
 
   const bindGridRegion = useCallback((node: HTMLDivElement | null) => {
     useMacroFocusStore.getState().setRegionRef("grid", node);
@@ -567,13 +595,15 @@ export function useContentGridContext({
   );
 
   const panelIds = useMemo(() => {
-    const ids = tabGroups.map((g) => g.panelIds[0] ?? g.id);
+    // Only visible groups participate in SortableContext / dnd — overflow
+    // status cards are non-draggable and live outside the grid container.
+    const ids = visibleTabGroups.map((g) => g.panelIds[0] ?? g.id);
     if (showPlaceholder && placeholderInGrid) {
       const insertIndex = Math.min(Math.max(0, placeholderIndex), ids.length);
       ids.splice(insertIndex, 0, GRID_PLACEHOLDER_ID);
     }
     return ids;
-  }, [tabGroups, showPlaceholder, placeholderIndex, placeholderInGrid]);
+  }, [visibleTabGroups, showPlaceholder, placeholderIndex, placeholderInGrid]);
 
   // Structurally-filtered fleet panel IDs. Delegates membership to
   // `buildFleetPanels` (single source of truth — see #5989) and projects to
@@ -874,6 +904,8 @@ export function useContentGridContext({
     emptyContent,
     gridTerminals,
     tabGroups,
+    visibleTabGroups,
+    overflowTabGroups,
     focusedId,
     maximizedId,
     maximizeTarget,

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -24,8 +24,10 @@ import { TerminalRefreshTier } from "@shared/types/panel";
 import type { TabGroup, TabGroupLocation } from "@shared/types/panel";
 import {
   computeGridColumns,
+  getMaxGridCapacity,
   GRID_TRANSITION_DURATION_MS,
   GRID_FIT_DELAY_MS,
+  ABSOLUTE_MAX_GRID_TERMINALS,
 } from "@/lib/terminalLayout";
 import {
   isSidebarLayoutTransitionLocked,
@@ -336,9 +338,14 @@ export function useContentGridContext({
 
   const layoutConfig = useLayoutConfigStore((state) => state.layoutConfig);
   const setGridDimensions = useLayoutConfigStore((state) => state.setGridDimensions);
-  const getMaxGridCapacity = useLayoutConfigStore((state) => state.getMaxGridCapacity);
-
-  const maxGridCapacity = getMaxGridCapacity();
+  // Subscribe reactively to the derived capacity so height-only resizes
+  // re-partition the grid. A `state.getMaxGridCapacity` function reference
+  // is stable across height changes and would leave the partition stale
+  // (verified against `useGridNavigation`'s inline-derived selector).
+  const maxGridCapacity = useLayoutConfigStore((state) => {
+    if (!state.gridDimensions) return ABSOLUTE_MAX_GRID_TERMINALS;
+    return getMaxGridCapacity(state.gridDimensions.width, state.gridDimensions.height);
+  });
   // Split the grid panels at the screen-fit capacity. Everything past the cap
   // renders in the overflow status strip (#8702) so we never paint terminals
   // narrower than MIN_TERMINAL_WIDTH_PX.
@@ -815,6 +822,21 @@ export function useContentGridContext({
       setFocused(maximizedGroupFocusTarget);
     }
   }, [focusedId, maximizedGroupFocusTarget, maximizedGroupPanels.length, setFocused]);
+
+  // Focus reconciliation when capacity shrinks (sidebar opens, window narrows):
+  // if `focusedId` has slipped into the overflow strip, arrow keys and Cmd+N
+  // can't reach it anymore. Drop focus onto the first visible panel instead so
+  // the user has a working keyboard model (#8702). Only fires when the focused
+  // panel is in the active worktree's grid set but no longer visible.
+  useEffect(() => {
+    if (!focusedId) return;
+    const focusedInVisible = visibleTabGroups.some((g) => g.panelIds.includes(focusedId));
+    if (focusedInVisible) return;
+    const focusedInOverflow = overflowTabGroups.some((g) => g.panelIds.includes(focusedId));
+    if (!focusedInOverflow) return;
+    const fallback = visibleTabGroups[0]?.panelIds[0] ?? null;
+    if (fallback) setFocused(fallback);
+  }, [focusedId, visibleTabGroups, overflowTabGroups, setFocused]);
 
   const gridContextMenuContent = (
     <ContextMenuContent>

--- a/src/hooks/useGridNavigation.ts
+++ b/src/hooks/useGridNavigation.ts
@@ -3,7 +3,7 @@ import { usePanelStore, useLayoutConfigStore, useWorktreeSelectionStore } from "
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useShallow } from "zustand/react/shallow";
-import { computeGridColumns } from "@/lib/terminalLayout";
+import { computeGridColumns, getMaxGridCapacity } from "@/lib/terminalLayout";
 import {
   isSidebarLayoutTransitionLocked,
   subscribeSidebarLayoutTransitionUnlock,
@@ -43,6 +43,15 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
     useShallow((state) => ({ armedIds: state.armedIds, armOrder: state.armOrder }))
   );
   const layoutConfig = useLayoutConfigStore((state) => state.layoutConfig);
+  // Subscribe reactively to the capacity cap so the keyboard-nav model
+  // tracks viewport changes. Without this, arrow keys would cycle into cells
+  // that don't exist on screen after a sidebar toggle (#8702). Falls back to
+  // `Infinity` pre-measurement so nothing is incorrectly clipped before the
+  // ResizeObserver fires.
+  const maxGridCapacity = useLayoutConfigStore((state) => {
+    if (!state.gridDimensions) return Number.POSITIVE_INFINITY;
+    return getMaxGridCapacity(state.gridDimensions.width, state.gridDimensions.height);
+  });
 
   const isFleetScopeEnabled = fleetScopeMode === "scoped" && isFleetScopeActive;
 
@@ -148,12 +157,18 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
   // getTabGroups reads tabGroups/panelIds/panelsById from the store via get();
   // reference them so exhaustive-deps treats them as real deps without a
   // suppression (which would force the React Compiler to bail out).
+  //
+  // Cap at `maxGridCapacity` so the nav model stays in sync with what
+  // ContentGridDefault actually renders — overflow panels live in the status
+  // strip, not the grid, and arrow keys must not cycle into cells that don't
+  // exist on screen (#8702).
   const gridGroups = useMemo(() => {
     void tabGroups;
     void panelIds;
     void panelsById;
-    return getTabGroups("grid", activeWorktreeId ?? undefined);
-  }, [getTabGroups, activeWorktreeId, tabGroups, panelIds, panelsById]);
+    const groups = getTabGroups("grid", activeWorktreeId ?? undefined);
+    return groups.length <= maxGridCapacity ? groups : groups.slice(0, maxGridCapacity);
+  }, [getTabGroups, activeWorktreeId, tabGroups, panelIds, panelsById, maxGridCapacity]);
 
   // Hysteresis input mirroring ContentGrid: keyboard-nav column count must
   // track the visual grid through the same sticky boundaries, otherwise arrow
@@ -334,8 +349,14 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
     if (isFleetScopeRender) {
       return fleetPanels.map((t) => t.id);
     }
+    // Same overflow cap as `gridGroups` — Cmd+N maps to visible cells only,
+    // never into the overflow status strip where panels can't take focus.
     const orderedGroups = getTabGroups("grid", activeWorktreeId ?? undefined);
-    return orderedGroups.flatMap((group) => {
+    const cappedGroups =
+      orderedGroups.length <= maxGridCapacity
+        ? orderedGroups
+        : orderedGroups.slice(0, maxGridCapacity);
+    return cappedGroups.flatMap((group) => {
       const resolvedId = group.panelIds.includes(group.activeTabId)
         ? group.activeTabId
         : group.panelIds[0];
@@ -349,6 +370,7 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
     tabGroups,
     panelIds,
     panelsById,
+    maxGridCapacity,
   ]);
 
   const findByIndex = useCallback(


### PR DESCRIPTION
Fixes a layout issue where the panel grid shrinks agent terminals to unusably small sizes.

Two root causes:

- `minmax(0, 1fr)` lets columns shrink all the way to zero width.
- The capacity fallback hits `ABSOLUTE_MAX`, so too many panels land in the grid at once.

## Changes

- **Column floor** — grid template now uses `minmax(min(100%, 380px), 1fr)`, so columns never go below `MIN_TERMINAL_WIDTH_PX`.
- **Overflow split** — `useContentGridContext` now computes `visibleTabGroups` and `overflowTabGroups` separately, keeping the grid bounded to what physically fits.
- **`OverflowStatusStrip`** — new component renders excess panels as status cards below the grid. Clicking a card dispatches `terminal.moveToDock` (MVP; swap-on-click promotion is a follow-up).
- **Throttling** — overflow panels get `TerminalRefreshTier.BACKGROUND` while in cards, same as docked panels.
- **Navigation** — arrow keys and `Cmd+N` in `useGridNavigation` are updated to operate on the visible grid only, so keyboard focus never lands on an overflow card.
- **Focus reconciliation** — if the focused panel slips into overflow (e.g. window narrows), focus moves to the first visible panel.

## Testing

- 12 new `OverflowStatusStrip` cases covering render, click dispatch, and overflow boundaries.
- All existing 717+ tests still green.
- Manual: open many agents on a small screen, resize narrower and wider, verify overflow cards appear/disappear correctly; click a card to move it to dock; arrow-key through the visible grid.

Resolves #8702