### PR TITLE
fix(help-panel): explain dropped assistant preference instead of silent null

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -8,7 +8,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { ExternalLink, Settings2 } from "lucide-react";
+import { ExternalLink, Settings2, ShieldAlert, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
@@ -131,6 +131,7 @@ export function HelpPanel({
     terminalId,
     agentId,
     preferredAgentId,
+    droppedPreferredAgentId,
     introDismissed,
     conversationTouched,
     focusRequest,
@@ -138,6 +139,7 @@ export function HelpPanel({
     setWidth,
     setOpen,
     dismissIntro,
+    clearDroppedPreferredAgent,
   } = useHelpPanelStore();
 
   const terminal = usePanelStore((s) => (terminalId ? s.panelsById[terminalId] : undefined));
@@ -656,27 +658,70 @@ export function HelpPanel({
             onOpenSettings={handleOpenSettings}
           />
         ) : (
-          <div className="flex-1 flex flex-col items-center justify-center gap-6 p-8 text-center">
-            <p className="text-sm text-daintree-text/70 max-w-[30ch]">
-              Use Daintree Assistant to configure and navigate Daintree.
-            </p>
-            <div className="flex flex-col gap-2">
-              <button
-                type="button"
-                onClick={handleOpenSettings}
-                className="flex items-center gap-1 text-[11px] text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          <div className="flex-1 flex flex-col">
+            {droppedPreferredAgentId && (
+              <div
+                role="alert"
+                className={cn(
+                  "flex items-start gap-2 px-3 py-2.5 mx-3 mt-3 mb-1",
+                  "rounded-[var(--radius-md)]",
+                  "bg-status-warning/10 border border-status-warning/40",
+                  "text-xs text-daintree-text/85"
+                )}
+                data-testid="help-dropped-agent-banner"
               >
-                <Settings2 className="w-3.5 h-3.5" />
-                Assistant settings
-              </button>
-              <button
-                type="button"
-                onClick={handleOpenAssistantDocs}
-                className="flex items-center gap-1 text-[11px] text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-              >
-                <ExternalLink className="w-3.5 h-3.5" />
-                Daintree Assistant guide
-              </button>
+                <ShieldAlert
+                  className="w-3.5 h-3.5 shrink-0 mt-0.5 text-status-warning"
+                  aria-hidden="true"
+                />
+                <div className="flex-1 select-text">
+                  <p className="font-medium text-daintree-text">
+                    {getAgentConfig(droppedPreferredAgentId)?.name ?? droppedPreferredAgentId} is no
+                    longer available
+                  </p>
+                  <p className="mt-0.5 text-daintree-text/70">
+                    The agent was removed or is no longer supported as an assistant backend.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={handleOpenSettings}
+                    className="mt-1 text-daintree-text/70 hover:text-daintree-text underline underline-offset-2 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                  >
+                    Open assistant settings
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  onClick={clearDroppedPreferredAgent}
+                  aria-label="Dismiss"
+                  className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </div>
+            )}
+            <div className="flex-1 flex flex-col items-center justify-center gap-6 p-8 text-center">
+              <p className="text-sm text-daintree-text/70 max-w-[30ch]">
+                Use Daintree Assistant to configure and navigate Daintree.
+              </p>
+              <div className="flex flex-col gap-2">
+                <button
+                  type="button"
+                  onClick={handleOpenSettings}
+                  className="flex items-center gap-1 text-[11px] text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                >
+                  <Settings2 className="w-3.5 h-3.5" />
+                  Assistant settings
+                </button>
+                <button
+                  type="button"
+                  onClick={handleOpenAssistantDocs}
+                  className="flex items-center gap-1 text-[11px] text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                >
+                  <ExternalLink className="w-3.5 h-3.5" />
+                  Daintree Assistant guide
+                </button>
+              </div>
             </div>
           </div>
         )}

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -122,6 +122,34 @@ describe("helpPanelStore persistence migration", () => {
     expect(store.getState().droppedPreferredAgentId).toBeNull();
   });
 
+  it("does not flag a non-built-in (user-defined / not-yet-loaded) preferredAgentId as dropped (issue #8775)", async () => {
+    // The user agent registry loads asynchronously after this synchronous
+    // rehydration, so a still-valid user-defined agent must NOT be treated as a
+    // drop or it would false-banner on every restart.
+    const legacyBlob = JSON.stringify({
+      state: { width: 420, preferredAgentId: "my-custom-agent" },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().preferredAgentId).toBeNull();
+    expect(store.getState().droppedPreferredAgentId).toBeNull();
+  });
+
+  it("setTerminal() clears droppedPreferredAgentId so the banner can't resurface after recovery (issue #8775)", async () => {
+    const legacyBlob = JSON.stringify({
+      state: { width: 420, preferredAgentId: "gemini" },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+    expect(store.getState().droppedPreferredAgentId).toBe("gemini");
+
+    store.getState().setTerminal("term-1", "claude", null);
+    expect(store.getState().droppedPreferredAgentId).toBeNull();
+  });
+
   it("clearDroppedPreferredAgent() clears the banner state without persisting it (issue #8775)", async () => {
     const legacyBlob = JSON.stringify({
       state: { width: 420, preferredAgentId: "gemini" },

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -99,6 +99,60 @@ describe("helpPanelStore persistence migration", () => {
     expect(store.getState().width).toBe(420);
   });
 
+  it("captures a dropped unsupported preferredAgentId as droppedPreferredAgentId (issue #8775)", async () => {
+    const legacyBlob = JSON.stringify({
+      state: { width: 420, preferredAgentId: "gemini" },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().preferredAgentId).toBeNull();
+    expect(store.getState().droppedPreferredAgentId).toBe("gemini");
+  });
+
+  it("leaves droppedPreferredAgentId null when no preference was persisted (issue #8775)", async () => {
+    const legacyBlob = JSON.stringify({
+      state: { width: 420, preferredAgentId: null },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().droppedPreferredAgentId).toBeNull();
+  });
+
+  it("clearDroppedPreferredAgent() clears the banner state without persisting it (issue #8775)", async () => {
+    const legacyBlob = JSON.stringify({
+      state: { width: 420, preferredAgentId: "gemini" },
+    });
+    const backing = installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+    expect(store.getState().droppedPreferredAgentId).toBe("gemini");
+
+    store.getState().clearDroppedPreferredAgent();
+    expect(store.getState().droppedPreferredAgentId).toBeNull();
+
+    const written = backing.get(STORAGE_KEY);
+    expect(written).toBeDefined();
+    expect(written!).not.toContain("droppedPreferredAgentId");
+  });
+
+  it("setPreferredAgent() clears droppedPreferredAgentId (issue #8775)", async () => {
+    const legacyBlob = JSON.stringify({
+      state: { width: 420, preferredAgentId: "gemini" },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+    expect(store.getState().droppedPreferredAgentId).toBe("gemini");
+
+    store.getState().setPreferredAgent("claude");
+    expect(store.getState().preferredAgentId).toBe("claude");
+    expect(store.getState().droppedPreferredAgentId).toBeNull();
+  });
+
   it("preserves a v0 preferredAgentId when migrating to v1 if the agent is supported", async () => {
     const v0Blob = JSON.stringify({
       version: 0,

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -30,6 +30,13 @@ interface HelpPanelState {
   terminalId: string | null;
   agentId: string | null;
   preferredAgentId: string | null;
+  /**
+   * Set at rehydration when a persisted preferredAgentId was dropped because the
+   * agent is no longer an assistant backend (CLI uninstalled or demoted from
+   * tier:"stable"). Transient (never persisted) — drives a one-shot banner so
+   * the silent null-out is explained instead of leaving a blank empty state.
+   */
+  droppedPreferredAgentId: string | null;
   sessionId: string | null;
   introDismissed: boolean;
   conversationTouched: boolean;
@@ -50,6 +57,7 @@ interface HelpPanelActions {
   setTerminal: (terminalId: string, agentId: string, sessionId: string | null) => void;
   clearTerminal: () => void;
   setPreferredAgent: (agentId: string | null) => void;
+  clearDroppedPreferredAgent: () => void;
   dismissIntro: () => void;
   markConversationStarted: () => void;
   requestFocus: () => void;
@@ -66,6 +74,7 @@ const initialState: HelpPanelState = {
   terminalId: null,
   agentId: null,
   preferredAgentId: null,
+  droppedPreferredAgentId: null,
   sessionId: null,
   introDismissed: false,
   conversationTouched: false,
@@ -123,7 +132,10 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
       clearTerminal: () =>
         set({ terminalId: null, agentId: null, sessionId: null, conversationTouched: false }),
 
-      setPreferredAgent: (agentId) => set({ preferredAgentId: agentId }),
+      setPreferredAgent: (agentId) =>
+        set({ preferredAgentId: agentId, droppedPreferredAgentId: null }),
+
+      clearDroppedPreferredAgent: () => set({ droppedPreferredAgentId: null }),
 
       dismissIntro: () => set({ introDismissed: true }),
 
@@ -160,6 +172,15 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
       }),
       merge: (persistedState: unknown, currentState) => {
         const persisted = persistedState as Partial<HelpPanelState>;
+        // Capture a persisted preference that's no longer a valid assistant
+        // backend so the empty state can explain the silent null-out instead of
+        // appearing blank. A null/missing preference is a clean first-run state,
+        // not a drop.
+        const droppedPreferredAgentId =
+          typeof persisted.preferredAgentId === "string" &&
+          !isAssistantSupportedAgentId(persisted.preferredAgentId)
+            ? persisted.preferredAgentId
+            : null;
         return {
           ...currentState,
           // The assistant can auto-launch as soon as it opens. Starting every
@@ -173,6 +194,7 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
           preferredAgentId: isAssistantSupportedAgentId(persisted.preferredAgentId)
             ? persisted.preferredAgentId
             : null,
+          droppedPreferredAgentId,
           introDismissed:
             typeof persisted.introDismissed === "boolean"
               ? persisted.introDismissed

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -3,6 +3,7 @@ import { persist } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { getAssistantSupportedAgentIds } from "../../shared/config/agentRegistry";
+import { isBuiltInAgentId } from "../../shared/config/agentIds";
 
 function isAssistantSupportedAgentId(value: unknown): value is string {
   return typeof value === "string" && getAssistantSupportedAgentIds().includes(value);
@@ -126,6 +127,9 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
           // choice (made via Settings) must survive terminal re-binds —
           // overwriting it here is what made #8353's agent switch a no-op.
           preferredAgentId: s.preferredAgentId ?? agentId,
+          // A launched session is a successful recovery — drop the stale banner
+          // so it can't resurface if the panel later returns to the empty state.
+          droppedPreferredAgentId: null,
           conversationTouched: false,
         })),
 
@@ -172,12 +176,15 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
       }),
       merge: (persistedState: unknown, currentState) => {
         const persisted = persistedState as Partial<HelpPanelState>;
-        // Capture a persisted preference that's no longer a valid assistant
-        // backend so the empty state can explain the silent null-out instead of
-        // appearing blank. A null/missing preference is a clean first-run state,
-        // not a drop.
+        // Capture a built-in preference that's no longer a valid assistant
+        // backend (demoted from tier:"stable") so the empty state can explain
+        // the silent null-out instead of appearing blank. Restricted to built-in
+        // IDs: the user agent registry loads asynchronously after this synchronous
+        // rehydration, so a still-valid user-defined agent would otherwise be
+        // false-flagged as dropped on every restart. A null/missing preference is
+        // a clean first-run state, not a drop.
         const droppedPreferredAgentId =
-          typeof persisted.preferredAgentId === "string" &&
+          isBuiltInAgentId(persisted.preferredAgentId) &&
           !isAssistantSupportedAgentId(persisted.preferredAgentId)
             ? persisted.preferredAgentId
             : null;


### PR DESCRIPTION
## Summary

- When the app rehydrated from localStorage, a persisted `preferredAgentId` that was no longer a valid assistant backend was silently nulled, leaving the Daintree Assistant panel showing a blank empty state with no explanation.
- Captures the dropped agent ID into a transient `droppedPreferredAgentId` field in the persist merge callback, then renders a one-shot soft-warning banner in the empty state naming the dropped agent with a link to assistant settings.
- Drop detection is restricted to built-in agent IDs: user-defined agents load asynchronously after synchronous rehydration, so including them would produce false positives on every restart.

Resolves #8775

## Changes

- `helpPanelStore.ts`: captures dropped built-in agent ID during `onRehydrateStorage` and clears it in `setPreferredAgent` and `setTerminal`; `droppedPreferredAgentId` excluded from persistence via the `partialize` allowlist.
- `HelpPanel.tsx`: renders a dismissible `DroppedAgentBanner` when `droppedPreferredAgentId` is set; banner closes on the X button or any `setPreferredAgent` interaction (including picking a new agent from the dropdown).

## Testing

- 41 store tests pass. New cases cover: capture dropped built-in, no-op on null, no-op on non-built-in, `clearDroppedPreferredAgent` clears and is not persisted, `setPreferredAgent` clears, `setTerminal` clears.
- Typecheck, lint, format, and build all clean.