### PR TITLE
fix(assistant): disclose MCP-server cascade on Daintree Assistant settings tab

### DIFF
--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -562,7 +562,7 @@ export function DaintreeAssistantSettingsTab() {
           ariaLabel="Allow the assistant to call Daintree control tools"
           disabled={loading}
         />
-        {settings.daintreeControl && (
+        {!loading && settings.daintreeControl && (
           <div
             className={cn(
               "flex items-start gap-2 p-3 rounded-[var(--radius-md)]",
@@ -691,8 +691,6 @@ export function DaintreeAssistantSettingsTab() {
           showInlineLoading ? (
             <p className="text-xs text-daintree-text/50">Loading…</p>
           ) : null
-        ) : !mcpStatus ? (
-          <p className="text-xs text-daintree-text/50">Couldn't load MCP status.</p>
         ) : runtimeSnapshot.state === "disabled" ? (
           <div className="space-y-2">
             <p className="text-xs text-daintree-text/60 select-text">
@@ -732,6 +730,8 @@ export function DaintreeAssistantSettingsTab() {
               </button>
             </div>
           </div>
+        ) : !mcpStatus ? (
+          <p className="text-xs text-daintree-text/50">Couldn't load MCP status.</p>
         ) : (
           <div className="contents">
             <div className="flex items-center gap-2">

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -15,6 +15,10 @@ import {
 } from "lucide-react";
 import { DaintreeIcon, McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
+import { useDeferredLoading } from "@/hooks";
+import { useMcpReadiness } from "@/hooks/useMcpReadiness";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { actionService } from "@/services/ActionService";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsInput } from "./SettingsInput";
@@ -110,6 +114,10 @@ const HIBERNATE_OPTIONS = [
 export function DaintreeAssistantSettingsTab() {
   const [settings, setSettings] = useState<HelpAssistantSettings>(DEFAULT_SETTINGS);
   const [mcpStatus, setMcpStatus] = useState<McpStatusSnapshot | null>(null);
+  // useMcpReadiness drives the 4-state Connection display reactively; the
+  // separate mcpStatus state still supplies apiKey for copy/rotate (not in
+  // the runtime snapshot). Keep both — they update independently (lesson #4958).
+  const runtimeSnapshot = useMcpReadiness();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -457,6 +465,15 @@ export function DaintreeAssistantSettingsTab() {
   const apiKeySuffix =
     mcpStatus?.apiKey && mcpStatus.apiKey.length >= 8 ? mcpStatus.apiKey.slice(-4) : "";
 
+  // Doherty gate for the initial status round-trip: render section chrome
+  // immediately and only show the inline "Loading…" text if it outlasts the
+  // threshold, avoiding a sub-400ms flicker.
+  const showInlineLoading = useDeferredLoading(loading, UI_DOHERTY_THRESHOLD);
+
+  const handleGoToMcpSettings = () => {
+    void actionService.dispatch("app.settings.openTab", { tab: "mcp" }, { source: "user" });
+  };
+
   const handleCopyConfig = async () => {
     try {
       const snippet = await window.electron.mcpServer.getConfigSnippet();
@@ -545,6 +562,19 @@ export function DaintreeAssistantSettingsTab() {
           ariaLabel="Allow the assistant to call Daintree control tools"
           disabled={loading}
         />
+        {settings.daintreeControl && (
+          <div
+            className={cn(
+              "flex items-start gap-2 p-3 rounded-[var(--radius-md)]",
+              "bg-overlay-subtle border border-daintree-border"
+            )}
+          >
+            <div className="text-xs text-daintree-text/70 leading-relaxed select-text">
+              Enabling this starts a local HTTP server on 127.0.0.1 so the assistant can call
+              Daintree actions. The MCP server tab has the connection details and API key.
+            </div>
+          </div>
+        )}
       </SettingsSection>
 
       {/* Hibernation */}
@@ -658,25 +688,56 @@ export function DaintreeAssistantSettingsTab() {
         description="The assistant talks to Daintree through the local MCP server. Use these controls to share access with external clients."
       >
         {loading ? (
-          <p className="text-xs text-daintree-text/50">Loading…</p>
+          showInlineLoading ? (
+            <p className="text-xs text-daintree-text/50">Loading…</p>
+          ) : null
         ) : !mcpStatus ? (
           <p className="text-xs text-daintree-text/50">Couldn't load MCP status.</p>
-        ) : !mcpStatus.enabled ? (
-          <p className="text-xs text-daintree-text/60 select-text">
-            MCP server is off. Turn it on in the MCP Server tab to share the connection with
-            external clients.
-          </p>
+        ) : runtimeSnapshot.state === "disabled" ? (
+          <div className="space-y-2">
+            <p className="text-xs text-daintree-text/60 select-text">
+              MCP server is off. Turn it on to share the connection with external clients.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={handleGoToMcpSettings}
+                className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
+              >
+                Open MCP server settings
+              </button>
+            </div>
+          </div>
+        ) : runtimeSnapshot.state === "starting" ? (
+          <div className="flex items-center gap-2">
+            <div className="w-2 h-2 rounded-full bg-daintree-text/30 shrink-0" />
+            <span className="text-xs text-daintree-text/60">Server is starting…</span>
+          </div>
+        ) : runtimeSnapshot.state === "failed" ? (
+          <div className="space-y-2">
+            <div className="flex items-start gap-2 p-3 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
+              <AlertCircle className="w-4 h-4 text-status-danger shrink-0 mt-0.5" />
+              <p className="text-xs text-status-danger leading-relaxed select-text">
+                MCP server failed to start.{" "}
+                {runtimeSnapshot.lastError ?? "Check the MCP server tab for details."}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={handleGoToMcpSettings}
+                className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
+              >
+                Open MCP server settings
+              </button>
+            </div>
+          </div>
         ) : (
           <div className="contents">
             <div className="flex items-center gap-2">
-              <div
-                className={cn(
-                  "w-2 h-2 rounded-full shrink-0",
-                  mcpStatus.port ? "bg-status-success" : "bg-daintree-text/30"
-                )}
-              />
+              <div className="w-2 h-2 rounded-full bg-status-success shrink-0" />
               <span className="text-xs text-daintree-text/60">
-                {mcpStatus.port ? `Running on port ${mcpStatus.port}` : "Server is starting…"}
+                {runtimeSnapshot.port ? `Running on port ${runtimeSnapshot.port}` : "Running"}
               </span>
             </div>
 

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -158,6 +158,7 @@ interface HelpAssistantApi {
 
 interface McpServerApi {
   getStatus: ReturnType<typeof vi.fn>;
+  getRuntimeState: ReturnType<typeof vi.fn>;
   setEnabled: ReturnType<typeof vi.fn>;
   rotateApiKey: ReturnType<typeof vi.fn>;
   getConfigSnippet: ReturnType<typeof vi.fn>;
@@ -189,6 +190,12 @@ function installApi(
       port: 45454,
       configuredPort: 45454,
       apiKey: "dnt-key-abc",
+    }),
+    getRuntimeState: vi.fn().mockResolvedValue({
+      enabled: true,
+      state: "ready",
+      port: 45454,
+      lastError: null,
     }),
     setEnabled: vi.fn().mockResolvedValue({
       enabled: true,
@@ -427,6 +434,12 @@ describe("DaintreeAssistantSettingsTab", () => {
           configuredPort: null,
           apiKey: "",
         }),
+        getRuntimeState: vi.fn().mockResolvedValue({
+          enabled: false,
+          state: "disabled",
+          port: null,
+          lastError: null,
+        }),
       }
     );
 
@@ -438,6 +451,50 @@ describe("DaintreeAssistantSettingsTab", () => {
     await waitForContent(container, "MCP server is off");
 
     expect(screen.queryByRole("button", { name: /rotate mcp key/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /copy mcp config/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /open mcp server settings/i })).toBeTruthy();
+  });
+
+  it("shows the local-server disclosure when Daintree control is on, and hides it when off", async () => {
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Daintree control");
+
+    // daintreeControl defaults to true in the mocked settings.
+    expect(container.textContent).toContain("starts a local HTTP server on 127.0.0.1");
+
+    fireEvent.click(screen.getByLabelText("Allow the assistant to call Daintree control tools"));
+
+    await waitFor(() => {
+      expect(container.textContent).not.toContain("starts a local HTTP server on 127.0.0.1");
+    });
+  });
+
+  it("surfaces the runtime error and a recovery link when the MCP server failed to start", async () => {
+    installApi(
+      {},
+      {
+        getRuntimeState: vi.fn().mockResolvedValue({
+          enabled: true,
+          state: "failed",
+          port: null,
+          lastError: "EADDRINUSE: port 45454 already in use",
+        }),
+      }
+    );
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "MCP server failed to start");
+
+    expect(container.textContent).toContain("EADDRINUSE: port 45454 already in use");
+    expect(screen.getByRole("button", { name: /open mcp server settings/i })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /copy mcp config/i })).toBeNull();
   });
 

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -498,6 +498,98 @@ describe("DaintreeAssistantSettingsTab", () => {
     expect(screen.queryByRole("button", { name: /copy mcp config/i })).toBeNull();
   });
 
+  it("renders the starting state without connection actions", async () => {
+    installApi(
+      {},
+      {
+        getRuntimeState: vi.fn().mockResolvedValue({
+          enabled: true,
+          state: "starting",
+          port: null,
+          lastError: null,
+        }),
+      }
+    );
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Server is starting…");
+
+    expect(screen.queryByRole("button", { name: /copy mcp config/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /rotate mcp key/i })).toBeNull();
+  });
+
+  it("still surfaces the failed runtime state when getStatus fails", async () => {
+    installApi(
+      {},
+      {
+        getStatus: vi.fn().mockRejectedValue(new Error("ipc down")),
+        getRuntimeState: vi.fn().mockResolvedValue({
+          enabled: true,
+          state: "failed",
+          port: null,
+          lastError: "EADDRINUSE: port 45454 already in use",
+        }),
+      }
+    );
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "MCP server failed to start");
+
+    expect(container.textContent).not.toContain("Couldn't load MCP status");
+    expect(screen.getByRole("button", { name: /open mcp server settings/i })).toBeTruthy();
+  });
+
+  it("renders the failed fallback copy when lastError is null", async () => {
+    installApi(
+      {},
+      {
+        getRuntimeState: vi.fn().mockResolvedValue({
+          enabled: true,
+          state: "failed",
+          port: null,
+          lastError: null,
+        }),
+      }
+    );
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Check the MCP server tab for details");
+  });
+
+  it("hides the local-server disclosure when Daintree control is persisted off", async () => {
+    installApi({
+      getSettings: vi.fn().mockResolvedValue({
+        docSearch: true,
+        daintreeControl: false,
+        tier: "action" as const,
+        bypassPermissions: false,
+        auditRetention: 7,
+        customArgs: "",
+      }),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Daintree control");
+
+    expect(container.textContent).not.toContain("starts a local HTTP server on 127.0.0.1");
+  });
+
   it("lists Codex in the agent dropdown when it passes the assistant gate", async () => {
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
 


### PR DESCRIPTION
## Summary

- The `daintreeControl` toggle was silently starting a localhost HTTP server with no UI disclosure — added an inline disclosure block under the toggle explaining what enabling it actually does.
- The Connection section was branching on a stale `mcpStatus.enabled` boolean instead of the four-state `McpRuntimeState` union; rewrote it to handle `disabled`, `starting`, `ready`, and `failed` states with distinct copy and recovery paths via `useMcpReadiness`.
- Gated the initial load with `useDeferredLoading(loading, UI_DOHERTY_THRESHOLD)` so the bare "Loading…" fallback no longer flickers for sub-400ms round-trips.

Resolves #8777

## Changes

- `DaintreeAssistantSettingsTab.tsx`: disclosure block under toggle (neutral surface, no accent); Connection section branched on `McpRuntimeState`; `failed` state surfaces `runtimeSnapshot.lastError` with a link to MCP settings; `disabled` and `failed` states route to the MCP tab via `actionService.dispatch("app.settings.openTab", { tab: "mcp" })`; `!mcpStatus` guard narrowed to the `ready` branch only so the other states still render when `getStatus()` fails.
- `DaintreeAssistantSettingsTab.test.tsx`: mocks `getRuntimeState`; adds coverage for disclosure visibility, all four runtime states, failed-when-`getStatus`-returns-null, and null `lastError` fallback. 29 tests pass.

## Testing

- `npm run check` clean — 0 errors, typecheck passes.
- 29 unit tests covering the new disclosure and all four `McpRuntimeState` branches.