### PR TITLE
fix(project-view): tighten cold-switch paint gate

### DIFF
--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -61,14 +61,14 @@ const EFFICIENCY_FREEZE_DEBOUNCE_MS = 500;
  * outgoing view stays attached so the user never sees an unfinished
  * frame. Crossing this bound is observable but never user-visible.
  */
-const DEFAULT_PAINT_GATE_TIMEOUT_MS = 3_000;
+const DEFAULT_PAINT_GATE_TIMEOUT_MS = 1_500;
 /**
  * Hard paint-gate timeout (ms). Last-resort ceiling — assumes the
  * incoming renderer is stuck or crashed and forcibly detaches the
  * outgoing view. Generous enough that legitimately slow cold starts
  * (low memory, thermal throttling) finish via the signal path instead.
  */
-const DEFAULT_PAINT_GATE_HARD_TIMEOUT_MS = 8_000;
+const DEFAULT_PAINT_GATE_HARD_TIMEOUT_MS = 4_000;
 /**
  * Period between renderer-memory samples for cached (non-active) views. 30 s
  * matches `ProcessMemoryMonitor` and keeps the synchronous `app.getAppMetrics()`
@@ -431,9 +431,28 @@ export class ProjectViewManager {
     );
 
     let visibleAt: number;
+    let loadFinishedAt: number;
     try {
       // Load the renderer with projectId context
       await this.loadView(view, projectId);
+      loadFinishedAt = performance.now();
+
+      // The incoming view is stacked behind the still-visible outgoing view,
+      // so Chromium's compositor marks it occluded and throttles its
+      // requestAnimationFrame callbacks. That stalls the renderer's double-rAF
+      // in `notifyViewPainted`, which is exactly the signal the paint gate is
+      // waiting on. Page.setWebLifecycleState("active") (via
+      // `unfreezeWebContents`) keeps Blink in the foreground lifecycle so rAF
+      // keeps firing — fire-and-forget because the gate's hard timeout is the
+      // backstop and the CDP error swallow-list absorbs transient failures.
+      // Must run after did-finish-load — calling earlier hangs the CDP session
+      // on an uninitialised frame host (Chromium 146).
+      void unfreezeWebContents(view.webContents).catch((err) => {
+        logWarn("projectview.coldstart.keepalive-failed", {
+          projectId,
+          error: formatErrorMessage(err, "unfreezeWebContents failed"),
+        });
+      });
 
       // Wait for the renderer to confirm React has committed its first
       // structural paint (sent via `APP_VIEW_PAINTED` after a double-rAF in
@@ -463,6 +482,7 @@ export class ProjectViewManager {
         projectId,
         durationMs: Math.round(performance.now() - coldStartAt),
         visibleMs: Math.round(visibleAt - coldStartAt),
+        loadToPaintMs: Math.round(visibleAt - loadFinishedAt),
         paintGateOutcome: gateResult,
       });
 

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -144,14 +144,14 @@ export interface ProjectViewManagerOptions {
   /** Number of project views to keep cached in memory (1–5, default: 1) */
   cachedProjectViews?: number;
   /**
-   * Override the soft paint-gate timeout (default 3000 ms). Crossing this
+   * Override the soft paint-gate timeout (default 1500 ms). Crossing this
    * bound only logs `projectview.paintgate.softtimeout` — the outgoing view
    * stays attached. Lower values are useful in tests to exercise the
    * soft-timeout warning path without forcing a real cold start.
    */
   paintGateTimeoutMs?: number;
   /**
-   * Override the hard paint-gate timeout (default 8000 ms). At this bound
+   * Override the hard paint-gate timeout (default 4000 ms). At this bound
    * the outgoing view is forcibly detached as a last resort. Lower values
    * are useful in tests to drive both the hard-timeout warning and the
    * fall-through deactivation deterministically.
@@ -443,16 +443,11 @@ export class ProjectViewManager {
       // in `notifyViewPainted`, which is exactly the signal the paint gate is
       // waiting on. Page.setWebLifecycleState("active") (via
       // `unfreezeWebContents`) keeps Blink in the foreground lifecycle so rAF
-      // keeps firing — fire-and-forget because the gate's hard timeout is the
-      // backstop and the CDP error swallow-list absorbs transient failures.
-      // Must run after did-finish-load — calling earlier hangs the CDP session
-      // on an uninitialised frame host (Chromium 146).
-      void unfreezeWebContents(view.webContents).catch((err) => {
-        logWarn("projectview.coldstart.keepalive-failed", {
-          projectId,
-          error: formatErrorMessage(err, "unfreezeWebContents failed"),
-        });
-      });
+      // keeps firing. Fire-and-forget: the helper swallows the CDP-error
+      // swallow-list and `console.warn`s unexpected failures itself, so no
+      // `.catch` here. Must run after did-finish-load — calling earlier hangs
+      // the CDP session on an uninitialised frame host (Chromium 146).
+      void unfreezeWebContents(view.webContents);
 
       // Wait for the renderer to confirm React has committed its first
       // structural paint (sent via `APP_VIEW_PAINTED` after a double-rAF in

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -502,7 +502,12 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
     // No timeout warning — gate resolved by signal.
     expect(
-      vi.mocked(logWarn).mock.calls.filter(([e]) => e === "projectview.paintgate.timeout")
+      vi
+        .mocked(logWarn)
+        .mock.calls.filter(
+          ([e]) =>
+            e === "projectview.paintgate.softtimeout" || e === "projectview.paintgate.hardtimeout"
+        )
     ).toHaveLength(0);
   });
 

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -162,6 +162,7 @@ vi.mock("../../utils/logger.js", () => ({
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { logInfo, logWarn } from "../../utils/logger.js";
 import { registerAppView } from "../webContentsRegistry.js";
+import { unfreezeWebContents } from "../../utils/webContentsLifecycle.js";
 
 function createMockWindow() {
   const children: unknown[] = [];
@@ -201,11 +202,13 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     vi.mocked(logInfo).mockClear();
     vi.mocked(logWarn).mockClear();
 
+    vi.mocked(unfreezeWebContents).mockClear();
+
     win = createMockWindow();
     // Use small, non-zero timeouts so tests can observe each phase:
     //  - soft (50 ms) fires the warning but keeps the outgoing view attached
     //  - hard (150 ms) is the last-resort fall-through that detaches
-    // Both must be set explicitly because the PVM defaults are 3 s / 8 s.
+    // Both must be set explicitly because the PVM defaults are 1.5 s / 4 s.
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 50,
@@ -643,5 +646,51 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     // The switch may resolve or reject depending on subsequent code paths;
     // we just need it to settle, not hang.
     await Promise.race([switchPromise, new Promise((r) => setTimeout(r, 100))]);
+  });
+
+  it("calls unfreezeWebContents on the incoming view after did-finish-load", async () => {
+    // The incoming view is stacked behind the still-visible outgoing view,
+    // so Chromium marks it occluded and throttles rAF — which is exactly the
+    // signal the paint gate is waiting on. unfreezeWebContents pushes the
+    // renderer back to lifecycle "active" so rAF keeps firing during the
+    // swap window. Must run AFTER did-finish-load; calling earlier hangs the
+    // CDP session on an uninitialised frame host (Chromium 146).
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+
+    // Let waitForPaint arm and did-finish-load schedule, then signal paint
+    // so the full performSwitch chain settles before we inspect the mock.
+    await Promise.resolve();
+    await Promise.resolve();
+    manager.signalViewPainted(incomingWc.id);
+    await switchPromise;
+
+    expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(unfreezeWebContents).mock.calls[0]?.[0]).toBe(incomingWc);
+  });
+
+  it("logs loadToPaintMs alongside projectview.coldstart", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+    manager.signalViewPainted(incomingWc.id);
+    await switchPromise;
+
+    const coldstartCall = vi
+      .mocked(logInfo)
+      .mock.calls.find(([event]) => event === "projectview.coldstart");
+    expect(coldstartCall).toBeDefined();
+    const payload = coldstartCall?.[1] as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      projectId: "proj-b",
+      paintGateOutcome: "signal",
+    });
+    expect(typeof payload.loadToPaintMs).toBe("number");
+    expect(payload.loadToPaintMs).toBeGreaterThanOrEqual(0);
   });
 });

--- a/shared/types/resourceProfile.ts
+++ b/shared/types/resourceProfile.ts
@@ -82,8 +82,8 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     lowMemoryFreeThresholdMb: null,
     fetchIntervalActiveMs: 20_000,
     fetchIntervalBackgroundMs: 3 * 60_000,
-    paintGateTimeoutMs: 3_000,
-    paintGateHardTimeoutMs: 8_000,
+    paintGateTimeoutMs: 1_500,
+    paintGateHardTimeoutMs: 4_000,
   },
   balanced: {
     pollIntervalActive: 2000,
@@ -96,8 +96,12 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     lowMemoryFreeThresholdMb: 768,
     fetchIntervalActiveMs: 30_000,
     fetchIntervalBackgroundMs: 5 * 60_000,
-    paintGateTimeoutMs: 3_000,
-    paintGateHardTimeoutMs: 8_000,
+    // Balanced cold-start paint-gate values must match
+    // `DEFAULT_PAINT_GATE_TIMEOUT_MS` / `DEFAULT_PAINT_GATE_HARD_TIMEOUT_MS` in
+    // `electron/window/ProjectViewManager.ts` — those constants are the
+    // fallback used until the profile push lands. Keep them in lockstep.
+    paintGateTimeoutMs: 1_500,
+    paintGateHardTimeoutMs: 4_000,
   },
   efficiency: {
     pollIntervalActive: 4000,
@@ -111,9 +115,10 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     fetchIntervalActiveMs: 45_000,
     fetchIntervalBackgroundMs: 10 * 60_000,
     // Cold starts under memory/thermal/battery pressure routinely run slower
-    // than the perf/balanced 3s soft bound — bumping to 5s keeps the
-    // anti-flash hand-off without false-timeout warning spam.
-    paintGateTimeoutMs: 5_000,
-    paintGateHardTimeoutMs: 12_000,
+    // than the perf/balanced 1.5s soft bound — keeping efficiency at a 2x
+    // headroom preserves the anti-flash hand-off without false-timeout
+    // warning spam on degraded hardware.
+    paintGateTimeoutMs: 2_500,
+    paintGateHardTimeoutMs: 6_000,
   },
 };


### PR DESCRIPTION
## Summary

Tightens the cold-switch paint gate for project views in three ways.

First, after the incoming view emits `did-finish-load`, we call `unfreezeWebContents` on its `webContents`. This sends a CDP `Page.setWebLifecycleState` `"active"` command, which keeps `requestAnimationFrame` firing while the view is stacked behind the still-visible outgoing view. Without it, Chromium 146 marks the occluded sibling as backgrounded and pauses rAF — which stalls the renderer's double-rAF in `notifyViewPainted`, which is the exact signal the paint gate is waiting on. The call has to happen after `did-finish-load`; calling it earlier hangs the CDP session on an uninitialised frame host.

A couple of things we deliberately don't do:

- We don't use `backgroundThrottling`. Since Electron 28 (#8599) it's window-wide, so disabling it on the BrowserWindow would silently un-throttle every cached sibling.
- We don't use `paintWhenInitiallyHidden`. That's a `BrowserWindow`-only flag and doesn't apply to `WebContentsView` cold starts.

Second, the `projectview.coldstart` log now carries `loadToPaintMs` so the gap between `did-finish-load` and the paint signal is measurable across cold switches.

Third, with the rAF stall removed, the paint-gate timeouts come down. Performance and Balanced drop from 3000 ms / 8000 ms to 1500 ms / 4000 ms. Efficiency drops from 5000 ms / 12000 ms to 2500 ms / 6000 ms, keeping a 2x headroom over Balanced for thermal, battery, and memory pressure. The `DEFAULT_PAINT_GATE_TIMEOUT_MS` and `DEFAULT_PAINT_GATE_HARD_TIMEOUT_MS` fallbacks in `ProjectViewManager` track Balanced.

Resolves #8818.

## Changes

- `electron/window/ProjectViewManager.ts` — call `unfreezeWebContents` on the incoming view after `did-finish-load`; capture `loadFinishedAt`; add `loadToPaintMs` to the `projectview.coldstart` log; update default fallbacks and the option JSDoc.
- `shared/types/resourceProfile.ts` — lower `paintGateTimeoutMs` / `paintGateHardTimeoutMs` on all three profiles.
- `electron/window/__tests__/ProjectViewManager.paintGate.test.ts` — two new tests for the keepalive and the `loadToPaintMs` field; fix a stale event name (`projectview.paintgate.timeout` → `softtimeout`/`hardtimeout`) in an existing regression test.

## Test plan

- [x] `npx vitest run electron/window/__tests__/ProjectViewManager.paintGate.test.ts` — 17 tests pass, including the two new ones.
- [x] `npx vitest run electron/window/__tests__/` — 517 tests pass.
- [x] `npm run check` — typecheck, lint, format, IPC channel maps all clean.