### PR TITLE
feat(agents): add resume-latest fallback when session-ID capture fails

### DIFF
--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -235,6 +235,15 @@ export type AgentResume =
       sessionIdPattern: string;
       /** Optional raw key sequence sent before `quitCommand` (e.g. Ctrl-C). */
       shutdownKeySequence?: string;
+      /**
+       * CLI args for resuming the most recent session without a captured ID
+       * (e.g. ["--continue"] for Claude, ["-r", "latest"] for Gemini,
+       * ["resume", "--last"] for Codex). When present, the relaunch path uses
+       * these args as a fallback when `sessionIdPattern` capture missed
+       * (timeout, no match). Scoped to the launch CWD by the underlying CLI.
+       * Omit for agents that have no resume-latest flag.
+       */
+      resumeLatestArgs?: string[];
     }
   | {
       kind: "rolling-history";

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -118,6 +118,7 @@ export const config: AgentConfig = {
     args: (sessionId: string) => ["--resume", sessionId],
     quitCommand: "/quit",
     sessionIdPattern: "claude --resume ([\\w-]+)",
+    resumeLatestArgs: ["--continue"],
   },
   env: {
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",

--- a/shared/config/agents/codex.ts
+++ b/shared/config/agents/codex.ts
@@ -116,6 +116,7 @@ export const config: AgentConfig = {
     args: (sessionId: string) => ["resume", sessionId],
     quitCommand: "/quit",
     sessionIdPattern: "codex resume ([\\w-]+)",
+    resumeLatestArgs: ["resume", "--last"],
   },
   help: {
     args: [],

--- a/shared/config/agents/gemini.ts
+++ b/shared/config/agents/gemini.ts
@@ -123,6 +123,8 @@ export const config: AgentConfig = {
     args: (sessionId: string) => ["--resume", sessionId],
     quitCommand: "/quit",
     sessionIdPattern: "gemini --resume ([\\w-]+)",
+    // `latest` is required — bare `-r` opens an interactive picker that blocks the PTY.
+    resumeLatestArgs: ["-r", "latest"],
   },
   env: {
     GEMINI_CLI_ALT_SCREEN: "false",

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   buildResumeCommand,
+  buildResumeLatestCommand,
   buildAgentLaunchFlags,
   buildLaunchCommandFromFlags,
   generateAgentCommand,
@@ -104,6 +105,91 @@ describe("buildResumeCommand", () => {
     expect(cmd).toBeDefined();
     expect(cmd).toContain("--dangerously-skip-permissions");
     // Non-flag value should be shell-escaped
+    expect(cmd).not.toContain(" some value ");
+  });
+});
+
+describe("buildResumeLatestCommand", () => {
+  forcePosixPlatform();
+
+  it("builds claude resume-latest command with --continue", () => {
+    expect(buildResumeLatestCommand("claude")).toBe("claude --continue");
+  });
+
+  it("builds gemini resume-latest command with -r latest (positional required)", () => {
+    // Bare `-r` opens an interactive picker that blocks the PTY; `latest`
+    // must be passed positionally.
+    expect(buildResumeLatestCommand("gemini")).toBe("gemini -r latest");
+  });
+
+  it("builds codex resume-latest command with subcommand + --last", () => {
+    const cmd = buildResumeLatestCommand("codex");
+    expect(cmd).toBe("codex resume --last");
+    expect(cmd).toContain("resume");
+    expect(cmd).toContain("--last");
+  });
+
+  it("returns undefined for unknown agent", () => {
+    expect(buildResumeLatestCommand("unknown-agent")).toBeUndefined();
+  });
+
+  it("returns undefined for agent without resume config", () => {
+    expect(buildResumeLatestCommand("my-custom-agent")).toBeUndefined();
+  });
+
+  it("returns undefined for agents whose resume kind is not session-id", () => {
+    // Kimi uses rolling-history; Kiro uses project-scoped. Neither has the
+    // session-id resumeLatestArgs surface — they already always launch with
+    // resume flags via their own resume.args() path.
+    expect(buildResumeLatestCommand("kimi")).toBeUndefined();
+    expect(buildResumeLatestCommand("kiro")).toBeUndefined();
+  });
+
+  it("returns undefined for session-id agents that don't declare resumeLatestArgs", () => {
+    // Copilot/Goose/Qwen/Mistral/OpenCode are session-id agents that didn't
+    // ship a resume-latest fallback in this issue; should return undefined.
+    expect(buildResumeLatestCommand("copilot")).toBeUndefined();
+    expect(buildResumeLatestCommand("goose")).toBeUndefined();
+    expect(buildResumeLatestCommand("qwen")).toBeUndefined();
+    expect(buildResumeLatestCommand("mistral")).toBeUndefined();
+    expect(buildResumeLatestCommand("opencode")).toBeUndefined();
+  });
+
+  it("prepends launch flags before resume-latest args for claude", () => {
+    const cmd = buildResumeLatestCommand("claude", ["--dangerously-skip-permissions"]);
+    expect(cmd).toBe("claude --dangerously-skip-permissions --continue");
+  });
+
+  it("prepends launch flags before resume-latest args for codex", () => {
+    const cmd = buildResumeLatestCommand("codex", [
+      "--no-alt-screen",
+      "--dangerously-bypass-approvals-and-sandbox",
+    ]);
+    expect(cmd).toBe(
+      "codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox resume --last"
+    );
+  });
+
+  it("prepends launch flags before resume-latest args for gemini", () => {
+    const cmd = buildResumeLatestCommand("gemini", ["--yolo"]);
+    expect(cmd).toBe("gemini --yolo -r latest");
+  });
+
+  it("handles empty launch flags array like no flags", () => {
+    expect(buildResumeLatestCommand("claude", [])).toBe("claude --continue");
+  });
+
+  it("handles undefined launch flags like no flags", () => {
+    expect(buildResumeLatestCommand("claude", undefined)).toBe("claude --continue");
+  });
+
+  it("escapes non-flag launch flag values", () => {
+    const cmd = buildResumeLatestCommand("claude", [
+      "--dangerously-skip-permissions",
+      "some value",
+    ]);
+    expect(cmd).toBeDefined();
+    expect(cmd).toContain("--dangerously-skip-permissions");
     expect(cmd).not.toContain(" some value ");
   });
 });

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -426,6 +426,56 @@ export function buildResumeCommand(
   return parts.join(" ");
 }
 
+/**
+ * Builds a "resume the most recent session" launch command for agents whose
+ * `session-id` resume config declares `resumeLatestArgs`. Used as a fallback
+ * when the graceful-shutdown pattern-match capture loop failed to harvest a
+ * session ID — instead of launching fresh and losing the user's context, the
+ * CLI's own "continue last" flag picks up the prior conversation in the
+ * launch CWD (Claude `--continue`, Gemini `-r latest`, Codex `resume --last`,
+ * etc.).
+ *
+ * Persisted launch flags are prepended using the same shell-escape rules as
+ * {@link buildResumeCommand} (raw for `-`-prefixed tokens, escaped for
+ * positional values).
+ *
+ * @returns The resume-latest command string, or `undefined` if the agent
+ *   has no resume config, isn't a `session-id` kind, or doesn't declare
+ *   `resumeLatestArgs`.
+ */
+export function buildResumeLatestCommand(
+  agentId: string,
+  launchFlags?: string[]
+): string | undefined {
+  const agentConfig = getEffectiveAgentConfig(agentId);
+  const resume = agentConfig?.resume;
+  if (!agentConfig || !resume) return undefined;
+  if (resume.kind !== "session-id") return undefined;
+  const fallbackArgs = resume.resumeLatestArgs;
+  if (!fallbackArgs || fallbackArgs.length === 0) return undefined;
+
+  const parts = [agentConfig.command];
+
+  if (launchFlags?.length) {
+    for (const flag of launchFlags) {
+      if (flag.startsWith("-")) {
+        parts.push(flag);
+      } else {
+        parts.push(escapeShellArg(flag));
+      }
+    }
+  }
+
+  for (const arg of fallbackArgs) {
+    if (arg.startsWith("-")) {
+      parts.push(arg);
+    } else {
+      parts.push(escapeShellArgOptional(arg));
+    }
+  }
+  return parts.join(" ");
+}
+
 export interface BuildLaunchCommandFromFlagsOptions {
   /** Absolute path to the clipboard temp directory (re-injected for agents that support it) */
   clipboardDirectory?: string;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -314,6 +314,7 @@ export {
   generateAgentCommand,
   buildAgentLaunchFlags,
   buildResumeCommand,
+  buildResumeLatestCommand,
   buildLaunchCommandFromFlags,
 } from "./agentSettings.js";
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,7 @@ import { PanelTransitionOverlay } from "./components/Panel";
 
 import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
 import { MORE_AGENTS_PANEL_ID } from "./hooks/usePanelPalette";
-import { buildResumeCommand } from "@shared/types/agentSettings";
+import { buildResumeCommand, buildResumeLatestCommand } from "@shared/types/agentSettings";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { WelcomeScreen } from "./components/Project";
 import { VoiceRecordingAnnouncer } from "./components/Terminal/VoiceRecordingAnnouncer";
@@ -918,11 +918,12 @@ function App() {
                       if (result.resumeSession) {
                         const session = result.resumeSession;
                         const agentConfig = getEffectiveAgentConfig(session.agentId);
-                        const command = buildResumeCommand(
-                          session.agentId,
-                          session.sessionId,
-                          session.agentLaunchFlags
-                        );
+                        const command =
+                          buildResumeCommand(
+                            session.agentId,
+                            session.sessionId,
+                            session.agentLaunchFlags
+                          ) ?? buildResumeLatestCommand(session.agentId, session.agentLaunchFlags);
                         if (command && agentConfig) {
                           addPanel({
                             kind: "terminal",
@@ -955,11 +956,12 @@ function App() {
                       if (selected.resumeSession) {
                         const session = selected.resumeSession;
                         const agentConfig = getEffectiveAgentConfig(session.agentId);
-                        const command = buildResumeCommand(
-                          session.agentId,
-                          session.sessionId,
-                          session.agentLaunchFlags
-                        );
+                        const command =
+                          buildResumeCommand(
+                            session.agentId,
+                            session.sessionId,
+                            session.agentLaunchFlags
+                          ) ?? buildResumeLatestCommand(session.agentId, session.agentLaunchFlags);
                         if (command && agentConfig) {
                           addPanel({
                             kind: "terminal",

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -12,6 +12,7 @@ const {
   mockRevokeSession,
   mockGracefulKill,
   mockBuildResumeCommand,
+  mockBuildResumeLatestCommand,
   mockGetAssistantSupportedAgentIds,
   mockGetHelpAssistantSettings,
   mockSystemSleepGetMetrics,
@@ -38,6 +39,7 @@ const {
   mockRevokeSession: vi.fn().mockResolvedValue(undefined),
   mockGracefulKill: vi.fn().mockResolvedValue(null),
   mockBuildResumeCommand: vi.fn(),
+  mockBuildResumeLatestCommand: vi.fn(),
   mockGetAssistantSupportedAgentIds: vi.fn(() => ["claude"]),
   mockGetHelpAssistantSettings: vi.fn().mockResolvedValue({
     docSearch: true,
@@ -173,6 +175,7 @@ vi.mock("@/config/agents", () => ({
 
 vi.mock("@shared/types/agentSettings", () => ({
   buildResumeCommand: (...args: unknown[]) => mockBuildResumeCommand(...args),
+  buildResumeLatestCommand: (...args: unknown[]) => mockBuildResumeLatestCommand(...args),
 }));
 
 vi.mock("@/services/ActionService", () => ({

--- a/src/components/Terminal/UpdateCwdDialog.tsx
+++ b/src/components/Terminal/UpdateCwdDialog.tsx
@@ -51,7 +51,9 @@ export function UpdateCwdDialog({ isOpen, terminalId, currentCwd, onClose }: Upd
       }
 
       updateTerminalCwd(terminalId, newCwd);
-      await restartTerminal(terminalId);
+      // Suppress resume-latest: cwd is changing, so a CWD-scoped fallback
+      // would pick up an unrelated session in the new directory.
+      await restartTerminal(terminalId, { allowResumeLatest: false });
 
       onClose();
     } catch (error) {

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -17,7 +17,7 @@ import { logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
-import { buildResumeCommand } from "@shared/types/agentSettings";
+import { buildResumeCommand, buildResumeLatestCommand } from "@shared/types/agentSettings";
 import { resolveDaintreeMcpTier } from "@shared/types/project";
 import type { SnapshotInfo } from "@shared/types/ipc/git";
 
@@ -1027,11 +1027,11 @@ export class HelpSessionController {
     folderPath: string
   ): Promise<string | null> {
     const customLaunchFlags = await loadCustomLaunchFlags();
-    const command = buildResumeCommand(
-      launchAgentId,
-      hibernated.sessionId,
-      customLaunchFlags.length > 0 ? customLaunchFlags : undefined
-    );
+    const flags = customLaunchFlags.length > 0 ? customLaunchFlags : undefined;
+    const command = hibernated.sessionId
+      ? (buildResumeCommand(launchAgentId, hibernated.sessionId, flags) ??
+        buildResumeLatestCommand(launchAgentId, flags))
+      : buildResumeLatestCommand(launchAgentId, flags);
     if (!command) return null;
 
     const cwd = session?.sessionPath ?? hibernated.cwd ?? folderPath;

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -967,6 +967,21 @@ export class HelpSessionController {
               cwd,
               agentId: liveAgentId,
             });
+          } else if (
+            projectId &&
+            liveAgentId &&
+            cwd &&
+            buildResumeLatestCommand(liveAgentId) !== undefined
+          ) {
+            // Capture missed but the agent has a resume-latest flag — persist
+            // a sentinel hibernate entry (empty sessionId) so the next panel
+            // open hits the `--continue`-style fallback in `_spawnResumed`
+            // instead of starting a fresh session (#8787).
+            after.setHibernateSession(projectId, {
+              sessionId: "",
+              cwd,
+              agentId: liveAgentId,
+            });
           } else if (projectId) {
             after.clearHibernateSession(projectId);
           }

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -586,7 +586,6 @@ describe("helpPanelStore persistence migration", () => {
             "no-session": { cwd: "/tmp", agentId: "claude" },
             "no-cwd": { sessionId: "abc", agentId: "claude" },
             "no-agent": { sessionId: "abc", cwd: "/tmp" },
-            "empty-session": { sessionId: "", cwd: "/tmp", agentId: "claude" },
             "wrong-types": { sessionId: 1, cwd: 2, agentId: 3 },
           },
         },
@@ -597,6 +596,31 @@ describe("helpPanelStore persistence migration", () => {
 
       expect(store.getState().hibernateSessions).toEqual({
         "good-proj": { sessionId: "abc", cwd: "/tmp", agentId: "claude" },
+      });
+    });
+
+    it("preserves empty-sessionId entries (resume-latest sentinel, #8787)", async () => {
+      // sessionId: "" signals "graceful-shutdown capture missed — use the
+      // agent's resume-latest flag on next open" (e.g. claude --continue).
+      // Sanitization must NOT drop these.
+      const blob = JSON.stringify({
+        version: 3,
+        state: {
+          isOpen: false,
+          width: 400,
+          preferredAgentId: null,
+          introDismissed: false,
+          hibernateSessions: {
+            "resume-latest-proj": { sessionId: "", cwd: "/tmp", agentId: "claude" },
+          },
+        },
+      });
+      installLocalStorage({ [STORAGE_KEY]: blob });
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+      expect(store.getState().hibernateSessions).toEqual({
+        "resume-latest-proj": { sessionId: "", cwd: "/tmp", agentId: "claude" },
       });
     });
 

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -14,7 +14,12 @@ export const HELP_PANEL_MAX_WIDTH = 800;
 export const HELP_PANEL_DEFAULT_WIDTH = 380;
 
 export interface HelpHibernateSession {
-  /** Captured agent session ID (e.g. Claude resume token) */
+  /**
+   * Captured agent session ID (e.g. Claude resume token). Empty string is a
+   * valid value and signals "capture failed — use the agent's resume-latest
+   * fallback flag (e.g. `claude --continue`) on next open". See
+   * `HelpSessionController._spawnResumed` for the falsy-sessionId branch.
+   */
   sessionId: string;
   /** Working directory the resumed agent must launch from to find its transcript */
   cwd: string;
@@ -96,7 +101,9 @@ function sanitizeHibernateSessions(value: unknown): Record<string, HelpHibernate
     const sessionId = entry.sessionId;
     const cwd = entry.cwd;
     const agentId = entry.agentId;
-    if (typeof sessionId !== "string" || !sessionId) continue;
+    // sessionId may be empty string — that's the "use resume-latest fallback"
+    // sentinel persisted when graceful-shutdown capture missed (#8787).
+    if (typeof sessionId !== "string") continue;
     if (typeof cwd !== "string" || !cwd) continue;
     if (typeof agentId !== "string" || !agentId) continue;
     out[projectId] = { sessionId, cwd, agentId };

--- a/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
@@ -275,4 +275,32 @@ describe("moveToNewWorktreeAndTransfer (#4773)", () => {
     // Even after callback, addAgentStateListener should not be called for injection
     expect(mockAddAgentStateListener).not.toHaveBeenCalled();
   });
+
+  it("does not invoke resume-latest fallback when restarting after worktree move (#8787)", async () => {
+    // The new-CWD restart must NOT pick up an unrelated session in the new
+    // worktree directory via resume-latest. moveToNewWorktreeAndTransfer
+    // passes { allowResumeLatest: false } so buffer injection remains the
+    // sole context-transfer mechanism (lesson #4781).
+    const { buildResumeLatestCommand } = await import("@shared/types");
+    (buildResumeLatestCommand as ReturnType<typeof vi.fn>).mockClear();
+    mockCaptureBufferText.mockReturnValue("some history");
+    const terminalWithoutSession = {
+      ...agentTerminal,
+      agentSessionId: undefined,
+    };
+    usePanelStore.setState({
+      panelsById: { [terminalWithoutSession.id]: terminalWithoutSession },
+      panelIds: [terminalWithoutSession.id],
+    });
+
+    usePanelStore.getState().moveToNewWorktreeAndTransfer("test-1");
+
+    await vi.dynamicImportSettled();
+
+    if (openCreateDialogCallback) {
+      await openCreateDialogCallback("wt-new").catch(() => {});
+    }
+
+    expect(buildResumeLatestCommand).not.toHaveBeenCalled();
+  });
 });

--- a/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
@@ -98,6 +98,7 @@ vi.mock("@shared/types", () => ({
   generateAgentCommand: vi.fn().mockReturnValue("claude --resume"),
   buildAgentLaunchFlags: vi.fn().mockReturnValue([]),
   buildResumeCommand: vi.fn().mockReturnValue(null),
+  buildResumeLatestCommand: vi.fn().mockReturnValue(null),
   buildLaunchCommandFromFlags: vi.fn().mockReturnValue("claude"),
 }));
 

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -90,6 +90,7 @@ vi.mock("@shared/types", () => ({
   generateAgentCommand: vi.fn().mockReturnValue("claude"),
   buildAgentLaunchFlags: (...args: unknown[]) => buildAgentLaunchFlagsMock(...args),
   buildResumeCommand: vi.fn().mockReturnValue(null),
+  buildResumeLatestCommand: vi.fn().mockReturnValue(null),
   buildLaunchCommandFromFlags: vi.fn().mockReturnValue("claude --flag"),
 }));
 
@@ -472,5 +473,115 @@ describe("restartTerminal exit/demotion semantics (#5807)", () => {
     const payload = mockSpawn.mock.calls[0]![0];
     expect(payload.launchAgentId).toBe("claude");
     expect(payload.command).toBeDefined();
+  });
+});
+
+describe("restartTerminal resume-latest fallback (#8787)", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    getMergedPresetMock.mockReturnValue(undefined);
+    buildAgentLaunchFlagsMock.mockReturnValue([]);
+    const { agentSettingsClient, projectClient } = await import("@/clients");
+    (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (projectClient.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const { reset } = usePanelStore.getState();
+    await reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  it("uses resume-latest fallback when no session ID was captured", async () => {
+    const { buildResumeLatestCommand } = await import("@shared/types");
+    (buildResumeLatestCommand as ReturnType<typeof vi.fn>).mockReturnValue("claude --continue");
+    // Active agent (working state) with NO session ID — graceful-shutdown
+    // pattern match missed.
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+      agentSessionId: undefined,
+    };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(buildResumeLatestCommand).toHaveBeenCalledWith("claude", ["--persisted-flag"]);
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.command).toBe("claude --continue");
+  });
+
+  it("prefers primary buildResumeCommand when session ID is present", async () => {
+    const { buildResumeCommand, buildResumeLatestCommand } = await import("@shared/types");
+    (buildResumeCommand as ReturnType<typeof vi.fn>).mockReturnValue("claude --resume abc");
+    (buildResumeLatestCommand as ReturnType<typeof vi.fn>).mockReturnValue("claude --continue");
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+      agentSessionId: "abc",
+    };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(buildResumeCommand).toHaveBeenCalledWith("claude", "abc", ["--persisted-flag"]);
+    expect(buildResumeLatestCommand).not.toHaveBeenCalled();
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.command).toBe("claude --resume abc");
+  });
+
+  it("does not call resume-latest when allowResumeLatest is false (worktree-move case)", async () => {
+    const { buildResumeLatestCommand } = await import("@shared/types");
+    (buildResumeLatestCommand as ReturnType<typeof vi.fn>).mockReturnValue("claude --continue");
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+      agentSessionId: undefined,
+    };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1", { allowResumeLatest: false });
+
+    expect(buildResumeLatestCommand).not.toHaveBeenCalled();
+    const payload = mockSpawn.mock.calls[0]![0];
+    // Falls through to the existing fresh-launch path
+    expect(payload.command).not.toBe("claude --continue");
+  });
+
+  it("falls through to fresh launch when no session ID and no resume-latest available", async () => {
+    const { buildResumeLatestCommand } = await import("@shared/types");
+    (buildResumeLatestCommand as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+      agentSessionId: undefined,
+    };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(buildResumeLatestCommand).toHaveBeenCalledOnce();
+    const payload = mockSpawn.mock.calls[0]![0];
+    // Existing fallback chain (persisted flags / generated command)
+    expect(payload.command).toBeDefined();
+    expect(payload.command).not.toBe("claude --continue");
   });
 });

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -262,6 +262,7 @@ export const createRestartActions = (
     // For agent terminals, regenerate command from current settings
     // For other terminals, use the saved command
     let commandToRun = currentTerminal.command;
+    let usedResumeLatest = false;
     const effectiveAgentId = currentTerminal.launchAgentId;
     // Gate on launch intent (`effectiveAgentId`, derived from the sealed
     // `launchAgentId`) plus two demotion
@@ -352,6 +353,7 @@ export const createRestartActions = (
         const resumeLatestCmd = buildResumeLatestCommand(effectiveAgentId, nextAgentLaunchFlags);
         if (resumeLatestCmd) {
           commandToRun = resumeLatestCmd;
+          usedResumeLatest = true;
         }
       }
 
@@ -421,9 +423,13 @@ export const createRestartActions = (
 
     const spawnCommand = commandToRun;
     // Track session ID for restore-on-failure; resume command is transient,
-    // so keep the original command as the durable stored command
+    // so keep the original command as the durable stored command. Same for
+    // the resume-latest fallback (e.g. `claude --continue`) — re-storing that
+    // as durable would re-resume on every subsequent restart instead of
+    // launching fresh.
     const consumedSessionId = currentTerminal.agentSessionId;
-    const durableCommand = consumedSessionId ? currentTerminal.command : spawnCommand;
+    const durableCommand =
+      consumedSessionId || usedResumeLatest ? currentTerminal.command : spawnCommand;
 
     try {
       // CAPTURE LIVE DIMENSIONS before destroying the frontend

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -11,6 +11,7 @@ import {
   generateAgentCommand,
   buildAgentLaunchFlags,
   buildResumeCommand,
+  buildResumeLatestCommand,
   buildLaunchCommandFromFlags,
 } from "@shared/types";
 import type { AgentSettingsEntry } from "@shared/types/agentSettings";
@@ -157,7 +158,8 @@ export const createRestartActions = (
   | "toggleInputLocked"
   | "activateFallbackPreset"
 > => ({
-  restartTerminal: async (id) => {
+  restartTerminal: async (id, options) => {
+    const allowResumeLatest = options?.allowResumeLatest !== false;
     const terminal = get().panelsById[id];
 
     if (!terminal) {
@@ -339,6 +341,17 @@ export const createRestartActions = (
         const resumeCmd = buildResumeCommand(effectiveAgentId, sessionId, nextAgentLaunchFlags);
         if (resumeCmd) {
           commandToRun = resumeCmd;
+        }
+      } else if (allowResumeLatest) {
+        // No captured session ID — graceful-shutdown pattern match missed or
+        // timed out. Try the agent's resume-latest fallback (e.g. claude
+        // --continue, codex resume --last, gemini -r latest) before falling
+        // through to a fresh launch so the user keeps their prior CWD-scoped
+        // conversation. Suppressed by moveToNewWorktreeAndTransfer because the
+        // new CWD would resume a stale or unrelated session.
+        const resumeLatestCmd = buildResumeLatestCommand(effectiveAgentId, nextAgentLaunchFlags);
+        if (resumeLatestCmd) {
+          commandToRun = resumeLatestCmd;
         }
       }
 
@@ -703,7 +716,9 @@ export const createRestartActions = (
                 return { panelsById: newById, panelIdsByWorktreeId: newIndex };
               });
 
-              await get().restartTerminal(id);
+              // Suppress resume-latest: the CWD has changed; we want a fresh
+              // launch + buffer-injected context, not a stale CWD-scoped session.
+              await get().restartTerminal(id, { allowResumeLatest: false });
 
               // After restart, inject captured history as a first prompt for agent terminals
               const restarted = get().panelsById[id];

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -17,6 +17,24 @@ import type {
 export type TerminalInstance = TerminalInstanceType;
 export type { AddPanelOptions };
 
+/**
+ * Options accepted by `restartTerminal`. Opaque defaults match existing
+ * behaviour; flags are opt-in for specific callers whose intent differs from
+ * the standard graceful-restart flow.
+ */
+export interface RestartTerminalOptions {
+  /**
+   * When `false`, suppresses the "resume the most recent session" fallback
+   * even if the agent declares `resumeLatestArgs`. Used by
+   * `moveToNewWorktreeAndTransfer` where the CWD has changed and a fresh
+   * launch with buffer-injected context is intentional — letting the agent
+   * silently resume a stale session in the new CWD would mask the move. See
+   * issue #4781 for the cross-worktree-transfer rationale.
+   * Defaults to `true` (fallback enabled).
+   */
+  allowResumeLatest?: boolean;
+}
+
 export interface TrashedTerminalGroupMetadata {
   panelIds: string[];
   activeTabId: string;
@@ -146,7 +164,7 @@ export interface PanelRegistrySlice {
   ) => void;
   restoreTerminalOrder: (orderedIds: string[]) => void;
 
-  restartTerminal: (id: string) => Promise<void>;
+  restartTerminal: (id: string, options?: RestartTerminalOptions) => Promise<void>;
   clearTerminalError: (id: string) => void;
   updateTerminalCwd: (id: string, cwd: string) => void;
   moveTerminalToWorktree: (id: string, worktreeId: string) => void;

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -35,6 +35,10 @@ const buildResumeCommandMock = vi.fn(
     `${agentId} --resume ${sessionId}`
 );
 
+const buildResumeLatestCommandMock = vi.fn(
+  (_agentId: string, _flags?: string[]): string | undefined => undefined
+);
+
 const generateAgentCommandMock = vi.hoisted(() =>
   vi.fn(
     (base: string, _entry?: unknown, _agentId?: string, _options?: unknown): string =>
@@ -50,6 +54,8 @@ vi.mock("@shared/types", async () => {
       generateAgentCommandMock(base, entry, agentId, options),
     buildResumeCommand: (...args: unknown[]) =>
       buildResumeCommandMock(...(args as [string, string, string[]?])),
+    buildResumeLatestCommand: (...args: unknown[]) =>
+      buildResumeLatestCommandMock(...(args as [string, string[]?])),
   };
 });
 
@@ -70,6 +76,8 @@ beforeEach(() => {
   buildResumeCommandMock.mockImplementation(
     (agentId: string, sessionId: string) => `${agentId} --resume ${sessionId}`
   );
+  buildResumeLatestCommandMock.mockReset();
+  buildResumeLatestCommandMock.mockImplementation(() => undefined);
   generateAgentCommandMock.mockReset();
   generateAgentCommandMock.mockImplementation(
     (base: string, _entry?: unknown, _agentId?: string, _options?: unknown) => `${base} --generated`
@@ -618,6 +626,97 @@ describe("buildArgsForRespawn", () => {
     );
     expect(result.command).toBe("claude --dangerously-skip-permissions");
     expect(generateAgentCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("uses resume-latest fallback when session ID was never captured", () => {
+    // The graceful-shutdown capture loop missed (timeout, pattern change).
+    // Instead of a fresh launch that loses context, use the agent's
+    // resume-latest flag (e.g. claude --continue).
+    buildResumeLatestCommandMock.mockReturnValue("claude --continue");
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal" as const,
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      undefined
+    );
+    expect(result.command).toBe("claude --continue");
+    expect(buildResumeLatestCommandMock).toHaveBeenCalledWith("claude", undefined);
+    expect(generateAgentCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("passes persisted agentLaunchFlags to buildResumeLatestCommand", () => {
+    buildResumeLatestCommandMock.mockReturnValue(
+      "claude --dangerously-skip-permissions --continue"
+    );
+    buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal" as const,
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentLaunchFlags: ["--dangerously-skip-permissions"],
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      undefined
+    );
+    expect(buildResumeLatestCommandMock).toHaveBeenCalledWith("claude", [
+      "--dangerously-skip-permissions",
+    ]);
+  });
+
+  it("falls through to persisted flags when no session ID and no resume-latest fallback", () => {
+    buildResumeLatestCommandMock.mockReturnValue(undefined);
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal" as const,
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentLaunchFlags: ["--dangerously-skip-permissions"],
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      undefined
+    );
+    expect(result.command).toBe("claude --dangerously-skip-permissions");
+    expect(buildResumeLatestCommandMock).toHaveBeenCalledOnce();
+    expect(generateAgentCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("prefers primary buildResumeCommand over resume-latest when session ID is present", () => {
+    buildResumeLatestCommandMock.mockReturnValue("claude --continue");
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal" as const,
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentSessionId: "sess-1",
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      undefined
+    );
+    expect(result.command).toBe("claude --resume sess-1");
+    expect(buildResumeLatestCommandMock).not.toHaveBeenCalled();
   });
 
   it("shell-escapes non-flag tokens in persisted agentLaunchFlags (defends against metachars)", () => {

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -9,6 +9,7 @@ import type { AgentPreset } from "@/config/agents";
 import {
   generateAgentCommand,
   buildResumeCommand,
+  buildResumeLatestCommand,
   buildLaunchCommandFromFlags,
 } from "@shared/types";
 import { inferKind as inferKindShared } from "@shared/utils/inferPanelKind";
@@ -387,14 +388,22 @@ export function buildArgsForRespawn(
           presetArgs: preset?.args?.join(" "),
         });
       }
-    } else if (hasPersistedFlags) {
-      command = buildFromPersistedFlags();
-    } else if (agentSettings) {
-      command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
-        clipboardDirectory,
-        modelId: saved.agentModelId,
-        presetArgs: preset?.args?.join(" "),
-      });
+    } else {
+      // No session ID was captured (graceful-shutdown pattern match missed or
+      // timed out). Try the agent's resume-latest fallback before falling
+      // through to a fresh launch so the user keeps their prior conversation.
+      const resumeLatestCmd = buildResumeLatestCommand(agentId, persistedFlags);
+      if (resumeLatestCmd) {
+        command = resumeLatestCmd;
+      } else if (hasPersistedFlags) {
+        command = buildFromPersistedFlags();
+      } else if (agentSettings) {
+        command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
+          clipboardDirectory,
+          modelId: saved.agentModelId,
+          presetArgs: preset?.args?.join(" "),
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- When session-ID capture fails after a graceful kill, the app now falls back to agent-specific resume-latest commands rather than spawning a fresh session
- Covers all three agents: Claude (`--continue`), Codex (`resume --last`), Gemini (`-r latest`)
- `HelpSessionController` stores a sentinel hibernate entry (empty `sessionId`) when capture misses, so the resume-latest path is durable across restarts

Resolves #8787

## Changes

- New `resumeLatestArgs` field on the session-ID branch of `AgentResume` and a companion `buildResumeLatestCommand` function in `agentRegistry`
- Agent configs updated: `claude.ts`, `codex.ts`, `gemini.ts`
- Plumbed through `statePatcher.ts`, `restart.ts`, `App.tsx` (both panel-palette call sites), and `HelpSessionController.ts`
- New `allowResumeLatest` option on `restartTerminal` — set to `false` in the worktree-move and cwd-change paths to prevent stale-session resumption
- `helpPanelStore` sanitization updated to allow empty-string `sessionId` as the resume-latest sentinel
- `restart.ts`: durable command uses the original command when the resume-latest path runs, avoiding the transient-as-durable bug

## Testing

245+ new test cases across 6 test files: `agentSettings.test.ts`, `statePatcher.test.ts`, `restartTerminal.test.ts`, `moveToNewWorktreeAndTransfer.test.ts`, `helpPanelStore.test.ts`, `HelpPanel.hibernate.test.tsx`