### PR TITLE
fix(worktree): unwrap content envelope in file diff viewer

### DIFF
--- a/src/components/Worktree/FileDiffModal.tsx
+++ b/src/components/Worktree/FileDiffModal.tsx
@@ -81,7 +81,7 @@ export function FileDiffModal({
       return;
     }
 
-    fetchDiff();
+    void fetchDiff();
   }, [isOpen, fetchDiff]);
 
   return (

--- a/src/components/Worktree/FileDiffModal.tsx
+++ b/src/components/Worktree/FileDiffModal.tsx
@@ -57,7 +57,7 @@ export function FileDiffModal({
     const requestId = ++requestRef.current;
     setDiff(undefined);
     try {
-      const result = await actionService.dispatch(
+      const result = await actionService.dispatch<{ content: string }>(
         "git.getFileDiff",
         { cwd: worktreePath, filePath, status },
         { source: "user" }
@@ -67,8 +67,7 @@ export function FileDiffModal({
         setDiff("ERROR");
         return;
       }
-      const diffResult = result.result;
-      setDiff(typeof diffResult === "string" ? diffResult || "NO_CHANGES" : "ERROR");
+      setDiff(result.result.content || "NO_CHANGES");
     } catch {
       if (requestRef.current !== requestId) return;
       setDiff("ERROR");

--- a/src/components/Worktree/__tests__/FileDiffModal.test.tsx
+++ b/src/components/Worktree/__tests__/FileDiffModal.test.tsx
@@ -48,6 +48,11 @@ describe("FileDiffModal", () => {
     await waitFor(() => {
       expect(capturedProps.diff).toBe("diff text");
     });
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "git.getFileDiff",
+      { cwd: "/repo", filePath: "src/index.ts", status: "modified" },
+      { source: "user" }
+    );
   });
 
   it("maps empty content to the NO_CHANGES sentinel", async () => {

--- a/src/components/Worktree/__tests__/FileDiffModal.test.tsx
+++ b/src/components/Worktree/__tests__/FileDiffModal.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { GitStatus } from "@shared/types";
+import { FileDiffModal } from "../FileDiffModal";
+
+// Capture the `diff` prop the lazy FileViewerModal receives so we can assert
+// what `fetchDiff` resolves to for each dispatch outcome.
+const { mockDispatch, capturedProps } = vi.hoisted(() => ({
+  mockDispatch: vi.fn(),
+  capturedProps: { diff: undefined as string | undefined },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (...args: unknown[]) => mockDispatch(...args),
+  },
+}));
+
+vi.mock("@/components/FileViewer/FileViewerModal", () => ({
+  FileViewerModal: (props: { diff?: string }) => {
+    capturedProps.diff = props.diff;
+    return <div data-testid="file-viewer-modal-stub" />;
+  },
+}));
+
+vi.mock("@/hooks/useBranchForPath", () => ({
+  useBranchForPath: () => "main",
+}));
+
+const baseProps = {
+  isOpen: true,
+  filePath: "src/index.ts",
+  status: "modified" as GitStatus,
+  worktreePath: "/repo",
+  onClose: vi.fn(),
+};
+
+describe("FileDiffModal", () => {
+  beforeEach(() => {
+    mockDispatch.mockReset();
+    capturedProps.diff = undefined;
+  });
+
+  it("unwraps the { content } envelope and passes the diff string to the viewer", async () => {
+    mockDispatch.mockResolvedValue({ ok: true, result: { content: "diff text" } });
+    render(<FileDiffModal {...baseProps} />);
+    await waitFor(() => {
+      expect(capturedProps.diff).toBe("diff text");
+    });
+  });
+
+  it("maps empty content to the NO_CHANGES sentinel", async () => {
+    mockDispatch.mockResolvedValue({ ok: true, result: { content: "" } });
+    render(<FileDiffModal {...baseProps} />);
+    await waitFor(() => {
+      expect(capturedProps.diff).toBe("NO_CHANGES");
+    });
+  });
+
+  it("maps a failed dispatch to the ERROR sentinel", async () => {
+    mockDispatch.mockResolvedValue({
+      ok: false,
+      error: { code: "EXECUTION_ERROR", message: "boom" },
+    });
+    render(<FileDiffModal {...baseProps} />);
+    await waitFor(() => {
+      expect(capturedProps.diff).toBe("ERROR");
+    });
+  });
+
+  it("maps a thrown dispatch error to the ERROR sentinel", async () => {
+    mockDispatch.mockRejectedValue(new Error("boom"));
+    render(<FileDiffModal {...baseProps} />);
+    await waitFor(() => {
+      expect(capturedProps.diff).toBe("ERROR");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `git.getFileDiff` wraps its return value in a `{ content: string }` envelope, but `FileDiffModal.fetchDiff` was still reading `result.result` as a raw string and checking `typeof diffResult === "string"` — which is always false for an object
- Every diff fetch fell through to the `"ERROR"` sentinel, so the viewer always showed "Failed to load diff"
- Fix: supply the `<{ content: string }>` generic to `dispatch` and read `result.result.content` directly

Resolves #8800

## Changes

- `FileDiffModal.tsx` — unwrap `result.result.content`; supply dispatch generic; mark the fire-and-forget `fetchDiff` call in the effect as `void`
- `FileDiffModal.test.tsx` — regression test covering all four dispatch outcomes: envelope unwrap, empty content (`NO_CHANGES`), `ok: false` (`ERROR`), thrown (`ERROR`); includes a dispatch-contract assertion

## Testing

New unit test in `src/components/Worktree/__tests__/FileDiffModal.test.tsx` covers the full dispatch contract. No manual reproduction needed — the bug was a type mismatch visible in the source.