### PR TITLE
fix(worktree): surface startup load failures instead of hanging the sidebar

### DIFF
--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -355,7 +355,7 @@ describe("worktree IPC adversarial", () => {
       const attachDirectPort = vi.fn();
       const host = { hostId: "h1" };
       const getHostForProject = vi.fn().mockReturnValue(host);
-      const brokerPort = vi.fn();
+      const brokerPort = vi.fn().mockReturnValue(true);
       registerRetryHandlers({ loadProject, attachDirectPort, getHostForProject, brokerPort });
 
       const event = eventWithSender();
@@ -366,9 +366,22 @@ describe("worktree IPC adversarial", () => {
       expect(brokerPort).toHaveBeenCalledWith(host, event.sender);
     });
 
+    it("rejects when the reload succeeds but the worktree port can't be brokered", async () => {
+      registerRetryHandlers({
+        loadProject: vi.fn().mockResolvedValue(undefined),
+        attachDirectPort: vi.fn(),
+        getHostForProject: vi.fn().mockReturnValue({ hostId: "h1" }),
+        brokerPort: vi.fn().mockReturnValue(false),
+      });
+
+      await expect(
+        getHandler(CHANNELS.WORKTREE_RETRY_PROJECT_LOAD)(eventWithSender())
+      ).rejects.toThrow(/couldn't connect to the worktree service/);
+    });
+
     it("skips brokering when no workspace host is available, without throwing", async () => {
       const attachDirectPort = vi.fn();
-      const brokerPort = vi.fn();
+      const brokerPort = vi.fn().mockReturnValue(true);
       registerRetryHandlers({
         loadProject: vi.fn().mockResolvedValue(undefined),
         attachDirectPort,

--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -323,4 +323,98 @@ describe("worktree IPC adversarial", () => {
 
     expect(resolveWorktreePatternMock).not.toHaveBeenCalled();
   });
+
+  describe("WORKTREE_RETRY_PROJECT_LOAD (#8796)", () => {
+    function eventWithSender(opts: { destroyed?: boolean } = {}): Electron.IpcMainInvokeEvent {
+      return {
+        sender: { id: 7, isDestroyed: () => opts.destroyed ?? false },
+      } as unknown as Electron.IpcMainInvokeEvent;
+    }
+
+    function registerRetryHandlers(svc: {
+      loadProject: ReturnType<typeof vi.fn>;
+      attachDirectPort: ReturnType<typeof vi.fn>;
+      getHostForProject: ReturnType<typeof vi.fn>;
+      brokerPort: ReturnType<typeof vi.fn>;
+    }) {
+      cleanup();
+      ipcHandlers.clear();
+      getWindowForWebContentsMock.mockReturnValue({ id: 7 });
+      cleanup = registerWorktreeHandlers({
+        worktreeService: {
+          loadProject: svc.loadProject,
+          attachDirectPort: svc.attachDirectPort,
+          getHostForProject: svc.getHostForProject,
+        },
+        worktreePortBroker: { brokerPort: svc.brokerPort },
+      } as unknown as HandlerDependencies);
+    }
+
+    it("brokers the worktree port after a successful reload", async () => {
+      const loadProject = vi.fn().mockResolvedValue(undefined);
+      const attachDirectPort = vi.fn();
+      const host = { hostId: "h1" };
+      const getHostForProject = vi.fn().mockReturnValue(host);
+      const brokerPort = vi.fn();
+      registerRetryHandlers({ loadProject, attachDirectPort, getHostForProject, brokerPort });
+
+      const event = eventWithSender();
+      await getHandler(CHANNELS.WORKTREE_RETRY_PROJECT_LOAD)(event);
+
+      expect(loadProject).toHaveBeenCalledWith("/repo", 7);
+      expect(attachDirectPort).toHaveBeenCalledWith(7, event.sender);
+      expect(brokerPort).toHaveBeenCalledWith(host, event.sender);
+    });
+
+    it("skips brokering when no workspace host is available, without throwing", async () => {
+      const attachDirectPort = vi.fn();
+      const brokerPort = vi.fn();
+      registerRetryHandlers({
+        loadProject: vi.fn().mockResolvedValue(undefined),
+        attachDirectPort,
+        getHostForProject: vi.fn().mockReturnValue(null),
+        brokerPort,
+      });
+
+      await expect(
+        getHandler(CHANNELS.WORKTREE_RETRY_PROJECT_LOAD)(eventWithSender())
+      ).resolves.toBeUndefined();
+      expect(attachDirectPort).toHaveBeenCalled();
+      expect(brokerPort).not.toHaveBeenCalled();
+    });
+
+    it("does not attach or broker when the reload itself fails", async () => {
+      const attachDirectPort = vi.fn();
+      const brokerPort = vi.fn();
+      registerRetryHandlers({
+        loadProject: vi.fn().mockRejectedValue(new Error("project folder is gone")),
+        attachDirectPort,
+        getHostForProject: vi.fn().mockReturnValue({ hostId: "h1" }),
+        brokerPort,
+      });
+
+      await expect(
+        getHandler(CHANNELS.WORKTREE_RETRY_PROJECT_LOAD)(eventWithSender())
+      ).rejects.toThrow(/project folder is gone/);
+      expect(attachDirectPort).not.toHaveBeenCalled();
+      expect(brokerPort).not.toHaveBeenCalled();
+    });
+
+    it("skips brokering when the sender webContents was destroyed", async () => {
+      const attachDirectPort = vi.fn();
+      const brokerPort = vi.fn();
+      registerRetryHandlers({
+        loadProject: vi.fn().mockResolvedValue(undefined),
+        attachDirectPort,
+        getHostForProject: vi.fn().mockReturnValue({ hostId: "h1" }),
+        brokerPort,
+      });
+
+      await expect(
+        getHandler(CHANNELS.WORKTREE_RETRY_PROJECT_LOAD)(eventWithSender({ destroyed: true }))
+      ).resolves.toBeUndefined();
+      expect(attachDirectPort).not.toHaveBeenCalled();
+      expect(brokerPort).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -131,7 +131,14 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
         deps.worktreeService.attachDirectPort(windowId, sender);
         const host = deps.worktreeService.getHostForProject(project.path);
         if (host && deps.worktreePortBroker) {
-          deps.worktreePortBroker.brokerPort(host, sender);
+          const brokered = deps.worktreePortBroker.brokerPort(host, sender);
+          if (!brokered) {
+            // The reload succeeded but the worktree MessagePort never
+            // connected, so the renderer's worktree store can't fetch its
+            // state. Throw so the error banner stays and Retry remains
+            // available, rather than leaving the sidebar silently stuck.
+            throw new Error("Reloaded the project but couldn't connect to the worktree service");
+          }
         }
       }
     } catch (error) {

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -120,6 +120,20 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     }
     try {
       await deps.worktreeService.loadProject(project.path, windowId);
+
+      // Re-establish the worktree MessagePort after a successful reload.
+      // `loadProject()` alone reloads the host but does not re-broker the
+      // port, so the renderer's worktree store never re-runs
+      // `fetchInitialState()` and the sidebar stays stuck on the loading
+      // skeleton even after a successful retry (#8796). Mirrors switch.ts.
+      const sender = ctx.event.sender;
+      if (!sender.isDestroyed()) {
+        deps.worktreeService.attachDirectPort(windowId, sender);
+        const host = deps.worktreeService.getHostForProject(project.path);
+        if (host && deps.worktreePortBroker) {
+          deps.worktreePortBroker.brokerPort(host, sender);
+        }
+      }
     } catch (error) {
       throw new Error(formatErrorMessage(error, "Failed to load worktrees"), { cause: error });
     }

--- a/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
+++ b/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
@@ -32,6 +32,20 @@ function makeWebContents(opts: { loading: boolean; destroyed?: boolean }): FakeW
   };
 }
 
+/**
+ * Replicates the status-target selection from windowServices.ts (#8796):
+ * prefer the project view's webContents, but fall through to the window's
+ * app webContents when it's already destroyed — selecting a destroyed
+ * target would silently drop the message.
+ */
+function selectStatusTarget(
+  initialAppViewWc: FakeWebContents | null,
+  fallbackWc: FakeWebContents | null
+): FakeWebContents | null {
+  if (initialAppViewWc && !initialAppViewWc.destroyed) return initialAppViewWc;
+  return fallbackWc;
+}
+
 /** Replicates the windowServices.ts worktree-load catch block (#8796). */
 function simulateStartupWorktreeLoadFailure(
   failedProjectId: string | undefined,
@@ -105,9 +119,35 @@ describe("windowServices startup worktree-load failure (#8796)", () => {
     expect(wc.sent).toHaveLength(0);
   });
 
+  it("does not send when the target webContents is already destroyed at call time", () => {
+    const wc = makeWebContents({ loading: false, destroyed: true });
+    simulateStartupWorktreeLoadFailure("proj-a", wc, new Error("folder is gone"));
+
+    expect(wc.sent).toHaveLength(0);
+  });
+
   it("does not throw when the target webContents is missing", () => {
     expect(() =>
       simulateStartupWorktreeLoadFailure("proj-a", null, new Error("folder is gone"))
     ).not.toThrow();
+  });
+
+  describe("status-target selection", () => {
+    it("prefers the project view's webContents when it is alive", () => {
+      const viewWc = makeWebContents({ loading: false });
+      const fallbackWc = makeWebContents({ loading: false });
+      expect(selectStatusTarget(viewWc, fallbackWc)).toBe(viewWc);
+    });
+
+    it("falls through to the app webContents when the project view is destroyed", () => {
+      const viewWc = makeWebContents({ loading: false, destroyed: true });
+      const fallbackWc = makeWebContents({ loading: false });
+      expect(selectStatusTarget(viewWc, fallbackWc)).toBe(fallbackWc);
+    });
+
+    it("uses the app webContents when there is no project view", () => {
+      const fallbackWc = makeWebContents({ loading: false });
+      expect(selectStatusTarget(null, fallbackWc)).toBe(fallbackWc);
+    });
   });
 });

--- a/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
+++ b/electron/window/__tests__/windowServicesWorktreeLoadError.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+
+/**
+ * Tests the startup worktree-load-failure decision logic from
+ * windowServices.ts (#8796).
+ *
+ * setupWindowServices cannot be imported directly (side effects, Electron
+ * deps), so we replicate the catch-block decision logic: given a resolved
+ * projectId and a target webContents, when — and what — does it send?
+ *
+ * The interesting branch is IPC timing: a `project:worktree-load-status`
+ * sent before the renderer wires its ipcRenderer listener is silently
+ * dropped, so the send must defer to `did-finish-load` while loading.
+ */
+
+type FakeWebContents = {
+  loading: boolean;
+  destroyed: boolean;
+  sent: { channel: string; payload: unknown }[];
+  pendingDidFinishLoad: (() => void)[];
+};
+
+const PROJECT_WORKTREE_LOAD_STATUS = "project:worktree-load-status";
+
+function makeWebContents(opts: { loading: boolean; destroyed?: boolean }): FakeWebContents {
+  return {
+    loading: opts.loading,
+    destroyed: opts.destroyed ?? false,
+    sent: [],
+    pendingDidFinishLoad: [],
+  };
+}
+
+/** Replicates the windowServices.ts worktree-load catch block (#8796). */
+function simulateStartupWorktreeLoadFailure(
+  failedProjectId: string | undefined,
+  statusTarget: FakeWebContents | null,
+  error: unknown
+): void {
+  if (!failedProjectId || !statusTarget) return;
+  const worktreeLoadError = formatErrorMessage(error, "Failed to load worktrees");
+  const sendLoadStatus = (): void => {
+    if (statusTarget.destroyed) return;
+    statusTarget.sent.push({
+      channel: PROJECT_WORKTREE_LOAD_STATUS,
+      payload: { projectId: failedProjectId, worktreeLoadError },
+    });
+  };
+  if (statusTarget.loading) {
+    statusTarget.pendingDidFinishLoad.push(sendLoadStatus);
+  } else {
+    sendLoadStatus();
+  }
+}
+
+describe("windowServices startup worktree-load failure (#8796)", () => {
+  it("sends the load-status immediately when the renderer has finished loading", () => {
+    const wc = makeWebContents({ loading: false });
+    simulateStartupWorktreeLoadFailure("proj-a", wc, new Error("folder is gone"));
+
+    expect(wc.sent).toEqual([
+      {
+        channel: PROJECT_WORKTREE_LOAD_STATUS,
+        payload: { projectId: "proj-a", worktreeLoadError: "folder is gone" },
+      },
+    ]);
+    expect(wc.pendingDidFinishLoad).toHaveLength(0);
+  });
+
+  it("defers the load-status until did-finish-load while the renderer is still loading", () => {
+    const wc = makeWebContents({ loading: true });
+    simulateStartupWorktreeLoadFailure("proj-a", wc, new Error("folder is gone"));
+
+    // Nothing sent yet — a message before the renderer wires its
+    // ipcRenderer listener would be silently dropped.
+    expect(wc.sent).toHaveLength(0);
+    expect(wc.pendingDidFinishLoad).toHaveLength(1);
+
+    wc.pendingDidFinishLoad.forEach((cb) => cb());
+    expect(wc.sent).toEqual([
+      {
+        channel: PROJECT_WORKTREE_LOAD_STATUS,
+        payload: { projectId: "proj-a", worktreeLoadError: "folder is gone" },
+      },
+    ]);
+  });
+
+  it("sends nothing when no projectId could be resolved (explicit-path window)", () => {
+    const wc = makeWebContents({ loading: false });
+    simulateStartupWorktreeLoadFailure(undefined, wc, new Error("folder is gone"));
+
+    expect(wc.sent).toHaveLength(0);
+    expect(wc.pendingDidFinishLoad).toHaveLength(0);
+  });
+
+  it("does not send when the webContents was destroyed before did-finish-load", () => {
+    const wc = makeWebContents({ loading: true });
+    simulateStartupWorktreeLoadFailure("proj-a", wc, new Error("folder is gone"));
+    expect(wc.pendingDidFinishLoad).toHaveLength(1);
+
+    // Window closed between the throw and did-finish-load.
+    wc.destroyed = true;
+    wc.pendingDidFinishLoad.forEach((cb) => cb());
+    expect(wc.sent).toHaveLength(0);
+  });
+
+  it("does not throw when the target webContents is missing", () => {
+    expect(() =>
+      simulateStartupWorktreeLoadFailure("proj-a", null, new Error("folder is gone"))
+    ).not.toThrow();
+  });
+});

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -15,6 +15,7 @@ import { runSmokeFunctionalChecks } from "../services/smokeTest.js";
 import { markPerformance } from "../utils/performance.js";
 import { getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { isSmokeTest, smokeTestStart } from "../setup/environment.js";
 import { shouldDeferRendererLoadForE2E, shouldEnableEarlyRenderer } from "./earlyRenderer.js";
 import { extractCliPath, getPendingCliPath, setPendingCliPath } from "../lifecycle/appLifecycle.js";
@@ -410,6 +411,32 @@ export async function setupWindowServices(
       }
     } catch (error) {
       console.error("[MAIN] Failed to load worktrees:", error);
+
+      // Surface the failure to the renderer so the sidebar shows the
+      // WorktreeLoadErrorBanner instead of an infinite loading skeleton
+      // (#8796). Without this, the worktree port is never brokered, the
+      // renderer's worktree store stays `isLoading: true`, and the sidebar
+      // hangs. Mirrors the project-switch path (projectCrud/switch.ts).
+      // The send is deferred until `did-finish-load` while the renderer is
+      // still loading — messages sent before the renderer wires its
+      // ipcRenderer listener are silently dropped.
+      const failedProjectId = restoreProject?.id;
+      const statusTarget = opts.initialAppView?.webContents ?? getAppWebContents(win);
+      if (failedProjectId && statusTarget) {
+        const worktreeLoadError = formatErrorMessage(error, "Failed to load worktrees");
+        const sendLoadStatus = (): void => {
+          if (statusTarget.isDestroyed()) return;
+          statusTarget.send(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, {
+            projectId: failedProjectId,
+            worktreeLoadError,
+          });
+        };
+        if (statusTarget.isLoading()) {
+          statusTarget.once("did-finish-load", sendLoadStatus);
+        } else {
+          sendLoadStatus();
+        }
+      }
     }
   } else if (projectPathForWorktrees && !workspaceReady) {
     console.warn("[MAIN] Workspace service unavailable - skipping worktree loading");

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -421,7 +421,12 @@ export async function setupWindowServices(
       // still loading — messages sent before the renderer wires its
       // ipcRenderer listener are silently dropped.
       const failedProjectId = restoreProject?.id;
-      const statusTarget = opts.initialAppView?.webContents ?? getAppWebContents(win);
+      // Prefer the project view's webContents, but fall through to the
+      // window's app webContents if it's already destroyed — selecting a
+      // destroyed target would silently drop the message and re-hang.
+      const initialViewWc = opts.initialAppView?.webContents;
+      const statusTarget =
+        initialViewWc && !initialViewWc.isDestroyed() ? initialViewWc : getAppWebContents(win);
       if (failedProjectId && statusTarget) {
         const worktreeLoadError = formatErrorMessage(error, "Failed to load worktrees");
         const sendLoadStatus = (): void => {


### PR DESCRIPTION
## Summary

On cold start the app tries to restore the last-active project. If the project folder was renamed or moved, the startup worktree load threw an error that was only `console.error`'d inside a try/catch in `windowServices.ts`. The worktree `MessagePort` was never brokered, so the renderer's worktree store stayed `isLoading: true` forever. From the user's side: an infinite skeleton with no error message and no way to recover.

Two main-process fixes:

- **`windowServices.ts`** — when a startup load fails, send `CHANNELS.PROJECT_WORKTREE_LOAD_STATUS` to the renderer with the formatted error so `SidebarContent` renders the existing `WorktreeLoadErrorBanner` (with its Retry action) instead of an infinite skeleton. The send is deferred via `did-finish-load` when the renderer is still initialising, so the message isn't silently dropped. A destroyed `initialAppView` webContents falls through to the window's app webContents.
- **`lifecycle.ts` `handleWorktreeRetryProjectLoad`** — re-brokers the worktree `MessagePort` after a successful retry. Previously `loadProject()` reloaded the host but never re-established the port, so the sidebar stayed stuck even after the user hit Retry. If `brokerPort()` fails the handler now throws, keeping the error banner and Retry available rather than leaving the sidebar silently stuck.

Resolves #8796.

## Changes

- `electron/window/windowServices.ts` — catch-block now forwards load errors to the renderer with deferred send and target fallback logic
- `electron/ipc/handlers/worktree/lifecycle.ts` — retry handler re-brokers the port on success, throws if brokering fails

## Testing

Extended `electron/ipc/handlers/__tests__/worktree.adversarial.test.ts` with retry-handler tests: port brokered on success, rejects when `brokerPort` fails, skips broker when no host / sender destroyed / reload fails.

New `electron/window/__tests__/windowServicesWorktreeLoadError.test.ts` covering the catch-block decision logic: immediate vs deferred send, `projectId` guard, destroyed-target guards, status-target selection.

24 tests pass.