### PR TITLE
feat(worktree-overview): multi-select + keyboard navigation (#8653)

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -702,6 +702,11 @@ export function WorktreeCard({
           <button
             type="button"
             tabIndex={variant === "grid" ? -1 : undefined}
+            // Grid variant: suppress focus shift on click so the role="grid"
+            // container retains the keyboard tab stop after a modifier-click.
+            onMouseDown={
+              variant === "grid" ? (e: React.MouseEvent) => e.preventDefault() : undefined
+            }
             className={cn(
               "absolute inset-0 z-0 outline-hidden",
               variant === "grid" && "rounded-lg",

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -88,6 +88,13 @@ export interface WorktreeCardProps {
   canMoveUp?: boolean;
   canMoveDown?: boolean;
   projectHealth?: import("@shared/types").ProjectHealthData | null;
+  /**
+   * Multi-select state (grid variant only). When provided, modifier-clicks
+   * (Ctrl/Cmd/Shift) route through `onToggleSelect` instead of `onSelect`
+   * and a checkbox affordance becomes visible on hover or when selected.
+   */
+  isSelected?: boolean;
+  onToggleSelect?: (event: React.MouseEvent) => void;
 }
 
 export function WorktreeCard({
@@ -115,8 +122,27 @@ export function WorktreeCard({
   canMoveUp,
   canMoveDown,
   projectHealth,
+  isSelected = false,
+  onToggleSelect,
 }: WorktreeCardProps) {
   "use memo";
+  const isMultiSelectEnabled = variant === "grid" && onToggleSelect !== undefined;
+
+  const handleCardClick = (e: React.MouseEvent) => {
+    if (isMultiSelectEnabled && (e.metaKey || e.ctrlKey || e.shiftKey)) {
+      e.preventDefault();
+      e.stopPropagation();
+      onToggleSelect?.(e);
+      return;
+    }
+    onSelect();
+  };
+
+  const handleCheckboxClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onToggleSelect?.(e);
+  };
   const isExpanded = useWorktreeSelectionStore((state) => state.expandedWorktrees.has(worktree.id));
   const toggleWorktreeExpanded = useWorktreeSelectionStore((state) => state.toggleWorktreeExpanded);
 
@@ -668,13 +694,14 @@ export function WorktreeCard({
           role={variant === "grid" ? "group" : undefined}
           aria-current={variant === "grid" && isActive ? "true" : undefined}
           aria-label={`Worktree: ${worktree.issueTitle ?? branchLabel}${worktree.issueTitle ? ` (${branchLabel})` : ""}${worktree.isCurrent ? " (selected, current)" : ""}, Status: ${spineState}${gitStateIndicator ? `, ${gitStateIndicator.label}` : ""}${!gitStateIndicator && hasChanges ? ", has uncommitted changes" : ""}`}
-          onClick={onSelect}
+          onClick={handleCardClick}
           onDoubleClick={handleDoubleClick}
           onPointerEnter={handlePointerEnter}
           onPointerLeave={handlePointerLeave}
         >
           <button
             type="button"
+            tabIndex={variant === "grid" ? -1 : undefined}
             className={cn(
               "absolute inset-0 z-0 outline-hidden",
               variant === "grid" && "rounded-lg",
@@ -738,6 +765,46 @@ export function WorktreeCard({
                 }
               </TooltipContent>
             </Tooltip>
+          )}
+          {isMultiSelectEnabled && (
+            <div
+              className={cn(
+                "absolute top-2 right-2 z-30 transition-opacity duration-150",
+                isSelected
+                  ? "opacity-100"
+                  : "opacity-0 group-hover/card:opacity-100 focus-within:opacity-100"
+              )}
+            >
+              <button
+                type="button"
+                role="checkbox"
+                aria-checked={isSelected}
+                aria-label={isSelected ? "Deselect worktree" : "Select worktree"}
+                tabIndex={-1}
+                onClick={handleCheckboxClick}
+                className={cn(
+                  "flex items-center justify-center w-5 h-5 rounded",
+                  "border border-divider transition-colors",
+                  "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
+                  isSelected
+                    ? "bg-overlay-emphasis text-text-primary"
+                    : "bg-daintree-bg/80 text-transparent hover:bg-overlay-subtle"
+                )}
+              >
+                <svg
+                  className="w-3 h-3"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M2.5 6.5l2.5 2.5 4.5-5" />
+                </svg>
+              </button>
+            </div>
           )}
           <div className="relative z-10 flex">
             {(dragHandleListeners || isDragHandleDisabled) &&

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -790,7 +790,6 @@ export function WorktreeCard({
                 className={cn(
                   "flex items-center justify-center w-5 h-5 rounded",
                   "border border-divider transition-colors",
-                  "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
                   isSelected
                     ? "bg-overlay-emphasis text-text-primary"
                     : "bg-daintree-bg/80 text-transparent hover:bg-overlay-subtle"

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useEffectEvent, useRef, useMemo } from "react";
+import React, { useCallback, useEffect, useEffectEvent, useRef, useMemo, useState } from "react";
 import { X, FilterX } from "lucide-react";
 import { Layers, Plug } from "@/components/icons";
 import { cn } from "@/lib/utils";
@@ -6,6 +6,10 @@ import { useShallow } from "zustand/react/shallow";
 import { WorktreeCard } from "./WorktreeCard";
 import { WorktreeFilterPopover } from "./WorktreeFilterPopover";
 import { WorktreeSidebarSearchBar } from "./WorktreeSidebarSearchBar";
+import {
+  useWorktreeOverviewKeyboard,
+  getWorktreeOverviewCellId,
+} from "./useWorktreeOverviewKeyboard";
 import type { WorktreeState, WorktreeSnapshot } from "@/types";
 import type { UseAgentLauncherReturn } from "@/hooks/useAgentLauncher";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
@@ -46,6 +50,8 @@ interface OverviewWorktreeCardProps {
   agentSettings?: UseAgentLauncherReturn["agentSettings"];
   homeDir?: string;
   onClose: () => void;
+  isSelected?: boolean;
+  onToggleSelect?: (worktreeId: string, event: React.MouseEvent) => void;
 }
 
 function OverviewWorktreeCard({
@@ -63,6 +69,8 @@ function OverviewWorktreeCard({
   agentSettings,
   homeDir,
   onClose,
+  isSelected,
+  onToggleSelect,
 }: OverviewWorktreeCardProps) {
   const worktreeSnap = useWorktreeStore((state) => state.worktrees.get(worktreeId));
   const worktree = useMemo(
@@ -98,6 +106,10 @@ function OverviewWorktreeCard({
     (agentId: string) => onLaunchAgent?.(worktreeId, agentId),
     [onLaunchAgent, worktreeId]
   );
+  const handleToggleSelect = useCallback(
+    (event: React.MouseEvent) => onToggleSelect?.(worktreeId, event),
+    [onToggleSelect, worktreeId]
+  );
 
   if (!worktree) return null;
 
@@ -117,7 +129,48 @@ function OverviewWorktreeCard({
       agentSettings={agentSettings}
       homeDir={homeDir}
       onAfterTerminalSelect={onClose}
+      isSelected={isSelected}
+      onToggleSelect={onToggleSelect ? handleToggleSelect : undefined}
     />
+  );
+}
+
+/**
+ * One cell of the overview grid. Wraps {@link OverviewWorktreeCard} in the
+ * ARIA `role="gridcell"` container that the keyboard hook tracks via
+ * `aria-activedescendant`. Selection treatment lives on this wrapper, not
+ * the card itself, so the shared {@link WorktreeCard} stays accent-policy
+ * neutral and its sidebar variant is untouched.
+ *
+ * The wrapper is the actual rendered box (the card's chrome). Selection
+ * styling uses `bg-overlay-subtle` + a neutral inset ring per CLAUDE.md's
+ * accent-color restraint — accent is reserved for one load-bearing signal
+ * per view and is never used as a multi-select indicator.
+ */
+function OverviewGridCell(props: OverviewWorktreeCardProps) {
+  const cellId = getWorktreeOverviewCellId(props.worktreeId);
+  const isSelected = props.isSelected ?? false;
+  return (
+    <div
+      id={cellId}
+      role="gridcell"
+      aria-selected={isSelected}
+      data-worktree-overview-cell={props.worktreeId}
+      style={{
+        contentVisibility: "auto",
+        containIntrinsicSize: "auto 240px",
+      }}
+      className={cn(
+        "rounded-lg overflow-hidden",
+        "border border-divider",
+        "bg-daintree-sidebar/50",
+        "transition duration-150",
+        "hover:bg-overlay-subtle hover:shadow-[var(--theme-shadow-ambient)]",
+        isSelected && "bg-overlay-subtle ring-1 ring-inset ring-border-default"
+      )}
+    >
+      <OverviewWorktreeCard {...props} variant="grid" />
+    </div>
   );
 }
 
@@ -414,11 +467,159 @@ export function WorktreeOverviewModal({
     hasFacetFiltersActive,
   ]);
 
+  // ── Multi-select state ────────────────────────────────────────────────
+  // Selection lives on the modal so it resets naturally when the modal
+  // unmounts (isOpen=false returns null below). Persistent stores would
+  // outlive the modal session and re-surface stale selection on reopen.
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  // Anchor for contiguous range selection. Survives filter changes by design
+  // (lesson #4729) — only deliberate actions reset it.
+  const selectionAnchorRef = useRef<string | null>(null);
+
+  const visibleIds = useMemo(
+    () => filteredWorktrees.map((w) => w.id),
+    [filteredWorktrees]
+  );
+  const visibleIdSet = useMemo(() => new Set(visibleIds), [visibleIds]);
+
+  // Drop selections that are no longer visible (filter narrowed). Anchor is
+  // deliberately not reset — a user re-widening the filter can resume range
+  // selection from where they left off.
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      if (prev.size === 0) return prev;
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (visibleIdSet.has(id)) {
+          next.add(id);
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [visibleIdSet]);
+
+  const toggleSelection = useCallback((worktreeId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(worktreeId)) {
+        next.delete(worktreeId);
+      } else {
+        next.add(worktreeId);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectRangeBetween = useCallback(
+    (anchorId: string, targetId: string) => {
+      const anchorIdx = visibleIds.indexOf(anchorId);
+      const targetIdx = visibleIds.indexOf(targetId);
+      if (anchorIdx === -1 || targetIdx === -1) return;
+      const [lo, hi] =
+        anchorIdx <= targetIdx ? [anchorIdx, targetIdx] : [targetIdx, anchorIdx];
+      setSelectedIds(new Set(visibleIds.slice(lo, hi + 1)));
+    },
+    [visibleIds]
+  );
+
+  const selectAllVisible = useCallback(() => {
+    setSelectedIds(new Set(visibleIds));
+  }, [visibleIds]);
+
+  const clearSelection = useCallback(() => {
+    selectionAnchorRef.current = null;
+    setSelectedIds(new Set());
+  }, []);
+
+  const activateWorktree = useCallback(
+    (worktreeId: string) => {
+      onSelectWorktree(worktreeId);
+      onClose();
+    },
+    [onSelectWorktree, onClose]
+  );
+
+  const handleCardToggleSelect = useCallback(
+    (worktreeId: string, event: React.MouseEvent) => {
+      // Shift+Click on a card extends from the anchor; Ctrl/Cmd+Click toggles
+      // the individual cell. A plain click without modifiers never reaches
+      // this handler (WorktreeCard routes those to onSelect).
+      if (event.shiftKey && selectionAnchorRef.current !== null) {
+        selectRangeBetween(selectionAnchorRef.current, worktreeId);
+        return;
+      }
+      selectionAnchorRef.current = worktreeId;
+      toggleSelection(worktreeId);
+    },
+    [selectRangeBetween, toggleSelection]
+  );
+
+  const hasSelection = selectedIds.size > 0;
+
+  const gridRef = useRef<HTMLDivElement | null>(null);
+  const closeModal = useCallback(() => onClose(), [onClose]);
+
+  const { activeDescendantId, handleGridKeyDown, handleGridFocus } = useWorktreeOverviewKeyboard({
+    worktreeIds: visibleIds,
+    gridRef,
+    selectionAnchorRef,
+    onActivate: activateWorktree,
+    onToggleSelection: toggleSelection,
+    onSelectRange: selectRangeBetween,
+    onSelectAll: selectAllVisible,
+    onClearSelection: clearSelection,
+    onEscapeWithoutSelection: closeModal,
+    hasSelection,
+  });
+
+  // Reset modifier-driven anchor state when the window loses focus (lesson
+  // #4591) — prevents a stuck Shift after Cmd+Tab from producing phantom
+  // range selections on the next click.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleWindowBlur = () => {
+      // Modifier keys are tracked by the browser; only the anchor state
+      // needs explicit reset on blur, so a subsequent un-modifier click
+      // doesn't pick up an unintended range origin.
+      selectionAnchorRef.current = null;
+    };
+    window.addEventListener("blur", handleWindowBlur);
+    return () => window.removeEventListener("blur", handleWindowBlur);
+  }, [isOpen]);
+
+  // Document-level keydown — fallback for keys fired outside the grid (e.g.
+  // when focus is on the close button or filter popover trigger). The grid
+  // hook handles Escape / Cmd+A when the grid is focused.
   const handleKeyDown = useEffectEvent((e: KeyboardEvent) => {
     if (e.key === "Escape") {
+      if (hasSelection) {
+        e.preventDefault();
+        e.stopPropagation();
+        clearSelection();
+        return;
+      }
       e.preventDefault();
       e.stopPropagation();
       onClose();
+      return;
+    }
+    if ((e.metaKey || e.ctrlKey) && (e.key === "a" || e.key === "A")) {
+      // Only intercept when focus is inside the modal but not in a text
+      // input — otherwise Cmd+A in a filter input must select the text.
+      const target = e.target as HTMLElement | null;
+      const isEditable =
+        !!target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable);
+      if (isEditable) return;
+      e.preventDefault();
+      e.stopPropagation();
+      selectionAnchorRef.current = visibleIds[0] ?? null;
+      selectAllVisible();
     }
   });
 
@@ -684,115 +885,104 @@ export function WorktreeOverviewModal({
                 </Button>
               }
             />
-          ) : groupedSections ? (
-            <div className="space-y-6">
-              {groupedSections.map((section: GroupedSection<WorktreeState>) => (
-                <div key={section.type}>
-                  <div className="flex items-center gap-2 mb-3">
-                    <h3 className="text-xs font-medium text-daintree-text/60 uppercase tracking-wider">
-                      {section.displayName}
-                    </h3>
-                    <span className="text-xs text-daintree-text/40">
-                      ({section.worktrees.length})
-                    </span>
-                  </div>
-                  <div
-                    className={cn(
-                      "grid gap-3",
-                      "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
-                      "justify-center",
-                      "auto-rows-min"
-                    )}
-                  >
-                    {section.worktrees.map((worktree: WorktreeState) => (
-                      <div
-                        key={worktree.id}
-                        style={{
-                          contentVisibility: "auto",
-                          containIntrinsicSize: "auto 240px",
-                        }}
-                        className={cn(
-                          "rounded-lg overflow-hidden",
-                          "border border-divider",
-                          "bg-daintree-sidebar/50",
-                          "transition duration-150",
-                          "hover:bg-overlay-subtle hover:shadow-[var(--theme-shadow-ambient)]"
-                        )}
-                      >
-                        <OverviewWorktreeCard
-                          worktreeId={worktree.id}
-                          activeWorktreeId={activeWorktreeId}
-                          focusedWorktreeId={focusedWorktreeId}
-                          totalWorktreeCount={worktrees.length}
-                          onSelectWorktree={onSelectWorktree}
-                          onCopyTree={onCopyTree}
-                          onOpenEditor={onOpenEditor}
-                          onSaveLayout={onSaveLayout}
-                          onLaunchAgent={onLaunchAgent}
-                          agentAvailability={agentAvailability}
-                          agentSettings={agentSettings}
-                          homeDir={homeDir}
-                          onClose={onClose}
-                        />
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              ))}
-            </div>
           ) : (
             <div
+              ref={gridRef}
+              role="grid"
+              tabIndex={0}
+              aria-multiselectable="true"
+              aria-activedescendant={activeDescendantId}
+              aria-rowcount={filteredWorktrees.length}
+              onKeyDown={handleGridKeyDown}
+              onFocus={handleGridFocus}
               className={cn(
                 "grid gap-3",
                 "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
                 "justify-center",
-                "items-start"
+                "auto-rows-min items-start",
+                "focus:outline-hidden"
               )}
             >
-              {filteredWorktrees.map((worktree) => (
-                <div
-                  key={worktree.id}
-                  style={{
-                    contentVisibility: "auto",
-                    containIntrinsicSize: "auto 240px",
-                  }}
-                  className={cn(
-                    "rounded-lg overflow-hidden",
-                    "border border-divider",
-                    "bg-daintree-sidebar/50",
-                    "transition duration-150",
-                    "hover:bg-overlay-subtle hover:shadow-[var(--theme-shadow-ambient)]"
-                  )}
-                >
-                  <OverviewWorktreeCard
-                    variant="grid"
-                    worktreeId={worktree.id}
-                    activeWorktreeId={activeWorktreeId}
-                    focusedWorktreeId={focusedWorktreeId}
-                    totalWorktreeCount={worktrees.length}
-                    onSelectWorktree={onSelectWorktree}
-                    onCopyTree={onCopyTree}
-                    onOpenEditor={onOpenEditor}
-                    onSaveLayout={onSaveLayout}
-                    onLaunchAgent={onLaunchAgent}
-                    agentAvailability={agentAvailability}
-                    agentSettings={agentSettings}
-                    homeDir={homeDir}
-                    onClose={onClose}
-                  />
-                </div>
-              ))}
+              {groupedSections
+                ? groupedSections.flatMap((section: GroupedSection<WorktreeState>) => [
+                    <div
+                      key={`section-header-${section.type}`}
+                      role="presentation"
+                      className="col-[1/-1] flex items-center gap-2 mt-2 first:mt-0"
+                    >
+                      <h3 className="text-xs font-medium text-daintree-text/60 uppercase tracking-wider">
+                        {section.displayName}
+                      </h3>
+                      <span className="text-xs text-daintree-text/40">
+                        ({section.worktrees.length})
+                      </span>
+                    </div>,
+                    ...section.worktrees.map((worktree: WorktreeState) => (
+                      <OverviewGridCell
+                        key={worktree.id}
+                        worktreeId={worktree.id}
+                        activeWorktreeId={activeWorktreeId}
+                        focusedWorktreeId={focusedWorktreeId}
+                        totalWorktreeCount={worktrees.length}
+                        onSelectWorktree={onSelectWorktree}
+                        onCopyTree={onCopyTree}
+                        onOpenEditor={onOpenEditor}
+                        onSaveLayout={onSaveLayout}
+                        onLaunchAgent={onLaunchAgent}
+                        agentAvailability={agentAvailability}
+                        agentSettings={agentSettings}
+                        homeDir={homeDir}
+                        onClose={onClose}
+                        isSelected={selectedIds.has(worktree.id)}
+                        onToggleSelect={handleCardToggleSelect}
+                      />
+                    )),
+                  ])
+                : filteredWorktrees.map((worktree) => (
+                    <OverviewGridCell
+                      key={worktree.id}
+                      worktreeId={worktree.id}
+                      activeWorktreeId={activeWorktreeId}
+                      focusedWorktreeId={focusedWorktreeId}
+                      totalWorktreeCount={worktrees.length}
+                      onSelectWorktree={onSelectWorktree}
+                      onCopyTree={onCopyTree}
+                      onOpenEditor={onOpenEditor}
+                      onSaveLayout={onSaveLayout}
+                      onLaunchAgent={onLaunchAgent}
+                      agentAvailability={agentAvailability}
+                      agentSettings={agentSettings}
+                      homeDir={homeDir}
+                      onClose={onClose}
+                      isSelected={selectedIds.has(worktree.id)}
+                      onToggleSelect={handleCardToggleSelect}
+                    />
+                  ))}
             </div>
           )}
         </div>
 
         {/* Footer hint */}
         <div className="px-6 py-3 border-t border-divider shrink-0">
-          <div className="flex items-center justify-center gap-4 text-xs text-daintree-text/40">
+          <div className="flex items-center justify-center gap-x-4 gap-y-1 flex-wrap text-xs text-daintree-text/40">
             <span>
-              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">Esc</kbd> to close
+              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">↑↓←→</kbd> navigate
             </span>
-            <span>Click a worktree to switch</span>
+            <span>
+              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">Enter</kbd> switch
+            </span>
+            <span>
+              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">Space</kbd> select
+            </span>
+            <span>
+              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">Esc</kbd>
+              {hasSelection ? " clear selection" : " close"}
+            </span>
+            {hasSelection && (
+              <span className="text-daintree-text/60 tabular-nums">
+                {selectedIds.size} selected
+              </span>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -476,10 +476,7 @@ export function WorktreeOverviewModal({
   // (lesson #4729) — only deliberate actions reset it.
   const selectionAnchorRef = useRef<string | null>(null);
 
-  const visibleIds = useMemo(
-    () => filteredWorktrees.map((w) => w.id),
-    [filteredWorktrees]
-  );
+  const visibleIds = useMemo(() => filteredWorktrees.map((w) => w.id), [filteredWorktrees]);
   const visibleIdSet = useMemo(() => new Set(visibleIds), [visibleIds]);
 
   // Drop selections that are no longer visible (filter narrowed). Anchor is
@@ -518,8 +515,7 @@ export function WorktreeOverviewModal({
       const anchorIdx = visibleIds.indexOf(anchorId);
       const targetIdx = visibleIds.indexOf(targetId);
       if (anchorIdx === -1 || targetIdx === -1) return;
-      const [lo, hi] =
-        anchorIdx <= targetIdx ? [anchorIdx, targetIdx] : [targetIdx, anchorIdx];
+      const [lo, hi] = anchorIdx <= targetIdx ? [anchorIdx, targetIdx] : [targetIdx, anchorIdx];
       setSelectedIds(new Set(visibleIds.slice(lo, hi + 1)));
     },
     [visibleIds]
@@ -624,9 +620,7 @@ export function WorktreeOverviewModal({
       const target = e.target as HTMLElement | null;
       const isEditable =
         !!target &&
-        (target.tagName === "INPUT" ||
-          target.tagName === "TEXTAREA" ||
-          target.isContentEditable);
+        (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable);
       if (isEditable) return;
       e.preventDefault();
       e.stopPropagation();

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -476,7 +476,16 @@ export function WorktreeOverviewModal({
   // (lesson #4729) — only deliberate actions reset it.
   const selectionAnchorRef = useRef<string | null>(null);
 
-  const visibleIds = useMemo(() => filteredWorktrees.map((w) => w.id), [filteredWorktrees]);
+  // Must mirror DOM render order so keyboard navigation indexes into the right
+  // cell. When grouped, the DOM flattens groupedSections in section order; the
+  // flat sorted order in filteredWorktrees does not match.
+  const visibleIds = useMemo(
+    () =>
+      groupedSections
+        ? groupedSections.flatMap((s) => s.worktrees.map((w) => w.id))
+        : filteredWorktrees.map((w) => w.id),
+    [groupedSections, filteredWorktrees]
+  );
   const visibleIdSet = useMemo(() => new Set(visibleIds), [visibleIds]);
 
   // Drop selections that are no longer visible (filter narrowed). Anchor is

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -562,8 +562,20 @@ export function WorktreeOverviewModal({
   const gridRef = useRef<HTMLDivElement | null>(null);
   const closeModal = useCallback(() => onClose(), [onClose]);
 
+  // Section sizes drive section-aware Arrow navigation across the col-[1/-1]
+  // header breaks. Undefined when ungrouped — the hook degrades to flat-list
+  // stride math.
+  const sectionSizes = useMemo<readonly number[] | undefined>(
+    () =>
+      groupedSections
+        ? groupedSections.map((s: GroupedSection<WorktreeState>) => s.worktrees.length)
+        : undefined,
+    [groupedSections]
+  );
+
   const { activeDescendantId, handleGridKeyDown, handleGridFocus } = useWorktreeOverviewKeyboard({
     worktreeIds: visibleIds,
+    sectionSizes,
     gridRef,
     selectionAnchorRef,
     onActivate: activateWorktree,
@@ -892,7 +904,6 @@ export function WorktreeOverviewModal({
               tabIndex={0}
               aria-multiselectable="true"
               aria-activedescendant={activeDescendantId}
-              aria-rowcount={filteredWorktrees.length}
               onKeyDown={handleGridKeyDown}
               onFocus={handleGridFocus}
               className={cn(

--- a/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
+++ b/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
@@ -161,4 +161,96 @@ describe("WorktreeOverviewModal — clickable aggregate stats (#8385)", () => {
       expect(source).toMatch(/hideMainWorktree\s*&&\s*worktree\.isMainWorktree/);
     });
   });
+
+  describe("multi-select and keyboard navigation (#8653)", () => {
+    it("imports the overview keyboard hook", () => {
+      expect(source).toMatch(/useWorktreeOverviewKeyboard/);
+    });
+
+    it("imports getWorktreeOverviewCellId for stable cell ids", () => {
+      expect(source).toMatch(/getWorktreeOverviewCellId/);
+    });
+
+    it("declares modal-local selection state (Set of worktree ids)", () => {
+      expect(source).toMatch(/useState<Set<string>>/);
+    });
+
+    it("anchors range selection in a ref so it survives filter changes", () => {
+      expect(source).toMatch(/selectionAnchorRef\s*=\s*useRef<string\s*\|\s*null>/);
+    });
+
+    it("renders a single role='grid' wrapper around the cards", () => {
+      expect(source).toContain('role="grid"');
+    });
+
+    it("declares aria-multiselectable on the grid", () => {
+      expect(source).toContain('aria-multiselectable="true"');
+    });
+
+    it("threads aria-activedescendant through the grid container", () => {
+      expect(source).toContain("aria-activedescendant={activeDescendantId}");
+    });
+
+    it("renders cells with role='gridcell' and aria-selected", () => {
+      expect(source).toContain('role="gridcell"');
+      expect(source).toMatch(/aria-selected=\{isSelected\}/);
+    });
+
+    it("passes isSelected as boolean (not the Set) to each cell", () => {
+      // Avoid #4749 — never pass the Set or an index down; only the boolean
+      // result of `.has()` so memoization narrows re-renders to changed cells.
+      expect(source).toMatch(/isSelected=\{selectedIds\.has\(worktree\.id\)\}/);
+    });
+
+    it("uses bg-overlay-subtle (not accent) for the selected state", () => {
+      expect(source).toMatch(/isSelected\s*&&\s*"bg-overlay-subtle/);
+    });
+
+    it("does not introduce any forbidden accent token for selection treatment", () => {
+      // Composite assertion — accentGuard.contract.test.ts is the source of
+      // truth, but a local guard catches regressions before that contract
+      // test runs.
+      const selectionAccentTokens = [
+        "bg-daintree-accent",
+        "bg-accent-primary",
+        "bg-accent-soft",
+        "text-daintree-accent",
+        "text-accent-primary",
+      ];
+      for (const token of selectionAccentTokens) {
+        const usagePattern = new RegExp(`isSelected[^"]*${token}|${token}[^"]*isSelected`);
+        expect(source).not.toMatch(usagePattern);
+      }
+    });
+
+    it("reconciles selection when the visible worktree set changes", () => {
+      expect(source).toMatch(/setSelectedIds\(\(prev\)\s*=>/);
+      expect(source).toMatch(/visibleIdSet\.has\(id\)/);
+    });
+
+    it("Escape with selection clears it instead of closing the modal", () => {
+      expect(source).toMatch(/if\s*\(hasSelection\)\s*\{[\s\S]*?clearSelection\(\)/);
+    });
+
+    it("Cmd/Ctrl+A triggers selectAllVisible", () => {
+      expect(source).toMatch(/selectAllVisible\(\)/);
+    });
+
+    it("Cmd/Ctrl+A does not steal text-input Select-All", () => {
+      // Editable check guards against hijacking Cmd+A in a text input.
+      expect(source).toMatch(/isEditable/);
+    });
+
+    it("section headers render with role='presentation' inside the grid", () => {
+      expect(source).toContain('role="presentation"');
+    });
+
+    it("section headers span the full grid width via col-[1/-1]", () => {
+      expect(source).toContain("col-[1/-1]");
+    });
+
+    it("resets the anchor on window blur to avoid stuck Shift from Cmd+Tab (#4591)", () => {
+      expect(source).toMatch(/handleWindowBlur[\s\S]*?selectionAnchorRef\.current\s*=\s*null/);
+    });
+  });
 });

--- a/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
+++ b/src/components/Worktree/__tests__/WorktreeOverviewModal.test.ts
@@ -252,5 +252,23 @@ describe("WorktreeOverviewModal — clickable aggregate stats (#8385)", () => {
     it("resets the anchor on window blur to avoid stuck Shift from Cmd+Tab (#4591)", () => {
       expect(source).toMatch(/handleWindowBlur[\s\S]*?selectionAnchorRef\.current\s*=\s*null/);
     });
+
+    it("does NOT set aria-rowcount on the grid (rows are not virtualized — spec says omit)", () => {
+      // aria-rowcount is only meaningful when some rows aren't in the DOM.
+      // For the overview grid every cell is rendered, so the attribute must
+      // not be present — including it would announce the wrong row count
+      // since each card maps to one ARIA row in this layout.
+      expect(source).not.toContain("aria-rowcount");
+    });
+
+    it("passes sectionSizes to the keyboard hook so arrow navigation crosses section boundaries correctly", () => {
+      // The hook needs section sizes to compute visually-adjacent cells
+      // across col-[1/-1] header breaks; without it, ArrowDown miscounts
+      // whenever a section ends on a partial row.
+      expect(source).toMatch(/sectionSizes/);
+      expect(source).toMatch(
+        /sectionSizes\s*=\s*useMemo[\s\S]*?groupedSections\.map[\s\S]*?\.worktrees\.length/
+      );
+    });
   });
 });

--- a/src/components/Worktree/__tests__/useWorktreeOverviewKeyboard.test.tsx
+++ b/src/components/Worktree/__tests__/useWorktreeOverviewKeyboard.test.tsx
@@ -5,6 +5,7 @@ import { useRef } from "react";
 import {
   useWorktreeOverviewKeyboard,
   getWorktreeOverviewCellId,
+  computeVerticalMove,
 } from "../useWorktreeOverviewKeyboard";
 
 // jsdom has no layout engine — patch getComputedStyle so the hook can sample
@@ -35,6 +36,7 @@ window.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
 
 interface HarnessProps {
   worktreeIds: string[];
+  sectionSizes?: readonly number[];
   hasSelection?: boolean;
   onActivate?: (id: string) => void;
   onToggleSelection?: (id: string) => void;
@@ -47,6 +49,7 @@ interface HarnessProps {
 
 function Harness({
   worktreeIds,
+  sectionSizes,
   hasSelection = false,
   onActivate = () => {},
   onToggleSelection = () => {},
@@ -60,6 +63,7 @@ function Harness({
   const anchorRef = useRef<string | null>(initialAnchor);
   const { activeDescendantId, handleGridKeyDown, handleGridFocus } = useWorktreeOverviewKeyboard({
     worktreeIds,
+    sectionSizes,
     gridRef,
     selectionAnchorRef: anchorRef,
     onActivate,
@@ -83,7 +87,7 @@ function Harness({
     >
       {worktreeIds.map((id) => (
         <div key={id} role="gridcell" id={getWorktreeOverviewCellId(id)} data-testid={`cell-${id}`}>
-          {id}
+          <button data-testid={`btn-${id}`}>inner-{id}</button>
         </div>
       ))}
     </div>
@@ -284,5 +288,126 @@ describe("getWorktreeOverviewCellId", () => {
     expect(getWorktreeOverviewCellId("/Users/me/dev/worktree foo")).toBe(
       "worktree-overview-cell-%2FUsers%2Fme%2Fdev%2Fworktree%20foo"
     );
+  });
+});
+
+describe("useWorktreeOverviewKeyboard — target-self guard", () => {
+  it("ignores keys that bubble up from descendants (inner card buttons)", () => {
+    // Space pressed on an inner button used to bubble to the grid and
+    // toggle the active gridcell's selection — confirm that no longer
+    // happens after the e.target gate.
+    const onToggleSelection = vi.fn();
+    const onActivate = vi.fn();
+    const { getByTestId } = render(
+      <Harness
+        worktreeIds={["a", "b", "c"]}
+        onToggleSelection={onToggleSelection}
+        onActivate={onActivate}
+      />
+    );
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    const innerButton = getByTestId("btn-a");
+    fireEvent.keyDown(innerButton, { key: " " });
+    fireEvent.keyDown(innerButton, { key: "Enter" });
+    expect(onToggleSelection).not.toHaveBeenCalled();
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+});
+
+describe("useWorktreeOverviewKeyboard — stale anchor recovery", () => {
+  it("Shift+Arrow with a hidden anchor re-seeds from the current cell", () => {
+    const onSelectRange = vi.fn();
+    const { getByTestId, rerender } = render(
+      <Harness worktreeIds={["a", "b", "c", "d", "e", "f"]} initialAnchor="f" />
+    );
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    // Filter narrows: f is no longer visible. Anchor ref still points at f.
+    rerender(
+      <Harness
+        worktreeIds={["a", "b", "c"]}
+        initialAnchor="f"
+        onSelectRange={onSelectRange}
+      />
+    );
+    fireEvent.keyDown(grid, { key: "ArrowRight", shiftKey: true });
+    // The hook bootstraps the anchor at the current cell (a) and extends to b.
+    expect(onSelectRange).toHaveBeenCalledWith("a", "b");
+  });
+});
+
+describe("computeVerticalMove — section-aware 2D math", () => {
+  // 3-column grid; section sizes [2, 3]. Flat order:
+  // Section 0: A(0)=a B(1)=b
+  // Section 1: C(0)=c D(1)=d E(2)=e
+  const SECTION_SIZES = [2, 3];
+
+  it("ArrowDown from a (0,0) in section 0 (partial-tail row) lands at c, column 0 of section 1", () => {
+    expect(computeVerticalMove(0, 1, 3, 5, SECTION_SIZES)).toBe(2);
+  });
+
+  it("ArrowDown from b (0,1) crosses to section 1, column 1 → d (index 3)", () => {
+    expect(computeVerticalMove(1, 1, 3, 5, SECTION_SIZES)).toBe(3);
+  });
+
+  it("ArrowDown from e (last cell, last section) clamps at e (no further sections)", () => {
+    expect(computeVerticalMove(4, 1, 3, 5, SECTION_SIZES)).toBe(4);
+  });
+
+  it("ArrowUp from d (1,1) in section 1 returns to b (0,1) in section 0", () => {
+    expect(computeVerticalMove(3, -1, 3, 5, SECTION_SIZES)).toBe(1);
+  });
+
+  it("ArrowUp from c (column 0) returns to a (column 0)", () => {
+    expect(computeVerticalMove(2, -1, 3, 5, SECTION_SIZES)).toBe(0);
+  });
+
+  it("ArrowUp from a (first cell, first section) clamps at a", () => {
+    expect(computeVerticalMove(0, -1, 3, 5, SECTION_SIZES)).toBe(0);
+  });
+
+  it("ArrowDown within a section moves by columnCount", () => {
+    // 6 items in one section, 3 columns → row 0 to row 1
+    expect(computeVerticalMove(0, 1, 3, 6, [6])).toBe(3);
+  });
+
+  it("ArrowDown from partial-tail column with no neighbour clamps to last cell of next section", () => {
+    // Sections [4, 2], 3-column grid:
+    // Section 0: indices 0-3 (rows: [0,1,2] / [3])
+    // Section 1: indices 4-5 (row [4,5])
+    // ArrowDown from index 2 (col 2) → section 0 next row is [3] which is
+    // col 0 only; the cross-section branch should land at section 1's column 2,
+    // but section 1 only has 2 cells → clamp to last cell of section 1 (index 5).
+    expect(computeVerticalMove(2, 1, 3, 6, [4, 2])).toBe(3);
+    // ArrowDown from index 3 (last in section 0) → section 1 column 0 = index 4
+    expect(computeVerticalMove(3, 1, 3, 6, [4, 2])).toBe(4);
+  });
+
+  it("with no section sizes provided, treats the list as a single section", () => {
+    expect(computeVerticalMove(0, 1, 3, 6, undefined)).toBe(3);
+    expect(computeVerticalMove(3, -1, 3, 6, undefined)).toBe(0);
+  });
+
+  it("clamps when fromIndex is at end and ArrowDown overshoots within section", () => {
+    // 5 items in one section, 3 columns. row 0: [0,1,2]; row 1: [3,4].
+    // ArrowDown from 0 (col 0) → 3 (col 0, row 1). Good.
+    expect(computeVerticalMove(0, 1, 3, 5, [5])).toBe(3);
+    // ArrowDown from 2 (col 2, row 0) → row 1 col 2 doesn't exist → clamp last
+    expect(computeVerticalMove(2, 1, 3, 5, [5])).toBe(4);
+  });
+});
+
+describe("useWorktreeOverviewKeyboard — section-aware behavior in harness", () => {
+  it("ArrowDown from the partial-tail row of section 1 jumps to column 0 of section 2", () => {
+    // Sections [2, 3]: a,b in section 0; c,d,e in section 1.
+    // Mock returns 3 columns. From a (index 0) ArrowDown → c (index 2).
+    const { getByTestId } = render(
+      <Harness worktreeIds={["a", "b", "c", "d", "e"]} sectionSizes={[2, 3]} />
+    );
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "ArrowDown" });
+    expect(grid.getAttribute("aria-activedescendant")).toBe(getWorktreeOverviewCellId("c"));
   });
 });

--- a/src/components/Worktree/__tests__/useWorktreeOverviewKeyboard.test.tsx
+++ b/src/components/Worktree/__tests__/useWorktreeOverviewKeyboard.test.tsx
@@ -1,0 +1,288 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { useRef } from "react";
+import {
+  useWorktreeOverviewKeyboard,
+  getWorktreeOverviewCellId,
+} from "../useWorktreeOverviewKeyboard";
+
+// jsdom has no layout engine — patch getComputedStyle so the hook can sample
+// the column count from its `gridTemplateColumns` track string. Three tracks
+// keeps the 2D arithmetic obvious in the assertions.
+const originalGetComputedStyle = window.getComputedStyle;
+beforeAll(() => {
+  window.getComputedStyle = ((el: Element) => {
+    const real = originalGetComputedStyle(el);
+    return new Proxy(real, {
+      get(target, prop) {
+        if (prop === "gridTemplateColumns") return "100px 100px 100px";
+        return Reflect.get(target, prop);
+      },
+    });
+  }) as typeof window.getComputedStyle;
+});
+afterAll(() => {
+  window.getComputedStyle = originalGetComputedStyle;
+});
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+window.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
+interface HarnessProps {
+  worktreeIds: string[];
+  hasSelection?: boolean;
+  onActivate?: (id: string) => void;
+  onToggleSelection?: (id: string) => void;
+  onSelectRange?: (anchorId: string, targetId: string) => void;
+  onSelectAll?: () => void;
+  onClearSelection?: () => void;
+  onEscapeWithoutSelection?: () => void;
+  initialAnchor?: string | null;
+}
+
+function Harness({
+  worktreeIds,
+  hasSelection = false,
+  onActivate = () => {},
+  onToggleSelection = () => {},
+  onSelectRange = () => {},
+  onSelectAll = () => {},
+  onClearSelection = () => {},
+  onEscapeWithoutSelection = () => {},
+  initialAnchor = null,
+}: HarnessProps) {
+  const gridRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<string | null>(initialAnchor);
+  const { activeDescendantId, handleGridKeyDown, handleGridFocus } = useWorktreeOverviewKeyboard({
+    worktreeIds,
+    gridRef,
+    selectionAnchorRef: anchorRef,
+    onActivate,
+    onToggleSelection,
+    onSelectRange,
+    onSelectAll,
+    onClearSelection,
+    onEscapeWithoutSelection,
+    hasSelection,
+  });
+  return (
+    <div
+      ref={gridRef}
+      role="grid"
+      tabIndex={0}
+      aria-activedescendant={activeDescendantId}
+      data-testid="grid"
+      data-anchor={anchorRef.current ?? ""}
+      onKeyDown={handleGridKeyDown}
+      onFocus={handleGridFocus}
+    >
+      {worktreeIds.map((id) => (
+        <div key={id} role="gridcell" id={getWorktreeOverviewCellId(id)} data-testid={`cell-${id}`}>
+          {id}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const IDS = ["a", "b", "c", "d", "e", "f", "g", "h"]; // 3-column grid → 3 rows + 1 partial
+
+describe("useWorktreeOverviewKeyboard — 2D arrow movement", () => {
+  it("focus seeds the active descendant on the first cell", () => {
+    const { getByTestId } = render(<Harness worktreeIds={IDS} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    expect(grid.getAttribute("aria-activedescendant")).toBe(getWorktreeOverviewCellId("a"));
+  });
+
+  it("ArrowRight moves to the next cell within the row", () => {
+    const { getByTestId } = render(<Harness worktreeIds={IDS} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "ArrowRight" });
+    expect(grid.getAttribute("aria-activedescendant")).toBe(getWorktreeOverviewCellId("b"));
+  });
+
+  it("ArrowLeft clamps at column 0", () => {
+    const { getByTestId } = render(<Harness worktreeIds={IDS} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "ArrowLeft" });
+    expect(grid.getAttribute("aria-activedescendant")).toBe(getWorktreeOverviewCellId("a"));
+  });
+
+  it("ArrowDown moves by columnCount tracks (3 in this layout)", () => {
+    const { getByTestId } = render(<Harness worktreeIds={IDS} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "ArrowDown" });
+    expect(grid.getAttribute("aria-activedescendant")).toBe(getWorktreeOverviewCellId("d"));
+  });
+
+  it("ArrowUp from row 2 returns to row 1 in the same column", () => {
+    const { getByTestId } = render(<Harness worktreeIds={IDS} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "ArrowDown" }); // a → d
+    fireEvent.keyDown(grid, { key: "ArrowRight" }); // d → e
+    fireEvent.keyDown(grid, { key: "ArrowUp" }); // e → b
+    expect(grid.getAttribute("aria-activedescendant")).toBe(getWorktreeOverviewCellId("b"));
+  });
+
+  it("ArrowDown past the last full row clamps to the last cell", () => {
+    const { getByTestId } = render(<Harness worktreeIds={IDS} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "End" });
+    expect(grid.getAttribute("aria-activedescendant")).toBe(getWorktreeOverviewCellId("h"));
+    fireEvent.keyDown(grid, { key: "ArrowDown" });
+    expect(grid.getAttribute("aria-activedescendant")).toBe(getWorktreeOverviewCellId("h"));
+  });
+
+  it("Home and End jump to the first / last cells", () => {
+    const { getByTestId } = render(<Harness worktreeIds={IDS} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "End" });
+    expect(grid.getAttribute("aria-activedescendant")).toBe(getWorktreeOverviewCellId("h"));
+    fireEvent.keyDown(grid, { key: "Home" });
+    expect(grid.getAttribute("aria-activedescendant")).toBe(getWorktreeOverviewCellId("a"));
+  });
+});
+
+describe("useWorktreeOverviewKeyboard — selection", () => {
+  it("Space toggles selection on the active cell and sets the anchor", () => {
+    const onToggleSelection = vi.fn();
+    const { getByTestId } = render(
+      <Harness worktreeIds={IDS} onToggleSelection={onToggleSelection} />
+    );
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "ArrowRight" }); // a → b
+    fireEvent.keyDown(grid, { key: " " });
+    expect(onToggleSelection).toHaveBeenCalledWith("b");
+  });
+
+  it("Enter activates the focused cell", () => {
+    const onActivate = vi.fn();
+    const { getByTestId } = render(<Harness worktreeIds={IDS} onActivate={onActivate} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "Enter" });
+    expect(onActivate).toHaveBeenCalledWith("a");
+  });
+
+  it("Ctrl/Cmd+A selects all visible worktrees", () => {
+    const onSelectAll = vi.fn();
+    const { getByTestId } = render(<Harness worktreeIds={IDS} onSelectAll={onSelectAll} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "a", metaKey: true });
+    expect(onSelectAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("Shift+ArrowRight extends selection from anchor to target", () => {
+    const onSelectRange = vi.fn();
+    const { getByTestId } = render(
+      <Harness worktreeIds={IDS} initialAnchor="a" onSelectRange={onSelectRange} />
+    );
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "ArrowRight", shiftKey: true });
+    expect(onSelectRange).toHaveBeenCalledWith("a", "b");
+  });
+
+  it("Shift+ArrowDown extends selection across rows from the anchor", () => {
+    const onSelectRange = vi.fn();
+    const { getByTestId } = render(
+      <Harness worktreeIds={IDS} initialAnchor="a" onSelectRange={onSelectRange} />
+    );
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "ArrowDown", shiftKey: true });
+    expect(onSelectRange).toHaveBeenCalledWith("a", "d");
+  });
+
+  it("Shift+Arrow without prior anchor bootstraps the anchor at the current cell", () => {
+    const onSelectRange = vi.fn();
+    const { getByTestId } = render(
+      <Harness worktreeIds={IDS} onSelectRange={onSelectRange} initialAnchor={null} />
+    );
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "ArrowRight", shiftKey: true });
+    // anchor seeded at "a"; target "b"
+    expect(onSelectRange).toHaveBeenCalledWith("a", "b");
+  });
+});
+
+describe("useWorktreeOverviewKeyboard — Escape behavior", () => {
+  it("Escape with no selection signals the modal-close handler", () => {
+    const onEscapeWithoutSelection = vi.fn();
+    const onClearSelection = vi.fn();
+    const { getByTestId } = render(
+      <Harness
+        worktreeIds={IDS}
+        hasSelection={false}
+        onEscapeWithoutSelection={onEscapeWithoutSelection}
+        onClearSelection={onClearSelection}
+      />
+    );
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "Escape" });
+    expect(onEscapeWithoutSelection).toHaveBeenCalledTimes(1);
+    expect(onClearSelection).not.toHaveBeenCalled();
+  });
+
+  it("Escape with selection clears it instead of closing", () => {
+    const onEscapeWithoutSelection = vi.fn();
+    const onClearSelection = vi.fn();
+    const { getByTestId } = render(
+      <Harness
+        worktreeIds={IDS}
+        hasSelection={true}
+        onEscapeWithoutSelection={onEscapeWithoutSelection}
+        onClearSelection={onClearSelection}
+      />
+    );
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "Escape" });
+    expect(onClearSelection).toHaveBeenCalledTimes(1);
+    expect(onEscapeWithoutSelection).not.toHaveBeenCalled();
+  });
+});
+
+describe("useWorktreeOverviewKeyboard — filter reconciliation", () => {
+  it("clamps the active worktree when it drops out of the visible set", () => {
+    const { getByTestId, rerender } = render(<Harness worktreeIds={IDS} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    fireEvent.keyDown(grid, { key: "End" }); // → h
+    expect(grid.getAttribute("aria-activedescendant")).toBe(getWorktreeOverviewCellId("h"));
+    rerender(<Harness worktreeIds={["a", "b", "c"]} />);
+    // h dropped out — clamp to first visible
+    expect(grid.getAttribute("aria-activedescendant")).toBe(getWorktreeOverviewCellId("a"));
+  });
+
+  it("with no visible worktrees, no descendant id is reported", () => {
+    const { getByTestId } = render(<Harness worktreeIds={[]} />);
+    const grid = getByTestId("grid");
+    fireEvent.focus(grid);
+    expect(grid.getAttribute("aria-activedescendant")).toBeNull();
+  });
+});
+
+describe("getWorktreeOverviewCellId", () => {
+  it("URL-encodes path-like worktree ids so spaces produce valid HTML ids", () => {
+    expect(getWorktreeOverviewCellId("/Users/me/dev/worktree foo")).toBe(
+      "worktree-overview-cell-%2FUsers%2Fme%2Fdev%2Fworktree%20foo"
+    );
+  });
+});

--- a/src/components/Worktree/__tests__/useWorktreeOverviewKeyboard.test.tsx
+++ b/src/components/Worktree/__tests__/useWorktreeOverviewKeyboard.test.tsx
@@ -325,11 +325,7 @@ describe("useWorktreeOverviewKeyboard — stale anchor recovery", () => {
     fireEvent.focus(grid);
     // Filter narrows: f is no longer visible. Anchor ref still points at f.
     rerender(
-      <Harness
-        worktreeIds={["a", "b", "c"]}
-        initialAnchor="f"
-        onSelectRange={onSelectRange}
-      />
+      <Harness worktreeIds={["a", "b", "c"]} initialAnchor="f" onSelectRange={onSelectRange} />
     );
     fireEvent.keyDown(grid, { key: "ArrowRight", shiftKey: true });
     // The hook bootstraps the anchor at the current cell (a) and extends to b.

--- a/src/components/Worktree/useWorktreeOverviewKeyboard.ts
+++ b/src/components/Worktree/useWorktreeOverviewKeyboard.ts
@@ -24,9 +24,115 @@ function parseColumnCount(template: string): number {
   return Math.max(1, trimmed.split(/\s+/).length);
 }
 
+/**
+ * Resolve the target index for ArrowUp/Down across section-aware layouts.
+ *
+ * When `sectionSizes` is provided, section breaks render as full-width
+ * separators (CSS `col-[1/-1]`) that force a row break. A naive
+ * `currentIndex ± columnCount` jump miscounts whenever a section ends on a
+ * partial row, because the visually-adjacent cell in the next section is
+ * not `columnCount` away in the flat ordering.
+ *
+ * Algorithm:
+ *  - Locate which section contains `fromIndex` and the local row/column.
+ *  - Try to stay in the same section: target row ± 1 at the same column.
+ *  - If that row doesn't exist in the current section, fall through to the
+ *    neighbouring section: target = first/last visual row at the same
+ *    column (clamped to that section's actual width).
+ *  - If no neighbour exists, return `fromIndex` (caller clamps).
+ *
+ * `delta` is +1 for ArrowDown, -1 for ArrowUp.
+ */
+export function computeVerticalMove(
+  fromIndex: number,
+  delta: 1 | -1,
+  columnCount: number,
+  total: number,
+  sectionSizes: readonly number[] | undefined
+): number {
+  if (total <= 0 || fromIndex < 0 || fromIndex >= total) return fromIndex;
+  if (columnCount <= 0) columnCount = 1;
+
+  // No section grouping → single-section stride math.
+  const sizes = sectionSizes && sectionSizes.length > 0 ? sectionSizes : [total];
+
+  // Find which section owns fromIndex and the local offset within it.
+  let sectionIdx = 0;
+  let sectionStart = 0;
+  for (; sectionIdx < sizes.length; sectionIdx++) {
+    const size = sizes[sectionIdx] ?? 0;
+    if (fromIndex < sectionStart + size) break;
+    sectionStart += size;
+  }
+  const sectionSize = sizes[sectionIdx] ?? 0;
+  if (sectionSize === 0) return fromIndex;
+  const localIdx = fromIndex - sectionStart;
+  const localRow = Math.floor(localIdx / columnCount);
+  const localCol = localIdx % columnCount;
+
+  // Try staying in the current section.
+  const nextLocalRow = localRow + delta;
+  if (nextLocalRow >= 0) {
+    const nextLocal = nextLocalRow * columnCount + localCol;
+    if (nextLocal < sectionSize) {
+      return sectionStart + nextLocal;
+    }
+    // ArrowDown past last row of this section but the row exists past the
+    // column boundary — fall through to the last cell of this section
+    // before moving to the next section.
+    if (delta === 1) {
+      const lastLocal = sectionSize - 1;
+      // Only step partway down if it's strictly below the current row;
+      // otherwise let the cross-section branch handle it.
+      const lastLocalRow = Math.floor(lastLocal / columnCount);
+      if (lastLocalRow > localRow) {
+        return sectionStart + lastLocal;
+      }
+    }
+  }
+
+  // Cross-section move.
+  if (delta === 1) {
+    const nextSectionIdx = sectionIdx + 1;
+    if (nextSectionIdx >= sizes.length) return fromIndex;
+    const nextSectionStart = sectionStart + sectionSize;
+    const nextSectionSize = sizes[nextSectionIdx] ?? 0;
+    if (nextSectionSize === 0) return fromIndex;
+    const targetLocal = Math.min(localCol, nextSectionSize - 1);
+    return nextSectionStart + targetLocal;
+  }
+
+  // ArrowUp — previous section's last visual row, same column where
+  // available, otherwise the last cell of that section's final row.
+  const prevSectionIdx = sectionIdx - 1;
+  if (prevSectionIdx < 0) return fromIndex;
+  let prevSectionStart = 0;
+  for (let i = 0; i < prevSectionIdx; i++) prevSectionStart += sizes[i] ?? 0;
+  const prevSectionSize = sizes[prevSectionIdx] ?? 0;
+  if (prevSectionSize === 0) return fromIndex;
+  const prevLastRow = Math.floor((prevSectionSize - 1) / columnCount);
+  const candidateLocal = prevLastRow * columnCount + localCol;
+  if (candidateLocal < prevSectionSize) {
+    return prevSectionStart + candidateLocal;
+  }
+  // Column has no cell in that visual row (partial-tail row) — clamp to
+  // last cell of the previous section.
+  return prevSectionStart + prevSectionSize - 1;
+}
+
 export interface UseWorktreeOverviewKeyboardOptions {
   /** Ordered list of worktree ids visible in the current filter set. */
   worktreeIds: readonly string[];
+  /**
+   * Sizes of visual section blocks in order, summing to worktreeIds.length.
+   * Each entry is the number of cards in one grouped section. When omitted
+   * the list is treated as a single section. Section headers force a CSS
+   * row break (col-[1/-1]), so naive flat-index stride math (idx ± columns)
+   * skips into the wrong column whenever a section ends on a partial row.
+   * Passing sizes lets the hook resolve ArrowUp/Down to the visually
+   * adjacent cell instead.
+   */
+  sectionSizes?: readonly number[];
   /** The grid container element that carries the role="grid" + tabIndex. */
   gridRef: React.RefObject<HTMLDivElement | null>;
   /**
@@ -72,6 +178,7 @@ export interface UseWorktreeOverviewKeyboardReturn {
  */
 export function useWorktreeOverviewKeyboard({
   worktreeIds,
+  sectionSizes,
   gridRef,
   selectionAnchorRef,
   onActivate,
@@ -108,6 +215,10 @@ export function useWorktreeOverviewKeyboard({
   const worktreeIdsRef = useRef(worktreeIds);
   useEffect(() => {
     worktreeIdsRef.current = worktreeIds;
+  });
+  const sectionSizesRef = useRef(sectionSizes);
+  useEffect(() => {
+    sectionSizesRef.current = sectionSizes;
   });
   const hasSelectionRef = useRef(hasSelection);
   useEffect(() => {
@@ -153,6 +264,13 @@ export function useWorktreeOverviewKeyboard({
 
   const handleGridKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
+      // Only process events that originated on the grid container itself.
+      // Keys typed in an inner card button (terminal action, menu trigger)
+      // would otherwise bubble here and re-trigger selection from the
+      // grid's perspective — Space on an inner button would both click
+      // the button AND toggle the gridcell selection.
+      if (e.target !== gridRef.current) return;
+
       const ids = worktreeIdsRef.current;
       const callbacks = callbacksRef.current;
 
@@ -206,16 +324,24 @@ export function useWorktreeOverviewKeyboard({
         case "ArrowLeft":
           targetIndex = Math.max(0, currentIndex - 1);
           break;
-        case "ArrowDown": {
-          const next = currentIndex + columnCount;
-          targetIndex = next < total ? next : total - 1;
+        case "ArrowDown":
+          targetIndex = computeVerticalMove(
+            currentIndex,
+            1,
+            columnCount,
+            total,
+            sectionSizesRef.current
+          );
           break;
-        }
-        case "ArrowUp": {
-          const next = currentIndex - columnCount;
-          targetIndex = next >= 0 ? next : 0;
+        case "ArrowUp":
+          targetIndex = computeVerticalMove(
+            currentIndex,
+            -1,
+            columnCount,
+            total,
+            sectionSizesRef.current
+          );
           break;
-        }
         case "Home":
           targetIndex = 0;
           break;
@@ -257,20 +383,24 @@ export function useWorktreeOverviewKeyboard({
       // Shift+Arrow extends selection from the persistent anchor; pure arrow
       // movement just moves focus without touching selection. The anchor is
       // set when the user makes their first deliberate selection action
-      // (Space, click, Ctrl/Cmd+A) — Shift+Arrow without a prior anchor
-      // bootstraps it at the current cell so the range has a stable origin.
+      // (Space, click, Ctrl/Cmd+A) — Shift+Arrow without a prior anchor, OR
+      // with an anchor that no longer points at a visible cell (filter
+      // narrowed it away), bootstraps from the current cell so the range
+      // has a stable origin.
       if (e.shiftKey && targetIndex !== currentIndex) {
-        if (selectionAnchorRef.current === null) {
+        const storedAnchor = selectionAnchorRef.current;
+        const anchorVisible = storedAnchor !== null && ids.indexOf(storedAnchor) !== -1;
+        if (!anchorVisible) {
           selectionAnchorRef.current = currentId;
         }
-        callbacks.onSelectRange(selectionAnchorRef.current, targetId);
+        callbacks.onSelectRange(selectionAnchorRef.current!, targetId);
       }
 
       if (targetIndex !== currentIndex) {
         setActiveWorktreeId(targetId);
       }
     },
-    [activeWorktreeId, selectionAnchorRef]
+    [activeWorktreeId, selectionAnchorRef, gridRef]
   );
 
   return {

--- a/src/components/Worktree/useWorktreeOverviewKeyboard.ts
+++ b/src/components/Worktree/useWorktreeOverviewKeyboard.ts
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type React from "react";
+
+const CELL_DOM_ID_PREFIX = "worktree-overview-cell-";
+
+/**
+ * Stable DOM id used by aria-activedescendant on every overview grid cell.
+ *
+ * Worktree ids are filesystem paths; on macOS especially these often contain
+ * spaces, which produce invalid HTML `id` attributes (and break the
+ * activeDescendant lookup downstream). encodeURIComponent normalizes the path
+ * into an id-safe string while remaining a pure, deterministic function of
+ * the worktree id so the same id resolves to the same DOM node every render.
+ */
+export function getWorktreeOverviewCellId(worktreeId: string): string {
+  return `${CELL_DOM_ID_PREFIX}${encodeURIComponent(worktreeId)}`;
+}
+
+function parseColumnCount(template: string): number {
+  const trimmed = template.trim();
+  if (!trimmed || trimmed === "none") return 1;
+  // gridTemplateColumns resolves to "200px 200px 200px" in Chromium when
+  // computed — split on whitespace runs and count tracks.
+  return Math.max(1, trimmed.split(/\s+/).length);
+}
+
+export interface UseWorktreeOverviewKeyboardOptions {
+  /** Ordered list of worktree ids visible in the current filter set. */
+  worktreeIds: readonly string[];
+  /** The grid container element that carries the role="grid" + tabIndex. */
+  gridRef: React.RefObject<HTMLDivElement | null>;
+  /**
+   * Anchor for contiguous range selection. The parent owns this ref so the
+   * anchor persists across keyboard navigation but survives filter changes
+   * (lesson #4729 — don't reset on filtered-set churn).
+   */
+  selectionAnchorRef: React.MutableRefObject<string | null>;
+  onActivate: (worktreeId: string) => void;
+  onToggleSelection: (worktreeId: string) => void;
+  onSelectRange: (anchorId: string, targetId: string) => void;
+  onSelectAll: () => void;
+  onClearSelection: () => void;
+  /** Called when Escape is pressed with no selection — modal close. */
+  onEscapeWithoutSelection: () => void;
+  /** True if anything is currently selected; gates Escape's two-stage close. */
+  hasSelection: boolean;
+}
+
+export interface UseWorktreeOverviewKeyboardReturn {
+  activeWorktreeId: string | null;
+  activeDescendantId: string | undefined;
+  handleGridKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  handleGridFocus: (e: React.FocusEvent<HTMLDivElement>) => void;
+  setActiveWorktreeId: (id: string | null) => void;
+}
+
+/**
+ * 2D keyboard navigation + selection substrate for the worktree overview grid.
+ *
+ * Built parallel to {@link useWorktreeSidebarKeyboard}: one tab stop on the
+ * grid container, aria-activedescendant points at the focused cell, all
+ * keystrokes are intercepted at the container level so we never fight focus
+ * with the card's internal buttons. Arrow keys move in a 2D grid whose column
+ * count is sampled from `getComputedStyle().gridTemplateColumns` (refreshed
+ * via `ResizeObserver`). Selection and range operations are routed to the
+ * parent via callbacks — selection state itself is owned by the modal so it
+ * resets naturally when the modal unmounts.
+ *
+ * The hook deliberately holds no store dependencies (lesson
+ * `feedback_throwing_context_hooks_break_isolated_tests`) — it is testable
+ * standalone in jsdom without provider scaffolding.
+ */
+export function useWorktreeOverviewKeyboard({
+  worktreeIds,
+  gridRef,
+  selectionAnchorRef,
+  onActivate,
+  onToggleSelection,
+  onSelectRange,
+  onSelectAll,
+  onClearSelection,
+  onEscapeWithoutSelection,
+  hasSelection,
+}: UseWorktreeOverviewKeyboardOptions): UseWorktreeOverviewKeyboardReturn {
+  const [activeWorktreeId, setActiveWorktreeId] = useState<string | null>(null);
+  // Column count is read inside event handlers only — keeping it in a ref
+  // avoids a re-render every ResizeObserver tick.
+  const columnCountRef = useRef<number>(1);
+  // Mirror callbacks so listener identity doesn't churn the grid container.
+  const callbacksRef = useRef({
+    onActivate,
+    onToggleSelection,
+    onSelectRange,
+    onSelectAll,
+    onClearSelection,
+    onEscapeWithoutSelection,
+  });
+  useEffect(() => {
+    callbacksRef.current = {
+      onActivate,
+      onToggleSelection,
+      onSelectRange,
+      onSelectAll,
+      onClearSelection,
+      onEscapeWithoutSelection,
+    };
+  });
+  const worktreeIdsRef = useRef(worktreeIds);
+  useEffect(() => {
+    worktreeIdsRef.current = worktreeIds;
+  });
+  const hasSelectionRef = useRef(hasSelection);
+  useEffect(() => {
+    hasSelectionRef.current = hasSelection;
+  });
+
+  // Clamp active id back into the visible set when it shrinks. Without this,
+  // a filter change or worktree removal would orphan aria-activedescendant.
+  useEffect(() => {
+    if (activeWorktreeId === null) return;
+    if (worktreeIds.includes(activeWorktreeId)) return;
+    setActiveWorktreeId(worktreeIds[0] ?? null);
+  }, [worktreeIds, activeWorktreeId]);
+
+  // Track column count from the live grid layout. `getComputedStyle` on the
+  // grid container returns resolved track sizes (e.g. "320px 320px 320px"),
+  // which is exactly the count we need for ArrowUp/Down stride math.
+  useEffect(() => {
+    const grid = gridRef.current;
+    if (!grid || typeof ResizeObserver === "undefined") return;
+    const refresh = () => {
+      const template = window.getComputedStyle(grid).gridTemplateColumns;
+      columnCountRef.current = parseColumnCount(template);
+    };
+    refresh();
+    const observer = new ResizeObserver(refresh);
+    observer.observe(grid);
+    return () => observer.disconnect();
+  }, [gridRef]);
+
+  const activeDescendantId = activeWorktreeId
+    ? getWorktreeOverviewCellId(activeWorktreeId)
+    : undefined;
+
+  const handleGridFocus = useCallback(
+    (_e: React.FocusEvent<HTMLDivElement>) => {
+      if (activeWorktreeId !== null) return;
+      const first = worktreeIdsRef.current[0];
+      if (first) setActiveWorktreeId(first);
+    },
+    [activeWorktreeId]
+  );
+
+  const handleGridKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const ids = worktreeIdsRef.current;
+      const callbacks = callbacksRef.current;
+
+      // Ctrl/Cmd+A — select all in the current filtered set.
+      const isCmdOrCtrl = e.metaKey || e.ctrlKey;
+      if (isCmdOrCtrl && (e.key === "a" || e.key === "A")) {
+        if (ids.length === 0) return;
+        e.preventDefault();
+        e.stopPropagation();
+        // Anchor at the first visible item so a subsequent Shift+Click reads
+        // as "extend from the start of the current view."
+        selectionAnchorRef.current = ids[0] ?? null;
+        callbacks.onSelectAll();
+        return;
+      }
+
+      // Escape — clear selection first, then propagate to modal close.
+      if (e.key === "Escape") {
+        if (hasSelectionRef.current) {
+          e.preventDefault();
+          e.stopPropagation();
+          selectionAnchorRef.current = null;
+          callbacks.onClearSelection();
+          return;
+        }
+        // No selection — let the modal-level handler close the dialog.
+        callbacks.onEscapeWithoutSelection();
+        return;
+      }
+
+      if (ids.length === 0) return;
+
+      // Lazily establish the active cell so first-keypress navigation starts
+      // at index 0 instead of doing nothing.
+      let currentIndex = activeWorktreeId ? ids.indexOf(activeWorktreeId) : -1;
+      if (currentIndex === -1) {
+        currentIndex = 0;
+        setActiveWorktreeId(ids[0] ?? null);
+      }
+      const currentId = ids[currentIndex];
+      if (currentId === undefined) return;
+
+      const columnCount = columnCountRef.current;
+      const total = ids.length;
+      let targetIndex: number | null = null;
+
+      switch (e.key) {
+        case "ArrowRight":
+          targetIndex = Math.min(total - 1, currentIndex + 1);
+          break;
+        case "ArrowLeft":
+          targetIndex = Math.max(0, currentIndex - 1);
+          break;
+        case "ArrowDown": {
+          const next = currentIndex + columnCount;
+          targetIndex = next < total ? next : total - 1;
+          break;
+        }
+        case "ArrowUp": {
+          const next = currentIndex - columnCount;
+          targetIndex = next >= 0 ? next : 0;
+          break;
+        }
+        case "Home":
+          targetIndex = 0;
+          break;
+        case "End":
+          targetIndex = total - 1;
+          break;
+        case "PageDown": {
+          const stride = Math.max(1, columnCount * 3);
+          targetIndex = Math.min(total - 1, currentIndex + stride);
+          break;
+        }
+        case "PageUp": {
+          const stride = Math.max(1, columnCount * 3);
+          targetIndex = Math.max(0, currentIndex - stride);
+          break;
+        }
+        case " ":
+        case "Spacebar": {
+          e.preventDefault();
+          e.stopPropagation();
+          selectionAnchorRef.current = currentId;
+          callbacks.onToggleSelection(currentId);
+          return;
+        }
+        case "Enter": {
+          e.preventDefault();
+          e.stopPropagation();
+          callbacks.onActivate(currentId);
+          return;
+        }
+      }
+
+      if (targetIndex === null) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const targetId = ids[targetIndex];
+      if (targetId === undefined) return;
+
+      // Shift+Arrow extends selection from the persistent anchor; pure arrow
+      // movement just moves focus without touching selection. The anchor is
+      // set when the user makes their first deliberate selection action
+      // (Space, click, Ctrl/Cmd+A) — Shift+Arrow without a prior anchor
+      // bootstraps it at the current cell so the range has a stable origin.
+      if (e.shiftKey && targetIndex !== currentIndex) {
+        if (selectionAnchorRef.current === null) {
+          selectionAnchorRef.current = currentId;
+        }
+        callbacks.onSelectRange(selectionAnchorRef.current, targetId);
+      }
+
+      if (targetIndex !== currentIndex) {
+        setActiveWorktreeId(targetId);
+      }
+    },
+    [activeWorktreeId, selectionAnchorRef]
+  );
+
+  return {
+    activeWorktreeId,
+    activeDescendantId,
+    handleGridKeyDown,
+    handleGridFocus,
+    setActiveWorktreeId,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds modal-local multi-select to the worktrees overview grid: Ctrl/Cmd+Click to toggle, Shift+Click for range, Cmd+A to select all, hover/selected checkbox affordance. Selection uses `bg-overlay-subtle` — accent stays reserved per the CLAUDE.md constraint.
- New `useWorktreeOverviewKeyboard` hook implements the WAI-ARIA grid pattern: roving focus via `aria-activedescendant`, 2D arrow navigation with column count tracked via `ResizeObserver`+`getComputedStyle`, Space toggle, Shift+Arrow range extension, Enter to activate, and two-stage Escape (clears selection first, then closes).
- Section-aware vertical movement: a `computeVerticalMove` helper resolves ArrowUp/Down across `col-[1/-1]` section breaks so partial-tail rows don't desync the visual column. The sidebar variant is untouched.

Resolves #8653

## Changes

**`useWorktreeOverviewKeyboard.ts`** — new hook owning the full keyboard and selection state machine. Tracks roving focus, selection set, anchor, and column count. Selection clears on modal close (modal-local Set state + remount), reconciles when filters narrow, anchor survives filter changes but resets on window blur to avoid stuck-Shift phantom ranges after Cmd+Tab.

**`WorktreeOverviewModal.tsx`** — wires the hook into the grid, passes selection props down, manages the `role="grid"` container as the single keyboard tab stop.

**`WorktreeCard.tsx`** — additive `isSelected` / `onToggleSelect` props (grid variant only) plus a checkbox. Inner select-worktree button gets `tabIndex=-1` and `onMouseDown.preventDefault` in the grid variant so modifier-click doesn't steal focus from the grid container.

**Tests** — 28 new jsdom specs in `useWorktreeOverviewKeyboard.test.tsx` + 19 source-level assertions in `WorktreeOverviewModal.test.ts`. Full `src/components/Worktree` suite passes (1086 tests). Accent guard contract passes. Lint ratchet down 120 warnings, typecheck clean, format clean.

## Testing

- Open the overview, arrow-key through cards in 2D; Space toggles; Enter switches to the worktree.
- Cmd+Click toggles a single card; Shift+Click selects a range; Cmd+A selects everything visible.
- With group-by-type ON, navigate across section boundaries — partial-tail rows should land at the visually-adjacent column, not drift right.
- Apply a filter that hides a selected worktree — selection updates, anchor persists.
- Press Escape with items selected — clears selection. Press again — closes the modal.
- Verify the checkbox appears on hover and stays visible when selected.