### PR TITLE
feat(settings): prefetch tab content on hover/focus

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -139,6 +139,15 @@ function SettingsDialogInner({
     () => new Set<SettingsTab>([initialTab])
   );
 
+  // AppDialog uses useAnimatedPresence and keeps children mounted through
+  // the ~120ms exit animation, so a hover-intent timer scheduled near close
+  // can fire while the dialog is animating out. Read this ref inside the
+  // timer callback to skip the speculative mount when the dialog is closing.
+  const isOpenRef = useRef(isOpen);
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
   const hasProject = !!projectId;
 
   useEffect(() => {
@@ -633,7 +642,13 @@ function SettingsDialogInner({
                       hasError={tabsWithErrors.has(tabId)}
                       onSelect={handleNavSelect}
                       onPrefetchImport={isLazy ? entry.importer : undefined}
-                      onPrefetchMount={isLazy ? () => markTabVisited(tabId) : undefined}
+                      onPrefetchMount={
+                        isLazy
+                          ? () => {
+                              if (isOpenRef.current) markTabVisited(tabId);
+                            }
+                          : undefined
+                      }
                     />
                   );
                 })}

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -76,6 +76,12 @@ let rememberedProjectTab: SettingsTab = "project:general";
 // attention after the user has oriented.
 const SETTINGS_HIGHLIGHT_DECAY_MS = 1500;
 
+// Hover-intent delay before speculatively mounting a settings tab's lazy
+// panel. Short enough that the panel's IPC reads are usually settled by the
+// time the user clicks; long enough that a mouse sweep across nav items
+// doesn't mount every tab at once.
+export const SETTINGS_TAB_HOVER_INTENT_MS = 150;
+
 // Lowercase the first letter so the label reads naturally mid-sentence
 // ("Requires voice input"), unless it starts with an initialism like
 // MCP / AI / API — those stay uppercase.
@@ -613,6 +619,7 @@ function SettingsDialogInner({
               <NavGroup key={group.label} label={group.label}>
                 {group.entries.map((entry) => {
                   const tabId = entry.id as SettingsTab;
+                  const isLazy = entry.importKind === "lazy";
                   return (
                     <NavItem
                       key={entry.id}
@@ -625,6 +632,8 @@ function SettingsDialogInner({
                       modified={modifiedTabs.has(tabId)}
                       hasError={tabsWithErrors.has(tabId)}
                       onSelect={handleNavSelect}
+                      onPrefetchImport={isLazy ? entry.importer : undefined}
+                      onPrefetchMount={isLazy ? () => markTabVisited(tabId) : undefined}
                     />
                   );
                 })}
@@ -1062,6 +1071,61 @@ export function scrollAndHighlightSettingsSection(sectionId: string): boolean {
   return true;
 }
 
+// Two-tier hover/focus prefetch for lazy settings tabs.
+//
+// - `onPrefetchImport` fires synchronously on enter — call the chunk's
+//   `import()` thunk. Idempotent: the browser module map dedupes repeat calls.
+// - `onPrefetchMount` fires after `delayMs` of sustained hover/focus — used
+//   to flip the tab into `visitedTabs` so its hidden panel mounts and the
+//   panel's `useEffect` IPC reads run before the user clicks.
+//
+// The delay timer is cancelled on leave/blur and on unmount to keep a
+// mouse-sweep across nav items from mounting every tab at once.
+export function useHoverIntentPrefetch({
+  onPrefetchImport,
+  onPrefetchMount,
+  delayMs = SETTINGS_TAB_HOVER_INTENT_MS,
+}: {
+  onPrefetchImport?: () => void;
+  onPrefetchMount?: () => void;
+  delayMs?: number;
+}): { onEnter: () => void; onLeave: () => void } {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    },
+    []
+  );
+
+  const onEnter = () => {
+    onPrefetchImport?.();
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (onPrefetchMount) {
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        onPrefetchMount();
+      }, delayMs);
+    }
+  };
+
+  const onLeave = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  return { onEnter, onLeave };
+}
+
 // Fires the scroll/highlight when its host subtree commits (via
 // useLayoutEffect — runs after DOM mutation, before paint). The active-tab
 // guard keeps inactive panels from racing each other when state cycles.
@@ -1119,6 +1183,13 @@ interface NavItemProps {
   modified?: boolean;
   hasError?: boolean;
   onSelect: (tab: SettingsTab) => void;
+  // Fires synchronously on pointer-enter / focus. Use to start downloading
+  // the tab's lazy chunk (import() is idempotent, no debounce needed).
+  onPrefetchImport?: () => void;
+  // Fires after SETTINGS_TAB_HOVER_INTENT_MS of sustained hover or focus.
+  // Use to speculatively mount the hidden tab panel so its IPC reads fire
+  // before the user clicks. Cancelled on leave/blur.
+  onPrefetchMount?: () => void;
 }
 
 function NavItem({
@@ -1131,9 +1202,15 @@ function NavItem({
   modified,
   hasError,
   onSelect,
+  onPrefetchImport,
+  onPrefetchMount,
 }: NavItemProps) {
   const active = activeTab === tab && !isSearching;
   const selected = activeTab === tab;
+  const { onEnter, onLeave } = useHoverIntentPrefetch({
+    onPrefetchImport,
+    onPrefetchMount,
+  });
   return (
     <button
       role="tab"
@@ -1143,6 +1220,10 @@ function NavItem({
       tabIndex={selected ? 0 : -1}
       data-tab={tab}
       onClick={() => onSelect(tab)}
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+      onFocus={onEnter}
+      onBlur={onLeave}
       className={cn(
         "relative text-left px-3 py-1.5 rounded-[var(--radius-md)] text-sm transition-colors flex items-center gap-2 w-full",
         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",

--- a/src/components/Settings/__tests__/SettingsDialog.prefetchTab.test.tsx
+++ b/src/components/Settings/__tests__/SettingsDialog.prefetchTab.test.tsx
@@ -202,4 +202,29 @@ describe("useHoverIntentPrefetch (issue #8760)", () => {
     });
     expect(onPrefetchMount).toHaveBeenCalledTimes(1);
   });
+
+  // Models the render-site gate added for the AppDialog exit-animation window:
+  // SettingsDialogInner wraps markTabVisited in an `isOpenRef.current` check
+  // so a timer scheduled within 150ms of close doesn't mount a hidden panel
+  // (which would fire its IPC reads against a closing dialog).
+  it("render-site isOpenRef gate suppresses the speculative mount during close", () => {
+    const markTabVisited = vi.fn();
+    const isOpenRef = { current: true };
+    const onPrefetchMount = () => {
+      if (isOpenRef.current) markTabVisited("agents");
+    };
+
+    const { result } = renderHook(() => useHoverIntentPrefetch({ onPrefetchMount }));
+
+    act(() => {
+      result.current.onEnter();
+    });
+    // User closes the dialog 100ms into the hover.
+    isOpenRef.current = false;
+    act(() => {
+      vi.advanceTimersByTime(SETTINGS_TAB_HOVER_INTENT_MS);
+    });
+
+    expect(markTabVisited).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/Settings/__tests__/SettingsDialog.prefetchTab.test.tsx
+++ b/src/components/Settings/__tests__/SettingsDialog.prefetchTab.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useHoverIntentPrefetch, SETTINGS_TAB_HOVER_INTENT_MS } from "../SettingsDialog";
+
+describe("useHoverIntentPrefetch (issue #8760)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires onPrefetchImport synchronously on enter", () => {
+    const onPrefetchImport = vi.fn();
+    const onPrefetchMount = vi.fn();
+    const { result } = renderHook(() =>
+      useHoverIntentPrefetch({ onPrefetchImport, onPrefetchMount })
+    );
+
+    act(() => {
+      result.current.onEnter();
+    });
+
+    expect(onPrefetchImport).toHaveBeenCalledTimes(1);
+    expect(onPrefetchMount).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onPrefetchMount before the hover-intent delay elapses", () => {
+    const onPrefetchMount = vi.fn();
+    const { result } = renderHook(() => useHoverIntentPrefetch({ onPrefetchMount }));
+
+    act(() => {
+      result.current.onEnter();
+    });
+    act(() => {
+      vi.advanceTimersByTime(SETTINGS_TAB_HOVER_INTENT_MS - 1);
+    });
+
+    expect(onPrefetchMount).not.toHaveBeenCalled();
+  });
+
+  it("fires onPrefetchMount exactly once after the hover-intent delay", () => {
+    const onPrefetchMount = vi.fn();
+    const { result } = renderHook(() => useHoverIntentPrefetch({ onPrefetchMount }));
+
+    act(() => {
+      result.current.onEnter();
+    });
+    act(() => {
+      vi.advanceTimersByTime(SETTINGS_TAB_HOVER_INTENT_MS);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(onPrefetchMount).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels onPrefetchMount when onLeave fires before the delay", () => {
+    const onPrefetchMount = vi.fn();
+    const { result } = renderHook(() => useHoverIntentPrefetch({ onPrefetchMount }));
+
+    act(() => {
+      result.current.onEnter();
+    });
+    act(() => {
+      vi.advanceTimersByTime(SETTINGS_TAB_HOVER_INTENT_MS - 1);
+    });
+    act(() => {
+      result.current.onLeave();
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(onPrefetchMount).not.toHaveBeenCalled();
+  });
+
+  it("repeated enter replaces (does not stack) the pending timer", () => {
+    const onPrefetchImport = vi.fn();
+    const onPrefetchMount = vi.fn();
+    const { result } = renderHook(() =>
+      useHoverIntentPrefetch({ onPrefetchImport, onPrefetchMount })
+    );
+
+    act(() => {
+      result.current.onEnter();
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      result.current.onEnter();
+    });
+    // First timer would have fired at 150ms. After re-enter at 100ms, the
+    // timer resets, so 50ms more is still under the new 150ms window.
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(onPrefetchMount).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onPrefetchMount).toHaveBeenCalledTimes(1);
+    expect(onPrefetchImport).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses the same code path for focus as for mouse enter (keyboard parity)", () => {
+    // onEnter is wired to both onMouseEnter and onFocus at the NavItem call
+    // site, so the same callback covers both pointer and keyboard arrow-key
+    // navigation through the tablist.
+    const onPrefetchImport = vi.fn();
+    const onPrefetchMount = vi.fn();
+    const { result } = renderHook(() =>
+      useHoverIntentPrefetch({ onPrefetchImport, onPrefetchMount })
+    );
+
+    act(() => {
+      result.current.onEnter();
+    });
+    act(() => {
+      vi.advanceTimersByTime(SETTINGS_TAB_HOVER_INTENT_MS);
+    });
+
+    expect(onPrefetchImport).toHaveBeenCalledTimes(1);
+    expect(onPrefetchMount).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the pending timer on unmount", () => {
+    const onPrefetchMount = vi.fn();
+    const { result, unmount } = renderHook(() => useHoverIntentPrefetch({ onPrefetchMount }));
+
+    act(() => {
+      result.current.onEnter();
+    });
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(onPrefetchMount).not.toHaveBeenCalled();
+  });
+
+  it("no-ops cleanly when only one or neither callback is provided", () => {
+    // Eager tabs (e.g. General) pass undefined for both callbacks — the
+    // hook must not crash and must not schedule a timer.
+    const { result } = renderHook(() => useHoverIntentPrefetch({}));
+
+    expect(() => {
+      act(() => {
+        result.current.onEnter();
+      });
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      act(() => {
+        result.current.onLeave();
+      });
+    }).not.toThrow();
+  });
+
+  it("import-only callback fires every enter; no mount timer is scheduled", () => {
+    // If only onPrefetchImport is wired, the hook should fire it on every
+    // enter without scheduling a delayed mount.
+    const onPrefetchImport = vi.fn();
+    const { result } = renderHook(() => useHoverIntentPrefetch({ onPrefetchImport }));
+
+    act(() => {
+      result.current.onEnter();
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    act(() => {
+      result.current.onEnter();
+    });
+
+    expect(onPrefetchImport).toHaveBeenCalledTimes(2);
+  });
+
+  it("delay defaults to SETTINGS_TAB_HOVER_INTENT_MS (150ms)", () => {
+    expect(SETTINGS_TAB_HOVER_INTENT_MS).toBe(150);
+  });
+
+  it("custom delayMs overrides the default", () => {
+    const onPrefetchMount = vi.fn();
+    const { result } = renderHook(() => useHoverIntentPrefetch({ onPrefetchMount, delayMs: 300 }));
+
+    act(() => {
+      result.current.onEnter();
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(onPrefetchMount).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(onPrefetchMount).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds hover/focus prefetch to settings tab navigation so content is ready before the click lands
- On `mouseenter` and `focus`, the chunk importer fires immediately; after a 150ms hover-intent delay (`SETTINGS_TAB_HOVER_INTENT_MS`), the tab is marked visited so the component mounts and runs its IPC reads speculatively
- Keyboard navigation gets the same treatment; a close-guard prevents mounting if the dialog is already exiting

## Changes

- `useHoverIntentPrefetch` hook encapsulates the two-tier logic (immediate import + delayed mount)
- `NavItem` extended with `onPrefetchImport` and `onPrefetchMount` callbacks; wired via `onMouseEnter`/`Leave`/`Focus`/`Blur` on the nav button
- Render site passes `entry.importer` and an `isOpen`-gated `markTabVisited` closure for lazy entries; `undefined` for the eager General tab
- Existing `requestIdleCallback` + `preloadAllSettingsTabs` fallback retained unchanged
- 12 isolated hook tests with `vi.useFakeTimers` covering enter, leave, timer, unmount, keyboard parity, and close-during-hover

## Testing

All 12 new unit tests pass. The existing settings dialog tests are unchanged. Manually verified that hovering a tab for >150ms populates content before clicking, and that a quick mouse sweep across the sidebar doesn't mount every tab at once.

Resolves #8760