### PR TITLE
feat(fleet): dim unmatched panes on fleet preset hover

### DIFF
--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -95,6 +95,7 @@ function resetStores() {
     armOrder: [],
     armOrderById: {},
     lastArmedId: null,
+    previewArmedIds: new Set<string>(),
   });
   useFleetPendingActionStore.setState({ pending: null });
   useFleetBroadcastConfirmStore.setState({ pending: null });

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -202,6 +202,13 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
   // preview is unmistakable but doesn't squat on the focus anchor color.
   const isFleetPreviewed = useFleetArmingStore((s) => s.previewArmedIds.has(id));
 
+  // Inverse of isFleetPreviewed: when a preset hover is *active* and this
+  // pane is NOT in the would-be-armed set, dim it so the matched panes
+  // stand out without competing visual chrome on the rest of the grid.
+  const isFleetDimmed = useFleetArmingStore(
+    (s) => s.previewArmedIds.size > 0 && !s.previewArmedIds.has(id)
+  );
+
   // One-shot ring pulse when this pane becomes the new primary on fleet
   // exit. Listens for the CustomEvent dispatched from FleetArmingRibbon's
   // exitFleet — keeps the cosmetic event out of any persistent store.
@@ -414,6 +421,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
         data-runtime-icon-id={terminalChrome.iconId || undefined}
         data-selected={isSelected || undefined}
         data-hibernated={isHibernated || undefined}
+        data-fleet-dimmed={isFleetDimmed || undefined}
         style={{
           contain: "content",
           ...(worktreeAccentColor
@@ -440,6 +448,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
                     : "border-overlay hover:border-tint/[0.08]"),
           location === "grid" && isMaximized && "border-0 rounded-none z-[var(--z-maximized)]",
           worktreeAccentColor && location === "grid" && !isMaximized && "panel-worktree-identity",
+          isFleetDimmed && "fleet-pane-dimmed",
           className
         )}
         onClick={handleClick}

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -20,6 +20,7 @@ import type { TabInfo } from "./TabButton";
 import { useDockBlockedState } from "@/components/Layout/useDockBlockedState";
 import { usePreferencesStore } from "@/store";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { useWorktreeColorMap } from "@/hooks/useWorktreeColorMap";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
@@ -205,11 +206,12 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
   // Inverse of isFleetPreviewed: when a preset hover is *active* and this
   // pane is NOT in the would-be-armed set, dim it so the matched panes
   // stand out without competing visual chrome on the rest of the grid.
-  // Gated on kind === "terminal" so browser, dev-preview, and other
-  // non-fleet panels (which are never in previewArmedIds) stay at full
-  // opacity — dimming them would imply they could have been armed.
+  // Gated on PTY-backed kinds so browser, dev-preview, and other non-fleet
+  // panels (which are never in previewArmedIds) stay at full opacity —
+  // dimming them would imply they could have been armed.
+  const isPtyKind = panelKindHasPty(kind);
   const isFleetDimmed = useFleetArmingStore(
-    (s) => kind === "terminal" && s.previewArmedIds.size > 0 && !s.previewArmedIds.has(id)
+    (s) => isPtyKind && s.previewArmedIds.size > 0 && !s.previewArmedIds.has(id)
   );
 
   // One-shot ring pulse when this pane becomes the new primary on fleet

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -205,8 +205,11 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
   // Inverse of isFleetPreviewed: when a preset hover is *active* and this
   // pane is NOT in the would-be-armed set, dim it so the matched panes
   // stand out without competing visual chrome on the rest of the grid.
+  // Gated on kind === "terminal" so browser, dev-preview, and other
+  // non-fleet panels (which are never in previewArmedIds) stay at full
+  // opacity — dimming them would imply they could have been armed.
   const isFleetDimmed = useFleetArmingStore(
-    (s) => s.previewArmedIds.size > 0 && !s.previewArmedIds.has(id)
+    (s) => kind === "terminal" && s.previewArmedIds.size > 0 && !s.previewArmedIds.has(id)
   );
 
   // One-shot ring pulse when this pane becomes the new primary on fleet

--- a/src/components/Panel/__tests__/ContentPanel.fleetDim.test.tsx
+++ b/src/components/Panel/__tests__/ContentPanel.fleetDim.test.tsx
@@ -68,12 +68,12 @@ vi.mock("@/components/ui/tooltip", () => ({
 import { ContentPanel } from "../ContentPanel";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 
-function renderPanel(id: string) {
+function renderPanel(id: string, kind: "terminal" | "browser" | "dev-preview" = "terminal") {
   return render(
     <ContentPanel
       id={id}
       title={`Panel ${id}`}
-      kind="dev-preview"
+      kind={kind}
       isFocused={false}
       onFocus={() => {}}
       onClose={() => {}}
@@ -119,6 +119,22 @@ describe("ContentPanel fleet-dim unmatched panes (#8696)", () => {
     const panel = container.querySelector('[data-panel-id="t-1"]');
     expect(panel?.getAttribute("data-fleet-dimmed")).toBeNull();
     expect(panel?.className.includes("fleet-pane-dimmed")).toBe(false);
+  });
+
+  it("never dims non-terminal panes (browser, dev-preview)", () => {
+    // Browser and dev-preview panes are never arm-eligible, so dimming
+    // them during a fleet preview would imply they could have been armed.
+    const { container: browser } = renderPanel("b-1", "browser");
+    const { container: devPreview } = renderPanel("d-1", "dev-preview");
+    act(() => {
+      useFleetArmingStore.setState({ previewArmedIds: new Set(["t-2"]) });
+    });
+    expect(
+      browser.querySelector('[data-panel-id="b-1"]')?.getAttribute("data-fleet-dimmed")
+    ).toBeNull();
+    expect(
+      devPreview.querySelector('[data-panel-id="d-1"]')?.getAttribute("data-fleet-dimmed")
+    ).toBeNull();
   });
 
   it("returns to undimmed when the preview clears", () => {

--- a/src/components/Panel/__tests__/ContentPanel.fleetDim.test.tsx
+++ b/src/components/Panel/__tests__/ContentPanel.fleetDim.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+/**
+ * ContentPanel — fleet preview "dim unmatched" container behavior (#8696).
+ *
+ * When a fleet state-preset menu item is hovered, panes that *would* be armed
+ * pick up the title-bar lift (`data-fleet-previewed`). Panes that would NOT
+ * be armed receive the `data-fleet-dimmed` attribute on the outer container,
+ * which is paired with the `.fleet-pane-dimmed` class that drops opacity to
+ * 0.5. With no preview active, neither attribute is set.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, cleanup } from "@testing-library/react";
+
+vi.mock("@/components/Terminal/TerminalContextMenu", () => ({
+  TerminalContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// useWorktreeStore throws when called outside of a provider in some test
+// setups — see memory note "throwing-context-hooks-break-isolated-tests".
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: (selector: (s: { worktrees: Map<string, unknown> }) => unknown) =>
+    selector({ worktrees: new Map() }),
+}));
+
+vi.mock("@/hooks/useWorktreeColorMap", () => ({
+  useWorktreeColorMap: () => undefined,
+}));
+
+vi.mock("@/components/DragDrop", () => ({
+  useIsDragging: () => false,
+}));
+
+vi.mock("@/components/Layout/useDockBlockedState", () => ({
+  useDockBlockedState: () => null,
+}));
+
+vi.mock("@/utils/terminalChrome", () => ({
+  deriveTerminalChrome: () => ({
+    agentId: undefined,
+    iconId: undefined,
+    runtimeKind: "shell",
+    isAgent: false,
+  }),
+}));
+
+vi.mock("@/utils/terminalAgentDisplayState", () => ({
+  getTerminalAgentDisplayState: () => undefined,
+}));
+
+vi.mock("@/components/Terminal/TerminalHeaderContent", () => ({
+  TerminalHeaderContent: () => null,
+}));
+
+vi.mock("@/store", () => ({
+  usePreferencesStore: (selector: (s: { showGridAgentHighlights: boolean }) => unknown) =>
+    selector({ showGridAgentHighlights: false }),
+}));
+
+// PanelHeader renders Radix tooltips; supply passthrough stand-ins so the
+// container renders without a TooltipProvider in the test harness.
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { ContentPanel } from "../ContentPanel";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+
+function renderPanel(id: string) {
+  return render(
+    <ContentPanel
+      id={id}
+      title={`Panel ${id}`}
+      kind="dev-preview"
+      isFocused={false}
+      onFocus={() => {}}
+      onClose={() => {}}
+    >
+      <div data-testid="panel-body" />
+    </ContentPanel>
+  );
+}
+
+describe("ContentPanel fleet-dim unmatched panes (#8696)", () => {
+  beforeEach(() => {
+    useFleetArmingStore.setState({ previewArmedIds: new Set<string>() });
+  });
+
+  afterEach(() => {
+    useFleetArmingStore.setState({ previewArmedIds: new Set<string>() });
+    cleanup();
+  });
+
+  it("does not dim when no preview is active", () => {
+    const { container } = renderPanel("t-1");
+    const panel = container.querySelector('[data-panel-id="t-1"]');
+    expect(panel).not.toBeNull();
+    expect(panel?.getAttribute("data-fleet-dimmed")).toBeNull();
+    expect(panel?.className.includes("fleet-pane-dimmed")).toBe(false);
+  });
+
+  it("dims when a preview is active and this pane is not in the set", () => {
+    const { container } = renderPanel("t-1");
+    act(() => {
+      useFleetArmingStore.setState({ previewArmedIds: new Set(["t-2", "t-3"]) });
+    });
+    const panel = container.querySelector('[data-panel-id="t-1"]');
+    expect(panel?.getAttribute("data-fleet-dimmed")).toBe("true");
+    expect(panel?.className.includes("fleet-pane-dimmed")).toBe(true);
+  });
+
+  it("does not dim when this pane IS in the preview set", () => {
+    const { container } = renderPanel("t-1");
+    act(() => {
+      useFleetArmingStore.setState({ previewArmedIds: new Set(["t-1", "t-2"]) });
+    });
+    const panel = container.querySelector('[data-panel-id="t-1"]');
+    expect(panel?.getAttribute("data-fleet-dimmed")).toBeNull();
+    expect(panel?.className.includes("fleet-pane-dimmed")).toBe(false);
+  });
+
+  it("returns to undimmed when the preview clears", () => {
+    const { container } = renderPanel("t-1");
+    act(() => {
+      useFleetArmingStore.setState({ previewArmedIds: new Set(["t-2"]) });
+    });
+    let panel = container.querySelector('[data-panel-id="t-1"]');
+    expect(panel?.getAttribute("data-fleet-dimmed")).toBe("true");
+    act(() => {
+      useFleetArmingStore.setState({ previewArmedIds: new Set<string>() });
+    });
+    panel = container.querySelector('[data-panel-id="t-1"]');
+    expect(panel?.getAttribute("data-fleet-dimmed")).toBeNull();
+  });
+});

--- a/src/components/Panel/__tests__/ContentPanel.fleetDim.test.tsx
+++ b/src/components/Panel/__tests__/ContentPanel.fleetDim.test.tsx
@@ -128,10 +128,12 @@ describe("ContentPanel fleet-dim unmatched panes (#8696)", () => {
     });
     let panel = container.querySelector('[data-panel-id="t-1"]');
     expect(panel?.getAttribute("data-fleet-dimmed")).toBe("true");
+    expect(panel?.className.includes("fleet-pane-dimmed")).toBe(true);
     act(() => {
       useFleetArmingStore.setState({ previewArmedIds: new Set<string>() });
     });
     panel = container.querySelector('[data-panel-id="t-1"]');
     expect(panel?.getAttribute("data-fleet-dimmed")).toBeNull();
+    expect(panel?.className.includes("fleet-pane-dimmed")).toBe(false);
   });
 });

--- a/src/styles/components/panels.css
+++ b/src/styles/components/panels.css
@@ -45,11 +45,15 @@
 /* Applied to ContentPanel's outer container when a fleet state-preset menu
  * item is hovered and this pane is NOT in the would-be-armed set. Recedes
  * unmatched panes so the matched panes' title-bar preview tint stands out
- * without competing visual chrome on the rest of the grid. Scoped to the
- * `opacity` property to keep transforms / shadows snappy (CLAUDE.md). */
+ * without competing visual chrome on the rest of the grid. Snaps on/off —
+ * the matched panes' title-bar tint already animates via PanelHeader's
+ * `transition-colors`, which carries the perceived motion. Adding an
+ * `opacity` transition here would need a stable selector (the class
+ * disappears on undim, taking its transition with it) and would clobber
+ * Tailwind's `transition-colors duration-300` on the grid-panel shorthand.
+ * A snap is also fine for a transient preview cue. */
 .fleet-pane-dimmed {
   opacity: 0.5;
-  transition: opacity 150ms ease-out;
 }
 
 /* Users with reduced-transparency preference still see the matched-pane

--- a/src/styles/components/panels.css
+++ b/src/styles/components/panels.css
@@ -41,3 +41,23 @@
   background: var(--floating-surface-bg, var(--theme-surface-panel-elevated));
   box-shadow: var(--floating-surface-shadow, var(--theme-shadow-floating));
 }
+
+/* Applied to ContentPanel's outer container when a fleet state-preset menu
+ * item is hovered and this pane is NOT in the would-be-armed set. Recedes
+ * unmatched panes so the matched panes' title-bar preview tint stands out
+ * without competing visual chrome on the rest of the grid. Scoped to the
+ * `opacity` property to keep transforms / shadows snappy (CLAUDE.md). */
+.fleet-pane-dimmed {
+  opacity: 0.5;
+  transition: opacity 150ms ease-out;
+}
+
+/* Users with reduced-transparency preference still see the matched-pane
+ * title-bar tint and the fleet ribbon's count — they don't need the dim
+ * cue, which would just feel like the app went stale. Mirrors the
+ * .surface-chrome reduced-transparency precedent above. */
+@media (prefers-reduced-transparency: reduce) {
+  .fleet-pane-dimmed {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the dim-unmatched-panes half of #8696 — the count-showing half was already on develop via #8715
- `isFleetDimmed` selector in `ContentPanel.tsx` gates on `kind === "terminal"` so browser and dev-preview panels stay at full opacity (dimming them would imply they could have been armed)
- `.fleet-pane-dimmed` in `panels.css` sets `opacity: 0.5` with no transition — the matched panes' title-bar tint already animates via `PanelHeader`'s `transition-colors`, which carries the perceived motion; adding a transition would clobber Tailwind's shorthand on the panel container
- `prefers-reduced-transparency: reduce` restores full opacity; users on that setting still see the title-bar tint and the ribbon count

Resolves #8696

## Changes

- `src/components/Panel/ContentPanel.tsx` — `isFleetDimmed` selector, `fleet-pane-dimmed` class + `data-fleet-dimmed` attribute on outer container
- `src/styles/components/panels.css` — `.fleet-pane-dimmed` rule + reduced-transparency override
- `src/components/Panel/__tests__/ContentPanel.fleetDim.test.tsx` — four unit tests covering no-preview, not-matched, matched, and clear-resets states
- `src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx` — `previewArmedIds` cleared in `resetStores()` to prevent state leaking across test cases

## Testing

- 525 unit tests passing across `Panel/__tests__`, `fleetArmingStore`, and `Fleet/__tests__`
- `npm run check` clean