### PR TITLE
fix(crash-recovery): add destructive confirm gate to reset-to-fresh path

### DIFF
--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -80,6 +80,14 @@ export function CrashRecoveryDialog({
       setResolving(true);
       try {
         await onResolve(action);
+      } catch (err) {
+        // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+        notify({
+          type: "error",
+          title: "Recovery failed",
+          message: formatErrorMessage(err, "Couldn't complete recovery action"),
+          duration: 6000,
+        });
       } finally {
         setResolving(false);
       }
@@ -455,7 +463,9 @@ export function CrashRecoveryDialog({
         description={
           hasPanels
             ? "All open panels listed below will be closed and their state will be discarded."
-            : "Your session will start with a clean layout."
+            : crash.hasBackup
+              ? "Your session will start with a clean layout and the existing session backup will be discarded."
+              : "Your session will start with a clean layout."
         }
         confirmLabel="Reset to clean layout"
         variant="destructive"

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -14,6 +14,7 @@ import {
 import { Plug } from "@/components/icons";
 import { AppDialog } from "../ui/AppDialog";
 import { Button } from "../ui/button";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { AnimatedLabel } from "../ui/AnimatedLabel";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
@@ -66,6 +67,7 @@ export function CrashRecoveryDialog({
   const [resolving, setResolving] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [privacyWarningShown, setPrivacyWarningShown] = useState(false);
+  const [showFreshConfirm, setShowFreshConfirm] = useState(false);
   const { copied, copy } = useCopyWithFeedback();
   const { copied: stackCopied, copy: copyStack } = useCopyWithFeedback();
 
@@ -96,6 +98,11 @@ export function CrashRecoveryDialog({
   const handleFresh = useCallback(() => {
     handleResolve({ kind: "fresh" });
   }, [handleResolve]);
+
+  const handleFreshConfirm = useCallback(() => {
+    setShowFreshConfirm(false);
+    handleFresh();
+  }, [handleFresh]);
 
   const togglePanel = useCallback((id: string) => {
     setSelectedIds((prev) => {
@@ -156,289 +163,317 @@ export function CrashRecoveryDialog({
   const crashDate = new Date(crash.entry.timestamp).toLocaleString();
 
   return (
-    <AppDialog
-      isOpen={true}
-      onClose={() => {}}
-      dismissible={false}
-      size="md"
-      data-testid="crash-recovery-dialog"
-    >
-      <AppDialog.Header>
-        <AppDialog.Title icon={<AlertTriangle className="h-5 w-5 text-status-warning" />}>
-          Daintree closed unexpectedly
-        </AppDialog.Title>
-      </AppDialog.Header>
+    <>
+      <AppDialog
+        isOpen={true}
+        onClose={() => {}}
+        dismissible={false}
+        size="md"
+        data-testid="crash-recovery-dialog"
+      >
+        <AppDialog.Header>
+          <AppDialog.Title icon={<AlertTriangle className="h-5 w-5 text-status-warning" />}>
+            Daintree closed unexpectedly
+          </AppDialog.Title>
+        </AppDialog.Header>
 
-      <AppDialog.Body className="space-y-4">
-        <p className="text-sm text-daintree-text/80">
-          The previous session ended unexpectedly on {crashDate}.
-          {hasPanels ? " Select which panels to restore:" : " Choose how to continue:"}
-        </p>
+        <AppDialog.Body className="space-y-4">
+          <p className="text-sm text-daintree-text/80">
+            The previous session ended unexpectedly on {crashDate}.
+            {hasPanels ? " Select which panels to restore:" : " Choose how to continue:"}
+          </p>
 
-        {hasPanels ? (
-          <>
-            <div className="border border-daintree-border rounded-lg overflow-hidden">
-              <div className="flex items-center justify-between px-3 py-2 bg-overlay-soft border-b border-daintree-border">
-                <button
-                  type="button"
-                  onClick={toggleAll}
-                  className="cursor-pointer text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors"
-                  data-testid="toggle-all-button"
+          {hasPanels ? (
+            <>
+              <div className="border border-daintree-border rounded-lg overflow-hidden">
+                <div className="flex items-center justify-between px-3 py-2 bg-overlay-soft border-b border-daintree-border">
+                  <button
+                    type="button"
+                    onClick={toggleAll}
+                    className="cursor-pointer text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors"
+                    data-testid="toggle-all-button"
+                  >
+                    {allSelected ? "Deselect all" : "Select all"}
+                  </button>
+                  <span className="text-xs tabular-nums text-daintree-text/50">
+                    {selectedCount} of {panels.length} selected
+                  </span>
+                </div>
+                <div
+                  className="max-h-48 overflow-y-auto divide-y divide-daintree-border/50"
+                  data-testid="panel-list"
                 >
-                  {allSelected ? "Deselect all" : "Select all"}
-                </button>
-                <span className="text-xs tabular-nums text-daintree-text/50">
-                  {selectedCount} of {panels.length} selected
-                </span>
+                  {panels.map((panel) => (
+                    <PanelRow
+                      key={panel.id}
+                      panel={panel}
+                      selected={selectedIds.has(panel.id)}
+                      onToggle={togglePanel}
+                    />
+                  ))}
+                </div>
               </div>
-              <div
-                className="max-h-48 overflow-y-auto divide-y divide-daintree-border/50"
-                data-testid="panel-list"
-              >
-                {panels.map((panel) => (
-                  <PanelRow
-                    key={panel.id}
-                    panel={panel}
-                    selected={selectedIds.has(panel.id)}
-                    onToggle={togglePanel}
-                  />
-                ))}
+
+              {suspectCount > 0 && (
+                <p
+                  className="text-xs text-status-warning/90 bg-status-warning/10 rounded px-2 py-1.5"
+                  data-testid="suspect-warning"
+                >
+                  <span className="tabular-nums">{suspectCount}</span> panel
+                  {suspectCount > 1 ? "s were" : " was"} created shortly before the crash and may be
+                  related.
+                </p>
+              )}
+
+              <div className="flex gap-2">
+                <Button
+                  onClick={handleRestoreSelected}
+                  disabled={resolving || selectedCount === 0}
+                  className="flex-1"
+                  data-testid="restore-selected-button"
+                >
+                  Restore selected (<span className="tabular-nums">{selectedCount}</span>)
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => setShowFreshConfirm(true)}
+                  disabled={resolving || showFreshConfirm}
+                  data-testid="fresh-button"
+                >
+                  Continue without restoring
+                </Button>
               </div>
-            </div>
 
-            {suspectCount > 0 && (
-              <p
-                className="text-xs text-status-warning/90 bg-status-warning/10 rounded px-2 py-1.5"
-                data-testid="suspect-warning"
-              >
-                <span className="tabular-nums">{suspectCount}</span> panel
-                {suspectCount > 1 ? "s were" : " was"} created shortly before the crash and may be
-                related.
-              </p>
-            )}
-
-            <div className="flex gap-2">
-              <Button
-                onClick={handleRestoreSelected}
-                disabled={resolving || selectedCount === 0}
-                className="flex-1"
-                data-testid="restore-selected-button"
-              >
-                Restore selected (<span className="tabular-nums">{selectedCount}</span>)
-              </Button>
-              <Button
-                variant="ghost"
-                onClick={handleFresh}
+              {backupDate && (
+                <p className="text-xs text-daintree-text/50">Session backup from {backupDate}</p>
+              )}
+            </>
+          ) : (
+            <div className="flex flex-col gap-2">
+              <button
+                type="button"
+                onClick={handleRestoreAll}
                 disabled={resolving}
+                className="cursor-pointer flex items-start gap-3 p-3 rounded-lg border border-daintree-border hover:border-daintree-accent hover:bg-overlay-soft text-left transition-colors disabled:opacity-50 disabled:pointer-events-none"
+                data-testid="restore-button"
+              >
+                <div className="mt-0.5 h-5 w-5 rounded-full bg-overlay-medium flex items-center justify-center shrink-0">
+                  <div className="h-2 w-2 rounded-full bg-daintree-text/40" />
+                </div>
+                <div>
+                  <div className="text-sm font-medium text-daintree-text">
+                    Restore previous session
+                  </div>
+                  {backupDate ? (
+                    <div className="text-xs text-daintree-text/60 mt-0.5">
+                      Restore session from {backupDate}
+                    </div>
+                  ) : (
+                    <div className="text-xs text-daintree-text/60 mt-0.5">
+                      No backup available — layout may be empty
+                    </div>
+                  )}
+                </div>
+              </button>
+
+              <button
+                type="button"
+                onClick={() => setShowFreshConfirm(true)}
+                disabled={resolving || showFreshConfirm}
+                className="cursor-pointer flex items-start gap-3 p-3 rounded-lg border border-daintree-border hover:border-daintree-border/80 hover:bg-overlay-soft text-left transition-colors disabled:opacity-50 disabled:pointer-events-none"
                 data-testid="fresh-button"
               >
-                Continue without restoring
-              </Button>
+                <div className="mt-0.5 h-5 w-5 rounded-full bg-daintree-text/10 flex items-center justify-center shrink-0">
+                  <div className="h-2 w-2 rounded-full bg-daintree-text/40" />
+                </div>
+                <div>
+                  <div className="text-sm font-medium text-daintree-text">
+                    Continue without restoring
+                  </div>
+                  <div className="text-xs text-daintree-text/60 mt-0.5">
+                    Reset to a clean layout — open panels will be cleared
+                  </div>
+                </div>
+              </button>
             </div>
+          )}
 
-            {backupDate && (
-              <p className="text-xs text-daintree-text/50">Session backup from {backupDate}</p>
-            )}
-          </>
-        ) : (
-          <div className="flex flex-col gap-2">
+          <div className="border border-daintree-border rounded-lg overflow-hidden">
             <button
               type="button"
-              onClick={handleRestoreAll}
-              disabled={resolving}
-              className="cursor-pointer flex items-start gap-3 p-3 rounded-lg border border-daintree-border hover:border-daintree-accent hover:bg-overlay-soft text-left transition-colors disabled:opacity-50 disabled:pointer-events-none"
-              data-testid="restore-button"
+              onClick={() => setDetailsOpen((o) => !o)}
+              className="cursor-pointer w-full flex items-center justify-between px-3 py-2 text-sm text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
+              data-testid="details-toggle"
             >
-              <div className="mt-0.5 h-5 w-5 rounded-full bg-overlay-medium flex items-center justify-center shrink-0">
-                <div className="h-2 w-2 rounded-full bg-daintree-text/40" />
-              </div>
-              <div>
-                <div className="text-sm font-medium text-daintree-text">
-                  Restore previous session
-                </div>
-                {backupDate ? (
-                  <div className="text-xs text-daintree-text/60 mt-0.5">
-                    Restore session from {backupDate}
-                  </div>
-                ) : (
-                  <div className="text-xs text-daintree-text/60 mt-0.5">
-                    No backup available — layout may be empty
+              <span className="font-medium">Error details</span>
+              {detailsOpen ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+            </button>
+
+            {detailsOpen && (
+              <div
+                className="px-3 pb-3 space-y-2 border-t border-daintree-border"
+                data-testid="details-section"
+              >
+                <DetailRow label="App version" value={crash.entry.appVersion} />
+                <DetailRow label="Platform" value={`${crash.entry.platform} ${crash.entry.arch}`} />
+                <DetailRow label="OS version" value={crash.entry.osVersion} />
+                {crash.entry.sessionDurationMs !== undefined && (
+                  <DetailRow
+                    label="Session duration"
+                    value={formatDuration(crash.entry.sessionDurationMs)}
+                  />
+                )}
+                {crash.entry.electronVersion && (
+                  <DetailRow label="Electron" value={crash.entry.electronVersion} />
+                )}
+                {crash.entry.totalMemory !== undefined && (
+                  <DetailRow
+                    label="Memory"
+                    value={`${formatBytesCompact(crash.entry.freeMemory ?? 0)} free / ${formatBytesCompact(crash.entry.totalMemory)} total`}
+                  />
+                )}
+                {crash.entry.panelCount !== undefined && (
+                  <DetailRow label="Panels" value={String(crash.entry.panelCount)} />
+                )}
+                {crash.entry.processUptime !== undefined && (
+                  <DetailRow
+                    label="Process uptime"
+                    value={formatDuration(crash.entry.processUptime * 1000)}
+                  />
+                )}
+                {crash.entry.errorMessage && (
+                  <div className="mt-2">
+                    <div className="text-xs text-daintree-text/50 mb-1">Error</div>
+                    <pre className="text-xs text-status-danger bg-status-danger/10 rounded p-2 overflow-x-auto whitespace-pre-wrap break-all select-text">
+                      {crash.entry.errorMessage}
+                    </pre>
                   </div>
                 )}
-              </div>
-            </button>
-
-            <button
-              type="button"
-              onClick={handleFresh}
-              disabled={resolving}
-              className="cursor-pointer flex items-start gap-3 p-3 rounded-lg border border-daintree-border hover:border-daintree-border/80 hover:bg-overlay-soft text-left transition-colors disabled:opacity-50 disabled:pointer-events-none"
-              data-testid="fresh-button"
-            >
-              <div className="mt-0.5 h-5 w-5 rounded-full bg-daintree-text/10 flex items-center justify-center shrink-0">
-                <div className="h-2 w-2 rounded-full bg-daintree-text/40" />
-              </div>
-              <div>
-                <div className="text-sm font-medium text-daintree-text">
-                  Continue without restoring
-                </div>
-                <div className="text-xs text-daintree-text/60 mt-0.5">
-                  Reset to a clean layout — open panels will be cleared
-                </div>
-              </div>
-            </button>
-          </div>
-        )}
-
-        <div className="border border-daintree-border rounded-lg overflow-hidden">
-          <button
-            type="button"
-            onClick={() => setDetailsOpen((o) => !o)}
-            className="cursor-pointer w-full flex items-center justify-between px-3 py-2 text-sm text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
-            data-testid="details-toggle"
-          >
-            <span className="font-medium">Error details</span>
-            {detailsOpen ? (
-              <ChevronDown className="h-4 w-4" />
-            ) : (
-              <ChevronRight className="h-4 w-4" />
-            )}
-          </button>
-
-          {detailsOpen && (
-            <div
-              className="px-3 pb-3 space-y-2 border-t border-daintree-border"
-              data-testid="details-section"
-            >
-              <DetailRow label="App version" value={crash.entry.appVersion} />
-              <DetailRow label="Platform" value={`${crash.entry.platform} ${crash.entry.arch}`} />
-              <DetailRow label="OS version" value={crash.entry.osVersion} />
-              {crash.entry.sessionDurationMs !== undefined && (
-                <DetailRow
-                  label="Session duration"
-                  value={formatDuration(crash.entry.sessionDurationMs)}
-                />
-              )}
-              {crash.entry.electronVersion && (
-                <DetailRow label="Electron" value={crash.entry.electronVersion} />
-              )}
-              {crash.entry.totalMemory !== undefined && (
-                <DetailRow
-                  label="Memory"
-                  value={`${formatBytesCompact(crash.entry.freeMemory ?? 0)} free / ${formatBytesCompact(crash.entry.totalMemory)} total`}
-                />
-              )}
-              {crash.entry.panelCount !== undefined && (
-                <DetailRow label="Panels" value={String(crash.entry.panelCount)} />
-              )}
-              {crash.entry.processUptime !== undefined && (
-                <DetailRow
-                  label="Process uptime"
-                  value={formatDuration(crash.entry.processUptime * 1000)}
-                />
-              )}
-              {crash.entry.errorMessage && (
-                <div className="mt-2">
-                  <div className="text-xs text-daintree-text/50 mb-1">Error</div>
-                  <pre className="text-xs text-status-danger bg-status-danger/10 rounded p-2 overflow-x-auto whitespace-pre-wrap break-all select-text">
-                    {crash.entry.errorMessage}
-                  </pre>
-                </div>
-              )}
-              {crash.entry.errorStack && (
-                <div>
-                  <div className="text-xs text-daintree-text/50 mb-1">Stack trace</div>
-                  <pre className="text-xs text-daintree-text/60 bg-overlay-soft rounded p-2 overflow-x-auto max-h-32 whitespace-pre-wrap break-all select-text">
-                    {crash.entry.errorStack}
-                  </pre>
-                </div>
-              )}
-
-              <div className="flex gap-2 pt-1">
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="text-xs h-7"
-                  onClick={handleOpenLogFile}
-                  data-testid="open-log-button"
-                >
-                  <FileText className="h-3 w-3 mr-1" />
-                  Open log file
-                </Button>
-
                 {crash.entry.errorStack && (
+                  <div>
+                    <div className="text-xs text-daintree-text/50 mb-1">Stack trace</div>
+                    <pre className="text-xs text-daintree-text/60 bg-overlay-soft rounded p-2 overflow-x-auto max-h-32 whitespace-pre-wrap break-all select-text">
+                      {crash.entry.errorStack}
+                    </pre>
+                  </div>
+                )}
+
+                <div className="flex gap-2 pt-1">
                   <Button
                     size="sm"
                     variant="ghost"
                     className="text-xs h-7"
-                    onClick={() => copyStack(crash.entry.errorStack!)}
-                    data-testid="copy-stack-button"
+                    onClick={handleOpenLogFile}
+                    data-testid="open-log-button"
                   >
-                    <Copy className="h-3 w-3 mr-1" />
-                    {stackCopied ? "Copied" : "Copy stack"}
+                    <FileText className="h-3 w-3 mr-1" />
+                    Open log file
                   </Button>
+
+                  {crash.entry.errorStack && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-xs h-7"
+                      onClick={() => copyStack(crash.entry.errorStack!)}
+                      data-testid="copy-stack-button"
+                    >
+                      <Copy className="h-3 w-3 mr-1" />
+                      {stackCopied ? "Copied" : "Copy stack"}
+                    </Button>
+                  )}
+
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-xs h-7"
+                    onClick={() => void handleReport()}
+                    data-testid="report-button"
+                  >
+                    <ExternalLink className="h-3 w-3 mr-1" />
+                    <AnimatedLabel
+                      label={
+                        copied
+                          ? "Copied!"
+                          : privacyWarningShown
+                            ? "Copy & report on GitHub"
+                            : "Report this crash"
+                      }
+                      animateKey={copied ? "copied" : privacyWarningShown ? "warn" : "default"}
+                    />
+                  </Button>
+                </div>
+
+                {privacyWarningShown && !copied && (
+                  <p
+                    className="text-xs text-status-warning/90 bg-status-warning/10 rounded px-2 py-1.5"
+                    data-testid="privacy-warning"
+                  >
+                    Opens GitHub Issues in your browser. The report includes platform info, app
+                    version, panel kinds, file paths, error message, and stack trace — and will be
+                    publicly visible. Review before pasting.
+                  </p>
                 )}
-
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="text-xs h-7"
-                  onClick={() => void handleReport()}
-                  data-testid="report-button"
-                >
-                  <ExternalLink className="h-3 w-3 mr-1" />
-                  <AnimatedLabel
-                    label={
-                      copied
-                        ? "Copied!"
-                        : privacyWarningShown
-                          ? "Copy & report on GitHub"
-                          : "Report this crash"
-                    }
-                    animateKey={copied ? "copied" : privacyWarningShown ? "warn" : "default"}
-                  />
-                </Button>
               </div>
+            )}
+          </div>
 
-              {privacyWarningShown && !copied && (
-                <p
-                  className="text-xs text-status-warning/90 bg-status-warning/10 rounded px-2 py-1.5"
-                  data-testid="privacy-warning"
-                >
-                  Opens GitHub Issues in your browser. The report includes platform info, app
-                  version, panel kinds, file paths, error message, and stack trace — and will be
-                  publicly visible. Review before pasting.
-                </p>
-              )}
-            </div>
+          {isInCrashLoop ? (
+            config.autoRestoreOnCrash && (
+              <p className="text-xs text-daintree-text/60" data-testid="auto-restore-paused">
+                Auto-restore paused — too many consecutive crashes.
+              </p>
+            )
+          ) : (
+            <label
+              className="flex items-center gap-2 cursor-pointer"
+              data-testid="auto-restore-label"
+            >
+              <input
+                type="checkbox"
+                checked={config.autoRestoreOnCrash}
+                onChange={(e) => handleAutoRestore(e.target.checked)}
+                className="accent-daintree-accent h-4 w-4"
+                data-testid="auto-restore-checkbox"
+              />
+              <span className="text-xs text-daintree-text/60">
+                Always restore sessions automatically
+              </span>
+            </label>
           )}
-        </div>
+        </AppDialog.Body>
+      </AppDialog>
 
-        {isInCrashLoop ? (
-          config.autoRestoreOnCrash && (
-            <p className="text-xs text-daintree-text/60" data-testid="auto-restore-paused">
-              Auto-restore paused — too many consecutive crashes.
-            </p>
-          )
-        ) : (
-          <label
-            className="flex items-center gap-2 cursor-pointer"
-            data-testid="auto-restore-label"
-          >
-            <input
-              type="checkbox"
-              checked={config.autoRestoreOnCrash}
-              onChange={(e) => handleAutoRestore(e.target.checked)}
-              className="accent-daintree-accent h-4 w-4"
-              data-testid="auto-restore-checkbox"
-            />
-            <span className="text-xs text-daintree-text/60">
-              Always restore sessions automatically
-            </span>
-          </label>
+      <ConfirmDialog
+        isOpen={showFreshConfirm}
+        onClose={() => setShowFreshConfirm(false)}
+        title="Reset to clean layout?"
+        description={
+          hasPanels
+            ? "All open panels listed below will be closed and their state will be discarded."
+            : "Your session will start with a clean layout."
+        }
+        confirmLabel="Reset to clean layout"
+        variant="destructive"
+        zIndex="nested"
+        onConfirm={handleFreshConfirm}
+      >
+        {hasPanels && (
+          <ul className="space-y-1.5">
+            {panels.map((panel) => (
+              <li key={panel.id} className="flex items-center gap-2 text-sm text-daintree-text/80">
+                <span className="shrink-0 text-daintree-text/50">{getPanelIcon(panel.kind)}</span>
+                <span className="truncate">{panel.title || panel.kind}</span>
+              </li>
+            ))}
+          </ul>
         )}
-      </AppDialog.Body>
-    </AppDialog>
+      </ConfirmDialog>
+    </>
   );
 }
 

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -282,9 +282,19 @@ describe("CrashRecoveryDialog", () => {
     });
 
     it("destructive confirm dialog does not show panel preview when panels is empty", () => {
-      setup({ crash: { panels: [] } });
+      setup({ crash: { panels: [], hasBackup: false } });
       fireEvent.click(screen.getByTestId("fresh-button"));
       expect(screen.getByText("Your session will start with a clean layout.")).toBeTruthy();
+    });
+
+    it("destructive confirm warns about discarded backup when panels empty but backup exists", () => {
+      setup({ crash: { panels: [], hasBackup: true } });
+      fireEvent.click(screen.getByTestId("fresh-button"));
+      expect(
+        screen.getByText(
+          "Your session will start with a clean layout and the existing session backup will be discarded."
+        )
+      ).toBeTruthy();
     });
 
     it("toggle all deselects when all are selected", () => {

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { ReactNode, ButtonHTMLAttributes } from "react";
 import { CrashRecoveryDialog } from "../CrashRecoveryDialog";
@@ -37,6 +37,37 @@ vi.mock("@/components/ui/AppDialog", () => {
   AppDialog.CloseButton = () => <button type="button">close</button>;
   AppDialog.Body = ({ children, className }: SectionProps) => (
     <div className={className}>{children}</div>
+  );
+  AppDialog.Description = ({ children }: SectionProps) => <p>{children}</p>;
+  AppDialog.Footer = ({
+    secondaryAction,
+    primaryAction,
+  }: {
+    secondaryAction?: { label: string; onClick: () => void; disabled?: boolean };
+    primaryAction?: { label: string; onClick: () => void; loading?: boolean; disabled?: boolean };
+  }) => (
+    <div>
+      {secondaryAction && (
+        <button
+          type="button"
+          data-confirm-role="cancel"
+          onClick={secondaryAction.onClick}
+          disabled={secondaryAction.disabled}
+        >
+          {secondaryAction.label}
+        </button>
+      )}
+      {primaryAction && (
+        <button
+          type="button"
+          data-confirm-role="confirm"
+          onClick={primaryAction.onClick}
+          disabled={primaryAction.disabled}
+        >
+          {primaryAction.label}
+        </button>
+      )}
+    </div>
   );
 
   return { AppDialog };
@@ -217,10 +248,43 @@ describe("CrashRecoveryDialog", () => {
       expect(call.panelIds).not.toContain("t2");
     });
 
-    it("calls onResolve with fresh when 'Continue without restoring' is clicked", async () => {
+    it("opens destructive confirm dialog when 'Continue without restoring' is clicked, does not call onResolve immediately", async () => {
       const { onResolve } = setup();
       fireEvent.click(screen.getByTestId("fresh-button"));
+      expect(onResolve).not.toHaveBeenCalled();
+      expect(screen.getByText("Reset to clean layout?")).toBeTruthy();
+    });
+
+    it("calls onResolve with fresh when confirm button is clicked in destructive dialog", async () => {
+      const { onResolve } = setup();
+      fireEvent.click(screen.getByTestId("fresh-button"));
+      fireEvent.click(screen.getByText("Reset to clean layout"));
       await waitFor(() => expect(onResolve).toHaveBeenCalledWith({ kind: "fresh" }));
+    });
+
+    it("does not call onResolve when cancel is clicked in destructive confirm dialog", async () => {
+      const { onResolve } = setup();
+      fireEvent.click(screen.getByTestId("fresh-button"));
+      fireEvent.click(screen.getByText("Cancel"));
+      expect(onResolve).not.toHaveBeenCalled();
+      // Fresh button should be re-enabled
+      const btn = screen.getByTestId("fresh-button") as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+
+    it("shows panel preview in destructive confirm dialog", () => {
+      setup();
+      fireEvent.click(screen.getByTestId("fresh-button"));
+      const confirm = screen.getByTestId("app-dialog");
+      expect(within(confirm).getByText("Shell")).toBeTruthy();
+      expect(within(confirm).getByText("Claude")).toBeTruthy();
+      expect(within(confirm).getByText("Docs")).toBeTruthy();
+    });
+
+    it("destructive confirm dialog does not show panel preview when panels is empty", () => {
+      setup({ crash: { panels: [] } });
+      fireEvent.click(screen.getByTestId("fresh-button"));
+      expect(screen.getByText("Your session will start with a clean layout.")).toBeTruthy();
     });
 
     it("toggle all deselects when all are selected", () => {
@@ -256,6 +320,19 @@ describe("CrashRecoveryDialog", () => {
       setup();
       expect(screen.getByTestId("toggle-all-button").className).toContain("cursor-pointer");
     });
+
+    it("restore-selected path is unaffected by destructive confirm gate", async () => {
+      const { onResolve } = setup();
+      fireEvent.click(screen.getByTestId("restore-selected-button"));
+      await waitFor(() =>
+        expect(onResolve).toHaveBeenCalledWith({
+          kind: "restore",
+          panelIds: expect.arrayContaining(["t1", "t2", "t3"]),
+        })
+      );
+      // Should not show confirm dialog
+      expect(screen.queryByText("Reset to clean layout?")).toBeNull();
+    });
   });
 
   describe("without panels (legacy fallback)", () => {
@@ -286,6 +363,15 @@ describe("CrashRecoveryDialog", () => {
           panelIds: [],
         })
       );
+    });
+
+    it("opens destructive confirm dialog on fresh in legacy mode and resolves on confirm", async () => {
+      const { onResolve } = setup({ crash: { panels: [] } });
+      fireEvent.click(screen.getByTestId("fresh-button"));
+      expect(onResolve).not.toHaveBeenCalled();
+      expect(screen.getByText("Reset to clean layout?")).toBeTruthy();
+      fireEvent.click(screen.getByText("Reset to clean layout"));
+      await waitFor(() => expect(onResolve).toHaveBeenCalledWith({ kind: "fresh" }));
     });
   });
 


### PR DESCRIPTION
## Summary
- Added a destructive `ConfirmDialog` gate on the reset-to-fresh path in the crash recovery dialog to prevent accidental data loss.
- Added error feedback (toast) when a recovery action fails, so the failure is visible rather than silent.
- Improved copy for the no-panels fallback path — distinguishes between clean layout start and backup discard.

47 tests pass, CI clean.

Resolves #8675

## Changes
- `src/components/Recovery/CrashRecoveryDialog.tsx` — Wired `ConfirmDialog` with `variant="destructive"` before the fresh-reset action, shared for both has-panels and no-panels paths. Panel preview shown in confirm body when panels exist. Wrapped `onResolve` in try/catch with toast on failure.
- `src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx` — 8 new tests covering confirm gate open/confirm/cancel/preview, no-panels copy variants, and the guard that restore-selected is unaffected.

## Testing
- 47 unit tests pass (vitest)
- ESLint clean (0 errors)
- Prettier clean