### PR TITLE
fix(toolbar): remove clipped freshness clock glyph from GitHub stat pill

### DIFF
--- a/src/components/Layout/FreshnessUtils.tsx
+++ b/src/components/Layout/FreshnessUtils.tsx
@@ -1,4 +1,3 @@
-import { Clock } from "lucide-react";
 import type { FreshnessLevel } from "@/hooks/useRepositoryStats";
 
 export type BadgeFreshnessCause = "stale" | "rate-limit" | "circuit-breaker";
@@ -15,13 +14,6 @@ export function freshnessClass(level: FreshnessLevel): string {
     default:
       return "";
   }
-}
-
-export function FreshnessGlyph({ level }: { level: FreshnessLevel }) {
-  if (level === "stale-disk" || level === "aging") {
-    return <Clock className="h-3 w-3 text-muted-foreground" aria-hidden="true" />;
-  }
-  return null;
 }
 
 export function formatTimeSince(timestamp: number | null, now: number): string {

--- a/src/components/Layout/GitHubStatPill.tsx
+++ b/src/components/Layout/GitHubStatPill.tsx
@@ -27,7 +27,6 @@ export interface GitHubStatPillProps {
   onPointerLeave?: (e: React.PointerEvent) => void;
 
   activityChip?: React.ReactNode;
-  freshnessGlyph?: React.ReactNode;
 }
 
 export function GitHubStatPill({
@@ -49,7 +48,6 @@ export function GitHubStatPill({
   onPointerEnter,
   onPointerLeave,
   activityChip,
-  freshnessGlyph,
 }: GitHubStatPillProps) {
   return (
     <>
@@ -84,7 +82,6 @@ export function GitHubStatPill({
             >
               {count ?? "—"}
             </span>
-            {freshnessGlyph}
             {activityChip}
           </Button>
         </TooltipTrigger>

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -41,7 +41,7 @@ import { buildCacheKey, getCache, setCache } from "@/lib/githubResourceCache";
 import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore";
 import type { Project } from "@shared/types";
 import type { GitHubRateLimitDetails, RepositoryStats } from "@shared/types";
-import { FreshnessGlyph, freshnessSuffix } from "./FreshnessUtils";
+import { freshnessSuffix } from "./FreshnessUtils";
 import {
   formatRateLimitCountdown,
   msUntilNextLabelChange,
@@ -736,7 +736,6 @@ export const GitHubStatsToolbarButton = memo(
                   style={{ clipPath: "polygon(0 0, 100% 0, 100% 100%)" }}
                 />
               }
-              freshnessGlyph={!isTokenError ? <FreshnessGlyph level={freshnessLevel} /> : null}
             />
             <GitHubStatPill
               buttonRef={prsButtonRef}
@@ -841,7 +840,6 @@ export const GitHubStatsToolbarButton = memo(
                   style={{ clipPath: "polygon(0 0, 100% 0, 100% 100%)" }}
                 />
               }
-              freshnessGlyph={!isTokenError ? <FreshnessGlyph level={freshnessLevel} /> : null}
             />
             <GitHubStatPill
               buttonRef={commitsButtonRef}
@@ -893,7 +891,6 @@ export const GitHubStatsToolbarButton = memo(
                 setCommitsOpen(open);
                 if (!open) commitsButtonRef.current?.focus();
               }}
-              freshnessGlyph={<FreshnessGlyph level={commitFreshnessLevel} />}
             />
             <GitHubStatusIndicator
               status={getGitHubIndicatorStatus()}

--- a/src/components/Layout/__tests__/FreshnessUtils.test.tsx
+++ b/src/components/Layout/__tests__/FreshnessUtils.test.tsx
@@ -1,9 +1,6 @@
-// @vitest-environment jsdom
 import { describe, it, expect } from "vitest";
-import { render } from "@testing-library/react";
 import {
   freshnessClass,
-  FreshnessGlyph,
   formatTimeSince,
   freshnessSuffix,
   badgeFreshnessSuffix,
@@ -28,34 +25,6 @@ describe("freshnessClass", () => {
     const result = freshnessClass("errored");
     expect(result).toBe("border-l-2 border-border-default italic");
     expect(result).not.toMatch(/\bopacity-/);
-  });
-});
-
-describe("FreshnessGlyph", () => {
-  it("renders nothing for fresh level", () => {
-    const { container } = render(<FreshnessGlyph level="fresh" />);
-    expect(container.querySelector("svg")).toBeNull();
-  });
-
-  it("renders a clock glyph for aging level (issue #8180 — replaces opacity dim)", () => {
-    const { container } = render(<FreshnessGlyph level="aging" />);
-    const svg = container.querySelector("svg");
-    expect(svg).not.toBeNull();
-    expect(svg?.getAttribute("aria-hidden")).toBe("true");
-    expect(svg?.getAttribute("class")).toContain("text-muted-foreground");
-  });
-
-  it("renders a clock glyph for stale-disk level", () => {
-    const { container } = render(<FreshnessGlyph level="stale-disk" />);
-    const svg = container.querySelector("svg");
-    expect(svg).not.toBeNull();
-    expect(svg?.getAttribute("aria-hidden")).toBe("true");
-    expect(svg?.getAttribute("class")).toContain("text-muted-foreground");
-  });
-
-  it("renders nothing for errored level (covered by GitHubStatusIndicator)", () => {
-    const { container } = render(<FreshnessGlyph level="errored" />);
-    expect(container.querySelector("svg")).toBeNull();
   });
 });
 

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshness.test.ts
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshness.test.ts
@@ -3,12 +3,13 @@ import fs from "fs/promises";
 import path from "path";
 
 /**
- * GitHubStatsToolbarButton — freshness tier wiring (issue #6536).
+ * GitHubStatsToolbarButton — freshness tier wiring (issue #6536, updated #8849).
  *
- * After extracting `freshnessOpacityClass`, `FreshnessGlyph`, `formatTimeSince`,
- * and `freshnessSuffix` to `FreshnessUtils.tsx`, the parent still wires these
- * into the three `GitHubStatPill` instances via the `className`, `freshnessGlyph`,
- * `ariaLabel`, and `tooltipContent` props.
+ * The parent wires freshness state into the three `GitHubStatPill` instances
+ * via `ariaLabel` and `tooltipContent` (both populated from `freshnessSuffix`).
+ * The in-pill clock glyph was removed in #8849 because it overflowed the
+ * fixed-width pill container; freshness is now signalled solely through the
+ * tooltip + aria-label copy.
  *
  * These are source assertions rather than render tests for the same reason as
  * `freshFetch`: the toolbar's eager dynamic-import effect resolves on a
@@ -26,22 +27,22 @@ describe("GitHubStatsToolbarButton freshness wiring", () => {
 
   it("imports freshness helpers from co-located FreshnessUtils", () => {
     expect(source).toContain('from "./FreshnessUtils"');
-    expect(source).toContain("FreshnessGlyph");
     expect(source).toContain("freshnessSuffix");
   });
 
   it("does not import or use freshnessOpacityClass or freshnessClass (issue #8180)", () => {
     // Opacity-as-stale reads as a disabled control on always-clickable pills
-    // (WCAG 1.4.3/1.4.11/4.1.2). Staleness is carried by FreshnessGlyph + the
-    // freshnessSuffix tooltip copy instead.
+    // (WCAG 1.4.3/1.4.11/4.1.2). Staleness is carried by the freshnessSuffix
+    // tooltip + aria-label copy instead (issue #8849 removed the in-pill glyph).
     expect(source).not.toContain("freshnessOpacityClass");
     expect(source).not.toContain("freshnessClass");
   });
 
-  it("passes FreshnessGlyph to all three GitHubStatPill instances", () => {
-    const glyphs = source.match(/freshnessGlyph=\{/g);
-    expect(glyphs).not.toBeNull();
-    expect(glyphs?.length).toBe(3);
+  it("does not pass an in-pill freshness glyph (issue #8849)", () => {
+    // The clock glyph overflowed the fixed-width pill container; freshness is
+    // now signalled via tooltip + aria-label only.
+    expect(source).not.toMatch(/freshnessGlyph=\{/);
+    expect(source).not.toContain("FreshnessGlyph");
   });
 
   it("does not dim any pill className via freshness opacity (issue #8180)", () => {
@@ -54,12 +55,6 @@ describe("GitHubStatsToolbarButton freshness wiring", () => {
     // opacity-75 (aging) and opacity-60 (stale-disk); neither should reappear.
     expect(source).not.toContain("opacity-75");
     expect(source).not.toContain("opacity-60");
-  });
-
-  it("wires the commits pill glyph to commitFreshnessLevel, not freshnessLevel", () => {
-    // Commits are git-local — a GitHub connectivity error must not dim or
-    // glyph the commits pill. commitFreshnessLevel maps errored→fresh.
-    expect(source).toContain("<FreshnessGlyph level={commitFreshnessLevel} />");
   });
 
   it("uses freshnessSuffix in ariaLabel and tooltipContent for freshness-aware copy", () => {


### PR DESCRIPTION
## Summary

The GitHub toolbar pill has a fixed width, so the freshness clock glyph was getting clipped inside the container. It doesn't add much value there, so this removes it entirely. The freshness signal still comes through `ariaLabel` and `tooltipContent` via `freshnessSuffix()` — nothing is lost from an accessibility or UX standpoint.

Resolves #8849

## Changes

- `FreshnessUtils.tsx` — removed `FreshnessGlyph` component and the `Clock` import
- `GitHubStatPill.tsx` — dropped the `freshnessGlyph` prop
- `GitHubStatsToolbarButton.tsx` — removed the `FreshnessGlyph` import and its three call sites
- `FreshnessUtils.test.tsx` — removed the `FreshnessGlyph` describe block
- `GitHubStatsToolbarButton.freshness.test.ts` — inverted assertions to confirm the glyph is absent

## Testing

34 targeted vitest tests pass. Full typecheck and lint/format clean.