### PR TITLE
fix(fleet): include skipped count in broadcast cancel announcement

### DIFF
--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -140,9 +140,9 @@ describe("tryFleetBroadcastFromEditor — a11y announcements", () => {
       // broadcast fires, then the batched path + cancel produce skippedCount>0.
       resolveFleetBroadcastConfirmation();
       for (let i = 0; i < 20; i += 1) await flush();
-      const msg = useAnnouncerStore.getState().polite?.msg ?? "";
-      expect(msg).toMatch(/Broadcast cancelled/);
-      expect(msg).toContain("7 terminals skipped");
+      expect(useAnnouncerStore.getState().polite?.msg).toBe(
+        "Broadcast cancelled — 5 sent, 7 terminals skipped"
+      );
     } finally {
       useFleetBroadcastProgressStore.setState({ advance: origAdvance });
     }

--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -2,7 +2,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
-import { useFleetBroadcastConfirmStore } from "@/store/fleetBroadcastConfirmStore";
+import {
+  useFleetBroadcastConfirmStore,
+  resolveFleetBroadcastConfirmation,
+} from "@/store/fleetBroadcastConfirmStore";
 import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore } from "@/store/panelStore";
@@ -109,6 +112,40 @@ describe("tryFleetBroadcastFromEditor — a11y announcements", () => {
     tryFleetBroadcastFromEditor("a", "hello", vi.fn());
     await flush();
     expect(useAnnouncerStore.getState().polite?.msg).toBe("Broadcast sent to 2 — 1 failed");
+  });
+
+  it("announces skipped count in batched-cancel path when preempted batches never fire", async () => {
+    // FLEET_LARGE_PASTE_BATCH_SIZE is 5. 12 targets with a 120-KB payload
+    // triggers the batched path. Cancel after the first batch settles so
+    // the remaining 7 are skipped.
+    const ids = Array.from({ length: 12 }, (_, i) => `t${i}`);
+    const agents = ids.map((id) => makeAgent(id));
+    const panelsById: Record<string, TerminalInstance> = {};
+    for (const a of agents) panelsById[a.id] = a;
+    usePanelStore.setState({ panelsById, panelIds: ids });
+    useFleetArmingStore.getState().armIds(ids);
+
+    let batchCount = 0;
+    const origAdvance = useFleetBroadcastProgressStore.getState().advance;
+    useFleetBroadcastProgressStore.setState({
+      advance: (b, f) => {
+        batchCount += 1;
+        origAdvance(b, f);
+        if (batchCount === 1) cancelActiveBroadcast();
+      },
+    });
+    try {
+      tryFleetBroadcastFromEditor(ids[0]!, "x".repeat(120_000), vi.fn());
+      // Large payload triggers confirmation flow — resolve it so the
+      // broadcast fires, then the batched path + cancel produce skippedCount>0.
+      resolveFleetBroadcastConfirmation();
+      for (let i = 0; i < 20; i += 1) await flush();
+      const msg = useAnnouncerStore.getState().polite?.msg ?? "";
+      expect(msg).toMatch(/Broadcast cancelled/);
+      expect(msg).toContain("7 terminals skipped");
+    } finally {
+      useFleetBroadcastProgressStore.setState({ advance: origAdvance });
+    }
   });
 
   it("announces partial cancel with both sent and failed counts", async () => {

--- a/src/components/Fleet/fleetEnterBroadcast.ts
+++ b/src/components/Fleet/fleetEnterBroadcast.ts
@@ -24,14 +24,22 @@ function plural(count: number, singular: string, pluralForm: string): string {
 }
 
 function buildBroadcastAnnouncement(result: FleetExecutionResult): string {
+  const skipped =
+    result.skippedCount > 0
+      ? `, ${plural(result.skippedCount, "terminal", "terminals")} skipped`
+      : "";
+
   if (result.cancelled) {
     if (result.successCount === 0 && result.failureCount === 0) {
+      if (result.skippedCount > 0) {
+        return `Broadcast cancelled — ${plural(result.skippedCount, "terminal", "terminals")} skipped`;
+      }
       return "Broadcast cancelled";
     }
     if (result.failureCount > 0) {
-      return `Broadcast cancelled — ${result.successCount} sent, ${result.failureCount} failed`;
+      return `Broadcast cancelled — ${result.successCount} sent, ${result.failureCount} failed${skipped}`;
     }
-    return `Broadcast cancelled — ${result.successCount} sent`;
+    return `Broadcast cancelled — ${result.successCount} sent${skipped}`;
   }
   if (result.failureCount > 0) {
     return `Broadcast sent to ${result.successCount} — ${result.failureCount} failed`;


### PR DESCRIPTION
Fixes #8687.

When a fleet broadcast is cancelled mid-flight, the announcer string was dropping the skipped count -- preempted terminals that never got sent to. So a 12-target broadcast cancelled after 3 sends with 1 failure and 8 skipped read to the user as "3 sent, 1 failed," with no mention of the other 8.

This adds the skipped count to the announcement and tightens the test from a fuzzy contains check to an exact match.

## Changes
- `buildBroadcastAnnouncement` in `fleetEnterBroadcast.ts` now includes `skippedCount` in every cancelled-result branch
- Added a batched-cancel test that asserts the exact announcement string for the skipped-terminals case