### PR TITLE
feat(help): show pinned ActionContext binding in HelpPanel footer

### DIFF
--- a/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
+++ b/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
@@ -80,6 +80,9 @@ describe("leaf preload namespace bindings", () => {
       expect(HELP_METHOD_CHANNELS.getFolderPath).toBe(CHANNELS.HELP_GET_FOLDER_PATH);
       expect(HELP_METHOD_CHANNELS.markTerminal).toBe(CHANNELS.HELP_MARK_TERMINAL);
       expect(HELP_METHOD_CHANNELS.unmarkTerminal).toBe(CHANNELS.HELP_UNMARK_TERMINAL);
+      expect(HELP_METHOD_CHANNELS.getPinnedActionContext).toBe(
+        CHANNELS.HELP_GET_PINNED_ACTION_CONTEXT
+      );
     });
 
     it("accessibility matches", () => {
@@ -339,6 +342,16 @@ describe("leaf preload namespace bindings", () => {
 
       expect(invoke).toHaveBeenCalledTimes(1);
       expect(invoke).toHaveBeenCalledWith("help:unmark-terminal", "term-1");
+    });
+
+    it("routes getPinnedActionContext() to help:get-pinned-action-context with the sessionId forwarded", async () => {
+      const invoke = vi.fn().mockResolvedValue(null);
+      const bindings = buildHelpPreloadBindings(invoke);
+
+      await bindings.getPinnedActionContext("session-7");
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("help:get-pinned-action-context", "session-7");
     });
   });
 

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -486,6 +486,7 @@ export const CHANNELS = {
   HELP_PROVISION_SESSION: "help:provision-session",
   HELP_REVOKE_SESSION: "help:revoke-session",
   HELP_TAKE_PENDING_HIBERNATION: "help:take-pending-hibernation",
+  HELP_GET_PINNED_ACTION_CONTEXT: "help:get-pinned-action-context",
 
   CLIPBOARD_SAVE_IMAGE: "clipboard:save-image",
   CLIPBOARD_THUMBNAIL_FROM_PATH: "clipboard:thumbnail-from-path",

--- a/electron/ipc/handlers/__tests__/help.pinnedSnapshot.test.ts
+++ b/electron/ipc/handlers/__tests__/help.pinnedSnapshot.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { pinnedSnapshotFromContext } from "../help.js";
+
+describe("pinnedSnapshotFromContext (#8772)", () => {
+  it("projects the active worktree triple, never the focused worktree id", () => {
+    // Regression guard: the id/name/branch must come from the same (active)
+    // worktree so the chip never labels one worktree with another's name.
+    const snapshot = pinnedSnapshotFromContext({
+      focusedWorktreeId: "wt-focused",
+      activeWorktreeId: "wt-active",
+      activeWorktreeName: "main",
+      activeWorktreeBranch: "develop",
+      focusedTerminalId: "term-1",
+    });
+    expect(snapshot).toEqual({
+      worktreeId: "wt-active",
+      worktreeName: "main",
+      worktreeBranch: "develop",
+      terminalId: "term-1",
+    });
+  });
+
+  it("returns null for a null context", () => {
+    expect(pinnedSnapshotFromContext(null)).toBeNull();
+  });
+
+  it("suppresses the snapshot when neither worktree nor terminal is present", () => {
+    expect(pinnedSnapshotFromContext({ dispatchSource: "user" })).toBeNull();
+  });
+
+  it("keeps a terminal-only context (worktreeId null) since the terminal is still actionable", () => {
+    expect(pinnedSnapshotFromContext({ focusedTerminalId: "term-9" })).toEqual({
+      worktreeId: null,
+      worktreeName: null,
+      worktreeBranch: null,
+      terminalId: "term-9",
+    });
+  });
+});

--- a/electron/ipc/handlers/help.preload.ts
+++ b/electron/ipc/handlers/help.preload.ts
@@ -7,6 +7,7 @@ export const HELP_METHOD_CHANNELS = {
   provisionSession: "help:provision-session",
   revokeSession: "help:revoke-session",
   takePendingHibernation: "help:take-pending-hibernation",
+  getPinnedActionContext: "help:get-pinned-action-context",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof HELP_METHOD_CHANNELS;

--- a/electron/ipc/handlers/help.ts
+++ b/electron/ipc/handlers/help.ts
@@ -72,22 +72,46 @@ async function handleProvisionSession(
   });
 }
 
+/**
+ * Projects an `ActionContext` onto the narrow, display-only snapshot the
+ * HelpPanel footer renders (#8772). Always reads the *active* worktree triple
+ * together — `ActionContext` only carries name/branch for the active worktree,
+ * so mixing in `focusedWorktreeId` would yield an id that doesn't match the
+ * name/branch beside it. The session's tool calls target the active worktree
+ * anyway. Returns null when the snapshot carries no identifying target (neither
+ * worktree nor terminal), so the chip is suppressed rather than rendered empty.
+ */
+export function pinnedSnapshotFromContext(
+  context: ActionContext | null
+): PinnedActionContextSnapshot | null {
+  if (!context) return null;
+  const worktreeId = context.activeWorktreeId ?? null;
+  const worktreeName = context.activeWorktreeName ?? null;
+  const worktreeBranch = context.activeWorktreeBranch ?? null;
+  const terminalId = context.focusedTerminalId ?? null;
+  if (worktreeId === null && terminalId === null) return null;
+  return { worktreeId, worktreeName, worktreeBranch, terminalId };
+}
+
 async function handleGetPinnedActionContext(
+  ctx: import("../types.js").IpcContext,
   sessionId: string
 ): Promise<PinnedActionContextSnapshot | null> {
   if (typeof sessionId !== "string" || !sessionId) return null;
   const { helpSessionService } = await getHelpSessionService();
-  const context = helpSessionService.getActionContextForSessionId(sessionId);
-  if (!context) return null;
-  const worktreeId = context.focusedWorktreeId ?? context.activeWorktreeId ?? null;
-  const worktreeName = context.activeWorktreeName ?? null;
-  const worktreeBranch = context.activeWorktreeBranch ?? null;
-  const terminalId = context.focusedTerminalId ?? null;
-  // Suppress the chip entirely when the snapshot carries no identifying
-  // target — a context with neither worktree nor terminal tells the user
-  // nothing actionable.
-  if (worktreeId === null && terminalId === null) return null;
-  return { worktreeId, worktreeName, worktreeBranch, terminalId };
+  // Per-window pin (#7002): only the renderer that minted the session may
+  // read its pinned context. The data is display-only (no token), but
+  // refusing cross-window reads keeps the namespace consistent with the rest
+  // of the per-view isolation discipline.
+  const ownerWebContentsId = helpSessionService.getWebContentsIdForSessionId(sessionId);
+  if (ownerWebContentsId !== null && ownerWebContentsId !== ctx.webContentsId) {
+    console.warn(
+      "[help] getPinnedActionContext: webContents mismatch — refusing cross-window read",
+      { fromWebContents: ctx.webContentsId, owner: ownerWebContentsId }
+    );
+    return null;
+  }
+  return pinnedSnapshotFromContext(helpSessionService.getActionContextForSessionId(sessionId));
 }
 
 async function handleRevokeSession(sessionId: string): Promise<void> {
@@ -133,7 +157,8 @@ export const helpNamespace = defineIpcNamespace({
     revokeSession: op(HELP_METHOD_CHANNELS.revokeSession, handleRevokeSession),
     getPinnedActionContext: op(
       HELP_METHOD_CHANNELS.getPinnedActionContext,
-      handleGetPinnedActionContext
+      handleGetPinnedActionContext,
+      { withContext: true }
     ),
     takePendingHibernation: op(
       HELP_METHOD_CHANNELS.takePendingHibernation,

--- a/electron/ipc/handlers/help.ts
+++ b/electron/ipc/handlers/help.ts
@@ -5,6 +5,7 @@ import type * as HelpSessionServiceModule from "../../services/HelpSessionServic
 import { getAgentAvailabilityStore } from "../../services/AgentAvailabilityStore.js";
 import type { HelpAssistantTier } from "../../../shared/types/ipc/maps.js";
 import type { ActionContext } from "../../../shared/types/actions.js";
+import type { PinnedActionContextSnapshot } from "../../../shared/types/ipc/help.js";
 
 let cachedHelpService: typeof HelpServiceModule | null = null;
 async function getHelpService(): Promise<typeof HelpServiceModule> {
@@ -71,6 +72,24 @@ async function handleProvisionSession(
   });
 }
 
+async function handleGetPinnedActionContext(
+  sessionId: string
+): Promise<PinnedActionContextSnapshot | null> {
+  if (typeof sessionId !== "string" || !sessionId) return null;
+  const { helpSessionService } = await getHelpSessionService();
+  const context = helpSessionService.getActionContextForSessionId(sessionId);
+  if (!context) return null;
+  const worktreeId = context.focusedWorktreeId ?? context.activeWorktreeId ?? null;
+  const worktreeName = context.activeWorktreeName ?? null;
+  const worktreeBranch = context.activeWorktreeBranch ?? null;
+  const terminalId = context.focusedTerminalId ?? null;
+  // Suppress the chip entirely when the snapshot carries no identifying
+  // target — a context with neither worktree nor terminal tells the user
+  // nothing actionable.
+  if (worktreeId === null && terminalId === null) return null;
+  return { worktreeId, worktreeName, worktreeBranch, terminalId };
+}
+
 async function handleRevokeSession(sessionId: string): Promise<void> {
   const { helpSessionService } = await getHelpSessionService();
   await helpSessionService.revokeSession(sessionId);
@@ -112,6 +131,10 @@ export const helpNamespace = defineIpcNamespace({
       withContext: true,
     }),
     revokeSession: op(HELP_METHOD_CHANNELS.revokeSession, handleRevokeSession),
+    getPinnedActionContext: op(
+      HELP_METHOD_CHANNELS.getPinnedActionContext,
+      handleGetPinnedActionContext
+    ),
     takePendingHibernation: op(
       HELP_METHOD_CHANNELS.takePendingHibernation,
       handleTakePendingHibernation,

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -349,6 +349,20 @@ export class HelpSessionService {
   }
 
   /**
+   * Renderer-safe sibling of `getActionContextForToken`, keyed on the public
+   * `sessionId` (persisted in `helpPanelStore`) instead of the bearer token.
+   * The HelpPanel footer uses this to surface the pinned worktree/terminal
+   * binding to the user (#8772) without the token ever crossing the IPC
+   * bridge. Returns null for unknown, revoked, or context-less sessions.
+   */
+  getActionContextForSessionId(sessionId: string): ActionContext | null {
+    if (!sessionId) return null;
+    const record = this.sessionsById.get(sessionId);
+    if (!record || record.revoked) return null;
+    return record.actionContext ?? null;
+  }
+
+  /**
    * Inverse of `terminalBySessionId` for the assistant-turn audit. Returns
    * the help-session id currently bound to a given terminal id, or null
    * when the terminal is not (or no longer) a help-session terminal. Linear

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -363,6 +363,20 @@ export class HelpSessionService {
   }
 
   /**
+   * Session-id keyed sibling of `getWebContentsIdForToken`. Lets the
+   * sessionId-facing IPC handlers (#8772) reject reads from a window other
+   * than the one that minted the session, mirroring the per-window pin from
+   * #7002 without exposing the bearer token. Returns null for unknown or
+   * revoked sessions.
+   */
+  getWebContentsIdForSessionId(sessionId: string): number | null {
+    if (!sessionId) return null;
+    const record = this.sessionsById.get(sessionId);
+    if (!record || record.revoked) return null;
+    return record.projectViewWebContentsId;
+  }
+
+  /**
    * Inverse of `terminalBySessionId` for the assistant-turn audit. Returns
    * the help-session id currently bound to a given terminal id, or null
    * when the terminal is not (or no longer) a help-session terminal. Linear

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -474,6 +474,32 @@ describe("HelpSessionService", () => {
     expect(service.getActionContextForToken(noCtx.token)).toBeNull();
   });
 
+  it("getActionContextForSessionId returns the snapshot keyed on the public session id and null for unknown / revoked / context-less sessions (#8772)", async () => {
+    const withCtx = await service.provisionSession({
+      ...provisionInput(),
+      actionContext: { focusedWorktreeId: "wt-1", focusedTerminalId: "term-9" },
+    });
+    if (!withCtx) throw new Error("expected result");
+
+    expect(service.getActionContextForSessionId(withCtx.sessionId)).toEqual({
+      focusedWorktreeId: "wt-1",
+      focusedTerminalId: "term-9",
+    });
+    expect(service.getActionContextForSessionId("not-a-real-session")).toBeNull();
+    expect(service.getActionContextForSessionId("")).toBeNull();
+
+    await service.revokeSession(withCtx.sessionId);
+    expect(service.getActionContextForSessionId(withCtx.sessionId)).toBeNull();
+
+    const noCtx = await service.provisionSession({
+      ...provisionInput(),
+      projectId: "proj-noctx-sid",
+      projectPath: "/tmp/proj-noctx-sid",
+    });
+    if (!noCtx) throw new Error("expected result");
+    expect(service.getActionContextForSessionId(noCtx.sessionId)).toBeNull();
+  });
+
   it("getWebContentsIdForToken returns the per-session pin when two sessions are minted from different views", async () => {
     // Distinct projectIds so the single-backend invariant (#7509) doesn't
     // displace `a` when `b` is provisioned. The intent of this test is the

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -129,6 +129,9 @@ export interface GeneratedElectronAPI {
     getFolderPath(
       ...args: IpcInvokeMap["help:get-folder-path"]["args"]
     ): Promise<IpcInvokeMap["help:get-folder-path"]["result"]>;
+    getPinnedActionContext(
+      ...args: IpcInvokeMap["help:get-pinned-action-context"]["args"]
+    ): Promise<IpcInvokeMap["help:get-pinned-action-context"]["result"]>;
     markTerminal(
       ...args: IpcInvokeMap["help:mark-terminal"]["args"]
     ): Promise<IpcInvokeMap["help:mark-terminal"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -297,6 +297,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: string | null;
   };
+  "help:get-pinned-action-context": {
+    args: [sessionId: string];
+    result: import("./help.js").PinnedActionContextSnapshot | null;
+  };
   "help:mark-terminal": {
     args: [terminalId: string];
     result: void;

--- a/shared/types/ipc/help.ts
+++ b/shared/types/ipc/help.ts
@@ -1,0 +1,14 @@
+/**
+ * Narrow, display-only projection of the `ActionContext` snapshot pinned to a
+ * help session at provision time (#8772). Returned by
+ * `help:get-pinned-action-context` so the HelpPanel footer can show which
+ * worktree/terminal the assistant's tool calls are bound to. Deliberately
+ * excludes the bearer token and runtime-only fields (`dispatchSource`, etc.) —
+ * only the fields the footer chip renders are exposed across the bridge.
+ */
+export interface PinnedActionContextSnapshot {
+  worktreeId: string | null;
+  worktreeName: string | null;
+  worktreeBranch: string | null;
+  terminalId: string | null;
+}

--- a/shared/types/ipc/index.ts
+++ b/shared/types/ipc/index.ts
@@ -27,3 +27,4 @@ export * from "./crashRecovery.js";
 export * from "./webviewConsole.js";
 export * from "./demo.js";
 export * from "./telemetryPreview.js";
+export * from "./help.js";

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -199,7 +199,9 @@ export function HelpPanel({
     pinnedContext?.terminalId != null &&
     (!pinnedTerminalPanel || pinnedTerminalPanel.exitCode !== undefined);
   const isPinnedWorktreeDiverged =
-    pinnedContext?.worktreeId != null && pinnedContext.worktreeId !== focusedWorktreeId;
+    pinnedContext?.worktreeId != null &&
+    focusedWorktreeId !== null &&
+    pinnedContext.worktreeId !== focusedWorktreeId;
 
   const agentConfig = agentId ? getAgentConfig(agentId) : undefined;
   const effectiveAgentId = isBuiltInAgentId(agentId) ? agentId : undefined;

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -44,6 +44,7 @@ import { useEscapeStack } from "@/hooks/useEscapeStack";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { TerminalRefreshTier } from "@/types";
 import { CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
+import type { PinnedActionContextSnapshot } from "@shared/types/ipc/help";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { TABBABLE_SELECTOR } from "@/lib/accessibility";
 import { HelpSessionController } from "@/controllers/HelpSessionController";
@@ -129,6 +130,7 @@ export function HelpPanel({
     isOpen,
     width,
     terminalId,
+    sessionId,
     agentId,
     preferredAgentId,
     droppedPreferredAgentId,
@@ -159,6 +161,45 @@ export function HelpPanel({
   const cliHasRealData = useCliAvailabilityStore((s) => s.hasRealData);
   const currentProject = useProjectStore((s) => s.currentProject);
   const hybridInputEnabled = useTerminalInputStore((s) => s.hybridInputEnabled);
+
+  // The ActionContext pinned to this session at launch (#8772). Fetched once
+  // per session id — the binding is fixed at provision time and only changes
+  // when the session itself is replaced, which swaps `sessionId`. The token
+  // never crosses the bridge; the getter is keyed on the public session id.
+  const [pinnedContext, setPinnedContext] = useState<PinnedActionContextSnapshot | null>(null);
+  useEffect(() => {
+    if (!sessionId) {
+      setPinnedContext(null);
+      return;
+    }
+    let cancelled = false;
+    void window.electron.help
+      .getPinnedActionContext(sessionId)
+      .then((snapshot) => {
+        if (!cancelled) setPinnedContext(snapshot);
+      })
+      .catch((err) => {
+        logWarn("HelpPanel: failed to fetch pinned action context", err);
+        if (!cancelled) setPinnedContext(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  const focusedWorktreeId = useWorktreeSelectionStore((s) => s.focusedWorktreeId);
+  const pinnedTerminalPanel = usePanelStore((s) =>
+    pinnedContext?.terminalId ? s.panelsById[pinnedContext.terminalId] : undefined
+  );
+  // Escalation: danger when the pinned terminal is gone or has exited (its
+  // PTY can no longer receive dispatched commands), warning when the user has
+  // since focused a different worktree than the one the session is bound to.
+  // Danger wins — a dead target is the more urgent mismatch.
+  const isPinnedTerminalDead =
+    pinnedContext?.terminalId != null &&
+    (!pinnedTerminalPanel || pinnedTerminalPanel.exitCode !== undefined);
+  const isPinnedWorktreeDiverged =
+    pinnedContext?.worktreeId != null && pinnedContext.worktreeId !== focusedWorktreeId;
 
   const agentConfig = agentId ? getAgentConfig(agentId) : undefined;
   const effectiveAgentId = isBuiltInAgentId(agentId) ? agentId : undefined;
@@ -729,26 +770,57 @@ export function HelpPanel({
 
       {/* Bottom info bar */}
       {showTerminal && agentConfig && !isMissingCli && (
-        <div className="flex items-center justify-between px-3 py-1.5 border-t border-daintree-border shrink-0 text-[11px] text-daintree-text/40">
-          <span className="flex items-center gap-1">
-            Using
-            <agentConfig.icon className="w-3.5 h-3.5" />
-            {agentConfig.name}
-          </span>
-          <button
-            type="button"
-            onClick={() =>
-              void actionService.dispatch(
-                "system.openExternal",
-                { url: DAINTREE_HOME_URL },
-                { source: "user" }
-              )
-            }
-            className="flex items-center gap-1 hover:text-daintree-text/60 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-          >
-            <DaintreeIcon className="w-3.5 h-3.5" />
-            Daintree.org
-          </button>
+        <div className="flex flex-col gap-1 border-t border-daintree-border shrink-0 px-3 py-1.5 text-[11px] text-daintree-text/40">
+          {pinnedContext && (
+            <span
+              className="flex items-center gap-1.5 min-w-0"
+              title={
+                isPinnedTerminalDead
+                  ? "The terminal this assistant was pinned to has closed — its tool calls can't reach it."
+                  : isPinnedWorktreeDiverged
+                    ? "This assistant is pinned to a different worktree than the one you have focused."
+                    : "Assistant tool calls are pinned to this worktree and terminal."
+              }
+            >
+              <span
+                aria-hidden
+                className={cn(
+                  "w-1.5 h-1.5 rounded-full shrink-0",
+                  isPinnedTerminalDead
+                    ? "bg-status-danger"
+                    : isPinnedWorktreeDiverged
+                      ? "bg-status-warning"
+                      : "bg-daintree-text/30"
+                )}
+              />
+              <span className="truncate">
+                {[pinnedContext.worktreeName, pinnedContext.worktreeBranch]
+                  .filter(Boolean)
+                  .join(" · ") || "Pinned session"}
+              </span>
+            </span>
+          )}
+          <div className="flex items-center justify-between">
+            <span className="flex items-center gap-1">
+              Using
+              <agentConfig.icon className="w-3.5 h-3.5" />
+              {agentConfig.name}
+            </span>
+            <button
+              type="button"
+              onClick={() =>
+                void actionService.dispatch(
+                  "system.openExternal",
+                  { url: DAINTREE_HOME_URL },
+                  { source: "user" }
+                )
+              }
+              className="flex items-center gap-1 hover:text-daintree-text/60 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+            >
+              <DaintreeIcon className="w-3.5 h-3.5" />
+              Daintree.org
+            </button>
+          </div>
         </div>
       )}
       <ConfirmDialog

--- a/src/components/HelpPanel/__tests__/HelpPanel.agentSwitch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.agentSwitch.test.tsx
@@ -90,7 +90,9 @@ vi.mock("@shared/config/agentIds", () => ({
 }));
 vi.mock("../../../shared/utils/agentAvailability", () => ({ isAgentInstalled: () => true }));
 vi.mock("@/lib/accessibility", () => ({ TABBABLE_SELECTOR: "button" }));
-vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: vi.fn() } }));
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn(), getContext: () => ({}) },
+}));
 vi.mock("@/lib/sidebarToggle", () => ({ suppressSidebarResizes: vi.fn() }));
 vi.mock("@/hooks/useEscapeStack", () => ({ useEscapeStack: vi.fn() }));
 vi.mock("@/types", () => ({ TerminalRefreshTier: { BACKGROUND: 0, ACTIVE: 1 } }));
@@ -208,6 +210,18 @@ function resetState() {
 beforeEach(() => {
   vi.clearAllMocks();
   resetState();
+
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      electron: {
+        help: {
+          getPinnedActionContext: vi.fn().mockResolvedValue({}),
+        },
+      },
+    },
+    writable: true,
+    configurable: true,
+  });
 });
 
 function bindTerminal(agentId: string, agentState = "idle") {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -217,7 +217,10 @@ vi.mock("@/config/agents", () => ({
 }));
 
 vi.mock("@/services/ActionService", () => ({
-  actionService: { dispatch: (...args: unknown[]) => mockDispatch(...args) },
+  actionService: {
+    dispatch: (...args: unknown[]) => mockDispatch(...args),
+    getContext: () => ({}),
+  },
 }));
 
 vi.mock("@/lib/notify", () => ({
@@ -456,6 +459,7 @@ beforeEach(() => {
           provisionSession: mockProvisionSession,
           revokeSession: mockRevokeSession,
           takePendingHibernation: mockTakePendingHibernation,
+          getPinnedActionContext: vi.fn().mockResolvedValue({}),
         },
         helpAssistant: {
           getSettings: mockGetHelpAssistantSettings,
@@ -630,6 +634,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
       projectId: "proj-default",
       projectPath: "/repo",
       agentId: "claude",
+      context: {},
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
@@ -658,6 +663,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
       projectId: "proj-late",
       projectPath: "/late-repo",
       agentId: "claude",
+      context: {},
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
@@ -775,6 +781,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
       projectId: "proj-default",
       projectPath: "/repo",
       agentId: "codex",
+      context: {},
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
@@ -1197,6 +1204,7 @@ describe("HelpPanel — session provisioning", () => {
       projectId: "proj-1",
       projectPath: "/repo",
       agentId: "claude",
+      context: {},
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -179,7 +179,10 @@ vi.mock("@shared/types/agentSettings", () => ({
 }));
 
 vi.mock("@/services/ActionService", () => ({
-  actionService: { dispatch: (...args: unknown[]) => mockDispatch(...args) },
+  actionService: {
+    dispatch: (...args: unknown[]) => mockDispatch(...args),
+    getContext: () => ({}),
+  },
 }));
 
 vi.mock("@/lib/notify", () => ({
@@ -392,6 +395,7 @@ beforeEach(() => {
           markTerminal: mockMarkTerminal,
           provisionSession: mockProvisionSession,
           revokeSession: mockRevokeSession,
+          getPinnedActionContext: vi.fn().mockResolvedValue({}),
         },
         helpAssistant: {
           getSettings: mockGetHelpAssistantSettings,

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -16,6 +16,7 @@ import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import type { ActionContext } from "@shared/types/actions";
 import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
 import { buildResumeCommand, buildResumeLatestCommand } from "@shared/types/agentSettings";
 import { resolveDaintreeMcpTier } from "@shared/types/project";
@@ -137,13 +138,15 @@ type ProvisionOutcome =
 
 async function provisionHelpSession(
   project: HelpProjectRef,
-  agentId: string
+  agentId: string,
+  context?: ActionContext
 ): Promise<ProvisionOutcome> {
   try {
     const result = await window.electron.help.provisionSession({
       projectId: project.id,
       projectPath: project.path,
       agentId,
+      ...(context && { context }),
     });
     if (!result) {
       return {
@@ -565,6 +568,12 @@ export class HelpSessionController {
     const launchProject = inputs.currentProject;
     this._isLaunching = true;
 
+    // Snapshot the focused worktree/terminal synchronously before any await
+    // so the session is pinned to what the user had focused at launch — the
+    // HelpPanel footer chip surfaces this binding (#8772), and pinned tool
+    // dispatch relies on the same snapshot (#8317).
+    const launchContext = actionService.getContext();
+
     const gen = ++this._launchGen;
     const replaceExisting = options.replaceExisting === true;
     const reservedId = options.requestedId ?? null;
@@ -602,7 +611,7 @@ export class HelpSessionController {
       useHelpPanelStore.getState().setTerminal(reservedId, launchAgentId, null);
     }
 
-    safeFireAndForget(this._executeLaunch(gen, options, launchProject, presetEnv), {
+    safeFireAndForget(this._executeLaunch(gen, options, launchProject, presetEnv, launchContext), {
       context: reservedId
         ? options.force
           ? "Help: run-anyway re-launch"
@@ -1017,7 +1026,9 @@ export class HelpSessionController {
       const launchProject = inputs.currentProject;
       this._hasAutoLaunched = true;
       const gen = ++this._launchGen;
-      safeFireAndForget(this._executeAutoLaunch(gen, launchAgentId, launchProject), {
+      // Snapshot focus synchronously before the async launch — see launch().
+      const launchContext = actionService.getContext();
+      safeFireAndForget(this._executeAutoLaunch(gen, launchAgentId, launchProject, launchContext), {
         context: "Auto-launching preferred help agent",
       });
       return;
@@ -1069,7 +1080,8 @@ export class HelpSessionController {
   private async _executeAutoLaunch(
     gen: number,
     launchAgentId: string,
-    launchProject: HelpProjectRef
+    launchProject: HelpProjectRef,
+    launchContext?: ActionContext
   ): Promise<void> {
     let session: HelpSessionRef | null = null;
     try {
@@ -1111,7 +1123,7 @@ export class HelpSessionController {
       this._hasBlockedThisSession = false;
       this._patch({ assistantVersionTooOld: null });
 
-      const outcome = await provisionHelpSession(launchProject, launchAgentId);
+      const outcome = await provisionHelpSession(launchProject, launchAgentId, launchContext);
       if (gen !== this._launchGen) {
         if (outcome.ok) session = outcome.session;
         this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
@@ -1247,7 +1259,8 @@ export class HelpSessionController {
     gen: number,
     options: HelpLaunchOptions,
     launchProject: HelpProjectRef,
-    presetEnv: Record<string, string> | undefined
+    presetEnv: Record<string, string> | undefined,
+    launchContext?: ActionContext
   ): Promise<void> {
     const launchAgentId = options.agentId;
     const reservedId = options.requestedId ?? null;
@@ -1295,7 +1308,7 @@ export class HelpSessionController {
         this._patch({ assistantVersionTooOld: null });
       }
 
-      const outcome = await provisionHelpSession(launchProject, launchAgentId);
+      const outcome = await provisionHelpSession(launchProject, launchAgentId, launchContext);
       if (gen !== this._launchGen) {
         if (outcome.ok) session = outcome.session;
         this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });


### PR DESCRIPTION
## Summary

- Adds a footer chip to `HelpPanel` showing which worktree and terminal the assistant's tool calls are targeting — previously there was no way to tell from the UI what context was actually pinned
- Adds `help:get-pinned-action-context`, a new per-window IPC getter that exposes the pinned context without leaking the bearer token to the renderer
- Threads `actionService.getContext()` through both the controller launch and auto-launch paths so the binding is actually recorded (sessions were previously provisioned with no context)

Resolves #8772

## Changes

- `electron/ipc/channels.ts`, `help.ts`, `help.preload.ts` — new `help:get-pinned-action-context` IPC handler, scoped per window via `WindowContext`
- `shared/types/ipc/help.ts`, `generated.ts`, `generated-api.ts` — IPC type definitions and codegen output
- `electron/services/HelpSessionService.ts` — `getPinnedActionContext()` method that returns worktree path, branch, terminal ID, and liveness without exposing session tokens
- `src/controllers/HelpSessionController.ts` — context threaded through `launch()` and `autoLaunch()` so the binding is stored on session creation
- `src/components/HelpPanel/HelpPanel.tsx` — footer chip with three states: neutral dot (everything aligned), `status-warning` (focused worktree diverges from pinned), `status-danger` (pinned terminal is dead)

## Testing

- Unit tests cover the new IPC handler snapshot, `HelpSessionService.getPinnedActionContext()`, and the updated `HelpPanel` (agent switch, help launch, and hibernate flows all stub the new mocks)
- `leafPreloadNamespaces` test updated to cover the new preload export
- All 26 096 Vitest tests passing; typecheck, lint, format clean