### PR TITLE
fix(worktree): show branch-derived issue title when GitHub fetch hasn't landed

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -146,6 +146,11 @@ class PullRequestService {
 
   private candidates = new Map<string, WorktreeContext>();
   private resolvedWorktrees = new Set<string>();
+  // Tracks worktrees with a confirmed successful issue-title fetch. Decoupled
+  // from `resolvedWorktrees` so a worktree whose PR resolved but whose issue
+  // title still failed (or was never fetched) remains eligible for retry on
+  // the next polling cycle (#8851).
+  private issueTitleFetchedWorktrees = new Set<string>();
   private detectedPRs = new Map<string, InternalLinkedPR>();
   private updateDebounceTimer: NodeJS.Timeout | null = null;
   private unsubscribers: (() => void)[] = [];
@@ -225,6 +230,7 @@ class PullRequestService {
       // correct provider reference. Compare with handleWorktreeRemove below.
       const clearedProviderId = this.detectedPRs.get(state.worktreeId)?.providerId;
       this.resolvedWorktrees.delete(state.worktreeId);
+      this.issueTitleFetchedWorktrees.delete(state.worktreeId);
       this.detectedPRs.delete(state.worktreeId);
 
       // Tag the clear with the OLD branch and provider so the renderer drops it
@@ -259,6 +265,7 @@ class PullRequestService {
       const clearedProviderId = this.detectedPRs.get(worktreeId)?.providerId;
       this.candidates.delete(worktreeId);
       this.resolvedWorktrees.delete(worktreeId);
+      this.issueTitleFetchedWorktrees.delete(worktreeId);
       this.detectedPRs.delete(worktreeId);
 
       events.emit("sys:pr:cleared", {
@@ -533,6 +540,7 @@ class PullRequestService {
     // their CI status — which contradicts the "I want fresh data now"
     // semantics of a manual refresh.
     this.resolvedWorktrees.clear();
+    this.issueTitleFetchedWorktrees.clear();
     // Re-resolve the forge provider on manual refresh so token changes
     // and provider installs/uninstalls take effect immediately. Clear the
     // in-flight branch-lookup dedup so a stale promise from the previous
@@ -557,6 +565,7 @@ class PullRequestService {
     this.stop();
     this.candidates.clear();
     this.resolvedWorktrees.clear();
+    this.issueTitleFetchedWorktrees.clear();
     this.detectedPRs.clear();
     this.consecutiveErrors = 0;
     this.nextRetryAt = 0;
@@ -863,6 +872,7 @@ class PullRequestService {
 
           if (!pr) {
             this.resolvedWorktrees.delete(worktreeId);
+            this.issueTitleFetchedWorktrees.delete(worktreeId);
             this.detectedPRs.delete(worktreeId);
             logInfo("PR no longer found during revalidation - clearing state", { worktreeId });
             events.emit("sys:pr:cleared", {
@@ -919,6 +929,51 @@ class PullRequestService {
       }
 
       this.updateBoostFromDetectedPRs();
+
+      // Retry issue-title fetches for any candidate that still lacks a
+      // confirmed successful title (#8851). Polling otherwise stops once all
+      // PRs resolve, leaving the offline branchDerivedTitle as the only
+      // visible label until the next manual refresh.
+      const issueRetryLookups: Promise<void>[] = [];
+      for (const [worktreeId, context] of this.candidates) {
+        if (!context.issueNumber || typeof context.issueNumber !== "number") continue;
+        if (this.issueTitleFetchedWorktrees.has(worktreeId)) continue;
+        const issueNumber = context.issueNumber;
+        const branchAtFetchStart = context.branchName;
+        issueRetryLookups.push(
+          provider
+            .getIssue(repo, issueNumber)
+            .then((issue) => {
+              const currentBranch = this.candidates.get(worktreeId)?.branchName;
+              if (currentBranch !== branchAtFetchStart) return;
+              if (issue) {
+                this.issueTitleFetchedWorktrees.add(worktreeId);
+                events.emit("sys:issue:detected", {
+                  worktreeId,
+                  issueNumber,
+                  issueTitle: issue.title,
+                  branchName: branchAtFetchStart,
+                  providerId,
+                  owner: repo.owner,
+                  repo: repo.repo,
+                  timestamp: Date.now(),
+                });
+              } else {
+                events.emit("sys:issue:not-found", {
+                  worktreeId,
+                  issueNumber,
+                  timestamp: Date.now(),
+                });
+              }
+            })
+            .catch(() => {
+              // Silent; will retry on the next revalidation cycle.
+            })
+        );
+      }
+      if (issueRetryLookups.length > 0) {
+        await Promise.allSettled(issueRetryLookups);
+      }
     } catch (error) {
       logWarn("Revalidation check error", {
         error: formatErrorMessage(error, "PR revalidation failed"),
@@ -932,6 +987,15 @@ class PullRequestService {
       issueNumber?: number;
       branchName?: string;
     }> = [];
+    // Issue-title lookup candidates include BOTH active and resolved
+    // worktrees that have an issue number and haven't had a successful title
+    // fetch yet (#8851). Resolved-PR worktrees still need this path because
+    // `revalidateResolvedPRs` only re-checks PR metadata, not issue titles.
+    const issueLookupCandidates: Array<{
+      worktreeId: string;
+      issueNumber: number;
+      branchName?: string;
+    }> = [];
     const lookupBranchByWorktreeId = new Map<string, string | undefined>();
     for (const [worktreeId, context] of this.candidates) {
       if (!this.resolvedWorktrees.has(worktreeId)) {
@@ -942,9 +1006,23 @@ class PullRequestService {
         });
         lookupBranchByWorktreeId.set(worktreeId, context.branchName);
       }
+      if (
+        context.issueNumber &&
+        typeof context.issueNumber === "number" &&
+        !this.issueTitleFetchedWorktrees.has(worktreeId)
+      ) {
+        issueLookupCandidates.push({
+          worktreeId,
+          issueNumber: context.issueNumber,
+          branchName: context.branchName,
+        });
+        if (!lookupBranchByWorktreeId.has(worktreeId)) {
+          lookupBranchByWorktreeId.set(worktreeId, context.branchName);
+        }
+      }
     }
 
-    if (activeCandidates.length === 0) {
+    if (activeCandidates.length === 0 && issueLookupCandidates.length === 0) {
       logDebug("No candidates to check for PRs");
       return;
     }
@@ -996,18 +1074,26 @@ class PullRequestService {
 
       // Issue lookups (independent of PR lookups, run in parallel per candidate)
       const issueLookups: Promise<void>[] = [];
-      for (const c of activeCandidates) {
-        const issueNumber = c.issueNumber ?? this.candidates.get(c.worktreeId)?.issueNumber;
-        if (!issueNumber || typeof issueNumber !== "number") continue;
+      for (const c of issueLookupCandidates) {
         const lookupBranch = lookupBranchByWorktreeId.get(c.worktreeId);
+        const branchAtFetchStart = this.candidates.get(c.worktreeId)?.branchName;
         issueLookups.push(
           provider
-            .getIssue(repo, issueNumber)
+            .getIssue(repo, c.issueNumber)
             .then((issue) => {
+              // Branch-token check (lesson #2243): if the worktree's branch
+              // changed during the fetch, the result is stale — don't write
+              // the fetched marker, let the next pass retry against the new
+              // branch's issue number.
+              const currentBranch = this.candidates.get(c.worktreeId)?.branchName;
+              if (currentBranch !== branchAtFetchStart) {
+                return;
+              }
               if (issue) {
+                this.issueTitleFetchedWorktrees.add(c.worktreeId);
                 events.emit("sys:issue:detected", {
                   worktreeId: c.worktreeId,
-                  issueNumber,
+                  issueNumber: c.issueNumber,
                   issueTitle: issue.title,
                   branchName: lookupBranch,
                   providerId,
@@ -1016,9 +1102,12 @@ class PullRequestService {
                   timestamp: Date.now(),
                 });
               } else {
+                // Null = forge confirmed not-found. Leave eligible for
+                // retry (no marker added) so private/transient cases get
+                // another chance on the next polling cycle.
                 events.emit("sys:issue:not-found", {
                   worktreeId: c.worktreeId,
-                  issueNumber,
+                  issueNumber: c.issueNumber,
                   timestamp: Date.now(),
                 });
               }

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -757,4 +757,73 @@ describe("PullRequestService", () => {
 
     pullRequestService.destroy();
   });
+
+  describe("issueTitle retry after PR resolved (#8851)", () => {
+    it("retries getIssue on subsequent checkForPRs runs after a resolved PR's first issue fetch returns null", async () => {
+      vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+      const mockImpl = mockForgeProviderResolved();
+      const getIssue = vi
+        .fn<() => Promise<{ number: number; title: string } | null>>()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue({
+          number: 88,
+          title: "Eventually fetched title",
+          state: "open",
+          rawState: "OPEN",
+          url: "https://github.com/o/r/issues/88",
+          rawData: null,
+        } as unknown as { number: number; title: string });
+      // Override the default null with our staged sequence.
+      mockImpl.getIssue = getIssue as unknown as typeof mockImpl.getIssue;
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      const detected: DaintreeEventMap["sys:issue:detected"][] = [];
+      const unsubscribe = events.on("sys:issue:detected", (payload) => detected.push(payload));
+
+      pullRequestService.initialize("/repo");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({
+          worktreeId: "wt-1",
+          branch: "feature/issue-88-thing",
+          issueNumber: 88,
+        })
+      );
+
+      // First pass: resolve the provider + PR via refresh() (clears throttle).
+      // The first getIssue returns null, so no fetched marker is written.
+      await pullRequestService.refresh();
+      expect(mockImpl.findPRByBranch).toHaveBeenCalledTimes(1);
+      expect(getIssue).toHaveBeenCalledTimes(1);
+      expect(detected).toHaveLength(0);
+
+      const svc = pullRequestService as unknown as {
+        checkForPRs: () => Promise<void>;
+        lastCheckAt: number;
+      };
+
+      // Second pass: bypass the 5s throttle, then trigger another check.
+      // The worktree is in resolvedWorktrees but NOT in
+      // issueTitleFetchedWorktrees, so the issue lookup must run again.
+      svc.lastCheckAt = Number.NEGATIVE_INFINITY;
+      await svc.checkForPRs();
+      expect(getIssue).toHaveBeenCalledTimes(2);
+      expect(detected).toHaveLength(1);
+      expect(detected[0]).toMatchObject({
+        worktreeId: "wt-1",
+        issueNumber: 88,
+        issueTitle: "Eventually fetched title",
+      });
+
+      // Third pass: the marker is now set; no further getIssue calls.
+      svc.lastCheckAt = Number.NEGATIVE_INFINITY;
+      await svc.checkForPRs();
+      expect(getIssue).toHaveBeenCalledTimes(2);
+
+      unsubscribe();
+      pullRequestService.destroy();
+    });
+  });
 });

--- a/electron/services/__tests__/issueExtractor.test.ts
+++ b/electron/services/__tests__/issueExtractor.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { extractIssueNumber, extractIssueNumberSync } from "../issueExtractor.js";
+import {
+  deriveIssueTitleFromBranch,
+  extractIssueNumber,
+  extractIssueNumberSync,
+} from "../issueExtractor.js";
 
 let seed = 0;
 function unique(value: string): string {
@@ -76,5 +80,55 @@ describe("issueExtractor", () => {
     await expect(extractIssueNumber(branch, folder)).resolves.toBe(
       extractIssueNumberSync(branch, folder)
     );
+  });
+});
+
+describe("deriveIssueTitleFromBranch", () => {
+  it("returns undefined for invalid or empty branch names", () => {
+    expect(deriveIssueTitleFromBranch("")).toBeUndefined();
+    expect(deriveIssueTitleFromBranch("   ")).toBeUndefined();
+    expect(deriveIssueTitleFromBranch(null as unknown as string)).toBeUndefined();
+    expect(deriveIssueTitleFromBranch(undefined as unknown as string)).toBeUndefined();
+  });
+
+  it("returns undefined when the branch has no issue-<n>-<slug> pattern", () => {
+    expect(deriveIssueTitleFromBranch("main")).toBeUndefined();
+    expect(deriveIssueTitleFromBranch("feature/my-work")).toBeUndefined();
+    expect(deriveIssueTitleFromBranch("issue-123")).toBeUndefined(); // no slug
+    expect(deriveIssueTitleFromBranch("issue-123-")).toBeUndefined(); // empty slug
+  });
+
+  it("derives a sentence-cased title from issue-<n>-<slug>", () => {
+    expect(deriveIssueTitleFromBranch("issue-8773-surface-assistant-launch")).toBe(
+      "Surface assistant launch"
+    );
+  });
+
+  it("strips a single branch prefix segment before parsing", () => {
+    expect(deriveIssueTitleFromBranch("feature/issue-8773-surface-assistant-launch")).toBe(
+      "Surface assistant launch"
+    );
+    expect(deriveIssueTitleFromBranch("bugfix/issue-42-fix-edge-case")).toBe("Fix edge case");
+  });
+
+  it("supports the slug-style prefix without a path separator", () => {
+    expect(deriveIssueTitleFromBranch("feature-123-add-tests")).toBe("Add tests");
+  });
+
+  it("leaves non-leading words lowercase (sentence case, not title case)", () => {
+    expect(deriveIssueTitleFromBranch("issue-7-add-oauth-support")).toBe("Add oauth support");
+    expect(deriveIssueTitleFromBranch("issue-9-fix-api-rate-limit")).toBe("Fix api rate limit");
+  });
+
+  it("collapses multiple separator characters into single spaces", () => {
+    expect(deriveIssueTitleFromBranch("issue-1-a--b--c")).toBe("A b c");
+  });
+
+  it("uses only the last path segment to find the slug", () => {
+    expect(deriveIssueTitleFromBranch("user/feature/issue-99-deep-nested")).toBe("Deep nested");
+  });
+
+  it("trims surrounding whitespace before parsing", () => {
+    expect(deriveIssueTitleFromBranch("  issue-1-hello-world  ")).toBe("Hello world");
   });
 });

--- a/electron/services/issueExtractor.ts
+++ b/electron/services/issueExtractor.ts
@@ -61,3 +61,29 @@ export async function extractIssueNumber(
 ): Promise<number | null> {
   return extractIssueNumberSync(branchName, folderName);
 }
+
+const BRANCH_SLUG_PATTERN = /^(?:[a-zA-Z]+-)?\d+-(.+)$/;
+
+/**
+ * Derive a sentence-cased title from Daintree's `issue-<n>-<slug>` branch
+ * naming convention so the worktree sidebar has an offline fallback when the
+ * canonical GitHub issue title hasn't been fetched yet. Lossy by design — the
+ * slug truncates and lower-cases the original title, so we don't try to
+ * reconstruct casing beyond capitalizing the first character.
+ */
+export function deriveIssueTitleFromBranch(branchName: string): string | undefined {
+  if (!branchName || typeof branchName !== "string") {
+    return undefined;
+  }
+  const trimmed = branchName.trim();
+  if (!trimmed) return undefined;
+
+  const lastSegment = trimmed.includes("/") ? trimmed.slice(trimmed.lastIndexOf("/") + 1) : trimmed;
+  const match = lastSegment.match(BRANCH_SLUG_PATTERN);
+  if (!match?.[1]) return undefined;
+
+  const slug = match[1].replace(/[_-]+/g, " ").trim();
+  if (!slug) return undefined;
+
+  return slug.charAt(0).toUpperCase() + slug.slice(1);
+}

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -360,7 +360,11 @@ export class WorkspaceService {
         if (!monitor) return;
         if (monitor.issueNumber !== issueNumber) return;
 
-        monitor.setIssueNumber(undefined);
+        // Don't clear monitor.issueNumber: it's the branch-parsed local fact
+        // (e.g., `issue-123` in `bugfix/issue-123-foo`). A "not found" from
+        // the forge means the issue may be private, deleted, or in another
+        // org — none of which invalidates the local number. Keeping it lets
+        // the offline branchDerivedTitle stay visible (#8851).
         monitor.setIssueTitle(undefined);
 
         // Clear the linked.issue projection but preserve any PR linkage

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -22,7 +22,11 @@ import { WorktreeRemovedError } from "../utils/errorTypes.js";
 import { categorizeWorktree } from "../services/worktree/mood.js";
 import { AdaptivePollingStrategy, NoteFileReader } from "../services/worktree/index.js";
 import { ensureSerializable } from "../../shared/utils/serialization.js";
-import { extractIssueNumberSync, extractIssueNumber } from "../services/issueExtractor.js";
+import {
+  extractIssueNumberSync,
+  extractIssueNumber,
+  deriveIssueTitleFromBranch,
+} from "../services/issueExtractor.js";
 import { FetchScheduler, type FetchSchedulerHost } from "./FetchScheduler.js";
 import { ResourcePollTimer, type ResourcePollTimerHost } from "./ResourcePollTimer.js";
 import { WatcherController, type WatcherControllerHost } from "./WatcherController.js";
@@ -142,6 +146,7 @@ export class WorktreeMonitor {
   private prCiStatus: GitHubPRCIStatus | undefined;
   private prTitle: string | undefined;
   private issueTitle: string | undefined;
+  private _branchDerivedTitle: string | undefined;
   private prLastUpdatedAt: number | undefined;
   private issueLastUpdatedAt: number | undefined;
 
@@ -266,6 +271,9 @@ export class WorktreeMonitor {
     this.path = worktree.path;
     this._name = worktree.name;
     this._branch = worktree.branch;
+    this._branchDerivedTitle = worktree.branch
+      ? deriveIssueTitleFromBranch(worktree.branch)
+      : undefined;
     this._gitDir = worktree.gitDir;
     this._isCurrent = worktree.isCurrent;
     this._isMainWorktree = Boolean(worktree.isMainWorktree);
@@ -497,6 +505,7 @@ export class WorktreeMonitor {
 
   set branch(value: string | undefined) {
     this._branch = value;
+    this._branchDerivedTitle = value ? deriveIssueTitleFromBranch(value) : undefined;
   }
 
   get isCurrent(): boolean {
@@ -1062,6 +1071,7 @@ export class WorktreeMonitor {
       prCiStatus: linkedPr ? linkedPrCiStatus : this.prCiStatus,
       prTitle: linkedPr ? linkedPr.title : this.prTitle,
       issueTitle: linkedIssue ? linkedIssue.title : this.issueTitle,
+      branchDerivedTitle: this._branchDerivedTitle,
       prLastUpdatedAt: this.prLastUpdatedAt,
       issueLastUpdatedAt: this.issueLastUpdatedAt,
       worktreeChanges: this.worktreeChanges,
@@ -1463,6 +1473,7 @@ export class WorktreeMonitor {
           this._issueNumber = undefined;
           void this.extractIssueNumberAsync(currentBranch, this._name);
         }
+        this._branchDerivedTitle = deriveIssueTitleFromBranch(currentBranch);
         this.issueTitle = undefined;
         // Clear PR info synchronously in the same emit as the branch change
         // so the renderer never sees a frame with the new branch but the old

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -36,6 +36,7 @@ vi.mock("../../utils/gitUtils.js", () => ({
 vi.mock("../../services/issueExtractor.js", () => ({
   extractIssueNumberSync: vi.fn().mockReturnValue(null),
   extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
 }));
 
 vi.mock("../../services/github/GitHubAuth.js", () => ({

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -51,6 +51,7 @@ vi.mock("../../services/worktree/mood.js", () => ({
 vi.mock("../../services/issueExtractor.js", () => ({
   extractIssueNumberSync: vi.fn().mockReturnValue(null),
   extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
 }));
 
 vi.mock("../../services/worktree/index.js", () => ({

--- a/electron/workspace-host/__tests__/WorkspaceService.deleteWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.deleteWorktree.test.ts
@@ -52,6 +52,7 @@ vi.mock("../../services/worktree/mood.js", () => ({
 vi.mock("../../services/issueExtractor.js", () => ({
   extractIssueNumberSync: vi.fn().mockReturnValue(null),
   extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
 }));
 
 vi.mock("../../services/worktree/index.js", () => ({

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -71,6 +71,7 @@ vi.mock("../../services/worktree/mood.js", () => ({
 vi.mock("../../services/issueExtractor.js", () => ({
   extractIssueNumberSync: vi.fn().mockReturnValue(null),
   extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
 }));
 
 vi.mock("../../services/worktree/index.js", () => ({

--- a/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
@@ -49,6 +49,7 @@ vi.mock("../../services/worktree/mood.js", () => ({
 vi.mock("../../services/issueExtractor.js", () => ({
   extractIssueNumberSync: vi.fn().mockReturnValue(null),
   extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
 }));
 
 vi.mock("../../services/worktree/index.js", () => ({

--- a/electron/workspace-host/__tests__/WorkspaceService.getFileDiff.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.getFileDiff.test.ts
@@ -49,6 +49,7 @@ vi.mock("../../services/worktree/mood.js", () => ({
 vi.mock("../../services/issueExtractor.js", () => ({
   extractIssueNumberSync: vi.fn().mockReturnValue(null),
   extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
 }));
 
 vi.mock("../../services/worktree/index.js", () => ({

--- a/electron/workspace-host/__tests__/WorkspaceService.lfs.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.lfs.test.ts
@@ -32,6 +32,7 @@ vi.mock("../../services/github/GitHubAuth.js", () => ({ GitHubAuth: vi.fn() }));
 vi.mock("../../services/issueExtractor.js", () => ({
   extractIssueNumber: vi.fn(),
   extractIssueNumberSync: vi.fn(),
+  deriveIssueTitleFromBranch: vi.fn(),
 }));
 vi.mock("../WorktreeLifecycleService.js", () => ({ WorktreeLifecycleService: vi.fn() }));
 vi.mock("../WorktreeMonitor.js", () => ({ WorktreeMonitor: vi.fn() }));

--- a/electron/workspace-host/__tests__/WorkspaceService.pauseResume.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.pauseResume.test.ts
@@ -50,6 +50,7 @@ vi.mock("../../services/worktree/mood.js", () => ({
 vi.mock("../../services/issueExtractor.js", () => ({
   extractIssueNumberSync: vi.fn().mockReturnValue(null),
   extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
 }));
 
 vi.mock("../../services/worktree/index.js", () => ({

--- a/electron/workspace-host/__tests__/WorkspaceService.rateLimit.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.rateLimit.test.ts
@@ -50,6 +50,7 @@ vi.mock("../../services/worktree/mood.js", () => ({
 vi.mock("../../services/issueExtractor.js", () => ({
   extractIssueNumberSync: vi.fn().mockReturnValue(null),
   extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
 }));
 
 vi.mock("../../services/worktree/index.js", () => ({

--- a/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
@@ -54,6 +54,7 @@ vi.mock("../../services/worktree/mood.js", () => ({
 vi.mock("../../services/issueExtractor.js", () => ({
   extractIssueNumberSync: vi.fn().mockReturnValue(null),
   extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
 }));
 
 vi.mock("../../services/worktree/index.js", () => ({

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -52,6 +52,7 @@ vi.mock("../../services/worktree/mood.js", () => ({
 vi.mock("../../services/issueExtractor.js", () => ({
   extractIssueNumberSync: vi.fn().mockReturnValue(null),
   extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
 }));
 
 vi.mock("../../utils/gitUtils.js", () => ({
@@ -492,6 +493,54 @@ describe("WorktreeMonitor", () => {
     monitor.clearPRInfo();
 
     expect(monitor.getSnapshot().prCiStatus).toBeUndefined();
+  });
+
+  describe("branchDerivedTitle in snapshot (#8851)", () => {
+    it("populates branchDerivedTitle from the worktree's initial branch", async () => {
+      const { deriveIssueTitleFromBranch } = await import("../../services/issueExtractor.js");
+      vi.mocked(deriveIssueTitleFromBranch).mockReturnValue("Surface assistant launch");
+
+      const monitor = new WorktreeMonitor(
+        { ...TEST_WORKTREE, branch: "feature/issue-8773-surface-assistant-launch" },
+        TEST_CONFIG,
+        makeCallbacks(),
+        "main"
+      );
+
+      expect(monitor.getSnapshot().branchDerivedTitle).toBe("Surface assistant launch");
+    });
+
+    it("recomputes branchDerivedTitle when branch is replaced via the setter", async () => {
+      const { deriveIssueTitleFromBranch } = await import("../../services/issueExtractor.js");
+      vi.mocked(deriveIssueTitleFromBranch)
+        .mockReturnValueOnce("First title")
+        .mockReturnValueOnce("Second title");
+
+      const monitor = new WorktreeMonitor(
+        { ...TEST_WORKTREE, branch: "feature/issue-1-first" },
+        TEST_CONFIG,
+        makeCallbacks(),
+        "main"
+      );
+      expect(monitor.getSnapshot().branchDerivedTitle).toBe("First title");
+
+      monitor.branch = "feature/issue-2-second";
+      expect(monitor.getSnapshot().branchDerivedTitle).toBe("Second title");
+    });
+
+    it("leaves branchDerivedTitle undefined when the branch lacks an issue-<n>-<slug> pattern", async () => {
+      const { deriveIssueTitleFromBranch } = await import("../../services/issueExtractor.js");
+      vi.mocked(deriveIssueTitleFromBranch).mockReturnValue(undefined);
+
+      const monitor = new WorktreeMonitor(
+        { ...TEST_WORKTREE, branch: "main" },
+        TEST_CONFIG,
+        makeCallbacks(),
+        "main"
+      );
+
+      expect(monitor.getSnapshot().branchDerivedTitle).toBeUndefined();
+    });
   });
 
   describe("linked is the source of truth (#8452)", () => {

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -106,6 +106,12 @@ export interface WorktreeSnapshot {
   prCiStatus?: GitHubPRCIStatus;
   prTitle?: string;
   issueTitle?: string;
+  /**
+   * Offline-derived sentence-cased title parsed from `issue-<n>-<slug>`
+   * branches, used as a fallback headline when `issueTitle` hasn't been
+   * fetched yet so the sidebar never shows the raw slug (#8851).
+   */
+  branchDerivedTitle?: string;
   prLastUpdatedAt?: number;
   issueLastUpdatedAt?: number;
   worktreeChanges?: WorktreeChanges | null;

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -186,6 +186,13 @@ export interface Worktree {
   /** GitHub issue title */
   issueTitle?: string;
 
+  /**
+   * Offline-derived sentence-cased title parsed from the `issue-<n>-<slug>`
+   * branch naming convention. Used as a fallback headline when `issueTitle`
+   * hasn't been fetched yet so the sidebar never shows the raw slug.
+   */
+  branchDerivedTitle?: string;
+
   /** Timestamp when the issue title was last updated by the workspace-host */
   issueLastUpdatedAt?: number;
 

--- a/src/components/DragDrop/WorktreeDragPreview.tsx
+++ b/src/components/DragDrop/WorktreeDragPreview.tsx
@@ -8,7 +8,8 @@ interface WorktreeDragPreviewProps {
 
 export function WorktreeDragPreview({ worktree }: WorktreeDragPreviewProps) {
   const branchLabel = worktree.isMainWorktree ? worktree.name : (worktree.branch ?? worktree.name);
-  const hasIssueTitle = !!(worktree.issueNumber && worktree.issueTitle);
+  const displayTitle = worktree.issueTitle ?? worktree.branchDerivedTitle;
+  const hasDisplayTitle = !!(worktree.issueNumber && displayTitle);
 
   return (
     <div
@@ -25,7 +26,7 @@ export function WorktreeDragPreview({ worktree }: WorktreeDragPreviewProps) {
         gap: 4,
       }}
     >
-      {hasIssueTitle ? (
+      {hasDisplayTitle ? (
         <>
           <div
             style={{
@@ -53,7 +54,7 @@ export function WorktreeDragPreview({ worktree }: WorktreeDragPreviewProps) {
                 textOverflow: "ellipsis",
               }}
             >
-              {worktree.issueTitle}
+              {displayTitle}
             </span>
           </div>
           <span

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -112,6 +112,7 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
     setFatalError: () => {},
     setReconnecting: () => {},
     setWatcherDegraded: () => {},
+    applyIssueNotFound: () => {},
   }));
   setCurrentViewStore(store);
 }

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -702,7 +702,7 @@ export function WorktreeCard({
           aria-busy={isBeingDeleted && !deleteError ? "true" : undefined}
           role={variant === "grid" ? "group" : undefined}
           aria-current={variant === "grid" && isActive ? "true" : undefined}
-          aria-label={`Worktree: ${worktree.issueTitle ?? branchLabel}${worktree.issueTitle ? ` (${branchLabel})` : ""}${worktree.isCurrent ? " (selected, current)" : ""}, Status: ${ariaStatusLabel}`}
+          aria-label={`Worktree: ${worktree.issueTitle ?? worktree.branchDerivedTitle ?? branchLabel}${(worktree.issueTitle ?? worktree.branchDerivedTitle) ? ` (${branchLabel})` : ""}${worktree.isCurrent ? " (selected, current)" : ""}, Status: ${ariaStatusLabel}`}
           onClick={handleCardClick}
           onDoubleClick={handleDoubleClick}
           onPointerEnter={handlePointerEnter}
@@ -721,7 +721,7 @@ export function WorktreeCard({
               variant === "grid" && "rounded-lg",
               (isDraggingSort || isWorktreeSortDragging) && "pointer-events-none"
             )}
-            aria-label={`Select worktree: ${worktree.issueTitle ?? branchLabel}${worktree.issueTitle ? ` (${branchLabel})` : ""}`}
+            aria-label={`Select worktree: ${worktree.issueTitle ?? worktree.branchDerivedTitle ?? branchLabel}${(worktree.issueTitle ?? worktree.branchDerivedTitle) ? ` (${branchLabel})` : ""}`}
           />
           {flashKey > 0 && (
             <div

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -19,7 +19,12 @@ interface NonMainSecondaryRowProps {
   underlineOnHover: boolean;
   hasUpstreamDelta: boolean;
   hasAuthFailedSignIn: boolean;
-  hasIssueTitle: boolean;
+  /**
+   * True when the headline above renders a title — canonical `issueTitle` or
+   * the offline `branchDerivedTitle` fallback. Drives the branch secondary
+   * line, which surfaces below either form of title (#8851).
+   */
+  hasDisplayTitle: boolean;
   hasPlanFile: boolean;
   badges: {
     onOpenIssue?: () => void;
@@ -36,7 +41,7 @@ export function NonMainSecondaryRow({
   underlineOnHover,
   hasUpstreamDelta,
   hasAuthFailedSignIn,
-  hasIssueTitle,
+  hasDisplayTitle,
   hasPlanFile,
   badges,
 }: NonMainSecondaryRowProps) {
@@ -99,7 +104,7 @@ export function NonMainSecondaryRow({
 
   return (
     <div className="flex flex-col gap-0.5 mt-1.5">
-      {worktree.issueNumber && !hasIssueTitle && (
+      {worktree.issueNumber && !hasDisplayTitle && (
         <IssueBadge
           issueNumber={worktree.issueNumber}
           worktreePath={worktree.path}
@@ -111,7 +116,7 @@ export function NonMainSecondaryRow({
       )}
       {upstreamFirst ? upstreamBadge : prBadge}
       {upstreamFirst ? prBadge : upstreamBadge}
-      {hasIssueTitle && (
+      {hasDisplayTitle && (
         <BranchLabel
           label={branchLabel}
           isActive={isActive}

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -254,7 +254,8 @@ export function WorktreeHeader({
     [menu]
   );
 
-  const hasIssueTitle = !!(worktree.issueNumber && worktree.issueTitle);
+  const displayTitle = worktree.issueTitle ?? worktree.branchDerivedTitle;
+  const hasDisplayTitle = !!(worktree.issueNumber && displayTitle);
   const hasPlanFile = Boolean(worktree.hasPlanFile);
   const hasFreshnessPill = !!(lastGitStatusCheckedAt && lastGitStatusCheckedAt > 0);
   const underlineOnHover = variant !== "sidebar" || isActive;
@@ -271,7 +272,7 @@ export function WorktreeHeader({
     worktree.fetchAuthFailed &&
     (worktree.isGitHubRemote || worktree.linked?.providerId === BUILTIN_GITHUB_PROVIDER_ID)
   );
-  const isMainStandardLayout = !!(isMainOnStandardBranch && !hasIssueTitle);
+  const isMainStandardLayout = !!(isMainOnStandardBranch && !hasDisplayTitle);
 
   const prState = worktree.linked?.pr?.state;
   const isPrLive = prState !== undefined && prState !== "closed" && prState !== "declined";
@@ -309,10 +310,10 @@ export function WorktreeHeader({
               aria-hidden="true"
             />
           )}
-          {hasIssueTitle ? (
+          {hasDisplayTitle ? (
             <IssueBadge
               issueNumber={worktree.issueNumber!}
-              issueTitle={worktree.issueTitle}
+              issueTitle={displayTitle}
               worktreePath={worktree.path}
               onOpen={badges.onOpenIssue}
               isHeadline
@@ -444,8 +445,8 @@ export function WorktreeHeader({
 
       {!isCollapsed &&
         !isMainStandardLayout &&
-        (hasIssueTitle ||
-          (worktree.issueNumber && !hasIssueTitle) ||
+        (hasDisplayTitle ||
+          worktree.issueNumber ||
           (worktree.linked?.pr &&
             worktree.linked.pr.state !== "closed" &&
             worktree.linked.pr.state !== "declined") ||
@@ -460,7 +461,7 @@ export function WorktreeHeader({
             underlineOnHover={underlineOnHover}
             hasUpstreamDelta={hasUpstreamDelta}
             hasAuthFailedSignIn={hasAuthFailedSignIn}
-            hasIssueTitle={hasIssueTitle}
+            hasDisplayTitle={hasDisplayTitle}
             hasPlanFile={hasPlanFile}
             badges={badges}
           />

--- a/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
@@ -68,7 +68,7 @@ function renderRow(overrides: RenderOverrides = {}) {
         underlineOnHover={false}
         hasUpstreamDelta={overrides.hasUpstreamDelta ?? false}
         hasAuthFailedSignIn={overrides.hasAuthFailedSignIn ?? false}
-        hasIssueTitle={false}
+        hasDisplayTitle={false}
         hasPlanFile={false}
         badges={{}}
       />

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -486,25 +486,11 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     cleanups.push(
       worktreePort.onEvent("issue-not-found", (data) => {
         const event = data as IssueNotFoundEvent;
-        const { worktrees } = store.getState();
-        const existing = worktrees.get(event.worktreeId);
-        if (!existing) return;
-        if (existing.issueNumber !== event.issueNumber) return;
-        // `linked` is the source of truth (#8452): clearing the issue must
-        // drop linked.issue too, mirroring the host's onIssueNotFound and the
-        // pr-cleared handler above. Preserve any PR linkage that's present.
-        store.getState().applyUpdate(
-          {
-            ...existing,
-            issueNumber: undefined,
-            issueTitle: undefined,
-            issueLastUpdatedAt: undefined,
-            linked: existing.linked?.pr
-              ? { providerId: existing.linked.providerId, pr: existing.linked.pr }
-              : null,
-          },
-          overlayVersion(store.getState().version)
-        );
+        // `applyIssueNotFound` bypasses `mergeIssueState`'s title-restoration
+        // rule (which would resurrect the old title because issueNumber stays
+        // unchanged) and preserves the branch-parsed issueNumber + the
+        // `branchDerivedTitle` fallback alongside clearing linked.issue (#8851).
+        store.getState().applyIssueNotFound(event.worktreeId, event.issueNumber);
       })
     );
 

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -1081,9 +1081,40 @@ describe("WorktreeStoreProvider issue-detected handler", () => {
     });
 
     const wt = store.getState().worktrees.get("wt-1");
-    expect(wt?.issueNumber).toBeUndefined();
+    // issueNumber survives a not-found response — the local branch-parsed
+    // value is authoritative, not the forge claim (#8851).
+    expect(wt?.issueNumber).toBe(88);
+    expect(wt?.issueTitle).toBeUndefined();
     expect(wt?.linked?.issue).toBeUndefined();
     expect(wt?.linked?.pr?.ref.number).toBe(1234);
+  });
+
+  it("issue-not-found preserves branchDerivedTitle so the sidebar still has a readable fallback (#8851)", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(
+        makeWorktree("wt-1", {
+          branch: "feature/issue-8851-sidebar",
+          issueNumber: 8851,
+          issueTitle: undefined,
+          branchDerivedTitle: "Sidebar shows branch",
+        }),
+        nextV()
+      );
+    });
+
+    act(() => {
+      emit("issue-not-found", {
+        type: "issue-not-found",
+        worktreeId: "wt-1",
+        issueNumber: 8851,
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBe(8851);
+    expect(wt?.branchDerivedTitle).toBe("Sidebar shows branch");
+    expect(wt?.issueTitle).toBeUndefined();
   });
 });
 

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -468,6 +468,7 @@ describe("destructive-action danger metadata", () => {
       setFatalError: () => {},
       setReconnecting: () => {},
       setWatcherDegraded: () => {},
+      applyIssueNotFound: () => {},
     }));
     setCurrentViewStore(viewStore);
     const contextOverride = {

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -1028,6 +1028,7 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.prTitle === b.prTitle &&
     a.issueNumber === b.issueNumber &&
     a.issueTitle === b.issueTitle &&
+    a.branchDerivedTitle === b.branchDerivedTitle &&
     a.prLastUpdatedAt === b.prLastUpdatedAt &&
     a.issueLastUpdatedAt === b.issueLastUpdatedAt &&
     a.hasPlanFile === b.hasPlanFile &&

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -216,6 +216,15 @@ export interface WorktreeViewActions {
     associations?: Record<string, ManualIssueAssociation>
   ): void;
   applyUpdate(state: WorktreeSnapshot, version: WorktreeEventVersion): void;
+  /**
+   * Clear forge-issue overlay without going through `mergeIssueState`, which
+   * would restore the previous `issueTitle` whenever `issueNumber` is
+   * unchanged (the manual-association preservation path). Used by the
+   * `issue-not-found` event handler so a 404 actually clears the title while
+   * keeping the branch-parsed `issueNumber` and the `branchDerivedTitle`
+   * fallback intact (#8851).
+   */
+  applyIssueNotFound(worktreeId: string, issueNumber: number): void;
   applyRemove(worktreeId: string, version: WorktreeEventVersion): void;
   setManualAssociation(worktreeId: string, assoc: ManualIssueAssociation): void;
   clearManualAssociation(worktreeId: string): void;
@@ -377,6 +386,26 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       const next = new Map(prev);
       next.set(state.id, merged);
       set({ worktrees: next, version, ...(tombstonesChanged ? { tombstones } : {}) });
+    },
+
+    applyIssueNotFound(worktreeId: string, issueNumber: number) {
+      const prev = get();
+      const existing = prev.worktrees.get(worktreeId);
+      if (!existing) return;
+      if (existing.issueNumber !== issueNumber) return;
+      // Direct mutation: bypasses mergeIssueState's title-restoration rule so
+      // the not-found response actually clears the title. issueNumber is the
+      // branch-parsed local fact and stays put.
+      const next = new Map(prev.worktrees);
+      next.set(worktreeId, {
+        ...existing,
+        issueTitle: undefined,
+        issueLastUpdatedAt: undefined,
+        linked: existing.linked?.pr
+          ? { providerId: existing.linked.providerId, pr: existing.linked.pr }
+          : null,
+      });
+      set({ worktrees: next });
     },
 
     setManualAssociation(worktreeId: string, assoc: ManualIssueAssociation) {


### PR DESCRIPTION
## Summary

The worktree sidebar was displaying the raw branch slug as the card headline instead of the human-readable issue title. For most worktrees this meant users were reading `issue-8773-surface-assistant-launch` where they should have seen a real title.

The root cause was two-fold: there was no branch-derived fallback at all (the branch slug had only ever yielded an issue *number*, never a title), and a couple of fetch bugs meant `issueTitle` was getting cleared and not retried even when it could have been recovered.

- Add `deriveIssueTitleFromBranch` in `issueExtractor.ts` — parses `issue-<n>-<slug>` branches into sentence-cased labels with no API call. New `branchDerivedTitle` field on `WorktreeSnapshot`, computed in `WorktreeMonitor` whenever the branch changes.
- Stop clearing `issueNumber` on forge 404s (both host and renderer paths) so a transient `getIssue()` failure no longer wipes the parsed issue number needed for future retries.
- Separate `issueTitleFetchedWorktrees` tracking from `resolvedWorktrees` in `PullRequestService` — resolved worktrees now keep retrying issue title fetches, and `revalidateResolvedPRs` triggers those retries too.
- `WorktreeHeader`, `NonMainSecondaryRow`, and `WorktreeDragPreview` use `issueTitle ?? branchDerivedTitle` so the readable label shows immediately on load, offline, and upgrades silently to the canonical GitHub title once fetched.

Resolves #8851

## Changes

- `issueExtractor.ts` — `deriveIssueTitleFromBranch` helper + 9 unit test cases
- `shared/types/worktree.ts` + `workspace-host.ts` — `branchDerivedTitle` field
- `WorktreeMonitor.ts` — compute `branchDerivedTitle` on branch change; 3 new test cases
- `PullRequestService.ts` — split title/PR tracking, retry on resolve; 1 new test case
- `WorkspaceService.ts` — `onIssueNotFound` preserves `issueNumber`
- `WorktreeStoreContext.tsx` + `createWorktreeStore.ts` — `applyIssueNotFound` preserves `issueNumber`; 2 updated test cases
- `WorktreeHeader`, `NonMainSecondaryRow`, `WorktreeDragPreview` — `issueTitle ?? branchDerivedTitle` fallback with broadened aria-labels
- 10 workspace-host mocks + 2 test mocks updated for new snapshot shape

## Testing

Unit tests cover the `deriveIssueTitleFromBranch` parser (9 cases including no-match, sentence-casing, truncated slugs), `WorktreeMonitor` branch-change propagation (3 cases), `PullRequestService` retry-on-resolve (1 case), and the store context `applyIssueNotFound` action (2 updated cases).