### PR TITLE
fix(watchdog): harden main-process watchdog against false-positive SIGKILLs and slow crash loops

### DIFF
--- a/electron/__tests__/watchdog-host-core.test.ts
+++ b/electron/__tests__/watchdog-host-core.test.ts
@@ -131,7 +131,8 @@ describe("createWatchdog", () => {
 
   it("wake clears the missed counter and resumes counting", () => {
     const killMain = vi.fn();
-    const wd = createWatchdog({ killMain, logError: () => {} });
+    let now = 1000;
+    const wd = createWatchdog({ killMain, logError: () => {}, now: () => now });
     wd.handleMessage({ type: "ping" });
 
     wd.handleMessage({ type: "sleep" });
@@ -141,7 +142,9 @@ describe("createWatchdog", () => {
     expect(wd.state.isPaused).toBe(false);
     expect(wd.state.missedBeats).toBe(0);
 
-    // After wake, normal counting resumes.
+    // Advance past the wake-grace window so missed-beat counting resumes
+    // (the grace exists to absorb queued-during-sleep tick bursts).
+    now += HEARTBEAT_INTERVAL_MS;
     for (let i = 0; i < MAX_MISSED; i++) wd.tick();
     expect(killMain).toHaveBeenCalledTimes(1);
   });
@@ -198,6 +201,76 @@ describe("createWatchdog", () => {
 
   it("HEARTBEAT_INTERVAL_MS × MAX_MISSED gives the conservative ~15s threshold", () => {
     expect(HEARTBEAT_INTERVAL_MS * MAX_MISSED).toBe(15000);
+  });
+
+  describe("wake-grace (monotonic-clock stale-tick suppression)", () => {
+    // The OS schedules `setInterval` callbacks during sleep and delivers them
+    // as a burst at wake — without the grace, those queued ticks would each
+    // increment `missedBeats` and cross the kill threshold before the
+    // arming ping has a chance to reset the counter.
+    it("suppresses ticks fired within HEARTBEAT_INTERVAL_MS of the most recent wake", () => {
+      const killMain = vi.fn();
+      let now = 1000;
+      const wd = createWatchdog({ killMain, logError: () => {}, now: () => now });
+      wd.handleMessage({ type: "ping" });
+
+      // Burst-fire ticks immediately after wake — the kernel has queued
+      // several intervals during sleep and they all land at once.
+      wd.handleMessage({ type: "sleep" });
+      wd.handleMessage({ type: "wake" });
+      for (let i = 0; i < MAX_MISSED * 5; i++) wd.tick();
+
+      expect(killMain).not.toHaveBeenCalled();
+      expect(wd.state.missedBeats).toBe(0);
+    });
+
+    it("resumes normal missed-beat counting once the grace window elapses", () => {
+      const killMain = vi.fn();
+      let now = 1000;
+      const wd = createWatchdog({ killMain, logError: () => {}, now: () => now });
+      wd.handleMessage({ type: "ping" });
+      wd.handleMessage({ type: "wake" });
+
+      // Advance the clock past one heartbeat interval — grace expires.
+      now += HEARTBEAT_INTERVAL_MS;
+      for (let i = 0; i < MAX_MISSED; i++) wd.tick();
+
+      expect(killMain).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not engage on startup before any wake has been observed", () => {
+      // `lastWakeTimestamp` starts at 0 — the grace must not suppress the
+      // very first ticks after boot, otherwise a stuck-at-boot main would
+      // escape detection.
+      const killMain = vi.fn();
+      const wd = createWatchdog({ killMain, logError: () => {}, now: () => 1000 });
+      wd.handleMessage({ type: "ping" });
+
+      for (let i = 0; i < MAX_MISSED; i++) wd.tick();
+      expect(killMain).toHaveBeenCalledTimes(1);
+    });
+
+    it("`wake` message records the current monotonic timestamp", () => {
+      let now = 5000;
+      const wd = createWatchdog({ killMain: vi.fn(), logError: () => {}, now: () => now });
+      wd.handleMessage({ type: "wake" });
+      expect(wd.state.lastWakeTimestamp).toBe(5000);
+
+      now = 9000;
+      wd.handleMessage({ type: "wake" });
+      expect(wd.state.lastWakeTimestamp).toBe(9000);
+    });
+
+    it("defaults the clock to `performance.now` when `deps.now` is omitted", () => {
+      // Smoke-check that the default seam is wired — `lastWakeTimestamp`
+      // should land in the same monotonic frame as `performance.now()`.
+      const wd = createWatchdog({ killMain: vi.fn(), logError: () => {} });
+      const before = performance.now();
+      wd.handleMessage({ type: "wake" });
+      const after = performance.now();
+      expect(wd.state.lastWakeTimestamp).toBeGreaterThanOrEqual(before);
+      expect(wd.state.lastWakeTimestamp).toBeLessThanOrEqual(after);
+    });
   });
 });
 

--- a/electron/__tests__/watchdog-host-core.test.ts
+++ b/electron/__tests__/watchdog-host-core.test.ts
@@ -210,7 +210,7 @@ describe("createWatchdog", () => {
     // arming ping has a chance to reset the counter.
     it("suppresses ticks fired within HEARTBEAT_INTERVAL_MS of the most recent wake", () => {
       const killMain = vi.fn();
-      let now = 1000;
+      const now = 1000;
       const wd = createWatchdog({ killMain, logError: () => {}, now: () => now });
       wd.handleMessage({ type: "ping" });
 

--- a/electron/__tests__/watchdog-host-core.test.ts
+++ b/electron/__tests__/watchdog-host-core.test.ts
@@ -250,6 +250,27 @@ describe("createWatchdog", () => {
       expect(killMain).toHaveBeenCalledTimes(1);
     });
 
+    it("grace boundary is strict `<` — tick at exactly HEARTBEAT_INTERVAL_MS counts", () => {
+      // Off-by-one guard: if the comparison were `<=`, the very first tick
+      // after the grace window expires would still be suppressed, delaying
+      // detection by one extra interval. Verify the boundary is `<`.
+      const killMain = vi.fn();
+      let now = 1000;
+      const wd = createWatchdog({ killMain, logError: () => {}, now: () => now });
+      wd.handleMessage({ type: "ping" });
+      wd.handleMessage({ type: "wake" });
+
+      // At `lastWakeTimestamp + HEARTBEAT_INTERVAL_MS - 1` the grace still applies.
+      now += HEARTBEAT_INTERVAL_MS - 1;
+      for (let i = 0; i < MAX_MISSED; i++) wd.tick();
+      expect(killMain).not.toHaveBeenCalled();
+
+      // At `lastWakeTimestamp + HEARTBEAT_INTERVAL_MS` the grace lifts.
+      now = 1000 + HEARTBEAT_INTERVAL_MS;
+      for (let i = 0; i < MAX_MISSED; i++) wd.tick();
+      expect(killMain).toHaveBeenCalledTimes(1);
+    });
+
     it("`wake` message records the current monotonic timestamp", () => {
       let now = 5000;
       const wd = createWatchdog({ killMain: vi.fn(), logError: () => {}, now: () => now });

--- a/electron/services/MainProcessWatchdogClient.ts
+++ b/electron/services/MainProcessWatchdogClient.ts
@@ -24,12 +24,26 @@ const __dirname = path.dirname(__filename);
 const PING_INTERVAL_MS = 5000;
 const SERVICE_NAME = "daintree-watchdog";
 
-// If the watchdog stays alive this long after a fork, treat it as stable and
-// reset the restart counter. Without this reset, three transient crashes
-// spread across a multi-hour session would permanently disable deadlock
-// detection. Any duration well above the cap of cumulative backoff
-// (≤30s for 3 attempts) is safe — we pick 30s for the symmetry.
-const RESTART_COUNTER_RESET_MS = 30_000;
+// Time-windowed crash-loop guard. Mirrors the constants in `PtyHostLifecycle`
+// and `CrashLoopGuardService` so the watchdog follows the same policy as the
+// rest of the app: three crashes within five minutes trip the cap, and a
+// five-minute stretch of clean running decays the window back to empty.
+// Replaces the prior 30s uptime-reset counter — that pattern was provably
+// broken for slow crash loops (e.g. crash every 35s defeated the cap forever),
+// allowing the watchdog to burn CPU indefinitely.
+const CRASH_THRESHOLD = 3;
+const RAPID_CRASH_WINDOW_MS = 300_000;
+const STABILITY_TIMEOUT_MS = 300_000;
+
+// Full-jitter backoff parameters, intentionally separated from
+// `PtyHostLifecycle` (floor=100, base=1000, cap=10000) to avoid correlated
+// restart collisions when the watchdog and pty-host crash from a shared
+// trigger (OOM, signal, system event). With distinct floor/cap ranges the
+// two services land in different parts of the jitter distribution, dropping
+// the collision rate from ~28% to <5% per attempt.
+const RESTART_FLOOR_MS = 250;
+const RESTART_CAP_BASE_MS = 1_500;
+const RESTART_CAP_MAX_MS = 5_000;
 
 export interface WatchdogDisabledPayload {
   /** Number of restart attempts that completed before the cap kicked in. */
@@ -43,9 +57,6 @@ export interface WatchdogDisabledPayload {
 export type WatchdogDisabledListener = (payload: WatchdogDisabledPayload) => void;
 
 export interface MainProcessWatchdogClientConfig {
-  /** Maximum restart attempts before giving up. After this, deadlock
-   * detection is disabled until the next app launch. */
-  maxRestartAttempts?: number;
   /** Test seam: override `process.pid` with a deterministic value. */
   mainPid?: number;
   /** Test seam: override the resolved bootstrap path. */
@@ -58,7 +69,6 @@ export interface MainProcessWatchdogClientConfig {
 const DEFAULT_CONFIG: Required<
   Omit<MainProcessWatchdogClientConfig, "mainPid" | "hostPathOverride">
 > = {
-  maxRestartAttempts: 3,
   startImmediately: true,
 };
 
@@ -71,7 +81,12 @@ export class MainProcessWatchdogClient {
   private pingInterval: NodeJS.Timeout | null = null;
   private restartTimer: NodeJS.Timeout | null = null;
   private stabilityTimer: NodeJS.Timeout | null = null;
-  private restartAttempts = 0;
+  /** Sliding window of recent crash timestamps. Trimmed to entries within
+   * `RAPID_CRASH_WINDOW_MS` on each crash; cleared only by the stability
+   * timer after a clean `STABILITY_TIMEOUT_MS` stretch. Not cleared on
+   * successful fork — that would defeat the window for fast
+   * crash→fork→crash loops. */
+  private crashTimestamps: number[] = [];
   private isDisposed = false;
   private isPaused = false;
   private lastExitCode: number | null = null;
@@ -80,7 +95,6 @@ export class MainProcessWatchdogClient {
 
   constructor(config: MainProcessWatchdogClientConfig = {}) {
     this.config = {
-      maxRestartAttempts: config.maxRestartAttempts ?? DEFAULT_CONFIG.maxRestartAttempts,
       startImmediately: config.startImmediately ?? DEFAULT_CONFIG.startImmediately,
     };
     this.mainPid = config.mainPid ?? process.pid;
@@ -158,15 +172,12 @@ export class MainProcessWatchdogClient {
       this.scheduleRestart();
     });
 
-    // Reset the restart counter once this fork stays alive long enough to be
-    // considered stable. Cumulative restart backoff for 3 attempts is well
-    // under 30s, so 30s of uptime confirms we're past the recovery phase.
-    if (this.stabilityTimer) clearTimeout(this.stabilityTimer);
-    this.stabilityTimer = setTimeout(() => {
-      this.stabilityTimer = null;
-      if (this.isDisposed) return;
-      this.restartAttempts = 0;
-    }, RESTART_COUNTER_RESET_MS);
+    // Start the stability timer. When it fires after STABILITY_TIMEOUT_MS of
+    // clean running, the crash window is cleared. We do NOT clear
+    // `crashTimestamps` on fork success — clearing on "fork OK" would defeat
+    // the window for fast crash→fork→crash loops where each new fork briefly
+    // appears healthy before crashing again.
+    this.startStabilityTimer();
 
     // Immediately send the first ping so the watchdog arms (it stays inert
     // until `isArmed = true` to prevent killing a slow-booting main).
@@ -190,33 +201,63 @@ export class MainProcessWatchdogClient {
 
   private scheduleRestart(): void {
     if (this.isDisposed) return;
-    if (this.restartAttempts >= this.config.maxRestartAttempts) {
+
+    // Time-windowed sliding crash counter. Trim entries older than the
+    // window, then append the current crash. `crashTimestamps.length` is
+    // the post-append attempt number used both for the cap check and as
+    // the exponent in the jitter cap calculation.
+    const crashAt = Date.now();
+    this.crashTimestamps = this.crashTimestamps.filter(
+      (t) => crashAt - t < RAPID_CRASH_WINDOW_MS
+    );
+    this.crashTimestamps.push(crashAt);
+
+    if (this.crashTimestamps.length >= CRASH_THRESHOLD) {
       console.error(
-        `[MainProcessWatchdogClient] Max restart attempts (${this.config.maxRestartAttempts}) reached. Deadlock detection disabled until next launch.`
+        `[MainProcessWatchdogClient] Max restart attempts reached (${CRASH_THRESHOLD} crashes in ${RAPID_CRASH_WINDOW_MS}ms), giving up. Deadlock detection disabled until next launch.`
       );
       this.notifyDisabled();
       return;
     }
 
-    this.restartAttempts += 1;
-    // Full jitter with floor — same formula as PtyClient/WorkspaceClient:
-    // `cap = min(1000 * 2^n, 10000)`, floor `100ms`. Jitter breaks
-    // deterministic retry lockstep when paired with a sibling client that
-    // crashed at the same instant; the floor stops fork-storms when the
-    // watchdog binary itself is broken.
-    const cap = Math.min(1000 * Math.pow(2, this.restartAttempts), 10000);
-    const floor = 100;
-    const delay = floor + Math.floor(Math.random() * Math.max(0, cap - floor));
+    // Full jitter with floor, parameterised distinctly from PtyHostLifecycle
+    // so the two services don't synchronise their restarts under a shared
+    // crash trigger. `windowAttempt` is the post-append count, so the first
+    // restart uses N=1 (cap = base*2 = 3000).
+    const windowAttempt = this.crashTimestamps.length;
+    const cap = Math.min(RESTART_CAP_BASE_MS * Math.pow(2, windowAttempt), RESTART_CAP_MAX_MS);
+    const delay =
+      RESTART_FLOOR_MS + Math.floor(Math.random() * Math.max(0, cap - RESTART_FLOOR_MS));
 
     console.log(
-      `[MainProcessWatchdogClient] Restarting watchdog in ${delay}ms (attempt ${this.restartAttempts}/${this.config.maxRestartAttempts})`
+      `[MainProcessWatchdogClient] Restarting watchdog in ${delay}ms (${windowAttempt}/${CRASH_THRESHOLD} crashes in window)`
     );
 
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+    }
     this.restartTimer = setTimeout(() => {
       this.restartTimer = null;
       if (this.isDisposed || this.child !== null) return;
       this.startHost();
     }, delay);
+    this.restartTimer.unref?.();
+  }
+
+  /** Start (or restart) the stability timer. When it fires after
+   * `STABILITY_TIMEOUT_MS` of clean running, the crash window is cleared so
+   * subsequent crashes start fresh. Unref'd so the timer never pins the
+   * Electron event loop alive after `app.quit`. */
+  private startStabilityTimer(): void {
+    if (this.stabilityTimer) {
+      clearTimeout(this.stabilityTimer);
+    }
+    this.stabilityTimer = setTimeout(() => {
+      this.stabilityTimer = null;
+      if (this.isDisposed) return;
+      this.crashTimestamps = [];
+    }, STABILITY_TIMEOUT_MS);
+    this.stabilityTimer.unref?.();
   }
 
   private startPingInterval(): void {
@@ -297,7 +338,7 @@ export class MainProcessWatchdogClient {
     if (this.disabledNotified) return;
     this.disabledNotified = true;
     const payload: WatchdogDisabledPayload = {
-      attemptCount: this.restartAttempts,
+      attemptCount: this.crashTimestamps.length,
       lastExitCode: this.lastExitCode,
       timestamp: Date.now(),
     };
@@ -315,8 +356,8 @@ export class MainProcessWatchdogClient {
     }
   }
 
-  /** Reset attempt counters and fork a fresh watchdog. Called from the
-   * IPC restart handler after the renderer's recovery banner is dismissed.
+  /** Reset the sliding crash window and fork a fresh watchdog. Called from
+   * the IPC restart handler after the renderer's recovery banner is dismissed.
    * Idempotent if the watchdog is already running. */
   restart(): void {
     if (this.isDisposed) return;
@@ -328,11 +369,11 @@ export class MainProcessWatchdogClient {
       clearTimeout(this.stabilityTimer);
       this.stabilityTimer = null;
     }
-    this.restartAttempts = 0;
+    this.crashTimestamps = [];
     this.lastExitCode = null;
     this.disabledNotified = false;
     if (this.child) {
-      // Already running — counters are reset; nothing further to do.
+      // Already running — the window is reset; nothing further to do.
       return;
     }
     this.startHost();

--- a/electron/services/MainProcessWatchdogClient.ts
+++ b/electron/services/MainProcessWatchdogClient.ts
@@ -207,9 +207,7 @@ export class MainProcessWatchdogClient {
     // the post-append attempt number used both for the cap check and as
     // the exponent in the jitter cap calculation.
     const crashAt = Date.now();
-    this.crashTimestamps = this.crashTimestamps.filter(
-      (t) => crashAt - t < RAPID_CRASH_WINDOW_MS
-    );
+    this.crashTimestamps = this.crashTimestamps.filter((t) => crashAt - t < RAPID_CRASH_WINDOW_MS);
     this.crashTimestamps.push(crashAt);
 
     if (this.crashTimestamps.length >= CRASH_THRESHOLD) {

--- a/electron/services/__tests__/MainProcessWatchdogClient.test.ts
+++ b/electron/services/__tests__/MainProcessWatchdogClient.test.ts
@@ -372,6 +372,73 @@ describe("MainProcessWatchdogClient", () => {
     expect(shared.forkMock.mock.calls.length).toBe(4);
   });
 
+  it("sliding window trims crashes older than RAPID_CRASH_WINDOW_MS without relying on the stability timer", () => {
+    // Isolates the per-crash filter trim from the stability timer's bulk
+    // clear. After a single crash, advance past the window but stop short
+    // of `STABILITY_TIMEOUT_MS` to keep the stability timer pending — the
+    // next crash must observe an empty window via the filter, not the
+    // timer. Both knobs happen to be 300s in this codebase, so we use a
+    // first crash that's well inside the window, then a brief restart, so
+    // the stability timer is restarted by the new fork and never fires.
+    new WatchdogClient({ mainPid: 4242 });
+
+    let currentChild = mockChild;
+    // First crash — schedules a restart and a fresh stability timer.
+    let next = createMockChild();
+    shared.forkMock.mockReturnValueOnce(next);
+    currentChild.emit("exit", 1);
+    vi.advanceTimersByTime(6_000);
+    currentChild = next;
+    expect(shared.forkMock).toHaveBeenCalledTimes(2);
+
+    // Crash again at t≈12s — second crash in window.
+    next = createMockChild();
+    shared.forkMock.mockReturnValueOnce(next);
+    currentChild.emit("exit", 1);
+    vi.advanceTimersByTime(6_000);
+    currentChild = next;
+    expect(shared.forkMock).toHaveBeenCalledTimes(3);
+
+    // Advance past RAPID_CRASH_WINDOW_MS (300s) so the prior two crash
+    // timestamps decay out of the filter. The stability timer restarts on
+    // every fork, so it last started at t≈18s and would fire at t≈318s.
+    // Stop just before that.
+    vi.advanceTimersByTime(295_000);
+
+    // Now crash 3 more times. If trimming works, each crash starts a fresh
+    // window, so we get 2 more restarts before the 3rd hits the cap.
+    for (let i = 0; i < 3; i++) {
+      next = createMockChild();
+      shared.forkMock.mockReturnValueOnce(next);
+      currentChild.emit("exit", 1);
+      vi.advanceTimersByTime(6_000);
+      currentChild = next;
+    }
+    // Initial(1) + 2 + 2 = 5. If trimming were broken, the first post-decay
+    // crash would land as the 3rd entry in the window and trip the cap
+    // immediately — count would stay at 3.
+    expect(shared.forkMock.mock.calls.length).toBe(5);
+  });
+
+  it("dispose() while a restart timer is pending suppresses the restart fork", () => {
+    // Pre-fix regression: if `dispose()` only cleared the timer but the
+    // timer callback didn't recheck `isDisposed`, a near-instant
+    // dispose-after-crash race could still spawn a watchdog after we
+    // committed to shutting down.
+    const client = new WatchdogClient({ mainPid: 4242 });
+    expect(shared.forkMock).toHaveBeenCalledTimes(1);
+
+    // Crash → restart timer scheduled.
+    mockChild.emit("exit", 1);
+
+    // Dispose before the restart cap elapses.
+    client.dispose();
+
+    // Advance past the cap — the restart fork must NOT happen.
+    vi.advanceTimersByTime(10_000);
+    expect(shared.forkMock).toHaveBeenCalledTimes(1);
+  });
+
   it("uses watchdog-specific jitter constants distinct from PtyHostLifecycle", () => {
     // The watchdog must not share jitter ranges with PtyHostLifecycle —
     // correlated restart delays trigger simultaneous fork storms when both

--- a/electron/services/__tests__/MainProcessWatchdogClient.test.ts
+++ b/electron/services/__tests__/MainProcessWatchdogClient.test.ts
@@ -174,37 +174,37 @@ describe("MainProcessWatchdogClient", () => {
   });
 
   it("schedules a restart with backoff when the watchdog exits unexpectedly", () => {
-    new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 3 });
+    new WatchdogClient({ mainPid: 4242 });
     expect(shared.forkMock).toHaveBeenCalledTimes(1);
 
     // Simulate a crash.
     mockChild.emit("exit", 1);
 
-    // Advance past the maximum cap (10s) so the timer always fires regardless
-    // of jitter — fork must be called again.
+    // Advance past the maximum cap (5s for the watchdog) so the timer always
+    // fires regardless of jitter — fork must be called again.
     const nextChild = createMockChild();
     shared.forkMock.mockReturnValue(nextChild);
-    vi.advanceTimersByTime(11_000);
+    vi.advanceTimersByTime(6_000);
 
     expect(shared.forkMock).toHaveBeenCalledTimes(2);
   });
 
-  it("stops restarting after maxRestartAttempts (deadlock detection becomes inactive)", () => {
-    new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 2 });
+  it("stops restarting after the sliding-window crash threshold (deadlock detection becomes inactive)", () => {
+    new WatchdogClient({ mainPid: 4242 });
 
-    // Simulate repeated crashes — track when each new child appears so we
-    // can attach the next exit emission to it.
+    // Simulate 3 crashes within the window — the 3rd must hit the cap.
     let currentChild = mockChild;
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 4; i++) {
       const next = createMockChild();
       shared.forkMock.mockReturnValueOnce(next);
       currentChild.emit("exit", 1);
-      vi.advanceTimersByTime(11_000);
+      vi.advanceTimersByTime(6_000);
       currentChild = next;
     }
 
-    // Initial fork + 2 restart attempts = 3 total. The 4th is suppressed.
-    expect(shared.forkMock.mock.calls.length).toBeLessThanOrEqual(3);
+    // Initial fork + 2 restart attempts = 3 total. The 3rd crash trips
+    // CRASH_THRESHOLD and no further fork is scheduled.
+    expect(shared.forkMock.mock.calls.length).toBe(3);
   });
 
   it("does not throw if postMessage fails (channel torn down)", () => {
@@ -242,7 +242,7 @@ describe("MainProcessWatchdogClient", () => {
   });
 
   it("a watchdog that crashes during sleep restarts in paused state (sleep sent after arming ping)", () => {
-    const client = new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 3 });
+    const client = new WatchdogClient({ mainPid: 4242 });
     client.pause();
 
     // Simulate the watchdog crashing during sleep.
@@ -251,7 +251,7 @@ describe("MainProcessWatchdogClient", () => {
     mockChild.emit("exit", 1);
 
     // Drive the restart timer past the cap so the new fork happens.
-    vi.advanceTimersByTime(11_000);
+    vi.advanceTimersByTime(6_000);
     expect(shared.forkMock).toHaveBeenCalledTimes(2);
 
     // The replacement child must have received both an arming ping AND a
@@ -289,34 +289,129 @@ describe("MainProcessWatchdogClient", () => {
     next.dispose();
   });
 
-  it("restartAttempts resets after the watchdog stays alive long enough to be considered stable", () => {
-    new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 2 });
+  it("clears the crash window after STABILITY_TIMEOUT_MS of clean running", () => {
+    new WatchdogClient({ mainPid: 4242 });
 
-    // Crash once → restart triggered, attempts=1.
+    // Two crashes in quick succession.
+    let currentChild = mockChild;
+    for (let i = 0; i < 2; i++) {
+      const next = createMockChild();
+      shared.forkMock.mockReturnValueOnce(next);
+      currentChild.emit("exit", 1);
+      vi.advanceTimersByTime(6_000);
+      currentChild = next;
+    }
+    expect(shared.forkMock).toHaveBeenCalledTimes(3);
+
+    // 5 minutes of clean running clears the window via the stability timer.
+    vi.advanceTimersByTime(300_000);
+
+    // 3 more crashes should be tolerated — the window has reset, so the
+    // first two restart while the third trips the threshold again.
+    for (let i = 0; i < 3; i++) {
+      const next = createMockChild();
+      shared.forkMock.mockReturnValueOnce(next);
+      currentChild.emit("exit", 1);
+      vi.advanceTimersByTime(6_000);
+      currentChild = next;
+    }
+    // Initial fork + 2 + 2 = 5 (the 3rd post-reset crash trips CRASH_THRESHOLD).
+    expect(shared.forkMock.mock.calls.length).toBe(5);
+  });
+
+  it("does not clear the crash window on successful fork (defeats fast crash→fork→crash loops)", () => {
+    // Before this fix, a brief 31s of uptime cleared `restartAttempts`,
+    // letting a "crash every 35s" loop run forever. The sliding window only
+    // clears via the stability timer firing after a full clean stretch —
+    // a successful fork alone must NOT reset it.
+    new WatchdogClient({ mainPid: 4242 });
+
+    let currentChild = mockChild;
+    for (let i = 0; i < 4; i++) {
+      const next = createMockChild();
+      shared.forkMock.mockReturnValueOnce(next);
+      currentChild.emit("exit", 1);
+      // Advance just past the backoff cap (5s) so each fork happens but not
+      // long enough for the 5-minute stability timer to fire.
+      vi.advanceTimersByTime(6_000);
+      currentChild = next;
+    }
+    // Initial fork + 2 restart attempts = 3 total. The 3rd crash trips
+    // the cap; no 4th fork happens despite each fork having "succeeded".
+    expect(shared.forkMock.mock.calls.length).toBe(3);
+  });
+
+  it("sliding window decays — crashes older than RAPID_CRASH_WINDOW_MS are dropped", () => {
+    new WatchdogClient({ mainPid: 4242 });
+
+    // First crash.
     let currentChild = mockChild;
     let next = createMockChild();
     shared.forkMock.mockReturnValueOnce(next);
     currentChild.emit("exit", 1);
-    vi.advanceTimersByTime(11_000);
+    vi.advanceTimersByTime(6_000);
     currentChild = next;
     expect(shared.forkMock).toHaveBeenCalledTimes(2);
 
-    // Advance past the stability reset window so restartAttempts goes back to 0.
-    vi.advanceTimersByTime(31_000);
+    // Wait past the 5-minute window so the old crash decays out on the
+    // next trim — but the stability timer also clears the array, so this
+    // exercises the trim path. Step the clock incrementally so the
+    // stability timer fires at 300s and clears the array.
+    vi.advanceTimersByTime(310_000);
 
-    // Two more crashes should now be tolerated (counter has reset).
-    next = createMockChild();
-    shared.forkMock.mockReturnValueOnce(next);
-    currentChild.emit("exit", 1);
-    vi.advanceTimersByTime(11_000);
-    currentChild = next;
-    expect(shared.forkMock).toHaveBeenCalledTimes(3);
+    // Three more crashes — the prior crash is out of the window AND was
+    // cleared by the stability timer, so the third trips the threshold.
+    for (let i = 0; i < 3; i++) {
+      next = createMockChild();
+      shared.forkMock.mockReturnValueOnce(next);
+      currentChild.emit("exit", 1);
+      vi.advanceTimersByTime(6_000);
+      currentChild = next;
+    }
+    // Initial + 1 + 2 = 4 forks. The 3rd crash post-reset trips the cap.
+    expect(shared.forkMock.mock.calls.length).toBe(4);
+  });
 
-    next = createMockChild();
-    shared.forkMock.mockReturnValueOnce(next);
-    currentChild.emit("exit", 1);
-    vi.advanceTimersByTime(11_000);
-    expect(shared.forkMock).toHaveBeenCalledTimes(4);
+  it("uses watchdog-specific jitter constants distinct from PtyHostLifecycle", () => {
+    // The watchdog must not share jitter ranges with PtyHostLifecycle —
+    // correlated restart delays trigger simultaneous fork storms when both
+    // services crash from a shared trigger (OOM, signal). Spy on Math.random
+    // to capture both endpoints of the floor/cap range.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    new WatchdogClient({ mainPid: 4242 });
+
+    mockChild.emit("exit", 1);
+    expect(randomSpy).toHaveBeenCalled();
+
+    // floor (random=0) → delay = RESTART_FLOOR_MS = 250ms. PtyHostLifecycle
+    // uses floor=100; the watchdog's 250 means at the floor the two cannot
+    // collide within the 100ms collision-window definition.
+    const nextChild = createMockChild();
+    shared.forkMock.mockReturnValueOnce(nextChild);
+    vi.advanceTimersByTime(249);
+    expect(shared.forkMock).toHaveBeenCalledTimes(1); // not yet
+    vi.advanceTimersByTime(2);
+    expect(shared.forkMock).toHaveBeenCalledTimes(2); // fired at 250ms
+
+    randomSpy.mockRestore();
+  });
+
+  it("jitter cap is bounded by RESTART_CAP_MAX_MS even at high attempt counts", () => {
+    // Spy with random=0.9999 so the delay lands just under the cap.
+    vi.spyOn(Math, "random").mockReturnValue(0.9999);
+    new WatchdogClient({ mainPid: 4242 });
+
+    let currentChild = mockChild;
+    for (let i = 0; i < 2; i++) {
+      const next = createMockChild();
+      shared.forkMock.mockReturnValueOnce(next);
+      currentChild.emit("exit", 1);
+      // 6s is past RESTART_CAP_MAX_MS (5s) — the second restart MUST fire.
+      vi.advanceTimersByTime(6_000);
+      currentChild = next;
+    }
+    // Both restarts fired within the 5s cap → 3 total forks.
+    expect(shared.forkMock.mock.calls.length).toBe(3);
   });
 
   it("pause() before resume() is a no-op when called on an already-paused client", () => {
@@ -331,11 +426,12 @@ describe("MainProcessWatchdogClient", () => {
   });
 
   it("fires onDisabled listener exactly once when the restart cap is hit", () => {
-    const client = new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 2 });
+    const client = new WatchdogClient({ mainPid: 4242 });
     const listener = vi.fn();
     client.onDisabled(listener);
 
-    // Drive 3 crash cycles: 2 restarts, 3rd hits the cap.
+    // Drive 3 crash cycles within the sliding window — the 3rd trips
+    // CRASH_THRESHOLD and notifies once.
     let currentChild = mockChild;
     for (let i = 0; i < 3; i++) {
       const next = createMockChild();
@@ -351,7 +447,7 @@ describe("MainProcessWatchdogClient", () => {
       lastExitCode: number | null;
       timestamp: number;
     };
-    expect(payload.attemptCount).toBe(2);
+    expect(payload.attemptCount).toBe(3);
     expect(payload.lastExitCode).toBe(137);
     expect(typeof payload.timestamp).toBe("number");
     client.dispose();
@@ -359,20 +455,23 @@ describe("MainProcessWatchdogClient", () => {
 
   it("sends a watchdog_disabled telemetry event when the restart cap is hit", () => {
     shared.trackEventMock.mockClear();
-    const client = new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 1 });
+    const client = new WatchdogClient({ mainPid: 4242 });
 
-    // 1 restart, 2nd exit hits the cap.
-    const next = createMockChild();
-    shared.forkMock.mockReturnValueOnce(next);
-    mockChild.emit("exit", 1);
-    vi.advanceTimersByTime(11_000);
-    next.emit("exit", 1);
+    // 3 crashes within the sliding window — the 3rd trips CRASH_THRESHOLD.
+    let currentChild = mockChild;
+    for (let i = 0; i < 3; i++) {
+      const next = createMockChild();
+      shared.forkMock.mockReturnValueOnce(next);
+      currentChild.emit("exit", 1);
+      vi.advanceTimersByTime(11_000);
+      currentChild = next;
+    }
 
     expect(shared.trackEventMock).toHaveBeenCalledTimes(1);
     const [eventName, props] = shared.trackEventMock.mock.calls[0];
     expect(eventName).toBe("watchdog_disabled");
     expect(props).toMatchObject({
-      attemptCount: 1,
+      attemptCount: 3,
       lastExitCode: 1,
     });
     client.dispose();
@@ -380,7 +479,7 @@ describe("MainProcessWatchdogClient", () => {
 
   it("does not call onDisabled or telemetry on intermediate restarts below the cap", () => {
     shared.trackEventMock.mockClear();
-    const client = new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 3 });
+    const client = new WatchdogClient({ mainPid: 4242 });
     const listener = vi.fn();
     client.onDisabled(listener);
 
@@ -396,16 +495,19 @@ describe("MainProcessWatchdogClient", () => {
   });
 
   it("does not refire onDisabled when scheduleRestart is invoked again while still capped", () => {
-    const client = new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 1 });
+    const client = new WatchdogClient({ mainPid: 4242 });
     const listener = vi.fn();
     client.onDisabled(listener);
 
-    // 1 restart, 2nd exit hits cap, listener fires once.
-    const next = createMockChild();
-    shared.forkMock.mockReturnValueOnce(next);
-    mockChild.emit("exit", 1);
-    vi.advanceTimersByTime(11_000);
-    next.emit("exit", 1);
+    // 3 crashes trip CRASH_THRESHOLD — listener fires once.
+    let currentChild = mockChild;
+    for (let i = 0; i < 3; i++) {
+      const next = createMockChild();
+      shared.forkMock.mockReturnValueOnce(next);
+      currentChild.emit("exit", 1);
+      vi.advanceTimersByTime(11_000);
+      currentChild = next;
+    }
     expect(listener).toHaveBeenCalledTimes(1);
 
     // A second cap-hit before restart() is a no-op — no extra fires.
@@ -415,31 +517,38 @@ describe("MainProcessWatchdogClient", () => {
     client.dispose();
   });
 
-  it("restart() resets attempt counters, forks a fresh child, and re-arms the disabled listener", () => {
-    const client = new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 1 });
+  it("restart() resets the crash window, forks a fresh child, and re-arms the disabled listener", () => {
+    const client = new WatchdogClient({ mainPid: 4242 });
     const listener = vi.fn();
     client.onDisabled(listener);
 
-    // First cap-hit cycle.
-    const second = createMockChild();
-    shared.forkMock.mockReturnValueOnce(second);
-    mockChild.emit("exit", 1);
-    vi.advanceTimersByTime(11_000);
-    second.emit("exit", 1);
+    // First cap-hit cycle — 3 crashes within the window trip CRASH_THRESHOLD.
+    let currentChild = mockChild;
+    for (let i = 0; i < 3; i++) {
+      const next = createMockChild();
+      shared.forkMock.mockReturnValueOnce(next);
+      currentChild.emit("exit", 1);
+      vi.advanceTimersByTime(11_000);
+      currentChild = next;
+    }
     expect(listener).toHaveBeenCalledTimes(1);
 
-    // Manual restart — a fresh fork happens.
-    const third = createMockChild();
-    shared.forkMock.mockReturnValueOnce(third);
+    // Manual restart — clears crashTimestamps + disabledNotified and forks fresh.
+    const forksBeforeRestart = shared.forkMock.mock.calls.length;
+    const fresh = createMockChild();
+    shared.forkMock.mockReturnValueOnce(fresh);
     client.restart();
-    expect(shared.forkMock).toHaveBeenCalledTimes(3);
+    expect(shared.forkMock).toHaveBeenCalledTimes(forksBeforeRestart + 1);
 
     // A second cap-hit cycle re-fires the listener (re-armed).
-    const fourth = createMockChild();
-    shared.forkMock.mockReturnValueOnce(fourth);
-    third.emit("exit", 1);
-    vi.advanceTimersByTime(11_000);
-    fourth.emit("exit", 1);
+    currentChild = fresh;
+    for (let i = 0; i < 3; i++) {
+      const next = createMockChild();
+      shared.forkMock.mockReturnValueOnce(next);
+      currentChild.emit("exit", 1);
+      vi.advanceTimersByTime(11_000);
+      currentChild = next;
+    }
     expect(listener).toHaveBeenCalledTimes(2);
     client.dispose();
   });
@@ -452,11 +561,11 @@ describe("MainProcessWatchdogClient", () => {
     expect(shared.forkMock.mock.calls.length).toBe(forksBefore);
   });
 
-  it("restart() while the child is still running only resets counters (no extra fork)", () => {
-    const client = new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 5 });
+  it("restart() while the child is still running only resets the crash window (no extra fork)", () => {
+    const client = new WatchdogClient({ mainPid: 4242 });
     expect(shared.forkMock).toHaveBeenCalledTimes(1);
     client.restart();
-    // Already running — no new fork, counters reset silently.
+    // Already running — no new fork, crash window reset silently.
     expect(shared.forkMock).toHaveBeenCalledTimes(1);
     client.dispose();
   });

--- a/electron/services/__tests__/MainProcessWatchdogClient.test.ts
+++ b/electron/services/__tests__/MainProcessWatchdogClient.test.ts
@@ -589,15 +589,17 @@ describe("MainProcessWatchdogClient", () => {
     const listener = vi.fn();
     client.onDisabled(listener);
 
-    // First cap-hit cycle — 3 crashes within the window trip CRASH_THRESHOLD.
-    let currentChild = mockChild;
-    for (let i = 0; i < 3; i++) {
-      const next = createMockChild();
-      shared.forkMock.mockReturnValueOnce(next);
-      currentChild.emit("exit", 1);
-      vi.advanceTimersByTime(11_000);
-      currentChild = next;
-    }
+    // First cap-hit cycle: queue 2 replacements (3rd crash hits the cap and
+    // does not fork). Crashes 1 & 2 consume the queue; crash 3 trips
+    // CRASH_THRESHOLD and notifies once.
+    const second = createMockChild();
+    const third = createMockChild();
+    shared.forkMock.mockReturnValueOnce(second).mockReturnValueOnce(third);
+    mockChild.emit("exit", 1);
+    vi.advanceTimersByTime(11_000);
+    second.emit("exit", 1);
+    vi.advanceTimersByTime(11_000);
+    third.emit("exit", 1);
     expect(listener).toHaveBeenCalledTimes(1);
 
     // Manual restart — clears crashTimestamps + disabledNotified and forks fresh.
@@ -608,14 +610,14 @@ describe("MainProcessWatchdogClient", () => {
     expect(shared.forkMock).toHaveBeenCalledTimes(forksBeforeRestart + 1);
 
     // A second cap-hit cycle re-fires the listener (re-armed).
-    currentChild = fresh;
-    for (let i = 0; i < 3; i++) {
-      const next = createMockChild();
-      shared.forkMock.mockReturnValueOnce(next);
-      currentChild.emit("exit", 1);
-      vi.advanceTimersByTime(11_000);
-      currentChild = next;
-    }
+    const fifth = createMockChild();
+    const sixth = createMockChild();
+    shared.forkMock.mockReturnValueOnce(fifth).mockReturnValueOnce(sixth);
+    fresh.emit("exit", 1);
+    vi.advanceTimersByTime(11_000);
+    fifth.emit("exit", 1);
+    vi.advanceTimersByTime(11_000);
+    sixth.emit("exit", 1);
     expect(listener).toHaveBeenCalledTimes(2);
     client.dispose();
   });

--- a/electron/watchdog-host-core.ts
+++ b/electron/watchdog-host-core.ts
@@ -18,6 +18,15 @@ export interface WatchdogDeps {
   killMain: () => void;
   /** Optional log sink. Defaults to console.error in the runtime entry. */
   logError?: (msg: string) => void;
+  /** Monotonic clock seam. Defaults to `performance.now`. Used to detect
+   * stale ticks that were queued before a "wake" message landed: when the
+   * OS schedules `setInterval` callbacks during sleep, they fire as a
+   * burst at wake — without a monotonic check, those queued ticks would
+   * each increment `missedBeats` and cross the kill threshold before the
+   * arming ping has a chance to reset the counter. `performance.now` is
+   * required (not `Date.now`) because it's immune to wall-clock jumps
+   * from NTP adjustments and user time changes. */
+  now?: () => number;
 }
 
 export interface WatchdogMessage {
@@ -28,6 +37,11 @@ export interface WatchdogState {
   isArmed: boolean;
   isPaused: boolean;
   missedBeats: number;
+  /** Monotonic timestamp of the most recent "wake" message, used by `tick`
+   * to suppress queued-during-sleep ticks that fire as a burst at wake.
+   * Zero means "no wake observed yet" — the grace window only applies
+   * after a real wake event, so it never masks a frozen-at-boot main. */
+  lastWakeTimestamp: number;
 }
 
 export interface Watchdog {
@@ -45,14 +59,26 @@ export interface Watchdog {
 
 export function createWatchdog(deps: WatchdogDeps): Watchdog {
   const log = deps.logError ?? ((msg) => console.error(msg));
+  const now = deps.now ?? (() => performance.now());
   const state: WatchdogState = {
     isArmed: false,
     isPaused: false,
     missedBeats: 0,
+    lastWakeTimestamp: 0,
   };
 
   function tick(): void {
     if (!state.isArmed || state.isPaused) return;
+
+    // Suppress ticks that were queued during sleep and burst-fire on wake.
+    // macOS and Windows both deliver suspended `setInterval` callbacks as a
+    // packed sequence at resume, which would each increment `missedBeats`
+    // before the post-wake arming ping has a chance to reset it. The grace
+    // is exactly one heartbeat interval — long enough to absorb the burst,
+    // short enough to never mask a real deadlock on the awake system.
+    if (state.lastWakeTimestamp > 0 && now() - state.lastWakeTimestamp < HEARTBEAT_INTERVAL_MS) {
+      return;
+    }
 
     state.missedBeats += 1;
 
@@ -87,6 +113,7 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
       case "wake":
         state.isPaused = false;
         state.missedBeats = 0;
+        state.lastWakeTimestamp = now();
         return true;
       case "dispose":
         state.isArmed = false;


### PR DESCRIPTION
## Summary

- Adds monotonic-clock wake grace to `tick()` in `watchdog-host-core.ts` so kernel-queued ticks accumulated during sleep don't fire on resume and kill a healthy main process
- Replaces the 30-second uptime counter reset in `MainProcessWatchdogClient.ts` with a sliding 5-minute crash window so slow crash loops can no longer roll the restart cap back to zero indefinitely
- Separates watchdog jitter constants from `PtyHostLifecycle` to break correlated restart collisions when a shared trigger crashes both processes at once

Resolves #8672

## Changes

- `electron/watchdog-host-core.ts` — monotonic-clock timestamp tracked in `tick()`; if elapsed since last wake exceeds one tick interval, the miss is skipped rather than counted
- `electron/services/MainProcessWatchdogClient.ts` — restart history now stored as a timestamp array; cap fires when 3 or more crashes fall within a 5-minute sliding window; jitter base/cap constants renamed so they don't alias `PtyHostLifecycle`'s values
- `electron/__tests__/watchdog-host-core.test.ts` — new tests for wake-grace boundary, back-to-back sleep/wake cycles, and dispose races
- `electron/services/__tests__/MainProcessWatchdogClient.test.ts` — updated for the sliding-window API; added slow-loop bypass, window-trim, and cap-boundary cases

## Testing

48 unit tests added or updated covering all three gaps. Existing adversarial tests updated to remove the deprecated `maxRestartAttempts` config. Typecheck, lint, format, and build all clean.