### PR TITLE
fix(fleet): replace count-based progress gate with duration-based gate

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -4,17 +4,15 @@ import { AnimatePresence, m, useReducedMotion } from "framer-motion";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import { isMac } from "@/lib/platform";
-import { useEscapeStack } from "@/hooks";
+import { useEscapeStack, useDeferredLoading } from "@/hooks";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import "./fleetRawInputBroadcast";
 import { useFleetEscapeChords } from "./useFleetEscapeChords";
 import { useFleetRibbonFlashes } from "./useFleetRibbonFlashes";
 import { buildConfirmMessage, type FleetConfirmActionId } from "./buildConfirmMessage";
 import { FleetCountChip } from "./FleetCountChip";
 import { SavedFleetsSection } from "./SavedFleetsSection";
-import {
-  FLEET_LARGE_PASTE_BATCH_SIZE,
-  FLEET_PROGRESS_VISIBILITY_THRESHOLD,
-} from "./fleetBroadcast";
+import { FLEET_LARGE_PASTE_BATCH_SIZE } from "./fleetBroadcast";
 import { cancelActiveBroadcast } from "./fleetEnterBroadcast";
 import {
   useFleetArmingStore,
@@ -61,6 +59,7 @@ export function FleetArmingRibbon(): ReactElement | null {
   const progressTotal = useFleetBroadcastProgressStore((s) => s.total);
   const progressFailed = useFleetBroadcastProgressStore((s) => s.failed);
   const progressActive = useFleetBroadcastProgressStore((s) => s.isActive);
+  const showProgress = useDeferredLoading(progressActive, UI_DOHERTY_THRESHOLD);
 
   const [popoverOpen, setPopoverOpen] = useState(false);
   // The selection menu is controlled so a fleet-delete request can close it
@@ -524,7 +523,7 @@ export function FleetArmingRibbon(): ReactElement | null {
             open={popoverOpen}
             onOpenChange={setPopoverOpen}
           />
-          {progressActive && progressTotal >= FLEET_PROGRESS_VISIBILITY_THRESHOLD && (
+          {showProgress && (
             <span
               className="text-[11px] tabular-nums text-daintree-text/70"
               data-testid="fleet-broadcast-progress"

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -806,7 +806,7 @@ describe("FleetArmingRibbon", () => {
       expect(screen.queryByTestId("fleet-broadcast-progress")).toBeNull();
     });
 
-    it("does not render when total is below the visibility threshold", () => {
+    it("does not render until the Doherty threshold elapses", () => {
       // Count no longer gates visibility — duration does. Counter hidden
       // until the Doherty threshold (400ms) elapses.
       vi.useFakeTimers();
@@ -948,6 +948,7 @@ describe("FleetArmingRibbon", () => {
         });
         const cancel = screen.getByTestId("fleet-broadcast-cancel");
         expect(cancel.getAttribute("aria-label")).toBe("Cancel broadcast");
+        expect(screen.getByTestId("fleet-broadcast-progress")).toBeTruthy();
       } finally {
         vi.useRealTimers();
       }

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -807,118 +807,190 @@ describe("FleetArmingRibbon", () => {
     });
 
     it("does not render when total is below the visibility threshold", () => {
-      useFleetBroadcastProgressStore.setState({ total: 5, isActive: true });
-      useFleetArmingStore.getState().armIds(["a", "b"]);
-      render(<FleetArmingRibbon />);
-      expect(screen.queryByTestId("fleet-broadcast-progress")).toBeNull();
+      // Count no longer gates visibility — duration does. Counter hidden
+      // until the Doherty threshold (400ms) elapses.
+      vi.useFakeTimers();
+      try {
+        useFleetBroadcastProgressStore.setState({ total: 3, isActive: true });
+        useFleetArmingStore.getState().armIds(["a", "b"]);
+        render(<FleetArmingRibbon />);
+        expect(screen.queryByTestId("fleet-broadcast-progress")).toBeNull();
+        act(() => {
+          vi.advanceTimersByTime(400);
+        });
+        expect(screen.getByTestId("fleet-broadcast-progress")).toBeTruthy();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
-    it("renders when isActive and total >= 10", () => {
-      useFleetBroadcastProgressStore.setState({
-        completed: 5,
-        total: 15,
-        isActive: true,
-      });
-      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
-      render(<FleetArmingRibbon />);
-      const el = screen.getByTestId("fleet-broadcast-progress");
-      expect(el.textContent).toContain("5/15");
+    it("renders when isActive and the Doherty threshold elapses", () => {
+      vi.useFakeTimers();
+      try {
+        useFleetBroadcastProgressStore.setState({
+          completed: 5,
+          total: 15,
+          isActive: true,
+        });
+        useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+        render(<FleetArmingRibbon />);
+        act(() => {
+          vi.advanceTimersByTime(400);
+        });
+        const el = screen.getByTestId("fleet-broadcast-progress");
+        expect(el.textContent).toContain("5/15");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("shows failure count when failed > 0", () => {
-      useFleetBroadcastProgressStore.setState({
-        completed: 8,
-        total: 12,
-        failed: 2,
-        isActive: true,
-      });
-      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
-      render(<FleetArmingRibbon />);
-      const el = screen.getByTestId("fleet-broadcast-progress");
-      expect(el.textContent).toContain("8/12");
-      expect(el.textContent).toContain("2 failed");
+      vi.useFakeTimers();
+      try {
+        useFleetBroadcastProgressStore.setState({
+          completed: 8,
+          total: 12,
+          failed: 2,
+          isActive: true,
+        });
+        useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+        render(<FleetArmingRibbon />);
+        act(() => {
+          vi.advanceTimersByTime(400);
+        });
+        const el = screen.getByTestId("fleet-broadcast-progress");
+        expect(el.textContent).toContain("8/12");
+        expect(el.textContent).toContain("2 failed");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("does not show failure count when failed is 0", () => {
-      useFleetBroadcastProgressStore.setState({
-        completed: 8,
-        total: 12,
-        failed: 0,
-        isActive: true,
-      });
-      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
-      render(<FleetArmingRibbon />);
-      const el = screen.getByTestId("fleet-broadcast-progress");
-      expect(el.textContent).toContain("8/12");
-      expect(el.textContent).not.toContain("failed");
+      vi.useFakeTimers();
+      try {
+        useFleetBroadcastProgressStore.setState({
+          completed: 8,
+          total: 12,
+          failed: 0,
+          isActive: true,
+        });
+        useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+        render(<FleetArmingRibbon />);
+        act(() => {
+          vi.advanceTimersByTime(400);
+        });
+        const el = screen.getByTestId("fleet-broadcast-progress");
+        expect(el.textContent).toContain("8/12");
+        expect(el.textContent).not.toContain("failed");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
-    it("renders at exact threshold boundary (total = 10)", () => {
-      useFleetBroadcastProgressStore.setState({
-        completed: 3,
-        total: 10,
-        isActive: true,
-      });
-      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
-      render(<FleetArmingRibbon />);
-      expect(screen.getByTestId("fleet-broadcast-progress")).toBeTruthy();
+    it("renders progress counter for small fleets after Doherty threshold", () => {
+      vi.useFakeTimers();
+      try {
+        useFleetBroadcastProgressStore.setState({
+          completed: 3,
+          total: 3,
+          isActive: true,
+        });
+        useFleetArmingStore.getState().armIds(["a", "b"]);
+        render(<FleetArmingRibbon />);
+        expect(screen.queryByTestId("fleet-broadcast-progress")).toBeNull();
+        act(() => {
+          vi.advanceTimersByTime(400);
+        });
+        expect(screen.getByTestId("fleet-broadcast-progress")).toBeTruthy();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("disappears when isActive becomes false mid-broadcast", () => {
-      useFleetBroadcastProgressStore.setState({
-        completed: 10,
-        total: 12,
-        isActive: true,
-      });
-      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
-      const { rerender } = render(<FleetArmingRibbon />);
-      expect(screen.getByTestId("fleet-broadcast-progress")).toBeTruthy();
+      vi.useFakeTimers();
+      try {
+        useFleetBroadcastProgressStore.setState({
+          completed: 10,
+          total: 12,
+          isActive: true,
+        });
+        useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+        const { rerender } = render(<FleetArmingRibbon />);
+        act(() => {
+          vi.advanceTimersByTime(400);
+        });
+        expect(screen.getByTestId("fleet-broadcast-progress")).toBeTruthy();
 
-      act(() => {
-        useFleetBroadcastProgressStore.setState({ isActive: false });
-      });
-      rerender(<FleetArmingRibbon />);
-      expect(screen.queryByTestId("fleet-broadcast-progress")).toBeNull();
+        act(() => {
+          useFleetBroadcastProgressStore.setState({ isActive: false });
+        });
+        rerender(<FleetArmingRibbon />);
+        expect(screen.queryByTestId("fleet-broadcast-progress")).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("renders a Cancel button alongside the progress counter when active", () => {
-      useFleetBroadcastProgressStore.setState({
-        completed: 3,
-        total: 12,
-        isActive: true,
-      });
-      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
-      render(<FleetArmingRibbon />);
-      const cancel = screen.getByTestId("fleet-broadcast-cancel");
-      expect(cancel.getAttribute("aria-label")).toBe("Cancel broadcast");
+      vi.useFakeTimers();
+      try {
+        useFleetBroadcastProgressStore.setState({
+          completed: 3,
+          total: 12,
+          isActive: true,
+        });
+        useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+        render(<FleetArmingRibbon />);
+        act(() => {
+          vi.advanceTimersByTime(400);
+        });
+        const cancel = screen.getByTestId("fleet-broadcast-cancel");
+        expect(cancel.getAttribute("aria-label")).toBe("Cancel broadcast");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("clicking Cancel flips the progress store cancelled flag", () => {
-      useFleetBroadcastProgressStore.setState({
-        completed: 3,
-        total: 12,
-        isActive: true,
-      });
-      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
-      render(<FleetArmingRibbon />);
-      fireEvent.click(screen.getByTestId("fleet-broadcast-cancel"));
-      expect(useFleetBroadcastProgressStore.getState().cancelled).toBe(true);
+      vi.useFakeTimers();
+      try {
+        useFleetBroadcastProgressStore.setState({
+          completed: 3,
+          total: 12,
+          isActive: true,
+        });
+        useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+        render(<FleetArmingRibbon />);
+        act(() => {
+          vi.advanceTimersByTime(400);
+        });
+        fireEvent.click(screen.getByTestId("fleet-broadcast-cancel"));
+        expect(useFleetBroadcastProgressStore.getState().cancelled).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
-    it("Cancel button is reachable for batched broadcasts below the counter threshold (6–9 targets)", () => {
-      // Batching kicks in at total > FLEET_LARGE_PASTE_BATCH_SIZE (5), but
-      // the numeric counter only shows at total >= 10. Without a separate
-      // gate, large-paste broadcasts to 6–9 targets had no Cancel surface.
-      useFleetBroadcastProgressStore.setState({
-        completed: 1,
-        total: 7,
-        isActive: true,
-      });
-      useFleetArmingStore.getState().armIds(["a", "b"]);
-      render(<FleetArmingRibbon />);
-      expect(screen.getByTestId("fleet-broadcast-cancel")).toBeTruthy();
-      // Counter still hidden because total < FLEET_PROGRESS_VISIBILITY_THRESHOLD.
-      expect(screen.queryByTestId("fleet-broadcast-progress")).toBeNull();
+    it("Cancel button is reachable for batched broadcasts — counter visible after Doherty", () => {
+      vi.useFakeTimers();
+      try {
+        useFleetBroadcastProgressStore.setState({
+          completed: 1,
+          total: 7,
+          isActive: true,
+        });
+        useFleetArmingStore.getState().armIds(["a", "b"]);
+        render(<FleetArmingRibbon />);
+        act(() => {
+          vi.advanceTimersByTime(400);
+        });
+        expect(screen.getByTestId("fleet-broadcast-cancel")).toBeTruthy();
+        expect(screen.getByTestId("fleet-broadcast-progress")).toBeTruthy();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("Cancel button does not render for non-batchable fleets (total ≤ 5)", () => {

--- a/src/components/Fleet/fleetBroadcast.ts
+++ b/src/components/Fleet/fleetBroadcast.ts
@@ -36,13 +36,6 @@ export const FLEET_LARGE_PASTE_BYTE_THRESHOLD = 102_400;
 export const FLEET_LARGE_PASTE_BATCH_SIZE = 5;
 
 /**
- * Minimum armed-target count at which the in-flight progress counter renders
- * in the fleet ribbon. Below this threshold the per-pane red-dot failure
- * indicators suffice — small fleets stay uncluttered.
- */
-export const FLEET_PROGRESS_VISIBILITY_THRESHOLD = 10;
-
-/**
  * Conservative — flags commands that are usually destructive outside a sandbox.
  * Intentionally does NOT try to be a shell parser. False positives are fine
  * (an extra confirm). False negatives are the real cost.


### PR DESCRIPTION
## Summary
- The fleet broadcast progress counter was gated on a count threshold of 10, so fleets of 2-6 terminals never saw in-flight progress. That's the common case, not an edge case.
- Replaced the count gate with the standard `useDeferredLoading` hook gated on `UI_DOHERTY_THRESHOLD` (400ms), consistent with every other deferred-loading surface in the app.
- Removes the `FLEET_PROGRESS_VISIBILITY_THRESHOLD` constant entirely.

Resolves #8686

## Changes
- `src/components/Fleet/fleetBroadcast.ts` — removed the `FLEET_PROGRESS_VISIBILITY_THRESHOLD` constant
- `src/components/Fleet/FleetArmingRibbon.tsx` — replaced `progressTotal >= FLEET_PROGRESS_VISIBILITY_THRESHOLD` with `useDeferredLoading(progressActive, UI_DOHERTY_THRESHOLD)`
- `src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx` — updated all progress counter tests to use fake timers and advance 400ms before asserting visibility

## Testing
- All existing FleetArmingRibbon tests pass with fake timers
- Added test for small fleets (total of 3) showing progress after the Doherty threshold