### PR TITLE
feat(help): add 'Check again' button to assistant version gate

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -557,6 +557,7 @@ export function HelpPanel({
   const approveTierOnce = useCallback(() => controller.approveTierOnce(), [controller]);
   const alwaysAllowTier = useCallback(() => controller.alwaysAllowTier(), [controller]);
   const cancelLaunch = useCallback(() => controller.cancelLaunch(), [controller]);
+  const checkVersionAgain = useCallback(() => controller.checkVersionAgain(), [controller]);
 
   // Esc-to-close. The xterm-helper-textarea check lets Escape reach the
   // running PTY when the assistant terminal has focus; the .cm-editor check
@@ -701,6 +702,8 @@ export function HelpPanel({
           <HelpPanelVersionGate
             versionTooOld={session.assistantVersionTooOld}
             onOpenSettings={handleOpenSettings}
+            onCheckAgain={checkVersionAgain}
+            isCheckingVersion={session.isCheckingVersion}
           />
         ) : session.phase !== "idle" && session.phase !== "live" ? (
           <HelpLaunchingState phase={session.phase} isLoading onCancel={cancelLaunch} />

--- a/src/components/HelpPanel/HelpPanelVersionGate.tsx
+++ b/src/components/HelpPanel/HelpPanelVersionGate.tsx
@@ -5,9 +5,16 @@ import type { VersionTooOld } from "@/controllers/HelpSessionController";
 interface HelpPanelVersionGateProps {
   versionTooOld: VersionTooOld;
   onOpenSettings: () => void;
+  onCheckAgain: () => void;
+  isCheckingVersion: boolean;
 }
 
-export function HelpPanelVersionGate({ versionTooOld, onOpenSettings }: HelpPanelVersionGateProps) {
+export function HelpPanelVersionGate({
+  versionTooOld,
+  onOpenSettings,
+  onCheckAgain,
+  isCheckingVersion,
+}: HelpPanelVersionGateProps) {
   return (
     <div
       className="flex-1 flex flex-col items-center justify-center gap-3 p-8 text-center"
@@ -32,6 +39,19 @@ export function HelpPanelVersionGate({ versionTooOld, onOpenSettings }: HelpPane
       >
         <Settings2 className="w-3.5 h-3.5" />
         <span>Update {versionTooOld.agentName}</span>
+      </button>
+      <button
+        type="button"
+        onClick={onCheckAgain}
+        disabled={isCheckingVersion}
+        className={cn(
+          "text-[11px] text-daintree-text/40 transition-colors",
+          "hover:text-daintree-text/60",
+          "disabled:opacity-50 disabled:cursor-default disabled:hover:text-daintree-text/40",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        )}
+      >
+        Check again
       </button>
     </div>
   );

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -2420,6 +2420,65 @@ describe("HelpPanel — assistantMinVersion gate (issue #7539)", () => {
     );
   });
 
+  it("'Check again' re-probes with refresh=true and clears the gate when the CLI is now current", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockGetAgentVersion.mockResolvedValue({
+      agentId: "claude",
+      installedVersion: "0.9.0",
+      latestVersion: "1.0.0",
+      updateAvailable: true,
+      lastChecked: Date.now(),
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "auto-term-1" } });
+
+    const { findByTestId, findByRole, queryByTestId } = render(<HelpPanel width={380} />);
+    await findByTestId("help-version-too-old");
+
+    // User updates the CLI outside Daintree, then clicks "Check again".
+    mockGetAgentVersion.mockResolvedValue({
+      agentId: "claude",
+      installedVersion: "1.2.0",
+      latestVersion: "1.2.0",
+      updateAvailable: false,
+      lastChecked: Date.now(),
+    });
+
+    const checkAgain = await findByRole("button", { name: /check again/i });
+    await act(async () => {
+      fireEvent.click(checkAgain);
+    });
+
+    // The re-probe must bypass the 12h cache (refresh=true).
+    expect(mockGetAgentVersion).toHaveBeenCalledWith("claude", true);
+    // Passing probe clears the gate.
+    expect(queryByTestId("help-version-too-old")).toBeNull();
+  });
+
+  it("'Check again' keeps the gate when the CLI is still too old", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockGetAgentVersion.mockResolvedValue({
+      agentId: "claude",
+      installedVersion: "0.9.0",
+      latestVersion: "1.0.0",
+      updateAvailable: true,
+      lastChecked: Date.now(),
+    });
+
+    const { findByTestId, findByRole, getByTestId } = render(<HelpPanel width={380} />);
+    await findByTestId("help-version-too-old");
+
+    const checkAgain = await findByRole("button", { name: /check again/i });
+    await act(async () => {
+      fireEvent.click(checkAgain);
+    });
+
+    expect(mockGetAgentVersion).toHaveBeenCalledWith("claude", true);
+    // Still blocked — the gate stays visible.
+    expect(getByTestId("help-version-too-old")).toBeTruthy();
+  });
+
   it("passes through when installed version equals assistantMinVersion", async () => {
     helpPanelState.preferredAgentId = "claude";
     mockGetFolderPath.mockResolvedValue("/help");

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -33,6 +33,10 @@ const HIBERNATE_BUSY_RECHECK_MS = 2 * 60 * 1000;
 const RESUME_BANNER_AUTO_DISMISS_MS = 10_000;
 const SNAPSHOT_BANNER_AUTO_DISMISS_MS = 12_000;
 
+// Minimum disabled period after a manual "Check again" click — keeps the
+// button from being hammered while a fresh (cache-bypassing) probe runs.
+const CHECK_AGAIN_COOLDOWN_MS = 5_000;
+
 export type HelpSessionPhase =
   | "idle"
   | "version-checking"
@@ -68,6 +72,12 @@ export interface HelpSessionSnapshot {
   tierMismatch: TierMismatchState | null;
   preflightSnapshot: SnapshotInfo | null;
   isApprovingTier: boolean;
+  /**
+   * True while a manual "Check again" version re-probe is in flight or its
+   * 5s cooldown is still running. Disables the gate's secondary button to
+   * prevent probe hammering.
+   */
+  isCheckingVersion: boolean;
 }
 
 export interface HelpProjectRef {
@@ -283,6 +293,7 @@ const INITIAL_SNAPSHOT: HelpSessionSnapshot = Object.freeze({
   tierMismatch: null,
   preflightSnapshot: null,
   isApprovingTier: false,
+  isCheckingVersion: false,
 });
 
 /**
@@ -318,6 +329,16 @@ export class HelpSessionController {
    * for the 12h AgentVersionService cache TTL. Cleared once a probe passes.
    */
   private _hasBlockedThisSession = false;
+  /**
+   * Backs the manual "Check again" cooldown. `isCheckingVersion` only clears
+   * once BOTH the probe has settled (`_checkAgainProbeSettled`) and the 5s
+   * minimum-disabled floor has elapsed (`_checkAgainCooldownFired`), so a
+   * fast probe can't re-enable the button before the cooldown is up and a
+   * slow probe can't be re-enabled by the timer while still in flight.
+   */
+  private _checkAgainCooldownTimer: ReturnType<typeof setTimeout> | null = null;
+  private _checkAgainCooldownFired = false;
+  private _checkAgainProbeSettled = false;
   /**
    * Once-per-terminal-id guard for the auto-snapshot pre-flight. Stores the
    * terminal id we last took a snapshot for so React 19 StrictMode's
@@ -393,6 +414,7 @@ export class HelpSessionController {
     this._clearHibernateTimer();
     this._clearResumeBannerTimer();
     this._clearSnapshotBannerTimer();
+    this._clearCheckAgainCooldownTimer();
     // Bumping the gen invalidates any in-flight launch so its post-await
     // checkpoints bail. Live store state is left intact so a StrictMode
     // synthetic unmount doesn't tear down the user's session; explicit
@@ -721,10 +743,87 @@ export class HelpSessionController {
     this._resetPhase();
   }
 
+  /**
+   * Manual "Check again" from the version gate. Re-probes the installed CLI
+   * version with `refresh=true` so a user who updated the CLI while the gate
+   * was visible recovers without reopening the panel (the version probe is
+   * otherwise cached for 12h). On a passing probe the gate clears and the
+   * normal auto-launch flow resumes; on a still-too-old result the gate
+   * refreshes with the latest versions. A 5s minimum cooldown keeps the
+   * button disabled to prevent probe hammering.
+   */
+  checkVersionAgain(): void {
+    if (this._snapshot.isCheckingVersion) return;
+    const block = this._snapshot.assistantVersionTooOld;
+    if (!block) return;
+
+    const { agentId, agentName } = block;
+    this._checkAgainCooldownFired = false;
+    this._checkAgainProbeSettled = false;
+    this._patch({ isCheckingVersion: true });
+    this._armCheckAgainCooldownTimer();
+
+    safeFireAndForget(
+      checkAssistantVersion(agentId, agentName, true)
+        .then((versionBlock) => {
+          // Stale-agent guard: the user may have switched preferred agents
+          // while the probe was in flight — don't act on a result that no
+          // longer matches what's blocking.
+          if (this._snapshot.assistantVersionTooOld?.agentId !== agentId) return;
+          if (versionBlock) {
+            this._patch({ assistantVersionTooOld: versionBlock });
+            return;
+          }
+          // Probe passed — clear the gate and let the normal idle→launch
+          // path re-evaluate. Resetting `_hasAutoLaunched` is required or
+          // `_maybeAutoLaunch` returns early.
+          this._hasBlockedThisSession = false;
+          this._hasAutoLaunched = false;
+          this._patch({ assistantVersionTooOld: null });
+          if (this._lastInputs) this._maybeAutoLaunch(this._lastInputs);
+        })
+        .catch((err) => {
+          // checkAssistantVersion already swallows probe failures and returns
+          // null; this guards against unexpected throws. The gate stays
+          // visible as its own retry surface, so no toast.
+          logError("HelpPanel: check-again version probe threw", err);
+        })
+        .finally(() => {
+          this._checkAgainProbeSettled = true;
+          this._maybeClearCheckingVersion();
+        }),
+      { context: "HelpPanel:checkVersionAgain" }
+    );
+  }
+
   // --- internal ---
 
   private _resetPhase(): void {
     this._patch({ phase: "idle" });
+  }
+
+  private _armCheckAgainCooldownTimer(): void {
+    this._clearCheckAgainCooldownTimer();
+    this._checkAgainCooldownTimer = setTimeout(() => {
+      this._checkAgainCooldownTimer = null;
+      this._checkAgainCooldownFired = true;
+      this._maybeClearCheckingVersion();
+    }, CHECK_AGAIN_COOLDOWN_MS);
+  }
+
+  private _clearCheckAgainCooldownTimer(): void {
+    if (this._checkAgainCooldownTimer) {
+      clearTimeout(this._checkAgainCooldownTimer);
+      this._checkAgainCooldownTimer = null;
+    }
+  }
+
+  // Re-enables the "Check again" button only once both the probe has settled
+  // and the 5s cooldown floor has elapsed.
+  private _maybeClearCheckingVersion(): void {
+    if (this._checkAgainProbeSettled && this._checkAgainCooldownFired) {
+      this._patch({ isCheckingVersion: false });
+    }
   }
 
   private _patch(partial: Partial<HelpSessionSnapshot>): void {
@@ -738,7 +837,8 @@ export class HelpSessionController {
       next.assistantVersionTooOld === this._snapshot.assistantVersionTooOld &&
       next.tierMismatch === this._snapshot.tierMismatch &&
       next.preflightSnapshot === this._snapshot.preflightSnapshot &&
-      next.isApprovingTier === this._snapshot.isApprovingTier
+      next.isApprovingTier === this._snapshot.isApprovingTier &&
+      next.isCheckingVersion === this._snapshot.isCheckingVersion
     ) {
       return;
     }

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -180,38 +180,70 @@ async function provisionHelpSession(
   }
 }
 
+/**
+ * Three-state version probe.
+ * - `ok`: version meets the minimum (or no minimum is configured).
+ * - `indeterminate`: the probe couldn't get a definitive answer (IPC threw,
+ *   no installed version reported, or semver comparison failed).
+ * - `too-old`: a definitive too-old result, carrying the gate payload.
+ *
+ * The launch paths collapse `ok`/`indeterminate` into "proceed" (transient
+ * failure is permissive — see `checkAssistantVersion`). The manual
+ * "Check again" path keeps them distinct so a transient failure doesn't
+ * silently dismiss the gate and auto-launch an outdated CLI.
+ */
+type VersionProbeResult =
+  | { status: "ok" }
+  | { status: "indeterminate" }
+  | { status: "too-old"; block: VersionTooOld };
+
 // `refresh=true` bypasses the 12h AgentVersionService cache — pass on retry
 // so a user who manually updates the CLI outside Daintree's update flow can
 // recover within one panel reopen instead of waiting for cache expiry.
-async function checkAssistantVersion(
+async function probeAssistantVersion(
   agentId: string,
   agentName: string,
   refresh = false
-): Promise<VersionTooOld | null> {
+): Promise<VersionProbeResult> {
   const config = getAgentConfig(agentId);
   const required = config?.assistantMinVersion;
-  if (!required) return null;
+  if (!required) return { status: "ok" };
 
   let info;
   try {
     info = await window.electron.system.getAgentVersion(agentId, refresh);
   } catch (err) {
     logError("Failed to probe assistant CLI version", err);
-    return null;
+    return { status: "indeterminate" };
   }
 
   const installed = info?.installedVersion;
-  if (!installed) return null;
+  if (!installed) return { status: "indeterminate" };
 
   try {
     if (semver.lt(installed, required)) {
-      return { agentId, agentName, installedVersion: installed, requiredVersion: required };
+      return {
+        status: "too-old",
+        block: { agentId, agentName, installedVersion: installed, requiredVersion: required },
+      };
     }
   } catch (err) {
     logError("Failed to compare assistant CLI version", err);
-    return null;
+    return { status: "indeterminate" };
   }
-  return null;
+  return { status: "ok" };
+}
+
+// Launch-path wrapper preserving the original permissive contract: any
+// non-definitive result (ok or indeterminate) returns null so the launch
+// proceeds; only a definitive too-old result blocks.
+async function checkAssistantVersion(
+  agentId: string,
+  agentName: string,
+  refresh = false
+): Promise<VersionTooOld | null> {
+  const result = await probeAssistantVersion(agentId, agentName, refresh);
+  return result.status === "too-old" ? result.block : null;
 }
 
 async function loadCustomLaunchFlags(): Promise<string[]> {
@@ -442,7 +474,11 @@ export class HelpSessionController {
     // post-dispatch check handles its own cleanup, so we don't bump
     // `_launchGen` here.
     if (prev && prev.preferredAgentId !== inputs.preferredAgentId) {
-      this._patch({ assistantVersionTooOld: null });
+      // Drop any in-flight "Check again" cooldown too — it belongs to the
+      // previous agent's gate; leaving it would disable the new gate's
+      // button until the stale probe settles.
+      this._clearCheckAgainCooldownTimer();
+      this._patch({ assistantVersionTooOld: null, isCheckingVersion: false });
     }
 
     // Reset auto-launch guard when the panel closes so the next open can
@@ -764,28 +800,34 @@ export class HelpSessionController {
     this._armCheckAgainCooldownTimer();
 
     safeFireAndForget(
-      checkAssistantVersion(agentId, agentName, true)
-        .then((versionBlock) => {
+      probeAssistantVersion(agentId, agentName, true)
+        .then((result) => {
           // Stale-agent guard: the user may have switched preferred agents
           // while the probe was in flight — don't act on a result that no
           // longer matches what's blocking.
           if (this._snapshot.assistantVersionTooOld?.agentId !== agentId) return;
-          if (versionBlock) {
-            this._patch({ assistantVersionTooOld: versionBlock });
+          if (result.status === "too-old") {
+            this._patch({ assistantVersionTooOld: result.block });
             return;
           }
-          // Probe passed — clear the gate and let the normal idle→launch
-          // path re-evaluate. Resetting `_hasAutoLaunched` is required or
-          // `_maybeAutoLaunch` returns early.
+          if (result.status === "indeterminate") {
+            // Couldn't get a definitive answer (transient probe failure).
+            // Keep the gate visible rather than dismissing it and
+            // auto-launching a CLI that may still be outdated.
+            return;
+          }
+          // status === "ok" — version is now current. Clear the gate and
+          // let the normal idle→launch path re-evaluate. Resetting
+          // `_hasAutoLaunched` is required or `_maybeAutoLaunch` bails.
           this._hasBlockedThisSession = false;
           this._hasAutoLaunched = false;
           this._patch({ assistantVersionTooOld: null });
           if (this._lastInputs) this._maybeAutoLaunch(this._lastInputs);
         })
         .catch((err) => {
-          // checkAssistantVersion already swallows probe failures and returns
-          // null; this guards against unexpected throws. The gate stays
-          // visible as its own retry surface, so no toast.
+          // probeAssistantVersion already swallows probe failures; this
+          // guards against unexpected throws. The gate stays visible as its
+          // own retry surface, so no toast.
           logError("HelpPanel: check-again version probe threw", err);
         })
         .finally(() => {

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -242,6 +242,7 @@ describe("HelpSessionController — subscribe / getSnapshot", () => {
     expect(snap.tierMismatch).toBeNull();
     expect(snap.preflightSnapshot).toBeNull();
     expect(snap.isApprovingTier).toBe(false);
+    expect(snap.isCheckingVersion).toBe(false);
   });
 
   it("returns the same snapshot reference when no state changes (Object.is stable)", () => {
@@ -536,5 +537,120 @@ describe("HelpSessionController — tier-mismatch handlers", () => {
     ctrl.dismissTierMismatch();
     expect(ctrl.getSnapshot().tierMismatch).toBeNull();
     ctrl.stop();
+  });
+});
+
+describe("HelpSessionController — checkVersionAgain", () => {
+  const block = {
+    agentId: "claude",
+    agentName: "Claude",
+    installedVersion: "0.9.0",
+    requiredVersion: "1.0.0",
+  };
+
+  function setBlock(ctrl: HelpSessionController) {
+    ctrl["_patch"]({ assistantVersionTooOld: { ...block } });
+  }
+
+  function getAgentVersionMock() {
+    return window.electron.system.getAgentVersion as ReturnType<typeof vi.fn>;
+  }
+
+  it("is a no-op when the version gate is not showing", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.checkVersionAgain();
+    expect(getAgentVersionMock()).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
+  it("is a no-op while a re-probe is already in flight", () => {
+    const ctrl = new HelpSessionController();
+    setBlock(ctrl);
+    ctrl["_patch"]({ isCheckingVersion: true });
+    ctrl.checkVersionAgain();
+    expect(getAgentVersionMock()).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
+  it("re-probes with refresh=true and clears the gate when the CLI is now current", async () => {
+    const ctrl = new HelpSessionController();
+    getAgentVersionMock().mockResolvedValue({ installedVersion: "1.2.0", latestVersion: "1.2.0" });
+    setBlock(ctrl);
+
+    ctrl.checkVersionAgain();
+    expect(getAgentVersionMock()).toHaveBeenCalledWith("claude", true);
+    expect(ctrl.getSnapshot().isCheckingVersion).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(ctrl.getSnapshot().assistantVersionTooOld).toBeNull();
+    });
+    ctrl.stop();
+  });
+
+  it("keeps the gate with refreshed versions when the CLI is still too old", async () => {
+    const ctrl = new HelpSessionController();
+    getAgentVersionMock().mockResolvedValue({ installedVersion: "0.9.5", latestVersion: "1.2.0" });
+    setBlock(ctrl);
+
+    ctrl.checkVersionAgain();
+    await vi.waitFor(() => {
+      expect(ctrl.getSnapshot().assistantVersionTooOld?.installedVersion).toBe("0.9.5");
+    });
+    ctrl.stop();
+  });
+
+  it("ignores a duplicate click while the first probe is still in flight", () => {
+    const ctrl = new HelpSessionController();
+    getAgentVersionMock().mockReturnValue(new Promise(() => {}));
+    setBlock(ctrl);
+
+    ctrl.checkVersionAgain();
+    ctrl.checkVersionAgain();
+    expect(getAgentVersionMock()).toHaveBeenCalledTimes(1);
+    ctrl.stop();
+  });
+
+  it("holds isCheckingVersion until both the probe settles and the 5s cooldown elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const ctrl = new HelpSessionController();
+      ctrl.start();
+      getAgentVersionMock().mockResolvedValue({
+        installedVersion: "1.2.0",
+        latestVersion: "1.2.0",
+      });
+      setBlock(ctrl);
+
+      ctrl.checkVersionAgain();
+      expect(ctrl.getSnapshot().isCheckingVersion).toBe(true);
+
+      // Probe resolves but the cooldown floor hasn't elapsed yet.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(ctrl.getSnapshot().isCheckingVersion).toBe(true);
+
+      // Cooldown elapses → button re-enables.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(ctrl.getSnapshot().isCheckingVersion).toBe(false);
+      ctrl.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stop() clears the pending cooldown timer", () => {
+    vi.useFakeTimers();
+    try {
+      const ctrl = new HelpSessionController();
+      ctrl.start();
+      getAgentVersionMock().mockReturnValue(new Promise(() => {}));
+      setBlock(ctrl);
+      ctrl.checkVersionAgain();
+      expect(ctrl.getSnapshot().isCheckingVersion).toBe(true);
+      ctrl.stop();
+      // No pending timers should remain after stop().
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -610,6 +610,63 @@ describe("HelpSessionController — checkVersionAgain", () => {
     ctrl.stop();
   });
 
+  it("keeps the gate when the probe fails transiently (does not dismiss on error)", async () => {
+    const ctrl = new HelpSessionController();
+    getAgentVersionMock().mockRejectedValue(new Error("probe failed"));
+    setBlock(ctrl);
+
+    ctrl.checkVersionAgain();
+    await vi.waitFor(() => {
+      // Probe settled; the gate must remain visible rather than clearing.
+      expect(getAgentVersionMock()).toHaveBeenCalled();
+    });
+    expect(ctrl.getSnapshot().assistantVersionTooOld).not.toBeNull();
+    ctrl.stop();
+  });
+
+  it("keeps the gate when the probe returns an undeterminable version", async () => {
+    const ctrl = new HelpSessionController();
+    getAgentVersionMock().mockResolvedValue({ installedVersion: null, latestVersion: null });
+    setBlock(ctrl);
+
+    ctrl.checkVersionAgain();
+    await vi.waitFor(() => {
+      expect(getAgentVersionMock()).toHaveBeenCalled();
+    });
+    expect(ctrl.getSnapshot().assistantVersionTooOld).not.toBeNull();
+    ctrl.stop();
+  });
+
+  it("does not re-enable the button on cooldown alone while a slow probe is still in flight", async () => {
+    vi.useFakeTimers();
+    try {
+      const ctrl = new HelpSessionController();
+      ctrl.start();
+      let resolveProbe: (v: { installedVersion: string }) => void = () => {};
+      getAgentVersionMock().mockReturnValue(
+        new Promise((resolve) => {
+          resolveProbe = resolve;
+        })
+      );
+      setBlock(ctrl);
+
+      ctrl.checkVersionAgain();
+      expect(ctrl.getSnapshot().isCheckingVersion).toBe(true);
+
+      // Cooldown elapses but the probe hasn't settled — button stays disabled.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(ctrl.getSnapshot().isCheckingVersion).toBe(true);
+
+      // Probe settles → button re-enables.
+      resolveProbe({ installedVersion: "1.2.0" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(ctrl.getSnapshot().isCheckingVersion).toBe(false);
+      ctrl.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("holds isCheckingVersion until both the probe settles and the 5s cooldown elapses", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary

- Adds a secondary "Check again" button to `HelpPanelVersionGate.tsx`. When the version gate fires (CLI too old), the version probe result is cached for 12 hours, so users previously had to close and reopen the panel to re-trigger it.
- The button calls a new method on `HelpSessionController` that runs a cache-bypassing probe (`refresh=true`). On a passing result it clears the gate and resumes auto-launch; on still-too-old it refreshes the displayed versions; on indeterminate or failed it keeps the gate visible rather than silently dismissing (no risk of auto-launching an outdated CLI).
- A 5-second cooldown prevents probe hammering.

Resolves #8774

## Changes

- `HelpSessionController.ts` — new `checkVersionAgain()` method with cooldown guard and three-branch result handling
- `HelpPanelVersionGate.tsx` — secondary "Check again" button wired to controller method
- `HelpPanel.tsx` — threads `onCheckAgain` callback from controller down to gate
- `HelpSessionController.test.ts` — unit tests covering all three result branches and the cooldown
- `HelpPanel.helpLaunch.test.tsx` — integration tests for the new gate interaction paths

## Testing

All 124 targeted unit and integration tests pass. `npm run check` (typecheck, lint, format, IPC codegen, build) green.