### PR TITLE
fix(fleet): stop raw-input broadcast from auto-entering fleet scope

### DIFF
--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -240,7 +240,12 @@ describe("broadcastFleetRawInput", () => {
     expect(notifyEnterPressedMock).not.toHaveBeenCalled();
   });
 
-  it("auto-enters fleet scope when broadcast targets cross worktrees in scoped mode (#8255)", () => {
+  it("does not enter fleet scope on broadcast even when targets span worktrees (#8797)", () => {
+    // Raw input broadcast must never rearrange the layout. Set up the exact
+    // conditions that used to auto-enter fleet scope — cross-worktree targets,
+    // scoped mode, hydrated — and assert the broadcast still goes out while
+    // `enterFleetScope` is never called. Fleet scope is now strictly opt-in
+    // via the `fleet.scope.enter` action.
     seedPanels([
       makeTerminal("t1", { worktreeId: "wt-1" }),
       makeTerminal("t2", { worktreeId: "wt-2" }),
@@ -250,90 +255,11 @@ describe("broadcastFleetRawInput", () => {
     worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
 
     expect(broadcastFleetRawInput("t1", "ls\r")).toBe(true);
-    expect(enterFleetScopeMock).toHaveBeenCalledTimes(1);
-  });
 
-  it("does not enter fleet scope when targets are same-worktree", () => {
-    seedPanels([
-      makeTerminal("t1", { worktreeId: "wt-1" }),
-      makeTerminal("t2", { worktreeId: "wt-1" }),
-    ]);
-    useFleetArmingStore.getState().armIds(["t1", "t2"]);
-    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
-    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
-
-    broadcastFleetRawInput("t1", "ls\r");
+    // The write still goes out to every target...
+    expect(broadcastMock).toHaveBeenCalledWith(["t1", "t2"], "ls\r");
+    // ...but the layout is left untouched.
     expect(enterFleetScopeMock).not.toHaveBeenCalled();
-  });
-
-  it("does not enter fleet scope in legacy mode even when cross-worktree", () => {
-    seedPanels([
-      makeTerminal("t1", { worktreeId: "wt-1" }),
-      makeTerminal("t2", { worktreeId: "wt-2" }),
-    ]);
-    useFleetArmingStore.getState().armIds(["t1", "t2"]);
-    useFleetScopeFlagStore.setState({ mode: "legacy", isHydrated: true });
-    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
-
-    broadcastFleetRawInput("t1", "ls\r");
-    expect(enterFleetScopeMock).not.toHaveBeenCalled();
-  });
-
-  it("does not enter fleet scope before hydration (preserves persisted-mode load order)", () => {
-    seedPanels([
-      makeTerminal("t1", { worktreeId: "wt-1" }),
-      makeTerminal("t2", { worktreeId: "wt-2" }),
-    ]);
-    useFleetArmingStore.getState().armIds(["t1", "t2"]);
-    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: false });
-    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
-
-    broadcastFleetRawInput("t1", "ls\r");
-    expect(enterFleetScopeMock).not.toHaveBeenCalled();
-  });
-
-  it("treats panels with undefined worktreeId as no-affiliation (no scope entry on their own)", () => {
-    const t1 = makeTerminal("t1", { worktreeId: "wt-1" });
-    const t2 = makeTerminal("t2");
-    // Strip the worktreeId so the lookup returns undefined.
-    delete (t2 as { worktreeId?: string }).worktreeId;
-    seedPanels([t1, t2]);
-    useFleetArmingStore.getState().armIds(["t1", "t2"]);
-    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
-    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
-
-    broadcastFleetRawInput("t1", "ls\r");
-    expect(enterFleetScopeMock).not.toHaveBeenCalled();
-  });
-
-  it("still enters fleet scope when an undefined-worktreeId target sits alongside a real cross-worktree target", () => {
-    const t1 = makeTerminal("t1", { worktreeId: "wt-1" });
-    const t2 = makeTerminal("t2");
-    delete (t2 as { worktreeId?: string }).worktreeId;
-    const t3 = makeTerminal("t3", { worktreeId: "wt-2" });
-    seedPanels([t1, t2, t3]);
-    useFleetArmingStore.getState().armIds(["t1", "t2", "t3"]);
-    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
-    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
-
-    broadcastFleetRawInput("t1", "ls\r");
-    expect(enterFleetScopeMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("enters fleet scope regardless of payload — non-Enter cross-worktree still promotes visibility", () => {
-    seedPanels([
-      makeTerminal("t1", { worktreeId: "wt-1" }),
-      makeTerminal("t2", { worktreeId: "wt-2" }),
-    ]);
-    useFleetArmingStore.getState().armIds(["t1", "t2"]);
-    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
-    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
-
-    // ESC+CR soft-newline (alt-Enter) — not a submit but still keystroke input.
-    expect(broadcastFleetRawInput("t1", "\x1b\r")).toBe(true);
-    expect(enterFleetScopeMock).toHaveBeenCalledTimes(1);
-    // notifyEnterPressed must NOT fire for the soft-newline payload.
-    expect(notifyEnterPressedMock).not.toHaveBeenCalled();
   });
 
   it("performs the raw broadcast alongside notifyEnterPressed for plain Enter", () => {

--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -5,16 +5,13 @@ import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { usePanelStore } from "@/store/panelStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import type { TerminalInstance } from "@shared/types";
 
 const broadcastMock = vi.hoisted(() => vi.fn<(ids: string[], data: string) => void>());
 const notifyUserInputMock = vi.hoisted(() => vi.fn<(id: string, data?: string) => void>());
 const notifyEnterPressedMock = vi.hoisted(() => vi.fn<(id: string) => void>());
 const clearDirectingStateMock = vi.hoisted(() => vi.fn<(id: string) => void>());
-const enterFleetScopeMock = vi.hoisted(() => vi.fn<() => void>());
-const worktreeSelectionStateRef = vi.hoisted(() => ({
-  current: { activeWorktreeId: "wt-1" as string | null },
-}));
 
 vi.mock("@/clients", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/clients")>();
@@ -32,15 +29,6 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     notifyUserInput: notifyUserInputMock,
     notifyEnterPressed: notifyEnterPressedMock,
     clearDirectingState: clearDirectingStateMock,
-  },
-}));
-
-vi.mock("@/store/worktreeStore", () => ({
-  useWorktreeSelectionStore: {
-    getState: () => ({
-      activeWorktreeId: worktreeSelectionStateRef.current.activeWorktreeId,
-      enterFleetScope: enterFleetScopeMock,
-    }),
   },
 }));
 
@@ -72,7 +60,6 @@ function resetStores(): void {
   notifyUserInputMock.mockReset();
   notifyEnterPressedMock.mockReset();
   clearDirectingStateMock.mockReset();
-  enterFleetScopeMock.mockReset();
   useFleetArmingStore.setState({
     armedIds: new Set<string>(),
     armOrder: [],
@@ -83,10 +70,8 @@ function resetStores(): void {
   });
   useFleetFailureStore.getState().clear();
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
-  // Default to unhydrated so existing tests don't accidentally trigger
-  // fleet-scope side effects. Cross-worktree tests opt in by hydrating.
   useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: false });
-  worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
+  useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1", isFleetScopeActive: false });
 }
 
 describe("broadcastFleetRawInput", () => {
@@ -244,22 +229,24 @@ describe("broadcastFleetRawInput", () => {
     // Raw input broadcast must never rearrange the layout. Set up the exact
     // conditions that used to auto-enter fleet scope — cross-worktree targets,
     // scoped mode, hydrated — and assert the broadcast still goes out while
-    // `enterFleetScope` is never called. Fleet scope is now strictly opt-in
-    // via the `fleet.scope.enter` action.
+    // fleet scope stays inactive. The real worktree store is observed (not a
+    // mock) so this guard catches scope entry via any path, not just a
+    // verbatim revert. Fleet scope is now strictly opt-in via the
+    // `fleet.scope.enter` action.
     seedPanels([
       makeTerminal("t1", { worktreeId: "wt-1" }),
       makeTerminal("t2", { worktreeId: "wt-2" }),
     ]);
     useFleetArmingStore.getState().armIds(["t1", "t2"]);
     useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
-    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1", isFleetScopeActive: false });
 
     expect(broadcastFleetRawInput("t1", "ls\r")).toBe(true);
 
     // The write still goes out to every target...
     expect(broadcastMock).toHaveBeenCalledWith(["t1", "t2"], "ls\r");
     // ...but the layout is left untouched.
-    expect(enterFleetScopeMock).not.toHaveBeenCalled();
+    expect(useWorktreeSelectionStore.getState().isFleetScopeActive).toBe(false);
   });
 
   it("performs the raw broadcast alongside notifyEnterPressed for plain Enter", () => {

--- a/src/components/Fleet/fleetRawInputBroadcast.ts
+++ b/src/components/Fleet/fleetRawInputBroadcast.ts
@@ -3,9 +3,7 @@ import { registerFleetInputBroadcastHandler } from "@/services/terminal/fleetInp
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { isFleetArmEligible, useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
-import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { usePanelStore } from "@/store/panelStore";
-import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { logWarn } from "@/utils/logger";
 import type { BroadcastWriteResultPayload } from "@shared/types";
 import { PERMANENT_FAILURE_CODES } from "./fleetBroadcast";
@@ -32,32 +30,6 @@ export function broadcastFleetRawInput(originId: string, data: string): boolean 
 
   const targets = resolveLiveFleetTargetIds();
   if (targets.length < 2 || !targets.includes(originId)) return false;
-
-  // Auto-enter fleet scope when targets span worktrees so cross-worktree
-  // armed terminals are actually rendered while raw input is in flight —
-  // otherwise the user is firing keystrokes into hidden panes. Gated on
-  // `mode === "scoped"` + hydrated so legacy users keep their existing
-  // silent-write behavior. `enterFleetScope` is idempotent.
-  const scopeFlag = useFleetScopeFlagStore.getState();
-  if (scopeFlag.isHydrated && scopeFlag.mode === "scoped") {
-    const { panelsById } = usePanelStore.getState();
-    const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
-    let hasCrossWorktreeTarget = false;
-    for (const id of targets) {
-      const targetWorktreeId = panelsById[id]?.worktreeId;
-      // `undefined` is treated as "no worktree affiliation" — global/unowned
-      // terminals don't drive scope entry on their own. A real cross-worktree
-      // target (a non-undefined id that differs from the active worktree) is
-      // still detected when present alongside such a terminal.
-      if (targetWorktreeId !== undefined && targetWorktreeId !== activeWorktreeId) {
-        hasCrossWorktreeTarget = true;
-        break;
-      }
-    }
-    if (hasCrossWorktreeTarget) {
-      useWorktreeSelectionStore.getState().enterFleetScope();
-    }
-  }
 
   terminalClient.broadcast(targets, data);
   // Mirror the origin's xterm onData → onUserInput path on every non-origin


### PR DESCRIPTION
## Summary

- Removed the auto-enter-fleet-scope block from `broadcastFleetRawInput` in `fleetRawInputBroadcast.ts` — raw keyboard broadcast to a fleet of armed terminals no longer rearranges the grid layout by entering fleet scope as a side effect
- Fleet scope remains fully functional as an explicit opt-in via the `fleet.scope.enter` action, bringing the raw-input path in line with `fleetEnterBroadcast.ts`, which never auto-entered scope
- Dropped the now-unused `useFleetScopeFlagStore` and `useWorktreeSelectionStore` imports

Resolves #8797

## Changes

- `fleetRawInputBroadcast.ts` — removed auto-enter block, cleaned up unused imports
- `fleetRawInputBroadcast.test.ts` — deleted 6 obsolete auto-enter test cases; replaced primary cross-worktree test with a negative regression guard that reads `isFleetScopeActive` from the real worktree store to confirm scope is never entered on broadcast

## Testing

24 unit tests pass. Typecheck, lint, and format all clean.