### PR TITLE
feat(action-palette): pinning, eviction, and wider frecency half-life

### DIFF
--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -165,6 +165,14 @@ describe("CRASH_CRITICAL_FIELDS", () => {
     expect(CRASH_CRITICAL_FIELDS.has("actionMruList")).toBe(true);
   });
 
+  it("includes actionPinnedIds", () => {
+    expect(CRASH_CRITICAL_FIELDS.has("actionPinnedIds")).toBe(true);
+  });
+
+  it("includes actionHiddenIds", () => {
+    expect(CRASH_CRITICAL_FIELDS.has("actionHiddenIds")).toBe(true);
+  });
+
   it("includes developerMode", () => {
     expect(CRASH_CRITICAL_FIELDS.has("developerMode")).toBe(true);
   });
@@ -189,8 +197,8 @@ describe("CRASH_CRITICAL_FIELDS", () => {
     expect(CRASH_CRITICAL_FIELDS.has("unknownField")).toBe(false);
   });
 
-  it("has exactly 10 fields", () => {
-    expect(CRASH_CRITICAL_FIELDS.size).toBe(10);
+  it("has exactly 12 fields", () => {
+    expect(CRASH_CRITICAL_FIELDS.size).toBe(12);
   });
 });
 
@@ -223,6 +231,14 @@ describe("shouldTriggerBackup", () => {
 
   it("returns true for actionMruList", () => {
     expect(shouldTriggerBackup({ actionMruList: [] })).toBe(true);
+  });
+
+  it("returns true for actionPinnedIds", () => {
+    expect(shouldTriggerBackup({ actionPinnedIds: [] })).toBe(true);
+  });
+
+  it("returns true for actionHiddenIds", () => {
+    expect(shouldTriggerBackup({ actionHiddenIds: [] })).toBe(true);
   });
 
   it("returns true for developerMode", () => {

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -18,6 +18,8 @@ export const CRASH_CRITICAL_FIELDS = new Set([
   "recipes",
   "mruList",
   "actionMruList",
+  "actionPinnedIds",
+  "actionHiddenIds",
   "developerMode",
   "fleetScopeMode",
 ]);
@@ -614,6 +616,44 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
           }
           updates.actionMruList = sanitized;
         }
+      }
+
+      if ("actionPinnedIds" in partialState && Array.isArray(partialState.actionPinnedIds)) {
+        const ACTION_ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9._-]{0,127}$/;
+        const MAX_PINNED = 100;
+        const seen = new Set<string>();
+        const sanitized: string[] = [];
+        for (const id of partialState.actionPinnedIds) {
+          if (
+            typeof id === "string" &&
+            ACTION_ID_PATTERN.test(id) &&
+            !seen.has(id) &&
+            sanitized.length < MAX_PINNED
+          ) {
+            seen.add(id);
+            sanitized.push(id);
+          }
+        }
+        updates.actionPinnedIds = sanitized;
+      }
+
+      if ("actionHiddenIds" in partialState && Array.isArray(partialState.actionHiddenIds)) {
+        const ACTION_ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9._-]{0,127}$/;
+        const MAX_HIDDEN = 200;
+        const seen = new Set<string>();
+        const sanitized: string[] = [];
+        for (const id of partialState.actionHiddenIds) {
+          if (
+            typeof id === "string" &&
+            ACTION_ID_PATTERN.test(id) &&
+            !seen.has(id) &&
+            sanitized.length < MAX_HIDDEN
+          ) {
+            seen.add(id);
+            sanitized.push(id);
+          }
+        }
+        updates.actionHiddenIds = sanitized;
       }
 
       if ("fleetScopeMode" in partialState) {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -118,6 +118,8 @@ export interface StoreSchema {
     panelGridConfig?: PanelGridConfig;
     mruList?: string[];
     actionMruList?: ActionFrecencyEntry[] | string[];
+    actionPinnedIds?: string[];
+    actionHiddenIds?: string[];
     fleetScopeMode?: "legacy" | "scoped";
   };
   userConfig: {

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -83,6 +83,10 @@ export interface AppState {
   mruList?: string[];
   /** Most-recently-used action frecency entries for the action palette (migrated from legacy string[] format) */
   actionMruList?: ActionFrecencyEntry[] | string[];
+  /** Action IDs pinned to the "Favorites" rail of the empty-query action palette. */
+  actionPinnedIds?: string[];
+  /** Action IDs the user has hidden from the "Recently used" rail of the action palette. */
+  actionHiddenIds?: string[];
   /** Whether Fleet scope primitive is active ("scoped") or feature is disabled ("legacy", default) */
   fleetScopeMode?: "legacy" | "scoped";
 }

--- a/shared/utils/__tests__/frecency.test.ts
+++ b/shared/utils/__tests__/frecency.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { computeFrecencyScore, FRECENCY_HALF_LIFE_MS } from "../frecency.js";
 
+describe("FRECENCY_HALF_LIFE_MS", () => {
+  it("is set to 14 days — pairs with the eviction affordance (issue #8815)", () => {
+    expect(FRECENCY_HALF_LIFE_MS).toBe(14 * 24 * 60 * 60 * 1000);
+  });
+});
+
 describe("computeFrecencyScore", () => {
   const NOW = 1_700_000_000_000;
 

--- a/shared/utils/frecency.ts
+++ b/shared/utils/frecency.ts
@@ -1,4 +1,4 @@
-export const FRECENCY_HALF_LIFE_MS = 5 * 24 * 60 * 60 * 1000;
+export const FRECENCY_HALF_LIFE_MS = 14 * 24 * 60 * 60 * 1000;
 // Exploration bias for never-accessed items: ~3 half-lives of stickiness so a
 // new item can accrue real frequency before decay buries it under a single
 // recent access of an older item. Without this seed, one click on a stale

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1125,6 +1125,7 @@ function App() {
                     totalResults={actionPalette.totalResults}
                     selectedIndex={actionPalette.selectedIndex}
                     isStale={actionPalette.isStale}
+                    pinnedCount={actionPalette.pinnedCount}
                     close={actionPalette.close}
                     setQuery={actionPalette.setQuery}
                     setSelectedIndex={actionPalette.setSelectedIndex}
@@ -1132,6 +1133,9 @@ function App() {
                     selectNext={actionPalette.selectNext}
                     executeAction={actionPalette.executeAction}
                     confirmSelection={actionPalette.confirmSelection}
+                    pinAction={actionPalette.pinAction}
+                    unpinAction={actionPalette.unpinAction}
+                    hideAction={actionPalette.hideAction}
                   />
                 </Suspense>
               )}

--- a/src/components/ActionPalette/ActionPalette.test.tsx
+++ b/src/components/ActionPalette/ActionPalette.test.tsx
@@ -60,6 +60,8 @@ function makeItem(id: string, title: string): ActionPaletteItemType {
 }
 
 const noop = () => {};
+const noopPin = () => true;
+const noopHide = () => {};
 
 describe("ActionPalette", () => {
   it("does not render the empty message when a typed query has zero matches", () => {
@@ -71,6 +73,7 @@ describe("ActionPalette", () => {
         totalResults={0}
         selectedIndex={0}
         isStale={false}
+        pinnedCount={0}
         close={noop}
         setQuery={noop}
         setSelectedIndex={noop}
@@ -78,6 +81,9 @@ describe("ActionPalette", () => {
         selectNext={noop}
         executeAction={noop}
         confirmSelection={noop}
+        pinAction={noopPin}
+        unpinAction={noop}
+        hideAction={noopHide}
       />
     );
 
@@ -93,6 +99,7 @@ describe("ActionPalette", () => {
         totalResults={0}
         selectedIndex={0}
         isStale={false}
+        pinnedCount={0}
         close={noop}
         setQuery={noop}
         setSelectedIndex={noop}
@@ -100,6 +107,9 @@ describe("ActionPalette", () => {
         selectNext={noop}
         executeAction={noop}
         confirmSelection={noop}
+        pinAction={noopPin}
+        unpinAction={noop}
+        hideAction={noopHide}
       />
     );
 
@@ -115,6 +125,7 @@ describe("ActionPalette", () => {
         totalResults={1}
         selectedIndex={0}
         isStale
+        pinnedCount={0}
         close={noop}
         setQuery={noop}
         setSelectedIndex={noop}
@@ -122,9 +133,64 @@ describe("ActionPalette", () => {
         selectNext={noop}
         executeAction={noop}
         confirmSelection={noop}
+        pinAction={noopPin}
+        unpinAction={noop}
+        hideAction={noopHide}
       />
     );
 
     expect(lastSearchablePaletteProps.current?.isFiltering).toBe(true);
+  });
+
+  it("passes a renderBody callback when on the empty-query rail with results", () => {
+    render(
+      <ActionPalette
+        isOpen
+        query=""
+        results={[makeItem("a.action", "Alpha")]}
+        totalResults={1}
+        selectedIndex={0}
+        isStale={false}
+        pinnedCount={0}
+        close={noop}
+        setQuery={noop}
+        setSelectedIndex={noop}
+        selectPrevious={noop}
+        selectNext={noop}
+        executeAction={noop}
+        confirmSelection={noop}
+        pinAction={noopPin}
+        unpinAction={noop}
+        hideAction={noopHide}
+      />
+    );
+
+    expect(typeof lastSearchablePaletteProps.current?.renderBody).toBe("function");
+  });
+
+  it("does NOT pass a renderBody callback when a query is typed", () => {
+    render(
+      <ActionPalette
+        isOpen
+        query="al"
+        results={[makeItem("a.action", "Alpha")]}
+        totalResults={1}
+        selectedIndex={0}
+        isStale={false}
+        pinnedCount={0}
+        close={noop}
+        setQuery={noop}
+        setSelectedIndex={noop}
+        selectPrevious={noop}
+        selectNext={noop}
+        executeAction={noop}
+        confirmSelection={noop}
+        pinAction={noopPin}
+        unpinAction={noop}
+        hideAction={noopHide}
+      />
+    );
+
+    expect(lastSearchablePaletteProps.current?.renderBody).toBeUndefined();
   });
 });

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
+import { PaletteOverflowNotice } from "@/components/ui/PaletteOverflowNotice";
 import { useEffectiveCombo } from "@/hooks/useKeybinding";
 import { useActionPrefsStore } from "@/store/actionPrefsStore";
 import { ActionPaletteItem } from "./ActionPaletteItem";
@@ -121,34 +122,37 @@ export function ActionPalette({
     const pinnedRows = results.slice(0, pinnedCount);
     const recentRows = results.slice(pinnedCount);
     return (
-      <div
-        ref={sectionedListRef}
-        id="action-palette-list"
-        role="listbox"
-        aria-label="Actions"
-        className={isStale ? "palette-results-stale" : undefined}
-        data-stale={isStale ? "true" : undefined}
-        aria-busy={isStale || undefined}
-      >
-        {pinnedRows.length > 0 && (
-          <>
-            <div className={SECTION_HEADER_CLASS} role="presentation">
-              Favorites
-            </div>
-            {pinnedRows.map((item, idx) => renderActionRow(item, idx))}
-          </>
-        )}
-        {recentRows.length > 0 && (
-          <>
-            <div className={SECTION_HEADER_CLASS} role="presentation">
-              Recently used
-            </div>
-            {recentRows.map((item, idx) => renderActionRow(item, pinnedCount + idx))}
-          </>
-        )}
-      </div>
+      <>
+        <div
+          ref={sectionedListRef}
+          id="action-palette-list"
+          role="listbox"
+          aria-label="Actions"
+          className={isStale ? "palette-results-stale" : undefined}
+          data-stale={isStale ? "true" : undefined}
+          aria-busy={isStale || undefined}
+        >
+          {pinnedRows.length > 0 && (
+            <>
+              <div className={SECTION_HEADER_CLASS} role="presentation">
+                Favorites
+              </div>
+              {pinnedRows.map((item, idx) => renderActionRow(item, idx))}
+            </>
+          )}
+          {recentRows.length > 0 && (
+            <>
+              <div className={SECTION_HEADER_CLASS} role="presentation">
+                Recently used
+              </div>
+              {recentRows.map((item, idx) => renderActionRow(item, pinnedCount + idx))}
+            </>
+          )}
+        </div>
+        <PaletteOverflowNotice shown={results.length} total={totalResults} />
+      </>
     );
-  }, [results, pinnedCount, isStale, renderActionRow]);
+  }, [results, pinnedCount, isStale, totalResults, renderActionRow]);
 
   return (
     <SearchablePalette<ActionPaletteItemType>

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -1,11 +1,15 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
 import { useEffectiveCombo } from "@/hooks/useKeybinding";
+import { useActionPrefsStore } from "@/store/actionPrefsStore";
 import { ActionPaletteItem } from "./ActionPaletteItem";
 import type {
   ActionPaletteItem as ActionPaletteItemType,
   UseActionPaletteReturn,
 } from "@/hooks/useActionPalette";
+
+const SECTION_HEADER_CLASS =
+  "px-3 py-1 text-[10px] font-medium tracking-wider uppercase text-daintree-text/40 select-none";
 
 // Module-level so SearchablePalette receives a stable reference and skips
 // re-renders driven only by a freshly-created callback identity.
@@ -23,6 +27,7 @@ type ActionPaletteProps = Pick<
   | "totalResults"
   | "selectedIndex"
   | "isStale"
+  | "pinnedCount"
   | "close"
   | "setQuery"
   | "setSelectedIndex"
@@ -30,6 +35,9 @@ type ActionPaletteProps = Pick<
   | "selectNext"
   | "executeAction"
   | "confirmSelection"
+  | "pinAction"
+  | "unpinAction"
+  | "hideAction"
 >;
 
 export function ActionPalette({
@@ -39,6 +47,7 @@ export function ActionPalette({
   totalResults,
   selectedIndex,
   isStale,
+  pinnedCount,
   close,
   setQuery,
   setSelectedIndex,
@@ -46,6 +55,9 @@ export function ActionPalette({
   selectNext,
   executeAction,
   confirmSelection,
+  pinAction,
+  unpinAction,
+  hideAction,
 }: ActionPaletteProps) {
   const handleSelect = useCallback(
     (item: ActionPaletteItemType) => {
@@ -55,6 +67,88 @@ export function ActionPalette({
   );
 
   const actionPaletteShortcut = useEffectiveCombo("action.palette.open");
+  const pinnedActionIds = useActionPrefsStore((state) => state.pinnedActionIds);
+
+  // The sectioned empty-query body renders headers as siblings of the row list,
+  // so the listbox children stay 1:1 with `results` for the parent's
+  // scroll-into-view logic. The custom scroll effect below scrolls within the
+  // sectioned listbox itself, keyed by `data-action-id` so the divider divs
+  // don't throw off the offset.
+  const sectionedListRef = useRef<HTMLDivElement>(null);
+  const showSections = !query.trim() && results.length > 0;
+
+  useEffect(() => {
+    if (!showSections) return;
+    const listEl = sectionedListRef.current;
+    if (!listEl || selectedIndex < 0 || selectedIndex >= results.length) return;
+    const selectedId = results[selectedIndex]?.id;
+    if (!selectedId) return;
+    const row = listEl.querySelector<HTMLElement>(`[data-action-id="${CSS.escape(selectedId)}"]`);
+    row?.scrollIntoView({ block: "nearest", behavior: "instant" });
+  }, [showSections, selectedIndex, results]);
+
+  const renderActionRow = useCallback(
+    (item: ActionPaletteItemType, index: number) => {
+      const isPinned = pinnedActionIds.includes(item.id);
+      return (
+        <div key={item.id} data-action-id={item.id}>
+          <ActionPaletteItem
+            item={item}
+            index={index}
+            isSelected={index === selectedIndex}
+            onSelect={handleSelect}
+            onHoverIndex={setSelectedIndex}
+            isPinned={isPinned}
+            onPin={pinAction}
+            onUnpin={unpinAction}
+            onHide={hideAction}
+          />
+        </div>
+      );
+    },
+    [
+      pinnedActionIds,
+      selectedIndex,
+      handleSelect,
+      setSelectedIndex,
+      pinAction,
+      unpinAction,
+      hideAction,
+    ]
+  );
+
+  const renderSectionedBody = useCallback(() => {
+    const pinnedRows = results.slice(0, pinnedCount);
+    const recentRows = results.slice(pinnedCount);
+    return (
+      <div
+        ref={sectionedListRef}
+        id="action-palette-list"
+        role="listbox"
+        aria-label="Actions"
+        className={isStale ? "palette-results-stale" : undefined}
+        data-stale={isStale ? "true" : undefined}
+        aria-busy={isStale || undefined}
+      >
+        {pinnedRows.length > 0 && (
+          <>
+            <div className={SECTION_HEADER_CLASS} role="presentation">
+              Favorites
+            </div>
+            {pinnedRows.map((item, idx) => renderActionRow(item, idx))}
+          </>
+        )}
+        {recentRows.length > 0 && (
+          <>
+            <div className={SECTION_HEADER_CLASS} role="presentation">
+              Recently used
+            </div>
+            {recentRows.map((item, idx) => renderActionRow(item, pinnedCount + idx))}
+          </>
+        )}
+      </div>
+    );
+  }, [results, pinnedCount, isStale, renderActionRow]);
 
   return (
     <SearchablePalette<ActionPaletteItemType>
@@ -71,16 +165,24 @@ export function ActionPalette({
       getItemId={getActionItemId}
       getActionLabel={getActionLabel}
       isFiltering={isStale}
-      renderItem={(item, index, isSelected, onHoverIndex) => (
-        <ActionPaletteItem
-          key={item.id}
-          item={item}
-          index={index}
-          isSelected={isSelected}
-          onSelect={handleSelect}
-          onHoverIndex={onHoverIndex}
-        />
-      )}
+      renderItem={(item, index, isSelected, onHoverIndex) => {
+        const isPinned = pinnedActionIds.includes(item.id);
+        return (
+          <ActionPaletteItem
+            key={item.id}
+            item={item}
+            index={index}
+            isSelected={isSelected}
+            onSelect={handleSelect}
+            onHoverIndex={onHoverIndex}
+            isPinned={isPinned}
+            onPin={pinAction}
+            onUnpin={unpinAction}
+            onHide={hideAction}
+          />
+        );
+      }}
+      renderBody={showSections ? renderSectionedBody : undefined}
       label="Actions"
       shortcut={actionPaletteShortcut}
       ariaLabel="Action palette"

--- a/src/components/ActionPalette/ActionPaletteItem.test.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.test.tsx
@@ -196,4 +196,126 @@ describe("ActionPaletteItem", () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith(item);
   });
+
+  describe("pin & hide affordances", () => {
+    it("renders the pin button when onPin is provided", () => {
+      render(
+        <ActionPaletteItem
+          item={makeItem()}
+          index={0}
+          isSelected={false}
+          onSelect={onSelect}
+          onPin={() => true}
+        />
+      );
+
+      expect(screen.getByRole("button", { name: /pin .* to favorites/i })).toBeTruthy();
+    });
+
+    it("renders the hide button when onHide is provided and the item is not pinned or destructive", () => {
+      render(
+        <ActionPaletteItem
+          item={makeItem()}
+          index={0}
+          isSelected={false}
+          onSelect={onSelect}
+          onHide={() => {}}
+        />
+      );
+
+      expect(screen.getByRole("button", { name: /hide .* from recently used/i })).toBeTruthy();
+    });
+
+    it("hides the hide button on destructive (danger:'confirm') items", () => {
+      render(
+        <ActionPaletteItem
+          item={makeItem({ danger: "confirm" })}
+          index={0}
+          isSelected={false}
+          onSelect={onSelect}
+          onHide={() => {}}
+        />
+      );
+
+      expect(screen.queryByRole("button", { name: /hide .* from recently used/i })).toBeNull();
+    });
+
+    it("calls onPin and stops propagation when the pin button is clicked", () => {
+      const onPin = vi.fn(() => true);
+      render(
+        <ActionPaletteItem
+          item={makeItem()}
+          index={0}
+          isSelected={false}
+          onSelect={onSelect}
+          onPin={onPin}
+        />
+      );
+
+      onSelect.mockClear();
+      const pinButton = screen.getByRole("button", { name: /pin .* to favorites/i });
+      fireEvent.click(pinButton);
+
+      expect(onPin).toHaveBeenCalledTimes(1);
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a rejection message when onPin returns false (e.g., destructive action)", () => {
+      const onPin = vi.fn(() => false);
+      render(
+        <ActionPaletteItem
+          item={makeItem({ danger: "confirm" })}
+          index={0}
+          isSelected={false}
+          onSelect={onSelect}
+          onPin={onPin}
+        />
+      );
+
+      const pinButton = screen.getByRole("button", { name: /pin .* to favorites/i });
+      fireEvent.click(pinButton);
+
+      expect(onPin).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("Can't pin destructive actions")).toBeTruthy();
+    });
+
+    it("uses 'Unpin' label and routes click to onUnpin when isPinned", () => {
+      const onUnpin = vi.fn();
+      const item = makeItem();
+      render(
+        <ActionPaletteItem
+          item={item}
+          index={0}
+          isSelected={false}
+          onSelect={onSelect}
+          onPin={() => true}
+          onUnpin={onUnpin}
+          isPinned
+        />
+      );
+
+      const unpinButton = screen.getByRole("button", { name: /unpin/i });
+      fireEvent.click(unpinButton);
+
+      expect(onUnpin).toHaveBeenCalledTimes(1);
+      expect(onUnpin).toHaveBeenCalledWith(item.id);
+    });
+
+    it("hides the hide button when the item is already pinned", () => {
+      render(
+        <ActionPaletteItem
+          item={makeItem()}
+          index={0}
+          isSelected={false}
+          onSelect={onSelect}
+          onPin={() => true}
+          onUnpin={() => {}}
+          onHide={() => {}}
+          isPinned
+        />
+      );
+
+      expect(screen.queryByRole("button", { name: /hide .* from recently used/i })).toBeNull();
+    });
+  });
 });

--- a/src/components/ActionPalette/ActionPaletteItem.test.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.test.tsx
@@ -70,7 +70,7 @@ describe("ActionPaletteItem", () => {
   });
 
   it("does not render disabled reason for disabled actions without a reason", () => {
-    const { container } = render(
+    render(
       <ActionPaletteItem
         item={makeItem({ enabled: false })}
         index={0}
@@ -81,11 +81,11 @@ describe("ActionPaletteItem", () => {
 
     expect(screen.getByText("Test Action")).toBeTruthy();
     expect(screen.getByText("Test description")).toBeTruthy();
-    expect(container.querySelector("button")?.getAttribute("aria-disabled")).toBe("true");
+    expect(screen.getByRole("option").getAttribute("aria-disabled")).toBe("true");
   });
 
   it("does not render disabled reason for enabled actions with disabledReason", () => {
-    const { container } = render(
+    render(
       <ActionPaletteItem
         item={makeItem({ enabled: true, disabledReason: "Should not show" })}
         index={0}
@@ -96,7 +96,7 @@ describe("ActionPaletteItem", () => {
 
     expect(screen.getByText("Test Action")).toBeTruthy();
     expect(screen.queryByText("Should not show")).toBeNull();
-    expect(container.querySelector("button")?.getAttribute("aria-disabled")).toBe("false");
+    expect(screen.getByRole("option").getAttribute("aria-disabled")).toBe("false");
   });
 
   it("renders keybinding when present", () => {
@@ -113,35 +113,31 @@ describe("ActionPaletteItem", () => {
   });
 
   it("applies selected styling with aria-selected and accent indicator", () => {
-    const { container } = render(
-      <ActionPaletteItem item={makeItem()} index={0} isSelected={true} onSelect={onSelect} />
-    );
+    render(<ActionPaletteItem item={makeItem()} index={0} isSelected={true} onSelect={onSelect} />);
 
-    const button = container.querySelector("button");
-    expect(button).toBeTruthy();
-    expect(button?.getAttribute("aria-selected")).toBe("true");
+    const row = screen.getByRole("option");
+    expect(row.getAttribute("aria-selected")).toBe("true");
     // Selected state is now CSS-driven via aria-selected: variants.
-    expect(button?.className).toContain("aria-selected:bg-overlay-soft");
-    expect(button?.className).toContain("aria-selected:before:bg-daintree-accent");
-    expect(button?.className).toContain("aria-selected:before:content-['']");
+    expect(row.className).toContain("aria-selected:bg-overlay-soft");
+    expect(row.className).toContain("aria-selected:before:bg-daintree-accent");
+    expect(row.className).toContain("aria-selected:before:content-['']");
   });
 
   it("does not branch styling on isSelected — selection is purely aria-driven", () => {
-    const { container: selectedContainer } = render(
+    const { rerender } = render(
       <ActionPaletteItem item={makeItem()} index={0} isSelected={true} onSelect={onSelect} />
     );
-    const { container: unselectedContainer } = render(
+    const selectedClass = screen.getByRole("option").className;
+    rerender(
       <ActionPaletteItem item={makeItem()} index={0} isSelected={false} onSelect={onSelect} />
     );
-
-    const selectedClass = selectedContainer.querySelector("button")?.className;
-    const unselectedClass = unselectedContainer.querySelector("button")?.className;
+    const unselectedClass = screen.getByRole("option").className;
     // Class lists must be identical — only aria-selected attribute differs.
     expect(selectedClass).toBe(unselectedClass);
   });
 
   it("lifts keybinding glyph contrast on selection via group-aria-selected", () => {
-    const { container } = render(
+    render(
       <ActionPaletteItem
         item={makeItem({ keybinding: "⌘K" })}
         index={0}
@@ -153,12 +149,12 @@ describe("ActionPaletteItem", () => {
     const kbd = screen.getByText("⌘K");
     expect(kbd.className).toContain("text-daintree-text/40");
     expect(kbd.className).toContain("group-aria-selected:text-daintree-text/60");
-    expect(container.querySelector("button")?.className).toContain("group");
+    expect(screen.getByRole("option").className).toContain("group");
   });
 
   it("calls onHoverIndex with index when pointer moves over the item", () => {
     const onHoverIndex = vi.fn();
-    const { container } = render(
+    render(
       <ActionPaletteItem
         item={makeItem()}
         index={3}
@@ -168,33 +164,53 @@ describe("ActionPaletteItem", () => {
       />
     );
 
-    const button = container.querySelector("button");
-    expect(button).toBeTruthy();
-    fireEvent.pointerMove(button!);
+    const row = screen.getByRole("option");
+    fireEvent.pointerMove(row);
     expect(onHoverIndex).toHaveBeenCalledTimes(1);
     expect(onHoverIndex).toHaveBeenCalledWith(3);
   });
 
   it("does not throw when onHoverIndex is omitted", () => {
-    const { container } = render(
+    render(
       <ActionPaletteItem item={makeItem()} index={0} isSelected={false} onSelect={onSelect} />
     );
 
-    const button = container.querySelector("button");
-    expect(() => fireEvent.pointerMove(button!)).not.toThrow();
+    const row = screen.getByRole("option");
+    expect(() => fireEvent.pointerMove(row)).not.toThrow();
   });
 
-  it("calls onSelect when an enabled item is clicked", () => {
+  it("calls onSelect when an enabled item's row body is clicked", () => {
     const item = makeItem({ enabled: true });
-    const { container } = render(
-      <ActionPaletteItem item={item} index={0} isSelected={false} onSelect={onSelect} />
-    );
+    render(<ActionPaletteItem item={item} index={0} isSelected={false} onSelect={onSelect} />);
 
-    const button = container.querySelector("button");
-    expect(button).toBeTruthy();
-    fireEvent.click(button!);
+    // The row body is the button labeled with the item's title (sibling of pin/hide buttons).
+    const rowButton = screen.getByRole("button", { name: item.title });
+    fireEvent.click(rowButton);
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith(item);
+  });
+
+  it("keeps pin/hide buttons clickable on a disabled MRU row (not nested in disabled button)", () => {
+    const item = makeItem({ enabled: false, disabledReason: "No focused terminal" });
+    const onHide = vi.fn();
+    const onPin = vi.fn(() => true);
+    render(
+      <ActionPaletteItem
+        item={item}
+        index={0}
+        isSelected={false}
+        onSelect={onSelect}
+        onPin={onPin}
+        onHide={onHide}
+      />
+    );
+
+    const pinButton = screen.getByRole("button", { name: /pin .* to favorites/i });
+    const hideButton = screen.getByRole("button", { name: /hide .* from recently used/i });
+    fireEvent.click(pinButton);
+    fireEvent.click(hideButton);
+    expect(onPin).toHaveBeenCalledTimes(1);
+    expect(onHide).toHaveBeenCalledTimes(1);
   });
 
   describe("pin & hide affordances", () => {

--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -1,4 +1,5 @@
-import { useCallback } from "react";
+import { memo, useCallback, useState } from "react";
+import { Pin, PinOff, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ActionPaletteItem as ActionPaletteItemType } from "@/hooks/useActionPalette";
 import { ACTION_CATEGORY_COLORS, ACTION_CATEGORY_DEFAULT_COLOR } from "@/config/categoryColors";
@@ -9,20 +10,68 @@ interface ActionPaletteItemProps {
   onSelect: (item: ActionPaletteItemType) => void;
   index: number;
   onHoverIndex?: (index: number) => void;
+  /** Whether this row is currently pinned (rendered in the Favorites section). */
+  isPinned?: boolean;
+  /** Optional pin/unpin callback. When omitted, the pin button is hidden. */
+  onPin?: (item: ActionPaletteItemType) => boolean;
+  onUnpin?: (id: string) => void;
+  /**
+   * Optional hide-from-recently-used callback. Hidden for pinned rows and for
+   * destructive actions (which never reach the rail anyway). When omitted, the
+   * hide button is hidden.
+   */
+  onHide?: (item: ActionPaletteItemType) => void;
 }
 
-export function ActionPaletteItem({
+function ActionPaletteItemInner({
   item,
   isSelected,
   onSelect,
   index,
   onHoverIndex,
+  isPinned = false,
+  onPin,
+  onUnpin,
+  onHide,
 }: ActionPaletteItemProps) {
   const categoryColor = ACTION_CATEGORY_COLORS[item.category] ?? ACTION_CATEGORY_DEFAULT_COLOR;
+  const [pinRejected, setPinRejected] = useState(false);
 
   const handleHover = useCallback(() => {
     onHoverIndex?.(index);
   }, [onHoverIndex, index]);
+
+  const handlePinClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (isPinned) {
+        onUnpin?.(item.id);
+        setPinRejected(false);
+        return;
+      }
+      const ok = onPin?.(item) ?? false;
+      if (!ok) {
+        setPinRejected(true);
+        // Auto-clear the rejection tooltip after a brief moment so the user
+        // can re-attempt without the message lingering forever.
+        window.setTimeout(() => setPinRejected(false), 2500);
+      }
+    },
+    [isPinned, onPin, onUnpin, item]
+  );
+
+  const handleHideClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      onHide?.(item);
+    },
+    [onHide, item]
+  );
+
+  const canShowPin = Boolean(onPin || (isPinned && onUnpin));
+  const canShowHide = Boolean(onHide) && !isPinned && item.danger !== "confirm";
 
   return (
     <button
@@ -64,13 +113,70 @@ export function ActionPaletteItem({
             {item.disabledReason}
           </div>
         )}
+        {pinRejected && (
+          <div
+            className="text-[10px] text-status-error mt-0.5 truncate"
+            role="status"
+            aria-live="polite"
+          >
+            Can't pin destructive actions
+          </div>
+        )}
       </div>
 
-      {item.keybinding && (
-        <span className="shrink-0 text-[11px] font-mono text-daintree-text/40 transition-colors group-aria-selected:text-daintree-text/60">
-          {item.keybinding}
-        </span>
-      )}
+      <div className="shrink-0 flex items-center gap-1">
+        {canShowHide && (
+          <span
+            role="button"
+            tabIndex={-1}
+            aria-label={`Hide '${item.title}' from Recently used`}
+            title="Hide from Recently used"
+            onPointerDown={(e) => e.preventDefault()}
+            onClick={handleHideClick}
+            className={cn(
+              "inline-flex items-center justify-center w-6 h-6 rounded-[var(--radius-sm)]",
+              "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-aria-selected:opacity-100",
+              "hover:bg-overlay-soft hover:text-daintree-text transition-colors",
+              "focus-visible:opacity-100"
+            )}
+          >
+            <EyeOff className="w-3.5 h-3.5" aria-hidden />
+          </span>
+        )}
+        {canShowPin && (
+          <span
+            role="button"
+            tabIndex={-1}
+            aria-label={isPinned ? `Unpin '${item.title}'` : `Pin '${item.title}' to Favorites`}
+            aria-pressed={isPinned}
+            title={isPinned ? "Unpin from Favorites" : "Pin to Favorites"}
+            onPointerDown={(e) => e.preventDefault()}
+            onClick={handlePinClick}
+            className={cn(
+              "inline-flex items-center justify-center w-6 h-6 rounded-[var(--radius-sm)]",
+              "transition-colors hover:bg-overlay-soft",
+              isPinned
+                ? "text-daintree-text/70 opacity-100"
+                : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-aria-selected:opacity-100",
+              "hover:text-daintree-text focus-visible:opacity-100"
+            )}
+          >
+            {isPinned ? (
+              <PinOff className="w-3.5 h-3.5" aria-hidden />
+            ) : (
+              <Pin className="w-3.5 h-3.5" aria-hidden />
+            )}
+          </span>
+        )}
+
+        {item.keybinding && (
+          <span className="text-[11px] font-mono text-daintree-text/40 transition-colors group-aria-selected:text-daintree-text/60">
+            {item.keybinding}
+          </span>
+        )}
+      </div>
     </button>
   );
 }
+
+export const ActionPaletteItem = memo(ActionPaletteItemInner);

--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -1,8 +1,10 @@
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { Pin, PinOff, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ActionPaletteItem as ActionPaletteItemType } from "@/hooks/useActionPalette";
 import { ACTION_CATEGORY_COLORS, ACTION_CATEGORY_DEFAULT_COLOR } from "@/config/categoryColors";
+
+const PIN_REJECT_DURATION_MS = 2500;
 
 interface ActionPaletteItemProps {
   item: ActionPaletteItemType;
@@ -36,6 +38,19 @@ function ActionPaletteItemInner({
 }: ActionPaletteItemProps) {
   const categoryColor = ACTION_CATEGORY_COLORS[item.category] ?? ACTION_CATEGORY_DEFAULT_COLOR;
   const [pinRejected, setPinRejected] = useState(false);
+  const rejectTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    // Cleanup the pin-rejection auto-dismiss timer on unmount so a row that's
+    // unmounted between pin-click and the 2.5s timeout doesn't fire setState
+    // on a torn-down component.
+    return () => {
+      if (rejectTimerRef.current !== null) {
+        window.clearTimeout(rejectTimerRef.current);
+        rejectTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const handleHover = useCallback(() => {
     onHoverIndex?.(index);
@@ -53,9 +68,13 @@ function ActionPaletteItemInner({
       const ok = onPin?.(item) ?? false;
       if (!ok) {
         setPinRejected(true);
-        // Auto-clear the rejection tooltip after a brief moment so the user
-        // can re-attempt without the message lingering forever.
-        window.setTimeout(() => setPinRejected(false), 2500);
+        if (rejectTimerRef.current !== null) {
+          window.clearTimeout(rejectTimerRef.current);
+        }
+        rejectTimerRef.current = window.setTimeout(() => {
+          setPinRejected(false);
+          rejectTimerRef.current = null;
+        }, PIN_REJECT_DURATION_MS);
       }
     },
     [isPinned, onPin, onUnpin, item]
@@ -70,82 +89,103 @@ function ActionPaletteItemInner({
     [onHide, item]
   );
 
+  const handleSelectClick = useCallback(() => {
+    if (!item.enabled) {
+      // Mirror the previous `disabled` behavior — disabled actions still
+      // dispatch (so ActionService surfaces the disabled-reason toast), but
+      // the click only fires if the user explicitly hits the row body. The
+      // pin/hide buttons live in a sibling element so they remain reachable
+      // even when the row is disabled.
+      onSelect(item);
+      return;
+    }
+    onSelect(item);
+  }, [item, onSelect]);
+
   const canShowPin = Boolean(onPin || (isPinned && onUnpin));
   const canShowHide = Boolean(onHide) && !isPinned && item.danger !== "confirm";
 
   return (
-    <button
-      id={`action-option-${item.id}`}
-      tabIndex={-1}
-      onPointerDown={(e) => e.preventDefault()}
-      onPointerMove={handleHover}
-      role="option"
-      aria-selected={isSelected}
-      aria-disabled={!item.enabled}
-      disabled={!item.enabled}
+    <div
       className={cn(
-        "group relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors",
+        "group relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] transition-colors",
         "border border-transparent text-daintree-text/70",
         "hover:bg-overlay-subtle hover:text-daintree-text",
         "aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text",
         "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
         "aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']",
-        !item.enabled && "opacity-40 cursor-not-allowed"
+        !item.enabled && "opacity-40"
       )}
-      onClick={() => onSelect(item)}
+      id={`action-option-${item.id}`}
+      role="option"
+      aria-selected={isSelected}
+      aria-disabled={!item.enabled}
+      onPointerDown={(e) => e.preventDefault()}
+      onPointerMove={handleHover}
     >
-      <span
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-label={item.title}
+        onClick={handleSelectClick}
         className={cn(
-          "shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium leading-tight",
-          categoryColor
+          "flex-1 min-w-0 flex items-center gap-3 text-left bg-transparent border-0 p-0",
+          !item.enabled && "cursor-not-allowed"
         )}
       >
-        {item.category}
-      </span>
+        <span
+          className={cn(
+            "shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium leading-tight",
+            categoryColor
+          )}
+        >
+          {item.category}
+        </span>
 
-      <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium truncate">{item.title}</div>
-        {item.description && (
-          <div className="text-xs text-daintree-text/50 truncate">{item.description}</div>
-        )}
-        {!item.enabled && item.disabledReason && (
-          <div className="text-[10px] text-daintree-text/40 italic truncate">
-            {item.disabledReason}
-          </div>
-        )}
-        {pinRejected && (
-          <div
-            className="text-[10px] text-status-error mt-0.5 truncate"
-            role="status"
-            aria-live="polite"
-          >
-            Can't pin destructive actions
-          </div>
-        )}
-      </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium truncate">{item.title}</div>
+          {item.description && (
+            <div className="text-xs text-daintree-text/50 truncate">{item.description}</div>
+          )}
+          {!item.enabled && item.disabledReason && (
+            <div className="text-[10px] text-daintree-text/40 italic truncate">
+              {item.disabledReason}
+            </div>
+          )}
+          {pinRejected && (
+            <div
+              className="text-[10px] text-status-error mt-0.5 truncate"
+              role="status"
+              aria-live="polite"
+            >
+              Can't pin destructive actions
+            </div>
+          )}
+        </div>
+      </button>
 
       <div className="shrink-0 flex items-center gap-1">
         {canShowHide && (
-          <span
-            role="button"
+          <button
+            type="button"
             tabIndex={-1}
             aria-label={`Hide '${item.title}' from Recently used`}
             title="Hide from Recently used"
             onPointerDown={(e) => e.preventDefault()}
             onClick={handleHideClick}
             className={cn(
-              "inline-flex items-center justify-center w-6 h-6 rounded-[var(--radius-sm)]",
+              "inline-flex items-center justify-center w-6 h-6 rounded-[var(--radius-sm)] bg-transparent border-0",
               "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-aria-selected:opacity-100",
               "hover:bg-overlay-soft hover:text-daintree-text transition-colors",
               "focus-visible:opacity-100"
             )}
           >
             <EyeOff className="w-3.5 h-3.5" aria-hidden />
-          </span>
+          </button>
         )}
         {canShowPin && (
-          <span
-            role="button"
+          <button
+            type="button"
             tabIndex={-1}
             aria-label={isPinned ? `Unpin '${item.title}'` : `Pin '${item.title}' to Favorites`}
             aria-pressed={isPinned}
@@ -153,7 +193,7 @@ function ActionPaletteItemInner({
             onPointerDown={(e) => e.preventDefault()}
             onClick={handlePinClick}
             className={cn(
-              "inline-flex items-center justify-center w-6 h-6 rounded-[var(--radius-sm)]",
+              "inline-flex items-center justify-center w-6 h-6 rounded-[var(--radius-sm)] bg-transparent border-0",
               "transition-colors hover:bg-overlay-soft",
               isPinned
                 ? "text-daintree-text/70 opacity-100"
@@ -166,7 +206,7 @@ function ActionPaletteItemInner({
             ) : (
               <Pin className="w-3.5 h-3.5" aria-hidden />
             )}
-          </span>
+          </button>
         )}
 
         {item.keybinding && (
@@ -175,7 +215,7 @@ function ActionPaletteItemInner({
           </span>
         )}
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -1,5 +1,14 @@
 import { useState, useEffect } from "react";
-import { Signal, FolderOpen, Trash2, Clock, HardDrive, AlertTriangle, Eye } from "lucide-react";
+import {
+  Signal,
+  FolderOpen,
+  Trash2,
+  Clock,
+  HardDrive,
+  AlertTriangle,
+  Eye,
+  EyeOff,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { notify } from "@/lib/notify";
 import { Button } from "@/components/ui/button";
@@ -8,6 +17,7 @@ import { SettingsSubtabBar } from "./SettingsSubtabBar";
 import type { SettingsSubtabItem } from "./SettingsSubtabBar";
 import { ANALYTICS_EVENTS } from "@shared/config/telemetry";
 import { actionService } from "@/services/ActionService";
+import { useActionPrefsStore } from "@/store/actionPrefsStore";
 import { logError } from "@/utils/logger";
 
 type TelemetryLevel = "off" | "errors" | "full";
@@ -236,6 +246,17 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
     void actionService.dispatch("telemetry.togglePreview", { active: true }, { source: "user" });
   };
 
+  const hiddenActionCount = useActionPrefsStore((state) => state.hiddenActionIds.length);
+  const handleResetHiddenCommands = () => {
+    useActionPrefsStore.getState().resetHiddenActions();
+    notify({
+      type: "success",
+      title: "Hidden commands reset",
+      message: "All previously hidden commands will appear in Recently used again.",
+      transient: true,
+    });
+  };
+
   return (
     <div className="space-y-6">
       <SettingsSubtabBar
@@ -420,6 +441,25 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
             >
               <Trash2 className={cn("w-4 h-4", cacheClearing && "animate-spin")} />
               {cacheClearing ? "Clearing…" : cacheCleared ? "Cache Cleared" : "Clear Cache"}
+            </Button>
+          </SettingsSection>
+
+          <SettingsSection
+            icon={EyeOff}
+            title="Hidden commands"
+            description="Commands you've hidden from 'Recently used' in the action palette. Resetting restores all of them."
+          >
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleResetHiddenCommands}
+              disabled={hiddenActionCount === 0}
+              className="text-daintree-text border-daintree-border hover:bg-daintree-border hover:text-daintree-text"
+            >
+              <EyeOff className="w-4 h-4" />
+              {hiddenActionCount === 0
+                ? "No hidden commands"
+                : `Reset hidden commands (${hiddenActionCount})`}
             </Button>
           </SettingsSection>
 

--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@/clients/appClient", () => ({
 
 import { usePaletteStore } from "@/store/paletteStore";
 import { useActionMruStore } from "@/store/actionMruStore";
+import { useActionPrefsStore } from "@/store/actionPrefsStore";
 import { useActionPalette } from "../useActionPalette";
 
 function makeEntry(
@@ -58,6 +59,7 @@ describe("useActionPalette", () => {
     getContextMock.mockReturnValue({});
     usePaletteStore.setState({ activePaletteId: null });
     useActionMruStore.setState({ actionFrecencyEntries: new Map() });
+    useActionPrefsStore.setState({ pinnedActionIds: [], hiddenActionIds: [] });
   });
 
   it("tolerates malformed action manifest entries with missing title", async () => {
@@ -744,6 +746,160 @@ describe("useActionPalette", () => {
       // Enabled browser.close must appear before disabled terminal.close, context boost notwithstanding
       expect(result.current.results[0]!.id).toBe("browser.close");
       expect(result.current.results[1]!.id).toBe("terminal.close");
+    });
+  });
+
+  describe("pin & hide affordances", () => {
+    it("prepends pinned actions ahead of Recently used on the empty-query rail", async () => {
+      listMock.mockReturnValue([
+        makeEntry("a.action", "Alpha"),
+        makeEntry("b.action", "Bravo"),
+        makeEntry("c.action", "Charlie"),
+      ]);
+
+      useActionMruStore.getState().hydrateActionMru(["b.action", "c.action"]);
+      useActionPrefsStore.getState().pinAction("a.action");
+
+      const { result } = renderHook(() => useActionPalette());
+
+      act(() => {
+        result.current.open();
+      });
+
+      await waitFor(() => {
+        expect(result.current.results.length).toBe(3);
+      });
+
+      expect(result.current.results.map((r) => r.id)).toEqual(["a.action", "b.action", "c.action"]);
+      expect(result.current.pinnedCount).toBe(1);
+    });
+
+    it("does not duplicate a pinned id that also appears in MRU", async () => {
+      listMock.mockReturnValue([makeEntry("a.action", "Alpha"), makeEntry("b.action", "Bravo")]);
+
+      useActionMruStore.getState().hydrateActionMru(["a.action", "b.action"]);
+      useActionPrefsStore.getState().pinAction("a.action");
+
+      const { result } = renderHook(() => useActionPalette());
+
+      act(() => result.current.open());
+
+      await waitFor(() => expect(result.current.results.length).toBe(2));
+
+      expect(result.current.results.map((r) => r.id)).toEqual(["a.action", "b.action"]);
+      expect(result.current.pinnedCount).toBe(1);
+    });
+
+    it("hides actions from the Recently used rail while keeping them in MRU", async () => {
+      listMock.mockReturnValue([
+        makeEntry("a.action", "Alpha"),
+        makeEntry("b.action", "Bravo"),
+        makeEntry("c.action", "Charlie"),
+      ]);
+
+      useActionMruStore.getState().hydrateActionMru(["a.action", "b.action", "c.action"]);
+      useActionPrefsStore.getState().hideAction("b.action");
+
+      const { result } = renderHook(() => useActionPalette());
+
+      act(() => result.current.open());
+
+      await waitFor(() => expect(result.current.results.length).toBe(2));
+
+      const ids = result.current.results.map((r) => r.id);
+      expect(ids).not.toContain("b.action");
+      expect(ids).toEqual(["a.action", "c.action"]);
+    });
+
+    it("refuses to pin a danger:'confirm' action and returns false", async () => {
+      listMock.mockReturnValue([
+        makeEntry("worktree.delete", "Delete worktree", true, "worktree", "confirm"),
+      ]);
+
+      const { result } = renderHook(() => useActionPalette());
+
+      act(() => result.current.open());
+
+      await waitFor(() => expect(result.current.isOpen).toBe(true));
+
+      let returned = true;
+      act(() => {
+        returned = result.current.pinAction(
+          result.current.results[0] ?? {
+            id: "worktree.delete",
+            title: "Delete worktree",
+            description: "",
+            category: "worktree",
+            enabled: true,
+            danger: "confirm",
+            kind: "command",
+            titleLower: "delete worktree",
+            categoryLower: "worktree",
+            descriptionLower: "",
+            titleAcronym: "DW",
+            keywordsLower: [],
+          }
+        );
+      });
+
+      expect(returned).toBe(false);
+      expect(useActionPrefsStore.getState().pinnedActionIds).toEqual([]);
+    });
+
+    it("strips danger:'confirm' ids from pinned even when persisted from a pre-fix session", async () => {
+      listMock.mockReturnValue([
+        makeEntry("a.action", "Alpha"),
+        makeEntry("worktree.delete", "Delete worktree", true, "worktree", "confirm"),
+      ]);
+
+      // Simulate a stale persisted state file with a danger id pinned.
+      useActionPrefsStore
+        .getState()
+        .hydrateActionPrefs({ pinnedIds: ["worktree.delete", "a.action"] });
+
+      const { result } = renderHook(() => useActionPalette());
+
+      act(() => result.current.open());
+
+      await waitFor(() => expect(result.current.results.length).toBe(1));
+
+      const ids = result.current.results.map((r) => r.id);
+      expect(ids).not.toContain("worktree.delete");
+      expect(ids).toEqual(["a.action"]);
+    });
+
+    it("ignores hidden ids during typed search (only the empty-query rail evicts)", async () => {
+      listMock.mockReturnValue([makeEntry("a.action", "Alpha"), makeEntry("b.action", "Bravo")]);
+      useActionPrefsStore.getState().hideAction("a.action");
+
+      const { result } = renderHook(() => useActionPalette());
+
+      act(() => result.current.open());
+      act(() => result.current.setQuery("alpha"));
+
+      await waitFor(() => expect(result.current.results.length).toBeGreaterThan(0), {
+        timeout: 2000,
+      });
+
+      // Hidden action still surfaces during search — the eviction only applies
+      // to the empty-query "Recently used" rail.
+      expect(result.current.results.map((r) => r.id)).toContain("a.action");
+    });
+
+    it("pinnedCount is 0 during typed search even when pinned items are in results", async () => {
+      listMock.mockReturnValue([makeEntry("a.action", "Alpha"), makeEntry("b.action", "Bravo")]);
+      useActionPrefsStore.getState().pinAction("a.action");
+
+      const { result } = renderHook(() => useActionPalette());
+
+      act(() => result.current.open());
+      act(() => result.current.setQuery("alpha"));
+
+      await waitFor(() => expect(result.current.results.length).toBeGreaterThan(0), {
+        timeout: 2000,
+      });
+
+      expect(result.current.pinnedCount).toBe(0);
     });
   });
 

--- a/src/hooks/app/useAppHydration.ts
+++ b/src/hooks/app/useAppHydration.ts
@@ -6,7 +6,12 @@ import { logError } from "@/utils/logger";
 import { usePanelStore } from "@/store";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useRecipeStore } from "@/store/recipeStore";
-import { useDiagnosticsStore, useFocusStore, useActionMruStore } from "@/store";
+import {
+  useDiagnosticsStore,
+  useFocusStore,
+  useActionMruStore,
+  useActionPrefsStore,
+} from "@/store";
 import type { HydrateResult } from "@shared/types/ipc/app";
 
 export function useAppHydration(
@@ -28,6 +33,7 @@ export function useAppHydration(
   const openDiagnosticsDock = useDiagnosticsStore((s) => s.openDock);
   const setFocusMode = useFocusStore((s) => s.setFocusMode);
   const hydrateActionMru = useActionMruStore((s) => s.hydrateActionMru);
+  const hydrateActionPrefs = useActionPrefsStore((s) => s.hydrateActionPrefs);
 
   useEffect(() => {
     if (!isElectronAvailable() || hasRestoredState.current || !enabled) {
@@ -53,6 +59,7 @@ export function useAppHydration(
             restoreTerminalOrder,
             hydrateMru,
             hydrateActionMru,
+            hydrateActionPrefs,
             beginHydrationBatch,
             flushHydrationBatch,
           },
@@ -103,6 +110,7 @@ export function useAppHydration(
     restoreTerminalOrder,
     hydrateMru,
     hydrateActionMru,
+    hydrateActionPrefs,
     beginHydrationBatch,
     flushHydrationBatch,
   ]);

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -6,6 +6,7 @@ import { notify } from "@/lib/notify";
 import type { ActionDanger, ActionManifestEntry } from "@shared/types/actions";
 import { usePaletteStore } from "@/store/paletteStore";
 import { useActionMruStore } from "@/store/actionMruStore";
+import { useActionPrefsStore } from "@/store/actionPrefsStore";
 import { extractAcronym, rankActionMatches } from "@/lib/actionPaletteSearch";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { useSearchablePalette } from "./useSearchablePalette";
@@ -35,6 +36,8 @@ export interface UseActionPaletteReturn {
   selectedIndex: number;
   isShowingRecentlyUsed: boolean;
   isStale: boolean;
+  /** Count of pinned items at the start of `results`. The remainder is "Recently used". */
+  pinnedCount: number;
   open: () => void;
   close: () => void;
   toggle: () => void;
@@ -44,6 +47,11 @@ export interface UseActionPaletteReturn {
   selectNext: () => void;
   executeAction: (item: ActionPaletteItem) => void;
   confirmSelection: () => void;
+  /** Pin an action to Favorites. Returns false (and surfaces a toast) when the action is `danger:"confirm"`. */
+  pinAction: (item: ActionPaletteItem) => boolean;
+  unpinAction: (id: string) => void;
+  /** Hide an action from Recently used. Fires a 30-second undo toast. No-op for pinned actions. */
+  hideAction: (item: ActionPaletteItem) => void;
 }
 
 const MAX_RESULTS = 20;
@@ -83,6 +91,8 @@ function toActionPaletteItem(entry: ActionManifestEntry): ActionPaletteItem {
 export function useActionPalette(): UseActionPaletteReturn {
   const isActionOpen = usePaletteStore((state) => state.activePaletteId === "action");
   const getSortedActionMruList = useActionMruStore((state) => state.getSortedActionMruList);
+  const pinnedActionIds = useActionPrefsStore((state) => state.pinnedActionIds);
+  const hiddenActionIds = useActionPrefsStore((state) => state.hiddenActionIds);
 
   const allActions = useMemo<ActionPaletteItem[]>(() => {
     if (!isActionOpen) return [];
@@ -92,29 +102,43 @@ export function useActionPalette(): UseActionPaletteReturn {
 
   const filterFn = useCallback(
     (items: ActionPaletteItem[], query: string): ActionPaletteItem[] => {
-      // Strip confirm-danger ids from the MRU list so destructive actions
+      // Strip confirm-danger ids from the MRU/Favorites lists so destructive actions
       // persisted from a pre-fix session don't keep surfacing in the
       // "Recently used" rail or get a search-rank bonus (issue #7481).
       const confirmDangerIds = new Set(
         items.filter((item) => item.danger === "confirm").map((item) => item.id)
       );
+      const hiddenSet = new Set(hiddenActionIds);
+      const pinnedSet = new Set(pinnedActionIds);
       const actionMruList = getSortedActionMruList()
         .map(({ id }) => id)
         .filter((id) => !confirmDangerIds.has(id));
 
       if (!query.trim()) {
-        if (actionMruList.length === 0) return [];
-
         const itemById = new Map(items.map((item) => [item.id, item]));
+
+        // Favorites: ordered by pin time (insertion order), strip danger:"confirm"
+        // and skip ids the action registry no longer exposes.
+        const pinnedItems: ActionPaletteItem[] = [];
+        for (const id of pinnedActionIds) {
+          if (confirmDangerIds.has(id)) continue;
+          const item = itemById.get(id);
+          if (item) pinnedItems.push(item);
+        }
+
+        // Recently used: filter out pinned ids (so they don't appear in both
+        // sections) and hidden ids (eviction).
         const enabled: ActionPaletteItem[] = [];
         const disabled: ActionPaletteItem[] = [];
         for (const id of actionMruList) {
+          if (pinnedSet.has(id) || hiddenSet.has(id)) continue;
           const item = itemById.get(id);
           if (!item) continue;
           if (item.enabled) enabled.push(item);
           else disabled.push(item);
         }
-        return [...enabled, ...disabled].slice(0, MAX_MRU_RESULTS);
+        const recentItems = [...enabled, ...disabled].slice(0, MAX_MRU_RESULTS);
+        return [...pinnedItems, ...recentItems];
       }
 
       const context = actionService.getContext();
@@ -124,7 +148,7 @@ export function useActionPalette(): UseActionPaletteReturn {
         isSettingsOpen: context.isSettingsOpen,
       });
     },
-    [getSortedActionMruList]
+    [getSortedActionMruList, pinnedActionIds, hiddenActionIds]
   );
 
   const {
@@ -200,6 +224,63 @@ export function useActionPalette(): UseActionPaletteReturn {
     }
   }, [isStale, results, selectedIndex, executeAction]);
 
+  const pinAction = useCallback((item: ActionPaletteItem): boolean => {
+    if (item.danger === "confirm") {
+      // Mirrors the MRU strip in `filterFn` — destructive actions must
+      // round-trip through ConfirmDialog and never appear in the Favorites
+      // rail (issue #7481). The pin button surfaces an inline tooltip so the
+      // user understands why the click was rejected; we still emit a
+      // diagnostic-tier console warn for audit logs.
+      console.warn(
+        `[useActionPalette] Refusing to pin destructive action '${item.id}' — danger:"confirm" actions cannot be pinned.`
+      );
+      return false;
+    }
+    useActionPrefsStore.getState().pinAction(item.id);
+    return true;
+  }, []);
+
+  const unpinAction = useCallback((id: string) => {
+    useActionPrefsStore.getState().unpinAction(id);
+  }, []);
+
+  const hideAction = useCallback((item: ActionPaletteItem) => {
+    const store = useActionPrefsStore.getState();
+    if (store.isActionPinned(item.id)) {
+      // Pinned actions can't be hidden — they're explicitly promoted to
+      // Favorites. Unpin first if the user wants to evict them.
+      return;
+    }
+    store.hideAction(item.id);
+    notify({
+      type: "success",
+      title: "Hidden from Recently used",
+      message: `'${item.title}' won't appear in the empty-query rail.`,
+      duration: 30_000,
+      urgent: true,
+      transient: true,
+      action: {
+        label: "Show in Recently used",
+        onClick: () => useActionPrefsStore.getState().showAction(item.id),
+      },
+    });
+  }, []);
+
+  // When the query is non-empty, results come from `rankActionMatches` (search
+  // scoring) and the section split doesn't apply. The empty-query branch is the
+  // only path where the first N items are pinned — count them up so consumers
+  // can render the "Favorites" / "Recently used" divider at the right offset.
+  const pinnedCount = useMemo(() => {
+    if (query.trim()) return 0;
+    const pinnedSet = new Set(pinnedActionIds);
+    let count = 0;
+    for (const item of results) {
+      if (pinnedSet.has(item.id)) count++;
+      else break;
+    }
+    return count;
+  }, [query, results, pinnedActionIds]);
+
   const isShowingRecentlyUsed = query.trim() === "" && results.length > 0;
 
   return {
@@ -210,6 +291,7 @@ export function useActionPalette(): UseActionPaletteReturn {
     selectedIndex,
     isShowingRecentlyUsed,
     isStale,
+    pinnedCount,
     open,
     close,
     toggle,
@@ -219,5 +301,8 @@ export function useActionPalette(): UseActionPaletteReturn {
     selectNext,
     executeAction,
     confirmSelection,
+    pinAction,
+    unpinAction,
+    hideAction,
   };
 }

--- a/src/store/__tests__/actionPrefsStore.test.ts
+++ b/src/store/__tests__/actionPrefsStore.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/clients/appClient", () => ({
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { useActionPrefsStore } from "../actionPrefsStore";
+
+describe("actionPrefsStore", () => {
+  beforeEach(() => {
+    useActionPrefsStore.setState({ pinnedActionIds: [], hiddenActionIds: [] });
+  });
+
+  describe("pinAction", () => {
+    it("adds an id to pinnedActionIds", () => {
+      useActionPrefsStore.getState().pinAction("worktree.create");
+      expect(useActionPrefsStore.getState().pinnedActionIds).toEqual(["worktree.create"]);
+    });
+
+    it("is idempotent — pinning the same id twice keeps a single entry", () => {
+      useActionPrefsStore.getState().pinAction("worktree.create");
+      useActionPrefsStore.getState().pinAction("worktree.create");
+      expect(useActionPrefsStore.getState().pinnedActionIds).toEqual(["worktree.create"]);
+    });
+
+    it("preserves insertion order across multiple pins", () => {
+      useActionPrefsStore.getState().pinAction("a.one");
+      useActionPrefsStore.getState().pinAction("a.two");
+      useActionPrefsStore.getState().pinAction("a.three");
+      expect(useActionPrefsStore.getState().pinnedActionIds).toEqual(["a.one", "a.two", "a.three"]);
+    });
+
+    it("caps pinned ids at 100", () => {
+      for (let i = 0; i < 105; i++) {
+        useActionPrefsStore.getState().pinAction(`a.action${i}`);
+      }
+      expect(useActionPrefsStore.getState().pinnedActionIds).toHaveLength(100);
+    });
+  });
+
+  describe("unpinAction", () => {
+    it("removes an id from pinnedActionIds", () => {
+      useActionPrefsStore.getState().pinAction("a.one");
+      useActionPrefsStore.getState().pinAction("a.two");
+      useActionPrefsStore.getState().unpinAction("a.one");
+      expect(useActionPrefsStore.getState().pinnedActionIds).toEqual(["a.two"]);
+    });
+
+    it("is idempotent — unpinning a non-pinned id is a no-op", () => {
+      useActionPrefsStore.getState().pinAction("a.one");
+      useActionPrefsStore.getState().unpinAction("a.unknown");
+      expect(useActionPrefsStore.getState().pinnedActionIds).toEqual(["a.one"]);
+    });
+  });
+
+  describe("hideAction", () => {
+    it("adds an id to hiddenActionIds", () => {
+      useActionPrefsStore.getState().hideAction("a.one");
+      expect(useActionPrefsStore.getState().hiddenActionIds).toEqual(["a.one"]);
+    });
+
+    it("is idempotent", () => {
+      useActionPrefsStore.getState().hideAction("a.one");
+      useActionPrefsStore.getState().hideAction("a.one");
+      expect(useActionPrefsStore.getState().hiddenActionIds).toEqual(["a.one"]);
+    });
+
+    it("caps hidden ids at 200", () => {
+      for (let i = 0; i < 205; i++) {
+        useActionPrefsStore.getState().hideAction(`a.action${i}`);
+      }
+      expect(useActionPrefsStore.getState().hiddenActionIds).toHaveLength(200);
+    });
+  });
+
+  describe("showAction", () => {
+    it("removes an id from hiddenActionIds (undo)", () => {
+      useActionPrefsStore.getState().hideAction("a.one");
+      useActionPrefsStore.getState().showAction("a.one");
+      expect(useActionPrefsStore.getState().hiddenActionIds).toEqual([]);
+    });
+  });
+
+  describe("resetHiddenActions", () => {
+    it("clears all hidden ids", () => {
+      useActionPrefsStore.getState().hideAction("a.one");
+      useActionPrefsStore.getState().hideAction("a.two");
+      useActionPrefsStore.getState().resetHiddenActions();
+      expect(useActionPrefsStore.getState().hiddenActionIds).toEqual([]);
+    });
+
+    it("leaves pinned ids untouched", () => {
+      useActionPrefsStore.getState().pinAction("a.pinned");
+      useActionPrefsStore.getState().hideAction("a.hidden");
+      useActionPrefsStore.getState().resetHiddenActions();
+      expect(useActionPrefsStore.getState().pinnedActionIds).toEqual(["a.pinned"]);
+      expect(useActionPrefsStore.getState().hiddenActionIds).toEqual([]);
+    });
+  });
+
+  describe("hydrateActionPrefs", () => {
+    it("replaces both lists", () => {
+      useActionPrefsStore.getState().pinAction("stale.pin");
+      useActionPrefsStore.getState().hideAction("stale.hide");
+      useActionPrefsStore
+        .getState()
+        .hydrateActionPrefs({ pinnedIds: ["fresh.pin"], hiddenIds: ["fresh.hide"] });
+      expect(useActionPrefsStore.getState().pinnedActionIds).toEqual(["fresh.pin"]);
+      expect(useActionPrefsStore.getState().hiddenActionIds).toEqual(["fresh.hide"]);
+    });
+
+    it("dedupes input", () => {
+      useActionPrefsStore
+        .getState()
+        .hydrateActionPrefs({ pinnedIds: ["a", "a", "b"], hiddenIds: ["x", "x", "y"] });
+      expect(useActionPrefsStore.getState().pinnedActionIds).toEqual(["a", "b"]);
+      expect(useActionPrefsStore.getState().hiddenActionIds).toEqual(["x", "y"]);
+    });
+
+    it("treats missing arrays as empty", () => {
+      useActionPrefsStore.getState().pinAction("a.one");
+      useActionPrefsStore.getState().hydrateActionPrefs({});
+      expect(useActionPrefsStore.getState().pinnedActionIds).toEqual([]);
+      expect(useActionPrefsStore.getState().hiddenActionIds).toEqual([]);
+    });
+  });
+
+  describe("isActionPinned / isActionHidden", () => {
+    it("reflects state", () => {
+      useActionPrefsStore.getState().pinAction("a.pinned");
+      useActionPrefsStore.getState().hideAction("a.hidden");
+      expect(useActionPrefsStore.getState().isActionPinned("a.pinned")).toBe(true);
+      expect(useActionPrefsStore.getState().isActionPinned("a.other")).toBe(false);
+      expect(useActionPrefsStore.getState().isActionHidden("a.hidden")).toBe(true);
+      expect(useActionPrefsStore.getState().isActionHidden("a.other")).toBe(false);
+    });
+  });
+});

--- a/src/store/actionPrefsStore.ts
+++ b/src/store/actionPrefsStore.ts
@@ -1,0 +1,52 @@
+import { create } from "zustand";
+import { createActionPrefsSlice, type ActionPrefsSlice } from "./slices/actionPrefsSlice";
+
+export const useActionPrefsStore = create<ActionPrefsSlice>()((...a) => ({
+  ...createActionPrefsSlice(...a),
+}));
+
+let lastPinned: string | null = null;
+let lastHidden: string | null = null;
+let inflightPinned: string | null = null;
+let inflightHidden: string | null = null;
+
+useActionPrefsStore.subscribe((state) => {
+  const pinnedJson = JSON.stringify(state.pinnedActionIds);
+  const hiddenJson = JSON.stringify(state.hiddenActionIds);
+
+  const pinnedChanged = pinnedJson !== lastPinned && pinnedJson !== inflightPinned;
+  const hiddenChanged = hiddenJson !== lastHidden && hiddenJson !== inflightHidden;
+
+  if (!pinnedChanged && !hiddenChanged) return;
+
+  const updates: {
+    actionPinnedIds?: string[];
+    actionHiddenIds?: string[];
+  } = {};
+
+  if (pinnedChanged) {
+    inflightPinned = pinnedJson;
+    updates.actionPinnedIds = [...state.pinnedActionIds];
+  }
+  if (hiddenChanged) {
+    inflightHidden = hiddenJson;
+    updates.actionHiddenIds = [...state.hiddenActionIds];
+  }
+
+  void import("@/clients/appClient")
+    .then(({ appClient }) => appClient.setState(updates))
+    .then(() => {
+      if (pinnedChanged) {
+        lastPinned = inflightPinned;
+        inflightPinned = null;
+      }
+      if (hiddenChanged) {
+        lastHidden = inflightHidden;
+        inflightHidden = null;
+      }
+    })
+    .catch(() => {
+      if (pinnedChanged) inflightPinned = null;
+      if (hiddenChanged) inflightHidden = null;
+    });
+});

--- a/src/store/actionPrefsStore.ts
+++ b/src/store/actionPrefsStore.ts
@@ -1,14 +1,32 @@
 import { create } from "zustand";
 import { createActionPrefsSlice, type ActionPrefsSlice } from "./slices/actionPrefsSlice";
 
-export const useActionPrefsStore = create<ActionPrefsSlice>()((...a) => ({
-  ...createActionPrefsSlice(...a),
-}));
-
-let lastPinned: string | null = null;
-let lastHidden: string | null = null;
+// Seed the persistence baseline with the initial store value (`[]`) so the
+// subscribe-to-persist path on app boot — where `hydrateActionPrefs` writes
+// the on-disk values back into the store — doesn't echo an identical payload
+// out to disk as a spurious round-trip.
+const EMPTY_JSON = JSON.stringify([]);
+let lastPinned: string = EMPTY_JSON;
+let lastHidden: string = EMPTY_JSON;
 let inflightPinned: string | null = null;
 let inflightHidden: string | null = null;
+
+export const useActionPrefsStore = create<ActionPrefsSlice>()((set, get, store) => {
+  const slice = createActionPrefsSlice(set, get, store);
+  const baseHydrate = slice.hydrateActionPrefs;
+  return {
+    ...slice,
+    hydrateActionPrefs: (prefs) => {
+      baseHydrate(prefs);
+      // After hydrate, prime the persistence baseline to the just-loaded values
+      // so the subscribe-to-persist handler doesn't fire a redundant
+      // `appClient.setState` with the same data we just read.
+      const next = get();
+      lastPinned = JSON.stringify(next.pinnedActionIds);
+      lastHidden = JSON.stringify(next.hiddenActionIds);
+    },
+  };
+});
 
 useActionPrefsStore.subscribe((state) => {
   const pinnedJson = JSON.stringify(state.pinnedActionIds);
@@ -24,29 +42,38 @@ useActionPrefsStore.subscribe((state) => {
     actionHiddenIds?: string[];
   } = {};
 
+  // Capture per-send copies so the `.then` handler can update `lastPinned`
+  // to the value we actually sent — reading the module-level `inflightPinned`
+  // at resolve time would clobber the bookkeeping if a newer mutation has
+  // already overwritten it (rapid pin→unpin sequence).
+  let sentPinnedJson: string | null = null;
+  let sentHiddenJson: string | null = null;
+
   if (pinnedChanged) {
     inflightPinned = pinnedJson;
+    sentPinnedJson = pinnedJson;
     updates.actionPinnedIds = [...state.pinnedActionIds];
   }
   if (hiddenChanged) {
     inflightHidden = hiddenJson;
+    sentHiddenJson = hiddenJson;
     updates.actionHiddenIds = [...state.hiddenActionIds];
   }
 
   void import("@/clients/appClient")
     .then(({ appClient }) => appClient.setState(updates))
     .then(() => {
-      if (pinnedChanged) {
-        lastPinned = inflightPinned;
-        inflightPinned = null;
+      if (sentPinnedJson !== null) {
+        lastPinned = sentPinnedJson;
+        if (inflightPinned === sentPinnedJson) inflightPinned = null;
       }
-      if (hiddenChanged) {
-        lastHidden = inflightHidden;
-        inflightHidden = null;
+      if (sentHiddenJson !== null) {
+        lastHidden = sentHiddenJson;
+        if (inflightHidden === sentHiddenJson) inflightHidden = null;
       }
     })
     .catch(() => {
-      if (pinnedChanged) inflightPinned = null;
-      if (hiddenChanged) inflightHidden = null;
+      if (sentPinnedJson !== null && inflightPinned === sentPinnedJson) inflightPinned = null;
+      if (sentHiddenJson !== null && inflightHidden === sentHiddenJson) inflightHidden = null;
     });
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -93,6 +93,7 @@ export type { TwoPaneSplitConfig, WorktreeRatioEntry } from "./twoPaneSplitStore
 export { useAppAgentStore, cleanupAppAgentStore } from "./appAgentStore";
 
 export { useActionMruStore } from "./actionMruStore";
+export { useActionPrefsStore } from "./actionPrefsStore";
 
 export { useScreenReaderStore } from "./screenReaderStore";
 export type { ScreenReaderMode } from "./screenReaderStore";

--- a/src/store/slices/actionPrefsSlice.ts
+++ b/src/store/slices/actionPrefsSlice.ts
@@ -43,7 +43,16 @@ export const createActionPrefsSlice: StateCreator<ActionPrefsSlice, [], [], Acti
     set((state) => {
       if (state.pinnedActionIds.includes(id)) return state;
       if (state.pinnedActionIds.length >= MAX_PINNED) return state;
-      return { pinnedActionIds: [...state.pinnedActionIds, id] };
+      // Pinning supersedes hiding — an action can't simultaneously be promoted
+      // to Favorites and evicted from Recently used. If the user pins a
+      // previously-hidden action via the search flow, restore visibility.
+      const wasHidden = state.hiddenActionIds.includes(id);
+      return {
+        pinnedActionIds: [...state.pinnedActionIds, id],
+        hiddenActionIds: wasHidden
+          ? state.hiddenActionIds.filter((hid) => hid !== id)
+          : state.hiddenActionIds,
+      };
     });
   },
 
@@ -74,10 +83,15 @@ export const createActionPrefsSlice: StateCreator<ActionPrefsSlice, [], [], Acti
   },
 
   hydrateActionPrefs: ({ pinnedIds, hiddenIds }) => {
-    set({
-      pinnedActionIds: pinnedIds ? dedupe(pinnedIds, MAX_PINNED) : [],
-      hiddenActionIds: hiddenIds ? dedupe(hiddenIds, MAX_HIDDEN) : [],
-    });
+    const pinned = pinnedIds ? dedupe(pinnedIds, MAX_PINNED) : [];
+    const pinnedSet = new Set(pinned);
+    // An ID can't simultaneously be pinned (Favorites) and hidden (Recently used
+    // eviction). If a stale persisted state has both, pin wins and we strip
+    // the duplicate from `hiddenActionIds` so unpinning later doesn't silently
+    // leave the action vanished.
+    const hiddenRaw = hiddenIds ? dedupe(hiddenIds, MAX_HIDDEN) : [];
+    const hidden = hiddenRaw.filter((id) => !pinnedSet.has(id));
+    set({ pinnedActionIds: pinned, hiddenActionIds: hidden });
   },
 
   isActionPinned: (id) => get().pinnedActionIds.includes(id),

--- a/src/store/slices/actionPrefsSlice.ts
+++ b/src/store/slices/actionPrefsSlice.ts
@@ -1,0 +1,85 @@
+import type { StateCreator } from "zustand";
+
+const MAX_PINNED = 100;
+const MAX_HIDDEN = 200;
+
+function dedupe(input: readonly string[], cap: number): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of input) {
+    if (typeof id === "string" && id.length > 0 && !seen.has(id)) {
+      seen.add(id);
+      out.push(id);
+      if (out.length >= cap) break;
+    }
+  }
+  return out;
+}
+
+export interface ActionPrefsSlice {
+  pinnedActionIds: string[];
+  hiddenActionIds: string[];
+  pinAction: (id: string) => void;
+  unpinAction: (id: string) => void;
+  hideAction: (id: string) => void;
+  showAction: (id: string) => void;
+  resetHiddenActions: () => void;
+  hydrateActionPrefs: (prefs: {
+    pinnedIds?: readonly string[];
+    hiddenIds?: readonly string[];
+  }) => void;
+  isActionPinned: (id: string) => boolean;
+  isActionHidden: (id: string) => boolean;
+}
+
+export const createActionPrefsSlice: StateCreator<ActionPrefsSlice, [], [], ActionPrefsSlice> = (
+  set,
+  get
+) => ({
+  pinnedActionIds: [],
+  hiddenActionIds: [],
+
+  pinAction: (id) => {
+    set((state) => {
+      if (state.pinnedActionIds.includes(id)) return state;
+      if (state.pinnedActionIds.length >= MAX_PINNED) return state;
+      return { pinnedActionIds: [...state.pinnedActionIds, id] };
+    });
+  },
+
+  unpinAction: (id) => {
+    set((state) => {
+      if (!state.pinnedActionIds.includes(id)) return state;
+      return { pinnedActionIds: state.pinnedActionIds.filter((pinned) => pinned !== id) };
+    });
+  },
+
+  hideAction: (id) => {
+    set((state) => {
+      if (state.hiddenActionIds.includes(id)) return state;
+      if (state.hiddenActionIds.length >= MAX_HIDDEN) return state;
+      return { hiddenActionIds: [...state.hiddenActionIds, id] };
+    });
+  },
+
+  showAction: (id) => {
+    set((state) => {
+      if (!state.hiddenActionIds.includes(id)) return state;
+      return { hiddenActionIds: state.hiddenActionIds.filter((hidden) => hidden !== id) };
+    });
+  },
+
+  resetHiddenActions: () => {
+    set((state) => (state.hiddenActionIds.length === 0 ? state : { hiddenActionIds: [] }));
+  },
+
+  hydrateActionPrefs: ({ pinnedIds, hiddenIds }) => {
+    set({
+      pinnedActionIds: pinnedIds ? dedupe(pinnedIds, MAX_PINNED) : [],
+      hiddenActionIds: hiddenIds ? dedupe(hiddenIds, MAX_HIDDEN) : [],
+    });
+  },
+
+  isActionPinned: (id) => get().pinnedActionIds.includes(id),
+  isActionHidden: (id) => get().hiddenActionIds.includes(id),
+});

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -94,6 +94,7 @@ export interface HydrationOptions {
   hydrateTabGroups?: (tabGroups: TabGroup[], options?: { skipPersist?: boolean }) => void;
   hydrateMru?: (list: string[]) => void;
   hydrateActionMru?: (list: ActionFrecencyEntry[] | string[]) => void;
+  hydrateActionPrefs?: (prefs: { pinnedIds?: string[]; hiddenIds?: string[] }) => void;
   restoreTerminalOrder?: (orderedIds: string[]) => void;
   /**
    * Optional hydration-batch hooks. When both are provided, each restore phase is
@@ -548,6 +549,19 @@ export async function hydrateAppState(
     // Restore action MRU list
     if (options.hydrateActionMru && Array.isArray(appState.actionMruList)) {
       options.hydrateActionMru(appState.actionMruList);
+    }
+
+    // Restore pinned/hidden action prefs (Favorites + hidden Recently used)
+    if (options.hydrateActionPrefs) {
+      const pinnedIds = Array.isArray(appState.actionPinnedIds)
+        ? appState.actionPinnedIds
+        : undefined;
+      const hiddenIds = Array.isArray(appState.actionHiddenIds)
+        ? appState.actionHiddenIds
+        : undefined;
+      if (pinnedIds || hiddenIds) {
+        options.hydrateActionPrefs({ pinnedIds, hiddenIds });
+      }
     }
   } catch (error) {
     logError("Failed to hydrate app state", error);


### PR DESCRIPTION
## Summary

- Splits the empty-query rail into **Favorites** (pinned, always on top) and **Recently used** sections. Pinned actions survive sessions, never decay.
- Adds a **Hide** affordance per row that evicts entries from Recently used with a 30-second undo toast and a **Reset hidden commands** lever in Privacy > Data & Storage.
- Widens `FRECENCY_HALF_LIFE_MS` from 5 days to 14 days -- five days was aggressive enough to erode weekly habits like release recipes and fleet broadcasts. Pairs cleanly with the new eviction path so the longer half-life doesn't compound noise.

Resolves #8815

## Changes

- New `actionPrefsStore` (`src/store/actionPrefsStore.ts` + `src/store/slices/actionPrefsSlice.ts`) holding `pinnedIds` and `hiddenIds`, persisted via the existing `AppState` hydration path alongside `actionMruList`.
- IPC sanitization in the `app/state` handler: `ACTION_ID_PATTERN` allowlist, caps at 100 pinned / 200 hidden, `CRASH_CRITICAL_FIELDS` expanded to cover the two new fields.
- `danger:"confirm"` actions stripped from the pinned set on load and rejected at pin-time with an inline tooltip -- mirrors the `confirmDangerIds` safeguard already applied to the MRU rail (#7481).
- `SearchablePalette.renderBody` used for the sectioned empty-query view; all other palettes remain flat (additive, opt-in).
- `ActionPaletteItem` wrapped in `React.memo`; pin and hide buttons are siblings of the row body so disabled rows keep the affordances reachable.

## Testing

- 140+ unit tests pass across 6 affected suites (`actionPrefsStore`, `ActionPalette`, `ActionPaletteItem`, `useActionPalette`, `app.state`, `frecency`).
- Typecheck and lint clean.