### PR TITLE
feat(agents): resolve model lists and context windows at runtime

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -770,6 +770,7 @@ export const CHANNELS = {
   // Agent preset channels
   AGENT_PRESETS_UPDATED: "agent-presets:updated",
   AGENT_CAPABILITIES_GET_CCR_PRESETS: "agent-capabilities:get-ccr-presets",
+  AGENT_CAPABILITIES_GET_RESOLVED_MODEL_LIST: "agent-capabilities:get-resolved-model-list",
 
   // Performance capture channels
   PERF_FLUSH_RENDERER_MARKS: "perf:flush-renderer-marks",

--- a/electron/ipc/handlers/agentCapabilities.preload.ts
+++ b/electron/ipc/handlers/agentCapabilities.preload.ts
@@ -6,6 +6,7 @@ export const AGENT_CAPABILITIES_METHOD_CHANNELS = {
   getAgentMetadata: "agent-capabilities:get-agent-metadata",
   isAgentEnabled: "agent-capabilities:is-agent-enabled",
   getCcrPresets: "agent-capabilities:get-ccr-presets",
+  getResolvedModelList: "agent-capabilities:get-resolved-model-list",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof AGENT_CAPABILITIES_METHOD_CHANNELS;

--- a/electron/ipc/handlers/agentCapabilities.ts
+++ b/electron/ipc/handlers/agentCapabilities.ts
@@ -7,11 +7,16 @@ import {
   getEffectiveAgentConfig,
   type AgentConfig,
 } from "../../../shared/config/agentRegistry.js";
-import type { AgentMetadata, AgentRegistry } from "../../../shared/types/ipc/agentCapabilities.js";
+import type {
+  AgentMetadata,
+  AgentRegistry,
+  ResolvedModelCatalog,
+} from "../../../shared/types/ipc/agentCapabilities.js";
 import type { AgentPreset } from "../../../shared/config/agentRegistry.js";
 import { isAgentPinned } from "../../../shared/utils/agentPinned.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { AGENT_CAPABILITIES_METHOD_CHANNELS } from "./agentCapabilities.preload.js";
+import { getAgentModelCatalogService } from "../../window/serviceRefs.js";
 
 function toAgentMetadata(config: AgentConfig, agentId: string): AgentMetadata {
   const isBuiltIn = agentId in AGENT_REGISTRY;
@@ -85,6 +90,38 @@ export const agentCapabilitiesNamespace = defineIpcNamespace({
       AGENT_CAPABILITIES_METHOD_CHANNELS.getCcrPresets,
       async (): Promise<AgentPreset[]> => {
         return CcrConfigService.getInstance().loadAndApply();
+      }
+    ),
+    getResolvedModelList: op(
+      AGENT_CAPABILITIES_METHOD_CHANNELS.getResolvedModelList,
+      async (agentId: string): Promise<ResolvedModelCatalog | null> => {
+        if (!agentId || typeof agentId !== "string") {
+          throw new Error("Invalid agentId");
+        }
+        if (agentId === "__proto__" || agentId === "constructor" || agentId === "prototype") {
+          throw new Error("Invalid agentId: reserved keyword");
+        }
+        const config = getEffectiveAgentConfig(agentId);
+        if (!config) return null;
+
+        const service = getAgentModelCatalogService();
+        if (service) {
+          try {
+            return await service.getResolvedModels(agentId);
+          } catch (err) {
+            console.warn(
+              "[agentCapabilities] getResolvedModelList resolver failed, returning bundled fallback",
+              err
+            );
+          }
+        }
+
+        return {
+          agentId,
+          models: config.models ? [...config.models] : [],
+          contextWindow: config.contextWindow ?? null,
+          source: "bundled",
+        };
       }
     ),
   },

--- a/electron/services/AgentModelCatalogService.ts
+++ b/electron/services/AgentModelCatalogService.ts
@@ -17,7 +17,11 @@ const execFileAsync = promisify(execFile);
 const ModelEntrySchema = z
   .object({
     name: z.string().optional(),
-    limit: z.object({ context: z.number().optional() }).passthrough().optional(),
+    // `limit.context` is read lazily as `unknown` at the catalog level so a
+    // single non-numeric value (e.g. `null`, `"unlimited"`, or any future
+    // type) never rejects the entire catalog. `extractRemote` guards with
+    // `typeof ctx === "number"` before reading the value.
+    limit: z.object({ context: z.unknown() }).passthrough().optional(),
   })
   .passthrough();
 
@@ -418,7 +422,14 @@ export class AgentModelCatalogService {
     } catch {
       return null;
     }
-    if (!Array.isArray(parsed)) return null;
+    // Real Codex emits `{"models": [...]}`; older or hypothetical bare-array
+    // shapes are still accepted so the catalog survives format changes.
+    const entries = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray((parsed as { models?: unknown } | null)?.models)
+        ? (parsed as { models: unknown[] }).models
+        : null;
+    if (!entries) return null;
 
     const CodexEntrySchema = z
       .object({
@@ -433,7 +444,7 @@ export class AgentModelCatalogService {
 
     const models: AgentModelConfig[] = [];
     let maxContext = 0;
-    for (const entry of parsed) {
+    for (const entry of entries) {
       const safe = CodexEntrySchema.safeParse(entry);
       if (!safe.success) continue;
       const id = safe.data.slug ?? safe.data.id;

--- a/electron/services/AgentModelCatalogService.ts
+++ b/electron/services/AgentModelCatalogService.ts
@@ -1,0 +1,488 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import { z } from "zod";
+
+import {
+  PROVIDER_TO_AGENT_ID,
+  getEffectiveAgentConfig,
+  type AgentModelConfig,
+} from "../../shared/config/agentRegistry.js";
+import type { ResolvedModelCatalog } from "../../shared/types/ipc/agentCapabilities.js";
+import { buildProbeEnv } from "../utils/spawnEnv.js";
+
+const execFileAsync = promisify(execFile);
+
+const ModelEntrySchema = z
+  .object({
+    name: z.string().optional(),
+    limit: z.object({ context: z.number().optional() }).passthrough().optional(),
+  })
+  .passthrough();
+
+const ProviderSchema = z
+  .object({
+    models: z.record(z.string(), ModelEntrySchema).optional(),
+  })
+  .passthrough();
+
+const CatalogSchema = z.record(z.string(), ProviderSchema);
+
+type ParsedCatalog = z.infer<typeof CatalogSchema>;
+
+interface AgentResolved {
+  models: AgentModelConfig[];
+  contextWindow: number | null;
+}
+
+interface DiskPayload {
+  fetchedAt: number;
+  raw: unknown;
+}
+
+interface CachedCatalog {
+  data: ParsedCatalog;
+  fetchedAt: number;
+}
+
+interface CatalogDeps {
+  /** Override for disk-cache path. Defaults to `app.getPath('userData')/models-catalog.json`. */
+  cachePath?: string;
+  /** Override for `fetch` (used by tests). Defaults to Electron's `net.fetch`. */
+  fetchImpl?: (
+    url: string,
+    init?: { signal?: AbortSignal; headers?: Record<string, string> }
+  ) => Promise<{
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+  }>;
+  /** Override for `execFile` (used by tests). Defaults to `node:child_process` execFile. */
+  execFileImpl?: typeof execFileAsync;
+  /** Override for the codex command name (used by tests). Defaults to `"codex"`. */
+  codexCommand?: string;
+}
+
+const CATALOG_URL = "https://models.dev/api.json";
+const TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 8000;
+const CODEX_TIMEOUT_MS = 5000;
+const MAX_CODEX_BUFFER = 256 * 1024;
+
+/**
+ * Resolves agent model lists and context windows at runtime against the
+ * unauthenticated `models.dev/api.json` catalog, with a disk-backed
+ * stale-while-revalidate cache (24h TTL) and singleflight dedup on the
+ * in-flight fetch. Bundled `models[]`/`contextWindow` values from
+ * `shared/config/agents/*.ts` remain the offline-safe fallback.
+ *
+ * Codex receives an additional offline enrichment pass from `codex debug
+ * models --bundled` when the Codex CLI is on PATH; remote and CLI sources
+ * are merged into the resolved list, with bundled IDs always present.
+ *
+ * Unknown model IDs (and remote/CLI failures) degrade silently per the
+ * issue constraint — `console.warn` only, never `notify()`.
+ */
+export class AgentModelCatalogService {
+  private inFlight: Promise<ParsedCatalog | null> | null = null;
+  private memCache: CachedCatalog | null = null;
+  private codexCache: {
+    models: AgentModelConfig[];
+    contextWindow: number | null;
+    fetchedAt: number;
+  } | null = null;
+  private codexInFlight: Promise<{
+    models: AgentModelConfig[];
+    contextWindow: number | null;
+  } | null> | null = null;
+
+  constructor(private readonly deps: CatalogDeps = {}) {}
+
+  /**
+   * Resolve the model catalog for a single agent. Always returns a usable
+   * shape — falls through to the bundled config when remote + CLI sources
+   * are unavailable.
+   */
+  async getResolvedModels(agentId: string): Promise<ResolvedModelCatalog> {
+    const bundled = this.getBundled(agentId);
+
+    let catalog: ParsedCatalog | null = null;
+    try {
+      catalog = await this.getCatalog();
+    } catch (err) {
+      // Singleflight wrapper already catches and returns null; this is a
+      // defensive guard so a bug in the resolver never throws into IPC.
+      console.warn("[AgentModelCatalogService] catalog resolution failed", err);
+    }
+
+    const remote = catalog ? this.extractRemote(agentId, catalog) : null;
+
+    let codex: AgentResolved | null = null;
+    if (agentId === "codex") {
+      codex = await this.getCodexCatalog();
+    }
+
+    const merged = this.merge(bundled, remote, codex);
+
+    let source: ResolvedModelCatalog["source"];
+    if (!remote && !codex) {
+      source = "bundled";
+    } else if (bundled.models.length === 0) {
+      source = "remote";
+    } else {
+      source = "merged";
+    }
+
+    return {
+      agentId,
+      models: merged.models,
+      contextWindow: merged.contextWindow,
+      source,
+    };
+  }
+
+  /**
+   * Force a refresh of the remote catalog (bypasses TTL but not singleflight).
+   * Used by tests; the IPC surface does not currently expose this.
+   */
+  clearCache(): void {
+    this.memCache = null;
+    this.codexCache = null;
+  }
+
+  private getBundled(agentId: string): AgentResolved {
+    const cfg = getEffectiveAgentConfig(agentId);
+    if (!cfg) return { models: [], contextWindow: null };
+    return {
+      models: cfg.models ? [...cfg.models] : [],
+      contextWindow: cfg.contextWindow ?? null,
+    };
+  }
+
+  private extractRemote(agentId: string, catalog: ParsedCatalog): AgentResolved | null {
+    const providerKey = Object.entries(PROVIDER_TO_AGENT_ID).find(
+      ([, mappedAgentId]) => mappedAgentId === agentId
+    )?.[0];
+    if (!providerKey) return null;
+
+    const provider = catalog[providerKey];
+    if (!provider?.models) return null;
+
+    const models: AgentModelConfig[] = [];
+    let maxContext = 0;
+    for (const [modelId, entry] of Object.entries(provider.models)) {
+      const parsed = ModelEntrySchema.safeParse(entry);
+      if (!parsed.success) continue;
+      const name = parsed.data.name ?? modelId;
+      const ctx = parsed.data.limit?.context;
+      if (typeof ctx === "number" && ctx > maxContext) {
+        maxContext = ctx;
+      }
+      models.push({
+        id: modelId,
+        name,
+        shortLabel: deriveShortLabel(name, modelId),
+      });
+    }
+
+    if (models.length === 0) return null;
+    return { models, contextWindow: maxContext > 0 ? maxContext : null };
+  }
+
+  private merge(
+    bundled: AgentResolved,
+    remote: AgentResolved | null,
+    codex: AgentResolved | null
+  ): AgentResolved {
+    if (!remote && !codex) return bundled;
+
+    const byId = new Map<string, AgentModelConfig>();
+    for (const m of bundled.models) byId.set(m.id, m);
+    if (remote) {
+      for (const m of remote.models) {
+        const existing = byId.get(m.id);
+        if (existing) {
+          byId.set(m.id, {
+            id: existing.id,
+            name: m.name || existing.name,
+            shortLabel: existing.shortLabel || m.shortLabel,
+          });
+        } else {
+          byId.set(m.id, m);
+        }
+      }
+    }
+    if (codex) {
+      for (const m of codex.models) {
+        const existing = byId.get(m.id);
+        if (existing) {
+          byId.set(m.id, {
+            id: existing.id,
+            name: m.name || existing.name,
+            shortLabel: existing.shortLabel || m.shortLabel,
+          });
+        } else {
+          byId.set(m.id, m);
+        }
+      }
+    }
+
+    const contextWindow =
+      codex?.contextWindow ?? remote?.contextWindow ?? bundled.contextWindow ?? null;
+
+    return {
+      models: Array.from(byId.values()),
+      contextWindow,
+    };
+  }
+
+  /** Returns parsed catalog or null when all sources fail. */
+  async getCatalog(): Promise<ParsedCatalog | null> {
+    if (this.memCache && Date.now() - this.memCache.fetchedAt < TTL_MS) {
+      return this.memCache.data;
+    }
+
+    if (this.inFlight) return this.inFlight;
+
+    this.inFlight = this.refreshCatalog()
+      .catch((err) => {
+        console.warn("[AgentModelCatalogService] catalog refresh failed", err);
+        return null;
+      })
+      .finally(() => {
+        this.inFlight = null;
+      });
+
+    const fresh = await this.inFlight;
+    if (fresh) return fresh;
+
+    // Network failed — fall back to disk if we never warmed memCache yet.
+    const disk = await this.readDisk();
+    if (disk) {
+      this.memCache = { data: disk.data, fetchedAt: disk.fetchedAt };
+      return disk.data;
+    }
+
+    return null;
+  }
+
+  private async refreshCatalog(): Promise<ParsedCatalog | null> {
+    const disk = await this.readDisk();
+    if (disk && Date.now() - disk.fetchedAt < TTL_MS) {
+      this.memCache = { data: disk.data, fetchedAt: disk.fetchedAt };
+      return disk.data;
+    }
+
+    const fetched = await this.fetchRemote();
+    if (fetched) {
+      this.memCache = { data: fetched.parsed, fetchedAt: fetched.fetchedAt };
+      // Best-effort persist; never block the resolver on a write failure.
+      void this.writeDisk(fetched.fetchedAt, fetched.raw).catch((err) => {
+        console.warn("[AgentModelCatalogService] disk write failed", err);
+      });
+      return fetched.parsed;
+    }
+
+    // Network failed but we have stale disk data — surface it so callers
+    // get something usable; the next call will retry the network.
+    if (disk) {
+      this.memCache = { data: disk.data, fetchedAt: disk.fetchedAt };
+      return disk.data;
+    }
+
+    return null;
+  }
+
+  private async fetchRemote(): Promise<{
+    parsed: ParsedCatalog;
+    raw: unknown;
+    fetchedAt: number;
+  } | null> {
+    const fetchImpl = this.deps.fetchImpl ?? (await getElectronNetFetch());
+    if (!fetchImpl) return null;
+
+    try {
+      const res = await fetchImpl(CATALOG_URL, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "Daintree-Electron",
+        },
+      });
+      if (!res.ok) {
+        console.warn(`[AgentModelCatalogService] HTTP ${res.status} from ${CATALOG_URL}`);
+        return null;
+      }
+      const raw = await res.json();
+      const parsed = CatalogSchema.safeParse(raw);
+      if (!parsed.success) {
+        console.warn("[AgentModelCatalogService] catalog schema rejected", parsed.error.message);
+        return null;
+      }
+      return { parsed: parsed.data, raw, fetchedAt: Date.now() };
+    } catch (err) {
+      console.warn("[AgentModelCatalogService] catalog fetch failed", err);
+      return null;
+    }
+  }
+
+  private async readDisk(): Promise<{ data: ParsedCatalog; fetchedAt: number } | null> {
+    const cachePath = await this.resolveCachePath();
+    if (!cachePath) return null;
+    try {
+      const text = await fs.readFile(cachePath, "utf-8");
+      const payload = JSON.parse(text) as Partial<DiskPayload>;
+      if (typeof payload.fetchedAt !== "number") return null;
+      const parsed = CatalogSchema.safeParse(payload.raw);
+      if (!parsed.success) return null;
+      return { data: parsed.data, fetchedAt: payload.fetchedAt };
+    } catch (err: unknown) {
+      if (isNodeError(err) && err.code === "ENOENT") return null;
+      console.warn("[AgentModelCatalogService] disk read failed", err);
+      return null;
+    }
+  }
+
+  private async writeDisk(fetchedAt: number, raw: unknown): Promise<void> {
+    const cachePath = await this.resolveCachePath();
+    if (!cachePath) return;
+    const dir = path.dirname(cachePath);
+    await fs.mkdir(dir, { recursive: true });
+    const payload: DiskPayload = { fetchedAt, raw };
+    await fs.writeFile(cachePath, JSON.stringify(payload), "utf-8");
+  }
+
+  private async resolveCachePath(): Promise<string | null> {
+    if (this.deps.cachePath) return this.deps.cachePath;
+    try {
+      const { app } = await import("electron");
+      return path.join(app.getPath("userData"), "models-catalog.json");
+    } catch {
+      // Outside Electron (tests without override) — skip disk cache.
+      return null;
+    }
+  }
+
+  private async getCodexCatalog(): Promise<AgentResolved | null> {
+    if (this.codexCache && Date.now() - this.codexCache.fetchedAt < TTL_MS) {
+      return { models: this.codexCache.models, contextWindow: this.codexCache.contextWindow };
+    }
+    if (this.codexInFlight) {
+      const result = await this.codexInFlight;
+      return result ?? null;
+    }
+    this.codexInFlight = this.fetchCodexCatalog()
+      .catch((err) => {
+        console.warn("[AgentModelCatalogService] codex catalog failed", err);
+        return null;
+      })
+      .finally(() => {
+        this.codexInFlight = null;
+      });
+    const result = await this.codexInFlight;
+    if (result) {
+      this.codexCache = { ...result, fetchedAt: Date.now() };
+    }
+    return result ?? null;
+  }
+
+  private async fetchCodexCatalog(): Promise<AgentResolved | null> {
+    const exec = this.deps.execFileImpl ?? execFileAsync;
+    const command = this.deps.codexCommand ?? "codex";
+    let stdout = "";
+    try {
+      const result = await exec(command, ["debug", "models", "--bundled"], {
+        timeout: CODEX_TIMEOUT_MS,
+        maxBuffer: MAX_CODEX_BUFFER,
+        shell: false,
+        windowsHide: true,
+        env: buildProbeEnv(),
+      });
+      stdout = result.stdout || result.stderr || "";
+    } catch (err: unknown) {
+      const code = isNodeError(err) ? err.code : undefined;
+      if (code === "ENOENT") return null;
+      if (isNodeError(err) && (err as NodeJS.ErrnoException & { killed?: boolean }).killed)
+        return null;
+      // Older Codex CLIs may not support `debug models`; treat any failure
+      // as a missing-source rather than escalating.
+      console.warn("[AgentModelCatalogService] codex debug models --bundled failed", err);
+      return null;
+    }
+
+    if (!stdout.trim()) return null;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      return null;
+    }
+    if (!Array.isArray(parsed)) return null;
+
+    const CodexEntrySchema = z
+      .object({
+        slug: z.string().optional(),
+        id: z.string().optional(),
+        display_name: z.string().optional(),
+        name: z.string().optional(),
+        context_window: z.number().optional(),
+        max_context_window: z.number().optional(),
+      })
+      .passthrough();
+
+    const models: AgentModelConfig[] = [];
+    let maxContext = 0;
+    for (const entry of parsed) {
+      const safe = CodexEntrySchema.safeParse(entry);
+      if (!safe.success) continue;
+      const id = safe.data.slug ?? safe.data.id;
+      if (!id) continue;
+      const name = safe.data.display_name ?? safe.data.name ?? id;
+      const ctx = safe.data.max_context_window ?? safe.data.context_window;
+      if (typeof ctx === "number" && ctx > maxContext) maxContext = ctx;
+      models.push({
+        id,
+        name,
+        shortLabel: deriveShortLabel(name, id),
+      });
+    }
+    if (models.length === 0) return null;
+    return { models, contextWindow: maxContext > 0 ? maxContext : null };
+  }
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err;
+}
+
+/**
+ * Resolve Electron's `net.fetch` lazily so this module can be imported in
+ * Node-only test runners. Returns a `fetch`-compatible function, or null
+ * when neither `net.fetch` nor a fallback exists.
+ */
+async function getElectronNetFetch(): Promise<CatalogDeps["fetchImpl"] | null> {
+  try {
+    const { net } = await import("electron");
+    if (typeof net?.fetch !== "function") return null;
+    return (url: string, init?: { signal?: AbortSignal; headers?: Record<string, string> }) =>
+      net.fetch(url, init).then((res) => ({
+        ok: res.ok,
+        status: res.status,
+        json: () => res.json() as Promise<unknown>,
+      }));
+  } catch {
+    return null;
+  }
+}
+
+const TRAILING_PARENS = /\s*\([^)]*\)\s*$/;
+
+function deriveShortLabel(name: string, id: string): string {
+  const stripped = name.replace(TRAILING_PARENS, "").trim();
+  if (stripped.length > 0 && stripped.length <= 24) return stripped;
+  // Fall back to last segment of the model ID with separators normalised.
+  const seg = id.split(/[/:]/).pop() ?? id;
+  if (seg.length <= 24) return seg;
+  return seg.slice(0, 24);
+}

--- a/electron/services/__tests__/AgentModelCatalogService.test.ts
+++ b/electron/services/__tests__/AgentModelCatalogService.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as path from "node:path";
+import * as os from "node:os";
+import * as fs from "node:fs/promises";
+
+import { AgentModelCatalogService } from "../AgentModelCatalogService.js";
+
+function makeCatalog(): Record<string, unknown> {
+  return {
+    anthropic: {
+      name: "Anthropic",
+      models: {
+        "claude-sonnet-4-6": {
+          name: "Claude Sonnet 4.6",
+          limit: { context: 1_000_000 },
+        },
+        "claude-opus-4-6": {
+          name: "Claude Opus 4.6",
+          limit: { context: 200_000 },
+        },
+        "claude-haiku-4-5-20251001": {
+          name: "Claude Haiku 4.5",
+          limit: { context: 200_000 },
+        },
+      },
+    },
+    openai: {
+      name: "OpenAI",
+      models: {
+        "gpt-5.4": {
+          name: "GPT-5.4",
+          limit: { context: 128_000 },
+        },
+        o3: {
+          name: "o3",
+          limit: { context: 200_000 },
+        },
+      },
+    },
+    google: {
+      name: "Google",
+      models: {
+        "gemini-2.5-pro": {
+          name: "Gemini 2.5 Pro",
+          limit: { context: 1_048_576 },
+        },
+      },
+    },
+  };
+}
+
+type FetchFn = NonNullable<ConstructorParameters<typeof AgentModelCatalogService>[0]>["fetchImpl"];
+type ExecFn = NonNullable<
+  ConstructorParameters<typeof AgentModelCatalogService>[0]
+>["execFileImpl"];
+
+function mockFetch(payload: unknown, opts: { ok?: boolean; status?: number } = {}): FetchFn {
+  return vi.fn(async () => ({
+    ok: opts.ok ?? true,
+    status: opts.status ?? 200,
+    json: async () => payload,
+  }));
+}
+
+function mockFailingFetch(error: unknown): FetchFn {
+  return vi.fn(async () => {
+    throw error;
+  });
+}
+
+async function makeTmpCachePath(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "model-catalog-test-"));
+  return path.join(dir, "models-catalog.json");
+}
+
+async function cleanup(cachePath: string): Promise<void> {
+  try {
+    await fs.rm(path.dirname(cachePath), { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+describe("AgentModelCatalogService", () => {
+  let cachePath: string;
+
+  beforeEach(async () => {
+    cachePath = await makeTmpCachePath();
+  });
+
+  afterEach(async () => {
+    await cleanup(cachePath);
+  });
+
+  it("returns remote-derived models merged with bundled IDs for claude", async () => {
+    const fetchImpl = mockFetch(makeCatalog());
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("claude");
+
+    expect(result.agentId).toBe("claude");
+    expect(result.models.map((m) => m.id)).toEqual(
+      expect.arrayContaining(["claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5-20251001"])
+    );
+    expect(result.contextWindow).toBe(1_000_000);
+    expect(result.source).toBe("merged");
+  });
+
+  it("preserves bundled shortLabel for known models", async () => {
+    const fetchImpl = mockFetch(makeCatalog());
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("claude");
+
+    const sonnet = result.models.find((m) => m.id === "claude-sonnet-4-6");
+    expect(sonnet?.shortLabel).toBe("Sonnet");
+  });
+
+  it("falls back to bundled when fetch fails", async () => {
+    const fetchImpl = mockFailingFetch(new Error("network down"));
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("claude");
+
+    expect(result.source).toBe("bundled");
+    expect(result.models.length).toBeGreaterThan(0);
+    expect(result.contextWindow).toBe(200_000);
+  });
+
+  it("falls back to bundled when fetch returns non-OK status", async () => {
+    const fetchImpl = mockFetch({}, { ok: false, status: 500 });
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("claude");
+
+    expect(result.source).toBe("bundled");
+    expect(result.models.length).toBeGreaterThan(0);
+  });
+
+  it("returns bundled when remote provider is missing for the agent", async () => {
+    const fetchImpl = mockFetch({
+      anthropic: {
+        models: {
+          "claude-sonnet-4-6": { name: "Claude Sonnet 4.6", limit: { context: 200_000 } },
+        },
+      },
+    });
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("aider");
+
+    expect(result.source).toBe("bundled");
+    expect(result.models.length).toBeGreaterThan(0);
+  });
+
+  it("tolerates malformed entries — bad entries skipped, valid ones surface", async () => {
+    const fetchImpl = mockFetch({
+      anthropic: {
+        models: {
+          "claude-sonnet-4-6": { name: "Claude Sonnet 4.6", limit: { context: 1_000_000 } },
+          "broken-model": { limit: { context: "not-a-number" } },
+          "claude-opus-4-6": { name: "Claude Opus 4.6", limit: { context: 200_000 } },
+        },
+      },
+    });
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("claude");
+
+    expect(result.models.map((m) => m.id)).toContain("claude-sonnet-4-6");
+    expect(result.models.map((m) => m.id)).toContain("claude-opus-4-6");
+    expect(result.models.find((m) => m.id === "broken-model")).toBeUndefined();
+  });
+
+  it("dedupes concurrent calls via singleflight", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => makeCatalog(),
+    })) as unknown as FetchFn;
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    await Promise.all([
+      service.getResolvedModels("claude"),
+      service.getResolvedModels("codex"),
+      service.getResolvedModels("gemini"),
+    ]);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses in-memory cache within TTL", async () => {
+    const fetchImpl = mockFetch(makeCatalog());
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    await service.getResolvedModels("claude");
+    await service.getResolvedModels("claude");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists fetched catalog to disk", async () => {
+    const fetchImpl = mockFetch(makeCatalog());
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    await service.getResolvedModels("claude");
+    // Allow the background disk write to flush.
+    await new Promise((r) => setTimeout(r, 10));
+
+    const text = await fs.readFile(cachePath, "utf-8");
+    const payload = JSON.parse(text);
+    expect(payload.raw.anthropic.models["claude-sonnet-4-6"]).toBeDefined();
+    expect(typeof payload.fetchedAt).toBe("number");
+  });
+
+  it("reads disk cache as fallback when network fails on cold start", async () => {
+    const populator = new AgentModelCatalogService({
+      cachePath,
+      fetchImpl: mockFetch(makeCatalog()),
+    });
+    await populator.getResolvedModels("claude");
+    await new Promise((r) => setTimeout(r, 10));
+
+    const offline = new AgentModelCatalogService({
+      cachePath,
+      fetchImpl: mockFailingFetch(new Error("offline")),
+    });
+    const result = await offline.getResolvedModels("claude");
+
+    expect(result.source).toBe("merged");
+    expect(result.models.map((m) => m.id)).toContain("claude-sonnet-4-6");
+  });
+
+  it("enriches codex models from the bundled CLI catalog", async () => {
+    const execFileImpl: ExecFn = vi.fn(async () => ({
+      stdout: JSON.stringify([
+        { slug: "gpt-5.4", display_name: "GPT-5.4", context_window: 200_000 },
+        { slug: "o3-mini", display_name: "o3-mini", context_window: 128_000 },
+      ]),
+      stderr: "",
+    })) as unknown as ExecFn;
+
+    const service = new AgentModelCatalogService({
+      cachePath,
+      fetchImpl: mockFetch(makeCatalog()),
+      execFileImpl,
+      codexCommand: "codex",
+    });
+
+    const result = await service.getResolvedModels("codex");
+
+    expect(result.models.map((m) => m.id)).toEqual(
+      expect.arrayContaining(["gpt-5.4", "o3", "o3-mini"])
+    );
+    // Codex CLI's context window is preferred when present.
+    expect(result.contextWindow).toBe(200_000);
+  });
+
+  it("silently ignores codex CLI failure", async () => {
+    const execFileImpl: ExecFn = vi.fn(async () => {
+      const err: NodeJS.ErrnoException = new Error("not found");
+      err.code = "ENOENT";
+      throw err;
+    }) as unknown as ExecFn;
+
+    const service = new AgentModelCatalogService({
+      cachePath,
+      fetchImpl: mockFetch(makeCatalog()),
+      execFileImpl,
+    });
+
+    const result = await service.getResolvedModels("codex");
+
+    expect(result.models.map((m) => m.id)).toContain("gpt-5.4");
+    expect(result.source).toBe("merged");
+  });
+
+  it("returns null for unknown agent IDs", async () => {
+    const fetchImpl = mockFetch(makeCatalog());
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("not-a-real-agent");
+
+    expect(result.source).toBe("bundled");
+    expect(result.models).toEqual([]);
+    expect(result.contextWindow).toBeNull();
+  });
+
+  it("derives shortLabel from name for remote-only models", async () => {
+    const fetchImpl = mockFetch({
+      anthropic: {
+        models: {
+          "claude-new-model": {
+            name: "Claude New (preview)",
+            limit: { context: 200_000 },
+          },
+        },
+      },
+    });
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("claude");
+
+    const newModel = result.models.find((m) => m.id === "claude-new-model");
+    expect(newModel).toBeDefined();
+    // Trailing parenthetical is stripped to keep the label short.
+    expect(newModel?.shortLabel).toBe("Claude New");
+  });
+});

--- a/electron/services/__tests__/AgentModelCatalogService.test.ts
+++ b/electron/services/__tests__/AgentModelCatalogService.test.ts
@@ -153,12 +153,13 @@ describe("AgentModelCatalogService", () => {
     expect(result.models.length).toBeGreaterThan(0);
   });
 
-  it("tolerates malformed entries — bad entries skipped, valid ones surface", async () => {
+  it("tolerates malformed entries — non-object entries skipped, valid ones surface", async () => {
     const fetchImpl = mockFetch({
       anthropic: {
         models: {
           "claude-sonnet-4-6": { name: "Claude Sonnet 4.6", limit: { context: 1_000_000 } },
-          "broken-model": { limit: { context: "not-a-number" } },
+          "string-entry": "not-an-object",
+          "null-entry": null,
           "claude-opus-4-6": { name: "Claude Opus 4.6", limit: { context: 200_000 } },
         },
       },
@@ -169,7 +170,8 @@ describe("AgentModelCatalogService", () => {
 
     expect(result.models.map((m) => m.id)).toContain("claude-sonnet-4-6");
     expect(result.models.map((m) => m.id)).toContain("claude-opus-4-6");
-    expect(result.models.find((m) => m.id === "broken-model")).toBeUndefined();
+    expect(result.models.find((m) => m.id === "string-entry")).toBeUndefined();
+    expect(result.models.find((m) => m.id === "null-entry")).toBeUndefined();
   });
 
   it("dedupes concurrent calls via singleflight", async () => {
@@ -284,6 +286,82 @@ describe("AgentModelCatalogService", () => {
     expect(result.source).toBe("bundled");
     expect(result.models).toEqual([]);
     expect(result.contextWindow).toBeNull();
+  });
+
+  it("accepts codex CLI output as a {models: [...]} object (real shape)", async () => {
+    const execFileImpl: ExecFn = vi.fn(async () => ({
+      stdout: JSON.stringify({
+        models: [
+          { slug: "gpt-5.5", display_name: "GPT-5.5", context_window: 256_000 },
+          { slug: "gpt-5.4", display_name: "GPT-5.4", context_window: 128_000 },
+        ],
+      }),
+      stderr: "",
+    })) as unknown as ExecFn;
+
+    const service = new AgentModelCatalogService({
+      cachePath,
+      fetchImpl: mockFetch({}),
+      execFileImpl,
+      codexCommand: "codex",
+    });
+
+    const result = await service.getResolvedModels("codex");
+
+    expect(result.models.map((m) => m.id)).toContain("gpt-5.5");
+    expect(result.contextWindow).toBe(256_000);
+  });
+
+  it("tolerates non-numeric limit.context anywhere in the remote catalog", async () => {
+    const fetchImpl = mockFetch({
+      anthropic: {
+        models: {
+          "claude-sonnet-4-6": { name: "Claude Sonnet 4.6", limit: { context: 200_000 } },
+          "claude-experimental": { name: "Claude Experimental", limit: { context: "unlimited" } },
+        },
+      },
+      // A whole separate provider with a malformed entry must not poison
+      // the catalog for the well-formed anthropic provider.
+      openai: {
+        models: {
+          "gpt-5.4": { name: "GPT-5.4", limit: { context: null } },
+        },
+      },
+    });
+    const service = new AgentModelCatalogService({ cachePath, fetchImpl });
+
+    const result = await service.getResolvedModels("claude");
+
+    expect(result.source).toBe("merged");
+    expect(result.models.map((m) => m.id)).toContain("claude-sonnet-4-6");
+    expect(result.models.map((m) => m.id)).toContain("claude-experimental");
+    expect(result.contextWindow).toBe(200_000);
+  });
+
+  it("dedupes concurrent codex CLI calls via singleflight", async () => {
+    const execFileImpl: ExecFn = vi.fn(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      return {
+        stdout: JSON.stringify({
+          models: [{ slug: "gpt-5.5", display_name: "GPT-5.5", context_window: 256_000 }],
+        }),
+        stderr: "",
+      };
+    }) as unknown as ExecFn;
+
+    const service = new AgentModelCatalogService({
+      cachePath,
+      fetchImpl: mockFetch({}),
+      execFileImpl,
+    });
+
+    await Promise.all([
+      service.getResolvedModels("codex"),
+      service.getResolvedModels("codex"),
+      service.getResolvedModels("codex"),
+    ]);
+
+    expect(execFileImpl).toHaveBeenCalledTimes(1);
   });
 
   it("derives shortLabel from name for remote-only models", async () => {

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -10,6 +10,7 @@ import {
 } from "../services/MainProcessWatchdogClient.js";
 import { CliAvailabilityService } from "../services/CliAvailabilityService.js";
 import { AgentVersionService } from "../services/AgentVersionService.js";
+import { AgentModelCatalogService } from "../services/AgentModelCatalogService.js";
 import { AgentUpdateHandler } from "../services/AgentUpdateHandler.js";
 import { PortalManager } from "../services/PortalManager.js";
 import { EventBuffer } from "../services/EventBuffer.js";
@@ -32,6 +33,8 @@ import {
   setMainProcessWatchdogClientRef,
   getAgentVersionService,
   setAgentVersionService,
+  getAgentModelCatalogService,
+  setAgentModelCatalogService,
   getAgentUpdateHandler,
   setAgentUpdateHandler,
   getWorkspaceClientRef,
@@ -147,6 +150,16 @@ export async function initPerWindowServices(
     const versionSvc = new AgentVersionService(cliAvailabilityService);
     setAgentVersionService(versionSvc);
     setAgentUpdateHandler(new AgentUpdateHandler(ptyClient, versionSvc, cliAvailabilityService));
+
+    if (!getAgentModelCatalogService()) {
+      const modelCatalogSvc = new AgentModelCatalogService();
+      setAgentModelCatalogService(modelCatalogSvc);
+      // Warm the cache in the background so the first renderer request hits
+      // populated data. Errors are already silenced inside getCatalog().
+      void modelCatalogSvc.getCatalog().catch(() => {
+        /* swallow — surfaced via console.warn inside the service */
+      });
+    }
 
     let lastCrashDetails: {
       crashType: string;

--- a/electron/window/serviceRefs.ts
+++ b/electron/window/serviceRefs.ts
@@ -9,6 +9,7 @@ import type { MainProcessWatchdogClient } from "../services/MainProcessWatchdogC
 import type { WorkspaceClient } from "../services/WorkspaceClient.js";
 import type { CliAvailabilityService } from "../services/CliAvailabilityService.js";
 import type { AgentVersionService } from "../services/AgentVersionService.js";
+import type { AgentModelCatalogService } from "../services/AgentModelCatalogService.js";
 import type { AgentUpdateHandler } from "../services/AgentUpdateHandler.js";
 import type { ResourceProfileService } from "../services/ResourceProfileService.js";
 import type { WorktreePortBroker } from "../services/WorktreePortBroker.js";
@@ -32,6 +33,7 @@ let mainProcessWatchdogClient: MainProcessWatchdogClient | null = null;
 let workspaceClient: WorkspaceClient | null = null;
 let cliAvailabilityService: CliAvailabilityService | null = null;
 let agentVersionService: AgentVersionService | null = null;
+let agentModelCatalogService: AgentModelCatalogService | null = null;
 let agentUpdateHandler: AgentUpdateHandler | null = null;
 let cleanupIpcHandlers: (() => void) | null = null;
 let cleanupErrorHandlers: (() => void) | null = null;
@@ -142,6 +144,12 @@ export function getAgentVersionService(): AgentVersionService | null {
 }
 export function setAgentVersionService(v: AgentVersionService | null): void {
   agentVersionService = v;
+}
+export function getAgentModelCatalogService(): AgentModelCatalogService | null {
+  return agentModelCatalogService;
+}
+export function setAgentModelCatalogService(v: AgentModelCatalogService | null): void {
+  agentModelCatalogService = v;
 }
 export function getAgentUpdateHandler(): AgentUpdateHandler | null {
   return agentUpdateHandler;

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -537,6 +537,22 @@ import { config as kiroConfig } from "./agents/kiro.js";
 import { BUILT_IN_AGENT_IDS, isBuiltInAgentId } from "./agentIds.js";
 import type { BuiltInAgentId } from "./agentIds.js";
 
+/**
+ * Mapping from `models.dev/api.json` provider keys to our agent IDs. The
+ * remote catalog groups models by provider (e.g. `"anthropic"` → claude),
+ * which is the inverse of how the local registry is keyed. Only agents whose
+ * model lists are covered by the remote catalog appear here; agents like
+ * `copilot` (multi-provider) and `aider` (broker without a single provider)
+ * stay on their bundled snapshot.
+ */
+export const PROVIDER_TO_AGENT_ID: Record<string, BuiltInAgentId> = {
+  anthropic: "claude",
+  openai: "codex",
+  google: "gemini",
+  alibaba: "qwen",
+  mistral: "mistral",
+};
+
 export const AGENT_REGISTRY: Record<BuiltInAgentId, AgentConfig> = {
   claude: claudeConfig,
   opencode: opencodeConfig,

--- a/shared/types/ipc/agentCapabilities.ts
+++ b/shared/types/ipc/agentCapabilities.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig } from "../../config/agentRegistry.js";
+import type { AgentConfig, AgentModelConfig } from "../../config/agentRegistry.js";
 
 export type AgentRegistry = Record<string, AgentConfig>;
 
@@ -23,4 +23,20 @@ export interface AgentMetadata {
   hasInstallHelp: boolean;
   isBuiltIn: boolean;
   isUserDefined: boolean;
+}
+
+/**
+ * Resolved model catalog for a single agent. Returned by the runtime
+ * catalog resolver (`agentCapabilities.getResolvedModelList`) so the
+ * renderer can present an up-to-date model picker without rebuilding
+ * the app. `source` is informational only — `"remote"` when at least
+ * one entry came from the live catalog fetch, `"bundled"` when the
+ * fetch failed or no remote entries matched and the static config
+ * was returned as-is.
+ */
+export interface ResolvedModelCatalog {
+  agentId: string;
+  models: AgentModelConfig[];
+  contextWindow: number | null;
+  source: "remote" | "bundled" | "merged";
 }

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -26,6 +26,9 @@ export interface GeneratedElectronAPI {
     getRegistry(
       ...args: IpcInvokeMap["agent-capabilities:get-registry"]["args"]
     ): Promise<IpcInvokeMap["agent-capabilities:get-registry"]["result"]>;
+    getResolvedModelList(
+      ...args: IpcInvokeMap["agent-capabilities:get-resolved-model-list"]["args"]
+    ): Promise<IpcInvokeMap["agent-capabilities:get-resolved-model-list"]["result"]>;
     isAgentEnabled(
       ...args: IpcInvokeMap["agent-capabilities:is-agent-enabled"]["args"]
     ): Promise<IpcInvokeMap["agent-capabilities:is-agent-enabled"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -24,6 +24,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("./agentCapabilities.js").AgentRegistry;
   };
+  "agent-capabilities:get-resolved-model-list": {
+    args: [agentId: string];
+    result: import("./agentCapabilities.js").ResolvedModelCatalog | null;
+  };
   "agent-capabilities:is-agent-enabled": {
     args: [agentId: string];
     result: boolean;

--- a/src/clients/agentCapabilitiesClient.ts
+++ b/src/clients/agentCapabilitiesClient.ts
@@ -1,4 +1,8 @@
-import type { AgentRegistry, AgentMetadata } from "@shared/types/ipc/agentCapabilities";
+import type {
+  AgentRegistry,
+  AgentMetadata,
+  ResolvedModelCatalog,
+} from "@shared/types/ipc/agentCapabilities";
 
 export const agentCapabilitiesClient = {
   getRegistry: (): Promise<AgentRegistry> => {
@@ -15,5 +19,9 @@ export const agentCapabilitiesClient = {
 
   isAgentEnabled: (agentId: string): Promise<boolean> => {
     return window.electron.agentCapabilities.isAgentEnabled(agentId);
+  },
+
+  getResolvedModelList: (agentId: string): Promise<ResolvedModelCatalog | null> => {
+    return window.electron.agentCapabilities.getResolvedModelList(agentId);
   },
 } as const;


### PR DESCRIPTION
## Summary

- Agent model lists and context windows were hard-coded static arrays that drifted the moment a provider shipped or renamed a model — this replaces them with runtime resolution
- New `AgentModelCatalogService` fetches from `https://models.dev/api.json` with a TTL cache, in-flight dedup, and timeout; falls back to the bundled static values when offline so the app stays functional without network access
- For Codex, `codex debug models --bundled` is queried directly when the CLI is detected — that's the offline-authoritative source for Codex context windows and takes precedence over the remote manifest

Resolves #8789

## Changes

- `AgentModelCatalogService` — new service handling remote fetch, TTL caching, Codex CLI query, and graceful fallback
- `agentCapabilities` IPC handler updated to source model lists and context windows from the catalog service
- Unknown model IDs degrade gracefully to a sensible default context window rather than surfacing an error
- Bundled static values in `agentRegistry` become the offline-safe snapshot rather than the source of truth
- `__tests__/AgentModelCatalogService.test.ts` — 387-line test suite covering fetch paths, cache behaviour, Codex CLI integration, and fallback

## Testing

- Unit tests cover the fetch/cache/fallback cycle, Codex CLI output parsing, and graceful degradation for unknown model IDs
- Manually verified the renderer receives resolved model lists via the `agentCapabilities` IPC bridge