### PR TITLE
fix(fleet): null sentinel for non-replayable failures, Tier-2 inline banner (#8705)

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -11,6 +11,7 @@ import { useFleetEscapeChords } from "./useFleetEscapeChords";
 import { useFleetRibbonFlashes } from "./useFleetRibbonFlashes";
 import { buildConfirmMessage, type FleetConfirmActionId } from "./buildConfirmMessage";
 import { FleetCountChip } from "./FleetCountChip";
+import { FleetFailureBanner } from "./FleetFailureBanner";
 import { SavedFleetsSection } from "./SavedFleetsSection";
 import { FLEET_LARGE_PASTE_BATCH_SIZE } from "./fleetBroadcast";
 import { cancelActiveBroadcast } from "./fleetEnterBroadcast";
@@ -463,7 +464,8 @@ export function FleetArmingRibbon(): ReactElement | null {
   // When a destructive broadcast (paste or Enter) is pending, the right-side
   // controls collapse to the confirm question so we keep one ribbon row
   // instead of stacking a second strip below. Per-pane red dots (PanelHeader)
-  // carry any post-broadcast failure state — no retry/dismiss buttons here.
+  // still carry per-target failure state; the `FleetFailureBanner` below
+  // adds the Tier-2 multi-terminal surface with the retry action.
   const isBroadcastConfirmActive = pendingBroadcast !== null;
 
   return (
@@ -486,6 +488,7 @@ export function FleetArmingRibbon(): ReactElement | null {
         }}
         onClose={() => setPendingDeleteFleetId(null)}
       />
+      <FleetFailureBanner />
       <AnimatePresence initial={false}>
         <m.div
           ref={ribbonRef}

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -391,7 +391,9 @@ export function FleetArmingRibbon(): ReactElement | null {
   // Render confirmation before the armedCount<2 null guard so single-agent
   // keybindings (fleet.restart / fleet.kill always require confirmation)
   // stay reachable — and so draining 3→1 while a confirm is pending
-  // doesn't strand a live Enter listener with no visible UI.
+  // doesn't strand a live Enter listener with no visible UI. The failure
+  // banner is rendered alongside so a prior partial-failure surface stays
+  // visible while the user is in the confirm flow.
   if (armedCount > 0 && pending !== null) {
     const message = buildConfirmMessage(
       pending.kind,
@@ -399,34 +401,37 @@ export function FleetArmingRibbon(): ReactElement | null {
       pending.sessionLossCount
     );
     return (
-      <div
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
-        className={cn(
-          "relative flex items-center gap-3 border-b border-daintree-border px-3 py-2 text-[12px] text-daintree-text",
-          // Keep the Fleet surface continuous through confirm-pending so the
-          // mode chrome doesn't visually exit and re-enter during a confirm.
-          "bg-category-amber-subtle",
-          "before:absolute before:inset-y-0 before:left-0 before:w-0.5 before:bg-[var(--color-category-amber-border)]"
-        )}
-        data-testid="fleet-arming-ribbon"
-        data-pending-action={pending.kind}
-      >
-        <span className="font-medium text-daintree-accent">{message}</span>
-        <div className="ml-auto flex items-center gap-2 text-[11px] text-daintree-text/70">
-          <span>
-            <kbd className="rounded border border-daintree-text/20 bg-tint/[0.08] px-1 py-0.5 font-mono text-[10px]">
-              Enter
-            </kbd>{" "}
-            to confirm
-          </span>
-          <span>
-            <kbd className="rounded border border-daintree-text/20 bg-tint/[0.08] px-1 py-0.5 font-mono text-[10px]">
-              Esc
-            </kbd>{" "}
-            to cancel
-          </span>
+      <div data-testid="fleet-arming-ribbon-group">
+        <FleetFailureBanner />
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className={cn(
+            "relative flex items-center gap-3 border-b border-daintree-border px-3 py-2 text-[12px] text-daintree-text",
+            // Keep the Fleet surface continuous through confirm-pending so the
+            // mode chrome doesn't visually exit and re-enter during a confirm.
+            "bg-category-amber-subtle",
+            "before:absolute before:inset-y-0 before:left-0 before:w-0.5 before:bg-[var(--color-category-amber-border)]"
+          )}
+          data-testid="fleet-arming-ribbon"
+          data-pending-action={pending.kind}
+        >
+          <span className="font-medium text-daintree-accent">{message}</span>
+          <div className="ml-auto flex items-center gap-2 text-[11px] text-daintree-text/70">
+            <span>
+              <kbd className="rounded border border-daintree-text/20 bg-tint/[0.08] px-1 py-0.5 font-mono text-[10px]">
+                Enter
+              </kbd>{" "}
+              to confirm
+            </span>
+            <span>
+              <kbd className="rounded border border-daintree-text/20 bg-tint/[0.08] px-1 py-0.5 font-mono text-[10px]">
+                Esc
+              </kbd>{" "}
+              to cancel
+            </span>
+          </div>
         </div>
       </div>
     );

--- a/src/components/Fleet/FleetFailureBanner.tsx
+++ b/src/components/Fleet/FleetFailureBanner.tsx
@@ -1,0 +1,56 @@
+import { type ReactElement } from "react";
+import { AlertCircle } from "lucide-react";
+import { InlineStatusBanner, type BannerAction } from "@/components/Terminal";
+import { useFleetFailureStore } from "@/store/fleetFailureStore";
+import { actionService } from "@/services/ActionService";
+
+/**
+ * Tier-2 inline banner that surfaces partial fleet broadcast failures.
+ * Sits above the fleet ribbon (#8705) — the Tier-1 per-pane red dots are
+ * still drawn by `PanelHeader`, but a multi-terminal failure escalates one
+ * tier per CLAUDE.md to make sure the user notices that *some* targets
+ * dropped the write.
+ *
+ * The action is omitted (not disabled) when `payload === null` — single
+ * keystrokes aren't meaningful to replay, and a native disabled button
+ * with a Radix tooltip silently fails to show the explanation on Chromium.
+ */
+export function FleetFailureBanner(): ReactElement | null {
+  const failedIds = useFleetFailureStore((s) => s.failedIds);
+  const payload = useFleetFailureStore((s) => s.payload);
+
+  if (failedIds.size === 0) return null;
+
+  const count = failedIds.size;
+  const noun = count === 1 ? "terminal" : "terminals";
+  const description =
+    payload === null
+      ? `${count} ${noun} rejected a keystroke. Single keystrokes can't be replayed.`
+      : `${count} ${noun} rejected the write.`;
+
+  const actions: BannerAction[] =
+    payload === null
+      ? []
+      : [
+          {
+            id: "retry",
+            label: "Retry failed",
+            variant: "primary",
+            onClick: () => {
+              void actionService.dispatch("fleet.retryFailures", undefined, { source: "user" });
+            },
+          },
+        ];
+
+  return (
+    <InlineStatusBanner
+      icon={AlertCircle}
+      severity="error"
+      title="Broadcast failed"
+      description={description}
+      actions={actions}
+      role="alert"
+      onClose={() => useFleetFailureStore.getState().clear()}
+    />
+  );
+}

--- a/src/components/Fleet/__tests__/FleetFailureBanner.test.tsx
+++ b/src/components/Fleet/__tests__/FleetFailureBanner.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// jsdom omits matchMedia; InlineStatusBanner reads it for prefers-reduced-motion.
+vi.stubGlobal(
+  "matchMedia",
+  vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+);
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { FleetFailureBanner } from "../FleetFailureBanner";
+import { useFleetFailureStore } from "@/store/fleetFailureStore";
+import { actionService } from "@/services/ActionService";
+
+function resetStore() {
+  useFleetFailureStore.setState({
+    failedIds: new Set(),
+    payload: null,
+    recordedAt: null,
+  });
+}
+
+describe("FleetFailureBanner", () => {
+  beforeEach(() => {
+    resetStore();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when there are no failed ids", () => {
+    const { container } = render(<FleetFailureBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders broadcast-failed banner with replay-capable copy when payload is non-null", () => {
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1", "t2"]),
+      payload: "ls\r",
+      recordedAt: Date.now(),
+    });
+    render(<FleetFailureBanner />);
+    expect(screen.getByText("Broadcast failed")).toBeTruthy();
+    expect(screen.getByText("2 terminals rejected the write.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry failed" })).toBeTruthy();
+  });
+
+  it("uses singular noun when exactly one target failed", () => {
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1"]),
+      payload: "ls\r",
+      recordedAt: Date.now(),
+    });
+    render(<FleetFailureBanner />);
+    expect(screen.getByText("1 terminal rejected the write.")).toBeTruthy();
+  });
+
+  it("omits the retry action and shows no-replay copy when payload is null", () => {
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1", "t2"]),
+      payload: null,
+      recordedAt: Date.now(),
+    });
+    render(<FleetFailureBanner />);
+    expect(
+      screen.getByText("2 terminals rejected a keystroke. Single keystrokes can't be replayed.")
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Retry failed" })).toBeNull();
+  });
+
+  it("dispatches fleet.retryFailures when the retry button is clicked", () => {
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1"]),
+      payload: "ls\r",
+      recordedAt: Date.now(),
+    });
+    render(<FleetFailureBanner />);
+    fireEvent.click(screen.getByRole("button", { name: "Retry failed" }));
+    expect(actionService.dispatch).toHaveBeenCalledWith("fleet.retryFailures", undefined, {
+      source: "user",
+    });
+  });
+
+  it("clears the failure store when the dismiss button is clicked", () => {
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1"]),
+      payload: "ls\r",
+      recordedAt: Date.now(),
+    });
+    render(<FleetFailureBanner />);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    const s = useFleetFailureStore.getState();
+    expect(s.failedIds.size).toBe(0);
+    expect(s.payload).toBeNull();
+    expect(s.recordedAt).toBeNull();
+  });
+});

--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -396,10 +396,11 @@ describe("applyFleetBroadcastResult", () => {
 
     const failure = useFleetFailureStore.getState();
     expect(Array.from(failure.failedIds)).toEqual(["t2"]);
-    // Payload is intentionally empty for raw-input failures — single
-    // keystrokes aren't meaningful to retry, and the `Retry failed` action
-    // checks for a non-null payload before firing.
-    expect(failure.payload).toBe("");
+    // Payload is intentionally null for raw-input failures — single
+    // keystrokes aren't meaningful to retry, and `fleet.retryFailures`
+    // guards on `payload == null` to skip the IPC write. An empty string
+    // would slip past the loose-equality guard (#8705).
+    expect(failure.payload).toBeNull();
 
     const arming = useFleetArmingStore.getState();
     expect(arming.armedIds.has("t2")).toBe(true);

--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -485,4 +485,27 @@ describe("applyFleetBroadcastResult", () => {
     expect(useFleetFailureStore.getState().failedIds.size).toBe(0);
     expect(useFleetArmingStore.getState().armedIds.size).toBe(2);
   });
+
+  it("dismisses a prior failure when the next write to that target succeeds", () => {
+    // Mirrors fleetEnterBroadcast's dismiss-on-success — a stale red dot
+    // shouldn't linger after the user has visibly recovered the pane.
+    seedPanels([makeTerminal("t1"), makeTerminal("t2")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+
+    applyFleetBroadcastResult({
+      results: [
+        { id: "t1", ok: true },
+        { id: "t2", ok: false, error: { code: "ENOSPC", message: "no space" } },
+      ],
+    });
+    expect(Array.from(useFleetFailureStore.getState().failedIds)).toEqual(["t2"]);
+
+    applyFleetBroadcastResult({
+      results: [
+        { id: "t1", ok: true },
+        { id: "t2", ok: true },
+      ],
+    });
+    expect(useFleetFailureStore.getState().failedIds.size).toBe(0);
+  });
 });

--- a/src/components/Fleet/fleetRawInputBroadcast.ts
+++ b/src/components/Fleet/fleetRawInputBroadcast.ts
@@ -123,8 +123,10 @@ export function broadcastFleetRawInput(originId: string, data: string): boolean 
  * - Non-permanent failures (e.g., `EAGAIN`) leave arming alone and record a
  *   transient failure entry so the user sees the chip. The chip's "Retry
  *   failed" path is a no-op for the raw-input transport (single keystrokes
- *   are not meaningful to replay), and `recordFailure` is called with an
- *   empty payload to make that explicit.
+ *   are not meaningful to replay), so `recordFailure` is called with a
+ *   `null` payload. `fleet.retryFailures` guards on `payload == null` and
+ *   will skip the IPC write — using `""` here would slip through that guard
+ *   and fire real empty-byte writes against live PTYs (#8705).
  *
  * Exported for testing — production wires this into the IPC subscription
  * registered at module load.
@@ -154,10 +156,10 @@ export function applyFleetBroadcastResult(payload: BroadcastWriteResultPayload):
   });
 
   if (nonPermanentFailedIds.length > 0) {
-    // Empty payload — raw input has no meaningful retry, and the
-    // `Retry failed` action checks for a non-null payload before firing.
+    // Null payload — raw input has no meaningful retry, and the
+    // `Retry failed` action checks for `payload == null` before firing.
     // The chip still surfaces so the user notices something rejected.
-    useFleetFailureStore.getState().recordFailure("", nonPermanentFailedIds);
+    useFleetFailureStore.getState().recordFailure(null, nonPermanentFailedIds);
   }
 
   if (permanentlyFailedIds.length > 0) {

--- a/src/components/Fleet/fleetRawInputBroadcast.ts
+++ b/src/components/Fleet/fleetRawInputBroadcast.ts
@@ -136,8 +136,12 @@ export function applyFleetBroadcastResult(payload: BroadcastWriteResultPayload):
 
   const nonPermanentFailedIds: string[] = [];
   const permanentlyFailedIds: string[] = [];
+  const succeededIds: string[] = [];
   for (const result of payload.results) {
-    if (result.ok) continue;
+    if (result.ok) {
+      succeededIds.push(result.id);
+      continue;
+    }
     const code = result.error?.code;
     // Missing errno → permanent. We can't tell if the target is recoverable,
     // so the safer default is to disarm rather than keep firing keystrokes.
@@ -145,6 +149,19 @@ export function applyFleetBroadcastResult(payload: BroadcastWriteResultPayload):
       permanentlyFailedIds.push(result.id);
     } else {
       nonPermanentFailedIds.push(result.id);
+    }
+  }
+
+  // A successful write to a previously-failed target clears the dot — same
+  // pattern as `fleetEnterBroadcast.ts`. Without this the banner persists
+  // after the user has visibly recovered (e.g. ENOSPC freed and the next
+  // keystroke landed).
+  if (succeededIds.length > 0) {
+    const failedSet = useFleetFailureStore.getState().failedIds;
+    if (failedSet.size > 0) {
+      for (const id of succeededIds) {
+        if (failedSet.has(id)) useFleetFailureStore.getState().dismissId(id);
+      }
     }
   }
 

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -40,10 +40,16 @@ vi.mock("@/store/persistence/panelPersistence", () => ({
   },
 }));
 
+vi.mock("@/components/Fleet/fleetExecution", () => ({
+  broadcastFleetLiteralPaste: vi.fn().mockResolvedValue({ failedIds: [] }),
+}));
+
 const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
 const { useFleetPendingActionStore } = await import("@/store/fleetPendingActionStore");
+const { useFleetFailureStore } = await import("@/store/fleetFailureStore");
 const { usePanelStore } = await import("@/store/panelStore");
 const { terminalClient } = await import("@/clients");
+const { broadcastFleetLiteralPaste } = await import("@/components/Fleet/fleetExecution");
 const { registerFleetActions } = await import("../fleetActions");
 
 type ActionRegistry = Awaited<
@@ -80,6 +86,7 @@ function resetStores(): void {
     lastArmedId: null,
   });
   useFleetPendingActionStore.setState({ pending: null });
+  useFleetFailureStore.setState({ failedIds: new Set(), payload: null, recordedAt: null });
   usePanelStore.setState({
     panelsById: {},
     panelIds: [],
@@ -550,5 +557,52 @@ describe("fleet.armFocused", () => {
     // becomes the lastArmedId — important for the existing exit-fleet
     // restore-focus behavior.
     expect(useFleetArmingStore.getState().lastArmedId).toBe("c");
+  });
+});
+
+describe("fleet.retryFailures", () => {
+  beforeEach(() => {
+    resetStores();
+    vi.clearAllMocks();
+  });
+
+  it("no-ops when payload is null (raw-input failures aren't replayable)", async () => {
+    // #8705: a `null` payload means "no meaningful retry"; the action must
+    // skip the IPC write. An empty-string sentinel would have slipped past
+    // the prior `payload == null` guard.
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1", "t2"]),
+      payload: null,
+      recordedAt: Date.now(),
+    });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.retryFailures");
+    expect(broadcastFleetLiteralPaste).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when failedIds is empty", async () => {
+    useFleetFailureStore.setState({
+      failedIds: new Set(),
+      payload: "ls\r",
+      recordedAt: Date.now(),
+    });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.retryFailures");
+    expect(broadcastFleetLiteralPaste).not.toHaveBeenCalled();
+  });
+
+  it("rebroadcasts the recorded payload to the failed targets when payload is non-null", async () => {
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1", "t2"]),
+      payload: "ls\r",
+      recordedAt: Date.now(),
+    });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.retryFailures");
+    expect(broadcastFleetLiteralPaste).toHaveBeenCalledTimes(1);
+    const [payload, targets] = (broadcastFleetLiteralPaste as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(payload).toBe("ls\r");
+    expect((targets as string[]).slice().sort()).toEqual(["t1", "t2"]);
   });
 });

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -605,4 +605,72 @@ describe("fleet.retryFailures", () => {
     expect(payload).toBe("ls\r");
     expect((targets as string[]).slice().sort()).toEqual(["t1", "t2"]);
   });
+
+  it("dismisses targets that succeeded on retry and preserves the ones that still fail", async () => {
+    (broadcastFleetLiteralPaste as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      failedIds: ["t2"],
+    });
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1", "t2", "t3"]),
+      payload: "ls\r",
+      recordedAt: Date.now(),
+    });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.retryFailures");
+    const s = useFleetFailureStore.getState();
+    expect(Array.from(s.failedIds)).toEqual(["t2"]);
+    expect(s.payload).toBe("ls\r");
+  });
+
+  it("clears the store entirely when every target succeeds on retry", async () => {
+    (broadcastFleetLiteralPaste as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      failedIds: [],
+    });
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1", "t2"]),
+      payload: "ls\r",
+      recordedAt: Date.now(),
+    });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.retryFailures");
+    const s = useFleetFailureStore.getState();
+    expect(s.failedIds.size).toBe(0);
+    expect(s.payload).toBeNull();
+    expect(s.recordedAt).toBeNull();
+  });
+
+  it("leaves the banner intact when invoked with a null payload (no silent clear)", async () => {
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1"]),
+      payload: null,
+      recordedAt: Date.now(),
+    });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.retryFailures");
+    const s = useFleetFailureStore.getState();
+    expect(s.failedIds.size).toBe(1);
+    expect(s.payload).toBeNull();
+  });
+
+  it("guards against double-dispatch (re-entrant retry while in flight)", async () => {
+    let resolveBroadcast: ((value: { failedIds: string[] }) => void) | null = null;
+    (broadcastFleetLiteralPaste as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () =>
+        new Promise<{ failedIds: string[] }>((resolve) => {
+          resolveBroadcast = resolve;
+        })
+    );
+    useFleetFailureStore.setState({
+      failedIds: new Set(["t1"]),
+      payload: "ls\r",
+      recordedAt: Date.now(),
+    });
+    const registry = await buildRegistry();
+    const first = run(registry, "fleet.retryFailures");
+    // Second call happens while the first is awaiting the broadcast.
+    await run(registry, "fleet.retryFailures");
+    expect(broadcastFleetLiteralPaste).toHaveBeenCalledTimes(1);
+    resolveBroadcast?.({ failedIds: [] });
+    await first;
+  });
 });

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -600,8 +600,9 @@ describe("fleet.retryFailures", () => {
     const registry = await buildRegistry();
     await run(registry, "fleet.retryFailures");
     expect(broadcastFleetLiteralPaste).toHaveBeenCalledTimes(1);
-    const [payload, targets] = (broadcastFleetLiteralPaste as ReturnType<typeof vi.fn>).mock
-      .calls[0];
+    const call = (broadcastFleetLiteralPaste as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call).toBeDefined();
+    const [payload, targets] = call as [string, string[]];
     expect(payload).toBe("ls\r");
     expect((targets as string[]).slice().sort()).toEqual(["t1", "t2"]);
   });
@@ -670,7 +671,7 @@ describe("fleet.retryFailures", () => {
     // Second call happens while the first is awaiting the broadcast.
     await run(registry, "fleet.retryFailures");
     expect(broadcastFleetLiteralPaste).toHaveBeenCalledTimes(1);
-    resolveBroadcast?.({ failedIds: [] });
+    (resolveBroadcast as ((value: { failedIds: string[] }) => void) | null)?.({ failedIds: [] });
     await first;
   });
 });

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -81,6 +81,14 @@ function requestConfirmation(kind: FleetPendingActionKind, targets: TerminalInst
   });
 }
 
+/**
+ * Module-level re-entrancy flag for `fleet.retryFailures`. A fast double-
+ * click on the banner's "Retry failed" button would otherwise dispatch
+ * two concurrent broadcasts against the same target set; for payloads
+ * ending in `\r` that double-executes the command in every pane.
+ */
+let retryInFlight = false;
+
 function clearPendingIf(kind: FleetPendingActionKind): void {
   const pending = useFleetPendingActionStore.getState().pending;
   if (pending && pending.kind === kind) {
@@ -319,14 +327,25 @@ export function registerFleetActions(actions: ActionRegistry): void {
     danger: "safe",
     scope: "renderer",
     run: async () => {
+      // Re-entrancy guard: a fast double-click on "Retry failed" would
+      // otherwise dispatch two concurrent broadcasts against the same
+      // target set before either's dismissId loop runs — for command-
+      // terminating payloads (`"make deploy\r"`) that double-executes
+      // the command.
+      if (retryInFlight) return;
       const { failedIds, payload } = useFleetFailureStore.getState();
       if (payload == null || failedIds.size === 0) return;
       // Snapshot once — `failedIds` mutates as dismissId fires inside the loop.
       const targets = Array.from(failedIds);
-      const result = await broadcastFleetLiteralPaste(payload, targets);
-      const stillFailed = new Set(result.failedIds);
-      for (const id of targets) {
-        if (!stillFailed.has(id)) useFleetFailureStore.getState().dismissId(id);
+      retryInFlight = true;
+      try {
+        const result = await broadcastFleetLiteralPaste(payload, targets);
+        const stillFailed = new Set(result.failedIds);
+        for (const id of targets) {
+          if (!stillFailed.has(id)) useFleetFailureStore.getState().dismissId(id);
+        }
+      } finally {
+        retryInFlight = false;
       }
     },
   }));

--- a/src/store/__tests__/fleetFailureStore.test.ts
+++ b/src/store/__tests__/fleetFailureStore.test.ts
@@ -61,6 +61,17 @@ describe("useFleetFailureStore", () => {
     expect(s.recordedAt).toBeNull();
   });
 
+  it("recordFailure accepts a null payload for non-replayable failures", () => {
+    // Raw-input broadcasts use null to signal "no meaningful retry" — the
+    // `Retry failed` action checks `payload == null` and skips the IPC
+    // write. Using "" here would slip through that guard (#8705).
+    useFleetFailureStore.getState().recordFailure(null, ["a", "b"]);
+    const s = useFleetFailureStore.getState();
+    expect(s.failedIds).toEqual(new Set(["a", "b"]));
+    expect(s.payload).toBeNull();
+    expect(s.recordedAt).toBeGreaterThan(0);
+  });
+
   it("dismissId removes a single id and preserves the rest", () => {
     useFleetFailureStore.getState().recordFailure("p", ["a", "b", "c"]);
     useFleetFailureStore.getState().dismissId("b");

--- a/src/store/fleetFailureStore.ts
+++ b/src/store/fleetFailureStore.ts
@@ -26,7 +26,7 @@ export interface FleetFailureSnapshot {
 }
 
 interface FleetFailureState extends FleetFailureSnapshot {
-  recordFailure: (payload: string, failedIds: Iterable<string>) => void;
+  recordFailure: (payload: string | null, failedIds: Iterable<string>) => void;
   /** Drop a single pane from the failure set (e.g. when retry succeeds). */
   dismissId: (id: string) => void;
   /** Clear everything (user acknowledged, fleet cleared, etc.). */


### PR DESCRIPTION
## Summary

- `fleet.retryFailures` was using `""` as the non-replayable sentinel value. Empty string slips past the `payload == null` guard and fires real empty-byte writes against live PTYs. Changed to `null` throughout.
- Added `FleetFailureBanner` — a Tier-2 inline error banner that surfaces partial fleet broadcast failures above the fleet ribbon. Retry is only offered when the payload is non-null (replayable).
- Added a re-entrancy guard on `fleet.retryFailures` so a fast double-click can't dispatch two concurrent broadcasts. Added dismiss-on-success to `applyFleetBroadcastResult` so a stale red dot doesn't linger after a subsequent write succeeds.

Resolves #8705

## Changes

- `fleetFailureStore.ts` — widened `recordFailure` to accept `string | null`; changed sentinel from `""` to `null`
- `fleetRawInputBroadcast.ts` — passes `null` on non-replayable failure paths
- `fleetActions.ts` — re-entrancy guard on retry dispatch; dismiss-on-success in `applyFleetBroadcastResult`
- `FleetFailureBanner.tsx` — new Tier-2 banner component; mounted in both branches of `FleetArmingRibbon`
- Tests — updated broken `toBe("")` assertion; 6 new tests covering null sentinel, retry partial/full success, null-payload no-op, double-dispatch guard, dismiss-on-success

## Testing

- Unit tests updated and extended; all pass
- Verified banner mounts correctly in both the confirm-pending early-return branch and the main animated ribbon branch
- Verified retry button absent when payload is `null`, present when replayable