### PR TITLE
feat(palette): surface destructive classification on action rows

### DIFF
--- a/docs/architecture/destructive-action-safeguards.md
+++ b/docs/architecture/destructive-action-safeguards.md
@@ -214,6 +214,22 @@ Direct `window.electron.*` IPC calls that skip `ActionService`. These are the hi
 | `src/components/Settings/McpServerSettingsTab.tsx` | `mcpServer.setEnabled(false)` (server toggle) | **Yes** — `ConfirmDialog` naming each connected external client; fires only when `listActiveClients()` is non-empty, else disables immediately (#8779) |
 | `src/components/Settings/DaintreeAssistantSettingsTab.tsx` | `helpAssistant.setSettings({ daintreeControl: false })` (assistant toggle) | **No** — disabling Daintree control has no MCP stop side-effect, so no external clients are severed; D0, no confirm needed (#8779) |
 
+## Palette pre-warn layers
+
+The action palette renders confirm-tier rows (`danger:"confirm"`) with a non-chromatic pre-warn so the destructive classification is visible before the user presses Enter. These signals supplement the `ConfirmDialog` wired at the call site — they do not replace it. The accent color stays reserved for the 2px selection bar; pre-warn relies on shape, position, and opacity only.
+
+Five layers ride on the existing manifest data (`danger`, `dangerRationale`); no per-action wiring is required:
+
+1. **Title ellipsis** — render-time `…` (`…`) suffix on the title text node. The action definition's `title` is never mutated. Apple HIG convention: an ellipsis on a label means activation requires further input or confirmation.
+2. **`TriangleAlert` icon** — monochrome Lucide glyph right-aligned next to the keybinding hint, at `text-daintree-text/40 group-aria-selected:text-daintree-text/50`. Parallels the keybinding hint opacity so it reads as secondary metadata, not as an alert chrome.
+3. **`dangerRationale` second line** — dimmed italic span inside the row's content column. CSS-hidden by default (`hidden group-aria-selected:block`) so unselected rows stay single-line; expands inline when the row is the active selection. The span carries a stable `id` (`${item.id}-danger-rationale`) so `aria-describedby` can point at a real DOM node.
+4. **`aria-haspopup="dialog"`** — set on every confirm-tier row regardless of selection state, so assistive tech announces that activation opens a dialog.
+5. **`aria-describedby`** — set on the row element only when the row is the active selection AND a rationale is present, so screen readers read title → rationale on the selected row without leaking unrelated rationale text on other rows.
+
+Implementation lives in `src/components/ActionPalette/ActionPaletteItem.tsx`; the data plumbing is in `src/hooks/useActionPalette.ts` (`ActionPaletteItem` interface + `toActionPaletteItem` mapper copy `dangerRationale` through from the manifest entry).
+
+This is a separate signal from the MRU exclusion documented in Hard rule #2 — confirm-tier actions are simultaneously excluded from the "Recently used" rail and from `ActionService.repeatLast`, and surfaced with pre-warn chrome when they appear via search.
+
 ## Maintenance
 
 - This document is the source of truth for which actions are considered destructive and what tier they belong to. Updates are part of any PR that adds a new destructive action, changes an `ActionDanger` value, or wires a new `ConfirmDialog`.

--- a/src/components/ActionPalette/ActionPaletteItem.test.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.test.tsx
@@ -334,4 +334,111 @@ describe("ActionPaletteItem", () => {
       expect(screen.queryByRole("button", { name: /hide .* from recently used/i })).toBeNull();
     });
   });
+
+  describe("confirm-tier rows", () => {
+    function confirmItem(overrides: Partial<ActionPaletteItemType> = {}): ActionPaletteItemType {
+      return makeItem({
+        id: "worktree-delete",
+        title: "Delete worktree",
+        danger: "confirm",
+        dangerRationale: "Removes the working tree and branch from disk",
+        ...overrides,
+      });
+    }
+
+    it("appends a HIG ellipsis suffix on confirm-tier titles", () => {
+      render(
+        <ActionPaletteItem item={confirmItem()} index={0} isSelected={false} onSelect={onSelect} />
+      );
+
+      expect(screen.getByText("Delete worktree …")).toBeTruthy();
+      expect(screen.queryByText("Delete worktree")).toBeNull();
+    });
+
+    it("does not append the ellipsis on safe-tier titles", () => {
+      render(
+        <ActionPaletteItem item={makeItem()} index={0} isSelected={false} onSelect={onSelect} />
+      );
+
+      expect(screen.getByText("Test Action")).toBeTruthy();
+      expect(screen.queryByText(/…/)).toBeNull();
+    });
+
+    it('sets aria-haspopup="dialog" on confirm-tier rows', () => {
+      const { container } = render(
+        <ActionPaletteItem item={confirmItem()} index={0} isSelected={false} onSelect={onSelect} />
+      );
+
+      expect(container.querySelector("button")?.getAttribute("aria-haspopup")).toBe("dialog");
+    });
+
+    it("does not set aria-haspopup on safe-tier rows", () => {
+      const { container } = render(
+        <ActionPaletteItem item={makeItem()} index={0} isSelected={false} onSelect={onSelect} />
+      );
+
+      expect(container.querySelector("button")?.getAttribute("aria-haspopup")).toBeNull();
+    });
+
+    it("renders a TriangleAlert icon on confirm-tier rows", () => {
+      const { container } = render(
+        <ActionPaletteItem item={confirmItem()} index={0} isSelected={false} onSelect={onSelect} />
+      );
+
+      const icon = container.querySelector('svg[aria-hidden="true"]');
+      expect(icon).toBeTruthy();
+      expect(icon?.getAttribute("class") ?? "").toContain("text-daintree-text/40");
+    });
+
+    it("does not render the alert icon on safe-tier rows", () => {
+      const { container } = render(
+        <ActionPaletteItem item={makeItem()} index={0} isSelected={false} onSelect={onSelect} />
+      );
+
+      expect(container.querySelector('svg[aria-hidden="true"]')).toBeNull();
+    });
+
+    it("links selected confirm-tier rows to their rationale via aria-describedby", () => {
+      const item = confirmItem();
+      const { container } = render(
+        <ActionPaletteItem item={item} index={0} isSelected={true} onSelect={onSelect} />
+      );
+
+      const button = container.querySelector("button");
+      const expectedId = `${item.id}-danger-rationale`;
+      expect(button?.getAttribute("aria-describedby")).toBe(expectedId);
+
+      const rationale = container.querySelector(`#${expectedId}`);
+      expect(rationale).toBeTruthy();
+      expect(rationale?.textContent).toBe("Removes the working tree and branch from disk");
+      expect(rationale?.className).toContain("hidden");
+      expect(rationale?.className).toContain("group-aria-selected:block");
+      expect(rationale?.className).toContain("italic");
+    });
+
+    it("omits aria-describedby on unselected confirm-tier rows", () => {
+      const item = confirmItem();
+      const { container } = render(
+        <ActionPaletteItem item={item} index={0} isSelected={false} onSelect={onSelect} />
+      );
+
+      expect(container.querySelector("button")?.getAttribute("aria-describedby")).toBeNull();
+      // Rationale node still in DOM (CSS-hidden) so the id target is stable across renders.
+      expect(container.querySelector(`#${item.id}-danger-rationale`)).toBeTruthy();
+    });
+
+    it("omits rationale node and aria-describedby when dangerRationale is missing", () => {
+      const item = confirmItem({ dangerRationale: undefined });
+      const { container } = render(
+        <ActionPaletteItem item={item} index={0} isSelected={true} onSelect={onSelect} />
+      );
+
+      const button = container.querySelector("button");
+      expect(button?.getAttribute("aria-describedby")).toBeNull();
+      expect(container.querySelector(`#${item.id}-danger-rationale`)).toBeNull();
+      // Suffix and icon still render — they gate on `danger === "confirm"`, not on rationale.
+      expect(screen.getByText("Delete worktree …")).toBeTruthy();
+      expect(container.querySelector('svg[aria-hidden="true"]')).toBeTruthy();
+    });
+  });
 });

--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
-import { Pin, PinOff, EyeOff } from "lucide-react";
+import { Pin, PinOff, EyeOff, TriangleAlert } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ActionPaletteItem as ActionPaletteItemType } from "@/hooks/useActionPalette";
 import { ACTION_CATEGORY_COLORS, ACTION_CATEGORY_DEFAULT_COLOR } from "@/config/categoryColors";
@@ -105,6 +105,13 @@ function ActionPaletteItemInner({
   const canShowPin = Boolean(onPin || (isPinned && onUnpin));
   const canShowHide = Boolean(onHide) && !isPinned && item.danger !== "confirm";
 
+  const isConfirmTier = item.danger === "confirm";
+  const hasRationale = isConfirmTier && Boolean(item.dangerRationale);
+  const rationaleId = hasRationale ? `${item.id}-danger-rationale` : undefined;
+  // HIG ellipsis (U+2026) signals "activation requires further input or confirmation".
+  // Appended at render time; the action definition's title is never mutated.
+  const displayTitle = isConfirmTier ? `${item.title} …` : item.title;
+
   return (
     <div
       className={cn(
@@ -127,6 +134,8 @@ function ActionPaletteItemInner({
         type="button"
         tabIndex={-1}
         aria-label={item.title}
+        aria-haspopup={isConfirmTier ? "dialog" : undefined}
+        aria-describedby={isSelected && rationaleId ? rationaleId : undefined}
         onClick={handleSelectClick}
         className={cn(
           "flex-1 min-w-0 flex items-center gap-3 text-left bg-transparent border-0 p-0",
@@ -143,13 +152,21 @@ function ActionPaletteItemInner({
         </span>
 
         <div className="flex-1 min-w-0">
-          <div className="text-sm font-medium truncate">{item.title}</div>
+          <div className="text-sm font-medium truncate">{displayTitle}</div>
           {item.description && (
             <div className="text-xs text-daintree-text/50 truncate">{item.description}</div>
           )}
           {!item.enabled && item.disabledReason && (
             <div className="text-[10px] text-daintree-text/40 italic truncate">
               {item.disabledReason}
+            </div>
+          )}
+          {hasRationale && (
+            <div
+              id={rationaleId}
+              className="hidden group-aria-selected:block text-xs text-daintree-text/50 italic truncate"
+            >
+              {item.dangerRationale}
             </div>
           )}
           {pinRejected && (
@@ -213,6 +230,13 @@ function ActionPaletteItemInner({
           <span className="text-[11px] font-mono text-daintree-text/40 transition-colors group-aria-selected:text-daintree-text/60">
             {item.keybinding}
           </span>
+        )}
+
+        {isConfirmTier && (
+          <TriangleAlert
+            aria-hidden="true"
+            className="shrink-0 size-3 text-daintree-text/40 transition-colors group-aria-selected:text-daintree-text/50"
+          />
         )}
       </div>
     </div>

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -18,6 +18,7 @@ export interface ActionPaletteItem {
   category: string;
   enabled: boolean;
   danger: ActionDanger;
+  dangerRationale?: string;
   disabledReason?: string;
   keybinding?: string;
   kind: string;
@@ -64,6 +65,10 @@ function toActionPaletteItem(entry: ActionManifestEntry): ActionPaletteItem {
   const category = typeof entry.category === "string" ? entry.category : "General";
   const disabledReason =
     typeof entry.disabledReason === "string" ? entry.disabledReason : undefined;
+  const dangerRationale =
+    typeof entry.dangerRationale === "string" && entry.dangerRationale.trim().length > 0
+      ? entry.dangerRationale
+      : undefined;
   const keywordsLower: readonly string[] = Array.isArray(entry.keywords)
     ? entry.keywords
         .filter((k): k is string => typeof k === "string" && k.length > 0)
@@ -77,6 +82,7 @@ function toActionPaletteItem(entry: ActionManifestEntry): ActionPaletteItem {
     category,
     enabled: entry.enabled,
     danger: entry.danger,
+    dangerRationale,
     disabledReason,
     keybinding: keybindingService.getDisplayCombo(entry.id),
     kind: entry.kind,

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -67,7 +67,7 @@ function toActionPaletteItem(entry: ActionManifestEntry): ActionPaletteItem {
     typeof entry.disabledReason === "string" ? entry.disabledReason : undefined;
   const dangerRationale =
     typeof entry.dangerRationale === "string" && entry.dangerRationale.trim().length > 0
-      ? entry.dangerRationale
+      ? entry.dangerRationale.trim()
       : undefined;
   const keywordsLower: readonly string[] = Array.isArray(entry.keywords)
     ? entry.keywords


### PR DESCRIPTION
## Summary

- `danger:"confirm"` actions in the palette were visually identical to safe ones — the only difference was the category chip colour. This closes that gap with three non-chromatic layers: an ellipsis suffix on the title (Apple HIG convention for actions requiring further input), a dimmed italic `dangerRationale` second line on the selected row only, and a neutral `TriangleAlert` icon next to the keybinding hint.
- `useActionPalette` now passes `dangerRationale` through to `ActionPaletteItem` — the field already existed on `ActionManifestEntry` but was never forwarded to the palette layer.
- Accessibility wired up: `aria-haspopup="dialog"` on every confirm-tier row, `aria-describedby` toggled onto the selected row pointing at the rationale span.

Resolves #8825

## Changes

- `src/hooks/useActionPalette.ts` — `ActionPaletteItem` interface extended with `dangerRationale?: string`; mapper trims and passes the field through
- `src/components/ActionPalette/ActionPaletteItem.tsx` — render layers for ellipsis suffix, rationale line (hidden group, revealed via `group-aria-selected:block`), alert icon, and aria attributes
- `src/components/ActionPalette/ActionPaletteItem.test.tsx` — 10 new tests covering confirm-tier rendering, rationale visibility gating, aria attributes, and safe-action exclusion (20 total, all passing)
- `docs/architecture/destructive-action-safeguards.md` — new "Palette pre-warn layers" section documenting the three signal tiers and their conditions

## Testing

All 20 `ActionPaletteItem` tests pass. Ran full `npm run check` — typecheck, lint, and format clean. Variable-height selected row tested against the existing virtualization path; `React.memo` boundary respected by passing `dangerRationale` as a stable primitive string.