### PR TITLE
feat(sidebar): replace bordered-row loading state with shimmer cards (#8804)

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -21,7 +21,7 @@ import {
 import { AlertTriangle, FolderOpen, LayoutGrid, Plus, RefreshCw, Zap } from "lucide-react";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
-import { Skeleton, SkeletonBone, SkeletonText, SkeletonHint } from "@/components/ui/Skeleton";
+import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
 import { ScrollIndicator } from "@/components/Worktree/ScrollIndicator";
 import {
   useAgentLauncher,
@@ -31,7 +31,6 @@ import {
   useAriaKeyshortcuts,
   useKeybindingDisplay,
   useDohertyGate,
-  useResizeObserverRaf,
 } from "@/hooks";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { WorktreeSidebarSearchBar, QuickStateFilterBar } from "@/components/Worktree";
@@ -118,10 +117,16 @@ const SIDEBAR_VIRTUOSO_OVERSCAN_PX = 600;
 // ~14s workspace-host restart budget so it fires before `setFatalError`.
 const RECONNECT_ESCALATE_MS = 10_000;
 
-// Skeleton row height matching collapsed WorktreeCard sidebar variant
-// (py-3=12px + min-h-[22px]=22px + py-3=12px + border-b=1px).
-const SKELETON_ROW_HEIGHT_PX = 47;
-const MIN_SKELETON_ROWS = 3;
+// Fixed-count shimmer card placeholders for the worktree sidebar loading state.
+// Mirrors the `.skel-card` design in index.html startup ghost (~80px per card):
+// padding 12px 16px, flex-column gap-8px, three bones — title / subtitle / detail.
+// Varied widths avoid a picket-fence read.
+const WORKTREE_SKELETON_CARDS = [
+  { id: "a", titleWidth: "58%", subtitleWidth: "44%" },
+  { id: "b", titleWidth: "42%", subtitleWidth: "55%" },
+  { id: "c", titleWidth: "52%", subtitleWidth: "38%" },
+  { id: "d", titleWidth: "36%", subtitleWidth: "48%" },
+] as const;
 
 function truncateSearchQuery(trimmedQuery: string) {
   const codepoints = Array.from(trimmedQuery);
@@ -483,18 +488,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const openFleetPicker = useCallback(() => setIsFleetPickerOpen(true), []);
   const closeFleetPicker = useCallback(() => setIsFleetPickerOpen(false), []);
 
-  const [skeletonContainerEl, setSkeletonContainerEl] = useState<HTMLElement | null>(null);
-  const [skeletonHeight, setSkeletonHeight] = useState(0);
-  const skeletonContainerRef = useCallback((el: HTMLElement | null) => {
-    setSkeletonContainerEl(el);
-  }, []);
-  useResizeObserverRaf(skeletonContainerEl, (entry) => {
-    setSkeletonHeight(entry.contentRect.height);
-  });
-  const skeletonRowCount = Math.max(
-    MIN_SKELETON_ROWS,
-    Number.isFinite(skeletonHeight) ? Math.floor(skeletonHeight / SKELETON_ROW_HEIGHT_PX) : 0
-  );
   useEffect(() => {
     if (!error) setIsRestartConfirmOpen(false);
   }, [error]);
@@ -1281,21 +1274,23 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         <div className="flex items-center px-4 py-4 border-b border-divider shrink-0">
           <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
         </div>
-        <div className="flex-1 min-h-0 relative overflow-hidden pb-8" ref={skeletonContainerRef}>
+        <div className="flex-1 min-h-0 relative overflow-hidden pb-8">
           <Skeleton label="Loading worktrees">
-            {Array.from({ length: skeletonRowCount }).map((_, i) => (
-              <div
-                key={i}
-                aria-hidden="true"
-                className="border-b border-border-default px-4 py-3"
-                style={{ height: SKELETON_ROW_HEIGHT_PX }}
-              >
-                <div className="flex items-center gap-2 min-h-[22px]">
-                  <SkeletonBone className="w-3.5 h-3.5 rounded-full shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <SkeletonText lines={2} lineHeightClassName="h-3" gapClassName="space-y-1" />
-                  </div>
-                </div>
+            {WORKTREE_SKELETON_CARDS.map((card) => (
+              <div key={card.id} aria-hidden="true" className="flex flex-col gap-2 px-4 py-3">
+                <SkeletonBone
+                  shimmer
+                  className="rounded-sm"
+                  heightPx={13}
+                  style={{ width: card.titleWidth }}
+                />
+                <SkeletonBone
+                  shimmer
+                  className="rounded-sm"
+                  heightPx={11}
+                  style={{ width: card.subtitleWidth }}
+                />
+                <SkeletonBone shimmer className="mt-1 w-[90%] rounded-md" heightPx={32} />
               </div>
             ))}
           </Skeleton>

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -118,9 +118,10 @@ const SIDEBAR_VIRTUOSO_OVERSCAN_PX = 600;
 const RECONNECT_ESCALATE_MS = 10_000;
 
 // Fixed-count shimmer card placeholders for the worktree sidebar loading state.
-// Mirrors the `.skel-card` design in index.html startup ghost (~80px per card):
-// padding 12px 16px, flex-column gap-8px, three bones — title / subtitle / detail.
-// Varied widths avoid a picket-fence read.
+// Follows the same 3-bone structure as the `.skel-card` design in the
+// index.html startup ghost — title / subtitle / detail at 13px / 11px / 32px,
+// padding py-3 px-4, gap-2 between bones. Card height ≈ 100px (24 padding +
+// 56 bones + 16 gap + 4 mt). Varied widths avoid a picket-fence read.
 const WORKTREE_SKELETON_CARDS = [
   { id: "a", titleWidth: "58%", subtitleWidth: "44%" },
   { id: "b", titleWidth: "42%", subtitleWidth: "55%" },

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -420,6 +420,16 @@ describe("SidebarContent initial loading skeleton — issues #7215, #8804", () =
     expect(source).not.toContain("MIN_SKELETON_ROWS");
   });
 
+  it("declares exactly 4 entries in WORKTREE_SKELETON_CARDS — #8804", () => {
+    // The 4-card count matches the index.html startup ghost and gives the
+    // sidebar a settled rhythm without filling the full viewport. Guards
+    // against silent inflation/deflation of the count.
+    const arrayMatch = source.match(/const WORKTREE_SKELETON_CARDS = \[([\s\S]*?)\] as const;/);
+    expect(arrayMatch).not.toBeNull();
+    const entries = arrayMatch![1].match(/\{\s*id:\s*"[a-z]+"/g) ?? [];
+    expect(entries).toHaveLength(4);
+  });
+
   it("renders the loading branch via WORKTREE_SKELETON_CARDS.map with no row borders — #8804", () => {
     const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
     const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -426,7 +426,8 @@ describe("SidebarContent initial loading skeleton — issues #7215, #8804", () =
     // against silent inflation/deflation of the count.
     const arrayMatch = source.match(/const WORKTREE_SKELETON_CARDS = \[([\s\S]*?)\] as const;/);
     expect(arrayMatch).not.toBeNull();
-    const entries = arrayMatch![1].match(/\{\s*id:\s*"[a-z]+"/g) ?? [];
+    if (!arrayMatch?.[1]) throw new Error("arrayMatch should have a captured group");
+    const entries = arrayMatch[1].match(/\{\s*id:\s*"[a-z]+"/g) ?? [];
     expect(entries).toHaveLength(4);
   });
 

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -361,17 +361,18 @@ describe("SidebarContent zero-worktrees taxonomy alignment — issue #6934", () 
   });
 });
 
-describe("SidebarContent initial loading skeleton — issue #7215", () => {
+describe("SidebarContent initial loading skeleton — issues #7215, #8804", () => {
   let source: string;
 
   beforeAll(async () => {
     source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
   });
 
-  it("imports Skeleton, SkeletonBone, SkeletonText, and SkeletonHint from the ui directory", () => {
+  it("imports Skeleton, SkeletonBone, and SkeletonHint from the ui directory (SkeletonText dropped in #8804)", () => {
     expect(source).toMatch(
-      /import \{ Skeleton, SkeletonBone, SkeletonText, SkeletonHint \} from "@\/components\/ui\/Skeleton"/
+      /import \{ Skeleton, SkeletonBone, SkeletonHint \} from "@\/components\/ui\/Skeleton"/
     );
+    expect(source).not.toContain("SkeletonText");
   });
 
   it("does not render the legacy 'Loading worktrees...' text in the loading branch", () => {
@@ -395,36 +396,44 @@ describe("SidebarContent initial loading skeleton — issue #7215", () => {
     expect(branch).toMatch(/<h2[^>]*>Worktrees<\/h2>/);
   });
 
-  it("uses SkeletonBone and SkeletonText without the immediate prop (400ms gate)", () => {
+  it("uses SkeletonBone with shimmer and no immediate prop (400ms Doherty gate) — #8804", () => {
     const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
     const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);
     const branch = source.slice(branchStart, branchEnd);
     expect(branch).toContain("<SkeletonBone");
-    expect(branch).toContain("<SkeletonText");
+    expect(branch).toContain("shimmer");
     expect(branch).not.toContain("immediate");
   });
 
-  it("marks the row wrapper aria-hidden and uses primitives that own inner aria-hidden", () => {
+  it("marks each card wrapper aria-hidden so the Skeleton primitive owns the live region", () => {
     const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
     const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);
     const branch = source.slice(branchStart, branchEnd);
     expect(branch).toContain('aria-hidden="true"');
   });
 
-  it("defines SKELETON_ROW_HEIGHT_PX = 47 matching the collapsed worktree row height", () => {
-    expect(source).toContain("SKELETON_ROW_HEIGHT_PX = 47");
+  it("defines WORKTREE_SKELETON_CARDS metadata for fixed-count shimmer cards — #8804", () => {
+    // #8804 replaces the dynamic-height row count with 4 fixed shimmer cards
+    // mirroring the index.html startup ghost `.skel-card` design.
+    expect(source).toContain("WORKTREE_SKELETON_CARDS");
+    expect(source).not.toContain("SKELETON_ROW_HEIGHT_PX");
+    expect(source).not.toContain("MIN_SKELETON_ROWS");
   });
 
-  it("uses fixed-height row containers with SKELETON_ROW_HEIGHT_PX to prevent layout shift", () => {
+  it("renders the loading branch via WORKTREE_SKELETON_CARDS.map with no row borders — #8804", () => {
     const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
     const branchEnd = source.indexOf("if (worktrees.length === 0)", branchStart);
     const branch = source.slice(branchStart, branchEnd);
-    expect(branch).toContain("SKELETON_ROW_HEIGHT_PX");
+    expect(branch).toContain("WORKTREE_SKELETON_CARDS.map");
+    expect(branch).not.toContain("border-b border-border-default");
   });
 
-  it("computes dynamic row count via useResizeObserverRaf with MIN_SKELETON_ROWS floor", () => {
-    expect(source).toContain("MIN_SKELETON_ROWS = 3");
-    expect(source).toContain("useResizeObserverRaf");
+  it("does not measure the skeleton container with useResizeObserverRaf — #8804", () => {
+    // The dynamic ResizeObserver-driven row count is replaced with a fixed
+    // 4-card layout. No measurement state should remain in the file.
+    expect(source).not.toContain("useResizeObserverRaf");
+    expect(source).not.toContain("skeletonContainerRef");
+    expect(source).not.toContain("skeletonRowCount");
   });
 
   it("renders SkeletonHint as sibling of Skeleton, not nested inside", () => {


### PR DESCRIPTION
## Summary

- The worktree sidebar's loading state used bordered fixed-height rows for its skeleton — a stack of hard horizontal lines that didn't match the app's visual language.
- This replaces it with 4 shimmer skeleton cards that match the startup ghost design in `index.html`. Each card has 3 bones: a title line, a subtitle line, and a detail block. Widths are varied across cards to avoid a picket-fence read.
- Removes the old height-measurement machinery (`SKELETON_ROW_HEIGHT_PX`, `MIN_SKELETON_ROWS`, `useResizeObserverRaf`, `skeletonContainerRef`, `skeletonHeight`, `skeletonRowCount`) since the fixed card count makes it unnecessary.

Resolves #8804

## Changes

- `SidebarContent.tsx` — swap bordered-row skeleton for 4 shimmer cards; drop removed state and imports
- `SidebarContent.emptyState.test.ts` — assert new card metadata, exact 4-card count, `shimmer` prop, no row borders, and absence of the legacy measurement state

## Testing

- Verified loading state renders 4 shimmer cards matching `index.html` startup ghost design
- Unit tests updated and passing; no regressions in the loading-skeleton assertions