### PR TITLE
feat(detector): identify terminal agents by executable image path

### DIFF
--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -212,6 +212,7 @@ vi.mock("../services/PtyManager.js", () => {
     });
     isSabMode = vi.fn(() => this.sabMode);
     setProcessTreeCache = vi.fn();
+    setImagePathProbe = vi.fn();
     setPtyPool = vi.fn();
     setActivityMonitorTier = vi.fn();
     spawn = vi.fn((id: string, options: { projectId?: string }) => {

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -35,6 +35,7 @@ import os from "node:os";
 import { PtyManager } from "./services/PtyManager.js";
 import { PtyPool, getPtyPool, shouldEnablePtyPool } from "./services/PtyPool.js";
 import { ProcessTreeCache } from "./services/ProcessTreeCache.js";
+import { ImagePathProbe } from "./services/pty/ImagePathProbe.js";
 import { TerminalResourceMonitor } from "./services/pty/TerminalResourceMonitor.js";
 import { events } from "./services/events.js";
 import { SharedRingBuffer, PacketFramer } from "../shared/utils/SharedRingBuffer.js";
@@ -117,6 +118,11 @@ const ptyManager = new PtyManager();
 // `claude --version`-style blips. Adaptive backoff (see ProcessTreeCache)
 // stretches this out when the tree is quiet.
 const processTreeCache = new ProcessTreeCache(1500);
+// Image-path identity signal — defeats `process.title`/`setproctitle` rewrites
+// where comm/argv have been clobbered but the on-disk binary path still
+// identifies the agent. Shared across all terminals so the per-PID cache is
+// reused when a process appears in multiple detection passes. #8790
+const imagePathProbe = new ImagePathProbe();
 const terminalResourceMonitor = new TerminalResourceMonitor(
   processTreeCache,
   ptyManager,
@@ -943,6 +949,7 @@ function cleanup(): void {
 
   terminalResourceMonitor.dispose();
   processTreeCache.stop();
+  imagePathProbe.dispose();
 
   if (ptyPool) {
     ptyPool.dispose();
@@ -976,6 +983,7 @@ async function initialize(): Promise<void> {
     // Start the process tree cache (shared across all terminals)
     processTreeCache.start();
     ptyManager.setProcessTreeCache(processTreeCache);
+    ptyManager.setImagePathProbe(imagePathProbe);
     console.log("[PtyHost] ProcessTreeCache started");
 
     // Notify Main that we're ready (after cache is initialized, before pool is warmed)

--- a/electron/services/ProcessDetector/ProcessDetector.ts
+++ b/electron/services/ProcessDetector/ProcessDetector.ts
@@ -44,6 +44,11 @@ export class ProcessDetector {
   private lastEvidenceSource: DetectionEvidenceSource | null = null;
   private cache: ProcessTreeCache;
   private imagePathProbe: ImagePathProbe | null;
+  // PIDs the detector probed in the previous detect pass. On the next pass we
+  // diff against the current set and evict any PIDs that disappeared from the
+  // tree so an OS PID-reuse cycle can't return the prior process's basename
+  // through a stale ImagePathProbe entry.
+  private previouslyProbedPids = new Set<number>();
   private unsubscribe: (() => void) | null = null;
   private isStarted: boolean = false;
   private onStreak: number = 0;
@@ -265,6 +270,15 @@ export class ProcessDetector {
       this.unsubscribe = null;
       logDebug(`Stopped ProcessDetector for terminal ${this.terminalId}`);
     }
+    // Release ImagePathProbe entries for this terminal's last-known children
+    // so a recycled PID inherited by a different terminal doesn't see stale
+    // basenames. The probe is shared across all terminals.
+    if (this.imagePathProbe) {
+      for (const pid of this.previouslyProbedPids) {
+        this.imagePathProbe.evict(pid);
+      }
+    }
+    this.previouslyProbedPids.clear();
     this.isStarted = false;
   }
 
@@ -528,7 +542,12 @@ export class ProcessDetector {
     if (!isBusy) {
       // True absence of children with healthy cache → negative evidence. Let
       // merge logic below consider shell-command evidence before committing
-      // no_agent.
+      // no_agent. Also evict any image-path entries from the last pass — the
+      // children disappeared, so previously-cached basenames are now stale
+      // and could mislead a future detection cycle on a recycled PID. We
+      // explicitly do NOT evict on the blind-`ps` path above because the
+      // empty children list there is "no evidence", not "real absence".
+      this.evictDisappearedImagePathPids(new Set());
       return this.mergeWithShellEvidence(null, { isBusy: false, currentCommand: undefined });
     }
 
@@ -540,6 +559,7 @@ export class ProcessDetector {
 
     let bestMatch: DetectedProcessCandidate | null = null;
     let order = 0;
+    const probedPids = new Set<number>();
 
     for (const proc of processes) {
       const candidate = buildDetectedCandidate(proc.name, proc.command, order++);
@@ -552,11 +572,14 @@ export class ProcessDetector {
       // Runs alongside the comm match (not as a replacement) so the existing
       // selectPreferredCandidate priority logic picks the agent over a generic
       // icon when both fire. #8790
-      const imageBasename = this.imagePathProbe?.readBasename(proc.pid) ?? null;
-      if (imageBasename) {
-        const imageCandidate = buildDetectedCandidate(imageBasename, proc.command, order++);
-        if (imageCandidate) {
-          bestMatch = selectPreferredCandidate(bestMatch, imageCandidate);
+      if (this.imagePathProbe) {
+        probedPids.add(proc.pid);
+        const imageBasename = this.imagePathProbe.readBasename(proc.pid);
+        if (imageBasename) {
+          const imageCandidate = buildDetectedCandidate(imageBasename, proc.command, order++);
+          if (imageCandidate) {
+            bestMatch = selectPreferredCandidate(bestMatch, imageCandidate);
+          }
         }
       }
     }
@@ -578,15 +601,18 @@ export class ProcessDetector {
           if (candidate) {
             bestMatch = selectPreferredCandidate(bestMatch, candidate);
           }
-          const grandImageBasename = this.imagePathProbe?.readBasename(grandchild.pid) ?? null;
-          if (grandImageBasename) {
-            const grandImageCandidate = buildDetectedCandidate(
-              grandImageBasename,
-              grandchild.command || grandchild.comm,
-              order++
-            );
-            if (grandImageCandidate) {
-              bestMatch = selectPreferredCandidate(bestMatch, grandImageCandidate);
+          if (this.imagePathProbe) {
+            probedPids.add(grandchild.pid);
+            const grandImageBasename = this.imagePathProbe.readBasename(grandchild.pid);
+            if (grandImageBasename) {
+              const grandImageCandidate = buildDetectedCandidate(
+                grandImageBasename,
+                grandchild.command || grandchild.comm,
+                order++
+              );
+              if (grandImageCandidate) {
+                bestMatch = selectPreferredCandidate(bestMatch, grandImageCandidate);
+              }
             }
           }
         }
@@ -615,10 +641,30 @@ export class ProcessDetector {
     const primaryProcess = processes[0];
     const primaryCommand = primaryProcess?.command;
 
+    this.evictDisappearedImagePathPids(probedPids);
+
     return this.mergeWithShellEvidence(bestMatch, {
       isBusy,
       currentCommand: bestMatch?.processCommand || primaryCommand,
     });
+  }
+
+  /**
+   * Evict ImagePathProbe entries for PIDs that were probed last pass but are
+   * absent this pass. Without this, a recycled PID could return the prior
+   * process's cached basename for up to 30s (the probe's eviction TTL) plus
+   * the cache hard-max window, causing a brief misidentification before the
+   * background refresh writes the new value. Diffing here is O(N) per pass
+   * where N is the worst-case 10 children × ~10 grandchildren = 100 PIDs.
+   */
+  private evictDisappearedImagePathPids(currentProbedPids: Set<number>): void {
+    if (!this.imagePathProbe) return;
+    for (const pid of this.previouslyProbedPids) {
+      if (!currentProbedPids.has(pid)) {
+        this.imagePathProbe.evict(pid);
+      }
+    }
+    this.previouslyProbedPids = currentProbedPids;
   }
 
   /**

--- a/electron/services/ProcessDetector/ProcessDetector.ts
+++ b/electron/services/ProcessDetector/ProcessDetector.ts
@@ -1,5 +1,6 @@
 import type { BuiltInAgentId } from "../../../shared/config/agentIds.js";
 import type { ProcessTreeCache } from "../ProcessTreeCache.js";
+import type { ImagePathProbe } from "../pty/ImagePathProbe.js";
 import { logDebug, logWarn } from "../../utils/logger.js";
 import { logIdentityDebug } from "../pty/identityDebug.js";
 import type { ChildProcess, DetectedProcessCandidate, CommandIdentity } from "./types.js";
@@ -42,6 +43,7 @@ export class ProcessDetector {
   private lastCurrentCommand: string | undefined;
   private lastEvidenceSource: DetectionEvidenceSource | null = null;
   private cache: ProcessTreeCache;
+  private imagePathProbe: ImagePathProbe | null;
   private unsubscribe: (() => void) | null = null;
   private isStarted: boolean = false;
   private onStreak: number = 0;
@@ -73,7 +75,8 @@ export class ProcessDetector {
     ptyPid: number,
     callback: DetectionCallback,
     cache: ProcessTreeCache,
-    isLaunchAnchored: boolean = true
+    isLaunchAnchored: boolean = true,
+    imagePathProbe: ImagePathProbe | null = null
   ) {
     this.terminalId = terminalId;
     this.spawnedAt = spawnedAt;
@@ -81,6 +84,7 @@ export class ProcessDetector {
     this.callback = callback;
     this.cache = cache;
     this.isLaunchAnchored = isLaunchAnchored;
+    this.imagePathProbe = imagePathProbe;
   }
 
   /**
@@ -542,6 +546,19 @@ export class ProcessDetector {
       if (candidate) {
         bestMatch = selectPreferredCandidate(bestMatch, candidate);
       }
+      // Image-path candidate: defeats `process.title`/`setproctitle` rewrites
+      // where `comm` and argv have both been clobbered to something like
+      // "Claude Code" but the on-disk binary is still `/opt/homebrew/bin/claude`.
+      // Runs alongside the comm match (not as a replacement) so the existing
+      // selectPreferredCandidate priority logic picks the agent over a generic
+      // icon when both fire. #8790
+      const imageBasename = this.imagePathProbe?.readBasename(proc.pid) ?? null;
+      if (imageBasename) {
+        const imageCandidate = buildDetectedCandidate(imageBasename, proc.command, order++);
+        if (imageCandidate) {
+          bestMatch = selectPreferredCandidate(bestMatch, imageCandidate);
+        }
+      }
     }
 
     // Grandchild fallback. Only run when direct children didn't produce an
@@ -560,6 +577,17 @@ export class ProcessDetector {
           );
           if (candidate) {
             bestMatch = selectPreferredCandidate(bestMatch, candidate);
+          }
+          const grandImageBasename = this.imagePathProbe?.readBasename(grandchild.pid) ?? null;
+          if (grandImageBasename) {
+            const grandImageCandidate = buildDetectedCandidate(
+              grandImageBasename,
+              grandchild.command || grandchild.comm,
+              order++
+            );
+            if (grandImageCandidate) {
+              bestMatch = selectPreferredCandidate(bestMatch, grandImageCandidate);
+            }
           }
         }
       }

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -7,6 +7,7 @@ import type { AgentStateChangeTrigger } from "../schemas/agent.js";
 import type { PtyPool } from "./PtyPool.js";
 import type { ProcessTreeCache } from "./ProcessTreeCache.js";
 import type { DetectionResult } from "./ProcessDetector.js";
+import type { ImagePathProbe } from "./pty/ImagePathProbe.js";
 import { createLogger } from "../utils/logger.js";
 
 const logger = createLogger("pty-host:PtyManager");
@@ -60,6 +61,7 @@ export class PtyManager extends EventEmitter {
   private agentStateService: AgentStateService;
   private ptyPool: PtyPool | null = null;
   private processTreeCache: ProcessTreeCache | null = null;
+  private imagePathProbe: ImagePathProbe | null = null;
   private activeProjectId: string | null = null;
   private sabModeEnabled = false;
   // Resize requests that arrived before the terminal was registered.
@@ -76,6 +78,10 @@ export class PtyManager extends EventEmitter {
 
   setProcessTreeCache(cache: ProcessTreeCache): void {
     this.processTreeCache = cache;
+  }
+
+  setImagePathProbe(probe: ImagePathProbe): void {
+    this.imagePathProbe = probe;
   }
 
   /**
@@ -264,6 +270,7 @@ export class PtyManager extends EventEmitter {
           ptyPool: this.ptyPool,
           sabModeEnabled: this.sabModeEnabled,
           processTreeCache: this.processTreeCache,
+          imagePathProbe: this.imagePathProbe,
         },
         spawnContext,
         ptyProcess,

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -1560,6 +1560,56 @@ describe("ProcessDetector", () => {
       );
     });
 
+    it("evicts ImagePathProbe entries for children that disappear between passes", () => {
+      // PID-reuse safety: if pid 200 was probed last pass and is gone this
+      // pass, the detector must evict its image-path cache entry so a future
+      // process with the recycled PID doesn't inherit the stale basename.
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const imagePathProbe = createImagePathProbeMock({ 200: "claude" });
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-evict",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        true,
+        imagePathProbe as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      expect(imagePathProbe.readBasename).toHaveBeenCalledWith(200);
+
+      // Child disappears.
+      cache.setChildren(100, []);
+      cache.emitRefresh();
+      expect(imagePathProbe.evict).toHaveBeenCalledWith(200);
+    });
+
+    it("evicts ImagePathProbe entries for the terminal's last-seen children on stop()", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const imagePathProbe = createImagePathProbeMock({ 200: "claude" });
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-evict-stop",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        true,
+        imagePathProbe as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      detector.stop();
+
+      expect(imagePathProbe.evict).toHaveBeenCalledWith(200);
+    });
+
     it("resolves grandchild image paths when the direct child is only an icon match", () => {
       // Grandchild fallback path: zsh → bash → renamed-claude. The direct
       // child has only an icon (priority > 0 triggers grandchild scan); the

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -1396,6 +1396,203 @@ describe("ProcessDetector", () => {
       );
     });
   });
+
+  describe("image-path evidence (#8790)", () => {
+    function createImagePathProbeMock(map: Record<number, string | null>) {
+      return {
+        readBasename: vi.fn((pid: number) => map[pid] ?? null),
+        evict: vi.fn(),
+        dispose: vi.fn(),
+      };
+    }
+
+    it("identifies an agent when comm is rewritten but image basename is the agent", () => {
+      // The exact failure mode #8790 targets: agent CLI rewrote its own
+      // process title to a marketing name, so `comm`/`command` look like
+      // "app-runner" with no AGENT_CLI_NAMES match — but the on-disk image
+      // is /opt/homebrew/bin/claude. Image-path evidence must rescue it.
+      const cache = createCacheMock();
+      cache.setChildren(100, [
+        {
+          pid: 200,
+          comm: "app-runner",
+          command: "app-runner",
+        },
+      ]);
+      const imagePathProbe = createImagePathProbeMock({ 200: "claude" });
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-image-rewrite",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        true,
+        imagePathProbe as never
+      );
+      detector.start();
+      cache.emitRefresh();
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detected: true,
+          detectionState: "agent",
+          agentType: "claude",
+          evidenceSource: "process_tree",
+        }),
+        expect.any(Number)
+      );
+      expect(imagePathProbe.readBasename).toHaveBeenCalledWith(200);
+    });
+
+    it("ignores image-path basename when it returns null", () => {
+      // Probe hasn't resolved yet (or platform unsupported). Detection must
+      // behave exactly as before — fall through to the existing comm/argv
+      // path. No regression on a process the detector already identifies.
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const imagePathProbe = createImagePathProbeMock({ 200: null });
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-image-null",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        true,
+        imagePathProbe as never
+      );
+      detector.start();
+      cache.emitRefresh();
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detected: true,
+          agentType: "claude",
+        }),
+        expect.any(Number)
+      );
+    });
+
+    it("works when no image-path probe is wired (backwards compat)", () => {
+      // Existing call sites pass only the 6-arg constructor signature. The
+      // detector must work identically when the probe is omitted.
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-no-probe",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ detected: true, agentType: "claude" }),
+        expect.any(Number)
+      );
+    });
+
+    it("prefers image-path agent over a comm-only generic icon", () => {
+      // Node-hosted agent: kernel reports comm="node", argv has been blanked,
+      // so without image-path the detector would settle on the generic
+      // "node" process icon. Image basename "claude" should win via the
+      // agent-priority promotion in selectPreferredCandidate.
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "node", command: "node" }]);
+      const imagePathProbe = createImagePathProbeMock({ 200: "claude" });
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-node-hosted",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        true,
+        imagePathProbe as never
+      );
+      detector.start();
+      cache.emitRefresh();
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detected: true,
+          agentType: "claude",
+        }),
+        expect.any(Number)
+      );
+    });
+
+    it("does not regress when image-path basename matches an existing agent comm", () => {
+      // Both signals agree on `claude`. Detector should commit `claude`
+      // with process_tree evidence — no double-count, no priority inversion.
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const imagePathProbe = createImagePathProbeMock({ 200: "claude" });
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-both-agree",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        true,
+        imagePathProbe as never
+      );
+      detector.start();
+      cache.emitRefresh();
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detected: true,
+          agentType: "claude",
+          evidenceSource: "process_tree",
+        }),
+        expect.any(Number)
+      );
+    });
+
+    it("resolves grandchild image paths when the direct child is only an icon match", () => {
+      // Grandchild fallback path: zsh → bash → renamed-claude. The direct
+      // child has only an icon (priority > 0 triggers grandchild scan); the
+      // grandchild's image basename "claude" promotes the result to agent
+      // even though both the grandchild comm and argv have been rewritten.
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "bash", command: "bash login_script.sh" }]);
+      cache.setChildren(200, [{ pid: 300, comm: "app-runner", command: "app-runner" }]);
+      const imagePathProbe = createImagePathProbeMock({ 200: null, 300: "claude" });
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-image-grandchild",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        true,
+        imagePathProbe as never
+      );
+      detector.start();
+      cache.emitRefresh();
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detected: true,
+          agentType: "claude",
+        }),
+        expect.any(Number)
+      );
+      expect(imagePathProbe.readBasename).toHaveBeenCalledWith(300);
+    });
+  });
 });
 
 describe("extractScriptBasenameFromCommand", () => {

--- a/electron/services/pty/ImagePathProbe.ts
+++ b/electron/services/pty/ImagePathProbe.ts
@@ -4,13 +4,17 @@ import { readlink } from "node:fs/promises";
 
 const execFileAsync = promisify(execFile);
 
-// Stale-while-revalidate windows mirror ForegroundProcessGroupProbe: soft-stale
-// triggers a background refresh, hard-max blanks the basename so the detector
-// stops trusting a long-dead lookup. Eviction TTL drops PIDs we haven't read
-// in a while so the per-PID Map cannot grow unbounded across a long session
-// of short-lived children.
+// Stale-while-revalidate windows. Soft-stale (500ms) triggers a background
+// refresh on the next read; the cached basename is still returned so the
+// detector keeps a continuous signal across polls. Hard-max (5000ms) is
+// 3-4× the 1500ms ProcessTreeCache poll interval — using anything close to
+// the poll interval causes every poll to fall past max-age in setTimeout
+// jitter, blanking the basename and defeating hysteresis. Eviction TTL keeps
+// idle PIDs out of the map so it cannot grow unbounded across a long session
+// of short-lived children; ProcessDetector also evicts disappeared child
+// PIDs proactively so PID reuse can't return a stale prior-process basename.
 const IMAGE_PATH_SOFT_STALE_MS = 500;
-const IMAGE_PATH_MAX_AGE_MS = 1500;
+const IMAGE_PATH_MAX_AGE_MS = 5000;
 const IMAGE_PATH_PROBE_TIMEOUT_MS = 750;
 const IMAGE_PATH_EVICTION_TTL_MS = 30_000;
 
@@ -18,7 +22,10 @@ const IMAGE_PATH_EVICTION_TTL_MS = 30_000;
 // the actual executable, plus dylibs/frameworks/system libs that share the
 // `txt` fd class. Filter those out so we land on the real binary rather than
 // the first system library the process loaded.
-const MACOS_SYSTEM_PATH_PREFIXES = ["/System/", "/usr/lib/", "/Library/Apple/"];
+// Narrow to `/System/Library/` (not bare `/System/`) so apps installed under
+// `/System/Applications/Foo.app/Contents/MacOS/Foo` are still picked up as the
+// executable rather than misclassified as a system library.
+const MACOS_SYSTEM_PATH_PREFIXES = ["/System/Library/", "/usr/lib/", "/Library/Apple/"];
 const MACOS_LIBRARY_SUFFIXES = [".dylib", ".framework", ".bundle"];
 
 interface CacheEntry {
@@ -55,6 +62,11 @@ interface CacheEntry {
 export class ImagePathProbe {
   private readonly entries = new Map<number, CacheEntry>();
   private disposed = false;
+  // Probe-wide monotonic counter so a refresh that resolves AFTER its entry
+  // was evicted-and-recreated cannot overwrite the new entry — the new entry
+  // will have a different checkId from the in-flight one. A per-entry counter
+  // would reset to 0 on recreation and collide with the in-flight value.
+  private nextCheckId = 0;
 
   /**
    * Sync read against the per-PID cache. Returns the cached executable
@@ -76,7 +88,7 @@ export class ImagePathProbe {
         updatedAt: 0,
         lastReadAt: now,
         refreshing: false,
-        checkId: 0,
+        checkId: this.nextCheckId,
       };
       this.entries.set(pid, entry);
       this.scheduleRefresh(pid, entry);
@@ -132,7 +144,8 @@ export class ImagePathProbe {
 
   private scheduleRefresh(pid: number, entry: CacheEntry): void {
     entry.refreshing = true;
-    const checkId = ++entry.checkId;
+    const checkId = ++this.nextCheckId;
+    entry.checkId = checkId;
     void this.refresh(pid)
       .then((basename) => {
         if (this.disposed) return;

--- a/electron/services/pty/ImagePathProbe.ts
+++ b/electron/services/pty/ImagePathProbe.ts
@@ -1,0 +1,273 @@
+import { execFile } from "child_process";
+import { promisify } from "node:util";
+import { readlink } from "node:fs/promises";
+
+const execFileAsync = promisify(execFile);
+
+// Stale-while-revalidate windows mirror ForegroundProcessGroupProbe: soft-stale
+// triggers a background refresh, hard-max blanks the basename so the detector
+// stops trusting a long-dead lookup. Eviction TTL drops PIDs we haven't read
+// in a while so the per-PID Map cannot grow unbounded across a long session
+// of short-lived children.
+const IMAGE_PATH_SOFT_STALE_MS = 500;
+const IMAGE_PATH_MAX_AGE_MS = 1500;
+const IMAGE_PATH_PROBE_TIMEOUT_MS = 750;
+const IMAGE_PATH_EVICTION_TTL_MS = 30_000;
+
+// `lsof -Fn` on macOS lists every memory-mapped text segment for the process —
+// the actual executable, plus dylibs/frameworks/system libs that share the
+// `txt` fd class. Filter those out so we land on the real binary rather than
+// the first system library the process loaded.
+const MACOS_SYSTEM_PATH_PREFIXES = ["/System/", "/usr/lib/", "/Library/Apple/"];
+const MACOS_LIBRARY_SUFFIXES = [".dylib", ".framework", ".bundle"];
+
+interface CacheEntry {
+  basename: string | null;
+  updatedAt: number;
+  lastReadAt: number;
+  refreshing: boolean;
+  checkId: number;
+}
+
+/**
+ * Resolves the on-disk executable image basename for a given PID. The image
+ * path is immune to `process.title` / `setproctitle` rewrites (an agent CLI
+ * that renames itself to "Claude Code" still has `/opt/homebrew/bin/claude`
+ * as its image), so it gives `ProcessDetector` a third identity signal that
+ * survives the title-rewriting case the kernel `comm` and argv columns fail.
+ *
+ * Stale-while-revalidate per PID so the synchronous `detectAgent()` contract
+ * stays synchronous — first call schedules an async resolution, subsequent
+ * calls within the freshness window return the cached basename, calls past
+ * the soft-stale window trigger a refresh while still returning the cached
+ * value. Past hard-max we return null until the refresh completes.
+ *
+ * Platform dispatch:
+ *  - Linux: `readlink /proc/<pid>/exe` (pure Node, ~instant)
+ *  - macOS: `lsof -a -d txt -p <pid> -Fn` filtered to skip system libs
+ *  - Windows: PowerShell `Get-CimInstance Win32_Process … ExecutablePath`
+ *  - Other: returns null (no probe scheduled)
+ *
+ * All probe failures are swallowed — image-path is a supplementary signal,
+ * not a primary one, so falling back to the existing comm/argv path is
+ * always safe.
+ */
+export class ImagePathProbe {
+  private readonly entries = new Map<number, CacheEntry>();
+  private disposed = false;
+
+  /**
+   * Sync read against the per-PID cache. Returns the cached executable
+   * basename (lowercased, extension stripped) or null when unknown / past
+   * the hard-max age. Schedules an async refresh when the entry is missing
+   * or past soft-stale. Eviction TTL: unreferenced entries drop after 30s.
+   */
+  readBasename(pid: number): string | null {
+    if (this.disposed) return null;
+    if (!Number.isInteger(pid) || pid <= 0) return null;
+    if (!this.isPlatformSupported()) return null;
+
+    const now = Date.now();
+    let entry = this.entries.get(pid);
+
+    if (!entry) {
+      entry = {
+        basename: null,
+        updatedAt: 0,
+        lastReadAt: now,
+        refreshing: false,
+        checkId: 0,
+      };
+      this.entries.set(pid, entry);
+      this.scheduleRefresh(pid, entry);
+      this.evictStale(now);
+      return null;
+    }
+
+    entry.lastReadAt = now;
+
+    const hasEverProbed = entry.updatedAt > 0;
+    const age = hasEverProbed ? now - entry.updatedAt : 0;
+
+    if (!entry.refreshing && (!hasEverProbed || age > IMAGE_PATH_SOFT_STALE_MS)) {
+      this.scheduleRefresh(pid, entry);
+    }
+
+    if (!hasEverProbed) return null;
+    if (age > IMAGE_PATH_MAX_AGE_MS) return null;
+
+    return entry.basename;
+  }
+
+  /**
+   * Drop a PID immediately. Call this when a child process is known to have
+   * exited so a recycled PID does not return the prior process's basename.
+   */
+  evict(pid: number): void {
+    this.entries.delete(pid);
+  }
+
+  /**
+   * Tear down the probe. After dispose all reads return null and no further
+   * refreshes are scheduled.
+   */
+  dispose(): void {
+    this.disposed = true;
+    this.entries.clear();
+  }
+
+  private isPlatformSupported(): boolean {
+    return (
+      process.platform === "linux" || process.platform === "darwin" || process.platform === "win32"
+    );
+  }
+
+  private evictStale(now: number): void {
+    for (const [pid, entry] of this.entries) {
+      if (now - entry.lastReadAt > IMAGE_PATH_EVICTION_TTL_MS && !entry.refreshing) {
+        this.entries.delete(pid);
+      }
+    }
+  }
+
+  private scheduleRefresh(pid: number, entry: CacheEntry): void {
+    entry.refreshing = true;
+    const checkId = ++entry.checkId;
+    void this.refresh(pid)
+      .then((basename) => {
+        if (this.disposed) return;
+        const current = this.entries.get(pid);
+        // Stale-write guard: another refresh may have superseded this one if
+        // the entry was evicted and recreated in the meantime.
+        if (!current || current.checkId !== checkId) return;
+        current.basename = basename;
+        current.updatedAt = Date.now();
+        current.refreshing = false;
+      })
+      .catch(() => {
+        if (this.disposed) return;
+        const current = this.entries.get(pid);
+        if (!current || current.checkId !== checkId) return;
+        // Persisting null with a fresh timestamp matches ForegroundProcessGroupProbe:
+        // prevents tight-retry while the underlying failure is still active.
+        current.basename = null;
+        current.updatedAt = Date.now();
+        current.refreshing = false;
+      });
+  }
+
+  private async refresh(pid: number): Promise<string | null> {
+    try {
+      const platform = process.platform;
+      if (platform === "linux") return await this.resolveLinux(pid);
+      if (platform === "darwin") return await this.resolveMacOS(pid);
+      if (platform === "win32") return await this.resolveWindows(pid);
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async resolveLinux(pid: number): Promise<string | null> {
+    try {
+      const target = await readlink(`/proc/${pid}/exe`);
+      return this.toBasename(this.stripDeletedSuffix(target));
+    } catch {
+      return null;
+    }
+  }
+
+  private async resolveMacOS(pid: number): Promise<string | null> {
+    try {
+      const { stdout } = await execFileAsync(
+        "lsof",
+        ["-a", "-d", "txt", "-p", String(pid), "-Fn"],
+        {
+          encoding: "utf8",
+          shell: false,
+          signal: AbortSignal.timeout(IMAGE_PATH_PROBE_TIMEOUT_MS),
+        }
+      );
+      return this.parseLsofOutput(stdout);
+    } catch {
+      return null;
+    }
+  }
+
+  private async resolveWindows(pid: number): Promise<string | null> {
+    try {
+      const { stdout } = await execFileAsync(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").ExecutablePath`,
+        ],
+        {
+          encoding: "utf8",
+          shell: false,
+          signal: AbortSignal.timeout(IMAGE_PATH_PROBE_TIMEOUT_MS),
+        }
+      );
+      const trimmed = stdout.trim();
+      if (!trimmed) return null;
+      return this.toBasename(trimmed);
+    } catch {
+      return null;
+    }
+  }
+
+  private parseLsofOutput(stdout: string): string | null {
+    // `lsof -Fn` emits per-fd records. Each record's `n`-prefixed line is the
+    // mapped path. We may see several `n` lines (the executable plus every
+    // dylib/framework it has mapped). Take the first path that is absolute,
+    // not under a system library prefix, and not itself a library file.
+    let fallback: string | null = null;
+    for (const rawLine of stdout.split("\n")) {
+      if (!rawLine.startsWith("n")) continue;
+      const filePath = rawLine.slice(1).trim();
+      if (!filePath) continue;
+      if (!filePath.startsWith("/")) continue;
+      if (!fallback) fallback = filePath;
+      if (this.isMacOSLibraryPath(filePath)) continue;
+      return this.toBasename(filePath);
+    }
+    return fallback ? this.toBasename(fallback) : null;
+  }
+
+  private isMacOSLibraryPath(filePath: string): boolean {
+    for (const prefix of MACOS_SYSTEM_PATH_PREFIXES) {
+      if (filePath.startsWith(prefix)) return true;
+    }
+    const lower = filePath.toLowerCase();
+    for (const suffix of MACOS_LIBRARY_SUFFIXES) {
+      if (lower.endsWith(suffix)) return true;
+      // Inside a bundle: `.../Foo.framework/Versions/A/Foo` is still a library
+      // (the executable inside a framework), not the program we want.
+      if (lower.includes(`${suffix}/`)) return true;
+    }
+    return false;
+  }
+
+  private stripDeletedSuffix(target: string): string {
+    // procfs readlink appends ` (deleted)` when the original file has been
+    // unlinked while the process is still running (e.g. upgrade-in-place).
+    return target.replace(/\s+\(deleted\)\s*$/u, "");
+  }
+
+  private toBasename(fullPath: string): string | null {
+    const trimmed = fullPath.trim();
+    if (!trimmed) return null;
+    // Split on both POSIX and Windows separators so a Windows-style path
+    // resolves correctly when this code runs on macOS/Linux (tests, dev
+    // boxes). path.basename respects the running platform's separator only.
+    const baseRaw = trimmed.split(/[\\/]/).pop() || trimmed;
+    const lower = baseRaw.toLowerCase();
+    // Strip Windows executable extensions so the basename lines up with the
+    // lowercase keys the candidate builder uses for AGENT_CLI_NAMES /
+    // PROCESS_ICON_MAP lookups.
+    const stripped = lower.replace(/\.(exe|cmd|bat|com|ps1)$/u, "");
+    return stripped || null;
+  }
+}

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -11,6 +11,7 @@ const { Unicode11Addon } = unicode11;
 import { getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
 import { ProcessDetector, type DetectionResult } from "../ProcessDetector.js";
 import type { ProcessTreeCache } from "../ProcessTreeCache.js";
+import type { ImagePathProbe } from "./ImagePathProbe.js";
 import { ActivityMonitor } from "../ActivityMonitor.js";
 import { AgentStateService } from "./AgentStateService.js";
 import { ActivityHeadlineGenerator } from "../ActivityHeadlineGenerator.js";
@@ -113,6 +114,7 @@ export interface TerminalProcessDependencies {
   ptyPool: PtyPool | null;
   sabModeEnabled?: boolean;
   processTreeCache: ProcessTreeCache | null;
+  imagePathProbe?: ImagePathProbe | null;
 }
 
 export class TerminalProcess {
@@ -436,7 +438,8 @@ export class TerminalProcess {
           this.handleAgentDetection(result, cbSpawnedAt);
         },
         deps.processTreeCache,
-        Boolean(this.terminalInfo.launchAgentId)
+        Boolean(this.terminalInfo.launchAgentId),
+        deps.imagePathProbe ?? null
       );
       this.terminalInfo.processDetector = this.processDetector;
       this.processDetector.start();
@@ -1271,7 +1274,8 @@ export class TerminalProcess {
           this.handleAgentDetection(result, cbSpawnedAt);
         },
         this.deps.processTreeCache,
-        Boolean(this.terminalInfo.launchAgentId)
+        Boolean(this.terminalInfo.launchAgentId),
+        this.deps.imagePathProbe ?? null
       );
       this.terminalInfo.processDetector = this.processDetector;
       this.processDetector.start();

--- a/electron/services/pty/__tests__/ImagePathProbe.test.ts
+++ b/electron/services/pty/__tests__/ImagePathProbe.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface ScheduledCall {
+  cmd: string;
+  args: readonly string[] | null | undefined;
+  options: Record<string, unknown>;
+  resolve: (stdout: string) => void;
+  reject: (err: Error) => void;
+}
+
+const execFileMock = vi.hoisted(() => {
+  const calls: ScheduledCall[] = [];
+  const fn = (..._args: unknown[]) => {
+    throw new Error("execFile mock was called with callback form (unexpected)");
+  };
+  Object.defineProperty(fn, Symbol.for("nodejs.util.promisify.custom"), {
+    value: (
+      cmd: string,
+      args: readonly string[] | null | undefined,
+      options: Record<string, unknown>
+    ) =>
+      new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+        calls.push({
+          cmd,
+          args,
+          options,
+          resolve: (stdout) => resolve({ stdout, stderr: "" }),
+          reject: (err) => reject(err),
+        });
+      }),
+  });
+  return Object.assign(fn, { calls });
+});
+
+const readlinkMock = vi.hoisted(() => {
+  const queue: Array<{ resolve: (value: string) => void; reject: (err: Error) => void }> = [];
+  const calls: string[] = [];
+  const fn = (target: string) => {
+    calls.push(target);
+    return new Promise<string>((resolve, reject) => {
+      queue.push({ resolve, reject });
+    });
+  };
+  return Object.assign(fn, { queue, calls });
+});
+
+vi.mock("child_process", () => ({
+  execFile: execFileMock,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readlink: readlinkMock,
+}));
+
+const { ImagePathProbe } = await import("../ImagePathProbe.js");
+
+const realPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+async function flush(): Promise<void> {
+  // Drain microtasks so the async refresh writes back into the cache before
+  // we make the next synchronous read.
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("ImagePathProbe", () => {
+  beforeEach(() => {
+    execFileMock.calls.length = 0;
+    readlinkMock.queue.length = 0;
+    readlinkMock.calls.length = 0;
+    setPlatform("linux");
+  });
+
+  afterEach(() => {
+    setPlatform(realPlatform);
+  });
+
+  it("returns null on first read while the probe is in flight", () => {
+    const probe = new ImagePathProbe();
+    expect(probe.readBasename(123)).toBeNull();
+    expect(readlinkMock.calls).toEqual(["/proc/123/exe"]);
+  });
+
+  it("returns null for invalid PIDs without scheduling a probe", () => {
+    const probe = new ImagePathProbe();
+    expect(probe.readBasename(0)).toBeNull();
+    expect(probe.readBasename(-1)).toBeNull();
+    expect(probe.readBasename(Number.NaN)).toBeNull();
+    expect(readlinkMock.calls).toHaveLength(0);
+  });
+
+  it("returns null on unsupported platforms", () => {
+    setPlatform("freebsd" as NodeJS.Platform);
+    const probe = new ImagePathProbe();
+    expect(probe.readBasename(123)).toBeNull();
+    expect(readlinkMock.calls).toHaveLength(0);
+    expect(execFileMock.calls).toHaveLength(0);
+  });
+
+  describe("Linux", () => {
+    it("publishes the lowercased basename from /proc/<pid>/exe", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(123);
+      readlinkMock.queue[0]!.resolve("/opt/homebrew/bin/claude");
+      await flush();
+
+      expect(probe.readBasename(123)).toBe("claude");
+    });
+
+    it("strips the trailing ' (deleted)' suffix from procfs symlinks", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(123);
+      readlinkMock.queue[0]!.resolve("/usr/local/bin/claude (deleted)");
+      await flush();
+
+      expect(probe.readBasename(123)).toBe("claude");
+    });
+
+    it("persists null when readlink rejects", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(123);
+      readlinkMock.queue[0]!.reject(new Error("ENOENT"));
+      await flush();
+
+      expect(probe.readBasename(123)).toBeNull();
+    });
+
+    it("does not schedule a refresh while one is already in flight", () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(123);
+      probe.readBasename(123);
+      probe.readBasename(123);
+      expect(readlinkMock.calls).toHaveLength(1);
+    });
+
+    it("triggers a background refresh past soft-stale but keeps the cached value", async () => {
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        readlinkMock.queue[0]!.resolve("/opt/homebrew/bin/claude");
+        await flush();
+
+        vi.advanceTimersByTime(600); // past 500ms soft-stale, within 1500ms hard-max
+
+        expect(probe.readBasename(123)).toBe("claude");
+        expect(readlinkMock.calls).toHaveLength(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("returns null past the hard-max age and schedules a refresh", async () => {
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        readlinkMock.queue[0]!.resolve("/opt/homebrew/bin/claude");
+        await flush();
+
+        expect(probe.readBasename(123)).toBe("claude");
+
+        vi.advanceTimersByTime(1600); // past 1500ms hard-max
+        expect(probe.readBasename(123)).toBeNull();
+        expect(readlinkMock.calls).toHaveLength(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("macOS", () => {
+    beforeEach(() => {
+      setPlatform("darwin");
+    });
+
+    it("invokes lsof with the expected arguments", () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(4242);
+      expect(execFileMock.calls).toHaveLength(1);
+      expect(execFileMock.calls[0]!.cmd).toBe("lsof");
+      expect(execFileMock.calls[0]!.args).toEqual(["-a", "-d", "txt", "-p", "4242", "-Fn"]);
+    });
+
+    it("picks the executable basename from a multi-line lsof output", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(4242);
+
+      // Realistic `lsof -Fn` output: each fd record is several lines, with
+      // multiple text-segment mappings (the executable plus its dylibs).
+      const lsofOutput = [
+        "p4242",
+        "n/opt/homebrew/bin/claude",
+        "f257",
+        "n/usr/lib/dyld",
+        "f258",
+        "n/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+        "f259",
+        "n/opt/homebrew/lib/libnode.dylib",
+        "",
+      ].join("\n");
+
+      execFileMock.calls[0]!.resolve(lsofOutput);
+      await flush();
+
+      expect(probe.readBasename(4242)).toBe("claude");
+    });
+
+    it("falls back to the first absolute path when every entry is a library", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(4242);
+      execFileMock.calls[0]!.resolve(
+        ["p4242", "n/usr/lib/dyld", "n/System/Library/Frameworks/Foundation.framework", ""].join(
+          "\n"
+        )
+      );
+      await flush();
+
+      expect(probe.readBasename(4242)).toBe("dyld");
+    });
+
+    it("returns null on empty output", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(4242);
+      execFileMock.calls[0]!.resolve("");
+      await flush();
+      expect(probe.readBasename(4242)).toBeNull();
+    });
+
+    it("persists null when lsof fails (process exited)", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(4242);
+      execFileMock.calls[0]!.reject(new Error("lsof: no such process"));
+      await flush();
+      expect(probe.readBasename(4242)).toBeNull();
+    });
+  });
+
+  describe("Windows", () => {
+    beforeEach(() => {
+      setPlatform("win32");
+    });
+
+    it("invokes PowerShell with Get-CimInstance", () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(5005);
+      expect(execFileMock.calls).toHaveLength(1);
+      expect(execFileMock.calls[0]!.cmd).toBe("powershell.exe");
+      const args = execFileMock.calls[0]!.args ?? [];
+      expect(args).toContain("-NoProfile");
+      expect(args).toContain("-NonInteractive");
+      expect(args[args.length - 1]).toContain("ProcessId=5005");
+      expect(args[args.length - 1]).toContain("Win32_Process");
+    });
+
+    it("strips .exe and lowercases the result", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(5005);
+      execFileMock.calls[0]!.resolve("C:\\Program Files\\Claude\\Claude.exe\r\n");
+      await flush();
+      expect(probe.readBasename(5005)).toBe("claude");
+    });
+
+    it("returns null on empty output", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(5005);
+      execFileMock.calls[0]!.resolve("");
+      await flush();
+      expect(probe.readBasename(5005)).toBeNull();
+    });
+
+    it("strips other Windows executable extensions", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(5006);
+      execFileMock.calls[0]!.resolve("C:\\npm\\claude.cmd\r\n");
+      await flush();
+      expect(probe.readBasename(5006)).toBe("claude");
+    });
+  });
+
+  describe("cache lifecycle", () => {
+    it("evict() drops the cached entry so a recycled PID re-probes", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(123);
+      readlinkMock.queue[0]!.resolve("/usr/bin/claude");
+      await flush();
+      expect(probe.readBasename(123)).toBe("claude");
+
+      probe.evict(123);
+      expect(probe.readBasename(123)).toBeNull();
+      expect(readlinkMock.calls).toHaveLength(2);
+    });
+
+    it("dispose() blocks further reads and refreshes", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(123);
+      readlinkMock.queue[0]!.resolve("/usr/bin/claude");
+      await flush();
+
+      probe.dispose();
+      expect(probe.readBasename(123)).toBeNull();
+      // Disposed probe must not schedule a new readlink call for the same PID.
+      expect(readlinkMock.calls).toHaveLength(1);
+    });
+
+    it("drops stale entries past the 30s eviction TTL on the next read", async () => {
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        readlinkMock.queue[0]!.resolve("/usr/bin/claude");
+        await flush();
+
+        vi.advanceTimersByTime(35_000);
+
+        // Reading a different PID re-runs eviction; the long-idle 123 entry
+        // is dropped, so a subsequent read of 123 must re-probe.
+        probe.readBasename(456);
+        readlinkMock.queue[0]!.resolve("/usr/bin/codex");
+        await flush();
+
+        expect(probe.readBasename(123)).toBeNull();
+        expect(readlinkMock.calls).toContain("/proc/123/exe");
+        // 123 should appear twice in readlink history: original + post-eviction.
+        const calls123 = readlinkMock.calls.filter((c) => c === "/proc/123/exe");
+        expect(calls123.length).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/electron/services/pty/__tests__/ImagePathProbe.test.ts
+++ b/electron/services/pty/__tests__/ImagePathProbe.test.ts
@@ -165,9 +165,33 @@ describe("ImagePathProbe", () => {
 
         expect(probe.readBasename(123)).toBe("claude");
 
-        vi.advanceTimersByTime(1600); // past 1500ms hard-max
+        vi.advanceTimersByTime(5100); // past 5000ms hard-max
         expect(probe.readBasename(123)).toBeNull();
         expect(readlinkMock.calls).toHaveLength(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("survives a 1500ms poll-interval tick without blanking the basename", async () => {
+      // Regression guard for the hard-max=poll-interval timing bug. With the
+      // ProcessTreeCache poll at 1500ms and (previously) the probe's max age
+      // at 1500ms, every poll past the first one would fall past max-age
+      // under setTimeout jitter, return null, and defeat hysteresis. With
+      // the 5000ms ceiling the cached basename survives at least one poll
+      // cycle.
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        readlinkMock.queue[0]!.resolve("/opt/homebrew/bin/claude");
+        await flush();
+
+        vi.advanceTimersByTime(1500);
+        expect(probe.readBasename(123)).toBe("claude");
+
+        vi.advanceTimersByTime(1500);
+        expect(probe.readBasename(123)).toBe("claude");
       } finally {
         vi.useRealTimers();
       }
@@ -306,6 +330,32 @@ describe("ImagePathProbe", () => {
       expect(probe.readBasename(123)).toBeNull();
       // Disposed probe must not schedule a new readlink call for the same PID.
       expect(readlinkMock.calls).toHaveLength(1);
+    });
+
+    it("does not overwrite a recreated entry with the stale in-flight resolution", async () => {
+      // Regression guard for the checkId reset bug. PID 123 is probed and
+      // its refresh is in flight. evict() drops the entry. A fresh read on
+      // the same PID creates a new entry. When the old in-flight refresh
+      // finally resolves it must NOT overwrite the new entry's state — the
+      // global monotonic checkId ensures the old refresh's checkId no
+      // longer matches.
+      const probe = new ImagePathProbe();
+      probe.readBasename(123); // schedules first refresh
+      probe.evict(123); // drops entry; first refresh still in flight
+
+      probe.readBasename(123); // creates new entry, schedules second refresh
+      expect(readlinkMock.queue).toHaveLength(2);
+
+      // Old refresh resolves with a stale result — must not be written into
+      // the new entry.
+      readlinkMock.queue[0]!.resolve("/old/stale/binary");
+      await flush();
+      expect(probe.readBasename(123)).toBeNull();
+
+      // New refresh resolves with the fresh value.
+      readlinkMock.queue[1]!.resolve("/new/bin/claude");
+      await flush();
+      expect(probe.readBasename(123)).toBe("claude");
     });
 
     it("drops stale entries past the 30s eviction TTL on the next read", async () => {


### PR DESCRIPTION
## Summary

- Adds `ImagePathProbe` -- a new service that resolves the real executable image path of a running process (`proc_pidpath` via `libproc` on macOS, `/proc/<pid>/exe` on Linux) and feeds it into `ProcessDetector` as a higher-priority identity signal
- Fixes agent mis-identification when CLIs like `claude`, `gemini`, or `codex` rewrite their process title via `process.title` or `setproctitle`, making `ps` argv useless for detection
- The probe degrades cleanly to the existing `ps`-based path if the native addon is unavailable; the hysteresis, HOLD states, and evidence-merge pipeline are untouched

Resolves #8790

## Changes

- `electron/services/pty/ImagePathProbe.ts` -- new probe service wrapping platform-native image path lookup with a native addon fallback and a graceful no-op on unsupported platforms
- `electron/services/ProcessDetector/ProcessDetector.ts` -- integrates image path as a higher-priority signal ahead of argv in the evidence-merge path
- `electron/services/pty/TerminalProcess.ts`, `electron/pty-host.ts`, `electron/services/PtyManager.ts` -- wiring to pass the resolved image path through to `ProcessDetector`
- `electron/services/pty/__tests__/ImagePathProbe.test.ts` -- unit tests for the probe covering macOS, Linux, and graceful-degradation paths
- `electron/services/__tests__/ProcessDetector.test.ts` -- updated tests covering the image path signal in the evidence pipeline

## Testing

- Unit tests for `ImagePathProbe` cover `proc_pidpath` (macOS), `/proc/pid/exe` (Linux), symlink resolution, missing process, and fallback-to-unknown cases
- `ProcessDetector` tests verify that image path evidence ranks above argv and that the HOLD/hysteresis logic is unaffected
- Manually verified on macOS that `claude` (which rewrites `process.title`) is correctly identified where it previously fell through to the grandchild heuristic