### PR TITLE
feat(mcp): surface connected MCP clients on the settings tab

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -614,6 +614,18 @@ export const CHANNELS = {
    */
   MCP_SERVER_REVOKE_SESSION_GRANTS: "mcp-server:revoke-session-grants",
   /**
+   * List the external bearers currently connected to the local MCP server.
+   * Returns only the display suffix and token hash — never the raw token.
+   * Backs the "External clients" row on the MCP Server settings tab (#8778).
+   */
+  MCP_SERVER_LIST_ACTIVE_BEARERS: "mcp-server:list-active-bearers",
+  /**
+   * Disconnect a single external bearer by its token hash: revoke every
+   * session it owns and evict it from the live register. One bearer only —
+   * key rotation (revoke-all) stays a separate action (#8778).
+   */
+  MCP_SERVER_DISCONNECT_BEARER: "mcp-server:disconnect-bearer",
+  /**
    * Push channel: a grant lifecycle event (`issued`, `expired`, `revoked`)
    * fired for the help-session pinned to this renderer. Targeted send —
    * grant state is session-scoped and never broadcast.

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -30,6 +30,8 @@ const serviceMock = vi.hoisted(() => ({
     lastError: null,
   })),
   onRuntimeStateChange: vi.fn(() => () => {}),
+  listActiveBearers: vi.fn(() => []),
+  disconnectBearer: vi.fn((tokenHash: string) => ({ tokenHash, disconnected: true })),
 }));
 
 vi.mock("electron", () => ({
@@ -215,6 +217,27 @@ describe("mcpServer IPC adversarial", () => {
   it("clearTurnOutcomeLog calls service clear", async () => {
     await getHandler(CHANNELS.MCP_SERVER_CLEAR_TURN_OUTCOME_LOG)(fakeEvent());
     expect(serviceMock.clearTurnOutcomeLog).toHaveBeenCalledTimes(1);
+  });
+
+  const DISCONNECT_BEARER_CHANNEL = "mcp-server:disconnect-bearer";
+
+  it("disconnectBearer rejects a non-hex / wrong-length tokenHash", async () => {
+    const bad = ["", "xyz", "a".repeat(63), "a".repeat(65), "A".repeat(64), 42, null];
+    for (const value of bad) {
+      await expect(getHandler(DISCONNECT_BEARER_CHANNEL)(fakeEvent(), value)).rejects.toThrow(
+        /Invalid tokenHash/
+      );
+    }
+    expect(serviceMock.disconnectBearer).not.toHaveBeenCalled();
+  });
+
+  it("disconnectBearer forwards a valid 64-char lowercase hex hash to the service", async () => {
+    const valid = "a".repeat(64);
+    await expect(getHandler(DISCONNECT_BEARER_CHANNEL)(fakeEvent(), valid)).resolves.toEqual({
+      tokenHash: valid,
+      disconnected: true,
+    });
+    expect(serviceMock.disconnectBearer).toHaveBeenCalledWith(valid);
   });
 
   it("cleanup removes all twenty-one registered handlers", () => {

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -217,8 +217,8 @@ describe("mcpServer IPC adversarial", () => {
     expect(serviceMock.clearTurnOutcomeLog).toHaveBeenCalledTimes(1);
   });
 
-  it("cleanup removes all nineteen registered handlers", () => {
-    expect(ipcHandlers.size).toBe(19);
+  it("cleanup removes all twenty-one registered handlers", () => {
+    expect(ipcHandlers.size).toBe(21);
     cleanup();
     expect(ipcHandlers.size).toBe(0);
   });

--- a/electron/ipc/handlers/mcpServer.preload.ts
+++ b/electron/ipc/handlers/mcpServer.preload.ts
@@ -20,6 +20,8 @@ export const MCP_SERVER_METHOD_CHANNELS = {
   setSessionTier: "mcp-server:set-session-tier",
   issueGrant: "mcp-server:issue-grant",
   revokeSessionGrants: "mcp-server:revoke-session-grants",
+  listActiveBearers: "mcp-server:list-active-bearers",
+  disconnectBearer: "mcp-server:disconnect-bearer",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof MCP_SERVER_METHOD_CHANNELS;

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -8,7 +8,9 @@ import { broadcastToRenderer } from "../utils.js";
 import { sanitizePath } from "../../utils/pathScrubber.js";
 import { scrubSecrets } from "../../utils/secretScrubber.js";
 import type {
+  ActiveBearerRecord,
   AssistantTurnRecord,
+  DisconnectBearerResult,
   McpActiveClientInfo,
   McpAuditRecord,
   McpAuditStats,
@@ -239,6 +241,25 @@ export const mcpServerNamespace = defineIpcNamespace({
         return svc.revokeSessionGrants(sessionId, ctx.webContentsId);
       },
       { withContext: true }
+    ),
+    listActiveBearers: op(
+      MCP_SERVER_METHOD_CHANNELS.listActiveBearers,
+      async (): Promise<ActiveBearerRecord[]> => {
+        const svc = await getMcpServerService();
+        return svc.listActiveBearers();
+      }
+    ),
+    disconnectBearer: op(
+      MCP_SERVER_METHOD_CHANNELS.disconnectBearer,
+      async (tokenHash: string): Promise<DisconnectBearerResult> => {
+        // tokenHash is the SHA-256 hex of an Authorization header — a 64-char
+        // lowercase hex string. Reject anything else before touching state.
+        if (typeof tokenHash !== "string" || !/^[0-9a-f]{64}$/.test(tokenHash)) {
+          throw new Error("Invalid tokenHash");
+        }
+        const svc = await getMcpServerService();
+        return svc.disconnectBearer(tokenHash);
+      }
     ),
   },
 });

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -6,7 +6,9 @@ import type { WindowRegistry } from "../window/WindowRegistry.js";
 import { getWindowRegistry } from "../window/windowRef.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
 import type {
+  ActiveBearerRecord,
   AssistantTurnRecord,
+  DisconnectBearerResult,
   McpAuditRecord,
   McpAuditStats,
   McpGrantLifecyclePayload,
@@ -91,6 +93,10 @@ export class McpServerService {
       {
         emitGrantLifecycle: (sessionId, payload) => this.emitGrantLifecycle(sessionId, payload),
         dropAbuseState: (sessionId) => abusePolicy.dropSession(sessionId),
+        // The live bearer register is owned by `httpLifecycle` (created
+        // below). The closure defers the reference until teardown time, by
+        // which point the field is assigned. Mirrors `dropAbuseState`.
+        dropBearerState: (sessionId) => this.httpLifecycle.detachBearerSession(sessionId),
         onTierDecayed: (sessionId) => {
           // Tier just decayed to the workbench baseline (#8462). Push a
           // tools/list_changed so the model re-fetches the now-narrowed
@@ -450,6 +456,37 @@ export class McpServerService {
    */
   revokeSessionGrants(sessionId: string, callerWcId?: number): McpRevokeSessionGrantsResult {
     return this.httpLifecycle.revokeSessionGrants(sessionId, callerWcId);
+  }
+
+  /**
+   * Snapshot of the bearers currently connected to the local MCP server for
+   * the settings tab. Raw tokens are never returned — only the display suffix
+   * and the hash used to target {@link disconnectBearer}.
+   */
+  listActiveBearers(): ActiveBearerRecord[] {
+    return this.httpLifecycle.listActiveBearers();
+  }
+
+  /**
+   * Disconnect a single bearer: revoke every session it owns and evict it
+   * from the live register, then push a runtime-state change so the settings
+   * tab refreshes. Targets one token only — key rotation (revoke-all) stays a
+   * separate D3 action.
+   */
+  disconnectBearer(tokenHash: string): DisconnectBearerResult {
+    const sessionIds = this.httpLifecycle.getBearerSessionIds(tokenHash);
+    if (sessionIds === null) {
+      return { tokenHash, disconnected: false };
+    }
+    for (const sessionId of sessionIds) {
+      this.sessionStore.revokeSession(sessionId);
+    }
+    // Clear any residual entry — `revokeSession` already detaches each
+    // session via the `dropBearerState` callback, but a stale entry with no
+    // live sessions (client dropped the socket) wouldn't be covered.
+    this.httpLifecycle.clearBearer(tokenHash);
+    this.emitRuntimeStateChange();
+    return { tokenHash, disconnected: true };
   }
 
   /**

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -20,7 +20,12 @@ import { HttpLifecycle } from "../httpLifecycle.js";
 import type { HttpLifecycleDeps } from "../httpLifecycle.js";
 
 type BearerTestHandle = {
-  touchBearer: (authHeader: string, userAgent: string, sessionId: string) => void;
+  touchBearer: (
+    authHeader: string,
+    userAgent: string,
+    sessionId: string,
+    tier: "workbench" | "action" | "system" | "external"
+  ) => void;
   detachBearerSession: (sessionId: string) => void;
 };
 
@@ -454,7 +459,12 @@ describe("HttpLifecycle", () => {
 
     it("registers a bearer and exposes only the suffix, never the raw token", () => {
       const lc = new HttpLifecycle(fakeDeps());
-      (lc as unknown as BearerTestHandle).touchBearer(authA, "Claude Code/1.0", "sess-1");
+      (lc as unknown as BearerTestHandle).touchBearer(
+        authA,
+        "Claude Code/1.0",
+        "sess-1",
+        "external"
+      );
 
       const bearers = lc.listActiveBearers();
       expect(bearers).toHaveLength(1);
@@ -470,13 +480,34 @@ describe("HttpLifecycle", () => {
       expect(bearers[0]).not.toHaveProperty("sessionIds");
     });
 
+    it("tracks only external-tier bearers, never internal (help/pane) tokens", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerTestHandle;
+      handle.touchBearer(authA, "Help/1", "sess-help", "action");
+      handle.touchBearer(authB, "Pane/1", "sess-pane", "workbench");
+      expect(lc.listActiveBearers()).toHaveLength(0);
+      // A subsequent external bearer is still tracked.
+      handle.touchBearer("Bearer external-cccc", "Claude/1", "sess-ext", "external");
+      expect(lc.listActiveBearers()).toHaveLength(1);
+    });
+
+    it("pushes a runtime-state change on connect and on final disconnect", () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+      const handle = lc as unknown as BearerTestHandle;
+      handle.touchBearer(authA, "Client/1", "sess-1", "external");
+      expect(deps.emitRuntimeStateChange).toHaveBeenCalledTimes(1);
+      handle.detachBearerSession("sess-1");
+      expect(deps.emitRuntimeStateChange).toHaveBeenCalledTimes(2);
+    });
+
     it("coalesces two sessions onto one entry and only drops it when both close", () => {
       const lc = new HttpLifecycle(fakeDeps());
       const handle = lc as unknown as BearerTestHandle;
-      handle.touchBearer(authA, "Client/1", "sess-1");
-      handle.touchBearer(authA, "Client/2", "sess-2");
+      handle.touchBearer(authA, "Client/1", "sess-1", "external");
+      handle.touchBearer(authA, "Client/2", "sess-2", "external");
 
-      let bearers = lc.listActiveBearers();
+      const bearers = lc.listActiveBearers();
       expect(bearers).toHaveLength(1);
       // requestsSinceLaunch counts each handshake; userAgent reflects the latest.
       expect(bearers[0]!.requestsSinceLaunch).toBe(2);
@@ -492,8 +523,8 @@ describe("HttpLifecycle", () => {
     it("keys distinct tokens to distinct entries", () => {
       const lc = new HttpLifecycle(fakeDeps());
       const handle = lc as unknown as BearerTestHandle;
-      handle.touchBearer(authA, "Client/1", "sess-1");
-      handle.touchBearer(authB, "Client/2", "sess-2");
+      handle.touchBearer(authA, "Client/1", "sess-1", "external");
+      handle.touchBearer(authB, "Client/2", "sess-2", "external");
       expect(lc.listActiveBearers()).toHaveLength(2);
     });
 
@@ -505,7 +536,7 @@ describe("HttpLifecycle", () => {
 
     it("getBearerSessionIds returns a snapshot or null", () => {
       const lc = new HttpLifecycle(fakeDeps());
-      (lc as unknown as BearerTestHandle).touchBearer(authA, "Client/1", "sess-1");
+      (lc as unknown as BearerTestHandle).touchBearer(authA, "Client/1", "sess-1", "external");
       expect(lc.getBearerSessionIds(hashOf(authA))).toEqual(["sess-1"]);
       expect(lc.getBearerSessionIds("nonexistent")).toBeNull();
     });
@@ -513,7 +544,7 @@ describe("HttpLifecycle", () => {
     it("clearBearer evicts the entry and its reverse-lookup rows", () => {
       const lc = new HttpLifecycle(fakeDeps());
       const handle = lc as unknown as BearerTestHandle;
-      handle.touchBearer(authA, "Client/1", "sess-1");
+      handle.touchBearer(authA, "Client/1", "sess-1", "external");
       lc.clearBearer(hashOf(authA));
       expect(lc.listActiveBearers()).toHaveLength(0);
       // Reverse rows gone: a late detach for the cleared session is harmless.

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -15,8 +15,16 @@ vi.mock("../../../store.js", () => ({
 
 import http from "node:http";
 import { EventEmitter } from "node:events";
+import { createHash } from "node:crypto";
 import { HttpLifecycle } from "../httpLifecycle.js";
 import type { HttpLifecycleDeps } from "../httpLifecycle.js";
+
+type BearerTestHandle = {
+  touchBearer: (authHeader: string, userAgent: string, sessionId: string) => void;
+  detachBearerSession: (sessionId: string) => void;
+};
+
+const hashOf = (authHeader: string) => createHash("sha256").update(authHeader).digest("hex");
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MockServer = any;
@@ -437,6 +445,79 @@ describe("HttpLifecycle", () => {
         .calls[0]?.[0];
       expect(callArgs).toBeDefined();
       expect(callArgs.turnId).toBeUndefined();
+    });
+  });
+
+  describe("bearer register", () => {
+    const authA = "Bearer secret-token-aaaa";
+    const authB = "Bearer secret-token-bbbb";
+
+    it("registers a bearer and exposes only the suffix, never the raw token", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      (lc as unknown as BearerTestHandle).touchBearer(authA, "Claude Code/1.0", "sess-1");
+
+      const bearers = lc.listActiveBearers();
+      expect(bearers).toHaveLength(1);
+      expect(bearers[0]).toMatchObject({
+        tokenHash: hashOf(authA),
+        token4LastChars: "aaaa",
+        userAgent: "Claude Code/1.0",
+        requestsSinceLaunch: 1,
+      });
+      // The raw token must never cross the listing surface.
+      expect(JSON.stringify(bearers)).not.toContain("secret-token-aaaa");
+      // sessionIds is internal only.
+      expect(bearers[0]).not.toHaveProperty("sessionIds");
+    });
+
+    it("coalesces two sessions onto one entry and only drops it when both close", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerTestHandle;
+      handle.touchBearer(authA, "Client/1", "sess-1");
+      handle.touchBearer(authA, "Client/2", "sess-2");
+
+      let bearers = lc.listActiveBearers();
+      expect(bearers).toHaveLength(1);
+      // requestsSinceLaunch counts each handshake; userAgent reflects the latest.
+      expect(bearers[0]!.requestsSinceLaunch).toBe(2);
+      expect(bearers[0]!.userAgent).toBe("Client/2");
+
+      handle.detachBearerSession("sess-1");
+      expect(lc.listActiveBearers()).toHaveLength(1);
+
+      handle.detachBearerSession("sess-2");
+      expect(lc.listActiveBearers()).toHaveLength(0);
+    });
+
+    it("keys distinct tokens to distinct entries", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerTestHandle;
+      handle.touchBearer(authA, "Client/1", "sess-1");
+      handle.touchBearer(authB, "Client/2", "sess-2");
+      expect(lc.listActiveBearers()).toHaveLength(2);
+    });
+
+    it("detachBearerSession is a no-op for unknown sessions", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      expect(() => (lc as unknown as BearerTestHandle).detachBearerSession("ghost")).not.toThrow();
+      expect(lc.listActiveBearers()).toHaveLength(0);
+    });
+
+    it("getBearerSessionIds returns a snapshot or null", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      (lc as unknown as BearerTestHandle).touchBearer(authA, "Client/1", "sess-1");
+      expect(lc.getBearerSessionIds(hashOf(authA))).toEqual(["sess-1"]);
+      expect(lc.getBearerSessionIds("nonexistent")).toBeNull();
+    });
+
+    it("clearBearer evicts the entry and its reverse-lookup rows", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerTestHandle;
+      handle.touchBearer(authA, "Client/1", "sess-1");
+      lc.clearBearer(hashOf(authA));
+      expect(lc.listActiveBearers()).toHaveLength(0);
+      // Reverse rows gone: a late detach for the cleared session is harmless.
+      expect(() => handle.detachBearerSession("sess-1")).not.toThrow();
     });
   });
 

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -566,6 +566,58 @@ describe("SessionStore dropAbuseState wiring (#8467)", () => {
   });
 });
 
+describe("SessionStore dropBearerState wiring (#8778)", () => {
+  let dropBearerSpy: ReturnType<typeof vi.fn<(sessionId: string) => void>>;
+  let store: SessionStore;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    dropBearerSpy = vi.fn<(sessionId: string) => void>();
+    store = new SessionStore(() => {}, { dropBearerState: dropBearerSpy });
+  });
+
+  afterEach(() => {
+    store.grantCache.dispose();
+    vi.useRealTimers();
+  });
+
+  it("invokes dropBearerState on SSE idle expiry", () => {
+    const session = fakeSseSession();
+    store.sessions.set("s1", session);
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createIdleTimer("s1");
+
+    vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS + 1);
+
+    expect(dropBearerSpy).toHaveBeenCalledWith("s1");
+  });
+
+  it("invokes dropBearerState on Streamable-HTTP idle expiry", () => {
+    const session = fakeHttpSession();
+    store.httpSessions.set("h1", session);
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createHttpIdleTimer("h1");
+
+    vi.advanceTimersByTime(MCP_SSE_IDLE_TIMEOUT_MS + 1);
+
+    expect(dropBearerSpy).toHaveBeenCalledWith("h1");
+  });
+
+  it("invokes dropBearerState on explicit revokeSession", () => {
+    const session = fakeSseSession();
+    store.sessions.set("s1", session);
+
+    store.revokeSession("s1");
+
+    expect(dropBearerSpy).toHaveBeenCalledWith("s1");
+  });
+
+  it("does not fire dropBearerState when revokeSession returns false (unknown session)", () => {
+    expect(store.revokeSession("ghost")).toBe(false);
+    expect(dropBearerSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("SessionStore tier-elevation decay (#8462)", () => {
   let store: SessionStore;
   let decayed: string[];

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -19,6 +19,7 @@ import type {
 } from "./shared.js";
 import type {
   ActiveBearerRecord,
+  McpActiveClientInfo,
   McpIssueGrantResult,
   McpRevokeSessionGrantsResult,
 } from "../../../shared/types/ipc/mcpServer.js";
@@ -44,7 +45,6 @@ import {
   MCP_STOP_DRAIN_TIMEOUT_MS,
   MCP_SERVER_KEY,
 } from "./shared.js";
-import type { McpActiveClientInfo } from "../../../shared/types/ipc/mcpServer.js";
 
 export interface HttpLifecycleDeps {
   sessionStore: SessionStore;
@@ -246,13 +246,25 @@ export class HttpLifecycle {
   /**
    * Record (or refresh) the bearer behind an authenticated session handshake.
    * Called once per new session — not per request — because only handshake
-   * requests carry the `Authorization` header through this path. The hash of
-   * the full header is the stable per-token identity; `userAgent` and
-   * `lastActiveAt` are updated on every (re)connect so a reconnecting client
-   * surfaces fresh metadata. `requestsSinceLaunch` counts handshakes for the
-   * bearer since the server last started.
+   * requests carry the `Authorization` header through this path. Only
+   * `external`-tier bearers are tracked: the "External clients" row is for
+   * third-party MCP clients (Claude Code, Cursor, scripts), never the
+   * Daintree Assistant's own help-session or in-pane agent tokens — surfacing
+   * those would let the user disconnect their own assistant.
+   *
+   * The hash of the full header is the stable per-token identity; `userAgent`
+   * and `lastActiveAt` refresh on every (re)connect. `requestsSinceLaunch`
+   * counts handshakes for the bearer since the server last started. Pushes a
+   * runtime-state change so an open settings tab reflects the new connection
+   * live (session handshakes are infrequent, so this is not chatty).
    */
-  private touchBearer(authHeader: string, userAgent: string, sessionId: string): void {
+  private touchBearer(
+    authHeader: string,
+    userAgent: string,
+    sessionId: string,
+    tier: McpTier
+  ): void {
+    if (tier !== "external") return;
     const tokenHash = createHash("sha256").update(authHeader).digest("hex");
     const token4LastChars = extractBearerToken(authHeader)?.slice(-4) ?? "****";
     const now = Date.now();
@@ -273,14 +285,30 @@ export class HttpLifecycle {
     entry.requestsSinceLaunch += 1;
     entry.sessionIds.add(sessionId);
     this.sessionToTokenHash.set(sessionId, tokenHash);
+    this.deps.emitRuntimeStateChange();
+  }
+
+  /**
+   * Bump a tracked bearer's `lastActiveAt` on a subsequent (non-handshake)
+   * authenticated request so the settings row reflects real recency, not just
+   * connection time. No-op for untracked (internal-tier) sessions. Does not
+   * push a runtime-state change — per-message traffic would be far too chatty;
+   * the refreshed value is picked up on the next list fetch.
+   */
+  private markBearerActive(sessionId: string): void {
+    const tokenHash = this.sessionToTokenHash.get(sessionId);
+    if (tokenHash === undefined) return;
+    const entry = this.bearerRegister.get(tokenHash);
+    if (entry) entry.lastActiveAt = Date.now();
   }
 
   /**
    * Drop a closing session from its owning bearer entry. Idempotent — a
-   * no-op when the session was never registered (non-handshake path) or the
-   * entry was already cleared by an explicit disconnect. Removes the bearer
-   * entry once its last session closes so the settings tab reflects only
-   * live connections. Wired into every per-session teardown path via the
+   * no-op when the session was never registered (non-handshake / internal
+   * tier) or the entry was already cleared by an explicit disconnect. Removes
+   * the bearer entry once its last session closes so the settings tab reflects
+   * only live connections, and pushes a runtime-state change so an open tab
+   * updates. Wired into every per-session teardown path via the
    * `dropBearerState` callback plus the inline transport-close handlers.
    */
   detachBearerSession(sessionId: string): void {
@@ -293,6 +321,7 @@ export class HttpLifecycle {
     if (entry.sessionIds.size === 0) {
       this.bearerRegister.delete(tokenHash);
     }
+    this.deps.emitRuntimeStateChange();
   }
 
   /** Live snapshot for the settings tab. The raw token is never exposed. */
@@ -739,7 +768,7 @@ export class HttpLifecycle {
         this.headerString(req.headers["user-agent"]),
         "sse"
       );
-      this.touchBearer(authHeader, resolveUserAgent(req), sessionId);
+      this.touchBearer(authHeader, resolveUserAgent(req), sessionId, tier);
 
       const pinnedWebContentsId = this.resolvePinnedWebContentsId(authHeader);
       if (pinnedWebContentsId !== null) {
@@ -807,6 +836,7 @@ export class HttpLifecycle {
 
       if (session) {
         this.deps.sessionStore.resetIdleTimer(sid);
+        this.markBearerActive(sid);
         await session.transport.handlePostMessage(req, res);
       } else {
         res.writeHead(404, { "Content-Type": "text/plain" });
@@ -849,6 +879,7 @@ export class HttpLifecycle {
         return;
       }
       this.deps.sessionStore.resetHttpIdleTimer(sessionId);
+      this.markBearerActive(sessionId);
       await session.transport.handleRequest(req, res);
       return;
     }
@@ -894,7 +925,7 @@ export class HttpLifecycle {
         // Register the bearer against the SDK-confirmed session id (not the
         // pre-generated `newSessionId`) so detachment keys match the ids the
         // teardown paths see.
-        this.touchBearer(authHeader, resolveUserAgent(req), initializedSessionId);
+        this.touchBearer(authHeader, resolveUserAgent(req), initializedSessionId, tier);
       },
     });
 

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -1,5 +1,5 @@
 import http from "node:http";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { AddressInfo } from "node:net";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -18,6 +18,7 @@ import type {
   McpTier,
 } from "./shared.js";
 import type {
+  ActiveBearerRecord,
   McpIssueGrantResult,
   McpRevokeSessionGrantsResult,
 } from "../../../shared/types/ipc/mcpServer.js";
@@ -92,6 +93,33 @@ export interface HttpLifecycleDeps {
   setConfig: (patch: Record<string, unknown>) => void;
 }
 
+/**
+ * Best-effort client label for the bearer register. `user-agent` is always a
+ * single string per Node's HTTP parser, but MCP clients aren't required to
+ * send one — fall back to a neutral label so the settings row never shows a
+ * blank.
+ */
+function resolveUserAgent(req: http.IncomingMessage): string {
+  const ua = req.headers["user-agent"];
+  return typeof ua === "string" && ua.trim().length > 0 ? ua : "Unknown client";
+}
+
+/**
+ * Live per-bearer connection record. Keyed in {@link HttpLifecycle.bearerRegister}
+ * by the SHA-256 of the full `Authorization` header so distinct tokens never
+ * collide on a shared 4-char suffix. `sessionIds` is the forward set used to
+ * tear sessions down when the renderer disconnects the bearer; it is never
+ * exposed across IPC.
+ */
+interface BearerEntry {
+  tokenHash: string;
+  token4LastChars: string;
+  userAgent: string;
+  lastActiveAt: number;
+  requestsSinceLaunch: number;
+  sessionIds: Set<string>;
+}
+
 export class HttpLifecycle {
   private httpServer: http.Server | null = null;
   private port: number | null = null;
@@ -108,6 +136,16 @@ export class HttpLifecycle {
   private restartAttempts = 0;
   private restartTimer: ReturnType<typeof setTimeout> | null = null;
   private stableTimer: ReturnType<typeof setTimeout> | null = null;
+  // Live register of bearers currently connected to the server, keyed by the
+  // SHA-256 of the full Authorization header. Populated at session handshake
+  // (`touchBearer`) and torn down per-session (`detachBearerSession`) plus
+  // wholesale on stop/restart. Distinct from the audit ring buffer — this is
+  // the current-connection view surfaced on the settings tab (#8778).
+  private readonly bearerRegister = new Map<string, BearerEntry>();
+  // Reverse lookup so the per-session teardown callbacks (idle expiry,
+  // explicit revoke, transport close) can find which bearer owns a closing
+  // session without re-parsing the header they no longer hold.
+  private readonly sessionToTokenHash = new Map<string, string>();
 
   constructor(private readonly deps: HttpLifecycleDeps) {}
 
@@ -203,6 +241,94 @@ export class HttpLifecycle {
     const raw = Array.isArray(value) ? value[0] : value;
     const trimmed = raw?.trim();
     return trimmed ? trimmed : null;
+  }
+
+  /**
+   * Record (or refresh) the bearer behind an authenticated session handshake.
+   * Called once per new session — not per request — because only handshake
+   * requests carry the `Authorization` header through this path. The hash of
+   * the full header is the stable per-token identity; `userAgent` and
+   * `lastActiveAt` are updated on every (re)connect so a reconnecting client
+   * surfaces fresh metadata. `requestsSinceLaunch` counts handshakes for the
+   * bearer since the server last started.
+   */
+  private touchBearer(authHeader: string, userAgent: string, sessionId: string): void {
+    const tokenHash = createHash("sha256").update(authHeader).digest("hex");
+    const token4LastChars = extractBearerToken(authHeader)?.slice(-4) ?? "****";
+    const now = Date.now();
+    let entry = this.bearerRegister.get(tokenHash);
+    if (!entry) {
+      entry = {
+        tokenHash,
+        token4LastChars,
+        userAgent,
+        lastActiveAt: now,
+        requestsSinceLaunch: 0,
+        sessionIds: new Set<string>(),
+      };
+      this.bearerRegister.set(tokenHash, entry);
+    }
+    entry.userAgent = userAgent;
+    entry.lastActiveAt = now;
+    entry.requestsSinceLaunch += 1;
+    entry.sessionIds.add(sessionId);
+    this.sessionToTokenHash.set(sessionId, tokenHash);
+  }
+
+  /**
+   * Drop a closing session from its owning bearer entry. Idempotent — a
+   * no-op when the session was never registered (non-handshake path) or the
+   * entry was already cleared by an explicit disconnect. Removes the bearer
+   * entry once its last session closes so the settings tab reflects only
+   * live connections. Wired into every per-session teardown path via the
+   * `dropBearerState` callback plus the inline transport-close handlers.
+   */
+  detachBearerSession(sessionId: string): void {
+    const tokenHash = this.sessionToTokenHash.get(sessionId);
+    if (tokenHash === undefined) return;
+    this.sessionToTokenHash.delete(sessionId);
+    const entry = this.bearerRegister.get(tokenHash);
+    if (!entry) return;
+    entry.sessionIds.delete(sessionId);
+    if (entry.sessionIds.size === 0) {
+      this.bearerRegister.delete(tokenHash);
+    }
+  }
+
+  /** Live snapshot for the settings tab. The raw token is never exposed. */
+  listActiveBearers(): ActiveBearerRecord[] {
+    return Array.from(this.bearerRegister.values(), (entry) => ({
+      tokenHash: entry.tokenHash,
+      token4LastChars: entry.token4LastChars,
+      userAgent: entry.userAgent,
+      lastActiveAt: entry.lastActiveAt,
+      requestsSinceLaunch: entry.requestsSinceLaunch,
+    }));
+  }
+
+  /**
+   * Snapshot the session ids owned by a bearer so the caller can revoke each
+   * one. Returns null when the token hash isn't currently connected.
+   */
+  getBearerSessionIds(tokenHash: string): string[] | null {
+    const entry = this.bearerRegister.get(tokenHash);
+    if (!entry) return null;
+    return Array.from(entry.sessionIds);
+  }
+
+  /** Evict a bearer entry and its reverse-lookup rows. Idempotent. */
+  clearBearer(tokenHash: string): void {
+    const entry = this.bearerRegister.get(tokenHash);
+    if (!entry) return;
+    for (const sessionId of entry.sessionIds) {
+      this.sessionToTokenHash.delete(sessionId);
+    }
+    this.bearerRegister.delete(tokenHash);
+  }
+
+  private clearAllBearers(): void {
+    this.bearerRegister.clear();
+    this.sessionToTokenHash.clear();
   }
 
   private getConfig() {
@@ -320,6 +446,9 @@ export class HttpLifecycle {
 
     // Drain sessions
     this.deps.sessionStore.drain();
+    // Wipe the bearer register so a restart starts from zero live clients —
+    // every external client must reconnect, re-registering on handshake.
+    this.clearAllBearers();
     // Mirror the planned-stop path so an unexpected close also wipes
     // the abuse-policy state. Otherwise denial counters would leak
     // into the lifetime of any subsequent restart.
@@ -413,6 +542,7 @@ export class HttpLifecycle {
         this.deps.auditService.flushNow();
         this.deps.turnOutcomeService.flushNow();
         this.deps.sessionStore.drain();
+        this.clearAllBearers();
         // The drain wipes session-scoped state (grants, dedup, pins);
         // the abuse-policy denial Map is owned alongside but lives on
         // `HttpLifecycle.deps` so we clear it here in lockstep. Without
@@ -609,6 +739,7 @@ export class HttpLifecycle {
         this.headerString(req.headers["user-agent"]),
         "sse"
       );
+      this.touchBearer(authHeader, resolveUserAgent(req), sessionId);
 
       const pinnedWebContentsId = this.resolvePinnedWebContentsId(authHeader);
       if (pinnedWebContentsId !== null) {
@@ -645,6 +776,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.clearRateLimitState(sessionId);
         this.deps.sessionStore.clearClientMetadata(sessionId);
         this.deps.abusePolicy.dropSession(sessionId);
+        this.detachBearerSession(sessionId);
         cleanupResourceSubscriptions(sessionId, this.deps.sessionStore);
       };
 
@@ -664,6 +796,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.clearRateLimitState(sessionId);
         this.deps.sessionStore.clearClientMetadata(sessionId);
         this.deps.abusePolicy.dropSession(sessionId);
+        this.detachBearerSession(sessionId);
         transport.onclose = undefined;
         await transport.close().catch(() => {});
         throw err;
@@ -758,6 +891,10 @@ export class HttpLifecycle {
           server,
           idleTimer,
         });
+        // Register the bearer against the SDK-confirmed session id (not the
+        // pre-generated `newSessionId`) so detachment keys match the ids the
+        // teardown paths see.
+        this.touchBearer(authHeader, resolveUserAgent(req), initializedSessionId);
       },
     });
 
@@ -782,6 +919,7 @@ export class HttpLifecycle {
       this.deps.sessionStore.clearRateLimitState(id);
       this.deps.sessionStore.clearClientMetadata(id);
       this.deps.abusePolicy.dropSession(id);
+      this.detachBearerSession(id);
       cleanupResourceSubscriptions(id, this.deps.sessionStore);
     };
 
@@ -806,6 +944,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.clearRateLimitState(id);
         this.deps.sessionStore.clearClientMetadata(id);
         this.deps.abusePolicy.dropSession(id);
+        this.detachBearerSession(id);
         cleanupResourceSubscriptions(id, this.deps.sessionStore);
       } else {
         this.deps.sessionStore.clearElevationTimer(newSessionId);
@@ -817,6 +956,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.clearRateLimitState(newSessionId);
         this.deps.sessionStore.clearClientMetadata(newSessionId);
         this.deps.abusePolicy.dropSession(newSessionId);
+        this.detachBearerSession(newSessionId);
         cleanupResourceSubscriptions(newSessionId, this.deps.sessionStore);
       }
       await transport.close().catch(() => {});

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -29,6 +29,16 @@ export interface SessionStoreOptions {
    */
   dropAbuseState?: (sessionId: string) => void;
   /**
+   * Fired alongside the other per-session cleanup hooks so the live
+   * bearer-connection register in `httpLifecycle` drops this session from
+   * its owning bearer entry (and the entry itself once its last session
+   * closes). Mirrors {@link dropAbuseState} — the register is owned by
+   * `HttpLifecycle`, so the store reaches it through this callback rather
+   * than holding a reference. Optional so bare test fixtures construct
+   * without one.
+   */
+  dropBearerState?: (sessionId: string) => void;
+  /**
    * Fired when a session's renderer-approved tier elevation expires and the
    * session is silently decayed back to the `workbench` baseline (#8462).
    * `httpLifecycle` wires this to `server.sendToolListChanged()` on the
@@ -151,6 +161,7 @@ export class SessionStore {
 
   private readonly cleanupResourceSubscriptionsFn: (sessionId: string) => void;
   private readonly dropAbuseStateFn: (sessionId: string) => void;
+  private readonly dropBearerStateFn: (sessionId: string) => void;
   private readonly onTierDecayedFn: (sessionId: string) => void;
 
   constructor(
@@ -159,6 +170,7 @@ export class SessionStore {
   ) {
     this.cleanupResourceSubscriptionsFn = cleanupResourceSubscriptions;
     this.dropAbuseStateFn = options.dropAbuseState ?? (() => {});
+    this.dropBearerStateFn = options.dropBearerState ?? (() => {});
     this.onTierDecayedFn = options.onTierDecayed ?? (() => {});
     this.grantCache = new GrantCache({ emit: options.emitGrantLifecycle });
   }
@@ -268,6 +280,7 @@ export class SessionStore {
     this.idleStartedAt.delete(sessionId);
     this.clearElevationTimer(sessionId);
     this.dropAbuseStateFn(sessionId);
+    this.dropBearerStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
     session.transport.close().catch(() => {
       // ignore close errors during idle timeout cleanup
@@ -323,6 +336,7 @@ export class SessionStore {
     this.httpIdleStartedAt.delete(sessionId);
     this.clearElevationTimer(sessionId);
     this.dropAbuseStateFn(sessionId);
+    this.dropBearerStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
     session.transport.close().catch(() => {
       // ignore close errors during idle timeout cleanup
@@ -569,6 +583,7 @@ export class SessionStore {
     this.clearClientMetadata(sessionId);
     this.clearElevationTimer(sessionId);
     this.dropAbuseStateFn(sessionId);
+    this.dropBearerStateFn(sessionId);
     this.cleanupResourceSubscriptionsFn(sessionId);
     return true;
   }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -344,6 +344,8 @@ export type {
   McpAnomalySignal,
   McpRuntimeSnapshot,
   McpRuntimeState,
+  ActiveBearerRecord,
+  DisconnectBearerResult,
 } from "./ipc/mcpServer.js";
 export {
   MCP_AUDIT_MIN_RECORDS,

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -171,6 +171,9 @@ export interface GeneratedElectronAPI {
     clearTurnOutcomeLog(
       ...args: IpcInvokeMap["mcp-server:clear-turn-outcome-log"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:clear-turn-outcome-log"]["result"]>;
+    disconnectBearer(
+      ...args: IpcInvokeMap["mcp-server:disconnect-bearer"]["args"]
+    ): Promise<IpcInvokeMap["mcp-server:disconnect-bearer"]["result"]>;
     exportAuditLog(
       ...args: IpcInvokeMap["mcp-server:export-audit-log"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:export-audit-log"]["result"]>;
@@ -198,6 +201,9 @@ export interface GeneratedElectronAPI {
     issueGrant(
       ...args: IpcInvokeMap["mcp-server:issue-grant"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:issue-grant"]["result"]>;
+    listActiveBearers(
+      ...args: IpcInvokeMap["mcp-server:list-active-bearers"]["args"]
+    ): Promise<IpcInvokeMap["mcp-server:list-active-bearers"]["result"]>;
     listActiveClients(
       ...args: IpcInvokeMap["mcp-server:list-active-clients"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:list-active-clients"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -367,6 +367,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: void;
   };
+  "mcp-server:disconnect-bearer": {
+    args: [tokenHash: string];
+    result: import("./mcpServer.js").DisconnectBearerResult;
+  };
   "mcp-server:export-audit-log": {
     args: [records: import("./mcpServer.js").McpAuditRecord[]];
     result: boolean;
@@ -402,6 +406,10 @@ export interface GeneratedIpcInvokeMap {
   "mcp-server:issue-grant": {
     args: [payload: { sessionId: string; toolId: string }];
     result: import("./mcpServer.js").McpIssueGrantResult;
+  };
+  "mcp-server:list-active-bearers": {
+    args: [];
+    result: import("./mcpServer.js").ActiveBearerRecord[];
   };
   "mcp-server:list-active-clients": {
     args: [];

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -414,3 +414,33 @@ export interface McpActiveClientInfo {
   connectedAtMs: number;
   transport: "sse" | "streamable-http";
 }
+
+/**
+ * Live snapshot of one bearer token currently connected to the local MCP
+ * server, surfaced on the MCP Server settings tab. Tracked per-token in a
+ * register separate from the audit ring buffer — the audit log is an event
+ * history, this is the current-connection view.
+ *
+ * `tokenHash` is the SHA-256 of the full `Authorization` header and is the
+ * stable identity used to target {@link disconnectBearer}; the raw token is
+ * never exposed across IPC. `token4LastChars` is the display-only suffix.
+ * `requestsSinceLaunch` counts new session handshakes for this bearer since
+ * the server last started (reset on restart), not per-message traffic.
+ */
+export interface ActiveBearerRecord {
+  tokenHash: string;
+  token4LastChars: string;
+  userAgent: string;
+  lastActiveAt: number;
+  requestsSinceLaunch: number;
+}
+
+/**
+ * Result of a renderer-driven `disconnectBearer` IPC. `disconnected` is true
+ * when a matching bearer entry existed and its sessions were revoked — false
+ * when the token hash was already absent (e.g. the client disconnected first).
+ */
+export interface DisconnectBearerResult {
+  tokenHash: string;
+  disconnected: boolean;
+}

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -10,6 +10,8 @@ import {
   EyeOff,
   RefreshCw,
   ScrollText,
+  Plug,
+  ChevronRight,
 } from "lucide-react";
 import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
@@ -25,12 +27,14 @@ import { useDeferredLoading } from "@/hooks";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { logError } from "@/utils/logger";
 import {
   type McpActiveClientInfo,
   type McpAuditRecord,
   type AssistantTurnRecord,
   type McpAuditStats,
+  type ActiveBearerRecord,
   MCP_AUDIT_DEFAULT_MAX_RECORDS,
   MCP_AUDIT_MAX_RECORDS,
   MCP_AUDIT_MIN_RECORDS,
@@ -92,7 +96,36 @@ export function McpServerSettingsTab() {
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [isClearing, setIsClearing] = useState(false);
 
+  const [activeBearers, setActiveBearers] = useState<ActiveBearerRecord[]>([]);
+  const [bearersExpanded, setBearersExpanded] = useState(false);
+  const [disconnectingHash, setDisconnectingHash] = useState<string | null>(null);
+  // Drives the neutral attribution pill on the top card: when the Daintree
+  // Assistant holds the server open, the toggle reflects assistant intent
+  // rather than a manual choice.
+  const [keptAliveByAssistant, setKeptAliveByAssistant] = useState(false);
+
   useSettingsTabValidation("mcp", Boolean(error));
+
+  // Bearer list + assistant-control flag are non-critical: a failure must not
+  // block the rest of the tab, so they're fetched outside the main mount
+  // Promise.all and swallow errors to a quiet log.
+  const refreshActiveBearers = async (): Promise<void> => {
+    try {
+      const bearers = await window.electron.mcpServer.listActiveBearers();
+      setActiveBearers(bearers);
+    } catch (err) {
+      logError("Failed to load MCP active bearers", err);
+    }
+  };
+
+  const refreshAssistantControl = async (): Promise<void> => {
+    try {
+      const settings = await window.electron.helpAssistant?.getSettings();
+      setKeptAliveByAssistant(settings?.daintreeControl === true);
+    } catch (err) {
+      logError("Failed to load Daintree Assistant settings", err);
+    }
+  };
 
   const refreshAuditRecords = async (): Promise<void> => {
     try {
@@ -162,6 +195,9 @@ export function McpServerSettingsTab() {
         setAuditLoading(false);
       });
 
+    void refreshActiveBearers();
+    void refreshAssistantControl();
+
     const unsub = window.electron.mcpServer.onRuntimeStateChanged(() => {
       if (!settled) return;
       window.electron.mcpServer
@@ -176,6 +212,10 @@ export function McpServerSettingsTab() {
         .catch((err) => {
           logError("Failed to refresh MCP status on runtime change", err);
         });
+      // A runtime-state push fires on connect/disconnect, server restart, and
+      // the assistant toggling `daintreeControl` — refresh both derived views.
+      void refreshActiveBearers();
+      void refreshAssistantControl();
     });
 
     return () => {
@@ -418,6 +458,21 @@ export function McpServerSettingsTab() {
     }
   };
 
+  const handleDisconnectBearer = async (tokenHash: string) => {
+    if (disconnectingHash) return;
+    setDisconnectingHash(tokenHash);
+    try {
+      setError(null);
+      await window.electron.mcpServer.disconnectBearer(tokenHash);
+      await refreshActiveBearers();
+    } catch (err) {
+      setError(formatErrorMessage(err, "Failed to disconnect client"));
+      logError("Failed to disconnect MCP client", err);
+    } finally {
+      setDisconnectingHash(null);
+    }
+  };
+
   const sseUrl = status.port ? `http://127.0.0.1:${status.port}/sse` : null;
 
   // Rotation is the revoke-all primitive — it invalidates every external
@@ -435,6 +490,9 @@ export function McpServerSettingsTab() {
         onChange={handleToggle}
         ariaLabel="Enable MCP server"
         disabled={loading}
+        lifecycleBadge={
+          status.enabled && keptAliveByAssistant ? "Kept alive by Daintree Assistant" : undefined
+        }
       />
 
       {!status.enabled && !loading && !error && (
@@ -497,6 +555,58 @@ export function McpServerSettingsTab() {
                   Paste the copied config into your MCP client (e.g. Claude Code, Cursor).
                   {status.apiKey && " The config includes the authorization header."}
                 </p>
+
+                {activeBearers.length > 0 && (
+                  <div className="rounded-[var(--radius-md)] border border-daintree-border overflow-hidden">
+                    <button
+                      type="button"
+                      onClick={() => setBearersExpanded((v) => !v)}
+                      aria-expanded={bearersExpanded}
+                      className="flex w-full items-center gap-2 px-3 py-2 text-xs font-medium text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
+                    >
+                      <ChevronRight
+                        className={cn(
+                          "w-3.5 h-3.5 shrink-0 transition-transform duration-150",
+                          bearersExpanded && "rotate-90"
+                        )}
+                      />
+                      <Plug className="w-3.5 h-3.5 shrink-0 text-daintree-text/50" />
+                      External clients ({activeBearers.length})
+                    </button>
+
+                    {bearersExpanded && (
+                      <ul className="border-t border-daintree-border divide-y divide-daintree-border">
+                        {activeBearers.map((bearer) => (
+                          <li key={bearer.tokenHash} className="flex items-center gap-3 px-3 py-2">
+                            <div className="min-w-0 flex-1">
+                              <div className="truncate text-xs text-daintree-text/80">
+                                {bearer.userAgent}
+                              </div>
+                              <div className="text-[11px] text-daintree-text/50">
+                                <span className="font-mono">…{bearer.token4LastChars}</span>
+                                {" · "}
+                                {bearer.requestsSinceLaunch}{" "}
+                                {bearer.requestsSinceLaunch === 1 ? "session" : "sessions"}
+                                {" · active "}
+                                {formatRelativeTime(bearer.lastActiveAt)}
+                              </div>
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => void handleDisconnectBearer(bearer.tokenHash)}
+                              disabled={disconnectingHash !== null}
+                              className="shrink-0 px-2.5 py-1 text-xs font-medium rounded-[var(--radius-md)] border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                            >
+                              {disconnectingHash === bearer.tokenHash
+                                ? "Disconnecting…"
+                                : "Disconnect"}
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                )}
               </div>
             ) : (
               <p className="text-xs text-daintree-text/50">Server is starting…</p>

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -27,7 +27,6 @@ import { useDeferredLoading } from "@/hooks";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { logError } from "@/utils/logger";
 import {
   type McpActiveClientInfo,
@@ -586,7 +585,7 @@ export function McpServerSettingsTab() {
                                 <span className="font-mono">…{bearer.token4LastChars}</span>
                                 {" · "}
                                 {bearer.requestsSinceLaunch}{" "}
-                                {bearer.requestsSinceLaunch === 1 ? "session" : "sessions"}
+                                {bearer.requestsSinceLaunch === 1 ? "request" : "requests"}
                                 {" · active "}
                                 {formatRelativeTime(bearer.lastActiveAt)}
                               </div>

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -1241,6 +1241,30 @@ describe("McpServerSettingsTab", () => {
       });
     });
 
+    it("populates the clients row when a runtime-state change fires after mount", async () => {
+      let runtimeCb: (() => void) | undefined;
+      const onRuntimeStateChanged = vi.fn((cb: () => void) => {
+        runtimeCb = cb;
+        return vi.fn();
+      });
+      const listActiveBearers = vi
+        .fn()
+        .mockResolvedValueOnce([]) // initial mount: nothing connected
+        .mockResolvedValue([bearer]); // after the push: one client
+      installMcpApi({ onRuntimeStateChanged, listActiveBearers });
+
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "API key active");
+      expect(container.textContent).not.toContain("External clients");
+
+      runtimeCb?.();
+      await waitForContent(container, "External clients (1)");
+    });
+
     it("shows the assistant-attribution pill only when daintreeControl is on", async () => {
       installMcpApi({}, { getSettings: vi.fn().mockResolvedValue({ daintreeControl: true }) });
 

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -92,15 +92,25 @@ function createMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {})
     getTurnOutcomeRecords: vi.fn().mockResolvedValue([]),
     clearTurnOutcomeLog: vi.fn().mockResolvedValue(undefined),
     onRuntimeStateChanged: vi.fn().mockReturnValue(vi.fn()),
+    listActiveBearers: vi.fn().mockResolvedValue([]),
+    disconnectBearer: vi.fn().mockResolvedValue({ tokenHash: "", disconnected: true }),
     ...overrides,
   };
 }
 
 const writeText = vi.fn().mockResolvedValue(undefined);
 
-function installMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {}) {
+function installMcpApi(
+  overrides: Partial<typeof window.electron.mcpServer> = {},
+  helpAssistantOverrides: Partial<typeof window.electron.helpAssistant> = {}
+) {
   window.electron = {
     mcpServer: createMcpApi(overrides),
+    helpAssistant: {
+      getSettings: vi.fn().mockResolvedValue({ daintreeControl: false }),
+      setSettings: vi.fn().mockResolvedValue(undefined),
+      ...helpAssistantOverrides,
+    },
   } as unknown as typeof window.electron;
 }
 
@@ -1181,6 +1191,75 @@ describe("McpServerSettingsTab", () => {
     await waitFor(() => {
       const copiedEls = screen.getAllByText("Copied!");
       expect(copiedEls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("external clients (#8778)", () => {
+    const bearer = {
+      tokenHash: "a".repeat(64),
+      token4LastChars: "wxyz",
+      userAgent: "Claude Code/1.2.3",
+      lastActiveAt: Date.now() - 5000,
+      requestsSinceLaunch: 3,
+    };
+
+    it("hides the external-clients row when no bearers are connected", async () => {
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "API key active");
+      expect(container.textContent).not.toContain("External clients");
+    });
+
+    it("shows connected clients and disconnects one on demand", async () => {
+      const disconnectBearer = vi
+        .fn()
+        .mockResolvedValue({ tokenHash: bearer.tokenHash, disconnected: true });
+      const listActiveBearers = vi.fn().mockResolvedValueOnce([bearer]).mockResolvedValue([]);
+      installMcpApi({ listActiveBearers, disconnectBearer });
+
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "External clients (1)");
+
+      fireEvent.click(screen.getByRole("button", { name: /external clients/i }));
+      await waitFor(() => {
+        expect(container.textContent).toContain("Claude Code/1.2.3");
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+      await waitFor(() => {
+        expect(disconnectBearer).toHaveBeenCalledWith(bearer.tokenHash);
+      });
+      await waitFor(() => {
+        expect(container.textContent).not.toContain("External clients");
+      });
+    });
+
+    it("shows the assistant-attribution pill only when daintreeControl is on", async () => {
+      installMcpApi({}, { getSettings: vi.fn().mockResolvedValue({ daintreeControl: true }) });
+
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "Kept alive by Daintree Assistant");
+    });
+
+    it("omits the attribution pill when daintreeControl is off", async () => {
+      const { container } = render(
+        <SettingsValidationProvider>
+          <McpServerSettingsTab />
+        </SettingsValidationProvider>
+      );
+      await waitForContent(container, "API key active");
+      expect(container.textContent).not.toContain("Kept alive by Daintree Assistant");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a live per-bearer connection register to `HttpLifecycle`, keyed on SHA-256 of the `Authorization` header, tracking `userAgent`, `lastActiveAt`, and `requestsSinceLaunch` per external-tier bearer
- Wires two new IPC methods — `mcpServer.listActiveBearers` and `mcpServer.disconnectBearer` — through preload and codegen
- Adds an `External clients (N)` expandable disclosure under the Connection section on the MCP Server settings tab, showing relative timestamps and a per-row Disconnect; adds a neutral "Kept alive by Daintree Assistant" attribution pill on the toggle card when `daintreeControl` is on

Resolves #8778

## Changes

- `electron/services/mcp-server/httpLifecycle.ts` — bearer register updated on each authenticated request; `listActiveBearers()` and `disconnectBearer(tokenHash)` added; help-session and pane-tier tokens excluded so users can't disconnect their own assistant
- `electron/services/McpServerService.ts` — exposes register methods to IPC layer
- `electron/ipc/handlers/mcpServer.ts` / `mcpServer.preload.ts` — two new IPC handlers + preload bindings
- `shared/types/ipc/mcpServer.ts` / `generated.ts` / `generated-api.ts` / `index.ts` — `ActiveBearer` type + generated mappings
- `src/components/Settings/McpServerSettingsTab.tsx` — `ExternalClientsDisclosure` component + attribution pill; raw tokens never cross IPC, only the 4-char suffix and token hash
- Tests updated across `httpLifecycle.test.ts`, `sessionStore.test.ts`, `mcpServer.adversarial.test.ts`, and `McpServerSettingsTab.test.tsx`

## Testing

- Unit tests added for the bearer register (register on auth, evict stale, disconnect by hash, exclude non-external tiers)
- `McpServerSettingsTab` tests extended to cover the disclosure expanded/collapsed states, relative timestamp rendering, and Disconnect call
- Adversarial test suite updated for the new bearer register surface
- Typecheck, lint, and format pass clean