### PR TITLE
feat(worktree): order row badges by salience and surface alarms when collapsed

### DIFF
--- a/src/components/Worktree/WorktreeCard/CollapsedAlarmPill.tsx
+++ b/src/components/Worktree/WorktreeCard/CollapsedAlarmPill.tsx
@@ -1,0 +1,30 @@
+import { CircleAlert } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { AlarmDescriptor } from "@/lib/worktreeAlarmTier";
+
+interface CollapsedAlarmPillProps {
+  alarm: AlarmDescriptor;
+}
+
+export function CollapsedAlarmPill({ alarm }: CollapsedAlarmPillProps) {
+  if (alarm.tier === 0) return null;
+
+  const isError = alarm.tone === "error";
+
+  return (
+    <span
+      data-testid="collapsed-alarm-pill"
+      data-alarm-kind={alarm.kind}
+      aria-label={alarm.label}
+      className={cn(
+        "inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded shrink-0 transition-colors pointer-events-none",
+        isError
+          ? "bg-status-error/10 text-status-error"
+          : "bg-status-warning/10 text-status-warning"
+      )}
+    >
+      <CircleAlert className="w-3 h-3 shrink-0" aria-hidden="true" />
+      <span>{alarm.label}</span>
+    </span>
+  );
+}

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -9,6 +9,7 @@ import type { WorktreeState } from "@/types";
 import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
 import { useResourceProfileStore } from "@/store/resourceProfileStore";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
+import { computeAlarmTier } from "@/lib/worktreeAlarmTier";
 
 interface NonMainSecondaryRowProps {
   worktree: WorktreeState;
@@ -54,8 +55,13 @@ export function NonMainSecondaryRow({
     worktree.linked.pr.state !== "declined";
   const showUpstreamBadge = hasUpstreamDelta || hasAuthFailedSignIn;
 
-  const prTier = worktree.linked?.pr?.ciStatus?.state === "failure" ? 4 : 0;
-  const upstreamTier = worktree.fetchAuthFailed ? 3 : (worktree.behindCount ?? 0) > 0 ? 2 : 0;
+  const prTier = showPRBadge
+    ? computeAlarmTier({ ciState: worktree.linked?.pr?.ciStatus?.state }).tier
+    : 0;
+  const upstreamTier = computeAlarmTier({
+    authFailed: hasAuthFailedSignIn,
+    behindCount: worktree.behindCount,
+  }).tier;
   const upstreamFirst = upstreamTier > prTier;
 
   const prBadge = showPRBadge ? (

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -48,6 +48,49 @@ export function NonMainSecondaryRow({
     [worktree.isCurrent, fetchIntervalActiveMs, fetchIntervalBackgroundMs]
   );
 
+  const showPRBadge =
+    worktree.linked?.pr &&
+    worktree.linked.pr.state !== "closed" &&
+    worktree.linked.pr.state !== "declined";
+  const showUpstreamBadge = hasUpstreamDelta || hasAuthFailedSignIn;
+
+  const prTier = worktree.linked?.pr?.ciStatus?.state === "failure" ? 4 : 0;
+  const upstreamTier = worktree.fetchAuthFailed ? 3 : (worktree.behindCount ?? 0) > 0 ? 2 : 0;
+  const upstreamFirst = upstreamTier > prTier;
+
+  const prBadge = showPRBadge ? (
+    <PRBadge
+      prNumber={worktree.linked!.pr!.ref.number}
+      prState={worktree.linked!.pr!.state}
+      prCiStatus={worktree.linked!.pr!.ciStatus}
+      isSubordinate={!!worktree.issueNumber}
+      worktreePath={worktree.path}
+      onOpen={badges.onOpenPR}
+      isActive={isActive}
+      underlineOnHover={underlineOnHover}
+      rowLastUpdatedAt={worktree.prLastUpdatedAt}
+      prDetectionPaused={prDetectionPaused}
+    />
+  ) : null;
+
+  const upstreamBadge = showUpstreamBadge ? (
+    <UpstreamSyncBadge
+      aheadCount={worktree.aheadCount}
+      behindCount={worktree.behindCount}
+      isFetchInFlight={Boolean(worktree.isFetchInFlight)}
+      lastFetchedAt={worktree.lastFetchedAt}
+      fetchAuthFailed={Boolean(worktree.fetchAuthFailed)}
+      fetchNetworkFailed={Boolean(worktree.fetchNetworkFailed)}
+      isGitHubProvider={worktree.linked?.providerId === BUILTIN_GITHUB_PROVIDER_ID}
+      containerGapClass="gap-1.5"
+      baseBranchName={worktree.baseBranchName}
+      baseAheadCount={worktree.baseAheadCount}
+      baseBehindCount={worktree.baseBehindCount}
+      baseMatchesUpstream={worktree.baseMatchesUpstream}
+      fetchIntervalMs={fetchIntervalMs}
+    />
+  ) : null;
+
   return (
     <div className="flex flex-col gap-0.5 mt-1.5">
       {worktree.issueNumber && !hasIssueTitle && (
@@ -60,39 +103,8 @@ export function NonMainSecondaryRow({
           rowLastUpdatedAt={worktree.issueLastUpdatedAt}
         />
       )}
-      {worktree.linked?.pr &&
-        worktree.linked.pr.state !== "closed" &&
-        worktree.linked.pr.state !== "declined" && (
-          <PRBadge
-            prNumber={worktree.linked.pr.ref.number}
-            prState={worktree.linked.pr.state}
-            prCiStatus={worktree.linked.pr.ciStatus}
-            isSubordinate={!!worktree.issueNumber}
-            worktreePath={worktree.path}
-            onOpen={badges.onOpenPR}
-            isActive={isActive}
-            underlineOnHover={underlineOnHover}
-            rowLastUpdatedAt={worktree.prLastUpdatedAt}
-            prDetectionPaused={prDetectionPaused}
-          />
-        )}
-      {(hasUpstreamDelta || hasAuthFailedSignIn) && (
-        <UpstreamSyncBadge
-          aheadCount={worktree.aheadCount}
-          behindCount={worktree.behindCount}
-          isFetchInFlight={Boolean(worktree.isFetchInFlight)}
-          lastFetchedAt={worktree.lastFetchedAt}
-          fetchAuthFailed={Boolean(worktree.fetchAuthFailed)}
-          fetchNetworkFailed={Boolean(worktree.fetchNetworkFailed)}
-          isGitHubProvider={worktree.linked?.providerId === BUILTIN_GITHUB_PROVIDER_ID}
-          containerGapClass="gap-1.5"
-          baseBranchName={worktree.baseBranchName}
-          baseAheadCount={worktree.baseAheadCount}
-          baseBehindCount={worktree.baseBehindCount}
-          baseMatchesUpstream={worktree.baseMatchesUpstream}
-          fetchIntervalMs={fetchIntervalMs}
-        />
-      )}
+      {upstreamFirst ? upstreamBadge : prBadge}
+      {upstreamFirst ? prBadge : upstreamBadge}
       {hasIssueTitle && (
         <BranchLabel
           label={branchLabel}

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -10,12 +10,14 @@ import type { AggregateCounts } from "./MainWorktreeSummaryRows";
 import { IssueBadge } from "./IssueBadge";
 import { EnvironmentPopover } from "./EnvironmentPopover";
 import { CollapsedSessionIndicators } from "./CollapsedSessionIndicators";
+import { CollapsedAlarmPill } from "./CollapsedAlarmPill";
 import { WorktreeActionsToolbar } from "./WorktreeActionsToolbar";
 import { MainWorktreeSecondaryRow } from "./MainWorktreeSecondaryRow";
 import { NonMainSecondaryRow } from "./NonMainSecondaryRow";
 import { scheduleFlip } from "@/utils/flipScheduler";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
+import { computeAlarmTier } from "@/lib/worktreeAlarmTier";
 
 export interface WorktreeHeaderProps {
   worktree: WorktreeState;
@@ -271,6 +273,18 @@ export function WorktreeHeader({
   );
   const isMainStandardLayout = !!(isMainOnStandardBranch && !hasIssueTitle);
 
+  const ciState = worktree.linked?.pr?.ciStatus?.state;
+  const collapsedAlarm = useMemo(
+    () =>
+      computeAlarmTier({
+        ciState,
+        fetchAuthFailed: worktree.fetchAuthFailed,
+        behindCount: worktree.behindCount,
+        isDetached: worktree.isDetached,
+      }),
+    [ciState, worktree.fetchAuthFailed, worktree.behindCount, worktree.isDetached]
+  );
+
   const { visibleStates, sessionAriaLabel } = useMemo(() => {
     if (!sessionStates || !sessionTotal || sessionTotal === 0) {
       return { visibleStates: [] as { state: AgentState; count: number }[], sessionAriaLabel: "" };
@@ -340,6 +354,7 @@ export function WorktreeHeader({
               {gitStateIndicator.label}
             </span>
           )}
+          {isCollapsed && <CollapsedAlarmPill alarm={collapsedAlarm} />}
         </div>
 
         {((isPinned && !isMainWorktree) ||

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -273,16 +273,17 @@ export function WorktreeHeader({
   );
   const isMainStandardLayout = !!(isMainOnStandardBranch && !hasIssueTitle);
 
-  const ciState = worktree.linked?.pr?.ciStatus?.state;
+  const prState = worktree.linked?.pr?.state;
+  const isPrLive = prState !== undefined && prState !== "closed" && prState !== "declined";
+  const ciState = isPrLive ? worktree.linked?.pr?.ciStatus?.state : undefined;
   const collapsedAlarm = useMemo(
     () =>
       computeAlarmTier({
         ciState,
-        fetchAuthFailed: worktree.fetchAuthFailed,
+        authFailed: hasAuthFailedSignIn,
         behindCount: worktree.behindCount,
-        isDetached: worktree.isDetached,
       }),
-    [ciState, worktree.fetchAuthFailed, worktree.behindCount, worktree.isDetached]
+    [ciState, hasAuthFailedSignIn, worktree.behindCount]
   );
 
   const { visibleStates, sessionAriaLabel } = useMemo(() => {

--- a/src/components/Worktree/WorktreeCard/__tests__/CollapsedAlarmPill.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/CollapsedAlarmPill.test.tsx
@@ -7,21 +7,15 @@ import { CollapsedAlarmPill } from "../CollapsedAlarmPill";
 import type { AlarmDescriptor } from "@/lib/worktreeAlarmTier";
 
 const none: AlarmDescriptor = { tier: 0, kind: "none", label: "", tone: "none" };
-const detached: AlarmDescriptor = {
-  tier: 1,
-  kind: "detached",
-  label: "Detached",
-  tone: "warning",
-};
-const behind: AlarmDescriptor = { tier: 2, kind: "behind", label: "Behind", tone: "warning" };
+const behind: AlarmDescriptor = { tier: 1, kind: "behind", label: "Behind", tone: "warning" };
 const authFailed: AlarmDescriptor = {
-  tier: 3,
+  tier: 2,
   kind: "auth-failed",
   label: "Auth failed",
   tone: "warning",
 };
 const ciFailed: AlarmDescriptor = {
-  tier: 4,
+  tier: 3,
   kind: "ci-failed",
   label: "CI failed",
   tone: "error",
@@ -57,14 +51,6 @@ describe("CollapsedAlarmPill", () => {
     expect(pill.className).toContain("bg-status-warning/10");
     expect(pill.textContent).toBe("Behind");
     expect(pill.getAttribute("data-alarm-kind")).toBe("behind");
-  });
-
-  it("renders detached chip with warning tone", () => {
-    const { getByTestId } = render(<CollapsedAlarmPill alarm={detached} />);
-    const pill = getByTestId("collapsed-alarm-pill");
-    expect(pill.className).toContain("bg-status-warning/10");
-    expect(pill.textContent).toBe("Detached");
-    expect(pill.getAttribute("data-alarm-kind")).toBe("detached");
   });
 
   it("does not use accent classes", () => {

--- a/src/components/Worktree/WorktreeCard/__tests__/CollapsedAlarmPill.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/CollapsedAlarmPill.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { CollapsedAlarmPill } from "../CollapsedAlarmPill";
+import type { AlarmDescriptor } from "@/lib/worktreeAlarmTier";
+
+const none: AlarmDescriptor = { tier: 0, kind: "none", label: "", tone: "none" };
+const detached: AlarmDescriptor = {
+  tier: 1,
+  kind: "detached",
+  label: "Detached",
+  tone: "warning",
+};
+const behind: AlarmDescriptor = { tier: 2, kind: "behind", label: "Behind", tone: "warning" };
+const authFailed: AlarmDescriptor = {
+  tier: 3,
+  kind: "auth-failed",
+  label: "Auth failed",
+  tone: "warning",
+};
+const ciFailed: AlarmDescriptor = {
+  tier: 4,
+  kind: "ci-failed",
+  label: "CI failed",
+  tone: "error",
+};
+
+describe("CollapsedAlarmPill", () => {
+  it("renders nothing for tier 0", () => {
+    const { container } = render(<CollapsedAlarmPill alarm={none} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders CI failed chip with error tone", () => {
+    const { getByTestId } = render(<CollapsedAlarmPill alarm={ciFailed} />);
+    const pill = getByTestId("collapsed-alarm-pill");
+    expect(pill.className).toContain("bg-status-error/10");
+    expect(pill.className).toContain("text-status-error");
+    expect(pill.textContent).toBe("CI failed");
+    expect(pill.getAttribute("data-alarm-kind")).toBe("ci-failed");
+  });
+
+  it("renders auth-failed chip with warning tone", () => {
+    const { getByTestId } = render(<CollapsedAlarmPill alarm={authFailed} />);
+    const pill = getByTestId("collapsed-alarm-pill");
+    expect(pill.className).toContain("bg-status-warning/10");
+    expect(pill.className).toContain("text-status-warning");
+    expect(pill.textContent).toBe("Auth failed");
+    expect(pill.getAttribute("data-alarm-kind")).toBe("auth-failed");
+  });
+
+  it("renders behind chip with warning tone", () => {
+    const { getByTestId } = render(<CollapsedAlarmPill alarm={behind} />);
+    const pill = getByTestId("collapsed-alarm-pill");
+    expect(pill.className).toContain("bg-status-warning/10");
+    expect(pill.textContent).toBe("Behind");
+    expect(pill.getAttribute("data-alarm-kind")).toBe("behind");
+  });
+
+  it("renders detached chip with warning tone", () => {
+    const { getByTestId } = render(<CollapsedAlarmPill alarm={detached} />);
+    const pill = getByTestId("collapsed-alarm-pill");
+    expect(pill.className).toContain("bg-status-warning/10");
+    expect(pill.textContent).toBe("Detached");
+    expect(pill.getAttribute("data-alarm-kind")).toBe("detached");
+  });
+
+  it("does not use accent classes", () => {
+    const { getByTestId } = render(<CollapsedAlarmPill alarm={ciFailed} />);
+    const pill = getByTestId("collapsed-alarm-pill");
+    expect(pill.className).not.toContain("accent");
+  });
+
+  it("uses transition-colors not transition-all", () => {
+    const { getByTestId } = render(<CollapsedAlarmPill alarm={ciFailed} />);
+    const pill = getByTestId("collapsed-alarm-pill");
+    expect(pill.className).toContain("transition-colors");
+    expect(pill.className).not.toContain("transition-all");
+  });
+
+  it("uses shrink-0 to survive narrow flex containers", () => {
+    const { getByTestId } = render(<CollapsedAlarmPill alarm={ciFailed} />);
+    expect(getByTestId("collapsed-alarm-pill").className).toContain("shrink-0");
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
@@ -9,6 +9,7 @@ import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 const prBadgeProps: Array<Record<string, unknown>> = [];
+const upstreamBadgeProps: Array<Record<string, unknown>> = [];
 
 vi.mock("react-dom", async () => {
   const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
@@ -18,13 +19,22 @@ vi.mock("react-dom", async () => {
 vi.mock("../PRBadge", () => ({
   PRBadge: (props: Record<string, unknown>) => {
     prBadgeProps.push(props);
-    return <div data-testid="pr-badge" />;
+    return <div data-testid="pr-badge" data-call-index={prBadgeProps.length - 1} />;
+  },
+}));
+
+vi.mock("../UpstreamSyncBadge", () => ({
+  UpstreamSyncBadge: (props: Record<string, unknown>) => {
+    upstreamBadgeProps.push(props);
+    return (
+      <div data-testid="upstream-sync-badge" data-call-index={upstreamBadgeProps.length - 1} />
+    );
   },
 }));
 
 import { NonMainSecondaryRow } from "../NonMainSecondaryRow";
 
-const worktree = {
+const baseWorktree = {
   id: "wt-1",
   path: "/repo",
   name: "feature",
@@ -42,16 +52,22 @@ const worktree = {
   },
 } as unknown as WorktreeState;
 
-function renderRow() {
+interface RenderOverrides {
+  worktree?: WorktreeState;
+  hasUpstreamDelta?: boolean;
+  hasAuthFailedSignIn?: boolean;
+}
+
+function renderRow(overrides: RenderOverrides = {}) {
   return render(
     <TooltipProvider>
       <NonMainSecondaryRow
-        worktree={worktree}
+        worktree={overrides.worktree ?? baseWorktree}
         branchLabel="feature/test"
         isActive
         underlineOnHover={false}
-        hasUpstreamDelta={false}
-        hasAuthFailedSignIn={false}
+        hasUpstreamDelta={overrides.hasUpstreamDelta ?? false}
+        hasAuthFailedSignIn={overrides.hasAuthFailedSignIn ?? false}
         hasIssueTitle={false}
         hasPlanFile={false}
         badges={{}}
@@ -60,9 +76,29 @@ function renderRow() {
   );
 }
 
+function ciFailureLinked() {
+  return {
+    providerId: "github",
+    pr: {
+      ref: { providerId: "github", owner: "test", repo: "test", number: 42, rawData: {} },
+      state: "open" as const,
+      url: "https://github.com/test/repo/pull/42",
+      ciStatus: {
+        state: "failure" as const,
+        total: 1,
+        passed: 0,
+        failed: 1,
+        pending: 0,
+        rawData: {},
+      },
+    },
+  };
+}
+
 describe("NonMainSecondaryRow → PRBadge circuit-breaker wiring", () => {
   beforeEach(() => {
     prBadgeProps.length = 0;
+    upstreamBadgeProps.length = 0;
     usePRCircuitBreakerStore.setState({ tripped: false });
   });
 
@@ -75,5 +111,103 @@ describe("NonMainSecondaryRow → PRBadge circuit-breaker wiring", () => {
     usePRCircuitBreakerStore.setState({ tripped: true });
     renderRow();
     expect(prBadgeProps.at(-1)?.prDetectionPaused).toBe(true);
+  });
+});
+
+describe("NonMainSecondaryRow → badge ordering by alarm tier", () => {
+  beforeEach(() => {
+    prBadgeProps.length = 0;
+    upstreamBadgeProps.length = 0;
+    usePRCircuitBreakerStore.setState({ tripped: false });
+  });
+
+  it("renders PR before UpstreamSync when no alarms are active", () => {
+    const { container } = renderRow({
+      worktree: { ...baseWorktree, behindCount: 0, fetchAuthFailed: false } as WorktreeState,
+      hasUpstreamDelta: true,
+    });
+    const order = Array.from(container.querySelectorAll("[data-testid]")).map((el) =>
+      el.getAttribute("data-testid")
+    );
+    const prIdx = order.indexOf("pr-badge");
+    const upIdx = order.indexOf("upstream-sync-badge");
+    expect(prIdx).toBeGreaterThanOrEqual(0);
+    expect(upIdx).toBeGreaterThanOrEqual(0);
+    expect(prIdx).toBeLessThan(upIdx);
+  });
+
+  it("PR stays first when CI failed (PR is the salient alarm)", () => {
+    const { container } = renderRow({
+      worktree: {
+        ...baseWorktree,
+        behindCount: 3,
+        linked: ciFailureLinked(),
+      } as WorktreeState,
+      hasUpstreamDelta: true,
+    });
+    const order = Array.from(container.querySelectorAll("[data-testid]")).map((el) =>
+      el.getAttribute("data-testid")
+    );
+    expect(order.indexOf("pr-badge")).toBeLessThan(order.indexOf("upstream-sync-badge"));
+  });
+
+  it("UpstreamSync moves before PR when fetchAuthFailed (auth > healthy PR)", () => {
+    const { container } = renderRow({
+      worktree: {
+        ...baseWorktree,
+        fetchAuthFailed: true,
+        isGitHubRemote: true,
+      } as WorktreeState,
+      hasUpstreamDelta: false,
+      hasAuthFailedSignIn: true,
+    });
+    const order = Array.from(container.querySelectorAll("[data-testid]")).map((el) =>
+      el.getAttribute("data-testid")
+    );
+    expect(order.indexOf("upstream-sync-badge")).toBeLessThan(order.indexOf("pr-badge"));
+  });
+
+  it("UpstreamSync moves before PR when behindCount > 0 (no CI failure)", () => {
+    const { container } = renderRow({
+      worktree: { ...baseWorktree, behindCount: 5 } as WorktreeState,
+      hasUpstreamDelta: true,
+    });
+    const order = Array.from(container.querySelectorAll("[data-testid]")).map((el) =>
+      el.getAttribute("data-testid")
+    );
+    expect(order.indexOf("upstream-sync-badge")).toBeLessThan(order.indexOf("pr-badge"));
+  });
+
+  it("CI failed beats fetchAuthFailed — PR stays first", () => {
+    const { container } = renderRow({
+      worktree: {
+        ...baseWorktree,
+        fetchAuthFailed: true,
+        isGitHubRemote: true,
+        linked: ciFailureLinked(),
+      } as WorktreeState,
+      hasAuthFailedSignIn: true,
+    });
+    const order = Array.from(container.querySelectorAll("[data-testid]")).map((el) =>
+      el.getAttribute("data-testid")
+    );
+    expect(order.indexOf("pr-badge")).toBeLessThan(order.indexOf("upstream-sync-badge"));
+  });
+
+  it("CI 'pending' does not flip the order (transient — no spatial churn)", () => {
+    const pendingLinked = ciFailureLinked();
+    pendingLinked.pr.ciStatus.state = "pending" as never;
+    const { container } = renderRow({
+      worktree: {
+        ...baseWorktree,
+        behindCount: 1,
+        linked: pendingLinked,
+      } as WorktreeState,
+      hasUpstreamDelta: true,
+    });
+    const order = Array.from(container.querySelectorAll("[data-testid]")).map((el) =>
+      el.getAttribute("data-testid")
+    );
+    expect(order.indexOf("upstream-sync-badge")).toBeLessThan(order.indexOf("pr-badge"));
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
@@ -148,10 +148,14 @@ describe("NonMainSecondaryRow → badge ordering by alarm tier", () => {
     const order = Array.from(container.querySelectorAll("[data-testid]")).map((el) =>
       el.getAttribute("data-testid")
     );
-    expect(order.indexOf("pr-badge")).toBeLessThan(order.indexOf("upstream-sync-badge"));
+    const prIdx = order.indexOf("pr-badge");
+    const upIdx = order.indexOf("upstream-sync-badge");
+    expect(prIdx).toBeGreaterThanOrEqual(0);
+    expect(upIdx).toBeGreaterThanOrEqual(0);
+    expect(prIdx).toBeLessThan(upIdx);
   });
 
-  it("UpstreamSync moves before PR when fetchAuthFailed (auth > healthy PR)", () => {
+  it("UpstreamSync moves before PR when auth-failed (auth > healthy PR)", () => {
     const { container } = renderRow({
       worktree: {
         ...baseWorktree,
@@ -164,7 +168,11 @@ describe("NonMainSecondaryRow → badge ordering by alarm tier", () => {
     const order = Array.from(container.querySelectorAll("[data-testid]")).map((el) =>
       el.getAttribute("data-testid")
     );
-    expect(order.indexOf("upstream-sync-badge")).toBeLessThan(order.indexOf("pr-badge"));
+    const prIdx = order.indexOf("pr-badge");
+    const upIdx = order.indexOf("upstream-sync-badge");
+    expect(prIdx).toBeGreaterThanOrEqual(0);
+    expect(upIdx).toBeGreaterThanOrEqual(0);
+    expect(upIdx).toBeLessThan(prIdx);
   });
 
   it("UpstreamSync moves before PR when behindCount > 0 (no CI failure)", () => {
@@ -175,10 +183,14 @@ describe("NonMainSecondaryRow → badge ordering by alarm tier", () => {
     const order = Array.from(container.querySelectorAll("[data-testid]")).map((el) =>
       el.getAttribute("data-testid")
     );
-    expect(order.indexOf("upstream-sync-badge")).toBeLessThan(order.indexOf("pr-badge"));
+    const prIdx = order.indexOf("pr-badge");
+    const upIdx = order.indexOf("upstream-sync-badge");
+    expect(prIdx).toBeGreaterThanOrEqual(0);
+    expect(upIdx).toBeGreaterThanOrEqual(0);
+    expect(upIdx).toBeLessThan(prIdx);
   });
 
-  it("CI failed beats fetchAuthFailed — PR stays first", () => {
+  it("CI failed beats auth-failed — PR stays first", () => {
     const { container } = renderRow({
       worktree: {
         ...baseWorktree,
@@ -191,7 +203,11 @@ describe("NonMainSecondaryRow → badge ordering by alarm tier", () => {
     const order = Array.from(container.querySelectorAll("[data-testid]")).map((el) =>
       el.getAttribute("data-testid")
     );
-    expect(order.indexOf("pr-badge")).toBeLessThan(order.indexOf("upstream-sync-badge"));
+    const prIdx = order.indexOf("pr-badge");
+    const upIdx = order.indexOf("upstream-sync-badge");
+    expect(prIdx).toBeGreaterThanOrEqual(0);
+    expect(upIdx).toBeGreaterThanOrEqual(0);
+    expect(prIdx).toBeLessThan(upIdx);
   });
 
   it("CI 'pending' does not flip the order (transient — no spatial churn)", () => {
@@ -208,6 +224,10 @@ describe("NonMainSecondaryRow → badge ordering by alarm tier", () => {
     const order = Array.from(container.querySelectorAll("[data-testid]")).map((el) =>
       el.getAttribute("data-testid")
     );
-    expect(order.indexOf("upstream-sync-badge")).toBeLessThan(order.indexOf("pr-badge"));
+    const prIdx = order.indexOf("pr-badge");
+    const upIdx = order.indexOf("upstream-sync-badge");
+    expect(prIdx).toBeGreaterThanOrEqual(0);
+    expect(upIdx).toBeGreaterThanOrEqual(0);
+    expect(upIdx).toBeLessThan(prIdx);
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -944,6 +944,117 @@ describe("WorktreeHeader cleanup button", () => {
   });
 });
 
+function ciFailureLinked(num: number) {
+  return {
+    linked: {
+      providerId: "daintree.github.github",
+      pr: {
+        ref: {
+          providerId: "daintree.github.github",
+          owner: "",
+          repo: "",
+          number: num,
+          rawData: null,
+        },
+        state: "open" as const,
+        url: `https://github.com/test/repo/pull/${num}`,
+        ciStatus: {
+          state: "failure" as const,
+          total: 1,
+          passed: 0,
+          failed: 1,
+          pending: 0,
+          rawData: null,
+        },
+      },
+    },
+  };
+}
+
+describe("WorktreeHeader collapsed alarm pill", () => {
+  it("renders the pill with CI-failed treatment when collapsed and CI failed", () => {
+    renderHeader({
+      isCollapsed: true,
+      worktree: { ...baseWorktree, ...ciFailureLinked(101) },
+    });
+    const pill = screen.getByTestId("collapsed-alarm-pill");
+    expect(pill.getAttribute("data-alarm-kind")).toBe("ci-failed");
+    expect(pill.className).toContain("text-status-error");
+    expect(pill.textContent).toBe("CI failed");
+  });
+
+  it("renders the pill with warning treatment for fetchAuthFailed", () => {
+    renderHeader({
+      isCollapsed: true,
+      worktree: { ...baseWorktree, fetchAuthFailed: true },
+    });
+    const pill = screen.getByTestId("collapsed-alarm-pill");
+    expect(pill.getAttribute("data-alarm-kind")).toBe("auth-failed");
+    expect(pill.className).toContain("text-status-warning");
+  });
+
+  it("renders the pill with warning treatment for behindCount > 0", () => {
+    renderHeader({
+      isCollapsed: true,
+      worktree: { ...baseWorktree, behindCount: 3 },
+    });
+    const pill = screen.getByTestId("collapsed-alarm-pill");
+    expect(pill.getAttribute("data-alarm-kind")).toBe("behind");
+    expect(pill.className).toContain("text-status-warning");
+  });
+
+  it("renders the pill with warning treatment for isDetached", () => {
+    renderHeader({
+      isCollapsed: true,
+      worktree: { ...baseWorktree, isDetached: true },
+    });
+    const pill = screen.getByTestId("collapsed-alarm-pill");
+    expect(pill.getAttribute("data-alarm-kind")).toBe("detached");
+    expect(pill.className).toContain("text-status-warning");
+  });
+
+  it("does not render when collapsed but no alarm fires", () => {
+    renderHeader({ isCollapsed: true });
+    expect(screen.queryByTestId("collapsed-alarm-pill")).toBeNull();
+  });
+
+  it("does not render when expanded — even with a CI failure", () => {
+    renderHeader({
+      isCollapsed: false,
+      worktree: { ...baseWorktree, ...ciFailureLinked(101) },
+    });
+    expect(screen.queryByTestId("collapsed-alarm-pill")).toBeNull();
+  });
+
+  it("caps to exactly one pill when multiple alarms fire (CI wins over auth)", () => {
+    const { container } = renderHeader({
+      isCollapsed: true,
+      worktree: {
+        ...baseWorktree,
+        fetchAuthFailed: true,
+        behindCount: 5,
+        isDetached: true,
+        ...ciFailureLinked(101),
+      },
+    });
+    const pills = container.querySelectorAll("[data-testid='collapsed-alarm-pill']");
+    expect(pills.length).toBe(1);
+    expect(pills[0]!.getAttribute("data-alarm-kind")).toBe("ci-failed");
+  });
+
+  it("renders for main worktree rows too (collapsed + behind)", () => {
+    renderHeader({
+      isCollapsed: true,
+      isMainWorktree: true,
+      isMainOnStandardBranch: true,
+      worktree: { ...baseWorktree, isMainWorktree: true, behindCount: 2 },
+    });
+    expect(screen.getByTestId("collapsed-alarm-pill").getAttribute("data-alarm-kind")).toBe(
+      "behind"
+    );
+  });
+});
+
 describe("WorktreeHeader icon button hit targets", () => {
   it("collapse button has p-1.5 for WCAG 24px minimum", () => {
     renderHeader({

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, fireEvent, act, cleanup } from "@testing-library/react"
 import type { ReactNode } from "react";
 import { WorktreeHeader, type WorktreeHeaderProps } from "../WorktreeHeader";
 import type { WorktreeState } from "@shared/types";
+import type { NormalizedPRState } from "@shared/types/forge";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { actionService } from "@/services/ActionService";
 
@@ -43,7 +44,7 @@ vi.mock("@/services/ActionService", () => ({
 
 const noop = () => {};
 
-function prLinked(num: number, state: "open" | "merged" | "closed" | "declined" = "open") {
+function prLinked(num: number, state: NormalizedPRState = "open") {
   return {
     linked: {
       providerId: "daintree.github.github",
@@ -55,7 +56,7 @@ function prLinked(num: number, state: "open" | "merged" | "closed" | "declined" 
           number: num,
           rawData: null,
         },
-        state,
+        state: state as NormalizedPRState,
         url: `https://github.com/test/repo/pull/${num}`,
       },
     },
@@ -956,7 +957,7 @@ function ciFailureLinked(num: number) {
           number: num,
           rawData: null,
         },
-        state: "open" as const,
+        state: "open" as NormalizedPRState,
         url: `https://github.com/test/repo/pull/${num}`,
         ciStatus: {
           state: "failure" as const,

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -983,14 +983,30 @@ describe("WorktreeHeader collapsed alarm pill", () => {
     expect(pill.textContent).toBe("CI failed");
   });
 
-  it("renders the pill with warning treatment for fetchAuthFailed", () => {
+  it("renders the pill with warning treatment for GitHub auth-failed remote", () => {
     renderHeader({
       isCollapsed: true,
-      worktree: { ...baseWorktree, fetchAuthFailed: true },
+      worktree: {
+        ...baseWorktree,
+        fetchAuthFailed: true,
+        isGitHubRemote: true,
+      },
     });
     const pill = screen.getByTestId("collapsed-alarm-pill");
     expect(pill.getAttribute("data-alarm-kind")).toBe("auth-failed");
     expect(pill.className).toContain("text-status-warning");
+  });
+
+  it("suppresses the auth-failed pill for non-GitHub remotes (matches expanded gating)", () => {
+    renderHeader({
+      isCollapsed: true,
+      worktree: {
+        ...baseWorktree,
+        fetchAuthFailed: true,
+        isGitHubRemote: false,
+      },
+    });
+    expect(screen.queryByTestId("collapsed-alarm-pill")).toBeNull();
   });
 
   it("renders the pill with warning treatment for behindCount > 0", () => {
@@ -1003,14 +1019,17 @@ describe("WorktreeHeader collapsed alarm pill", () => {
     expect(pill.className).toContain("text-status-warning");
   });
 
-  it("renders the pill with warning treatment for isDetached", () => {
+  it("does not duplicate gitStateIndicator for detached HEAD", () => {
+    // gitStateIndicator already labels detached in the title row;
+    // computeAlarmTier deliberately excludes detached so collapsed rows
+    // don't end up with two side-by-side "detached"/"Detached" labels.
     renderHeader({
       isCollapsed: true,
       worktree: { ...baseWorktree, isDetached: true },
+      gitStateIndicator: { kind: "detached", label: "detached", tone: "warning" },
     });
-    const pill = screen.getByTestId("collapsed-alarm-pill");
-    expect(pill.getAttribute("data-alarm-kind")).toBe("detached");
-    expect(pill.className).toContain("text-status-warning");
+    expect(screen.queryByTestId("collapsed-alarm-pill")).toBeNull();
+    expect(screen.getByText("detached")).toBeDefined();
   });
 
   it("does not render when collapsed but no alarm fires", () => {
@@ -1026,14 +1045,28 @@ describe("WorktreeHeader collapsed alarm pill", () => {
     expect(screen.queryByTestId("collapsed-alarm-pill")).toBeNull();
   });
 
+  it("does not fire a stale CI-failed alarm when the linked PR is closed", () => {
+    const closed = ciFailureLinked(101);
+    closed.linked.pr.state = "closed";
+    renderHeader({ isCollapsed: true, worktree: { ...baseWorktree, ...closed } });
+    expect(screen.queryByTestId("collapsed-alarm-pill")).toBeNull();
+  });
+
+  it("does not fire a stale CI-failed alarm when the linked PR is declined", () => {
+    const declined = ciFailureLinked(101);
+    declined.linked.pr.state = "declined";
+    renderHeader({ isCollapsed: true, worktree: { ...baseWorktree, ...declined } });
+    expect(screen.queryByTestId("collapsed-alarm-pill")).toBeNull();
+  });
+
   it("caps to exactly one pill when multiple alarms fire (CI wins over auth)", () => {
     const { container } = renderHeader({
       isCollapsed: true,
       worktree: {
         ...baseWorktree,
         fetchAuthFailed: true,
+        isGitHubRemote: true,
         behindCount: 5,
-        isDetached: true,
         ...ciFailureLinked(101),
       },
     });

--- a/src/lib/__tests__/worktreeAlarmTier.test.ts
+++ b/src/lib/__tests__/worktreeAlarmTier.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { computeAlarmTier } from "../worktreeAlarmTier";
+
+describe("computeAlarmTier", () => {
+  describe("tier 0 (none)", () => {
+    it("returns tier 0 when no alarm fields are set", () => {
+      expect(computeAlarmTier({})).toEqual({
+        tier: 0,
+        kind: "none",
+        label: "",
+        tone: "none",
+      });
+    });
+
+    it("treats undefined behindCount as 0", () => {
+      expect(computeAlarmTier({ behindCount: undefined }).tier).toBe(0);
+    });
+
+    it("treats behindCount === 0 as tier 0", () => {
+      expect(computeAlarmTier({ behindCount: 0 }).tier).toBe(0);
+    });
+
+    it("treats CI 'success' as tier 0", () => {
+      expect(computeAlarmTier({ ciState: "success" }).tier).toBe(0);
+    });
+
+    it("treats CI 'pending' as tier 0 (transient — would churn on every push)", () => {
+      expect(computeAlarmTier({ ciState: "pending" }).tier).toBe(0);
+    });
+
+    it("treats CI 'neutral' as tier 0", () => {
+      expect(computeAlarmTier({ ciState: "neutral" }).tier).toBe(0);
+    });
+
+    it("treats CI 'unknown' as tier 0", () => {
+      expect(computeAlarmTier({ ciState: "unknown" }).tier).toBe(0);
+    });
+
+    it("treats missing ciState as tier 0", () => {
+      expect(computeAlarmTier({ ciState: undefined }).tier).toBe(0);
+    });
+  });
+
+  describe("single-tier resolutions", () => {
+    it("returns tier 1 (detached)", () => {
+      expect(computeAlarmTier({ isDetached: true })).toEqual({
+        tier: 1,
+        kind: "detached",
+        label: "Detached",
+        tone: "warning",
+      });
+    });
+
+    it("returns tier 2 (behind) for any behindCount > 0", () => {
+      expect(computeAlarmTier({ behindCount: 1 })).toEqual({
+        tier: 2,
+        kind: "behind",
+        label: "Behind",
+        tone: "warning",
+      });
+      expect(computeAlarmTier({ behindCount: 99 }).tier).toBe(2);
+    });
+
+    it("returns tier 3 (auth-failed)", () => {
+      expect(computeAlarmTier({ fetchAuthFailed: true })).toEqual({
+        tier: 3,
+        kind: "auth-failed",
+        label: "Auth failed",
+        tone: "warning",
+      });
+    });
+
+    it("returns tier 4 (CI failed) for ciState === 'failure'", () => {
+      expect(computeAlarmTier({ ciState: "failure" })).toEqual({
+        tier: 4,
+        kind: "ci-failed",
+        label: "CI failed",
+        tone: "error",
+      });
+    });
+  });
+
+  describe("priority cascade — higher tier wins", () => {
+    it("CI failure beats auth-failed", () => {
+      expect(computeAlarmTier({ ciState: "failure", fetchAuthFailed: true }).tier).toBe(4);
+    });
+
+    it("CI failure beats behind", () => {
+      expect(computeAlarmTier({ ciState: "failure", behindCount: 3 }).tier).toBe(4);
+    });
+
+    it("CI failure beats detached", () => {
+      expect(computeAlarmTier({ ciState: "failure", isDetached: true }).tier).toBe(4);
+    });
+
+    it("auth-failed beats behind", () => {
+      expect(computeAlarmTier({ fetchAuthFailed: true, behindCount: 5 }).tier).toBe(3);
+    });
+
+    it("auth-failed beats detached", () => {
+      expect(computeAlarmTier({ fetchAuthFailed: true, isDetached: true }).tier).toBe(3);
+    });
+
+    it("behind beats detached", () => {
+      expect(computeAlarmTier({ behindCount: 1, isDetached: true }).tier).toBe(2);
+    });
+
+    it("all alarms at once → tier 4", () => {
+      expect(
+        computeAlarmTier({
+          ciState: "failure",
+          fetchAuthFailed: true,
+          behindCount: 7,
+          isDetached: true,
+        }).tier
+      ).toBe(4);
+    });
+  });
+});

--- a/src/lib/__tests__/worktreeAlarmTier.test.ts
+++ b/src/lib/__tests__/worktreeAlarmTier.test.ts
@@ -39,40 +39,37 @@ describe("computeAlarmTier", () => {
     it("treats missing ciState as tier 0", () => {
       expect(computeAlarmTier({ ciState: undefined }).tier).toBe(0);
     });
+
+    it("does not include detached HEAD — gitStateIndicator already labels it", () => {
+      // Detached is intentionally NOT in the alarm set; the title row's
+      // gitStateIndicator surfaces it on both collapsed and expanded states.
+      expect(computeAlarmTier({}).tier).toBe(0);
+    });
   });
 
   describe("single-tier resolutions", () => {
-    it("returns tier 1 (detached)", () => {
-      expect(computeAlarmTier({ isDetached: true })).toEqual({
-        tier: 1,
-        kind: "detached",
-        label: "Detached",
-        tone: "warning",
-      });
-    });
-
-    it("returns tier 2 (behind) for any behindCount > 0", () => {
+    it("returns tier 1 (behind) for any behindCount > 0", () => {
       expect(computeAlarmTier({ behindCount: 1 })).toEqual({
-        tier: 2,
+        tier: 1,
         kind: "behind",
         label: "Behind",
         tone: "warning",
       });
-      expect(computeAlarmTier({ behindCount: 99 }).tier).toBe(2);
+      expect(computeAlarmTier({ behindCount: 99 }).tier).toBe(1);
     });
 
-    it("returns tier 3 (auth-failed)", () => {
-      expect(computeAlarmTier({ fetchAuthFailed: true })).toEqual({
-        tier: 3,
+    it("returns tier 2 (auth-failed)", () => {
+      expect(computeAlarmTier({ authFailed: true })).toEqual({
+        tier: 2,
         kind: "auth-failed",
         label: "Auth failed",
         tone: "warning",
       });
     });
 
-    it("returns tier 4 (CI failed) for ciState === 'failure'", () => {
+    it("returns tier 3 (CI failed) for ciState === 'failure'", () => {
       expect(computeAlarmTier({ ciState: "failure" })).toEqual({
-        tier: 4,
+        tier: 3,
         kind: "ci-failed",
         label: "CI failed",
         tone: "error",
@@ -82,38 +79,25 @@ describe("computeAlarmTier", () => {
 
   describe("priority cascade — higher tier wins", () => {
     it("CI failure beats auth-failed", () => {
-      expect(computeAlarmTier({ ciState: "failure", fetchAuthFailed: true }).tier).toBe(4);
+      expect(computeAlarmTier({ ciState: "failure", authFailed: true }).tier).toBe(3);
     });
 
     it("CI failure beats behind", () => {
-      expect(computeAlarmTier({ ciState: "failure", behindCount: 3 }).tier).toBe(4);
-    });
-
-    it("CI failure beats detached", () => {
-      expect(computeAlarmTier({ ciState: "failure", isDetached: true }).tier).toBe(4);
+      expect(computeAlarmTier({ ciState: "failure", behindCount: 3 }).tier).toBe(3);
     });
 
     it("auth-failed beats behind", () => {
-      expect(computeAlarmTier({ fetchAuthFailed: true, behindCount: 5 }).tier).toBe(3);
+      expect(computeAlarmTier({ authFailed: true, behindCount: 5 }).tier).toBe(2);
     });
 
-    it("auth-failed beats detached", () => {
-      expect(computeAlarmTier({ fetchAuthFailed: true, isDetached: true }).tier).toBe(3);
-    });
-
-    it("behind beats detached", () => {
-      expect(computeAlarmTier({ behindCount: 1, isDetached: true }).tier).toBe(2);
-    });
-
-    it("all alarms at once → tier 4", () => {
+    it("all alarms at once → tier 3", () => {
       expect(
         computeAlarmTier({
           ciState: "failure",
-          fetchAuthFailed: true,
+          authFailed: true,
           behindCount: 7,
-          isDetached: true,
         }).tier
-      ).toBe(4);
+      ).toBe(3);
     });
   });
 });

--- a/src/lib/worktreeAlarmTier.ts
+++ b/src/lib/worktreeAlarmTier.ts
@@ -1,0 +1,46 @@
+import type { CIStatusState } from "@shared/types/forge";
+
+export type AlarmTier = 0 | 1 | 2 | 3 | 4;
+
+export type AlarmKind = "none" | "detached" | "behind" | "auth-failed" | "ci-failed";
+
+export type AlarmTone = "none" | "warning" | "error";
+
+export interface AlarmDescriptor {
+  tier: AlarmTier;
+  kind: AlarmKind;
+  label: string;
+  tone: AlarmTone;
+}
+
+export interface AlarmTierInput {
+  ciState?: CIStatusState;
+  fetchAuthFailed?: boolean;
+  behindCount?: number;
+  isDetached?: boolean;
+}
+
+const NONE: AlarmDescriptor = { tier: 0, kind: "none", label: "", tone: "none" };
+
+/**
+ * Reduce a worktree's alarm-relevant fields to a single salience tier so the
+ * collapsed alarm pill and the expanded badge ordering share one source of
+ * truth. Only `"failure"` CI maps to the top tier — transient pending/neutral
+ * states stay at tier 0 to avoid spatial churn on every push. Inputs are
+ * primitives so callers can pin a narrow `useMemo` dep array.
+ */
+export function computeAlarmTier(input: AlarmTierInput): AlarmDescriptor {
+  if (input.ciState === "failure") {
+    return { tier: 4, kind: "ci-failed", label: "CI failed", tone: "error" };
+  }
+  if (input.fetchAuthFailed === true) {
+    return { tier: 3, kind: "auth-failed", label: "Auth failed", tone: "warning" };
+  }
+  if ((input.behindCount ?? 0) > 0) {
+    return { tier: 2, kind: "behind", label: "Behind", tone: "warning" };
+  }
+  if (input.isDetached === true) {
+    return { tier: 1, kind: "detached", label: "Detached", tone: "warning" };
+  }
+  return NONE;
+}

--- a/src/lib/worktreeAlarmTier.ts
+++ b/src/lib/worktreeAlarmTier.ts
@@ -1,8 +1,8 @@
 import type { CIStatusState } from "@shared/types/forge";
 
-export type AlarmTier = 0 | 1 | 2 | 3 | 4;
+export type AlarmTier = 0 | 1 | 2 | 3;
 
-export type AlarmKind = "none" | "detached" | "behind" | "auth-failed" | "ci-failed";
+export type AlarmKind = "none" | "behind" | "auth-failed" | "ci-failed";
 
 export type AlarmTone = "none" | "warning" | "error";
 
@@ -14,10 +14,18 @@ export interface AlarmDescriptor {
 }
 
 export interface AlarmTierInput {
+  /**
+   * CI roll-up state for the worktree's linked PR. Callers should pass
+   * `undefined` when the PR is closed/declined so a stale `"failure"` value
+   * doesn't surface a phantom alarm on a closed PR.
+   */
   ciState?: CIStatusState;
-  fetchAuthFailed?: boolean;
+  /**
+   * True when the auth-failed treatment is eligible to render — caller must
+   * have applied any provider gate (e.g. GitHub-only) before passing this in.
+   */
+  authFailed?: boolean;
   behindCount?: number;
-  isDetached?: boolean;
 }
 
 const NONE: AlarmDescriptor = { tier: 0, kind: "none", label: "", tone: "none" };
@@ -25,22 +33,20 @@ const NONE: AlarmDescriptor = { tier: 0, kind: "none", label: "", tone: "none" }
 /**
  * Reduce a worktree's alarm-relevant fields to a single salience tier so the
  * collapsed alarm pill and the expanded badge ordering share one source of
- * truth. Only `"failure"` CI maps to the top tier — transient pending/neutral
- * states stay at tier 0 to avoid spatial churn on every push. Inputs are
- * primitives so callers can pin a narrow `useMemo` dep array.
+ * truth. Only `"failure"` CI maps above tier 0 — transient pending/neutral
+ * states stay quiet to avoid spatial churn on every push. Detached HEAD is
+ * deliberately not in the alarm set; `gitStateIndicator` already surfaces it
+ * in the title row, so adding it here would double-label collapsed rows.
  */
 export function computeAlarmTier(input: AlarmTierInput): AlarmDescriptor {
   if (input.ciState === "failure") {
-    return { tier: 4, kind: "ci-failed", label: "CI failed", tone: "error" };
+    return { tier: 3, kind: "ci-failed", label: "CI failed", tone: "error" };
   }
-  if (input.fetchAuthFailed === true) {
-    return { tier: 3, kind: "auth-failed", label: "Auth failed", tone: "warning" };
+  if (input.authFailed === true) {
+    return { tier: 2, kind: "auth-failed", label: "Auth failed", tone: "warning" };
   }
   if ((input.behindCount ?? 0) > 0) {
-    return { tier: 2, kind: "behind", label: "Behind", tone: "warning" };
-  }
-  if (input.isDetached === true) {
-    return { tier: 1, kind: "detached", label: "Detached", tone: "warning" };
+    return { tier: 1, kind: "behind", label: "Behind", tone: "warning" };
   }
   return NONE;
 }


### PR DESCRIPTION
## Summary

Two things were broken in the worktree dashboard: collapsed rows hid actionable alarms entirely, and expanded rows stacked badges in a fixed positional order regardless of how critical each signal was.

- Collapsed rows now hoist the highest-priority alarm into the title row as a `CollapsedAlarmPill` chip (CI failure > auth-failed > behind upstream), so a failing PR is visible without expanding the row
- Expanded rows reorder PR and upstream-sync badges by salience tier on threshold-crossings only, so spatial order doesn't churn on every poll tick
- Both surfaces derive their priority from the same `computeAlarmTier` helper in `src/lib/worktreeAlarmTier.ts`, keeping the two in agreement

Resolves #8379

## Changes

- `src/lib/worktreeAlarmTier.ts` — pure helper that reduces CI state, gated auth-failed, and behind-count to a single tier (3 = CI failed, 2 = auth-failed, 1 = behind, 0 = none); detached HEAD excluded as `gitStateIndicator` already labels it in the title row
- `src/components/Worktree/WorktreeCard/CollapsedAlarmPill.tsx` — new chip using `bg-status-error/10 text-status-error` for CI tier and `bg-status-warning/10 text-status-warning` for warning tiers; `shrink-0`, `pointer-events-none`, `transition-colors` only
- `WorktreeHeader` — collapsed alarm rendered inside the title `flex-1` container after `gitStateIndicator`, gated on `isCollapsed`; CI state only considered when a live PR is linked; auth-failed only passed through when the provider is GitHub
- `NonMainSecondaryRow` — `upstreamFirst` boolean flips PR vs `UpstreamSyncBadge` order by salience; reorder gated on actual tier change, not poll ticks

## Testing

- `src/lib/__tests__/worktreeAlarmTier.test.ts` — full priority matrix and cascade cases
- `src/components/Worktree/WorktreeCard/__tests__/CollapsedAlarmPill.test.tsx` — chip styling per tier
- Extended `NonMainSecondaryRow.test.tsx` — badge ordering by tier with presence guards
- Extended `WorktreeHeader.test.tsx` — collapsed pill rendering, closed-PR stale CI suppression, non-GitHub auth-failed suppression, detached double-label prevention
- 125 targeted tests pass; typecheck, lint, and format clean