### PR TITLE
feat(fleet): add recency fields to FleetSavedScope for frecency ranking

### DIFF
--- a/electron/services/__tests__/projectSettingsCodec.test.ts
+++ b/electron/services/__tests__/projectSettingsCodec.test.ts
@@ -394,4 +394,134 @@ describe("decodeFleetSavedScopes (internal)", () => {
   it("drops invalid entries and returns undefined when all are dropped", () => {
     expect(__internal.decodeFleetSavedScopes([{ garbage: true }])).toBeUndefined();
   });
+
+  it("preserves valid recency fields on a snapshot scope", () => {
+    const result = __internal.decodeFleetSavedScopes([
+      {
+        kind: "snapshot",
+        id: "s1",
+        name: "Recency",
+        terminalIds: ["a"],
+        createdAt: 1700000000000,
+        lastUsedAt: 1710000000000,
+        usageHistory: [1709000000000, 1710000000000],
+      },
+    ]);
+    const scope = result?.[0];
+    expect(scope?.kind).toBe("snapshot");
+    expect((scope as { lastUsedAt?: number } | undefined)?.lastUsedAt).toBe(1710000000000);
+    expect((scope as { usageHistory?: number[] } | undefined)?.usageHistory).toEqual([
+      1709000000000, 1710000000000,
+    ]);
+  });
+
+  it("preserves valid recency fields on a predicate scope", () => {
+    const result = __internal.decodeFleetSavedScopes([
+      {
+        kind: "predicate",
+        id: "p1",
+        name: "Recency",
+        scope: "all",
+        stateFilter: "working",
+        createdAt: 1700000000000,
+        lastUsedAt: 1710000000000,
+        usageHistory: [1709000000000, 1710000000000],
+      },
+    ]);
+    const scope = result?.[0];
+    expect(scope?.kind).toBe("predicate");
+    expect((scope as { lastUsedAt?: number } | undefined)?.lastUsedAt).toBe(1710000000000);
+    expect((scope as { usageHistory?: number[] } | undefined)?.usageHistory).toEqual([
+      1709000000000, 1710000000000,
+    ]);
+  });
+
+  it("decodes a scope without recency fields (backwards compat)", () => {
+    const result = __internal.decodeFleetSavedScopes([
+      {
+        kind: "snapshot",
+        id: "s1",
+        name: "No Recency",
+        terminalIds: ["a"],
+        createdAt: 1700000000000,
+      },
+    ]);
+    const scope = result?.[0];
+    expect(scope).toBeDefined();
+    expect((scope as { lastUsedAt?: unknown } | undefined)?.lastUsedAt).toBeUndefined();
+    expect((scope as { usageHistory?: unknown } | undefined)?.usageHistory).toBeUndefined();
+  });
+
+  it("silently drops malformed lastUsedAt (non-number)", () => {
+    const result = __internal.decodeFleetSavedScopes([
+      {
+        kind: "snapshot",
+        id: "s1",
+        name: "Bad",
+        terminalIds: ["a"],
+        createdAt: 1700000000000,
+        lastUsedAt: "not-a-number",
+      },
+    ]);
+    expect(result?.[0]).toBeDefined();
+    expect((result?.[0] as { lastUsedAt?: unknown } | undefined)?.lastUsedAt).toBeUndefined();
+  });
+
+  it("silently drops malformed lastUsedAt (NaN)", () => {
+    const result = __internal.decodeFleetSavedScopes([
+      {
+        kind: "snapshot",
+        id: "s1",
+        name: "Bad",
+        terminalIds: ["a"],
+        createdAt: 1700000000000,
+        lastUsedAt: NaN,
+      },
+    ]);
+    expect(result?.[0]).toBeDefined();
+    expect((result?.[0] as { lastUsedAt?: unknown } | undefined)?.lastUsedAt).toBeUndefined();
+  });
+
+  it("filters non-finite entries from usageHistory", () => {
+    const result = __internal.decodeFleetSavedScopes([
+      {
+        kind: "snapshot",
+        id: "s1",
+        name: "Bad",
+        terminalIds: ["a"],
+        createdAt: 1700000000000,
+        usageHistory: [1709000000000, "bad", NaN, Infinity, 1710000000000],
+      },
+    ]);
+    const history = (result?.[0] as { usageHistory?: number[] } | undefined)?.usageHistory;
+    expect(history).toEqual([1709000000000, 1710000000000]);
+  });
+
+  it("drops usageHistory when it is not an array", () => {
+    const result = __internal.decodeFleetSavedScopes([
+      {
+        kind: "snapshot",
+        id: "s1",
+        name: "Bad",
+        terminalIds: ["a"],
+        createdAt: 1700000000000,
+        usageHistory: "not-an-array",
+      },
+    ]);
+    expect((result?.[0] as { usageHistory?: unknown } | undefined)?.usageHistory).toBeUndefined();
+  });
+
+  it("drops usageHistory when filtered result is empty", () => {
+    const result = __internal.decodeFleetSavedScopes([
+      {
+        kind: "snapshot",
+        id: "s1",
+        name: "Bad",
+        terminalIds: ["a"],
+        createdAt: 1700000000000,
+        usageHistory: ["all", "bad", "entries"],
+      },
+    ]);
+    expect((result?.[0] as { usageHistory?: unknown } | undefined)?.usageHistory).toBeUndefined();
+  });
 });

--- a/electron/services/projectSettingsCodec.ts
+++ b/electron/services/projectSettingsCodec.ts
@@ -18,9 +18,11 @@ import type {
   CopyTreeSettings,
   DaintreeMcpTier,
   FleetSavedScope,
+  PredicateFleetSavedScope,
   ProjectSettings,
   ProjectTerminalSettings,
   ResourceEnvironment,
+  SnapshotFleetSavedScope,
 } from "../../shared/types/project.js";
 import type { CommandOverride } from "../../shared/types/commands.js";
 import type { NotificationSettings } from "../../shared/types/ipc/api.js";
@@ -151,27 +153,41 @@ function decodeFleetSavedScopes(raw: unknown): FleetSavedScope[] | undefined {
     if (typeof o.id !== "string" || !o.id.trim()) continue;
     if (typeof o.name !== "string" || !o.name.trim()) continue;
     if (typeof o.createdAt !== "number" || !Number.isFinite(o.createdAt)) continue;
+
+    const lastUsedAt =
+      typeof o.lastUsedAt === "number" && Number.isFinite(o.lastUsedAt) ? o.lastUsedAt : undefined;
+    const usageHistory = Array.isArray(o.usageHistory)
+      ? o.usageHistory.filter((t): t is number => typeof t === "number" && Number.isFinite(t))
+      : undefined;
+    const usageHistoryFiltered = usageHistory && usageHistory.length > 0 ? usageHistory : undefined;
+
     if (o.kind === "snapshot") {
       if (!Array.isArray(o.terminalIds)) continue;
       const terminalIds = o.terminalIds.filter((t): t is string => typeof t === "string");
-      out.push({
+      const scope: SnapshotFleetSavedScope = {
         kind: "snapshot",
         id: o.id,
         name: o.name,
         terminalIds,
         createdAt: o.createdAt,
-      });
+      };
+      if (lastUsedAt !== undefined) scope.lastUsedAt = lastUsedAt;
+      if (usageHistoryFiltered !== undefined) scope.usageHistory = usageHistoryFiltered;
+      out.push(scope);
     } else if (o.kind === "predicate") {
       if (typeof o.scope !== "string" || !VALID_PREDICATE_SCOPES.has(o.scope)) continue;
       if (typeof o.stateFilter !== "string" || !VALID_PREDICATE_STATES.has(o.stateFilter)) continue;
-      out.push({
+      const scope: PredicateFleetSavedScope = {
         kind: "predicate",
         id: o.id,
         name: o.name,
         scope: o.scope as "current" | "all",
         stateFilter: o.stateFilter as "all" | "working" | "waiting" | "finished",
         createdAt: o.createdAt,
-      });
+      };
+      if (lastUsedAt !== undefined) scope.lastUsedAt = lastUsedAt;
+      if (usageHistoryFiltered !== undefined) scope.usageHistory = usageHistoryFiltered;
+      out.push(scope);
     }
   }
   return out.length > 0 ? out : undefined;

--- a/electron/services/projectSettingsCodec.ts
+++ b/electron/services/projectSettingsCodec.ts
@@ -159,7 +159,8 @@ function decodeFleetSavedScopes(raw: unknown): FleetSavedScope[] | undefined {
     const usageHistory = Array.isArray(o.usageHistory)
       ? o.usageHistory.filter((t): t is number => typeof t === "number" && Number.isFinite(t))
       : undefined;
-    const usageHistoryFiltered = usageHistory && usageHistory.length > 0 ? usageHistory : undefined;
+    const usageHistoryFiltered =
+      usageHistory && usageHistory.length > 0 ? usageHistory.slice(-20) : undefined;
 
     if (o.kind === "snapshot") {
       if (!Array.isArray(o.terminalIds)) continue;

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -305,6 +305,10 @@ export interface SnapshotFleetSavedScope {
   name: string;
   terminalIds: string[];
   createdAt: number;
+  /** Timestamp of last run (milliseconds since epoch) */
+  lastUsedAt?: number;
+  /** Timestamps of recent runs for frecency scoring (capped at 20 entries) */
+  usageHistory?: number[];
 }
 
 /** Predicate fleet scope: stores a filter rule that is re-evaluated against the current panel set on recall. */
@@ -316,6 +320,10 @@ export interface PredicateFleetSavedScope {
   /** "all" maps to armAll(scope); "working"/"waiting"/"finished" map to armByState(preset, scope, false). */
   stateFilter: "all" | "working" | "waiting" | "finished";
   createdAt: number;
+  /** Timestamp of last run (milliseconds since epoch) */
+  lastUsedAt?: number;
+  /** Timestamps of recent runs for frecency scoring (capped at 20 entries) */
+  usageHistory?: number[];
 }
 
 /** A saved fleet scope — a named selection persisted per-project for quick recall. */

--- a/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
@@ -379,8 +379,11 @@ describe("fleet.recallNamedFleet", () => {
     await run(registry, "fleet.recallNamedFleet", { id: "p1" });
 
     expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
-    // Saved scopes were never modified by recall — only save/delete may write.
-    expect(saveSettingsMock).not.toHaveBeenCalled();
+    // Recall stamps recency on the matched scope even when zero panes
+    // resolve — the user action of recalling the fleet is still a "use".
+    const saved = saveSettingsMock.mock.calls[0]?.[1].fleetSavedScopes[0] as FleetSavedScope;
+    expect(saved.lastUsedAt).toBeGreaterThan(0);
+    expect(saved.usageHistory).toHaveLength(1);
   });
 
   it("predicate stateFilter='all' calls armAll(scope)", async () => {
@@ -450,6 +453,142 @@ describe("fleet.recallNamedFleet", () => {
     expect(armed.has("a")).toBe(true);
     expect(armed.has("c")).toBe(true);
     expect(armed.has("b")).toBe(false);
+  });
+
+  it("stamps lastUsedAt and usageHistory on recall with no prior recency", async () => {
+    seedPanels([makeAgent("a")]);
+    const scope: FleetSavedScope = {
+      kind: "snapshot",
+      id: "s1",
+      name: "Snap",
+      terminalIds: ["a"],
+      createdAt: 1,
+    };
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [scope] });
+    saveSettingsMock.mockResolvedValue(undefined);
+    useProjectSettingsStore.setState({ projectId: "proj-1", settings: null });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "s1" });
+
+    const settings = saveSettingsMock.mock.calls[0]?.[1];
+    expect(settings).toBeDefined();
+    const saved = settings.fleetSavedScopes[0] as FleetSavedScope;
+    expect(saved.lastUsedAt).toBeGreaterThan(0);
+    expect(saved.usageHistory).toHaveLength(1);
+    expect(saved.usageHistory?.[0]).toBe(saved.lastUsedAt);
+  });
+
+  it("appends to existing usageHistory and caps at 20", async () => {
+    seedPanels([makeAgent("a")]);
+    const priorHistory = Array.from({ length: 19 }, (_, i) => 1000 + i);
+    const scope: FleetSavedScope = {
+      kind: "snapshot",
+      id: "s1",
+      name: "Snap",
+      terminalIds: ["a"],
+      createdAt: 1,
+      lastUsedAt: priorHistory[priorHistory.length - 1],
+      usageHistory: [...priorHistory],
+    };
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [scope] });
+    saveSettingsMock.mockResolvedValue(undefined);
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "s1" });
+
+    const saved = saveSettingsMock.mock.calls[0]?.[1].fleetSavedScopes[0] as FleetSavedScope;
+    expect(saved.usageHistory).toHaveLength(20);
+    // First 19 entries preserved, newest appended
+    expect(saved.usageHistory?.slice(0, 19)).toEqual(priorHistory);
+    expect(saved.usageHistory?.[19]).toBeGreaterThan(priorHistory[priorHistory.length - 1]!);
+  });
+
+  it("does not mutate unrelated scopes when stamping recency", async () => {
+    seedPanels([makeAgent("a")]);
+    const unrelated: FleetSavedScope = {
+      kind: "predicate",
+      id: "p1",
+      name: "Other",
+      scope: "all",
+      stateFilter: "working",
+      createdAt: 1,
+    };
+    const target: FleetSavedScope = {
+      kind: "snapshot",
+      id: "s1",
+      name: "Target",
+      terminalIds: ["a"],
+      createdAt: 1,
+    };
+    getSettingsMock.mockResolvedValue({
+      runCommands: [],
+      fleetSavedScopes: [unrelated, target],
+    });
+    saveSettingsMock.mockResolvedValue(undefined);
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "s1" });
+
+    const saved = saveSettingsMock.mock.calls[0]?.[1].fleetSavedScopes;
+    expect(saved).toHaveLength(2);
+    const unrelatedSaved = saved[0] as FleetSavedScope;
+    expect(unrelatedSaved.lastUsedAt).toBeUndefined();
+    expect(unrelatedSaved.usageHistory).toBeUndefined();
+  });
+
+  it("writes through to useProjectSettingsStore after stamping", async () => {
+    seedPanels([makeAgent("a")]);
+    const scope: FleetSavedScope = {
+      kind: "snapshot",
+      id: "s1",
+      name: "Snap",
+      terminalIds: ["a"],
+      createdAt: 1,
+    };
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [scope] });
+    saveSettingsMock.mockResolvedValue(undefined);
+    useProjectSettingsStore.setState({ projectId: "proj-1", settings: null });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "s1" });
+
+    const storeScopes = useProjectSettingsStore.getState().settings?.fleetSavedScopes;
+    expect(storeScopes).toHaveLength(1);
+    const stored = storeScopes?.[0] as FleetSavedScope | undefined;
+    expect(stored?.lastUsedAt).toBeGreaterThan(0);
+    expect(stored?.usageHistory).toHaveLength(1);
+  });
+
+  it("missing-id recall does not call saveSettings", async () => {
+    seedPanels([makeAgent("a")]);
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [] });
+    saveSettingsMock.mockResolvedValue(undefined);
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "missing" });
+
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("aborts the recency write when the project switches mid-recall", async () => {
+    seedPanels([makeAgent("a")]);
+    const scope: FleetSavedScope = {
+      kind: "snapshot",
+      id: "s1",
+      name: "Snap",
+      terminalIds: ["a"],
+      createdAt: 1,
+    };
+    getSettingsMock.mockImplementation(async () => {
+      setCurrentProject("proj-2");
+      return { runCommands: [], fleetSavedScopes: [scope] };
+    });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "s1" });
+
+    expect(saveSettingsMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -455,6 +455,18 @@ export function registerFleetActions(actions: ActionRegistry): void {
         const scope = (current.fleetSavedScopes ?? []).find((s) => s.id === id);
         if (!scope) return;
         applySavedScope(scope);
+
+        const now = Date.now();
+        scope.lastUsedAt = now;
+        scope.usageHistory = [...(scope.usageHistory ?? []), now].slice(-20);
+
+        if (useProjectStore.getState().currentProject?.id !== projectId) return;
+        projectClient.saveSettings(projectId, current).catch((err) => {
+          console.warn("Failed to persist fleet recency stamp:", err);
+        });
+        if (useProjectSettingsStore.getState().projectId === projectId) {
+          useProjectSettingsStore.getState().setSettings(current);
+        }
       } catch (error) {
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
         notify({


### PR DESCRIPTION
## Summary
Adds `lastUsedAt` and `usageHistory` fields to `FleetSavedScope` so saved fleet scopes can be ranked by recent use. This mirrors the pattern `TerminalRecipe` already uses. The fields are stamped when a saved fleet is recalled, with codec-level validation that handles malformed data and backwards compat gracefully.

Resolves #8692

## Changes
- Added optional `lastUsedAt` and `usageHistory` fields to `SnapshotFleetSavedScope` and `PredicateFleetSavedScope` in shared types
- Extended `decodeFleetSavedScopes` to parse, validate, and cap the new fields at 20 entries
- Stamped recency on recall in the `fleet.recallNamedFleet` action, writing through to project settings
- Added test coverage for: valid recency parsing, malformed data rejection, backwards compat, usageHistory capping at 20, unrelated scope isolation, store write-through, and project-switch abort

## Testing
- Ran the full test suite for the affected modules (`projectSettingsCodec.test.ts`, `savedFleetActions.test.ts`)
- Typechecked, lint, and format all pass