### PR TITLE
perf(build): fix eager vendor-motion chunk defeating LazyMotion deferral

### DIFF
--- a/first-render-chunk-baseline.json
+++ b/first-render-chunk-baseline.json
@@ -7,32 +7,32 @@
     ],
     "missing": []
   },
-  "chunkCount": 49,
+  "chunkCount": 51,
   "chunks": {
-    "_ActionService-BD_IEB7I.js": {
-      "file": "assets/ActionService-BD_IEB7I.js",
+    "_ActionService-C2zQQkyA.js": {
+      "file": "assets/ActionService-C2zQQkyA.js",
       "raw": 47469,
-      "gzip": 11784
+      "gzip": 11783
     },
     "_DockPopoverChildContext-ChP2H22b.js": {
       "file": "assets/DockPopoverChildContext-ChP2H22b.js",
       "raw": 392,
       "gzip": 281
     },
-    "_Spinner-D0RG4ksY.js": {
-      "file": "assets/Spinner-D0RG4ksY.js",
+    "_Spinner-DCsWVOGB.js": {
+      "file": "assets/Spinner-DCsWVOGB.js",
       "raw": 580,
-      "gzip": 398
+      "gzip": 400
     },
-    "_TerminalInstanceService-Bcuef0iQ.js": {
-      "file": "assets/TerminalInstanceService-Bcuef0iQ.js",
-      "raw": 237500,
-      "gzip": 63859
+    "_TerminalInstanceService-D3ZoUZuC.js": {
+      "file": "assets/TerminalInstanceService-D3ZoUZuC.js",
+      "raw": 237462,
+      "gzip": 63834
     },
-    "_YarnIcon-d7ZowL7V.js": {
-      "file": "assets/YarnIcon-d7ZowL7V.js",
+    "_YarnIcon-DAoy-kiD.js": {
+      "file": "assets/YarnIcon-DAoy-kiD.js",
       "raw": 50371,
-      "gzip": 15761
+      "gzip": 15758
     },
     "_agentIds-BGUhMH1o.js": {
       "file": "assets/agentIds-BGUhMH1o.js",
@@ -44,15 +44,15 @@
       "raw": 40239,
       "gzip": 8862
     },
-    "_agentSettingsStore-Bq4sKao6.js": {
-      "file": "assets/agentSettingsStore-Bq4sKao6.js",
-      "raw": 18111,
-      "gzip": 5893
+    "_agentSettingsStore-BRZChoP2.js": {
+      "file": "assets/agentSettingsStore-BRZChoP2.js",
+      "raw": 18110,
+      "gzip": 5895
     },
-    "_agents-YDfwcmY-.js": {
-      "file": "assets/agents-YDfwcmY-.js",
+    "_agents-CdFHQRPD.js": {
+      "file": "assets/agents-CdFHQRPD.js",
       "raw": 5687,
-      "gzip": 2329
+      "gzip": 2328
     },
     "_animationUtils-gokF-ql-.js": {
       "file": "assets/animationUtils-gokF-ql-.js",
@@ -64,10 +64,10 @@
       "raw": 364,
       "gzip": 197
     },
-    "_appThemeStore-CZzlj9wZ.js": {
-      "file": "assets/appThemeStore-CZzlj9wZ.js",
+    "_appThemeStore-C4OSE8Oy.js": {
+      "file": "assets/appThemeStore-C4OSE8Oy.js",
       "raw": 4133,
-      "gzip": 1393
+      "gzip": 1392
     },
     "_clients-B46vBAnG.js": {
       "file": "assets/clients-B46vBAnG.js",
@@ -84,8 +84,8 @@
       "raw": 507,
       "gzip": 197
     },
-    "_devServerDetection-_LUh8wK_.js": {
-      "file": "assets/devServerDetection-_LUh8wK_.js",
+    "_devServerDetection-BpcXT5Td.js": {
+      "file": "assets/devServerDetection-BpcXT5Td.js",
       "raw": 692,
       "gzip": 405
     },
@@ -109,15 +109,15 @@
       "raw": 597,
       "gzip": 305
     },
-    "_notificationSettingsStore-DuyqMf-A.js": {
-      "file": "assets/notificationSettingsStore-DuyqMf-A.js",
+    "_notificationSettingsStore-CHREBWM9.js": {
+      "file": "assets/notificationSettingsStore-CHREBWM9.js",
       "raw": 1951,
-      "gzip": 600
+      "gzip": 598
     },
-    "_notify-SUPYAXKc.js": {
-      "file": "assets/notify-SUPYAXKc.js",
+    "_notify-DhvSVZ9l.js": {
+      "file": "assets/notify-DhvSVZ9l.js",
       "raw": 9274,
-      "gzip": 3536
+      "gzip": 3538
     },
     "_path-Z0ZMZY69.js": {
       "file": "assets/path-Z0ZMZY69.js",
@@ -134,20 +134,20 @@
       "raw": 1348,
       "gzip": 735
     },
-    "_projectSettingsStore-CbmsWjHb.js": {
-      "file": "assets/projectSettingsStore-CbmsWjHb.js",
+    "_projectSettingsStore-CFJO60YP.js": {
+      "file": "assets/projectSettingsStore-CFJO60YP.js",
       "raw": 1920,
-      "gzip": 830
+      "gzip": 828
     },
-    "_projectStore-DGJpEK1H.js": {
-      "file": "assets/projectStore-DGJpEK1H.js",
-      "raw": 15129,
-      "gzip": 5046
+    "_projectStore-Bwf7akYu.js": {
+      "file": "assets/projectStore-Bwf7akYu.js",
+      "raw": 15128,
+      "gzip": 5044
     },
-    "_radix-loader-CpBpwuzG.js": {
-      "file": "assets/radix-loader-CpBpwuzG.js",
+    "_radix-loader-DVaZuFjj.js": {
+      "file": "assets/radix-loader-DVaZuFjj.js",
       "raw": 1065,
-      "gzip": 584
+      "gzip": 585
     },
     "_rolldown-runtime-BYbx6iT9.js": {
       "file": "assets/rolldown-runtime-BYbx6iT9.js",
@@ -159,45 +159,45 @@
       "raw": 6339,
       "gzip": 2423
     },
-    "_store-ApmCYkgj.js": {
-      "file": "assets/store-ApmCYkgj.js",
+    "_store-CScacg51.js": {
+      "file": "assets/store-CScacg51.js",
       "raw": 34011,
-      "gzip": 9996
+      "gzip": 9998
     },
-    "_systemWakeStore-cgMoB5P5.js": {
-      "file": "assets/systemWakeStore-cgMoB5P5.js",
+    "_systemWakeStore-Bm8sjiAU.js": {
+      "file": "assets/systemWakeStore-Bm8sjiAU.js",
       "raw": 4126,
-      "gzip": 1506
+      "gzip": 1501
     },
-    "_terminalInputStore-DIpd-8Wf.js": {
-      "file": "assets/terminalInputStore-DIpd-8Wf.js",
-      "raw": 7242,
-      "gzip": 2462
+    "_terminalInputStore-CztmYWum.js": {
+      "file": "assets/terminalInputStore-CztmYWum.js",
+      "raw": 7209,
+      "gzip": 2447
     },
     "_theme-CWFyV7D3.js": {
       "file": "assets/theme-CWFyV7D3.js",
       "raw": 81761,
       "gzip": 18430
     },
-    "_uiStore-Dy0HlWJC.js": {
-      "file": "assets/uiStore-Dy0HlWJC.js",
+    "_uiStore-BD_C-l11.js": {
+      "file": "assets/uiStore-BD_C-l11.js",
       "raw": 3625,
-      "gzip": 1141
+      "gzip": 1140
     },
-    "_useFindInPage-B7xKypRA.js": {
-      "file": "assets/useFindInPage-B7xKypRA.js",
+    "_useFindInPage-BEL0W-LD.js": {
+      "file": "assets/useFindInPage-BEL0W-LD.js",
       "raw": 31583,
-      "gzip": 9889
+      "gzip": 9888
     },
-    "_utils-OKqyCzKx.js": {
-      "file": "assets/utils-OKqyCzKx.js",
+    "_utils-DcOT_bIO.js": {
+      "file": "assets/utils-DcOT_bIO.js",
       "raw": 218,
-      "gzip": 192
+      "gzip": 190
     },
-    "_vendor-DdKuKMwv.js": {
-      "file": "assets/vendor-DdKuKMwv.js",
-      "raw": 517312,
-      "gzip": 167045
+    "_vendor-C1evQpdv.js": {
+      "file": "assets/vendor-C1evQpdv.js",
+      "raw": 425479,
+      "gzip": 137355
     },
     "_vendor-editor-DCJ2nCoQ.js": {
       "file": "assets/vendor-editor-DCJ2nCoQ.js",
@@ -209,10 +209,20 @@
       "raw": 48930,
       "gzip": 14742
     },
-    "_vendor-motion-W5EkcZZp.js": {
-      "file": "assets/vendor-motion-W5EkcZZp.js",
-      "raw": 44157,
-      "gzip": 15892
+    "_vendor-motion~index-DR4T-X0K.js": {
+      "file": "assets/vendor-motion~index-DR4T-X0K.js",
+      "raw": 12980,
+      "gzip": 5372
+    },
+    "_vendor-motion~index~BrowserPane~DevPreviewPane~FileViewerModal~HybridInputBar~ReviewPane~Ap~f0jpa849-DrXG8GdX.js": {
+      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~FileViewerModal~HybridInputBar~ReviewPane~Ap~f0jpa849-DrXG8GdX.js",
+      "raw": 31563,
+      "gzip": 11377
+    },
+    "_vendor-motion~index~BrowserPane~DevPreviewPane~FileViewerModal~HybridInputBar~ReviewPane~Ap~k862lu9h-ByLiEPqR.js": {
+      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~FileViewerModal~HybridInputBar~ReviewPane~Ap~k862lu9h-ByLiEPqR.js",
+      "raw": 269,
+      "gzip": 201
     },
     "_vendor-radix-utils-B8hOEnPQ.js": {
       "file": "assets/vendor-radix-utils-B8hOEnPQ.js",
@@ -234,33 +244,33 @@
       "raw": 74222,
       "gzip": 19574
     },
-    "_viewportPresets-BR-485Wi.js": {
-      "file": "assets/viewportPresets-BR-485Wi.js",
+    "_viewportPresets-1tZgI4bj.js": {
+      "file": "assets/viewportPresets-1tZgI4bj.js",
       "raw": 1062,
       "gzip": 484
     },
     "index.html": {
-      "file": "assets/index-CJeJW1C4.js",
-      "raw": 537037,
-      "gzip": 168630
+      "file": "assets/index-cyXCmjqi.js",
+      "raw": 537326,
+      "gzip": 168780
     },
     "src/components/Browser/BrowserPane.tsx": {
-      "file": "assets/BrowserPane-amUEL9Ce.js",
+      "file": "assets/BrowserPane-BvC1Kr55.js",
       "raw": 21052,
-      "gzip": 7407
+      "gzip": 7405
     },
     "src/components/DevPreview/DevPreviewPane.tsx": {
-      "file": "assets/DevPreviewPane-s63N2QTK.js",
+      "file": "assets/DevPreviewPane-BpDwUnIW.js",
       "raw": 69736,
-      "gzip": 21113
+      "gzip": 21116
     }
   },
   "eagerTotals": {
-    "raw": 3089742,
-    "gzip": 928997
+    "raw": 2998780,
+    "gzip": 900464
   },
   "totals": {
-    "raw": 7221132,
-    "gzip": 2281011
+    "raw": 7224137,
+    "gzip": 2284548
   }
 }

--- a/first-render-chunk-baseline.json
+++ b/first-render-chunk-baseline.json
@@ -7,440 +7,215 @@
     ],
     "missing": []
   },
-  "chunkCount": 270,
+  "chunkCount": 49,
   "chunks": {
-    "_ActionService-RslQ_ueJ.js": {
-      "file": "assets/ActionService-RslQ_ueJ.js",
-      "raw": 33788,
-      "gzip": 8179
+    "_ActionService-BD_IEB7I.js": {
+      "file": "assets/ActionService-BD_IEB7I.js",
+      "raw": 47469,
+      "gzip": 11784
     },
-    "_AgentCard-Dt3HCXpJ.js": {
-      "file": "assets/AgentCard-Dt3HCXpJ.js",
-      "raw": 12508,
-      "gzip": 4632
-    },
-    "_DiffViewer-CQUVML7V.js": {
-      "file": "assets/DiffViewer-CQUVML7V.js",
-      "raw": 31121,
-      "gzip": 11552
-    },
-    "_DockPopoverChildContext-ynb1Cny2.js": {
-      "file": "assets/DockPopoverChildContext-ynb1Cny2.js",
+    "_DockPopoverChildContext-ChP2H22b.js": {
+      "file": "assets/DockPopoverChildContext-ChP2H22b.js",
       "raw": 392,
       "gzip": 281
     },
-    "_GitHubDropdownSkeletons-BAgpEInj.js": {
-      "file": "assets/GitHubDropdownSkeletons-BAgpEInj.js",
-      "raw": 6507,
-      "gzip": 1998
-    },
-    "_KeyboardShortcuts-BavkHHPX.js": {
-      "file": "assets/KeyboardShortcuts-BavkHHPX.js",
-      "raw": 7194,
-      "gzip": 2699
-    },
-    "_LiveTimeAgo-C_HeeC3u.js": {
-      "file": "assets/LiveTimeAgo-C_HeeC3u.js",
-      "raw": 2478,
-      "gzip": 1265
-    },
-    "_McpAuditLogViewer-GquJTjlE.js": {
-      "file": "assets/McpAuditLogViewer-GquJTjlE.js",
-      "raw": 8439,
-      "gzip": 3068
-    },
-    "_PaletteStrip-DHErTp7-.js": {
-      "file": "assets/PaletteStrip-DHErTp7-.js",
-      "raw": 632,
-      "gzip": 432
-    },
-    "_RecipeEditor-qR_j-Elz.js": {
-      "file": "assets/RecipeEditor-qR_j-Elz.js",
-      "raw": 14426,
-      "gzip": 3518
-    },
-    "_ReviewHubContent-D9Cc82iI.js": {
-      "file": "assets/ReviewHubContent-D9Cc82iI.js",
-      "raw": 115320,
-      "gzip": 30609
-    },
-    "_SearchablePalette-DZBZ3Agd.js": {
-      "file": "assets/SearchablePalette-DZBZ3Agd.js",
-      "raw": 32713,
-      "gzip": 11405
-    },
-    "_SettingsCheckbox-Dd_XTmyF.js": {
-      "file": "assets/SettingsCheckbox-Dd_XTmyF.js",
-      "raw": 3332,
-      "gzip": 1577
-    },
-    "_SettingsChoicebox-CImX15Ul.js": {
-      "file": "assets/SettingsChoicebox-CImX15Ul.js",
-      "raw": 4140,
-      "gzip": 1623
-    },
-    "_SettingsFlushRegistry-D4LkiXfD.js": {
-      "file": "assets/SettingsFlushRegistry-D4LkiXfD.js",
-      "raw": 1314,
-      "gzip": 710
-    },
-    "_SettingsInput-BQzmOGxP.js": {
-      "file": "assets/SettingsInput-BQzmOGxP.js",
-      "raw": 2123,
-      "gzip": 975
-    },
-    "_SettingsSection-Clp93bnR.js": {
-      "file": "assets/SettingsSection-Clp93bnR.js",
-      "raw": 1570,
-      "gzip": 881
-    },
-    "_SettingsSelect-DS2atd1N.js": {
-      "file": "assets/SettingsSelect-DS2atd1N.js",
-      "raw": 2179,
-      "gzip": 1007
-    },
-    "_SettingsSubtabBar-B4o4L9GQ.js": {
-      "file": "assets/SettingsSubtabBar-B4o4L9GQ.js",
-      "raw": 1815,
-      "gzip": 962
-    },
-    "_SettingsSwitch-BCuTl9SI.js": {
-      "file": "assets/SettingsSwitch-BCuTl9SI.js",
-      "raw": 1972,
-      "gzip": 861
-    },
-    "_SettingsSwitchCard-CSSydkMW.js": {
-      "file": "assets/SettingsSwitchCard-CSSydkMW.js",
-      "raw": 4134,
-      "gzip": 1958
-    },
-    "_SettingsValidationRegistry-DOy4qOQS.js": {
-      "file": "assets/SettingsValidationRegistry-DOy4qOQS.js",
-      "raw": 1239,
-      "gzip": 688
-    },
-    "_ShortcutReferenceDialog-DVdi4Dwf.js": {
-      "file": "assets/ShortcutReferenceDialog-DVdi4Dwf.js",
-      "raw": 4682,
-      "gzip": 2088
-    },
-    "_Spinner-CL4u7o_q.js": {
-      "file": "assets/Spinner-CL4u7o_q.js",
+    "_Spinner-D0RG4ksY.js": {
+      "file": "assets/Spinner-D0RG4ksY.js",
       "raw": 580,
-      "gzip": 396
+      "gzip": 398
     },
-    "_TerminalInstanceService-PSKPFlQf.js": {
-      "file": "assets/TerminalInstanceService-PSKPFlQf.js",
-      "raw": 221599,
-      "gzip": 59341
+    "_TerminalInstanceService-Bcuef0iQ.js": {
+      "file": "assets/TerminalInstanceService-Bcuef0iQ.js",
+      "raw": 237500,
+      "gzip": 63859
     },
-    "_TruncatedTooltip-DEJMK9Zn.js": {
-      "file": "assets/TruncatedTooltip-DEJMK9Zn.js",
-      "raw": 1324,
-      "gzip": 808
-    },
-    "_YarnIcon-BxaD62AZ.js": {
-      "file": "assets/YarnIcon-BxaD62AZ.js",
+    "_YarnIcon-d7ZowL7V.js": {
+      "file": "assets/YarnIcon-d7ZowL7V.js",
       "raw": 50371,
-      "gzip": 15759
+      "gzip": 15761
     },
-    "_agentRegistry-by6K6dGN.js": {
-      "file": "assets/agentRegistry-by6K6dGN.js",
-      "raw": 40410,
-      "gzip": 8946
+    "_agentIds-BGUhMH1o.js": {
+      "file": "assets/agentIds-BGUhMH1o.js",
+      "raw": 270,
+      "gzip": 204
     },
-    "_agentSettingsStore-CJ3Up28V.js": {
-      "file": "assets/agentSettingsStore-CJ3Up28V.js",
-      "raw": 16468,
-      "gzip": 5397
+    "_agentRegistry-DUPDq0Ho.js": {
+      "file": "assets/agentRegistry-DUPDq0Ho.js",
+      "raw": 40239,
+      "gzip": 8862
     },
-    "_agents-y1noft8V.js": {
-      "file": "assets/agents-y1noft8V.js",
+    "_agentSettingsStore-Bq4sKao6.js": {
+      "file": "assets/agentSettingsStore-Bq4sKao6.js",
+      "raw": 18111,
+      "gzip": 5893
+    },
+    "_agents-YDfwcmY-.js": {
+      "file": "assets/agents-YDfwcmY-.js",
       "raw": 5687,
       "gzip": 2329
     },
-    "_appClient-Cj2qup3O.js": {
-      "file": "assets/appClient-Cj2qup3O.js",
+    "_animationUtils-gokF-ql-.js": {
+      "file": "assets/animationUtils-gokF-ql-.js",
+      "raw": 986,
+      "gzip": 453
+    },
+    "_appClient-B1_n5MKf.js": {
+      "file": "assets/appClient-B1_n5MKf.js",
       "raw": 364,
       "gzip": 197
     },
-    "_appThemeStore-dAMca3p8.js": {
-      "file": "assets/appThemeStore-dAMca3p8.js",
-      "raw": 4145,
-      "gzip": 1397
+    "_appThemeStore-CZzlj9wZ.js": {
+      "file": "assets/appThemeStore-CZzlj9wZ.js",
+      "raw": 4133,
+      "gzip": 1393
     },
-    "_appThemeViewTransition-C_daPpYH.js": {
-      "file": "assets/appThemeViewTransition-C_daPpYH.js",
-      "raw": 735,
-      "gzip": 438
+    "_clients-B46vBAnG.js": {
+      "file": "assets/clients-B46vBAnG.js",
+      "raw": 22461,
+      "gzip": 5638
     },
-    "_categoryColors-By_eWwv9.js": {
-      "file": "assets/categoryColors-By_eWwv9.js",
-      "raw": 1371,
-      "gzip": 486
-    },
-    "_checklistItems-CC5SR_sJ.js": {
-      "file": "assets/checklistItems-CC5SR_sJ.js",
-      "raw": 827,
-      "gzip": 473
-    },
-    "_clients-QKgdBxVH.js": {
-      "file": "assets/clients-QKgdBxVH.js",
-      "raw": 20668,
-      "gzip": 5168
-    },
-    "_clike-CWlSj2jT.js": {
-      "file": "assets/clike-CWlSj2jT.js",
-      "raw": 768,
-      "gzip": 483
-    },
-    "_commandsClient-DjMXuZan.js": {
-      "file": "assets/commandsClient-DjMXuZan.js",
+    "_commandsClient-LWwSlIFK.js": {
+      "file": "assets/commandsClient-LWwSlIFK.js",
       "raw": 203,
       "gzip": 114
     },
-    "_copyTreeClient-BcrsQav4.js": {
-      "file": "assets/copyTreeClient-BcrsQav4.js",
+    "_copyTreeClient-C5Urx0vx.js": {
+      "file": "assets/copyTreeClient-C5Urx0vx.js",
       "raw": 507,
       "gzip": 197
     },
-    "_css-K2AH56mt.js": {
-      "file": "assets/css-K2AH56mt.js",
-      "raw": 1295,
-      "gzip": 646
+    "_devServerDetection-_LUh8wK_.js": {
+      "file": "assets/devServerDetection-_LUh8wK_.js",
+      "raw": 692,
+      "gzip": 405
     },
-    "_devServerDetection-rDBAF-M0.js": {
-      "file": "assets/devServerDetection-rDBAF-M0.js",
-      "raw": 432,
-      "gzip": 296
+    "_errorMessage-CtTMVRB6.js": {
+      "file": "assets/errorMessage-CtTMVRB6.js",
+      "raw": 3457,
+      "gzip": 1390
     },
-    "_dist-D-CZq_Kh.js": {
-      "file": "assets/dist-D-CZq_Kh.js",
-      "raw": 25820,
-      "gzip": 11826
+    "_forgeProviderIds-DUqhfDBm.js": {
+      "file": "assets/forgeProviderIds-DUqhfDBm.js",
+      "raw": 221,
+      "gzip": 170
     },
-    "_dist-DySMiBIw.js": {
-      "file": "assets/dist-DySMiBIw.js",
-      "raw": 84602,
-      "gzip": 32595
-    },
-    "_envVars-BasTmjVn.js": {
-      "file": "assets/envVars-BasTmjVn.js",
-      "raw": 129,
-      "gzip": 133
-    },
-    "_errorMessage-B-9EYoRB.js": {
-      "file": "assets/errorMessage-B-9EYoRB.js",
-      "raw": 5868,
-      "gzip": 2329
-    },
-    "_folderName-SLx7VF0z.js": {
-      "file": "assets/folderName-SLx7VF0z.js",
-      "raw": 803,
-      "gzip": 428
-    },
-    "_gitPullRebaseConfirmStore-Cz64yeMU.js": {
-      "file": "assets/gitPullRebaseConfirmStore-Cz64yeMU.js",
-      "raw": 317,
-      "gzip": 201
-    },
-    "_gitPushConfirmStore-BOSRWzBP.js": {
-      "file": "assets/gitPushConfirmStore-BOSRWzBP.js",
-      "raw": 317,
-      "gzip": 201
-    },
-    "_githubConfigStore-Dn7FPLIV.js": {
-      "file": "assets/githubConfigStore-Dn7FPLIV.js",
-      "raw": 659,
-      "gzip": 335
-    },
-    "_githubFilterStore-B8TmN6xw.js": {
-      "file": "assets/githubFilterStore-B8TmN6xw.js",
-      "raw": 886,
-      "gzip": 402
-    },
-    "_githubRateLimitStore-BoDEifmQ.js": {
-      "file": "assets/githubRateLimitStore-BoDEifmQ.js",
-      "raw": 215,
-      "gzip": 156
-    },
-    "_globalEnvClient-CxNpzj0p.js": {
-      "file": "assets/globalEnvClient-CxNpzj0p.js",
+    "_globalEnvClient-DUHxoiFq.js": {
+      "file": "assets/globalEnvClient-DUHxoiFq.js",
       "raw": 436,
       "gzip": 274
     },
-    "_logger-BBiZsQQ1.js": {
-      "file": "assets/logger-BBiZsQQ1.js",
+    "_logger-CNEaHcct.js": {
+      "file": "assets/logger-CNEaHcct.js",
       "raw": 597,
       "gzip": 305
     },
-    "_markup-D3goqdIU.js": {
-      "file": "assets/markup-D3goqdIU.js",
-      "raw": 2941,
-      "gzip": 1178
-    },
-    "_mcpConfirmStore-X98YED_Z.js": {
-      "file": "assets/mcpConfirmStore-X98YED_Z.js",
-      "raw": 806,
-      "gzip": 433
-    },
-    "_memoryLeakConfigStore-BWDEhfqk.js": {
-      "file": "assets/memoryLeakConfigStore-BWDEhfqk.js",
-      "raw": 304,
-      "gzip": 199
-    },
-    "_notificationSettingsStore-7ifRGxYO.js": {
-      "file": "assets/notificationSettingsStore-7ifRGxYO.js",
+    "_notificationSettingsStore-DuyqMf-A.js": {
+      "file": "assets/notificationSettingsStore-DuyqMf-A.js",
       "raw": 1951,
-      "gzip": 601
+      "gzip": 600
     },
-    "_notify-Dr-OfE6t.js": {
-      "file": "assets/notify-Dr-OfE6t.js",
+    "_notify-SUPYAXKc.js": {
+      "file": "assets/notify-SUPYAXKc.js",
       "raw": 9274,
-      "gzip": 3540
+      "gzip": 3536
     },
-    "_panelSpawning-uS9DBeQG.js": {
-      "file": "assets/panelSpawning-uS9DBeQG.js",
-      "raw": 11728,
-      "gzip": 4473
-    },
-    "_path-BORhKaM5.js": {
-      "file": "assets/path-BORhKaM5.js",
+    "_path-Z0ZMZY69.js": {
+      "file": "assets/path-Z0ZMZY69.js",
       "raw": 1234,
       "gzip": 605
     },
-    "_persistedStoreRegistry-DHLBhAMA.js": {
-      "file": "assets/persistedStoreRegistry-DHLBhAMA.js",
-      "raw": 9248,
-      "gzip": 2946
+    "_persistedStoreRegistry-BicILN93.js": {
+      "file": "assets/persistedStoreRegistry-BicILN93.js",
+      "raw": 9297,
+      "gzip": 2953
     },
-    "_preload-helper-CX0F4GpD.js": {
-      "file": "assets/preload-helper-CX0F4GpD.js",
+    "_preload-helper-DoRJmi8c.js": {
+      "file": "assets/preload-helper-DoRJmi8c.js",
       "raw": 1348,
       "gzip": 735
     },
-    "_projectSettingsStore-DF0ETkOJ.js": {
-      "file": "assets/projectSettingsStore-DF0ETkOJ.js",
-      "raw": 1915,
-      "gzip": 837
+    "_projectSettingsStore-CbmsWjHb.js": {
+      "file": "assets/projectSettingsStore-CbmsWjHb.js",
+      "raw": 1920,
+      "gzip": 830
     },
-    "_projectStore-BB3f9fc_.js": {
-      "file": "assets/projectStore-BB3f9fc_.js",
-      "raw": 13955,
-      "gzip": 4681
+    "_projectStore-DGJpEK1H.js": {
+      "file": "assets/projectStore-DGJpEK1H.js",
+      "raw": 15129,
+      "gzip": 5046
     },
-    "_radix-loader-CLYvGiqa.js": {
-      "file": "assets/radix-loader-CLYvGiqa.js",
+    "_radix-loader-CpBpwuzG.js": {
+      "file": "assets/radix-loader-CpBpwuzG.js",
       "raw": 1065,
-      "gzip": 588
+      "gzip": 584
     },
     "_rolldown-runtime-BYbx6iT9.js": {
       "file": "assets/rolldown-runtime-BYbx6iT9.js",
       "raw": 826,
       "gzip": 473
     },
-    "_safeStorage-OWVGK_-B.js": {
-      "file": "assets/safeStorage-OWVGK_-B.js",
-      "raw": 6331,
-      "gzip": 2422
+    "_safeStorage-CkijxjBb.js": {
+      "file": "assets/safeStorage-CkijxjBb.js",
+      "raw": 6339,
+      "gzip": 2423
     },
-    "_select-BEcCDoiA.js": {
-      "file": "assets/select-BEcCDoiA.js",
-      "raw": 9641,
-      "gzip": 3406
+    "_store-ApmCYkgj.js": {
+      "file": "assets/store-ApmCYkgj.js",
+      "raw": 34011,
+      "gzip": 9996
     },
-    "_settingsTabRegistry-A_78LQ7x.js": {
-      "file": "assets/settingsTabRegistry-A_78LQ7x.js",
-      "raw": 65161,
-      "gzip": 16817
-    },
-    "_simple-mode-B9ErAHMD.js": {
-      "file": "assets/simple-mode-B9ErAHMD.js",
-      "raw": 2295,
-      "gzip": 1099
-    },
-    "_sortableAnnouncements-UcEI1uGw.js": {
-      "file": "assets/sortableAnnouncements-UcEI1uGw.js",
-      "raw": 3407,
-      "gzip": 1700
-    },
-    "_svg-CAXG-2MA.js": {
-      "file": "assets/svg-CAXG-2MA.js",
-      "raw": 121,
-      "gzip": 127
-    },
-    "_svgSanitizer-Dqw0NOm6.js": {
-      "file": "assets/svgSanitizer-Dqw0NOm6.js",
-      "raw": 1966,
-      "gzip": 999
-    },
-    "_systemWakeStore-HvIQi6OZ.js": {
-      "file": "assets/systemWakeStore-HvIQi6OZ.js",
+    "_systemWakeStore-cgMoB5P5.js": {
+      "file": "assets/systemWakeStore-cgMoB5P5.js",
       "raw": 4126,
-      "gzip": 1515
+      "gzip": 1506
     },
-    "_terminalInputStore-CYrxR5WA.js": {
-      "file": "assets/terminalInputStore-CYrxR5WA.js",
-      "raw": 7145,
-      "gzip": 2412
+    "_terminalInputStore-DIpd-8Wf.js": {
+      "file": "assets/terminalInputStore-DIpd-8Wf.js",
+      "raw": 7242,
+      "gzip": 2462
     },
-    "_theme-BK8aPnTM.js": {
-      "file": "assets/theme-BK8aPnTM.js",
-      "raw": 80929,
-      "gzip": 18128
+    "_theme-CWFyV7D3.js": {
+      "file": "assets/theme-CWFyV7D3.js",
+      "raw": 81761,
+      "gzip": 18430
     },
-    "_uiStore-DIzjtRVj.js": {
-      "file": "assets/uiStore-DIzjtRVj.js",
+    "_uiStore-Dy0HlWJC.js": {
+      "file": "assets/uiStore-Dy0HlWJC.js",
       "raw": 3625,
-      "gzip": 1144
+      "gzip": 1141
     },
-    "_useAgentDiscoveryOnboarding-LkgWej4D.js": {
-      "file": "assets/useAgentDiscoveryOnboarding-LkgWej4D.js",
-      "raw": 2773,
-      "gzip": 1050
+    "_useFindInPage-B7xKypRA.js": {
+      "file": "assets/useFindInPage-B7xKypRA.js",
+      "raw": 31583,
+      "gzip": 9889
     },
-    "_useFindInPage-DRDBUrrx.js": {
-      "file": "assets/useFindInPage-DRDBUrrx.js",
-      "raw": 31560,
-      "gzip": 9848
-    },
-    "_utils-DXZJwFPf.js": {
-      "file": "assets/utils-DXZJwFPf.js",
+    "_utils-OKqyCzKx.js": {
+      "file": "assets/utils-OKqyCzKx.js",
       "raw": 218,
       "gzip": 192
     },
-    "_vendor-2j7B9pWz.js": {
-      "file": "assets/vendor-2j7B9pWz.js",
-      "raw": 425474,
-      "gzip": 137259
+    "_vendor-DdKuKMwv.js": {
+      "file": "assets/vendor-DdKuKMwv.js",
+      "raw": 517312,
+      "gzip": 167045
     },
     "_vendor-editor-DCJ2nCoQ.js": {
       "file": "assets/vendor-editor-DCJ2nCoQ.js",
       "raw": 450309,
       "gzip": 145334
     },
-    "_vendor-icons-DUuUOeEj.js": {
-      "file": "assets/vendor-icons-DUuUOeEj.js",
-      "raw": 48585,
-      "gzip": 14660
+    "_vendor-icons-DylfXlX7.js": {
+      "file": "assets/vendor-icons-DylfXlX7.js",
+      "raw": 48930,
+      "gzip": 14742
     },
-    "_vendor-motion-Bn0puKrQ.js": {
-      "file": "assets/vendor-motion-Bn0puKrQ.js",
-      "raw": 133079,
-      "gzip": 43154
+    "_vendor-motion-W5EkcZZp.js": {
+      "file": "assets/vendor-motion-W5EkcZZp.js",
+      "raw": 44157,
+      "gzip": 15892
     },
-    "_vendor-radix-BRAyrQjZ.js": {
-      "file": "assets/vendor-radix-BRAyrQjZ.js",
-      "raw": 5056,
-      "gzip": 1920
-    },
-    "_vendor-radix-overlay-CFSsOYXg.js": {
-      "file": "assets/vendor-radix-overlay-CFSsOYXg.js",
-      "raw": 105042,
-      "gzip": 31873
-    },
-    "_vendor-radix-utils-C5GfsDKb.js": {
-      "file": "assets/vendor-radix-utils-C5GfsDKb.js",
+    "_vendor-radix-utils-B8hOEnPQ.js": {
+      "file": "assets/vendor-radix-utils-B8hOEnPQ.js",
       "raw": 14557,
       "gzip": 3262
     },
@@ -449,919 +224,43 @@
       "raw": 181960,
       "gzip": 56449
     },
-    "_vendor-xterm-BYLkEf-P.js": {
-      "file": "assets/vendor-xterm-BYLkEf-P.js",
+    "_vendor-xterm-BBb7-BTx.js": {
+      "file": "assets/vendor-xterm-BBb7-BTx.js",
       "raw": 483783,
       "gzip": 127757
     },
-    "_vendor-xterm-webgl-DYOqWTNb.js": {
-      "file": "assets/vendor-xterm-webgl-DYOqWTNb.js",
-      "raw": 120961,
-      "gzip": 33517
+    "_vendor-zod-DsZjdFKX.js": {
+      "file": "assets/vendor-zod-DsZjdFKX.js",
+      "raw": 74222,
+      "gzip": 19574
     },
-    "_vendor-zod-e2rqZAkt.js": {
-      "file": "assets/vendor-zod-e2rqZAkt.js",
-      "raw": 73735,
-      "gzip": 19421
-    },
-    "_viewportPresets-C5bFDtRK.js": {
-      "file": "assets/viewportPresets-C5bFDtRK.js",
+    "_viewportPresets-BR-485Wi.js": {
+      "file": "assets/viewportPresets-BR-485Wi.js",
       "raw": 1062,
       "gzip": 484
     },
     "index.html": {
-      "file": "assets/index-DWetA42l.js",
-      "raw": 543704,
-      "gzip": 169743
-    },
-    "node_modules/@codemirror/lang-cpp/dist/index.js": {
-      "file": "assets/dist-sqRLbGvT.js",
-      "raw": 100552,
-      "gzip": 32451
-    },
-    "node_modules/@codemirror/lang-go/dist/index.js": {
-      "file": "assets/dist-Czz1VKf6.js",
-      "raw": 30696,
-      "gzip": 12279
-    },
-    "node_modules/@codemirror/lang-html/dist/index.js": {
-      "file": "assets/dist-DrIq0M5f.js",
-      "raw": 28273,
-      "gzip": 11202
-    },
-    "node_modules/@codemirror/lang-java/dist/index.js": {
-      "file": "assets/dist-S3RqgiXL.js",
-      "raw": 40720,
-      "gzip": 16122
-    },
-    "node_modules/@codemirror/lang-jinja/dist/index.js": {
-      "file": "assets/dist-oaPPFXyf.js",
-      "raw": 20718,
-      "gzip": 9022
-    },
-    "node_modules/@codemirror/lang-json/dist/index.js": {
-      "file": "assets/dist-iA5LYmF1.js",
-      "raw": 2002,
-      "gzip": 1244
-    },
-    "node_modules/@codemirror/lang-less/dist/index.js": {
-      "file": "assets/dist-Sky4enFz.js",
-      "raw": 16245,
-      "gzip": 7203
-    },
-    "node_modules/@codemirror/lang-liquid/dist/index.js": {
-      "file": "assets/dist-kvmkVdke.js",
-      "raw": 20972,
-      "gzip": 9372
-    },
-    "node_modules/@codemirror/lang-markdown/dist/index.js": {
-      "file": "assets/dist-BEg45WAZ.js",
-      "raw": 43672,
-      "gzip": 14943
-    },
-    "node_modules/@codemirror/lang-php/dist/index.js": {
-      "file": "assets/dist-C0LjED9c.js",
-      "raw": 97754,
-      "gzip": 27869
-    },
-    "node_modules/@codemirror/lang-python/dist/index.js": {
-      "file": "assets/dist-Af62g5Cr.js",
-      "raw": 44572,
-      "gzip": 18504
-    },
-    "node_modules/@codemirror/lang-rust/dist/index.js": {
-      "file": "assets/dist-kRpF17eq.js",
-      "raw": 70807,
-      "gzip": 25038
-    },
-    "node_modules/@codemirror/lang-sass/dist/index.js": {
-      "file": "assets/dist-h_5fDWSf.js",
-      "raw": 22969,
-      "gzip": 9956
-    },
-    "node_modules/@codemirror/lang-sql/dist/index.js": {
-      "file": "assets/dist-QYLdw_X7.js",
-      "raw": 17039,
-      "gzip": 7238
-    },
-    "node_modules/@codemirror/lang-vue/dist/index.js": {
-      "file": "assets/dist-B-_VOt0q.js",
-      "raw": 3339,
-      "gzip": 1677
-    },
-    "node_modules/@codemirror/lang-wast/dist/index.js": {
-      "file": "assets/dist-DWfpmxuA.js",
-      "raw": 2620,
-      "gzip": 1461
-    },
-    "node_modules/@codemirror/lang-xml/dist/index.js": {
-      "file": "assets/dist-CeiS7n52.js",
-      "raw": 14348,
-      "gzip": 5701
-    },
-    "node_modules/@codemirror/lang-yaml/dist/index.js": {
-      "file": "assets/dist-BKlf00rn.js",
-      "raw": 11568,
-      "gzip": 5060
-    },
-    "node_modules/@codemirror/legacy-modes/mode/apl.js": {
-      "file": "assets/apl-HYRstREL.js",
-      "raw": 2292,
-      "gzip": 1194
-    },
-    "node_modules/@codemirror/legacy-modes/mode/asciiarmor.js": {
-      "file": "assets/asciiarmor-BDXCrhAK.js",
-      "raw": 792,
-      "gzip": 402
-    },
-    "node_modules/@codemirror/legacy-modes/mode/asn1.js": {
-      "file": "assets/asn1-CnSBhb0M.js",
-      "raw": 3956,
-      "gzip": 1912
-    },
-    "node_modules/@codemirror/legacy-modes/mode/asterisk.js": {
-      "file": "assets/asterisk-AqV7rnIi.js",
-      "raw": 4079,
-      "gzip": 1750
-    },
-    "node_modules/@codemirror/legacy-modes/mode/brainfuck.js": {
-      "file": "assets/brainfuck-Dv46-iL9.js",
-      "raw": 599,
-      "gzip": 318
-    },
-    "node_modules/@codemirror/legacy-modes/mode/clike.js": {
-      "file": "assets/clike-GRffz5hY.js",
-      "raw": 22061,
-      "gzip": 7643
-    },
-    "node_modules/@codemirror/legacy-modes/mode/clojure.js": {
-      "file": "assets/clojure-DzgT_fqE.js",
-      "raw": 9406,
-      "gzip": 3961
-    },
-    "node_modules/@codemirror/legacy-modes/mode/cmake.js": {
-      "file": "assets/cmake-Co1237r5.js",
-      "raw": 780,
-      "gzip": 460
-    },
-    "node_modules/@codemirror/legacy-modes/mode/cobol.js": {
-      "file": "assets/cobol-rUaLketb.js",
-      "raw": 6223,
-      "gzip": 2949
-    },
-    "node_modules/@codemirror/legacy-modes/mode/coffeescript.js": {
-      "file": "assets/coffeescript-DQyfHE86.js",
-      "raw": 3855,
-      "gzip": 1678
-    },
-    "node_modules/@codemirror/legacy-modes/mode/commonlisp.js": {
-      "file": "assets/commonlisp-Buue1PGW.js",
-      "raw": 2320,
-      "gzip": 1093
-    },
-    "node_modules/@codemirror/legacy-modes/mode/crystal.js": {
-      "file": "assets/crystal-BMWO0kOJ.js",
-      "raw": 5020,
-      "gzip": 2068
-    },
-    "node_modules/@codemirror/legacy-modes/mode/css.js": {
-      "file": "assets/css-DaxibPo5.js",
-      "raw": 24708,
-      "gzip": 8241
-    },
-    "node_modules/@codemirror/legacy-modes/mode/cypher.js": {
-      "file": "assets/cypher-CmpGfiBR.js",
-      "raw": 3182,
-      "gzip": 1488
-    },
-    "node_modules/@codemirror/legacy-modes/mode/d.js": {
-      "file": "assets/d-qmdtoIzU.js",
-      "raw": 3673,
-      "gzip": 1651
-    },
-    "node_modules/@codemirror/legacy-modes/mode/diff.js": {
-      "file": "assets/diff-B40m6u1h.js",
-      "raw": 302,
-      "gzip": 233
-    },
-    "node_modules/@codemirror/legacy-modes/mode/dockerfile.js": {
-      "file": "assets/dockerfile-CrC2HXHP.js",
-      "raw": 1906,
-      "gzip": 651
-    },
-    "node_modules/@codemirror/legacy-modes/mode/dtd.js": {
-      "file": "assets/dtd-569ynYVj.js",
-      "raw": 2092,
-      "gzip": 865
-    },
-    "node_modules/@codemirror/legacy-modes/mode/dylan.js": {
-      "file": "assets/dylan-Dxolp30i.js",
-      "raw": 4041,
-      "gzip": 1624
-    },
-    "node_modules/@codemirror/legacy-modes/mode/ecl.js": {
-      "file": "assets/ecl-D9ftekdu.js",
-      "raw": 5092,
-      "gzip": 2277
-    },
-    "node_modules/@codemirror/legacy-modes/mode/eiffel.js": {
-      "file": "assets/eiffel-CkEtwXKk.js",
-      "raw": 1692,
-      "gzip": 905
-    },
-    "node_modules/@codemirror/legacy-modes/mode/elm.js": {
-      "file": "assets/elm-l13j1wIu.js",
-      "raw": 1866,
-      "gzip": 793
-    },
-    "node_modules/@codemirror/legacy-modes/mode/erlang.js": {
-      "file": "assets/erlang-DAN01sKu.js",
-      "raw": 7846,
-      "gzip": 2859
-    },
-    "node_modules/@codemirror/legacy-modes/mode/factor.js": {
-      "file": "assets/factor-DfP4xpu7.js",
-      "raw": 1669,
-      "gzip": 608
-    },
-    "node_modules/@codemirror/legacy-modes/mode/forth.js": {
-      "file": "assets/forth-BSp-YOKj.js",
-      "raw": 2541,
-      "gzip": 1298
-    },
-    "node_modules/@codemirror/legacy-modes/mode/fortran.js": {
-      "file": "assets/fortran-BtIRmo6s.js",
-      "raw": 3862,
-      "gzip": 1922
-    },
-    "node_modules/@codemirror/legacy-modes/mode/gas.js": {
-      "file": "assets/gas-okqIRy8I.js",
-      "raw": 4550,
-      "gzip": 1271
-    },
-    "node_modules/@codemirror/legacy-modes/mode/gherkin.js": {
-      "file": "assets/gherkin-DIlSAX9i.js",
-      "raw": 10156,
-      "gzip": 4959
-    },
-    "node_modules/@codemirror/legacy-modes/mode/groovy.js": {
-      "file": "assets/groovy-Dn6VQ7le.js",
-      "raw": 4103,
-      "gzip": 1735
-    },
-    "node_modules/@codemirror/legacy-modes/mode/haskell.js": {
-      "file": "assets/haskell-DxXJRRAf.js",
-      "raw": 4159,
-      "gzip": 1866
-    },
-    "node_modules/@codemirror/legacy-modes/mode/haxe.js": {
-      "file": "assets/haxe-Cf0nItU4.js",
-      "raw": 7862,
-      "gzip": 2889
-    },
-    "node_modules/@codemirror/legacy-modes/mode/idl.js": {
-      "file": "assets/idl-Cvfwv-t2.js",
-      "raw": 9826,
-      "gzip": 4390
-    },
-    "node_modules/@codemirror/legacy-modes/mode/javascript.js": {
-      "file": "assets/javascript-DTYiZxje.js",
-      "raw": 17020,
-      "gzip": 5665
-    },
-    "node_modules/@codemirror/legacy-modes/mode/julia.js": {
-      "file": "assets/julia-DblmoJFJ.js",
-      "raw": 5263,
-      "gzip": 2144
-    },
-    "node_modules/@codemirror/legacy-modes/mode/livescript.js": {
-      "file": "assets/livescript-BrEoHJNb.js",
-      "raw": 4081,
-      "gzip": 1612
-    },
-    "node_modules/@codemirror/legacy-modes/mode/lua.js": {
-      "file": "assets/lua-CJYZIOxF.js",
-      "raw": 3130,
-      "gzip": 1391
-    },
-    "node_modules/@codemirror/legacy-modes/mode/mathematica.js": {
-      "file": "assets/mathematica-_lb7LF2w.js",
-      "raw": 1899,
-      "gzip": 799
-    },
-    "node_modules/@codemirror/legacy-modes/mode/mbox.js": {
-      "file": "assets/mbox-DVSWpjvv.js",
-      "raw": 1386,
-      "gzip": 644
-    },
-    "node_modules/@codemirror/legacy-modes/mode/mirc.js": {
-      "file": "assets/mirc-HJ_OiA9S.js",
-      "raw": 5917,
-      "gzip": 2654
-    },
-    "node_modules/@codemirror/legacy-modes/mode/mllike.js": {
-      "file": "assets/mllike-CAogpScc.js",
-      "raw": 4823,
-      "gzip": 1561
-    },
-    "node_modules/@codemirror/legacy-modes/mode/modelica.js": {
-      "file": "assets/modelica-ClHXRjNC.js",
-      "raw": 2795,
-      "gzip": 1276
-    },
-    "node_modules/@codemirror/legacy-modes/mode/mscgen.js": {
-      "file": "assets/mscgen-RkaI3Wun.js",
-      "raw": 3499,
-      "gzip": 962
-    },
-    "node_modules/@codemirror/legacy-modes/mode/mumps.js": {
-      "file": "assets/mumps-BDM5N1HF.js",
-      "raw": 1836,
-      "gzip": 947
-    },
-    "node_modules/@codemirror/legacy-modes/mode/nginx.js": {
-      "file": "assets/nginx-CCLdsjVh.js",
-      "raw": 7409,
-      "gzip": 2726
-    },
-    "node_modules/@codemirror/legacy-modes/mode/nsis.js": {
-      "file": "assets/nsis-D7nr8PP2.js",
-      "raw": 6804,
-      "gzip": 2948
-    },
-    "node_modules/@codemirror/legacy-modes/mode/ntriples.js": {
-      "file": "assets/ntriples-eSjNy-wo.js",
-      "raw": 2077,
-      "gzip": 729
-    },
-    "node_modules/@codemirror/legacy-modes/mode/octave.js": {
-      "file": "assets/octave-DBhtMLa2.js",
-      "raw": 2101,
-      "gzip": 1071
-    },
-    "node_modules/@codemirror/legacy-modes/mode/oz.js": {
-      "file": "assets/oz-BLbZxzRs.js",
-      "raw": 2881,
-      "gzip": 1260
-    },
-    "node_modules/@codemirror/legacy-modes/mode/pascal.js": {
-      "file": "assets/pascal-Np678dv2.js",
-      "raw": 2256,
-      "gzip": 1166
-    },
-    "node_modules/@codemirror/legacy-modes/mode/perl.js": {
-      "file": "assets/perl-BMAF4owQ.js",
-      "raw": 9750,
-      "gzip": 3385
-    },
-    "node_modules/@codemirror/legacy-modes/mode/pig.js": {
-      "file": "assets/pig-DcQVJtaQ.js",
-      "raw": 2513,
-      "gzip": 1343
-    },
-    "node_modules/@codemirror/legacy-modes/mode/powershell.js": {
-      "file": "assets/powershell-DoRBeRu_.js",
-      "raw": 7699,
-      "gzip": 3257
-    },
-    "node_modules/@codemirror/legacy-modes/mode/properties.js": {
-      "file": "assets/properties-B37uA8mM.js",
-      "raw": 664,
-      "gzip": 340
-    },
-    "node_modules/@codemirror/legacy-modes/mode/protobuf.js": {
-      "file": "assets/protobuf-CbnG0ULD.js",
-      "raw": 802,
-      "gzip": 503
-    },
-    "node_modules/@codemirror/legacy-modes/mode/pug.js": {
-      "file": "assets/pug-BJIdq0R8.js",
-      "raw": 6670,
-      "gzip": 1959
-    },
-    "node_modules/@codemirror/legacy-modes/mode/puppet.js": {
-      "file": "assets/puppet-XBx4vPoj.js",
-      "raw": 2540,
-      "gzip": 1189
-    },
-    "node_modules/@codemirror/legacy-modes/mode/python.js": {
-      "file": "assets/python-CGVkiFJK.js",
-      "raw": 6284,
-      "gzip": 2658
-    },
-    "node_modules/@codemirror/legacy-modes/mode/q.js": {
-      "file": "assets/q-CLUHQG7r.js",
-      "raw": 3691,
-      "gzip": 1669
-    },
-    "node_modules/@codemirror/legacy-modes/mode/r.js": {
-      "file": "assets/r-C5KvXt2_.js",
-      "raw": 3008,
-      "gzip": 1346
-    },
-    "node_modules/@codemirror/legacy-modes/mode/rpm.js": {
-      "file": "assets/rpm-C6saGGsY.js",
-      "raw": 1290,
-      "gzip": 628
-    },
-    "node_modules/@codemirror/legacy-modes/mode/ruby.js": {
-      "file": "assets/ruby-V0hba-ss.js",
-      "raw": 5104,
-      "gzip": 2133
-    },
-    "node_modules/@codemirror/legacy-modes/mode/sas.js": {
-      "file": "assets/sas-BcrdT3Yq.js",
-      "raw": 9331,
-      "gzip": 4065
-    },
-    "node_modules/@codemirror/legacy-modes/mode/scheme.js": {
-      "file": "assets/scheme-DGLeEzLC.js",
-      "raw": 6363,
-      "gzip": 2377
-    },
-    "node_modules/@codemirror/legacy-modes/mode/shell.js": {
-      "file": "assets/shell-JaDGgh8g.js",
-      "raw": 2449,
-      "gzip": 1192
-    },
-    "node_modules/@codemirror/legacy-modes/mode/sieve.js": {
-      "file": "assets/sieve-C6xwK0CJ.js",
-      "raw": 1615,
-      "gzip": 769
-    },
-    "node_modules/@codemirror/legacy-modes/mode/smalltalk.js": {
-      "file": "assets/smalltalk-BC00GFeL.js",
-      "raw": 1996,
-      "gzip": 849
-    },
-    "node_modules/@codemirror/legacy-modes/mode/sparql.js": {
-      "file": "assets/sparql-C4F3rhn-.js",
-      "raw": 3331,
-      "gzip": 1586
-    },
-    "node_modules/@codemirror/legacy-modes/mode/stex.js": {
-      "file": "assets/stex-89pGYNe_.js",
-      "raw": 3121,
-      "gzip": 1172
-    },
-    "node_modules/@codemirror/legacy-modes/mode/stylus.js": {
-      "file": "assets/stylus-7UM7tb2e.js",
-      "raw": 23526,
-      "gzip": 8497
-    },
-    "node_modules/@codemirror/legacy-modes/mode/swift.js": {
-      "file": "assets/swift-zXQmejLw.js",
-      "raw": 3762,
-      "gzip": 1802
-    },
-    "node_modules/@codemirror/legacy-modes/mode/tcl.js": {
-      "file": "assets/tcl-XaTr_Heq.js",
-      "raw": 2353,
-      "gzip": 1211
-    },
-    "node_modules/@codemirror/legacy-modes/mode/textile.js": {
-      "file": "assets/textile-DbEjrOq0.js",
-      "raw": 6772,
-      "gzip": 2429
-    },
-    "node_modules/@codemirror/legacy-modes/mode/toml.js": {
-      "file": "assets/toml-CmjYyCe1.js",
-      "raw": 1190,
-      "gzip": 534
-    },
-    "node_modules/@codemirror/legacy-modes/mode/troff.js": {
-      "file": "assets/troff-D0AwqgXG.js",
-      "raw": 957,
-      "gzip": 436
-    },
-    "node_modules/@codemirror/legacy-modes/mode/ttcn-cfg.js": {
-      "file": "assets/ttcn-cfg-CEiPyZHt.js",
-      "raw": 4078,
-      "gzip": 1707
-    },
-    "node_modules/@codemirror/legacy-modes/mode/ttcn.js": {
-      "file": "assets/ttcn-xi-J0rA-.js",
-      "raw": 4824,
-      "gzip": 2115
-    },
-    "node_modules/@codemirror/legacy-modes/mode/turtle.js": {
-      "file": "assets/turtle-vG4sPfW7.js",
-      "raw": 1957,
-      "gzip": 882
-    },
-    "node_modules/@codemirror/legacy-modes/mode/vb.js": {
-      "file": "assets/vb-CVFCjHdj.js",
-      "raw": 3650,
-      "gzip": 1776
-    },
-    "node_modules/@codemirror/legacy-modes/mode/vbscript.js": {
-      "file": "assets/vbscript-DqGNTd8S.js",
-      "raw": 5431,
-      "gzip": 2514
-    },
-    "node_modules/@codemirror/legacy-modes/mode/velocity.js": {
-      "file": "assets/velocity-BPaFWmTj.js",
-      "raw": 2703,
-      "gzip": 1100
-    },
-    "node_modules/@codemirror/legacy-modes/mode/verilog.js": {
-      "file": "assets/verilog-1OrLGsRE.js",
-      "raw": 8435,
-      "gzip": 3477
-    },
-    "node_modules/@codemirror/legacy-modes/mode/vhdl.js": {
-      "file": "assets/vhdl-xQIDYgBW.js",
-      "raw": 3312,
-      "gzip": 1498
-    },
-    "node_modules/@codemirror/legacy-modes/mode/webidl.js": {
-      "file": "assets/webidl-CtRTdUKD.js",
-      "raw": 2449,
-      "gzip": 1227
-    },
-    "node_modules/@codemirror/legacy-modes/mode/xquery.js": {
-      "file": "assets/xquery-BCtP1o1Q.js",
-      "raw": 6225,
-      "gzip": 2541
-    },
-    "node_modules/@codemirror/legacy-modes/mode/yacas.js": {
-      "file": "assets/yacas-CzqZTwAk.js",
-      "raw": 2141,
-      "gzip": 1081
-    },
-    "node_modules/@codemirror/legacy-modes/mode/z80.js": {
-      "file": "assets/z80-50vYbkis.js",
-      "raw": 1755,
-      "gzip": 789
-    },
-    "node_modules/refractor/lang/c.js": {
-      "file": "assets/c-DLNvjts7.js",
-      "raw": 1973,
-      "gzip": 1029
-    },
-    "node_modules/refractor/lang/cpp.js": {
-      "file": "assets/cpp-C8pr4PZI.js",
-      "raw": 2711,
-      "gzip": 1276
-    },
-    "node_modules/refractor/lang/csharp.js": {
-      "file": "assets/csharp-CM4Tv2YM.js",
-      "raw": 6491,
-      "gzip": 2542
-    },
-    "node_modules/refractor/lang/docker.js": {
-      "file": "assets/docker-Cq2sHBpe.js",
-      "raw": 1629,
-      "gzip": 757
-    },
-    "node_modules/refractor/lang/go.js": {
-      "file": "assets/go-S1vB6hNf.js",
-      "raw": 1075,
-      "gzip": 682
-    },
-    "node_modules/refractor/lang/graphql.js": {
-      "file": "assets/graphql-Da8Qi-mC.js",
-      "raw": 2592,
-      "gzip": 1183
-    },
-    "node_modules/refractor/lang/java.js": {
-      "file": "assets/java-CEqX3Og8.js",
-      "raw": 2888,
-      "gzip": 1296
-    },
-    "node_modules/refractor/lang/kotlin.js": {
-      "file": "assets/kotlin-D55NHGCI.js",
-      "raw": 2053,
-      "gzip": 1018
-    },
-    "node_modules/refractor/lang/less.js": {
-      "file": "assets/less-B2s4UkkH.js",
-      "raw": 793,
-      "gzip": 445
-    },
-    "node_modules/refractor/lang/makefile.js": {
-      "file": "assets/makefile-DDN_GHPw.js",
-      "raw": 1008,
-      "gzip": 596
-    },
-    "node_modules/refractor/lang/php.js": {
-      "file": "assets/php-CTiqiqRg.js",
-      "raw": 7581,
-      "gzip": 2528
-    },
-    "node_modules/refractor/lang/python.js": {
-      "file": "assets/python-LszU87xa.js",
-      "raw": 2168,
-      "gzip": 1125
-    },
-    "node_modules/refractor/lang/ruby.js": {
-      "file": "assets/ruby-4yBNdYde.js",
-      "raw": 3686,
-      "gzip": 1542
-    },
-    "node_modules/refractor/lang/rust.js": {
-      "file": "assets/rust-BI95UAWj.js",
-      "raw": 2542,
-      "gzip": 1213
-    },
-    "node_modules/refractor/lang/sass.js": {
-      "file": "assets/sass-DDbSjqEn.js",
-      "raw": 1203,
-      "gzip": 537
-    },
-    "node_modules/refractor/lang/scss.js": {
-      "file": "assets/scss-C3SmMPtf.js",
-      "raw": 1429,
-      "gzip": 697
-    },
-    "node_modules/refractor/lang/sql.js": {
-      "file": "assets/sql-CY5drcWc.js",
-      "raw": 3325,
-      "gzip": 1871
-    },
-    "node_modules/refractor/lang/swift.js": {
-      "file": "assets/swift-C-RXXRfz.js",
-      "raw": 3005,
-      "gzip": 1330
-    },
-    "node_modules/refractor/lang/toml.js": {
-      "file": "assets/toml-0e0UyVps.js",
-      "raw": 1031,
-      "gzip": 541
-    },
-    "node_modules/refractor/lang/yaml.js": {
-      "file": "assets/yaml-DFu0ZKZm.js",
-      "raw": 2049,
-      "gzip": 905
-    },
-    "plugins/builtin/github/renderer/components/CommitList.tsx": {
-      "file": "assets/CommitList-D35G4Mnk.js",
-      "raw": 12656,
-      "gzip": 4866
-    },
-    "plugins/builtin/github/renderer/components/GitHubResourceList.tsx": {
-      "file": "assets/GitHubResourceList-B9J3zvNF.js",
-      "raw": 50049,
-      "gzip": 16597
-    },
-    "src/App.tsx": {
-      "file": "assets/App-cVGJPKfk.js",
-      "raw": 1340851,
-      "gzip": 373543
-    },
-    "src/components/ActionPalette/ActionPalette.tsx": {
-      "file": "assets/ActionPalette-DX9ma6xF.js",
-      "raw": 4074,
-      "gzip": 1861
+      "file": "assets/index-CJeJW1C4.js",
+      "raw": 537037,
+      "gzip": 168630
     },
     "src/components/Browser/BrowserPane.tsx": {
-      "file": "assets/BrowserPane-BbTxxdIF.js",
-      "raw": 21026,
-      "gzip": 7392
+      "file": "assets/BrowserPane-amUEL9Ce.js",
+      "raw": 21052,
+      "gzip": 7407
     },
     "src/components/DevPreview/DevPreviewPane.tsx": {
-      "file": "assets/DevPreviewPane-D7SlBjVC.js",
-      "raw": 37511,
-      "gzip": 11670
-    },
-    "src/components/FileViewer/FileViewerModalHost.tsx": {
-      "file": "assets/FileViewerModalHost-Cn6_FrWd.js",
-      "raw": 3727,
-      "gzip": 1904
-    },
-    "src/components/Git/GitPullRebaseConfirmDialog.tsx": {
-      "file": "assets/GitPullRebaseConfirmDialog-upO8pkdZ.js",
-      "raw": 4919,
-      "gzip": 2150
-    },
-    "src/components/Git/GitPushConfirmDialog.tsx": {
-      "file": "assets/GitPushConfirmDialog-NGw3kpqt.js",
-      "raw": 4843,
-      "gzip": 2134
-    },
-    "src/components/LogLevelPalette/LogLevelPalette.tsx": {
-      "file": "assets/LogLevelPalette-QGoCkrRA.js",
-      "raw": 5364,
-      "gzip": 2277
-    },
-    "src/components/McpConfirmDialog.tsx": {
-      "file": "assets/McpConfirmDialog-gsdtsbuB.js",
-      "raw": 2521,
-      "gzip": 1266
-    },
-    "src/components/Onboarding/CelebrationConfetti.tsx": {
-      "file": "assets/CelebrationConfetti-H89ojfIN.js",
-      "raw": 2922,
-      "gzip": 1475
-    },
-    "src/components/Onboarding/GettingStartedChecklist.tsx": {
-      "file": "assets/GettingStartedChecklist-W10jxDqb.js",
-      "raw": 8255,
-      "gzip": 3498
-    },
-    "src/components/Onboarding/OnboardingFlow.tsx": {
-      "file": "assets/OnboardingFlow-BhJ72oOF.js",
-      "raw": 48891,
-      "gzip": 15296
-    },
-    "src/components/PanelPalette/PanelPalette.tsx": {
-      "file": "assets/PanelPalette-0qYKpVRP.js",
-      "raw": 7677,
-      "gzip": 3666
-    },
-    "src/components/Project/AutomationTab.tsx": {
-      "file": "assets/AutomationTab-Dd6AbqTi.js",
-      "raw": 33273,
-      "gzip": 9480
-    },
-    "src/components/Project/ContextTab.tsx": {
-      "file": "assets/ContextTab-DgXHua2d.js",
-      "raw": 11734,
-      "gzip": 2700
-    },
-    "src/components/Project/CreateProjectFolderDialog.tsx": {
-      "file": "assets/CreateProjectFolderDialog-BzBHgdfQ.js",
-      "raw": 3555,
-      "gzip": 1508
-    },
-    "src/components/Project/EnvironmentVariablesEditor.tsx": {
-      "file": "assets/EnvironmentVariablesEditor-BJcw0HFN.js",
-      "raw": 7365,
-      "gzip": 2642
-    },
-    "src/components/Project/ForgeProviderTab.tsx": {
-      "file": "assets/ForgeProviderTab-C49alBaE.js",
-      "raw": 3949,
-      "gzip": 1554
-    },
-    "src/components/Project/GeneralTab.tsx": {
-      "file": "assets/GeneralTab-CiJkqOhR.js",
-      "raw": 20606,
-      "gzip": 5930
-    },
-    "src/components/Project/ProjectNotificationsTab.tsx": {
-      "file": "assets/ProjectNotificationsTab-B0MYyKCi.js",
-      "raw": 9914,
-      "gzip": 3580
-    },
-    "src/components/Project/RecipesTab.tsx": {
-      "file": "assets/RecipesTab-CvduGQAR.js",
-      "raw": 12480,
-      "gzip": 4398
-    },
-    "src/components/QuickSwitcher/QuickSwitcher.tsx": {
-      "file": "assets/QuickSwitcher-ByLs0436.js",
-      "raw": 5190,
-      "gzip": 2327
-    },
-    "src/components/Settings/AgentSettings.tsx": {
-      "file": "assets/AgentSettings-C6Ow6_4j.js",
-      "raw": 90266,
-      "gzip": 26427
-    },
-    "src/components/Settings/CommandOverridesTab.tsx": {
-      "file": "assets/CommandOverridesTab-Cy10OAfJ.js",
-      "raw": 13004,
-      "gzip": 4242
-    },
-    "src/components/Settings/DaintreeAssistantSettingsTab.tsx": {
-      "file": "assets/DaintreeAssistantSettingsTab-DWcv_f5O.js",
-      "raw": 21693,
-      "gzip": 7466
-    },
-    "src/components/Settings/EnvironmentSettingsTab.tsx": {
-      "file": "assets/EnvironmentSettingsTab-iLFdwDk1.js",
-      "raw": 6394,
-      "gzip": 2536
-    },
-    "src/components/Settings/ForgeIntegrationsTab.tsx": {
-      "file": "assets/ForgeIntegrationsTab-ClPeWxnx.js",
-      "raw": 7577,
-      "gzip": 2813
-    },
-    "src/components/Settings/GitHubSettingsTab.tsx": {
-      "file": "assets/GitHubSettingsTab-CygZbjRA.js",
-      "raw": 6788,
-      "gzip": 2106
-    },
-    "src/components/Settings/IntegrationsTab.tsx": {
-      "file": "assets/IntegrationsTab-B3aakuPh.js",
-      "raw": 10868,
-      "gzip": 3095
-    },
-    "src/components/Settings/KeyboardShortcutsTab.tsx": {
-      "file": "assets/KeyboardShortcutsTab-DV30lC3T.js",
-      "raw": 8895,
-      "gzip": 3116
-    },
-    "src/components/Settings/McpServerSettingsTab.tsx": {
-      "file": "assets/McpServerSettingsTab-16Ig83O9.js",
-      "raw": 14109,
-      "gzip": 4336
-    },
-    "src/components/Settings/NotificationSettingsTab.tsx": {
-      "file": "assets/NotificationSettingsTab-Yz0V8C7s.js",
-      "raw": 15666,
-      "gzip": 4964
-    },
-    "src/components/Settings/PortalSettingsTab.tsx": {
-      "file": "assets/PortalSettingsTab-CmxBKyqY.js",
-      "raw": 14641,
-      "gzip": 5113
-    },
-    "src/components/Settings/PrivacyDataTab.tsx": {
-      "file": "assets/PrivacyDataTab-DFaN50pf.js",
-      "raw": 11843,
-      "gzip": 3596
-    },
-    "src/components/Settings/SettingsDialog.tsx": {
-      "file": "assets/SettingsDialog-BpqkwkVd.js",
-      "raw": 37026,
-      "gzip": 12676
-    },
-    "src/components/Settings/TerminalAppearanceTab.tsx": {
-      "file": "assets/TerminalAppearanceTab-DjrPkj49.js",
-      "raw": 23985,
-      "gzip": 8023
-    },
-    "src/components/Settings/TerminalSettingsTab.tsx": {
-      "file": "assets/TerminalSettingsTab-DRgaOdBB.js",
-      "raw": 19877,
-      "gzip": 5652
-    },
-    "src/components/Settings/ToolbarSettingsTab.tsx": {
-      "file": "assets/ToolbarSettingsTab-Ls8lYPkk.js",
-      "raw": 13428,
-      "gzip": 4945
-    },
-    "src/components/Settings/TroubleshootingTab.tsx": {
-      "file": "assets/TroubleshootingTab-DB7zY5r3.js",
-      "raw": 18157,
-      "gzip": 6153
-    },
-    "src/components/Settings/VoiceInputSettingsTab.tsx": {
-      "file": "assets/VoiceInputSettingsTab-BrjrgLzr.js",
-      "raw": 23521,
-      "gzip": 8201
-    },
-    "src/components/Settings/WorktreeSettingsTab.tsx": {
-      "file": "assets/WorktreeSettingsTab-B0lTp9pn.js",
-      "raw": 8152,
-      "gzip": 2354
-    },
-    "src/components/Terminal/HybridInputBar.tsx": {
-      "file": "assets/HybridInputBar-DsIg6bTp.js",
-      "raw": 126266,
-      "gzip": 37895
-    },
-    "src/components/Terminal/PanelLimitConfirmDialog.tsx": {
-      "file": "assets/PanelLimitConfirmDialog-H6_BbBOT.js",
-      "raw": 1536,
-      "gzip": 897
-    },
-    "src/components/Terminal/SendToAgentPalette.tsx": {
-      "file": "assets/SendToAgentPalette-CCyxScTL.js",
-      "raw": 4065,
-      "gzip": 1816
-    },
-    "src/components/TerminalPalette/NewTerminalPalette.tsx": {
-      "file": "assets/NewTerminalPalette-Dj_C001T.js",
-      "raw": 4466,
-      "gzip": 2180
-    },
-    "src/components/ThemePalette/ThemePalette.tsx": {
-      "file": "assets/ThemePalette-BIQuubLA.js",
-      "raw": 5309,
-      "gzip": 2536
-    },
-    "src/components/Worktree/CrossWorktreeDiff.tsx": {
-      "file": "assets/CrossWorktreeDiff-wEVeoFC9.js",
-      "raw": 8263,
-      "gzip": 3166
-    },
-    "src/components/Worktree/NewWorktreeDialog.tsx": {
-      "file": "assets/NewWorktreeDialog-vXWVBXu1.js",
-      "raw": 50160,
-      "gzip": 14914
-    },
-    "src/components/ui/radix-deferred.ts": {
-      "file": "assets/radix-deferred-biOWgG4H.js",
-      "raw": 199,
-      "gzip": 153
-    },
-    "src/lib/motionFeatures.ts": {
-      "file": "assets/motionFeatures-Bo_zkw9R.js",
-      "raw": 69,
-      "gzip": 84
-    },
-    "src/panels/review/ReviewPane.tsx": {
-      "file": "assets/ReviewPane-DGHpDLFy.js",
-      "raw": 1109,
-      "gzip": 667
+      "file": "assets/DevPreviewPane-s63N2QTK.js",
+      "raw": 69736,
+      "gzip": 21113
     }
   },
+  "eagerTotals": {
+    "raw": 3089742,
+    "gzip": 928997
+  },
   "totals": {
-    "raw": 6921832,
-    "gzip": 2182840
+    "raw": 7221132,
+    "gzip": 2281011
   }
 }

--- a/scripts/check-first-render-chunk-budget.mjs
+++ b/scripts/check-first-render-chunk-budget.mjs
@@ -319,9 +319,7 @@ function compareToBaseline(report, threshold) {
   lines.push("");
   lines.push(`- baseline gzip: ${baselineTotalGzip} bytes`);
   lines.push(`- current gzip:  ${currentTotalGzip} bytes`);
-  lines.push(
-    `- delta:         ${totalDelta >= 0 ? "+" : ""}${totalDelta} bytes (not gated)`
-  );
+  lines.push(`- delta:         ${totalDelta >= 0 ? "+" : ""}${totalDelta} bytes (not gated)`);
 
   mkdirSync(path.dirname(SUMMARY_FILE), { recursive: true });
   writeFileSync(SUMMARY_FILE, lines.join("\n") + "\n");

--- a/scripts/check-first-render-chunk-budget.mjs
+++ b/scripts/check-first-render-chunk-budget.mjs
@@ -18,7 +18,7 @@
 //   node scripts/check-first-render-chunk-budget.mjs --threshold 0.10  # 10% growth allowed
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
 
@@ -34,13 +34,24 @@ const SUMMARY_FILE = path.join(DIST, "first-render-chunk-summary.md");
 // entries below are React.lazy boundaries in src/panels/registry.tsx that
 // resolve immediately when a persisted browser/dev-preview panel is restored
 // — i.e. on the first-render path even though they're nominally "lazy".
-const LAZY_FIRST_RENDER_SEEDS = [
+export const LAZY_FIRST_RENDER_SEEDS = [
   "src/components/Browser/BrowserPane.tsx",
   "src/components/DevPreview/DevPreviewPane.tsx",
 ];
 
 const DEFAULT_THRESHOLD = 0.05;
 const UPDATE_SHRINKAGE_THRESHOLD = 0.1;
+
+// Pure shrink guard: returns an error message when the eager gzip would drop
+// more than `threshold` (fraction) below the prior baseline, else null. Kept
+// pure (no IO / no process.exit) so it's directly unit-testable, mirroring
+// check-renderer-import-budget.mjs.
+export function shrinkageGuardError(priorGzip, nextGzip, threshold) {
+  if (typeof priorGzip !== "number" || priorGzip <= 0) return null;
+  const drop = (priorGzip - nextGzip) / priorGzip;
+  if (drop <= threshold) return null;
+  return `eager first-render gzip would drop from ${priorGzip} to ${nextGzip} (${(drop * 100).toFixed(1)}% shrinkage > ${(threshold * 100).toFixed(0)}% threshold)`;
+}
 
 function parseArgs(argv) {
   const args = { isUpdate: false, force: false, override: false, threshold: DEFAULT_THRESHOLD };
@@ -81,11 +92,24 @@ function readManifest() {
 }
 
 // BFS the manifest graph. `imports[]` and `dynamicImports[]` reference other
-// manifest keys (source paths). Both contribute to the closure because once
-// any seed is hydrated the lazy panels load synchronously on the first paint.
-// Visiting by manifest key (not file name) avoids double-counting chunks
-// shared via Rolldown's `codeSplitting.groups` (vendor-react, vendor-xterm…).
-function collectClosure(manifest, seedKeys) {
+// manifest keys (source paths). Visiting by manifest key (not file name) avoids
+// double-counting chunks shared via Rolldown's `codeSplitting.groups`
+// (vendor-react, vendor-xterm…).
+//
+// `followDynamic` selects the closure semantics:
+//   • false (eager) — follow only `imports[]`. This is the true "download
+//     before interactive" cost: the entry plus everything statically reachable
+//     from it (and from the explicit first-render seeds). This is the GATED
+//     metric — the regression CI fails on.
+//   • true (total)  — follow both `imports[]` and `dynamicImports[]`, i.e. the
+//     entire reachable bundle. Report-only, retained as a coarse total-bundle
+//     regression signal.
+//
+// The seeds (renderer entry + LAZY_FIRST_RENDER_SEEDS) are always enqueued
+// explicitly regardless of `followDynamic` — they're first-paint paths by
+// definition (a persisted browser/dev-preview panel restores synchronously),
+// not edges discovered by walking `dynamicImports[]`.
+export function collectClosure(manifest, seedKeys, { followDynamic = true } = {}) {
   const visited = new Set();
   const queue = [];
 
@@ -98,13 +122,17 @@ function collectClosure(manifest, seedKeys) {
   while (queue.length > 0) {
     const key = queue.shift();
     if (visited.has(key)) continue;
-    visited.add(key);
 
     const chunk = manifest[key];
+    // Skip keys not present in the manifest — the closure measures real
+    // chunks only, so a dangling import reference must not enter the set.
     if (!chunk) continue;
+    visited.add(key);
 
     for (const dep of chunk.imports ?? []) queue.push(dep);
-    for (const dep of chunk.dynamicImports ?? []) queue.push(dep);
+    if (followDynamic) {
+      for (const dep of chunk.dynamicImports ?? []) queue.push(dep);
+    }
   }
 
   return visited;
@@ -131,16 +159,10 @@ function gzipBytesFor(file) {
   return { ok: true, raw: buf.byteLength, gzip: gz };
 }
 
-function buildReport(manifest) {
-  const entryKey = findEntryKey(manifest);
-  if (!entryKey) {
-    console.error("::error::no entry chunk found in manifest (no chunk has isEntry: true)");
-    process.exit(1);
-  }
-
-  const seedKeys = [entryKey, ...LAZY_FIRST_RENDER_SEEDS];
-  const closure = collectClosure(manifest, seedKeys);
-
+// Size every chunk in a closure, returning the per-chunk map, summed
+// raw/gzip totals, and any missing-file errors. Pure given a manifest +
+// closure set, so the gzip work is shared between the eager and total walks.
+function sizeClosure(manifest, closure) {
   const chunks = {};
   let totalRaw = 0;
   let totalGzip = 0;
@@ -159,9 +181,28 @@ function buildReport(manifest) {
     totalGzip += sized.gzip;
   }
 
-  if (missing.length > 0) {
-    for (const m of missing) console.warn(`::warning::${m}`);
+  return { chunks, totals: { raw: totalRaw, gzip: totalGzip }, missing };
+}
+
+function buildReport(manifest) {
+  const entryKey = findEntryKey(manifest);
+  if (!entryKey) {
+    console.error("::error::no entry chunk found in manifest (no chunk has isEntry: true)");
+    process.exit(1);
   }
+
+  const seedKeys = [entryKey, ...LAZY_FIRST_RENDER_SEEDS];
+
+  // Eager walk (gated): the static first-render closure.
+  const eagerClosure = collectClosure(manifest, seedKeys, { followDynamic: false });
+  const eager = sizeClosure(manifest, eagerClosure);
+
+  // Total walk (report-only): the full reachable bundle, retained as a coarse
+  // total-bundle regression signal.
+  const totalClosure = collectClosure(manifest, seedKeys, { followDynamic: true });
+  const total = sizeClosure(manifest, totalClosure);
+
+  for (const m of [...eager.missing, ...total.missing]) console.warn(`::warning::${m}`);
 
   const seedsResolved = LAZY_FIRST_RENDER_SEEDS.filter((s) => Boolean(manifest[s]));
   const seedsMissing = LAZY_FIRST_RENDER_SEEDS.filter((s) => !manifest[s]);
@@ -174,9 +215,13 @@ function buildReport(manifest) {
   return {
     entryKey,
     seeds: { resolved: seedsResolved, missing: seedsMissing },
-    chunkCount: Object.keys(chunks).length,
-    chunks,
-    totals: { raw: totalRaw, gzip: totalGzip },
+    // `chunks`/`chunkCount` describe the eager first-render set — the purpose
+    // of this baseline file. `eagerTotals` is the gated metric; `totals` is the
+    // full-bundle figure kept for report-only regression visibility.
+    chunkCount: Object.keys(eager.chunks).length,
+    chunks: eager.chunks,
+    eagerTotals: eager.totals,
+    totals: total.totals,
   };
 }
 
@@ -184,16 +229,18 @@ function writeBaseline(report, { force }) {
   if (existsSync(BASELINE_FILE) && !force) {
     try {
       const prior = JSON.parse(readFileSync(BASELINE_FILE, "utf8"));
-      const priorGzip = prior?.totals?.gzip ?? 0;
-      if (priorGzip > 0) {
-        const drop = (priorGzip - report.totals.gzip) / priorGzip;
-        if (drop > UPDATE_SHRINKAGE_THRESHOLD) {
-          console.error(
-            `::error::refusing to update baseline — first-render gzip would drop from ${priorGzip} to ${report.totals.gzip} (${(drop * 100).toFixed(1)}% shrinkage > ${(UPDATE_SHRINKAGE_THRESHOLD * 100).toFixed(0)}% threshold).`
-          );
-          console.error("   If the shrinkage is intentional, re-run with --force.");
-          process.exit(1);
-        }
+      // Guard the gated metric (eager first-render gzip), not the report-only
+      // total — that's the figure CI fails on and the one --force is meant to
+      // re-baseline after an intentional shrink.
+      const guardError = shrinkageGuardError(
+        prior?.eagerTotals?.gzip,
+        report.eagerTotals.gzip,
+        UPDATE_SHRINKAGE_THRESHOLD
+      );
+      if (guardError) {
+        console.error(`::error::refusing to update baseline — ${guardError}.`);
+        console.error("   If the shrinkage is intentional, re-run with --force.");
+        process.exit(1);
       }
     } catch {
       // Unparseable prior — let the update proceed.
@@ -212,12 +259,13 @@ function writeBaseline(report, { force }) {
     seeds: report.seeds,
     chunkCount: report.chunkCount,
     chunks: sortedChunks,
+    eagerTotals: report.eagerTotals,
     totals: report.totals,
   };
 
   writeFileSync(BASELINE_FILE, JSON.stringify(out, null, 2) + "\n");
   console.log(
-    `[check-first-render-chunk-budget] baseline updated: ${report.chunkCount} chunks, total gzip=${report.totals.gzip}`
+    `[check-first-render-chunk-budget] baseline updated: ${report.chunkCount} eager chunks, eager gzip=${report.eagerTotals.gzip} (total bundle gzip=${report.totals.gzip})`
   );
 }
 
@@ -230,14 +278,33 @@ function compareToBaseline(report, threshold) {
   }
 
   const baseline = JSON.parse(readFileSync(BASELINE_FILE, "utf8"));
-  const baselineGzip = baseline?.totals?.gzip ?? 0;
-  const currentGzip = report.totals.gzip;
+
+  // The gate is the eager first-render closure. A baseline predating the
+  // eager/total split has no `eagerTotals` — there's nothing meaningful to
+  // compare against, so demand a refresh rather than silently passing.
+  if (typeof baseline?.eagerTotals?.gzip !== "number") {
+    console.error(
+      "::error::baseline is missing `eagerTotals` — it predates the eager/total split."
+    );
+    console.error("   Re-run `npm run first-render-chunk-budget:update -- --force` to refresh it.");
+    process.exit(1);
+  }
+
+  const baselineGzip = baseline.eagerTotals.gzip;
+  const currentGzip = report.eagerTotals.gzip;
   const delta = currentGzip - baselineGzip;
   const ratio = baselineGzip > 0 ? delta / baselineGzip : 0;
   const overBudget = ratio > threshold;
 
+  // Report-only: the full reachable bundle (eager + dynamic). Not gated.
+  const baselineTotalGzip = baseline?.totals?.gzip ?? 0;
+  const currentTotalGzip = report.totals.gzip;
+  const totalDelta = currentTotalGzip - baselineTotalGzip;
+
   const lines = [];
   lines.push("# First-render chunk gzip budget");
+  lines.push("");
+  lines.push("## Eager first-render closure (gated)");
   lines.push("");
   lines.push(`- baseline gzip: ${baselineGzip} bytes`);
   lines.push(`- current gzip:  ${currentGzip} bytes`);
@@ -245,8 +312,16 @@ function compareToBaseline(report, threshold) {
     `- delta:         ${delta >= 0 ? "+" : ""}${delta} bytes (${(ratio * 100).toFixed(2)}%)`
   );
   lines.push(`- threshold:     +${(threshold * 100).toFixed(1)}%`);
-  lines.push(`- chunks:        ${report.chunkCount}`);
+  lines.push(`- eager chunks:  ${report.chunkCount}`);
   lines.push(`- result:        ${overBudget ? "OVER BUDGET" : "OK"}`);
+  lines.push("");
+  lines.push("## Total reachable bundle (report-only)");
+  lines.push("");
+  lines.push(`- baseline gzip: ${baselineTotalGzip} bytes`);
+  lines.push(`- current gzip:  ${currentTotalGzip} bytes`);
+  lines.push(
+    `- delta:         ${totalDelta >= 0 ? "+" : ""}${totalDelta} bytes (not gated)`
+  );
 
   mkdirSync(path.dirname(SUMMARY_FILE), { recursive: true });
   writeFileSync(SUMMARY_FILE, lines.join("\n") + "\n");
@@ -288,4 +363,10 @@ function main() {
   process.exit(1);
 }
 
-main();
+// Only run main when invoked directly (not when imported by tests).
+// pathToFileURL percent-encodes paths with spaces/other non-URL characters so
+// the comparison against the already-encoded import.meta.url doesn't silently
+// mismatch (which would no-op the check).
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-first-render-chunk-budget.test.mjs
+++ b/scripts/check-first-render-chunk-budget.test.mjs
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import {
+  collectClosure,
+  shrinkageGuardError,
+  LAZY_FIRST_RENDER_SEEDS,
+} from "./check-first-render-chunk-budget.mjs";
+
+// Synthetic manifest mirroring the Vite 8 / Rolldown shape: top-level keys are
+// either source paths (for entries / lazy seeds) or `_vendor-*.js` keys for
+// shared chunks. Each entry has a `file` and optional `imports[]` /
+// `dynamicImports[]` arrays of manifest keys. The motion case under test:
+// `_vendor-motion.js` (LazyMotion/MotionConfig) is a STATIC import of the
+// entry, while `_vendor-motion-features.js` (domMax) is reachable only via the
+// dynamic `import("./lib/motionFeatures")` boundary — the #8821 split.
+function makeManifest(extra = {}) {
+  return {
+    "index.html": {
+      file: "assets/index-abc.js",
+      isEntry: true,
+      imports: ["_vendor-react.js", "_vendor-motion.js"],
+      dynamicImports: ["src/lib/motionFeatures.ts", "src/components/Browser/BrowserPane.tsx"],
+    },
+    "_vendor-react.js": { file: "assets/vendor-react-def.js", imports: [], dynamicImports: [] },
+    "_vendor-motion.js": {
+      file: "assets/vendor-motion-ghi.js",
+      imports: ["_vendor-react.js"],
+      dynamicImports: [],
+    },
+    "src/lib/motionFeatures.ts": {
+      file: "assets/motionFeatures-jkl.js",
+      imports: ["_vendor-motion-features.js"],
+      dynamicImports: [],
+    },
+    "_vendor-motion-features.js": {
+      file: "assets/vendor-motion-features-mno.js",
+      imports: [],
+      dynamicImports: [],
+    },
+    "src/components/Browser/BrowserPane.tsx": {
+      file: "assets/BrowserPane-pqr.js",
+      imports: ["_vendor-browser.js"],
+      dynamicImports: [],
+    },
+    "_vendor-browser.js": { file: "assets/vendor-browser-stu.js", imports: [], dynamicImports: [] },
+    "src/components/DevPreview/DevPreviewPane.tsx": {
+      file: "assets/DevPreviewPane-vwx.js",
+      imports: [],
+      dynamicImports: [],
+    },
+    ...extra,
+  };
+}
+
+describe("collectClosure — eager walk (followDynamic: false)", () => {
+  it("follows imports[] only, excluding the dynamic domMax boundary", () => {
+    const manifest = makeManifest();
+    const closure = collectClosure(manifest, ["index.html"], { followDynamic: false });
+    expect([...closure].sort()).toEqual(["_vendor-motion.js", "_vendor-react.js", "index.html"]);
+  });
+
+  it("does NOT pull domMax (motionFeatures) into the eager closure", () => {
+    const manifest = makeManifest();
+    const closure = collectClosure(manifest, ["index.html"], { followDynamic: false });
+    expect(closure.has("src/lib/motionFeatures.ts")).toBe(false);
+    expect(closure.has("_vendor-motion-features.js")).toBe(false);
+  });
+
+  it("keeps eager LazyMotion/MotionConfig (vendor-motion) in the closure", () => {
+    const manifest = makeManifest();
+    const closure = collectClosure(manifest, ["index.html"], { followDynamic: false });
+    expect(closure.has("_vendor-motion.js")).toBe(true);
+  });
+});
+
+describe("collectClosure — total walk (default followDynamic: true)", () => {
+  it("follows both imports[] and dynamicImports[], including domMax", () => {
+    const manifest = makeManifest();
+    const closure = collectClosure(manifest, ["index.html"]);
+    expect(closure.has("src/lib/motionFeatures.ts")).toBe(true);
+    expect(closure.has("_vendor-motion-features.js")).toBe(true);
+    expect(closure.has("src/components/Browser/BrowserPane.tsx")).toBe(true);
+  });
+});
+
+describe("collectClosure — first-render seeds", () => {
+  it("always enqueues explicit seeds regardless of followDynamic", () => {
+    const manifest = makeManifest();
+    const seeds = ["index.html", ...LAZY_FIRST_RENDER_SEEDS];
+
+    // BrowserPane/DevPreviewPane are first-render seeds even though they're
+    // nominally lazy — they're passed in as seedKeys, not discovered by
+    // walking dynamicImports[]. They must appear in the eager closure.
+    const eager = collectClosure(manifest, seeds, { followDynamic: false });
+    expect(eager.has("src/components/Browser/BrowserPane.tsx")).toBe(true);
+    expect(eager.has("src/components/DevPreview/DevPreviewPane.tsx")).toBe(true);
+    // And the BrowserPane's own static import is reachable from the seed.
+    expect(eager.has("_vendor-browser.js")).toBe(true);
+    // domMax is still excluded — it isn't a seed and only the dynamic edge
+    // reaches it.
+    expect(eager.has("_vendor-motion-features.js")).toBe(false);
+  });
+
+  it("visits each shared chunk exactly once (identity = manifest key)", () => {
+    // Both index.html and _vendor-motion.js import _vendor-react.js.
+    const manifest = makeManifest();
+    const closure = collectClosure(manifest, ["index.html"], { followDynamic: false });
+    const reactChunks = [...closure].filter((k) => k === "_vendor-react.js");
+    expect(reactChunks.length).toBe(1);
+  });
+
+  it("skips seed keys not present in the manifest", () => {
+    const manifest = makeManifest();
+    const closure = collectClosure(manifest, ["src/missing-entry.tsx"], { followDynamic: false });
+    expect(closure.size).toBe(0);
+  });
+
+  it("tolerates chunks with missing imports/dynamicImports arrays", () => {
+    const manifest = {
+      "index.html": { file: "a.js", isEntry: true, imports: ["_x.js"] },
+      "_x.js": { file: "x.js" },
+    };
+    const closure = collectClosure(manifest, ["index.html"], { followDynamic: false });
+    expect([...closure].sort()).toEqual(["_x.js", "index.html"]);
+  });
+
+  it("skips imports referencing keys absent from the manifest", () => {
+    const manifest = {
+      "index.html": { file: "a.js", isEntry: true, imports: ["_missing.js", "_present.js"] },
+      "_present.js": { file: "p.js", imports: [] },
+    };
+    const closure = collectClosure(manifest, ["index.html"], { followDynamic: false });
+    expect(closure.has("_present.js")).toBe(true);
+    expect(closure.has("_missing.js")).toBe(false);
+  });
+});
+
+describe("shrinkageGuardError", () => {
+  const THRESHOLD = 0.1; // 10%
+
+  it("returns null when eager gzip is unchanged", () => {
+    expect(shrinkageGuardError(100, 100, THRESHOLD)).toBeNull();
+  });
+
+  it("returns null when eager gzip grows (not a shrinkage)", () => {
+    expect(shrinkageGuardError(100, 120, THRESHOLD)).toBeNull();
+  });
+
+  it("returns null when shrinkage is below threshold (5%)", () => {
+    expect(shrinkageGuardError(100, 95, THRESHOLD)).toBeNull();
+  });
+
+  it("returns null at exactly the threshold (10% drop)", () => {
+    expect(shrinkageGuardError(100, 90, THRESHOLD)).toBeNull();
+  });
+
+  it("returns an error message when shrinkage exceeds threshold (the domMax exit)", () => {
+    // The #8821 fix removes ~43KB from the eager closure — a large intentional
+    // shrink that must trip the guard so --force is required to re-baseline.
+    const err = shrinkageGuardError(100000, 57000, THRESHOLD);
+    expect(err).not.toBeNull();
+    expect(err).toContain("100000");
+    expect(err).toContain("57000");
+  });
+
+  it("returns null when priorGzip is 0 / missing (no usable baseline)", () => {
+    expect(shrinkageGuardError(0, 50, THRESHOLD)).toBeNull();
+    expect(shrinkageGuardError(undefined, 50, THRESHOLD)).toBeNull();
+    expect(shrinkageGuardError(null, 50, THRESHOLD)).toBeNull();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -365,8 +365,16 @@ export default defineConfig(({ command, mode }) => {
                 priority: 60,
               },
               {
+                // `tags: ["$initial"]` restricts this group to framer-motion
+                // code statically reachable from an entry (LazyMotion,
+                // MotionConfig). The domMax feature set is reachable only
+                // through the dynamic import("./lib/motionFeatures") boundary,
+                // so it is NOT $initial-tagged and Rolldown keeps it in its own
+                // async chunk — preserving the LazyMotion deferral instead of
+                // sweeping ~43KB gzip into the eager first-paint closure (#8821).
                 name: "vendor-motion",
                 test: /node_modules[\\/](framer-motion|motion-dom|motion-utils)[\\/]/,
+                tags: ["$initial"],
                 priority: 50,
               },
               {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -365,16 +365,23 @@ export default defineConfig(({ command, mode }) => {
                 priority: 60,
               },
               {
-                // `tags: ["$initial"]` restricts this group to framer-motion
-                // code statically reachable from an entry (LazyMotion,
-                // MotionConfig). The domMax feature set is reachable only
-                // through the dynamic import("./lib/motionFeatures") boundary,
-                // so it is NOT $initial-tagged and Rolldown keeps it in its own
-                // async chunk — preserving the LazyMotion deferral instead of
-                // sweeping ~43KB gzip into the eager first-paint closure (#8821).
+                // `entriesAware: true` makes Rolldown split this group by the
+                // set of entries that import each module rather than merging
+                // everything into one chunk. The eager motion runtime
+                // (LazyMotion, MotionConfig, `m`) is imported by the renderer
+                // entry and stays eager; the heavy `domMax` feature subtree is
+                // reachable only through the dynamic import("./lib/motionFeatures")
+                // boundary, so it lands in its own deferred subgroup chunk off
+                // the first-paint path — preserving the LazyMotion deferral
+                // instead of sweeping ~43KB gzip into the eager closure (#8821).
+                // A plain `$initial` tag is insufficient: it evicts domMax from
+                // this group, but the orphaned modules then fall into the eager
+                // catch-all `vendor` chunk. `entriesAwareMergeThreshold: 0`
+                // disables small-subgroup merging so the deferred split holds.
                 name: "vendor-motion",
                 test: /node_modules[\\/](framer-motion|motion-dom|motion-utils)[\\/]/,
-                tags: ["$initial"],
+                entriesAware: true,
+                entriesAwareMergeThreshold: 0,
                 priority: 50,
               },
               {


### PR DESCRIPTION
## Summary

- The `vendor-motion` manual chunk group in `vite.config.ts` was sweeping framer-motion's heavy `domMax` feature set (~43KB gzip) into an eager first-paint chunk, completely defeating the `LazyMotion` dynamic import deferral wired in `App.tsx`.
- Added `entriesAware: true` and `entriesAwareMergeThreshold: 0` to the chunk group so Rolldown splits by importing entry-set — the eager motion runtime stays eager; `domMax` lands in its own deferred chunk off the first-paint path.
- The budget script was walking both static and dynamic imports, so deferring code never moved the measured number. It now computes a separate eager-only closure (the new gated metric) alongside the existing total walk.

Closes #8821

## Changes

- `vite.config.ts` — `entriesAware: true` + `entriesAwareMergeThreshold: 0` on the `vendor-motion` group
- `scripts/check-first-render-chunk-budget.mjs` — `collectClosure()` gains a `followDynamic` option; `buildReport()` computes `eagerTotals` (static imports only) and `totals` (both edges); `compareToBaseline()` gates on `eagerTotals`; shrink guard reads `eagerTotals.gzip`; execution guard added so the module is importable by tests
- `scripts/check-first-render-chunk-budget.test.mjs` — new 15-test vitest suite covering both walk modes, seed handling, shared-chunk dedup, missing-key handling, and the shrink guard
- `first-render-chunk-baseline.json` — regenerated; eager first-paint gzip drops 28,533 bytes

## Testing

- `vite build` passes; manifest confirms `motionFeatures.ts` imports a deferred `vendor-motion~motionFeatures` chunk (17.36KB gzip) not in the eager closure
- vitest 15/15 pass for the new budget script test suite
- `npm run check` (typecheck, lint, format, ratchets) passes