### PR TITLE
fix(fleet): declutter cold-start picker footer

### DIFF
--- a/src/components/Fleet/FleetPickerContent.tsx
+++ b/src/components/Fleet/FleetPickerContent.tsx
@@ -49,9 +49,10 @@ export interface FleetPickerContentProps {
  * through alongside fuzzy hits.
  *
  * Keyboard model: search input is focused for typing (Space types space,
- * Cmd+A selects query text). Tab moves focus into the listbox; once there,
- * Space toggles, ArrowUp/Down navigate, Cmd+A selects all visible, Cmd+Shift+I
- * inverts. First Esc clears the search query (handled by the consumer via
+ * Cmd+A selects query text). Tab moves focus through any `headerSlot`
+ * controls and then into the listbox; once there, Space toggles,
+ * ArrowUp/Down navigate, Cmd+A selects all visible, Cmd+Shift+I inverts.
+ * First Esc clears the search query (handled by the consumer via
  * `useEscapeStack` over `clearSearch`); second Esc closes the picker.
  */
 export function FleetPickerContent({
@@ -191,9 +192,14 @@ export function FleetPickerFooterHint({
   driftCount,
   hasVisibleRows,
 }: FleetPickerFooterHintProps): ReactElement | null {
+  // `role="status"` keeps drift changes announced to screen readers — the
+  // removed footer status span carried this and the drift count is the only
+  // dynamic copy left in the hint row.
   const driftNotice =
     driftCount > 0 ? (
-      <span className="text-daintree-text/45 tabular-nums">{driftCount} became ineligible</span>
+      <span role="status" className="text-daintree-text/45 tabular-nums">
+        {driftCount} became ineligible
+      </span>
     ) : null;
 
   if (!hasVisibleRows) return driftNotice;

--- a/src/components/Fleet/FleetPickerContent.tsx
+++ b/src/components/Fleet/FleetPickerContent.tsx
@@ -28,6 +28,13 @@ export interface FleetPickerContentProps {
    * instead.
    */
   autoFocusSearch?: boolean;
+  /**
+   * Optional consumer-rendered controls placed below the search input, inside
+   * the same search section. Keeps layer-specific concerns (e.g. the
+   * cold-start palette's bulk-selection helpers) with the consumer — the
+   * ribbon-add popover passes nothing and gets no extra row.
+   */
+  headerSlot?: React.ReactNode;
 }
 
 /**
@@ -51,6 +58,7 @@ export function FleetPickerContent({
   picker,
   testIdPrefix,
   autoFocusSearch = true,
+  headerSlot,
 }: FleetPickerContentProps): ReactElement {
   const {
     query,
@@ -117,6 +125,7 @@ export function FleetPickerContent({
             data-testid={`${testIdPrefix}-search`}
           />
         </div>
+        {headerSlot}
       </div>
 
       <div

--- a/src/components/Fleet/FleetPickerPalette.tsx
+++ b/src/components/Fleet/FleetPickerPalette.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState, type ReactElement } from "re
 import { Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
-import { FleetPickerContent } from "@/components/Fleet/FleetPickerContent";
+import { FleetPickerContent, FleetPickerFooterHint } from "@/components/Fleet/FleetPickerContent";
 import { useFleetPicker } from "@/hooks/useFleetPicker";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
@@ -117,6 +117,49 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
     });
   }, [agentVisibleIds, picker]);
 
+  // Bulk-selection helpers live in the list's search section, not the commit
+  // footer — they act on the list, and the footer is reserved for commit
+  // controls (mode toggle + Cancel + Arm). Passed to `FleetPickerContent` as a
+  // slot so the layer-agnostic component stays unaware of palette concerns.
+  const selectionHelpers = (
+    <div role="group" aria-label="Selection helpers" className="flex items-center gap-1.5 pt-2">
+      <button
+        type="button"
+        onClick={handleToggleAllVisible}
+        disabled={picker.visibleIds.length === 0}
+        data-testid="fleet-picker-cold-start-select-all"
+        className={cn(
+          "rounded px-2.5 py-1 text-[12px] text-daintree-text/70",
+          "hover:bg-tint/[0.08] hover:text-daintree-text",
+          "disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+        )}
+      >
+        {selectAllLabel}
+      </button>
+      <button
+        type="button"
+        onClick={handleSelectAgents}
+        disabled={agentVisibleIds.length === 0}
+        data-testid="fleet-picker-cold-start-select-agents"
+        className={cn(
+          "rounded px-2.5 py-1 text-[12px] text-daintree-text/70",
+          "hover:bg-tint/[0.08] hover:text-daintree-text",
+          "disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+        )}
+      >
+        Select agents
+      </button>
+    </div>
+  );
+
+  // `FleetPickerFooterHint` collapses to nothing when the list is empty and
+  // nothing has drifted — skip the bordered strip entirely in that case so
+  // there's no empty bar between the list and the footer.
+  const hasVisibleRows = picker.visibleTerminals.length > 0;
+  const showFooterHint = hasVisibleRows || picker.driftCount > 0;
+
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="Select terminals to arm">
       <div className="flex flex-col">
@@ -137,90 +180,61 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
                 picker={picker}
                 testIdPrefix="fleet-picker-cold-start"
                 autoFocusSearch
+                headerSlot={selectionHelpers}
               />
             </div>
 
-            <div className="flex items-center justify-between gap-2 border-t border-daintree-border px-3 py-2">
-              <div className="flex items-center gap-1.5">
-                <span
-                  role="status"
-                  className="text-[11px] tabular-nums text-daintree-text/55"
-                  data-testid="fleet-picker-cold-start-status"
-                >
-                  {hasQuery
-                    ? `Matches ${picker.visibleTerminals.length} of ${picker.eligibleTerminals.length}`
-                    : "Select terminals to arm"}
-                  {picker.driftCount > 0 ? ` · ${picker.driftCount} ineligible` : ""}
-                </span>
+            {showFooterHint && (
+              <div className="flex flex-wrap items-center gap-1.5 border-t border-daintree-border/50 px-3 py-1.5 text-[11px] text-daintree-text/55">
+                <FleetPickerFooterHint
+                  confirmedCount={picker.confirmedIds.length}
+                  driftCount={picker.driftCount}
+                  hasVisibleRows={hasVisibleRows}
+                />
+              </div>
+            )}
+
+            <div className="flex flex-nowrap items-center justify-between gap-2 border-t border-daintree-border px-3 py-2">
+              <div
+                className="flex gap-1 text-[11px]"
+                role="radiogroup"
+                aria-label="Commit mode"
+                data-testid="fleet-picker-cold-start-commit-mode"
+              >
                 <button
                   type="button"
-                  onClick={handleToggleAllVisible}
-                  disabled={picker.visibleIds.length === 0}
-                  data-testid="fleet-picker-cold-start-select-all"
+                  role="radio"
+                  aria-checked={commitMode === "replace"}
+                  onClick={() => setCommitMode("replace")}
+                  data-testid="fleet-picker-cold-start-commit-mode-replace"
                   className={cn(
-                    "rounded px-2.5 py-1 text-[12px] text-daintree-text/70",
-                    "hover:bg-tint/[0.08] hover:text-daintree-text",
-                    "disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none",
-                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                    "rounded px-2 py-1 transition-colors",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
+                    commitMode === "replace"
+                      ? "bg-tint/[0.14] text-daintree-text"
+                      : "bg-tint/[0.04] text-daintree-text/70 hover:bg-tint/[0.08]"
                   )}
                 >
-                  {selectAllLabel}
+                  Replace
                 </button>
                 <button
                   type="button"
-                  onClick={handleSelectAgents}
-                  disabled={agentVisibleIds.length === 0}
-                  data-testid="fleet-picker-cold-start-select-agents"
+                  role="radio"
+                  aria-checked={commitMode === "append"}
+                  onClick={() => setCommitMode("append")}
+                  data-testid="fleet-picker-cold-start-commit-mode-append"
                   className={cn(
-                    "rounded px-2.5 py-1 text-[12px] text-daintree-text/70",
-                    "hover:bg-tint/[0.08] hover:text-daintree-text",
-                    "disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none",
-                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                    "rounded px-2 py-1 transition-colors",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
+                    commitMode === "append"
+                      ? "bg-tint/[0.14] text-daintree-text"
+                      : "bg-tint/[0.04] text-daintree-text/70 hover:bg-tint/[0.08]"
                   )}
                 >
-                  Select agents
+                  Append
                 </button>
               </div>
               <div className="flex items-center gap-1.5">
-                <div
-                  className="flex gap-1 text-[11px]"
-                  role="radiogroup"
-                  aria-label="Commit mode"
-                  data-testid="fleet-picker-cold-start-commit-mode"
-                >
-                  <button
-                    type="button"
-                    role="radio"
-                    aria-checked={commitMode === "replace"}
-                    onClick={() => setCommitMode("replace")}
-                    data-testid="fleet-picker-cold-start-commit-mode-replace"
-                    className={cn(
-                      "rounded px-2 py-1 transition-colors",
-                      "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
-                      commitMode === "replace"
-                        ? "bg-tint/[0.14] text-daintree-text"
-                        : "bg-tint/[0.04] text-daintree-text/70 hover:bg-tint/[0.08]"
-                    )}
-                  >
-                    Replace
-                  </button>
-                  <button
-                    type="button"
-                    role="radio"
-                    aria-checked={commitMode === "append"}
-                    onClick={() => setCommitMode("append")}
-                    data-testid="fleet-picker-cold-start-commit-mode-append"
-                    className={cn(
-                      "rounded px-2 py-1 transition-colors",
-                      "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
-                      commitMode === "append"
-                        ? "bg-tint/[0.14] text-daintree-text"
-                        : "bg-tint/[0.04] text-daintree-text/70 hover:bg-tint/[0.08]"
-                    )}
-                  >
-                    Append
-                  </button>
-                </div>
                 <button
                   type="button"
                   onClick={onClose}

--- a/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
+++ b/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
@@ -119,8 +119,7 @@ describe("FleetPickerPalette", () => {
     seedTerminals([makeTerminal("t1")]);
     renderPalette([makeWorktreeSnap("wt-1", "main")]);
     await act(async () => {});
-    // "Select terminals to arm" appears in both the h2 header and the footer
-    // status span (which is now a persistent prompt), so scope to the heading.
+    // The dialog title renders as the h2 heading.
     expect(screen.getByRole("heading", { name: "Select terminals to arm" })).toBeTruthy();
     expect(screen.getByTestId("fleet-picker-cold-start-root")).toBeTruthy();
   });
@@ -274,7 +273,7 @@ describe("FleetPickerPalette", () => {
     expect(confirm.disabled).toBe(true);
   });
 
-  describe("Select all / Select agents footer buttons", () => {
+  describe("Select all / Select agents helper buttons", () => {
     it("renders 'Select all' and selects all visible terminals on click", async () => {
       // No active worktree → no preselection, so the Arm button starts at 0
       // and clicking "Select all" must populate the selection.
@@ -541,31 +540,6 @@ describe("FleetPickerPalette", () => {
       expect(confirm.textContent).toContain("Arm selected");
     });
 
-    it("footer status reads as a persistent prompt with role='status'", async () => {
-      seedTerminals([makeTerminal("t1")]);
-      renderPalette([makeWorktreeSnap("wt-1", "main")]);
-      await act(async () => {});
-
-      const status = screen.getByTestId("fleet-picker-cold-start-status");
-      expect(status.getAttribute("role")).toBe("status");
-      expect(status.textContent).toBe("Select terminals to arm");
-    });
-
-    it("footer status shows 'Matches N of M' when a query narrows the list", async () => {
-      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
-      seedTerminals([makeTerminal("alpha"), makeTerminal("beta"), makeTerminal("gamma")]);
-      renderPalette([makeWorktreeSnap("wt-1", "main")]);
-      await act(async () => {});
-
-      const search = screen.getByTestId("fleet-picker-cold-start-search") as HTMLInputElement;
-      await act(async () => {
-        fireEvent.change(search, { target: { value: "alpha" } });
-      });
-      await act(async () => {});
-
-      const status = screen.getByTestId("fleet-picker-cold-start-status");
-      expect(status.textContent).toContain("Matches 1 of 3");
-    });
   });
 
   describe("Replace / Append commit-mode toggle", () => {

--- a/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
+++ b/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, fireEvent, screen, act } from "@testing-library/react";
+import { render, fireEvent, screen, act, within } from "@testing-library/react";
 
 vi.mock("@/components/ui/ScrollShadow", () => ({
   ScrollShadow: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -540,6 +540,43 @@ describe("FleetPickerPalette", () => {
       expect(confirm.textContent).toContain("Arm selected");
     });
 
+    it("footer holds only commit controls — bulk-selection helpers sit above the list", async () => {
+      seedTerminals([makeTerminal("t1", { worktreeId: "wt-1" })]);
+      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      await act(async () => {});
+
+      // The commit footer is the row that hosts the Replace/Append toggle.
+      const footer = screen.getByTestId("fleet-picker-cold-start-commit-mode")
+        .parentElement as HTMLElement;
+      const inFooter = within(footer);
+      expect(inFooter.getByTestId("fleet-picker-cold-start-confirm")).toBeTruthy();
+      expect(inFooter.getByText("Cancel")).toBeTruthy();
+      // The decluttered footer must not carry the bulk-selection helpers or
+      // the dropped status text — that's the whole point of #8802.
+      expect(inFooter.queryByTestId("fleet-picker-cold-start-select-all")).toBeNull();
+      expect(inFooter.queryByTestId("fleet-picker-cold-start-select-agents")).toBeNull();
+      expect(inFooter.queryByTestId("fleet-picker-cold-start-status")).toBeNull();
+
+      // The helpers still exist — relocated into the list's search section.
+      expect(screen.getByTestId("fleet-picker-cold-start-select-all")).toBeTruthy();
+      expect(screen.getByTestId("fleet-picker-cold-start-select-agents")).toBeTruthy();
+    });
+
+    it("surfaces the drift count as a live region when a selected terminal drifts out", async () => {
+      seedTerminals([
+        makeTerminal("t1", { worktreeId: "wt-1" }),
+        makeTerminal("t2", { worktreeId: "wt-1" }),
+      ]);
+      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      await act(async () => {});
+
+      // Both terminals start pre-selected; drift t2 out of the panel store.
+      seedTerminals([makeTerminal("t1", { worktreeId: "wt-1" })]);
+      await act(async () => {});
+
+      const drift = screen.getByText("1 became ineligible");
+      expect(drift.getAttribute("role")).toBe("status");
+    });
   });
 
   describe("Replace / Append commit-mode toggle", () => {


### PR DESCRIPTION
## Summary

- The `FleetPickerPalette` footer was cramming seven controls into a single `justify-between` row: status text, `Deselect all`, `Select agents`, the `Replace`/`Append` toggle, `Cancel`, and the primary `Arm` button. The row overflowed, wrapping every label.
- Footer is now stripped to commit controls only: the `Replace`/`Append` toggle on the left, `Cancel` and `Arm` on the right. Bulk-selection helpers (`Deselect all`, `Select agents`) move to a `headerSlot` above the list where they act on the list, not the commit.
- Redundant idle status text ("Select terminals to arm") dropped. `FleetPickerFooterHint` wired into the dialog for the first time.

Resolves #8802

## Changes

- `FleetPickerContent.tsx` — adds `headerSlot` prop and JSDoc; exposes drift count via `role="status"` live region
- `FleetPickerPalette.tsx` — footer trimmed to `Replace`/`Append` + `Cancel` + `Arm`; bulk-selection helpers and drift notice moved to `headerSlot`; `FleetPickerFooterHint` now rendered
- `FleetPickerPalette.test.tsx` — removes 2 obsolete idle-status tests; adds 2 regression tests covering the new header placement and footer-only layout

## Testing

309 Fleet tests pass. Typecheck, lint, format, and build all clean.