### PR TITLE
perf(startup): fork workspace host concurrently with PTY host

### DIFF
--- a/electron/window/__tests__/windowServicesProjectBinding.test.ts
+++ b/electron/window/__tests__/windowServicesProjectBinding.test.ts
@@ -290,7 +290,9 @@ describe("windowServices workspace prewarm ordering (#8828)", () => {
 
   it("only sets the IPC-visible ref after PTY-ready, never before", () => {
     const actions = simulateWorkspaceInit({ initialProjectId: "proj-a" }, storeWithProjectA);
-    expect(order(actions, "setWorkspaceClientRef")).toBeGreaterThan(order(actions, "ptyWaitForReady"));
+    expect(order(actions, "setWorkspaceClientRef")).toBeGreaterThan(
+      order(actions, "ptyWaitForReady")
+    );
   });
 
   it("continues startup when prewarm throws synchronously (PTY-ready and ref still happen)", () => {

--- a/electron/window/__tests__/windowServicesProjectBinding.test.ts
+++ b/electron/window/__tests__/windowServicesProjectBinding.test.ts
@@ -64,6 +64,39 @@ function simulateBootstrap(
   return actions;
 }
 
+/**
+ * Replicates the workspace-init ordering from windowServices.ts (#8828):
+ * the workspace client is constructed and the project host prewarmed BEFORE
+ * the PTY-ready await, so the two utility-process forks overlap. The IPC-visible
+ * ref must still only be set AFTER PTY-ready.
+ */
+function simulateWorkspaceInit(
+  opts: Opts,
+  projectStore: { getProjectById: (id: string) => Project | undefined },
+  prewarmThrows = false
+) {
+  const actions: { action: string; args?: Record<string, unknown> }[] = [];
+
+  actions.push({ action: "getWorkspaceClient" });
+
+  const prewarmPath =
+    opts.initialProjectPath ??
+    (opts.initialProjectId ? projectStore.getProjectById(opts.initialProjectId)?.path : undefined);
+  if (prewarmPath) {
+    try {
+      if (prewarmThrows) throw new Error("synchronous prewarm failure");
+      actions.push({ action: "prewarmProject", args: { path: prewarmPath } });
+    } catch {
+      actions.push({ action: "prewarmFailedSync" });
+    }
+  }
+
+  actions.push({ action: "ptyWaitForReady" });
+  actions.push({ action: "setWorkspaceClientRef" });
+
+  return actions;
+}
+
 const PROJECT_A: Project = { id: "proj-a", name: "Project A", path: "/projects/a" };
 
 const storeWithProjectA = {
@@ -212,5 +245,59 @@ describe("windowServices project binding (#5492)", () => {
       const actions = simulateBootstrap(opts, storeWithProjectA);
       expect(actions.find((a) => a.action === "initializeTaskQueue")).toBeUndefined();
     });
+  });
+});
+
+describe("windowServices workspace prewarm ordering (#8828)", () => {
+  const order = (actions: { action: string }[], name: string) =>
+    actions.findIndex((a) => a.action === name);
+
+  it("prewarms before awaiting PTY-ready for a restore window (initialProjectId)", () => {
+    const actions = simulateWorkspaceInit({ initialProjectId: "proj-a" }, storeWithProjectA);
+    expect(actions).toContainEqual({ action: "prewarmProject", args: { path: "/projects/a" } });
+    expect(order(actions, "prewarmProject")).toBeLessThan(order(actions, "ptyWaitForReady"));
+  });
+
+  it("prewarms before awaiting PTY-ready for an explicit-path window (initialProjectPath)", () => {
+    const actions = simulateWorkspaceInit({ initialProjectPath: "/cli/project" }, emptyStore);
+    expect(actions).toContainEqual({ action: "prewarmProject", args: { path: "/cli/project" } });
+    expect(order(actions, "prewarmProject")).toBeLessThan(order(actions, "ptyWaitForReady"));
+  });
+
+  it("prefers initialProjectPath over the store lookup when both are set", () => {
+    const actions = simulateWorkspaceInit(
+      { initialProjectId: "proj-a", initialProjectPath: "/override/path" },
+      storeWithProjectA
+    );
+    expect(actions).toContainEqual({ action: "prewarmProject", args: { path: "/override/path" } });
+  });
+
+  it("does NOT prewarm when no project path can be resolved (unbound window)", () => {
+    const actions = simulateWorkspaceInit({}, storeWithProjectA);
+    expect(actions.find((a) => a.action === "prewarmProject")).toBeUndefined();
+  });
+
+  it("does NOT prewarm when the store has no matching project", () => {
+    const actions = simulateWorkspaceInit({ initialProjectId: "proj-missing" }, emptyStore);
+    expect(actions.find((a) => a.action === "prewarmProject")).toBeUndefined();
+  });
+
+  it("constructs the workspace client before prewarming and PTY-ready", () => {
+    const actions = simulateWorkspaceInit({ initialProjectId: "proj-a" }, storeWithProjectA);
+    expect(order(actions, "getWorkspaceClient")).toBeLessThan(order(actions, "prewarmProject"));
+    expect(order(actions, "getWorkspaceClient")).toBeLessThan(order(actions, "ptyWaitForReady"));
+  });
+
+  it("only sets the IPC-visible ref after PTY-ready, never before", () => {
+    const actions = simulateWorkspaceInit({ initialProjectId: "proj-a" }, storeWithProjectA);
+    expect(order(actions, "setWorkspaceClientRef")).toBeGreaterThan(order(actions, "ptyWaitForReady"));
+  });
+
+  it("continues startup when prewarm throws synchronously (PTY-ready and ref still happen)", () => {
+    const actions = simulateWorkspaceInit({ initialProjectId: "proj-a" }, storeWithProjectA, true);
+    expect(actions.find((a) => a.action === "prewarmProject")).toBeUndefined();
+    expect(actions).toContainEqual({ action: "prewarmFailedSync" });
+    expect(actions.find((a) => a.action === "ptyWaitForReady")).toBeDefined();
+    expect(actions.find((a) => a.action === "setWorkspaceClientRef")).toBeDefined();
   });
 });

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -186,20 +186,46 @@ export async function setupWindowServices(
   // are started on-demand when loadProject() is called, not at init time.
   const ptyClient = getPtyClient();
   if (!getWorkspaceClientRef()) {
-    console.log("[MAIN] Waiting for Pty Host to be ready before initializing Workspace Client...");
-    try {
-      await ptyClient!.waitForReady();
-      console.log("[MAIN] Pty Host ready, initializing Workspace Client...");
-      markPerformance(PERF_MARKS.SERVICE_INIT_PTY_READY);
-    } catch (error) {
-      console.error("[MAIN] Pty Host failed to start:", error);
-    }
-
+    // Construct the workspace client and prewarm its per-project host
+    // concurrently with the PTY host fork. The two utility processes load
+    // native modules independently (node-pty vs better-sqlite3 + @parcel/watcher)
+    // and share no IPC/memory, so dispatching the workspace host fork while we
+    // await PTY-ready overlaps the two native loads instead of serializing them
+    // behind the PTY handshake (#8828).
     const workspaceClient = getWorkspaceClient({
       maxRestartAttempts: 3,
       healthCheckIntervalMs: 10000,
       showCrashDialog: false,
     });
+
+    // Resolve the project path this window will load so the workspace host can
+    // start forking now. getProjectById is a synchronous SQLite read on the
+    // already-open shared DB, so it's safe before projectStore.initialize().
+    const prewarmPath =
+      opts.initialProjectPath ??
+      (opts.initialProjectId
+        ? projectStore.getProjectById(opts.initialProjectId)?.path
+        : undefined);
+    if (prewarmPath) {
+      console.log("[MAIN] Prewarming workspace host concurrently with PTY host:", prewarmPath);
+      try {
+        // Fire-and-forget: prewarmProject sets up the host initPromise and a
+        // dormant-cleanup timer; async failure self-heals inside the pool.
+        workspaceClient.prewarmProject(prewarmPath);
+      } catch (error) {
+        console.warn("[MAIN] prewarmProject failed synchronously:", error);
+      }
+    }
+
+    console.log("[MAIN] Waiting for Pty Host to be ready...");
+    try {
+      await ptyClient!.waitForReady();
+      console.log("[MAIN] Pty Host ready");
+      markPerformance(PERF_MARKS.SERVICE_INIT_PTY_READY);
+    } catch (error) {
+      console.error("[MAIN] Pty Host failed to start:", error);
+    }
+
     setWorkspaceClientRef(workspaceClient);
 
     // Give PluginService the WorkspaceClient reference now that it's ready.

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -201,20 +201,23 @@ export async function setupWindowServices(
     // Resolve the project path this window will load so the workspace host can
     // start forking now. getProjectById is a synchronous SQLite read on the
     // already-open shared DB, so it's safe before projectStore.initialize().
-    const prewarmPath =
-      opts.initialProjectPath ??
-      (opts.initialProjectId
-        ? projectStore.getProjectById(opts.initialProjectId)?.path
-        : undefined);
-    if (prewarmPath) {
-      console.log("[MAIN] Prewarming workspace host concurrently with PTY host:", prewarmPath);
-      try {
+    // Derivation + dispatch are wrapped together: a failed lookup or a
+    // synchronous prewarm error must not abort startup — the host self-heals
+    // and loadProject() forks a fresh one later if needed.
+    try {
+      const prewarmPath =
+        opts.initialProjectPath ??
+        (opts.initialProjectId
+          ? projectStore.getProjectById(opts.initialProjectId)?.path
+          : undefined);
+      if (prewarmPath) {
+        console.log("[MAIN] Prewarming workspace host concurrently with PTY host:", prewarmPath);
         // Fire-and-forget: prewarmProject sets up the host initPromise and a
         // dormant-cleanup timer; async failure self-heals inside the pool.
         workspaceClient.prewarmProject(prewarmPath);
-      } catch (error) {
-        console.warn("[MAIN] prewarmProject failed synchronously:", error);
       }
+    } catch (error) {
+      console.warn("[MAIN] Workspace host prewarm failed; will fork on demand:", error);
     }
 
     console.log("[MAIN] Waiting for Pty Host to be ready...");


### PR DESCRIPTION
## Summary

- The workspace host was being prewarmed after `PTY-ready`, so its native module loads (`better-sqlite3` and `@parcel/watcher`) serialized behind the PTY host's `node-pty` load. This reorders `electron/window/windowServices.ts` to construct `WorkspaceClient` and trigger the prewarm before awaiting `PTY-ready`, making the two loads overlap.
- `setWorkspaceClientRef` still runs after `PTY-ready` to preserve the IPC ref-visibility invariant — only the prewarm dispatch moves.
- The prewarm path is derived from `initialProjectPath` or a synchronous `getProjectById` lookup, wrapped in `try/catch` so failures fall back to on-demand forking.

Resolves #8828

## Changes

- `electron/window/windowServices.ts` — reordered to dispatch workspace host prewarm before `await` of PTY-ready; `setWorkspaceClientRef` stays in place after PTY handshake.
- `electron/window/__tests__/windowServicesProjectBinding.test.ts` — 8 new regression tests asserting prewarm ordering, prewarm-path derivation, and error fallback behaviour.

## Testing

- 25 vitest tests pass (`npm run test -- windowServicesProjectBinding`).
- `npm run check` fully green (typecheck, lint, format).
- Observable at runtime via the existing `WORKSPACE_HOST_FORK_DISPATCHED` perf mark arriving before `SERVICE_INIT_PTY_READY`.