### PR TITLE
fix(fleet): add ENOTCONN, ENXIO, EINVAL to permanent broadcast failure codes

### DIFF
--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -403,6 +403,8 @@ describe("applyFleetBroadcastResult", () => {
 
     const arming = useFleetArmingStore.getState();
     expect(arming.armedIds.has("t2")).toBe(true);
+
+    expect(clearDirectingStateMock).not.toHaveBeenCalled();
   });
 
   it("treats failures with no errno code as permanent (defensive default)", () => {
@@ -453,7 +455,7 @@ describe("applyFleetBroadcastResult", () => {
       results: [
         { id: "t1", ok: true },
         { id: "t2", ok: false, error: { code: "EPIPE", message: "broken pipe" } },
-        { id: "t3", ok: false, error: { code: "ENOSPC", message: "no space" } },
+        { id: "t3", ok: false, error: { code: "EAGAIN", message: "would block" } },
         { id: "t4", ok: true },
       ],
     });
@@ -463,6 +465,9 @@ describe("applyFleetBroadcastResult", () => {
     expect(arming.armedIds.has("t3")).toBe(true);
 
     expect(Array.from(useFleetFailureStore.getState().failedIds)).toEqual(["t3"]);
+
+    expect(clearDirectingStateMock).toHaveBeenCalledWith("t2");
+    expect(clearDirectingStateMock).not.toHaveBeenCalledWith("t3");
   });
 
   it("does nothing when every target succeeded", () => {

--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -390,7 +390,7 @@ describe("applyFleetBroadcastResult", () => {
     applyFleetBroadcastResult({
       results: [
         { id: "t1", ok: true },
-        { id: "t2", ok: false, error: { code: "ENOSPC", message: "no space" } },
+        { id: "t2", ok: false, error: { code: "EAGAIN", message: "would block" } },
       ],
     });
 
@@ -421,6 +421,28 @@ describe("applyFleetBroadcastResult", () => {
     expect(arming.armedIds.has("t2")).toBe(false);
     expect(useFleetFailureStore.getState().failedIds.size).toBe(0);
   });
+
+  it.each(["ENOTCONN", "ENXIO", "EINVAL"])(
+    "disarms the target on %s without recording a chip",
+    (code) => {
+      seedPanels([makeTerminal("t1"), makeTerminal("t2")]);
+      useFleetArmingStore.getState().armIds(["t1", "t2"]);
+      broadcastFleetRawInput("t1", "x");
+
+      applyFleetBroadcastResult({
+        results: [
+          { id: "t1", ok: true },
+          { id: "t2", ok: false, error: { code, message: `write failure: ${code}` } },
+        ],
+      });
+
+      const arming = useFleetArmingStore.getState();
+      expect(arming.armedIds.has("t2")).toBe(false);
+      expect(arming.armedIds.has("t1")).toBe(true);
+      expect(useFleetFailureStore.getState().failedIds.size).toBe(0);
+      expect(clearDirectingStateMock).toHaveBeenCalledWith("t2");
+    }
+  );
 
   it("handles a mixed batch — disarm permanent, record non-permanent", () => {
     seedPanels([makeTerminal("t1"), makeTerminal("t2"), makeTerminal("t3"), makeTerminal("t4")]);

--- a/src/components/Fleet/fleetRawInputBroadcast.ts
+++ b/src/components/Fleet/fleetRawInputBroadcast.ts
@@ -19,6 +19,9 @@ const PERMANENT_FAILURE_CODES: ReadonlySet<string> = new Set([
   "EIO",
   "EBADF",
   "ECONNRESET",
+  "ENOTCONN",
+  "ENXIO",
+  "EINVAL",
 ]);
 
 function resolveLiveFleetTargetIds(): string[] {
@@ -117,7 +120,7 @@ export function broadcastFleetRawInput(originId: string, data: string): boolean 
  *   and we'd just thrash the store. An unknown errno is treated as permanent
  *   on purpose: the safer default is to stop typing into a target whose
  *   write semantics we can't reason about.
- * - Non-permanent failures (e.g., `ENOSPC`) leave arming alone and record a
+ * - Non-permanent failures (e.g., `EAGAIN`) leave arming alone and record a
  *   transient failure entry so the user sees the chip. The chip's "Retry
  *   failed" path is a no-op for the raw-input transport (single keystrokes
  *   are not meaningful to replay), and `recordFailure` is called with an

--- a/src/components/Fleet/fleetRawInputBroadcast.ts
+++ b/src/components/Fleet/fleetRawInputBroadcast.ts
@@ -137,7 +137,7 @@ export function applyFleetBroadcastResult(payload: BroadcastWriteResultPayload):
   for (const result of payload.results) {
     if (result.ok) continue;
     const code = result.error?.code;
-    // Unknown errno → permanent. We can't tell if the target is recoverable,
+    // Missing errno → permanent. We can't tell if the target is recoverable,
     // so the safer default is to disarm rather than keep firing keystrokes.
     if (!code || PERMANENT_FAILURE_CODES.has(code)) {
       permanentlyFailedIds.push(result.id);


### PR DESCRIPTION
## Summary
- `ENOTCONN` (Windows ConPTY disconnect), `ENXIO` (BSD/macOS pty teardown), and `EINVAL` (structurally-invalid-write default) now auto-disarm fleet broadcast targets, matching existing `EPIPE`/`EIO`/`EBADF`/`ECONNRESET` behavior.
- Without these in the permanent failure set, a target that hit one of these codes stayed armed, the directing indicator stayed on, and the user kept firing keystrokes into a dead pipe with no real signal.
- Replaced `ENOSPC` with `EAGAIN` as the non-permanent test fixture -- `ENOSPC` is a filesystem errno that can't come from `pty.write()`.

Resolves #8690

## Changes
- Added `ENOTCONN`, `ENXIO`, `EINVAL` to `PERMANENT_FAILURE_CODES` in `fleetRawInputBroadcast.ts`
- Updated the missing-errno JSDoc comment and the non-permanent example from `ENOSPC` to `EAGAIN`
- Added an `it.each` regression test for the three new codes, verifying disarm + no chip + `clearDirectingState` call
- Hardened existing test assertions with `clearDirectingState` checks on the non-permanent and mixed-batch cases

## Testing
- Unit tests pass: the `it.each` block covers all three new codes, and the hardened assertions confirm `clearDirectingState` fires only for permanent failures and not for transient ones.