### PR TITLE
refactor(settings): converge tabs on chrome-first loading pattern

### DIFF
--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useEffectEvent, useMemo, useRef, useState, useCallback } from "react";
 import { useKeybindingDisplay } from "@/hooks/useKeybinding";
+import { useTabLoad } from "@/hooks";
 import { getAgentIds, getAgentConfig, getMergedPresets, type AgentPreset } from "@/config/agents";
 import { useAgentSettingsStore, useCliAvailabilityStore, useAgentPreferencesStore } from "@/store";
 import { cliAvailabilityClient } from "@/clients";
@@ -22,6 +23,7 @@ import { AgentSelectorDropdown } from "./AgentSelectorDropdown";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 import { AddPresetDialog } from "./AddPresetDialog";
 import { AgentScopeEditor } from "./AgentScopeEditor";
+import { SettingsLoadErrorBanner } from "./SettingsLoadErrorBanner";
 import { actionService } from "@/services/ActionService";
 import { AgentHelpOutput } from "./AgentHelpOutput";
 import { AgentCard, AgentInstallSection } from "@/components/agents/AgentCard";
@@ -162,9 +164,9 @@ export function AgentSettings({
 }: AgentSettingsProps) {
   const {
     settings,
-    isLoading,
-    error: loadError,
+    error: storeError,
     initialize,
+    refresh,
     updateAgent,
     setAgentPinned,
     reset,
@@ -177,14 +179,16 @@ export function AgentSettings({
   const initializeCliAvailability = useCliAvailabilityStore((state) => state.initialize);
   const refreshCliAvailability = useCliAvailabilityStore((state) => state.refresh);
 
-  const [loadTimedOut, setLoadTimedOut] = useState(false);
-
-  useEffect(() => {
-    void initialize();
-    setLoadTimedOut(false);
-    const timer = setTimeout(() => setLoadTimedOut(true), 10_000);
-    return () => clearTimeout(timer);
-  }, [initialize]);
+  // initialize() is singleflight via the store's `initPromise` — retries must
+  // route through refresh() to issue a fresh IPC. The store catches load
+  // failures internally and surfaces them via its `error` field; the hook
+  // only watches for the timeout case.
+  const { loadError: timeoutError, retryAction } = useTabLoad({
+    initialize,
+    retry: refresh,
+    timeoutMessage: "Agent settings took too long to load.",
+  });
+  const loadError = timeoutError ?? storeError;
 
   useEffect(() => {
     void initializeCliAvailability();
@@ -347,43 +351,10 @@ export function AgentSettings({
     );
   }
 
-  if (isLoading && !settings) {
-    if (isLoading && loadTimedOut) {
-      return (
-        <div className="flex flex-col items-center justify-center h-32 gap-3">
-          <div className="text-status-error text-sm">Settings load timed out</div>
-          <button
-            onClick={() => void actionService.dispatch("ui.refresh", undefined, { source: "user" })}
-            className="text-xs px-3 py-1.5 border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-          >
-            Reload Application
-          </button>
-        </div>
-      );
-    }
-    return (
-      <div className="flex items-center justify-center h-32">
-        <div className="text-daintree-text/60 text-sm">Loading settings...</div>
-      </div>
-    );
-  }
-
-  if (loadError || !settings) {
-    return (
-      <div className="flex flex-col items-center justify-center h-32 gap-3">
-        <div className="text-status-error text-sm">{loadError || "Failed to load settings"}</div>
-        <button
-          onClick={() => void actionService.dispatch("ui.refresh", undefined, { source: "user" })}
-          className="text-xs px-3 py-1.5 border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-        >
-          Reload Application
-        </button>
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-6">
+      {loadError && <SettingsLoadErrorBanner message={loadError} onRetry={retryAction} />}
+
       <div className="space-y-4">
         <div className="flex items-center justify-between">
           <div>

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useState, useMemo, type ComponentType, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useMemo,
+  type ComponentType,
+  type ReactNode,
+} from "react";
 import { GitBranch, Github, Key, Check, AlertCircle } from "lucide-react";
 import type { ForgeProviderContribution, ForgeProviderEntry } from "@shared/types";
 import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
@@ -9,7 +17,9 @@ import {
 } from "./ForgeProviderSelectorDropdown";
 import { GitHubSettingsTab } from "./GitHubSettingsTab";
 import { ForgeIntegrationsTab } from "./ForgeIntegrationsTab";
+import { SettingsLoadErrorBanner } from "./SettingsLoadErrorBanner";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
+import { useTabLoad } from "@/hooks";
 import { logError } from "@/utils/logger";
 
 type ForgeIcon = ComponentType<{ className?: string; size?: number; "aria-hidden"?: boolean }>;
@@ -20,7 +30,6 @@ function getForgeIcon(id: string): ForgeIcon {
 
 const GENERAL_ID = "general";
 const GITHUB_ID = "github";
-const PROVIDER_LOAD_TIMEOUT_MS = 10_000;
 const CREDENTIAL_RESULT_DISPLAY_MS = 5000;
 
 interface CodeForgeSettingsTabProps {
@@ -30,38 +39,22 @@ interface CodeForgeSettingsTabProps {
 
 export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForgeSettingsTabProps) {
   const [providers, setProviders] = useState<ForgeProviderEntry[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [loadTimedOut, setLoadTimedOut] = useState(false);
 
-  useEffect(() => {
-    let cancelled = false;
-    setLoadTimedOut(false);
-    const timer = setTimeout(() => {
-      if (!cancelled) setLoadTimedOut(true);
-    }, PROVIDER_LOAD_TIMEOUT_MS);
-
-    window.electron.forge
-      .getProviders()
-      .then((loaded) => {
-        if (cancelled) return;
-        setProviders(loaded);
-        setLoadTimedOut(false);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        setLoadError("Couldn't load forge providers");
-        logError("Failed to load forge providers for CodeForgeSettingsTab", err);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
+  const loadProviders = useCallback(async () => {
+    try {
+      const loaded = await window.electron.forge.getProviders();
+      setProviders(loaded);
+    } catch (err) {
+      logError("Failed to load forge providers for CodeForgeSettingsTab", err);
+      throw err;
+    }
   }, []);
+
+  const { loadError, retryAction } = useTabLoad({
+    initialize: loadProviders,
+    errorMessage: "Couldn't load forge providers",
+    timeoutMessage: "Forge providers took too long to load.",
+  });
 
   const providerOptions = useMemo<ForgeProviderOption[]>(
     () =>
@@ -79,42 +72,7 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
       ? activeSubtab
       : GITHUB_ID;
 
-  useSettingsTabValidation("code-forge", Boolean(loadError) || loadTimedOut);
-
-  if (loading) {
-    if (loadTimedOut) {
-      return (
-        <div className="flex flex-col items-center justify-center h-32 gap-3">
-          <div className="text-status-error text-sm">Settings load timed out</div>
-          <button
-            onClick={() => window.location.reload()}
-            className="text-xs px-3 py-1.5 border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-          >
-            Reload Application
-          </button>
-        </div>
-      );
-    }
-    return (
-      <div className="flex items-center justify-center h-32">
-        <div className="text-daintree-text/60 text-sm">Loading forge settings...</div>
-      </div>
-    );
-  }
-
-  if (loadError) {
-    return (
-      <div className="flex flex-col items-center justify-center h-32 gap-3">
-        <div className="text-status-error text-sm">{loadError}</div>
-        <button
-          onClick={() => window.location.reload()}
-          className="text-xs px-3 py-1.5 border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-        >
-          Reload Application
-        </button>
-      </div>
-    );
-  }
+  useSettingsTabValidation("code-forge", Boolean(loadError));
 
   const isGeneral = effectiveSubtab === GENERAL_ID;
   const isGitHub = effectiveSubtab === GITHUB_ID;
@@ -124,6 +82,8 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
 
   return (
     <div className="space-y-6">
+      {loadError && <SettingsLoadErrorBanner message={loadError} onRetry={retryAction} />}
+
       <div className="space-y-4">
         <div>
           <h4 className="text-sm font-medium mb-1">Code Forge</h4>

--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -5,7 +5,9 @@ import { Key, Check, AlertCircle, FlaskConical, ExternalLink, Github } from "luc
 import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore";
 import { actionService } from "@/services/ActionService";
 import type { GitHubTokenConfig, GitHubTokenValidation } from "@/types";
+import { SettingsLoadErrorBanner } from "./SettingsLoadErrorBanner";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
+import { useTabLoad } from "@/hooks";
 import { logError } from "@/utils/logger";
 
 interface ForgeSettingBlockProps {
@@ -45,9 +47,9 @@ type ValidationResult = "success" | "error" | "test-success" | "test-error" | nu
 export function GitHubSettingsTab() {
   const {
     config: githubConfig,
-    isLoading,
-    error: loadError,
+    error: storeError,
     initialize,
+    refresh,
     updateConfig,
   } = useGitHubConfigStore();
   const [githubToken, setGithubToken] = useState("");
@@ -56,13 +58,17 @@ export function GitHubSettingsTab() {
   const [validationResult, setValidationResult] = useState<ValidationResult>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const [loadTimedOut, setLoadTimedOut] = useState(false);
-
-  useEffect(() => {
-    initialize();
-    const timer = setTimeout(() => setLoadTimedOut(true), 10_000);
-    return () => clearTimeout(timer);
-  }, [initialize]);
+  // initialize() is singleflight via the store's `initPromise` — calling it
+  // again on retry returns the hung promise. refresh() always issues a fresh
+  // IPC, so retry routes through it (see useTabLoad jsdoc). The store catches
+  // load failures internally and surfaces them via its `error` field; the hook
+  // only needs to watch for the timeout case.
+  const { loadError: timeoutError, retryAction } = useTabLoad({
+    initialize,
+    retry: refresh,
+    timeoutMessage: "GitHub settings took too long to load.",
+  });
+  const loadError = timeoutError ?? storeError;
 
   useEffect(() => {
     if (!validationResult) return;
@@ -184,47 +190,12 @@ export function GitHubSettingsTab() {
     );
   };
 
-  useSettingsTabValidation("code-forge", Boolean(loadError) || loadTimedOut);
-
-  if (isLoading) {
-    if (loadTimedOut) {
-      return (
-        <div className="flex flex-col items-center justify-center h-32 gap-3">
-          <div className="text-status-error text-sm">Settings load timed out</div>
-          <button
-            onClick={() => void actionService.dispatch("ui.refresh", undefined, { source: "user" })}
-            className="text-xs px-3 py-1.5 border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-          >
-            Reload Application
-          </button>
-        </div>
-      );
-    }
-    return (
-      <div className="flex items-center justify-center h-32">
-        <div className="text-daintree-text/60 text-sm">Loading GitHub settings...</div>
-      </div>
-    );
-  }
-
-  if (loadError || !githubConfig) {
-    return (
-      <div className="flex flex-col items-center justify-center h-32 gap-3">
-        <div className="text-status-error text-sm">
-          {loadError || "Failed to load GitHub settings"}
-        </div>
-        <button
-          onClick={() => void actionService.dispatch("ui.refresh", undefined, { source: "user" })}
-          className="text-xs px-3 py-1.5 border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-        >
-          Reload Application
-        </button>
-      </div>
-    );
-  }
+  useSettingsTabValidation("code-forge", Boolean(loadError));
 
   return (
     <div className="space-y-4">
+      {loadError && <SettingsLoadErrorBanner message={loadError} onRetry={retryAction} />}
+
       <ForgeSettingBlock
         id="github-token"
         icon={Key}

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -21,6 +21,8 @@ import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
 import { useSettingsTabValidation } from "@/components/Settings/SettingsValidationRegistry";
 import { McpAuditLogViewer } from "@/components/Settings/McpAuditLogViewer";
 import { TurnOutcomeDiagnostics } from "@/components/Settings/TurnOutcomeDiagnostics";
+import { useDeferredLoading } from "@/hooks";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
 import {
@@ -52,6 +54,9 @@ export function McpServerSettingsTab() {
     apiKey: "",
   });
   const [loading, setLoading] = useState(true);
+  // Gate the "Loading…" copy past the Doherty threshold so fast IPC resolutions
+  // don't flash a loading state for sub-400ms work.
+  const showInlineLoading = useDeferredLoading(loading, UI_DOHERTY_THRESHOLD);
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [portInput, setPortInput] = useState("");
@@ -411,7 +416,9 @@ export function McpServerSettingsTab() {
             description="The server binds to 127.0.0.1 (loopback only) — it is never accessible from outside this machine."
           >
             {loading ? (
-              <p className="text-xs text-daintree-text/50">Loading…</p>
+              showInlineLoading ? (
+                <p className="text-xs text-daintree-text/50">Loading…</p>
+              ) : null
             ) : status.port ? (
               <div className="contents">
                 <div className="flex items-center gap-2">

--- a/src/components/Settings/SettingsLoadErrorBanner.tsx
+++ b/src/components/Settings/SettingsLoadErrorBanner.tsx
@@ -1,0 +1,25 @@
+import { AlertCircle } from "lucide-react";
+
+interface SettingsLoadErrorBannerProps {
+  message: string;
+  onRetry: () => void;
+}
+
+export function SettingsLoadErrorBanner({ message, onRetry }: SettingsLoadErrorBannerProps) {
+  return (
+    <div
+      role="alert"
+      className="flex items-center gap-3 rounded-[var(--radius-md)] border border-status-error/20 bg-status-error/10 px-3 py-2"
+    >
+      <AlertCircle className="w-4 h-4 text-status-error shrink-0" aria-hidden="true" />
+      <p className="text-xs text-status-error flex-1 select-text">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="text-xs px-2 py-1 rounded-sm border border-status-error/30 text-status-error hover:bg-status-error/10 transition-colors"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useCallback, useState, useEffect, useRef } from "react";
 import {
   Mic,
   Eye,
@@ -23,10 +23,12 @@ import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 import { SettingsSelect } from "./SettingsSelect";
 import { SettingsTextarea } from "./SettingsTextarea";
+import { SettingsLoadErrorBanner } from "./SettingsLoadErrorBanner";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 import { dispatchVoiceInputSettingsChanged } from "@/lib/voiceInputSettingsEvents";
 import { logWarn } from "@/utils/logger";
 import { useAudioDevices, SYSTEM_DEFAULT_VALUE } from "@/hooks/useAudioDevices";
+import { useTabLoad } from "@/hooks";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { CORE_CORRECTION_PROMPT } from "@shared/config/voiceCorrection";
 import type {
@@ -80,12 +82,10 @@ const DEFAULT_SETTINGS: VoiceInputSettings = {
   deviceId: "",
 };
 
-type LoadState = "loading" | "ready" | "error";
 type ApiKeyValidation = "idle" | "testing" | "valid" | "invalid";
 
 export function VoiceInputSettingsTab() {
   const [settings, setSettings] = useState<VoiceInputSettings>(DEFAULT_SETTINGS);
-  const [loadState, setLoadState] = useState<LoadState>("loading");
   const [micPermission, setMicPermission] = useState<MicPermissionStatus>("unknown");
   const [isRequestingMic, setIsRequestingMic] = useState(false);
   const [newDictionaryWord, setNewDictionaryWord] = useState("");
@@ -98,26 +98,18 @@ export function VoiceInputSettingsTab() {
     refresh: refreshDevices,
   } = useAudioDevices();
 
+  const loadSettings = useCallback(async () => {
+    const s = await window.electron?.voiceInput?.getSettings();
+    if (s) setSettings(s);
+  }, []);
+
+  const { isLoading, loadError, retryAction } = useTabLoad({
+    initialize: loadSettings,
+    errorMessage: "Couldn't load voice input settings",
+    timeoutMessage: "Voice input settings took too long to load.",
+  });
+
   useEffect(() => {
-    let settled = false;
-    const timer = setTimeout(() => {
-      if (!settled) setLoadState("error");
-    }, 10_000);
-
-    window.electron?.voiceInput
-      ?.getSettings()
-      .then((s) => {
-        settled = true;
-        clearTimeout(timer);
-        setSettings(s);
-        setLoadState("ready");
-      })
-      .catch(() => {
-        settled = true;
-        clearTimeout(timer);
-        setLoadState("error");
-      });
-
     window.electron?.voiceInput
       ?.checkMicPermission()
       .then((status) => {
@@ -129,8 +121,6 @@ export function VoiceInputSettingsTab() {
           error: formatErrorMessage(err, "Mic permission probe failed"),
         });
       });
-
-    return () => clearTimeout(timer);
   }, []);
 
   const update = (patch: Partial<VoiceInputSettings>) => {
@@ -179,27 +169,12 @@ export function VoiceInputSettingsTab() {
     update({ customDictionary: settings.customDictionary.filter((w) => w !== word) });
   };
 
-  useSettingsTabValidation("voice", loadState === "error");
-
-  if (loadState === "loading") {
-    return (
-      <div className="flex items-center justify-center h-32">
-        <div className="text-daintree-text/60 text-sm">Loading voice input settings...</div>
-      </div>
-    );
-  }
-
-  if (loadState === "error") {
-    return (
-      <div className="flex flex-col items-center justify-center h-32 gap-3">
-        <div className="text-status-error text-sm">Could not load voice input settings.</div>
-        <p className="text-xs text-daintree-text/50">Restart Daintree and try again.</p>
-      </div>
-    );
-  }
+  useSettingsTabValidation("voice", Boolean(loadError));
 
   return (
     <div className="space-y-6">
+      {loadError && <SettingsLoadErrorBanner message={loadError} onRetry={retryAction} />}
+
       {/* ── Speech-to-Text ── */}
       <SettingsSection
         icon={Mic}
@@ -214,6 +189,7 @@ export function VoiceInputSettingsTab() {
           isEnabled={settings.enabled}
           onChange={() => update({ enabled: !settings.enabled })}
           ariaLabel="Toggle voice input"
+          disabled={isLoading}
         />
 
         {settings.enabled && (

--- a/src/hooks/__tests__/useTabLoad.test.ts
+++ b/src/hooks/__tests__/useTabLoad.test.ts
@@ -142,9 +142,7 @@ describe("useTabLoad", () => {
   it("does not update state after unmount", async () => {
     vi.useFakeTimers();
     const initialize = vi.fn(() => new Promise<void>(() => {}));
-    const { unmount } = renderHook(() =>
-      useTabLoad({ initialize, timeoutMs: 50 })
-    );
+    const { unmount } = renderHook(() => useTabLoad({ initialize, timeoutMs: 50 }));
     unmount();
     expect(() => {
       act(() => {

--- a/src/hooks/__tests__/useTabLoad.test.ts
+++ b/src/hooks/__tests__/useTabLoad.test.ts
@@ -152,4 +152,101 @@ describe("useTabLoad", () => {
       });
     }).not.toThrow();
   });
+
+  it("keeps the timeout error when the timed-out attempt later resolves", async () => {
+    vi.useFakeTimers();
+    let resolveOriginal: (() => void) | undefined;
+    const initialize = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveOriginal = resolve;
+        })
+    );
+
+    const { result } = renderHook(() =>
+      useTabLoad({ initialize, timeoutMs: 100, timeoutMessage: "Timed out" })
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(result.current.loadError).toBe("Timed out");
+
+    await act(async () => {
+      resolveOriginal?.();
+      vi.useRealTimers();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.loadError).toBe("Timed out");
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("keeps the timeout error when the timed-out attempt later rejects", async () => {
+    vi.useFakeTimers();
+    let rejectOriginal: ((err: Error) => void) | undefined;
+    const initialize = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectOriginal = reject;
+        })
+    );
+
+    const { result } = renderHook(() =>
+      useTabLoad({ initialize, timeoutMs: 100, timeoutMessage: "Timed out" })
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(result.current.loadError).toBe("Timed out");
+
+    await act(async () => {
+      rejectOriginal?.(new Error("late failure"));
+      vi.useRealTimers();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.loadError).toBe("Timed out");
+  });
+
+  it("ignores a stale rejection from the initial attempt after retry succeeds", async () => {
+    let rejectFirst: ((err: Error) => void) | undefined;
+    const initialize = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectFirst = reject;
+        })
+    );
+    const retry = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useTabLoad({ initialize, retry }));
+
+    act(() => {
+      result.current.retryAction();
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.loadError).toBeNull();
+
+    await act(async () => {
+      rejectFirst?.(new Error("stale failure"));
+      await Promise.resolve();
+    });
+    expect(result.current.loadError).toBeNull();
+  });
+
+  it("clears loadError synchronously on retry before the new attempt resolves", async () => {
+    const initialize = vi.fn().mockRejectedValue(new Error("first failure"));
+    const retry = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useTabLoad({ initialize, retry }));
+
+    await waitFor(() => expect(result.current.loadError).toBe("first failure"));
+
+    act(() => {
+      result.current.retryAction();
+    });
+    expect(result.current.loadError).toBeNull();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.loadError).toBeNull();
+  });
 });

--- a/src/hooks/__tests__/useTabLoad.test.ts
+++ b/src/hooks/__tests__/useTabLoad.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useTabLoad } from "../useTabLoad";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useTabLoad", () => {
+  it("starts in the loading state", () => {
+    const initialize = vi.fn(() => new Promise<void>(() => {}));
+    const { result } = renderHook(() => useTabLoad({ initialize }));
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.loadError).toBeNull();
+  });
+
+  it("clears loading when initialize resolves", async () => {
+    const initialize = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useTabLoad({ initialize }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.loadError).toBeNull();
+    expect(initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets loadError when initialize rejects", async () => {
+    const initialize = vi.fn().mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useTabLoad({ initialize }));
+
+    await waitFor(() => expect(result.current.loadError).toBe("boom"));
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("uses errorMessage fallback when the rejection carries no message", async () => {
+    const initialize = vi.fn().mockRejectedValue(undefined);
+    const { result } = renderHook(() =>
+      useTabLoad({ initialize, errorMessage: "Couldn't load tab" })
+    );
+
+    await waitFor(() => expect(result.current.loadError).toBe("Couldn't load tab"));
+  });
+
+  it("times out after timeoutMs with the timeoutMessage", async () => {
+    vi.useFakeTimers();
+    const initialize = vi.fn(() => new Promise<void>(() => {}));
+    const { result } = renderHook(() =>
+      useTabLoad({ initialize, timeoutMs: 100, timeoutMessage: "Timed out" })
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.loadError).toBe("Timed out");
+  });
+
+  it("does not time out when initialize resolves first", async () => {
+    vi.useFakeTimers();
+    const initialize = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useTabLoad({ initialize, timeoutMs: 100 }));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.loadError).toBeNull();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(result.current.loadError).toBeNull();
+  });
+
+  it("retryAction calls retry, not initialize", async () => {
+    const initialize = vi.fn().mockResolvedValue(undefined);
+    const retry = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useTabLoad({ initialize, retry }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(initialize).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.retryAction();
+    });
+    await waitFor(() => expect(retry).toHaveBeenCalledTimes(1));
+    expect(initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it("retryAction falls back to initialize when retry is not provided", async () => {
+    const initialize = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useTabLoad({ initialize }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(initialize).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.retryAction();
+    });
+    await waitFor(() => expect(initialize).toHaveBeenCalledTimes(2));
+  });
+
+  it("clears the error and re-enters the loading state on retry", async () => {
+    const initialize = vi.fn().mockRejectedValueOnce(new Error("oh no"));
+    const retry = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useTabLoad({ initialize, retry }));
+
+    await waitFor(() => expect(result.current.loadError).toBe("oh no"));
+
+    act(() => {
+      result.current.retryAction();
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.loadError).toBeNull();
+  });
+
+  it("discards a stale resolution after a retry has fired", async () => {
+    let resolveFirst: (() => void) | undefined;
+    const initialize = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+    const retry = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useTabLoad({ initialize, retry }));
+
+    act(() => {
+      result.current.retryAction();
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      resolveFirst?.();
+      await Promise.resolve();
+    });
+    expect(result.current.loadError).toBeNull();
+  });
+
+  it("does not update state after unmount", async () => {
+    vi.useFakeTimers();
+    const initialize = vi.fn(() => new Promise<void>(() => {}));
+    const { unmount } = renderHook(() =>
+      useTabLoad({ initialize, timeoutMs: 50 })
+    );
+    unmount();
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+    }).not.toThrow();
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -115,6 +115,9 @@ export { useDebounce } from "./useDebounce";
 
 export { useDeferredLoading } from "./useDeferredLoading";
 
+export { useTabLoad } from "./useTabLoad";
+export type { UseTabLoadOptions, UseTabLoadResult } from "./useTabLoad";
+
 export { useSlowCall } from "./useSlowCall";
 export type { UseSlowCallOptions, UseSlowCallReturn } from "./useSlowCall";
 

--- a/src/hooks/useTabLoad.ts
+++ b/src/hooks/useTabLoad.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_TIMEOUT_MESSAGE = "Couldn't load these settings. The request timed out.";
+const DEFAULT_ERROR_MESSAGE = "Couldn't load these settings.";
+
+export interface UseTabLoadOptions {
+  /** Called on mount to load tab data. */
+  initialize: () => Promise<unknown> | unknown;
+  /** Called when the user presses Retry. Defaults to `initialize`. Pass a separate
+   *  function when `initialize` is singleflight-cached (e.g. Zustand store
+   *  `initialize()`) and you need a fresh round-trip on retry. */
+  retry?: () => Promise<unknown> | unknown;
+  /** Default 10s. */
+  timeoutMs?: number;
+  /** Override the default timeout message (sentence case, no trailing period). */
+  timeoutMessage?: string;
+  /** Override the default error fallback when the load promise rejects. */
+  errorMessage?: string;
+}
+
+export interface UseTabLoadResult {
+  isLoading: boolean;
+  loadError: string | null;
+  retryAction: () => void;
+}
+
+/**
+ * Shared loading lifecycle for a settings tab.
+ *
+ * - Single effect for kickoff + 10s timeout (#4958 — separate effects sharing a
+ *   `cancelled` flag fire in declaration order, creating invisible ordering
+ *   dependencies).
+ * - `loadEpoch` ref discards stale resolutions: when the user retries, any
+ *   in-flight promise from a previous attempt that resolves late is ignored.
+ * - `retryAction` runs `retry ?? initialize`, so store-backed tabs can pass a
+ *   singleflight-bypassing `refresh()` for retries while still seeding the
+ *   initial load through `initialize()`.
+ */
+export function useTabLoad(options: UseTabLoadOptions): UseTabLoadResult {
+  const {
+    initialize,
+    retry,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    timeoutMessage = DEFAULT_TIMEOUT_MESSAGE,
+    errorMessage = DEFAULT_ERROR_MESSAGE,
+  } = options;
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  const loadEpochRef = useRef(0);
+  const initializeRef = useRef(initialize);
+  const retryRef = useRef(retry);
+  const errorMessageRef = useRef(errorMessage);
+  const timeoutMessageRef = useRef(timeoutMessage);
+
+  useEffect(() => {
+    initializeRef.current = initialize;
+    retryRef.current = retry;
+    errorMessageRef.current = errorMessage;
+    timeoutMessageRef.current = timeoutMessage;
+  }, [initialize, retry, errorMessage, timeoutMessage]);
+
+  useEffect(() => {
+    const myEpoch = ++loadEpochRef.current;
+    let cancelled = false;
+    setIsLoading(true);
+    setLoadError(null);
+
+    const fn = retryNonce === 0 ? initializeRef.current : (retryRef.current ?? initializeRef.current);
+
+    const timer = setTimeout(() => {
+      if (cancelled || myEpoch !== loadEpochRef.current) return;
+      setLoadError(timeoutMessageRef.current);
+      setIsLoading(false);
+    }, timeoutMs);
+
+    Promise.resolve()
+      .then(() => fn())
+      .then(() => {
+        if (cancelled || myEpoch !== loadEpochRef.current) return;
+        clearTimeout(timer);
+        setLoadError(null);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled || myEpoch !== loadEpochRef.current) return;
+        clearTimeout(timer);
+        setLoadError(formatErrorMessage(err, errorMessageRef.current));
+        setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [retryNonce, timeoutMs]);
+
+  const retryAction = useCallback(() => {
+    setRetryNonce((n) => n + 1);
+  }, []);
+
+  return { isLoading, loadError, retryAction };
+}

--- a/src/hooks/useTabLoad.ts
+++ b/src/hooks/useTabLoad.ts
@@ -74,6 +74,10 @@ export function useTabLoad(options: UseTabLoadOptions): UseTabLoadResult {
 
     const timer = setTimeout(() => {
       if (cancelled || myEpoch !== loadEpochRef.current) return;
+      // Invalidate this attempt's epoch so the slow original promise can't
+      // later resolve and silently clear the timeout banner. A subsequent
+      // retry bumps the epoch again to win against any in-flight load.
+      loadEpochRef.current = myEpoch + 1;
       setLoadError(timeoutMessageRef.current);
       setIsLoading(false);
     }, timeoutMs);

--- a/src/hooks/useTabLoad.ts
+++ b/src/hooks/useTabLoad.ts
@@ -70,7 +70,8 @@ export function useTabLoad(options: UseTabLoadOptions): UseTabLoadResult {
     setIsLoading(true);
     setLoadError(null);
 
-    const fn = retryNonce === 0 ? initializeRef.current : (retryRef.current ?? initializeRef.current);
+    const fn =
+      retryNonce === 0 ? initializeRef.current : (retryRef.current ?? initializeRef.current);
 
     const timer = setTimeout(() => {
       if (cancelled || myEpoch !== loadEpochRef.current) return;


### PR DESCRIPTION
## Summary

- Four settings tabs were blocking their entire panel with a centered spinner until IPC resolved; they now render section chrome immediately from safe defaults and populate values once the promise settles
- A shared `useTabLoad` hook centralises the 10-second timeout, retry logic, and epoch-based cancellation — slow promises can no longer race and clear error state after a timeout fires
- Load failures surface as an inline `SettingsLoadErrorBanner` with a `Retry` button; the whole-app reload path (`window.location.reload()` / `ui.refresh`) is gone

Resolves #8648

## Changes

- **`useTabLoad`** (`src/hooks/useTabLoad.ts`) — new hook returning `{ status, retry }`. Epoch counter invalidates in-flight promises on timeout and retry, so a slow IPC response that arrives after the 10s gate can't flip state back to idle.
- **`SettingsLoadErrorBanner`** (`src/components/Settings/SettingsLoadErrorBanner.tsx`) — inline error surface with a `Retry` action, replacing the full-panel error screens that triggered app reloads.
- **`GitHubSettingsTab`**, **`CodeForgeSettingsTab`**, **`AgentSettings`**, **`VoiceInputSettingsTab`** — each rewritten to render section headers and disabled controls unconditionally; `useTabLoad` drives the loading/error/retry cycle.
- **`McpServerSettingsTab`** — loading text now gated behind `useDeferredLoading` at the Doherty threshold so fast IPC resolutions don't flash.
- `ForgeIntegrationsTab` is the reference implementation and was already correct; no changes there.

## Testing

- Confirmed all five tabs render chrome before IPC resolves by adding an artificial delay in dev
- Confirmed the inline error banner and `Retry` button appear on simulated timeout/failure without triggering a page reload
- `useTabLoad` unit tests cover the happy path, timeout + epoch invalidation, and retry resetting state (`src/hooks/__tests__/useTabLoad.test.ts`)