### PR TITLE
feat(mcp): confirm and gracefully drain MCP-server stop (#8779)

### DIFF
--- a/docs/architecture/destructive-action-safeguards.md
+++ b/docs/architecture/destructive-action-safeguards.md
@@ -185,6 +185,15 @@ The emergency recovery page (`public/recovery.html`) is a zero-React surface loa
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `public/recovery-renderer.js` `btn-reset` → `RECOVERY_RESET_AND_RELOAD` | (bypass — static HTML, no `ActionService`) | **Yes** — inline Disclosure confirm section with panel-count + backup-timestamp preview (#8697) | n/a (bypass) | local-irreversible (`appState` overwritten; `cachedBackupSnapshot` nulled; backup file on disk survives) | one window's sessions + layout | D1 | Done (#8697) — confirm wired at the JS call site; IPC fires only after explicit confirm button click | — |
 
+### MCP server
+
+The MCP server is a shared surface: while it's running, external clients (Claude Code, Cursor, custom scripts) hold live sessions against it. Disabling it severs those sessions, which is a Tier-D2 shared-state mutation _only when external clients are connected_ — with zero external clients it's reversible-local (D0, flip the toggle back on). Both disable paths call IPC directly and bypass `ActionService`. On the server side, `httpLifecycle.stop()` now drains in-flight requests (`server.close()` + `closeIdleConnections()`, racing a 3s deadline before force-closing) instead of eagerly destroying every socket (#8779).
+
+| Action / call site | Current | UI confirm | Consent in breadcrumb | Reversibility | Blast | Tier | Recommendation | Follow-up |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `McpServerSettingsTab.tsx` `handleToggle` → `mcpServer.setEnabled(false)` (bypass — direct IPC) | confirm-when-connected | **Yes** — `ConfirmDialog` (default variant) names each connected external client (user-agent + relative connect time) before the stop fires; gated on `listActiveClients().length > 0`, zero clients disables immediately (#8779) | n/a (bypass) | shared-state (live external sessions severed; recovery is re-enable + each client reconnects) | every connected external client | D2 (D0 when no external clients) | Done (#8779) — confirm wired at the toggle call site; the named-client preview satisfies the "content, not count" rule; in-flight calls drain gracefully on the server side | — |
+| `DaintreeAssistantSettingsTab.tsx` `toggleDaintreeControl` → `helpAssistant.setSettings({ daintreeControl: false })` (bypass — direct IPC) | safe | n/a — turning off Daintree control does not stop the MCP server (the auto-couple is one-directional: turning it _on_ enables MCP, turning it _off_ leaves the server up for any other clients) | n/a (bypass) | reversible (toggle back on) | the assistant's own consumer only | D0 | Leave — no MCP side-effect on disable, so no clients are severed and no confirm is warranted (#8779) | — |
+
 ## Known bypasses
 
 Direct `window.electron.*` IPC calls that skip `ActionService`. These are the highest-risk locations because the action's `danger` rating cannot gate them — the confirmation must live in the component itself.
@@ -202,6 +211,8 @@ Direct `window.electron.*` IPC calls that skip `ActionService`. These are the hi
 | `src/components/Recovery/SafeModeBanner.tsx` | `app.resetAndRelaunch` (safe-mode restart) | **Yes** — `ConfirmDialog` with destructive variant + `logs.openFile` recovery (#8685) |
 | `public/recovery-renderer.js` | `recovery:reset-and-reload` (emergency recovery page) | **Yes** — inline vanilla-JS Disclosure confirm with panel count + backup timestamp preview; React is unavailable on this surface (#8697) |
 | `src/components/Fleet/fleetEnterBroadcast.ts` | `fleet.broadcast` (Enter-broadcast → `executeFleetBroadcast` → `terminalClient.submit`) | **Yes** — `ConfirmDialog` via `fleetBroadcastConfirmStore` + `FleetArmingRibbon` with per-target resolved-payload preview, destructive-substring callout, and per-target opt-out (#8689) |
+| `src/components/Settings/McpServerSettingsTab.tsx` | `mcpServer.setEnabled(false)` (server toggle) | **Yes** — `ConfirmDialog` naming each connected external client; fires only when `listActiveClients()` is non-empty, else disables immediately (#8779) |
+| `src/components/Settings/DaintreeAssistantSettingsTab.tsx` | `helpAssistant.setSettings({ daintreeControl: false })` (assistant toggle) | **No** — disabling Daintree control has no MCP stop side-effect, so no external clients are severed; D0, no confirm needed (#8779) |
 
 ## Maintenance
 

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -537,6 +537,12 @@ export const CHANNELS = {
   MCP_SERVER_SET_PORT: "mcp-server:set-port",
   MCP_SERVER_ROTATE_API_KEY: "mcp-server:rotate-api-key",
   MCP_SERVER_GET_CONFIG_SNIPPET: "mcp-server:get-config-snippet",
+  /**
+   * Snapshot the externally-connected MCP clients (api-key / unauthenticated
+   * loopback sessions, excluding renderer-pinned help-assistant bearers) so
+   * the disable-confirmation can name who's about to be severed (#8779).
+   */
+  MCP_SERVER_LIST_ACTIVE_CLIENTS: "mcp-server:list-active-clients",
   MCP_SERVER_GET_AUDIT_RECORDS: "mcp-server:get-audit-records",
   MCP_SERVER_CLEAR_AUDIT_LOG: "mcp-server:clear-audit-log",
   MCP_SERVER_SET_AUDIT_ENABLED: "mcp-server:set-audit-enabled",

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -217,8 +217,8 @@ describe("mcpServer IPC adversarial", () => {
     expect(serviceMock.clearTurnOutcomeLog).toHaveBeenCalledTimes(1);
   });
 
-  it("cleanup removes all eighteen registered handlers", () => {
-    expect(ipcHandlers.size).toBe(18);
+  it("cleanup removes all nineteen registered handlers", () => {
+    expect(ipcHandlers.size).toBe(19);
     cleanup();
     expect(ipcHandlers.size).toBe(0);
   });

--- a/electron/ipc/handlers/mcpServer.preload.ts
+++ b/electron/ipc/handlers/mcpServer.preload.ts
@@ -6,6 +6,7 @@ export const MCP_SERVER_METHOD_CHANNELS = {
   setPort: "mcp-server:set-port",
   rotateApiKey: "mcp-server:rotate-api-key",
   getConfigSnippet: "mcp-server:get-config-snippet",
+  listActiveClients: "mcp-server:list-active-clients",
   getAuditRecords: "mcp-server:get-audit-records",
   getAuditConfig: "mcp-server:get-audit-config",
   getAuditStats: "mcp-server:get-audit-stats",

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -9,6 +9,7 @@ import { sanitizePath } from "../../utils/pathScrubber.js";
 import { scrubSecrets } from "../../utils/secretScrubber.js";
 import type {
   AssistantTurnRecord,
+  McpActiveClientInfo,
   McpAuditRecord,
   McpAuditStats,
   McpIssueGrantResult,
@@ -69,6 +70,13 @@ export const mcpServerNamespace = defineIpcNamespace({
       const svc = await getMcpServerService();
       return svc.getConfigSnippet();
     }),
+    listActiveClients: op(
+      MCP_SERVER_METHOD_CHANNELS.listActiveClients,
+      async (): Promise<McpActiveClientInfo[]> => {
+        const svc = await getMcpServerService();
+        return svc.listActiveClients();
+      }
+    ),
     getAuditRecords: op(
       MCP_SERVER_METHOD_CHANNELS.getAuditRecords,
       async (): Promise<McpAuditRecord[]> => {

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -286,7 +286,10 @@ export class McpServerService {
     this.persistConfig({ enabled });
     if (enabled && this._registry && !this.isRunning) {
       await this.httpLifecycle.start(this._registry);
-    } else if (!enabled && this.isRunning) {
+    } else if (!enabled && (this.isRunning || this.httpLifecycle.isStartInFlight)) {
+      // `stop()` awaits any in-flight `start()` before closing, so a disable
+      // that races a slow start still tears the server down instead of
+      // leaving it listening after the user turned it off.
       await this.httpLifecycle.stop();
     } else if (wasEnabled !== enabled) {
       if (!enabled) this.httpLifecycle.setLastError(null);

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -354,6 +354,10 @@ export class McpServerService {
     await this.httpLifecycle.stop();
   }
 
+  listActiveClients(): import("../../shared/types/ipc/mcpServer.js").McpActiveClientInfo[] {
+    return this.httpLifecycle.listActiveClients();
+  }
+
   getStatus(): {
     enabled: boolean;
     port: number | null;

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -24,6 +24,7 @@ type MockServer = any;
 function mockServer(port = 45454): MockServer {
   const s = new EventEmitter() as unknown as MockServer;
   s.closeAllConnections = vi.fn();
+  s.closeIdleConnections = vi.fn();
   s.close = vi.fn((cb?: () => void) => {
     cb?.();
     return s;
@@ -59,6 +60,8 @@ function fakeDeps(overrides?: Partial<HttpLifecycleDeps>): HttpLifecycleDeps {
       armTierElevationTimer: vi.fn(),
       clearElevationTimer: vi.fn(),
       revokeSession: vi.fn(() => false),
+      registerClientMetadata: vi.fn(),
+      listExternalActiveClients: vi.fn(() => []),
     },
     auditService: {
       hydrate: vi.fn(),
@@ -201,13 +204,16 @@ describe("HttpLifecycle", () => {
   });
 
   describe("stop()", () => {
-    it("calls closeAllConnections before close", async () => {
+    it("drains gracefully: closeIdleConnections after close starts, no eager closeAllConnections (#8779)", async () => {
       const deps = fakeDeps();
       const s = mockServer();
       (s as MockServer & { listening: boolean }).listening = true;
       const callOrder: string[] = [];
       s.closeAllConnections.mockImplementation(() => {
         callOrder.push("closeAllConnections");
+      });
+      s.closeIdleConnections.mockImplementation(() => {
+        callOrder.push("closeIdleConnections");
       });
       s.close.mockImplementation((cb?: () => void) => {
         callOrder.push("close");
@@ -221,24 +227,33 @@ describe("HttpLifecycle", () => {
 
       await lc.stop();
 
-      expect(callOrder[0]).toBe("closeAllConnections");
-      expect(callOrder[1]).toBe("close");
+      // close() starts the drain; closeIdleConnections() drops bare keep-alive
+      // sockets immediately after. The eager force-kill is gone — when close
+      // completes within the deadline closeAllConnections is never called.
+      expect(callOrder[0]).toBe("close");
+      expect(callOrder).toContain("closeIdleConnections");
+      expect(s.closeAllConnections).not.toHaveBeenCalled();
     });
 
-    it("resolves after timeout when close hangs", async () => {
+    it("force-closes connections only after the 3s drain deadline (#8779)", async () => {
       const deps = fakeDeps();
       const s = mockServer();
       (s as MockServer & { listening: boolean }).listening = true;
-      s.close.mockImplementation(() => s); // never calls callback
+      s.close.mockImplementation(() => s); // never calls callback — close hangs
 
       const lc = new HttpLifecycle(deps);
       (lc as unknown as { httpServer: MockServer }).httpServer = s;
       (lc as unknown as { port: number }).port = 45454;
 
       const stopPromise = lc.stop();
-      await vi.advanceTimersByTimeAsync(11_000);
+      // Before the deadline the active sockets are left to drain.
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(s.closeAllConnections).not.toHaveBeenCalled();
+      // Past the 3s deadline the remaining sockets are force-closed.
+      await vi.advanceTimersByTimeAsync(2_000);
 
       await expect(stopPromise).resolves.toBeUndefined();
+      expect(s.closeIdleConnections).toHaveBeenCalled();
       expect(s.closeAllConnections).toHaveBeenCalled();
       expect((lc as unknown as { httpServer: unknown }).httpServer).toBeNull();
     });

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -235,6 +235,23 @@ describe("HttpLifecycle", () => {
       expect(s.closeAllConnections).not.toHaveBeenCalled();
     });
 
+    it("does not log a timeout warning when close completes within the deadline (#8779)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const deps = fakeDeps();
+      const s = mockServer();
+      (s as MockServer & { listening: boolean }).listening = true;
+
+      const lc = new HttpLifecycle(deps);
+      (lc as unknown as { httpServer: MockServer }).httpServer = s;
+      (lc as unknown as { port: number }).port = 45454;
+
+      await lc.stop();
+      // Fire the (already-resolved) deadline timer — its callback must not warn.
+      await vi.advanceTimersByTimeAsync(4_000);
+
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("server.close() timed out"));
+    });
+
     it("force-closes connections only after the 3s drain deadline (#8779)", async () => {
       const deps = fakeDeps();
       const s = mockServer();

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -877,4 +877,16 @@ describe("SessionStore.listExternalActiveClients (#8779)", () => {
 
     expect(store.listExternalActiveClients()).toEqual([]);
   });
+
+  it("clearClientMetadata drops a normally-disconnected client from the list", () => {
+    addExternal("ext", "Claude Code", "streamable-http");
+    expect(store.listExternalActiveClients()).toHaveLength(1);
+
+    // Mirrors the inline transport.onclose cleanup in httpLifecycle, which
+    // deletes the session map entry and clears its metadata.
+    store.httpSessions.delete("ext");
+    store.clearClientMetadata("ext");
+
+    expect(store.listExternalActiveClients()).toEqual([]);
+  });
 });

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -779,3 +779,102 @@ describe("SessionStore tier-elevation decay (#8462)", () => {
     expect(decayed).toEqual([]);
   });
 });
+
+describe("SessionStore.listExternalActiveClients (#8779)", () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    store = new SessionStore(() => {});
+  });
+
+  afterEach(() => {
+    store.grantCache.dispose();
+    vi.useRealTimers();
+  });
+
+  function addExternal(
+    sessionId: string,
+    userAgent: string | null,
+    transport: "sse" | "streamable-http"
+  ): void {
+    if (transport === "sse") {
+      store.sessions.set(sessionId, fakeSseSession());
+    } else {
+      store.httpSessions.set(sessionId, fakeHttpSession());
+    }
+    store.sessionTierMap.set(sessionId, "external");
+    store.registerClientMetadata(sessionId, userAgent, transport);
+  }
+
+  it("lists external SSE and HTTP clients with their captured metadata", () => {
+    vi.setSystemTime(new Date("2026-05-21T00:00:00Z"));
+    addExternal("ext-sse", "Claude Code/1.2", "sse");
+    addExternal("ext-http", "Cursor/0.9", "streamable-http");
+
+    const clients = store.listExternalActiveClients();
+    expect(clients).toHaveLength(2);
+    const bySession = new Map(clients.map((c) => [c.sessionId, c]));
+    expect(bySession.get("ext-sse")).toMatchObject({
+      userAgent: "Claude Code/1.2",
+      transport: "sse",
+      connectedAtMs: Date.now(),
+    });
+    expect(bySession.get("ext-http")).toMatchObject({
+      userAgent: "Cursor/0.9",
+      transport: "streamable-http",
+    });
+  });
+
+  it("excludes the internal help-assistant (renderer-pinned) session", () => {
+    addExternal("ext", "Claude Code", "streamable-http");
+    // A help-session bearer: external-classified at handshake but pinned to a
+    // renderer WebContents — Daintree's own consumer, must not self-name.
+    store.httpSessions.set("internal", fakeHttpSession());
+    store.sessionTierMap.set("internal", "external");
+    store.sessionWebContentsMap.set("internal", 7);
+    store.registerClientMetadata("internal", "node", "streamable-http");
+
+    const clients = store.listExternalActiveClients();
+    expect(clients.map((c) => c.sessionId)).toEqual(["ext"]);
+  });
+
+  it("excludes non-external (workbench/action/system) sessions", () => {
+    addExternal("ext", "Claude Code", "sse");
+    store.sessions.set("pane", fakeSseSession());
+    store.sessionTierMap.set("pane", "action");
+    store.registerClientMetadata("pane", "pane-token-client", "sse");
+
+    const clients = store.listExternalActiveClients();
+    expect(clients.map((c) => c.sessionId)).toEqual(["ext"]);
+  });
+
+  it("falls back to null user-agent and a present timestamp when none captured", () => {
+    store.sessions.set("ext", fakeSseSession());
+    store.sessionTierMap.set("ext", "external");
+    // No registerClientMetadata call — simulates a pre-metadata session.
+
+    const clients = store.listExternalActiveClients();
+    expect(clients).toHaveLength(1);
+    expect(clients[0]!.userAgent).toBeNull();
+    expect(typeof clients[0]!.connectedAtMs).toBe("number");
+  });
+
+  it("drops metadata on revokeSession so the client no longer lists", () => {
+    addExternal("ext", "Claude Code", "streamable-http");
+    expect(store.listExternalActiveClients()).toHaveLength(1);
+
+    store.revokeSession("ext");
+
+    expect(store.listExternalActiveClients()).toEqual([]);
+  });
+
+  it("clears all metadata on drain()", () => {
+    addExternal("a", "ua-a", "sse");
+    addExternal("b", "ua-b", "streamable-http");
+
+    store.drain();
+
+    expect(store.listExternalActiveClients()).toEqual([]);
+  });
+});

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -115,6 +115,16 @@ export class HttpLifecycle {
     return this.httpServer !== null && this.httpServer.listening && this.port !== null;
   }
 
+  /**
+   * True while a `start()` is mid-flight (socket not yet bound). Lets
+   * `setEnabled(false)` route through `stop()` — which awaits the start —
+   * instead of no-op'ing and leaving a server that comes up after the user
+   * already turned it off.
+   */
+  get isStartInFlight(): boolean {
+    return this.startPromise !== null;
+  }
+
   get currentPort(): number | null {
     return this.port;
   }
@@ -456,7 +466,11 @@ export class HttpLifecycle {
             }),
             new Promise<void>((resolve) => {
               setTimeout(() => {
-                console.warn("[MCP] server.close() timed out after 3s — force-closing connections");
+                if (!drained) {
+                  console.warn(
+                    "[MCP] server.close() timed out after 3s — force-closing connections"
+                  );
+                }
                 resolve();
               }, MCP_STOP_DRAIN_TIMEOUT_MS).unref?.();
             }),
@@ -629,6 +643,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionContextMap.delete(sessionId);
         this.deps.sessionStore.clearDedupState(sessionId);
         this.deps.sessionStore.clearRateLimitState(sessionId);
+        this.deps.sessionStore.clearClientMetadata(sessionId);
         this.deps.abusePolicy.dropSession(sessionId);
         cleanupResourceSubscriptions(sessionId, this.deps.sessionStore);
       };
@@ -647,6 +662,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionContextMap.delete(sessionId);
         this.deps.sessionStore.clearDedupState(sessionId);
         this.deps.sessionStore.clearRateLimitState(sessionId);
+        this.deps.sessionStore.clearClientMetadata(sessionId);
         this.deps.abusePolicy.dropSession(sessionId);
         transport.onclose = undefined;
         await transport.close().catch(() => {});
@@ -764,6 +780,7 @@ export class HttpLifecycle {
       this.deps.sessionStore.sessionContextMap.delete(id);
       this.deps.sessionStore.clearDedupState(id);
       this.deps.sessionStore.clearRateLimitState(id);
+      this.deps.sessionStore.clearClientMetadata(id);
       this.deps.abusePolicy.dropSession(id);
       cleanupResourceSubscriptions(id, this.deps.sessionStore);
     };
@@ -787,6 +804,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionContextMap.delete(id);
         this.deps.sessionStore.clearDedupState(id);
         this.deps.sessionStore.clearRateLimitState(id);
+        this.deps.sessionStore.clearClientMetadata(id);
         this.deps.abusePolicy.dropSession(id);
         cleanupResourceSubscriptions(id, this.deps.sessionStore);
       } else {
@@ -797,6 +815,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.sessionContextMap.delete(newSessionId);
         this.deps.sessionStore.clearDedupState(newSessionId);
         this.deps.sessionStore.clearRateLimitState(newSessionId);
+        this.deps.sessionStore.clearClientMetadata(newSessionId);
         this.deps.abusePolicy.dropSession(newSessionId);
         cleanupResourceSubscriptions(newSessionId, this.deps.sessionStore);
       }

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -40,8 +40,10 @@ import {
   RESTART_MAX_DELAY_MS,
   RESTART_JITTER_MS,
   RESTART_STABLE_RESET_MS,
+  MCP_STOP_DRAIN_TIMEOUT_MS,
   MCP_SERVER_KEY,
 } from "./shared.js";
+import type { McpActiveClientInfo } from "../../../shared/types/ipc/mcpServer.js";
 
 export interface HttpLifecycleDeps {
   sessionStore: SessionStore;
@@ -184,6 +186,13 @@ export class HttpLifecycle {
     const token = extractBearerToken(authHeader);
     if (!token) return null;
     return this.helpSessionActionContextResolver(token);
+  }
+
+  /** Normalize a possibly-array request header to a trimmed string or null. */
+  private headerString(value: string | string[] | undefined): string | null {
+    const raw = Array.isArray(value) ? value[0] : value;
+    const trimmed = raw?.trim();
+    return trimmed ? trimmed : null;
   }
 
   private getConfig() {
@@ -426,19 +435,37 @@ export class HttpLifecycle {
 
         let wasRunning = false;
         if (this.httpServer) {
-          wasRunning = this.httpServer.listening;
-          this.httpServer.closeAllConnections();
+          const server = this.httpServer;
+          wasRunning = server.listening;
+          // Graceful drain (#8779): stop accepting new connections, then let
+          // in-flight requests finish naturally. `closeIdleConnections()`
+          // drops bare keep-alive sockets immediately so they don't hold
+          // `close()` open; active requests keep their socket until the
+          // response ends. The eager `closeAllConnections()` that used to
+          // run *here* force-destroyed in-flight tool calls before they
+          // could complete — it now fires only as the deadline fallback
+          // below so a hung external client can't block the toggle forever.
+          let drained = false;
           await Promise.race([
             new Promise<void>((resolve) => {
-              this.httpServer!.close(() => resolve());
+              server.close(() => {
+                drained = true;
+                resolve();
+              });
+              server.closeIdleConnections();
             }),
             new Promise<void>((resolve) => {
               setTimeout(() => {
-                console.warn("[MCP] server.close() timed out after 10s — force-clearing");
+                console.warn("[MCP] server.close() timed out after 3s — force-closing connections");
                 resolve();
-              }, 10_000).unref?.();
+              }, MCP_STOP_DRAIN_TIMEOUT_MS).unref?.();
             }),
           ]);
+          if (!drained) {
+            // Deadline hit with sockets still active — sever them so the
+            // listening port is released before the next start.
+            server.closeAllConnections();
+          }
           this.httpServer = null;
           this.port = null;
         }
@@ -563,6 +590,11 @@ export class HttpLifecycle {
       const sessionId = transport.sessionId;
       const tier = resolveTokenTier(authHeader, this.apiKeyBearerHash, this.helpTokenValidator);
       this.deps.sessionStore.sessionTierMap.set(sessionId, tier);
+      this.deps.sessionStore.registerClientMetadata(
+        sessionId,
+        this.headerString(req.headers["user-agent"]),
+        "sse"
+      );
 
       const pinnedWebContentsId = this.resolvePinnedWebContentsId(authHeader);
       if (pinnedWebContentsId !== null) {
@@ -676,6 +708,11 @@ export class HttpLifecycle {
     const authHeader = req.headers.authorization ?? "";
     const tier = resolveTokenTier(authHeader, this.apiKeyBearerHash, this.helpTokenValidator);
     this.deps.sessionStore.sessionTierMap.set(newSessionId, tier);
+    this.deps.sessionStore.registerClientMetadata(
+      newSessionId,
+      this.headerString(req.headers["user-agent"]),
+      "streamable-http"
+    );
 
     const pinnedWebContentsId = this.resolvePinnedWebContentsId(authHeader);
     if (pinnedWebContentsId !== null) {
@@ -1015,6 +1052,15 @@ export class HttpLifecycle {
     }
     const revokedCount = this.deps.sessionStore.grantCache.revokeSession(sessionId, "user");
     return { sessionId, revokedCount };
+  }
+
+  /**
+   * Snapshot the externally-connected clients for the disable-confirmation
+   * dialog (#8779). Empty when the server isn't listening.
+   */
+  listActiveClients(): McpActiveClientInfo[] {
+    if (!this.isRunning) return [];
+    return this.deps.sessionStore.listExternalActiveClients();
   }
 
   getStatus(): {

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -184,7 +184,13 @@ export class SessionStore {
     this.sessionTransport.set(sessionId, transport);
   }
 
-  private clearClientMetadata(sessionId: string): void {
+  /**
+   * Drop a session's connection metadata. Public so the inline
+   * `transport.onclose` / connect-failure cleanup closures in `httpLifecycle`
+   * can tear it down in lockstep with the other per-session maps on a normal
+   * disconnect (not just idle expiry / revoke / drain).
+   */
+  clearClientMetadata(sessionId: string): void {
     this.sessionConnectedAtMs.delete(sessionId);
     this.sessionUserAgent.delete(sessionId);
     this.sessionTransport.delete(sessionId);

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -1,4 +1,5 @@
 import type { ActionContext } from "../../../shared/types/actions.js";
+import type { McpActiveClientInfo } from "../../../shared/types/ipc/mcpServer.js";
 import type { McpTier, McpSseSession, McpHttpSession, RateLimitConfig } from "./shared.js";
 import {
   MCP_SSE_IDLE_TIMEOUT_MS,
@@ -117,6 +118,16 @@ export class SessionStore {
   private readonly idleStartedAt = new Map<string, number>();
   private readonly httpIdleStartedAt = new Map<string, number>();
 
+  // Connection metadata captured at handshake, keyed by sessionId, so the
+  // MCP-disable confirmation can name the external clients about to be
+  // severed (#8779). `connectedAtMs` is the handshake wall-clock; `userAgent`
+  // is the raw header (null when absent); `clientTransport` records which
+  // surface the session arrived on. Torn down in lockstep with the other
+  // per-session maps on drain / revoke / idle expiry.
+  private readonly sessionConnectedAtMs = new Map<string, number>();
+  private readonly sessionUserAgent = new Map<string, string | null>();
+  private readonly sessionTransport = new Map<string, "sse" | "streamable-http">();
+
   // Tier-elevation decay timers, keyed by sessionId (unique across SSE and
   // HTTP). A renderer-approved "Always allow" elevation is bounded to
   // MCP_TIER_ELEVATION_TTL_MS; on expiry the session silently decays to the
@@ -155,6 +166,53 @@ export class SessionStore {
   clearDedupState(sessionId: string): void {
     this.dedupInFlight.delete(sessionId);
     this.dedupResultCache.delete(sessionId);
+  }
+
+  /**
+   * Record handshake-time connection metadata for a session so the
+   * MCP-disable confirmation can name it later (#8779). Called once per
+   * session from the SSE and Streamable HTTP handshake paths, after the
+   * tier has been stamped. Cleared by every per-session teardown path.
+   */
+  registerClientMetadata(
+    sessionId: string,
+    userAgent: string | null,
+    transport: "sse" | "streamable-http"
+  ): void {
+    this.sessionConnectedAtMs.set(sessionId, Date.now());
+    this.sessionUserAgent.set(sessionId, userAgent);
+    this.sessionTransport.set(sessionId, transport);
+  }
+
+  private clearClientMetadata(sessionId: string): void {
+    this.sessionConnectedAtMs.delete(sessionId);
+    this.sessionUserAgent.delete(sessionId);
+    this.sessionTransport.delete(sessionId);
+  }
+
+  /**
+   * Snapshot the currently-connected external clients — sessions classified
+   * `external` (api-key / unauthenticated loopback) that are NOT pinned to a
+   * renderer WebContents. Renderer-pinned sessions are Daintree's own
+   * help-assistant bearers; naming them in the disable dialog would be
+   * recursive (#8779). Pane-token sessions resolve to a non-`external` tier
+   * and are filtered out by the tier check. Returns one entry per live
+   * session across both transports.
+   */
+  listExternalActiveClients(): McpActiveClientInfo[] {
+    const out: McpActiveClientInfo[] = [];
+    const sessionIds = new Set<string>([...this.sessions.keys(), ...this.httpSessions.keys()]);
+    for (const sessionId of sessionIds) {
+      if (this.sessionTierMap.get(sessionId) !== "external") continue;
+      if (this.sessionWebContentsMap.has(sessionId)) continue;
+      out.push({
+        sessionId,
+        userAgent: this.sessionUserAgent.get(sessionId) ?? null,
+        connectedAtMs: this.sessionConnectedAtMs.get(sessionId) ?? Date.now(),
+        transport: this.sessionTransport.get(sessionId) ?? "streamable-http",
+      });
+    }
+    return out;
   }
 
   /**
@@ -200,6 +258,7 @@ export class SessionStore {
     this.sessionContextMap.delete(sessionId);
     this.clearDedupState(sessionId);
     this.clearRateLimitState(sessionId);
+    this.clearClientMetadata(sessionId);
     this.idleStartedAt.delete(sessionId);
     this.clearElevationTimer(sessionId);
     this.dropAbuseStateFn(sessionId);
@@ -254,6 +313,7 @@ export class SessionStore {
     this.sessionContextMap.delete(sessionId);
     this.clearDedupState(sessionId);
     this.clearRateLimitState(sessionId);
+    this.clearClientMetadata(sessionId);
     this.httpIdleStartedAt.delete(sessionId);
     this.clearElevationTimer(sessionId);
     this.dropAbuseStateFn(sessionId);
@@ -500,6 +560,7 @@ export class SessionStore {
     this.sessionContextMap.delete(sessionId);
     this.clearDedupState(sessionId);
     this.clearRateLimitState(sessionId);
+    this.clearClientMetadata(sessionId);
     this.clearElevationTimer(sessionId);
     this.dropAbuseStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
@@ -549,6 +610,9 @@ export class SessionStore {
     this.sessionTierMap.clear();
     this.sessionWebContentsMap.clear();
     this.sessionContextMap.clear();
+    this.sessionConnectedAtMs.clear();
+    this.sessionUserAgent.clear();
+    this.sessionTransport.clear();
     // Wholesale teardown: drop grants without per-entry audit noise but
     // keep the sweep timer so the store can be reused after a subsequent
     // `start()`. The audit ring buffer still carries each grant's original

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -116,6 +116,15 @@ export const RESTART_MAX_DELAY_MS = 15_000;
 export const RESTART_JITTER_MS = 250;
 export const RESTART_STABLE_RESET_MS = 30_000;
 
+/**
+ * Deadline for the graceful stop drain (#8779). `server.close()` lets
+ * in-flight requests finish; if they don't complete within this window the
+ * remaining sockets are force-closed so the listening port is released for
+ * the next start. Short by design — a settings toggle shouldn't hang on a
+ * stuck external client, and well-behaved tool calls finish well inside 3s.
+ */
+export const MCP_STOP_DRAIN_TIMEOUT_MS = 3_000;
+
 export function mapAgentStateToBusyState(state: AgentState | undefined): "working" | "idle" {
   return state === "working" ? "working" : "idle";
 }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -330,6 +330,7 @@ export { CONNECTIVITY_SERVICE_KEYS } from "./ipc/connectivity.js";
 
 // MCP server audit log + runtime state + turn outcomes
 export type {
+  McpActiveClientInfo,
   McpAuditRecord,
   McpAuditResult,
   McpAuditStats,

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -192,6 +192,9 @@ export interface GeneratedElectronAPI {
     issueGrant(
       ...args: IpcInvokeMap["mcp-server:issue-grant"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:issue-grant"]["result"]>;
+    listActiveClients(
+      ...args: IpcInvokeMap["mcp-server:list-active-clients"]["args"]
+    ): Promise<IpcInvokeMap["mcp-server:list-active-clients"]["result"]>;
     revokeSessionGrants(
       ...args: IpcInvokeMap["mcp-server:revoke-session-grants"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:revoke-session-grants"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -395,6 +395,10 @@ export interface GeneratedIpcInvokeMap {
     args: [payload: { sessionId: string; toolId: string }];
     result: import("./mcpServer.js").McpIssueGrantResult;
   };
+  "mcp-server:list-active-clients": {
+    args: [];
+    result: import("./mcpServer.js").McpActiveClientInfo[];
+  };
   "mcp-server:revoke-session-grants": {
     args: [payload: { sessionId: string }];
     result: import("./mcpServer.js").McpRevokeSessionGrantsResult;

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -393,3 +393,24 @@ export interface McpServerStatusSnapshot {
   configuredPort: number | null;
   apiKey: string;
 }
+
+/**
+ * Descriptor for one externally-connected MCP client, returned by
+ * `mcp-server:list-active-clients`. Powers the Tier-D2 confirmation that
+ * names the clients about to be severed when the user disables the server
+ * (#8779). Only sessions classified as `external` (api-key bearer or
+ * unauthenticated loopback) are listed — renderer-pinned help-session
+ * bearers and pane tokens are Daintree's own internal consumers and would
+ * be recursive to name in a dialog the user is using to turn them off.
+ *
+ * `userAgent` is the raw `User-Agent` header captured at handshake (Claude
+ * Code, Cursor, a custom script…), or `null` when the client sent none.
+ * `connectedAtMs` is the wall-clock epoch the session handshook so the
+ * renderer can render a relative "connected N minutes ago".
+ */
+export interface McpActiveClientInfo {
+  sessionId: string;
+  userAgent: string | null;
+  connectedAtMs: number;
+  transport: "sse" | "streamable-http";
+}

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -717,8 +717,8 @@ export function McpServerSettingsTab() {
         title="Stop MCP server?"
         description={
           disableClients.length === 1
-            ? "Turning the server off disconnects the client below. Any tool call it has in flight is allowed to finish first."
-            : `Turning the server off disconnects the ${disableClients.length} clients below. Any tool calls they have in flight are allowed to finish first.`
+            ? "Turning the server off disconnects the client below and stops accepting new tool calls."
+            : `Turning the server off disconnects the ${disableClients.length} clients below and stops accepting new tool calls.`
         }
         confirmLabel="Stop sharing"
         cancelLabel="Keep running"

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -23,9 +23,11 @@ import { McpAuditLogViewer } from "@/components/Settings/McpAuditLogViewer";
 import { TurnOutcomeDiagnostics } from "@/components/Settings/TurnOutcomeDiagnostics";
 import { useDeferredLoading } from "@/hooks";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
 import {
+  type McpActiveClientInfo,
   type McpAuditRecord,
   type AssistantTurnRecord,
   type McpAuditStats,
@@ -81,6 +83,12 @@ export function McpServerSettingsTab() {
 
   const [showRotateConfirm, setShowRotateConfirm] = useState(false);
   const [isRotating, setIsRotating] = useState(false);
+  // Tier-D2 disable confirmation (#8779): populated only when the user turns
+  // the server off while external clients are connected, so the dialog can
+  // name who's about to be severed before the stop fires.
+  const [disableClients, setDisableClients] = useState<McpActiveClientInfo[]>([]);
+  const [showDisableConfirm, setShowDisableConfirm] = useState(false);
+  const [isDisabling, setIsDisabling] = useState(false);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [isClearing, setIsClearing] = useState(false);
 
@@ -180,15 +188,54 @@ export function McpServerSettingsTab() {
     };
   }, []);
 
+  const applyEnabled = async (enabled: boolean) => {
+    const newStatus = await window.electron.mcpServer.setEnabled(enabled);
+    setStatus(newStatus);
+  };
+
   const handleToggle = async () => {
     try {
       setError(null);
-      const newStatus = await window.electron.mcpServer.setEnabled(!status.enabled);
-      setStatus(newStatus);
+      // Enabling is always D0 — flip immediately. Disabling severs whatever
+      // external clients are connected, so gate it on a D2 confirm that names
+      // them. Zero external clients → reversible-local, no ceremony (#8779).
+      if (!status.enabled) {
+        await applyEnabled(true);
+        return;
+      }
+      const clients = await window.electron.mcpServer.listActiveClients();
+      if (clients.length === 0) {
+        await applyEnabled(false);
+        return;
+      }
+      setDisableClients(clients);
+      setShowDisableConfirm(true);
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to update MCP server"));
       logError("Failed to update MCP server", err);
     }
+  };
+
+  const confirmDisable = async () => {
+    if (isDisabling) return;
+    setIsDisabling(true);
+    try {
+      setError(null);
+      await applyEnabled(false);
+      setShowDisableConfirm(false);
+      setDisableClients([]);
+    } catch (err) {
+      setError(formatErrorMessage(err, "Failed to update MCP server"));
+      logError("Failed to update MCP server", err);
+    } finally {
+      setIsDisabling(false);
+    }
+  };
+
+  const handleCancelDisable = () => {
+    if (isDisabling) return;
+    setShowDisableConfirm(false);
+    setDisableClients([]);
   };
 
   const handleCopyConfig = async () => {
@@ -663,6 +710,39 @@ export function McpServerSettingsTab() {
           <p className="text-xs text-status-danger">{error}</p>
         </div>
       )}
+
+      <ConfirmDialog
+        isOpen={showDisableConfirm}
+        onClose={isDisabling ? undefined : handleCancelDisable}
+        title="Stop MCP server?"
+        description={
+          disableClients.length === 1
+            ? "Turning the server off disconnects the client below. Any tool call it has in flight is allowed to finish first."
+            : `Turning the server off disconnects the ${disableClients.length} clients below. Any tool calls they have in flight are allowed to finish first.`
+        }
+        confirmLabel="Stop sharing"
+        cancelLabel="Keep running"
+        onConfirm={confirmDisable}
+        isConfirmLoading={isDisabling}
+        variant="default"
+        zIndex="nested"
+      >
+        <ul className="space-y-1.5">
+          {disableClients.map((client) => (
+            <li
+              key={client.sessionId}
+              className="flex items-center justify-between gap-3 p-2 rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border"
+            >
+              <span className="text-xs text-daintree-text/80 truncate">
+                {client.userAgent ?? "Unknown client"}
+              </span>
+              <span className="text-[11px] text-daintree-text/50 shrink-0">
+                connected {formatRelativeTime(client.connectedAtMs)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </ConfirmDialog>
 
       <ConfirmDialog
         isOpen={showRotateConfirm}

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -659,6 +659,28 @@ describe("McpServerSettingsTab", () => {
     expect(screen.queryByRole("heading", { name: /stop mcp server\?/i })).toBeNull();
   });
 
+  it("surfaces an error and does not stop the server when listActiveClients fails (#8779)", async () => {
+    const setEnabledMock = vi.fn();
+    installMcpApi({
+      setEnabled: setEnabledMock,
+      listActiveClients: vi.fn().mockRejectedValue(new Error("clients lookup failed")),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "MCP server");
+
+    fireEvent.click(screen.getByLabelText("Enable MCP server"));
+
+    await waitForContent(container, "clients lookup failed");
+    expect(setEnabledMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole("heading", { name: /stop mcp server\?/i })).toBeNull();
+    expect(mockedNotify).not.toHaveBeenCalled();
+  });
+
   it("shows inline error for invalid audit max records instead of notifying", async () => {
     const { container } = render(
       <SettingsValidationProvider>

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -75,6 +75,7 @@ function createMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {})
     }),
     setEnabled: vi.fn(),
     setPort: vi.fn(),
+    listActiveClients: vi.fn().mockResolvedValue([]),
     getConfigSnippet: vi.fn().mockResolvedValue("http://127.0.0.1:9020/sse"),
     rotateApiKey: vi.fn().mockResolvedValue("dnt-key-rotated789"),
     getAuditRecords: vi.fn().mockResolvedValue([]),
@@ -553,6 +554,109 @@ describe("McpServerSettingsTab", () => {
     await waitForContent(container, "toggle failed");
     expect(mockedNotify).not.toHaveBeenCalled();
     expect(mockedLogError).toHaveBeenCalledWith("Failed to update MCP server", expect.any(Error));
+  });
+
+  it("disabling with connected external clients opens a confirm dialog naming them before stopping (#8779)", async () => {
+    const setEnabledMock = vi.fn().mockResolvedValue({
+      enabled: false,
+      port: null,
+      configuredPort: 9020,
+      apiKey: "dnt-key-abc123",
+    });
+    installMcpApi({
+      setEnabled: setEnabledMock,
+      listActiveClients: vi.fn().mockResolvedValue([
+        {
+          sessionId: "s1",
+          userAgent: "Claude Code/1.2",
+          connectedAtMs: Date.now() - 120_000,
+          transport: "streamable-http",
+        },
+      ]),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "MCP server");
+
+    fireEvent.click(screen.getByLabelText("Enable MCP server"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /stop mcp server\?/i })).toBeTruthy();
+    });
+    // The named client must appear; setEnabled must not have fired yet.
+    expect(screen.getByText("Claude Code/1.2")).toBeTruthy();
+    expect(setEnabledMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /^stop sharing$/i }));
+
+    await waitFor(() => {
+      expect(setEnabledMock).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("Stop dialog can be canceled without disabling the server (#8779)", async () => {
+    const setEnabledMock = vi.fn();
+    installMcpApi({
+      setEnabled: setEnabledMock,
+      listActiveClients: vi.fn().mockResolvedValue([
+        {
+          sessionId: "s1",
+          userAgent: "Cursor/0.9",
+          connectedAtMs: Date.now(),
+          transport: "sse",
+        },
+      ]),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "MCP server");
+
+    fireEvent.click(screen.getByLabelText("Enable MCP server"));
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /stop mcp server\?/i })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^keep running$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /stop mcp server\?/i })).toBeNull();
+    });
+    expect(setEnabledMock).not.toHaveBeenCalled();
+  });
+
+  it("disabling with no connected clients stops immediately without a dialog (#8779)", async () => {
+    const setEnabledMock = vi.fn().mockResolvedValue({
+      enabled: false,
+      port: null,
+      configuredPort: 9020,
+      apiKey: "dnt-key-abc123",
+    });
+    installMcpApi({
+      setEnabled: setEnabledMock,
+      listActiveClients: vi.fn().mockResolvedValue([]),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "MCP server");
+
+    fireEvent.click(screen.getByLabelText("Enable MCP server"));
+
+    await waitFor(() => {
+      expect(setEnabledMock).toHaveBeenCalledWith(false);
+    });
+    expect(screen.queryByRole("heading", { name: /stop mcp server\?/i })).toBeNull();
   });
 
   it("shows inline error for invalid audit max records instead of notifying", async () => {


### PR DESCRIPTION
## Summary

- Disabling the MCP server toggle previously silently severed every connected external client mid-request — no warning, no preview, and the stop path eagerly called `closeAllConnections()` before `server.close()`, defeating the existing race timeout.
- `httpLifecycle.stop()` now calls `server.close()` + `closeIdleConnections()` (drops idle keep-alive sockets) raced against a 3s deadline (`MCP_STOP_DRAIN_TIMEOUT_MS`), force-closing remaining sockets only on timeout.
- Turning the MCP Server toggle off when external clients are connected now opens a `ConfirmDialog` listing each client by user-agent and relative connect time ("Stop sharing" / "Keep running"). Zero clients skip straight to disable (D0).

Resolves #8779.

## Changes

- **Graceful drain** — `httpLifecycle.ts`: `server.close()` + `closeIdleConnections()` raced against `MCP_STOP_DRAIN_TIMEOUT_MS` (3s); active sockets get a grace window, idle keep-alive sockets are dropped immediately.
- **Tier-D2 confirmation** — `McpServerSettingsTab.tsx`: new `StopMcpConfirmDialog` component renders named client rows; only shown when `activeClients.length > 0`.
- **`mcp-server:list-active-clients` IPC** — `sessionStore.ts` captures user-agent, connect time, and transport per session at handshake; filters to external-tier sessions only (api-key / unauthenticated loopback), excluding the renderer-pinned help-assistant. Backed by new channel in `channels.ts`, handler in `mcpServer.ts`, preload in `mcpServer.preload.ts`, and types in `shared/types/ipc/mcpServer.ts`. This is the enumeration primitive `#8778` needs.
- **`daintreeControl` toggle documented as D0** — verified that `helpAssistant.setSettings({ daintreeControl: false })` has no MCP stop side-effect (the auto-couple is one-directional: enabling MCP, not disabling), so no confirm is warranted there.
- **Audit doc** — `docs/architecture/destructive-action-safeguards.md` gains an MCP section plus known-bypass rows for both direct-IPC toggle paths.

## Dependency note

Issue #8779 notes a dependency on #8778 (connected-clients list UI). That PR is still open, so this one ships the minimal `list-active-clients` primitive it needs. There's a possible merge-overlap on `sessionStore.ts` if #8778 lands first — worth a quick diff check at merge time.

## Drain scope

Graceful drain operates at the TCP/socket layer — idle sockets are dropped, active sockets get a 3s grace window. Session transports are still torn down on stop, so the dialog copy states the real consequence (disconnect + stop accepting new tool calls) rather than claiming in-flight tool calls will complete.

## Testing

- `sessionStore.test.ts` — metadata capture, external-client filter, teardown cleanup, stale-log suppression.
- `httpLifecycle.test.ts` — drain ordering, deadline force-close, idle-socket drop.
- `McpServerSettingsTab.test.tsx` — dialog renders named clients, cancel keeps server running, zero-client path disables immediately, `listActiveClients` failure is handled gracefully.
- `npm run check` (lint / format / typecheck / IPC drift) clean.