### PR TITLE
fix(gpu): surface ANGLE fallback state in Troubleshooting tab

### DIFF
--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -64,6 +64,7 @@ vi.mock("../../utils/gpuDetection.js", () => ({
 
 vi.mock("../../services/GpuCrashMonitorService.js", () => ({
   isGpuDisabledByFlag: vi.fn(() => false),
+  isGpuAngleFallbackByFlag: vi.fn(() => false),
 }));
 
 const crashGuard = {

--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -329,6 +329,7 @@ describe("app:boot handler", () => {
       agentSettings: { agents: {} },
       gpuWebGLHardware: true,
       gpuHardwareAccelerationDisabled: false,
+      gpuAngleFallbackActive: false,
       safeMode: false,
       isWindowsStore: false,
     };

--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -64,7 +64,7 @@ vi.mock("../../utils/gpuDetection.js", () => ({
 
 vi.mock("../../services/GpuCrashMonitorService.js", () => ({
   isGpuDisabledByFlag: vi.fn(() => false),
-  isGpuAngleFallbackByFlag: vi.fn(() => false),
+  isGpuAngleFallbackApplied: vi.fn(() => false),
 }));
 
 const crashGuard = {

--- a/electron/ipc/handlers/__tests__/gpu.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/gpu.handlers.test.ts
@@ -33,6 +33,7 @@ vi.mock("../../../store.js", () => ({ store: storeMock }));
 
 const gpuMonitorMock = vi.hoisted(() => ({
   isGpuDisabledByFlag: vi.fn(() => false),
+  isGpuAngleFallbackByFlag: vi.fn(() => false),
   writeGpuDisabledFlag: vi.fn(),
   clearGpuDisabledFlag: vi.fn(),
   clearGpuAngleFallbackFlag: vi.fn(),
@@ -106,5 +107,60 @@ describe("GPU_SET_HARDWARE_ACCELERATION handler", () => {
     await handlerPromise;
 
     expect(appMock.exit).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("GPU_GET_STATUS handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ipcMainMock._handlers.clear();
+  });
+
+  it("returns both flag states as false by default", async () => {
+    gpuMonitorMock.isGpuDisabledByFlag.mockReturnValue(false);
+    gpuMonitorMock.isGpuAngleFallbackByFlag.mockReturnValue(false);
+
+    registerGpuHandlers();
+    const handler = ipcMainMock._handlers.get("gpu:get-status")!;
+
+    const result = await handler({} as Electron.IpcMainInvokeEvent);
+
+    expect(result).toEqual({
+      hardwareAccelerationDisabled: false,
+      angleFallbackActive: false,
+    });
+  });
+
+  it("reports angleFallbackActive=true when the ANGLE flag exists", async () => {
+    gpuMonitorMock.isGpuDisabledByFlag.mockReturnValue(false);
+    gpuMonitorMock.isGpuAngleFallbackByFlag.mockReturnValue(true);
+
+    registerGpuHandlers();
+    const handler = ipcMainMock._handlers.get("gpu:get-status")!;
+
+    const result = (await handler({} as Electron.IpcMainInvokeEvent)) as {
+      hardwareAccelerationDisabled: boolean;
+      angleFallbackActive: boolean;
+    };
+
+    expect(result.angleFallbackActive).toBe(true);
+    expect(result.hardwareAccelerationDisabled).toBe(false);
+    expect(gpuMonitorMock.isGpuAngleFallbackByFlag).toHaveBeenCalledWith("/tmp/user-data");
+  });
+
+  it("reports hardwareAccelerationDisabled=true when the disable flag exists", async () => {
+    gpuMonitorMock.isGpuDisabledByFlag.mockReturnValue(true);
+    gpuMonitorMock.isGpuAngleFallbackByFlag.mockReturnValue(false);
+
+    registerGpuHandlers();
+    const handler = ipcMainMock._handlers.get("gpu:get-status")!;
+
+    const result = (await handler({} as Electron.IpcMainInvokeEvent)) as {
+      hardwareAccelerationDisabled: boolean;
+      angleFallbackActive: boolean;
+    };
+
+    expect(result.hardwareAccelerationDisabled).toBe(true);
+    expect(result.angleFallbackActive).toBe(false);
   });
 });

--- a/electron/ipc/handlers/__tests__/gpu.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/gpu.handlers.test.ts
@@ -34,6 +34,7 @@ vi.mock("../../../store.js", () => ({ store: storeMock }));
 const gpuMonitorMock = vi.hoisted(() => ({
   isGpuDisabledByFlag: vi.fn(() => false),
   isGpuAngleFallbackByFlag: vi.fn(() => false),
+  isGpuAngleFallbackApplied: vi.fn(() => false),
   writeGpuDisabledFlag: vi.fn(),
   clearGpuDisabledFlag: vi.fn(),
   clearGpuAngleFallbackFlag: vi.fn(),
@@ -118,7 +119,7 @@ describe("GPU_GET_STATUS handler", () => {
 
   it("returns both flag states as false by default", async () => {
     gpuMonitorMock.isGpuDisabledByFlag.mockReturnValue(false);
-    gpuMonitorMock.isGpuAngleFallbackByFlag.mockReturnValue(false);
+    gpuMonitorMock.isGpuAngleFallbackApplied.mockReturnValue(false);
 
     registerGpuHandlers();
     const handler = ipcMainMock._handlers.get("gpu:get-status")!;
@@ -131,9 +132,9 @@ describe("GPU_GET_STATUS handler", () => {
     });
   });
 
-  it("reports angleFallbackActive=true when the ANGLE flag exists", async () => {
+  it("reports angleFallbackActive=true when ANGLE is actually applied", async () => {
     gpuMonitorMock.isGpuDisabledByFlag.mockReturnValue(false);
-    gpuMonitorMock.isGpuAngleFallbackByFlag.mockReturnValue(true);
+    gpuMonitorMock.isGpuAngleFallbackApplied.mockReturnValue(true);
 
     registerGpuHandlers();
     const handler = ipcMainMock._handlers.get("gpu:get-status")!;
@@ -145,12 +146,33 @@ describe("GPU_GET_STATUS handler", () => {
 
     expect(result.angleFallbackActive).toBe(true);
     expect(result.hardwareAccelerationDisabled).toBe(false);
-    expect(gpuMonitorMock.isGpuAngleFallbackByFlag).toHaveBeenCalledWith("/tmp/user-data");
+    expect(gpuMonitorMock.isGpuAngleFallbackApplied).toHaveBeenCalledWith("/tmp/user-data");
+  });
+
+  it("reports angleFallbackActive=false when the flag exists but ANGLE is not applied", async () => {
+    // Mirrors the macOS / Linux X11 / Windows case: GpuCrashMonitorService
+    // writes the flag on any platform after the first GPU crash, but
+    // environment.ts only appends the ANGLE switches on Linux Wayland.
+    // isGpuAngleFallbackApplied gates on platform so non-Wayland users
+    // don't see a misleading "running in ANGLE mode" warning.
+    gpuMonitorMock.isGpuDisabledByFlag.mockReturnValue(false);
+    gpuMonitorMock.isGpuAngleFallbackByFlag.mockReturnValue(true);
+    gpuMonitorMock.isGpuAngleFallbackApplied.mockReturnValue(false);
+
+    registerGpuHandlers();
+    const handler = ipcMainMock._handlers.get("gpu:get-status")!;
+
+    const result = (await handler({} as Electron.IpcMainInvokeEvent)) as {
+      hardwareAccelerationDisabled: boolean;
+      angleFallbackActive: boolean;
+    };
+
+    expect(result.angleFallbackActive).toBe(false);
   });
 
   it("reports hardwareAccelerationDisabled=true when the disable flag exists", async () => {
     gpuMonitorMock.isGpuDisabledByFlag.mockReturnValue(true);
-    gpuMonitorMock.isGpuAngleFallbackByFlag.mockReturnValue(false);
+    gpuMonitorMock.isGpuAngleFallbackApplied.mockReturnValue(false);
 
     registerGpuHandlers();
     const handler = ipcMainMock._handlers.get("gpu:get-status")!;

--- a/electron/ipc/handlers/app/gpu.ts
+++ b/electron/ipc/handlers/app/gpu.ts
@@ -3,6 +3,7 @@ import { CHANNELS } from "../../channels.js";
 import { store } from "../../../store.js";
 import {
   isGpuDisabledByFlag,
+  isGpuAngleFallbackByFlag,
   writeGpuDisabledFlag,
   clearGpuDisabledFlag,
   clearGpuAngleFallbackFlag,
@@ -17,6 +18,7 @@ export function registerGpuHandlers(): () => void {
     const userDataPath = app.getPath("userData");
     return {
       hardwareAccelerationDisabled: isGpuDisabledByFlag(userDataPath),
+      angleFallbackActive: isGpuAngleFallbackByFlag(userDataPath),
     };
   };
   handlers.push(typedHandle(CHANNELS.GPU_GET_STATUS, handleGetStatus));

--- a/electron/ipc/handlers/app/gpu.ts
+++ b/electron/ipc/handlers/app/gpu.ts
@@ -3,7 +3,7 @@ import { CHANNELS } from "../../channels.js";
 import { store } from "../../../store.js";
 import {
   isGpuDisabledByFlag,
-  isGpuAngleFallbackByFlag,
+  isGpuAngleFallbackApplied,
   writeGpuDisabledFlag,
   clearGpuDisabledFlag,
   clearGpuAngleFallbackFlag,
@@ -18,7 +18,7 @@ export function registerGpuHandlers(): () => void {
     const userDataPath = app.getPath("userData");
     return {
       hardwareAccelerationDisabled: isGpuDisabledByFlag(userDataPath),
-      angleFallbackActive: isGpuAngleFallbackByFlag(userDataPath),
+      angleFallbackActive: isGpuAngleFallbackApplied(userDataPath),
     };
   };
   handlers.push(typedHandle(CHANNELS.GPU_GET_STATUS, handleGetStatus));

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -25,7 +25,7 @@ export const CRASH_CRITICAL_FIELDS = new Set([
 import { getGpuFeatureStatus, isWebGLHardwareAccelerated } from "../../../utils/gpuDetection.js";
 import {
   isGpuDisabledByFlag,
-  isGpuAngleFallbackByFlag,
+  isGpuAngleFallbackApplied,
 } from "../../../services/GpuCrashMonitorService.js";
 import { getCrashLoopGuard } from "../../../services/CrashLoopGuardService.js";
 import { closeTelemetry } from "../../../services/TelemetryService.js";
@@ -294,7 +294,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       agentSettings: store.get("agentSettings"),
       gpuWebGLHardware,
       gpuHardwareAccelerationDisabled: isGpuDisabledByFlag(app.getPath("userData")),
-      gpuAngleFallbackActive: isGpuAngleFallbackByFlag(app.getPath("userData")),
+      gpuAngleFallbackActive: isGpuAngleFallbackApplied(app.getPath("userData")),
       safeMode: inSafeMode,
       isWindowsStore:
         (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore === true,

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -23,7 +23,10 @@ export const CRASH_CRITICAL_FIELDS = new Set([
 ]);
 
 import { getGpuFeatureStatus, isWebGLHardwareAccelerated } from "../../../utils/gpuDetection.js";
-import { isGpuDisabledByFlag } from "../../../services/GpuCrashMonitorService.js";
+import {
+  isGpuDisabledByFlag,
+  isGpuAngleFallbackByFlag,
+} from "../../../services/GpuCrashMonitorService.js";
 import { getCrashLoopGuard } from "../../../services/CrashLoopGuardService.js";
 import { closeTelemetry } from "../../../services/TelemetryService.js";
 import { inferKind } from "../../../../shared/utils/inferPanelKind.js";
@@ -291,6 +294,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       agentSettings: store.get("agentSettings"),
       gpuWebGLHardware,
       gpuHardwareAccelerationDisabled: isGpuDisabledByFlag(app.getPath("userData")),
+      gpuAngleFallbackActive: isGpuAngleFallbackByFlag(app.getPath("userData")),
       safeMode: inSafeMode,
       isWindowsStore:
         (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore === true,

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -3,7 +3,7 @@ import { store } from "../store.js";
 import { projectStore } from "./ProjectStore.js";
 import { TerminalSnapshotSchema, filterValidTerminalEntries } from "../schemas/ipc.js";
 import { getGpuFeatureStatus, isWebGLHardwareAccelerated } from "../utils/gpuDetection.js";
-import { isGpuDisabledByFlag } from "./GpuCrashMonitorService.js";
+import { isGpuDisabledByFlag, isGpuAngleFallbackByFlag } from "./GpuCrashMonitorService.js";
 import { getCrashLoopGuard } from "./CrashLoopGuardService.js";
 import type { HydrateResult } from "../../shared/types/ipc/app.js";
 import { inferKind } from "../../shared/utils/inferPanelKind.js";
@@ -84,6 +84,7 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
     agentSettings: store.get("agentSettings"),
     gpuWebGLHardware,
     gpuHardwareAccelerationDisabled: isGpuDisabledByFlag(app.getPath("userData")),
+    gpuAngleFallbackActive: isGpuAngleFallbackByFlag(app.getPath("userData")),
     safeMode: inSafeMode,
     isWindowsStore: (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore === true,
     settingsRecovery: null,

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -3,7 +3,7 @@ import { store } from "../store.js";
 import { projectStore } from "./ProjectStore.js";
 import { TerminalSnapshotSchema, filterValidTerminalEntries } from "../schemas/ipc.js";
 import { getGpuFeatureStatus, isWebGLHardwareAccelerated } from "../utils/gpuDetection.js";
-import { isGpuDisabledByFlag, isGpuAngleFallbackByFlag } from "./GpuCrashMonitorService.js";
+import { isGpuDisabledByFlag, isGpuAngleFallbackApplied } from "./GpuCrashMonitorService.js";
 import { getCrashLoopGuard } from "./CrashLoopGuardService.js";
 import type { HydrateResult } from "../../shared/types/ipc/app.js";
 import { inferKind } from "../../shared/utils/inferPanelKind.js";
@@ -84,7 +84,7 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
     agentSettings: store.get("agentSettings"),
     gpuWebGLHardware,
     gpuHardwareAccelerationDisabled: isGpuDisabledByFlag(app.getPath("userData")),
-    gpuAngleFallbackActive: isGpuAngleFallbackByFlag(app.getPath("userData")),
+    gpuAngleFallbackActive: isGpuAngleFallbackApplied(app.getPath("userData")),
     safeMode: inSafeMode,
     isWindowsStore: (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore === true,
     settingsRecovery: null,

--- a/electron/services/DiagnosticsCollector.ts
+++ b/electron/services/DiagnosticsCollector.ts
@@ -227,13 +227,20 @@ async function collectGpu() {
   const result: Record<string, unknown> = {};
 
   try {
-    const { isGpuDisabledByFlag, isGpuAngleFallbackByFlag } =
+    const { isGpuDisabledByFlag, isGpuAngleFallbackByFlag, isGpuAngleFallbackApplied } =
       await import("./GpuCrashMonitorService.js");
-    result.hardwareAccelerationDisabled = isGpuDisabledByFlag(app.getPath("userData"));
-    result.angleFallbackActive = isGpuAngleFallbackByFlag(app.getPath("userData"));
+    const userDataPath = app.getPath("userData");
+    result.hardwareAccelerationDisabled = isGpuDisabledByFlag(userDataPath);
+    // Both surfaced: `angleFallbackActive` reflects what the app is actually
+    // running with (platform-gated, matches the renderer signal). The raw
+    // flag is also reported so support can tell when a non-Linux-Wayland
+    // user has tripped the crash listener even though ANGLE wasn't engaged.
+    result.angleFallbackActive = isGpuAngleFallbackApplied(userDataPath);
+    result.angleFallbackFlag = isGpuAngleFallbackByFlag(userDataPath);
   } catch {
     result.hardwareAccelerationDisabled = "unknown";
     result.angleFallbackActive = "unknown";
+    result.angleFallbackFlag = "unknown";
   }
 
   try {

--- a/electron/services/DiagnosticsCollector.ts
+++ b/electron/services/DiagnosticsCollector.ts
@@ -227,10 +227,13 @@ async function collectGpu() {
   const result: Record<string, unknown> = {};
 
   try {
-    const { isGpuDisabledByFlag } = await import("./GpuCrashMonitorService.js");
+    const { isGpuDisabledByFlag, isGpuAngleFallbackByFlag } =
+      await import("./GpuCrashMonitorService.js");
     result.hardwareAccelerationDisabled = isGpuDisabledByFlag(app.getPath("userData"));
+    result.angleFallbackActive = isGpuAngleFallbackByFlag(app.getPath("userData"));
   } catch {
     result.hardwareAccelerationDisabled = "unknown";
+    result.angleFallbackActive = "unknown";
   }
 
   try {

--- a/electron/services/GpuCrashMonitorService.ts
+++ b/electron/services/GpuCrashMonitorService.ts
@@ -40,6 +40,23 @@ export function isGpuAngleFallbackByFlag(userDataPath: string): boolean {
   return fs.existsSync(path.join(userDataPath, GPU_ANGLE_FALLBACK_FLAG));
 }
 
+/**
+ * True only when the app is *actually* running with ANGLE/Vulkan fallback.
+ * The crash listener writes `gpu-angle-fallback.flag` on any platform after
+ * the first GPU crash, but `electron/setup/environment.ts` only appends the
+ * ANGLE switches on Linux Wayland (and only when hardware acceleration is
+ * still on). Use this for UI surfaces so macOS / Linux X11 / Windows don't
+ * show a misleading "running in ANGLE mode" warning when ANGLE was never
+ * engaged. Keep `isGpuAngleFallbackByFlag` for raw-flag inspection
+ * (diagnostics, environment-module bootstrap).
+ */
+export function isGpuAngleFallbackApplied(userDataPath: string): boolean {
+  if (process.platform !== "linux") return false;
+  if (process.env.XDG_SESSION_TYPE !== "wayland") return false;
+  if (isGpuDisabledByFlag(userDataPath)) return false;
+  return isGpuAngleFallbackByFlag(userDataPath);
+}
+
 export function writeGpuAngleFallbackFlag(userDataPath: string): void {
   fs.writeFileSync(path.join(userDataPath, GPU_ANGLE_FALLBACK_FLAG), String(Date.now()), "utf8");
 }

--- a/electron/services/__tests__/AppHydrationService.adversarial.test.ts
+++ b/electron/services/__tests__/AppHydrationService.adversarial.test.ts
@@ -98,6 +98,7 @@ vi.mock("../../utils/gpuDetection.js", async () => {
 
 vi.mock("../GpuCrashMonitorService.js", () => ({
   isGpuDisabledByFlag: isGpuDisabledByFlagMock,
+  isGpuAngleFallbackApplied: vi.fn(() => false),
 }));
 
 describe("AppHydrationService adversarial", () => {

--- a/electron/services/__tests__/GpuCrashMonitorService.test.ts
+++ b/electron/services/__tests__/GpuCrashMonitorService.test.ts
@@ -60,6 +60,7 @@ import {
   writeGpuDisabledFlag,
   clearGpuDisabledFlag,
   isGpuAngleFallbackByFlag,
+  isGpuAngleFallbackApplied,
   writeGpuAngleFallbackFlag,
   clearGpuAngleFallbackFlag,
   GPU_CRASH_WINDOW_MS,
@@ -137,6 +138,60 @@ describe("GpuCrashMonitorService", () => {
       clearGpuAngleFallbackFlag(tmpDir);
       expect(isGpuDisabledByFlag(tmpDir)).toBe(true);
       expect(isGpuAngleFallbackByFlag(tmpDir)).toBe(false);
+    });
+  });
+
+  describe("isGpuAngleFallbackApplied (platform-gated)", () => {
+    const originalPlatform = process.platform;
+    const originalSessionType = process.env.XDG_SESSION_TYPE;
+
+    afterEach(() => {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+      if (originalSessionType === undefined) {
+        delete process.env.XDG_SESSION_TYPE;
+      } else {
+        process.env.XDG_SESSION_TYPE = originalSessionType;
+      }
+    });
+
+    it("returns false on macOS even when the flag exists", () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      writeGpuAngleFallbackFlag(tmpDir);
+      expect(isGpuAngleFallbackApplied(tmpDir)).toBe(false);
+    });
+
+    it("returns false on Windows even when the flag exists", () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      writeGpuAngleFallbackFlag(tmpDir);
+      expect(isGpuAngleFallbackApplied(tmpDir)).toBe(false);
+    });
+
+    it("returns false on Linux X11 (XDG_SESSION_TYPE != wayland)", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.XDG_SESSION_TYPE = "x11";
+      writeGpuAngleFallbackFlag(tmpDir);
+      expect(isGpuAngleFallbackApplied(tmpDir)).toBe(false);
+    });
+
+    it("returns false on Linux Wayland when hardware acceleration is nuclear-disabled", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.XDG_SESSION_TYPE = "wayland";
+      writeGpuAngleFallbackFlag(tmpDir);
+      writeGpuDisabledFlag(tmpDir);
+      expect(isGpuAngleFallbackApplied(tmpDir)).toBe(false);
+    });
+
+    it("returns true on Linux Wayland with the flag present and acceleration on", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.XDG_SESSION_TYPE = "wayland";
+      writeGpuAngleFallbackFlag(tmpDir);
+      expect(isGpuAngleFallbackApplied(tmpDir)).toBe(true);
+    });
+
+    it("returns false on Linux Wayland when the flag is absent", () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.XDG_SESSION_TYPE = "wayland";
+      expect(isGpuAngleFallbackApplied(tmpDir)).toBe(false);
     });
   });
 

--- a/electron/services/__tests__/prefetchHydrateCache.test.ts
+++ b/electron/services/__tests__/prefetchHydrateCache.test.ts
@@ -25,6 +25,7 @@ function makeHydrate(projectId: string): HydrateResult {
     agentSettings: {} as HydrateResult["agentSettings"],
     gpuWebGLHardware: true,
     gpuHardwareAccelerationDisabled: false,
+    gpuAngleFallbackActive: false,
     safeMode: false,
     isWindowsStore: false,
     settingsRecovery: null,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1189,7 +1189,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     };
   };
   gpu: {
-    getStatus(): Promise<{ hardwareAccelerationDisabled: boolean }>;
+    getStatus(): Promise<{ hardwareAccelerationDisabled: boolean; angleFallbackActive: boolean }>;
     setHardwareAcceleration(enabled: boolean): Promise<void>;
   };
   // Invoke methods come from GeneratedElectronAPI; onTelemetryConsentChanged is a renderer-only subscription.

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -119,6 +119,13 @@ export interface HydrateResult {
   agentSettings: import("../agentSettings.js").AgentSettings;
   gpuWebGLHardware: boolean;
   gpuHardwareAccelerationDisabled: boolean;
+  /**
+   * True when the app is running with ANGLE/Vulkan fallback rendering after a
+   * prior GPU crash (the `gpu-angle-fallback.flag` file exists in userData).
+   * Surfaced so the renderer can show a Tier 2 inline warning explaining the
+   * degraded backend; re-enabling hardware acceleration clears the flag.
+   */
+  gpuAngleFallbackActive: boolean;
   safeMode: boolean;
   /**
    * True when running inside an MSIX/AppX (Microsoft Store) container, where

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1224,7 +1224,7 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
   // GPU
   "gpu:get-status": {
     args: [];
-    result: { hardwareAccelerationDisabled: boolean };
+    result: { hardwareAccelerationDisabled: boolean; angleFallbackActive: boolean };
   };
   "gpu:set-hardware-acceleration": {
     args: [enabled: boolean];

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -165,10 +165,12 @@ function DownloadDiagnosticsSection() {
 
 function HardwareAccelerationSection() {
   const [disabled, setDisabled] = useState<boolean | null>(null);
+  const [angleFallback, setAngleFallback] = useState<boolean>(false);
 
   useEffect(() => {
     window.electron.gpu.getStatus().then((status) => {
       setDisabled(status.hardwareAccelerationDisabled);
+      setAngleFallback(status.angleFallbackActive);
     });
   }, []);
 
@@ -202,6 +204,16 @@ function HardwareAccelerationSection() {
           <AlertTriangle className="w-3 h-3" />
           GPU acceleration was disabled due to repeated crashes. Re-enable to restore full
           performance.
+        </p>
+      )}
+
+      {!disabled && angleFallback && (
+        <p className="text-xs text-status-warning/80 flex items-start gap-1.5 select-text">
+          <AlertTriangle className="w-3 h-3 mt-0.5 shrink-0" />
+          <span>
+            GPU is running in ANGLE/Vulkan fallback mode after a crash. Performance may be reduced —
+            toggle hardware acceleration off and back on to restore the default backend.
+          </span>
         </p>
       )}
     </SettingsSection>

--- a/src/hooks/__tests__/useAppBoot.test.tsx
+++ b/src/hooks/__tests__/useAppBoot.test.tsx
@@ -12,6 +12,7 @@ function makeBootResult(): BootResult {
     agentSettings: {} as BootResult["agentSettings"],
     gpuWebGLHardware: true,
     gpuHardwareAccelerationDisabled: false,
+    gpuAngleFallbackActive: false,
     safeMode: false,
     isWindowsStore: false,
     settingsRecovery: null,

--- a/src/hooks/__tests__/useCrashRecoveryGate.test.tsx
+++ b/src/hooks/__tests__/useCrashRecoveryGate.test.tsx
@@ -39,6 +39,7 @@ function makeBootResult(overrides?: Partial<BootResult>): BootResult {
     agentSettings: {} as BootResult["agentSettings"],
     gpuWebGLHardware: true,
     gpuHardwareAccelerationDisabled: false,
+    gpuAngleFallbackActive: false,
     safeMode: false,
     isWindowsStore: false,
     settingsRecovery: null,

--- a/src/utils/stateHydration/__tests__/recoveryNotifications.test.ts
+++ b/src/utils/stateHydration/__tests__/recoveryNotifications.test.ts
@@ -19,6 +19,7 @@ function makeHydrateResult(overrides: Partial<HydrateResult>): HydrateResult {
     project: null,
     gpuWebGLHardware: true,
     gpuHardwareAccelerationDisabled: false,
+    gpuAngleFallbackActive: false,
     safeMode: false,
     settingsRecovery: null,
     projectStateRecovery: null,
@@ -58,6 +59,13 @@ describe("dispatchRecoveryNotifications", () => {
 
     it("does not fire when the flag is false", () => {
       dispatchRecoveryNotifications(makeHydrateResult({ gpuHardwareAccelerationDisabled: false }));
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GPU ANGLE fallback", () => {
+    it("does not fire a toast — ANGLE state is surfaced only as an inline Settings banner", () => {
+      dispatchRecoveryNotifications(makeHydrateResult({ gpuAngleFallbackActive: true }));
       expect(notifyMock).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary

- On a first-strike GPU crash, `GpuCrashMonitorService` relaunches silently on the ANGLE/Vulkan fallback path with no UI signal. Users have no way to know they're running in degraded mode.
- Wires a `isGpuAngleFallbackApplied` boolean through the IPC layer (`gpu:get-status`) and `HydrateResult` so the renderer has the signal it needs.
- Adds a Tier 2 inline warning row in the Troubleshooting settings tab, matching the existing nuclear-disable warning pattern. Gated to Linux Wayland only, where the ANGLE switch is actually applied, so no false positives on macOS, Linux X11, or Windows.
- Updates `DiagnosticsCollector` to report both the raw flag and the applied state for support purposes.

Resolves #8673

## Changes

- `GpuCrashMonitorService` -- writes the fallback flag on any platform; exposes `isGpuAngleFallbackApplied` gated to Linux Wayland
- `shared/types/ipc/app.ts` -- adds `gpuAngleFallbackActive` to `GpuStatusResult` and `AppBootState`
- `electron/ipc/handlers/app/gpu.ts` + `state.ts` -- threads the flag through both IPC handlers
- `AppHydrationService` -- includes the flag in `HydrateResult`
- `DiagnosticsCollector` -- reports raw flag and applied state separately
- `TroubleshootingTab` -- Tier 2 inline warning row, visible only when `gpuAngleFallbackActive` is true
- Tests for all new paths across `GpuCrashMonitorService`, `gpu.handlers`, `app.state`, `useAppBoot`, `useCrashRecoveryGate`, `recoveryNotifications`, and `prefetchHydrateCache`

## Testing

- All existing and new unit tests pass
- Typecheck, lint, and format clean
- Fallback signal verified gated correctly: flag writes on any platform; renderer only sees it as active on Linux Wayland