### PR TITLE
refactor(mcp): cite upstream Claude Code issues in literal-token comments

### DIFF
--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -1225,11 +1225,18 @@ export class HelpSessionService {
     }
     if (settings.daintreeControl && port) {
       // Bake the literal token into the file rather than `${DAINTREE_MCP_TOKEN}`
-      // substitution. Claude Code's env substitution in `headers` is broken
-      // (sends the literal placeholder, gets 401). Same reason as
-      // McpPaneConfigService.ts. The session dir is 0o700 and the file is
-      // 0o600. Token rotates on every provision; the in-memory map is the
-      // auth boundary, so the literal on disk is dead the moment its session
+      // substitution. Claude Code's `${VAR}` substitution in `headers` is still
+      // broken as of v2.1.83 through v2.1.133 (tested May 2026): the placeholder
+      // is not
+      // forwarded to the wire (anthropics/claude-code#6204), and headers are
+      // dropped on POST requests for the SSE transport (#28293). Worse, `claude
+      // mcp add`/`claude mcp remove` rewrite `${VAR}` to its literal env value
+      // when they touch `.mcp.json` (#18692, #57131), so env substitution would
+      // leak every session bearer to disk the moment a user runs either
+      // subcommand. The literal-token path avoids that class of leak entirely.
+      // Same reason as McpPaneConfigService.ts. The session dir is 0o700 and the
+      // file is 0o600. Token rotates on every provision; the in-memory map is
+      // the auth boundary, so the literal on disk is dead the moment its session
       // is revoked.
       mcpServers["daintree"] = {
         type: "sse",

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -1227,13 +1227,13 @@ export class HelpSessionService {
       // Bake the literal token into the file rather than `${DAINTREE_MCP_TOKEN}`
       // substitution. Claude Code's `${VAR}` substitution in `headers` is still
       // broken as of v2.1.83 through v2.1.133 (tested May 2026): the placeholder
-      // is not
-      // forwarded to the wire (anthropics/claude-code#6204), and headers are
-      // dropped on POST requests for the SSE transport (#28293). Worse, `claude
-      // mcp add`/`claude mcp remove` rewrite `${VAR}` to its literal env value
-      // when they touch `.mcp.json` (#18692, #57131), so env substitution would
-      // leak every session bearer to disk the moment a user runs either
+      // is not forwarded to the wire (anthropics/claude-code#6204). Worse,
+      // `claude mcp add`/`claude mcp remove` rewrite `${VAR}` to its literal env
+      // value when they touch `.mcp.json` (#18692, #57131), so env substitution
+      // would leak every session bearer to disk the moment a user runs either
       // subcommand. The literal-token path avoids that class of leak entirely.
+      // (Separately, #28293 drops headers on SSE-transport POSTs regardless of
+      // literal-vs-substituted value — a known limitation neither path fixes.)
       // Same reason as McpPaneConfigService.ts. The session dir is 0o700 and the
       // file is 0o600. Token rotates on every provision; the in-memory map is
       // the auth boundary, so the literal on disk is dead the moment its session

--- a/electron/services/McpPaneConfigService.ts
+++ b/electron/services/McpPaneConfigService.ts
@@ -82,12 +82,11 @@ export class McpPaneConfigService {
     // Bake the token literal into the file rather than using ${VAR} substitution.
     // Claude Code's `${VAR}` substitution in `headers` is still broken as of
     // v2.1.83 through v2.1.133 (tested May 2026): placeholders aren't forwarded
-    // to the
-    // wire (anthropics/claude-code#6204) and headers are dropped on SSE POSTs
-    // (#28293). `claude mcp add`/`remove` also rewrite `${VAR}` to its literal
-    // env value (#18692, #57131), which would leak the session bearer to disk —
-    // the literal-token path sidesteps that leak class. Same reason as
-    // HelpSessionService.ts.
+    // to the wire (anthropics/claude-code#6204). `claude mcp add`/`remove` also
+    // rewrite `${VAR}` to its literal env value (#18692, #57131), which would
+    // leak the session bearer to disk — the literal-token path sidesteps that
+    // leak class. (#28293 separately drops headers on SSE POSTs regardless of
+    // value; neither path fixes it.) Same reason as HelpSessionService.ts.
     const payload = {
       mcpServers: {
         [MCP_SERVER_KEY]: {

--- a/electron/services/McpPaneConfigService.ts
+++ b/electron/services/McpPaneConfigService.ts
@@ -80,7 +80,14 @@ export class McpPaneConfigService {
     const token = randomUUID();
 
     // Bake the token literal into the file rather than using ${VAR} substitution.
-    // Claude Code's env substitution in `headers` has an active bug; literal value is reliable.
+    // Claude Code's `${VAR}` substitution in `headers` is still broken as of
+    // v2.1.83 through v2.1.133 (tested May 2026): placeholders aren't forwarded
+    // to the
+    // wire (anthropics/claude-code#6204) and headers are dropped on SSE POSTs
+    // (#28293). `claude mcp add`/`remove` also rewrite `${VAR}` to its literal
+    // env value (#18692, #57131), which would leak the session bearer to disk —
+    // the literal-token path sidesteps that leak class. Same reason as
+    // HelpSessionService.ts.
     const payload = {
       mcpServers: {
         [MCP_SERVER_KEY]: {

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -233,7 +233,7 @@ describe("HelpSessionService", () => {
 
   it("creates a session dir with a .mcp.json that bakes the literal session token into the Authorization header", async () => {
     // Claude Code's `${VAR}` substitution in `headers` is still broken as of
-    // v2.1.83 through v2.1.133 (anthropics/claude-code#6204, #28293) and `mcp
+    // v2.1.83 through v2.1.133 (anthropics/claude-code#6204) and `mcp
     // add/remove` rewrite it to a literal env value, leaking the bearer to disk
     // (#18692, #57131) — must bake the literal token. Same reason as
     // McpPaneConfigService.ts.

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -232,9 +232,11 @@ describe("HelpSessionService", () => {
   });
 
   it("creates a session dir with a .mcp.json that bakes the literal session token into the Authorization header", async () => {
-    // Claude Code's `${VAR}` substitution in `headers` is broken (sends the
-    // literal placeholder, gets 401) — must bake the literal token. Same
-    // reason as McpPaneConfigService.ts.
+    // Claude Code's `${VAR}` substitution in `headers` is still broken as of
+    // v2.1.83 through v2.1.133 (anthropics/claude-code#6204, #28293) and `mcp
+    // add/remove` rewrite it to a literal env value, leaking the bearer to disk
+    // (#18692, #57131) — must bake the literal token. Same reason as
+    // McpPaneConfigService.ts.
     const result = await service.provisionSession(provisionInput());
     expect(result).not.toBeNull();
     if (!result) throw new Error("expected result");

--- a/electron/services/__tests__/McpPaneConfigService.test.ts
+++ b/electron/services/__tests__/McpPaneConfigService.test.ts
@@ -49,8 +49,8 @@ describe("McpPaneConfigService", () => {
     expect(parsed.mcpServers.daintree.url).toBe("http://127.0.0.1:45454/sse");
     expect(parsed.mcpServers.daintree.headers.Authorization).toBe(`Bearer ${token}`);
     // Token must NOT be ${VAR}-style — Claude Code's header env substitution is
-    // still broken (anthropics/claude-code#6204, #28293) and `mcp add/remove`
-    // leak it to disk (#18692, #57131); the literal bearer is the reliable path.
+    // still broken (anthropics/claude-code#6204) and `mcp add/remove` rewrite it
+    // to a literal, leaking it to disk (#18692, #57131); literal is reliable.
     expect(parsed.mcpServers.daintree.headers.Authorization).not.toContain("${");
   });
 

--- a/electron/services/__tests__/McpPaneConfigService.test.ts
+++ b/electron/services/__tests__/McpPaneConfigService.test.ts
@@ -48,7 +48,9 @@ describe("McpPaneConfigService", () => {
     expect(parsed.mcpServers.daintree.type).toBe("sse");
     expect(parsed.mcpServers.daintree.url).toBe("http://127.0.0.1:45454/sse");
     expect(parsed.mcpServers.daintree.headers.Authorization).toBe(`Bearer ${token}`);
-    // Token must NOT be ${VAR}-style — Claude's env substitution is buggy.
+    // Token must NOT be ${VAR}-style — Claude Code's header env substitution is
+    // still broken (anthropics/claude-code#6204, #28293) and `mcp add/remove`
+    // leak it to disk (#18692, #57131); the literal bearer is the reliable path.
     expect(parsed.mcpServers.daintree.headers.Authorization).not.toContain("${");
   });
 


### PR DESCRIPTION
## Summary

- Comment-only refactor — no logic changes. Replaced vague "env substitution broken" notes at the two Claude Code MCP config writer sites (`HelpSessionService.writeMcpConfig` and `McpPaneConfigService.preparePaneConfig`) with precise upstream issue citations.
- `anthropics/claude-code#6204`: `${VAR}` placeholders are not forwarded to the wire, which is why we write the literal token. `anthropics/claude-code#18692` and `anthropics/claude-code#57131`: `claude mcp add`/`remove` rewrites `${VAR}` to the live env value on disk, leaking the session bearer. `anthropics/claude-code#28293`: headers are silently dropped on SSE POST regardless of value (separate limitation, noted separately).
- Version range tested: v2.1.83 through v2.1.133 (May 2026).

Resolves #8776

## Changes

- `electron/services/HelpSessionService.ts` — expanded comment block with issue citations
- `electron/services/McpPaneConfigService.ts` — same
- `electron/services/__tests__/HelpSessionService.test.ts` — updated test comments to match
- `electron/services/__tests__/McpPaneConfigService.test.ts` — same

## Testing

141 vitest tests pass. Lint, typecheck, and format all clean.