### PR TITLE
perf(github): adaptive budget-aware rate-limit throttling

### DIFF
--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -32,11 +32,15 @@ import type { RateLimitInfo } from "../../../shared/types/forge.js";
 // two in sync if the projection rule changes.
 function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
   if (!payload.blocked) {
-    return { limit: null, remaining: null, resetAt: null };
+    return {
+      limit: payload.limit ?? null,
+      remaining: payload.remaining ?? null,
+      resetAt: null,
+    };
   }
   return {
-    limit: null,
-    remaining: 0,
+    limit: payload.limit ?? null,
+    remaining: payload.remaining ?? 0,
     resetAt: payload.resetAt ?? null,
     ...(payload.kind === "secondary" ? { secondaryThrottled: true } : {}),
   };

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -38,9 +38,12 @@ function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
       resetAt: null,
     };
   }
+  // When blocked, force `remaining: 0` — the renderer's GitHub-flavored
+  // projection treats `remaining === 0` as the "blocked" signal, so the exact
+  // (1–50) hard-stop-band count must not leak through as a non-zero value.
   return {
     limit: payload.limit ?? null,
-    remaining: payload.remaining ?? 0,
+    remaining: 0,
     resetAt: payload.resetAt ?? null,
     ...(payload.kind === "secondary" ? { secondaryThrottled: true } : {}),
   };

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -327,9 +327,12 @@ function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
       resetAt: null,
     };
   }
+  // When blocked, force `remaining: 0` — the renderer's GitHub-flavored
+  // projection treats `remaining === 0` as the "blocked" signal, so the exact
+  // (1–50) hard-stop-band count must not leak through as a non-zero value.
   return {
     limit: payload.limit ?? null,
-    remaining: payload.remaining ?? 0,
+    remaining: 0,
     resetAt: payload.resetAt ?? null,
     ...(payload.kind === "secondary" ? { secondaryThrottled: true } : {}),
   };

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -319,11 +319,17 @@ const workspaceService = new WorkspaceService(sendEvent);
 // event payload is provider-agnostic.
 function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
   if (!payload.blocked) {
-    return { limit: null, remaining: null, resetAt: null };
+    // Forward the observed GraphQL budget (if any) so the toolbar can show a
+    // remaining-quota indicator even while requests still flow.
+    return {
+      limit: payload.limit ?? null,
+      remaining: payload.remaining ?? null,
+      resetAt: null,
+    };
   }
   return {
-    limit: null,
-    remaining: 0,
+    limit: payload.limit ?? null,
+    remaining: payload.remaining ?? 0,
     resetAt: payload.resetAt ?? null,
     ...(payload.kind === "secondary" ? { secondaryThrottled: true } : {}),
   };
@@ -344,6 +350,10 @@ gitHubRateLimitService.onStateChange((state) => {
     providerId: BUILTIN_GITHUB_PROVIDER_ID,
     state: rateLimitInfo,
   });
+  // Pace background fetch cadence against the observed GraphQL budget so
+  // multiple instances drawing on the same per-user token budget back off in
+  // step as it depletes — and snap back when it resets.
+  workspaceService.applyFetchThrottle(state.throttleMultiplier ?? 1);
 });
 
 // Handle requests from Main

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -555,8 +555,8 @@ export class WorkspaceService {
           circuitBreakerThreshold: this.circuitBreakerThreshold,
           gitWatchEnabled: this.gitWatchEnabled,
           gitWatchDebounceMs: this.gitWatchDebounceMs,
-          fetchIntervalActiveMs: this.fetchIntervalActiveMs,
-          fetchIntervalBackgroundMs: this.fetchIntervalBackgroundMs,
+          fetchIntervalActiveMs: this.throttledFetchActiveMs,
+          fetchIntervalBackgroundMs: this.throttledFetchBackgroundMs,
         });
 
         existingMonitor.ensureWatcherState();
@@ -695,8 +695,8 @@ export class WorkspaceService {
         circuitBreakerThreshold: this.circuitBreakerThreshold,
         gitWatchEnabled: this.gitWatchEnabled,
         gitWatchDebounceMs: this.gitWatchDebounceMs,
-        fetchIntervalActiveMs: this.fetchIntervalActiveMs,
-        fetchIntervalBackgroundMs: this.fetchIntervalBackgroundMs,
+        fetchIntervalActiveMs: this.throttledFetchActiveMs,
+        fetchIntervalBackgroundMs: this.throttledFetchBackgroundMs,
       },
       {
         onUpdate: (snapshot) => {
@@ -2216,10 +2216,25 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       const baseInterval = isActive ? this.pollIntervalActive : this.pollIntervalBackground;
       monitor.updateConfig({
         basePollingInterval: baseInterval,
-        fetchIntervalActiveMs: this.fetchIntervalActiveMs,
-        fetchIntervalBackgroundMs: this.fetchIntervalBackgroundMs,
+        fetchIntervalActiveMs: this.throttledFetchActiveMs,
+        fetchIntervalBackgroundMs: this.throttledFetchBackgroundMs,
       });
     }
+  }
+
+  /**
+   * Focused-tier fetch interval with the active GitHub rate-limit throttle
+   * folded in. Used everywhere a monitor's fetch cadence is (re)written —
+   * syncMonitors, addNewWorktreeMonitor, updateMonitorConfig — so an unrelated
+   * config push can't silently clobber an in-effect throttle back to baseline.
+   */
+  private get throttledFetchActiveMs(): number {
+    return Math.round(this.fetchIntervalActiveMs * this._lastAppliedThrottleMultiplier);
+  }
+
+  /** Background-tier fetch interval with the active throttle folded in. */
+  private get throttledFetchBackgroundMs(): number {
+    return Math.round(this.fetchIntervalBackgroundMs * this._lastAppliedThrottleMultiplier);
   }
 
   /**

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -92,6 +92,11 @@ export class WorkspaceService {
   private pollIntervalBackground: number = DEFAULT_BACKGROUND_WORKTREE_INTERVAL_MS;
   private fetchIntervalActiveMs: number = 30_000;
   private fetchIntervalBackgroundMs: number = 5 * 60_000;
+  // Last GitHub rate-limit cadence multiplier applied to monitor fetch
+  // schedulers. Tracked so a recovery (multiplier back to 1) can be detected
+  // and trigger an immediate re-arm. The user-configured base intervals above
+  // are never overwritten by throttling — see applyFetchThrottle.
+  private _lastAppliedThrottleMultiplier: number = 1;
   private adaptiveBackoff: boolean = true;
   private pollIntervalMax: number = 30000;
   private circuitBreakerThreshold: number = 3;
@@ -2215,6 +2220,41 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         fetchIntervalBackgroundMs: this.fetchIntervalBackgroundMs,
       });
     }
+  }
+
+  /**
+   * Apply a GitHub rate-limit cadence multiplier to every monitor's background
+   * fetch scheduler.
+   *
+   * The multiplier always scales the user-configured base intervals
+   * (`fetchIntervalActiveMs` / `fetchIntervalBackgroundMs`) — never an
+   * already-throttled value — so repeated calls can't compound. When the
+   * multiplier returns to `1` (budget recovered), each scheduler is re-armed at
+   * the short startup-tier delay so fresh ahead/behind data lands promptly
+   * instead of waiting out a previously-stretched window.
+   *
+   * Driven by `gitHubRateLimitService` budget notifications relayed through the
+   * workspace-host `onStateChange` handler.
+   */
+  applyFetchThrottle(multiplier: number): void {
+    const safeMultiplier = Number.isFinite(multiplier) && multiplier >= 1 ? multiplier : 1;
+    const previous = this._lastAppliedThrottleMultiplier;
+    const recovered = safeMultiplier === 1 && previous > 1;
+
+    const activeMs = Math.round(this.fetchIntervalActiveMs * safeMultiplier);
+    const backgroundMs = Math.round(this.fetchIntervalBackgroundMs * safeMultiplier);
+
+    for (const monitor of this.monitors.values()) {
+      monitor.updateConfig({
+        fetchIntervalActiveMs: activeMs,
+        fetchIntervalBackgroundMs: backgroundMs,
+      });
+      if (recovered) {
+        monitor.rescheduleFetch(true);
+      }
+    }
+
+    this._lastAppliedThrottleMultiplier = safeMultiplier;
   }
 
   setPollingEnabled(enabled: boolean): void {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -933,6 +933,16 @@ export class WorktreeMonitor {
     return this.fetchScheduler.triggerNow();
   }
 
+  /**
+   * Re-arm the background fetch timer. `initial=true` uses the short
+   * startup-tier delay (2-5s) so a snap-back after GitHub rate-limit recovery
+   * gets fresh data promptly instead of waiting a full (possibly stretched)
+   * cadence window.
+   */
+  rescheduleFetch(initial: boolean): void {
+    this.fetchScheduler.reschedule(initial);
+  }
+
   async refresh(): Promise<void> {
     // A stopped monitor has nothing to refresh. This also makes the ENOENT
     // preflight below idempotent: the first removal detection calls stop(),

--- a/electron/workspace-host/__tests__/WorkspaceService.rateLimit.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.rateLimit.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import type { WorkspaceService } from "../WorkspaceService.js";
+import type { WorktreeMonitor } from "../WorktreeMonitor.js";
+import type { Worktree } from "../../../shared/types/worktree.js";
+
+const mockSimpleGit = {
+  raw: vi.fn().mockResolvedValue(undefined),
+  branch: vi.fn().mockResolvedValue({ current: "main" }),
+};
+
+vi.mock("simple-git", () => ({
+  simpleGit: vi.fn(() => mockSimpleGit),
+}));
+
+vi.mock("../../utils/fs.js", () => ({
+  waitForPathExists: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createHardenedGit: vi.fn(() => mockSimpleGit),
+  validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
+}));
+
+vi.mock("../../utils/git.js", () => ({
+  invalidateGitStatusCache: vi.fn(),
+  getWorktreeChangesWithStats: vi.fn().mockResolvedValue({
+    head: "abc123",
+    isDirty: false,
+    stagedFileCount: 0,
+    unstagedFileCount: 0,
+    untrackedFileCount: 0,
+    conflictedFileCount: 0,
+    changedFileCount: 0,
+    changes: [],
+  }),
+}));
+
+vi.mock("../../utils/gitUtils.js", () => ({
+  getGitDir: vi.fn().mockReturnValue("/test/worktree/.git"),
+  getGitCommonDir: vi.fn().mockReturnValue(null),
+  clearGitDirCache: vi.fn(),
+}));
+
+vi.mock("../../services/worktree/mood.js", () => ({
+  categorizeWorktree: vi.fn().mockReturnValue("stable"),
+}));
+
+vi.mock("../../services/issueExtractor.js", () => ({
+  extractIssueNumberSync: vi.fn().mockReturnValue(null),
+  extractIssueNumber: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../../services/worktree/index.js", () => ({
+  AdaptivePollingStrategy: vi.fn(function () {
+    return {
+      getCurrentInterval: vi.fn().mockReturnValue(2000),
+      updateInterval: vi.fn(),
+      reportActivity: vi.fn(),
+      updateConfig: vi.fn(),
+      isCircuitBreakerTripped: vi.fn().mockReturnValue(false),
+      reset: vi.fn(),
+      setBaseInterval: vi.fn(),
+      calculateNextInterval: vi.fn().mockReturnValue(2000),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordNoChange: vi.fn(),
+    };
+  }),
+  NoteFileReader: vi.fn(function () {
+    return { read: vi.fn().mockResolvedValue({}) };
+  }),
+}));
+
+vi.mock("../../services/github/GitHubAuth.js", () => ({
+  GitHubAuth: vi.fn().mockImplementation(() => ({
+    getToken: vi.fn().mockResolvedValue(null),
+  })),
+}));
+
+const mockPullRequestService = {
+  initialize: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+  reset: vi.fn(),
+  refresh: vi.fn(),
+  getStatus: vi.fn().mockReturnValue({
+    state: "idle",
+    isPolling: false,
+    candidateCount: 0,
+    resolvedCount: 0,
+    isEnabled: true,
+  }),
+};
+
+vi.mock("../../services/PullRequestService.js", () => ({
+  pullRequestService: mockPullRequestService,
+}));
+
+vi.mock("../../services/events.js", () => ({
+  events: new EventEmitter(),
+}));
+
+vi.mock("../../utils/gitFileWatcher.js", () => {
+  return {
+    GitFileWatcher: class {
+      start() {
+        return false;
+      }
+      dispose() {}
+    },
+  };
+});
+
+vi.mock("fs/promises", () => ({
+  stat: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  access: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  cp: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+function createTestWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: "/test/worktree",
+    path: "/test/worktree",
+    name: "feature/test",
+    branch: "feature/test",
+    isCurrent: false,
+    isMainWorktree: false,
+    gitDir: "/test/worktree/.git",
+    ...overrides,
+  };
+}
+
+// Base fetch intervals — match WorkspaceService defaults.
+const BASE_ACTIVE_MS = 30_000;
+const BASE_BACKGROUND_MS = 5 * 60_000;
+
+describe("WorkspaceService.applyFetchThrottle", () => {
+  let service: WorkspaceService;
+  let WorktreeMonitorClass: typeof WorktreeMonitor;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const WorkspaceServiceModule = await import("../WorkspaceService.js");
+    service = new WorkspaceServiceModule.WorkspaceService(vi.fn() as any);
+
+    const WorktreeMonitorModule = await import("../WorktreeMonitor.js");
+    WorktreeMonitorClass = WorktreeMonitorModule.WorktreeMonitor;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function registerMonitor(id: string): WorktreeMonitor {
+    const wt = createTestWorktree({ id, path: id });
+    const monitor = new WorktreeMonitorClass(
+      wt,
+      {
+        basePollingInterval: 10000,
+        adaptiveBackoff: false,
+        pollIntervalMax: 30000,
+        circuitBreakerThreshold: 3,
+        gitWatchEnabled: false,
+      },
+      { onUpdate: vi.fn() },
+      "main"
+    );
+    service["monitors"].set(id, monitor);
+    return monitor;
+  }
+
+  it("scales every monitor's fetch intervals by the multiplier", () => {
+    const a = registerMonitor("/wt/a");
+    const b = registerMonitor("/wt/b");
+    const updateA = vi.spyOn(a, "updateConfig");
+    const updateB = vi.spyOn(b, "updateConfig");
+
+    service.applyFetchThrottle(3);
+
+    expect(updateA).toHaveBeenCalledWith({
+      fetchIntervalActiveMs: BASE_ACTIVE_MS * 3,
+      fetchIntervalBackgroundMs: BASE_BACKGROUND_MS * 3,
+    });
+    expect(updateB).toHaveBeenCalledWith({
+      fetchIntervalActiveMs: BASE_ACTIVE_MS * 3,
+      fetchIntervalBackgroundMs: BASE_BACKGROUND_MS * 3,
+    });
+  });
+
+  it("does not compound when the same multiplier is applied twice", () => {
+    const a = registerMonitor("/wt/a");
+    const updateA = vi.spyOn(a, "updateConfig");
+
+    service.applyFetchThrottle(3);
+    service.applyFetchThrottle(3);
+
+    // Both calls scale from the base intervals — never from 3x → 9x.
+    for (const call of updateA.mock.calls) {
+      expect(call[0]).toEqual({
+        fetchIntervalActiveMs: BASE_ACTIVE_MS * 3,
+        fetchIntervalBackgroundMs: BASE_BACKGROUND_MS * 3,
+      });
+    }
+  });
+
+  it("snaps back to base intervals and re-arms fetch on recovery to multiplier 1", () => {
+    const a = registerMonitor("/wt/a");
+    const updateA = vi.spyOn(a, "updateConfig");
+    const rescheduleA = vi.spyOn(a, "rescheduleFetch");
+
+    service.applyFetchThrottle(4);
+    updateA.mockClear();
+    rescheduleA.mockClear();
+
+    service.applyFetchThrottle(1);
+
+    expect(updateA).toHaveBeenCalledWith({
+      fetchIntervalActiveMs: BASE_ACTIVE_MS,
+      fetchIntervalBackgroundMs: BASE_BACKGROUND_MS,
+    });
+    expect(rescheduleA).toHaveBeenCalledWith(true);
+  });
+
+  it("does not re-arm fetch when the multiplier was already 1", () => {
+    const a = registerMonitor("/wt/a");
+    const rescheduleA = vi.spyOn(a, "rescheduleFetch");
+
+    service.applyFetchThrottle(1);
+
+    expect(rescheduleA).not.toHaveBeenCalled();
+  });
+
+  it("clamps an invalid multiplier (< 1, NaN) to 1", () => {
+    const a = registerMonitor("/wt/a");
+    const updateA = vi.spyOn(a, "updateConfig");
+
+    service.applyFetchThrottle(0);
+    service.applyFetchThrottle(Number.NaN);
+
+    for (const call of updateA.mock.calls) {
+      expect(call[0]).toEqual({
+        fetchIntervalActiveMs: BASE_ACTIVE_MS,
+        fetchIntervalBackgroundMs: BASE_BACKGROUND_MS,
+      });
+    }
+  });
+});

--- a/electron/workspace-host/__tests__/WorkspaceService.rateLimit.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.rateLimit.test.ts
@@ -254,4 +254,21 @@ describe("WorkspaceService.applyFetchThrottle", () => {
       });
     }
   });
+
+  it("preserves the active throttle across an unrelated monitor-config push", () => {
+    const a = registerMonitor("/wt/a");
+    service.applyFetchThrottle(4);
+
+    const updateA = vi.spyOn(a, "updateConfig");
+    // A config push that does not touch fetch intervals must still write the
+    // *throttled* cadence — never clobber it back to the raw base.
+    service.updateMonitorConfig({} as any);
+
+    expect(updateA).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fetchIntervalActiveMs: BASE_ACTIVE_MS * 4,
+        fetchIntervalBackgroundMs: BASE_BACKGROUND_MS * 4,
+      })
+    );
+  });
 });

--- a/plugins/builtin/github/main/GitHubQueries.ts
+++ b/plugins/builtin/github/main/GitHubQueries.ts
@@ -10,6 +10,7 @@ export const REPO_STATS_QUERY = `
       cost
       remaining
       resetAt
+      limit
     }
   }
 `;
@@ -81,6 +82,7 @@ export const REPO_STATS_AND_PAGE_QUERY = `
       cost
       remaining
       resetAt
+      limit
     }
   }
 `;
@@ -121,6 +123,7 @@ export const PROJECT_HEALTH_QUERY = `
       cost
       remaining
       resetAt
+      limit
     }
   }
 `;
@@ -193,6 +196,7 @@ export const LIST_ISSUES_QUERY = `
       cost
       remaining
       resetAt
+      limit
     }
   }
 `;
@@ -252,6 +256,7 @@ export const LIST_PRS_QUERY = `
       cost
       remaining
       resetAt
+      limit
     }
   }
 `;
@@ -340,6 +345,7 @@ export const SEARCH_QUERY = `
       cost
       remaining
       resetAt
+      limit
     }
   }
 `;
@@ -405,6 +411,7 @@ export const GET_ISSUE_QUERY = `
       cost
       remaining
       resetAt
+      limit
     }
   }
 `;
@@ -430,6 +437,7 @@ export const GET_PR_REVIEW_THREADS_QUERY = `
       cost
       remaining
       resetAt
+      limit
     }
   }
 `;
@@ -485,6 +493,7 @@ export const GET_PR_QUERY = `
       cost
       remaining
       resetAt
+      limit
     }
   }
 `;
@@ -631,7 +640,7 @@ export function buildBatchPRQuery(
     }
   }
 
-  return `query { ${issueQueries.join("\n")} ${branchQueries.join("\n")} rateLimit { cost remaining resetAt } }`;
+  return `query { ${issueQueries.join("\n")} ${branchQueries.join("\n")} rateLimit { cost remaining resetAt limit } }`;
 }
 
 /**
@@ -694,7 +703,7 @@ export function buildBatchBranchPRQuery(owner: string, repo: string, branches: s
     `;
   });
 
-  return `query { ${parts.join("\n")} rateLimit { cost remaining resetAt } }`;
+  return `query { ${parts.join("\n")} rateLimit { cost remaining resetAt limit } }`;
 }
 
 /**
@@ -749,5 +758,5 @@ export function buildBatchRequiredChecksQuery(
     `
   );
 
-  return `query { ${parts.join("\n")} rateLimit { cost remaining resetAt } }`;
+  return `query { ${parts.join("\n")} rateLimit { cost remaining resetAt limit } }`;
 }

--- a/plugins/builtin/github/main/GitHubRateLimitService.ts
+++ b/plugins/builtin/github/main/GitHubRateLimitService.ts
@@ -23,11 +23,102 @@ const SECONDARY_BACKOFF_MAX_MS = 5 * 60 * 1000;
 // primary blocks where the response header is absent.
 const GLOBAL_RESOURCE_KEY = "__global__";
 
+// Points held back from background-poll budgeting so interactive, on-demand
+// GitHub requests always keep headroom even while background pollers throttle.
+export const INTERACTIVE_RESERVE = 100;
+
+// At or below this remaining-points figure the GraphQL budget is treated as
+// exhausted and background GraphQL calls are hard-blocked until the window
+// resets. A small non-zero band (vs. a strict `=== 0`) absorbs the cost of a
+// poll that races the reset boundary.
+export const HARD_BLOCK_THRESHOLD = 50;
+
+// Graduated throttling engages once remaining drops below this fraction of the
+// window limit and releases once it climbs back above THROTTLE_RELEASE_RATIO.
+// The gap between the two is deliberate hysteresis (lesson #4629) so a budget
+// hovering near 50% doesn't flap the multiplier on every poll.
+const THROTTLE_ENGAGE_RATIO = 0.5;
+const THROTTLE_RELEASE_RATIO = 0.6;
+
+// A single anomalously-low reading must not stretch intervals — require this
+// many consecutive depleted readings before engaging the throttle.
+const DEPLETED_READINGS_TO_ENGAGE = 2;
+
+// Upper bound on the cadence multiplier so a near-empty budget can't stretch a
+// background interval into effectively never polling.
+export const MAX_THROTTLE_MULTIPLIER = 10;
+
+// Denominator for the dimensionless multiplier — the focused-tier base cadence.
+// `computeThrottleMultiplier` returns "safe per-poll interval ÷ this", which
+// callers then apply uniformly to both focused and background intervals.
+const THROTTLE_BASE_INTERVAL_MS = 30_000;
+
+// Suppress listener churn: only re-notify on a budget reading when the
+// multiplier moves by more than this fraction of its last-notified value.
+const MEANINGFUL_MULTIPLIER_DELTA = 0.05;
+
 interface BlockState {
   kind: GitHubRateLimitKind;
   resumeAt: number;
   resource: string;
   requestId?: string;
+}
+
+/**
+ * Observed GraphQL budget state. Distinct from {@link BlockState}: a depleted
+ * budget stretches the background poll cadence (graduated throttle) without
+ * gating requests, whereas a block hard-stops them.
+ */
+export interface BudgetState {
+  /** Points left in the window at the last observed reading. */
+  remaining: number;
+  /** Window limit (5000 for authenticated users), or null if not reported. */
+  limit: number | null;
+  /** Epoch milliseconds when the budget window resets. */
+  resetAt: number;
+  /** Background-poll cadence multiplier derived from the reading (≥ 1). */
+  multiplier: number;
+  /** Whether graduated throttling is currently engaged (hysteresis-gated). */
+  engaged: boolean;
+  /** Consecutive depleted readings — drives the engage hysteresis. */
+  consecutiveDepletedReadings: number;
+}
+
+/**
+ * Compute a background-poll cadence multiplier from an observed GraphQL budget.
+ *
+ * Spreads the spendable budget (`remaining` minus {@link INTERACTIVE_RESERVE})
+ * evenly across the time left until the window resets, yielding a safe
+ * per-poll interval, then expresses that as a multiple of the focused-tier
+ * base cadence. Returns `1` (no throttling) for healthy budgets, invalid
+ * inputs, or an already-past reset; returns {@link MAX_THROTTLE_MULTIPLIER}
+ * when the spendable budget is exhausted.
+ */
+export function computeThrottleMultiplier(
+  remaining: number,
+  limit: number,
+  resetAtMs: number,
+  nowMs: number = Date.now()
+): number {
+  if (
+    !Number.isFinite(remaining) ||
+    !Number.isFinite(limit) ||
+    !Number.isFinite(resetAtMs) ||
+    limit <= 0
+  ) {
+    return 1;
+  }
+
+  const spendable = remaining - INTERACTIVE_RESERVE;
+  if (spendable <= 0) return MAX_THROTTLE_MULTIPLIER;
+
+  const timeToResetMs = resetAtMs - nowMs;
+  if (timeToResetMs <= 0) return 1;
+
+  const safeIntervalMs = timeToResetMs / spendable;
+  const multiplier = safeIntervalMs / THROTTLE_BASE_INTERVAL_MS;
+  if (!Number.isFinite(multiplier) || multiplier <= 1) return 1;
+  return Math.min(multiplier, MAX_THROTTLE_MULTIPLIER);
 }
 
 export interface ShouldBlockResult {
@@ -45,6 +136,14 @@ class GitHubRateLimitServiceImpl {
   // Drives jittered exponential backoff when GitHub returns a 403/429 without
   // an explicit `retry-after` header.
   private consecutiveSecondaryHits = 0;
+  // Last observed GraphQL budget, or null until a budget-carrying response is
+  // seen. Drives the graduated background-poll throttle.
+  private _budgetState: BudgetState | null = null;
+  // Multiplier carried by the last listener notification — used to suppress
+  // re-notifying on sub-threshold budget drift.
+  private _lastNotifiedMultiplier = 1;
+  // Whether the first budget reading has been pushed to listeners yet.
+  private _hasNotifiedBudget = false;
 
   /**
    * Register a subscriber that fires on every state transition (entering a
@@ -189,14 +288,22 @@ class GitHubRateLimitServiceImpl {
   }
 
   /**
-   * Feed GraphQL `rateLimit { cost remaining resetAt }` data into the
-   * service. When `remaining` is 0 the service marks a `"primary"` block
-   * under the `"graphql"` resource key. Ignores missing or malformed
-   * rateLimit objects silently.
+   * Feed GraphQL `rateLimit { cost remaining resetAt limit }` data into the
+   * service.
+   *
+   * - At or below {@link HARD_BLOCK_THRESHOLD} remaining points, marks a
+   *   `"primary"` block under the `"graphql"` resource key (the legacy
+   *   `remaining === 0` behavior, widened by a small hard-stop band).
+   * - Above that, when `limit` is reported, records the budget and computes a
+   *   graduated background-poll throttle multiplier. The multiplier engages
+   *   only after two consecutive depleted readings (single-blip immunity) and
+   *   releases with hysteresis once the budget recovers.
+   *
+   * Ignores missing or malformed rateLimit objects silently.
    */
   updateFromGraphQL(data: Record<string, unknown>): void {
     const rateLimit = data?.rateLimit as
-      | { cost?: number; remaining?: number; resetAt?: string }
+      | { cost?: number; remaining?: number; resetAt?: string; limit?: number }
       | undefined;
     if (!rateLimit) return;
 
@@ -204,17 +311,87 @@ class GitHubRateLimitServiceImpl {
     const resetAt = rateLimit.resetAt;
     if (typeof remaining !== "number" || typeof resetAt !== "string") return;
 
-    if (remaining === 0) {
-      const resetMs = Date.parse(resetAt);
-      if (Number.isFinite(resetMs)) {
-        this.markBlocked("primary", resetMs + PRIMARY_RESET_BUFFER_MS, "graphql");
-      }
+    const resetMs = Date.parse(resetAt);
+    if (!Number.isFinite(resetMs)) return;
+
+    const limit = typeof rateLimit.limit === "number" ? rateLimit.limit : null;
+
+    // Budget exhausted (or within the hard-stop band): hard-block GraphQL
+    // until the window resets, exactly as the legacy `remaining === 0` path.
+    if (remaining <= HARD_BLOCK_THRESHOLD) {
+      this._budgetState = {
+        remaining,
+        limit,
+        resetAt: resetMs,
+        multiplier: MAX_THROTTLE_MULTIPLIER,
+        engaged: true,
+        consecutiveDepletedReadings: DEPLETED_READINGS_TO_ENGAGE,
+      };
+      this._lastNotifiedMultiplier = MAX_THROTTLE_MULTIPLIER;
+      this._hasNotifiedBudget = true;
+      this.markBlocked("primary", resetMs + PRIMARY_RESET_BUFFER_MS, "graphql");
+      return;
+    }
+
+    // Graduated throttling needs a window limit to compute a depletion ratio.
+    if (limit === null || limit <= 0) return;
+
+    this.recordBudgetReading(remaining, limit, resetMs);
+  }
+
+  /**
+   * Fold a healthy (non-blocking) budget reading into {@link _budgetState},
+   * applying engage/release hysteresis, and notify listeners when the derived
+   * multiplier moves meaningfully.
+   */
+  private recordBudgetReading(remaining: number, limit: number, resetAt: number): void {
+    const previous = this._budgetState;
+    const depleted = remaining < limit * THROTTLE_ENGAGE_RATIO;
+    const recovered = remaining > limit * THROTTLE_RELEASE_RATIO;
+
+    const consecutiveDepletedReadings = depleted
+      ? (previous?.consecutiveDepletedReadings ?? 0) + 1
+      : 0;
+
+    let engaged = previous?.engaged ?? false;
+    if (engaged) {
+      // Stay engaged through the 50–60% hysteresis band; release only above it.
+      if (recovered) engaged = false;
+    } else if (consecutiveDepletedReadings >= DEPLETED_READINGS_TO_ENGAGE) {
+      engaged = true;
+    }
+
+    const multiplier = engaged ? computeThrottleMultiplier(remaining, limit, resetAt) : 1;
+
+    this._budgetState = {
+      remaining,
+      limit,
+      resetAt,
+      multiplier,
+      engaged,
+      consecutiveDepletedReadings,
+    };
+
+    const lastMultiplier = this._lastNotifiedMultiplier;
+    const meaningfulChange =
+      Math.abs(multiplier - lastMultiplier) >
+      Math.max(lastMultiplier, 1) * MEANINGFUL_MULTIPLIER_DELTA;
+
+    if (!this._hasNotifiedBudget || meaningfulChange) {
+      this._hasNotifiedBudget = true;
+      this._lastNotifiedMultiplier = multiplier;
+      this.notifyListeners();
     }
   }
 
   /** Snapshot for push/pull consumers. Collapses multi-resource state to a single payload. */
   getState(): GitHubRateLimitPayload {
     this.autoClearExpired();
+    return this.withBudget(this.computeBlockPayload());
+  }
+
+  /** Block-only projection of current state, before budget fields are folded in. */
+  private computeBlockPayload(): GitHubRateLimitPayload {
     if (this.states.size === 0) {
       return { blocked: false, kind: null };
     }
@@ -237,10 +414,37 @@ class GitHubRateLimitServiceImpl {
     return { blocked: false, kind: null };
   }
 
-  /** Drop any active block (token change, fresh 2xx, manual reset). */
+  /**
+   * Fold the observed GraphQL budget (remaining / limit / throttle multiplier)
+   * into a payload. No-op when no budget has been observed, so the unblocked
+   * cold-start payload stays `{ blocked: false, kind: null }`.
+   */
+  private withBudget(payload: GitHubRateLimitPayload): GitHubRateLimitPayload {
+    const budget = this._budgetState;
+    if (!budget) return payload;
+    const decorated: GitHubRateLimitPayload = {
+      ...payload,
+      remaining: budget.remaining,
+      throttleMultiplier: budget.multiplier,
+    };
+    if (budget.limit !== null) {
+      decorated.limit = budget.limit;
+    }
+    return decorated;
+  }
+
+  /** Drop any active block and budget state (token change, fresh 2xx, manual reset). */
   clear(): void {
     this.consecutiveSecondaryHits = 0;
-    if (this.states.size === 0) return;
+    const hadBudget = this._budgetState !== null;
+    this._budgetState = null;
+    this._lastNotifiedMultiplier = 1;
+    this._hasNotifiedBudget = false;
+    if (this.states.size === 0) {
+      // Still surface the cleared budget so consumers snap back to baseline.
+      if (hadBudget) this.notifyListeners();
+      return;
+    }
     this.states.clear();
     logInfo("GitHub rate limit cleared");
     this.notifyListeners();
@@ -250,11 +454,19 @@ class GitHubRateLimitServiceImpl {
   _resetForTests(): void {
     this.states.clear();
     this.consecutiveSecondaryHits = 0;
+    this._budgetState = null;
+    this._lastNotifiedMultiplier = 1;
+    this._hasNotifiedBudget = false;
   }
 
   /** Test-only inspector. */
   _getConsecutiveSecondaryHitsForTests(): number {
     return this.consecutiveSecondaryHits;
+  }
+
+  /** Test-only inspector for the observed GraphQL budget state. */
+  _getBudgetStateForTests(): Readonly<BudgetState> | null {
+    return this._budgetState;
   }
 
   private clearResource(resource: string): void {
@@ -295,15 +507,30 @@ class GitHubRateLimitServiceImpl {
   }
 
   private autoClearExpired(): void {
-    let anyCleared = false;
+    let blocksCleared = false;
     for (const [key, state] of this.states) {
       if (state.resumeAt <= Date.now()) {
         this.states.delete(key);
-        anyCleared = true;
+        blocksCleared = true;
       }
     }
-    if (anyCleared) {
+
+    // The GraphQL budget window rolls over at its own `resetAt`; once past, the
+    // observed remaining/limit and any throttle derived from them are stale.
+    // Drop them so the cadence snaps back to baseline — recovery is
+    // server-authoritative and needs no hysteresis (lesson #4629).
+    let budgetCleared = false;
+    if (this._budgetState && this._budgetState.resetAt <= Date.now()) {
+      this._budgetState = null;
+      this._lastNotifiedMultiplier = 1;
+      this._hasNotifiedBudget = false;
+      budgetCleared = true;
+    }
+
+    if (blocksCleared) {
       logInfo("GitHub rate limit block(s) expired");
+    }
+    if (blocksCleared || budgetCleared) {
       this.notifyListeners();
     }
   }

--- a/plugins/builtin/github/main/GitHubRateLimitService.ts
+++ b/plugins/builtin/github/main/GitHubRateLimitService.ts
@@ -57,6 +57,12 @@ const THROTTLE_BASE_INTERVAL_MS = 30_000;
 // multiplier moves by more than this fraction of its last-notified value.
 const MEANINGFUL_MULTIPLIER_DELTA = 0.05;
 
+// Extra delay past the budget window's reset before the one-shot recovery
+// sweep runs. Covers the PRIMARY_RESET_BUFFER_MS applied to a hard block
+// raised in the same window, so a single timer clears both the throttle and
+// the block.
+const BUDGET_SWEEP_BUFFER_MS = PRIMARY_RESET_BUFFER_MS + 1_000;
+
 interface BlockState {
   kind: GitHubRateLimitKind;
   resumeAt: number;
@@ -144,6 +150,9 @@ class GitHubRateLimitServiceImpl {
   private _lastNotifiedMultiplier = 1;
   // Whether the first budget reading has been pushed to listeners yet.
   private _hasNotifiedBudget = false;
+  // One-shot timer that sweeps stale budget state just after the window
+  // resets, so a stretched cadence doesn't defer throttle recovery.
+  private _budgetResetTimer: ReturnType<typeof setTimeout> | null = null;
 
   /**
    * Register a subscriber that fires on every state transition (entering a
@@ -329,6 +338,7 @@ class GitHubRateLimitServiceImpl {
       };
       this._lastNotifiedMultiplier = MAX_THROTTLE_MULTIPLIER;
       this._hasNotifiedBudget = true;
+      this.scheduleBudgetResetSweep(resetMs);
       this.markBlocked("primary", resetMs + PRIMARY_RESET_BUFFER_MS, "graphql");
       return;
     }
@@ -381,6 +391,38 @@ class GitHubRateLimitServiceImpl {
       this._hasNotifiedBudget = true;
       this._lastNotifiedMultiplier = multiplier;
       this.notifyListeners();
+    }
+
+    // Arm the recovery sweep only while throttling — an un-throttled cadence
+    // polls often enough to refresh budget state on its own.
+    if (engaged) {
+      this.scheduleBudgetResetSweep(resetAt);
+    } else {
+      this.clearBudgetResetTimer();
+    }
+  }
+
+  /**
+   * Arm a one-shot timer that runs {@link autoClearExpired} just after the
+   * GraphQL budget window resets, so the throttle snaps back to baseline
+   * promptly even when a stretched cadence means no GitHub call would
+   * otherwise touch the service for a while.
+   */
+  private scheduleBudgetResetSweep(resetAtMs: number): void {
+    this.clearBudgetResetTimer();
+    const delay = Math.max(0, resetAtMs + BUDGET_SWEEP_BUFFER_MS - Date.now());
+    const timer = setTimeout(() => {
+      this._budgetResetTimer = null;
+      this.autoClearExpired();
+    }, delay);
+    timer.unref?.();
+    this._budgetResetTimer = timer;
+  }
+
+  private clearBudgetResetTimer(): void {
+    if (this._budgetResetTimer) {
+      clearTimeout(this._budgetResetTimer);
+      this._budgetResetTimer = null;
     }
   }
 
@@ -440,6 +482,7 @@ class GitHubRateLimitServiceImpl {
     this._budgetState = null;
     this._lastNotifiedMultiplier = 1;
     this._hasNotifiedBudget = false;
+    this.clearBudgetResetTimer();
     if (this.states.size === 0) {
       // Still surface the cleared budget so consumers snap back to baseline.
       if (hadBudget) this.notifyListeners();
@@ -457,6 +500,7 @@ class GitHubRateLimitServiceImpl {
     this._budgetState = null;
     this._lastNotifiedMultiplier = 1;
     this._hasNotifiedBudget = false;
+    this.clearBudgetResetTimer();
   }
 
   /** Test-only inspector. */
@@ -524,6 +568,7 @@ class GitHubRateLimitServiceImpl {
       this._budgetState = null;
       this._lastNotifiedMultiplier = 1;
       this._hasNotifiedBudget = false;
+      this.clearBudgetResetTimer();
       budgetCleared = true;
     }
 

--- a/plugins/builtin/github/main/__tests__/GitHubRateLimitService.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubRateLimitService.test.ts
@@ -1,10 +1,29 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { gitHubRateLimitService } from "../GitHubRateLimitService.js";
+import {
+  gitHubRateLimitService,
+  computeThrottleMultiplier,
+  INTERACTIVE_RESERVE,
+  MAX_THROTTLE_MULTIPLIER,
+} from "../GitHubRateLimitService.js";
 import type { GitHubRateLimitPayload } from "../../../../../shared/types/ipc/github.js";
 
 function makeHeaders(entries: Record<string, string>): Headers {
   return new Headers(entries);
+}
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+/** Build a GraphQL `rateLimit`-carrying payload with a reset one hour out. */
+function graphQLData(remaining: number, limit?: number): Record<string, unknown> {
+  return {
+    rateLimit: {
+      cost: 1,
+      remaining,
+      resetAt: new Date(Date.now() + ONE_HOUR_MS).toISOString(),
+      ...(limit !== undefined ? { limit } : {}),
+    },
+  };
 }
 
 describe("GitHubRateLimitService", () => {
@@ -253,12 +272,13 @@ describe("GitHubRateLimitService", () => {
       expect(block.reason).toBe("primary");
     });
 
-    it("does nothing when remaining > 0", () => {
-      gitHubRateLimitService.updateFromGraphQL({
-        rateLimit: { cost: 5, remaining: 4995, resetAt: new Date().toISOString() },
-      });
+    it("does not block on a healthy budget", () => {
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(4995, 5000));
 
       expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+      const budget = gitHubRateLimitService._getBudgetStateForTests();
+      expect(budget?.engaged).toBe(false);
+      expect(budget?.multiplier).toBe(1);
     });
 
     it("ignores missing rateLimit object", () => {
@@ -276,6 +296,130 @@ describe("GitHubRateLimitService", () => {
         rateLimit: { remaining: "0", resetAt: new Date().toISOString() },
       });
       expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+    });
+
+    it("hard-blocks at or below the hard-block threshold", () => {
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(30, 5000));
+
+      const block = gitHubRateLimitService.shouldBlockRequest("graphql");
+      expect(block.blocked).toBe(true);
+      expect(block.reason).toBe("primary");
+      expect(gitHubRateLimitService._getBudgetStateForTests()?.multiplier).toBe(
+        MAX_THROTTLE_MULTIPLIER
+      );
+    });
+
+    it("does not throttle without a reported limit", () => {
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(200));
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(200));
+
+      // No `limit` → no depletion ratio → budget state never recorded.
+      expect(gitHubRateLimitService._getBudgetStateForTests()).toBeNull();
+    });
+
+    it("does not engage the throttle on a single depleted reading", () => {
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+
+      const budget = gitHubRateLimitService._getBudgetStateForTests();
+      expect(budget?.engaged).toBe(false);
+      expect(budget?.consecutiveDepletedReadings).toBe(1);
+      expect(budget?.multiplier).toBe(1);
+    });
+
+    it("engages a graduated throttle after two consecutive depleted readings", () => {
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+
+      const budget = gitHubRateLimitService._getBudgetStateForTests();
+      expect(budget?.engaged).toBe(true);
+      // remaining 150, reserve 100 → 50 spendable over ~1h → ~2.4x cadence.
+      expect(budget?.multiplier).toBeGreaterThan(1);
+      expect(budget?.multiplier).toBeLessThanOrEqual(MAX_THROTTLE_MULTIPLIER);
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+    });
+
+    it("releases the throttle once the budget recovers above the release ratio", () => {
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+      expect(gitHubRateLimitService._getBudgetStateForTests()?.engaged).toBe(true);
+
+      // 3500 / 5000 = 70% — above the 60% release ratio.
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(3500, 5000));
+
+      const budget = gitHubRateLimitService._getBudgetStateForTests();
+      expect(budget?.engaged).toBe(false);
+      expect(budget?.multiplier).toBe(1);
+    });
+
+    it("stays engaged within the hysteresis band (50–60%)", () => {
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+
+      // 2800 / 5000 = 56% — between engage (50%) and release (60%).
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(2800, 5000));
+
+      expect(gitHubRateLimitService._getBudgetStateForTests()?.engaged).toBe(true);
+    });
+
+    it("carries remaining, limit, and throttleMultiplier in the pushed payload", () => {
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+
+      const state = gitHubRateLimitService.getState();
+      expect(state.blocked).toBe(false);
+      expect(state.remaining).toBe(150);
+      expect(state.limit).toBe(5000);
+      expect(state.throttleMultiplier).toBeGreaterThan(1);
+    });
+
+    it("does not re-notify on a sub-threshold budget reading", () => {
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+      const callsAfterEngage = listener.mock.calls.length;
+
+      // Identical reading — multiplier unchanged, so no fresh notification.
+      gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+
+      expect(listener.mock.calls.length).toBe(callsAfterEngage);
+    });
+  });
+
+  describe("computeThrottleMultiplier()", () => {
+    const now = Date.now();
+
+    it("returns 1 for a healthy budget", () => {
+      expect(computeThrottleMultiplier(4000, 5000, now + ONE_HOUR_MS, now)).toBe(1);
+    });
+
+    it("returns a multiplier above 1 for a depleted budget", () => {
+      // 150 remaining − 100 reserve = 50 spendable over 1h → 72s/poll → 2.4x.
+      const m = computeThrottleMultiplier(150, 5000, now + ONE_HOUR_MS, now);
+      expect(m).toBeCloseTo(2.4, 1);
+    });
+
+    it("returns the max multiplier when the spendable budget is exhausted", () => {
+      expect(computeThrottleMultiplier(INTERACTIVE_RESERVE, 5000, now + ONE_HOUR_MS, now)).toBe(
+        MAX_THROTTLE_MULTIPLIER
+      );
+      expect(computeThrottleMultiplier(40, 5000, now + ONE_HOUR_MS, now)).toBe(
+        MAX_THROTTLE_MULTIPLIER
+      );
+    });
+
+    it("clamps an extreme stretch to the max multiplier", () => {
+      expect(computeThrottleMultiplier(101, 5000, now + 24 * ONE_HOUR_MS, now)).toBe(
+        MAX_THROTTLE_MULTIPLIER
+      );
+    });
+
+    it("returns 1 when the reset is already in the past", () => {
+      expect(computeThrottleMultiplier(150, 5000, now - 1000, now)).toBe(1);
+    });
+
+    it("returns 1 for invalid inputs", () => {
+      expect(computeThrottleMultiplier(Number.NaN, 5000, now + ONE_HOUR_MS, now)).toBe(1);
+      expect(computeThrottleMultiplier(150, 0, now + ONE_HOUR_MS, now)).toBe(1);
+      expect(computeThrottleMultiplier(150, 5000, Number.NaN, now)).toBe(1);
     });
   });
 

--- a/plugins/builtin/github/main/__tests__/GitHubRateLimitService.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubRateLimitService.test.ts
@@ -382,6 +382,27 @@ describe("GitHubRateLimitService", () => {
 
       expect(listener.mock.calls.length).toBe(callsAfterEngage);
     });
+
+    it("snaps the throttle back when the budget window resets (passive sweep)", () => {
+      vi.useFakeTimers();
+      try {
+        gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+        gitHubRateLimitService.updateFromGraphQL(graphQLData(150, 5000));
+        expect(gitHubRateLimitService._getBudgetStateForTests()?.engaged).toBe(true);
+        listener.mockClear();
+
+        // Advance past the window reset without any further GitHub call — the
+        // one-shot sweep must clear the stale budget on its own.
+        vi.advanceTimersByTime(ONE_HOUR_MS + 60_000);
+
+        expect(gitHubRateLimitService._getBudgetStateForTests()).toBeNull();
+        expect(listener).toHaveBeenCalledWith(
+          expect.objectContaining({ blocked: false, kind: null })
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("computeThrottleMultiplier()", () => {

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -48,7 +48,7 @@ const REPO_METADATA_QUERY = `
       licenseInfo { name }
       repositoryTopics(first: 20) { nodes { topic { name } } }
     }
-    rateLimit { cost remaining resetAt }
+    rateLimit { cost remaining resetAt limit }
   }
 `;
 
@@ -83,7 +83,7 @@ const PR_CI_STATUS_QUERY = `
         }
       }
     }
-    rateLimit { cost remaining resetAt }
+    rateLimit { cost remaining resetAt limit }
   }
 `;
 

--- a/shared/types/ipc/github.ts
+++ b/shared/types/ipc/github.ts
@@ -33,6 +33,19 @@ export interface GitHubRateLimitPayload {
   resetAt?: number;
   /** `x-ratelimit-resource` bucket name when the block is per-resource primary */
   resource?: string;
+  /**
+   * Points left in the current GraphQL budget window, from the last observed
+   * `rateLimit` node. Absent until a budget-carrying response is seen.
+   */
+  remaining?: number;
+  /** Total points in the GraphQL budget window (5000 for authenticated users). */
+  limit?: number;
+  /**
+   * Background-poll cadence multiplier derived from the remaining budget. `1`
+   * at full speed; values above `1` stretch background fetch intervals so
+   * multiple instances drawing on the same token budget back off in step.
+   */
+  throttleMultiplier?: number;
 }
 
 /** A single rate-limit bucket as reported by `/rate_limit` */


### PR DESCRIPTION
## Summary

The old rate-limit handling was binary — fetch at full speed until `remaining === 0`, then hard-block. That works fine in isolation but falls apart when multiple Daintree instances share the same 5000-point/hr token budget: one instance burns the budget and everyone else gets hard-blocked without warning.

This replaces the hard-block with graduated, budget-aware throttling. Background fetch cadence stretches proportionally as the budget depletes, keeping a small reserve (100 points) for interactive on-demand requests. Multiple instances drawing on the same token back off in step.

Resolves #8756

## Changes

- New pure `computeThrottleMultiplier` function — takes current `remaining`/`limit` and returns a linear-stretch multiplier; fully unit-tested in isolation.
- `GitHubRateLimitService.updateFromGraphQL` now reads `rateLimit.limit`, tracks budget state, and only engages throttling after two consecutive depleted readings (single-blip immunity). Release hysteresis is 50% on normal recovery, 60% after full depletion, to avoid rapid cycling.
- `GitHubRateLimitPayload` IPC type gains optional `remaining`, `limit`, and `throttleMultiplier` fields — backwards-compatible with existing consumers.
- `WorkspaceService.applyFetchThrottle` fans the multiplier out to all worktree fetch schedulers, always scaling from the user-configured base interval (no compounding across calls).
- One-shot recovery sweep snaps fetch cadence back to base when the budget window resets.
- `rateLimit` selection added to every GraphQL query so the budget state stays current.

## Testing

- Unit tests cover `computeThrottleMultiplier` across the full depletion curve, single-blip immunity, hysteresis boundaries, and the recovery sweep (`GitHubRateLimitService.test.ts`, `WorkspaceService.rateLimit.test.ts`).
- Existing rate-limit tests updated to account for the new `limit` field in GraphQL responses.