### PR TITLE
fix(github): keep toolbar issue/PR count badge from showing a persistent dash

### DIFF
--- a/plugins/builtin/github/main/GitHubStats.ts
+++ b/plugins/builtin/github/main/GitHubStats.ts
@@ -342,6 +342,19 @@ export async function getRepoStatsAndPage(
             endCursor: snapshot.prs.endCursor,
           },
         });
+        // Re-stamp the durable caches too. The 60s in-memory caches above keep
+        // hot polls fast, but the 10-min durable caches (disk + probe + snapshot)
+        // are the failure-mode fallback: if a later full fetch errors, they're
+        // what keeps the badge from going `—`. Without re-stamping them here, a
+        // run of probe-match hits lets all three age out behind the in-memory
+        // caches, leaving no fallback when the next probe miss falls through.
+        persistentCache.set(cacheKey, freshStats, cwd);
+        repoActivityProbeCache.set(cacheKey, probeResult);
+        repoStatsAndPageSnapshotCache.set(cacheKey, {
+          stats: freshStats,
+          issues: snapshot.issues,
+          prs: snapshot.prs,
+        });
         return {
           stats: freshStats,
           issues: { ...snapshot.issues },

--- a/plugins/builtin/github/main/GitHubStats.ts
+++ b/plugins/builtin/github/main/GitHubStats.ts
@@ -342,19 +342,17 @@ export async function getRepoStatsAndPage(
             endCursor: snapshot.prs.endCursor,
           },
         });
-        // Re-stamp the durable caches too. The 60s in-memory caches above keep
-        // hot polls fast, but the 10-min durable caches (disk + probe + snapshot)
-        // are the failure-mode fallback: if a later full fetch errors, they're
-        // what keeps the badge from going `—`. Without re-stamping them here, a
-        // run of probe-match hits lets all three age out behind the in-memory
-        // caches, leaving no fallback when the next probe miss falls through.
+        // Re-stamp the durable disk cache too. The 60s in-memory caches above
+        // keep hot polls fast, but the disk cache is the failure-mode fallback:
+        // the error paths below read `persistentCache.get` to serve last-known
+        // counts when a full fetch fails. Without this, a run of probe-match
+        // hits lets the disk cache age out behind the in-memory caches, so the
+        // eventual probe-miss + failed fetch has no fallback and the badge goes
+        // `—`. The probe/snapshot caches are intentionally NOT re-stamped — they
+        // keep their 10-min TTL so list content can't go stale indefinitely
+        // behind a continuously-matching probe; aging out just forces a full
+        // refresh, which the disk re-stamp keeps safe.
         persistentCache.set(cacheKey, freshStats, cwd);
-        repoActivityProbeCache.set(cacheKey, probeResult);
-        repoStatsAndPageSnapshotCache.set(cacheKey, {
-          stats: freshStats,
-          issues: snapshot.issues,
-          prs: snapshot.prs,
-        });
         return {
           stats: freshStats,
           issues: { ...snapshot.issues },

--- a/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
@@ -266,42 +266,50 @@ describe("getRepoStatsAndPage — activity-probe gate (issue #8757)", () => {
     expect(repoStatsAndPageSnapshotCache.get(CACHE_KEY)).toEqual(goodSnapshot);
   });
 
-  it("re-stamps the durable disk + probe + snapshot caches on a probe-match hit (issue #8826)", async () => {
+  it("re-stamps the durable disk cache on a probe-match hit so the fallback can't age out (issue #8826)", async () => {
     mockClient.mockImplementation(async (query: string) => {
       if (query.includes("GetRepoActivityProbe")) return probeResponse("p1", "i1", "r1");
       return statsResponse(5, 3);
     });
 
     await getRepoStatsAndPage("/test", false);
-    const firstSnapshot = repoStatsAndPageSnapshotCache.get(CACHE_KEY);
-    expect(firstSnapshot).toBeDefined();
 
     // Only the 60s memory caches expire; the durable caches survive so the
     // next call takes the probe-match fast path.
     expireMemoryCaches();
     mockStatsCache.set.mockClear();
 
-    const result = await getRepoStatsAndPage("/test", false);
+    await getRepoStatsAndPage("/test", false);
 
     // Optimization preserved — no second expensive stats query.
     expect(statsQueryCount()).toBe(1);
     // The durable disk cache is re-written on the fast path so it can't age out
-    // behind the in-memory caches and leave the badge with no fallback.
+    // behind the in-memory caches and leave the error-path fallback empty.
     expect(mockStatsCache.set).toHaveBeenCalledWith(
       CACHE_KEY,
       expect.objectContaining({ issueCount: 5, prCount: 3 }),
       "/test"
     );
-    // Probe + snapshot durable caches are re-stamped (TTLs advanced).
-    expect(repoActivityProbeCache.get(CACHE_KEY)).toEqual({
-      pushedAt: "p1",
-      issueUpdatedAt: "i1",
-      prUpdatedAt: "r1",
+  });
+
+  it("does not re-stamp the probe/snapshot TTLs on a probe-match hit (keeps the 10-min staleness cap)", async () => {
+    mockClient.mockImplementation(async (query: string) => {
+      if (query.includes("GetRepoActivityProbe")) return probeResponse("p1", "i1", "r1");
+      return statsResponse(5, 3);
     });
-    const restamped = repoStatsAndPageSnapshotCache.get(CACHE_KEY);
-    expect(restamped).toBeDefined();
-    expect(restamped?.stats.issueCount).toBe(5);
-    expect(restamped?.stats.lastUpdated).toBe(result.stats?.lastUpdated);
+
+    await getRepoStatsAndPage("/test", false);
+    const probeBefore = repoActivityProbeCache.get(CACHE_KEY);
+    const snapshotBefore = repoStatsAndPageSnapshotCache.get(CACHE_KEY);
+
+    expireMemoryCaches();
+    await getRepoStatsAndPage("/test", false);
+
+    // Probe/snapshot caches are read, not rewritten — their original entries
+    // (and TTLs) are untouched so list content can't live indefinitely behind
+    // a continuously-matching probe.
+    expect(repoActivityProbeCache.get(CACHE_KEY)).toBe(probeBefore);
+    expect(repoStatsAndPageSnapshotCache.get(CACHE_KEY)).toBe(snapshotBefore);
   });
 
   it("re-runs the full query after clearPRCaches invalidates the snapshot", async () => {

--- a/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
@@ -266,6 +266,44 @@ describe("getRepoStatsAndPage — activity-probe gate (issue #8757)", () => {
     expect(repoStatsAndPageSnapshotCache.get(CACHE_KEY)).toEqual(goodSnapshot);
   });
 
+  it("re-stamps the durable disk + probe + snapshot caches on a probe-match hit (issue #8826)", async () => {
+    mockClient.mockImplementation(async (query: string) => {
+      if (query.includes("GetRepoActivityProbe")) return probeResponse("p1", "i1", "r1");
+      return statsResponse(5, 3);
+    });
+
+    await getRepoStatsAndPage("/test", false);
+    const firstSnapshot = repoStatsAndPageSnapshotCache.get(CACHE_KEY);
+    expect(firstSnapshot).toBeDefined();
+
+    // Only the 60s memory caches expire; the durable caches survive so the
+    // next call takes the probe-match fast path.
+    expireMemoryCaches();
+    mockStatsCache.set.mockClear();
+
+    const result = await getRepoStatsAndPage("/test", false);
+
+    // Optimization preserved — no second expensive stats query.
+    expect(statsQueryCount()).toBe(1);
+    // The durable disk cache is re-written on the fast path so it can't age out
+    // behind the in-memory caches and leave the badge with no fallback.
+    expect(mockStatsCache.set).toHaveBeenCalledWith(
+      CACHE_KEY,
+      expect.objectContaining({ issueCount: 5, prCount: 3 }),
+      "/test"
+    );
+    // Probe + snapshot durable caches are re-stamped (TTLs advanced).
+    expect(repoActivityProbeCache.get(CACHE_KEY)).toEqual({
+      pushedAt: "p1",
+      issueUpdatedAt: "i1",
+      prUpdatedAt: "r1",
+    });
+    const restamped = repoStatsAndPageSnapshotCache.get(CACHE_KEY);
+    expect(restamped).toBeDefined();
+    expect(restamped?.stats.issueCount).toBe(5);
+    expect(restamped?.stats.lastUpdated).toBe(result.stats?.lastUpdated);
+  });
+
   it("re-runs the full query after clearPRCaches invalidates the snapshot", async () => {
     mockClient.mockImplementation(async (query: string) => {
       if (query.includes("GetRepoActivityProbe")) return probeResponse("p1", "i1", "r1");

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -498,6 +498,58 @@ describe("useRepositoryStats", () => {
       });
     });
 
+    it("preserves a confirmed 0 across a failed poll instead of flashing a dash", async () => {
+      const project = { id: "p", path: "/repo/preserve-zero" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+
+      let pushHandler: ((payload: unknown) => void) | undefined;
+      onRepoStatsAndPageUpdatedMock.mockImplementation((cb: (p: unknown) => void) => {
+        pushHandler = cb;
+        return () => {};
+      });
+
+      // Fresh poll confirms the repo genuinely has 0 open issues and 0 PRs.
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 7,
+        issueCount: 0,
+        prCount: 0,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(0);
+        expect(result.current.stats?.prCount).toBe(0);
+      });
+
+      // A failed poll surfaces null counts — the confirmed 0 must be preserved,
+      // not replaced with a `—` dash.
+      const failedPush: RepositoryStats = {
+        commitCount: 7,
+        issueCount: null,
+        prCount: null,
+        loading: false,
+        stale: true,
+        ghError: "timeout",
+        lastUpdated: 2000,
+      };
+      await act(async () => {
+        pushHandler?.(makePushPayload(project.path, failedPush, 2000));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isStale).toBe(true);
+        expect(result.current.stats?.issueCount).toBe(0);
+        expect(result.current.stats?.prCount).toBe(0);
+      });
+    });
+
     it("shows a genuine 0 from a fresh fetch instead of a preserved count", async () => {
       const project = { id: "p", path: "/repo/confirmed-zero" };
       getCurrentMock.mockResolvedValue(project);

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -446,6 +446,108 @@ describe("useRepositoryStats", () => {
       });
     });
 
+    it("preserves last known counts when a stale push payload arrives with null counts", async () => {
+      const project = { id: "p", path: "/repo/preserve-null" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+      // Fresh poll establishes known good counts: 3 issues, 2 PRs.
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 7,
+        issueCount: 3,
+        prCount: 2,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      });
+
+      let pushHandler: ((payload: unknown) => void) | undefined;
+      onRepoStatsAndPageUpdatedMock.mockImplementation((cb: (p: unknown) => void) => {
+        pushHandler = cb;
+        return () => {};
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(3);
+        expect(result.current.stats?.prCount).toBe(2);
+      });
+
+      // A failed poll surfaces null counts with an error — preserve the last
+      // good counts instead of flashing a `—` dash in the toolbar badge.
+      const failedPush: RepositoryStats = {
+        commitCount: 7,
+        issueCount: null,
+        prCount: null,
+        loading: false,
+        stale: true,
+        ghError: "rate limited",
+        lastUpdated: 2000,
+      };
+      await act(async () => {
+        pushHandler?.(makePushPayload(project.path, failedPush, 2000));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isStale).toBe(true);
+        // Preserved counts shown despite the nulls in the payload.
+        expect(result.current.stats?.issueCount).toBe(3);
+        expect(result.current.stats?.prCount).toBe(2);
+      });
+    });
+
+    it("shows a genuine 0 from a fresh fetch instead of a preserved count", async () => {
+      const project = { id: "p", path: "/repo/confirmed-zero" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+
+      let pushHandler: ((payload: unknown) => void) | undefined;
+      onRepoStatsAndPageUpdatedMock.mockImplementation((cb: (p: unknown) => void) => {
+        pushHandler = cb;
+        return () => {};
+      });
+
+      // Fresh poll establishes known good counts: 3 issues, 2 PRs.
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 7,
+        issueCount: 3,
+        prCount: 2,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(3);
+        expect(result.current.stats?.prCount).toBe(2);
+      });
+
+      // A fresh (non-stale) fetch confirms the repo now has 0 open issues/PRs —
+      // this is real data and must show 0, not the previously preserved counts.
+      const freshZero: RepositoryStats = {
+        commitCount: 7,
+        issueCount: 0,
+        prCount: 0,
+        loading: false,
+        stale: false,
+        lastUpdated: 2000,
+      };
+      await act(async () => {
+        pushHandler?.(makePushPayload(project.path, freshZero, 2000));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(0);
+        expect(result.current.stats?.prCount).toBe(0);
+      });
+    });
+
     it("ignores a push payload whose projectPath differs from the active project", async () => {
       const project = { id: "p", path: "/repo/active" };
       getCurrentMock.mockResolvedValue(project);

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -145,19 +145,17 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       const shouldPreserve = repoStats.stale === true || repoStats.ghError !== undefined;
 
       if (!shouldPreserve) {
-        // Fresh successful data - update preserved counts and accept genuine 0s
-        if (repoStats.issueCount !== null && repoStats.issueCount > 0) {
+        // Fresh successful data — record the confirmed counts so a later
+        // stale/errored poll can fall back to them. `null` in the ref means
+        // "no count ever confirmed"; a confirmed `0` is stored as `0` (not
+        // `null`) so a repo with genuinely zero open issues/PRs still preserves
+        // that `0` on a failed poll instead of flashing a `—` dash.
+        if (repoStats.issueCount !== null) {
           lastKnownCountsRef.current.issueCount = repoStats.issueCount;
-        } else if (repoStats.issueCount === 0) {
-          // Clear preserved count on confirmed 0 from successful fetch
-          lastKnownCountsRef.current.issueCount = null;
         }
 
-        if (repoStats.prCount !== null && repoStats.prCount > 0) {
+        if (repoStats.prCount !== null) {
           lastKnownCountsRef.current.prCount = repoStats.prCount;
-        } else if (repoStats.prCount === 0) {
-          // Clear preserved count on confirmed 0 from successful fetch
-          lastKnownCountsRef.current.prCount = null;
         }
       }
 

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -162,16 +162,23 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       }
 
       // Apply preservation: use preserved counts only when data is stale/errored
+      // and the incoming count is either a failed-fetch null or a stale 0. A
+      // failed poll surfaces `issueCount: null`, which would otherwise erase a
+      // valid prior count and flash a `—` dash in the toolbar badge; a stale
+      // broadcast can surface `0`, which would flash a `0`. Both are preserved
+      // while a genuine fresh `0` (shouldPreserve === false) still shows `0`.
       const preservedStats: RepositoryStats = {
         ...repoStats,
         issueCount:
           shouldPreserve &&
-          repoStats.issueCount === 0 &&
+          (repoStats.issueCount === null || repoStats.issueCount === 0) &&
           lastKnownCountsRef.current.issueCount !== null
             ? lastKnownCountsRef.current.issueCount
             : repoStats.issueCount,
         prCount:
-          shouldPreserve && repoStats.prCount === 0 && lastKnownCountsRef.current.prCount !== null
+          shouldPreserve &&
+          (repoStats.prCount === null || repoStats.prCount === 0) &&
+          lastKnownCountsRef.current.prCount !== null
             ? lastKnownCountsRef.current.prCount
             : repoStats.prCount,
       };


### PR DESCRIPTION
Fixes two independent root causes that combined to produce a persistent `—` in the toolbar GitHub issue/PR count badges.

## Root cause 1 — renderer drops a valid count on a null poll result

`applyStatsResult` in `useRepositoryStats.ts` preserved the prior count only when an incoming stale/errored result had `count === 0`. A failed poll returns `issueCount: null`, not `0`, so it fell straight through and erased whatever the badge was showing. Fixed by preserving on both `null` and `0` when the result is stale/errored. Confirmed zeros are now stored in `lastKnownCountsRef` as `0` (previously `null`) so repos with genuinely zero open items also keep their count across a failed poll. A genuine fresh `0` still shows `0`.

## Root cause 2 — probe-match path never re-warms the durable disk cache

The probe-match fast path in `GitHubStats.ts` re-warmed only the three 60-second in-memory caches. It never wrote back to the 10-minute `persistentCache`. After ~10 minutes of continuous probe hits the disk fallback expired silently, so a probe miss followed by a failed full fetch had no fallback left and returned `stats: null`. Fixed by re-stamping `persistentCache` on each probe-match. The probe and snapshot caches are intentionally left at their 10-minute TTL so list content can't go stale behind a continuously-matching probe.

## Changes

- `src/hooks/useRepositoryStats.ts` — preserve last known count on `null` as well as `0`; store confirmed zeros as `0` not `null`
- `plugins/builtin/github/main/GitHubStats.ts` — re-stamp `persistentCache` on probe-match
- `src/hooks/__tests__/useRepositoryStats.test.tsx` — null-preservation, confirmed-zero persistence, genuine-fresh-zero cases
- `plugins/builtin/github/main/__tests__/GitHubStats.test.ts` — disk cache re-stamped on probe-match; probe/snapshot TTLs untouched

Resolves #8826

## Testing

- Targeted unit tests: 40 renderer + 13 backend, all passing
- Full check suite clean (typecheck, lint, format, IPC codegen)