### PR TITLE
feat(mcp): harden McpConfirmDialog against rapid-click approval

### DIFF
--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -14,6 +14,14 @@ import { useMcpConfirmStore } from "@/store/mcpConfirmStore";
 const CONFIRMATION_TIMEOUT_MS = 28_000;
 
 /**
+ * Lower-bound read-time gate for destructive dispatches. `resolveOnce` guards
+ * the second click; this disables the primary button briefly after each item
+ * is promoted so a click meant for the previous modal can't silently approve a
+ * freshly-promoted destructive write before the user has read it.
+ */
+const CONFIRM_COOLDOWN_MS = 1_200;
+
+/**
  * Singleton dialog driven by the MCP confirmation queue. Mounted once near
  * the top of `App.tsx`. Reads `current` from `useMcpConfirmStore` and
  * surfaces one `ConfirmDialog` at a time — concurrent agent calls queue
@@ -72,7 +80,8 @@ export function McpConfirmDialog() {
   // Severity follows the action's registry classification, not the fact that
   // an MCP client dispatched it. Provenance is already conveyed by the
   // "Run '…'?" framing; only genuinely destructive dispatches earn red.
-  const variant = current.danger === "confirm" ? "destructive" : "default";
+  const isDestructive = current.danger === "confirm";
+  const variant = isDestructive ? "destructive" : "default";
 
   return (
     <ErrorBoundary variant="component" componentName="McpConfirmDialog" resetKeys={[resetKey]}>
@@ -85,6 +94,8 @@ export function McpConfirmDialog() {
         cancelLabel="Cancel"
         onConfirm={() => resolveOnce(current.requestId, "approved")}
         variant={variant}
+        confirmCooldownMs={isDestructive ? CONFIRM_COOLDOWN_MS : undefined}
+        cooldownKey={current.requestId}
       >
         <div className="space-y-2">
           <div className="text-xs text-daintree-text/60 uppercase tracking-wide">Arguments</div>

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -56,7 +56,14 @@ export function McpConfirmDialog() {
     // queued item could outlive main's 30s deadline and degrade to a generic
     // timeout error instead of `CONFIRMATION_TIMEOUT`.
     const elapsed = Date.now() - enqueuedAt;
-    const remaining = Math.max(500, CONFIRMATION_TIMEOUT_MS - elapsed);
+    // Destructive dispatches disable the confirm button for CONFIRM_COOLDOWN_MS
+    // after promotion. A deeply-queued item could otherwise have less budget
+    // left than the cooldown and auto-time-out before the user can ever click —
+    // so floor the window above the cooldown for those. The floor still lands
+    // under main's 30s deadline (28s budget + ~1.5s), preserving the clean
+    // CONFIRMATION_TIMEOUT outcome.
+    const floor = current.danger === "confirm" ? CONFIRM_COOLDOWN_MS + 300 : 500;
+    const remaining = Math.max(floor, CONFIRMATION_TIMEOUT_MS - elapsed);
     const timer = setTimeout(() => {
       resolveOnce(requestId, "timeout");
     }, remaining);

--- a/src/components/__tests__/McpConfirmDialog.test.tsx
+++ b/src/components/__tests__/McpConfirmDialog.test.tsx
@@ -202,4 +202,99 @@ describe("McpConfirmDialog", () => {
       vi.useRealTimers();
     }
   });
+
+  it("arms the cooldown for the first destructive item even when mounted empty", () => {
+    vi.useFakeTimers();
+    try {
+      render(<McpConfirmDialog />); // current === null, dialog mounted closed
+
+      act(() => {
+        void enqueue({ actionTitle: "Delete worktree", danger: "confirm" });
+      });
+
+      // The false→true transition must arm synchronously (useLayoutEffect), so
+      // the button is already disabled without advancing any timers.
+      const btn = screen.getByRole("button", {
+        name: "Delete worktree",
+      }) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores a click on a freshly-promoted item that lands before its cooldown clears", async () => {
+    vi.useFakeTimers();
+    try {
+      const pA = enqueue({ requestId: "A", actionTitle: "Delete worktree", danger: "confirm" });
+      const pB = enqueue({ requestId: "B", actionTitle: "Reset branch", danger: "confirm" });
+
+      render(<McpConfirmDialog />);
+
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+      const aBtn = screen.getByRole("button", { name: "Delete worktree" });
+      act(() => {
+        aBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await expect(pA).resolves.toBe("approved");
+
+      // B is now visible; a click landing immediately (before its cooldown
+      // elapses) must not approve it.
+      const bBtn = screen.getByRole("button", { name: "Reset branch" });
+      act(() => {
+        bBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      const sentinel = Symbol("pending");
+      const race = Promise.race([
+        pB,
+        new Promise((resolve) => setTimeout(() => resolve(sentinel), 20)),
+      ]);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20);
+      });
+      expect(await race).toBe(sentinel);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the auto-timeout window above the cooldown for a long-queued destructive item", async () => {
+    vi.useFakeTimers();
+    try {
+      const p = enqueue({ actionTitle: "Delete worktree", danger: "confirm" });
+
+      // Simulate ~27.5s spent queued behind earlier modals before promotion,
+      // so only ~500ms of the 28s budget remains at render time.
+      act(() => {
+        vi.advanceTimersByTime(27_500);
+      });
+
+      render(<McpConfirmDialog />);
+      const btn = screen.getByRole("button", {
+        name: "Delete worktree",
+      }) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+
+      // The 1200ms cooldown must clear before the auto-timeout fires — the old
+      // Math.max(500, …) floor would have timed the item out first, making it
+      // unapproveable.
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+      expect(btn.disabled).toBe(false);
+
+      act(() => {
+        btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await expect(p).resolves.toBe("approved");
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/components/__tests__/McpConfirmDialog.test.tsx
+++ b/src/components/__tests__/McpConfirmDialog.test.tsx
@@ -88,28 +88,118 @@ describe("McpConfirmDialog", () => {
   });
 
   it("resolves exactly once on a rapid double-confirm, never approving the queued item", async () => {
-    const pA = enqueue({ requestId: "A", actionTitle: "Delete worktree" });
-    const pB = enqueue({ requestId: "B", actionTitle: "Push branch" });
+    vi.useFakeTimers();
+    try {
+      const pA = enqueue({ requestId: "A", actionTitle: "Delete worktree" });
+      const pB = enqueue({ requestId: "B", actionTitle: "Push branch" });
 
-    render(<McpConfirmDialog />);
+      render(<McpConfirmDialog />);
 
-    const confirmBtn = screen.getByRole("button", { name: "Delete worktree" });
+      // danger:"confirm" arms the read-time cooldown, which disables the
+      // button on mount. Clear it so the double-click can land.
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
 
-    // Two native clicks dispatched within a single batched update — both
-    // handlers run against the same render snapshot (item A visible) before
-    // React advances the queue, mirroring a real double-click.
-    act(() => {
-      confirmBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      confirmBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
+      const confirmBtn = screen.getByRole("button", { name: "Delete worktree" });
 
-    await expect(pA).resolves.toBe("approved");
+      // Two native clicks dispatched within a single batched update — both
+      // handlers run against the same render snapshot (item A visible) before
+      // React advances the queue, mirroring a real double-click.
+      act(() => {
+        confirmBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        confirmBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
 
-    const sentinel = Symbol("pending");
-    const bOutcome = await Promise.race([
-      pB,
-      new Promise((resolve) => setTimeout(() => resolve(sentinel), 20)),
-    ]);
-    expect(bOutcome).toBe(sentinel);
+      await expect(pA).resolves.toBe("approved");
+
+      const sentinel = Symbol("pending");
+      const race = Promise.race([
+        pB,
+        new Promise((resolve) => setTimeout(() => resolve(sentinel), 20)),
+      ]);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20);
+      });
+      expect(await race).toBe(sentinel);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("disables the confirm button on mount for danger:confirm, re-enabling after the cooldown", () => {
+    vi.useFakeTimers();
+    try {
+      void enqueue({ actionTitle: "Delete worktree", danger: "confirm" });
+      render(<McpConfirmDialog />);
+
+      const confirmBtn = screen.getByRole("button", {
+        name: "Delete worktree",
+      }) as HTMLButtonElement;
+      expect(confirmBtn.disabled).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+      expect(confirmBtn.disabled).toBe(false);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not gate non-destructive dispatches with a cooldown", () => {
+    vi.useFakeTimers();
+    try {
+      void enqueue({ actionTitle: "List worktrees", danger: "safe" });
+      render(<McpConfirmDialog />);
+
+      const confirmBtn = screen.getByRole("button", {
+        name: "List worktrees",
+      }) as HTMLButtonElement;
+      expect(confirmBtn.disabled).toBe(false);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("restarts the cooldown when a fresh destructive item is promoted", async () => {
+    vi.useFakeTimers();
+    try {
+      const pA = enqueue({ requestId: "A", actionTitle: "Delete worktree", danger: "confirm" });
+      enqueue({ requestId: "B", actionTitle: "Reset branch", danger: "confirm" });
+
+      render(<McpConfirmDialog />);
+
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+      const firstBtn = screen.getByRole("button", {
+        name: "Delete worktree",
+      }) as HTMLButtonElement;
+      expect(firstBtn.disabled).toBe(false);
+
+      act(() => {
+        firstBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await expect(pA).resolves.toBe("approved");
+
+      // Item B is now promoted into the same mounted dialog — its cooldown
+      // must arm afresh so a click meant for A can't approve B.
+      const secondBtn = screen.getByRole("button", {
+        name: "Reset branch",
+      }) as HTMLButtonElement;
+      expect(secondBtn.disabled).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+      expect(secondBtn.disabled).toBe(false);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/components/__tests__/McpConfirmDialog.test.tsx
+++ b/src/components/__tests__/McpConfirmDialog.test.tsx
@@ -47,6 +47,23 @@ function enqueue(
   });
 }
 
+const PENDING_PROBE_MS = 20;
+
+// Assert a confirmation promise has NOT settled: race it against a short
+// fake-timer probe and require the probe to win. Used to prove a queued item
+// was never approved by a click meant for a different modal.
+async function expectStillPending(promise: Promise<unknown>) {
+  const sentinel = Symbol("pending");
+  const race = Promise.race([
+    promise,
+    new Promise((resolve) => setTimeout(() => resolve(sentinel), PENDING_PROBE_MS)),
+  ]);
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(PENDING_PROBE_MS);
+  });
+  expect(await race).toBe(sentinel);
+}
+
 describe("McpConfirmDialog", () => {
   beforeEach(() => {
     __resetMcpConfirmStoreForTesting();
@@ -113,15 +130,7 @@ describe("McpConfirmDialog", () => {
 
       await expect(pA).resolves.toBe("approved");
 
-      const sentinel = Symbol("pending");
-      const race = Promise.race([
-        pB,
-        new Promise((resolve) => setTimeout(() => resolve(sentinel), 20)),
-      ]);
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(20);
-      });
-      expect(await race).toBe(sentinel);
+      await expectStillPending(pB);
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();
@@ -169,7 +178,7 @@ describe("McpConfirmDialog", () => {
     vi.useFakeTimers();
     try {
       const pA = enqueue({ requestId: "A", actionTitle: "Delete worktree", danger: "confirm" });
-      enqueue({ requestId: "B", actionTitle: "Reset branch", danger: "confirm" });
+      void enqueue({ requestId: "B", actionTitle: "Reset branch", danger: "confirm" });
 
       render(<McpConfirmDialog />);
 
@@ -248,15 +257,7 @@ describe("McpConfirmDialog", () => {
         bBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       });
 
-      const sentinel = Symbol("pending");
-      const race = Promise.race([
-        pB,
-        new Promise((resolve) => setTimeout(() => resolve(sentinel), 20)),
-      ]);
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(20);
-      });
-      expect(await race).toBe(sentinel);
+      await expectStillPending(pB);
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -46,6 +46,22 @@ type ConfirmDialogBaseProps = {
    * either gate fails.
    */
   confirmDisabled?: boolean;
+  /**
+   * Opt-in lower-bound read-time gate: disable the primary action for this
+   * many milliseconds after the dialog opens (or after {@link cooldownKey}
+   * changes). Stops a rapid click from confirming a destructive action before
+   * the user has had time to read it. Off by default; stacks with
+   * {@link confirmDisabled} and the typed-name gate.
+   */
+  confirmCooldownMs?: number;
+  /**
+   * Resets the {@link confirmCooldownMs} clock whenever it changes, even while
+   * the dialog stays mounted with `isOpen` continuously true. Required for
+   * queue-driven singletons (e.g. McpConfirmDialog) where one confirmation is
+   * promoted into the same dialog as the previous one resolves — pass the
+   * per-item id so each freshly-promoted item earns its own cooldown.
+   */
+  cooldownKey?: string | number;
   zIndex?: DialogZIndex;
   initialFocus?: DialogInitialFocus;
 };
@@ -72,6 +88,8 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
     onConfirm,
     isConfirmLoading = false,
     confirmDisabled = false,
+    confirmCooldownMs,
+    cooldownKey,
     variant,
     zIndex,
     initialFocus,
@@ -85,6 +103,26 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
   useEffect(() => {
     if (!isOpen) setTypedValue("");
   }, [isOpen]);
+
+  // Lazily seed the cooldown as active so the primary button never flashes
+  // enabled for a frame before the effect runs. `confirmCooldownMs <= 0` (and
+  // NaN, which is falsy) falls through to "no cooldown".
+  const [isCooldownActive, setIsCooldownActive] = useState(() =>
+    Boolean(isOpen && confirmCooldownMs && confirmCooldownMs > 0)
+  );
+
+  useEffect(() => {
+    if (!isOpen || !confirmCooldownMs || confirmCooldownMs <= 0) {
+      setIsCooldownActive(false);
+      return;
+    }
+    setIsCooldownActive(true);
+    const timer = setTimeout(() => setIsCooldownActive(false), confirmCooldownMs);
+    // Cleanup is load-bearing: under React StrictMode the effect runs
+    // setup/cleanup/setup on mount, so without clearing the first timer it
+    // would resolve early and drop the cooldown before it elapsed.
+    return () => clearTimeout(timer);
+  }, [isOpen, confirmCooldownMs, cooldownKey]);
 
   if (variant !== "destructive" && DESTRUCTIVE_CONFIRM_LABEL_RE.test(confirmLabel)) {
     warnOnce(
@@ -127,6 +165,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
   const isTypedMatched = !hasTypedNameGate || typedValue === typedNameTarget;
 
   const handleConfirm = () => {
+    if (isCooldownActive) return;
     if (hasTypedNameGate && !isTypedMatched) return;
     if (confirmDisabled) return;
     return onConfirm();
@@ -171,7 +210,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
           label: confirmLabel,
           onClick: handleConfirm,
           loading: isConfirmLoading,
-          disabled: (hasTypedNameGate && !isTypedMatched) || confirmDisabled,
+          disabled: (hasTypedNameGate && !isTypedMatched) || confirmDisabled || isCooldownActive,
           intent: variant === "destructive" ? "destructive" : "default",
         }}
       />

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { AppDialog, type DialogInitialFocus, type DialogZIndex } from "@/components/ui/AppDialog";
 import { TypedNameConfirmInput } from "@/components/ui/TypedNameConfirmInput";
 
@@ -111,7 +111,12 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
     Boolean(isOpen && confirmCooldownMs && confirmCooldownMs > 0)
   );
 
-  useEffect(() => {
+  // useLayoutEffect (not useEffect) so the re-arm is synchronous before paint:
+  // when the singleton dialog transitions isOpen false→true, or cooldownKey
+  // changes to a freshly-promoted item while staying open, the button must
+  // already be disabled in the first painted frame — a passive effect would
+  // leave a one-frame enabled gap that defeats the read-time guarantee.
+  useLayoutEffect(() => {
     if (!isOpen || !confirmCooldownMs || confirmCooldownMs <= 0) {
       setIsCooldownActive(false);
       return;

--- a/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -1137,6 +1137,33 @@ describe("ConfirmDialog confirmCooldownMs gate", () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses the typed-name Enter submit while the cooldown is active", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete worktree"
+        onConfirm={onConfirm}
+        variant="destructive"
+        typedNameTarget="my-thing"
+        confirmCooldownMs={1200}
+      />
+    );
+
+    const input = screen.getByLabelText(/^Type my-thing to confirm$/i);
+    fireEvent.change(input, { target: { value: "my-thing" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1200);
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
   it("restarts the cooldown when cooldownKey changes while staying open", () => {
     const props = {
       isOpen: true as const,

--- a/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConfirmDialog, __devWarnedKeys } from "../ConfirmDialog";
 import { TypedNameConfirmInput } from "../TypedNameConfirmInput";
@@ -1022,5 +1022,145 @@ describe("TypedNameConfirmInput preamble prop", () => {
 
     const input = screen.getByLabelText(/^Type my-thing to confirm$/i);
     expect(input.getAttribute("aria-invalid")).not.toBe("true");
+  });
+});
+
+describe("ConfirmDialog confirmCooldownMs gate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __devWarnedKeys.clear();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  function getConfirm() {
+    return screen.getByRole("button", { name: "Delete worktree" }) as HTMLButtonElement;
+  }
+
+  it("disables the primary button on open and re-enables it after the cooldown", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete worktree"
+        onConfirm={() => {}}
+        variant="destructive"
+        confirmCooldownMs={1200}
+      />
+    );
+
+    expect(getConfirm().disabled).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1199);
+    });
+    expect(getConfirm().disabled).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(getConfirm().disabled).toBe(false);
+  });
+
+  it("does not gate the button when confirmCooldownMs is absent", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete worktree"
+        onConfirm={() => {}}
+        variant="destructive"
+      />
+    );
+
+    expect(getConfirm().disabled).toBe(false);
+  });
+
+  it("treats zero and negative cooldowns as no cooldown", () => {
+    const { rerender } = render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete worktree"
+        onConfirm={() => {}}
+        variant="destructive"
+        confirmCooldownMs={0}
+      />
+    );
+    expect(getConfirm().disabled).toBe(false);
+
+    rerender(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete worktree"
+        onConfirm={() => {}}
+        variant="destructive"
+        confirmCooldownMs={-5}
+      />
+    );
+    expect(getConfirm().disabled).toBe(false);
+  });
+
+  it("ignores a click while the cooldown is active, then fires after it elapses", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete worktree"
+        onConfirm={onConfirm}
+        variant="destructive"
+        confirmCooldownMs={1200}
+      />
+    );
+
+    fireEvent.click(getConfirm());
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1200);
+    });
+    fireEvent.click(getConfirm());
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("restarts the cooldown when cooldownKey changes while staying open", () => {
+    const props = {
+      isOpen: true as const,
+      onClose: () => {},
+      title: "Delete it?",
+      confirmLabel: "Delete worktree",
+      onConfirm: () => {},
+      variant: "destructive" as const,
+      confirmCooldownMs: 1200,
+    };
+    const { rerender } = render(<ConfirmDialog {...props} cooldownKey="A" />);
+
+    act(() => {
+      vi.advanceTimersByTime(1200);
+    });
+    expect(getConfirm().disabled).toBe(false);
+
+    // A new item is promoted into the same mounted dialog — the clock restarts.
+    rerender(<ConfirmDialog {...props} cooldownKey="B" />);
+    expect(getConfirm().disabled).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1200);
+    });
+    expect(getConfirm().disabled).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Adds opt-in `confirmCooldownMs` and `cooldownKey` props to `ConfirmDialog` that disable the primary button for a short window after open (or after `cooldownKey` changes), closing the lower-bound rapid-click gap that `resolveOnce` and the 28s `CONFIRMATION_TIMEOUT_MS` don't cover
- `McpConfirmDialog` opts in with a 1.2s cooldown keyed on `requestId`, active only for `danger: "confirm"` dispatches; the cooldown stacks cleanly with the existing `confirmDisabled` and typed-name gates
- Auto-timeout is floored above the cooldown so a deeply-queued destructive item can't time out before its cooldown clears; non-MCP consumers (`recipe delete`, `terminal kill`, etc.) are unaffected — opt-in, default off

Resolves #8824

## Changes

- `src/components/ui/ConfirmDialog.tsx` — `confirmCooldownMs` + `cooldownKey` props; cooldown armed via `useLayoutEffect`, `clearTimeout` cleanup is StrictMode-safe
- `src/components/McpConfirmDialog.tsx` — opts in with 1.2s cooldown keyed on `requestId`, only when `current.danger === "confirm"`; auto-timeout floored above cooldown
- `src/components/ui/__tests__/ConfirmDialog.test.tsx` — cooldown unit tests (button disabled during window, re-arms on key change, stacks with `confirmDisabled`)
- `src/components/__tests__/McpConfirmDialog.test.tsx` — integration tests for cooldown opt-in path, timeout floor, non-dangerous items bypass

## Testing

73 tests pass. Lint, format, and typecheck are clean.