### PR TITLE
feat(fleet): split saved fleets into Pinned and Smart-Sets sections

### DIFF
--- a/src/components/Fleet/SavedFleetRow.tsx
+++ b/src/components/Fleet/SavedFleetRow.tsx
@@ -19,8 +19,9 @@ export function SavedFleetRow({ scope, onRequestDelete }: SavedFleetRowProps): R
   const isStale = scope.kind === "snapshot" && count === 0;
   return (
     <DropdownMenuItem
-      disabled={isStale}
+      aria-disabled={isStale || undefined}
       onSelect={() => {
+        if (isStale) return;
         void actionService.dispatch("fleet.recallNamedFleet", { id: scope.id }, { source: "user" });
       }}
       data-testid="fleet-saved-row"

--- a/src/components/Fleet/SavedFleetRow.tsx
+++ b/src/components/Fleet/SavedFleetRow.tsx
@@ -16,13 +16,15 @@ export function SavedFleetRow({ scope, onRequestDelete }: SavedFleetRowProps): R
   // need for a panelStore subscription that would burn cycles while closed.
   const count = computeSavedScopePaneCount(scope);
   const flavorLabel = scope.kind === "snapshot" ? "Snapshot" : "Live";
+  const isStale = scope.kind === "snapshot" && count === 0;
   return (
     <DropdownMenuItem
+      disabled={isStale}
       onSelect={() => {
         void actionService.dispatch("fleet.recallNamedFleet", { id: scope.id }, { source: "user" });
       }}
       data-testid="fleet-saved-row"
-      className="flex items-center gap-2"
+      className={isStale ? "flex items-center gap-2 opacity-50" : "flex items-center gap-2"}
     >
       <span className="flex-1 truncate">{scope.name}</span>
       <span className="text-[10px] text-daintree-text/50 tabular-nums">

--- a/src/components/Fleet/SavedFleetsSection.tsx
+++ b/src/components/Fleet/SavedFleetsSection.tsx
@@ -2,7 +2,11 @@ import type { ReactElement } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
-import { DropdownMenuLabel, DropdownMenuSeparator } from "@/components/ui/dropdown-menu";
+import {
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
 import { SavedFleetRow } from "./SavedFleetRow";
 import { SaveFleetForm } from "./SaveFleetForm";
 
@@ -10,22 +14,47 @@ interface SavedFleetsSectionProps {
   onRequestDelete: (id: string) => void;
 }
 
+const PRESET_PREDICATE_KEYS = new Set([
+  "waiting:current",
+  "waiting:all",
+  "working:current",
+  "working:all",
+  "all:current",
+]);
+
+function isPresetPredicate(scope: { kind: string; stateFilter?: string; scope?: string }): boolean {
+  if (scope.kind !== "predicate") return false;
+  return PRESET_PREDICATE_KEYS.has(`${scope.stateFilter}:${scope.scope}`);
+}
+
 export function SavedFleetsSection({ onRequestDelete }: SavedFleetsSectionProps): ReactElement {
   const armedCount = useFleetArmingStore((s) => s.armedIds.size);
   const savedScopes = useProjectSettingsStore(
     useShallow((s) => s.settings?.fleetSavedScopes ?? [])
   );
+
+  const snapshotScopes = savedScopes.filter((s) => s.kind === "snapshot");
+  const smartSetScopes = savedScopes.filter((s) => s.kind === "predicate" && !isPresetPredicate(s));
+
   return (
     <>
       <DropdownMenuSeparator />
-      {savedScopes.length > 0 ? (
-        <>
-          <DropdownMenuLabel>Saved fleets</DropdownMenuLabel>
-          {savedScopes.map((scope) => (
+      {snapshotScopes.length > 0 && (
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Pinned</DropdownMenuLabel>
+          {snapshotScopes.map((scope) => (
             <SavedFleetRow key={scope.id} scope={scope} onRequestDelete={onRequestDelete} />
           ))}
-        </>
-      ) : null}
+        </DropdownMenuGroup>
+      )}
+      {smartSetScopes.length > 0 && (
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Smart-Sets</DropdownMenuLabel>
+          {smartSetScopes.map((scope) => (
+            <SavedFleetRow key={scope.id} scope={scope} onRequestDelete={onRequestDelete} />
+          ))}
+        </DropdownMenuGroup>
+      )}
       <SaveFleetForm armedCount={armedCount} />
     </>
   );

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -67,6 +67,9 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
       {children}
     </div>
   ),
+  DropdownMenuGroup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dropdown-group">{children}</div>
+  ),
   DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DropdownMenuSeparator: () => <hr />,
 }));

--- a/src/components/Fleet/__tests__/SavedFleetsSection.test.tsx
+++ b/src/components/Fleet/__tests__/SavedFleetsSection.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+
+vi.mock("framer-motion", () => {
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ children, ...props }, ref) => (
+      <div ref={ref} {...props}>
+        {children}
+      </div>
+    )
+  );
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    domAnimation: {},
+    domMax: {},
+    m: { div: MotionDiv },
+    motion: { div: MotionDiv },
+    useReducedMotion: () => false,
+  };
+});
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuGroup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dropdown-group">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+    disabled?: boolean;
+  }) => (
+    <div
+      role="menuitem"
+      data-disabled={disabled ? "true" : undefined}
+      onClick={(e) => {
+        if (disabled) return;
+        onSelect?.(e as unknown as Event);
+      }}
+    >
+      {children}
+    </div>
+  ),
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/actions/definitions/fleetActions", () => ({
+  computeSavedScopePaneCount: vi.fn((scope: { terminalIds?: string[]; stateFilter?: string }) => {
+    if (scope.terminalIds) return scope.terminalIds.length;
+    return 3;
+  }),
+}));
+
+import { SavedFleetsSection } from "../SavedFleetsSection";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import type { FleetSavedScope } from "@shared/types";
+
+const SNAPSHOT_A: FleetSavedScope = {
+  kind: "snapshot",
+  id: "snap-a",
+  name: "My terminals",
+  terminalIds: ["t1", "t2"],
+  createdAt: 1000,
+};
+
+const SNAPSHOT_B: FleetSavedScope = {
+  kind: "snapshot",
+  id: "snap-b",
+  name: "Stale snapshot",
+  terminalIds: [],
+  createdAt: 2000,
+};
+
+const PREDICATE_WAITING_CURRENT: FleetSavedScope = {
+  kind: "predicate",
+  id: "pred-wc",
+  name: "Waiting here",
+  stateFilter: "waiting",
+  scope: "current",
+  createdAt: 3000,
+};
+
+const PREDICATE_WORKING_ALL: FleetSavedScope = {
+  kind: "predicate",
+  id: "pred-wa",
+  name: "Working all",
+  stateFilter: "working",
+  scope: "all",
+  createdAt: 4000,
+};
+
+const PREDICATE_ALL_CURRENT: FleetSavedScope = {
+  kind: "predicate",
+  id: "pred-ac",
+  name: "All current",
+  stateFilter: "all",
+  scope: "current",
+  createdAt: 5000,
+};
+
+const PREDICATE_FINISHED_CURRENT: FleetSavedScope = {
+  kind: "predicate",
+  id: "pred-fc",
+  name: "Finished here",
+  stateFilter: "finished",
+  scope: "current",
+  createdAt: 6000,
+};
+
+const PREDICATE_ALL_ALL: FleetSavedScope = {
+  kind: "predicate",
+  id: "pred-aa",
+  name: "All everything",
+  stateFilter: "all",
+  scope: "all",
+  createdAt: 7000,
+};
+
+function setSavedScopes(scopes: FleetSavedScope[]) {
+  useProjectSettingsStore.setState({
+    settings: {
+      fleetSavedScopes: scopes,
+    },
+  } as any);
+}
+
+beforeEach(() => {
+  useProjectSettingsStore.setState({ settings: {} } as any);
+  useFleetArmingStore.setState({ armedIds: new Set() });
+});
+
+describe("SavedFleetsSection", () => {
+  it("renders snapshots under Pinned label", () => {
+    setSavedScopes([SNAPSHOT_A, SNAPSHOT_B]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    expect(screen.getByText("Pinned")).toBeDefined();
+    expect(screen.getByText("My terminals")).toBeDefined();
+    expect(screen.getByText("Stale snapshot")).toBeDefined();
+  });
+
+  it("renders non-preset predicates under Smart-Sets label", () => {
+    setSavedScopes([PREDICATE_FINISHED_CURRENT, PREDICATE_ALL_ALL]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    expect(screen.getByText("Smart-Sets")).toBeDefined();
+    expect(screen.getByText("Finished here")).toBeDefined();
+    expect(screen.getByText("All everything")).toBeDefined();
+  });
+
+  it("suppresses predicates matching hardcoded presets", () => {
+    setSavedScopes([
+      PREDICATE_WAITING_CURRENT,
+      PREDICATE_WAITING_CURRENT, // same combo as preset
+      PREDICATE_WORKING_ALL, // same combo as preset
+      PREDICATE_ALL_CURRENT, // same combo as preset (armAll current)
+      PREDICATE_FINISHED_CURRENT, // not a preset
+    ]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    // Only the non-preset predicate should appear
+    expect(screen.getByText("Smart-Sets")).toBeDefined();
+    expect(screen.getByText("Finished here")).toBeDefined();
+    expect(screen.queryByText("Waiting here")).toBeNull();
+    expect(screen.queryByText("Working all")).toBeNull();
+    expect(screen.queryByText("All current")).toBeNull();
+  });
+
+  it("shows both sections when both kinds exist", () => {
+    setSavedScopes([SNAPSHOT_A, PREDICATE_FINISHED_CURRENT]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    expect(screen.getByText("Pinned")).toBeDefined();
+    expect(screen.getByText("Smart-Sets")).toBeDefined();
+    expect(screen.getByText("My terminals")).toBeDefined();
+    expect(screen.getByText("Finished here")).toBeDefined();
+  });
+
+  it("shows only Pinned when no non-preset predicates exist", () => {
+    setSavedScopes([SNAPSHOT_A, PREDICATE_WAITING_CURRENT]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    expect(screen.getByText("Pinned")).toBeDefined();
+    expect(screen.queryByText("Smart-Sets")).toBeNull();
+  });
+
+  it("shows only Smart-Sets when no snapshots exist", () => {
+    setSavedScopes([PREDICATE_FINISHED_CURRENT]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    expect(screen.queryByText("Pinned")).toBeNull();
+    expect(screen.getByText("Smart-Sets")).toBeDefined();
+  });
+
+  it("shows neither section label when no saved scopes exist", () => {
+    setSavedScopes([]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    expect(screen.queryByText("Pinned")).toBeNull();
+    expect(screen.queryByText("Smart-Sets")).toBeNull();
+  });
+
+  it("renders stale snapshot with disabled attribute", () => {
+    setSavedScopes([SNAPSHOT_B]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    expect(screen.getByText("Stale snapshot")).toBeDefined();
+    const rows = screen.getAllByRole("menuitem");
+    const staleRow = rows.find((r) => r.textContent?.includes("Stale snapshot"));
+    expect(staleRow).toBeDefined();
+    expect(staleRow!.getAttribute("data-disabled")).toBe("true");
+  });
+
+  it("fires onRequestDelete when delete button clicked", () => {
+    const onDelete = vi.fn();
+    setSavedScopes([SNAPSHOT_A]);
+    render(<SavedFleetsSection onRequestDelete={onDelete} />);
+    const deleteBtn = screen.getByLabelText('Delete fleet "My terminals"');
+    fireEvent.click(deleteBtn);
+    expect(onDelete).toHaveBeenCalledWith("snap-a");
+  });
+});

--- a/src/components/Fleet/__tests__/SavedFleetsSection.test.tsx
+++ b/src/components/Fleet/__tests__/SavedFleetsSection.test.tsx
@@ -269,9 +269,10 @@ describe("SavedFleetsSection", () => {
     render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
     const groups = screen.getAllByTestId("dropdown-group");
     expect(groups).toHaveLength(2);
-    expect(groups[0].textContent).toContain("Pinned");
-    expect(groups[0].textContent).toContain("My terminals");
-    expect(groups[1].textContent).toContain("Smart-Sets");
-    expect(groups[1].textContent).toContain("Finished here");
+    const [first, second] = groups as [HTMLElement, HTMLElement];
+    expect(first.textContent).toContain("Pinned");
+    expect(first.textContent).toContain("My terminals");
+    expect(second.textContent).toContain("Smart-Sets");
+    expect(second.textContent).toContain("Finished here");
   });
 });

--- a/src/components/Fleet/__tests__/SavedFleetsSection.test.tsx
+++ b/src/components/Fleet/__tests__/SavedFleetsSection.test.tsx
@@ -31,18 +31,23 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
     children,
     onSelect,
     disabled,
+    "aria-disabled": ariaDisabled,
+    ...rest
   }: {
     children: React.ReactNode;
     onSelect?: (e: Event) => void;
     disabled?: boolean;
+    "aria-disabled"?: boolean;
   }) => (
     <div
       role="menuitem"
       data-disabled={disabled ? "true" : undefined}
+      aria-disabled={ariaDisabled ? "true" : undefined}
       onClick={(e) => {
         if (disabled) return;
         onSelect?.(e as unknown as Event);
       }}
+      {...rest}
     >
       {children}
     </div>
@@ -64,6 +69,7 @@ vi.mock("@/services/actions/definitions/fleetActions", () => ({
   }),
 }));
 
+import { actionService } from "@/services/ActionService";
 import { SavedFleetsSection } from "../SavedFleetsSection";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
@@ -141,6 +147,7 @@ function setSavedScopes(scopes: FleetSavedScope[]) {
 beforeEach(() => {
   useProjectSettingsStore.setState({ settings: {} } as any);
   useFleetArmingStore.setState({ armedIds: new Set() });
+  vi.clearAllMocks();
 });
 
 describe("SavedFleetsSection", () => {
@@ -207,14 +214,14 @@ describe("SavedFleetsSection", () => {
     expect(screen.queryByText("Smart-Sets")).toBeNull();
   });
 
-  it("renders stale snapshot with disabled attribute", () => {
+  it("renders stale snapshot with aria-disabled", () => {
     setSavedScopes([SNAPSHOT_B]);
     render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
     expect(screen.getByText("Stale snapshot")).toBeDefined();
     const rows = screen.getAllByRole("menuitem");
     const staleRow = rows.find((r) => r.textContent?.includes("Stale snapshot"));
     expect(staleRow).toBeDefined();
-    expect(staleRow!.getAttribute("data-disabled")).toBe("true");
+    expect(staleRow!.getAttribute("aria-disabled")).toBe("true");
   });
 
   it("fires onRequestDelete when delete button clicked", () => {
@@ -224,5 +231,47 @@ describe("SavedFleetsSection", () => {
     const deleteBtn = screen.getByLabelText('Delete fleet "My terminals"');
     fireEvent.click(deleteBtn);
     expect(onDelete).toHaveBeenCalledWith("snap-a");
+  });
+
+  it("fires onRequestDelete when stale snapshot delete button clicked", () => {
+    const onDelete = vi.fn();
+    setSavedScopes([SNAPSHOT_B]);
+    render(<SavedFleetsSection onRequestDelete={onDelete} />);
+    const deleteBtn = screen.getByLabelText('Delete fleet "Stale snapshot"');
+    fireEvent.click(deleteBtn);
+    expect(onDelete).toHaveBeenCalledWith("snap-b");
+  });
+
+  it("dispatches recall when live snapshot row is selected", () => {
+    setSavedScopes([SNAPSHOT_A]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    const rows = screen.getAllByRole("menuitem");
+    const liveRow = rows.find((r) => r.textContent?.includes("My terminals"));
+    fireEvent.click(liveRow!);
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "fleet.recallNamedFleet",
+      { id: "snap-a" },
+      { source: "user" }
+    );
+  });
+
+  it("does not dispatch recall when stale snapshot row is selected", () => {
+    setSavedScopes([SNAPSHOT_B]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    const rows = screen.getAllByRole("menuitem");
+    const staleRow = rows.find((r) => r.textContent?.includes("Stale snapshot"));
+    fireEvent.click(staleRow!);
+    expect(actionService.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("renders Pinned group before Smart-Sets group in DOM order", () => {
+    setSavedScopes([SNAPSHOT_A, PREDICATE_FINISHED_CURRENT]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    const groups = screen.getAllByTestId("dropdown-group");
+    expect(groups).toHaveLength(2);
+    expect(groups[0].textContent).toContain("Pinned");
+    expect(groups[0].textContent).toContain("My terminals");
+    expect(groups[1].textContent).toContain("Smart-Sets");
+    expect(groups[1].textContent).toContain("Finished here");
   });
 });


### PR DESCRIPTION
## Summary
- Splits `SavedFleetsSection` into Pinned (snapshot) and Smart-Sets (predicate) sections so users can tell at a glance whether they're recalling a frozen snapshot or a live query.
- Stale snapshots get `aria-disabled` plus dimmed styling, with an `onSelect` guard that prevents accidental recall.
- Deduplicates predicate presets against those already shown in `FleetArmingRibbon`.

Resolves #8693

## Changes
- `SavedFleetsSection` -- two-section layout with Pinned / Smart-Sets headers, preset dedup logic
- `SavedFleetRow` -- stale-snapshot dimming via `aria-disabled` + `opacity-50` + `onSelect` guard
- 13 new tests covering section split, stale dimming, and preset dedup
- `DropdownMenuGroup` mock added to `FleetArmingRibbon` tests

## Testing
106 tests pass. Typecheck and lint clean.