### PR TITLE
feat(help): surface launch FSM phase in HelpPanel during auto-launch

### DIFF
--- a/src/components/HelpPanel/HelpLaunchingState.tsx
+++ b/src/components/HelpPanel/HelpLaunchingState.tsx
@@ -1,0 +1,65 @@
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
+import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
+import type { HelpSessionPhase } from "@/controllers/HelpSessionController";
+
+interface HelpLaunchingStateProps {
+  /** Current launch FSM phase. The parent only mounts this for non-idle/non-live phases. */
+  phase: HelpSessionPhase;
+  /** Drives the 400ms Doherty gate — keep true while the launch is in flight. */
+  isLoading: boolean;
+  /** Aborts the in-flight launch. Surfaced as a Cancel button by `SkeletonHint` at 15s. */
+  onCancel: () => void;
+}
+
+// Exhaustive over HelpSessionPhase so adding a phase without a label fails to
+// compile. idle/live never reach the rendered skeleton (the parent gates them
+// out), so they map to an empty label.
+function phaseLabel(phase: HelpSessionPhase): string {
+  switch (phase) {
+    case "version-checking":
+      return "Checking version…";
+    case "provisioning":
+      return "Provisioning session…";
+    case "launching":
+      return "Starting assistant…";
+    case "hibernating":
+      return "Saving session…";
+    case "idle":
+    case "live":
+      return "";
+  }
+}
+
+/**
+ * Phase-labeled loading skeleton for the assistant launch sequence. Replaces
+ * the static empty state while auto-launch / select-agent runs (6–45s), so the
+ * panel proves it's working instead of looking idle. Gated behind the 400ms
+ * Doherty threshold to avoid flicker on fast launches; `SkeletonHint` escalates
+ * copy at 5s/10s and surfaces Cancel at 15s for the long tail.
+ */
+export function HelpLaunchingState({ phase, isLoading, onCancel }: HelpLaunchingStateProps) {
+  const show = useDohertyGate(isLoading);
+  if (!show) return null;
+
+  const label = phaseLabel(phase);
+
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center gap-6 p-8 relative">
+      <Skeleton label={label} className="flex flex-col items-center gap-4 w-full max-w-[28ch]">
+        <div className="w-full flex flex-col gap-2.5" aria-hidden="true">
+          <SkeletonBone className="h-3 w-3/5" />
+          <SkeletonBone className="h-2.5 w-full" />
+          <SkeletonBone className="h-2.5 w-4/5" />
+        </div>
+        <p aria-hidden="true" className="text-xs text-daintree-text/60">
+          {label}
+        </p>
+      </Skeleton>
+
+      <SkeletonHint
+        className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto"
+        onCancel={onCancel}
+      />
+    </div>
+  );
+}

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -23,6 +23,7 @@ import { HelpIntroBanner } from "./HelpIntroBanner";
 import { HelpPanelHeader } from "./HelpPanelHeader";
 import { HelpPanelBanners } from "./HelpPanelBanners";
 import { HelpPanelVersionGate } from "./HelpPanelVersionGate";
+import { HelpLaunchingState } from "./HelpLaunchingState";
 import {
   useHelpPanelStore,
   HELP_PANEL_MIN_WIDTH,
@@ -555,6 +556,7 @@ export function HelpPanel({
   const dismissTierMismatch = useCallback(() => controller.dismissTierMismatch(), [controller]);
   const approveTierOnce = useCallback(() => controller.approveTierOnce(), [controller]);
   const alwaysAllowTier = useCallback(() => controller.alwaysAllowTier(), [controller]);
+  const cancelLaunch = useCallback(() => controller.cancelLaunch(), [controller]);
 
   // Esc-to-close. The xterm-helper-textarea check lets Escape reach the
   // running PTY when the assistant terminal has focus; the .cm-editor check
@@ -700,6 +702,8 @@ export function HelpPanel({
             versionTooOld={session.assistantVersionTooOld}
             onOpenSettings={handleOpenSettings}
           />
+        ) : session.phase !== "idle" && session.phase !== "live" ? (
+          <HelpLaunchingState phase={session.phase} isLoading onCancel={cancelLaunch} />
         ) : (
           <div className="flex-1 flex flex-col">
             {droppedPreferredAgentId && (

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { render, fireEvent, act } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, fireEvent, act, screen, cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockDispatch,
@@ -420,6 +420,14 @@ function resetState() {
   });
 }
 
+afterEach(() => {
+  // Unmount any rendered HelpPanel so its controller's in-flight launch can't
+  // leak fire-and-forget state updates into the next test (#8771 added phase
+  // patches on the launch success/abandon paths, which surfaced this latent
+  // cross-test bleed).
+  cleanup();
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
   resetState();
@@ -721,6 +729,11 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
   it("does not commit terminal and cleans up if user navigated away (preferredAgentId cleared) during in-flight launch", async () => {
     helpPanelState.preferredAgentId = "claude";
     mockGetFolderPath.mockResolvedValue("/help");
+    // Two supported agents so clearing the preference doesn't trip the
+    // single-supported-agent auto-launch fallback — this test isolates the
+    // in-flight launch's cleanup, not the fallback path.
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
 
     let resolveDispatch: (v: unknown) => void = () => {};
     mockDispatch.mockReturnValue(
@@ -2793,5 +2806,54 @@ describe("HelpPanel — HybridInputBar wiring (issue #8185)", () => {
     expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
 
     document.body.removeChild(editor);
+  });
+});
+
+describe("HelpPanel — launch loading state (issue #8771)", () => {
+  it("renders the phase-labeled launch skeleton once the Doherty gate elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      helpPanelState.preferredAgentId = "claude";
+      mockGetFolderPath.mockResolvedValue("/help");
+      // Hold dispatch so the launch parks at the "launching" phase.
+      let resolveDispatch: (value: unknown) => void = () => {};
+      mockDispatch.mockReturnValue(
+        new Promise((r) => {
+          resolveDispatch = r;
+        })
+      );
+
+      await act(async () => {
+        render(<HelpPanel width={380} />);
+      });
+
+      // Drain the in-flight launch microtasks and open the 400ms gate.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(450);
+      });
+
+      // The label renders twice — once sr-only (Skeleton aria) and once visible.
+      expect(screen.getAllByText("Starting assistant…").length).toBeGreaterThan(0);
+      // The static empty-state value prop must not show while launching.
+      expect(screen.queryByText(/Use Daintree Assistant to configure/i)).toBeNull();
+
+      await act(async () => {
+        resolveDispatch({ ok: true, result: { terminalId: "term-1" } });
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not render the launch skeleton on the idle multi-agent empty state", () => {
+    helpPanelState.preferredAgentId = null;
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+
+    render(<HelpPanel width={380} />);
+
+    expect(screen.queryByText("Starting assistant…")).toBeNull();
+    expect(screen.queryByText("Provisioning session…")).toBeNull();
+    expect(screen.getByText(/Use Daintree Assistant to configure/i)).toBeTruthy();
   });
 });

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -707,7 +707,25 @@ export class HelpSessionController {
     );
   }
 
+  /**
+   * Abort an in-flight launch from the loading-state Cancel affordance.
+   * Bumps the launch generation so the in-flight async checkpoints bail at
+   * their next gen-check (cleaning up via `_abandonInFlightLaunch`), clears
+   * the reentrancy guard synchronously so a subsequent user-initiated launch
+   * isn't silently dropped, and drops the phase back to idle so the panel
+   * returns to its empty state immediately.
+   */
+  cancelLaunch(): void {
+    this._launchGen++;
+    this._isLaunching = false;
+    this._resetPhase();
+  }
+
   // --- internal ---
+
+  private _resetPhase(): void {
+    this._patch({ phase: "idle" });
+  }
 
   private _patch(partial: Partial<HelpSessionSnapshot>): void {
     // Spread-merge first, then structurally compare per-field. Reusing the
@@ -950,6 +968,13 @@ export class HelpSessionController {
       return;
     }
 
+    // Past the active-agent recheck — hibernation will actually run now, so
+    // surface it. The panel is closed during the gracefulKill window, so this
+    // is only visible if the user reopens mid-teardown (handled below); the
+    // teardown completion resets the phase so a later reopen lands on a clean
+    // empty state rather than a stuck "Saving session…".
+    this._patch({ phase: "hibernating" });
+
     // Use the projectId captured at arm time, not the live currentProject.
     // The user may have switched projects between panel close and timer
     // fire — writing project A's session into project B's hibernate slot
@@ -969,7 +994,10 @@ export class HelpSessionController {
           // in flight. Terminal is still live — don't tear it down out
           // from under them. The captured session ID is also discarded;
           // the next hibernation cycle will capture a fresh one.
-          if (after.isOpen) return;
+          if (after.isOpen) {
+            this._patch({ phase: "live" });
+            return;
+          }
           if (capturedSessionId && projectId && liveAgentId && cwd) {
             after.setHibernateSession(projectId, {
               sessionId: capturedSessionId,
@@ -997,10 +1025,16 @@ export class HelpSessionController {
           usePanelStore.getState().removePanel(initialTerminalId);
           revokeHelpSession(sessionToRevoke);
           useHelpPanelStore.getState().clearTerminal();
+          this._resetPhase();
         })
         .catch((err) => {
           const after = useHelpPanelStore.getState();
-          if (after.terminalId !== initialTerminalId || after.isOpen) return;
+          if (after.terminalId !== initialTerminalId || after.isOpen) {
+            if (after.isOpen && after.terminalId === initialTerminalId) {
+              this._patch({ phase: "live" });
+            }
+            return;
+          }
           logError("HelpPanel: gracefulKill during hibernate failed", err);
           if (projectId) {
             useHelpPanelStore.getState().clearHibernateSession(projectId);
@@ -1008,6 +1042,7 @@ export class HelpSessionController {
           usePanelStore.getState().removePanel(initialTerminalId);
           revokeHelpSession(sessionToRevoke);
           useHelpPanelStore.getState().clearTerminal();
+          this._resetPhase();
         }),
       { context: "HelpPanel:hibernate gracefulKill" }
     );
@@ -1084,7 +1119,13 @@ export class HelpSessionController {
     launchContext?: ActionContext
   ): Promise<void> {
     let session: HelpSessionRef | null = null;
+    // Tracks whether the launch reached its terminal-bound success state. The
+    // finally resets the phase to idle on any non-success exit (error, bail)
+    // that is still the current generation, so the loading skeleton never
+    // sticks; a superseded generation leaves the phase to its new owner.
+    let reached = false;
     try {
+      this._patch({ phase: "version-checking" });
       const folderPath = await window.electron.help.getFolderPath();
       if (gen !== this._launchGen) {
         this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
@@ -1121,7 +1162,7 @@ export class HelpSessionController {
         return;
       }
       this._hasBlockedThisSession = false;
-      this._patch({ assistantVersionTooOld: null });
+      this._patch({ assistantVersionTooOld: null, phase: "provisioning" });
 
       const outcome = await provisionHelpSession(launchProject, launchAgentId, launchContext);
       if (gen !== this._launchGen) {
@@ -1140,6 +1181,7 @@ export class HelpSessionController {
       }
       session = outcome.session;
       this._pendingSessionId = session.sessionId;
+      this._patch({ phase: "launching" });
       const cwd = session.sessionPath;
       const env = buildHelpEnv(session, launchProject.id, launchAgentId);
 
@@ -1177,7 +1219,8 @@ export class HelpSessionController {
           window.electron.help.markTerminal(resumedId).catch((err) => {
             logError("Failed to mark help terminal", err);
           });
-          this._patch({ showResumeBanner: true });
+          reached = true;
+          this._patch({ phase: "live", showResumeBanner: true });
           this._armResumeBannerAutoDismiss();
           return;
         }
@@ -1223,6 +1266,13 @@ export class HelpSessionController {
         revokeHelpSession(session?.sessionId ?? null);
         this._pendingSessionId = null;
         this._hasAutoLaunched = false;
+        // The preference changed mid-launch, so re-evaluate against the
+        // current inputs rather than waiting on an incidental re-render to
+        // re-fire the effect — the new preferred agent should auto-launch
+        // now. Earlier this was driven solely by the next syncInputs render,
+        // which a transient phase re-render could consume before this reset
+        // landed, swallowing the relaunch.
+        if (this._lastInputs) this._maybeAutoLaunch(this._lastInputs);
         return;
       }
 
@@ -1246,12 +1296,16 @@ export class HelpSessionController {
         .getState()
         .setTerminal(result.result.terminalId, launchAgentId, session?.sessionId ?? null);
       this._pendingSessionId = null;
+      reached = true;
+      this._patch({ phase: "live" });
       window.electron.help.markTerminal(result.result.terminalId).catch((err) => {
         logError("Failed to mark help terminal", err);
       });
     } catch (err) {
       logError("HelpPanel: auto-launch threw", err);
       this._hasAutoLaunched = false;
+    } finally {
+      if (gen === this._launchGen && !reached) this._resetPhase();
     }
   }
 
@@ -1266,7 +1320,14 @@ export class HelpSessionController {
     const reservedId = options.requestedId ?? null;
     const resetAutoLaunch = options.isAutoLaunch === true;
     let session: HelpSessionRef | null = null;
+    // See `_executeAutoLaunch`: the finally drops the phase back to idle on a
+    // non-success exit that's still the current generation.
+    let reached = false;
     try {
+      // reservedId paths (newSession/runAnyway) skip the version gate, so they
+      // open straight at "provisioning"; the empty-state flow starts at the
+      // version probe.
+      this._patch({ phase: reservedId ? "provisioning" : "version-checking" });
       const folderPath = await window.electron.help.getFolderPath();
       if (gen !== this._launchGen) {
         this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
@@ -1305,7 +1366,7 @@ export class HelpSessionController {
           return;
         }
         this._hasBlockedThisSession = false;
-        this._patch({ assistantVersionTooOld: null });
+        this._patch({ assistantVersionTooOld: null, phase: "provisioning" });
       }
 
       const outcome = await provisionHelpSession(launchProject, launchAgentId, launchContext);
@@ -1332,6 +1393,7 @@ export class HelpSessionController {
       if (!reservedId) {
         this._pendingSessionId = session.sessionId;
       }
+      this._patch({ phase: "launching" });
       const cwd = session.sessionPath;
       const helpEnv = buildHelpEnv(session, launchProject.id, launchAgentId);
       const env: Record<string, string> | undefined =
@@ -1374,7 +1436,8 @@ export class HelpSessionController {
             window.electron.help.markTerminal(resumedId).catch((err) => {
               logError("Failed to mark help terminal", err);
             });
-            this._patch({ showResumeBanner: true });
+            reached = true;
+            this._patch({ phase: "live", showResumeBanner: true });
             this._armResumeBannerAutoDismiss();
             return;
           }
@@ -1455,6 +1518,8 @@ export class HelpSessionController {
           .setTerminal(finalTerminalId, launchAgentId, session?.sessionId ?? null);
         this._pendingSessionId = null;
       }
+      reached = true;
+      this._patch({ phase: "live" });
       window.electron.help.markTerminal(finalTerminalId).catch((err) => {
         logError("Failed to mark help terminal", err);
       });
@@ -1473,6 +1538,7 @@ export class HelpSessionController {
       notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
     } finally {
       this._isLaunching = false;
+      if (gen === this._launchGen && !reached) this._resetPhase();
     }
   }
 }

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -989,7 +989,16 @@ export class HelpSessionController {
         .gracefulKill(initialTerminalId)
         .then((capturedSessionId) => {
           const after = useHelpPanelStore.getState();
-          if (after.terminalId !== initialTerminalId) return;
+          if (after.terminalId !== initialTerminalId) {
+            // Another flow took over the slot, or the panel was torn down
+            // (e.g. `handleTerminalPanelMissing` cleared the terminal) while
+            // the kill was in flight. If a new launch took over it already
+            // wrote its own phase; only when the phase is still "hibernating"
+            // is this hibernate the last writer, so drop back to idle and
+            // don't strand the "Saving session…" skeleton.
+            if (this._snapshot.phase === "hibernating") this._resetPhase();
+            return;
+          }
           // Critical race: user reopened the panel while gracefulKill was
           // in flight. Terminal is still live — don't tear it down out
           // from under them. The captured session ID is also discarded;
@@ -1029,10 +1038,14 @@ export class HelpSessionController {
         })
         .catch((err) => {
           const after = useHelpPanelStore.getState();
-          if (after.terminalId !== initialTerminalId || after.isOpen) {
-            if (after.isOpen && after.terminalId === initialTerminalId) {
-              this._patch({ phase: "live" });
-            }
+          if (after.terminalId !== initialTerminalId) {
+            // See the `.then()` guard: only reset when this hibernate is still
+            // the phase's last writer.
+            if (this._snapshot.phase === "hibernating") this._resetPhase();
+            return;
+          }
+          if (after.isOpen) {
+            this._patch({ phase: "live" });
             return;
           }
           logError("HelpPanel: gracefulKill during hibernate failed", err);
@@ -1271,8 +1284,13 @@ export class HelpSessionController {
         // re-fire the effect — the new preferred agent should auto-launch
         // now. Earlier this was driven solely by the next syncInputs render,
         // which a transient phase re-render could consume before this reset
-        // landed, swallowing the relaunch.
-        if (this._lastInputs) this._maybeAutoLaunch(this._lastInputs);
+        // landed, swallowing the relaunch. Read `preferredAgentId` straight
+        // from the store (not the possibly-stale `_lastInputs`) so the re-eval
+        // launches the agent that actually superseded this one, never looping
+        // on the old agent.
+        if (this._lastInputs) {
+          this._maybeAutoLaunch({ ...this._lastInputs, preferredAgentId: currentPreferred });
+        }
         return;
       }
 
@@ -1304,6 +1322,10 @@ export class HelpSessionController {
     } catch (err) {
       logError("HelpPanel: auto-launch threw", err);
       this._hasAutoLaunched = false;
+      // A throw after provisioning (e.g. agent.launch rejecting) would
+      // otherwise strand the minted MCP session token.
+      revokeHelpSession(session?.sessionId ?? null);
+      this._pendingSessionId = null;
     } finally {
       if (gen === this._launchGen && !reached) this._resetPhase();
     }

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -422,6 +422,63 @@ describe("HelpSessionController — launch phase FSM", () => {
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     ctrl.stop();
   });
+
+  it("_fireHibernate resets the phase to idle if terminalId is cleared mid-kill (no stuck skeleton)", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.isOpen = false;
+    panelStoreState.panelsById = { "term-1": { id: "term-1", cwd: "/p" } };
+    let resolveKill: (v: string | null) => void = () => {};
+    (window.electron.terminal.gracefulKill as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((r) => {
+        resolveKill = r;
+      })
+    );
+    ctrl["_hibernateArmedFor"] = { terminalId: "term-1", agentId: "claude", projectId: "proj" };
+
+    ctrl["_fireHibernate"]("term-1", "claude", "proj");
+    expect(ctrl.getSnapshot().phase).toBe("hibernating");
+
+    // The panel disappears while the kill is in flight (handleTerminalPanelMissing).
+    helpPanelState.terminalId = null;
+    resolveKill("captured-sess");
+
+    await vi.waitFor(() => {
+      expect(ctrl.getSnapshot().phase).toBe("idle");
+    });
+    ctrl.stop();
+  });
+
+  it("revokes the provisioned session when agent.launch rejects after provisioning", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.preferredAgentId = "claude";
+    (window.electron.help.provisionSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      sessionId: "sess-leak",
+      sessionPath: "/help",
+      token: "tok-leak",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    vi.mocked(actionService.dispatch).mockRejectedValue(new Error("dispatch boom") as never);
+
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude"],
+      visibilityEpoch: 0,
+    });
+
+    await vi.waitFor(() => {
+      expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-leak");
+    });
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+    ctrl.stop();
+  });
 });
 
 describe("HelpSessionController — tier-mismatch handlers", () => {

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -93,6 +93,7 @@ vi.mock("@/utils/safeFireAndForget", () => ({
 }));
 
 import { HelpSessionController } from "../HelpSessionController";
+import { actionService } from "@/services/ActionService";
 
 function resetState() {
   helpPanelState.isOpen = false;
@@ -326,6 +327,99 @@ describe("HelpSessionController — syncInputs", () => {
       visibilityEpoch: 0,
     });
     expect(ctrl.getSnapshot().assistantVersionTooOld).toBeNull();
+    ctrl.stop();
+  });
+});
+
+describe("HelpSessionController — launch phase FSM", () => {
+  it("cancelLaunch() resets phase to idle, clears the launching guard, and bumps the gen", () => {
+    const ctrl = new HelpSessionController();
+    ctrl["_patch"]({ phase: "provisioning" });
+    ctrl["_isLaunching"] = true;
+    const genBefore = ctrl["_launchGen"] as number;
+
+    ctrl.cancelLaunch();
+
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+    expect(ctrl["_isLaunching"]).toBe(false);
+    expect(ctrl["_launchGen"]).toBe(genBefore + 1);
+  });
+
+  it("auto-launch enters version-checking synchronously and reaches live on success", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.preferredAgentId = "claude";
+    (window.electron.help.provisionSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      sessionId: "sess-1",
+      sessionPath: "/help",
+      token: "tok-1",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    vi.mocked(actionService.dispatch).mockResolvedValue({
+      ok: true,
+      result: { terminalId: "term-1" },
+    } as never);
+
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude"],
+      visibilityEpoch: 0,
+    });
+
+    // The first phase write happens synchronously, before the first await.
+    expect(ctrl.getSnapshot().phase).toBe("version-checking");
+
+    await vi.waitFor(() => {
+      expect(ctrl.getSnapshot().phase).toBe("live");
+    });
+    ctrl.stop();
+  });
+
+  it("auto-launch resets the phase to idle when provisioning fails", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.preferredAgentId = "claude";
+    // Default provisionSession resolves null → outcome not ok.
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude"],
+      visibilityEpoch: 0,
+    });
+
+    await vi.waitFor(() => {
+      expect(ctrl.getSnapshot().phase).toBe("idle");
+    });
+    expect(vi.mocked(actionService.dispatch)).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
+  it("_fireHibernate surfaces the hibernating phase, then resets to idle after teardown", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.isOpen = false;
+    panelStoreState.panelsById = { "term-1": { id: "term-1", cwd: "/p" } };
+    (window.electron.terminal.gracefulKill as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "captured-sess"
+    );
+    ctrl["_hibernateArmedFor"] = { terminalId: "term-1", agentId: "claude", projectId: "proj" };
+
+    ctrl["_fireHibernate"]("term-1", "claude", "proj");
+    expect(ctrl.getSnapshot().phase).toBe("hibernating");
+
+    await vi.waitFor(() => {
+      expect(ctrl.getSnapshot().phase).toBe("idle");
+    });
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     ctrl.stop();
   });
 });


### PR DESCRIPTION
## Summary

- `HelpPanel` previously showed a static "Use Daintree Assistant…" empty state for the entire 6–45s auto-launch window — `HelpSessionPhase` values existed on the snapshot but were never written or rendered
- Wires phase transitions (`version-checking` → `provisioning` → `launching` → `live`, plus `hibernating`) through both launch flows in `HelpSessionController`, and renders a new Doherty-gated, phase-labeled `HelpLaunchingState` skeleton with a Cancel affordance in the content area when phase is non-idle/non-live
- Adds `cancelLaunch()`, hardens a latent gap where a preferred-agent switch mid-launch could be swallowed (controller now re-evaluates auto-launch after a stale-agent abort), and fixes two review findings: `hibernating` phase could stick if `terminalId` was cleared mid-kill; MCP session leak if `agent.launch` threw after provisioning

Resolves #8771

## Changes

- `HelpSessionController.ts` — writes phase on every state transition; `cancelLaunch()` method; stale-agent re-evaluation after abort; MCP cleanup on throw; `hibernating` phase cleared on kill completion
- `HelpLaunchingState.tsx` — new skeleton component, Doherty-gated (`animate-pulse-delayed`), phase label, Cancel via `SkeletonHint`; signal lives in the content area per issue guardrail (not `panel-state-*` borders or `AssistantHeaderStateIndicator`)
- `HelpPanel.tsx` — routes to `HelpLaunchingState` when `phase` is non-idle/non-live; spatial handoff to the live terminal at `phase === 'live'`
- Patch seam kept clean for #8773 (`launchError`)

## Testing

- 138 unit tests pass (`HelpSessionController.test.ts` + `HelpPanel.helpLaunch.test.tsx` both extended)
- `npm run check` clean (typecheck + lint + format)