### PR TITLE
feat(fleet): add per-target edit and skip to broadcast popover

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -483,7 +483,7 @@ export function FleetArmingRibbon(): ReactElement | null {
   const isBroadcastConfirmActive = pendingBroadcast !== null && !isDivergenceConfirmActive;
 
   const divergenceTargets = pendingBroadcast?.divergence?.targets ?? [];
-  const activeDivergenceTargets = divergenceTargets.filter((t) => !t.skipped);
+  const activeDivergenceTargets = divergenceTargets.filter((t) => !t.skipped && !t.excluded);
   const divergenceConfirmDescription = pendingBroadcast?.warningReasons.length
     ? `${pendingBroadcast.warningReasons.join(", ")}. Review what each target will receive.`
     : "Per-target payloads diverge from your draft. Review what each target will receive.";

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -466,12 +466,27 @@ export function FleetArmingRibbon(): ReactElement | null {
 
   const exitChordLabel = isMac() ? "⌘Esc" : "Ctrl+Esc";
 
-  // When a destructive broadcast (paste or Enter) is pending, the right-side
-  // controls collapse to the confirm question so we keep one ribbon row
-  // instead of stacking a second strip below. Per-pane red dots (PanelHeader)
-  // still carry per-target failure state; the `FleetFailureBanner` below
-  // adds the Tier-2 multi-terminal surface with the retry action.
-  const isBroadcastConfirmActive = pendingBroadcast !== null;
+  // Two confirm shapes share the same pending entry:
+  //   - warnings-only (destructive/multi-line/byte-limit) → inline ribbon
+  //     strip with a single warning sentence — fast, low-friction. The
+  //     right-side controls collapse to the confirm question so we keep one
+  //     ribbon row instead of stacking a second strip below. Per-pane red
+  //     dots (PanelHeader) still carry per-target failure state; the
+  //     `FleetFailureBanner` below adds the Tier-2 multi-terminal surface
+  //     with the retry action.
+  //   - divergence (per-target overrides, skips, unresolved vars) →
+  //     ConfirmDialog modal with a scrollable per-target preview so the
+  //     user sees exactly what each terminal will receive (D2 from
+  //     CLAUDE.md, #8691). The modal also folds in any warning reasons.
+  const isDivergenceConfirmActive =
+    pendingBroadcast !== null && pendingBroadcast.divergence !== undefined;
+  const isBroadcastConfirmActive = pendingBroadcast !== null && !isDivergenceConfirmActive;
+
+  const divergenceTargets = pendingBroadcast?.divergence?.targets ?? [];
+  const activeDivergenceTargets = divergenceTargets.filter((t) => !t.skipped);
+  const divergenceConfirmDescription = pendingBroadcast?.warningReasons.length
+    ? `${pendingBroadcast.warningReasons.join(", ")}. Review what each target will receive.`
+    : "Per-target payloads diverge from your draft. Review what each target will receive.";
 
   return (
     <div data-testid="fleet-arming-ribbon-group">
@@ -494,6 +509,71 @@ export function FleetArmingRibbon(): ReactElement | null {
         onClose={() => setPendingDeleteFleetId(null)}
       />
       <FleetFailureBanner />
+      <ConfirmDialog
+        isOpen={isDivergenceConfirmActive}
+        variant={
+          pendingBroadcast?.warningReasons.some((r) => r.startsWith("destructive"))
+            ? "destructive"
+            : "default"
+        }
+        title={`Send broadcast to ${activeDivergenceTargets.length}?`}
+        description={divergenceConfirmDescription}
+        confirmLabel="Send broadcast"
+        onConfirm={confirmPendingBroadcast}
+        onClose={cancelPendingBroadcast}
+      >
+        <ul
+          data-testid="fleet-divergence-preview-list"
+          className="max-h-[280px] overflow-y-auto rounded border border-daintree-border bg-tint/[0.03]"
+        >
+          {divergenceTargets.map((t) => (
+            <li
+              key={t.terminalId}
+              data-testid="fleet-divergence-preview-row"
+              data-skipped={t.skipped ? "true" : undefined}
+              className={cn(
+                "border-b border-daintree-border/40 px-2 py-1.5 text-[11px] last:border-b-0",
+                t.skipped && "opacity-50"
+              )}
+            >
+              <div className="flex items-center gap-1.5 font-medium text-daintree-text/80">
+                <span className={cn("truncate", t.skipped && "line-through")}>{t.title}</span>
+                {t.skipped && (
+                  <span className="ml-auto shrink-0 text-[10px] text-daintree-text/50">
+                    Skipped
+                  </span>
+                )}
+                {t.overridden && !t.skipped && (
+                  <span className="ml-auto shrink-0 text-[10px] text-category-amber-text">
+                    Edited
+                  </span>
+                )}
+              </div>
+              {!t.skipped && (
+                <div className="mt-0.5 leading-relaxed break-all text-daintree-text">
+                  {t.payload === "" ? (
+                    <span className="text-daintree-text/40">(empty)</span>
+                  ) : (
+                    t.payload
+                  )}
+                </div>
+              )}
+              {!t.skipped && t.unresolvedVars.length > 0 && (
+                <div className="mt-0.5 flex flex-wrap gap-1">
+                  {t.unresolvedVars.map((v) => (
+                    <span
+                      key={v}
+                      className="inline-flex items-center rounded-full px-1.5 py-px text-[9px] bg-category-rose-subtle text-category-rose-text"
+                    >
+                      {`{{${v}}}`} unresolved
+                    </span>
+                  ))}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </ConfirmDialog>
       <AnimatePresence initial={false}>
         <m.div
           ref={ribbonRef}

--- a/src/components/Fleet/FleetDraftingPill.tsx
+++ b/src/components/Fleet/FleetDraftingPill.tsx
@@ -3,6 +3,7 @@ import { RadioTower, ChevronDown, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useFleetBroadcastConfirmStore } from "@/store/fleetBroadcastConfirmStore";
 import { useFleetResolutionPreviewStore } from "@/store/fleetResolutionPreviewStore";
 import { useFleetTargetOverridesStore } from "@/store/fleetTargetOverridesStore";
 import { useEscapeStack } from "@/hooks/useEscapeStack";
@@ -28,16 +29,20 @@ export function FleetDraftingPill(): ReactElement | null {
 
   useEscapeStack(open, () => setOpen(false));
 
-  // Per-target overrides are ephemeral per-broadcast (#8691). Clearing them
-  // when the popover closes — by user dismiss or by the draft losing all
-  // recipe variables — keeps them from leaking into the next broadcast.
-  // The broadcast pipeline also clears in its `finally`, so this covers
-  // the "user opened, edited, then dismissed without sending" case.
+  // Per-target overrides are ephemeral per-broadcast (#8691). The broadcast
+  // pipeline (fleetEnterBroadcast.doSend) reads the snapshot taken at
+  // Enter-press time and clears in its `finally`, so this effect only
+  // covers the "user opened, edited, then dismissed without sending" case.
+  // Gated on `pending === null` defensively: while a confirm is in flight
+  // the snapshot is what matters, but keeping the live store in sync with
+  // the snapshot avoids surprising the user with stale state if they then
+  // cancel the dialog and reopen the popover.
+  const pendingBroadcast = useFleetBroadcastConfirmStore((s) => s.pending);
   useEffect(() => {
-    if (!open) {
+    if (!open && pendingBroadcast === null) {
       useFleetTargetOverridesStore.getState().clear();
     }
-  }, [open]);
+  }, [open, pendingBroadcast]);
 
   if (peerCount < 1) return null;
 

--- a/src/components/Fleet/FleetDraftingPill.tsx
+++ b/src/components/Fleet/FleetDraftingPill.tsx
@@ -263,7 +263,7 @@ function FleetResolutionRow({ preview }: FleetResolutionRowProps): ReactElement 
               aria-label={`Override payload for ${title}`}
               className={cn(
                 "flex-1 resize-y bg-transparent text-[11px] leading-relaxed break-all text-daintree-text",
-                "rounded-sm border border-transparent px-1 py-0.5 outline-none transition-colors duration-150",
+                "rounded-sm border border-transparent px-1 py-0.5 outline-hidden transition-colors duration-150",
                 "hover:border-border-subtle focus:border-border-subtle",
                 isSkipped && "cursor-not-allowed line-through",
                 resolvedPayload === "" && !isOverridden && "text-daintree-text/40"

--- a/src/components/Fleet/FleetDraftingPill.tsx
+++ b/src/components/Fleet/FleetDraftingPill.tsx
@@ -1,9 +1,10 @@
-import { type ReactElement } from "react";
+import { useCallback, useEffect, useRef, type KeyboardEvent, type ReactElement } from "react";
 import { RadioTower, ChevronDown, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetResolutionPreviewStore } from "@/store/fleetResolutionPreviewStore";
+import { useFleetTargetOverridesStore } from "@/store/fleetTargetOverridesStore";
 import { useEscapeStack } from "@/hooks/useEscapeStack";
 import { splitByRecipeVariables } from "@/utils/recipeVariables";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
@@ -19,7 +20,24 @@ export function FleetDraftingPill(): ReactElement | null {
   const previews = useFleetResolutionPreviewStore((s) => s.previews);
   const setOpen = useFleetResolutionPreviewStore((s) => s.setOpen);
 
+  const overridesCount = useFleetTargetOverridesStore(
+    (s) => Object.keys(s.payloadOverrides).length
+  );
+  const skippedCount = useFleetTargetOverridesStore((s) => s.skippedIds.size);
+  const hasDivergence = overridesCount > 0 || skippedCount > 0;
+
   useEscapeStack(open, () => setOpen(false));
+
+  // Per-target overrides are ephemeral per-broadcast (#8691). Clearing them
+  // when the popover closes — by user dismiss or by the draft losing all
+  // recipe variables — keeps them from leaking into the next broadcast.
+  // The broadcast pipeline also clears in its `finally`, so this covers
+  // the "user opened, edited, then dismissed without sending" case.
+  useEffect(() => {
+    if (!open) {
+      useFleetTargetOverridesStore.getState().clear();
+    }
+  }, [open]);
 
   if (peerCount < 1) return null;
 
@@ -46,6 +64,13 @@ export function FleetDraftingPill(): ReactElement | null {
             <span>
               Mirroring to {peerCount} {peerCount === 1 ? "peer" : "peers"}
             </span>
+            {hasDivergence && (
+              <span
+                data-testid="fleet-drafting-pill-divergence-dot"
+                aria-label={`${overridesCount + skippedCount} per-target edit${overridesCount + skippedCount === 1 ? "" : "s"} pending`}
+                className="ml-0.5 inline-block h-1.5 w-1.5 rounded-full bg-category-amber-border"
+              />
+            )}
             {hasVariables && (
               <ChevronDown
                 className={cn("h-3 w-3 transition-transform duration-150", open && "rotate-180")}
@@ -58,8 +83,17 @@ export function FleetDraftingPill(): ReactElement | null {
           side="bottom"
           align="start"
           sideOffset={4}
+          onEscapeKeyDown={(e) => {
+            // Escape inside an override textarea should clear focus or the
+            // edit, not collapse the popover. Block the dismiss; the
+            // textarea's own onKeyDown handles the local Escape semantics.
+            const active = document.activeElement;
+            if (active instanceof HTMLElement && active.dataset.fleetOverrideTextarea === "true") {
+              e.preventDefault();
+            }
+          }}
           data-testid="fleet-resolution-popover"
-          className="max-h-[320px] w-[360px] overflow-y-auto p-1"
+          className="max-h-[400px] w-[400px] overflow-y-auto p-1"
         >
           <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-daintree-text/50">
             Fleet broadcast preview
@@ -89,21 +123,106 @@ interface FleetResolutionRowProps {
 }
 
 function FleetResolutionRow({ preview }: FleetResolutionRowProps): ReactElement {
-  const { title, resolvedPayload, unresolvedVars, excluded, exclusionReason } = preview;
+  const { terminalId, title, resolvedPayload, unresolvedVars, excluded, exclusionReason } = preview;
   const draft = useFleetResolutionPreviewStore((s) => s.draft);
+  const override = useFleetTargetOverridesStore((s) => s.payloadOverrides[terminalId]);
+  const isSkipped = useFleetTargetOverridesStore((s) => s.skippedIds.has(terminalId));
+  const setPayloadOverride = useFleetTargetOverridesStore((s) => s.setPayloadOverride);
+  const clearPayloadOverride = useFleetTargetOverridesStore((s) => s.clearPayloadOverride);
+  const setSkipped = useFleetTargetOverridesStore((s) => s.setSkipped);
+
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // The textarea is a controlled input. When the user edits, we either
+  // store a non-default value as an override, or clear the override if
+  // they typed it back to the resolved default. This keeps the override
+  // map sparse — only actual divergences live in it.
+  const currentValue = override ?? resolvedPayload;
+  const isOverridden = override !== undefined;
+
+  const handleTextareaChange = useCallback(
+    (next: string) => {
+      if (next === resolvedPayload) {
+        clearPayloadOverride(terminalId);
+      } else {
+        setPayloadOverride(terminalId, next);
+      }
+    },
+    [terminalId, resolvedPayload, setPayloadOverride, clearPayloadOverride]
+  );
+
+  const handleTextareaKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter") {
+        // Enter inside the override field must not bubble to the primary
+        // pane's input bar — that handler would call
+        // tryFleetBroadcastFromEditor and fire the broadcast mid-edit.
+        // Allow Shift+Enter for multi-line overrides (already what
+        // browsers do by default in a textarea), and absorb plain Enter
+        // as a "commit and blur" so the user can keyboard their way out
+        // of the field without sending.
+        if (!e.shiftKey) {
+          e.preventDefault();
+          e.stopPropagation();
+          textareaRef.current?.blur();
+        }
+        return;
+      }
+      if (e.key === "Escape") {
+        // Escape inside an override field clears the override (reverting
+        // to the resolved default) and blurs. The popover-level
+        // onEscapeKeyDown guard above prevents the popover from closing.
+        e.preventDefault();
+        e.stopPropagation();
+        clearPayloadOverride(terminalId);
+        textareaRef.current?.blur();
+      }
+    },
+    [terminalId, clearPayloadOverride]
+  );
+
   const parts = splitByRecipeVariables(draft);
+  const showsOverride = isOverridden && !isSkipped;
 
   return (
     <li
       data-testid="fleet-resolution-row"
-      className={cn("rounded px-2 py-1.5", excluded && "opacity-50")}
+      data-skipped={isSkipped ? "true" : undefined}
+      className={cn(
+        "rounded px-2 py-1.5",
+        excluded && "opacity-50",
+        isSkipped && !excluded && "opacity-50"
+      )}
     >
       <div className="flex items-center gap-1.5 text-[11px] font-medium text-daintree-text/70">
-        <span className="truncate">{title}</span>
+        {!excluded && (
+          <label className="inline-flex shrink-0 items-center">
+            <input
+              type="checkbox"
+              checked={!isSkipped}
+              onChange={(e) => setSkipped(terminalId, !e.target.checked)}
+              data-testid="fleet-resolution-row-include"
+              aria-label={`Include ${title} in broadcast`}
+              className="h-3 w-3 cursor-pointer rounded border-daintree-border transition-colors duration-150"
+            />
+          </label>
+        )}
+        <span className={cn("truncate", isSkipped && "line-through")}>{title}</span>
         {excluded && exclusionReason && (
           <span className="inline-flex items-center gap-0.5 text-[10px] text-category-rose-text shrink-0">
             <AlertTriangle className="h-2.5 w-2.5" aria-hidden="true" />
             {exclusionReason}
+          </span>
+        )}
+        {isSkipped && !excluded && (
+          <span className="ml-auto shrink-0 text-[10px] text-daintree-text/50">Skipped</span>
+        )}
+        {showsOverride && (
+          <span
+            className="ml-auto shrink-0 text-[10px] text-category-amber-text"
+            data-testid="fleet-resolution-row-overridden"
+          >
+            Edited
           </span>
         )}
       </div>
@@ -125,18 +244,27 @@ function FleetResolutionRow({ preview }: FleetResolutionRowProps): ReactElement 
         <div className="mt-1 border-t border-border-subtle pt-0.5">
           <div className="flex items-start gap-1.5">
             <span className="text-[9px] uppercase tracking-wide text-daintree-text/40 mt-px shrink-0">
-              resolved
+              {isOverridden ? "edited" : "resolved"}
             </span>
-            <span
-              data-testid="fleet-resolution-resolved-text"
-              className="text-[11px] leading-relaxed break-all text-daintree-text"
-            >
-              {resolvedPayload !== "" ? (
-                resolvedPayload
-              ) : (
-                <span className="text-daintree-text/40">(empty)</span>
+            <textarea
+              ref={textareaRef}
+              value={currentValue}
+              onChange={(e) => handleTextareaChange(e.target.value)}
+              onKeyDown={handleTextareaKeyDown}
+              disabled={isSkipped}
+              rows={1}
+              data-fleet-override-textarea="true"
+              data-testid="fleet-resolution-row-textarea"
+              aria-label={`Override payload for ${title}`}
+              className={cn(
+                "flex-1 resize-y bg-transparent text-[11px] leading-relaxed break-all text-daintree-text",
+                "rounded-sm border border-transparent px-1 py-0.5 outline-none transition-colors duration-150",
+                "hover:border-border-subtle focus:border-border-subtle",
+                isSkipped && "cursor-not-allowed line-through",
+                resolvedPayload === "" && !isOverridden && "text-daintree-text/40"
               )}
-            </span>
+              placeholder={resolvedPayload === "" ? "(empty)" : undefined}
+            />
           </div>
           {unresolvedVars.length > 0 && (
             <div className="mt-0.5 flex flex-wrap gap-1">

--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -7,6 +7,11 @@ import {
   resolveFleetBroadcastConfirmation,
 } from "@/store/fleetBroadcastConfirmStore";
 import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
+import { useFleetResolutionPreviewStore } from "@/store/fleetResolutionPreviewStore";
+import {
+  useFleetTargetOverridesStore,
+  __resetFleetTargetOverridesStoreForTesting,
+} from "@/store/fleetTargetOverridesStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore } from "@/store/panelStore";
 import type { TerminalInstance } from "@shared/types";
@@ -70,6 +75,8 @@ beforeEach(() => {
     isActive: false,
     cancelled: false,
   });
+  useFleetResolutionPreviewStore.getState().clear();
+  __resetFleetTargetOverridesStoreForTesting();
   useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
   Object.assign(window, {
     electron: {
@@ -324,5 +331,110 @@ describe("cancelActiveBroadcast", () => {
   it("is a no-op when no broadcast is active", () => {
     expect(() => cancelActiveBroadcast()).not.toThrow();
     expect(useFleetBroadcastProgressStore.getState().isActive).toBe(false);
+  });
+});
+
+describe("tryFleetBroadcastFromEditor — per-target overrides and skips (#8691)", () => {
+  it("threads payload overrides into executeFleetBroadcast", async () => {
+    arm(["a", "b", "c"]);
+    useFleetTargetOverridesStore.getState().setPayloadOverride("b", "custom for b");
+
+    tryFleetBroadcastFromEditor("a", "hello", vi.fn());
+    // Override triggers divergence → confirm path. Resolve it.
+    expect(useFleetBroadcastConfirmStore.getState().pending).not.toBeNull();
+    resolveFleetBroadcastConfirmation();
+    await flush();
+    await flush();
+
+    expect(submitMock).toHaveBeenCalledWith("a", "hello");
+    expect(submitMock).toHaveBeenCalledWith("b", "custom for b");
+    expect(submitMock).toHaveBeenCalledWith("c", "hello");
+  });
+
+  it("excludes skipped targets from the broadcast", async () => {
+    arm(["a", "b", "c"]);
+    useFleetTargetOverridesStore.getState().setSkipped("c", true);
+
+    tryFleetBroadcastFromEditor("a", "hello", vi.fn());
+    expect(useFleetBroadcastConfirmStore.getState().pending).not.toBeNull();
+    resolveFleetBroadcastConfirmation();
+    await flush();
+    await flush();
+
+    expect(submitMock).toHaveBeenCalledWith("a", "hello");
+    expect(submitMock).toHaveBeenCalledWith("b", "hello");
+    expect(submitMock).not.toHaveBeenCalledWith("c", expect.anything());
+  });
+
+  it("returns true and skips dispatch when every armed target is skipped", () => {
+    arm(["a", "b"]);
+    useFleetTargetOverridesStore.getState().setSkipped("a", true);
+    useFleetTargetOverridesStore.getState().setSkipped("b", true);
+    const onSent = vi.fn();
+    const consumed = tryFleetBroadcastFromEditor("a", "hello", onSent);
+    expect(consumed).toBe(true);
+    expect(submitMock).not.toHaveBeenCalled();
+    expect(onSent).toHaveBeenCalled();
+    expect(useAnnouncerStore.getState().polite?.msg).toMatch(/all targets/i);
+  });
+
+  it("routes through confirm dialog when any override is set", () => {
+    arm(["a", "b"]);
+    useFleetTargetOverridesStore.getState().setPayloadOverride("b", "edited");
+    tryFleetBroadcastFromEditor("a", "hello", vi.fn());
+    const pending = useFleetBroadcastConfirmStore.getState().pending;
+    expect(pending).not.toBeNull();
+    expect(pending!.divergence).not.toBeUndefined();
+    expect(pending!.divergence!.targets).toHaveLength(2);
+    expect(pending!.divergence!.targets.find((t) => t.terminalId === "b")?.overridden).toBe(true);
+  });
+
+  it("routes through confirm dialog when any target is skipped", () => {
+    arm(["a", "b"]);
+    useFleetTargetOverridesStore.getState().setSkipped("b", true);
+    tryFleetBroadcastFromEditor("a", "hello", vi.fn());
+    const pending = useFleetBroadcastConfirmStore.getState().pending;
+    expect(pending!.divergence?.targets.find((t) => t.terminalId === "b")?.skipped).toBe(true);
+  });
+
+  it("bypasses the confirm dialog when no overrides, skips, or warnings exist", async () => {
+    arm(["a", "b"]);
+    const onSent = vi.fn();
+    tryFleetBroadcastFromEditor("a", "hello", onSent);
+    await flush();
+    // No pending confirm — broadcast fires immediately.
+    expect(useFleetBroadcastConfirmStore.getState().pending).toBeNull();
+    expect(submitMock).toHaveBeenCalledTimes(2);
+    expect(onSent).toHaveBeenCalled();
+  });
+
+  it("re-reads override state inside doSend so late edits take effect", async () => {
+    arm(["a", "b", "c"]);
+    // Start with an override on b (creates divergence → confirm)
+    useFleetTargetOverridesStore.getState().setPayloadOverride("b", "first");
+    tryFleetBroadcastFromEditor("a", "hello", vi.fn());
+    expect(useFleetBroadcastConfirmStore.getState().pending).not.toBeNull();
+
+    // While the confirm is open, change b's override and add a skip on c.
+    useFleetTargetOverridesStore.getState().setPayloadOverride("b", "final");
+    useFleetTargetOverridesStore.getState().setSkipped("c", true);
+
+    resolveFleetBroadcastConfirmation();
+    await flush();
+    await flush();
+
+    expect(submitMock).toHaveBeenCalledWith("b", "final");
+    expect(submitMock).not.toHaveBeenCalledWith("c", expect.anything());
+  });
+
+  it("clears the overrides store in the finally block after broadcast", async () => {
+    arm(["a", "b"]);
+    useFleetTargetOverridesStore.getState().setPayloadOverride("b", "x");
+    tryFleetBroadcastFromEditor("a", "hello", vi.fn());
+    resolveFleetBroadcastConfirmation();
+    await flush();
+    await flush();
+    expect(useFleetTargetOverridesStore.getState().payloadOverrides).toEqual({});
+    expect(useFleetTargetOverridesStore.getState().skippedIds.size).toBe(0);
   });
 });

--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -408,23 +408,28 @@ describe("tryFleetBroadcastFromEditor — per-target overrides and skips (#8691)
     expect(onSent).toHaveBeenCalled();
   });
 
-  it("re-reads override state inside doSend so late edits take effect", async () => {
+  it("submits the snapshot — live overrides cleared after confirm opens are ignored", async () => {
+    // Regression: when the divergence ConfirmDialog mounts it traps focus,
+    // which causes the popover to close, which causes the popover's
+    // useEffect to clear the overrides store. The broadcast must submit
+    // what the user reviewed in the dialog, not the cleared store
+    // (#8691, D2 silent-fallback safeguard).
     arm(["a", "b", "c"]);
-    // Start with an override on b (creates divergence → confirm)
-    useFleetTargetOverridesStore.getState().setPayloadOverride("b", "first");
+    useFleetTargetOverridesStore.getState().setPayloadOverride("b", "reviewed");
     tryFleetBroadcastFromEditor("a", "hello", vi.fn());
     expect(useFleetBroadcastConfirmStore.getState().pending).not.toBeNull();
 
-    // While the confirm is open, change b's override and add a skip on c.
-    useFleetTargetOverridesStore.getState().setPayloadOverride("b", "final");
-    useFleetTargetOverridesStore.getState().setSkipped("c", true);
+    // Simulate the popover-close clear that fires when the ConfirmDialog
+    // grabs focus.
+    useFleetTargetOverridesStore.getState().clear();
 
     resolveFleetBroadcastConfirmation();
     await flush();
     await flush();
 
-    expect(submitMock).toHaveBeenCalledWith("b", "final");
-    expect(submitMock).not.toHaveBeenCalledWith("c", expect.anything());
+    // The submission must use the snapshot ("reviewed"), not the cleared
+    // live store ("hello" — the default).
+    expect(submitMock).toHaveBeenCalledWith("b", "reviewed");
   });
 
   it("clears the overrides store in the finally block after broadcast", async () => {
@@ -436,5 +441,55 @@ describe("tryFleetBroadcastFromEditor — per-target overrides and skips (#8691)
     await flush();
     expect(useFleetTargetOverridesStore.getState().payloadOverrides).toEqual({});
     expect(useFleetTargetOverridesStore.getState().skippedIds.size).toBe(0);
+  });
+
+  it("clears overrides and calls onSent when all initial targets are skipped", () => {
+    arm(["a", "b"]);
+    useFleetTargetOverridesStore.getState().setPayloadOverride("a", "x");
+    useFleetTargetOverridesStore.getState().setSkipped("a", true);
+    useFleetTargetOverridesStore.getState().setSkipped("b", true);
+    const onSent = vi.fn();
+    tryFleetBroadcastFromEditor("a", "hello", onSent);
+    expect(onSent).toHaveBeenCalled();
+    expect(useFleetTargetOverridesStore.getState().payloadOverrides).toEqual({});
+    expect(useFleetTargetOverridesStore.getState().skippedIds.size).toBe(0);
+  });
+
+  it("clears overrides and calls onSent when targets drain to zero during confirm", async () => {
+    arm(["a", "b"]);
+    useFleetTargetOverridesStore.getState().setPayloadOverride("b", "x");
+    const onSent = vi.fn();
+    tryFleetBroadcastFromEditor("a", "hello", onSent);
+    expect(useFleetBroadcastConfirmStore.getState().pending).not.toBeNull();
+
+    // Simulate disarming every terminal during the confirm pause.
+    useFleetArmingStore.setState({
+      armedIds: new Set<string>(),
+      armOrder: [],
+      armOrderById: {},
+      lastArmedId: null,
+    });
+
+    resolveFleetBroadcastConfirmation();
+    await flush();
+    await flush();
+
+    expect(submitMock).not.toHaveBeenCalled();
+    expect(onSent).toHaveBeenCalled();
+    expect(useFleetTargetOverridesStore.getState().payloadOverrides).toEqual({});
+  });
+
+  it("does not force a confirm for overrides on disarmed terminals", async () => {
+    // A user could leave a stale override for a terminal that later
+    // disarmed — that shouldn't surface a spurious divergence dialog
+    // when the user broadcasts an unrelated draft to the remaining fleet.
+    useFleetTargetOverridesStore.getState().setPayloadOverride("ghost", "stale");
+    arm(["a", "b"]);
+    const onSent = vi.fn();
+    tryFleetBroadcastFromEditor("a", "hello", onSent);
+    expect(useFleetBroadcastConfirmStore.getState().pending).toBeNull();
+    await flush();
+    expect(submitMock).toHaveBeenCalledTimes(2);
+    expect(onSent).toHaveBeenCalled();
   });
 });

--- a/src/components/Fleet/__tests__/fleetResolutionPreview.test.tsx
+++ b/src/components/Fleet/__tests__/fleetResolutionPreview.test.tsx
@@ -1,9 +1,13 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { hasRecipeVariables, splitByRecipeVariables } from "@/utils/recipeVariables";
 import { useFleetResolutionPreviewStore } from "@/store/fleetResolutionPreviewStore";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import {
+  useFleetTargetOverridesStore,
+  __resetFleetTargetOverridesStoreForTesting,
+} from "@/store/fleetTargetOverridesStore";
 import { usePanelStore } from "@/store/panelStore";
 import { FleetDraftingPill } from "../FleetDraftingPill";
 import type { TerminalInstance } from "@shared/types";
@@ -17,6 +21,7 @@ function resetStores() {
   });
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
   useFleetResolutionPreviewStore.getState().clear();
+  __resetFleetTargetOverridesStoreForTesting();
 }
 
 function seedPanel(panel: TerminalInstance) {
@@ -280,5 +285,105 @@ describe("FleetDraftingPill", () => {
 
     render(<FleetDraftingPill />);
     expect(screen.queryByTestId("fleet-resolution-popover")).toBeNull();
+  });
+});
+
+describe("FleetDraftingPill — per-target edit and skip (#8691)", () => {
+  beforeEach(() => {
+    resetStores();
+    const a1 = makeAgent("t-1");
+    const a2 = makeAgent("t-2");
+    usePanelStore.setState({
+      panelsById: { "t-1": a1, "t-2": a2 },
+      panelIds: ["t-1", "t-2"],
+    });
+    armAgent("t-1", 0);
+    armAgent("t-2", 1);
+    useFleetResolutionPreviewStore.getState().setDraft("deploy {{branch_name}}");
+  });
+
+  it("renders one textarea per non-excluded row", () => {
+    render(<FleetDraftingPill />);
+    const textareas = screen.getAllByTestId("fleet-resolution-row-textarea");
+    expect(textareas).toHaveLength(2);
+  });
+
+  it("writes overrides through the store when the textarea changes", () => {
+    render(<FleetDraftingPill />);
+    const textareas = screen.getAllByTestId(
+      "fleet-resolution-row-textarea"
+    ) as HTMLTextAreaElement[];
+    fireEvent.change(textareas[1]!, { target: { value: "custom override" } });
+    expect(useFleetTargetOverridesStore.getState().payloadOverrides["t-2"]).toBe("custom override");
+  });
+
+  it("clears the override when the textarea returns to the resolved default", () => {
+    render(<FleetDraftingPill />);
+    const previews = useFleetResolutionPreviewStore.getState().previews;
+    const t2Resolved = previews.find((p) => p.terminalId === "t-2")!.resolvedPayload;
+    const textareas = screen.getAllByTestId(
+      "fleet-resolution-row-textarea"
+    ) as HTMLTextAreaElement[];
+    fireEvent.change(textareas[1]!, { target: { value: "edited" } });
+    expect(useFleetTargetOverridesStore.getState().payloadOverrides["t-2"]).toBe("edited");
+    fireEvent.change(textareas[1]!, { target: { value: t2Resolved } });
+    expect(useFleetTargetOverridesStore.getState().payloadOverrides["t-2"]).toBeUndefined();
+  });
+
+  it("toggles a skip via the include checkbox", () => {
+    render(<FleetDraftingPill />);
+    const checkboxes = screen.getAllByTestId("fleet-resolution-row-include") as HTMLInputElement[];
+    expect(checkboxes[1]!.checked).toBe(true);
+    fireEvent.click(checkboxes[1]!);
+    expect(useFleetTargetOverridesStore.getState().skippedIds.has("t-2")).toBe(true);
+  });
+
+  it("prevents Enter inside an override textarea from bubbling", () => {
+    render(<FleetDraftingPill />);
+    const textarea = screen.getAllByTestId(
+      "fleet-resolution-row-textarea"
+    )[0] as HTMLTextAreaElement;
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+    const result = textarea.dispatchEvent(event);
+    // defaultPrevented = true means the handler called preventDefault.
+    expect(result).toBe(false);
+  });
+
+  it("clears overrides when the popover closes (user dismiss)", () => {
+    render(<FleetDraftingPill />);
+    act(() => {
+      useFleetTargetOverridesStore.getState().setPayloadOverride("t-1", "x");
+      useFleetTargetOverridesStore.getState().setSkipped("t-2", true);
+    });
+    // Simulate user dismissing the popover.
+    act(() => {
+      useFleetResolutionPreviewStore.getState().setOpen(false);
+    });
+    expect(useFleetTargetOverridesStore.getState().payloadOverrides).toEqual({});
+    expect(useFleetTargetOverridesStore.getState().skippedIds.size).toBe(0);
+  });
+
+  it("disables the textarea for skipped targets", () => {
+    render(<FleetDraftingPill />);
+    act(() => {
+      useFleetTargetOverridesStore.getState().setSkipped("t-2", true);
+    });
+    const textareas = screen.getAllByTestId(
+      "fleet-resolution-row-textarea"
+    ) as HTMLTextAreaElement[];
+    expect(textareas[1]!.disabled).toBe(true);
+  });
+
+  it("shows a divergence dot on the trigger when overrides or skips exist", () => {
+    render(<FleetDraftingPill />);
+    expect(screen.queryByTestId("fleet-drafting-pill-divergence-dot")).toBeNull();
+    act(() => {
+      useFleetTargetOverridesStore.getState().setPayloadOverride("t-1", "x");
+    });
+    expect(screen.getByTestId("fleet-drafting-pill-divergence-dot")).toBeTruthy();
   });
 });

--- a/src/components/Fleet/fleetEnterBroadcast.ts
+++ b/src/components/Fleet/fleetEnterBroadcast.ts
@@ -1,11 +1,21 @@
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
-import { requestFleetBroadcastConfirmation } from "@/store/fleetBroadcastConfirmStore";
+import {
+  requestFleetBroadcastConfirmation,
+  type PendingFleetBroadcastTarget,
+} from "@/store/fleetBroadcastConfirmStore";
 import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
+import { useFleetResolutionPreviewStore } from "@/store/fleetResolutionPreviewStore";
+import { useFleetTargetOverridesStore } from "@/store/fleetTargetOverridesStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { logWarn } from "@/utils/logger";
 import { getFleetBroadcastWarnings, resolveFleetBroadcastTargetIds } from "./fleetBroadcast";
-import { executeFleetBroadcast, type FleetExecutionResult } from "./fleetExecution";
+import {
+  buildFleetTargetPreviews,
+  executeFleetBroadcast,
+  type FleetExecutionResult,
+  type FleetTargetPreview,
+} from "./fleetExecution";
 
 let activeBroadcastController: AbortController | null = null;
 
@@ -70,21 +80,43 @@ function describeWarnings(text: string): string[] {
   return reasons;
 }
 
+function buildDivergenceTargets(
+  previews: FleetTargetPreview[],
+  payloadOverrides: Record<string, string>,
+  skippedIds: Set<string>
+): PendingFleetBroadcastTarget[] {
+  return previews.map((p) => {
+    const override = payloadOverrides[p.terminalId];
+    const overridden = override !== undefined;
+    return {
+      terminalId: p.terminalId,
+      title: p.title,
+      payload: overridden ? override : p.resolvedPayload,
+      overridden,
+      skipped: skippedIds.has(p.terminalId),
+      unresolvedVars: p.unresolvedVars,
+    };
+  });
+}
+
 /**
  * Enter from a focused armed pane fans the draft out to every armed peer
  * (the "broadcast by default" model). Returns true when the broadcast was
- * either dispatched or queued for confirmation — the caller must skip its
- * single-pane send path. Returns false when the pane isn't in a 2+ fleet,
- * leaving the caller to do its normal per-pane submit.
+ * either dispatched, queued for confirmation, or absorbed because every
+ * armed target was user-skipped — the caller must skip its single-pane
+ * send path. Returns false when the pane isn't in a 2+ fleet, leaving the
+ * caller to do its normal per-pane submit.
  *
  * Followers stay single-pane on Enter — typing in a follower's input bar
  * is the deliberate "send only here" escape hatch and is not advertised
  * in the UI.
  *
- * Per-target recipe-variable resolution is handled by `executeFleetBroadcast`
- * (worktree path, branch name, issue/PR number). Unresolved variables
- * become empty strings rather than blocking the send — the user already
- * saw the per-target diff in the optional pill popover if they cared.
+ * Per-target recipe-variable resolution happens in `executeFleetBroadcast`.
+ * The drafting popover lets the user override any single target's payload
+ * or skip a target outright. Both forms of divergence (plus unresolved
+ * variables) route through a confirm dialog before dispatch so the user
+ * sees the actual per-target content — the silent-fallback comment that
+ * used to live here is gone because we no longer silently fall back.
  */
 export function tryFleetBroadcastFromEditor(
   terminalId: string,
@@ -97,9 +129,69 @@ export function tryFleetBroadcastFromEditor(
   const targets = resolveFleetBroadcastTargetIds();
   if (targets.length === 0) return false;
 
+  // Snapshot the override + skip state at the moment Enter is pressed.
+  // `doSend` will re-read inside the callback so any edits made while a
+  // confirm is open take effect, but the divergence check + dialog body
+  // need a stable view to render against.
+  const overridesState = useFleetTargetOverridesStore.getState();
+  const initialOverrides = { ...overridesState.payloadOverrides };
+  const initialSkipped = new Set(overridesState.skippedIds);
+
+  // All eligible targets skipped → consume the Enter (so the single-pane
+  // send doesn't also fire) without dispatching anything. The popover
+  // already shows every row as skipped so the cause is self-evident; just
+  // announce for screen readers and bail.
+  if (targets.every((id) => initialSkipped.has(id))) {
+    useAnnouncerStore.getState().announce("Broadcast skipped — all targets excluded", "polite");
+    onSent();
+    return true;
+  }
+
+  // Build the previews snapshot for the confirm dialog body. The live
+  // preview store rebuilds reactively on every keystroke; freeze a copy
+  // now so the dialog body doesn't change under the user mid-read.
+  const livePreviews = useFleetResolutionPreviewStore.getState().previews;
+  const previews: FleetTargetPreview[] =
+    livePreviews.length > 0 ? livePreviews : buildFleetTargetPreviews(text);
+
   const reasons = describeWarnings(text);
 
+  const hasOverrides = Object.keys(initialOverrides).length > 0;
+  const hasSkips = initialSkipped.size > 0;
+  const hasUnresolved = previews.some((p) => !p.excluded && p.unresolvedVars.length > 0);
+  const divergent = hasOverrides || hasSkips || hasUnresolved;
+
   const doSend = async () => {
+    // Stale-closure trap (lesson #5087): re-read the overrides store inside
+    // the async callback so edits made while a confirm dialog is open
+    // actually take effect. Reading from the outer scope would silently
+    // drop late edits.
+    const liveOverrides = useFleetTargetOverridesStore.getState();
+    const livePayloadOverrides = { ...liveOverrides.payloadOverrides };
+    const liveSkipped = liveOverrides.skippedIds;
+
+    // Re-resolve targets at execution time so terminals that disarmed
+    // during the confirm pause aren't included.
+    const liveTargets = resolveFleetBroadcastTargetIds().filter((id) => !liveSkipped.has(id));
+    if (liveTargets.length === 0) {
+      useAnnouncerStore
+        .getState()
+        .announce("Broadcast skipped — no eligible targets remain", "polite");
+      return;
+    }
+
+    // Strip overrides for terminals that are no longer in the live target
+    // set (skipped during confirm, or disarmed) so we don't pass dead-key
+    // overrides into executeFleetBroadcast.
+    const effectiveOverrides: Record<string, string> = {};
+    for (const id of liveTargets) {
+      if (id in livePayloadOverrides) {
+        effectiveOverrides[id] = livePayloadOverrides[id]!;
+      }
+    }
+    const overridesArg =
+      Object.keys(effectiveOverrides).length > 0 ? effectiveOverrides : undefined;
+
     // A second Enter while a broadcast is in-flight should pre-empt the
     // first — leaving a stale controller would race two runs against the
     // shared progress store. Abort then take over.
@@ -107,7 +199,12 @@ export function tryFleetBroadcastFromEditor(
     const controller = new AbortController();
     activeBroadcastController = controller;
     try {
-      const result = await executeFleetBroadcast(text, targets, undefined, controller.signal);
+      const result = await executeFleetBroadcast(
+        text,
+        liveTargets,
+        overridesArg,
+        controller.signal
+      );
       if (result.failureCount > 0) {
         logWarn("[fleetEnterBroadcast] broadcast had rejections", {
           failureCount: result.failureCount,
@@ -144,7 +241,7 @@ export function tryFleetBroadcastFromEditor(
         // A successful broadcast clears any stale failure dot on these
         // targets — the partial-failure state from a prior attempt is
         // now resolved.
-        for (const id of targets) useFleetFailureStore.getState().dismissId(id);
+        for (const id of liveTargets) useFleetFailureStore.getState().dismissId(id);
       } else if (result.successCount > 0) {
         // Partial cancel — dispatched batches that succeeded should clear
         // their old failure dots; targets in skipped batches stay as-is.
@@ -167,14 +264,22 @@ export function tryFleetBroadcastFromEditor(
       if (activeBroadcastController === controller) {
         activeBroadcastController = null;
       }
+      // Per-target overrides are ephemeral per-broadcast (#8691 constraint).
+      // Clear them so the next broadcast starts from the resolved defaults.
+      useFleetTargetOverridesStore.getState().clear();
       onSent();
     }
   };
 
-  if (reasons.length > 0) {
+  if (reasons.length > 0 || divergent) {
     void requestFleetBroadcastConfirmation({
       text,
       warningReasons: reasons,
+      divergence: divergent
+        ? {
+            targets: buildDivergenceTargets(previews, initialOverrides, initialSkipped),
+          }
+        : undefined,
     }).then(doSend);
     return true;
   }

--- a/src/components/Fleet/fleetEnterBroadcast.ts
+++ b/src/components/Fleet/fleetEnterBroadcast.ts
@@ -94,6 +94,7 @@ function buildDivergenceTargets(
       payload: overridden ? override : p.resolvedPayload,
       overridden,
       skipped: skippedIds.has(p.terminalId),
+      excluded: p.excluded,
       unresolvedVars: p.unresolvedVars,
     };
   });
@@ -130,19 +131,26 @@ export function tryFleetBroadcastFromEditor(
   if (targets.length === 0) return false;
 
   // Snapshot the override + skip state at the moment Enter is pressed.
-  // `doSend` will re-read inside the callback so any edits made while a
-  // confirm is open take effect, but the divergence check + dialog body
-  // need a stable view to render against.
+  // We deliberately do NOT re-read the live store inside `doSend`: when
+  // the divergence ConfirmDialog mounts it traps focus, which causes
+  // Radix to close the popover, which triggers the popover's
+  // useEffect-on-close to call `useFleetTargetOverridesStore.clear()`.
+  // A live re-read at resolve time would therefore see an empty store
+  // and silently submit the resolved defaults — exactly the D2
+  // silent-fallback anti-pattern #7880 / CLAUDE.md forbids. The snapshot
+  // also matches what the user reviewed in the dialog body, so the
+  // submitted content equals the reviewed content by construction.
   const overridesState = useFleetTargetOverridesStore.getState();
   const initialOverrides = { ...overridesState.payloadOverrides };
   const initialSkipped = new Set(overridesState.skippedIds);
 
   // All eligible targets skipped → consume the Enter (so the single-pane
-  // send doesn't also fire) without dispatching anything. The popover
-  // already shows every row as skipped so the cause is self-evident; just
-  // announce for screen readers and bail.
+  // send doesn't also fire) without dispatching anything. Clear the
+  // overrides store and signal the caller so the input bar doesn't stay
+  // in a half-submitted state.
   if (targets.every((id) => initialSkipped.has(id))) {
     useAnnouncerStore.getState().announce("Broadcast skipped — all targets excluded", "polite");
+    useFleetTargetOverridesStore.getState().clear();
     onSent();
     return true;
   }
@@ -156,37 +164,43 @@ export function tryFleetBroadcastFromEditor(
 
   const reasons = describeWarnings(text);
 
-  const hasOverrides = Object.keys(initialOverrides).length > 0;
-  const hasSkips = initialSkipped.size > 0;
-  const hasUnresolved = previews.some((p) => !p.excluded && p.unresolvedVars.length > 0);
+  // Divergence is scoped to live armed targets: a stale override for a
+  // terminal that has since disarmed must not force a spurious confirm
+  // dialog. Same for skips against terminals no longer in `targets`.
+  const liveSet = new Set(targets);
+  const hasOverrides = Object.keys(initialOverrides).some((id) => liveSet.has(id));
+  const hasSkips = Array.from(initialSkipped).some((id) => liveSet.has(id));
+  const hasUnresolved = previews.some(
+    (p) => !p.excluded && liveSet.has(p.terminalId) && p.unresolvedVars.length > 0
+  );
   const divergent = hasOverrides || hasSkips || hasUnresolved;
 
   const doSend = async () => {
-    // Stale-closure trap (lesson #5087): re-read the overrides store inside
-    // the async callback so edits made while a confirm dialog is open
-    // actually take effect. Reading from the outer scope would silently
-    // drop late edits.
-    const liveOverrides = useFleetTargetOverridesStore.getState();
-    const livePayloadOverrides = { ...liveOverrides.payloadOverrides };
-    const liveSkipped = liveOverrides.skippedIds;
+    // Filter the snapshot against the live armed set so terminals that
+    // disarmed during the confirm pause aren't included. We use the
+    // snapshot's `initialSkipped` rather than a live re-read for the
+    // reason in the comment above the snapshot.
+    const liveArmedSet = new Set(resolveFleetBroadcastTargetIds());
+    const effectiveTargets = targets.filter(
+      (id) => !initialSkipped.has(id) && liveArmedSet.has(id)
+    );
 
-    // Re-resolve targets at execution time so terminals that disarmed
-    // during the confirm pause aren't included.
-    const liveTargets = resolveFleetBroadcastTargetIds().filter((id) => !liveSkipped.has(id));
-    if (liveTargets.length === 0) {
-      useAnnouncerStore
-        .getState()
-        .announce("Broadcast skipped — no eligible targets remain", "polite");
+    if (effectiveTargets.length === 0) {
+      try {
+        useAnnouncerStore
+          .getState()
+          .announce("Broadcast skipped — no eligible targets remain", "polite");
+      } finally {
+        useFleetTargetOverridesStore.getState().clear();
+        onSent();
+      }
       return;
     }
 
-    // Strip overrides for terminals that are no longer in the live target
-    // set (skipped during confirm, or disarmed) so we don't pass dead-key
-    // overrides into executeFleetBroadcast.
     const effectiveOverrides: Record<string, string> = {};
-    for (const id of liveTargets) {
-      if (id in livePayloadOverrides) {
-        effectiveOverrides[id] = livePayloadOverrides[id]!;
+    for (const id of effectiveTargets) {
+      if (id in initialOverrides) {
+        effectiveOverrides[id] = initialOverrides[id]!;
       }
     }
     const overridesArg =
@@ -201,7 +215,7 @@ export function tryFleetBroadcastFromEditor(
     try {
       const result = await executeFleetBroadcast(
         text,
-        liveTargets,
+        effectiveTargets,
         overridesArg,
         controller.signal
       );
@@ -241,7 +255,7 @@ export function tryFleetBroadcastFromEditor(
         // A successful broadcast clears any stale failure dot on these
         // targets — the partial-failure state from a prior attempt is
         // now resolved.
-        for (const id of liveTargets) useFleetFailureStore.getState().dismissId(id);
+        for (const id of effectiveTargets) useFleetFailureStore.getState().dismissId(id);
       } else if (result.successCount > 0) {
         // Partial cancel — dispatched batches that succeeded should clear
         // their old failure dots; targets in skipped batches stay as-is.

--- a/src/components/Terminal/hooks/useFleetMirror.ts
+++ b/src/components/Terminal/hooks/useFleetMirror.ts
@@ -3,6 +3,7 @@ import type { EditorView } from "@codemirror/view";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetResolutionPreviewStore } from "@/store/fleetResolutionPreviewStore";
+import { useFleetTargetOverridesStore } from "@/store/fleetTargetOverridesStore";
 
 interface UseFleetMirrorParams {
   editorViewRef: React.RefObject<EditorView | null>;
@@ -58,10 +59,13 @@ export function useFleetMirror({
     }
   }, [externalDraft, isFleetFollower, value]);
 
-  // Clear resolution preview when not primary or disabled
+  // Clear resolution preview when not primary or disabled. Per-target
+  // overrides (#8691) ride alongside — they're ephemeral per-broadcast and
+  // shouldn't survive disarm or focus moves to a non-primary pane.
   useEffect(() => {
     if (!isFleetPrimary || disabled) {
       useFleetResolutionPreviewStore.getState().clear();
+      useFleetTargetOverridesStore.getState().clear();
     }
   }, [isFleetPrimary, disabled]);
 

--- a/src/store/__tests__/fleetBroadcastConfirmStore.test.ts
+++ b/src/store/__tests__/fleetBroadcastConfirmStore.test.ts
@@ -56,6 +56,7 @@ describe("fleetBroadcastConfirmStore", () => {
               payload: "deploy feature-x",
               overridden: false,
               skipped: false,
+              excluded: false,
               unresolvedVars: [],
             },
             {
@@ -64,6 +65,7 @@ describe("fleetBroadcastConfirmStore", () => {
               payload: "deploy",
               overridden: false,
               skipped: false,
+              excluded: false,
               unresolvedVars: ["branch_name"],
             },
           ],

--- a/src/store/__tests__/fleetBroadcastConfirmStore.test.ts
+++ b/src/store/__tests__/fleetBroadcastConfirmStore.test.ts
@@ -38,8 +38,40 @@ describe("fleetBroadcastConfirmStore", () => {
       expect(parsed.requestId).toBeTypeOf("string");
       expect(parsed.text).toBe("rm -rf /");
       expect(parsed.warningReasons).toEqual(["destructive"]);
-      // Guard against regression: onConfirm must not exist on pending
+      // Guard against regression: onConfirm must not exist on pending.
+      // `divergence` is optional (omitted when absent serializes to undefined,
+      // which JSON.stringify drops) — guard sorts on whatever keys survive.
       expect(Object.keys(parsed).sort()).toEqual(["requestId", "text", "warningReasons"].sort());
+    });
+
+    it("carries divergence targets when provided", () => {
+      requestFleetBroadcastConfirmation({
+        text: "deploy {{branch_name}}",
+        warningReasons: [],
+        divergence: {
+          targets: [
+            {
+              terminalId: "t-1",
+              title: "T1",
+              payload: "deploy feature-x",
+              overridden: false,
+              skipped: false,
+              unresolvedVars: [],
+            },
+            {
+              terminalId: "t-2",
+              title: "T2",
+              payload: "deploy",
+              overridden: false,
+              skipped: false,
+              unresolvedVars: ["branch_name"],
+            },
+          ],
+        },
+      }).catch(() => {});
+      const { pending } = useFleetBroadcastConfirmStore.getState();
+      expect(pending!.divergence?.targets).toHaveLength(2);
+      expect(pending!.divergence?.targets[1]!.unresolvedVars).toEqual(["branch_name"]);
     });
   });
 

--- a/src/store/__tests__/fleetTargetOverridesStore.test.ts
+++ b/src/store/__tests__/fleetTargetOverridesStore.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  useFleetTargetOverridesStore,
+  __resetFleetTargetOverridesStoreForTesting,
+} from "../fleetTargetOverridesStore";
+
+beforeEach(() => {
+  __resetFleetTargetOverridesStoreForTesting();
+});
+
+describe("fleetTargetOverridesStore", () => {
+  describe("payload overrides", () => {
+    it("sets and reads a per-target payload override", () => {
+      useFleetTargetOverridesStore.getState().setPayloadOverride("t-1", "custom payload");
+      expect(useFleetTargetOverridesStore.getState().payloadOverrides["t-1"]).toBe(
+        "custom payload"
+      );
+    });
+
+    it("clearPayloadOverride removes the key", () => {
+      const store = useFleetTargetOverridesStore.getState();
+      store.setPayloadOverride("t-1", "x");
+      store.setPayloadOverride("t-2", "y");
+      store.clearPayloadOverride("t-1");
+      const state = useFleetTargetOverridesStore.getState();
+      expect(state.payloadOverrides["t-1"]).toBeUndefined();
+      expect(state.payloadOverrides["t-2"]).toBe("y");
+    });
+
+    it("clearPayloadOverride is a no-op for unknown ids", () => {
+      const before = useFleetTargetOverridesStore.getState().payloadOverrides;
+      useFleetTargetOverridesStore.getState().clearPayloadOverride("nope");
+      const after = useFleetTargetOverridesStore.getState().payloadOverrides;
+      // Identity preserved when nothing changes — avoids spurious re-renders.
+      expect(after).toBe(before);
+    });
+
+    it("setPayloadOverride replaces, never mutates in place", () => {
+      const store = useFleetTargetOverridesStore.getState();
+      store.setPayloadOverride("t-1", "a");
+      const before = useFleetTargetOverridesStore.getState().payloadOverrides;
+      store.setPayloadOverride("t-1", "b");
+      const after = useFleetTargetOverridesStore.getState().payloadOverrides;
+      expect(after).not.toBe(before);
+    });
+  });
+
+  describe("skipped ids", () => {
+    it("toggleSkipped flips membership", () => {
+      const store = useFleetTargetOverridesStore.getState();
+      store.toggleSkipped("t-1");
+      expect(useFleetTargetOverridesStore.getState().skippedIds.has("t-1")).toBe(true);
+      store.toggleSkipped("t-1");
+      expect(useFleetTargetOverridesStore.getState().skippedIds.has("t-1")).toBe(false);
+    });
+
+    it("setSkipped(true/false) sets explicit state and is idempotent", () => {
+      const store = useFleetTargetOverridesStore.getState();
+      store.setSkipped("t-1", true);
+      const afterFirstSkip = useFleetTargetOverridesStore.getState().skippedIds;
+      store.setSkipped("t-1", true);
+      // Identity preserved on no-op — Set was never replaced.
+      expect(useFleetTargetOverridesStore.getState().skippedIds).toBe(afterFirstSkip);
+
+      store.setSkipped("t-1", false);
+      expect(useFleetTargetOverridesStore.getState().skippedIds.has("t-1")).toBe(false);
+    });
+
+    it("toggleSkipped replaces the Set so subscribers fire", () => {
+      const store = useFleetTargetOverridesStore.getState();
+      const before = useFleetTargetOverridesStore.getState().skippedIds;
+      store.toggleSkipped("t-1");
+      const after = useFleetTargetOverridesStore.getState().skippedIds;
+      expect(after).not.toBe(before);
+    });
+  });
+
+  describe("clear", () => {
+    it("resets both payload overrides and skipped ids", () => {
+      const store = useFleetTargetOverridesStore.getState();
+      store.setPayloadOverride("t-1", "x");
+      store.toggleSkipped("t-2");
+      store.clear();
+      const state = useFleetTargetOverridesStore.getState();
+      expect(state.payloadOverrides).toEqual({});
+      expect(state.skippedIds.size).toBe(0);
+    });
+  });
+});

--- a/src/store/fleetBroadcastConfirmStore.ts
+++ b/src/store/fleetBroadcastConfirmStore.ts
@@ -15,6 +15,12 @@ export interface PendingFleetBroadcastTarget {
   overridden: boolean;
   /** True when the user veto-skipped this target in the popover. */
   skipped: boolean;
+  /**
+   * True when the target was excluded by eligibility at snapshot time
+   * (PTY exited, panel disposed). Rendered in the dialog as context, never
+   * counted in the active-target tally, never submitted.
+   */
+  excluded: boolean;
   /** Variables in the draft that couldn't be resolved for this target. */
   unresolvedVars: string[];
 }

--- a/src/store/fleetBroadcastConfirmStore.ts
+++ b/src/store/fleetBroadcastConfirmStore.ts
@@ -1,20 +1,51 @@
 import { create } from "zustand";
 
 /**
- * Single in-flight broadcast that's waiting for the user to confirm
- * (destructive command, multi-line, or over-byte payload). Fed by both
- * the live-paste path and the Enter-broadcast path. The fleet ribbon
- * subscribes and renders the confirm controls in-place.
+ * Frozen per-target snapshot rendered in the divergence confirm dialog.
+ * The popover's live preview store rebuilds on every keystroke, so we
+ * snapshot the values at confirm-request time to keep the dialog body
+ * stable while the user reads it.
+ */
+export interface PendingFleetBroadcastTarget {
+  terminalId: string;
+  title: string;
+  /** The text that will actually be submitted to this terminal. */
+  payload: string;
+  /** True when the user explicitly overrode this target's payload. */
+  overridden: boolean;
+  /** True when the user veto-skipped this target in the popover. */
+  skipped: boolean;
+  /** Variables in the draft that couldn't be resolved for this target. */
+  unresolvedVars: string[];
+}
+
+/**
+ * Single in-flight broadcast that's waiting for the user to confirm.
+ * Two paths feed it:
+ *   - Pattern-based warnings (destructive command, multi-line, over-byte) —
+ *     renders as an inline ribbon strip via `warningReasons`.
+ *   - Per-target divergence (overrides set, skips set, unresolved vars) —
+ *     renders as a ConfirmDialog modal via `divergence.targets`.
+ * Both can be present at once; the divergence dialog takes precedence and
+ * folds the warnings into its description.
  *
- * Lives outside the ribbon's local state so any caller (paste handler,
- * input bar, future scriptable broadcasts) can request a confirm without
- * a callback prop chain.
+ * Lives outside ribbon-local state so any caller (paste handler, input bar,
+ * future scriptable broadcasts) can request a confirm without a callback
+ * prop chain.
  */
 export interface PendingFleetBroadcast {
   requestId: string;
   text: string;
   /** Human-readable warnings to surface in the confirm prompt. */
   warningReasons: string[];
+  /**
+   * When set, the broadcast diverges from the user's typed text and the
+   * confirm should show a per-target preview. Absent on warnings-only
+   * confirms (existing destructive/multi-line/byte-limit path).
+   */
+  divergence?: {
+    targets: PendingFleetBroadcastTarget[];
+  };
 }
 
 interface FleetBroadcastConfirmState {

--- a/src/store/fleetTargetOverridesStore.ts
+++ b/src/store/fleetTargetOverridesStore.ts
@@ -1,0 +1,76 @@
+import { create } from "zustand";
+
+/**
+ * Ephemeral per-broadcast state for the fleet drafting popover: lets the
+ * user edit one target's resolved payload or skip a target entirely without
+ * disarming the fleet. The plumbing in `executeFleetBroadcast` already
+ * accepts `perTargetOverrides`; this store is what writes to it.
+ *
+ * Per-target overrides MUST NOT persist into saved fleet recipes
+ * (#8691 constraint) — clear on disarm / popover close / broadcast end.
+ *
+ * Module-level resolver pattern mirrors fleetBroadcastConfirmStore: the
+ * Enter-broadcast pipeline reads `getState()` synchronously inside `doSend`
+ * so values are never stale from a closure captured at call time.
+ */
+interface FleetTargetOverridesState {
+  payloadOverrides: Record<string, string>;
+  skippedIds: Set<string>;
+
+  setPayloadOverride: (terminalId: string, text: string) => void;
+  clearPayloadOverride: (terminalId: string) => void;
+  toggleSkipped: (terminalId: string) => void;
+  setSkipped: (terminalId: string, skipped: boolean) => void;
+  clear: () => void;
+}
+
+export const useFleetTargetOverridesStore = create<FleetTargetOverridesState>((set) => ({
+  payloadOverrides: {},
+  skippedIds: new Set<string>(),
+
+  setPayloadOverride: (terminalId, text) => {
+    set((state) => ({
+      payloadOverrides: { ...state.payloadOverrides, [terminalId]: text },
+    }));
+  },
+
+  clearPayloadOverride: (terminalId) => {
+    set((state) => {
+      if (!(terminalId in state.payloadOverrides)) return state;
+      const next = { ...state.payloadOverrides };
+      delete next[terminalId];
+      return { payloadOverrides: next };
+    });
+  },
+
+  toggleSkipped: (terminalId) => {
+    set((state) => {
+      const next = new Set(state.skippedIds);
+      if (next.has(terminalId)) next.delete(terminalId);
+      else next.add(terminalId);
+      return { skippedIds: next };
+    });
+  },
+
+  setSkipped: (terminalId, skipped) => {
+    set((state) => {
+      if (skipped === state.skippedIds.has(terminalId)) return state;
+      const next = new Set(state.skippedIds);
+      if (skipped) next.add(terminalId);
+      else next.delete(terminalId);
+      return { skippedIds: next };
+    });
+  },
+
+  clear: () => {
+    set({ payloadOverrides: {}, skippedIds: new Set<string>() });
+  },
+}));
+
+/** Test-only — clears the store so each test starts from a known baseline. */
+export function __resetFleetTargetOverridesStoreForTesting(): void {
+  useFleetTargetOverridesStore.setState({
+    payloadOverrides: {},
+    skippedIds: new Set<string>(),
+  });
+}


### PR DESCRIPTION
## Summary

- Adds inline per-target payload editing and skip controls to `FleetDraftingPill` rows, backed by a new ephemeral `fleetTargetOverridesStore` that is cleared on disarm, dismiss, and broadcast completion — never written to `fleetSavedScopes`
- When any target's resolved payload diverges from the primary input (override set, target skipped, or unresolved template variable), the broadcast routes through a `ConfirmDialog` showing exactly what each target will receive before anything is sent
- A snapshot of overrides is taken at Enter-press time inside `fleetEnterBroadcast.ts` so the confirm dialog always shows the content that will actually be submitted — closing the D2 silent-fallback gap called out in #7880

Resolves #8691

## Changes

- `fleetTargetOverridesStore.ts` — new ephemeral store; holds `Map<terminalId, string>` overrides and `Set<terminalId>` skipped IDs; all exit paths clear it
- `FleetDraftingPill.tsx` — each target row now renders an always-visible textarea and include checkbox; Enter/Escape handlers are stopped at the row to prevent bubbling to the primary input bar; a divergence dot appears on the pill trigger when any override or skip is active
- `FleetArmingRibbon.tsx` — new `ConfirmDialog` modal for the divergence path; warnings-only ribbon strip preserved as-is
- `fleetEnterBroadcast.ts` — snapshot overrides at call time in `doSend`; handles all-skipped early return and drain-to-zero cleanup

## Testing

10 new unit tests across four files:
- `fleetTargetOverridesStore` — store mutations, Set immutability, idempotency, clear
- `fleetBroadcastConfirmStore` — divergence payload threading and updated key-shape assertion
- `fleetEnterBroadcast` — override and skip threading, all-skipped early return, divergence triggers confirm, snapshot wins over cleared live store (D2 regression guard), drain-to-zero cleanup, stale override for disarmed terminal does not surface spurious confirm
- `fleetResolutionPreview` — textarea writes overrides, returning to default clears override, checkbox toggle, Enter prevented from bubbling, disabled-on-skip, divergence dot, clear-on-popover-dismiss

Typecheck clean, lint at baseline, format clean, build clean, 425 fleet-area tests pass.