### PR TITLE
refactor(settings): keep ImageViewerTab chrome visible during async load

### DIFF
--- a/src/components/Settings/ImageViewerTab.tsx
+++ b/src/components/Settings/ImageViewerTab.tsx
@@ -121,70 +121,66 @@ export function ImageViewerTab() {
         description="Choose the application that opens when you click 'Open in Image Viewer' in the file viewer."
       >
         <div className="space-y-4">
-          {isLoading ? (
-            <p className="text-xs text-daintree-text/40">Loading…</p>
-          ) : (
-            <>
-              <div className="space-y-2">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="radio"
-                    name="imageViewerMode"
-                    value="os"
-                    checked={mode === "os"}
-                    onChange={() => handleModeChange("os")}
-                    className="accent-daintree-accent"
-                  />
-                  <span className="text-sm text-daintree-text">Use OS default</span>
-                </label>
-                <p className="text-xs text-daintree-text/40 ml-6">
-                  Opens images with your system default viewer (Preview on macOS, Photos on
-                  Windows).
-                </p>
+          <div className="space-y-2">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="imageViewerMode"
+                value="os"
+                checked={mode === "os"}
+                onChange={() => handleModeChange("os")}
+                disabled={isLoading}
+                className="accent-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <span className="text-sm text-daintree-text">Use OS default</span>
+            </label>
+            <p className="text-xs text-daintree-text/40 ml-6">
+              Opens images with your system default viewer (Preview on macOS, Photos on Windows).
+            </p>
 
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="radio"
-                    name="imageViewerMode"
-                    value="custom"
-                    checked={mode === "custom"}
-                    onChange={() => handleModeChange("custom")}
-                    className="accent-daintree-accent"
-                  />
-                  <span className="text-sm text-daintree-text">Custom command</span>
-                </label>
-              </div>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="imageViewerMode"
+                value="custom"
+                checked={mode === "custom"}
+                onChange={() => handleModeChange("custom")}
+                disabled={isLoading}
+                className="accent-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <span className="text-sm text-daintree-text">Custom command</span>
+            </label>
+          </div>
 
-              {mode === "custom" && (
-                <div className="space-y-1 ml-6">
-                  <label className="text-xs text-daintree-text/60">Command</label>
-                  <input
-                    type="text"
-                    value={customCommand}
-                    onChange={(e) => handleCommandChange(e.target.value)}
-                    placeholder="e.g. open -a Photoshop, gimp"
-                    className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:border-daintree-accent transition-colors font-mono"
-                  />
-                  <p className="text-xs text-daintree-text/40">
-                    The file path will be appended as the last argument.
-                  </p>
-                </div>
-              )}
-
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={handleSave}
-                  disabled={isSaving || isLoading}
-                  className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
-                >
-                  {isSaving ? "Saving…" : "Save"}
-                </button>
-                {saved && <span className="text-xs text-status-success">Saved</span>}
-              </div>
-
-              {saveError && <p className="text-xs text-status-error">{saveError}</p>}
-            </>
+          {mode === "custom" && (
+            <div className="space-y-1 ml-6">
+              <label className="text-xs text-daintree-text/60">Command</label>
+              <input
+                type="text"
+                value={customCommand}
+                onChange={(e) => handleCommandChange(e.target.value)}
+                disabled={isLoading}
+                placeholder="e.g. open -a Photoshop, gimp"
+                className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:border-daintree-accent transition-colors font-mono disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <p className="text-xs text-daintree-text/40">
+                The file path will be appended as the last argument.
+              </p>
+            </div>
           )}
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleSave}
+              disabled={isSaving || isLoading}
+              className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
+            >
+              {isSaving ? "Saving…" : "Save"}
+            </button>
+            {saved && <span className="text-xs text-status-success">Saved</span>}
+          </div>
+
+          {saveError && <p className="text-xs text-status-error">{saveError}</p>}
         </div>
       </SettingsSection>
     </div>

--- a/src/components/Settings/ImageViewerTab.tsx
+++ b/src/components/Settings/ImageViewerTab.tsx
@@ -13,6 +13,7 @@ export function ImageViewerTab() {
   const [customCommand, setCustomCommand] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
   const isMountedRef = useRef(true);
@@ -33,12 +34,16 @@ export function ImageViewerTab() {
     setCustomCommand("");
     setSaved(false);
     setSaveError(null);
+    setLoadError(null);
     setIsLoading(true);
     let cancelled = false;
     let timedOut = false;
     const timer = setTimeout(() => {
       timedOut = true;
-      if (!cancelled && isMountedRef.current) setIsLoading(false);
+      if (!cancelled && isMountedRef.current) {
+        setLoadError("Settings took too long to load. Reopen the tab to retry.");
+        setIsLoading(false);
+      }
     }, 10_000);
     window.electron.project
       .getSettings(activeProjectId)
@@ -53,6 +58,7 @@ export function ImageViewerTab() {
       .catch((err) => {
         if (cancelled || !isMountedRef.current) return;
         logError("[ImageViewerTab] Failed to load settings", err);
+        setLoadError(formatErrorMessage(err, "Couldn't load image viewer settings"));
       })
       .finally(() => {
         clearTimeout(timer);
@@ -75,7 +81,7 @@ export function ImageViewerTab() {
   };
 
   const handleSave = async () => {
-    if (!activeProjectId || isSaving || isLoading) return;
+    if (!activeProjectId || isSaving || isLoading || loadError) return;
     if (mode === "custom" && !customCommand.trim()) {
       setSaveError("Custom command cannot be empty");
       return;
@@ -129,7 +135,7 @@ export function ImageViewerTab() {
                 value="os"
                 checked={mode === "os"}
                 onChange={() => handleModeChange("os")}
-                disabled={isLoading}
+                disabled={isLoading || Boolean(loadError)}
                 className="accent-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed"
               />
               <span className="text-sm text-daintree-text">Use OS default</span>
@@ -145,7 +151,7 @@ export function ImageViewerTab() {
                 value="custom"
                 checked={mode === "custom"}
                 onChange={() => handleModeChange("custom")}
-                disabled={isLoading}
+                disabled={isLoading || Boolean(loadError)}
                 className="accent-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed"
               />
               <span className="text-sm text-daintree-text">Custom command</span>
@@ -159,7 +165,7 @@ export function ImageViewerTab() {
                 type="text"
                 value={customCommand}
                 onChange={(e) => handleCommandChange(e.target.value)}
-                disabled={isLoading}
+                disabled={isLoading || Boolean(loadError)}
                 placeholder="e.g. open -a Photoshop, gimp"
                 className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:border-daintree-accent transition-colors font-mono disabled:opacity-50 disabled:cursor-not-allowed"
               />
@@ -172,7 +178,7 @@ export function ImageViewerTab() {
           <div className="flex items-center gap-2">
             <button
               onClick={handleSave}
-              disabled={isSaving || isLoading}
+              disabled={isSaving || isLoading || Boolean(loadError)}
               className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
             >
               {isSaving ? "Saving…" : "Save"}
@@ -180,6 +186,7 @@ export function ImageViewerTab() {
             {saved && <span className="text-xs text-status-success">Saved</span>}
           </div>
 
+          {loadError && <p className="text-xs text-status-error">{loadError}</p>}
           {saveError && <p className="text-xs text-status-error">{saveError}</p>}
         </div>
       </SettingsSection>

--- a/src/components/Settings/__tests__/ImageViewerTab.test.tsx
+++ b/src/components/Settings/__tests__/ImageViewerTab.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ImageViewerTab } from "../ImageViewerTab";
+import { useProjectStore } from "@/store/projectStore";
+import type { Project } from "@shared/types/project";
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+vi.mock("@/clients", () => ({
+  projectClient: {
+    getSettings: vi.fn(async () => ({})),
+    saveSettings: vi.fn(async () => undefined),
+  },
+}));
+
+function setProject(project: Project | null) {
+  useProjectStore.setState({ currentProject: project });
+}
+
+type DeferredSettings = {
+  promise: Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferredSettings(): DeferredSettings {
+  let resolve!: (value: unknown) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function installElectron(getSettings: () => Promise<unknown>) {
+  window.electron = {
+    project: {
+      getSettings: vi.fn(getSettings),
+    },
+  } as unknown as typeof window.electron;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setProject(null);
+});
+
+describe("ImageViewerTab", () => {
+  it("renders section chrome and disabled controls while settings are loading", async () => {
+    const deferred = deferredSettings();
+    installElectron(() => deferred.promise as Promise<unknown>);
+    setProject({ id: "proj-1", path: "/repo", name: "Repo" } as Project);
+
+    render(<ImageViewerTab />);
+
+    // Section chrome appears immediately, before the load resolves.
+    expect(screen.getByText("Image viewer")).toBeTruthy();
+    expect(screen.getByText(/Choose the application that opens when you click/i)).toBeTruthy();
+
+    const osRadio = screen.getByRole("radio", { name: /Use OS default/i }) as HTMLInputElement;
+    const customRadio = screen.getByRole("radio", {
+      name: /Custom command/i,
+    }) as HTMLInputElement;
+    const saveButton = screen.getByRole("button", { name: /save/i }) as HTMLButtonElement;
+
+    expect(osRadio).toBeTruthy();
+    expect(customRadio).toBeTruthy();
+    expect(saveButton).toBeTruthy();
+    expect(osRadio.disabled).toBe(true);
+    expect(customRadio.disabled).toBe(true);
+    expect(saveButton.disabled).toBe(true);
+
+    deferred.resolve({});
+    await waitFor(() => {
+      expect(osRadio.disabled).toBe(false);
+    });
+  });
+
+  it("populates and enables controls after settings resolve with custom mode", async () => {
+    installElectron(async () => ({
+      preferredImageViewer: { mode: "custom", customCommand: "open -a Photoshop" },
+    }));
+    setProject({ id: "proj-1", path: "/repo", name: "Repo" } as Project);
+
+    render(<ImageViewerTab />);
+
+    const customInput = (await waitFor(() =>
+      screen.getByDisplayValue("open -a Photoshop")
+    )) as HTMLInputElement;
+    expect(customInput.disabled).toBe(false);
+
+    const customRadio = screen.getByRole("radio", {
+      name: /Custom command/i,
+    }) as HTMLInputElement;
+    expect(customRadio.checked).toBe(true);
+    expect(customRadio.disabled).toBe(false);
+  });
+
+  it("shows the empty-project hint when no project is open", async () => {
+    installElectron(async () => ({}));
+    render(<ImageViewerTab />);
+    expect(
+      screen.getByText(/Open a project to configure its image viewer preference/i)
+    ).toBeTruthy();
+    expect(window.electron.project.getSettings).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Settings/__tests__/ImageViewerTab.test.tsx
+++ b/src/components/Settings/__tests__/ImageViewerTab.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { ImageViewerTab } from "../ImageViewerTab";
 import { useProjectStore } from "@/store/projectStore";
 import type { Project } from "@shared/types/project";
@@ -110,5 +110,61 @@ describe("ImageViewerTab", () => {
       screen.getByText(/Open a project to configure its image viewer preference/i)
     ).toBeTruthy();
     expect(window.electron.project.getSettings).not.toHaveBeenCalled();
+  });
+
+  it("blocks Save when the settings load rejects", async () => {
+    installElectron(async () => {
+      throw new Error("ipc blew up");
+    });
+    setProject({ id: "proj-1", path: "/repo", name: "Repo" } as Project);
+
+    render(<ImageViewerTab />);
+
+    const saveButton = (await waitFor(() => {
+      const btn = screen.getByRole("button", { name: /save/i }) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+      return btn;
+    })) as HTMLButtonElement;
+
+    // Section chrome stays visible; an error message surfaces.
+    expect(screen.getByText("Image viewer")).toBeTruthy();
+    expect(screen.getByText(/ipc blew up|Couldn't load image viewer settings/i)).toBeTruthy();
+
+    // Radios remain disabled — load failed, the persisted value is unknown.
+    const osRadio = screen.getByRole("radio", { name: /Use OS default/i }) as HTMLInputElement;
+    const customRadio = screen.getByRole("radio", {
+      name: /Custom command/i,
+    }) as HTMLInputElement;
+    expect(osRadio.disabled).toBe(true);
+    expect(customRadio.disabled).toBe(true);
+    expect(saveButton.disabled).toBe(true);
+  });
+
+  it("blocks Save when the settings load times out", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    try {
+      const deferred = deferredSettings();
+      installElectron(() => deferred.promise as Promise<unknown>);
+      setProject({ id: "proj-1", path: "/repo", name: "Repo" } as Project);
+
+      render(<ImageViewerTab />);
+
+      // Before the timeout fires, controls are merely loading.
+      const osRadio = screen.getByRole("radio", { name: /Use OS default/i }) as HTMLInputElement;
+      expect(osRadio.disabled).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(screen.getByText(/took too long to load/i)).toBeTruthy();
+
+      const saveButton = screen.getByRole("button", { name: /save/i }) as HTMLButtonElement;
+      expect(saveButton.disabled).toBe(true);
+      // Radios remain disabled so user can't overwrite unknown data.
+      expect(osRadio.disabled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- `ImageViewerTab` was hiding all form controls behind a bare "Loading..." line while the async bridge call resolved. Controls now render immediately and are disabled until data arrives, matching the pattern the rest of the settings tabs already use.
- Adds a `loadError` state with a 10-second timeout. If the load rejects or stalls, the Save button is blocked and the radio/input controls are disabled — so a failed load can't silently overwrite the persisted preference with the default `"os"` value.
- 5 unit tests: chrome visible during deferred load, controls populate after resolve, no-project hint, save blocked on rejection, save blocked on timeout.

Resolves #8658

## Changes

- `src/components/Settings/ImageViewerTab.tsx` — removed the `isLoading` ternary that hid the form; controls render unconditionally with `disabled={isLoading}`. Added `loadError` state set on `.catch()` and on the 10-second timeout guard.
- `src/components/Settings/__tests__/ImageViewerTab.test.tsx` (new) — 5 tests covering the above.

## Testing

Unit tests added and passing. Manually verified the tab renders its chrome immediately on open and populates values once the bridge call settles.