### PR TITLE
perf(boot): defer PTY host fork past first renderer load

### DIFF
--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -115,6 +115,15 @@ export interface PtyClientConfig {
   showCrashDialog?: boolean;
   /** Memory limit in MB for PTY Host process (default: 512) */
   memoryLimitMb?: number;
+  /**
+   * When true the constructor wires up the host lifecycle but does NOT fork the
+   * PTY host. The caller forks it later via {@link PtyClient.start} once its
+   * prerequisites are met — for the app boot path that is the early PATH
+   * refresh (#8625), deferred so the host fork no longer blocks the first
+   * renderer load (#8827). Defaults to false so every other caller keeps the
+   * construct-and-fork behavior.
+   */
+  deferStart?: boolean;
 }
 
 const DEFAULT_CONFIG: Required<PtyClientConfig> = {
@@ -125,6 +134,7 @@ const DEFAULT_CONFIG: Required<PtyClientConfig> = {
   healthCheckIntervalMs: 5000,
   showCrashDialog: true,
   memoryLimitMb: 512,
+  deferStart: false,
 };
 
 const MAX_MISSED_HEARTBEATS = 3;
@@ -182,6 +192,7 @@ export class PtyClient extends EventEmitter {
     { projectId: string | null; projectPath?: string; mode: "active" | "switch" }
   >();
   private shouldResyncProjectContext = false;
+  private hostStartRequested = false;
   private pendingMessagePorts = new Map<number, MessagePortMain>();
   private terminalPids: Map<string, number> = new Map();
   private resourceMonitoringEnabled = false;
@@ -306,9 +317,32 @@ export class PtyClient extends EventEmitter {
       logWarn: (message) => console.warn(message),
     };
 
-    this.lifecycle.start();
+    if (!this.config.deferStart) {
+      this.start();
+    }
+  }
 
+  /**
+   * Fork the PTY host. Called automatically from the constructor unless
+   * `deferStart` was set, in which case the caller invokes this once the early
+   * PATH refresh has resolved so node-pty inherits the user's full PATH
+   * (#8625/#8827). Idempotent — a second call once the host has already been
+   * requested is a no-op, so the multi-window boot path can call it
+   * unconditionally. Auto-restarts go through `lifecycle.start()` directly and
+   * are unaffected by this guard.
+   */
+  start(): void {
+    if (this.hostStartRequested) {
+      return;
+    }
+    this.hostStartRequested = true;
+    this.lifecycle.start();
     console.log("[PtyClient] Pty Host started");
+  }
+
+  /** Whether {@link PtyClient.start} has forked (or requested) the host yet. */
+  isHostStarted(): boolean {
+    return this.hostStartRequested;
   }
 
   /** Wait for the host to be ready */

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -378,6 +378,19 @@ export class PtyClient extends EventEmitter {
     if (this.needsRespawn) {
       this.needsRespawn = false;
       this.respawnPending();
+    } else if (this.pendingSpawns.size > 0) {
+      // Initial host-ready replay (#8827). With deferred start the host forks
+      // only after the early PATH refresh, so any spawn requested during that
+      // window had its send() dropped — the host's message listener isn't
+      // attached until it emits "ready" (also true for the brief construct→
+      // ready window on the non-deferred path). Replay those spawns now so a
+      // terminal launched before the host was ready isn't silently lost.
+      // Double-spawn-safe: on the first "ready" no spawn could have been
+      // delivered yet. The restart-only side effects (port refresh, stale-kill
+      // clearing) stay in respawnPending() above.
+      for (const [id, options] of this.pendingSpawns) {
+        this.send({ type: "spawn", id, options });
+      }
     }
     const pendingPortWindowIds = new Set(this.pendingMessagePorts.keys());
     this.flushPendingMessagePorts();

--- a/electron/services/__tests__/PtyClient.deferStart.test.ts
+++ b/electron/services/__tests__/PtyClient.deferStart.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import { EventEmitter } from "events";
+
+// Mock Electron modules before importing PtyClient (mirrors PtyClient.handshake.test.ts).
+vi.mock("electron", () => ({
+  utilityProcess: {
+    fork: vi.fn(),
+  },
+  dialog: {
+    showMessageBox: vi.fn().mockResolvedValue({ response: 0 }),
+  },
+  app: {
+    getPath: vi.fn().mockReturnValue("/mock/user/data"),
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+}));
+
+import { utilityProcess } from "electron";
+
+interface MockUtilityProcess extends EventEmitter {
+  postMessage: Mock;
+  kill: Mock;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+}
+
+/**
+ * #8827: the app boot path constructs PtyClient with `deferStart: true` so the
+ * PTY host fork no longer blocks the first renderer load. The fork is triggered
+ * later by `start()`, after the early PATH refresh resolves. These tests pin
+ * that contract: deferStart skips the constructor fork, `start()` forks exactly
+ * once, and the default (non-deferred) path keeps forking in the constructor.
+ */
+describe("PtyClient deferStart", () => {
+  let mockChild: MockUtilityProcess;
+  let PtyClientClass: typeof import("../PtyClient.js").PtyClient;
+  let forkMock: Mock;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+
+    mockChild = Object.assign(new EventEmitter(), {
+      postMessage: vi.fn(),
+      kill: vi.fn(),
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+    });
+
+    (utilityProcess.fork as Mock).mockReturnValue(mockChild);
+
+    vi.resetModules();
+    vi.doMock("electron", () => ({
+      utilityProcess: {
+        fork: vi.fn().mockReturnValue(mockChild),
+      },
+      dialog: {
+        showMessageBox: vi.fn().mockResolvedValue({ response: 0 }),
+      },
+      app: {
+        getPath: vi.fn().mockReturnValue("/mock/user/data"),
+        on: vi.fn(),
+        off: vi.fn(),
+      },
+    }));
+
+    const module = await import("../PtyClient.js");
+    PtyClientClass = module.PtyClient;
+    forkMock = (await import("electron")).utilityProcess.fork as unknown as Mock;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("does not fork the host in the constructor when deferStart is true", () => {
+    const client = new PtyClientClass({ deferStart: true });
+
+    expect(forkMock).not.toHaveBeenCalled();
+    expect(client.isHostStarted()).toBe(false);
+
+    client.dispose();
+  });
+
+  it("forks the host exactly once when start() is called after a deferred construction", () => {
+    const client = new PtyClientClass({ deferStart: true });
+    expect(forkMock).not.toHaveBeenCalled();
+
+    client.start();
+
+    expect(forkMock).toHaveBeenCalledTimes(1);
+    expect(client.isHostStarted()).toBe(true);
+
+    client.dispose();
+  });
+
+  it("treats a second start() call as a no-op (idempotent)", () => {
+    const client = new PtyClientClass({ deferStart: true });
+
+    client.start();
+    client.start();
+    client.start();
+
+    expect(forkMock).toHaveBeenCalledTimes(1);
+    expect(client.isHostStarted()).toBe(true);
+
+    client.dispose();
+  });
+
+  it("forks in the constructor when deferStart is unset (default behavior)", () => {
+    const client = new PtyClientClass();
+
+    expect(forkMock).toHaveBeenCalledTimes(1);
+    expect(client.isHostStarted()).toBe(true);
+
+    client.dispose();
+  });
+});

--- a/electron/services/__tests__/PtyClient.deferStart.test.ts
+++ b/electron/services/__tests__/PtyClient.deferStart.test.ts
@@ -116,4 +116,46 @@ describe("PtyClient deferStart", () => {
 
     client.dispose();
   });
+
+  it("replays a spawn requested before the deferred host was ready", () => {
+    const client = new PtyClientClass({ deferStart: true });
+
+    // Spawn while the host has not forked yet — the send() is dropped (no child).
+    client.spawn("t1", { cwd: "/tmp", cols: 80, rows: 30 });
+    expect(mockChild.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "spawn", id: "t1" })
+    );
+
+    // Fork the host, then signal ready — the queued spawn must be replayed.
+    client.start();
+    mockChild.emit("message", { type: "ready" });
+
+    expect(mockChild.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "spawn", id: "t1" })
+    );
+
+    client.dispose();
+  });
+
+  it("queues a MessagePort requested before start() and flushes it on ready", () => {
+    const client = new PtyClientClass({ deferStart: true });
+    const port = { close: vi.fn(), postMessage: vi.fn(), start: vi.fn() };
+
+    // No host child yet — the port is queued rather than forwarded.
+    client.connectMessagePort(7, port as never);
+    expect(mockChild.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "connect-port", windowId: 7 }),
+      expect.anything()
+    );
+
+    client.start();
+    mockChild.emit("message", { type: "ready" });
+
+    expect(mockChild.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "connect-port", windowId: 7 }),
+      [port]
+    );
+
+    client.dispose();
+  });
 });

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -20,7 +20,7 @@ import { ProjectSwitchService } from "../services/ProjectSwitchService.js";
 import { notificationService } from "../services/NotificationService.js";
 import { logInfo } from "../utils/logger.js";
 import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
-import { getEarlyPathRefreshPromise, isDemoMode } from "../setup/environment.js";
+import { isDemoMode } from "../setup/environment.js";
 import type { WindowContext, WindowRegistry } from "./WindowRegistry.js";
 import { registerDeferredTask, finalizeDeferredRegistration } from "./deferredInitQueue.js";
 import { toDisposable } from "../utils/lifecycle.js";
@@ -102,27 +102,15 @@ export async function initPerWindowServices(
   if (!ptyClient) {
     console.log("[MAIN] Starting critical services...");
 
-    // Wait for the early PATH refresh (kicked off in app.whenReady) before
-    // forking the PTY host so node-pty inherits the user's full PATH —
-    // version-manager shims (mise/asdf/Volta) and user-local bin dirs are
-    // otherwise invisible to packaged builds (#8625). Awaiting a settled
-    // promise is a no-op when the refresh already finished. If the kick-off
-    // never ran (test/headless contexts), skip the await rather than block.
-    //
-    // Trade-off note: this still gates the first renderer load — IPC
-    // handlers and `startRendererLoad` in windowServices.ts run after
-    // `await initPerWindowServices`. In the P95 case the probe is already
-    // settled (~50ms via shell-env) and the await is instant; in the
-    // worst case it inherits refreshPath's 10s internal timeout, which is
-    // strictly better than the old fixPath() that ran synchronously at
-    // module load, before app.whenReady's intrinsic startup work could
-    // overlap. Fully unblocking renderer load is a follow-up — it requires
-    // registering IPC handlers with a deferred ptyClient ref so PtyClient
-    // construction can move past startRendererLoad.
-    const earlyPathRefresh = getEarlyPathRefreshPromise();
-    if (earlyPathRefresh) {
-      await earlyPathRefresh;
-    }
+    // PtyClient is constructed with `deferStart` so the PTY host fork does NOT
+    // happen here — it is triggered by `ptyClient.start()` in
+    // windowServices.ts *after* `startRendererLoad`, which awaits the early
+    // PATH refresh immediately before forking. That keeps the #8625 invariant
+    // (PATH refresh → PTY fork, so node-pty inherits version-manager shims and
+    // user-local bin dirs in packaged builds) while no longer gating the first
+    // renderer load on the refresh (#8827). Constructing the client here keeps
+    // a live `ptyClient` reference available to IPC handlers at registration
+    // time — only the host fork is deferred, not the client object.
 
     // Start the external main-process watchdog before PtyClient so a deadlock
     // during PTY host fork (worst case: a synchronous spawn that hangs) is
@@ -144,6 +132,10 @@ export async function initPerWindowServices(
     ptyClient = new PtyClient({
       healthCheckIntervalMs: 5000,
       showCrashDialog: false,
+      // Defer the host fork to windowServices.ts (#8827) — see the comment
+      // above. The client object is live now; the fork waits on the PATH
+      // refresh after startRendererLoad.
+      deferStart: true,
     });
     setPtyClientRef(ptyClient);
 

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -16,7 +16,7 @@ import { markPerformance } from "../utils/performance.js";
 import { getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
-import { isSmokeTest, smokeTestStart } from "../setup/environment.js";
+import { isSmokeTest, smokeTestStart, getEarlyPathRefreshPromise } from "../setup/environment.js";
 import { shouldDeferRendererLoadForE2E, shouldEnableEarlyRenderer } from "./earlyRenderer.js";
 import { extractCliPath, getPendingCliPath, setPendingCliPath } from "../lifecycle/appLifecycle.js";
 import type { WindowContext, WindowRegistry } from "./WindowRegistry.js";
@@ -182,9 +182,26 @@ export async function setupWindowServices(
     console.log("[MAIN] E2E renderer-load deferral enabled — waiting for services");
   }
 
+  // Fork the PTY host now — *after* startRendererLoad — so first paint is no
+  // longer blocked by the early PATH refresh (#8827). PtyClient was constructed
+  // with `deferStart` in initPerWindowServices, so the host has not forked yet.
+  // We await the early PATH refresh here, immediately before forking, so
+  // node-pty inherits the user's full PATH (the #8625 invariant: PATH refresh →
+  // PTY fork). Awaiting a settled promise is a no-op; on the P95 path the probe
+  // resolved in ~50ms during the renderer bundle load, so the host forks before
+  // the renderer hydrates. First window only — `start()` is idempotent and
+  // `isHostStarted()` short-circuits subsequent windows.
+  const ptyClient = getPtyClient();
+  if (ptyClient && !ptyClient.isHostStarted()) {
+    const earlyPathRefresh = getEarlyPathRefreshPromise();
+    if (earlyPathRefresh) {
+      await earlyPathRefresh;
+    }
+    ptyClient.start();
+  }
+
   // Initialize workspace client (first window only) — per-project hosts
   // are started on-demand when loadProject() is called, not at init time.
-  const ptyClient = getPtyClient();
   if (!getWorkspaceClientRef()) {
     // Construct the workspace client and prewarm its per-project host
     // concurrently with the PTY host fork. The two utility processes load

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -16,7 +16,12 @@ import { markPerformance } from "../utils/performance.js";
 import { getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
-import { isSmokeTest, smokeTestStart, getEarlyPathRefreshPromise } from "../setup/environment.js";
+import {
+  isSmokeTest,
+  smokeTestStart,
+  getEarlyPathRefreshPromise,
+  kickOffEarlyPathRefresh,
+} from "../setup/environment.js";
 import { shouldDeferRendererLoadForE2E, shouldEnableEarlyRenderer } from "./earlyRenderer.js";
 import { extractCliPath, getPendingCliPath, setPendingCliPath } from "../lifecycle/appLifecycle.js";
 import type { WindowContext, WindowRegistry } from "./WindowRegistry.js";
@@ -193,10 +198,12 @@ export async function setupWindowServices(
   // `isHostStarted()` short-circuits subsequent windows.
   const ptyClient = getPtyClient();
   if (ptyClient && !ptyClient.isHostStarted()) {
-    const earlyPathRefresh = getEarlyPathRefreshPromise();
-    if (earlyPathRefresh) {
-      await earlyPathRefresh;
-    }
+    // Fall back to kicking off the refresh here if it was never started (e.g. a
+    // custom entry path that skips main.ts's app.whenReady kickoff). The kickoff
+    // is idempotent — it returns the cached promise when already running — so
+    // this never double-runs the probe and guarantees the #8625 invariant holds
+    // before the fork rather than silently skipping it on a null promise.
+    await (getEarlyPathRefreshPromise() ?? kickOffEarlyPathRefresh());
     ptyClient.start();
   }
 


### PR DESCRIPTION
## Summary

- Defers forking the PTY host until after the first renderer has started loading, so first paint is no longer blocked by the early PATH refresh (up to 10s worst case on slow machines)
- `PtyClient` gains a `deferStart` constructor option (wires host lifecycle but doesn't fork), an idempotent `start()`, and `isHostStarted()` — `initPerWindowServices` opts in, and `windowServices.ts` calls `ptyClient.start()` after `startRendererLoad`
- The PATH refresh is still awaited immediately before the fork to preserve the #8625 invariant — `node-pty` inherits version-manager shims — with a fallback to `kickOffEarlyPathRefresh()` if the promise is null

Resolves #8827

## Changes

- `electron/services/PtyClient.ts` — `deferStart` option, `start()` + `isHostStarted()`, spawn queue replay in `handleReady` (double-spawn-safe)
- `electron/window/perWindowInit.ts` — constructs `PtyClient` with `deferStart: true`, drops the blocking PATH-refresh await; `ptyClient` ref stays live so IPC-handler registration needed no changes
- `electron/window/windowServices.ts` — forks the host via `ptyClient.start()` after `startRendererLoad`, awaiting the early PATH refresh gate immediately before the fork
- `electron/services/__tests__/PtyClient.deferStart.test.ts` — new test file covering: `deferStart` skips ctor fork, `start()` forks once and is idempotent, default forks in ctor, spawn replay, MessagePort flush

## Testing

Full `npm run check` passes (typecheck, lint, format, IPC codegen). New unit tests in `PtyClient.deferStart.test.ts` cover the deferred-start contract end-to-end including the spawn replay and MessagePort flush paths.