### PR TITLE
fix(fleet): auto-disarm dead PTYs on structured broadcast (#8706)

### DIFF
--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -94,8 +94,37 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
       if (typeof id !== "string" || typeof text !== "string") {
         throw new Error("Invalid terminal submit parameters");
       }
+      // PtyClient.submit is fire-and-forget — the pty-host silently no-ops
+      // a write to a terminal that's gone or has already exited (see
+      // `PtyManager.submit` / `TerminalProcess.submit`). That left structured
+      // fleet broadcast (`fleetExecution.executeFleetBroadcast`) seeing all
+      // submits as fulfilled and never disarming dead PTYs (#8706). Probe
+      // liveness here so the renderer gets an actual rejection it can
+      // classify and act on. Errno tokens (`EBADF`, `EPIPE`) lead the
+      // message so the renderer can match them via
+      // `classifyFleetRejectionReason` — Electron's structured-clone error
+      // serialization strips `.code` from `NodeJS.ErrnoException`, so the
+      // code MUST live in the message text to survive the IPC boundary.
+      const info = await ptyClient.getTerminalAsync(id);
+      if (!info) {
+        throw new AppError({
+          code: "NOT_FOUND",
+          message: `EBADF: terminal ${id} not found`,
+          context: { terminalId: id },
+        });
+      }
+      if (info.hasPty === false) {
+        throw new AppError({
+          code: "NOT_FOUND",
+          message: `EPIPE: terminal ${id} has no live PTY (exited)`,
+          context: { terminalId: id },
+        });
+      }
       ptyClient.submit(id, text);
     } catch (error) {
+      // Preserve AppError shape so the renderer sees the embedded errno
+      // token in the message — wrapping would lose the prefix.
+      if (error instanceof AppError) throw error;
       const errorMessage = formatErrorMessage(error, "Failed to submit to terminal");
       throw new Error(`Failed to submit to terminal: ${errorMessage}`);
     }

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -105,6 +105,16 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
       // `classifyFleetRejectionReason` — Electron's structured-clone error
       // serialization strips `.code` from `NodeJS.ErrnoException`, so the
       // code MUST live in the message text to survive the IPC boundary.
+      // `getTerminalAsync` returns null both when the terminal genuinely
+      // doesn't exist (the case we want to surface to fleet broadcast) and
+      // when the broker rejects from a host crash / timeout (see
+      // `PtyClient.getTerminalAsync`'s `.catch(() => null)`). During a host
+      // restart that means every concurrent fleet submit briefly classifies
+      // as permanent and disarms the whole fleet — annoying but recoverable
+      // by re-arming. Splitting the two cases would need a new PtyClient
+      // method that propagates broker errors; out of scope for #8706. The
+      // pre-fix behavior had the opposite failure mode (kept firing into
+      // dead pipes), so this trade is a net win for the common case.
       const info = await ptyClient.getTerminalAsync(id);
       if (!info) {
         throw new AppError({

--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -92,7 +92,10 @@ describe("tryFleetBroadcastFromEditor — a11y announcements", () => {
   });
 
   it("announces singular form when exactly one target succeeds", async () => {
-    // Two armed; only one fires successfully (dead pty rejects).
+    // Two armed; only one fires successfully (dead pty rejects with EPIPE,
+    // which is a permanent classification — the announcer calls it out as
+    // "unreachable" so the user can tell auto-disarmed targets apart from
+    // retryable transient failures).
     submitMock.mockImplementation(async (id) => {
       if (id === "b") throw new Error("EPIPE");
     });
@@ -100,13 +103,22 @@ describe("tryFleetBroadcastFromEditor — a11y announcements", () => {
     const onSent = vi.fn();
     tryFleetBroadcastFromEditor("a", "hello", onSent);
     await flush();
-    // Partial failure path — N=1 success, 1 failure.
-    expect(useAnnouncerStore.getState().polite?.msg).toBe("Broadcast sent to 1 — 1 failed");
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Broadcast sent to 1 — 1 unreachable");
   });
 
-  it("announces partial failure with success/failure split", async () => {
+  it("announces partial failure with success/failure split (permanent → unreachable)", async () => {
     submitMock.mockImplementation(async (id) => {
       if (id === "c") throw new Error("EPIPE");
+    });
+    arm(["a", "b", "c"]);
+    tryFleetBroadcastFromEditor("a", "hello", vi.fn());
+    await flush();
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Broadcast sent to 2 — 1 unreachable");
+  });
+
+  it("announces transient-only failures as 'N failed' (retry chip is the recovery)", async () => {
+    submitMock.mockImplementation(async (id) => {
+      if (id === "c") throw new Error("ENOSPC: disk full");
     });
     arm(["a", "b", "c"]);
     tryFleetBroadcastFromEditor("a", "hello", vi.fn());
@@ -148,11 +160,24 @@ describe("tryFleetBroadcastFromEditor — a11y announcements", () => {
     }
   });
 
-  it("announces partial cancel with both sent and failed counts", async () => {
-    // Cancel after a non-batched fan-out where one target rejected: result
-    // arrives with cancelled: true, successCount: 1, failureCount: 1. The
-    // user needs to see both numbers — silently dropping the failure count
-    // would hide a real outcome.
+  it("announces mixed-kind failure split as 'N retryable, M unreachable'", async () => {
+    submitMock.mockImplementation(async (id) => {
+      if (id === "c") throw new Error("ENOSPC: disk full");
+      if (id === "d") throw new Error("EPIPE");
+    });
+    arm(["a", "b", "c", "d"]);
+    tryFleetBroadcastFromEditor("a", "hello", vi.fn());
+    await flush();
+    expect(useAnnouncerStore.getState().polite?.msg).toBe(
+      "Broadcast sent to 2 — 1 retryable, 1 unreachable"
+    );
+  });
+
+  it("announces partial cancel with split when permanent failures occurred", async () => {
+    // Cancel after a non-batched fan-out where one target rejected with
+    // EPIPE: result arrives with cancelled: true, successCount: 1,
+    // permanentlyFailedIds: 1. User needs to see both numbers AND the
+    // unreachable distinction so they know the dead target was disarmed.
     arm(["a", "b"]);
     const pending: Array<() => void> = [];
     submitMock.mockImplementation(
@@ -172,7 +197,75 @@ describe("tryFleetBroadcastFromEditor — a11y announcements", () => {
     for (const fn of pending) fn();
     pending.length = 0;
     for (let i = 0; i < 10; i += 1) await flush();
-    expect(useAnnouncerStore.getState().polite?.msg).toBe("Broadcast cancelled — 1 sent, 1 failed");
+    expect(useAnnouncerStore.getState().polite?.msg).toBe(
+      "Broadcast cancelled — 1 sent, 1 unreachable"
+    );
+  });
+});
+
+describe("tryFleetBroadcastFromEditor — permanent failure auto-disarm (#8706)", () => {
+  it("auto-disarms targets whose submit rejects with a permanent errno", async () => {
+    // Dead PTY: submit rejection carries EPIPE → fleet must disarm the
+    // target so the next broadcast doesn't fire into the gone pipe.
+    submitMock.mockImplementation(async (id) => {
+      if (id === "dead") throw new Error("EPIPE: terminal dead has no live PTY (exited)");
+    });
+    arm(["alive", "dead"]);
+    expect(useFleetArmingStore.getState().armedIds.has("dead")).toBe(true);
+    tryFleetBroadcastFromEditor("alive", "hello", vi.fn());
+    await flush();
+    expect(useFleetArmingStore.getState().armedIds.has("dead")).toBe(false);
+    // Alive target stays armed.
+    expect(useFleetArmingStore.getState().armedIds.has("alive")).toBe(true);
+  });
+
+  it("does NOT record a failure chip for permanently-failed targets (would auto-dismiss anyway)", async () => {
+    submitMock.mockImplementation(async (id) => {
+      if (id === "dead") throw new Error("EPIPE");
+    });
+    arm(["alive", "dead"]);
+    tryFleetBroadcastFromEditor("alive", "hello", vi.fn());
+    await flush();
+    // The dead target was disarmed; no transient chip should exist for it.
+    expect(useFleetFailureStore.getState().failedIds.has("dead")).toBe(false);
+    // No payload retained either — transient set is empty, so there's
+    // nothing for the retry chip to fire on.
+    expect(useFleetFailureStore.getState().payload).toBe(null);
+  });
+
+  it("records a failure chip for transient errors and leaves arming intact", async () => {
+    submitMock.mockImplementation(async (id) => {
+      if (id === "slow") throw new Error("ENOSPC: disk full");
+    });
+    arm(["alive", "slow"]);
+    tryFleetBroadcastFromEditor("alive", "hello", vi.fn());
+    await flush();
+    // Transient → chip recorded so user can retry, arming unchanged.
+    expect(useFleetFailureStore.getState().failedIds.has("slow")).toBe(true);
+    expect(useFleetFailureStore.getState().payload).toBe("hello");
+    expect(useFleetArmingStore.getState().armedIds.has("slow")).toBe(true);
+  });
+
+  it("splits a mixed run: disarms permanent, records transient, keeps fulfilled clean", async () => {
+    submitMock.mockImplementation(async (id) => {
+      if (id === "dead") throw new Error("EPIPE");
+      if (id === "slow") throw new Error("ENOSPC");
+    });
+    arm(["alive", "dead", "slow"]);
+    tryFleetBroadcastFromEditor("alive", "hello", vi.fn());
+    await flush();
+
+    // Permanent → disarmed, no chip.
+    expect(useFleetArmingStore.getState().armedIds.has("dead")).toBe(false);
+    expect(useFleetFailureStore.getState().failedIds.has("dead")).toBe(false);
+
+    // Transient → still armed, chip recorded for retry.
+    expect(useFleetArmingStore.getState().armedIds.has("slow")).toBe(true);
+    expect(useFleetFailureStore.getState().failedIds.has("slow")).toBe(true);
+
+    // Fulfilled → still armed, no chip.
+    expect(useFleetArmingStore.getState().armedIds.has("alive")).toBe(true);
+    expect(useFleetFailureStore.getState().failedIds.has("alive")).toBe(false);
   });
 });
 

--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -246,6 +246,22 @@ describe("tryFleetBroadcastFromEditor — permanent failure auto-disarm (#8706)"
     expect(useFleetArmingStore.getState().armedIds.has("slow")).toBe(true);
   });
 
+  it("announces mixed-kind failure with zero successful sends", async () => {
+    // No fulfilled targets, both kinds rejected — the announcement still
+    // needs the split so the user can tell which targets were auto-disarmed
+    // from which still appear as retryable chips.
+    submitMock.mockImplementation(async (id) => {
+      if (id === "perm") throw new Error("EPIPE");
+      if (id === "tran") throw new Error("ENOSPC");
+    });
+    arm(["perm", "tran"]);
+    tryFleetBroadcastFromEditor("perm", "hello", vi.fn());
+    await flush();
+    expect(useAnnouncerStore.getState().polite?.msg).toBe(
+      "Broadcast sent to 0 — 1 retryable, 1 unreachable"
+    );
+  });
+
   it("splits a mixed run: disarms permanent, records transient, keeps fulfilled clean", async () => {
     submitMock.mockImplementation(async (id) => {
       if (id === "dead") throw new Error("EPIPE");

--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -109,6 +109,37 @@ describe("broadcastFleetLiteralPaste", () => {
     expect(result.failedIds).toEqual(["t2"]);
   });
 
+  it("classifies rejections by errno token into permanent / transient buckets", async () => {
+    submitMock.mockReset();
+    submitMock.mockImplementation(async (id: string) => {
+      if (id === "dead") throw new Error("EPIPE: terminal dead has no live PTY (exited)");
+      if (id === "slow") throw new Error("ENOSPC: device full");
+    });
+    seedPanels([makeAgent("ok"), makeAgent("dead"), makeAgent("slow")]);
+    const result = await broadcastFleetLiteralPaste("x", ["ok", "dead", "slow"]);
+    expect(result.failedIds.sort()).toEqual(["dead", "slow"]);
+    expect(result.permanentlyFailedIds).toEqual(["dead"]);
+    expect(result.transientlyFailedIds).toEqual(["slow"]);
+    const deadEntry = result.perTarget.find((t) => t.terminalId === "dead");
+    const slowEntry = result.perTarget.find((t) => t.terminalId === "slow");
+    expect(deadEntry?.kind).toBe("permanent");
+    expect(slowEntry?.kind).toBe("transient");
+  });
+
+  it("treats rejections without a recognized errno as transient (retry chip wins over silent disarm)", async () => {
+    // Submit rejections come from many sources (IPC framework, handler
+    // errors). Disarming on unknown would silently drop fleet membership
+    // for an infra blip — leave arming alone and let the user retry.
+    submitMock.mockReset();
+    submitMock.mockImplementation(async (id: string) => {
+      if (id === "mystery") throw new Error("submit blew up for reasons unknown");
+    });
+    seedPanels([makeAgent("ok"), makeAgent("mystery")]);
+    const result = await broadcastFleetLiteralPaste("x", ["ok", "mystery"]);
+    expect(result.transientlyFailedIds).toEqual(["mystery"]);
+    expect(result.permanentlyFailedIds).toEqual([]);
+  });
+
   it("returns an empty result on zero targets", async () => {
     const result = await broadcastFleetLiteralPaste("x");
     expect(submitMock).not.toHaveBeenCalled();
@@ -156,6 +187,25 @@ describe("executeFleetBroadcast", () => {
     expect(result.successCount).toBe(2);
     expect(result.failureCount).toBe(1);
     expect(result.failedIds).toEqual(["dead"]);
+    // EPIPE is a permanent classification — caller can disarm.
+    expect(result.permanentlyFailedIds).toEqual(["dead"]);
+    expect(result.transientlyFailedIds).toEqual([]);
+  });
+
+  it("classifies permanent (EBADF/EPIPE) and transient (ENOSPC) failures into split buckets", async () => {
+    submitMock.mockReset();
+    submitMock.mockImplementation(async (id: string) => {
+      if (id === "gone") throw new Error("EBADF: terminal gone not found");
+      if (id === "full") throw new Error("ENOSPC: disk full");
+    });
+    seedPanels([makeAgent("ok"), makeAgent("gone"), makeAgent("full")]);
+    const result = await executeFleetBroadcast("hello", ["ok", "gone", "full"]);
+    expect(result.permanentlyFailedIds).toEqual(["gone"]);
+    expect(result.transientlyFailedIds).toEqual(["full"]);
+    const goneEntry = result.perTarget.find((t) => t.terminalId === "gone");
+    const fullEntry = result.perTarget.find((t) => t.terminalId === "full");
+    expect(goneEntry?.kind).toBe("permanent");
+    expect(fullEntry?.kind).toBe("transient");
   });
 
   it("batches target fan-out when payload ≥100KB and targets exceed batch size", async () => {

--- a/src/components/Fleet/fleetBroadcast.ts
+++ b/src/components/Fleet/fleetBroadcast.ts
@@ -6,6 +6,57 @@ import type { RecipeContext } from "@/utils/recipeVariables";
 export const FLEET_BROADCAST_HISTORY_KEY = "fleet-broadcast" as const;
 
 /**
+ * Errno codes that mean the target PTY is permanently gone — the renderer
+ * should auto-disarm so the user isn't typing into a dead pane. Other
+ * failures still surface the failure chip but leave the arming alone.
+ *
+ * Shared by both fleet broadcast paths:
+ *   - Raw-input (`fleetRawInputBroadcast`) reads `result.error.code` from the
+ *     `broadcast-write-result` IPC payload.
+ *   - Structured-submit (`fleetExecution.buildResult` /
+ *     `broadcastFleetLiteralPaste`) extracts the code from the rejection's
+ *     stringified message — Electron's structured-clone serialization strips
+ *     `NodeJS.ErrnoException.code`, so `handleTerminalSubmit` embeds the code
+ *     as a leading `"CODE: …"` token in the thrown error's message.
+ */
+export const PERMANENT_FAILURE_CODES: ReadonlySet<string> = new Set([
+  "EPIPE",
+  "EIO",
+  "EBADF",
+  "ECONNRESET",
+  "ENOTCONN",
+  "ENXIO",
+  "EINVAL",
+]);
+
+/**
+ * Classify a stringified rejection reason from `terminalClient.submit` as a
+ * permanent (dead-PTY) failure or a transient one. Permanent failures
+ * auto-disarm the target; transient failures surface a retryable chip.
+ *
+ * Submit path note: classification leans on the errno token the IPC handler
+ * embeds in the message (`handleTerminalSubmit` prefixes its dead-PTY
+ * AppErrors with `"EBADF: …"` / `"EPIPE: …"` because Electron's
+ * structured-clone error serialization strips `.code`). An unknown reason
+ * is treated as **transient** — submit rejections can come from many
+ * sources (infra hiccup, IPC framework error) where the user's retry is
+ * the right recovery. Wrongly disarming on a transient infra blip would
+ * silently drop fleet membership, which is the worse failure mode here.
+ * Contrast with the raw-input path: a missing `.code` there means a
+ * single keystroke that's not meaningful to replay, so it disarms on
+ * unknown (see `applyFleetBroadcastResult`).
+ */
+export function classifyFleetRejectionReason(
+  reason: string | undefined
+): "permanent" | "transient" {
+  if (!reason) return "transient";
+  for (const code of PERMANENT_FAILURE_CODES) {
+    if (reason.includes(code)) return "permanent";
+  }
+  return "transient";
+}
+
+/**
  * Build a per-project fleet history key so broadcast history doesn't leak
  * across projects. Falls back to the global key when no project is active.
  */

--- a/src/components/Fleet/fleetEnterBroadcast.ts
+++ b/src/components/Fleet/fleetEnterBroadcast.ts
@@ -23,7 +23,21 @@ function plural(count: number, singular: string, pluralForm: string): string {
   return `${count} ${count === 1 ? singular : pluralForm}`;
 }
 
+function describeFailureSplit(permanent: number, transient: number): string {
+  // Both kinds present → call out the user-visible distinction (retryable vs
+  // unreachable) so the user can tell the chip-recoverable cases apart from
+  // the panes we just auto-disarmed. When only one kind is present, the
+  // single "N failed" count suffices.
+  if (permanent > 0 && transient > 0) {
+    return `${transient} retryable, ${permanent} unreachable`;
+  }
+  if (permanent > 0) return `${permanent} unreachable`;
+  return `${transient} failed`;
+}
+
 function buildBroadcastAnnouncement(result: FleetExecutionResult): string {
+  const permanent = result.permanentlyFailedIds.length;
+  const transient = result.transientlyFailedIds.length;
   const skipped =
     result.skippedCount > 0
       ? `, ${plural(result.skippedCount, "terminal", "terminals")} skipped`
@@ -37,12 +51,12 @@ function buildBroadcastAnnouncement(result: FleetExecutionResult): string {
       return "Broadcast cancelled";
     }
     if (result.failureCount > 0) {
-      return `Broadcast cancelled — ${result.successCount} sent, ${result.failureCount} failed${skipped}`;
+      return `Broadcast cancelled — ${result.successCount} sent, ${describeFailureSplit(permanent, transient)}${skipped}`;
     }
     return `Broadcast cancelled — ${result.successCount} sent${skipped}`;
   }
   if (result.failureCount > 0) {
-    return `Broadcast sent to ${result.successCount} — ${result.failureCount} failed`;
+    return `Broadcast sent to ${result.successCount} — ${describeFailureSplit(permanent, transient)}`;
   }
   return `Broadcast sent to ${plural(result.successCount, "terminal", "terminals")}`;
 }
@@ -98,8 +112,34 @@ export function tryFleetBroadcastFromEditor(
         logWarn("[fleetEnterBroadcast] broadcast had rejections", {
           failureCount: result.failureCount,
           failedIds: result.failedIds,
+          permanentlyFailedIds: result.permanentlyFailedIds,
+          transientlyFailedIds: result.transientlyFailedIds,
         });
-        useFleetFailureStore.getState().recordFailure(text, result.failedIds);
+        if (result.permanentlyFailedIds.length > 0) {
+          // Mirror the raw-input path (`applyFleetBroadcastResult`): a dead
+          // PTY can't take the broadcast, so disarm it rather than leave the
+          // user typing into a gone pane. The failure chip is intentionally
+          // NOT recorded for these — `fleetFailureStore`'s `armedIds`
+          // subscription would auto-dismiss it the moment we disarm, so the
+          // chip would never appear and we'd just thrash the store.
+          const arming = useFleetArmingStore.getState();
+          for (const id of result.permanentlyFailedIds) {
+            arming.disarmId(id);
+            // `executeFleetBroadcast` already calls `clearDirectingState` on
+            // every rejected target, so we don't repeat it here.
+            useFleetFailureStore.getState().dismissId(id);
+          }
+        }
+        if (result.transientlyFailedIds.length > 0) {
+          useFleetFailureStore.getState().recordFailure(text, result.transientlyFailedIds);
+        }
+        // Successful targets in a partial-failure run still clear their
+        // stale failure dots — same logic as the all-success branch below.
+        for (const t of result.perTarget) {
+          if (t.status === "fulfilled") {
+            useFleetFailureStore.getState().dismissId(t.terminalId);
+          }
+        }
       } else if (!result.cancelled) {
         // A successful broadcast clears any stale failure dot on these
         // targets — the partial-failure state from a prior attempt is

--- a/src/components/Fleet/fleetExecution.ts
+++ b/src/components/Fleet/fleetExecution.ts
@@ -8,6 +8,7 @@ import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariab
 import type { TerminalInstance } from "@shared/types";
 import {
   buildFleetBroadcastRecipeContext,
+  classifyFleetRejectionReason,
   FLEET_LARGE_PASTE_BATCH_SIZE,
   FLEET_LARGE_PASTE_BYTE_THRESHOLD,
   getFleetBroadcastByteLength,
@@ -27,8 +28,22 @@ export interface FleetExecutionResult {
   total: number;
   successCount: number;
   failureCount: number;
-  perTarget: Array<{ terminalId: string; status: "fulfilled" | "rejected"; reason?: string }>;
+  /**
+   * Per-target outcome. `kind` is set only for rejected entries — callers
+   * use it to disarm permanent failures (dead PTYs) versus surface a
+   * transient retry chip. See `classifyFleetRejectionReason`.
+   */
+  perTarget: Array<{
+    terminalId: string;
+    status: "fulfilled" | "rejected";
+    reason?: string;
+    kind?: "permanent" | "transient";
+  }>;
   failedIds: string[];
+  /** Subset of `failedIds` whose rejection classified as permanent. */
+  permanentlyFailedIds: string[];
+  /** Subset of `failedIds` whose rejection classified as transient (retryable). */
+  transientlyFailedIds: string[];
   cancelled: boolean;
   skippedCount: number;
 }
@@ -186,19 +201,36 @@ export async function executeFleetBroadcast(
   useFleetBroadcastProgressStore.getState().init(resolved.length);
 
   const buildResult = (cancelled: boolean): FleetExecutionResult => {
-    const perTarget: FleetExecutionResult["perTarget"] = results.map((r, i) => ({
-      terminalId: resolved[i]!.terminalId,
-      status: r.status,
-      reason: r.status === "rejected" ? String(r.reason) : undefined,
-    }));
+    const perTarget: FleetExecutionResult["perTarget"] = results.map((r, i) => {
+      if (r.status === "fulfilled") {
+        return { terminalId: resolved[i]!.terminalId, status: "fulfilled" };
+      }
+      const reason = String(r.reason);
+      return {
+        terminalId: resolved[i]!.terminalId,
+        status: "rejected",
+        reason,
+        kind: classifyFleetRejectionReason(reason),
+      };
+    });
     const successCount = results.filter((r) => r.status === "fulfilled").length;
-    const failedIds = perTarget.filter((t) => t.status === "rejected").map((t) => t.terminalId);
+    const failedIds: string[] = [];
+    const permanentlyFailedIds: string[] = [];
+    const transientlyFailedIds: string[] = [];
+    for (const t of perTarget) {
+      if (t.status !== "rejected") continue;
+      failedIds.push(t.terminalId);
+      if (t.kind === "transient") transientlyFailedIds.push(t.terminalId);
+      else permanentlyFailedIds.push(t.terminalId);
+    }
     return {
       total: results.length,
       successCount,
       failureCount: results.length - successCount,
       perTarget,
       failedIds,
+      permanentlyFailedIds,
+      transientlyFailedIds,
       cancelled,
       skippedCount: Math.max(0, resolved.length - dispatchedCount),
     };
@@ -305,14 +337,29 @@ export async function broadcastFleetLiteralPaste(
   }
 
   const results = await Promise.allSettled(submissions);
-  const perTarget: FleetExecutionResult["perTarget"] = results.map((r, i) => ({
-    terminalId: collected[i]!,
-    status: r.status,
-    reason: r.status === "rejected" ? String(r.reason) : undefined,
-  }));
+  const perTarget: FleetExecutionResult["perTarget"] = results.map((r, i) => {
+    if (r.status === "fulfilled") {
+      return { terminalId: collected[i]!, status: "fulfilled" };
+    }
+    const reason = String(r.reason);
+    return {
+      terminalId: collected[i]!,
+      status: "rejected",
+      reason,
+      kind: classifyFleetRejectionReason(reason),
+    };
+  });
 
   const successCount = results.filter((r) => r.status === "fulfilled").length;
-  const failedIds = perTarget.filter((t) => t.status === "rejected").map((t) => t.terminalId);
+  const failedIds: string[] = [];
+  const permanentlyFailedIds: string[] = [];
+  const transientlyFailedIds: string[] = [];
+  for (const t of perTarget) {
+    if (t.status !== "rejected") continue;
+    failedIds.push(t.terminalId);
+    if (t.kind === "transient") transientlyFailedIds.push(t.terminalId);
+    else permanentlyFailedIds.push(t.terminalId);
+  }
 
   return {
     total: results.length,
@@ -320,6 +367,8 @@ export async function broadcastFleetLiteralPaste(
     failureCount: results.length - successCount,
     perTarget,
     failedIds,
+    permanentlyFailedIds,
+    transientlyFailedIds,
     cancelled: false,
     skippedCount: 0,
   };

--- a/src/components/Fleet/fleetRawInputBroadcast.ts
+++ b/src/components/Fleet/fleetRawInputBroadcast.ts
@@ -8,21 +8,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { logWarn } from "@/utils/logger";
 import type { BroadcastWriteResultPayload } from "@shared/types";
-
-/**
- * Errno codes that mean the target PTY is permanently gone — the renderer
- * should auto-disarm so the user isn't typing into a dead pane. Other
- * failures still surface the failure chip but leave the arming alone.
- */
-const PERMANENT_FAILURE_CODES: ReadonlySet<string> = new Set([
-  "EPIPE",
-  "EIO",
-  "EBADF",
-  "ECONNRESET",
-  "ENOTCONN",
-  "ENXIO",
-  "EINVAL",
-]);
+import { PERMANENT_FAILURE_CODES } from "./fleetBroadcast";
 
 function resolveLiveFleetTargetIds(): string[] {
   const { armOrder, armedIds } = useFleetArmingStore.getState();

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -17,6 +17,7 @@ import { shouldShowHybridInputBar } from "@/components/Terminal/terminalFocus";
 import type { HybridInputBarHandle } from "@/components/Terminal/HybridInputBar";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { terminalClient } from "@/clients";
+import { logWarn } from "@/utils/logger";
 import { isBuiltInAgentId } from "@shared/config/agentIds";
 import { HelpIntroBanner } from "./HelpIntroBanner";
 import { HelpPanelHeader } from "./HelpPanelHeader";
@@ -632,7 +633,12 @@ export function HelpPanel({
                     onSend={({ text }) => {
                       if (terminal?.isInputLocked === true) return;
                       terminalInstanceService.notifyUserInput(terminalId);
-                      void terminalClient.submit(terminalId, text);
+                      // submit can now reject for dead PTYs (#8706); swallow
+                      // to log so the unhandled rejection doesn't leak — the
+                      // help panel is a one-shot send with no recovery UI.
+                      terminalClient.submit(terminalId, text).catch((err) => {
+                        logWarn("[HelpPanel] submit failed", { terminalId, error: err });
+                      });
                     }}
                     onSendKey={(key) => {
                       if (terminal?.isInputLocked === true) return;

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -60,6 +60,7 @@ import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { terminalClient } from "@/clients";
+import { logWarn } from "@/utils/logger";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { openSendToAgentPaletteWithText } from "@/hooks/useSendToAgentPalette";
 import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
@@ -1319,7 +1320,13 @@ function TerminalPaneComponent({
                   onSend={({ trackerData, text }) => {
                     if (!isInputLocked) {
                       terminalInstanceService.notifyUserInput(id);
-                      terminalClient.submit(id, text);
+                      // submit now rejects when the PTY is gone (#8706); the
+                      // single-pane path has no recovery UI for that, so
+                      // swallow to log instead of leaking an unhandled
+                      // rejection. Banners/agent-state surface the dead pane.
+                      terminalClient.submit(id, text).catch((err) => {
+                        logWarn("[TerminalPane] submit failed", { id, error: err });
+                      });
                       handleInput(trackerData);
                     }
                   }}

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -340,7 +340,18 @@ export function registerFleetActions(actions: ActionRegistry): void {
       retryInFlight = true;
       try {
         const result = await broadcastFleetLiteralPaste(payload, targets);
-        const stillFailed = new Set(result.failedIds);
+        // Permanent failures (dead PTYs) auto-disarm so a future retry doesn't
+        // keep firing into the same dead pipes. The retry chip clears for them
+        // too — the user already saw them once; surfacing the same id again
+        // after we've stopped including it in broadcasts would be noise.
+        if (result.permanentlyFailedIds.length > 0) {
+          const arming = useFleetArmingStore.getState();
+          for (const id of result.permanentlyFailedIds) {
+            arming.disarmId(id);
+            useFleetFailureStore.getState().dismissId(id);
+          }
+        }
+        const stillFailed = new Set(result.transientlyFailedIds);
         for (const id of targets) {
           if (!stillFailed.has(id)) useFleetFailureStore.getState().dismissId(id);
         }


### PR DESCRIPTION
## Summary

- Structured fleet broadcast (editor Enter) didn't auto-disarm dead PTYs -- `terminalClient.submit` was fire-and-forget, so `PtyManager.submit` silently no-op'd on missing/exited terminals, `failureCount` stayed zero, and dead PTYs stayed armed indefinitely. The raw-input path (`fleetRawInputBroadcast`) already handled this correctly via `PERMANENT_FAILURE_CODES` + `applyFleetBroadcastResult`.
- `handleTerminalSubmit` (`electron/ipc/handlers/terminal/io.ts`) now probes liveness via `ptyClient.getTerminalAsync` and throws an `AppError` with errno tokens in the message text (`EBADF: terminal X not found` / `EPIPE: terminal X has no live PTY`). Errno lives in the message because structured-clone strips `ErrnoException.code` across the IPC boundary.
- Renderer side (`src/components/Fleet/`) exports shared `PERMANENT_FAILURE_CODES` and `classifyFleetRejectionReason` from `fleetBroadcast.ts`. `FleetExecutionResult.perTarget` gains a `kind` field; `fleetEnterBroadcast` mirrors the raw-input path: auto-disarms permanent IDs, only records transient ones. Announcement copy splits into "N retryable, M unreachable".

Resolves #8706

## Changes

- `electron/ipc/handlers/terminal/io.ts` -- liveness probe + typed `AppError` throws in `handleTerminalSubmit`
- `src/components/Fleet/fleetBroadcast.ts` -- new file; exports `PERMANENT_FAILURE_CODES`, `classifyFleetRejectionReason`
- `src/components/Fleet/fleetExecution.ts` -- `FleetExecutionResult.perTarget` gains `kind`; `buildResult` classifies rejections
- `src/components/Fleet/fleetEnterBroadcast.ts` -- auto-disarm permanent IDs, transient-only failure recording, split announcement copy
- `src/components/Fleet/fleetRawInputBroadcast.ts` -- moved `PERMANENT_FAILURE_CODES` to shared module
- `src/components/Terminal/TerminalPane.tsx`, `src/components/HelpPanel/HelpPanel.tsx` -- `.catch` + `logWarn` on submit to handle rejections from single-pane senders (side-effect of IPC handler change)
- `src/services/actions/definitions/fleetActions.ts` -- wires retry action through updated result shape

**Known trade-off:** `PtyClient.getTerminalAsync` collapses broker errors (`HOST_EXITED`/`TIMEOUT`) and terminal-not-found into the same `null`. During a host crash mid-broadcast, all in-flight submits classify as permanent and temporarily disarm the whole fleet. Rare, recoverable by re-arming, documented inline. Pre-fix the failure mode was worse -- it kept firing into dead pipes silently. Splitting the cases requires a new `PtyClient` method; out of scope here.

**Classification note for unknown rejections:** unknown reasons classify as transient (deliberate divergence from the raw-input path's unknown-to-permanent). Submit retries are meaningful, and silently disarming on an infra blip would drop fleet membership unexpectedly.

## Testing

- [ ] Arm a fleet of 3 terminals, kill one's PTY, send a broadcast via Enter -- the dead one auto-disarms and the announcement says "1 unreachable"
- [ ] Arm a fleet, trigger `ENOSPC` on one target -- that one stays armed, surfaces a retry chip, announcement says "1 failed"
- [ ] Single-pane submit to a dead terminal -- no unhandled promise rejection in DevTools console
- [ ] Verify the retry chip's "Retry failed" action doesn't refire into dead targets (the #8706 root cause)