### PR TITLE
fix(action-palette): Enter on a disabled row is a silent no-op

### DIFF
--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -432,6 +432,38 @@ describe("useActionPalette", () => {
     expect(result.current.isOpen).toBe(true);
   });
 
+  it("confirmSelection (Enter) on a disabled item is a silent no-op (#8814)", async () => {
+    listMock.mockReturnValue([makeEntry("a.action", "Alpha", false)]);
+
+    const { result } = renderHook(() => useActionPalette());
+
+    act(() => {
+      result.current.open();
+    });
+
+    act(() => {
+      result.current.setQuery("alpha");
+    });
+
+    await waitFor(
+      () => {
+        expect(result.current.results.length).toBe(1);
+        expect(result.current.isStale).toBe(false);
+      },
+      { timeout: 2000 }
+    );
+
+    act(() => {
+      result.current.confirmSelection();
+    });
+
+    // The real Enter-key path runs through confirmSelection -> executeAction.
+    // Same expectation: no dispatch, palette stays open, MRU untouched.
+    expect(useActionMruStore.getState().getSortedActionMruList().length).toBe(0);
+    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(result.current.isOpen).toBe(true);
+  });
+
   it("uses frecency as tiebreaker in non-empty query results", async () => {
     listMock.mockReturnValue([
       makeEntry("action.terminal.open", "Terminal Open"),

--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -401,7 +401,7 @@ describe("useActionPalette", () => {
     expect(dispatchMock).toHaveBeenCalledWith("worktree.delete", {}, { source: "user" });
   });
 
-  it("does NOT record frecency when executeAction is called on disabled item", async () => {
+  it("is a silent no-op when executeAction is called on a disabled item (#8814)", async () => {
     listMock.mockReturnValue([makeEntry("a.action", "Alpha", false)]);
 
     const { result } = renderHook(() => useActionPalette());
@@ -425,11 +425,11 @@ describe("useActionPalette", () => {
       result.current.executeAction(result.current.results[0]!);
     });
 
-    // Dispatch still runs so ActionService can surface the disabled-reason toast,
-    // but MRU stays clean — repeated attempts on a disabled item must not promote
-    // it to the top of the palette.
+    // Enter on a disabled row is a silent no-op: palette stays open, no
+    // dispatch fires, MRU stays clean, no toast (issue #8814).
     expect(useActionMruStore.getState().getSortedActionMruList().length).toBe(0);
-    expect(dispatchMock).toHaveBeenCalledWith("a.action", {}, { source: "user" });
+    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(result.current.isOpen).toBe(true);
   });
 
   it("uses frecency as tiebreaker in non-empty query results", async () => {

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -174,12 +174,13 @@ export function useActionPalette(): UseActionPaletteReturn {
 
   const executeAction = useCallback(
     (item: ActionPaletteItem) => {
-      // Only record frecency for enabled items so disabled actions don't get
-      // promoted to the top from repeated attempts. Dispatch still runs for
-      // disabled items so ActionService can surface the disabled-reason toast.
-      // Also skip confirm-danger actions (e.g. "Delete worktree") so destructive
-      // actions don't land in the "Recently used" rail (issue #7481).
-      if (item.enabled && item.danger !== "confirm") {
+      // Enter on a disabled row is a silent no-op: palette stays open, no
+      // dispatch, no toast. The inline disabled-reason text in the row already
+      // explains why it's unavailable (issue #8814).
+      if (!item.enabled) return;
+      // Skip confirm-danger actions (e.g. "Delete worktree") from frecency so
+      // destructive actions don't land in the "Recently used" rail (#7481).
+      if (item.danger !== "confirm") {
         useActionMruStore.getState().recordActionMru(item.id);
       }
       close();

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -12,7 +12,6 @@ import type {
 } from "../../shared/types/actions.js";
 import type { AnyActionDefinition } from "./actions/actionTypes";
 import { logWarn } from "@/utils/logger";
-import { notify } from "@/lib/notify";
 import { keybindingService } from "./KeybindingService";
 import { shortcutHintStore } from "../store/shortcutHintStore";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -332,16 +331,9 @@ export class ActionService {
         logWarn("Action disabledReason threw during dispatch", { actionId, error: err });
       }
       const disabledReason = reasonText ?? "Action is currently disabled";
-      // Suppress the toast for agent-sourced dispatches — MCP introspection
-      // probes shouldn't surface as user-visible warnings. The DISABLED error
-      // is still returned to the caller.
-      if (reasonText && source !== "agent") {
-        notify({
-          type: "warning",
-          title: `'${definition.title}' disabled`,
-          message: reasonText,
-        });
-      }
+      // No toast: disabled state is already visible on the originating surface
+      // (palette row, menu item, button). Callers receive the DISABLED error
+      // and may decide to surface it themselves (issue #8814).
       const error: ActionError = {
         code: "DISABLED",
         message: disabledReason,

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -325,7 +325,7 @@ describe("ActionService", () => {
       expect(mockRun).not.toHaveBeenCalled();
     });
 
-    it("should show warning toast when disabled action has disabledReason", async () => {
+    it("should NOT show warning toast when disabled action has disabledReason (#8814)", async () => {
       const action: ActionDefinition = {
         id: "actions.list" as ActionId,
         title: "Test Action",
@@ -346,13 +346,9 @@ describe("ActionService", () => {
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.error.code).toBe("DISABLED");
+        expect(result.error.message).toBe("No focused terminal");
       }
-      expect(notifyMock).toHaveBeenCalledTimes(1);
-      expect(notifyMock).toHaveBeenCalledWith({
-        type: "warning",
-        title: "'Test Action' disabled",
-        message: "No focused terminal",
-      });
+      expect(notifyMock).not.toHaveBeenCalled();
     });
 
     it("should NOT show toast when disabled action has no disabledReason", async () => {
@@ -376,7 +372,7 @@ describe("ActionService", () => {
       expect(notifyMock).not.toHaveBeenCalled();
     });
 
-    it("should show toast for disabled action from non-agent sources", async () => {
+    it("should NOT show toast for disabled action from any source (#8814)", async () => {
       const action: ActionDefinition = {
         id: "actions.list" as ActionId,
         title: "Test Action",
@@ -397,11 +393,11 @@ describe("ActionService", () => {
         notifyMock.mockClear();
         const result = await service.dispatch("actions.list", undefined, { source });
         expect(result.ok).toBe(false);
-        expect(notifyMock).toHaveBeenCalledWith({
-          type: "warning",
-          title: "'Test Action' disabled",
-          message: "Disabled for test",
-        });
+        if (!result.ok) {
+          expect(result.error.code).toBe("DISABLED");
+          expect(result.error.message).toBe("Disabled for test");
+        }
+        expect(notifyMock).not.toHaveBeenCalled();
       }
     });
 


### PR DESCRIPTION
## Summary

Pressing Enter on a disabled row in the action palette was firing a warning toast and closing the palette. The inline disabled-reason text under the row already carries the signal, so the toast is redundant and noisy. Enter on a disabled row should just do nothing.

Resolves #8814

## Changes

- `ActionService.dispatch` no longer emits a `notify` warning for the disabled branch — `DISABLED` error is still returned, just silently
- `useActionPalette.executeAction` early-returns when `item.enabled === false`, before `close()` and MRU recording — palette stays open, cursor stays on the row
- Removed the now-unused `notify` import from `ActionService.ts`
- Existing tests updated to assert no toast is emitted for any source (user or non-agent)
- New test covers the `confirmSelection` (Enter key) path on a disabled item

## Testing

Targeted vitest runs pass — 126 tests, +1 new. All 9 pre-push checks (typecheck, lint, format, build, IPC drift) green.