### PR TITLE
fix(crash-loop): quarantine corrupt state and sweep stale temp files

### DIFF
--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -71,6 +71,7 @@ const crashGuard = {
   isSafeMode: vi.fn(() => false),
   getCrashCount: vi.fn(() => 0),
   getLastCrashTimestamp: vi.fn(() => null),
+  getQuarantinedStatePath: vi.fn(() => null),
   resetForNormalBoot: vi.fn(),
 };
 

--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -320,7 +320,9 @@ describe("app:boot handler", () => {
 
   it("surfaces crashLoopStateRecovery only when in safe mode AND quarantine path is set", async () => {
     crashGuard.isSafeMode.mockReturnValue(true);
-    crashGuard.getQuarantinedStatePath.mockReturnValue("/tmp/crash-loop-state.json.corrupted.42");
+    (crashGuard.getQuarantinedStatePath as any).mockReturnValue(
+      "/tmp/crash-loop-state.json.corrupted.42"
+    );
 
     const result = (await invokeBoot()) as { crashLoopStateRecovery: unknown };
     expect(result.crashLoopStateRecovery).toEqual({
@@ -330,7 +332,9 @@ describe("app:boot handler", () => {
 
   it("omits crashLoopStateRecovery when not in safe mode (silent corruption is log-only)", async () => {
     crashGuard.isSafeMode.mockReturnValue(false);
-    crashGuard.getQuarantinedStatePath.mockReturnValue("/tmp/crash-loop-state.json.corrupted.42");
+    (crashGuard.getQuarantinedStatePath as any).mockReturnValue(
+      "/tmp/crash-loop-state.json.corrupted.42"
+    );
 
     const result = (await invokeBoot()) as { crashLoopStateRecovery: unknown };
     expect(result.crashLoopStateRecovery).toBeNull();

--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -318,6 +318,32 @@ describe("app:boot handler", () => {
     expect(result.crashPending).toBeNull();
   });
 
+  it("surfaces crashLoopStateRecovery only when in safe mode AND quarantine path is set", async () => {
+    crashGuard.isSafeMode.mockReturnValue(true);
+    crashGuard.getQuarantinedStatePath.mockReturnValue("/tmp/crash-loop-state.json.corrupted.42");
+
+    const result = (await invokeBoot()) as { crashLoopStateRecovery: unknown };
+    expect(result.crashLoopStateRecovery).toEqual({
+      quarantinedPath: "/tmp/crash-loop-state.json.corrupted.42",
+    });
+  });
+
+  it("omits crashLoopStateRecovery when not in safe mode (silent corruption is log-only)", async () => {
+    crashGuard.isSafeMode.mockReturnValue(false);
+    crashGuard.getQuarantinedStatePath.mockReturnValue("/tmp/crash-loop-state.json.corrupted.42");
+
+    const result = (await invokeBoot()) as { crashLoopStateRecovery: unknown };
+    expect(result.crashLoopStateRecovery).toBeNull();
+  });
+
+  it("omits crashLoopStateRecovery when in safe mode but no quarantine occurred", async () => {
+    crashGuard.isSafeMode.mockReturnValue(true);
+    crashGuard.getQuarantinedStatePath.mockReturnValue(null);
+
+    const result = (await invokeBoot()) as { crashLoopStateRecovery: unknown };
+    expect(result.crashLoopStateRecovery).toBeNull();
+  });
+
   it("propagates the cache-hit fast path from handleAppHydrate (no disk read)", async () => {
     const cachedResult = {
       appState: { terminals: [], sidebarWidth: 350 },

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -67,6 +67,9 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
           crashCount: cacheGuard.getCrashCount(),
           lastCrashAt: cacheGuard.getLastCrashTimestamp(),
           settingsRecovery: consumePendingSettingsRecovery(),
+          // Crash-loop quarantine notifications are gated on safe mode; the
+          // fast path runs only when safe mode is inactive, so clear the field.
+          crashLoopStateRecovery: null,
         };
       }
     }
@@ -305,6 +308,12 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       projectStateRecovery: projectStateQuarantinedPath
         ? { quarantinedPath: projectStateQuarantinedPath }
         : null,
+      // Surface the crash-loop quarantine only when safe mode is also active —
+      // a silent reset on the happy path would be more noise than signal.
+      crashLoopStateRecovery:
+        inSafeMode && guard.getQuarantinedStatePath()
+          ? { quarantinedPath: guard.getQuarantinedStatePath()! }
+          : null,
     };
   };
   handlers.push(typedHandle(CHANNELS.APP_HYDRATE, handleAppHydrate));

--- a/electron/services/CrashLoopGuardService.ts
+++ b/electron/services/CrashLoopGuardService.ts
@@ -215,10 +215,12 @@ export class CrashLoopGuardService {
       if (
         parsed.version === 1 &&
         typeof parsed.crashes === "number" &&
+        Number.isFinite(parsed.crashes) &&
         Array.isArray(parsed.launches) &&
         parsed.launches.every((ts) => typeof ts === "number" && Number.isFinite(ts)) &&
         typeof parsed.cleanExit === "boolean" &&
-        typeof parsed.lastReset === "number"
+        typeof parsed.lastReset === "number" &&
+        Number.isFinite(parsed.lastReset)
       ) {
         return parsed as CrashLoopState;
       }
@@ -349,10 +351,12 @@ export function isSafeModeActive(userDataPath?: string): boolean {
     if (
       parsed.version === 1 &&
       typeof parsed.crashes === "number" &&
+      Number.isFinite(parsed.crashes) &&
       Array.isArray(parsed.launches) &&
       parsed.launches.every((ts) => typeof ts === "number" && Number.isFinite(ts)) &&
       typeof parsed.cleanExit === "boolean" &&
-      typeof parsed.lastReset === "number"
+      typeof parsed.lastReset === "number" &&
+      Number.isFinite(parsed.lastReset)
     ) {
       if (parsed.cleanExit) return false;
       const now = Date.now();

--- a/electron/services/CrashLoopGuardService.ts
+++ b/electron/services/CrashLoopGuardService.ts
@@ -9,6 +9,17 @@ const HARD_STOP_THRESHOLD = 5;
 const STABILITY_TIMEOUT_MS = 5 * 60 * 1000;
 const RAPID_CRASH_WINDOW_MS = 300_000;
 
+// Grace window before a leftover `.tmp` from `resilientAtomicWriteFileSync` is
+// swept. Matches the precedent in `terminalSessionPersistence.ts` — long enough
+// to dodge concurrent boots, short enough to keep the userData dir tidy.
+const TMP_ORPHAN_TTL_MS = 5 * 60 * 1000;
+// Number of `.corrupted.*` siblings to retain for forensics. Older entries are
+// pruned at boot so a chronic crash loop can't fill the userData directory.
+const KEEP_CORRUPTED_SIBLINGS = 3;
+
+const TMP_FILE_RE = /^crash-loop-state\.json\.(\d+)-[a-z0-9]+\.tmp$/;
+const CORRUPTED_FILE_RE = /^crash-loop-state\.json\.corrupted\.(\d+)$/;
+
 interface CrashLoopState {
   version: 1;
   crashes: number;
@@ -27,6 +38,19 @@ function freshState(): CrashLoopState {
   };
 }
 
+// Tighten perms on the quarantined file — it inherits the original (potentially
+// 0o644) mode but may contain partial state useful only for forensics. Mirrors
+// `tightenFilePermissions` in `electron/store.ts`. Windows ignores POSIX mode
+// bits, so the platform guard keeps it a no-op there.
+function tightenFilePermissions(filePath: string): void {
+  if (process.platform === "win32") return;
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch (err) {
+    console.warn("[CrashLoopGuard] Failed to tighten file permissions:", filePath, err);
+  }
+}
+
 export class CrashLoopGuardService {
   private userData: string;
   private statePath: string;
@@ -36,6 +60,7 @@ export class CrashLoopGuardService {
   private initialized = false;
   private crashCount = 0;
   private lastCrashAt: number | undefined;
+  private quarantinedStatePath: string | null = null;
 
   constructor() {
     this.userData = app.getPath("userData");
@@ -45,6 +70,13 @@ export class CrashLoopGuardService {
   initialize(): void {
     if (this.initialized) return;
     this.initialized = true;
+
+    // Sweep stale `.tmp` residue and prune old `.corrupted.*` siblings before
+    // reading state. Both are best-effort — boot must proceed even if cleanup
+    // throws. Pruning before quarantine guarantees the current boot's
+    // quarantined file (if any) is never pruned in the same run.
+    this.sweepStaleTmpFiles();
+    this.pruneCorruptedSiblings();
 
     const state = this.readState();
     const now = Date.now();
@@ -110,6 +142,15 @@ export class CrashLoopGuardService {
   }
 
   /**
+   * Path of the corrupt state file that was quarantined during the most recent
+   * `initialize()` call, or `null` when no corruption was detected. The IPC
+   * layer gates the renderer notification on `isSafeMode() && this !== null`.
+   */
+  getQuarantinedStatePath(): string | null {
+    return this.quarantinedStatePath;
+  }
+
+  /**
    * User-initiated reset: cancel the stability timer first so it can't
    * fire between our write and exit and clobber the fresh state, then
    * atomically clear the state file and reset in-memory flags.
@@ -165,10 +206,10 @@ export class CrashLoopGuardService {
   }
 
   private readState(): CrashLoopState {
+    if (!fs.existsSync(this.statePath)) {
+      return freshState();
+    }
     try {
-      if (!fs.existsSync(this.statePath)) {
-        return freshState();
-      }
       const raw = fs.readFileSync(this.statePath, "utf8");
       const parsed = JSON.parse(raw) as Partial<CrashLoopState>;
       if (
@@ -181,11 +222,105 @@ export class CrashLoopGuardService {
       ) {
         return parsed as CrashLoopState;
       }
-      console.warn("[CrashLoopGuard] Invalid state file, using fresh state");
+      console.warn("[CrashLoopGuard] Invalid state structure — quarantining and resetting");
+      this.quarantineStateFile();
       return freshState();
+    } catch (err) {
+      console.warn("[CrashLoopGuard] Failed to parse state file — quarantining and resetting", err);
+      this.quarantineStateFile();
+      return freshState();
+    }
+  }
+
+  /**
+   * Rename the corrupt state file to a `.corrupted.<timestamp>` sibling so it
+   * survives for forensics, then tighten perms (best-effort, POSIX only). The
+   * rename is the authoritative quarantine event — if `chmod` fails the file
+   * is still moved and `quarantinedStatePath` is set. `quarantinedStatePath`
+   * is only set on the first successful rename per service instance, so a
+   * second `initialize()` (already idempotent) can't overwrite the first.
+   */
+  private quarantineStateFile(): void {
+    const quarantinePath = `${this.statePath}.corrupted.${Date.now()}`;
+    try {
+      fs.renameSync(this.statePath, quarantinePath);
+    } catch (err) {
+      console.warn("[CrashLoopGuard] Failed to quarantine corrupt state file:", err);
+      return;
+    }
+    tightenFilePermissions(quarantinePath);
+    if (this.quarantinedStatePath === null) {
+      this.quarantinedStatePath = quarantinePath;
+    }
+    console.log(`[CrashLoopGuard] Quarantined corrupt state file to ${quarantinePath}`);
+  }
+
+  /**
+   * Sweep `.tmp` residue left by `resilientAtomicWriteFileSync` if the process
+   * was SIGKILL'd between write and rename. The tmp name embeds `Date.now()`,
+   * so we parse the timestamp from the filename (`statSync` fallback only when
+   * the regex doesn't capture it). All errors are swallowed — boot must
+   * proceed regardless.
+   */
+  private sweepStaleTmpFiles(): void {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(this.userData);
     } catch {
-      console.warn("[CrashLoopGuard] Failed to read state file, using fresh state");
-      return freshState();
+      return;
+    }
+    const now = Date.now();
+    for (const entry of entries) {
+      const match = TMP_FILE_RE.exec(entry);
+      if (!match) continue;
+      const ts = Number.parseInt(match[1]!, 10);
+      if (!Number.isFinite(ts)) continue;
+      if (now - ts < TMP_ORPHAN_TTL_MS) continue;
+      const tmpPath = path.join(this.userData, entry);
+      try {
+        fs.unlinkSync(tmpPath);
+        console.log(`[CrashLoopGuard] Swept stale tmp file ${tmpPath}`);
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+          console.warn(`[CrashLoopGuard] Failed to sweep tmp file ${tmpPath}:`, err);
+        }
+      }
+    }
+  }
+
+  /**
+   * Prune `.corrupted.<ts>` siblings beyond `KEEP_CORRUPTED_SIBLINGS` so a
+   * chronic crash loop can't fill the userData directory. Sort by the
+   * timestamp embedded in the filename (descending), retain the newest N,
+   * unlink the rest. Best-effort — boot must proceed even if cleanup fails.
+   */
+  private pruneCorruptedSiblings(): void {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(this.userData);
+    } catch {
+      return;
+    }
+    const corrupted: Array<{ entry: string; ts: number }> = [];
+    for (const entry of entries) {
+      const match = CORRUPTED_FILE_RE.exec(entry);
+      if (!match) continue;
+      const ts = Number.parseInt(match[1]!, 10);
+      if (!Number.isFinite(ts)) continue;
+      corrupted.push({ entry, ts });
+    }
+    if (corrupted.length <= KEEP_CORRUPTED_SIBLINGS) return;
+    corrupted.sort((a, b) => b.ts - a.ts);
+    for (const { entry } of corrupted.slice(KEEP_CORRUPTED_SIBLINGS)) {
+      const corruptedPath = path.join(this.userData, entry);
+      try {
+        fs.unlinkSync(corruptedPath);
+        console.log(`[CrashLoopGuard] Pruned old corrupted sibling ${corruptedPath}`);
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+          console.warn(`[CrashLoopGuard] Failed to prune ${corruptedPath}:`, err);
+        }
+      }
     }
   }
 

--- a/electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts
@@ -196,6 +196,7 @@ describe("CrashLoopGuardService adversarial", () => {
       statePath,
       JSON.stringify({
         version: 1,
+        // eslint-disable-next-line no-loss-of-precision
         crashes: 1e309, // → Infinity after JSON.parse
         launches: [],
         cleanExit: false,
@@ -218,6 +219,7 @@ describe("CrashLoopGuardService adversarial", () => {
         crashes: 0,
         launches: [],
         cleanExit: false,
+        // eslint-disable-next-line no-loss-of-precision
         lastReset: 1e309,
       }),
       "utf8"

--- a/electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts
@@ -187,6 +187,48 @@ describe("CrashLoopGuardService adversarial", () => {
     readdirSpy.mockRestore();
   });
 
+  it("quarantines state with non-finite numeric fields (Infinity from JSON overflow)", () => {
+    // JSON.parse turns numeric overflow into Infinity. Without an isFinite
+    // guard the file would pass type validation, then JSON.stringify on the
+    // write-back would emit `null` — corrupting the file on the next boot
+    // instead of the current one. Quarantine immediately.
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({
+        version: 1,
+        crashes: 1e309, // → Infinity after JSON.parse
+        launches: [],
+        cleanExit: false,
+        lastReset: Date.now(),
+      }),
+      "utf8"
+    );
+
+    const guard = new CrashLoopGuardService();
+    guard.initialize();
+
+    expect(guard.getQuarantinedStatePath()).toMatch(/\.corrupted\.\d+$/);
+  });
+
+  it("quarantines state when lastReset is Infinity", () => {
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({
+        version: 1,
+        crashes: 0,
+        launches: [],
+        cleanExit: false,
+        lastReset: 1e309,
+      }),
+      "utf8"
+    );
+
+    const guard = new CrashLoopGuardService();
+    guard.initialize();
+
+    expect(guard.getQuarantinedStatePath()).toMatch(/\.corrupted\.\d+$/);
+  });
+
   it("prune tolerates `.corrupted.*` siblings with malformed timestamps", () => {
     // A malformed entry that would parse to NaN if naively coerced.
     fs.writeFileSync(

--- a/electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts
@@ -150,6 +150,60 @@ describe("CrashLoopGuardService adversarial", () => {
     expect(Array.isArray(parsed.launches)).toBe(true);
   });
 
+  it("quarantine survives a chmod failure (rename is authoritative)", () => {
+    writeStateFile(statePath, { not: "valid", structure: true });
+    const chmodSpy = vi.spyOn(fs, "chmodSync").mockImplementationOnce(() => {
+      throw Object.assign(new Error("EPERM: not permitted"), { code: "EPERM" });
+    });
+
+    const guard = new CrashLoopGuardService();
+    guard.initialize();
+
+    expect(guard.getQuarantinedStatePath()).toMatch(/\.corrupted\.\d+$/);
+    expect(fs.existsSync(guard.getQuarantinedStatePath()!)).toBe(true);
+    chmodSpy.mockRestore();
+  });
+
+  it("rename failure in quarantine leaves quarantinedStatePath null without throwing", () => {
+    writeStateFile(statePath, { not: "valid" });
+    const renameSpy = vi.spyOn(fs, "renameSync").mockImplementationOnce(() => {
+      throw Object.assign(new Error("EBUSY"), { code: "EBUSY" });
+    });
+
+    const guard = new CrashLoopGuardService();
+    expect(() => guard.initialize()).not.toThrow();
+    expect(guard.getQuarantinedStatePath()).toBeNull();
+    renameSpy.mockRestore();
+  });
+
+  it("sweep failure (readdirSync throws) does not prevent boot", () => {
+    const readdirSpy = vi.spyOn(fs, "readdirSync").mockImplementationOnce(() => {
+      throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+    });
+
+    const guard = new CrashLoopGuardService();
+    expect(() => guard.initialize()).not.toThrow();
+    expect(guard.isSafeMode()).toBe(false);
+    readdirSpy.mockRestore();
+  });
+
+  it("prune tolerates `.corrupted.*` siblings with malformed timestamps", () => {
+    // A malformed entry that would parse to NaN if naively coerced.
+    fs.writeFileSync(
+      path.join(tmpDir, "crash-loop-state.json.corrupted.not-a-number"),
+      "x",
+      "utf8"
+    );
+    // The regex requires \d+, so this entry is ignored entirely.
+    const guard = new CrashLoopGuardService();
+    expect(() => guard.initialize()).not.toThrow();
+
+    // Non-matching entry is preserved (we only act on regex matches).
+    expect(fs.existsSync(path.join(tmpDir, "crash-loop-state.json.corrupted.not-a-number"))).toBe(
+      true
+    );
+  });
+
   it("does not keep relaunch disabled after old launches roll out of the hard-stop window", () => {
     const now = Date.now();
     writeStateFile(statePath, {

--- a/electron/services/__tests__/CrashLoopGuardService.test.ts
+++ b/electron/services/__tests__/CrashLoopGuardService.test.ts
@@ -260,6 +260,59 @@ describe("CrashLoopGuardService", () => {
     expect(guard.shouldRelaunch()).toBe(true);
   });
 
+  it("quarantines a corrupt state file instead of silently discarding it", () => {
+    fs.writeFileSync(statePath, "not valid json!!!", "utf8");
+
+    const guard = new CrashLoopGuardService();
+    guard.initialize();
+
+    const quarantinedPath = guard.getQuarantinedStatePath();
+    expect(quarantinedPath).toMatch(/crash-loop-state\.json\.corrupted\.\d+$/);
+    expect(fs.existsSync(quarantinedPath!)).toBe(true);
+    // The quarantined file still contains the original corrupt bytes.
+    expect(fs.readFileSync(quarantinedPath!, "utf8")).toBe("not valid json!!!");
+  });
+
+  it("quarantines a state file with an invalid structure", () => {
+    writeState({ version: 2, foo: "bar" });
+
+    const guard = new CrashLoopGuardService();
+    guard.initialize();
+
+    const quarantinedPath = guard.getQuarantinedStatePath();
+    expect(quarantinedPath).toMatch(/crash-loop-state\.json\.corrupted\.\d+$/);
+    expect(fs.existsSync(quarantinedPath!)).toBe(true);
+  });
+
+  it("does not quarantine when the state file is missing (first run)", () => {
+    expect(fs.existsSync(statePath)).toBe(false);
+
+    const guard = new CrashLoopGuardService();
+    guard.initialize();
+
+    expect(guard.getQuarantinedStatePath()).toBeNull();
+    // No `.corrupted.*` siblings created.
+    const siblings = fs
+      .readdirSync(tmpDir)
+      .filter((e) => e.startsWith("crash-loop-state.json.corrupted."));
+    expect(siblings).toHaveLength(0);
+  });
+
+  it("does not quarantine a valid state file", () => {
+    writeState({
+      version: 1,
+      crashes: 0,
+      launches: [],
+      cleanExit: true,
+      lastReset: Date.now(),
+    });
+
+    const guard = new CrashLoopGuardService();
+    guard.initialize();
+
+    expect(guard.getQuarantinedStatePath()).toBeNull();
+  });
+
   it("handles invalid state structure gracefully", () => {
     writeState({ version: 2, foo: "bar" });
 
@@ -268,6 +321,95 @@ describe("CrashLoopGuardService", () => {
 
     expect(guard.isSafeMode()).toBe(false);
     expect(guard.shouldRelaunch()).toBe(true);
+  });
+
+  describe("stale tmp sweep", () => {
+    it("deletes a stale `.tmp` left by a crashed atomic write", () => {
+      const staleTs = Date.now() - 6 * 60 * 1000; // 6 min ago, beyond 5-min TTL
+      const tmpPath = path.join(tmpDir, `crash-loop-state.json.${staleTs}-abc123.tmp`);
+      fs.writeFileSync(tmpPath, "stale data", "utf8");
+
+      const guard = new CrashLoopGuardService();
+      guard.initialize();
+
+      expect(fs.existsSync(tmpPath)).toBe(false);
+    });
+
+    it("preserves a fresh `.tmp` (within the 5-min TTL)", () => {
+      const freshTs = Date.now() - 60 * 1000; // 1 min ago
+      const tmpPath = path.join(tmpDir, `crash-loop-state.json.${freshTs}-abc123.tmp`);
+      fs.writeFileSync(tmpPath, "in-flight write", "utf8");
+
+      const guard = new CrashLoopGuardService();
+      guard.initialize();
+
+      expect(fs.existsSync(tmpPath)).toBe(true);
+    });
+
+    it("only sweeps tmp files that match the crash-loop naming pattern", () => {
+      const otherTmp = path.join(tmpDir, "settings.json.123-abc.tmp");
+      fs.writeFileSync(otherTmp, "not ours", "utf8");
+
+      const guard = new CrashLoopGuardService();
+      guard.initialize();
+
+      expect(fs.existsSync(otherTmp)).toBe(true);
+    });
+  });
+
+  describe("corrupted sibling prune", () => {
+    it("retains the 3 most-recent `.corrupted.*` siblings and prunes older ones", () => {
+      // Drop 5 corrupted siblings with ascending timestamps so the prune sort
+      // is well-defined.
+      const timestamps = [1000, 2000, 3000, 4000, 5000];
+      for (const ts of timestamps) {
+        fs.writeFileSync(path.join(tmpDir, `crash-loop-state.json.corrupted.${ts}`), "x", "utf8");
+      }
+
+      const guard = new CrashLoopGuardService();
+      guard.initialize();
+
+      const survivors = fs
+        .readdirSync(tmpDir)
+        .filter((e) => e.startsWith("crash-loop-state.json.corrupted."))
+        .sort();
+      // The three newest (3000, 4000, 5000) survive — 1000 and 2000 are gone.
+      expect(survivors).toEqual([
+        "crash-loop-state.json.corrupted.3000",
+        "crash-loop-state.json.corrupted.4000",
+        "crash-loop-state.json.corrupted.5000",
+      ]);
+    });
+
+    it("does not prune when there are 3 or fewer siblings", () => {
+      for (const ts of [1000, 2000, 3000]) {
+        fs.writeFileSync(path.join(tmpDir, `crash-loop-state.json.corrupted.${ts}`), "x", "utf8");
+      }
+
+      const guard = new CrashLoopGuardService();
+      guard.initialize();
+
+      const survivors = fs
+        .readdirSync(tmpDir)
+        .filter((e) => e.startsWith("crash-loop-state.json.corrupted."));
+      expect(survivors).toHaveLength(3);
+    });
+
+    it("does not prune the just-quarantined sibling from the current boot", () => {
+      // Two older siblings already on disk.
+      for (const ts of [1000, 2000]) {
+        fs.writeFileSync(path.join(tmpDir, `crash-loop-state.json.corrupted.${ts}`), "x", "utf8");
+      }
+      // And a corrupt state file the current boot will quarantine.
+      fs.writeFileSync(statePath, "garbage", "utf8");
+
+      const guard = new CrashLoopGuardService();
+      guard.initialize();
+
+      const quarantinedPath = guard.getQuarantinedStatePath();
+      expect(quarantinedPath).not.toBeNull();
+      expect(fs.existsSync(quarantinedPath!)).toBe(true);
+    });
   });
 
   it("only counts crashes within the rapid crash window", () => {

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -97,6 +97,11 @@ export interface ProjectStateRecovery {
   quarantinedPath: string;
 }
 
+/** Describes a crash-loop state file that was quarantined due to corruption */
+export interface CrashLoopStateRecovery {
+  quarantinedPath: string;
+}
+
 /**
  * Combined cold-start payload — collapses the three independent IPC round-trips
  * the renderer used to fire on mount (`crash-recovery:get-pending`,
@@ -141,4 +146,11 @@ export interface HydrateResult {
   lastCrashAt?: number;
   settingsRecovery?: SettingsRecovery | null;
   projectStateRecovery?: ProjectStateRecovery | null;
+  /**
+   * Populated only when the crash-loop state file was corrupt AND the boot
+   * also tripped safe mode — the renderer banner gates on `safeMode === true`
+   * to avoid surfacing a silent reset that didn't affect the user. Silent
+   * corruption with no safe-mode trip is log-only.
+   */
+  crashLoopStateRecovery?: CrashLoopStateRecovery | null;
 }

--- a/src/utils/stateHydration/__tests__/recoveryNotifications.test.ts
+++ b/src/utils/stateHydration/__tests__/recoveryNotifications.test.ts
@@ -23,6 +23,7 @@ function makeHydrateResult(overrides: Partial<HydrateResult>): HydrateResult {
     safeMode: false,
     settingsRecovery: null,
     projectStateRecovery: null,
+    crashLoopStateRecovery: null,
   };
   return Object.assign(base, overrides) as HydrateResult;
 }
@@ -127,15 +128,38 @@ describe("dispatchRecoveryNotifications", () => {
     });
   });
 
-  it("can fire all three notifications in one call", () => {
+  describe("crash-loop state recovery", () => {
+    it("notifies with the quarantined path", () => {
+      dispatchRecoveryNotifications(
+        makeHydrateResult({
+          crashLoopStateRecovery: { quarantinedPath: "/tmp/crash-loop.bad" },
+        })
+      );
+
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      const arg = notifyMock.mock.calls[0]![0];
+      expect(arg.title).toBe("Crash-loop state corrupted");
+      expect(arg.message).toContain("/tmp/crash-loop.bad");
+      expect(arg.priority).toBe("high");
+      expect(arg.duration).toBe(0);
+    });
+
+    it("does not fire when crashLoopStateRecovery is null", () => {
+      dispatchRecoveryNotifications(makeHydrateResult({ crashLoopStateRecovery: null }));
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("can fire all four notifications in one call", () => {
     dispatchRecoveryNotifications(
       makeHydrateResult({
         gpuHardwareAccelerationDisabled: true,
         settingsRecovery: { kind: "restored-from-backup" },
         projectStateRecovery: { quarantinedPath: "/tmp/p" },
+        crashLoopStateRecovery: { quarantinedPath: "/tmp/c" },
       })
     );
 
-    expect(notifyMock).toHaveBeenCalledTimes(3);
+    expect(notifyMock).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/utils/stateHydration/recoveryNotifications.ts
+++ b/src/utils/stateHydration/recoveryNotifications.ts
@@ -57,4 +57,15 @@ export function dispatchRecoveryNotifications(hydrateResult: HydrateResult): voi
       duration: 0,
     });
   }
+
+  if (hydrateResult.crashLoopStateRecovery) {
+    const { quarantinedPath } = hydrateResult.crashLoopStateRecovery;
+    notify({
+      type: "warning",
+      title: "Crash-loop state corrupted",
+      message: `The crash-loop tracker file was corrupted and has been reset. The corrupt file is preserved at: ${quarantinedPath}`,
+      priority: "high",
+      duration: 0,
+    });
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #8684.

- `CrashLoopGuardService.readState()` now **quarantines** a corrupt or schema-invalid `crash-loop-state.json` to `.corrupted.<ts>` instead of silently resetting it via `freshState()`. Mirrors the existing `quarantineCorruptConfig` pattern in `electron/store.ts` (rename + best-effort `chmod 0o600` on non-Windows).
- `initialize()` now **sweeps stale `.tmp` residue** (5-minute TTL) left behind when `resilientAtomicWriteFileSync` is SIGKILL'd between write and rename, and **prunes `.corrupted.*` siblings** beyond `N=3` so a chronic crash loop can't fill the userData directory.
- New `CrashLoopStateRecovery` field on `HydrateResult`, surfaced **only when `safeMode === true` AND a quarantine occurred** — silent corruption that didn't trip safe mode stays log-only per the `notify()` four-question gate.
- Renderer surface: `dispatchRecoveryNotifications` gets a third branch matching the existing project-state pattern (high-priority warning toast, `duration: 0`).
- Hardened number validation: `Number.isFinite()` guards on `crashes` and `lastReset` so JSON-overflow `Infinity` (`1e309 → Infinity`) is caught immediately instead of corrupting the file one boot later when `JSON.stringify` serializes it as `null`.

Plan ordering: sweep + prune run **before** `readState()`, so the current boot's quarantine file is never pruned in the same run. `isSafeModeActive()` (the pre-`app.whenReady` standalone) intentionally stays read-only — letting it also quarantine would race with the service's `readState()`.

## Test plan

- [x] Unit: 10 new cases in `CrashLoopGuardService.test.ts`
- [x] Adversarial: 5 new cases in `CrashLoopGuardService.adversarial.test.ts`
- [x] IPC: 3 new cases in `app.state.test.ts` covering the `safeMode && quarantined` gate
- [x] Renderer: 3 new cases in `recoveryNotifications.test.ts`
- [x] `npm run check` — typecheck, lint, format, ipc checks all clean
- [ ] Manual: corrupt the on-disk `crash-loop-state.json`, restart, confirm `.corrupted.<ts>` sibling appears and app boots normally