### PR TITLE
feat(crash-recovery): surface suspect panels with banner and pre-deselect on repeat crash

### DIFF
--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -17,6 +17,12 @@ import { Button } from "../ui/button";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { AnimatedLabel } from "../ui/AnimatedLabel";
 import { SettingsSwitch } from "../Settings/SettingsSwitch";
+import { InlineStatusBanner } from "../Terminal/InlineStatusBanner";
+import {
+  getSuspectPanelBannerTitle,
+  SUSPECT_PANEL_BANNER_DESCRIPTION_DESELECTED,
+  SUSPECT_PANEL_BANNER_DESCRIPTION_SELECTED,
+} from "./recoveryCopy";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -61,9 +67,10 @@ export function CrashRecoveryDialog({
   const panels = useMemo(() => crash.panels ?? [], [crash.panels]);
   const hasPanels = panels.length > 0;
   const isInCrashLoop = (crash.crashCount ?? 0) >= 2;
+  const shouldDeselectSuspects = (crash.crashCount ?? 0) >= 1;
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(
-    () => new Set(panels.map((p) => p.id))
+    () => new Set(panels.filter((p) => !(shouldDeselectSuspects && p.isSuspect)).map((p) => p.id))
   );
   const [resolving, setResolving] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
@@ -224,14 +231,21 @@ export function CrashRecoveryDialog({
               </div>
 
               {suspectCount > 0 && (
-                <p
-                  className="text-xs text-status-warning/90 bg-status-warning/10 rounded px-2 py-1.5"
-                  data-testid="suspect-warning"
-                >
-                  <span className="tabular-nums">{suspectCount}</span> panel
-                  {suspectCount > 1 ? "s were" : " was"} created shortly before the crash and may be
-                  related.
-                </p>
+                <div data-testid="suspect-warning" className="rounded-md overflow-hidden">
+                  <InlineStatusBanner
+                    severity="warning"
+                    icon={AlertTriangle}
+                    title={getSuspectPanelBannerTitle(suspectCount, shouldDeselectSuspects)}
+                    description={
+                      shouldDeselectSuspects
+                        ? SUSPECT_PANEL_BANNER_DESCRIPTION_DESELECTED
+                        : SUSPECT_PANEL_BANNER_DESCRIPTION_SELECTED
+                    }
+                    actions={[]}
+                    role="status"
+                    ariaLive="polite"
+                  />
+                </div>
               )}
 
               <div className="flex gap-2">

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -84,6 +84,25 @@ vi.mock("@/components/ui/button", () => ({
   ),
 }));
 
+vi.mock("@/components/Terminal/InlineStatusBanner", () => ({
+  InlineStatusBanner: ({
+    title,
+    description,
+    severity,
+  }: {
+    title: ReactNode;
+    description?: ReactNode;
+    severity?: string;
+  }) => (
+    <div data-testid="inline-status-banner" data-severity={severity ?? "error"}>
+      <span data-testid="inline-status-banner-title">{title}</span>
+      {description ? (
+        <span data-testid="inline-status-banner-description">{description}</span>
+      ) : null}
+    </div>
+  ),
+}));
+
 const mockPanels = [
   {
     id: "t1",
@@ -224,12 +243,96 @@ describe("CrashRecoveryDialog", () => {
       expect(screen.getByTestId("suspect-warning")).toBeTruthy();
     });
 
+    it("renders the suspect warning as a warning-severity InlineStatusBanner", () => {
+      setup();
+      const banner = within(screen.getByTestId("suspect-warning")).getByTestId(
+        "inline-status-banner"
+      );
+      expect(banner.getAttribute("data-severity")).toBe("warning");
+    });
+
+    it("suspect banner title uses the 'created shortly before the crash' phrasing when crashCount is undefined", () => {
+      setup();
+      const title = within(screen.getByTestId("suspect-warning")).getByTestId(
+        "inline-status-banner-title"
+      );
+      expect(title.textContent).toContain("1 panel created shortly before the crash");
+    });
+
+    it("suspect banner title says 'deselected' when crashCount is at least 1", () => {
+      setup({ crash: { crashCount: 1 } });
+      const title = within(screen.getByTestId("suspect-warning")).getByTestId(
+        "inline-status-banner-title"
+      );
+      expect(title.textContent).toContain("1 panel deselected");
+      expect(title.textContent).toContain("created shortly before the crash");
+    });
+
+    it("suspect banner description prompts re-check when suspects were auto-deselected", () => {
+      setup({ crash: { crashCount: 1 } });
+      const desc = within(screen.getByTestId("suspect-warning")).getByTestId(
+        "inline-status-banner-description"
+      );
+      expect(desc.textContent).toContain("Re-check");
+    });
+
+    it("suspect banner is omitted when there are no suspect panels", () => {
+      setup({
+        crash: {
+          panels: [
+            { id: "t1", kind: "terminal", title: "Shell", location: "grid", isSuspect: false },
+          ],
+        },
+      });
+      expect(screen.queryByTestId("suspect-warning")).toBeNull();
+    });
+
     it("all panels are selected by default", () => {
       setup();
       const checkbox1 = screen.getByTestId("panel-checkbox-t1") as HTMLInputElement;
       const checkbox2 = screen.getByTestId("panel-checkbox-t2") as HTMLInputElement;
       expect(checkbox1.checked).toBe(true);
       expect(checkbox2.checked).toBe(true);
+    });
+
+    it("pre-deselects suspect panels when crashCount is at least 1", () => {
+      setup({ crash: { crashCount: 1 } });
+      const suspect = screen.getByTestId("panel-checkbox-t2") as HTMLInputElement;
+      const nonSuspect1 = screen.getByTestId("panel-checkbox-t1") as HTMLInputElement;
+      const nonSuspect3 = screen.getByTestId("panel-checkbox-t3") as HTMLInputElement;
+      expect(suspect.checked).toBe(false);
+      expect(nonSuspect1.checked).toBe(true);
+      expect(nonSuspect3.checked).toBe(true);
+    });
+
+    it("pre-deselects suspect panels when crashCount is in a crash loop", () => {
+      setup({ crash: { crashCount: 3 } });
+      const suspect = screen.getByTestId("panel-checkbox-t2") as HTMLInputElement;
+      expect(suspect.checked).toBe(false);
+    });
+
+    it("keeps suspect panels selected when crashCount is 0", () => {
+      setup({ crash: { crashCount: 0 } });
+      const suspect = screen.getByTestId("panel-checkbox-t2") as HTMLInputElement;
+      expect(suspect.checked).toBe(true);
+    });
+
+    it("restore-selected omits pre-deselected suspect panels by default when crashCount >= 1", async () => {
+      const { onResolve } = setup({ crash: { crashCount: 1 } });
+      fireEvent.click(screen.getByTestId("restore-selected-button"));
+      await waitFor(() =>
+        expect(onResolve).toHaveBeenCalledWith({
+          kind: "restore",
+          panelIds: expect.arrayContaining(["t1", "t3"]),
+        })
+      );
+      const call = (onResolve as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      expect(call.panelIds).not.toContain("t2");
+    });
+
+    it("selection count reflects auto-deselection when crashCount >= 1", () => {
+      setup({ crash: { crashCount: 1 } });
+      expect(screen.getByText("2 of 3 selected")).toBeTruthy();
     });
 
     it("calls onResolve with selected panel IDs when Restore Selected is clicked", async () => {

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -335,6 +335,70 @@ describe("CrashRecoveryDialog", () => {
       expect(screen.getByText("2 of 3 selected")).toBeTruthy();
     });
 
+    it("lets the user re-check a pre-deselected suspect and include it in restore", async () => {
+      const { onResolve } = setup({ crash: { crashCount: 1 } });
+      const suspect = screen.getByTestId("panel-checkbox-t2") as HTMLInputElement;
+      expect(suspect.checked).toBe(false);
+      fireEvent.click(suspect);
+      expect((screen.getByTestId("panel-checkbox-t2") as HTMLInputElement).checked).toBe(true);
+      fireEvent.click(screen.getByTestId("restore-selected-button"));
+      await waitFor(() =>
+        expect(onResolve).toHaveBeenCalledWith({
+          kind: "restore",
+          panelIds: expect.arrayContaining(["t1", "t2", "t3"]),
+        })
+      );
+    });
+
+    it("pre-deselects every suspect when multiple panels are flagged", () => {
+      setup({
+        crash: {
+          crashCount: 1,
+          panels: [
+            { id: "t1", kind: "terminal", title: "Shell", location: "grid", isSuspect: false },
+            { id: "t2", kind: "terminal", title: "Claude", location: "dock", isSuspect: true },
+            { id: "t3", kind: "browser", title: "Docs", location: "grid", isSuspect: true },
+          ],
+        },
+      });
+      expect((screen.getByTestId("panel-checkbox-t1") as HTMLInputElement).checked).toBe(true);
+      expect((screen.getByTestId("panel-checkbox-t2") as HTMLInputElement).checked).toBe(false);
+      expect((screen.getByTestId("panel-checkbox-t3") as HTMLInputElement).checked).toBe(false);
+      expect(screen.getByText("1 of 3 selected")).toBeTruthy();
+      const title = within(screen.getByTestId("suspect-warning")).getByTestId(
+        "inline-status-banner-title"
+      );
+      expect(title.textContent).toContain("2 panels deselected");
+    });
+
+    it("disables restore-selected when every panel is a pre-deselected suspect", () => {
+      setup({
+        crash: {
+          crashCount: 1,
+          panels: [
+            { id: "t1", kind: "terminal", title: "Shell", location: "grid", isSuspect: true },
+            { id: "t2", kind: "terminal", title: "Claude", location: "dock", isSuspect: true },
+          ],
+        },
+      });
+      expect((screen.getByTestId("panel-checkbox-t1") as HTMLInputElement).checked).toBe(false);
+      expect((screen.getByTestId("panel-checkbox-t2") as HTMLInputElement).checked).toBe(false);
+      const restoreBtn = screen.getByTestId("restore-selected-button") as HTMLButtonElement;
+      expect(restoreBtn.disabled).toBe(true);
+      // Toggle-all should still let the user opt back in
+      fireEvent.click(screen.getByTestId("toggle-all-button"));
+      expect((screen.getByTestId("panel-checkbox-t1") as HTMLInputElement).checked).toBe(true);
+      expect((screen.getByTestId("panel-checkbox-t2") as HTMLInputElement).checked).toBe(true);
+    });
+
+    it("suspect banner description suggests deselecting when crashCount is 0", () => {
+      setup({ crash: { crashCount: 0 } });
+      const desc = within(screen.getByTestId("suspect-warning")).getByTestId(
+        "inline-status-banner-description"
+      );
+      expect(desc.textContent).toContain("Consider deselecting");
+    });
+
     it("calls onResolve with selected panel IDs when Restore Selected is clicked", async () => {
       const { onResolve } = setup();
       // Deselect t2

--- a/src/components/Recovery/recoveryCopy.ts
+++ b/src/components/Recovery/recoveryCopy.ts
@@ -52,3 +52,16 @@ export function getRestoreConfirmationTitle(suspectCount: number): string {
   }
   return "Session recovered after unexpected exit.";
 }
+
+export function getSuspectPanelBannerTitle(count: number, deselected: boolean): string {
+  const noun = count === 1 ? "panel" : "panels";
+  if (deselected) {
+    return `${count} ${noun} deselected — created shortly before the crash`;
+  }
+  return `${count} ${noun} created shortly before the crash`;
+}
+
+export const SUSPECT_PANEL_BANNER_DESCRIPTION_DESELECTED =
+  "These panels may have caused the crash. Re-check to include them.";
+export const SUSPECT_PANEL_BANNER_DESCRIPTION_SELECTED =
+  "These panels may be related to the crash. Consider deselecting before restoring.";


### PR DESCRIPTION
## Summary

Two changes to the crash recovery dialog to make suspect panels harder to ignore and safer to handle.

- When `crash.crashCount >= 1`, suspect panels are pre-deselected from the initial restore selection — so a repeat crash defaults to the safer subset rather than blindly re-selecting the likely trigger. Users can still re-check them in one click.
- Replaces the soft `text-xs text-status-warning/90` paragraph with an `InlineStatusBanner severity="warning"`, matching `SafeModeBanner`, `HostCrashBanner`, and the other banners in `src/components/Recovery/`.
- New copy constants in `recoveryCopy.ts`: `getSuspectPanelBannerTitle` (selected/deselected variants), `SUSPECT_PANEL_BANNER_DESCRIPTION_DESELECTED`, `SUSPECT_PANEL_BANNER_DESCRIPTION_SELECTED`.

Resolves #8679

## Changes

- `src/components/Recovery/CrashRecoveryDialog.tsx` — pre-deselect logic + banner swap
- `src/components/Recovery/recoveryCopy.ts` — new copy constants
- `src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx` — 12 new tests (62 total)

## Testing

62 unit tests passing. Covers first-crash vs repeat-crash selection seeding, banner variant switching (deselected/selected), and edge cases from review.