### PR TITLE
fix(empty-state): replace bare no-worktree text with structured EmptyState

### DIFF
--- a/src/components/Terminal/ContentGridDefault.tsx
+++ b/src/components/Terminal/ContentGridDefault.tsx
@@ -74,6 +74,7 @@ export function ContentGridDefault({
                     <ContentGridEmptyState
                       hasActiveWorktree={ctx.hasActiveWorktree}
                       hasWorktrees={ctx.worktreeMap.size > 0}
+                      isWorktreeInitialized={ctx.isWorktreeInitialized}
                       activeWorktreeName={ctx.activeWorktreeName}
                       activeWorktreeId={ctx.activeWorktreeId}
                       activeWorktreeBranch={ctx.activeWorktreeBranch}

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -1,8 +1,11 @@
-import { GitBranch, Settings } from "lucide-react";
+import { FolderOpen, GitBranch, Settings } from "lucide-react";
 import { DaintreeIcon } from "@/components/icons";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Button } from "@/components/ui/button";
 import { ProjectPulseCard } from "@/components/Pulse";
 import { useHomeDir } from "@/hooks/app/useHomeDir";
 import { svgToDataUrl, sanitizeSvg } from "@/lib/svg";
+import { actionService } from "@/services/ActionService";
 import { usePanelStore } from "@/store/panelStore";
 import { useRecipeStore } from "@/store/recipeStore";
 import { formatPath, middleTruncate } from "@/utils/textParsing";
@@ -14,6 +17,7 @@ const PATH_TRUNCATE_LENGTH = 52;
 export function ContentGridEmptyState({
   hasActiveWorktree,
   hasWorktrees,
+  isWorktreeInitialized,
   activeWorktreeName,
   activeWorktreeId,
   activeWorktreeBranch,
@@ -28,6 +32,7 @@ export function ContentGridEmptyState({
 }: {
   hasActiveWorktree: boolean;
   hasWorktrees: boolean;
+  isWorktreeInitialized: boolean;
   activeWorktreeName?: string | null;
   activeWorktreeId?: string | null;
   activeWorktreeBranch?: string | null;
@@ -145,16 +150,35 @@ export function ContentGridEmptyState({
           </div>
         )}
 
-        {!hasActiveWorktree && (
-          <p
-            className="text-sm text-daintree-text/60 max-w-md leading-relaxed text-center"
-            role="status"
-            aria-live="polite"
-          >
-            {hasWorktrees
-              ? "Select a worktree in the sidebar to get started"
-              : "Open a directory in the sidebar to get started"}
-          </p>
+        {!hasActiveWorktree && !isWorktreeInitialized && null}
+        {!hasActiveWorktree && isWorktreeInitialized && hasWorktrees && (
+          <EmptyState
+            variant="zero-data"
+            scale="canvas"
+            icon={<FolderOpen />}
+            title="Select a worktree"
+            description="Choose a worktree from the sidebar to open it in the canvas."
+          />
+        )}
+        {!hasActiveWorktree && isWorktreeInitialized && !hasWorktrees && (
+          <EmptyState
+            variant="zero-data"
+            scale="canvas"
+            icon={<FolderOpen />}
+            title="Open a Git repository to get started"
+            description="Worktrees let you work on multiple tasks in isolated environments."
+            action={
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  void actionService.dispatch("project.openDialog", undefined, { source: "user" });
+                }}
+              >
+                Open directory...
+              </Button>
+            }
+          />
         )}
 
         {hasActiveWorktree && recipesProjectId !== null && !recipesLoading && (

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -172,7 +172,7 @@ export function ContentGridEmptyState({
                 variant="outline"
                 size="sm"
                 onClick={() => {
-                  void actionService.dispatch("project.openDialog", undefined, { source: "user" });
+                  void actionService.dispatch("project.add", undefined, { source: "user" });
                 }}
               >
                 Open directory...

--- a/src/components/Terminal/ContentGridFleetScope.tsx
+++ b/src/components/Terminal/ContentGridFleetScope.tsx
@@ -57,6 +57,7 @@ export function ContentGridFleetScope({
               <ContentGridEmptyState
                 hasActiveWorktree={ctx.hasActiveWorktree}
                 hasWorktrees={ctx.worktreeMap.size > 0}
+                isWorktreeInitialized={ctx.isWorktreeInitialized}
                 activeWorktreeName={ctx.activeWorktreeName}
                 activeWorktreeId={ctx.activeWorktreeId}
                 activeWorktreeBranch={ctx.activeWorktreeBranch}

--- a/src/components/Terminal/__tests__/contentGridEmptyContent.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyContent.test.ts
@@ -73,7 +73,7 @@ describe("ContentGrid richer project identity (issue #7472)", () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
     expect(content).toContain("detached at ");
     expect(content).toContain("activeWorktreeHead.slice(0, 7)");
-    expect(content).toContain('import { GitBranch, Settings } from "lucide-react"');
+    expect(content).toMatch(/import \{ .*GitBranch, Settings \} from "lucide-react"/);
     expect(content).toContain("<GitBranch ");
   });
 });

--- a/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
@@ -49,21 +49,23 @@ describe("ContentGrid EmptyState — quiet no-worktree variants (issue #6935)", 
     expect(content).not.toContain("View documentation");
     expect(content).not.toContain("status-warning");
     expect(content).not.toContain("handleOpenHelp");
-    expect(content).not.toContain("actionService");
   });
 
-  it("renders muted helper text with role=status / aria-live=polite for both empty variants", async () => {
+  it("renders structured EmptyState with role=status / aria-live=polite for both empty variants", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
-    expect(content).toContain('role="status"');
-    expect(content).toContain('aria-live="polite"');
-    expect(content).toContain("text-daintree-text/60");
+    expect(content).toContain('variant="zero-data"');
+    expect(content).toContain('scale="canvas"');
+    expect(content).toContain("<EmptyState");
   });
 
-  it("branches helper text on hasWorktrees: select-worktree vs open-directory", async () => {
+  it("branches empty state on hasWorktrees: select-worktree vs open-directory with button", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
-    expect(content).toContain("Select a worktree in the sidebar to get started");
-    expect(content).toContain("Open a directory in the sidebar to get started");
-    expect(content).toMatch(/hasWorktrees\s*\n?\s*\?\s*"Select a worktree/);
+    expect(content).toContain("Select a worktree");
+    expect(content).toContain("Choose a worktree from the sidebar to open it in the canvas.");
+    expect(content).toContain("Open a Git repository to get started");
+    expect(content).toContain("Worktrees let you work on multiple tasks in isolated environments.");
+    expect(content).toContain("Open directory...");
+    expect(content).toContain("project.openDialog");
   });
 
   it("gates the project-icon hero on hasActiveWorktree so empty states stay silent", async () => {
@@ -71,5 +73,63 @@ describe("ContentGrid EmptyState — quiet no-worktree variants (issue #6935)", 
     expect(content).toMatch(
       /\{hasActiveWorktree && \(\s*\n\s*<div className="mb-6 flex flex-col items-center text-center"/
     );
+  });
+});
+
+describe("ContentGrid EmptyState — initialization gate (issue #8645)", () => {
+  it("accepts isWorktreeInitialized prop", async () => {
+    const content = await readFile(EMPTY_STATE_PATH, "utf-8");
+    expect(content).toContain("isWorktreeInitialized: boolean");
+  });
+
+  it("guards no-worktree branch on isWorktreeInitialized to prevent cold-start copy flash", async () => {
+    const content = await readFile(EMPTY_STATE_PATH, "utf-8");
+    expect(content).toContain("!hasActiveWorktree && !isWorktreeInitialized");
+    expect(content).toContain("!hasActiveWorktree && isWorktreeInitialized && hasWorktrees");
+    expect(content).toContain("!hasActiveWorktree && isWorktreeInitialized && !hasWorktrees");
+  });
+
+  it("does not render bare <p> with text-daintree-text/60 in the no-worktree branch", async () => {
+    const content = await readFile(EMPTY_STATE_PATH, "utf-8");
+    // The old bare <p> with diluted text color is gone — replaced by EmptyState
+    const lines = content.split("\n");
+    const noWorktreeSection = lines.filter(
+      (line) => !line.includes("hasActiveWorktree") || line.includes("!hasActiveWorktree")
+    );
+    const hasOldPattern = noWorktreeSection.some(
+      (line) =>
+        line.includes("<p") && line.includes("text-daintree-text/60") && line.includes("max-w-md")
+    );
+    expect(hasOldPattern).toBe(false);
+  });
+});
+
+describe("ContentGrid EmptyState — structured empty state integration (issue #8645)", () => {
+  it("imports EmptyState, Button, FolderOpen, and actionService", async () => {
+    const content = await readFile(EMPTY_STATE_PATH, "utf-8");
+    expect(content).toContain('from "@/components/ui/EmptyState"');
+    expect(content).toContain('from "@/components/ui/button"');
+    expect(content).toContain('from "@/services/ActionService"');
+    expect(content).toContain("FolderOpen");
+  });
+
+  it("renders Button variant=outline size=sm for opening a directory", async () => {
+    const content = await readFile(EMPTY_STATE_PATH, "utf-8");
+    expect(content).toContain('variant="outline"');
+    expect(content).toContain('size="sm"');
+    expect(content).toContain("Open directory...");
+  });
+
+  it("dispatches project.openDialog via actionService with source: user", async () => {
+    const content = await readFile(EMPTY_STATE_PATH, "utf-8");
+    expect(content).toContain('actionService.dispatch("project.openDialog"');
+    expect(content).toContain('source: "user"');
+  });
+
+  it("uses FolderOpen icon in both zero-data variants", async () => {
+    const content = await readFile(EMPTY_STATE_PATH, "utf-8");
+    // FolderOpen should appear in both EmptyState renders (hasWorktrees + !hasWorktrees)
+    const folderOpenCount = (content.match(/<FolderOpen \/>/g) || []).length;
+    expect(folderOpenCount).toBe(2);
   });
 });

--- a/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
@@ -65,7 +65,7 @@ describe("ContentGrid EmptyState — quiet no-worktree variants (issue #6935)", 
     expect(content).toContain("Open a Git repository to get started");
     expect(content).toContain("Worktrees let you work on multiple tasks in isolated environments.");
     expect(content).toContain("Open directory...");
-    expect(content).toContain("project.openDialog");
+    expect(content).toContain('"project.add"');
   });
 
   it("gates the project-icon hero on hasActiveWorktree so empty states stay silent", async () => {
@@ -120,9 +120,9 @@ describe("ContentGrid EmptyState — structured empty state integration (issue #
     expect(content).toContain("Open directory...");
   });
 
-  it("dispatches project.openDialog via actionService with source: user", async () => {
+  it("dispatches project.add via actionService with source: user", async () => {
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
-    expect(content).toContain('actionService.dispatch("project.openDialog"');
+    expect(content).toContain('actionService.dispatch("project.add"');
     expect(content).toContain('source: "user"');
   });
 

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -140,6 +140,7 @@ export interface ContentGridContext {
   projectIconSvg: string | undefined;
   worktreeMap: ReturnType<typeof useWorktrees>["worktreeMap"];
   isInTrash: (id: string) => boolean;
+  isWorktreeInitialized: boolean;
   getTabGroupPanels: (groupId: string, location?: TabGroupLocation) => TerminalInstance[];
   getPanelGroup: (panelId: string) => TabGroup | undefined;
   getActiveTabId: (groupId: string) => string | null;
@@ -214,7 +215,7 @@ export function useContentGridContext({
   );
   const isProjectSwitching = false;
   const { projectIconSvg } = useProjectBranding(currentProject?.id);
-  const { worktreeMap } = useWorktrees();
+  const { worktreeMap, isInitialized: isWorktreeInitialized } = useWorktrees();
   const activeWorktree = activeWorktreeId ? worktreeMap.get(activeWorktreeId) : null;
   const hasActiveWorktree = activeWorktreeId != null && activeWorktree != null;
   const activeWorktreeName = activeWorktree
@@ -976,6 +977,7 @@ export function useContentGridContext({
     projectIconSvg,
     worktreeMap,
     isInTrash,
+    isWorktreeInitialized,
     getTabGroupPanels,
     getPanelGroup,
     getActiveTabId,


### PR DESCRIPTION
## Summary
- Replaces bare no-worktree text in `ContentGridEmptyState` with proper `EmptyState` components using `variant="zero-data"`
- Adds an `isWorktreeInitialized` gate to prevent cold-start copy flash before worktree data settles
- No-worktrees variant gets an "Open directory..." CTA that dispatches `project.add` through `actionService`

Resolves #8645

## Changes
- `ContentGridEmptyState` — three-way branch: uninit (render nothing), init+none (open-directory CTA), init+some (select-a-worktree)
- `useContentGridContext` — exposes `isWorktreeInitialized` from `useWorktrees().isInitialized`
- `ContentGridDefault` / `ContentGridFleetScope` — thread the new prop through
- Tests cover all three gating branches and verify the old bare `<p>` pattern is gone

## Testing
- Unit tests pass
- Verified no copy flash on cold start