### PR TITLE
fix(ui): restore truncation in combobox trigger Buttons

### DIFF
--- a/src/components/ui/__tests__/button.test.tsx
+++ b/src/components/ui/__tests__/button.test.tsx
@@ -186,9 +186,11 @@ describe("Button loading state", () => {
     expect(button.hasAttribute("aria-busy")).toBe(false);
     expect(button.hasAttribute("aria-disabled")).toBe(false);
     expect(button.hasAttribute("data-loading")).toBe(false);
-    expect(container.querySelector('[data-slot="button-content"]')!.className).not.toContain(
-      "opacity-30"
-    );
+    const content = container.querySelector('[data-slot="button-content"]')!;
+    expect(content.className).not.toContain("opacity-30");
+    // Wrapper must return to display:contents so caller layout (truncate,
+    // justify-between) keeps working after loading resolves.
+    expect(content.className).toBe("contents");
   });
 
   it("preserves the accessible name on an icon-only loading button", () => {

--- a/src/components/ui/__tests__/button.test.tsx
+++ b/src/components/ui/__tests__/button.test.tsx
@@ -66,6 +66,22 @@ describe("Button loading state", () => {
     expect(content.className).not.toContain("opacity-30");
   });
 
+  // Regression: #8843 — the content wrapper must be transparent to layout when
+  // not loading, so caller patterns like `w-full justify-between` + `truncate`
+  // reach the actual text/chevron row. `display: contents` is what makes the
+  // wrapper's children behave as direct flex items of the <button>.
+  it("renders the content wrapper as display:contents when not loading", () => {
+    const { container } = render(
+      <Button className="w-full justify-between">
+        <span className="truncate">label</span>
+        <svg data-testid="chevron" />
+      </Button>
+    );
+    const content = container.querySelector('[data-slot="button-content"]')!;
+    expect(content.className).toBe("contents");
+    expect(content.className).not.toContain("inline-flex");
+  });
+
   it("renders an aria-hidden spinner overlay and sets ARIA state when loading", () => {
     const { container } = render(<Button loading>Save</Button>);
     const button = container.querySelector("button")!;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -154,13 +154,22 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {asChild ? (
           <Slottable>{children}</Slottable>
         ) : (
+          // `display: contents` when not loading so the wrapper is transparent
+          // to layout — children are flex items of the <button> directly, which
+          // restores caller patterns like `w-full justify-between` + `truncate`.
+          // When loading, the wrapper becomes a real flex box so `opacity-30`
+          // can dim the label uniformly behind the absolute spinner overlay.
           <span
             data-slot="button-content"
-            className={cn(
-              "inline-flex items-center justify-center",
-              GAP_CLASS_MAP[resolvedSize],
-              loading && "opacity-30 transition-opacity duration-150 ease-out"
-            )}
+            className={
+              loading
+                ? cn(
+                    "inline-flex items-center justify-center",
+                    GAP_CLASS_MAP[resolvedSize],
+                    "opacity-30 transition-opacity duration-150 ease-out"
+                  )
+                : "contents"
+            }
           >
             {children}
           </span>


### PR DESCRIPTION
## Summary

- Fixes a regression in `Button` where commit `055ac8300` wrapped children in a `<span data-slot="button-content">` using `inline-flex`, breaking the `truncate` + `w-full` + `justify-between` layout pattern used by combobox trigger buttons.
- Fix uses `display: contents` on the wrapper when not loading, making it transparent to layout so children become direct flex items of the `<button>` again. When loading, it switches to `inline-flex opacity-30` so the dim-on-load effect still works.
- Fixes all five affected triggers in one place: `IssueSelector`, `BaseBranchCombobox`, `ExistingBranchPicker`, `RecipePickerPopover`, `ProjectSwitcher`.

Resolves #8843

## Changes

- `src/components/ui/button.tsx` — `<span data-slot="button-content">` now conditionally applies `display: contents` (not loading) vs `inline-flex opacity-30` (loading)
- `src/components/ui/__tests__/button.test.tsx` — asserts `display: contents` is applied on initial render and restored after a loading→not-loading rerender

## Testing

- Vitest: 18/18 passing, including new assertions on the `button-content` slot behavior
- TypeScript: clean
- ESLint: clean (3750 pre-existing warnings, no new)
- Prettier: clean
- Build: clean