### PR TITLE
fix(grid-nav): read column counts from rendered grid snapshot

### DIFF
--- a/src/components/Terminal/__tests__/gridLayoutSnapshot.test.ts
+++ b/src/components/Terminal/__tests__/gridLayoutSnapshot.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getGridLayoutSnapshot,
+  setGridLayoutSnapshot,
+  subscribeGridLayoutSnapshot,
+} from "../gridLayoutSnapshot";
+
+// The snapshot is `useGridNavigation`'s authoritative source for column counts
+// after #8857. These tests guard the subscribe-and-deduplicate contract that
+// `useSyncExternalStore` relies on — a stale read or a missed listener call
+// would re-introduce the drift bug.
+describe("gridLayoutSnapshot", () => {
+  beforeEach(() => {
+    setGridLayoutSnapshot({ gridCols: 1, gridItemCount: 0, fleetGridCols: 1 });
+  });
+
+  it("returns the latest snapshot after set", () => {
+    setGridLayoutSnapshot({ gridCols: 3, gridItemCount: 9, fleetGridCols: 2 });
+    expect(getGridLayoutSnapshot()).toEqual({
+      gridCols: 3,
+      gridItemCount: 9,
+      fleetGridCols: 2,
+    });
+  });
+
+  it("notifies subscribers when any field changes", () => {
+    let calls = 0;
+    const unsubscribe = subscribeGridLayoutSnapshot(() => {
+      calls += 1;
+    });
+
+    setGridLayoutSnapshot({ gridCols: 2, gridItemCount: 0, fleetGridCols: 1 });
+    setGridLayoutSnapshot({ gridCols: 2, gridItemCount: 4, fleetGridCols: 1 });
+    setGridLayoutSnapshot({ gridCols: 2, gridItemCount: 4, fleetGridCols: 3 });
+
+    unsubscribe();
+    expect(calls).toBe(3);
+  });
+
+  it("skips notifications when the snapshot is structurally unchanged", () => {
+    let calls = 0;
+    const unsubscribe = subscribeGridLayoutSnapshot(() => {
+      calls += 1;
+    });
+
+    setGridLayoutSnapshot({ gridCols: 2, gridItemCount: 4, fleetGridCols: 1 });
+    setGridLayoutSnapshot({ gridCols: 2, gridItemCount: 4, fleetGridCols: 1 });
+
+    unsubscribe();
+    expect(calls).toBe(1);
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    let calls = 0;
+    const unsubscribe = subscribeGridLayoutSnapshot(() => {
+      calls += 1;
+    });
+
+    setGridLayoutSnapshot({ gridCols: 2, gridItemCount: 4, fleetGridCols: 1 });
+    unsubscribe();
+    setGridLayoutSnapshot({ gridCols: 3, gridItemCount: 9, fleetGridCols: 1 });
+
+    expect(calls).toBe(1);
+  });
+});

--- a/src/components/Terminal/gridLayoutSnapshot.ts
+++ b/src/components/Terminal/gridLayoutSnapshot.ts
@@ -1,8 +1,13 @@
-// Module-level snapshot of the current grid layout (column count + item
-// count). `GridPanel.handleToggleMaximize` needs these two values only at
-// click time — passing them as reactive props would churn `GridPanel`'s prop
-// identity on every sibling add/remove and defeat its `React.memo`. Reading
-// them imperatively from this snapshot keeps the props stable.
+// Module-level snapshot of the current grid layout (column counts + item
+// count). Two consumers read this imperatively rather than via React props:
+//
+// - `GridPanel.handleToggleMaximize` needs `gridCols`/`gridItemCount` at click
+//   time; reactive props would churn `GridPanel`'s prop identity on every
+//   sibling add/remove and defeat its `React.memo`.
+// - `useGridNavigation` needs the *authoritative* `gridCols`/`fleetGridCols`
+//   at render-memo time. Computing them independently drifted from
+//   `useContentGridContext` whenever maximize/restore, drag placeholder, or
+//   hysteresis state were in flight (#8857).
 //
 // A module-level singleton is safe here because there is exactly one content
 // grid per renderer: each project gets its own `WebContentsView` with an
@@ -12,14 +17,33 @@
 export interface GridLayoutSnapshot {
   gridCols: number;
   gridItemCount: number;
+  fleetGridCols: number;
 }
 
-let snapshot: GridLayoutSnapshot = { gridCols: 1, gridItemCount: 0 };
+let snapshot: GridLayoutSnapshot = { gridCols: 1, gridItemCount: 0, fleetGridCols: 1 };
+const listeners = new Set<() => void>();
 
 export function setGridLayoutSnapshot(next: GridLayoutSnapshot): void {
+  if (
+    snapshot.gridCols === next.gridCols &&
+    snapshot.gridItemCount === next.gridItemCount &&
+    snapshot.fleetGridCols === next.fleetGridCols
+  ) {
+    return;
+  }
   snapshot = next;
+  for (const listener of listeners) listener();
 }
 
 export function getGridLayoutSnapshot(): GridLayoutSnapshot {
   return snapshot;
+}
+
+// `useGridNavigation` subscribes via `useSyncExternalStore` so a column-count
+// change driven by a pure resize (no store state change) still triggers a
+// re-render of the navigation hook — otherwise the post-resize keypress would
+// step through a stale row/column model.
+export function subscribeGridLayoutSnapshot(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
 }

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -694,8 +694,17 @@ export function useContentGridContext({
   //   click time so stable props don't churn its `React.memo`.
   // - `useGridNavigation` reads `gridCols`/`fleetGridCols` at memo time so the
   //   keyboard-nav layout always agrees with the rendered grid (#8857).
-  useEffect(() => {
+  //
+  // `useLayoutEffect` rather than `useEffect`: the write must land before
+  // paint so a keypress immediately after a maximize/restore commit never
+  // reads a stale column count. Cleanup resets to defaults on unmount so a
+  // project switch doesn't briefly serve the previous grid's values while
+  // the new `useContentGridContext` mounts.
+  useLayoutEffect(() => {
     setGridLayoutSnapshot({ gridCols, gridItemCount, fleetGridCols });
+    return () => {
+      setGridLayoutSnapshot({ gridCols: 1, gridItemCount: 0, fleetGridCols: 1 });
+    };
   }, [gridCols, gridItemCount, fleetGridCols]);
 
   const prevFleetGridColsRef = useRef(fleetGridCols);

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -589,13 +589,6 @@ export function useContentGridContext({
     hysteresisGridCols,
   ]);
 
-  // Mirror the live grid layout into a module-level snapshot so
-  // `GridPanel.handleToggleMaximize` can read `gridCols`/`gridItemCount`
-  // imperatively at click time instead of taking them as reactive props.
-  useEffect(() => {
-    setGridLayoutSnapshot({ gridCols, gridItemCount });
-  }, [gridCols, gridItemCount]);
-
   const layoutTransition: Transition = useMemo(
     () => ({
       duration: isProjectSwitching ? 0 : GRID_TRANSITION_DURATION_MS / 1000,
@@ -694,6 +687,16 @@ export function useContentGridContext({
       hysteresisFleetCols
     );
   }, [isFleetScopeRender, fleetPanels, layoutConfig, gridWidth, hysteresisFleetCols]);
+
+  // Mirror the live grid layout into a module-level snapshot. Two consumers
+  // read it imperatively rather than as React props:
+  // - `GridPanel.handleToggleMaximize` reads `gridCols`/`gridItemCount` at
+  //   click time so stable props don't churn its `React.memo`.
+  // - `useGridNavigation` reads `gridCols`/`fleetGridCols` at memo time so the
+  //   keyboard-nav layout always agrees with the rendered grid (#8857).
+  useEffect(() => {
+    setGridLayoutSnapshot({ gridCols, gridItemCount, fleetGridCols });
+  }, [gridCols, gridItemCount, fleetGridCols]);
 
   const prevFleetGridColsRef = useRef(fleetGridCols);
   useLayoutEffect(() => {

--- a/src/hooks/__tests__/useGridNavigation.test.tsx
+++ b/src/hooks/__tests__/useGridNavigation.test.tsx
@@ -7,7 +7,6 @@ interface GridPosition {
   terminalId: string;
   row: number;
   col: number;
-  center: { x: number; y: number };
 }
 
 const createRowMajor = (positions: GridPosition[]) => {
@@ -102,7 +101,6 @@ describe("Grid Navigation Logic", () => {
       terminalId: pos.id,
       row: pos.row,
       col: pos.col,
-      center: { x: pos.col * 150, y: pos.row * 150 },
     }));
   };
 
@@ -275,7 +273,6 @@ describe("Grid Navigation Logic", () => {
                 terminalId: resolvedId,
                 row: Math.floor(index / cols),
                 col: index % cols,
-                center: { x: (index % cols) * 150, y: Math.floor(index / cols) * 150 },
               }
             : null;
         })
@@ -439,7 +436,6 @@ describe("Grid Navigation Logic", () => {
         terminalId: id,
         row: Math.floor(index / cols),
         col: index % cols,
-        center: { x: (index % cols) * 150, y: Math.floor(index / cols) * 150 },
       }));
     };
 

--- a/src/hooks/useGridNavigation.ts
+++ b/src/hooks/useGridNavigation.ts
@@ -1,15 +1,14 @@
-import { useMemo, useCallback, useEffect, useRef, useState } from "react";
-import { usePanelStore, useLayoutConfigStore, useWorktreeSelectionStore } from "@/store";
+import { useMemo, useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import { usePanelStore, useWorktreeSelectionStore } from "@/store";
 import { getClosingIdsSnapshot } from "@/services/terminal/optimisticPanelClose";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useShallow } from "zustand/react/shallow";
-import { computeGridColumns } from "@/lib/terminalLayout";
-import {
-  isSidebarLayoutTransitionLocked,
-  subscribeSidebarLayoutTransitionUnlock,
-} from "@/lib/layoutTransitionLock";
 import { buildFleetPanels } from "@/components/Terminal/contentGridFleetPanels";
+import {
+  getGridLayoutSnapshot,
+  subscribeGridLayoutSnapshot,
+} from "@/components/Terminal/gridLayoutSnapshot";
 
 export type NavigationDirection = "up" | "down" | "left" | "right";
 
@@ -19,13 +18,8 @@ interface GridPosition {
   col: number;
 }
 
-interface UseGridNavigationOptions {
-  containerSelector?: string;
-}
-
-export function useGridNavigation(options: UseGridNavigationOptions = {}) {
+export function useGridNavigation() {
   "use no memo";
-  const { containerSelector = "#panel-grid" } = options;
 
   const { panelIds, panelsById, focusedId, tabGroups, getTabGroups } = usePanelStore(
     useShallow((state) => ({
@@ -43,7 +37,6 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
   const { armedIds, armOrder } = useFleetArmingStore(
     useShallow((state) => ({ armedIds: state.armedIds, armOrder: state.armOrder }))
   );
-  const layoutConfig = useLayoutConfigStore((state) => state.layoutConfig);
 
   const isFleetScopeEnabled = fleetScopeMode === "scoped" && isFleetScopeActive;
 
@@ -77,9 +70,6 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
     [panelIds, panelsById, activeWorktreeId]
   );
 
-  // Track container width for responsive layout (mirrors ContentGrid)
-  const [gridWidth, setGridWidth] = useState<number | null>(null);
-
   // Fleet scope projection: must mirror ContentGrid's fleetPanels exactly so
   // the focus model lines up with what's rendered. Drift here was the cause
   // of #5989 (Cmd+Alt+Arrow no-op when fleet scope spanned worktrees).
@@ -92,62 +82,6 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
   // armed panel has been moved to dock/trash, ContentGrid falls through to
   // the normal active-worktree grid; the nav model has to match.
   const isFleetScopeRender = isFleetScopeEnabled && fleetPanels.length > 0;
-
-  useEffect(() => {
-    let observedContainer: Element | null = null;
-
-    const findAndObserve = () => {
-      const container = document.querySelector(containerSelector);
-      if (!container) return null;
-
-      const observer = new ResizeObserver((entries) => {
-        const entry = entries[0];
-        if (!entry) return;
-        // Skip mid-transition widths so keyboard-nav column count doesn't
-        // briefly snap to a different grid layout while sidebars animate
-        // (#6979).
-        if (isSidebarLayoutTransitionLocked()) return;
-        const newWidth = entry.contentRect.width;
-        setGridWidth((prev) => (prev === newWidth ? prev : newWidth));
-      });
-
-      observer.observe(container);
-      observedContainer = container;
-      // Skip initial measurement during a sidebar lock — the unlock
-      // subscriber below will resync once the transition completes.
-      if (!isSidebarLayoutTransitionLocked()) {
-        setGridWidth(container.clientWidth);
-      }
-
-      return observer;
-    };
-
-    const observer = findAndObserve();
-
-    const unsubscribe = subscribeSidebarLayoutTransitionUnlock(() => {
-      const node = observedContainer ?? document.querySelector(containerSelector);
-      if (!node) return;
-      const width = node.clientWidth;
-      setGridWidth((prev) => (prev === width ? prev : width));
-    });
-
-    if (!observer) {
-      const retryTimer = setTimeout(findAndObserve, 100);
-      return () => {
-        clearTimeout(retryTimer);
-        unsubscribe();
-      };
-    }
-
-    return () => {
-      observer.disconnect();
-      unsubscribe();
-    };
-    // isFleetScopeRender is a dep because ContentGrid swaps the rendered tree
-    // (different React key) when fleet scope toggles, which detaches the old
-    // #panel-grid node. Re-running the effect re-binds the observer to the
-    // new node so gridCols continues to track resizes.
-  }, [containerSelector, isFleetScopeRender]);
 
   // Derive visual grid groups (one cell per tab group), matching ContentGrid.
   // getTabGroups reads tabGroups/panelIds/panelsById from the store via get();
@@ -163,38 +97,14 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
     return getTabGroups("grid", activeWorktreeId ?? undefined);
   }, [getTabGroups, activeWorktreeId, tabGroups, panelIds, panelsById]);
 
-  // Hysteresis input mirroring ContentGrid: keyboard-nav column count must
-  // track the visual grid through the same sticky boundaries, otherwise arrow
-  // navigation maps to wrong cells when count drops into the buffer zone.
-  // Two refs (normal vs fleet) mirror ContentGrid's split so a normal-grid
-  // history doesn't bleed into a fleet-scope render.
-  const hysteresisNavGridColsRef = useRef<number | undefined>(undefined);
-  const hysteresisNavFleetColsRef = useRef<number | undefined>(undefined);
-
-  // Compute gridCols using visual group count, matching ContentGrid's gridItemCount.
-  // In fleet scope render, count is fleet panels (matches ContentGrid.fleetGridCols).
-  const gridCols = useMemo(() => {
-    const { strategy, value } = layoutConfig;
-    const count = isFleetScopeRender ? Math.max(fleetPanels.length, 1) : gridGroups.length;
-    return computeGridColumns(
-      count,
-      gridWidth,
-      strategy,
-      value,
-      isFleetScopeRender ? hysteresisNavFleetColsRef.current : hysteresisNavGridColsRef.current
-    );
-  }, [isFleetScopeRender, fleetPanels.length, gridGroups.length, layoutConfig, gridWidth]);
-
-  useEffect(() => {
-    // Only retain hysteresis state for the automatic strategy. Fixed strategies
-    // produce user-chosen counts that must not bias a later auto computation.
-    const value = layoutConfig.strategy === "automatic" ? gridCols : undefined;
-    if (isFleetScopeRender) {
-      hysteresisNavFleetColsRef.current = value;
-    } else {
-      hysteresisNavGridColsRef.current = value;
-    }
-  }, [gridCols, isFleetScopeRender, layoutConfig.strategy]);
+  // Read the authoritative column counts from `useContentGridContext`'s
+  // snapshot. Computing them independently here drifted from the rendered
+  // grid whenever maximize/restore, drag placeholder, or hysteresis state
+  // were in flight (#8857). `useSyncExternalStore` re-renders this hook on
+  // every column change — including pure-resize changes that don't otherwise
+  // touch subscribed store state.
+  const snapshot = useSyncExternalStore(subscribeGridLayoutSnapshot, getGridLayoutSnapshot);
+  const gridCols = isFleetScopeRender ? snapshot.fleetGridCols : snapshot.gridCols;
 
   // Compute grid layout from visual groups (no DOM measurement). Fleet branch
   // treats each armed panel as its own single-cell position, mirroring how

--- a/src/lib/terminalLayout.ts
+++ b/src/lib/terminalLayout.ts
@@ -200,8 +200,11 @@ export function getAutoGridCols(
  * Single source of truth for grid column calculation across all layout strategies.
  * Enforces the 2-pane invariant: exactly 2 panes should ALWAYS be 2x1 layout.
  *
- * This function is used by both ContentGrid.tsx (for rendering) and
- * useGridNavigation.ts (for keyboard navigation) to ensure consistency.
+ * Called only by `useContentGridContext.tsx` (rendering). `useGridNavigation`
+ * reads the computed result through `gridLayoutSnapshot` rather than running
+ * this function a second time — independent re-derivation drifted from the
+ * rendered grid whenever maximize/restore, drag placeholder, or hysteresis
+ * state were in flight (#8857).
  */
 export function computeGridColumns(
   count: number,


### PR DESCRIPTION
## Summary

- `useGridNavigation` was recomputing `gridCols` independently from the CSS grid, so on resize the navigation model drifted from the actual layout and focus landed on the wrong panel
- A module-level snapshot now stores `gridCols` and `fleetGridCols`, written by a `useLayoutEffect` in `useContentGridContext` and reset on unmount — `useGridNavigation` reads from the snapshot instead of recomputing
- The snapshot exposes a `subscribe` API so `useSyncExternalStore` re-renders correctly on resize-only changes

Resolves #8857

## Changes

- `gridLayoutSnapshot.ts` — extended with `fleetGridCols` and a `subscribe`/`getSnapshot` contract
- `useContentGridContext.tsx` — writes both column counts to the snapshot in a layout effect, with unmount cleanup
- `useGridNavigation.ts` — removed independent column-count derivation; reads `gridCols`/`fleetGridCols` from the snapshot via `useSyncExternalStore`
- `gridLayoutSnapshot.test.ts` — new test covering the subscribe and dedupe contract
- `useGridNavigation.test.tsx` — stale `center` field stripped from test fixtures

## Testing

- New `gridLayoutSnapshot.test.ts` covers snapshot writes, subscribe callbacks, and deduplication on unchanged values
- Existing `useGridNavigation.test.tsx` suite passes with the stale field removed
- Full vitest + tsc green; lint ratchet improved by 31 warnings