### PR TITLE
fix(layout): recalibrate auto-grid columns for laptops and wide displays

### DIFF
--- a/src/lib/__tests__/terminalLayout.test.ts
+++ b/src/lib/__tests__/terminalLayout.test.ts
@@ -13,7 +13,7 @@ import {
   GRID_TRANSITION_DURATION_MS,
 } from "../terminalLayout";
 
-const C = COMFORTABLE_PANEL_WIDTH_PX; // size-driven denominator (800)
+const C = COMFORTABLE_PANEL_WIDTH_PX; // size-driven denominator (480, #8859)
 
 describe("getAutoGridCols", () => {
   describe("single terminal", () => {
@@ -40,35 +40,40 @@ describe("getAutoGridCols", () => {
     const many = 12;
 
     it("uses 1 column until two comfortable panels fit (2 × C)", () => {
-      expect(getAutoGridCols(many, C)).toBe(1); // floor(800/800)=1
-      expect(getAutoGridCols(many, 2 * C - 1)).toBe(1); // 1599 → 1
+      expect(getAutoGridCols(many, C)).toBe(1); // floor(480/480)=1
+      expect(getAutoGridCols(many, 2 * C - 1)).toBe(1); // 959 → 1
     });
 
     it("widens to 2 columns at 2 × C", () => {
-      expect(getAutoGridCols(many, 2 * C)).toBe(2); // 1600 → 2
-      expect(getAutoGridCols(many, 3 * C - 1)).toBe(2); // 2399 → 2
+      expect(getAutoGridCols(many, 2 * C)).toBe(2); // 960 → 2
+      expect(getAutoGridCols(many, 3 * C - 1)).toBe(2); // 1439 → 2
     });
 
     it("widens to 3 columns at 3 × C", () => {
-      expect(getAutoGridCols(many, 3 * C)).toBe(3); // 2400 → 3
+      expect(getAutoGridCols(many, 3 * C)).toBe(3); // 1440 → 3
+      expect(getAutoGridCols(many, 4 * C - 1)).toBe(3); // 1919 → 3
     });
 
-    it("hard-caps at 3 columns regardless of width", () => {
-      // Literal 3 (not AUTO_GRID_MAX_COLS) so a silent constant bump is caught —
-      // the issue treats the 3-column ceiling as a researched design contract.
-      expect(getAutoGridCols(many, 4 * C)).toBe(3);
-      expect(getAutoGridCols(many, 10 * C)).toBe(3);
-      expect(getAutoGridCols(100, 99999)).toBe(3);
+    it("widens to 4 columns at 4 × C", () => {
+      expect(getAutoGridCols(many, 4 * C)).toBe(4); // 1920 → 4
     });
 
-    it("pins AUTO_GRID_MAX_COLS to the 3-column design contract", () => {
-      expect(AUTO_GRID_MAX_COLS).toBe(3);
+    it("hard-caps at 4 columns regardless of width", () => {
+      // Literal 4 (not AUTO_GRID_MAX_COLS) so a silent constant bump is caught —
+      // the issue treats the 4-column ceiling as the at-a-glance limit (#8859).
+      expect(getAutoGridCols(many, 5 * C)).toBe(4);
+      expect(getAutoGridCols(many, 10 * C)).toBe(4);
+      expect(getAutoGridCols(100, 99999)).toBe(4);
     });
 
-    it("places the 1→2 column boundary at 1600px (1080p/1440p land on 2)", () => {
+    it("pins AUTO_GRID_MAX_COLS to the 4-column design contract", () => {
+      expect(AUTO_GRID_MAX_COLS).toBe(4);
+    });
+
+    it('places the 1→2 column boundary at 960px (13" MacBook Air gets 2)', () => {
       // Literal pixels (not C) to verify the product-facing breakpoint directly.
-      expect(getAutoGridCols(many, 1599)).toBe(1);
-      expect(getAutoGridCols(many, 1600)).toBe(2);
+      expect(getAutoGridCols(many, 959)).toBe(1);
+      expect(getAutoGridCols(many, 960)).toBe(2);
     });
 
     it("is driven by width, not panel count, at a fixed width", () => {
@@ -81,34 +86,48 @@ describe("getAutoGridCols", () => {
   });
 
   describe("no empty columns", () => {
-    const wide = 4 * C; // would fit 3 columns by width
+    const wide = 4 * C; // fits 4 columns at the new cap
 
     it("never uses more columns than panels", () => {
-      expect(getAutoGridCols(2, wide)).toBe(2); // capped by count, not the 3-col width fit
+      expect(getAutoGridCols(2, wide)).toBe(2); // capped by count, not the 4-col width fit
       expect(getAutoGridCols(3, wide)).toBe(3);
-      expect(getAutoGridCols(5, wide)).toBe(3); // still capped at AUTO_GRID_MAX_COLS
+      expect(getAutoGridCols(4, wide)).toBe(4);
+      expect(getAutoGridCols(6, wide)).toBe(4); // still capped at AUTO_GRID_MAX_COLS
     });
   });
 
   describe("fallback width", () => {
-    it("uses the first-paint fallback (2-column band) when width is null", () => {
-      expect(getAutoGridCols(4, null)).toBe(2);
-      expect(getAutoGridCols(10, null)).toBe(2);
-      expect(getAutoGridCols(2, null)).toBe(2);
+    it("uses the first-paint fallback (3-column band) when width is null", () => {
+      // FALLBACK_GRID_WIDTH_PX (1680) lands in the 3-column band with C=480.
+      expect(getAutoGridCols(4, null)).toBe(3);
+      expect(getAutoGridCols(10, null)).toBe(3);
+      expect(getAutoGridCols(2, null)).toBe(2); // capped by count
     });
 
     it("uses the fallback for non-positive transient widths", () => {
-      expect(getAutoGridCols(4, 0)).toBe(2);
-      expect(getAutoGridCols(4, -100)).toBe(2);
+      expect(getAutoGridCols(4, 0)).toBe(3);
+      expect(getAutoGridCols(4, -100)).toBe(3);
     });
   });
 
   describe("breakpoint hysteresis (width-driven Schmitt trigger)", () => {
     const many = 12;
-    // 2→3 boundary: widen at 3×C (2400), narrow at 3×C − buffer.
-    const threeColNarrow = 3 * C - GRID_HYSTERESIS_BUFFER_PX; // 2320
-    // 1→2 boundary: widen at 2×C (1600), narrow at 2×C − buffer.
-    const twoColNarrow = 2 * C - GRID_HYSTERESIS_BUFFER_PX; // 1520
+    // 3→4 boundary: widen at 4×C (1920), narrow at 4×C − buffer.
+    const fourColNarrow = 4 * C - GRID_HYSTERESIS_BUFFER_PX; // 1840
+    // 2→3 boundary: widen at 3×C (1440), narrow at 3×C − buffer.
+    const threeColNarrow = 3 * C - GRID_HYSTERESIS_BUFFER_PX; // 1360
+    // 1→2 boundary: widen at 2×C (960), narrow at 2×C − buffer.
+    const twoColNarrow = 2 * C - GRID_HYSTERESIS_BUFFER_PX; // 880
+
+    it("holds 4 columns through the narrow buffer once widened", () => {
+      // Natural width target is 3 cols here, but a sticky 4 holds above narrowAt.
+      expect(getAutoGridCols(many, fourColNarrow, 4)).toBe(4);
+      expect(getAutoGridCols(many, fourColNarrow + 10, 4)).toBe(4);
+    });
+
+    it("narrows from 4 to 3 columns once below the buffer", () => {
+      expect(getAutoGridCols(many, fourColNarrow - 1, 4)).toBe(3);
+    });
 
     it("holds 3 columns through the narrow buffer once widened", () => {
       // Natural width target is 2 cols here, but a sticky 3 holds above narrowAt.
@@ -132,32 +151,34 @@ describe("getAutoGridCols", () => {
       // prev=1 must not bias an upward widen — width drives that.
       expect(getAutoGridCols(many, 2 * C, 1)).toBe(2);
       expect(getAutoGridCols(many, 3 * C, 2)).toBe(3);
+      expect(getAutoGridCols(many, 4 * C, 3)).toBe(4);
     });
 
     it("a narrowing viewport overrides a sticky wide count", () => {
-      // Even with previousCols=3, a width that fits only 1 column wins.
-      expect(getAutoGridCols(many, C - 1, 3)).toBe(1);
+      // Even with previousCols=4, a width that fits only 1 column wins.
+      expect(getAutoGridCols(many, C - 1, 4)).toBe(1);
     });
 
     it("preserves pure width-driven behavior when previousCols is undefined", () => {
+      expect(getAutoGridCols(many, fourColNarrow, undefined)).toBe(3);
       expect(getAutoGridCols(many, threeColNarrow, undefined)).toBe(2);
       expect(getAutoGridCols(many, twoColNarrow, undefined)).toBe(1);
     });
 
     it("respects no-empty-columns under a sticky prior", () => {
-      // 2 panels cap at 2 cols even if a stale previousCols=3 leaks in.
-      expect(getAutoGridCols(2, 3 * C, 3)).toBe(2);
+      // 2 panels cap at 2 cols even if a stale previousCols=4 leaks in.
+      expect(getAutoGridCols(2, 4 * C, 4)).toBe(2);
     });
 
     it("holds a chained sequence through a staged narrowing drag", () => {
       // Simulate the per-render previousCols handoff as the window shrinks
-      // across the 2→3 boundary: 2450 → 2350 → 2300.
-      const at2450 = getAutoGridCols(many, 2450, 2); // widens to 3
-      const at2350 = getAutoGridCols(many, 2350, at2450); // sticky 3 (≥2320)
-      const at2300 = getAutoGridCols(many, 2300, at2350); // drops to 2 (<2320)
-      expect(at2450).toBe(3);
-      expect(at2350).toBe(3);
-      expect(at2300).toBe(2);
+      // across the 3→4 boundary: 1960 → 1860 → 1810.
+      const at1960 = getAutoGridCols(many, 1960, 3); // widens to 4
+      const at1860 = getAutoGridCols(many, 1860, at1960); // sticky 4 (≥1840)
+      const at1810 = getAutoGridCols(many, 1810, at1860); // drops to 3 (<1840)
+      expect(at1960).toBe(4);
+      expect(at1860).toBe(4);
+      expect(at1810).toBe(3);
     });
   });
 });
@@ -241,7 +262,7 @@ describe("computeGridColumns", () => {
 
     it("handles transitions with varying widths", () => {
       const narrow = 1.5 * MIN_TERMINAL_WIDTH_PX; // 570 — below the 2-pane gate
-      const twoFit = 2.2 * C; // ~1760 — fits 2 columns
+      const twoFit = 2.2 * C; // ~1056 — fits 2 columns
 
       // Narrow: 2 panels stack (each would get < MIN_TERMINAL_WIDTH_PX side by side).
       expect(computeGridColumns(2, narrow, "automatic")).toBe(1);
@@ -255,7 +276,7 @@ describe("computeGridColumns", () => {
 
     it("uses the null-width fallback during transitions", () => {
       expect(computeGridColumns(2, null, "automatic")).toBe(2); // invariant
-      expect(computeGridColumns(3, null, "automatic")).toBe(2); // fallback fits 2 cols
+      expect(computeGridColumns(3, null, "automatic")).toBe(3); // fallback fits 3 cols
     });
   });
 
@@ -324,9 +345,9 @@ describe("computeGridColumns", () => {
     });
 
     it("forwards previousCols to the automatic hysteresis path", () => {
-      // 2320 = 3×C − buffer: a sticky 3 holds, a fresh measurement narrows to 2.
-      expect(computeGridColumns(12, 2320, "automatic", undefined, 3)).toBe(3);
-      expect(computeGridColumns(12, 2319, "automatic", undefined, 3)).toBe(2);
+      // 1360 = 3×C − buffer: a sticky 3 holds, a fresh measurement narrows to 2.
+      expect(computeGridColumns(12, 1360, "automatic", undefined, 3)).toBe(3);
+      expect(computeGridColumns(12, 1359, "automatic", undefined, 3)).toBe(2);
     });
   });
 
@@ -334,7 +355,7 @@ describe("computeGridColumns", () => {
     const wide = 3 * C;
 
     it("handles null width gracefully", () => {
-      expect(computeGridColumns(4, null, "automatic")).toBe(2); // fallback fits 2
+      expect(computeGridColumns(4, null, "automatic")).toBe(3); // fallback fits 3
       expect(computeGridColumns(2, null, "automatic")).toBe(2); // invariant
     });
 

--- a/src/lib/__tests__/terminalLayout.test.ts
+++ b/src/lib/__tests__/terminalLayout.test.ts
@@ -76,6 +76,13 @@ describe("getAutoGridCols", () => {
       expect(getAutoGridCols(many, 960)).toBe(2);
     });
 
+    it('keeps 13" MacBook Air-class widths on 2 columns (#8859)', () => {
+      // Issue #8859: typical usable grid width on a 13" MBA with sidebars
+      // visible is ~1100-1200px; that must stay at 2 columns, not collapse to 1.
+      expect(getAutoGridCols(many, 1100)).toBe(2);
+      expect(getAutoGridCols(many, 1200)).toBe(2);
+    });
+
     it("is driven by width, not panel count, at a fixed width", () => {
       // Same width → same column count whether 3 panels or 50 are open.
       const wide = 3 * C; // fits 3 columns

--- a/src/lib/terminalLayout.ts
+++ b/src/lib/terminalLayout.ts
@@ -17,16 +17,19 @@ export const MIN_TERMINAL_HEIGHT_PX = 200;
 
 /**
  * Comfortable panel width — the size-driven denominator for the automatic
- * column count. A terminal needs ~624-672px for 80 columns and ~780-840px for
- * 100 columns at typical monospace sizes; rich agent TUIs render diffs and
- * tables best at 100-120 columns. ~720-800px gives a comfortable monitoring
- * width plus panel chrome. Pinned at the top of that range so a typical
- * 1080p/1440p grid lands on 2 columns (each panel ≥800px) and only a large
- * display reaches 3 — favoring fewer, larger panels over more, smaller ones.
+ * column count. Sized so the breakpoints land where real displays do (#8859):
+ *   - 1→2 columns at 960px — keeps a 13" MacBook Air's grid (~1100-1200px
+ *     usable after sidebars) at 2 columns instead of collapsing to 1.
+ *   - 2→3 columns at 1440px — typical 1440p displays settle on 3 columns.
+ *   - 3→4 columns at 1920px — wide monitors (1080p ultrawide, 4K, Pro Display
+ *     XDR class) reach a 4th column, paired with the raised `AUTO_GRID_MAX_COLS`.
+ * Per-panel readability is enforced separately by `MIN_TERMINAL_WIDTH_PX` via
+ * the CSS grid `minmax` track — the comfortable width sets the column-count
+ * breakpoint, not the rendered panel width.
  *
  * Tunable in one place against the app's actual terminal font size.
  */
-export const COMFORTABLE_PANEL_WIDTH_PX = 800;
+export const COMFORTABLE_PANEL_WIDTH_PX = 480;
 
 /**
  * Comfortable panel height — the `gridAutoRows` minimum. Enough for ~24-30
@@ -37,15 +40,15 @@ export const COMFORTABLE_PANEL_WIDTH_PX = 800;
 export const COMFORTABLE_PANEL_HEIGHT_PX = 520;
 
 /**
- * Hard upper bound on automatic columns. A 4th column shrinks every panel and
- * pushes the fleet past what a person can scan at a glance: multiple-object
- * tracking and subitizing both cap around 4 items (dropping toward 3 under
- * load), control-room standards (EEMUA 201, ISO 11064-5) cap an operator at a
- * 2x2 quad, and dashboard convention puts the at-a-glance ceiling at 3 tiles
- * per row. Beyond 3 columns' worth of panels, add rows and scroll — don't
- * widen. The explicit `fixed-columns` strategy is the escape hatch for 4+.
+ * Hard upper bound on automatic columns. Subitizing and multiple-object
+ * tracking both land at ~4 items, control-room standards (EEMUA 201, ISO
+ * 11064-5) cap an operator at a 2x2 quad, so 4 is the at-a-glance ceiling.
+ * Bands: 1 col under 960px, 2 cols at 960-1439px, 3 cols at 1440-1919px,
+ * 4 cols at 1920px+. Beyond what a 4-wide row fits at comfortable size, add
+ * rows and scroll — don't widen. The explicit `fixed-columns` strategy is the
+ * escape hatch for 5+.
  */
-export const AUTO_GRID_MAX_COLS = 3;
+export const AUTO_GRID_MAX_COLS = 4;
 
 /**
  * Breakpoint hysteresis buffer. Once the grid widens to N columns it holds N
@@ -56,8 +59,8 @@ export const GRID_HYSTERESIS_BUFFER_PX = 80;
 
 /**
  * Grid width assumed on the first paint, before the ResizeObserver reports a
- * real measurement. Sits in the 2-column band so the common case doesn't flash
- * from 1 → 2 columns on mount.
+ * real measurement. Sits in the 3-column band (floor(1680/480)=3) so the common
+ * 1440p case doesn't flash from a lower count to 3 columns on mount.
  */
 const FALLBACK_GRID_WIDTH_PX = 1680;
 
@@ -145,7 +148,7 @@ function clampAutoCols(cols: number): number {
  * Once panels exceed what fits at comfortable size, the grid scrolls
  * vertically (handled by `gridAutoRows` + the scroll container).
  *
- *   columns = clamp(1, floor(containerWidth / COMFORTABLE_PANEL_WIDTH_PX), 3)
+ *   columns = clamp(1, floor(containerWidth / COMFORTABLE_PANEL_WIDTH_PX), 4)
  *
  * Design principles:
  * - Spatial permanence: column count tracks the container width, not the fleet
@@ -169,7 +172,7 @@ export function getAutoGridCols(
   if (count <= 1) return 1;
 
   // Non-positive transient widths during layout transitions fall back to a
-  // first-paint default in the 2-column band.
+  // first-paint default in the 3-column band.
   const containerWidth = width && width > 0 ? width : FALLBACK_GRID_WIDTH_PX;
 
   // Size-driven target: how many comfortable panels fit, capped at the
@@ -178,8 +181,8 @@ export function getAutoGridCols(
 
   // Hysteresis: once widened to N columns, hold N until the container narrows a
   // buffer past the N-column threshold (N * COMFORTABLE_PANEL_WIDTH_PX). Walk
-  // highest → lowest so a sticky 3 isn't relaxed prematurely by the 2-column
-  // check; the first band that still has room wins.
+  // highest → lowest so a sticky wider count isn't relaxed prematurely by a
+  // lower-band check; the first band that still has room wins.
   if (previousCols !== undefined) {
     for (let cols = clampAutoCols(previousCols); cols > targetCols; cols--) {
       if (containerWidth >= cols * COMFORTABLE_PANEL_WIDTH_PX - GRID_HYSTERESIS_BUFFER_PX) {

--- a/src/services/actions/definitions/terminalLayoutActions.ts
+++ b/src/services/actions/definitions/terminalLayoutActions.ts
@@ -188,10 +188,10 @@ export function registerTerminalLayoutActions(
         );
       const currentIndex = gridTerminals.findIndex((t) => t!.id === focusedId);
       if (currentIndex < 0) return;
-      const { layoutConfig } = useLayoutConfigStore.getState();
+      const { layoutConfig, gridDimensions } = useLayoutConfigStore.getState();
       const cols = computeGridColumns(
         gridTerminals.length,
-        null,
+        gridDimensions?.width ?? null,
         layoutConfig.strategy,
         layoutConfig.value
       );
@@ -227,10 +227,10 @@ export function registerTerminalLayoutActions(
         );
       const currentIndex = gridTerminals.findIndex((t) => t!.id === focusedId);
       if (currentIndex < 0) return;
-      const { layoutConfig } = useLayoutConfigStore.getState();
+      const { layoutConfig, gridDimensions } = useLayoutConfigStore.getState();
       const cols = computeGridColumns(
         gridTerminals.length,
-        null,
+        gridDimensions?.width ?? null,
         layoutConfig.strategy,
         layoutConfig.value
       );


### PR DESCRIPTION
## Summary

- `COMFORTABLE_PANEL_WIDTH_PX` was set to 800, which is far too wide — terminals were routinely landing in a single column on laptop-sized grids. Reduced to 480 with breakpoints at 960/1440/1920px and `AUTO_GRID_MAX_COLS` raised from 3 to 4 so wide displays actually use the space.
- Secondary fix: `moveUp`/`moveDown` terminal actions were calling `computeGridColumns` with a `null` `gridWidth`, causing the row-jump calculation to always use `FALLBACK_GRID_WIDTH_PX` instead of the real grid width. Now reads from `layoutConfigStore.gridDimensions.width`, matching the pattern already used in `useGridNavigation`.
- Test contracts updated to match the new calibration.

Closes #8859

## Changes

- `src/lib/terminalLayout.ts` — recalibrated `COMFORTABLE_PANEL_WIDTH_PX` (800→480), new breakpoints, `AUTO_GRID_MAX_COLS` (3→4)
- `src/services/actions/definitions/terminalLayoutActions.ts` — `moveUp`/`moveDown` now pass real grid width from `layoutConfigStore.gridDimensions.width`
- `src/lib/__tests__/terminalLayout.test.ts` — design-contract pins updated for the new calibration

## Testing

54 unit tests in `terminalLayout.test.ts` passing. Typecheck, lint (0 errors, ratchet down 30 warnings), and build all clean.