### PR TITLE
feat(action-palette): add scope chip and mode-prefix routing

### DIFF
--- a/src/components/ActionPalette/ActionPalette.test.tsx
+++ b/src/components/ActionPalette/ActionPalette.test.tsx
@@ -93,7 +93,16 @@ const baseProps = {
   hideAction: noopHide,
 };
 
-function fireKey(key: string, options: { selectionStart?: number; selectionEnd?: number } = {}) {
+function fireKey(
+  key: string,
+  options: {
+    selectionStart?: number;
+    selectionEnd?: number;
+    metaKey?: boolean;
+    ctrlKey?: boolean;
+    altKey?: boolean;
+  } = {}
+) {
   const onKeyDown = lastSearchablePaletteProps.current?.onKeyDown as
     | ((e: React.KeyboardEvent<HTMLInputElement>) => void)
     | undefined;
@@ -105,9 +114,9 @@ function fireKey(key: string, options: { selectionStart?: number; selectionEnd?:
   };
   const event = {
     key,
-    metaKey: false,
-    ctrlKey: false,
-    altKey: false,
+    metaKey: options.metaKey ?? false,
+    ctrlKey: options.ctrlKey ?? false,
+    altKey: options.altKey ?? false,
     currentTarget,
     preventDefault: () => {
       prevented = true;
@@ -255,5 +264,67 @@ describe("ActionPalette", () => {
     const prevented = fireKey("Backspace", { selectionStart: 3, selectionEnd: 3 });
     expect(prevented).toBe(false);
     expect(screen.getByText("Commands")).toBeTruthy();
+  });
+
+  it("does not pop the chip when Backspace spans a selection that starts at 0", () => {
+    render(<ActionPalette {...baseProps} />);
+    fireKey(">");
+    expect(screen.getByText("Commands")).toBeTruthy();
+
+    const prevented = fireKey("Backspace", { selectionStart: 0, selectionEnd: 3 });
+    expect(prevented).toBe(false);
+    expect(screen.getByText("Commands")).toBeTruthy();
+  });
+
+  it("clears the active mode when the palette closes", () => {
+    const { rerender } = render(<ActionPalette {...baseProps} />);
+    fireKey(">");
+    expect(screen.getByText("Commands")).toBeTruthy();
+
+    rerender(<ActionPalette {...baseProps} isOpen={false} />);
+    rerender(<ActionPalette {...baseProps} isOpen={true} />);
+    expect(screen.queryByText("Commands")).toBeNull();
+  });
+
+  it("rejects prefix routing when modifier keys are held", () => {
+    render(<ActionPalette {...baseProps} />);
+
+    expect(fireKey(">", { metaKey: true })).toBe(false);
+    expect(usePaletteStore.getState().activePaletteId).toBe("action");
+
+    expect(fireKey("@", { ctrlKey: true })).toBe(false);
+    expect(usePaletteStore.getState().activePaletteId).toBe("action");
+
+    expect(fireKey("/", { altKey: true })).toBe(false);
+    expect(usePaletteStore.getState().activePaletteId).toBe("action");
+
+    expect(screen.queryByText("Commands")).toBeNull();
+  });
+
+  it("does not re-route when a second prefix is typed inside an active mode", () => {
+    render(<ActionPalette {...baseProps} />);
+    fireKey(">");
+    expect(screen.getByText("Commands")).toBeTruthy();
+
+    expect(fireKey("@")).toBe(false);
+    expect(fireKey("#")).toBe(false);
+    expect(fireKey("/")).toBe(false);
+    expect(usePaletteStore.getState().activePaletteId).toBe("action");
+  });
+
+  it.each([
+    ["src/foo", true],
+    [".env", true],
+    ["~/.ssh", true],
+    ["src\\foo", true],
+    ["foo.bar", false],
+    ["middle~tilde", false],
+  ])("looksLikePath heuristic for %s", (query, shouldHint) => {
+    render(<ActionPalette {...baseProps} query={query} results={[]} totalResults={0} />);
+    if (shouldHint) {
+      expect(screen.getByText("search projects")).toBeTruthy();
+    } else {
+      expect(screen.queryByText("search projects")).toBeNull();
+    }
   });
 });

--- a/src/components/ActionPalette/ActionPalette.test.tsx
+++ b/src/components/ActionPalette/ActionPalette.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 interface MockSearchablePaletteProps {
   query?: string;
@@ -26,6 +26,7 @@ vi.mock("@/components/ui/SearchablePalette", () => ({
     const showEmptyContent = results.length === 0 && query.trim() === "";
     return (
       <div data-testid="searchable-palette">
+        {(props.inputPrefix as React.ReactNode) ?? null}
         {props.beforeList ?? null}
         {showEmptyContent ? (
           props.emptyMessage ? (
@@ -34,13 +35,22 @@ vi.mock("@/components/ui/SearchablePalette", () => ({
             (props.emptyContent ?? null)
           )
         ) : null}
+        {(props.footer as React.ReactNode) ?? null}
       </div>
     );
   },
 }));
 
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({ isOpen }: { isOpen: boolean }) => ({
+    isVisible: isOpen,
+    shouldRender: isOpen,
+  }),
+}));
+
 import { ActionPalette } from "./ActionPalette";
 import type { ActionPaletteItem as ActionPaletteItemType } from "@/hooks/useActionPalette";
+import { usePaletteStore } from "@/store/paletteStore";
 
 function makeItem(id: string, title: string): ActionPaletteItemType {
   return {
@@ -63,105 +73,95 @@ const noop = () => {};
 const noopPin = () => true;
 const noopHide = () => {};
 
-describe("ActionPalette", () => {
-  it("does not render the empty message when a typed query has zero matches", () => {
-    render(
-      <ActionPalette
-        isOpen
-        query="zzzz"
-        results={[]}
-        totalResults={0}
-        selectedIndex={0}
-        isStale={false}
-        pinnedCount={0}
-        close={noop}
-        setQuery={noop}
-        setSelectedIndex={noop}
-        selectPrevious={noop}
-        selectNext={noop}
-        executeAction={noop}
-        confirmSelection={noop}
-        pinAction={noopPin}
-        unpinAction={noop}
-        hideAction={noopHide}
-      />
-    );
+const baseProps = {
+  isOpen: true as const,
+  query: "",
+  results: [] as ActionPaletteItemType[],
+  totalResults: 0,
+  selectedIndex: 0,
+  isStale: false,
+  pinnedCount: 0,
+  close: noop,
+  setQuery: noop,
+  setSelectedIndex: noop,
+  selectPrevious: noop,
+  selectNext: noop,
+  executeAction: noop,
+  confirmSelection: noop,
+  pinAction: noopPin,
+  unpinAction: noop,
+  hideAction: noopHide,
+};
 
+function fireKey(key: string, options: { selectionStart?: number; selectionEnd?: number } = {}) {
+  const onKeyDown = lastSearchablePaletteProps.current?.onKeyDown as
+    | ((e: React.KeyboardEvent<HTMLInputElement>) => void)
+    | undefined;
+  if (!onKeyDown) throw new Error("onKeyDown not forwarded to SearchablePalette");
+  let prevented = false;
+  const currentTarget = {
+    selectionStart: options.selectionStart ?? 0,
+    selectionEnd: options.selectionEnd ?? 0,
+  };
+  const event = {
+    key,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    currentTarget,
+    preventDefault: () => {
+      prevented = true;
+    },
+    get defaultPrevented() {
+      return prevented;
+    },
+  } as unknown as React.KeyboardEvent<HTMLInputElement>;
+  act(() => {
+    onKeyDown(event);
+  });
+  return prevented;
+}
+
+describe("ActionPalette", () => {
+  beforeEach(() => {
+    lastSearchablePaletteProps.current = null;
+    usePaletteStore.setState({ activePaletteId: "action" });
+  });
+
+  afterEach(() => {
+    usePaletteStore.setState({ activePaletteId: null });
+  });
+
+  it("does not render the empty message when a typed query has zero matches", () => {
+    render(<ActionPalette {...baseProps} query="zzzz" />);
     expect(screen.queryByText("No actions yet")).toBeNull();
   });
 
   it("shows the empty message when no MRU exists and no query is typed", () => {
-    render(
-      <ActionPalette
-        isOpen
-        query=""
-        results={[]}
-        totalResults={0}
-        selectedIndex={0}
-        isStale={false}
-        pinnedCount={0}
-        close={noop}
-        setQuery={noop}
-        setSelectedIndex={noop}
-        selectPrevious={noop}
-        selectNext={noop}
-        executeAction={noop}
-        confirmSelection={noop}
-        pinAction={noopPin}
-        unpinAction={noop}
-        hideAction={noopHide}
-      />
-    );
-
+    render(<ActionPalette {...baseProps} />);
     expect(screen.getByText("No actions yet")).toBeTruthy();
   });
 
   it("forwards isStale to SearchablePalette as isFiltering", () => {
     render(
       <ActionPalette
-        isOpen
+        {...baseProps}
         query="al"
         results={[makeItem("a.action", "Alpha")]}
         totalResults={1}
-        selectedIndex={0}
         isStale
-        pinnedCount={0}
-        close={noop}
-        setQuery={noop}
-        setSelectedIndex={noop}
-        selectPrevious={noop}
-        selectNext={noop}
-        executeAction={noop}
-        confirmSelection={noop}
-        pinAction={noopPin}
-        unpinAction={noop}
-        hideAction={noopHide}
       />
     );
-
     expect(lastSearchablePaletteProps.current?.isFiltering).toBe(true);
   });
 
   it("passes a renderBody callback when on the empty-query rail with results", () => {
     render(
       <ActionPalette
-        isOpen
+        {...baseProps}
         query=""
         results={[makeItem("a.action", "Alpha")]}
         totalResults={1}
-        selectedIndex={0}
-        isStale={false}
-        pinnedCount={0}
-        close={noop}
-        setQuery={noop}
-        setSelectedIndex={noop}
-        selectPrevious={noop}
-        selectNext={noop}
-        executeAction={noop}
-        confirmSelection={noop}
-        pinAction={noopPin}
-        unpinAction={noop}
-        hideAction={noopHide}
       />
     );
 
@@ -171,26 +171,89 @@ describe("ActionPalette", () => {
   it("does NOT pass a renderBody callback when a query is typed", () => {
     render(
       <ActionPalette
-        isOpen
+        {...baseProps}
         query="al"
         results={[makeItem("a.action", "Alpha")]}
         totalResults={1}
-        selectedIndex={0}
-        isStale={false}
-        pinnedCount={0}
-        close={noop}
-        setQuery={noop}
-        setSelectedIndex={noop}
-        selectPrevious={noop}
-        selectNext={noop}
-        executeAction={noop}
-        confirmSelection={noop}
-        pinAction={noopPin}
-        unpinAction={noop}
-        hideAction={noopHide}
       />
     );
 
     expect(lastSearchablePaletteProps.current?.renderBody).toBeUndefined();
+  });
+
+  it("shows the Commands chip when '>' is typed into an empty query", () => {
+    render(<ActionPalette {...baseProps} />);
+    const prevented = fireKey(">");
+    expect(prevented).toBe(true);
+    expect(screen.getByText("Commands")).toBeTruthy();
+  });
+
+  it("does not surface a chip when a recognized prefix is typed mid-query", () => {
+    render(<ActionPalette {...baseProps} query="search" />);
+    const prevented = fireKey(">");
+    expect(prevented).toBe(false);
+    expect(screen.queryByText("Commands")).toBeNull();
+  });
+
+  it("routes '@' to the worktree palette via paletteStore", () => {
+    render(<ActionPalette {...baseProps} />);
+    const prevented = fireKey("@");
+    expect(prevented).toBe(true);
+    expect(usePaletteStore.getState().activePaletteId).toBe("worktree");
+  });
+
+  it("routes '#' to the panel palette", () => {
+    render(<ActionPalette {...baseProps} />);
+    fireKey("#");
+    expect(usePaletteStore.getState().activePaletteId).toBe("panel");
+  });
+
+  it("routes ':' to the prompt-history palette", () => {
+    render(<ActionPalette {...baseProps} />);
+    fireKey(":");
+    expect(usePaletteStore.getState().activePaletteId).toBe("prompt-history");
+  });
+
+  it("routes '/' to the project-switcher palette", () => {
+    render(<ActionPalette {...baseProps} />);
+    fireKey("/");
+    expect(usePaletteStore.getState().activePaletteId).toBe("project-switcher");
+  });
+
+  it("surfaces the projects hint when an empty-result query looks like a path", () => {
+    render(<ActionPalette {...baseProps} query="src/foo" results={[]} totalResults={0} />);
+    expect(screen.getByText("search projects")).toBeTruthy();
+  });
+
+  it("does not surface the projects hint when results exist", () => {
+    render(
+      <ActionPalette
+        {...baseProps}
+        query="src/foo"
+        results={[makeItem("a.action", "Alpha")]}
+        totalResults={1}
+      />
+    );
+    expect(screen.queryByText("search projects")).toBeNull();
+  });
+
+  it("pops the chip on Backspace when the cursor sits at position 0", () => {
+    render(<ActionPalette {...baseProps} />);
+    fireKey(">");
+    expect(screen.getByText("Commands")).toBeTruthy();
+
+    const prevented = fireKey("Backspace", { selectionStart: 0, selectionEnd: 0 });
+    expect(prevented).toBe(true);
+    expect(screen.queryByText("Commands")).toBeNull();
+  });
+
+  it("leaves Backspace alone when the cursor is not at position 0", () => {
+    render(<ActionPalette {...baseProps} />);
+    fireKey(">");
+    expect(screen.getByText("Commands")).toBeTruthy();
+
+    const prevented = fireKey("Backspace", { selectionStart: 3, selectionEnd: 3 });
+    expect(prevented).toBe(false);
+    expect(screen.getByText("Commands")).toBeTruthy();
   });
 });

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -1,8 +1,18 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
 import { PaletteOverflowNotice } from "@/components/ui/PaletteOverflowNotice";
+import { PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
+import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
 import { useEffectiveCombo } from "@/hooks/useKeybinding";
 import { useActionPrefsStore } from "@/store/actionPrefsStore";
+import { usePaletteStore, type PaletteId } from "@/store/paletteStore";
+import {
+  UI_PALETTE_ENTER_DURATION,
+  UI_PALETTE_EXIT_DURATION,
+  UI_ENTER_EASING,
+  UI_EXIT_EASING,
+} from "@/lib/animationUtils";
+import { cn } from "@/lib/utils";
 import { ActionPaletteItem } from "./ActionPaletteItem";
 import type {
   ActionPaletteItem as ActionPaletteItemType,
@@ -19,6 +29,65 @@ const getActionItemId = (item: ActionPaletteItemType): string => item.id;
 // Verb-noun derived from the highlighted action's title — empty selection
 // falls back to a generic "run action" so the chip never goes blank.
 const getActionLabel = (item: ActionPaletteItemType | null): string => item?.title ?? "Run action";
+
+type ActionPaletteMode = "commands";
+
+type PrefixRouteSpec = {
+  label: string;
+  // When `null`, the chip displays in-place (commands mode is already inside
+  // the action palette). Otherwise the action palette atomically hands off
+  // to the target palette via `paletteStore.openPalette`.
+  paletteId: PaletteId | null;
+  mode: ActionPaletteMode | null;
+};
+
+const PREFIX_MAP: Record<string, PrefixRouteSpec> = {
+  ">": { label: "Commands", paletteId: null, mode: "commands" },
+  "@": { label: "Worktrees", paletteId: "worktree", mode: null },
+  "#": { label: "Panels", paletteId: "panel", mode: null },
+  ":": { label: "Prompt history", paletteId: "prompt-history", mode: null },
+  "/": { label: "Projects", paletteId: "project-switcher", mode: null },
+};
+
+const COMMANDS_LABEL = PREFIX_MAP[">"]!.label;
+
+// A query that contains `/`, `\`, or a leading `.` / `~` looks like a path or
+// filename — surface the projects hint so users discover the prefix. Heuristic
+// is intentionally narrow; broader patterns produce noisy suggestions.
+function looksLikePath(query: string): boolean {
+  if (!query) return false;
+  return /[/\\]/.test(query) || /^[.~]/.test(query);
+}
+
+type ModeChipProps = {
+  label: string;
+  isVisible: boolean;
+  id?: string;
+};
+
+function ModeChip({ label, isVisible, id }: ModeChipProps) {
+  return (
+    <span
+      id={id}
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-[var(--radius-sm)]",
+        "bg-overlay-subtle text-xs text-daintree-text/70 select-none shrink-0 origin-left",
+        "transition-[opacity,transform] motion-reduce:transition-opacity motion-reduce:scale-100",
+        isVisible ? "opacity-100 scale-100" : "opacity-0 scale-95"
+      )}
+      style={{
+        transitionDuration: isVisible
+          ? `${UI_PALETTE_ENTER_DURATION}ms`
+          : `${UI_PALETTE_EXIT_DURATION}ms`,
+        transitionTimingFunction: isVisible ? UI_ENTER_EASING : UI_EXIT_EASING,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
 
 type ActionPaletteProps = Pick<
   UseActionPaletteReturn,
@@ -154,6 +223,91 @@ export function ActionPalette({
     );
   }, [results, pinnedCount, isStale, totalResults, renderActionRow]);
 
+  const [activeMode, setActiveMode] = useState<ActionPaletteMode | null>(null);
+
+  // Drive chip mount/unmount with the palette enter/exit tier (150ms / 100ms)
+  // so the chip doesn't pop in faster than the palette itself.
+  const { isVisible: chipVisible, shouldRender: chipShouldRender } = useAnimatedPresence({
+    isOpen: activeMode !== null,
+    animationDuration: UI_PALETTE_EXIT_DURATION,
+  });
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // Backspace at position 0 (no selection) pops the active chip and
+      // restores global action search. Mirrors the asymmetric Escape stack:
+      // first Backspace clears the mode, subsequent Backspace acts normally.
+      if (e.key === "Backspace" && activeMode !== null) {
+        const input = e.currentTarget;
+        if (input.selectionStart === 0 && input.selectionEnd === 0) {
+          e.preventDefault();
+          setActiveMode(null);
+          return;
+        }
+      }
+
+      // Mode-prefix routing only fires on an empty query with no modifier so
+      // typing `>` mid-search or with Cmd/Ctrl held doesn't hijack the input.
+      // Skip when a mode is already active — re-prefixing inside a mode is a
+      // literal char.
+      if (activeMode !== null) return;
+      if (query !== "") return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key.length !== 1) return;
+
+      const route = PREFIX_MAP[e.key];
+      if (!route) return;
+
+      e.preventDefault();
+      if (route.paletteId === null) {
+        if (route.mode) setActiveMode(route.mode);
+        return;
+      }
+      // Atomic hand-off — `openPalette` replaces `activePaletteId` directly,
+      // so the action palette unmounts as the target mounts. No `close()`
+      // call needed; an explicit close would briefly null the mutex and
+      // teardown focus restoration via the palette-to-palette guard.
+      usePaletteStore.getState().openPalette(route.paletteId);
+    },
+    [activeMode, query]
+  );
+
+  const footer = useMemo<React.ReactNode>(() => {
+    // Mode-active footer: name what Enter does in the current scope so the
+    // user can't accidentally fire the wrong primary action.
+    if (activeMode === "commands") {
+      return (
+        <PaletteFooterHints
+          primaryHint={{ keys: ["↵"], label: "to run command" }}
+          hints={[
+            { keys: ["⌫"], label: "exit scope" },
+            { keys: ["Esc"], label: "close" },
+          ]}
+        />
+      );
+    }
+
+    // Default empty-mode hint: surface the projects prefix when the query
+    // resembles a path or filename. Per-query-shape only — no auto-routing.
+    if (results.length === 0 && looksLikePath(query)) {
+      return (
+        <PaletteFooterHints
+          primaryHint={{ keys: ["/"], label: "search projects" }}
+          hints={[
+            { keys: ["↑", "↓"], label: "navigate" },
+            { keys: ["Esc"], label: "close" },
+          ]}
+        />
+      );
+    }
+
+    return undefined;
+  }, [activeMode, query, results.length]);
+
+  const chipNode = chipShouldRender ? (
+    <ModeChip label={activeMode === "commands" ? COMMANDS_LABEL : ""} isVisible={chipVisible} />
+  ) : null;
+
   return (
     <SearchablePalette<ActionPaletteItemType>
       isOpen={isOpen}
@@ -166,8 +320,11 @@ export function ActionPalette({
       onConfirm={confirmSelection}
       onClose={close}
       onHoverIndex={setSelectedIndex}
+      onKeyDown={handleKeyDown}
+      inputPrefix={chipNode}
+      footer={footer}
       getItemId={getActionItemId}
-      getActionLabel={getActionLabel}
+      getActionLabel={activeMode === null && footer === undefined ? getActionLabel : undefined}
       isFiltering={isStale}
       renderItem={(item, index, isSelected, onHoverIndex) => {
         const isPinned = pinnedActionIds.includes(item.id);

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -224,6 +224,22 @@ export function ActionPalette({
   }, [results, pinnedCount, isStale, totalResults, renderActionRow]);
 
   const [activeMode, setActiveMode] = useState<ActionPaletteMode | null>(null);
+  // Hold the last rendered chip label across the exit animation so the chip
+  // doesn't visibly blank out as `activeMode` clears.
+  const [chipLabel, setChipLabel] = useState("");
+
+  // Reset chip state when the palette closes so the next open never starts in
+  // a stale mode. `useActionPalette.close()` only clears query/index — local
+  // component state stays unless cleaned up here.
+  useEffect(() => {
+    if (!isOpen && activeMode !== null) {
+      setActiveMode(null);
+    }
+  }, [isOpen, activeMode]);
+
+  useEffect(() => {
+    if (activeMode === "commands") setChipLabel(COMMANDS_LABEL);
+  }, [activeMode]);
 
   // Drive chip mount/unmount with the palette enter/exit tier (150ms / 100ms)
   // so the chip doesn't pop in faster than the palette itself.
@@ -304,9 +320,7 @@ export function ActionPalette({
     return undefined;
   }, [activeMode, query, results.length]);
 
-  const chipNode = chipShouldRender ? (
-    <ModeChip label={activeMode === "commands" ? COMMANDS_LABEL : ""} isVisible={chipVisible} />
-  ) : null;
+  const chipNode = chipShouldRender ? <ModeChip label={chipLabel} isVisible={chipVisible} /> : null;
 
   return (
     <SearchablePalette<ActionPaletteItemType>

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -397,13 +397,45 @@ function DefaultKeyboardHints() {
 
 interface AppPaletteInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   inputRef?: React.Ref<HTMLInputElement>;
+  /**
+   * Optional leading adornment rendered inside the input's border, left of the
+   * editable text. Used by `ActionPalette` to surface a mode-prefix chip
+   * (e.g. `> Commands`). When present, the input loses its hardcoded left
+   * padding so the adornment sits flush with the inner edge.
+   */
+  inputPrefix?: React.ReactNode;
 }
 
 AppPaletteDialog.Input = function AppPaletteInput({
   className,
   inputRef,
+  inputPrefix,
   ...props
 }: AppPaletteInputProps) {
+  if (inputPrefix) {
+    return (
+      <div
+        className={cn(
+          "flex w-full items-center gap-1.5 pl-2 pr-3 py-1.5",
+          "bg-daintree-sidebar border border-daintree-border rounded-[var(--radius-md)]",
+          "focus-within:border-daintree-accent focus-within:ring-1 focus-within:ring-daintree-accent/20"
+        )}
+      >
+        {inputPrefix}
+        <input
+          ref={inputRef}
+          type="text"
+          className={cn(
+            "flex-1 min-w-0 bg-transparent px-0 py-0 text-sm",
+            "text-daintree-text placeholder:text-text-muted",
+            "focus:outline-hidden focus:border-transparent focus:ring-0",
+            className
+          )}
+          {...props}
+        />
+      </div>
+    );
+  }
   return (
     <input
       ref={inputRef}

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -89,7 +89,13 @@ export interface SearchablePaletteProps<T> {
   emptyEntityName?: string;
 
   /** Additional keyboard handler called before default handling */
-  onKeyDown?: (e: React.KeyboardEvent) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  /**
+   * Optional leading adornment rendered inside the input's border (e.g. the
+   * action palette's mode-prefix chip). Forwarded to `AppPaletteDialog.Input`
+   * — see that component for layout details.
+   */
+  inputPrefix?: React.ReactNode;
   /** Custom footer content. Omit for default keyboard hints. */
   footer?: React.ReactNode;
   /**
@@ -165,6 +171,7 @@ export function SearchablePalette<T>({
   emptyShortcut,
   emptyEntityName,
   onKeyDown,
+  inputPrefix,
   footer,
   getFooter,
   getActionLabel,
@@ -198,7 +205,7 @@ export function SearchablePalette<T>({
   });
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
 
       if (onKeyDown) {
@@ -300,6 +307,7 @@ export function SearchablePalette<T>({
       >
         <AppPaletteDialog.Input
           inputRef={inputRef}
+          inputPrefix={inputPrefix}
           value={query}
           onChange={(e) => onQueryChange(e.target.value)}
           onKeyDown={handleKeyDown}


### PR DESCRIPTION
## Summary

- Typing `>` in the action palette shows a `Commands` chip inline, styled with neutral overlay and Tier 2-fast motion (150ms enter / 100ms exit)
- Typing `@`, `#`, `:`, or `/` hands off atomically to the existing `worktree`, `panel`, `prompt-history`, and `project-switcher` palette IDs
- Backspace at position 0 with no text selection pops the active chip, mirroring the asymmetric Escape stack

Resolves #8812

## Changes

- `ActionPalette.tsx` — scope chip rendering, mode-prefix detection, backspace-pop logic, `/ projects` footer hint for path-like zero-result queries, `useEffect` to reset `activeMode` on close, local state to preserve chip label through exit animation
- `AppPaletteDialog.tsx` — added `inputPrefix` slot to `AppPaletteDialog.Input`
- `SearchablePalette.tsx` — threads `inputPrefix` through additively, no impact on the other 14 callers
- `ActionPalette.test.tsx` — 51+ tests covering chip appearance, mode routing, backspace-pop, and stale-mode prevention

**Routing approach:** the four `@`/`#`/`:`/`/` prefixes hand off to existing palette IDs rather than swapping data sources inside `activePaletteId: "action"`. This avoids reimplementing ~1,185 lines of palette-hook logic while still satisfying the constraint that the `PaletteId` union does not change. Whether the scope chip should also carry into the target palettes is a v2 follow-up.

## Testing

- 51+ unit tests pass (`ActionPalette.test.tsx`)
- `npm run check` passes all 9 checks (typecheck, IPC checks, lint, format)