### PR TITLE
feat(sidebar): rebuild first-load skeleton on shared primitives

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -13,7 +13,7 @@ import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { AlertTriangle, FolderOpen, LayoutGrid, Plus, RefreshCw, Zap } from "lucide-react";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
-import { Skeleton } from "@/components/ui/Skeleton";
+import { Skeleton, SkeletonBone, SkeletonText, SkeletonHint } from "@/components/ui/Skeleton";
 import { ScrollIndicator } from "@/components/Worktree/ScrollIndicator";
 import {
   useAgentLauncher,
@@ -23,6 +23,7 @@ import {
   useAriaKeyshortcuts,
   useKeybindingDisplay,
   useDeferredLoading,
+  useResizeObserverRaf,
 } from "@/hooks";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
@@ -109,6 +110,11 @@ const SIDEBAR_VIRTUOSO_OVERSCAN_PX = 600;
 // indicator never flickers on transient reconnects, and below the worst-case
 // ~14s workspace-host restart budget so it fires before `setFatalError`.
 const RECONNECT_ESCALATE_MS = 10_000;
+
+// Skeleton row height matching collapsed WorktreeCard sidebar variant
+// (py-3=12px + min-h-[22px]=22px + py-3=12px + border-b=1px).
+const SKELETON_ROW_HEIGHT_PX = 47;
+const MIN_SKELETON_ROWS = 3;
 
 function truncateSearchQuery(trimmedQuery: string) {
   const codepoints = Array.from(trimmedQuery);
@@ -427,6 +433,19 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const [isRestartConfirmOpen, setIsRestartConfirmOpen] = useState(false);
   const openFleetPicker = useCallback(() => setIsFleetPickerOpen(true), []);
   const closeFleetPicker = useCallback(() => setIsFleetPickerOpen(false), []);
+
+  const [skeletonContainerEl, setSkeletonContainerEl] = useState<HTMLElement | null>(null);
+  const [skeletonHeight, setSkeletonHeight] = useState(0);
+  const skeletonContainerRef = useCallback((el: HTMLElement | null) => {
+    setSkeletonContainerEl(el);
+  }, []);
+  useResizeObserverRaf(skeletonContainerEl, (entry) => {
+    setSkeletonHeight(entry.contentRect.height);
+  });
+  const skeletonRowCount = Math.max(
+    MIN_SKELETON_ROWS,
+    Math.floor(skeletonHeight / SKELETON_ROW_HEIGHT_PX)
+  );
   useEffect(() => {
     if (!error) setIsRestartConfirmOpen(false);
   }, [error]);
@@ -1213,18 +1232,26 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         <div className="flex items-center px-4 py-4 border-b border-divider shrink-0">
           <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
         </div>
-        <Skeleton label="Loading worktrees">
-          {[0, 1, 2].map((i) => (
-            <div
-              key={i}
-              aria-hidden="true"
-              className="border-b border-border-default px-4 py-3 flex flex-col gap-1.5"
-            >
-              <div className="h-3.5 w-2/3 bg-muted rounded animate-pulse-delayed" />
-              <div className="h-3 w-1/3 bg-muted rounded animate-pulse-delayed" />
-            </div>
-          ))}
-        </Skeleton>
+        <div className="flex-1 min-h-0 relative" ref={skeletonContainerRef}>
+          <Skeleton label="Loading worktrees">
+            {Array.from({ length: skeletonRowCount }).map((_, i) => (
+              <div
+                key={i}
+                aria-hidden="true"
+                className="border-b border-border-default px-4 py-3"
+                style={{ height: SKELETON_ROW_HEIGHT_PX }}
+              >
+                <div className="flex items-center gap-2 min-h-[22px]">
+                  <SkeletonBone className="w-3.5 h-3.5 rounded-full shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <SkeletonText lines={2} lineHeightClassName="h-3" gapClassName="space-y-1" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </Skeleton>
+          <SkeletonHint className="absolute bottom-4 left-1/2 -translate-x-1/2 pointer-events-auto" />
+        </div>
       </div>
     );
   }

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -444,7 +444,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   });
   const skeletonRowCount = Math.max(
     MIN_SKELETON_ROWS,
-    Math.floor(skeletonHeight / SKELETON_ROW_HEIGHT_PX)
+    Number.isFinite(skeletonHeight) ? Math.floor(skeletonHeight / SKELETON_ROW_HEIGHT_PX) : 0
   );
   useEffect(() => {
     if (!error) setIsRestartConfirmOpen(false);
@@ -1232,7 +1232,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         <div className="flex items-center px-4 py-4 border-b border-divider shrink-0">
           <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
         </div>
-        <div className="flex-1 min-h-0 relative" ref={skeletonContainerRef}>
+        <div className="flex-1 min-h-0 relative overflow-hidden pb-8" ref={skeletonContainerRef}>
           <Skeleton label="Loading worktrees">
             {Array.from({ length: skeletonRowCount }).map((_, i) => (
               <div

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -368,13 +368,13 @@ describe("SidebarContent initial loading skeleton — issue #7215", () => {
     source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
   });
 
-  it("imports the Skeleton primitive from the ui directory", () => {
-    expect(source).toMatch(/import \{ Skeleton \} from "@\/components\/ui\/Skeleton"/);
+  it("imports Skeleton, SkeletonBone, SkeletonText, and SkeletonHint from the ui directory", () => {
+    expect(source).toMatch(
+      /import \{ Skeleton, SkeletonBone, SkeletonText, SkeletonHint \} from "@\/components\/ui\/Skeleton"/
+    );
   });
 
   it("does not render the legacy 'Loading worktrees...' text in the loading branch", () => {
-    // Doherty Threshold: showing immediate text on mount draws attention to a
-    // sub-400ms wait. The skeleton's animate-pulse-delayed gates the reveal.
     expect(source).not.toContain("Loading worktrees...");
   });
 
@@ -395,25 +395,44 @@ describe("SidebarContent initial loading skeleton — issue #7215", () => {
     expect(branch).toMatch(/<h2[^>]*>Worktrees<\/h2>/);
   });
 
-  it("uses animate-pulse-delayed on the bone elements (CSS-gated 400ms reveal)", () => {
-    // The CSS-only delay is sufficient — see CLAUDE.md "Loading Indicators":
-    // animate-pulse-delayed enforces the gate automatically. Do not stack a
-    // useDeferredLoading hook on top of it (double-gating).
+  it("uses SkeletonBone and SkeletonText without the immediate prop (400ms gate)", () => {
     const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
     const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);
     const branch = source.slice(branchStart, branchEnd);
-    expect(branch).toContain("animate-pulse-delayed");
-    expect(branch).not.toContain("animate-pulse-immediate");
+    expect(branch).toContain("<SkeletonBone");
+    expect(branch).toContain("<SkeletonText");
+    expect(branch).not.toContain("immediate");
   });
 
-  it("marks bone row containers aria-hidden so AT only announces the wrapper status", () => {
-    // Per Skeleton.tsx's documented contract: each bone should be aria-hidden.
-    // The wrapper carries role=status + aria-busy=true for the live-region
-    // announcement; the placeholder bones must not pollute the AT tree.
+  it("marks the row wrapper aria-hidden and uses primitives that own inner aria-hidden", () => {
     const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
     const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);
     const branch = source.slice(branchStart, branchEnd);
     expect(branch).toContain('aria-hidden="true"');
+  });
+
+  it("defines SKELETON_ROW_HEIGHT_PX = 47 matching the collapsed worktree row height", () => {
+    expect(source).toContain("SKELETON_ROW_HEIGHT_PX = 47");
+  });
+
+  it("uses fixed-height row containers with SKELETON_ROW_HEIGHT_PX to prevent layout shift", () => {
+    const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
+    const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);
+    const branch = source.slice(branchStart, branchEnd);
+    expect(branch).toContain("SKELETON_ROW_HEIGHT_PX");
+  });
+
+  it("computes dynamic row count via useResizeObserverRaf with MIN_SKELETON_ROWS floor", () => {
+    expect(source).toContain("MIN_SKELETON_ROWS = 3");
+    expect(source).toContain("useResizeObserverRaf");
+  });
+
+  it("renders SkeletonHint as sibling of Skeleton, not nested inside", () => {
+    expect(source).toContain("<SkeletonHint");
+    const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
+    const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);
+    const branch = source.slice(branchStart, branchEnd);
+    expect(branch).toMatch(/<\/Skeleton>[\s\S]*?<SkeletonHint/);
   });
 });
 


### PR DESCRIPTION
## Summary
The sidebar first-load skeleton was raw `<div>` bones with a hardcoded 3-row count. This rebuilds it on the shared `SkeletonBone`, `SkeletonText`, and `SkeletonHint` primitives and makes the row count dynamic so the skeleton fills the container instead.

Resolves #8649.

## Changes
- Replaced raw `<div>` bones with `SkeletonBone` and `SkeletonText` primitives for consistency with the rest of the app
- Row count now computed dynamically via `useResizeObserverRaf` with a `MIN_SKELETON_ROWS` floor, so the skeleton fills the available space instead of always showing 3 rows
- `overflow-hidden` on the container to clip the skeleton at the sidebar boundary
- Fixed-height rows (`SKELETON_ROW_HEIGHT_PX = 47`, matching the collapsed `WorktreeCard` sidebar variant) eliminate layout shift
- `SkeletonHint` rendered as a sibling caption below the skeleton
- Tests updated with coverage for the new primitives, dynamic row count, fixed-height rows, and caption placement

## Testing
- Typecheck, lint, and format pass
- `SidebarContent.emptyState.test.ts` -- all skeleton assertions updated and passing