### PR TITLE
Rework panel grid: size-driven layout, custom scrollbar, faster close path

### DIFF
--- a/e2e/helpers/stress.ts
+++ b/e2e/helpers/stress.ts
@@ -30,6 +30,31 @@ export interface FrameProbeResult {
   p95GapMs: number;
 }
 
+export interface LoafProbeScript {
+  sourceURL?: string;
+  sourceFunctionName?: string;
+  invoker?: string;
+  invokerType?: string;
+  duration?: number;
+  executionStart?: number;
+  forcedStyleAndLayoutDuration?: number;
+}
+
+export interface LoafProbeEntry {
+  startTime: number;
+  duration: number;
+  blockingDuration?: number;
+  forcedStyleAndLayoutDuration?: number;
+  scripts: LoafProbeScript[];
+}
+
+export interface LoafProbeResult {
+  supported: boolean;
+  count: number;
+  maxDurationMs: number;
+  entries: LoafProbeEntry[];
+}
+
 export interface TerminalStats {
   terminalCount: number;
   withPty: number;
@@ -373,6 +398,78 @@ export async function stopFrameProbe(page: Page): Promise<FrameProbeResult> {
       maxGapMs: gaps[gaps.length - 1],
       avgGapMs: sum / gaps.length,
       p95GapMs: gaps[p95Index],
+    };
+  });
+}
+
+export async function startLoafProbe(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const w = window as unknown as Record<string, unknown>;
+    if (!("PerformanceObserver" in window)) {
+      w.__daintreeLoafProbe = { supported: false, entries: [], stop: () => {} };
+      return false;
+    }
+    const supported = PerformanceObserver.supportedEntryTypes ?? [];
+    if (!supported.includes("long-animation-frame")) {
+      w.__daintreeLoafProbe = { supported: false, entries: [], stop: () => {} };
+      return false;
+    }
+
+    const entries: Array<Record<string, unknown>> = [];
+    const observer = new PerformanceObserver((list) => {
+      for (const raw of list.getEntries()) {
+        const entry = raw as PerformanceEntry & {
+          blockingDuration?: number;
+          forcedStyleAndLayoutDuration?: number;
+          scripts?: Array<Record<string, unknown>>;
+        };
+        entries.push({
+          startTime: entry.startTime,
+          duration: entry.duration,
+          blockingDuration: entry.blockingDuration,
+          forcedStyleAndLayoutDuration: entry.forcedStyleAndLayoutDuration,
+          scripts: (entry.scripts ?? []).map((script) => ({
+            sourceURL: script.sourceURL,
+            sourceFunctionName: script.sourceFunctionName,
+            invoker: script.invoker,
+            invokerType: script.invokerType,
+            duration: script.duration,
+            executionStart: script.executionStart,
+            forcedStyleAndLayoutDuration: script.forcedStyleAndLayoutDuration,
+          })),
+        });
+      }
+    });
+    observer.observe({ type: "long-animation-frame" } as PerformanceObserverInit);
+    w.__daintreeLoafProbe = {
+      supported: true,
+      entries,
+      stop: () => observer.disconnect(),
+    };
+    return true;
+  });
+}
+
+export async function stopLoafProbe(page: Page): Promise<LoafProbeResult> {
+  return page.evaluate(() => {
+    const w = window as unknown as Record<string, unknown>;
+    const probe = w.__daintreeLoafProbe as
+      | { supported: boolean; entries: LoafProbeEntry[]; stop: () => void }
+      | undefined;
+    if (!probe) {
+      return { supported: false, count: 0, maxDurationMs: 0, entries: [] };
+    }
+
+    probe.stop();
+    delete w.__daintreeLoafProbe;
+
+    const entries = probe.entries;
+    const maxDurationMs = entries.reduce((max, entry) => Math.max(max, entry.duration), 0);
+    return {
+      supported: probe.supported,
+      count: entries.length,
+      maxDurationMs,
+      entries,
     };
   });
 }

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -864,22 +864,26 @@ describe("ResourceProfileService", () => {
     expect(balanced.pollIntervalBackground).toBe(10000);
     expect(balanced.processTreePollInterval).toBe(2500);
     expect(balanced.projectStatsPollInterval).toBe(5000);
-    expect(balanced.maxWebGLContexts).toBe(16);
-    expect(balanced.passiveWebGLThreshold).toBe(12);
+    expect(balanced.webglUpperThreshold).toBe(12);
+    expect(balanced.webglLowerThreshold).toBe(10);
     expect(balanced.memoryPressureInactiveMs).toBe(30 * 60 * 1000);
     expect(balanced.lowMemoryFreeThresholdMb).toBe(768);
   });
 
-  it("performance and efficiency WebGL ceilings stay pinned", () => {
-    expect(RESOURCE_PROFILE_CONFIGS.performance.maxWebGLContexts).toBe(24);
-    expect(RESOURCE_PROFILE_CONFIGS.performance.passiveWebGLThreshold).toBe(24);
-    expect(RESOURCE_PROFILE_CONFIGS.efficiency.maxWebGLContexts).toBe(8);
-    expect(RESOURCE_PROFILE_CONFIGS.efficiency.passiveWebGLThreshold).toBe(8);
+  it("performance and efficiency WebGL thresholds stay pinned", () => {
+    // Performance pushes closer to Chromium's 16-context cap.
+    expect(RESOURCE_PROFILE_CONFIGS.performance.webglUpperThreshold).toBe(14);
+    expect(RESOURCE_PROFILE_CONFIGS.performance.webglLowerThreshold).toBe(12);
+    // Efficiency kicks to DOM-mode sooner on constrained hardware.
+    expect(RESOURCE_PROFILE_CONFIGS.efficiency.webglUpperThreshold).toBe(8);
+    expect(RESOURCE_PROFILE_CONFIGS.efficiency.webglLowerThreshold).toBe(6);
   });
 
-  it("every profile keeps passiveWebGLThreshold <= maxWebGLContexts", () => {
+  it("every profile keeps webglLowerThreshold <= webglUpperThreshold", () => {
+    // The mode-switch hysteresis assumes lower <= upper. A profile that
+    // inverted them would oscillate forever at the boundary.
     for (const config of Object.values(RESOURCE_PROFILE_CONFIGS)) {
-      expect(config.passiveWebGLThreshold).toBeLessThanOrEqual(config.maxWebGLContexts);
+      expect(config.webglLowerThreshold).toBeLessThanOrEqual(config.webglUpperThreshold);
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "sideEffects": [
     "**/*.css",
+    "./electron/setup/environment.ts",
     "./src/main.tsx",
     "./src/lib/trustedTypesPolicy.ts",
     "./src/config/terminalFont.ts",

--- a/shared/types/resourceProfile.ts
+++ b/shared/types/resourceProfile.ts
@@ -9,14 +9,21 @@ export interface ResourceProfileConfig {
   processTreePollInterval: number;
   /** ProjectStatsService polling interval (ms) */
   projectStatsPollInterval: number;
-  /** Max WebGL contexts in the renderer */
-  maxWebGLContexts: number;
   /**
-   * Passive-mode gate: once this many agent terminals hold or are queued for a
-   * WebGL context, new acquisitions are suppressed (DOM renderer) to stop
-   * release/reacquire churn under large visible fleets.
+   * Upper threshold for the WebGL mode switch. When the count of terminals
+   * wanting WebGL exceeds this value, every active context is released and
+   * the manager flips to DOM-mode. Must stay below 16 to leave headroom for
+   * Chromium's per-renderer WebGL-context cap.
    */
-  passiveWebGLThreshold: number;
+  webglUpperThreshold: number;
+  /**
+   * Lower threshold for the WebGL mode switch. Once the count drops to this
+   * value or below, the manager flips back to WebGL-mode and re-attaches an
+   * addon to every want via a rAF-staggered drain. The gap between upper and
+   * lower is the hysteresis band — opening/closing one panel at the boundary
+   * will not flap the fleet.
+   */
+  webglLowerThreshold: number;
   /** FetchScheduler focused (isCurrent) fetch interval (ms) */
   fetchIntervalActiveMs: number;
   /** FetchScheduler background (non-current) fetch interval (ms) */
@@ -63,8 +70,8 @@ export interface ResourceProfilePayload {
  * - pollIntervalBackground: 10000 (WorkspaceService DEFAULT_BACKGROUND_WORKTREE_INTERVAL_MS)
  * - processTreePollInterval: 2500 (ProcessTreeCache constructor default)
  * - projectStatsPollInterval: 5000 (ProjectStatsService DEFAULT_POLL_INTERVAL_MS)
- * - maxWebGLContexts: 16 (TerminalWebGLConfig initial value)
- * - passiveWebGLThreshold: 12 (TerminalWebGLConfig initial value)
+ * - webglUpperThreshold: 12 (TerminalWebGLConfig initial value)
+ * - webglLowerThreshold: 10 (TerminalWebGLConfig initial value)
  * - memoryPressureInactiveMs: 1800000 (HibernationService MEMORY_PRESSURE_INACTIVE_MS = 30min)
  */
 export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileConfig> = {
@@ -73,11 +80,11 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     pollIntervalBackground: 5000,
     processTreePollInterval: 2000,
     projectStatsPollInterval: 5000,
-    // Performance mode disables the passive gate (threshold == max) so all
-    // slots fill before DOM fallback kicks in. Only reached under low-pressure
-    // conditions, so coexisting WebGL consumers have ample budget.
-    maxWebGLContexts: 24,
-    passiveWebGLThreshold: 24,
+    // Performance pushes closer to Chromium's 16-context cap. Higher upper +
+    // 2-slot hysteresis still leaves room for devtools / OffscreenCanvas while
+    // letting more agents render through WebGL simultaneously.
+    webglUpperThreshold: 14,
+    webglLowerThreshold: 12,
     memoryPressureInactiveMs: 60 * 60 * 1000, // 60 min
     lowMemoryFreeThresholdMb: null,
     fetchIntervalActiveMs: 20_000,
@@ -90,8 +97,8 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     pollIntervalBackground: 10000,
     processTreePollInterval: 2500,
     projectStatsPollInterval: 5000,
-    maxWebGLContexts: 16,
-    passiveWebGLThreshold: 12,
+    webglUpperThreshold: 12,
+    webglLowerThreshold: 10,
     memoryPressureInactiveMs: 30 * 60 * 1000, // 30 min
     lowMemoryFreeThresholdMb: 768,
     fetchIntervalActiveMs: 30_000,
@@ -108,8 +115,10 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     pollIntervalBackground: 20000,
     processTreePollInterval: 5000,
     projectStatsPollInterval: 25000,
-    maxWebGLContexts: 8,
-    passiveWebGLThreshold: 8,
+    // Efficiency kicks to DOM-mode sooner on constrained hardware where each
+    // active WebGL context is comparatively more expensive.
+    webglUpperThreshold: 8,
+    webglLowerThreshold: 6,
     memoryPressureInactiveMs: 15 * 60 * 1000, // 15 min
     lowMemoryFreeThresholdMb: 1024,
     fetchIntervalActiveMs: 45_000,

--- a/src/components/DragDrop/SortableTerminal.tsx
+++ b/src/components/DragDrop/SortableTerminal.tsx
@@ -28,6 +28,8 @@ interface SortableTerminalProps {
   groupPanelIds?: string[];
   /** Shared layout transition for the FLIP animation. When omitted, framer-motion's default is used. */
   layoutTransition?: Transition;
+  /** Disable FLIP on latency-critical paths such as optimistic close. */
+  layoutEnabled?: boolean;
 }
 
 export function SortableTerminal({
@@ -39,6 +41,7 @@ export function SortableTerminal({
   groupId,
   groupPanelIds,
   layoutTransition,
+  layoutEnabled = true,
 }: SortableTerminalProps) {
   const dragData: DragData = {
     terminal,
@@ -84,7 +87,7 @@ export function SortableTerminal({
 
   return (
     <m.div
-      layout="position"
+      layout={layoutEnabled ? "position" : false}
       transition={layoutTransition}
       transformTemplate={pixelSnapTransform}
       data-terminal-id={terminal.id}

--- a/src/components/Terminal/ContentGridDefault.tsx
+++ b/src/components/Terminal/ContentGridDefault.tsx
@@ -13,6 +13,7 @@ import {
   SortableGridPlaceholder,
 } from "@/components/DragDrop";
 import { GridShell } from "./GridShell";
+import { GridScrollbar, GRID_SCROLLBAR_GUTTER_PX } from "./GridScrollbar";
 import { TerminalCountWarning } from "./TerminalCountWarning";
 import { ContentGridEmptyState } from "./ContentGridEmptyState";
 import type { ContentGridContext } from "./useContentGridContext";
@@ -98,12 +99,13 @@ export function ContentGridDefault({
                   // are added or removed above the viewport — Chromium 146
                   // reflow would otherwise produce visible stutter (#8805).
                   overflowAnchor: "none",
-                  // Reserve gutter width so a row of cells doesn't reflow when
-                  // the scrollbar appears mid-burst.
-                  scrollbarGutter: "stable",
                   // Stop xterm scrollback / overflow strip-of-history from
                   // chaining into the outer chrome via overscroll bounces.
                   overscrollBehavior: "contain",
+                  // Reserve a real gutter on the right for the custom
+                  // GridScrollbar so panels never sit under the handle. The
+                  // native scrollbar is hidden in CSS; this is the only gutter.
+                  paddingRight: ctx.isScrollMode ? GRID_SCROLLBAR_GUTTER_PX : undefined,
                 }}
                 id="panel-grid"
                 data-grid-container="true"
@@ -200,6 +202,10 @@ export function ContentGridDefault({
               </div>
             </GridShell>
           </SortableContext>
+          <GridScrollbar
+            scrollRoot={ctx.gridScrollRoot}
+            revision={`${ctx.gridItemCount}:${ctx.gridCols}:${ctx.isScrollMode}:${ctx.scrollRowHeight}`}
+          />
         </div>
       </div>
     </GridScrollRootContext.Provider>

--- a/src/components/Terminal/ContentGridDefault.tsx
+++ b/src/components/Terminal/ContentGridDefault.tsx
@@ -159,6 +159,7 @@ export function ContentGridDefault({
                             sourceIndex={index}
                             disabled={isGroupDisabled}
                             layoutTransition={ctx.layoutTransition}
+                            layoutEnabled={ctx.layoutAnimationEnabled}
                           >
                             <GridPanel
                               terminalId={terminal.id}
@@ -180,6 +181,7 @@ export function ContentGridDefault({
                             groupId={group.id}
                             groupPanelIds={group.panelIds}
                             layoutTransition={ctx.layoutTransition}
+                            layoutEnabled={ctx.layoutAnimationEnabled}
                           >
                             <GridTabGroup
                               group={group}

--- a/src/components/Terminal/ContentGridDefault.tsx
+++ b/src/components/Terminal/ContentGridDefault.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { SortableContext, rectSortingStrategy } from "@dnd-kit/sortable";
 import { LayoutGroup } from "framer-motion";
 import { cn } from "@/lib/utils";
-import { COMFORTABLE_PANEL_HEIGHT_PX, MIN_TERMINAL_WIDTH_PX } from "@/lib/terminalLayout";
+import { GRID_MIN_PANEL_ROWS, MIN_TERMINAL_WIDTH_PX, pxForRows } from "@/lib/terminalLayout";
 import { GridNotificationBar } from "./GridNotificationBar";
 import { GridPanel } from "./GridPanel";
 import { GridTabGroup } from "./GridTabGroup";
@@ -16,6 +16,12 @@ import { GridShell } from "./GridShell";
 import { TerminalCountWarning } from "./TerminalCountWarning";
 import { ContentGridEmptyState } from "./ContentGridEmptyState";
 import type { ContentGridContext } from "./useContentGridContext";
+
+// Non-scroll row floor: the small minimum a row shrinks to before the grid has
+// to scroll. Rows stretch above it (`1fr`) to fill the viewport when there is
+// room. Mirrors `gridRowsOverflow`'s per-row minimum so the scroll-mode flip
+// lines up exactly with the point this floor would overflow.
+const NON_SCROLL_ROW_MIN_PX = pxForRows(GRID_MIN_PANEL_ROWS);
 
 export function ContentGridDefault({
   ctx,
@@ -78,7 +84,7 @@ export function ContentGridDefault({
                   gridTemplateColumns: `repeat(${ctx.gridCols}, minmax(min(100%, ${MIN_TERMINAL_WIDTH_PX}px), 1fr))`,
                   gridAutoRows: ctx.isScrollMode
                     ? `${ctx.scrollRowHeight}px`
-                    : `minmax(${COMFORTABLE_PANEL_HEIGHT_PX}px, 1fr)`,
+                    : `minmax(${NON_SCROLL_ROW_MIN_PX}px, 1fr)`,
                   gap: "4px",
                   backgroundColor: "var(--color-grid-bg)",
                   overflowX: "hidden",

--- a/src/components/Terminal/ContentGridDefault.tsx
+++ b/src/components/Terminal/ContentGridDefault.tsx
@@ -76,11 +76,17 @@ export function ContentGridDefault({
                 style={{
                   display: "grid",
                   gridTemplateColumns: `repeat(${ctx.gridCols}, minmax(min(100%, ${MIN_TERMINAL_WIDTH_PX}px), 1fr))`,
-                  gridAutoRows: `minmax(${COMFORTABLE_PANEL_HEIGHT_PX}px, 1fr)`,
+                  gridAutoRows: ctx.isScrollMode
+                    ? `${ctx.scrollRowHeight}px`
+                    : `minmax(${COMFORTABLE_PANEL_HEIGHT_PX}px, 1fr)`,
                   gap: "4px",
                   backgroundColor: "var(--color-grid-bg)",
                   overflowX: "hidden",
-                  overflowY: "auto",
+                  // Scroll mode shows the dedicated grid scrollbar at all
+                  // times (`scroll`) so the user can always see the grid
+                  // itself scrolls; non-scroll mode only scrolls if a short
+                  // window genuinely clips the quad (`auto`).
+                  overflowY: ctx.isScrollMode ? "scroll" : "auto",
                   // Prevent Chromium's scroll-anchor algorithm from fighting
                   // framer-motion's `LayoutGroup` layout-projection when panels
                   // are added or removed above the viewport — Chromium 146

--- a/src/components/Terminal/ContentGridFleetScope.tsx
+++ b/src/components/Terminal/ContentGridFleetScope.tsx
@@ -91,7 +91,7 @@ export function ContentGridFleetScope({
                   return (
                     <m.div
                       key={terminal.id}
-                      layout="position"
+                      layout={ctx.layoutAnimationEnabled ? "position" : false}
                       transition={ctx.layoutTransition}
                       transformTemplate={pixelSnapTransform}
                       className="h-full min-w-0"

--- a/src/components/Terminal/GridScrollbar.tsx
+++ b/src/components/Terminal/GridScrollbar.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+/** Total horizontal space the custom scrollbar reserves (bar + edge margin). */
+export const GRID_SCROLLBAR_GUTTER_PX = 22;
+
+/** Visible bar width. */
+const BAR_WIDTH_PX = 14;
+/** Margin between the bar and the grid's right edge. */
+const BAR_INSET_PX = 4;
+/** Vertical inset of the track inside the grid viewport (top and bottom each). */
+const TRACK_INSET_PX = 4;
+/** Smallest the handle ever gets, so it stays grabbable on huge fleets. */
+const THUMB_MIN_PX = 44;
+
+export interface ScrollMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+/**
+ * Pure handle geometry. Returns `null` when the content does not overflow —
+ * the caller renders nothing. Otherwise `height` is proportional to the
+ * visible fraction (clamped to `minThumb`) and `top` is the handle's offset
+ * within the track for the current scroll position.
+ */
+export function computeThumbGeometry(
+  m: ScrollMetrics,
+  trackHeight: number,
+  minThumb: number
+): { height: number; top: number } | null {
+  const maxScroll = m.scrollHeight - m.clientHeight;
+  if (maxScroll <= 1 || trackHeight <= 0 || m.scrollHeight <= 0) return null;
+  const raw = (m.clientHeight / m.scrollHeight) * trackHeight;
+  const height = Math.min(trackHeight, Math.max(minThumb, Math.round(raw)));
+  const travel = trackHeight - height;
+  const top = travel > 0 ? Math.round((m.scrollTop / maxScroll) * travel) : 0;
+  return { height, top };
+}
+
+/**
+ * A custom, always-visible scroll handle for the agent panel grid — modelled
+ * on xterm's (VS Code's) slider rather than the OS scrollbar. The native
+ * scrollbar on `#panel-grid` is hidden in CSS; this overlays a chunky,
+ * physical handle that shows scroll position and can be dragged. The grid
+ * still scrolls by wheel / keyboard / programmatic scroll independently.
+ *
+ * `revision` changes whenever the grid layout could have changed the content
+ * height (panel open/close, column count, scroll-mode flip) — a plain scroll
+ * listener and ResizeObserver miss those because `scrollHeight` grows without
+ * either firing.
+ */
+export function GridScrollbar({
+  scrollRoot,
+  revision,
+}: {
+  scrollRoot: HTMLElement | null;
+  revision: string | number;
+}) {
+  const [metrics, setMetrics] = useState<ScrollMetrics>({
+    scrollTop: 0,
+    scrollHeight: 0,
+    clientHeight: 0,
+  });
+  const [phase, setPhase] = useState<"idle" | "hover" | "drag">("idle");
+  const trackRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{ startY: number; startScrollTop: number } | null>(null);
+
+  useEffect(() => {
+    const el = scrollRoot;
+    if (!el) return;
+    const measure = () => {
+      setMetrics((prev) => {
+        const next: ScrollMetrics = {
+          scrollTop: el.scrollTop,
+          scrollHeight: el.scrollHeight,
+          clientHeight: el.clientHeight,
+        };
+        return prev.scrollTop === next.scrollTop &&
+          prev.scrollHeight === next.scrollHeight &&
+          prev.clientHeight === next.clientHeight
+          ? prev
+          : next;
+      });
+    };
+    measure();
+    el.addEventListener("scroll", measure, { passive: true });
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener("scroll", measure);
+      ro.disconnect();
+    };
+  }, [scrollRoot, revision]);
+
+  const trackHeight = Math.max(0, metrics.clientHeight - 2 * TRACK_INSET_PX);
+  const geometry = computeThumbGeometry(metrics, trackHeight, THUMB_MIN_PX);
+
+  const onThumbPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!scrollRoot) return;
+      e.preventDefault();
+      e.stopPropagation();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      dragRef.current = { startY: e.clientY, startScrollTop: scrollRoot.scrollTop };
+      setPhase("drag");
+    },
+    [scrollRoot]
+  );
+
+  const onThumbPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      const track = trackRef.current;
+      if (!drag || !track || !scrollRoot) return;
+      const live: ScrollMetrics = {
+        scrollTop: scrollRoot.scrollTop,
+        scrollHeight: scrollRoot.scrollHeight,
+        clientHeight: scrollRoot.clientHeight,
+      };
+      const geo = computeThumbGeometry(live, track.clientHeight, THUMB_MIN_PX);
+      if (!geo) return;
+      const travel = track.clientHeight - geo.height;
+      if (travel <= 0) return;
+      const maxScroll = live.scrollHeight - live.clientHeight;
+      const next = drag.startScrollTop + ((e.clientY - drag.startY) / travel) * maxScroll;
+      scrollRoot.scrollTop = Math.max(0, Math.min(maxScroll, next));
+    },
+    [scrollRoot]
+  );
+
+  const endDrag = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    dragRef.current = null;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    setPhase("idle");
+  }, []);
+
+  const onTrackPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      // A click in the empty track pages toward the click, like a real scrollbar.
+      const track = trackRef.current;
+      if (!scrollRoot || !track || !geometry) return;
+      e.stopPropagation();
+      const clickY = e.clientY - track.getBoundingClientRect().top;
+      const dir = clickY < geometry.top ? -1 : 1;
+      scrollRoot.scrollBy({ top: dir * scrollRoot.clientHeight * 0.9, behavior: "smooth" });
+    },
+    [scrollRoot, geometry]
+  );
+
+  if (!scrollRoot || !geometry) return null;
+
+  const maxScroll = metrics.scrollHeight - metrics.clientHeight;
+  const valueNow = maxScroll > 0 ? Math.round((metrics.scrollTop / maxScroll) * 100) : 0;
+
+  return (
+    <div
+      ref={trackRef}
+      data-no-dnd
+      onPointerDown={onTrackPointerDown}
+      className="absolute z-20"
+      style={{
+        right: BAR_INSET_PX,
+        top: TRACK_INSET_PX,
+        bottom: TRACK_INSET_PX,
+        width: BAR_WIDTH_PX,
+      }}
+    >
+      <div
+        role="scrollbar"
+        aria-orientation="vertical"
+        aria-controls="panel-grid"
+        aria-valuenow={valueNow}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        tabIndex={-1}
+        onPointerDown={onThumbPointerDown}
+        onPointerMove={onThumbPointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        onPointerEnter={() => setPhase((p) => (p === "drag" ? p : "hover"))}
+        onPointerLeave={() => setPhase((p) => (p === "drag" ? p : "idle"))}
+        className={cn(
+          "absolute inset-x-0 cursor-default rounded-[7px] transition-colors",
+          phase === "idle" ? "bg-[var(--scrollbar-thumb)]" : "bg-[var(--scrollbar-thumb-hover)]"
+        )}
+        style={{ height: geometry.height, top: geometry.top }}
+      />
+    </div>
+  );
+}

--- a/src/components/Terminal/GridScrollbar.tsx
+++ b/src/components/Terminal/GridScrollbar.tsx
@@ -159,7 +159,6 @@ export function GridScrollbar({
       // otherwise land on dead space. Forward the delta to the grid so the
       // wheel scrolls the grid no matter where the cursor sits.
       if (!scrollRoot) return;
-      e.stopPropagation();
       const px =
         e.deltaMode === 2
           ? e.deltaY * scrollRoot.clientHeight
@@ -202,7 +201,6 @@ export function GridScrollbar({
         onPointerMove={onThumbPointerMove}
         onPointerUp={endDrag}
         onPointerCancel={endDrag}
-        onLostPointerCapture={endDrag}
         onPointerEnter={() => setPhase((p) => (p === "drag" ? p : "hover"))}
         onPointerLeave={() => setPhase((p) => (p === "drag" ? p : "idle"))}
         className={cn(

--- a/src/components/Terminal/GridScrollbar.tsx
+++ b/src/components/Terminal/GridScrollbar.tsx
@@ -125,7 +125,9 @@ export function GridScrollbar({
       if (travel <= 0) return;
       const maxScroll = live.scrollHeight - live.clientHeight;
       const next = drag.startScrollTop + ((e.clientY - drag.startY) / travel) * maxScroll;
-      scrollRoot.scrollTop = Math.max(0, Math.min(maxScroll, next));
+      // `scrollTo` (a method call) rather than assigning `scrollRoot.scrollTop`:
+      // the React Compiler forbids writing to a prop's property.
+      scrollRoot.scrollTo({ top: Math.max(0, Math.min(maxScroll, next)) });
     },
     [scrollRoot]
   );

--- a/src/components/Terminal/GridScrollbar.tsx
+++ b/src/components/Terminal/GridScrollbar.tsx
@@ -159,6 +159,7 @@ export function GridScrollbar({
       // otherwise land on dead space. Forward the delta to the grid so the
       // wheel scrolls the grid no matter where the cursor sits.
       if (!scrollRoot) return;
+      e.stopPropagation();
       const px =
         e.deltaMode === 2
           ? e.deltaY * scrollRoot.clientHeight
@@ -201,6 +202,7 @@ export function GridScrollbar({
         onPointerMove={onThumbPointerMove}
         onPointerUp={endDrag}
         onPointerCancel={endDrag}
+        onLostPointerCapture={endDrag}
         onPointerEnter={() => setPhase((p) => (p === "drag" ? p : "hover"))}
         onPointerLeave={() => setPhase((p) => (p === "drag" ? p : "idle"))}
         className={cn(

--- a/src/components/Terminal/GridScrollbar.tsx
+++ b/src/components/Terminal/GridScrollbar.tsx
@@ -153,6 +153,23 @@ export function GridScrollbar({
     [scrollRoot, geometry]
   );
 
+  const onWheel = useCallback(
+    (e: React.WheelEvent<HTMLDivElement>) => {
+      // The scrollbar overlays the grid's gutter, so a wheel over it would
+      // otherwise land on dead space. Forward the delta to the grid so the
+      // wheel scrolls the grid no matter where the cursor sits.
+      if (!scrollRoot) return;
+      const px =
+        e.deltaMode === 2
+          ? e.deltaY * scrollRoot.clientHeight
+          : e.deltaMode === 1
+            ? e.deltaY * 16
+            : e.deltaY;
+      scrollRoot.scrollBy({ top: px });
+    },
+    [scrollRoot]
+  );
+
   if (!scrollRoot || !geometry) return null;
 
   const maxScroll = metrics.scrollHeight - metrics.clientHeight;
@@ -163,6 +180,7 @@ export function GridScrollbar({
       ref={trackRef}
       data-no-dnd
       onPointerDown={onTrackPointerDown}
+      onWheel={onWheel}
       className="absolute z-20"
       style={{
         right: BAR_INSET_PX,

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -10,6 +10,7 @@ import { GridPanel } from "./GridPanel";
 import type { TabGroup } from "@/types";
 import type { TabInfo } from "@/components/Panel/TabButton";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
+import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
 import { focusPanelInput } from "./terminalFocusRegistry";
 import { getGroupAmbientAgentState } from "@/components/Layout/useDockBlockedState";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
@@ -229,7 +230,12 @@ export const GridTabGroup = React.memo(function GridTabGroup({
           setFocused(nextPanel.id);
         }
       }
-      trashPanel(tabId);
+      requestPanelClose({
+        hideIds: [tabId],
+        commit: () => {
+          trashPanel(tabId);
+        },
+      });
     },
     [activeTabId, panels, group.id, setActiveTab, setFocused, trashPanel]
   );

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -13,7 +13,6 @@ import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplication
 import { focusPanelInput } from "./terminalFocusRegistry";
 import { getGroupAmbientAgentState } from "@/components/Layout/useDockBlockedState";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
-import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
 
 export interface GridTabGroupProps {
   group: TabGroup;
@@ -230,16 +229,7 @@ export const GridTabGroup = React.memo(function GridTabGroup({
           setFocused(nextPanel.id);
         }
       }
-      requestPanelClose({
-        hideIds: [tabId],
-        commit: () => {
-          try {
-            trashPanel(tabId);
-          } catch (error) {
-            logError("Failed to trash terminal tab", error);
-          }
-        },
-      });
+      trashPanel(tabId);
     },
     [activeTabId, panels, group.id, setActiveTab, setFocused, trashPanel]
   );

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -13,6 +13,7 @@ import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplication
 import { focusPanelInput } from "./terminalFocusRegistry";
 import { getGroupAmbientAgentState } from "@/components/Layout/useDockBlockedState";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
 
 export interface GridTabGroupProps {
   group: TabGroup;
@@ -229,7 +230,16 @@ export const GridTabGroup = React.memo(function GridTabGroup({
           setFocused(nextPanel.id);
         }
       }
-      trashPanel(tabId);
+      requestPanelClose({
+        hideIds: [tabId],
+        commit: () => {
+          try {
+            trashPanel(tabId);
+          } catch (error) {
+            logError("Failed to trash terminal tab", error);
+          }
+        },
+      });
     },
     [activeTabId, panels, group.id, setActiveTab, setFocused, trashPanel]
   );

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -5,8 +5,6 @@ import { usePanelStore } from "@/store/panelStore";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelLimitStore, shouldShowSoftWarning } from "@/store/panelLimitStore";
 import { InlineStatusBanner } from "./InlineStatusBanner";
-import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
-import { logError } from "@/utils/logger";
 
 interface TerminalCountWarningProps {
   className?: string;
@@ -81,9 +79,6 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
       onOpenBulkActions();
     } else {
       const { panelsById, panelIds } = usePanelStore.getState();
-      const gridIds: string[] = [];
-      const dockIds: string[] = [];
-
       for (const id of panelIds) {
         const t = panelsById[id];
         if (
@@ -92,39 +87,8 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
           t.location !== "trash" &&
           t.ephemeral !== true
         ) {
-          if (t.location === "dock") {
-            dockIds.push(t.id);
-          } else {
-            gridIds.push(t.id);
-          }
+          usePanelStore.getState().trashPanel(t.id);
         }
-      }
-
-      // Process dock panels immediately
-      const trashPanel = usePanelStore.getState().trashPanel;
-      for (const id of dockIds) {
-        try {
-          trashPanel(id);
-        } catch (error) {
-          logError("Failed to trash dock terminal pane from warning cleanup", error);
-        }
-      }
-
-      // Process grid panels via optimistic close
-      if (gridIds.length > 0) {
-        requestPanelClose({
-          hideIds: gridIds,
-          commit: () => {
-            const currentTrashPanel = usePanelStore.getState().trashPanel;
-            for (const id of gridIds) {
-              try {
-                currentTrashPanel(id);
-              } catch (error) {
-                logError("Failed to trash grid terminal pane from warning cleanup", error);
-              }
-            }
-          },
-        });
       }
     }
   }, [onOpenBulkActions]);

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -5,6 +5,8 @@ import { usePanelStore } from "@/store/panelStore";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelLimitStore, shouldShowSoftWarning } from "@/store/panelLimitStore";
 import { InlineStatusBanner } from "./InlineStatusBanner";
+import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
+import { logError } from "@/utils/logger";
 
 interface TerminalCountWarningProps {
   className?: string;
@@ -79,6 +81,9 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
       onOpenBulkActions();
     } else {
       const { panelsById, panelIds } = usePanelStore.getState();
+      const gridIds: string[] = [];
+      const dockIds: string[] = [];
+
       for (const id of panelIds) {
         const t = panelsById[id];
         if (
@@ -87,8 +92,39 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
           t.location !== "trash" &&
           t.ephemeral !== true
         ) {
-          usePanelStore.getState().trashPanel(t.id);
+          if (t.location === "dock") {
+            dockIds.push(t.id);
+          } else {
+            gridIds.push(t.id);
+          }
         }
+      }
+
+      // Process dock panels immediately
+      const trashPanel = usePanelStore.getState().trashPanel;
+      for (const id of dockIds) {
+        try {
+          trashPanel(id);
+        } catch (error) {
+          logError("Failed to trash dock terminal pane from warning cleanup", error);
+        }
+      }
+
+      // Process grid panels via optimistic close
+      if (gridIds.length > 0) {
+        requestPanelClose({
+          hideIds: gridIds,
+          commit: () => {
+            const currentTrashPanel = usePanelStore.getState().trashPanel;
+            for (const id of gridIds) {
+              try {
+                currentTrashPanel(id);
+              } catch (error) {
+                logError("Failed to trash grid terminal pane from warning cleanup", error);
+              }
+            }
+          },
+        });
       }
     }
   }, [onOpenBulkActions]);

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -5,6 +5,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelLimitStore, shouldShowSoftWarning } from "@/store/panelLimitStore";
 import { InlineStatusBanner } from "./InlineStatusBanner";
+import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
 
 interface TerminalCountWarningProps {
   className?: string;
@@ -79,6 +80,7 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
       onOpenBulkActions();
     } else {
       const { panelsById, panelIds } = usePanelStore.getState();
+      const idsToClose: string[] = [];
       for (const id of panelIds) {
         const t = panelsById[id];
         if (
@@ -87,9 +89,17 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
           t.location !== "trash" &&
           t.ephemeral !== true
         ) {
-          usePanelStore.getState().trashPanel(t.id);
+          idsToClose.push(t.id);
         }
       }
+      if (idsToClose.length === 0) return;
+      requestPanelClose({
+        hideIds: idsToClose,
+        commit: () => {
+          const latest = usePanelStore.getState();
+          idsToClose.forEach((id) => latest.trashPanel(id));
+        },
+      });
     }
   }, [onOpenBulkActions]);
 

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -62,7 +62,7 @@ import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { terminalClient } from "@/clients";
-import { logWarn } from "@/utils/logger";
+import { logWarn, logError } from "@/utils/logger";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { openSendToAgentPaletteWithText } from "@/hooks/useSendToAgentPalette";
 import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
@@ -80,7 +80,7 @@ import { decideChromeAction } from "./multiSelectGestures";
 import { registerPanelFocusHandler } from "./terminalFocusRegistry";
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
 import type { TerminalRuntimeIdentity } from "@shared/types/panel";
-
+import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 
 export type {};
@@ -803,7 +803,20 @@ function TerminalPaneComponent({
   };
 
   const handleTrash = () => {
-    trashPanel(id);
+    if (location === "dock") {
+      trashPanel(id);
+    } else {
+      requestPanelClose({
+        hideIds: [id],
+        commit: () => {
+          try {
+            trashPanel(id);
+          } catch (error) {
+            logError("Failed to trash terminal pane", error);
+          }
+        },
+      });
+    }
   };
 
   const handleDismissReconnectError = () => {

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -62,7 +62,7 @@ import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { terminalClient } from "@/clients";
-import { logWarn, logError } from "@/utils/logger";
+import { logWarn } from "@/utils/logger";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { openSendToAgentPaletteWithText } from "@/hooks/useSendToAgentPalette";
 import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
@@ -80,7 +80,7 @@ import { decideChromeAction } from "./multiSelectGestures";
 import { registerPanelFocusHandler } from "./terminalFocusRegistry";
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
 import type { TerminalRuntimeIdentity } from "@shared/types/panel";
-import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
+
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 
 export type {};
@@ -803,20 +803,7 @@ function TerminalPaneComponent({
   };
 
   const handleTrash = () => {
-    if (location === "dock") {
-      trashPanel(id);
-    } else {
-      requestPanelClose({
-        hideIds: [id],
-        commit: () => {
-          try {
-            trashPanel(id);
-          } catch (error) {
-            logError("Failed to trash terminal pane", error);
-          }
-        },
-      });
-    }
+    trashPanel(id);
   };
 
   const handleDismissReconnectError = () => {

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -444,12 +444,14 @@ export function XtermAdapter({
       // doesn't background a terminal that has already been re-attached elsewhere.
       terminalInstanceService.setVisible(terminalId, false, attachGen);
 
-      // Flush pending resizes before unmount — but never for a panel the user
-      // just optimistically closed. That panel is being torn down; flushing
-      // its pending resize force-drains queued output and reflows scrollback
-      // synchronously inside the close click, which is exactly the blocking
-      // work the optimistic close exists to avoid.
-      if (!isOptimisticallyClosing(terminalId)) {
+      // Settle pending resizes before unmount. For a panel the user just
+      // optimistically closed, *cancel* the pending resize rather than flush
+      // it — flushing force-drains queued output and reflows scrollback
+      // synchronously inside the close click. Cancelling still clears the
+      // job/debounce so no stale resize fires after teardown or on undo.
+      if (isOptimisticallyClosing(terminalId)) {
+        terminalInstanceService.cancelPendingResize(terminalId);
+      } else {
         terminalInstanceService.flushResize(terminalId);
       }
 

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -444,14 +444,12 @@ export function XtermAdapter({
       // doesn't background a terminal that has already been re-attached elsewhere.
       terminalInstanceService.setVisible(terminalId, false, attachGen);
 
-      // Settle pending resizes before unmount. For a panel the user just
-      // optimistically closed, *cancel* the pending resize rather than flush
-      // it — flushing force-drains queued output and reflows scrollback
-      // synchronously inside the close click. Cancelling still clears the
-      // job/debounce so no stale resize fires after teardown or on undo.
-      if (isOptimisticallyClosing(terminalId)) {
-        terminalInstanceService.cancelPendingResize(terminalId);
-      } else {
+      // Flush pending resizes before unmount — but never for a panel the user
+      // just optimistically closed. That panel is being torn down; flushing
+      // its pending resize force-drains queued output and reflows scrollback
+      // synchronously inside the close click, which is exactly the blocking
+      // work the optimistic close exists to avoid.
+      if (!isOptimisticallyClosing(terminalId)) {
         terminalInstanceService.flushResize(terminalId);
       }
 

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { TerminalRefreshTier } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { writeTerminalInputOrFleet } from "@/services/terminal/fleetInputRouter";
+import { isOptimisticallyClosing } from "@/services/terminal/optimisticPanelClose";
 import { useTerminalAppearance } from "@/hooks/useTerminalAppearance";
 import { getScrollbackForType, PERFORMANCE_MODE_SCROLLBACK } from "@/utils/scrollbackConfig";
 import { getXtermOptions } from "@/config/xtermConfig";
@@ -443,8 +444,14 @@ export function XtermAdapter({
       // doesn't background a terminal that has already been re-attached elsewhere.
       terminalInstanceService.setVisible(terminalId, false, attachGen);
 
-      // Flush pending resizes before unmount
-      terminalInstanceService.flushResize(terminalId);
+      // Flush pending resizes before unmount — but never for a panel the user
+      // just optimistically closed. That panel is being torn down; flushing
+      // its pending resize force-drains queued output and reflows scrollback
+      // synchronously inside the close click, which is exactly the blocking
+      // work the optimistic close exists to avoid.
+      if (!isOptimisticallyClosing(terminalId)) {
+        terminalInstanceService.flushResize(terminalId);
+      }
 
       terminalInstanceService.detach(terminalId, container);
 

--- a/src/components/Terminal/__tests__/GridScrollbar.test.ts
+++ b/src/components/Terminal/__tests__/GridScrollbar.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { computeThumbGeometry } from "../GridScrollbar";
+
+describe("computeThumbGeometry", () => {
+  it("returns null when the content does not overflow", () => {
+    expect(
+      computeThumbGeometry({ scrollTop: 0, scrollHeight: 500, clientHeight: 500 }, 500, 44)
+    ).toBeNull();
+    expect(
+      computeThumbGeometry({ scrollTop: 0, scrollHeight: 400, clientHeight: 500 }, 500, 44)
+    ).toBeNull();
+  });
+
+  it("returns null for a degenerate track", () => {
+    expect(
+      computeThumbGeometry({ scrollTop: 0, scrollHeight: 2000, clientHeight: 1000 }, 0, 44)
+    ).toBeNull();
+  });
+
+  it("sizes the handle to the visible fraction of the content", () => {
+    expect(
+      computeThumbGeometry({ scrollTop: 0, scrollHeight: 2000, clientHeight: 1000 }, 1000, 44)
+    ).toEqual({ height: 500, top: 0 });
+  });
+
+  it("positions the handle flush to the track bottom when scrolled to the end", () => {
+    const geo = computeThumbGeometry(
+      { scrollTop: 1000, scrollHeight: 2000, clientHeight: 1000 },
+      1000,
+      44
+    );
+    expect(geo).not.toBeNull();
+    expect(geo!.top).toBe(1000 - geo!.height);
+  });
+
+  it("clamps the handle to a minimum height for a huge fleet", () => {
+    const geo = computeThumbGeometry(
+      { scrollTop: 0, scrollHeight: 100000, clientHeight: 1000 },
+      1000,
+      44
+    );
+    expect(geo!.height).toBe(44);
+  });
+
+  it("keeps the handle inside the track at every scroll position", () => {
+    for (const scrollTop of [0, 250, 500, 900, 1000]) {
+      const geo = computeThumbGeometry(
+        { scrollTop, scrollHeight: 2000, clientHeight: 1000 },
+        800,
+        44
+      )!;
+      expect(geo.top).toBeGreaterThanOrEqual(0);
+      expect(geo.top + geo.height).toBeLessThanOrEqual(800);
+    }
+  });
+});

--- a/src/components/Terminal/__tests__/TerminalCountWarning.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalCountWarning.test.tsx
@@ -47,6 +47,11 @@ vi.mock("@/store/panelLimitStore", () => ({
   },
 }));
 
+const requestPanelCloseMock = vi.hoisted(() => vi.fn());
+vi.mock("@/services/terminal/optimisticPanelClose", () => ({
+  requestPanelClose: requestPanelCloseMock,
+}));
+
 beforeAll(() => {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
@@ -73,6 +78,7 @@ beforeEach(() => {
   };
   panelState.panelIds = ["a", "b", "c", "d", "e"];
   panelState.trashPanel = vi.fn();
+  requestPanelCloseMock.mockClear();
   limitState.softWarningLimit = 4;
   limitState.warningsDisabled = false;
   limitState.lastSoftWarningDismissedAt = null;
@@ -131,6 +137,23 @@ describe("TerminalCountWarning", () => {
     expect(className).toContain("focus-visible:outline");
     expect(className).toContain("focus-visible:outline-daintree-accent");
     expect(className).not.toMatch(/(^|\s)focus:ring-/);
+  });
+
+  it("routes completed-agent cleanup through optimistic close", () => {
+    panelState.panelsById.f = {
+      id: "f",
+      location: "grid",
+      agentState: "completed",
+      ephemeral: false,
+    };
+    panelState.panelIds = [...panelState.panelIds, "f"];
+    render(<TerminalCountWarning />);
+
+    fireEvent.click(screen.getByRole("button", { name: /close.*completed agent/i }));
+
+    expect(requestPanelCloseMock).toHaveBeenCalledTimes(1);
+    expect(requestPanelCloseMock.mock.calls[0]?.[0].hideIds).toEqual(["f"]);
+    expect(panelState.trashPanel).not.toHaveBeenCalled();
   });
 
   it("waits the full 250ms exit animation before unmounting on dismiss", () => {

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -107,6 +107,9 @@ vi.mock("@/config/xtermConfig", () => ({
 }));
 
 vi.mock("@/config/terminalFont", () => ({
+  DEFAULT_TERMINAL_FONT_FAMILY: "monospace",
+  DEFAULT_TERMINAL_FONT_SIZE: 12,
+  ensureTerminalFontLoaded: () => Promise.resolve(),
   terminalFontReady: Object.assign(Promise.resolve(), { status: "fulfilled", value: undefined }),
 }));
 

--- a/src/components/Terminal/__tests__/contentGridMotion.test.ts
+++ b/src/components/Terminal/__tests__/contentGridMotion.test.ts
@@ -68,10 +68,12 @@ describe("ContentGrid panel motion (issue #6162)", () => {
     expect(content).toContain("prevGridColsRef");
     expect(content).toContain("suppressResizesDuringLayoutTransition");
     // The pass is skipped entirely while switching projects or dragging, and
-    // the resize-lock is armed whenever the survivors' boxes change — a
-    // column-count change or a layout-changing close.
+    // the resize-lock is armed whenever the survivors' boxes change — a column
+    // change, a scroll-geometry flip, or a layout-changing close.
     expect(content).toMatch(/if\s*\(isProjectSwitching\s*\|\|\s*isDraggingRef\.current\)\s*return/);
-    expect(content).toMatch(/if\s*\(colsChanged\s*\|\|\s*layoutChangingClose\)\s*\{/);
+    expect(content).toMatch(
+      /if\s*\(colsChanged\s*\|\|\s*scrollGeoChanged\s*\|\|\s*layoutChangingClose\)\s*\{/
+    );
     expect(content).toContain("GRID_PLACEHOLDER_ID");
   });
 

--- a/src/components/Terminal/__tests__/contentGridMotion.test.ts
+++ b/src/components/Terminal/__tests__/contentGridMotion.test.ts
@@ -68,9 +68,10 @@ describe("ContentGrid panel motion (issue #6162)", () => {
     expect(content).toContain("prevGridColsRef");
     expect(content).toContain("suppressResizesDuringLayoutTransition");
     // The pass is skipped entirely while switching projects or dragging, and
-    // the resize-lock is only armed on an actual column-count change.
+    // the resize-lock is armed whenever the survivors' boxes change — a
+    // column-count change or a layout-changing close.
     expect(content).toMatch(/if\s*\(isProjectSwitching\s*\|\|\s*isDraggingRef\.current\)\s*return/);
-    expect(content).toMatch(/if\s*\(colsChanged\)\s*\{/);
+    expect(content).toMatch(/if\s*\(colsChanged\s*\|\|\s*layoutChangingClose\)\s*\{/);
     expect(content).toContain("GRID_PLACEHOLDER_ID");
   });
 

--- a/src/components/Terminal/__tests__/contentGridMotion.test.ts
+++ b/src/components/Terminal/__tests__/contentGridMotion.test.ts
@@ -38,19 +38,28 @@ describe("ContentGrid panel motion (issue #6162)", () => {
     expect(fleetContent).toContain('LayoutGroup id="fleet-grid"');
   });
 
-  it("derives a shared layoutTransition that drops to 0 during project switch", async () => {
+  it("derives a shared layoutTransition that drops to 0 during project switch and close", async () => {
     const content = await readFile(CONTEXT_PATH, "utf-8");
     expect(content).toMatch(
-      /duration:\s*isProjectSwitching\s*\?\s*0\s*:\s*GRID_TRANSITION_DURATION_MS\s*\/\s*1000/
+      /isProjectSwitching\s*\|\|\s*closingIds\.size\s*>\s*0\s*\?\s*0\s*:\s*GRID_TRANSITION_DURATION_MS\s*\/\s*1000/
     );
   });
 
-  it("passes layoutTransition to every SortableTerminal in the main grid", async () => {
+  it("passes layout controls to every SortableTerminal in the main grid", async () => {
     const content = await readFile(DEFAULT_PATH, "utf-8");
     const sortableMatches = content.match(/<SortableTerminal\b/g) ?? [];
     const propMatches = content.match(/layoutTransition=\{ctx\.layoutTransition\}/g) ?? [];
+    const enabledMatches = content.match(/layoutEnabled=\{ctx\.layoutAnimationEnabled\}/g) ?? [];
     expect(sortableMatches.length).toBeGreaterThan(0);
     expect(propMatches.length).toBe(sortableMatches.length);
+    expect(enabledMatches.length).toBe(sortableMatches.length);
+  });
+
+  it("disables FLIP layout projection while an optimistic close is in flight", async () => {
+    const content = await readFile(CONTEXT_PATH, "utf-8");
+    expect(content).toContain(
+      "const layoutAnimationEnabled = !isProjectSwitching && closingIds.size === 0"
+    );
   });
 
   it("snaps FLIP translations to integer pixels to avoid xterm canvas blur", async () => {

--- a/src/components/Terminal/__tests__/contentGridMotion.test.ts
+++ b/src/components/Terminal/__tests__/contentGridMotion.test.ts
@@ -68,12 +68,10 @@ describe("ContentGrid panel motion (issue #6162)", () => {
     expect(content).toContain("prevGridColsRef");
     expect(content).toContain("suppressResizesDuringLayoutTransition");
     // The pass is skipped entirely while switching projects or dragging, and
-    // the resize-lock is armed whenever the survivors' boxes change — a column
-    // change, a scroll-geometry flip, or a layout-changing close.
+    // the resize-lock is armed whenever the survivors' boxes change — a
+    // column-count change or a layout-changing close.
     expect(content).toMatch(/if\s*\(isProjectSwitching\s*\|\|\s*isDraggingRef\.current\)\s*return/);
-    expect(content).toMatch(
-      /if\s*\(colsChanged\s*\|\|\s*scrollGeoChanged\s*\|\|\s*layoutChangingClose\)\s*\{/
-    );
+    expect(content).toMatch(/if\s*\(colsChanged\s*\|\|\s*layoutChangingClose\)\s*\{/);
     expect(content).toContain("GRID_PLACEHOLDER_ID");
   });
 

--- a/src/components/Terminal/__tests__/contentGridMotion.test.ts
+++ b/src/components/Terminal/__tests__/contentGridMotion.test.ts
@@ -71,7 +71,9 @@ describe("ContentGrid panel motion (issue #6162)", () => {
     // the resize-lock is armed whenever the survivors' boxes change — a
     // column-count change or a layout-changing close.
     expect(content).toMatch(/if\s*\(isProjectSwitching\s*\|\|\s*isDraggingRef\.current\)\s*return/);
-    expect(content).toMatch(/if\s*\(colsChanged\s*\|\|\s*layoutChangingClose\)\s*\{/);
+    expect(content).toMatch(
+      /if\s*\(colsChanged\s*\|\|\s*scrollGeoChanged\s*\|\|\s*layoutChangingClose\)\s*\{/
+    );
     expect(content).toContain("GRID_PLACEHOLDER_ID");
   });
 

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -785,7 +785,7 @@ export function useContentGridContext({
     }
   });
   const prevGridColsRef = useRef(gridCols);
-  const prevTerminalCountRef = useRef(gridTerminals.length);
+  const prevPanelCountRef = useRef(panelIds.length);
   const prevScrollGeoRef = useRef(`${isScrollMode}:${scrollRowHeight}`);
   useLayoutEffect(() => {
     void gridCols;
@@ -798,8 +798,8 @@ export function useContentGridContext({
     const scrollGeoChanged = prevScrollGeoRef.current !== scrollGeoKey;
     prevScrollGeoRef.current = scrollGeoKey;
 
-    const isPureClose = gridTerminals.length < prevTerminalCountRef.current;
-    prevTerminalCountRef.current = gridTerminals.length;
+    const isPureClose = panelIds.length < prevPanelCountRef.current;
+    prevPanelCountRef.current = panelIds.length;
 
     setHysteresisGridCols(
       layoutConfig.strategy === "automatic" && !showPlaceholder ? gridCols : undefined
@@ -819,17 +819,15 @@ export function useContentGridContext({
       runGridBatchFit();
     }
 
-    // Any change to the survivors' boxes resizes every panel. Each panel's own
-    // ResizeObserver in XtermAdapter would otherwise fire an un-chunked resize
-    // on top of the coalesced pass above — a resize storm and the main cause
-    // of close-path lag. Lock the panels for the transition window so the
-    // single chunked pass is the only resize. Arm on a column change, a
-    // scroll-geometry flip (which can also land on the deferred-flush render,
-    // where `panelIds` is already settled so `isPureClose` is false), or a
-    // layout-changing close.
+    // A layout-changing close (or a column change) resizes every survivor's
+    // box. Each panel's own ResizeObserver in XtermAdapter would otherwise
+    // fire its own un-chunked resize on top of the coalesced pass above — a
+    // resize storm that is the main cause of close-path lag. Lock the panels
+    // for the transition window so the single chunked pass is the only resize;
+    // the lock's unlock pass is the corrective backstop.
     const layoutChangingClose = isPureClose && !survivorGeometryStable;
-    if (colsChanged || scrollGeoChanged || layoutChangingClose) {
-      const realPanelIds = gridTerminals.map((t) => t.id);
+    if (colsChanged || layoutChangingClose) {
+      const realPanelIds = panelIds.filter((id) => id !== GRID_PLACEHOLDER_ID);
       if (realPanelIds.length > 0) {
         terminalInstanceService.suppressResizesDuringLayoutTransition(
           realPanelIds,
@@ -840,7 +838,6 @@ export function useContentGridContext({
   }, [
     gridCols,
     panelIds,
-    gridTerminals,
     isScrollMode,
     scrollRowHeight,
     isProjectSwitching,

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -819,11 +819,14 @@ export function useContentGridContext({
       runGridBatchFit();
     }
 
-    // A column-count change shifts cell widths, so the per-host ResizeObserver
-    // would otherwise fire an uncoordinated second resize through the 200ms
-    // FLIP. Lock those panels for the transition window; the lock's unlock pass
-    // doubles as the corrective backstop for any panel not yet laid out here.
-    if (colsChanged) {
+    // A layout-changing close (or a column change) resizes every survivor's
+    // box. Each panel's own ResizeObserver in XtermAdapter would otherwise
+    // fire its own un-chunked resize on top of the coalesced pass above — a
+    // resize storm that is the main cause of close-path lag. Lock the panels
+    // for the transition window so the single chunked pass is the only resize;
+    // the lock's unlock pass is the corrective backstop.
+    const layoutChangingClose = isPureClose && !survivorGeometryStable;
+    if (colsChanged || layoutChangingClose) {
       const realPanelIds = panelIds.filter((id) => id !== GRID_PLACEHOLDER_ID);
       if (realPanelIds.length > 0) {
         terminalInstanceService.suppressResizesDuringLayoutTransition(

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -785,22 +785,39 @@ export function useContentGridContext({
     }
   });
   const prevGridColsRef = useRef(gridCols);
+  const prevPanelCountRef = useRef(panelIds.length);
+  const prevScrollGeoRef = useRef(`${isScrollMode}:${scrollRowHeight}`);
   useLayoutEffect(() => {
     void gridCols;
     void panelIds;
 
     const colsChanged = prevGridColsRef.current !== gridCols;
     prevGridColsRef.current = gridCols;
+
+    const scrollGeoKey = `${isScrollMode}:${scrollRowHeight}`;
+    const scrollGeoChanged = prevScrollGeoRef.current !== scrollGeoKey;
+    prevScrollGeoRef.current = scrollGeoKey;
+
+    const isPureClose = panelIds.length < prevPanelCountRef.current;
+    prevPanelCountRef.current = panelIds.length;
+
     setHysteresisGridCols(
       layoutConfig.strategy === "automatic" && !showPlaceholder ? gridCols : undefined
     );
 
     if (isProjectSwitching || isDraggingRef.current) return;
 
-    // Schedule a coalesced sibling resize off the open/close path — the click
-    // never waits on N xterm resizes, and a burst of opens/closes collapses
-    // into a single pass once it settles (see scheduleBatchResize).
-    runGridBatchFit();
+    // Closing a panel in scroll mode leaves every survivor at its exact size —
+    // fixed column tracks, fixed row height. Resizing them all on the close
+    // path is pure waste and a real source of close-path lag, so skip the
+    // batch fit when nothing about the survivors' geometry actually changed.
+    const survivorGeometryStable = isScrollMode && isPureClose && !colsChanged && !scrollGeoChanged;
+    if (!survivorGeometryStable) {
+      // Schedule a coalesced sibling resize off the open/close path — the click
+      // never waits on N xterm resizes, and a burst of opens/closes collapses
+      // into a single pass once it settles (see scheduleBatchResize).
+      runGridBatchFit();
+    }
 
     // A column-count change shifts cell widths, so the per-host ResizeObserver
     // would otherwise fire an uncoordinated second resize through the 200ms
@@ -815,7 +832,15 @@ export function useContentGridContext({
         );
       }
     }
-  }, [gridCols, panelIds, isProjectSwitching, layoutConfig.strategy, showPlaceholder]);
+  }, [
+    gridCols,
+    panelIds,
+    isScrollMode,
+    scrollRowHeight,
+    isProjectSwitching,
+    layoutConfig.strategy,
+    showPlaceholder,
+  ]);
 
   const allGroupsAreSinglePanel = tabGroups.every((g) => g.panelIds.length === 1);
   const useTwoPaneSplitMode =

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -826,7 +826,7 @@ export function useContentGridContext({
     // for the transition window so the single chunked pass is the only resize;
     // the lock's unlock pass is the corrective backstop.
     const layoutChangingClose = isPureClose && !survivorGeometryStable;
-    if (colsChanged || layoutChangingClose) {
+    if (colsChanged || scrollGeoChanged || layoutChangingClose) {
       const realPanelIds = panelIds.filter((id) => id !== GRID_PLACEHOLDER_ID);
       if (realPanelIds.length > 0) {
         terminalInstanceService.suppressResizesDuringLayoutTransition(

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -35,7 +35,11 @@ import {
 } from "@/services/terminal/optimisticPanelClose";
 import { TerminalRefreshTier } from "@shared/types/panel";
 import type { TabGroup, TabGroupLocation } from "@shared/types/panel";
-import { computeGridColumns, GRID_TRANSITION_DURATION_MS } from "@/lib/terminalLayout";
+import {
+  computeGridColumns,
+  computeScrollRowHeight,
+  GRID_TRANSITION_DURATION_MS,
+} from "@/lib/terminalLayout";
 import {
   isSidebarLayoutTransitionLocked,
   subscribeSidebarLayoutTransitionUnlock,
@@ -95,6 +99,10 @@ export interface ContentGridContext {
   maximizedGroupFocusTarget: string | null;
   gridCols: number;
   fleetGridCols: number;
+  /** True once the grid becomes a vertical scroll surface (5+ panels / 3+ rows). */
+  isScrollMode: boolean;
+  /** Fixed row height (px) used in scroll mode; ignored in non-scroll quad mode. */
+  scrollRowHeight: number;
   layoutTransition: Transition;
   layoutConfig: ReturnType<typeof useLayoutConfigStore.getState>["layoutConfig"];
   gridWidth: number | null;
@@ -368,6 +376,7 @@ export function useContentGridContext({
 
   const layoutConfig = useLayoutConfigStore((state) => state.layoutConfig);
   const setGridDimensions = useLayoutConfigStore((state) => state.setGridDimensions);
+  const gridDimensions = useLayoutConfigStore((state) => state.gridDimensions);
 
   // The scroll container that hosts the panel grid. Held as state (not a ref)
   // so `TerminalPane`'s IntersectionObserver effect can depend on its identity
@@ -587,6 +596,18 @@ export function useContentGridContext({
     activeWorktreeId,
     hysteresisGridCols,
   ]);
+
+  // Scroll mode: once the grid would need more than two rows (or holds 5+
+  // panels) it stops trying to fit everything and becomes a vertical scan
+  // surface with fixed-height rows. Fixed rows — rather than a `1fr` stretch —
+  // are what keep closing a panel cheap: a close never restretches and
+  // resizes every surviving terminal.
+  const gridRows = gridCols > 0 ? Math.ceil(gridItemCount / gridCols) : gridItemCount;
+  const isScrollMode = gridItemCount >= 5 || gridRows > 2;
+  const scrollRowHeight = useMemo(
+    () => computeScrollRowHeight(gridDimensions?.height ?? null),
+    [gridDimensions?.height]
+  );
 
   const layoutTransition: Transition = useMemo(
     () => ({
@@ -972,6 +993,8 @@ export function useContentGridContext({
     maximizedGroupFocusTarget,
     gridCols,
     fleetGridCols,
+    isScrollMode,
+    scrollRowHeight,
     layoutTransition,
     layoutConfig,
     gridWidth,

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -785,7 +785,7 @@ export function useContentGridContext({
     }
   });
   const prevGridColsRef = useRef(gridCols);
-  const prevPanelCountRef = useRef(panelIds.length);
+  const prevTerminalCountRef = useRef(gridTerminals.length);
   const prevScrollGeoRef = useRef(`${isScrollMode}:${scrollRowHeight}`);
   useLayoutEffect(() => {
     void gridCols;
@@ -798,8 +798,8 @@ export function useContentGridContext({
     const scrollGeoChanged = prevScrollGeoRef.current !== scrollGeoKey;
     prevScrollGeoRef.current = scrollGeoKey;
 
-    const isPureClose = panelIds.length < prevPanelCountRef.current;
-    prevPanelCountRef.current = panelIds.length;
+    const isPureClose = gridTerminals.length < prevTerminalCountRef.current;
+    prevTerminalCountRef.current = gridTerminals.length;
 
     setHysteresisGridCols(
       layoutConfig.strategy === "automatic" && !showPlaceholder ? gridCols : undefined
@@ -819,15 +819,17 @@ export function useContentGridContext({
       runGridBatchFit();
     }
 
-    // A layout-changing close (or a column change) resizes every survivor's
-    // box. Each panel's own ResizeObserver in XtermAdapter would otherwise
-    // fire its own un-chunked resize on top of the coalesced pass above — a
-    // resize storm that is the main cause of close-path lag. Lock the panels
-    // for the transition window so the single chunked pass is the only resize;
-    // the lock's unlock pass is the corrective backstop.
+    // Any change to the survivors' boxes resizes every panel. Each panel's own
+    // ResizeObserver in XtermAdapter would otherwise fire an un-chunked resize
+    // on top of the coalesced pass above — a resize storm and the main cause
+    // of close-path lag. Lock the panels for the transition window so the
+    // single chunked pass is the only resize. Arm on a column change, a
+    // scroll-geometry flip (which can also land on the deferred-flush render,
+    // where `panelIds` is already settled so `isPureClose` is false), or a
+    // layout-changing close.
     const layoutChangingClose = isPureClose && !survivorGeometryStable;
-    if (colsChanged || layoutChangingClose) {
-      const realPanelIds = panelIds.filter((id) => id !== GRID_PLACEHOLDER_ID);
+    if (colsChanged || scrollGeoChanged || layoutChangingClose) {
+      const realPanelIds = gridTerminals.map((t) => t.id);
       if (realPanelIds.length > 0) {
         terminalInstanceService.suppressResizesDuringLayoutTransition(
           realPanelIds,
@@ -838,6 +840,7 @@ export function useContentGridContext({
   }, [
     gridCols,
     panelIds,
+    gridTerminals,
     isScrollMode,
     scrollRowHeight,
     isProjectSwitching,

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -105,6 +105,7 @@ export interface ContentGridContext {
   /** Fixed row height (px) used in scroll mode; ignored in non-scroll quad mode. */
   scrollRowHeight: number;
   layoutTransition: Transition;
+  layoutAnimationEnabled: boolean;
   layoutConfig: ReturnType<typeof useLayoutConfigStore.getState>["layoutConfig"];
   gridWidth: number | null;
   isFleetScopeRender: boolean;
@@ -624,11 +625,12 @@ export function useContentGridContext({
 
   const layoutTransition: Transition = useMemo(
     () => ({
-      duration: isProjectSwitching ? 0 : GRID_TRANSITION_DURATION_MS / 1000,
+      duration: isProjectSwitching || closingIds.size > 0 ? 0 : GRID_TRANSITION_DURATION_MS / 1000,
       ease: [0.22, 1, 0.36, 1],
     }),
-    [isProjectSwitching]
+    [isProjectSwitching, closingIds.size]
   );
+  const layoutAnimationEnabled = !isProjectSwitching && closingIds.size === 0;
 
   const gridAgentMenuItems = useMemo(() => {
     return getEffectiveAgentIds()
@@ -1037,6 +1039,7 @@ export function useContentGridContext({
     isScrollMode,
     scrollRowHeight,
     layoutTransition,
+    layoutAnimationEnabled,
     layoutConfig,
     gridWidth,
     isFleetScopeRender,

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -38,6 +38,7 @@ import type { TabGroup, TabGroupLocation } from "@shared/types/panel";
 import {
   computeGridColumns,
   computeScrollRowHeight,
+  gridRowsOverflow,
   GRID_TRANSITION_DURATION_MS,
 } from "@/lib/terminalLayout";
 import {
@@ -604,21 +605,21 @@ export function useContentGridContext({
     hysteresisGridCols,
   ]);
 
-  // Scroll mode: once the grid would need more than two rows (or holds 5+
-  // panels) it stops trying to fit everything and becomes a vertical scan
-  // surface with fixed-height rows. Fixed rows — rather than a `1fr` stretch —
-  // are what keep closing a panel cheap: a close never restretches and resizes
-  // every surviving terminal.
+  // Scroll mode is the last resort: the grid scrolls only once its rows would
+  // overflow the visible height even at the small `GRID_MIN_PANEL_ROWS` floor.
+  // Panel count never triggers it — a tall display fits many rows first. When
+  // it does scroll, rows are fixed-height (not a `1fr` stretch) so closing a
+  // panel never restretches and resizes every surviving terminal.
   //
-  // The scroll-mode count uses real grid groups (`tabGroups.length`), not
+  // The row count uses real grid groups (`tabGroups.length`), not
   // `gridItemCount`: a drag placeholder must not flip row-height mode mid-drag.
   // `closingIds.size` is added back so an in-flight optimistic close keeps the
-  // pre-close count — a 5→4 close otherwise exits scroll mode on the click path
-  // and restretches the survivors, the exact resize fixed rows exist to avoid.
-  // The layout settles to quad mode once the canonical commit clears `closingIds`.
+  // pre-close count — a close otherwise exits scroll mode on the click path and
+  // restretches the survivors, the exact resize fixed rows exist to avoid. The
+  // layout settles once the canonical commit clears `closingIds`.
   const scrollModeCount = tabGroups.length + closingIds.size;
   const scrollModeRows = gridCols > 0 ? Math.ceil(scrollModeCount / gridCols) : scrollModeCount;
-  const isScrollMode = scrollModeCount >= 5 || scrollModeRows > 2;
+  const isScrollMode = gridRowsOverflow(scrollModeRows, gridHeight);
   const scrollRowHeight = useMemo(() => computeScrollRowHeight(gridHeight), [gridHeight]);
 
   const layoutTransition: Transition = useMemo(

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -376,7 +376,6 @@ export function useContentGridContext({
 
   const layoutConfig = useLayoutConfigStore((state) => state.layoutConfig);
   const setGridDimensions = useLayoutConfigStore((state) => state.setGridDimensions);
-  const gridDimensions = useLayoutConfigStore((state) => state.gridDimensions);
 
   // The scroll container that hosts the panel grid. Held as state (not a ref)
   // so `TerminalPane`'s IntersectionObserver effect can depend on its identity
@@ -402,6 +401,11 @@ export function useContentGridContext({
     preMaximizeLayoutRef.current = preMaximizeLayout;
   }, [preMaximizeLayout]);
   const [gridWidth, setGridWidth] = useState<number | null>(null);
+  // Grid height is tracked locally (like `gridWidth`) rather than read from the
+  // layout store: the store's `gridDimensions` is reset to null whenever the
+  // ResizeObserver effect re-subscribes (it re-runs on every panel open/close),
+  // which would blip `scrollRowHeight` to its default and resize every terminal.
+  const [gridHeight, setGridHeight] = useState<number | null>(null);
 
   const { placeholderIndex, sourceContainer } = useDndPlaceholder();
   const isDragging = useIsDragging();
@@ -494,6 +498,7 @@ export function useContentGridContext({
         if (entry) {
           const { width, height } = entry.contentRect;
           setGridWidth((prev) => (prev === width ? prev : width));
+          setGridHeight((prev) => (prev === height ? prev : height));
           setGridDimensions({ width, height });
         }
       });
@@ -507,6 +512,7 @@ export function useContentGridContext({
     // below will sync the grid once the transition completes.
     if (!isSidebarLayoutTransitionLocked()) {
       setGridWidth(container.clientWidth);
+      setGridHeight(container.clientHeight);
       setGridDimensions({ width: container.clientWidth, height: container.clientHeight });
     }
 
@@ -528,6 +534,7 @@ export function useContentGridContext({
         const width = measureNode.clientWidth;
         const height = measureNode.clientHeight;
         setGridWidth((prev) => (prev === width ? prev : width));
+        setGridHeight((prev) => (prev === height ? prev : height));
         setGridDimensions({ width, height });
       });
     });
@@ -600,14 +607,19 @@ export function useContentGridContext({
   // Scroll mode: once the grid would need more than two rows (or holds 5+
   // panels) it stops trying to fit everything and becomes a vertical scan
   // surface with fixed-height rows. Fixed rows — rather than a `1fr` stretch —
-  // are what keep closing a panel cheap: a close never restretches and
-  // resizes every surviving terminal.
-  const gridRows = gridCols > 0 ? Math.ceil(gridItemCount / gridCols) : gridItemCount;
-  const isScrollMode = gridItemCount >= 5 || gridRows > 2;
-  const scrollRowHeight = useMemo(
-    () => computeScrollRowHeight(gridDimensions?.height ?? null),
-    [gridDimensions?.height]
-  );
+  // are what keep closing a panel cheap: a close never restretches and resizes
+  // every surviving terminal.
+  //
+  // The scroll-mode count uses real grid groups (`tabGroups.length`), not
+  // `gridItemCount`: a drag placeholder must not flip row-height mode mid-drag.
+  // `closingIds.size` is added back so an in-flight optimistic close keeps the
+  // pre-close count — a 5→4 close otherwise exits scroll mode on the click path
+  // and restretches the survivors, the exact resize fixed rows exist to avoid.
+  // The layout settles to quad mode once the canonical commit clears `closingIds`.
+  const scrollModeCount = tabGroups.length + closingIds.size;
+  const scrollModeRows = gridCols > 0 ? Math.ceil(scrollModeCount / gridCols) : scrollModeCount;
+  const isScrollMode = scrollModeCount >= 5 || scrollModeRows > 2;
+  const scrollRowHeight = useMemo(() => computeScrollRowHeight(gridHeight), [gridHeight]);
 
   const layoutTransition: Transition = useMemo(
     () => ({

--- a/src/config/xtermConfig.ts
+++ b/src/config/xtermConfig.ts
@@ -35,7 +35,11 @@ export const BASE_TERMINAL_OPTIONS = {
   cursorBlink: true,
   cursorStyle: "block" as const,
   cursorInactiveStyle: "block" as const,
-  lineHeight: 1.1,
+  // Exactly 1.0 — a fractional line height makes xterm's DOM renderer leave
+  // vertical sub-pixel gaps between stacked box-drawing characters, breaking
+  // the box borders that agent TUIs draw. (The WebGL renderer hid this by
+  // custom-drawing those glyphs to the cell; the DOM renderer cannot.)
+  lineHeight: 1.0,
   letterSpacing: 0,
   fontWeight: "normal" as const,
   fontWeightBold: "700" as const,
@@ -109,11 +113,11 @@ export function getTerminalMetrics(fontSize: number): {
   cellWidth: number;
   cellHeight: number;
 } {
-  // These ratios are based on typical monospace font rendering
-  // and should match the lineHeight setting
+  // These ratios are based on typical monospace font rendering and must match
+  // the `lineHeight` setting in BASE_TERMINAL_OPTIONS (1.0).
   return {
     cellWidth: Math.max(6, Math.floor(fontSize * 0.6)),
-    cellHeight: Math.max(10, Math.floor(fontSize * 1.1)),
+    cellHeight: Math.max(10, Math.floor(fontSize)),
   };
 }
 

--- a/src/controllers/TerminalRegistryController.ts
+++ b/src/controllers/TerminalRegistryController.ts
@@ -28,7 +28,7 @@ import type {
 import { getAgentConfig } from "@/config/agents";
 import { getTerminalAppearanceSnapshot } from "@/hooks/useTerminalAppearance";
 import { getScrollbackForType, PERFORMANCE_MODE_SCROLLBACK } from "@/utils/scrollbackConfig";
-import { getXtermOptions } from "@/config/xtermConfig";
+import { getXtermOptions, calculateTerminalDimensions } from "@/config/xtermConfig";
 import { TerminalRefreshTier } from "@/types";
 
 // Dock terminal dimensions
@@ -155,12 +155,11 @@ class TerminalRegistryController {
 
       // For offscreen agents, prewarmTerminal's fit() already handles initial
       // PTY resize through settled strategy. Only send explicit resize for
-      // active grid spawns where fit() is skipped.
+      // active grid spawns where fit() is skipped. Cell metrics come from
+      // calculateTerminalDimensions so the lineHeight assumption stays in
+      // sync with xtermConfig (1.0 — see BASE_TERMINAL_OPTIONS).
       if (isAgent && !offscreen) {
-        const cellWidth = Math.max(6, Math.floor(fontSize * 0.6));
-        const cellHeight = Math.max(10, Math.floor(fontSize * 1.1));
-        const cols = Math.max(20, Math.min(500, Math.floor(widthPx / cellWidth)));
-        const rows = Math.max(10, Math.min(200, Math.floor(heightPx / cellHeight)));
+        const { cols, rows } = calculateTerminalDimensions(widthPx, heightPx, fontSize);
         terminalInstanceService.sendPtyResize(id, cols, rows);
       }
     } catch (error) {

--- a/src/hooks/__tests__/useResourceProfile.test.tsx
+++ b/src/hooks/__tests__/useResourceProfile.test.tsx
@@ -2,7 +2,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useResourceProfile } from "../useResourceProfile";
-import { getMaxContexts, setMaxContexts } from "../../services/terminal/TerminalWebGLConfig";
+import {
+  getWebglLowerThreshold,
+  getWebglUpperThreshold,
+  setWebglThresholds,
+} from "../../services/terminal/TerminalWebGLConfig";
+import { useResourceProfileStore } from "../../store/resourceProfileStore";
+import { terminalInstanceService } from "../../services/terminal/TerminalInstanceService";
 import type { ResourceProfilePayload } from "@shared/types/resourceProfile";
 
 vi.mock("@xterm/addon-webgl", () => ({
@@ -13,12 +19,13 @@ type ResourceCallback = (payload: ResourceProfilePayload) => void;
 
 let capturedCallback: ResourceCallback | null = null;
 const cleanupFn = vi.fn();
-const originalMaxContexts = getMaxContexts();
+const originalUpper = getWebglUpperThreshold();
+const originalLower = getWebglLowerThreshold();
 
-function makePayload(maxWebGLContexts: number): ResourceProfilePayload {
+function makePayload(upper: number, lower: number): ResourceProfilePayload {
   return {
     profile: "balanced",
-    config: { maxWebGLContexts },
+    config: { webglUpperThreshold: upper, webglLowerThreshold: lower },
   } as unknown as ResourceProfilePayload;
 }
 
@@ -38,7 +45,7 @@ describe("useResourceProfile", () => {
   });
 
   afterEach(() => {
-    setMaxContexts(originalMaxContexts);
+    setWebglThresholds(originalUpper, originalLower);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (window as any).electron;
   });
@@ -53,24 +60,55 @@ describe("useResourceProfile", () => {
     expect(cleanupFn).toHaveBeenCalledTimes(1);
   });
 
-  it("propagates maxWebGLContexts to the shared config singleton", () => {
+  it("propagates both thresholds to the shared config singleton", () => {
     renderHook(() => useResourceProfile());
 
     act(() => {
-      capturedCallback!(makePayload(7));
+      capturedCallback!(makePayload(7, 5));
     });
 
-    expect(getMaxContexts()).toBe(7);
+    expect(getWebglUpperThreshold()).toBe(7);
+    expect(getWebglLowerThreshold()).toBe(5);
   });
 
   it("payload mutations are visible to TerminalWebGLManager via the shared config", async () => {
     renderHook(() => useResourceProfile());
 
     act(() => {
-      capturedCallback!(makePayload(5));
+      capturedCallback!(makePayload(6, 4));
     });
 
     const { TerminalWebGLManager } = await import("../../services/terminal/TerminalWebGLManager");
-    expect(TerminalWebGLManager.MAX_CONTEXTS).toBe(5);
+    expect(TerminalWebGLManager.UPPER_THRESHOLD).toBe(6);
+    expect(TerminalWebGLManager.LOWER_THRESHOLD).toBe(4);
+  });
+
+  it("updates the resource-profile store on each payload", () => {
+    renderHook(() => useResourceProfile());
+
+    act(() => {
+      capturedCallback!({
+        profile: "efficiency",
+        config: { webglUpperThreshold: 8, webglLowerThreshold: 6 },
+      } as unknown as ResourceProfilePayload);
+    });
+
+    expect(useResourceProfileStore.getState().profile).toBe("efficiency");
+  });
+
+  it("calls refreshWebGLMode so threshold changes flip live managers immediately", () => {
+    // Spy on the service method so a regression that drops the refresh call
+    // (e.g. someone reorders or removes the line in useResourceProfile) is
+    // caught here — otherwise the threshold-changes-don't-flip bug from the
+    // pre-fix code would silently return.
+    const refreshSpy = vi.spyOn(terminalInstanceService, "refreshWebGLMode");
+    renderHook(() => useResourceProfile());
+
+    act(() => {
+      capturedCallback!(makePayload(5, 3));
+    });
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    refreshSpy.mockRestore();
   });
 });

--- a/src/hooks/useResourceProfile.ts
+++ b/src/hooks/useResourceProfile.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
-import { setMaxContexts, setPassiveThreshold } from "../services/terminal/TerminalWebGLConfig";
+import { setWebglThresholds } from "../services/terminal/TerminalWebGLConfig";
+import { terminalInstanceService } from "../services/terminal/TerminalInstanceService";
 import { useResourceProfileStore } from "../store/resourceProfileStore";
 import type { ResourceProfilePayload } from "@shared/types/resourceProfile";
 
@@ -7,8 +8,12 @@ export function useResourceProfile(): void {
   useEffect(() => {
     const cleanup = window.electron.system.onResourceProfileChanged(
       (payload: ResourceProfilePayload) => {
-        setMaxContexts(payload.config.maxWebGLContexts);
-        setPassiveThreshold(payload.config.passiveWebGLThreshold);
+        setWebglThresholds(payload.config.webglUpperThreshold, payload.config.webglLowerThreshold);
+        // Threshold writes alone don't move the live manager out of its
+        // current mode — nudge it so a profile downgrade with N wants > new
+        // upper flips to dom immediately instead of waiting on the next
+        // consumer event to evaluate it.
+        terminalInstanceService.refreshWebGLMode();
         useResourceProfileStore.getState().setProfile(payload.profile);
       }
     );

--- a/src/index.css
+++ b/src/index.css
@@ -780,44 +780,18 @@ code.hljs {
     background: var(--scrollbar-track);
   }
 
-  /* The scrollable agent grid uses a wider, more visible scrollbar so users
-     can tell at a glance that the grid itself scrolls (separate from xterm's
-     own viewport). Chromium 146 ignores all `::-webkit-scrollbar-*` rules
-     when `scrollbar-width` is set to any non-`auto` keyword on a matched
-     element — Tailwind v4's global `* { scrollbar-width: thin }` would
-     otherwise mask everything below. Reset it to `auto` first. The thumb
-     uses `background-clip: padding-box` plus a grid-bg-coloured border so
-     the visible thumb is narrower than the 14px gutter; the inset gap
-     blends into the grid background instead of showing a transparent
-     stripe. xterm scrollbars are isolated by `.xterm .xterm-viewport`
-     specificity and are unaffected. */
+  /* The agent grid draws its own scrollbar — the GridScrollbar component, a
+     chunky physical handle modelled on xterm's (VS Code's) slider, sitting in
+     a real reserved gutter. The native scrollbar is hidden entirely: the grid
+     still scrolls via wheel, keyboard and programmatic scroll; only the visual
+     bar is replaced. xterm's own viewport scrollbar is unaffected — it is
+     scoped by `.xterm .xterm-viewport`. */
   #panel-grid {
-    scrollbar-width: auto;
+    scrollbar-width: none;
   }
 
   #panel-grid::-webkit-scrollbar {
-    width: 14px;
-    height: 14px;
-  }
-
-  #panel-grid::-webkit-scrollbar-track {
-    background: var(--color-grid-bg);
-  }
-
-  #panel-grid::-webkit-scrollbar-thumb {
-    background: var(--scrollbar-thumb);
-    background-clip: padding-box;
-    /* A 2px inset leaves a ~10px visible thumb in the 14px gutter — a meaty,
-       clearly-visible grab target so the grid's own scroll is unmistakable
-       and distinct from the thinner xterm viewport scrollbar. */
-    border: 2px solid var(--color-grid-bg);
-    border-radius: 7px;
-    min-height: 48px;
-  }
-
-  #panel-grid::-webkit-scrollbar-thumb:hover {
-    background: var(--scrollbar-thumb-hover);
-    background-clip: padding-box;
+    display: none;
   }
 
   /* Color vision deficiency overrides — Red-Green (Deuteranopia / Protanopia) */

--- a/src/index.css
+++ b/src/index.css
@@ -807,9 +807,12 @@ code.hljs {
   #panel-grid::-webkit-scrollbar-thumb {
     background: var(--scrollbar-thumb);
     background-clip: padding-box;
-    border: 3px solid var(--color-grid-bg);
+    /* A 2px inset leaves a ~10px visible thumb in the 14px gutter — a meaty,
+       clearly-visible grab target so the grid's own scroll is unmistakable
+       and distinct from the thinner xterm viewport scrollbar. */
+    border: 2px solid var(--color-grid-bg);
     border-radius: 7px;
-    min-height: 40px;
+    min-height: 48px;
   }
 
   #panel-grid::-webkit-scrollbar-thumb:hover {

--- a/src/lib/__tests__/terminalLayout.test.ts
+++ b/src/lib/__tests__/terminalLayout.test.ts
@@ -4,189 +4,316 @@ import {
   getGridFitMetrics,
   getMaxGridCapacity,
   computeGridColumns,
+  computeAutomaticGridCols,
+  applyHysteresis,
+  computeScrollRowHeight,
+  desiredAutoCols,
+  getPanelLayoutMode,
+  pxForCols,
+  pxForRows,
+  maxFeasibleCols,
+  DEFAULT_TERMINAL_METRICS,
   MIN_TERMINAL_WIDTH_PX,
   MIN_TERMINAL_HEIGHT_PX,
-  COMFORTABLE_PANEL_WIDTH_PX,
+  READABLE_GRID_MIN_COLS,
+  COMPACT_GRID_MIN_COLS,
+  ABSOLUTE_MIN_COLS,
+  AGENT_WIDE_COLS,
+  MAX_USEFUL_COLS,
+  READABLE_MIN_ROWS,
+  TARGET_GRID_ROWS,
+  MAX_SCROLL_ROWS,
   AUTO_GRID_MAX_COLS,
-  GRID_HYSTERESIS_BUFFER_PX,
+  GRID_GAP_PX,
+  GRID_PADDING_PX,
   ABSOLUTE_MAX_GRID_TERMINALS,
   GRID_TRANSITION_DURATION_MS,
+  type TerminalMetrics,
 } from "../terminalLayout";
 
-const C = COMFORTABLE_PANEL_WIDTH_PX; // size-driven denominator (480, #8859)
+// Exact container width at which `n` readable comfortable (80-col) panels fit.
+// Mirrors `maxFeasibleCols`' nth boundary: `wCols(n)` yields exactly n columns
+// of feasibility and `wCols(n) - 1` yields n - 1. Derived from the engine's own
+// metric model so the tests stay correct if the metrics are tuned.
+const wCols = (n: number) =>
+  pxForCols(READABLE_GRID_MIN_COLS) * n + GRID_GAP_PX * (n - 1) + GRID_PADDING_PX;
 
-describe("getAutoGridCols", () => {
-  describe("single terminal", () => {
-    it("should return 1 for count of 0", () => {
+// Same, for compact density (64-col floor).
+const wColsCompact = (n: number) =>
+  pxForCols(COMPACT_GRID_MIN_COLS) * n + GRID_GAP_PX * (n - 1) + GRID_PADDING_PX;
+
+describe("desiredAutoCols — count-driven progression", () => {
+  it("steps 1 → 2 → 3 then settles at 2 for 4+", () => {
+    expect(desiredAutoCols(0)).toBe(1);
+    expect(desiredAutoCols(1)).toBe(1);
+    expect(desiredAutoCols(2)).toBe(2);
+    expect(desiredAutoCols(3)).toBe(3);
+    expect(desiredAutoCols(4)).toBe(2);
+    expect(desiredAutoCols(5)).toBe(2);
+    expect(desiredAutoCols(20)).toBe(2);
+  });
+
+  it("treats negative counts as a single panel", () => {
+    expect(desiredAutoCols(-1)).toBe(1);
+  });
+});
+
+describe("getPanelLayoutMode", () => {
+  it("routes 1 → single, 2 → split, 3+ → grid", () => {
+    expect(getPanelLayoutMode(0)).toBe("single");
+    expect(getPanelLayoutMode(1)).toBe("single");
+    expect(getPanelLayoutMode(2)).toBe("split");
+    expect(getPanelLayoutMode(3)).toBe("grid");
+    expect(getPanelLayoutMode(9)).toBe("grid");
+  });
+});
+
+describe("pxForCols / pxForRows — character-cell geometry", () => {
+  it("derives panel width from cell width plus chrome", () => {
+    const m = DEFAULT_TERMINAL_METRICS;
+    expect(pxForCols(80)).toBe(
+      Math.ceil(80 * m.cellWidth + m.paddingX + m.scrollbarWidth + m.borderX)
+    );
+    // More columns is always wider.
+    expect(pxForCols(120)).toBeGreaterThan(pxForCols(80));
+    expect(pxForCols(80)).toBeGreaterThan(pxForCols(50));
+  });
+
+  it("derives panel height from cell height plus header and chrome", () => {
+    const m = DEFAULT_TERMINAL_METRICS;
+    expect(pxForRows(24)).toBe(
+      Math.ceil(24 * m.cellHeight + m.headerHeight + m.paddingY + m.borderY)
+    );
+    expect(pxForRows(40)).toBeGreaterThan(pxForRows(24));
+  });
+
+  it("honors custom measured metrics", () => {
+    const wide: TerminalMetrics = { ...DEFAULT_TERMINAL_METRICS, cellWidth: 12 };
+    expect(pxForCols(80, wide)).toBeGreaterThan(pxForCols(80));
+  });
+});
+
+describe("maxFeasibleCols", () => {
+  it("returns at least 1 even for degenerate inputs", () => {
+    expect(maxFeasibleCols(0, 700)).toBe(1);
+    expect(maxFeasibleCols(700, 0)).toBe(1);
+    expect(maxFeasibleCols(-100, 700)).toBe(1);
+  });
+
+  it("counts how many minimum-width panels fit, accounting for gaps", () => {
+    const mpw = pxForCols(READABLE_GRID_MIN_COLS);
+    expect(maxFeasibleCols(wCols(1), mpw)).toBe(1);
+    expect(maxFeasibleCols(wCols(2), mpw)).toBe(2);
+    expect(maxFeasibleCols(wCols(3), mpw)).toBe(3);
+    expect(maxFeasibleCols(wCols(3) - 1, mpw)).toBe(2);
+  });
+});
+
+describe("getAutoGridCols — count-driven feel inside a readability envelope", () => {
+  describe("single / zero panels", () => {
+    it("returns 1 for 0 or 1 panel regardless of width", () => {
       expect(getAutoGridCols(0, null)).toBe(1);
-    });
-
-    it("should return 1 for count of 1 regardless of width", () => {
       expect(getAutoGridCols(1, null)).toBe(1);
-      expect(getAutoGridCols(1, 500)).toBe(1);
-      expect(getAutoGridCols(1, 1000)).toBe(1);
       expect(getAutoGridCols(1, 5000)).toBe(1);
-    });
-
-    it("should handle negative counts defensively", () => {
-      expect(getAutoGridCols(-1, null)).toBe(1);
-      expect(getAutoGridCols(-10, null)).toBe(1);
+      expect(getAutoGridCols(-3, 5000)).toBe(1);
     });
   });
 
-  describe("size-driven column count (count never adds a column)", () => {
-    // With many panels open, the column count is purely floor(width / C),
-    // capped at AUTO_GRID_MAX_COLS. Panel count only limits via no-empty-columns.
-    const many = 12;
-
-    it("uses 1 column until two comfortable panels fit (2 × C)", () => {
-      expect(getAutoGridCols(many, C)).toBe(1); // floor(480/480)=1
-      expect(getAutoGridCols(many, 2 * C - 1)).toBe(1); // 959 → 1
-    });
-
-    it("widens to 2 columns at 2 × C", () => {
-      expect(getAutoGridCols(many, 2 * C)).toBe(2); // 960 → 2
-      expect(getAutoGridCols(many, 3 * C - 1)).toBe(2); // 1439 → 2
-    });
-
-    it("widens to 3 columns at 3 × C", () => {
-      expect(getAutoGridCols(many, 3 * C)).toBe(3); // 1440 → 3
-      expect(getAutoGridCols(many, 4 * C - 1)).toBe(3); // 1919 → 3
-    });
-
-    it("widens to 4 columns at 4 × C", () => {
-      expect(getAutoGridCols(many, 4 * C)).toBe(4); // 1920 → 4
-    });
-
-    it("hard-caps at 4 columns regardless of width", () => {
-      // Literal 4 (not AUTO_GRID_MAX_COLS) so a silent constant bump is caught —
-      // the issue treats the 4-column ceiling as the at-a-glance limit (#8859).
-      expect(getAutoGridCols(many, 5 * C)).toBe(4);
-      expect(getAutoGridCols(many, 10 * C)).toBe(4);
-      expect(getAutoGridCols(100, 99999)).toBe(4);
-    });
-
-    it("pins AUTO_GRID_MAX_COLS to the 4-column design contract", () => {
-      expect(AUTO_GRID_MAX_COLS).toBe(4);
-    });
-
-    it('places the 1→2 column boundary at 960px (13" MacBook Air gets 2)', () => {
-      // Literal pixels (not C) to verify the product-facing breakpoint directly.
-      expect(getAutoGridCols(many, 959)).toBe(1);
-      expect(getAutoGridCols(many, 960)).toBe(2);
-    });
-
-    it('keeps 13" MacBook Air-class widths on 2 columns (#8859)', () => {
-      // Issue #8859: typical usable grid width on a 13" MBA with sidebars
-      // visible is ~1100-1200px; that must stay at 2 columns, not collapse to 1.
-      expect(getAutoGridCols(many, 1100)).toBe(2);
-      expect(getAutoGridCols(many, 1200)).toBe(2);
-    });
-
-    it("is driven by width, not panel count, at a fixed width", () => {
-      // Same width → same column count whether 3 panels or 50 are open.
-      const wide = 3 * C; // fits 3 columns
-      expect(getAutoGridCols(3, wide)).toBe(3);
-      expect(getAutoGridCols(10, wide)).toBe(3);
-      expect(getAutoGridCols(50, wide)).toBe(3);
+  describe("two panels", () => {
+    it("always reports 2 columns (the split layout handles narrow windows)", () => {
+      expect(getAutoGridCols(2, null)).toBe(2);
+      expect(getAutoGridCols(2, 300)).toBe(2);
+      expect(getAutoGridCols(2, 5000)).toBe(2);
     });
   });
 
-  describe("no empty columns", () => {
-    const wide = 4 * C; // fits 4 columns at the new cap
+  describe("three panels — three-across only when readable", () => {
+    it("renders three columns once three readable panels fit", () => {
+      expect(getAutoGridCols(3, wCols(3))).toBe(3);
+      expect(getAutoGridCols(3, wCols(3) + 500)).toBe(3);
+    });
 
-    it("never uses more columns than panels", () => {
-      expect(getAutoGridCols(2, wide)).toBe(2); // capped by count, not the 4-col width fit
-      expect(getAutoGridCols(3, wide)).toBe(3);
-      expect(getAutoGridCols(4, wide)).toBe(4);
-      expect(getAutoGridCols(6, wide)).toBe(4); // still capped at AUTO_GRID_MAX_COLS
+    it("falls back to two columns when three do not fit", () => {
+      expect(getAutoGridCols(3, wCols(3) - 1)).toBe(2);
+      expect(getAutoGridCols(3, wCols(2))).toBe(2);
+    });
+
+    it("falls back to one column on a genuinely small container", () => {
+      expect(getAutoGridCols(3, wCols(2) - 1)).toBe(1);
     });
   });
 
-  describe("fallback width", () => {
-    it("uses the first-paint fallback (3-column band) when width is null", () => {
-      // FALLBACK_GRID_WIDTH_PX (1680) lands in the 3-column band with C=480.
-      expect(getAutoGridCols(4, null)).toBe(3);
-      expect(getAutoGridCols(10, null)).toBe(3);
-      expect(getAutoGridCols(2, null)).toBe(2); // capped by count
+  describe("four-plus panels — the two-column monitoring rail", () => {
+    it("settles at two columns and never sprawls wider, however wide the screen", () => {
+      expect(getAutoGridCols(4, wCols(2))).toBe(2);
+      expect(getAutoGridCols(4, wCols(3))).toBe(2);
+      expect(getAutoGridCols(4, wCols(4))).toBe(2);
+      expect(getAutoGridCols(8, 6000)).toBe(2);
+      expect(getAutoGridCols(20, 9999)).toBe(2);
     });
 
-    it("uses the fallback for non-positive transient widths", () => {
-      expect(getAutoGridCols(4, 0)).toBe(3);
-      expect(getAutoGridCols(4, -100)).toBe(3);
+    it("drops to one column when two readable panels do not fit", () => {
+      expect(getAutoGridCols(6, wCols(2) - 1)).toBe(1);
+    });
+
+    it("never reports four columns from the automatic engine", () => {
+      // Direct regression guard for the 4-column sprawl (#8859 over-correction).
+      for (const count of [4, 5, 8, 12, 30]) {
+        expect(getAutoGridCols(count, 100000)).toBeLessThanOrEqual(2);
+      }
+    });
+  });
+
+  describe("first paint (width unknown)", () => {
+    it("lands on the predictable count-driven shape immediately", () => {
+      expect(getAutoGridCols(2, null)).toBe(2);
+      expect(getAutoGridCols(3, null)).toBe(3);
+      expect(getAutoGridCols(4, null)).toBe(2);
+      expect(getAutoGridCols(8, null)).toBe(2);
+    });
+
+    it("treats transient non-positive widths as unknown", () => {
+      expect(getAutoGridCols(3, 0)).toBe(3);
+      expect(getAutoGridCols(3, -100)).toBe(3);
+    });
+  });
+
+  describe("compact density (opt-in)", () => {
+    it("widens a 4+ grid to three columns on a wide container", () => {
+      expect(getAutoGridCols(4, wColsCompact(3), undefined, { density: "compact" })).toBe(3);
+      expect(getAutoGridCols(8, wColsCompact(3), undefined, { density: "compact" })).toBe(3);
+    });
+
+    it("still falls back to two columns when three compact panels do not fit", () => {
+      expect(getAutoGridCols(4, wColsCompact(3) - 1, undefined, { density: "compact" })).toBe(2);
+    });
+
+    it("comfortable density keeps 4+ at two columns at the same width", () => {
+      expect(getAutoGridCols(4, wColsCompact(3))).toBe(2);
     });
   });
 
   describe("breakpoint hysteresis (width-driven Schmitt trigger)", () => {
-    const many = 12;
-    // 3→4 boundary: widen at 4×C (1920), narrow at 4×C − buffer.
-    const fourColNarrow = 4 * C - GRID_HYSTERESIS_BUFFER_PX; // 1840
-    // 2→3 boundary: widen at 3×C (1440), narrow at 3×C − buffer.
-    const threeColNarrow = 3 * C - GRID_HYSTERESIS_BUFFER_PX; // 1360
-    // 1→2 boundary: widen at 2×C (960), narrow at 2×C − buffer.
-    const twoColNarrow = 2 * C - GRID_HYSTERESIS_BUFFER_PX; // 880
-
-    it("holds 4 columns through the narrow buffer once widened", () => {
-      // Natural width target is 3 cols here, but a sticky 4 holds above narrowAt.
-      expect(getAutoGridCols(many, fourColNarrow, 4)).toBe(4);
-      expect(getAutoGridCols(many, fourColNarrow + 10, 4)).toBe(4);
+    it("holds the wider column count through the narrow buffer", () => {
+      // At a width that freshly computes 2 columns, a sticky previous 3 holds.
+      const held = getAutoGridCols(3, wCols(3) - 1, 3);
+      const fresh = getAutoGridCols(3, wCols(3) - 1, undefined);
+      expect(fresh).toBe(2);
+      expect(held).toBe(3);
     });
 
-    it("narrows from 4 to 3 columns once below the buffer", () => {
-      expect(getAutoGridCols(many, fourColNarrow - 1, 4)).toBe(3);
+    it("narrows once the container drops well past the threshold", () => {
+      // Far below the 3-column threshold: hysteresis cannot hold 3.
+      expect(getAutoGridCols(3, wCols(2), 3)).toBe(2);
     });
 
-    it("holds 3 columns through the narrow buffer once widened", () => {
-      // Natural width target is 2 cols here, but a sticky 3 holds above narrowAt.
-      expect(getAutoGridCols(many, threeColNarrow, 3)).toBe(3);
-      expect(getAutoGridCols(many, threeColNarrow + 10, 3)).toBe(3);
+    it("never widens past the natural target when previousCols is smaller", () => {
+      expect(getAutoGridCols(3, wCols(3), 1)).toBe(3);
+      expect(getAutoGridCols(4, wCols(4), 1)).toBe(2);
     });
 
-    it("narrows from 3 to 2 columns once below the buffer", () => {
-      expect(getAutoGridCols(many, threeColNarrow - 1, 3)).toBe(2);
+    it("does not smooth a column drop caused by opening more panels", () => {
+      // Going from 3 panels (3 cols) to 4 panels must drop to 2 immediately —
+      // count changes are predictable, only width changes are smoothed.
+      expect(getAutoGridCols(4, wCols(4), 3)).toBe(2);
     });
 
-    it("holds 2 columns through the narrow buffer once widened", () => {
-      expect(getAutoGridCols(many, twoColNarrow, 2)).toBe(2);
+    it("a narrowing viewport overrides a stale wide previousCols", () => {
+      // Far below even the two-column threshold: hysteresis cannot rescue a
+      // stale previous count of 3.
+      expect(getAutoGridCols(6, wCols(1), 3)).toBe(1);
     });
+  });
+});
 
-    it("narrows from 2 to 1 column once below the buffer", () => {
-      expect(getAutoGridCols(many, twoColNarrow - 1, 2)).toBe(1);
-    });
+describe("applyHysteresis", () => {
+  it("passes the target through untouched without a previous count", () => {
+    expect(applyHysteresis(2, undefined, 1500, 700, 3)).toBe(2);
+  });
 
-    it("does not widen past the natural target when previousCols is smaller", () => {
-      // prev=1 must not bias an upward widen — width drives that.
-      expect(getAutoGridCols(many, 2 * C, 1)).toBe(2);
-      expect(getAutoGridCols(many, 3 * C, 2)).toBe(3);
-      expect(getAutoGridCols(many, 4 * C, 3)).toBe(4);
-    });
+  it("never lowers a count that already grew", () => {
+    expect(applyHysteresis(3, 2, 1500, 700, 3)).toBe(3);
+  });
 
-    it("a narrowing viewport overrides a sticky wide count", () => {
-      // Even with previousCols=4, a width that fits only 1 column wins.
-      expect(getAutoGridCols(many, C - 1, 4)).toBe(1);
-    });
+  it("caps a held count by the count-justified ceiling", () => {
+    // previous=3 but only 2 columns are count-justified now → cannot hold 3.
+    expect(applyHysteresis(2, 3, 100000, 700, 2)).toBe(2);
+  });
+});
 
-    it("preserves pure width-driven behavior when previousCols is undefined", () => {
-      expect(getAutoGridCols(many, fourColNarrow, undefined)).toBe(3);
-      expect(getAutoGridCols(many, threeColNarrow, undefined)).toBe(2);
-      expect(getAutoGridCols(many, twoColNarrow, undefined)).toBe(1);
-    });
+describe("computeScrollRowHeight", () => {
+  it("targets the comfortable row height when container height is unknown", () => {
+    expect(computeScrollRowHeight(null)).toBe(pxForRows(TARGET_GRID_ROWS));
+  });
 
-    it("respects no-empty-columns under a sticky prior", () => {
-      // 2 panels cap at 2 cols even if a stale previousCols=4 leaks in.
-      expect(getAutoGridCols(2, 4 * C, 4)).toBe(2);
-    });
+  it("stays within the readable row-height tiers", () => {
+    for (const h of [400, 900, 1500, 3000]) {
+      const rh = computeScrollRowHeight(h);
+      expect(rh).toBeGreaterThanOrEqual(pxForRows(READABLE_MIN_ROWS));
+      expect(rh).toBeLessThanOrEqual(pxForRows(MAX_SCROLL_ROWS));
+    }
+  });
 
-    it("holds a chained sequence through a staged narrowing drag", () => {
-      // Simulate the per-render previousCols handoff as the window shrinks
-      // across the 3→4 boundary: 1960 → 1860 → 1810.
-      const at1960 = getAutoGridCols(many, 1960, 3); // widens to 4
-      const at1860 = getAutoGridCols(many, 1860, at1960); // sticky 4 (≥1840)
-      const at1810 = getAutoGridCols(many, 1810, at1860); // drops to 3 (<1840)
-      expect(at1960).toBe(4);
-      expect(at1860).toBe(4);
-      expect(at1810).toBe(3);
-    });
+  it("caps at the max row height on very tall containers", () => {
+    expect(computeScrollRowHeight(4000)).toBe(pxForRows(MAX_SCROLL_ROWS));
+  });
+
+  it("grows the row height as the container gets taller (two rows + peek)", () => {
+    expect(computeScrollRowHeight(1700)).toBeGreaterThan(computeScrollRowHeight(900));
+  });
+});
+
+describe("computeAutomaticGridCols (explicit options form)", () => {
+  it("matches getAutoGridCols for the comfortable default", () => {
+    expect(computeAutomaticGridCols({ count: 3, width: wCols(3) })).toBe(3);
+    expect(computeAutomaticGridCols({ count: 4, width: wCols(4) })).toBe(2);
+  });
+
+  it("respects custom metrics — wider cells need more room for three across", () => {
+    const wideCells: TerminalMetrics = { ...DEFAULT_TERMINAL_METRICS, cellWidth: 14 };
+    const narrowCells: TerminalMetrics = { ...DEFAULT_TERMINAL_METRICS, cellWidth: 6 };
+    const width = wCols(3);
+    expect(computeAutomaticGridCols({ count: 3, width, metrics: narrowCells })).toBe(3);
+    expect(computeAutomaticGridCols({ count: 3, width, metrics: wideCells })).toBeLessThan(3);
+  });
+});
+
+describe("computeGridColumns — strategy dispatch", () => {
+  it("returns 1 for an empty grid", () => {
+    expect(computeGridColumns(0, wCols(3), "automatic")).toBe(1);
+  });
+
+  it("keeps the 2-pane invariant across every strategy", () => {
+    expect(computeGridColumns(2, null, "automatic")).toBe(2);
+    expect(computeGridColumns(2, 300, "automatic")).toBe(2);
+    expect(computeGridColumns(2, wCols(3), "automatic")).toBe(2);
+    expect(computeGridColumns(2, 300, "fixed-rows", 3)).toBe(2);
+    expect(computeGridColumns(2, 300, "fixed-columns", 1)).toBe(2);
+  });
+
+  it("uses the count-driven automatic engine for 3+ panels", () => {
+    expect(computeGridColumns(3, wCols(3), "automatic")).toBe(3);
+    expect(computeGridColumns(3, wCols(2), "automatic")).toBe(2);
+    expect(computeGridColumns(6, wCols(4), "automatic")).toBe(2);
+  });
+
+  it("honors the fixed-columns strategy", () => {
+    expect(computeGridColumns(4, wCols(4), "fixed-columns", 3)).toBe(3);
+    expect(computeGridColumns(4, wCols(4), "fixed-columns", 0)).toBe(1);
+    expect(computeGridColumns(4, wCols(4), "fixed-columns", 15)).toBe(10);
+  });
+
+  it("derives columns from the fixed-rows strategy", () => {
+    expect(computeGridColumns(6, wCols(4), "fixed-rows", 2)).toBe(3);
+    expect(computeGridColumns(6, wCols(4), "fixed-rows", 3)).toBe(2);
+    expect(computeGridColumns(5, wCols(4), "fixed-rows", 2)).toBe(3);
+    expect(computeGridColumns(4, wCols(4), "fixed-rows", 0)).toBe(4);
+    expect(computeGridColumns(4, wCols(4), "fixed-rows", 15)).toBe(1);
+  });
+
+  it("forwards previousCols into the automatic hysteresis path", () => {
+    expect(computeGridColumns(3, wCols(3) - 1, "automatic", undefined, 3)).toBe(3);
+    expect(computeGridColumns(3, wCols(3) - 1, "automatic", undefined, undefined)).toBe(2);
   });
 });
 
@@ -198,7 +325,6 @@ describe("getGridFitMetrics", () => {
   });
 
   it("returns max cols, rows, and fit count for a known viewport", () => {
-    // 1200×700: ~3 cols × ~3 rows = 9 panels fit before scrolling.
     const fit = getGridFitMetrics(1200, 700);
     expect(fit).not.toBeNull();
     expect(fit!.maxCols).toBeGreaterThanOrEqual(3);
@@ -206,191 +332,42 @@ describe("getGridFitMetrics", () => {
     expect(fit!.fitCount).toBe(fit!.maxCols * fit!.maxRows);
   });
 
-  it("returns at least 1 col and 1 row even at the smallest valid viewport", () => {
+  it("returns at least 1 col and 1 row at the smallest valid viewport", () => {
     const fit = getGridFitMetrics(MIN_TERMINAL_WIDTH_PX, MIN_TERMINAL_HEIGHT_PX);
     expect(fit).not.toBeNull();
     expect(fit!.maxCols).toBe(1);
     expect(fit!.maxRows).toBe(1);
-    expect(fit!.fitCount).toBe(1);
   });
 });
 
-describe("getMaxGridCapacity (legacy fit hint, no longer a hard cap)", () => {
-  it("returns the ABSOLUTE_MAX_GRID_TERMINALS fallback when dimensions are unknown", () => {
+describe("getMaxGridCapacity", () => {
+  it("returns the legacy fallback when dimensions are unknown", () => {
     expect(getMaxGridCapacity(null, null)).toBe(ABSOLUTE_MAX_GRID_TERMINALS);
-    expect(getMaxGridCapacity(1000, null)).toBe(ABSOLUTE_MAX_GRID_TERMINALS);
-    expect(getMaxGridCapacity(null, 800)).toBe(ABSOLUTE_MAX_GRID_TERMINALS);
   });
 
   it("reports the on-screen panel fit for a typical laptop viewport", () => {
-    const width = 1200;
-    const height = 700;
-    const capacity = getMaxGridCapacity(width, height);
+    const capacity = getMaxGridCapacity(1200, 700);
     expect(capacity).toBeGreaterThanOrEqual(6);
     expect(capacity).toBeLessThanOrEqual(9);
   });
-
-  it("scales past the legacy 16-panel cap on large monitors", () => {
-    // 2200×1200 fits 5 cols × 5 rows = 25 on-screen panels — no longer clamped.
-    expect(getMaxGridCapacity(2200, 1200)).toBeGreaterThan(ABSOLUTE_MAX_GRID_TERMINALS);
-    expect(getMaxGridCapacity(5000, 3000)).toBeGreaterThan(ABSOLUTE_MAX_GRID_TERMINALS);
-  });
-
-  it("returns at least 1 for any valid dimensions", () => {
-    expect(getMaxGridCapacity(400, 250)).toBeGreaterThanOrEqual(1);
-    expect(getMaxGridCapacity(MIN_TERMINAL_WIDTH_PX, MIN_TERMINAL_HEIGHT_PX)).toBe(1);
-  });
 });
 
-describe("grid transition timing constants", () => {
-  it("GRID_TRANSITION_DURATION_MS is 200", () => {
+describe("layout constants", () => {
+  it("orders the column-width tiers", () => {
+    expect(ABSOLUTE_MIN_COLS).toBeLessThan(COMPACT_GRID_MIN_COLS);
+    expect(COMPACT_GRID_MIN_COLS).toBeLessThan(READABLE_GRID_MIN_COLS);
+    expect(READABLE_GRID_MIN_COLS).toBeLessThan(AGENT_WIDE_COLS);
+    expect(AGENT_WIDE_COLS).toBeLessThan(MAX_USEFUL_COLS);
+  });
+
+  it("orders the row-height tiers", () => {
+    expect(READABLE_MIN_ROWS).toBeLessThan(TARGET_GRID_ROWS);
+    expect(TARGET_GRID_ROWS).toBeLessThan(MAX_SCROLL_ROWS);
+  });
+
+  it("pins the at-a-glance ceiling and transition timing", () => {
+    expect(AUTO_GRID_MAX_COLS).toBe(4);
     expect(GRID_TRANSITION_DURATION_MS).toBe(200);
-  });
-});
-
-describe("computeGridColumns", () => {
-  describe("2→3 panel transitions (regression test for issue #1754)", () => {
-    const wide = 3 * C; // fits 3 columns
-
-    it("keeps 2 and 3 panels at 2 columns when only 2 fit by count", () => {
-      // 2 panels honor the side-by-side invariant; 3 panels follow the width
-      // formula (3 cols fit at this width).
-      expect(computeGridColumns(2, wide, "automatic")).toBe(2);
-      expect(computeGridColumns(3, wide, "automatic")).toBe(3);
-    });
-
-    it("returns correct columns for 3 panels across strategies", () => {
-      expect(computeGridColumns(3, wide, "automatic")).toBe(3);
-      expect(computeGridColumns(3, wide, "fixed-columns", 2)).toBe(2);
-      expect(computeGridColumns(3, wide, "fixed-columns", 3)).toBe(3);
-      expect(computeGridColumns(3, wide, "fixed-rows", 1)).toBe(3);
-      expect(computeGridColumns(3, wide, "fixed-rows", 2)).toBe(2);
-    });
-
-    it("handles transitions with varying widths", () => {
-      const narrow = 1.5 * MIN_TERMINAL_WIDTH_PX; // 570 — below the 2-pane gate
-      const twoFit = 2.2 * C; // ~1056 — fits 2 columns
-
-      // Narrow: 2 panels stack (each would get < MIN_TERMINAL_WIDTH_PX side by side).
-      expect(computeGridColumns(2, narrow, "automatic")).toBe(1);
-      // Narrow: 3 panels also constrained to 1 column.
-      expect(computeGridColumns(3, narrow, "automatic")).toBe(1);
-
-      // Two columns fit: both 2 and 3 panels land on 2 columns.
-      expect(computeGridColumns(2, twoFit, "automatic")).toBe(2);
-      expect(computeGridColumns(3, twoFit, "automatic")).toBe(2);
-    });
-
-    it("uses the null-width fallback during transitions", () => {
-      expect(computeGridColumns(2, null, "automatic")).toBe(2); // invariant
-      expect(computeGridColumns(3, null, "automatic")).toBe(3); // fallback fits 3 cols
-    });
-  });
-
-  describe("2-pane invariant (width-gated for automatic, unconditional for fixed)", () => {
-    const sideBySideMin = MIN_TERMINAL_WIDTH_PX * 2; // 760 — two readable panes
-    const wide = 3 * C;
-
-    it("forces 2 columns for 2 automatic panes once both fit side by side", () => {
-      expect(computeGridColumns(2, sideBySideMin, "automatic")).toBe(2);
-      expect(computeGridColumns(2, sideBySideMin + 200, "automatic")).toBe(2);
-      expect(computeGridColumns(2, wide, "automatic")).toBe(2);
-      expect(computeGridColumns(2, null, "automatic")).toBe(2);
-    });
-
-    it("stacks 2 automatic panes when the window is too narrow for side by side", () => {
-      // Key behavior change: a 300px window can't show 2 readable panes.
-      expect(computeGridColumns(2, 300, "automatic")).toBe(1);
-      expect(computeGridColumns(2, sideBySideMin - 1, "automatic")).toBe(1);
-    });
-
-    it("preserves the 2-column preference for transient non-positive widths", () => {
-      // A 0/negative measurement mid-transition must not collapse 2 panes to 1.
-      expect(computeGridColumns(2, 0, "automatic")).toBe(2);
-      expect(computeGridColumns(2, -50, "automatic")).toBe(2);
-    });
-
-    it("keeps the unconditional 2x1 invariant for fixed strategies (unchanged)", () => {
-      expect(computeGridColumns(2, 300, "fixed-rows", 3)).toBe(2);
-      expect(computeGridColumns(2, 500, "fixed-rows", 3)).toBe(2);
-      expect(computeGridColumns(2, wide, "fixed-rows", 1)).toBe(2);
-      expect(computeGridColumns(2, wide, "fixed-rows", 10)).toBe(2);
-      // Even when the user explicitly sets columns=1, 2 panes stay 2x1.
-      expect(computeGridColumns(2, 300, "fixed-columns", 1)).toBe(2);
-      expect(computeGridColumns(2, wide, "fixed-columns", 4)).toBe(2);
-    });
-  });
-
-  describe("non-2-pane cases follow normal logic", () => {
-    const wide = 3 * C;
-    const narrow = 1.5 * MIN_TERMINAL_WIDTH_PX; // 570
-
-    it("returns 1 column for 0 or 1 pane in automatic/fixed-rows mode", () => {
-      expect(computeGridColumns(0, wide, "automatic")).toBe(1);
-      expect(computeGridColumns(1, wide, "automatic")).toBe(1);
-      expect(computeGridColumns(1, wide, "fixed-rows", 3)).toBe(1);
-    });
-
-    it("respects fixed-columns setting even for 1 pane", () => {
-      expect(computeGridColumns(1, wide, "fixed-columns", 2)).toBe(2);
-      expect(computeGridColumns(1, wide, "fixed-columns", 1)).toBe(1);
-    });
-
-    it("respects width constraints for 3+ panes in automatic mode", () => {
-      expect(computeGridColumns(6, narrow, "automatic")).toBe(1);
-      expect(computeGridColumns(6, wide, "automatic")).toBe(3);
-    });
-
-    it("uses fixed-columns value for 3+ panes", () => {
-      expect(computeGridColumns(4, wide, "fixed-columns", 2)).toBe(2);
-      expect(computeGridColumns(4, wide, "fixed-columns", 4)).toBe(4);
-    });
-
-    it("calculates columns from fixed-rows for 3+ panes", () => {
-      expect(computeGridColumns(6, wide, "fixed-rows", 2)).toBe(3);
-      expect(computeGridColumns(6, wide, "fixed-rows", 3)).toBe(2);
-    });
-
-    it("forwards previousCols to the automatic hysteresis path", () => {
-      // 1360 = 3×C − buffer: a sticky 3 holds, a fresh measurement narrows to 2.
-      expect(computeGridColumns(12, 1360, "automatic", undefined, 3)).toBe(3);
-      expect(computeGridColumns(12, 1359, "automatic", undefined, 3)).toBe(2);
-    });
-  });
-
-  describe("edge cases", () => {
-    const wide = 3 * C;
-
-    it("handles null width gracefully", () => {
-      expect(computeGridColumns(4, null, "automatic")).toBe(3); // fallback fits 3
-      expect(computeGridColumns(2, null, "automatic")).toBe(2); // invariant
-    });
-
-    it("clamps fixed-columns value to a valid range", () => {
-      expect(computeGridColumns(4, wide, "fixed-columns", 0)).toBe(1);
-      expect(computeGridColumns(4, wide, "fixed-columns", 15)).toBe(10);
-    });
-
-    it("clamps fixed-rows value to a valid range", () => {
-      expect(computeGridColumns(4, wide, "fixed-rows", 0)).toBe(4);
-      expect(computeGridColumns(4, wide, "fixed-rows", 15)).toBe(1);
-    });
-
-    it("handles 2 panes with a missing value parameter", () => {
-      expect(computeGridColumns(2, wide, "fixed-rows")).toBe(2);
-      expect(computeGridColumns(2, wide, "fixed-columns")).toBe(2);
-    });
-
-    it("handles 2 panes with invalid value parameters", () => {
-      expect(computeGridColumns(2, wide, "fixed-rows", 0)).toBe(2);
-      expect(computeGridColumns(2, wide, "fixed-columns", 0)).toBe(2);
-    });
-
-    it("handles non-even division for fixed-rows", () => {
-      // 5 panes / 2 rows = ceil(2.5) = 3 columns
-      expect(computeGridColumns(5, wide, "fixed-rows", 2)).toBe(3);
-      // 7 panes / 3 rows = ceil(2.33) = 3 columns
-      expect(computeGridColumns(7, wide, "fixed-rows", 3)).toBe(3);
-    });
+    expect(GRID_PADDING_PX).toBeGreaterThan(0);
   });
 });

--- a/src/lib/__tests__/terminalLayout.test.ts
+++ b/src/lib/__tests__/terminalLayout.test.ts
@@ -106,6 +106,7 @@ describe("maxFeasibleCols", () => {
     expect(maxFeasibleCols(wCols(2), mpw)).toBe(2);
     expect(maxFeasibleCols(wCols(3), mpw)).toBe(3);
     expect(maxFeasibleCols(wCols(3) - 1, mpw)).toBe(2);
+    expect(maxFeasibleCols(wCols(2) - 1, mpw)).toBe(1);
   });
 });
 
@@ -214,8 +215,17 @@ describe("getAutoGridCols — count-driven feel inside a readability envelope", 
 
     it("does not smooth a column drop caused by opening more panels", () => {
       // Going from 3 panels (3 cols) to 4 panels must drop to 2 immediately —
-      // count changes are predictable, only width changes are smoothed.
+      // a close/open that lowers the column ceiling is never smoothed.
       expect(getAutoGridCols(4, wCols(4), 3)).toBe(2);
+    });
+
+    it("may hold a readable wider count for one render when a panel opens at a boundary", () => {
+      // Opening the 3rd panel one pixel below the 2-column boundary: a fresh
+      // compute is 1, but the prior committed 2 columns are still ~readable
+      // (within the hysteresis buffer), so 2 is held for this render. The held
+      // count stays count-justified — it never leaves empty columns.
+      expect(getAutoGridCols(3, wCols(2) - 1, undefined)).toBe(1);
+      expect(getAutoGridCols(3, wCols(2) - 1, 2)).toBe(2);
     });
 
     it("a narrowing viewport overrides a stale wide previousCols", () => {
@@ -246,10 +256,12 @@ describe("computeScrollRowHeight", () => {
     expect(computeScrollRowHeight(null)).toBe(pxForRows(TARGET_GRID_ROWS));
   });
 
-  it("stays within the readable row-height tiers", () => {
+  it("stays between the target and max row-height tiers", () => {
+    // The effective floor is the 32-row target — two-rows-plus-peek can only
+    // raise the height — and the ceiling is the 40-row max.
     for (const h of [400, 900, 1500, 3000]) {
       const rh = computeScrollRowHeight(h);
-      expect(rh).toBeGreaterThanOrEqual(pxForRows(READABLE_MIN_ROWS));
+      expect(rh).toBeGreaterThanOrEqual(pxForRows(TARGET_GRID_ROWS));
       expect(rh).toBeLessThanOrEqual(pxForRows(MAX_SCROLL_ROWS));
     }
   });

--- a/src/lib/__tests__/terminalLayout.test.ts
+++ b/src/lib/__tests__/terminalLayout.test.ts
@@ -1,62 +1,37 @@
 import { describe, it, expect } from "vitest";
 import {
   getAutoGridCols,
-  getGridFitMetrics,
-  getMaxGridCapacity,
-  computeGridColumns,
   computeAutomaticGridCols,
+  computeGridColumns,
   applyHysteresis,
   computeScrollRowHeight,
-  desiredAutoCols,
+  gridRowsOverflow,
+  getGridFitMetrics,
+  getMaxGridCapacity,
   getPanelLayoutMode,
   pxForCols,
   pxForRows,
   maxFeasibleCols,
   DEFAULT_TERMINAL_METRICS,
-  MIN_TERMINAL_WIDTH_PX,
-  MIN_TERMINAL_HEIGHT_PX,
-  READABLE_GRID_MIN_COLS,
-  COMPACT_GRID_MIN_COLS,
+  GRID_MIN_PANEL_COLS,
+  GRID_MIN_PANEL_ROWS,
   ABSOLUTE_MIN_COLS,
-  AGENT_WIDE_COLS,
-  MAX_USEFUL_COLS,
-  READABLE_MIN_ROWS,
-  TARGET_GRID_ROWS,
-  MAX_SCROLL_ROWS,
   AUTO_GRID_MAX_COLS,
   GRID_GAP_PX,
   GRID_PADDING_PX,
+  MIN_TERMINAL_WIDTH_PX,
+  MIN_TERMINAL_HEIGHT_PX,
   ABSOLUTE_MAX_GRID_TERMINALS,
   GRID_TRANSITION_DURATION_MS,
   type TerminalMetrics,
 } from "../terminalLayout";
 
-// Exact container width at which `n` readable comfortable (80-col) panels fit.
-// Mirrors `maxFeasibleCols`' nth boundary: `wCols(n)` yields exactly n columns
-// of feasibility and `wCols(n) - 1` yields n - 1. Derived from the engine's own
-// metric model so the tests stay correct if the metrics are tuned.
+// Exact container width at which `n` minimum-width panels fit across. Mirrors
+// `maxFeasibleCols`' nth boundary — `wCols(n)` yields exactly n columns of
+// feasibility, `wCols(n) - 1` yields n - 1. Derived from the engine's own
+// metric model so the tests survive a metric tune.
 const wCols = (n: number) =>
-  pxForCols(READABLE_GRID_MIN_COLS) * n + GRID_GAP_PX * (n - 1) + GRID_PADDING_PX;
-
-// Same, for compact density (64-col floor).
-const wColsCompact = (n: number) =>
-  pxForCols(COMPACT_GRID_MIN_COLS) * n + GRID_GAP_PX * (n - 1) + GRID_PADDING_PX;
-
-describe("desiredAutoCols — count-driven progression", () => {
-  it("steps 1 → 2 → 3 then settles at 2 for 4+", () => {
-    expect(desiredAutoCols(0)).toBe(1);
-    expect(desiredAutoCols(1)).toBe(1);
-    expect(desiredAutoCols(2)).toBe(2);
-    expect(desiredAutoCols(3)).toBe(3);
-    expect(desiredAutoCols(4)).toBe(2);
-    expect(desiredAutoCols(5)).toBe(2);
-    expect(desiredAutoCols(20)).toBe(2);
-  });
-
-  it("treats negative counts as a single panel", () => {
-    expect(desiredAutoCols(-1)).toBe(1);
-  });
-});
+  pxForCols(GRID_MIN_PANEL_COLS) * n + GRID_GAP_PX * (n - 1) + GRID_PADDING_PX;
 
 describe("getPanelLayoutMode", () => {
   it("routes 1 → single, 2 → split, 3+ → grid", () => {
@@ -64,229 +39,188 @@ describe("getPanelLayoutMode", () => {
     expect(getPanelLayoutMode(1)).toBe("single");
     expect(getPanelLayoutMode(2)).toBe("split");
     expect(getPanelLayoutMode(3)).toBe("grid");
-    expect(getPanelLayoutMode(9)).toBe("grid");
+    expect(getPanelLayoutMode(12)).toBe("grid");
   });
 });
 
 describe("pxForCols / pxForRows — character-cell geometry", () => {
-  it("derives panel width from cell width plus chrome", () => {
+  it("derives panel size from cell geometry plus chrome", () => {
     const m = DEFAULT_TERMINAL_METRICS;
-    expect(pxForCols(80)).toBe(
-      Math.ceil(80 * m.cellWidth + m.paddingX + m.scrollbarWidth + m.borderX)
+    expect(pxForCols(60)).toBe(
+      Math.ceil(60 * m.cellWidth + m.paddingX + m.scrollbarWidth + m.borderX)
     );
-    // More columns is always wider.
-    expect(pxForCols(120)).toBeGreaterThan(pxForCols(80));
-    expect(pxForCols(80)).toBeGreaterThan(pxForCols(50));
-  });
-
-  it("derives panel height from cell height plus header and chrome", () => {
-    const m = DEFAULT_TERMINAL_METRICS;
-    expect(pxForRows(24)).toBe(
-      Math.ceil(24 * m.cellHeight + m.headerHeight + m.paddingY + m.borderY)
+    expect(pxForRows(16)).toBe(
+      Math.ceil(16 * m.cellHeight + m.headerHeight + m.paddingY + m.borderY)
     );
-    expect(pxForRows(40)).toBeGreaterThan(pxForRows(24));
+    expect(pxForCols(120)).toBeGreaterThan(pxForCols(60));
   });
 
   it("honors custom measured metrics", () => {
     const wide: TerminalMetrics = { ...DEFAULT_TERMINAL_METRICS, cellWidth: 12 };
-    expect(pxForCols(80, wide)).toBeGreaterThan(pxForCols(80));
+    expect(pxForCols(60, wide)).toBeGreaterThan(pxForCols(60));
   });
 });
 
 describe("maxFeasibleCols", () => {
-  it("returns at least 1 even for degenerate inputs", () => {
-    expect(maxFeasibleCols(0, 700)).toBe(1);
-    expect(maxFeasibleCols(700, 0)).toBe(1);
-    expect(maxFeasibleCols(-100, 700)).toBe(1);
+  it("returns at least 1 for degenerate inputs", () => {
+    expect(maxFeasibleCols(0, 532)).toBe(1);
+    expect(maxFeasibleCols(532, 0)).toBe(1);
+    expect(maxFeasibleCols(-100, 532)).toBe(1);
   });
 
   it("counts how many minimum-width panels fit, accounting for gaps", () => {
-    const mpw = pxForCols(READABLE_GRID_MIN_COLS);
+    const mpw = pxForCols(GRID_MIN_PANEL_COLS);
     expect(maxFeasibleCols(wCols(1), mpw)).toBe(1);
     expect(maxFeasibleCols(wCols(2), mpw)).toBe(2);
-    expect(maxFeasibleCols(wCols(3), mpw)).toBe(3);
+    expect(maxFeasibleCols(wCols(4), mpw)).toBe(4);
     expect(maxFeasibleCols(wCols(3) - 1, mpw)).toBe(2);
-    expect(maxFeasibleCols(wCols(2) - 1, mpw)).toBe(1);
   });
 });
 
-describe("getAutoGridCols — count-driven feel inside a readability envelope", () => {
-  describe("single / zero panels", () => {
-    it("returns 1 for 0 or 1 panel regardless of width", () => {
-      expect(getAutoGridCols(0, null)).toBe(1);
-      expect(getAutoGridCols(1, null)).toBe(1);
-      expect(getAutoGridCols(1, 5000)).toBe(1);
-      expect(getAutoGridCols(-3, 5000)).toBe(1);
-    });
+describe("getAutoGridCols — size-driven, fit-as-many-across", () => {
+  it("returns 1 for 0 or 1 panel, 2 for exactly 2 panels", () => {
+    expect(getAutoGridCols(0, 5000)).toBe(1);
+    expect(getAutoGridCols(1, 5000)).toBe(1);
+    expect(getAutoGridCols(2, 300)).toBe(2);
+    expect(getAutoGridCols(2, 5000)).toBe(2);
   });
 
-  describe("two panels", () => {
-    it("always reports 2 columns (the split layout handles narrow windows)", () => {
-      expect(getAutoGridCols(2, null)).toBe(2);
-      expect(getAutoGridCols(2, 300)).toBe(2);
-      expect(getAutoGridCols(2, 5000)).toBe(2);
-    });
+  it("scales the column count with available width", () => {
+    expect(getAutoGridCols(8, wCols(1))).toBe(1);
+    expect(getAutoGridCols(8, wCols(2))).toBe(2);
+    expect(getAutoGridCols(8, wCols(3))).toBe(3);
+    expect(getAutoGridCols(8, wCols(4))).toBe(4);
   });
 
-  describe("three panels — three-across only when readable", () => {
-    it("renders three columns once three readable panels fit", () => {
-      expect(getAutoGridCols(3, wCols(3))).toBe(3);
-      expect(getAutoGridCols(3, wCols(3) + 500)).toBe(3);
-    });
-
-    it("falls back to two columns when three do not fit", () => {
-      expect(getAutoGridCols(3, wCols(3) - 1)).toBe(2);
-      expect(getAutoGridCols(3, wCols(2))).toBe(2);
-    });
-
-    it("falls back to one column on a genuinely small container", () => {
-      expect(getAutoGridCols(3, wCols(2) - 1)).toBe(1);
-    });
+  it("gives a wide display 3-4 columns for a large fleet (not a 2-col rail)", () => {
+    // The core fix: many panels on a big screen spread across 3-4 columns
+    // instead of being pinned to 2.
+    expect(getAutoGridCols(12, wCols(3))).toBe(3);
+    expect(getAutoGridCols(12, wCols(4))).toBe(4);
+    expect(getAutoGridCols(20, 6000)).toBe(4);
   });
 
-  describe("four-plus panels — the two-column monitoring rail", () => {
-    it("settles at two columns and never sprawls wider, however wide the screen", () => {
-      expect(getAutoGridCols(4, wCols(2))).toBe(2);
-      expect(getAutoGridCols(4, wCols(3))).toBe(2);
-      expect(getAutoGridCols(4, wCols(4))).toBe(2);
-      expect(getAutoGridCols(8, 6000)).toBe(2);
-      expect(getAutoGridCols(20, 9999)).toBe(2);
-    });
-
-    it("drops to one column when two readable panels do not fit", () => {
-      expect(getAutoGridCols(6, wCols(2) - 1)).toBe(1);
-    });
-
-    it("never reports four columns from the automatic engine", () => {
-      // Direct regression guard for the 4-column sprawl (#8859 over-correction).
-      for (const count of [4, 5, 8, 12, 30]) {
-        expect(getAutoGridCols(count, 100000)).toBeLessThanOrEqual(2);
-      }
-    });
+  it("caps at the at-a-glance ceiling of 4 columns", () => {
+    expect(getAutoGridCols(30, 100000)).toBe(AUTO_GRID_MAX_COLS);
+    expect(AUTO_GRID_MAX_COLS).toBe(4);
   });
 
-  describe("first paint (width unknown)", () => {
-    it("lands on the predictable count-driven shape immediately", () => {
-      expect(getAutoGridCols(2, null)).toBe(2);
-      expect(getAutoGridCols(3, null)).toBe(3);
-      expect(getAutoGridCols(4, null)).toBe(2);
-      expect(getAutoGridCols(8, null)).toBe(2);
-    });
-
-    it("treats transient non-positive widths as unknown", () => {
-      expect(getAutoGridCols(3, 0)).toBe(3);
-      expect(getAutoGridCols(3, -100)).toBe(3);
-    });
+  it("never shows more columns than panels", () => {
+    expect(getAutoGridCols(3, 100000)).toBe(3);
+    expect(getAutoGridCols(2, 100000)).toBe(2);
   });
 
-  describe("compact density (opt-in)", () => {
-    it("widens a 4+ grid to three columns on a wide container", () => {
-      expect(getAutoGridCols(4, wColsCompact(3), undefined, { density: "compact" })).toBe(3);
-      expect(getAutoGridCols(8, wColsCompact(3), undefined, { density: "compact" })).toBe(3);
-    });
-
-    it("still falls back to two columns when three compact panels do not fit", () => {
-      expect(getAutoGridCols(4, wColsCompact(3) - 1, undefined, { density: "compact" })).toBe(2);
-    });
-
-    it("comfortable density keeps 4+ at two columns at the same width", () => {
-      expect(getAutoGridCols(4, wColsCompact(3))).toBe(2);
-    });
+  it("packs a 3-panel row across only when three panels fit", () => {
+    expect(getAutoGridCols(3, wCols(3))).toBe(3);
+    expect(getAutoGridCols(3, wCols(3) - 1)).toBe(2);
+    expect(getAutoGridCols(3, wCols(2) - 1)).toBe(1);
   });
 
-  describe("breakpoint hysteresis (width-driven Schmitt trigger)", () => {
+  it("first paint (unknown width) assumes the count-justified shape fits", () => {
+    expect(getAutoGridCols(2, null)).toBe(2);
+    expect(getAutoGridCols(3, null)).toBe(3);
+    expect(getAutoGridCols(12, null)).toBe(4);
+  });
+
+  it("compact density packs to a tighter floor", () => {
+    // A width that fits 2 comfortable columns fits 3 compact ones.
+    const width = pxForCols(ABSOLUTE_MIN_COLS) * 3 + GRID_GAP_PX * 2 + GRID_PADDING_PX;
+    expect(getAutoGridCols(8, width)).toBeLessThan(3);
+    expect(getAutoGridCols(8, width, undefined, { density: "compact" })).toBe(3);
+  });
+
+  describe("breakpoint hysteresis", () => {
     it("holds the wider column count through the narrow buffer", () => {
-      // At a width that freshly computes 2 columns, a sticky previous 3 holds.
-      const held = getAutoGridCols(3, wCols(3) - 1, 3);
-      const fresh = getAutoGridCols(3, wCols(3) - 1, undefined);
+      const fresh = getAutoGridCols(8, wCols(3) - 1, undefined);
+      const held = getAutoGridCols(8, wCols(3) - 1, 3);
       expect(fresh).toBe(2);
       expect(held).toBe(3);
     });
 
     it("narrows once the container drops well past the threshold", () => {
-      // Far below the 3-column threshold: hysteresis cannot hold 3.
-      expect(getAutoGridCols(3, wCols(2), 3)).toBe(2);
-    });
-
-    it("never widens past the natural target when previousCols is smaller", () => {
-      expect(getAutoGridCols(3, wCols(3), 1)).toBe(3);
-      expect(getAutoGridCols(4, wCols(4), 1)).toBe(2);
-    });
-
-    it("does not smooth a column drop caused by opening more panels", () => {
-      // Going from 3 panels (3 cols) to 4 panels must drop to 2 immediately —
-      // a close/open that lowers the column ceiling is never smoothed.
-      expect(getAutoGridCols(4, wCols(4), 3)).toBe(2);
-    });
-
-    it("may hold a readable wider count for one render when a panel opens at a boundary", () => {
-      // Opening the 3rd panel one pixel below the 2-column boundary: a fresh
-      // compute is 1, but the prior committed 2 columns are still ~readable
-      // (within the hysteresis buffer), so 2 is held for this render. The held
-      // count stays count-justified — it never leaves empty columns.
-      expect(getAutoGridCols(3, wCols(2) - 1, undefined)).toBe(1);
-      expect(getAutoGridCols(3, wCols(2) - 1, 2)).toBe(2);
+      expect(getAutoGridCols(8, wCols(2), 3)).toBe(2);
     });
 
     it("a narrowing viewport overrides a stale wide previousCols", () => {
-      // Far below even the two-column threshold: hysteresis cannot rescue a
-      // stale previous count of 3.
-      expect(getAutoGridCols(6, wCols(1), 3)).toBe(1);
+      expect(getAutoGridCols(8, wCols(1), 4)).toBe(1);
     });
+  });
+});
+
+describe("computeAutomaticGridCols — explicit options form", () => {
+  it("matches getAutoGridCols for the comfortable default", () => {
+    expect(computeAutomaticGridCols({ count: 12, width: wCols(4) })).toBe(4);
+  });
+
+  it("respects custom metrics — wider cells fit fewer columns", () => {
+    const wideCells: TerminalMetrics = { ...DEFAULT_TERMINAL_METRICS, cellWidth: 16 };
+    expect(
+      computeAutomaticGridCols({ count: 8, width: wCols(4), metrics: wideCells })
+    ).toBeLessThan(4);
   });
 });
 
 describe("applyHysteresis", () => {
-  it("passes the target through untouched without a previous count", () => {
-    expect(applyHysteresis(2, undefined, 1500, 700, 3)).toBe(2);
+  it("passes the target through without a previous count", () => {
+    expect(applyHysteresis(2, undefined, 1500, 532, 4)).toBe(2);
   });
 
   it("never lowers a count that already grew", () => {
-    expect(applyHysteresis(3, 2, 1500, 700, 3)).toBe(3);
+    expect(applyHysteresis(3, 2, 1500, 532, 4)).toBe(3);
   });
 
   it("caps a held count by the count-justified ceiling", () => {
-    // previous=3 but only 2 columns are count-justified now → cannot hold 3.
-    expect(applyHysteresis(2, 3, 100000, 700, 2)).toBe(2);
+    expect(applyHysteresis(2, 4, 100000, 532, 2)).toBe(2);
   });
 });
 
-describe("computeScrollRowHeight", () => {
-  it("targets the comfortable row height when container height is unknown", () => {
-    expect(computeScrollRowHeight(null)).toBe(pxForRows(TARGET_GRID_ROWS));
+describe("gridRowsOverflow — the only thing that triggers scroll mode", () => {
+  it("never overflows for a single row", () => {
+    expect(gridRowsOverflow(1, 100)).toBe(false);
+    expect(gridRowsOverflow(0, 100)).toBe(false);
   });
 
-  it("stays between the target and max row-height tiers", () => {
-    // The effective floor is the 32-row target — two-rows-plus-peek can only
-    // raise the height — and the ceiling is the 40-row max.
-    for (const h of [400, 900, 1500, 3000]) {
-      const rh = computeScrollRowHeight(h);
-      expect(rh).toBeGreaterThanOrEqual(pxForRows(TARGET_GRID_ROWS));
-      expect(rh).toBeLessThanOrEqual(pxForRows(MAX_SCROLL_ROWS));
+  it("does not overflow when unknown height", () => {
+    expect(gridRowsOverflow(8, null)).toBe(false);
+  });
+
+  it("overflows only once minimum-height rows exceed the viewport", () => {
+    const minRow = pxForRows(GRID_MIN_PANEL_ROWS);
+    const threeRows = 3 * minRow + 2 * GRID_GAP_PX + GRID_PADDING_PX;
+    expect(gridRowsOverflow(3, threeRows)).toBe(false);
+    expect(gridRowsOverflow(3, threeRows - 1)).toBe(true);
+  });
+
+  it("fits many rows on a tall display before scrolling", () => {
+    // A tall display packs several rows in — panel count alone never scrolls.
+    expect(gridRowsOverflow(4, 1600)).toBe(false);
+    expect(gridRowsOverflow(2, 700)).toBe(false);
+  });
+});
+
+describe("computeScrollRowHeight — packed, viewport-only", () => {
+  it("falls back to the minimum row height when height is unknown", () => {
+    expect(computeScrollRowHeight(null)).toBe(pxForRows(GRID_MIN_PANEL_ROWS));
+  });
+
+  it("never goes below the minimum row height", () => {
+    for (const h of [300, 700, 1200, 2400]) {
+      expect(computeScrollRowHeight(h)).toBeGreaterThanOrEqual(pxForRows(GRID_MIN_PANEL_ROWS));
     }
   });
 
-  it("caps at the max row height on very tall containers", () => {
-    expect(computeScrollRowHeight(4000)).toBe(pxForRows(MAX_SCROLL_ROWS));
+  it("stays packed — a scroll row is never more than twice the minimum", () => {
+    for (const h of [300, 700, 1200, 2400]) {
+      expect(computeScrollRowHeight(h)).toBeLessThanOrEqual(2 * pxForRows(GRID_MIN_PANEL_ROWS));
+    }
   });
 
-  it("grows the row height as the container gets taller (two rows + peek)", () => {
-    expect(computeScrollRowHeight(1700)).toBeGreaterThan(computeScrollRowHeight(900));
-  });
-});
-
-describe("computeAutomaticGridCols (explicit options form)", () => {
-  it("matches getAutoGridCols for the comfortable default", () => {
-    expect(computeAutomaticGridCols({ count: 3, width: wCols(3) })).toBe(3);
-    expect(computeAutomaticGridCols({ count: 4, width: wCols(4) })).toBe(2);
-  });
-
-  it("respects custom metrics — wider cells need more room for three across", () => {
-    const wideCells: TerminalMetrics = { ...DEFAULT_TERMINAL_METRICS, cellWidth: 14 };
-    const narrowCells: TerminalMetrics = { ...DEFAULT_TERMINAL_METRICS, cellWidth: 6 };
-    const width = wCols(3);
-    expect(computeAutomaticGridCols({ count: 3, width, metrics: narrowCells })).toBe(3);
-    expect(computeAutomaticGridCols({ count: 3, width, metrics: wideCells })).toBeLessThan(3);
+  it("divides the viewport across the rows it can hold", () => {
+    const minRow = pxForRows(GRID_MIN_PANEL_ROWS);
+    const height = 1200;
+    const rh = computeScrollRowHeight(height);
+    const visible = Math.floor((height - GRID_PADDING_PX + GRID_GAP_PX) / (minRow + GRID_GAP_PX));
+    expect(visible * rh + (visible - 1) * GRID_GAP_PX).toBeLessThanOrEqual(height);
   });
 });
 
@@ -298,88 +232,64 @@ describe("computeGridColumns — strategy dispatch", () => {
   it("keeps the 2-pane invariant across every strategy", () => {
     expect(computeGridColumns(2, null, "automatic")).toBe(2);
     expect(computeGridColumns(2, 300, "automatic")).toBe(2);
-    expect(computeGridColumns(2, wCols(3), "automatic")).toBe(2);
+    expect(computeGridColumns(2, wCols(4), "automatic")).toBe(2);
     expect(computeGridColumns(2, 300, "fixed-rows", 3)).toBe(2);
     expect(computeGridColumns(2, 300, "fixed-columns", 1)).toBe(2);
   });
 
-  it("uses the count-driven automatic engine for 3+ panels", () => {
-    expect(computeGridColumns(3, wCols(3), "automatic")).toBe(3);
-    expect(computeGridColumns(3, wCols(2), "automatic")).toBe(2);
-    expect(computeGridColumns(6, wCols(4), "automatic")).toBe(2);
+  it("uses the size-driven automatic engine for 3+ panels", () => {
+    expect(computeGridColumns(12, wCols(4), "automatic")).toBe(4);
+    expect(computeGridColumns(12, wCols(2), "automatic")).toBe(2);
   });
 
   it("honors the fixed-columns strategy", () => {
-    expect(computeGridColumns(4, wCols(4), "fixed-columns", 3)).toBe(3);
-    expect(computeGridColumns(4, wCols(4), "fixed-columns", 0)).toBe(1);
-    expect(computeGridColumns(4, wCols(4), "fixed-columns", 15)).toBe(10);
+    expect(computeGridColumns(8, wCols(4), "fixed-columns", 3)).toBe(3);
+    expect(computeGridColumns(8, wCols(4), "fixed-columns", 0)).toBe(1);
+    expect(computeGridColumns(8, wCols(4), "fixed-columns", 15)).toBe(10);
   });
 
   it("derives columns from the fixed-rows strategy", () => {
     expect(computeGridColumns(6, wCols(4), "fixed-rows", 2)).toBe(3);
     expect(computeGridColumns(6, wCols(4), "fixed-rows", 3)).toBe(2);
-    expect(computeGridColumns(5, wCols(4), "fixed-rows", 2)).toBe(3);
-    expect(computeGridColumns(4, wCols(4), "fixed-rows", 0)).toBe(4);
-    expect(computeGridColumns(4, wCols(4), "fixed-rows", 15)).toBe(1);
   });
 
   it("forwards previousCols into the automatic hysteresis path", () => {
-    expect(computeGridColumns(3, wCols(3) - 1, "automatic", undefined, 3)).toBe(3);
-    expect(computeGridColumns(3, wCols(3) - 1, "automatic", undefined, undefined)).toBe(2);
+    expect(computeGridColumns(8, wCols(3) - 1, "automatic", undefined, 3)).toBe(3);
+    expect(computeGridColumns(8, wCols(3) - 1, "automatic", undefined, undefined)).toBe(2);
   });
 });
 
-describe("getGridFitMetrics", () => {
+describe("getGridFitMetrics / getMaxGridCapacity", () => {
   it("returns null when dimensions are unknown", () => {
     expect(getGridFitMetrics(null, null)).toBeNull();
-    expect(getGridFitMetrics(1000, null)).toBeNull();
-    expect(getGridFitMetrics(null, 800)).toBeNull();
   });
 
   it("returns max cols, rows, and fit count for a known viewport", () => {
     const fit = getGridFitMetrics(1200, 700);
     expect(fit).not.toBeNull();
-    expect(fit!.maxCols).toBeGreaterThanOrEqual(3);
-    expect(fit!.maxRows).toBeGreaterThanOrEqual(3);
     expect(fit!.fitCount).toBe(fit!.maxCols * fit!.maxRows);
   });
 
   it("returns at least 1 col and 1 row at the smallest valid viewport", () => {
     const fit = getGridFitMetrics(MIN_TERMINAL_WIDTH_PX, MIN_TERMINAL_HEIGHT_PX);
-    expect(fit).not.toBeNull();
     expect(fit!.maxCols).toBe(1);
     expect(fit!.maxRows).toBe(1);
   });
-});
 
-describe("getMaxGridCapacity", () => {
-  it("returns the legacy fallback when dimensions are unknown", () => {
+  it("falls back to the legacy constant when dimensions are unknown", () => {
     expect(getMaxGridCapacity(null, null)).toBe(ABSOLUTE_MAX_GRID_TERMINALS);
-  });
-
-  it("reports the on-screen panel fit for a typical laptop viewport", () => {
-    const capacity = getMaxGridCapacity(1200, 700);
-    expect(capacity).toBeGreaterThanOrEqual(6);
-    expect(capacity).toBeLessThanOrEqual(9);
   });
 });
 
 describe("layout constants", () => {
-  it("orders the column-width tiers", () => {
-    expect(ABSOLUTE_MIN_COLS).toBeLessThan(COMPACT_GRID_MIN_COLS);
-    expect(COMPACT_GRID_MIN_COLS).toBeLessThan(READABLE_GRID_MIN_COLS);
-    expect(READABLE_GRID_MIN_COLS).toBeLessThan(AGENT_WIDE_COLS);
-    expect(AGENT_WIDE_COLS).toBeLessThan(MAX_USEFUL_COLS);
-  });
-
-  it("orders the row-height tiers", () => {
-    expect(READABLE_MIN_ROWS).toBeLessThan(TARGET_GRID_ROWS);
-    expect(TARGET_GRID_ROWS).toBeLessThan(MAX_SCROLL_ROWS);
+  it("keeps the panel minimums reasonably small", () => {
+    expect(GRID_MIN_PANEL_COLS).toBeLessThan(80);
+    expect(GRID_MIN_PANEL_COLS).toBeGreaterThanOrEqual(ABSOLUTE_MIN_COLS);
+    expect(GRID_MIN_PANEL_ROWS).toBeLessThan(24);
   });
 
   it("pins the at-a-glance ceiling and transition timing", () => {
     expect(AUTO_GRID_MAX_COLS).toBe(4);
     expect(GRID_TRANSITION_DURATION_MS).toBe(200);
-    expect(GRID_PADDING_PX).toBeGreaterThan(0);
   });
 });

--- a/src/lib/terminalLayout.ts
+++ b/src/lib/terminalLayout.ts
@@ -4,8 +4,14 @@ import type { PanelLayoutStrategy } from "@shared/types";
 type TerminalLayoutStrategy = PanelLayoutStrategy;
 
 /**
- * Minimum terminal width in pixels for readability.
- * Terminals narrower than this become difficult to read due to line wrapping.
+ * Absolute emergency minimum terminal width in pixels. A panel narrower than
+ * this is barely usable — agent TUIs wrap and fragment badly. The automatic
+ * grid never targets this width; it is only the lower bound for the two-pane
+ * split (an intentional focused mode the user can resize) and the CSS
+ * `minmax` floor that stops a column track collapsing entirely.
+ *
+ * The automatic grid targets a measured *readable* width instead — see
+ * `READABLE_GRID_MIN_COLS` / `pxForCols`.
  */
 export const MIN_TERMINAL_WIDTH_PX = 380;
 
@@ -16,53 +22,37 @@ export const MIN_TERMINAL_WIDTH_PX = 380;
 export const MIN_TERMINAL_HEIGHT_PX = 200;
 
 /**
- * Comfortable panel width — the size-driven denominator for the automatic
- * column count. Sized so the breakpoints land where real displays do (#8859):
- *   - 1→2 columns at 960px — keeps a 13" MacBook Air's grid (~1100-1200px
- *     usable after sidebars) at 2 columns instead of collapsing to 1.
- *   - 2→3 columns at 1440px — typical 1440p displays settle on 3 columns.
- *   - 3→4 columns at 1920px — wide monitors (1080p ultrawide, 4K, Pro Display
- *     XDR class) reach a 4th column, paired with the raised `AUTO_GRID_MAX_COLS`.
- * Per-panel readability is enforced separately by `MIN_TERMINAL_WIDTH_PX` via
- * the CSS grid `minmax` track — the comfortable width sets the column-count
- * breakpoint, not the rendered panel width.
- *
- * Tunable in one place against the app's actual terminal font size.
+ * @deprecated Superseded by the measured-readability model. The automatic
+ * column count is no longer `floor(width / COMFORTABLE_PANEL_WIDTH_PX)` — it is
+ * count-driven, gated by how many *measured* readable panels fit. Kept exported
+ * only so legacy importers compile; do not use in new code.
  */
 export const COMFORTABLE_PANEL_WIDTH_PX = 480;
 
 /**
- * Comfortable panel height — the `gridAutoRows` minimum. Enough for ~24-30
- * terminal rows plus the panel header. Rows stretch to fill spare vertical
- * room (`1fr`) but never shrink below this; once stacked rows exceed the
- * visible grid height, the container scrolls vertically (#8807).
+ * Comfortable panel height — the `gridAutoRows` minimum in non-scroll (quad)
+ * mode. Enough for ~24-30 terminal rows plus the panel header. In scroll mode
+ * rows are fixed-height (see `computeScrollRowHeight`) so a panel close never
+ * resizes every sibling.
  */
 export const COMFORTABLE_PANEL_HEIGHT_PX = 520;
 
 /**
  * Hard upper bound on automatic columns. Subitizing and multiple-object
- * tracking both land at ~4 items, control-room standards (EEMUA 201, ISO
- * 11064-5) cap an operator at a 2x2 quad, so 4 is the at-a-glance ceiling.
- * Bands: 1 col under 960px, 2 cols at 960-1439px, 3 cols at 1440-1919px,
- * 4 cols at 1920px+. Beyond what a 4-wide row fits at comfortable size, add
- * rows and scroll — don't widen. The explicit `fixed-columns` strategy is the
- * escape hatch for 5+.
+ * tracking both land at ~4 items; the automatic grid never exceeds it. The
+ * count-driven model in practice tops out at 3 (exactly 3 panels) and settles
+ * at 2 for 4+ — see `desiredAutoCols`. The explicit `fixed-columns` strategy is
+ * the escape hatch for a denser overview.
  */
 export const AUTO_GRID_MAX_COLS = 4;
 
 /**
  * Breakpoint hysteresis buffer. Once the grid widens to N columns it holds N
- * until the container narrows this far past the N-column threshold, so dragging
- * the window across a boundary doesn't thrash the layout (Schmitt trigger).
+ * until the container narrows this far past the N-column width requirement, so
+ * dragging the window across a boundary doesn't thrash the layout (Schmitt
+ * trigger). Applied to *measured* panel width, not a fixed pixel band.
  */
 export const GRID_HYSTERESIS_BUFFER_PX = 80;
-
-/**
- * Grid width assumed on the first paint, before the ResizeObserver reports a
- * real measurement. Sits in the 3-column band (floor(1680/480)=3) so the common
- * 1440p case doesn't flash from a lower count to 3 columns on mount.
- */
-const FALLBACK_GRID_WIDTH_PX = 1680;
 
 /**
  * Hard upper limit retained for legacy callers that fall back to it when grid
@@ -84,6 +74,227 @@ export const GRID_TRANSITION_DURATION_MS = 200;
  */
 export const SIDEBAR_TRANSITION_MS = 250;
 export const SIDEBAR_TOGGLE_LOCK_MS = SIDEBAR_TRANSITION_MS;
+
+// ---------------------------------------------------------------------------
+// Measured-readability model
+//
+// A terminal panel is a text grid with chrome around it, not a card. Panel
+// sizing is therefore derived from terminal character-cell geometry, not
+// arbitrary pixel constants. The column count comes from a predictable,
+// count-driven progression — but the grid refuses to make agent terminals
+// unreadable to satisfy that progression. "Count-driven feel inside a measured
+// readability envelope."
+// ---------------------------------------------------------------------------
+
+/** Column-width tiers, in terminal character columns. */
+export const ABSOLUTE_MIN_COLS = 50; // emergency lower bound (two-pane split)
+export const READABLE_GRID_MIN_COLS = 80; // default automatic-grid lower bound
+export const COMPACT_GRID_MIN_COLS = 64; // automatic-grid lower bound, compact density
+export const AGENT_WIDE_COLS = 120; // desirable when space allows
+export const MAX_USEFUL_COLS = 160; // beyond this, lines are too long to scan
+
+/** Row-height tiers, in terminal text rows. */
+export const READABLE_MIN_ROWS = 24;
+export const TARGET_GRID_ROWS = 32;
+export const MAX_SCROLL_ROWS = 40;
+
+/** Grid chrome geometry (pixels). */
+export const GRID_GAP_PX = 4;
+export const GRID_PADDING_PX = 8;
+export const GRID_SCROLLBAR_PX = 14;
+export const GRID_PEEK_PX = 96;
+
+/**
+ * Measured geometry of a single terminal panel, sourced from the live xterm
+ * instance where possible (see the cell-metrics plumbing) and falling back to
+ * `DEFAULT_TERMINAL_METRICS` before a measurement lands.
+ */
+export interface TerminalMetrics {
+  /** Width of one monospace character cell, px. */
+  cellWidth: number;
+  /** Height of one text row, px. */
+  cellHeight: number;
+  /** Panel header bar height, px. */
+  headerHeight: number;
+  /** Total horizontal panel padding (both sides), px. */
+  paddingX: number;
+  /** Total vertical panel padding (top + bottom), px. */
+  paddingY: number;
+  /** Width allowance for the terminal's own (inner) scrollbar, px. */
+  scrollbarWidth: number;
+  /** Total horizontal border allowance, px. */
+  borderX: number;
+  /** Total vertical border allowance, px. */
+  borderY: number;
+}
+
+/**
+ * Conservative defaults for a ~14px monospace terminal font, used until a real
+ * xterm measurement is threaded in. Slightly generous so the grid does not
+ * promise more columns than the rendered panels can actually display readably.
+ */
+export const DEFAULT_TERMINAL_METRICS: TerminalMetrics = {
+  cellWidth: 8.4,
+  cellHeight: 18,
+  headerHeight: 34,
+  paddingX: 16,
+  paddingY: 8,
+  scrollbarWidth: 10,
+  borderX: 2,
+  borderY: 2,
+};
+
+/** Automatic-grid density. `comfortable` is the default; `compact` is opt-in. */
+export type GridDensity = "comfortable" | "compact";
+
+/** Pixel width a panel needs to render `cols` readable character columns. */
+export function pxForCols(
+  cols: number,
+  metrics: TerminalMetrics = DEFAULT_TERMINAL_METRICS
+): number {
+  return Math.ceil(
+    cols * metrics.cellWidth + metrics.paddingX + metrics.scrollbarWidth + metrics.borderX
+  );
+}
+
+/** Pixel height a panel needs to render `rows` text rows plus its header. */
+export function pxForRows(
+  rows: number,
+  metrics: TerminalMetrics = DEFAULT_TERMINAL_METRICS
+): number {
+  return Math.ceil(
+    rows * metrics.cellHeight + metrics.headerHeight + metrics.paddingY + metrics.borderY
+  );
+}
+
+/**
+ * Greatest number of columns that fit `width`, given a per-panel minimum
+ * width, accounting for grid padding and inter-panel gaps. Always >= 1.
+ */
+export function maxFeasibleCols(width: number, minPanelWidth: number): number {
+  if (!(width > 0) || !(minPanelWidth > 0)) return 1;
+  const effective = width - GRID_PADDING_PX;
+  return Math.max(1, Math.floor((effective + GRID_GAP_PX) / (minPanelWidth + GRID_GAP_PX)));
+}
+
+/**
+ * Count-driven desired column count — the predictable progression the user
+ * feels when opening panels, *before* the readability gate is applied:
+ *   1 → 1, 2 → 2, 3 → 3, 4+ → 2 (the two-column monitoring rail).
+ * Four-plus deliberately settles at two columns rather than chasing width;
+ * `fixed-columns` is the manual escape hatch for a denser overview.
+ */
+export function desiredAutoCols(count: number): number {
+  if (count <= 1) return 1;
+  if (count === 2) return 2;
+  if (count === 3) return 3;
+  return 2;
+}
+
+/**
+ * Breakpoint hysteresis (Schmitt trigger). `target` is the freshly computed
+ * width-feasible column count; `previous` is the last committed count.
+ *
+ * Only *width* changes are smoothed — hold the wider previous count until the
+ * container narrows `GRID_HYSTERESIS_BUFFER_PX` past what that count needs.
+ * Count changes (opening/closing panels) are never smoothed: `countCeiling`
+ * caps the held value so closing a panel drops columns immediately and the
+ * count-driven progression stays predictable.
+ */
+export function applyHysteresis(
+  target: number,
+  previous: number | undefined,
+  width: number | null,
+  minPanelWidth: number,
+  countCeiling: number
+): number {
+  if (!width || width <= 0 || previous === undefined) return target;
+  if (previous <= target) return target;
+  // Holding a wider count is only valid if the current panel count still
+  // justifies it — otherwise a close would leave empty columns.
+  const held = Math.min(previous, countCeiling);
+  if (held <= target) return target;
+  const downgradeThreshold =
+    held * minPanelWidth + (held - 1) * GRID_GAP_PX - GRID_HYSTERESIS_BUFFER_PX;
+  return width >= downgradeThreshold ? held : target;
+}
+
+/**
+ * The automatic grid's column count: a count-driven progression gated by how
+ * many *measured readable* panels actually fit the container width.
+ *
+ * - `comfortable` density gates on 80-column panels; `compact` on 64-column.
+ * - Three panels render three-across only when three readable panels fit,
+ *   otherwise fall back to 2 (or 1 on a genuinely tiny container).
+ * - Four-plus panels settle at two columns; `compact` may use three on a
+ *   genuinely wide container as a deliberate density choice.
+ * - `previousCols` enables width hysteresis (see `applyHysteresis`).
+ *
+ * `width === null` (first paint) assumes the count-driven ideal fits, so the
+ * grid lands on its predictable shape immediately and only narrows once a real
+ * measurement proves a column would be unreadable.
+ */
+export function computeAutomaticGridCols({
+  count,
+  width,
+  previousCols,
+  metrics = DEFAULT_TERMINAL_METRICS,
+  density = "comfortable",
+}: {
+  count: number;
+  width: number | null;
+  previousCols?: number;
+  metrics?: TerminalMetrics;
+  density?: GridDensity;
+}): number {
+  if (count <= 1) return 1;
+  if (count === 2) return 2;
+
+  const readableCols = density === "compact" ? COMPACT_GRID_MIN_COLS : READABLE_GRID_MIN_COLS;
+  const minPanelWidth = pxForCols(readableCols, metrics);
+
+  // Count/density-justified ceiling — the most columns this panel count may
+  // use before the width gate. Comfortable density follows the pure
+  // count-driven progression (`desiredAutoCols`); compact density (opt-in)
+  // lets a 4+ grid reach three columns on a wide enough container.
+  let maxCols = Math.min(count, desiredAutoCols(count));
+  if (count >= 4 && density === "compact") maxCols = 3;
+
+  // Width gate: how many readable panels actually fit. First paint (no
+  // measurement yet) assumes the count-driven ideal fits, so the grid lands
+  // on its predictable shape immediately and only narrows once measured.
+  const feasible = width && width > 0 ? maxFeasibleCols(width, minPanelWidth) : maxCols;
+
+  const target = Math.min(maxCols, feasible);
+  return applyHysteresis(target, previousCols, width, minPanelWidth, maxCols);
+}
+
+/**
+ * Fixed row height (px) for scroll mode. Aims for two readable rows plus a
+ * peek of the next, clamped between a 24-row floor and a 40-row ceiling so the
+ * grid keeps a consistent vertical rhythm and the peek signals "more below".
+ */
+export function computeScrollRowHeight(
+  containerHeight: number | null,
+  metrics: TerminalMetrics = DEFAULT_TERMINAL_METRICS
+): number {
+  const min = pxForRows(READABLE_MIN_ROWS, metrics);
+  const target = pxForRows(TARGET_GRID_ROWS, metrics);
+  const max = pxForRows(MAX_SCROLL_ROWS, metrics);
+  const twoRowsPlusPeek =
+    containerHeight && containerHeight > 0
+      ? Math.floor((containerHeight - GRID_PEEK_PX - GRID_GAP_PX) / 2)
+      : target;
+  const desired = Math.max(target, twoRowsPlusPeek);
+  return Math.min(max, Math.max(min, desired));
+}
+
+/** Layout mode for a given panel count: 1 → single, 2 → split, 3+ → grid. */
+export function getPanelLayoutMode(count: number): "single" | "split" | "grid" {
+  if (count <= 1) return "single";
+  if (count === 2) return "split";
+  return "grid";
+}
 
 export interface GridFitMetrics {
   /** Max columns that fit at MIN_TERMINAL_WIDTH_PX, given the container width. */
@@ -108,9 +319,8 @@ export function getGridFitMetrics(
 ): GridFitMetrics | null {
   if (!width || !height) return null;
 
-  // Account for grid gap (4px between terminals) and padding (8px total)
-  const gap = 4;
-  const padding = 8;
+  const gap = GRID_GAP_PX;
+  const padding = GRID_PADDING_PX;
   const effectiveWidth = width - padding;
   const effectiveHeight = height - padding;
 
@@ -123,10 +333,6 @@ export function getGridFitMetrics(
  * Number of panels that fit in the on-screen grid at the readability floors,
  * before the grid scrolls vertically. Falls back to ABSOLUTE_MAX_GRID_TERMINALS
  * when dimensions are not yet known.
- *
- * Historically used as a hard panel cap; now strictly a fit hint for layout
- * calculations and the scroll-pre-warm margin. Panel creation gates on
- * `panelLimitStore.hardLimit` instead.
  */
 export function getMaxGridCapacity(width: number | null, height: number | null): number {
   const fit = getGridFitMetrics(width, height);
@@ -134,71 +340,33 @@ export function getMaxGridCapacity(width: number | null, height: number | null):
   return fit.fitCount;
 }
 
-/** Clamp a raw column count into the automatic layout's [1, AUTO_GRID_MAX_COLS] range. */
-function clampAutoCols(cols: number): number {
-  return Math.min(AUTO_GRID_MAX_COLS, Math.max(1, cols));
-}
-
 /**
- * Pure function to calculate optimal grid columns for automatic layout.
- *
- * Size-driven, not count-driven: the column count comes from how many
- * comfortably-sized panels fit the available container width, hard-capped at
- * `AUTO_GRID_MAX_COLS`. Panel count never adds a column — only width does.
- * Once panels exceed what fits at comfortable size, the grid scrolls
- * vertically (handled by `gridAutoRows` + the scroll container).
- *
- *   columns = clamp(1, floor(containerWidth / COMFORTABLE_PANEL_WIDTH_PX), 4)
- *
- * Design principles:
- * - Spatial permanence: column count tracks the container width, not the fleet
- *   size — hiding the sidebar/assistant widens the grid and adds a column for
- *   free, while opening more panels just adds scrollable rows.
- * - Comfortable panels: each column targets `COMFORTABLE_PANEL_WIDTH_PX`, not a
- *   minimum-readable floor. Favor fewer, larger panels over more, smaller ones.
- * - Predictable: same inputs always produce same outputs.
- *
- * Breakpoint hysteresis: when `previousCols` is supplied (the column count from
- * the prior render), the function holds the wider count until the container
- * narrows `GRID_HYSTERESIS_BUFFER_PX` past the N-column threshold, so dragging
- * the window across a boundary doesn't thrash the layout. Calling without
- * `previousCols` is pure width-driven with no stickiness.
+ * Automatic-layout column count. Thin back-compat wrapper over
+ * `computeAutomaticGridCols` — keeps the historical `(count, width,
+ * previousCols)` signature for existing callers while the count-driven
+ * readability model does the real work. Pass `opts` to thread measured
+ * terminal metrics or a compact density.
  */
 export function getAutoGridCols(
   count: number,
   width: number | null,
-  previousCols?: number
+  previousCols?: number,
+  opts?: { metrics?: TerminalMetrics; density?: GridDensity }
 ): number {
   if (count <= 1) return 1;
-
-  // Non-positive transient widths during layout transitions fall back to a
-  // first-paint default in the 3-column band.
-  const containerWidth = width && width > 0 ? width : FALLBACK_GRID_WIDTH_PX;
-
-  // Size-driven target: how many comfortable panels fit, capped at the
-  // at-a-glance ceiling.
-  let targetCols = clampAutoCols(Math.floor(containerWidth / COMFORTABLE_PANEL_WIDTH_PX));
-
-  // Hysteresis: once widened to N columns, hold N until the container narrows a
-  // buffer past the N-column threshold (N * COMFORTABLE_PANEL_WIDTH_PX). Walk
-  // highest → lowest so a sticky wider count isn't relaxed prematurely by a
-  // lower-band check; the first band that still has room wins.
-  if (previousCols !== undefined) {
-    for (let cols = clampAutoCols(previousCols); cols > targetCols; cols--) {
-      if (containerWidth >= cols * COMFORTABLE_PANEL_WIDTH_PX - GRID_HYSTERESIS_BUFFER_PX) {
-        targetCols = cols;
-        break;
-      }
-    }
-  }
-
-  // Never show more columns than panels (no empty columns).
-  return Math.min(targetCols, count);
+  return computeAutomaticGridCols({
+    count,
+    width,
+    previousCols,
+    metrics: opts?.metrics,
+    density: opts?.density,
+  });
 }
 
 /**
- * Single source of truth for grid column calculation across all layout strategies.
- * Enforces the 2-pane invariant: exactly 2 panes should ALWAYS be 2x1 layout.
+ * Single source of truth for grid column calculation across all layout
+ * strategies. Enforces the 2-pane invariant (exactly 2 panes → 2 columns when
+ * they fit side by side).
  *
  * Called only by `useContentGridContext.tsx` (rendering). `useGridNavigation`
  * reads the computed result through `gridLayoutSnapshot` rather than running
@@ -211,32 +379,31 @@ export function computeGridColumns(
   gridWidth: number | null,
   strategy: TerminalLayoutStrategy,
   value?: number,
-  previousCols?: number
+  previousCols?: number,
+  opts?: { metrics?: TerminalMetrics; density?: GridDensity }
 ): number {
   if (count === 0) return 1;
 
-  // 2-pane invariant: prefer a 2x1 layout for exactly 2 panes, avoiding the
-  // undesirable 1x2 (vertical stacking) layout. The explicit fixed strategies
-  // keep this unconditionally (unchanged — they're a user opt-in). The
-  // automatic strategy gates it on width: force 2 columns only when the
-  // container can fit two readable panes side by side (≥ MIN_TERMINAL_WIDTH_PX
-  // each). On a narrower window it falls through to the size-driven formula,
-  // which stacks them into 1 column. `gridWidth === null` (first paint) keeps
-  // the 2-column preference, as do transient non-positive measurements during
-  // layout transitions.
-  if (
-    count === 2 &&
-    (strategy !== "automatic" ||
+  // 2-pane invariant: a 2x1 layout for exactly 2 panes, never a 1x2 stack,
+  // whenever the container can fit two absolute-minimum panes side by side.
+  // (N=2 normally renders the dedicated split layout rather than the grid;
+  // this keeps the grid path correct for the maximize/placeholder edge cases
+  // that still route here.)
+  if (count === 2) {
+    const minTwoPaneWidth = pxForCols(ABSOLUTE_MIN_COLS, opts?.metrics) * 2 + GRID_GAP_PX;
+    if (
+      strategy !== "automatic" ||
       gridWidth === null ||
       gridWidth <= 0 ||
-      gridWidth >= MIN_TERMINAL_WIDTH_PX * 2)
-  ) {
-    return 2;
+      gridWidth >= minTwoPaneWidth
+    ) {
+      return 2;
+    }
   }
 
   switch (strategy) {
     case "automatic":
-      return getAutoGridCols(count, gridWidth, previousCols);
+      return getAutoGridCols(count, gridWidth, previousCols, opts);
     case "fixed-rows": {
       const rows = Math.max(1, Math.min(value ?? 3, 10));
       return Math.ceil(count / rows);
@@ -244,6 +411,6 @@ export function computeGridColumns(
     case "fixed-columns":
       return Math.max(1, Math.min(value ?? 2, 10));
     default:
-      return getAutoGridCols(count, gridWidth, previousCols);
+      return getAutoGridCols(count, gridWidth, previousCols, opts);
   }
 }

--- a/src/lib/terminalLayout.ts
+++ b/src/lib/terminalLayout.ts
@@ -39,10 +39,9 @@ export const COMFORTABLE_PANEL_HEIGHT_PX = 520;
 
 /**
  * Hard upper bound on automatic columns. Subitizing and multiple-object
- * tracking both land at ~4 items; the automatic grid never exceeds it. The
- * count-driven model in practice tops out at 3 (exactly 3 panels) and settles
- * at 2 for 4+ — see `desiredAutoCols`. The explicit `fixed-columns` strategy is
- * the escape hatch for a denser overview.
+ * tracking both land at ~4 items; the size-driven grid never exceeds it, so a
+ * very wide display tops out at a 4-column scan surface rather than sprawling
+ * further. The explicit `fixed-columns` strategy is the escape hatch for more.
  */
 export const AUTO_GRID_MAX_COLS = 4;
 
@@ -178,18 +177,17 @@ export function maxFeasibleCols(width: number, minPanelWidth: number): number {
 }
 
 /**
- * Count-driven desired column count — the predictable progression the user
- * feels when opening panels, *before* the readability gate is applied:
- *   1 → 1, 2 → 2, 3 → 3, 4+ → 2 (the two-column monitoring rail).
- * Four-plus deliberately settles at two columns rather than chasing width;
- * `fixed-columns` is the manual escape hatch for a denser overview.
+ * The automatic grid packs panels toward a *reasonably small* minimum so it
+ * fits as many as possible on screen before it ever scrolls. These are the
+ * floors panels shrink down to — not a comfortable target.
+ *   - 60 columns: a terminal stays monitorable well below the 80-column
+ *     "comfortable" width. 60 keeps agent output legible while letting a wide
+ *     display carry 3-4 columns.
+ *   - 16 rows: enough to watch an agent's recent activity. Small on purpose so
+ *     a tall display packs several rows in before the grid has to scroll.
  */
-export function desiredAutoCols(count: number): number {
-  if (count <= 1) return 1;
-  if (count === 2) return 2;
-  if (count === 3) return 3;
-  return 2;
-}
+export const GRID_MIN_PANEL_COLS = 60;
+export const GRID_MIN_PANEL_ROWS = 16;
 
 /**
  * Breakpoint hysteresis (Schmitt trigger). `target` is the freshly computed
@@ -226,19 +224,17 @@ export function applyHysteresis(
 }
 
 /**
- * The automatic grid's column count: a count-driven progression gated by how
- * many *measured readable* panels actually fit the container width.
+ * The automatic grid's column count. Size-driven: as many columns as fit the
+ * container at the small `GRID_MIN_PANEL_COLS` floor, capped at
+ * `AUTO_GRID_MAX_COLS` and never more than the panel count.
  *
- * - `comfortable` density gates on 80-column panels; `compact` on 64-column.
- * - Three panels render three-across only when three readable panels fit,
- *   otherwise fall back to 2 (or 1 on a genuinely tiny container).
- * - Four-plus panels settle at two columns; `compact` may use three on a
- *   genuinely wide container as a deliberate density choice.
- * - `previousCols` enables width hysteresis (see `applyHysteresis`).
+ * A wide display therefore carries 3-4 columns; a typical laptop 1-2. Panels
+ * stretch to fill the column track when there is room and shrink toward the
+ * floor as more open — the grid fits as much as it can across before it has
+ * to add scrolling rows.
  *
- * `width === null` (first paint) assumes the count-driven ideal fits, so the
- * grid lands on its predictable shape immediately and only narrows once a real
- * measurement proves a column would be unreadable.
+ * `previousCols` enables width hysteresis (see `applyHysteresis`).
+ * `width === null` (first paint) assumes the count-justified shape fits.
  */
 export function computeAutomaticGridCols({
   count,
@@ -256,43 +252,56 @@ export function computeAutomaticGridCols({
   if (count <= 1) return 1;
   if (count === 2) return 2;
 
-  const readableCols = density === "compact" ? COMPACT_GRID_MIN_COLS : READABLE_GRID_MIN_COLS;
-  const minPanelWidth = pxForCols(readableCols, metrics);
+  // Compact density packs to a tighter floor; comfortable uses the standard one.
+  const minCols = density === "compact" ? ABSOLUTE_MIN_COLS : GRID_MIN_PANEL_COLS;
+  const minPanelWidth = pxForCols(minCols, metrics);
 
-  // Count/density-justified ceiling — the most columns this panel count may
-  // use before the width gate. Comfortable density follows the pure
-  // count-driven progression (`desiredAutoCols`); compact density (opt-in)
-  // lets a 4+ grid reach three columns on a wide enough container.
-  let maxCols = Math.min(count, desiredAutoCols(count));
-  if (count >= 4 && density === "compact") maxCols = 3;
+  // No empty columns, and never past the at-a-glance ceiling.
+  const countCeiling = Math.min(count, AUTO_GRID_MAX_COLS);
 
-  // Width gate: how many readable panels actually fit. First paint (no
-  // measurement yet) assumes the count-driven ideal fits, so the grid lands
-  // on its predictable shape immediately and only narrows once measured.
-  const feasible = width && width > 0 ? maxFeasibleCols(width, minPanelWidth) : maxCols;
+  // Width gate: how many minimum-width panels fit across. First paint (no
+  // measurement yet) assumes the count-justified shape fits.
+  const feasible = width && width > 0 ? maxFeasibleCols(width, minPanelWidth) : countCeiling;
 
-  const target = Math.min(maxCols, feasible);
-  return applyHysteresis(target, previousCols, width, minPanelWidth, maxCols);
+  const target = Math.min(countCeiling, feasible);
+  return applyHysteresis(target, previousCols, width, minPanelWidth, countCeiling);
 }
 
 /**
- * Fixed row height (px) for scroll mode. Aims for two readable rows plus a
- * peek of the next, clamped between a 24-row floor and a 40-row ceiling so the
- * grid keeps a consistent vertical rhythm and the peek signals "more below".
+ * Whether `rows` rows of panels overflow the visible grid height even at the
+ * `GRID_MIN_PANEL_ROWS` floor. Until they do, the grid fits everything on
+ * screen (rows stretch to fill); once they do, it scrolls. This is the only
+ * thing that puts the grid into scroll mode — panel count never does.
+ */
+export function gridRowsOverflow(
+  rows: number,
+  containerHeight: number | null,
+  metrics: TerminalMetrics = DEFAULT_TERMINAL_METRICS
+): boolean {
+  if (rows <= 1) return false;
+  if (!containerHeight || containerHeight <= 0) return false;
+  const minRow = pxForRows(GRID_MIN_PANEL_ROWS, metrics);
+  const needed = rows * minRow + (rows - 1) * GRID_GAP_PX + GRID_PADDING_PX;
+  return needed > containerHeight;
+}
+
+/**
+ * Row height (px) for scroll mode. The grid only scrolls once even
+ * minimum-height rows overflow the viewport, so scroll rows sit at — or just
+ * above — the `GRID_MIN_PANEL_ROWS` floor: the rows that fit are divided
+ * evenly so they fill the viewport with no wasted strip. The height depends
+ * only on the viewport, never the panel count, so closing a panel in scroll
+ * mode never resizes the survivors.
  */
 export function computeScrollRowHeight(
   containerHeight: number | null,
   metrics: TerminalMetrics = DEFAULT_TERMINAL_METRICS
 ): number {
-  const min = pxForRows(READABLE_MIN_ROWS, metrics);
-  const target = pxForRows(TARGET_GRID_ROWS, metrics);
-  const max = pxForRows(MAX_SCROLL_ROWS, metrics);
-  const twoRowsPlusPeek =
-    containerHeight && containerHeight > 0
-      ? Math.floor((containerHeight - GRID_PEEK_PX - GRID_GAP_PX) / 2)
-      : target;
-  const desired = Math.max(target, twoRowsPlusPeek);
-  return Math.min(max, Math.max(min, desired));
+  const minRow = pxForRows(GRID_MIN_PANEL_ROWS, metrics);
+  if (!containerHeight || containerHeight <= 0) return minRow;
+  const usable = containerHeight - GRID_PADDING_PX;
+  const visibleRows = Math.max(1, Math.floor((usable + GRID_GAP_PX) / (minRow + GRID_GAP_PX)));
+  return Math.max(minRow, Math.floor((usable - (visibleRows - 1) * GRID_GAP_PX) / visibleRows));
 }
 
 /** Layout mode for a given panel count: 1 → single, 2 → split, 3+ → grid. */

--- a/src/lib/terminalLayout.ts
+++ b/src/lib/terminalLayout.ts
@@ -195,11 +195,13 @@ export function desiredAutoCols(count: number): number {
  * Breakpoint hysteresis (Schmitt trigger). `target` is the freshly computed
  * width-feasible column count; `previous` is the last committed count.
  *
- * Only *width* changes are smoothed — hold the wider previous count until the
- * container narrows `GRID_HYSTERESIS_BUFFER_PX` past what that count needs.
- * Count changes (opening/closing panels) are never smoothed: `countCeiling`
- * caps the held value so closing a panel drops columns immediately and the
- * count-driven progression stays predictable.
+ * Smooths width-driven thrash near a column breakpoint: the wider previous
+ * count is held until the container narrows `GRID_HYSTERESIS_BUFFER_PX` past
+ * that count's feasibility boundary. The held count is always capped by
+ * `countCeiling` — the current panel count's column ceiling — so it can never
+ * leave empty columns or outlive a panel close that lowers the ceiling. A
+ * panel *open* right at a width boundary may hold one extra column for a
+ * render; that stays within the readability buffer and is intentional.
  */
 export function applyHysteresis(
   target: number,
@@ -214,8 +216,12 @@ export function applyHysteresis(
   // justifies it — otherwise a close would leave empty columns.
   const held = Math.min(previous, countCeiling);
   if (held <= target) return target;
+  // Mirror `maxFeasibleCols`' nth-column boundary exactly — n panels plus
+  // (n-1) gaps plus the grid padding — then hold `held` until the container
+  // narrows the full buffer past it. Omitting the padding term silently
+  // widened the effective buffer by `GRID_PADDING_PX`.
   const downgradeThreshold =
-    held * minPanelWidth + (held - 1) * GRID_GAP_PX - GRID_HYSTERESIS_BUFFER_PX;
+    held * minPanelWidth + (held - 1) * GRID_GAP_PX + GRID_PADDING_PX - GRID_HYSTERESIS_BUFFER_PX;
   return width >= downgradeThreshold ? held : target;
 }
 

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -5,7 +5,6 @@ import { terminalInstanceService } from "@/services/terminal/TerminalInstanceSer
 import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
 import { fireWatchNotification } from "@/lib/watchNotification";
 import { usePanelStore } from "@/store/panelStore";
-import { logError } from "@/utils/logger";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import {
   useTerminalPendingDestructiveActionStore,
@@ -74,23 +73,7 @@ export function registerTerminalLifecycleActions(
       const state = usePanelStore.getState();
       const targetId = terminalId ?? state.focusedId;
       if (targetId) {
-        const terminal = state.panelsById[targetId];
-        if (terminal) {
-          if (terminal.location === "dock") {
-            state.trashPanel(targetId);
-          } else {
-            requestPanelClose({
-              hideIds: [targetId],
-              commit: () => {
-                try {
-                  usePanelStore.getState().trashPanel(targetId);
-                } catch (error) {
-                  logError("Failed to trash terminal via terminal.trash", error);
-                }
-              },
-            });
-          }
-        }
+        state.trashPanel(targetId);
       }
     },
   }));
@@ -460,45 +443,7 @@ export function registerTerminalLifecycleActions(
           (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
         );
       });
-
-      const gridIds: string[] = [];
-      const dockIds: string[] = [];
-      for (const id of idsToClose) {
-        const t = state.panelsById[id];
-        if (t) {
-          if (t.location === "dock") {
-            dockIds.push(id);
-          } else {
-            gridIds.push(id);
-          }
-        }
-      }
-
-      // Process dock immediately
-      dockIds.forEach((id) => {
-        try {
-          state.trashPanel(id);
-        } catch (error) {
-          logError("Failed to trash dock terminal via terminal.closeAll", error);
-        }
-      });
-
-      // Process grid panels via optimistic close
-      if (gridIds.length > 0) {
-        requestPanelClose({
-          hideIds: gridIds,
-          commit: () => {
-            const trashPanel = usePanelStore.getState().trashPanel;
-            gridIds.forEach((id) => {
-              try {
-                trashPanel(id);
-              } catch (error) {
-                logError("Failed to trash grid terminal via terminal.closeAll", error);
-              }
-            });
-          },
-        });
-      }
+      idsToClose.forEach((id) => state.trashPanel(id));
     },
   }));
 

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -73,7 +73,15 @@ export function registerTerminalLifecycleActions(
       const state = usePanelStore.getState();
       const targetId = terminalId ?? state.focusedId;
       if (targetId) {
-        state.trashPanel(targetId);
+        const target = state.panelsById[targetId];
+        if (target?.location === "grid" || target?.location === undefined) {
+          requestPanelClose({
+            hideIds: [targetId],
+            commit: () => usePanelStore.getState().trashPanel(targetId),
+          });
+        } else {
+          state.trashPanel(targetId);
+        }
       }
     },
   }));
@@ -443,7 +451,14 @@ export function registerTerminalLifecycleActions(
           (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
         );
       });
-      idsToClose.forEach((id) => state.trashPanel(id));
+      if (idsToClose.length === 0) return;
+      requestPanelClose({
+        hideIds: idsToClose,
+        commit: () => {
+          const latest = usePanelStore.getState();
+          idsToClose.forEach((id) => latest.trashPanel(id));
+        },
+      });
     },
   }));
 

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -5,6 +5,7 @@ import { terminalInstanceService } from "@/services/terminal/TerminalInstanceSer
 import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
 import { fireWatchNotification } from "@/lib/watchNotification";
 import { usePanelStore } from "@/store/panelStore";
+import { logError } from "@/utils/logger";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import {
   useTerminalPendingDestructiveActionStore,
@@ -73,7 +74,23 @@ export function registerTerminalLifecycleActions(
       const state = usePanelStore.getState();
       const targetId = terminalId ?? state.focusedId;
       if (targetId) {
-        state.trashPanel(targetId);
+        const terminal = state.panelsById[targetId];
+        if (terminal) {
+          if (terminal.location === "dock") {
+            state.trashPanel(targetId);
+          } else {
+            requestPanelClose({
+              hideIds: [targetId],
+              commit: () => {
+                try {
+                  usePanelStore.getState().trashPanel(targetId);
+                } catch (error) {
+                  logError("Failed to trash terminal via terminal.trash", error);
+                }
+              },
+            });
+          }
+        }
       }
     },
   }));
@@ -443,7 +460,45 @@ export function registerTerminalLifecycleActions(
           (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
         );
       });
-      idsToClose.forEach((id) => state.trashPanel(id));
+
+      const gridIds: string[] = [];
+      const dockIds: string[] = [];
+      for (const id of idsToClose) {
+        const t = state.panelsById[id];
+        if (t) {
+          if (t.location === "dock") {
+            dockIds.push(id);
+          } else {
+            gridIds.push(id);
+          }
+        }
+      }
+
+      // Process dock immediately
+      dockIds.forEach((id) => {
+        try {
+          state.trashPanel(id);
+        } catch (error) {
+          logError("Failed to trash dock terminal via terminal.closeAll", error);
+        }
+      });
+
+      // Process grid panels via optimistic close
+      if (gridIds.length > 0) {
+        requestPanelClose({
+          hideIds: gridIds,
+          commit: () => {
+            const trashPanel = usePanelStore.getState().trashPanel;
+            gridIds.forEach((id) => {
+              try {
+                trashPanel(id);
+              } catch (error) {
+                logError("Failed to trash grid terminal via terminal.closeAll", error);
+              }
+            });
+          },
+        });
+      }
     },
   }));
 

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1436,6 +1436,18 @@ class TerminalInstanceService {
     this.resizeController.flushResize(id);
   }
 
+  /**
+   * Cancel a panel's pending resize job and debounce timer *without* applying
+   * it. Used on optimistic close: `flushResize` would force-drain queued
+   * output and reflow scrollback synchronously inside the close click, but the
+   * pending job still has to be cleared so no stale resize fires after the
+   * panel is detached or restored from trash.
+   */
+  cancelPendingResize(id: string): void {
+    const managed = this.instances.get(id);
+    if (managed) this.resizeController.clearResizeJob(managed);
+  }
+
   sendPtyResize(id: string, cols: number, rows: number): void {
     this.resizeController.sendPtyResize(id, cols, rows);
   }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -311,6 +311,15 @@ class TerminalInstanceService {
     this.webGLManager.setHardwareAvailable(available);
   }
 
+  // Triggered when the renderer receives a new ResourceProfilePayload — the
+  // thresholds have already been written into TerminalWebGLConfig by the time
+  // this runs, so we just nudge the manager to re-check its mode against the
+  // new band. Without this, a profile downgrade can leave more wants on WebGL
+  // than the new upper allows until the next consumer event happens to land.
+  refreshWebGLMode(): void {
+    this.webGLManager.refreshMode();
+  }
+
   notifyUserInput(id: string, data = ""): void {
     this.onUserInput(id, data);
   }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1436,18 +1436,6 @@ class TerminalInstanceService {
     this.resizeController.flushResize(id);
   }
 
-  /**
-   * Cancel a panel's pending resize job and debounce timer *without* applying
-   * it. Used on optimistic close: `flushResize` would force-drain queued
-   * output and reflow scrollback synchronously inside the close click, but the
-   * pending job still has to be cleared so no stale resize fires after the
-   * panel is detached or restored from trash.
-   */
-  cancelPendingResize(id: string): void {
-    const managed = this.instances.get(id);
-    if (managed) this.resizeController.clearResizeJob(managed);
-  }
-
   sendPtyResize(id: string, cols: number, rows: number): void {
     this.resizeController.sendPtyResize(id, cols, rows);
   }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1575,7 +1575,13 @@ class TerminalInstanceService {
     this.resizePassAbort?.abort();
     const controller = new AbortController();
     this.resizePassAbort = controller;
-    void this.executeResizePass(ids, controller).catch((error) => {
+    const run = () => this.executeResizePass(ids, controller);
+    const task =
+      typeof scheduler !== "undefined" && typeof scheduler.postTask === "function"
+        ? scheduler.postTask(run, { priority: "user-visible", signal: controller.signal })
+        : run();
+    void task.catch((error) => {
+      if (error instanceof Error && error.name === "AbortError") return;
       logError("terminal resize pass failed", error);
     });
   }

--- a/src/services/terminal/TerminalWebGLConfig.ts
+++ b/src/services/terminal/TerminalWebGLConfig.ts
@@ -1,27 +1,46 @@
-// Mutable WebGL pool size, isolated from xterm imports so the eager renderer
-// chunk can update it (via useResourceProfile) without pulling @xterm/addon-webgl.
-// Initial value matches the balanced resource profile (see RESOURCE_PROFILE_CONFIGS).
-let maxContexts = 16;
+// Mode-switch thresholds for the WebGL pool. Held in a tiny module isolated
+// from xterm imports so the eager renderer chunk can update them (via
+// useResourceProfile) without pulling @xterm/addon-webgl into the entry bundle.
+//
+// The manager runs in one of two modes based on how many terminals currently
+// want WebGL. When count exceeds `upperThreshold` it flips to DOM mode and
+// releases every active context. When count drops back to `lowerThreshold` or
+// below it flips back and re-attaches every want via a rAF-staggered drain.
+// The gap between the two values is hysteresis: opening/closing a single panel
+// at the boundary will not flap the whole fleet.
+//
+// Chromium hard-caps active WebGL contexts at 16 per renderer process and
+// silently evicts the oldest on overflow (webglcontextlost), so the upper
+// threshold must stay comfortably below 16 to leave headroom for devtools,
+// OffscreenCanvas, and any future non-terminal WebGL consumer.
+// Initial values match the balanced resource profile.
 
-export function getMaxContexts(): number {
-  return maxContexts;
+let upperThreshold = 12;
+let lowerThreshold = 10;
+
+export function getWebglUpperThreshold(): number {
+  return upperThreshold;
 }
 
-export function setMaxContexts(n: number): void {
-  maxContexts = Math.max(1, n);
+export function getWebglLowerThreshold(): number {
+  return lowerThreshold;
 }
 
-// Passive-mode gate: once this many agent terminals already hold (or are
-// queued for) a WebGL context, new acquisitions are suppressed and those
-// terminals render via the DOM renderer instead. This stops the release/
-// reacquire churn that flashes terminals when a large fleet (20+) is visible
-// at once. Initial value matches the balanced resource profile.
-let passiveThreshold = 12;
-
-export function getPassiveThreshold(): number {
-  return passiveThreshold;
+export function setWebglUpperThreshold(n: number): void {
+  upperThreshold = Math.max(1, n);
+  if (lowerThreshold > upperThreshold) {
+    lowerThreshold = upperThreshold;
+  }
 }
 
-export function setPassiveThreshold(n: number): void {
-  passiveThreshold = Math.max(1, n);
+export function setWebglLowerThreshold(n: number): void {
+  lowerThreshold = Math.max(0, Math.min(n, upperThreshold));
+}
+
+// Atomically set both. Order matters: setting upper first lets the lower
+// setter clamp against the new upper without flipping through an intermediate
+// invalid state where lower > upper.
+export function setWebglThresholds(upper: number, lower: number): void {
+  setWebglUpperThreshold(upper);
+  setWebglLowerThreshold(lower);
 }

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -1,24 +1,45 @@
 import type { WebglAddon as WebglAddonType } from "@xterm/addon-webgl";
 import type { IDisposable } from "@xterm/xterm";
 import {
-  getMaxContexts,
-  getPassiveThreshold,
-  setMaxContexts as setConfiguredMaxContexts,
-  setPassiveThreshold as setConfiguredPassiveThreshold,
+  getWebglLowerThreshold,
+  getWebglUpperThreshold,
+  setWebglLowerThreshold as setConfiguredLowerThreshold,
+  setWebglThresholds as setConfiguredThresholds,
+  setWebglUpperThreshold as setConfiguredUpperThreshold,
 } from "./TerminalWebGLConfig";
-import { WRITE_BURST_RECENCY_MS, type ManagedTerminal } from "./types";
+import { type ManagedTerminal } from "./types";
 
-const WEBGL_DISABLED = import.meta.env.DAINTREE_DISABLE_WEBGL === "1";
+// WebGL is gated by a count-based mode switch, not per-context eviction.
+// Below the upper threshold, every wanting terminal gets WebGL. Above it,
+// the manager flips to DOM mode and releases every active context in one
+// pass; it flips back to WebGL once the count returns to the lower threshold.
+// The hysteresis gap prevents flapping when a single panel opens or closes at
+// the boundary.
+//
+// DAINTREE_DISABLE_WEBGL=1 is an escape hatch for deterministic environments
+// (E2E suites, perf benchmarks) — when set, the manager starts with
+// hardwareAvailable=false so every ensureContext is a no-op. Vite exposes
+// DAINTREE_* env vars to import.meta.env via envPrefix in vite.config.ts.
+//
+// Why this shape instead of an LRU pool:
+// Chromium hard-caps active WebGL contexts at 16 per renderer and silently
+// evicts the oldest on overflow (webglcontextlost — see crbug 40939743). An
+// LRU pool inside our renderer was making the same eviction decisions
+// Chromium was already making one layer below, producing visible churn at
+// 12-20 visible agent terminals: contexts cycled out, fell back to DOM,
+// reacquired, flashed. The mode switch is a single coordinated decision
+// applied to every terminal at once, which trades one wholesale repaint per
+// boundary crossing for the continuous churn we had before.
 
 type WebglAddonConstructor = new () => WebglAddonType;
 
 // @xterm/addon-webgl loads via dynamic import so it stays out of the renderer's
 // eager critical path. ensureContext() routes every new request through a
 // requestAnimationFrame drain queue (one attach per frame): without that
-// stagger, a burst of synchronous attaches during bulk worktree creation
-// over-subscribes Chromium's 16-context-per-renderer cap, causing silent
-// eviction of older contexts that then sit blank for 3s waiting on
-// webglcontextrestored before xterm's onContextLoss fires (see #7467).
+// stagger, a burst of synchronous attaches during bulk worktree creation or a
+// DOM→WebGL mode flip over-subscribes Chromium's 16-context-per-renderer cap,
+// causing silent eviction of older contexts that then sit blank for 3s waiting
+// on webglcontextrestored before xterm's onContextLoss fires (see #7467).
 let WebglAddonClass: WebglAddonConstructor | null = null;
 let webglAddonLoadPromise: Promise<WebglAddonConstructor> | null = null;
 
@@ -108,18 +129,12 @@ interface WebGLEntry {
   atlasResyncDisposable: IDisposable | null;
 }
 
-export class TerminalWebGLManager {
-  // Chromium caps active WebGL contexts at 16 per renderer process.
-  // Reserve 4 slots for potential non-terminal WebGL consumers in the
-  // main renderer (browser/dev-preview panels are process-isolated via
-  // <webview> partitions and have their own budgets). The pool size lives
-  // in TerminalWebGLConfig so the eager renderer chunk can adjust it
-  // without dragging @xterm/addon-webgl into the entry bundle.
+type Mode = "webgl" | "dom";
 
+export class TerminalWebGLManager {
   // Circuit breaker: if N genuine context-loss events occur within W ms,
   // disable WebGL for the rest of the session to avoid strobing reacquisition
-  // on systems with persistent GPU faults. Two recurrence paths to keep in
-  // mind when tuning these constants:
+  // on systems with persistent GPU faults. Two recurrence paths matter:
   //   1. M-series Macs on external displays at fractional scaling — repeated
   //      per-context faults spaced over seconds; each loss is a distinct GPU
   //      event and must each count toward the threshold (issue #6163).
@@ -131,45 +146,50 @@ export class TerminalWebGLManager {
   // To preserve case 1 while neutralising case 2, recordContextLoss is fed
   // through scheduleContextLossFlush: per-frame burst coalescing means one
   // GPU event = one breaker tick regardless of how many pool entries fired.
-  // Timestamps are taken at flush time (next rAF), not at event-dispatch time;
-  // this matters only if rAF is suppressed for longer than LOSS_WINDOW_MS (e.g.
-  // a fully backgrounded renderer), which is not a path we render WebGL on.
   private static readonly LOSS_THRESHOLD = 3;
   private static readonly LOSS_WINDOW_MS = 60_000;
 
-  static get MAX_CONTEXTS(): number {
-    return getMaxContexts();
+  static get UPPER_THRESHOLD(): number {
+    return getWebglUpperThreshold();
   }
 
-  static setMaxContexts(n: number): void {
-    setConfiguredMaxContexts(n);
+  static get LOWER_THRESHOLD(): number {
+    return getWebglLowerThreshold();
   }
 
-  static setPassiveThreshold(n: number): void {
-    setConfiguredPassiveThreshold(n);
+  static setWebglUpperThreshold(n: number): void {
+    setConfiguredUpperThreshold(n);
   }
 
+  static setWebglLowerThreshold(n: number): void {
+    setConfiguredLowerThreshold(n);
+  }
+
+  static setWebglThresholds(upper: number, lower: number): void {
+    setConfiguredThresholds(upper, lower);
+  }
+
+  // Every terminal that currently wants WebGL. The consumer (visibility/agent
+  // gating in TerminalInstanceService) decides what "wants" means; the manager
+  // just counts. wants stays populated in DOM mode so a later flip back to
+  // WebGL re-attaches every still-wanting terminal in one pass.
+  private wants = new Map<string, ManagedTerminal>();
   private pool = new Map<string, WebGLEntry>();
-  private lruOrder: string[] = [];
-  private hardwareAvailable = true;
+  private mode: Mode = "webgl";
+  // Start with hardware unavailable if the env-level disable is set; mode
+  // is "webgl" so the first ensureContext is what flips to "dom" cleanly via
+  // evaluateMode (mirrors the breaker path).
+  private hardwareAvailable = import.meta.env.DAINTREE_DISABLE_WEBGL !== "1";
   private hasLoggedSoftwareSkip = false;
-  private lossTimestamps: number[] = [];
   private hasLoggedBreakerTrip = false;
-  // Burst coalescer for context-loss events: a bulk GPU-process eviction can
-  // synchronously fire webglcontextlost on every pool entry within one frame.
-  // pendingLossCount accumulates raw notifications; flushContextLoss records
-  // exactly one breaker tick per frame regardless of how many fired.
+  private hasLoggedModeFlip = false;
+
+  // Coalesce a burst of webglcontextlost events (one per active pool entry on
+  // a bulk GPU eviction — see LOSS_THRESHOLD comment) into one breaker tick.
+  private lossTimestamps: number[] = [];
   private pendingLossCount = 0;
   private lossCoalesceRafId: number | null = null;
-  // Pool-pressure diagnostics (Tier 0 — silent log). Eviction at a full pool is
-  // expected behaviour in 20–30 terminal tiled fleets and falls back seamlessly
-  // to the DOM renderer, so this is observable-only, not user-facing. Rate
-  // limited to one console.warn per minute, mirroring hasLoggedBreakerTrip.
-  private evictionCount = 0;
-  // -Infinity so the first eviction always crosses the interval and warns,
-  // independent of the absolute clock value (real epoch or a faked time of 0).
-  private lastEvictionWarnAt = Number.NEGATIVE_INFINITY;
-  private static readonly EVICTION_WARN_INTERVAL_MS = 60_000;
+
   // Queue of pending ensure requests: drained one-per-rAF so each context
   // allocation completes its GPU IPC roundtrip before the next is requested.
   private pendingEnsures = new Map<string, ManagedTerminal>();
@@ -178,6 +198,7 @@ export class TerminalWebGLManager {
   // under a test shim that invokes the callback inline).
   private pendingDrainScheduled = false;
   private pendingEnsureRafId: number | null = null;
+
   // xterm shares one module-global TextureAtlas across every terminal with a
   // matching font/theme config. A page-merge (TextureAtlas._mergePages) splices
   // pages and rewrites glyph texturePage indices, but each WebGL renderer keeps
@@ -202,11 +223,15 @@ export class TerminalWebGLManager {
   private atlasResyncRafId: number | null = null;
 
   setHardwareAvailable(available: boolean): void {
+    const wasAvailable = this.hardwareAvailable;
     this.hardwareAvailable = available;
+    if (wasAvailable && !available) {
+      // Hardware degraded — force DOM mode regardless of count and stay there.
+      this.flipToDom();
+    }
   }
 
   ensureContext(id: string, managed: ManagedTerminal): void {
-    if (WEBGL_DISABLED) return;
     if (!this.hardwareAvailable) {
       if (!this.hasLoggedSoftwareSkip && !this.hasLoggedBreakerTrip) {
         console.warn("[TerminalWebGLManager] Skipping WebGL: software-only GPU detected");
@@ -216,48 +241,54 @@ export class TerminalWebGLManager {
     }
     if (!managed.isOpened) return;
 
-    // Passive-mode gate: when a large agent fleet is visible at once, the pool
-    // (capped well below the visible count) would otherwise cycle the same
-    // terminals through release/reacquire, flashing them. Once the threshold of
-    // contexts is occupied, suppress new acquisitions — those terminals stay on
-    // the DOM renderer. Existing pooled contexts are untouched and drain
-    // naturally via releaseContext/onTerminalDestroyed; the next ensure from a
-    // newly-visible terminal passes the gate once the count falls back below it.
-    // Re-ensures of terminals already pooled (LRU touch) or already queued must
-    // pass through — they don't add a new context, and gating them on the raw
-    // pool+queue size would spuriously suppress an unrelated free slot.
-    if (!this.pool.has(id) && !this.pendingEnsures.has(id)) {
-      if (this.pool.size + this.pendingEnsures.size >= getPassiveThreshold()) return;
+    const wasWanted = this.wants.has(id);
+    this.wants.set(id, managed);
+    if (!wasWanted) {
+      this.evaluateMode();
     }
-
-    // Dedupe: latest request per id wins until the queue drains.
-    this.pendingEnsures.set(id, managed);
-
-    if (WebglAddonClass) {
-      this.scheduleDrain();
-      return;
+    // In WebGL mode, queue an attach for this id if not already pooled. In
+    // DOM mode the want is tracked but no attach happens until the next flip
+    // back. attachWithLoadedAddon dedups via pool.has(id), so a repeat ensure
+    // on an already-attached terminal is a cheap no-op.
+    if (this.mode === "webgl" && !this.pool.has(id)) {
+      this.queueAttach(id, managed);
     }
-
-    void loadWebglAddon().then(
-      () => this.scheduleDrain(),
-      () => {
-        // Retain pending; a subsequent ensureContext call will retry the load.
-      }
-    );
   }
 
   releaseContext(id: string): void {
+    const wasWanted = this.wants.delete(id);
     this.pendingEnsures.delete(id);
     if (this.pool.has(id)) {
-      this.doRelease(id);
+      this.dropPoolEntry(id);
     }
+    if (wasWanted) {
+      this.evaluateMode();
+    }
+  }
+
+  // External re-evaluation hook. Threshold changes pushed from the main
+  // process via useResourceProfile arrive between consumer events; without
+  // this, a profile downgrade from balanced (12/10) to efficiency (8/6) would
+  // leave 9+ wants on WebGL until the next ensure/release happens to land.
+  refreshMode(): void {
+    this.evaluateMode();
   }
 
   isActive(id: string): boolean {
     return this.pool.has(id);
   }
 
+  // Test/diagnostic introspection — not part of the consumer API.
+  getMode(): Mode {
+    return this.mode;
+  }
+
+  getWantsSize(): number {
+    return this.wants.size;
+  }
+
   onTerminalDestroyed(id: string): void {
+    const wasWanted = this.wants.delete(id);
     this.pendingEnsures.delete(id);
     const entry = this.pool.get(id);
     if (entry) {
@@ -282,7 +313,9 @@ export class TerminalWebGLManager {
       // Chromium budget the same way #7467 stalled the attach path.
       forceGpuSlotRelease(entry.addon);
       this.pool.delete(id);
-      this.removeFromLru(id);
+    }
+    if (wasWanted) {
+      this.evaluateMode();
     }
   }
 
@@ -297,6 +330,7 @@ export class TerminalWebGLManager {
     this.pendingEnsureRafId = null;
     this.pendingDrainScheduled = false;
     this.pendingEnsures.clear();
+    this.wants.clear();
     if (this.atlasResyncRafId !== null) {
       try {
         cancelAnimationFrame(this.atlasResyncRafId);
@@ -316,8 +350,91 @@ export class TerminalWebGLManager {
     this.lossCoalesceRafId = null;
     this.pendingLossCount = 0;
     for (const id of [...this.pool.keys()]) {
-      this.doRelease(id);
+      this.dropPoolEntry(id);
     }
+  }
+
+  private evaluateMode(): void {
+    if (!this.hardwareAvailable) {
+      // Hardware-unavailable is a one-way trip — stay in DOM regardless of count.
+      if (this.mode !== "dom") this.flipToDom();
+      return;
+    }
+    const count = this.wants.size;
+    if (this.mode === "webgl" && count > getWebglUpperThreshold()) {
+      this.flipToDom();
+    } else if (this.mode === "dom" && count <= getWebglLowerThreshold()) {
+      this.flipToWebgl();
+    }
+  }
+
+  private flipToDom(): void {
+    if (this.mode === "dom") return;
+    this.mode = "dom";
+    if (!this.hasLoggedModeFlip) {
+      console.warn(
+        `[TerminalWebGLManager] Switching to DOM renderer (wants=${this.wants.size}, upper=${getWebglUpperThreshold()})`
+      );
+      this.hasLoggedModeFlip = true;
+    }
+    // Cancel any pending attaches — none will be honored in DOM mode.
+    this.pendingEnsures.clear();
+    if (this.pendingEnsureRafId !== null) {
+      try {
+        cancelAnimationFrame(this.pendingEnsureRafId);
+      } catch {
+        // ignore
+      }
+      this.pendingEnsureRafId = null;
+    }
+    this.pendingDrainScheduled = false;
+
+    // Release every active context. Each terminal falls back to xterm's DOM
+    // renderer on its next paint. Trigger a refresh on visible terminals so
+    // the renderer swap is one frame, not deferred until the next write.
+    for (const id of [...this.pool.keys()]) {
+      const entry = this.pool.get(id);
+      if (!entry) continue;
+      const managed = entry.managed;
+      this.dropPoolEntry(id);
+      if (managed.isOpened && managed.isVisible && managed.terminal.rows > 0) {
+        try {
+          managed.terminal.refresh(0, managed.terminal.rows - 1);
+        } catch {
+          // ignore — next user-driven paint will catch up regardless
+        }
+      }
+    }
+  }
+
+  private flipToWebgl(): void {
+    if (this.mode === "webgl") return;
+    this.mode = "webgl";
+    // Reset the mode-flip warning so a future downgrade is logged again
+    // (per-session, but recoverable across the cycle).
+    this.hasLoggedModeFlip = false;
+    // Queue every still-wanting terminal for attach. The rAF drain serialises
+    // them so the bulk attach never over-subscribes the 16-context budget.
+    for (const [id, managed] of this.wants) {
+      if (!this.pool.has(id)) {
+        this.queueAttach(id, managed);
+      }
+    }
+  }
+
+  private queueAttach(id: string, managed: ManagedTerminal): void {
+    // Dedupe: latest request per id wins until the queue drains.
+    this.pendingEnsures.set(id, managed);
+    if (WebglAddonClass) {
+      this.scheduleDrain();
+      return;
+    }
+    void loadWebglAddon().then(
+      () => this.scheduleDrain(),
+      () => {
+        // Retain pending; a subsequent ensureContext call will retry the load.
+      }
+    );
   }
 
   private scheduleDrain(): void {
@@ -340,14 +457,19 @@ export class TerminalWebGLManager {
       this.pendingEnsures.clear();
       return;
     }
+    // A mode flip during an in-flight drain is honored — flipToDom clears
+    // pendingEnsures so the next entries().next() returns done immediately.
+    if (this.mode !== "webgl") {
+      this.pendingEnsures.clear();
+      return;
+    }
     const next = this.pendingEnsures.entries().next();
     if (next.done) return;
     const [id, managed] = next.value;
     this.pendingEnsures.delete(id);
-    if (managed.isOpened) {
-      // attachWithLoadedAddon dedups via pool.has(id) and routes the
-      // already-active case through moveLruToEnd so the touch semantics of
-      // a repeat ensure are preserved.
+    // Re-check the want: the terminal may have called releaseContext between
+    // queueing and now (visibility change, agent ended, etc).
+    if (managed.isOpened && this.wants.has(id)) {
       this.attachWithLoadedAddon(id, managed, WebglAddonClass);
     }
     if (this.pendingEnsures.size > 0) {
@@ -401,8 +523,7 @@ export class TerminalWebGLManager {
     }
   };
 
-  // Coalesce a burst of webglcontextlost events (one per active pool entry on
-  // a bulk GPU eviction — see LOSS_THRESHOLD comment) into one breaker tick.
+  // Coalesce a burst of webglcontextlost events into one breaker tick.
   private scheduleContextLossFlush(): void {
     this.pendingLossCount += 1;
     if (this.lossCoalesceRafId !== null) return;
@@ -424,9 +545,9 @@ export class TerminalWebGLManager {
   private reacquireContext(id: string, entry: WebGLEntry): void {
     if (this.pool.get(id) !== entry) return;
     const managed = entry.managed;
-    this.doRelease(id);
-    if (managed.isOpened) {
-      this.ensureContext(id, managed);
+    this.dropPoolEntry(id);
+    if (managed.isOpened && this.wants.has(id) && this.mode === "webgl") {
+      this.queueAttach(id, managed);
     }
   }
 
@@ -435,17 +556,17 @@ export class TerminalWebGLManager {
     managed: ManagedTerminal,
     AddonClass: WebglAddonConstructor
   ): void {
-    if (this.pool.has(id)) {
-      this.moveLruToEnd(id);
+    if (this.pool.has(id)) return;
+    // No eviction branch: the mode switch guarantees the pool never exceeds
+    // upperThreshold while we are in WebGL mode. The real path that can reach
+    // here over the line is a threshold change pushed via setWebglThresholds
+    // between when this attach was queued and when the rAF drain landed —
+    // refreshMode() is best-effort but the queue can already be in flight.
+    // Re-evaluating here flips to DOM and clears pendingEnsures, so the next
+    // drain iteration bails immediately.
+    if (this.wants.size > getWebglUpperThreshold()) {
+      this.evaluateMode();
       return;
-    }
-
-    if (this.pool.size >= getMaxContexts()) {
-      const evictId = this.pickEvictTarget();
-      if (evictId) {
-        this.doRelease(evictId);
-        this.recordEvictionForDiagnostics();
-      }
     }
 
     let addon: WebglAddonType | null = null;
@@ -460,7 +581,18 @@ export class TerminalWebGLManager {
         if (this.pool.get(id)?.addon === ownAddon) {
           // record before release; pool entry still valid here
           this.scheduleContextLossFlush();
-          this.releaseContext(id);
+          // Drop the dead pool entry but LEAVE the terminal in `wants`.
+          // A context loss kills the addon, not the consumer's eligibility:
+          // calling releaseContext() would decrement the mode-switch count
+          // and silently drop the terminal from the next dom→webgl recovery.
+          // We deliberately do NOT auto-requeue here — a bulk Chromium
+          // eviction (caused BY too many contexts) would re-request the
+          // contexts immediately and re-trigger the same eviction, looping
+          // until the breaker trips after 3 cycles. Instead the terminal
+          // sits on the DOM renderer (which renders correctly under
+          // lineHeight: 1.0) until a consumer-side re-ensure happens
+          // (visibility change, tier transition, mode flip).
+          this.dropPoolEntry(id);
         }
       });
       managed.terminal.loadAddon(addon);
@@ -492,7 +624,11 @@ export class TerminalWebGLManager {
         const captureHandler = (): void => {
           if (this.pool.get(id)?.addon !== ownAddon) return;
           this.scheduleContextLossFlush();
-          this.releaseContext(id);
+          // Same reasoning as the onContextLoss handler above — drop the
+          // pool entry but keep the want, and do not auto-requeue. The next
+          // consumer event (visibility / tier / mode flip) will restore
+          // WebGL; until then the terminal renders via DOM.
+          this.dropPoolEntry(id);
           try {
             if (managed.isOpened && managed.terminal.rows > 0) {
               managed.terminal.refresh(0, managed.terminal.rows - 1);
@@ -513,7 +649,6 @@ export class TerminalWebGLManager {
         captureDisposable,
         atlasResyncDisposable,
       });
-      this.lruOrder.push(id);
     } catch {
       try {
         clDisposable?.dispose();
@@ -538,15 +673,18 @@ export class TerminalWebGLManager {
     }
   }
 
-  private doRelease(id: string): void {
+  // Drop the pool entry for an id without touching the wants set. Internal —
+  // used by the context-loss path (the addon died but the consumer still wants
+  // WebGL) and by mode flips. The public releaseContext() wraps this and also
+  // mutates wants because that path means "consumer no longer wants WebGL".
+  private dropPoolEntry(id: string): void {
     const entry = this.pool.get(id);
     if (!entry) return;
 
-    // Delete from pool/lru first so the capture-phase listener (and stale
+    // Delete from pool first so the capture-phase listener (and stale
     // onContextLoss fires) treat the loseContext below as a self-initiated
     // release rather than a real eviction.
     this.pool.delete(id);
-    this.removeFromLru(id);
 
     try {
       entry.contextLossDisposable.dispose();
@@ -588,104 +726,6 @@ export class TerminalWebGLManager {
         );
         this.hasLoggedBreakerTrip = true;
       }
-    }
-  }
-
-  // Eviction priority scorer. Returns the pool id that should give up its
-  // WebGL slot first under pool pressure. Lower tier = evict sooner; LRU
-  // position breaks ties within a tier so existing recency semantics survive.
-  //
-  // Tiers (most → least evictable):
-  //   0  done/idle (no agent, or completed/exited/idle) — DOM renderer is fine
-  //   1  waiting, unfocused, not recently writing — idle between prompts
-  //   2  working but drained (pendingWrites 0, no recent write), unfocused
-  //   3  waiting + in an active write burst (lastWriteAt within window)
-  //   4  focused — user is looking at it; glyph quality matters
-  //   5  working with queued writes — actively streaming output
-  //   6  focused + directing — user typing into a live agent; never evict first
-  //
-  // Reads the live `managed` ref on each pool entry (mutated in place by the
-  // write and agent-state controllers), so no cross-controller coupling.
-  private pickEvictTarget(): string | undefined {
-    const lruIndex = new Map<string, number>();
-    for (let i = 0; i < this.lruOrder.length; i++) {
-      lruIndex.set(this.lruOrder[i]!, i);
-    }
-
-    const now = Date.now();
-    let bestId: string | undefined;
-    let bestTier = Number.POSITIVE_INFINITY;
-    let bestLru = Number.POSITIVE_INFINITY;
-
-    for (const [id, entry] of this.pool) {
-      const m = entry.managed;
-      const state = m.agentState ?? "idle";
-      const focused = m.isFocused === true;
-      const pending = m.pendingWrites ?? 0;
-      const recentlyWriting =
-        m.lastWriteAt !== undefined && now - m.lastWriteAt < WRITE_BURST_RECENCY_MS;
-
-      let tier: number;
-      if (state === "directing" && focused) {
-        tier = 6;
-      } else if (state === "working" && pending > 0) {
-        tier = 5;
-      } else if (focused) {
-        tier = 4;
-      } else if (recentlyWriting && state === "waiting") {
-        // Burst protection only applies to "waiting" — an agent between prompts
-        // that just streamed output. A recent lastWriteAt on a done state
-        // (idle/completed/exited) is a final flush, not an ongoing burst, so
-        // those fall through to tier 0 below.
-        tier = 3;
-      } else if (state === "working" && pending === 0 && !recentlyWriting) {
-        tier = 2;
-      } else if (state === "waiting" && !recentlyWriting) {
-        tier = 1;
-      } else if (state === "idle" || state === "completed" || state === "exited") {
-        tier = 0;
-      } else {
-        // "waiting" while recently writing, or any unmapped state — keep it
-        // above the cleanly-idle tier but below focused/active work.
-        tier = 2;
-      }
-
-      const lru = lruIndex.get(id) ?? Number.POSITIVE_INFINITY;
-      if (tier < bestTier || (tier === bestTier && lru < bestLru)) {
-        bestTier = tier;
-        bestLru = lru;
-        bestId = id;
-      }
-    }
-
-    // Fall back to the LRU front if the pool/LRU ever desynchronise.
-    return bestId ?? this.lruOrder[0]!;
-  }
-
-  private recordEvictionForDiagnostics(): void {
-    this.evictionCount += 1;
-    const now = Date.now();
-    if (now - this.lastEvictionWarnAt > TerminalWebGLManager.EVICTION_WARN_INTERVAL_MS) {
-      console.warn(
-        `[TerminalWebGLManager] Pool pressure: evicted ${this.evictionCount} WebGL context(s) since last warning (pool=${this.pool.size}/${getMaxContexts()})`
-      );
-      this.evictionCount = 0;
-      this.lastEvictionWarnAt = now;
-    }
-  }
-
-  private moveLruToEnd(id: string): void {
-    const idx = this.lruOrder.indexOf(id);
-    if (idx !== -1) {
-      this.lruOrder.splice(idx, 1);
-    }
-    this.lruOrder.push(id);
-  }
-
-  private removeFromLru(id: string): void {
-    const idx = this.lruOrder.indexOf(id);
-    if (idx !== -1) {
-      this.lruOrder.splice(idx, 1);
     }
   }
 }

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -11,8 +11,9 @@ import { type ManagedTerminal } from "./types";
 
 // WebGL is gated by a count-based mode switch, not per-context eviction.
 // Below the upper threshold, every wanting terminal gets WebGL. Above it,
-// the manager flips to DOM mode and releases every active context in one
-// pass; it flips back to WebGL once the count returns to the lower threshold.
+// the manager flips to DOM mode and releases active contexts through a
+// requestAnimationFrame drain queue; it flips back to WebGL once the count
+// returns to the lower threshold.
 // The hysteresis gap prevents flapping when a single panel opens or closes at
 // the boundary.
 //
@@ -199,6 +200,13 @@ export class TerminalWebGLManager {
   private pendingDrainScheduled = false;
   private pendingEnsureRafId: number | null = null;
 
+  // Queue of active contexts to release after a fleet-wide DOM-mode downgrade.
+  // Releasing a WebGL addon forces synchronous GPU-side context loss, so the
+  // downgrade is paced the same way as attach: one terminal per frame.
+  private pendingReleases = new Map<string, ManagedTerminal>();
+  private pendingReleaseDrainScheduled = false;
+  private pendingReleaseRafId: number | null = null;
+
   // xterm shares one module-global TextureAtlas across every terminal with a
   // matching font/theme config. A page-merge (TextureAtlas._mergePages) splices
   // pages and rewrites glyph texturePage indices, but each WebGL renderer keeps
@@ -258,6 +266,7 @@ export class TerminalWebGLManager {
   releaseContext(id: string): void {
     const wasWanted = this.wants.delete(id);
     this.pendingEnsures.delete(id);
+    this.pendingReleases.delete(id);
     if (this.pool.has(id)) {
       this.dropPoolEntry(id);
     }
@@ -290,6 +299,7 @@ export class TerminalWebGLManager {
   onTerminalDestroyed(id: string): void {
     const wasWanted = this.wants.delete(id);
     this.pendingEnsures.delete(id);
+    this.pendingReleases.delete(id);
     const entry = this.pool.get(id);
     if (entry) {
       try {
@@ -330,6 +340,16 @@ export class TerminalWebGLManager {
     this.pendingEnsureRafId = null;
     this.pendingDrainScheduled = false;
     this.pendingEnsures.clear();
+    if (this.pendingReleaseRafId !== null) {
+      try {
+        cancelAnimationFrame(this.pendingReleaseRafId);
+      } catch {
+        // ignore
+      }
+    }
+    this.pendingReleaseRafId = null;
+    this.pendingReleaseDrainScheduled = false;
+    this.pendingReleases.clear();
     this.wants.clear();
     if (this.atlasResyncRafId !== null) {
       try {
@@ -389,27 +409,19 @@ export class TerminalWebGLManager {
     }
     this.pendingDrainScheduled = false;
 
-    // Release every active context. Each terminal falls back to xterm's DOM
-    // renderer on its next paint. Trigger a refresh on visible terminals so
-    // the renderer swap is one frame, not deferred until the next write.
-    for (const id of [...this.pool.keys()]) {
-      const entry = this.pool.get(id);
-      if (!entry) continue;
-      const managed = entry.managed;
-      this.dropPoolEntry(id);
-      if (managed.isOpened && managed.isVisible && managed.terminal.rows > 0) {
-        try {
-          managed.terminal.refresh(0, managed.terminal.rows - 1);
-        } catch {
-          // ignore — next user-driven paint will catch up regardless
-        }
-      }
+    // Release active contexts progressively. Each terminal falls back to
+    // xterm's DOM renderer on its next paint. Visible terminals refresh when
+    // their release lands so the renderer swap is not deferred until output.
+    for (const [id, entry] of this.pool) {
+      this.pendingReleases.set(id, entry.managed);
     }
+    this.scheduleReleaseDrain();
   }
 
   private flipToWebgl(): void {
     if (this.mode === "webgl") return;
     this.mode = "webgl";
+    this.cancelReleaseDrain();
     // Reset the mode-flip warning so a future downgrade is logged again
     // (per-session, but recoverable across the cycle).
     this.hasLoggedModeFlip = false;
@@ -474,6 +486,64 @@ export class TerminalWebGLManager {
     }
     if (this.pendingEnsures.size > 0) {
       this.scheduleDrain();
+    }
+  };
+
+  private scheduleReleaseDrain(): void {
+    if (this.pendingReleaseDrainScheduled) return;
+    if (this.pendingReleases.size === 0) return;
+    this.pendingReleaseDrainScheduled = true;
+    const id = requestAnimationFrame(this.drainOneRelease);
+    // If drainOneRelease ran synchronously (test shim or unusual host), it
+    // will have already cleared pendingReleaseDrainScheduled and there is no
+    // rAF id to cancel.
+    if (this.pendingReleaseDrainScheduled) {
+      this.pendingReleaseRafId = id;
+    }
+  }
+
+  private cancelReleaseDrain(): void {
+    if (this.pendingReleaseRafId !== null) {
+      try {
+        cancelAnimationFrame(this.pendingReleaseRafId);
+      } catch {
+        // ignore
+      }
+    }
+    this.pendingReleaseRafId = null;
+    this.pendingReleaseDrainScheduled = false;
+    this.pendingReleases.clear();
+  }
+
+  private drainOneRelease = (): void => {
+    this.pendingReleaseDrainScheduled = false;
+    this.pendingReleaseRafId = null;
+
+    // A quick recovery back to WebGL makes the release queue stale. Keep any
+    // still-active contexts instead of churning them through DOM and back.
+    if (this.mode !== "dom") {
+      this.pendingReleases.clear();
+      return;
+    }
+
+    const next = this.pendingReleases.entries().next();
+    if (next.done) return;
+    const [id, managed] = next.value;
+    this.pendingReleases.delete(id);
+
+    if (this.pool.has(id)) {
+      this.dropPoolEntry(id);
+      if (managed.isOpened && managed.isVisible && managed.terminal.rows > 0) {
+        try {
+          managed.terminal.refresh(0, managed.terminal.rows - 1);
+        } catch {
+          // ignore — next user-driven paint will catch up regardless
+        }
+      }
+    }
+
+    if (this.pendingReleases.size > 0) {
+      this.scheduleReleaseDrain();
     }
   };
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
@@ -74,6 +74,8 @@ type AdversarialService = {
   webGLManager: {
     ensureContext: (id: string, managed: ManagedTerminal) => void;
     isActive: (id: string) => boolean;
+    getMode: () => "webgl" | "dom";
+    getWantsSize: () => number;
   };
   resizeController: {
     fit: (id: string) => void;
@@ -190,7 +192,8 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
 
 describe("TerminalInstanceService adversarial", () => {
   let service: AdversarialService;
-  let originalMaxContexts: number;
+  let originalUpperThreshold: number;
+  let originalLowerThreshold: number;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -223,7 +226,8 @@ describe("TerminalInstanceService adversarial", () => {
     service.instances.clear();
 
     const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-    originalMaxContexts = TerminalWebGLManager.MAX_CONTEXTS;
+    originalUpperThreshold = TerminalWebGLManager.UPPER_THRESHOLD;
+    originalLowerThreshold = TerminalWebGLManager.LOWER_THRESHOLD;
     await preloadMockWebglAddon();
   });
 
@@ -231,7 +235,7 @@ describe("TerminalInstanceService adversarial", () => {
     service.dispose();
     document.body.innerHTML = "";
     const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-    TerminalWebGLManager.setMaxContexts(originalMaxContexts);
+    TerminalWebGLManager.setWebglThresholds(originalUpperThreshold, originalLowerThreshold);
     vi.useRealTimers();
   });
 
@@ -266,9 +270,13 @@ describe("TerminalInstanceService adversarial", () => {
     expect(managedB.lastReflowAt).toBeGreaterThan(0);
   });
 
-  it("ATTACH_EVICTS_OLDEST_WEBGL_LEASE_ON_EXHAUSTION", async () => {
+  it("ATTACH_FLIPS_TO_DOM_WHEN_WANTS_EXCEEDS_UPPER_THRESHOLD", async () => {
+    // The previous per-context LRU eviction model is gone. The manager now
+    // tracks a count of wanters and flips wholesale to DOM mode when wants
+    // exceed the upper threshold. Set upper=1, lower=0: the second attach
+    // pushes wants to 2, crosses upper, and releases both contexts together.
     const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-    TerminalWebGLManager.setMaxContexts(1);
+    TerminalWebGLManager.setWebglThresholds(1, 0);
 
     const managedA = makeManaged({
       kind: "terminal",
@@ -287,12 +295,21 @@ describe("TerminalInstanceService adversarial", () => {
     vi.spyOn(service.resizeController, "fit").mockImplementation(() => undefined);
 
     service.attach("a", document.createElement("div"));
-    service.attach("b", document.createElement("div"));
+    // 'a' attached cleanly (1 wants, 1 upper).
+    expect(service.webGLManager.isActive("a")).toBe(true);
+    expect(testState.webglAddons).toHaveLength(1);
 
-    expect(testState.webglAddons).toHaveLength(2);
-    expect(testState.webglAddons[0]!.dispose).toHaveBeenCalledTimes(1);
+    service.attach("b", document.createElement("div"));
+    // Crossing upper (1→2 wants) flips to DOM — both released, neither active.
+    expect(service.webGLManager.getMode()).toBe("dom");
     expect(service.webGLManager.isActive("a")).toBe(false);
-    expect(service.webGLManager.isActive("b")).toBe(true);
+    expect(service.webGLManager.isActive("b")).toBe(false);
+    // ensureContext for 'b' evaluates mode BEFORE queueing the attach (the
+    // count from setting wants flips us straight to dom), so only 'a' ever
+    // had an addon constructed. Pin the exact count to lock that ordering.
+    expect(testState.webglAddons).toHaveLength(1);
+    // 'a's addon was disposed by flipToDom.
+    expect(testState.webglAddons[0]!.dispose).toHaveBeenCalledTimes(1);
   });
 
   it("ATTACH_AFTER_DESTROY_RETURNS_NULL", () => {

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -200,11 +200,10 @@ describe("TerminalWebGLManager", () => {
     mod.__testing.setWebglAddonClass(
       WebglAddonMock as unknown as new () => InstanceType<typeof webglMod.WebglAddon>
     );
-    // The passive-mode threshold is module-level state that survives across
-    // tests. Reset to the balanced default so order doesn't matter; blocks that
-    // need to fill the pool past it (LRU eviction, eviction priority) raise it
-    // in their own beforeEach, which runs after this one.
-    mod.TerminalWebGLManager.setPassiveThreshold(8);
+    // Thresholds are module-level state that survives across tests. Reset to
+    // a tight band that's high enough for any single-suite tests to attach
+    // freely; the mode-switch describe block raises/lowers them as needed.
+    mod.TerminalWebGLManager.setWebglThresholds(32, 28);
     manager = new mod.TerminalWebGLManager();
   });
 
@@ -516,6 +515,38 @@ describe("TerminalWebGLManager", () => {
     expect(manager.isActive("t1")).toBe(false);
   });
 
+  it("context loss keeps the terminal in `wants` so future mode flips include it (regression)", () => {
+    // The old (LRU) manager called releaseContext() on loss, which under the
+    // new mode-switch model would also decrement wants and silently drop the
+    // terminal from future dom→webgl flips. This pins the new semantic:
+    // context loss drops the dead pool entry but leaves the want intact so
+    // the next consumer re-ensure (visibility change, tier transition, mode
+    // flip) restores WebGL automatically. We deliberately do NOT auto-requeue
+    // here — re-queuing in response to a Chromium-bulk-eviction loss would
+    // immediately re-trigger the eviction and loop until the breaker trips.
+    let contextLossHandler: (() => void) | undefined;
+    mockOnContextLoss.mockImplementation((handler: () => void) => {
+      contextLossHandler = handler;
+      return { dispose: vi.fn() };
+    });
+
+    const managed = makeManagedTerminal();
+    manager.ensureContext("t1", managed);
+    expect(manager.getWantsSize()).toBe(1);
+
+    contextLossHandler!();
+
+    // Pool entry dropped, but want preserved across the loss.
+    expect(manager.isActive("t1")).toBe(false);
+    expect(manager.getWantsSize()).toBe(1);
+    // No auto-reattach — addon constructor called exactly once.
+    expect(WebglAddonMock).toHaveBeenCalledTimes(1);
+    // A consumer re-ensure brings WebGL back without flipping mode.
+    manager.ensureContext("t1", managed);
+    expect(manager.isActive("t1")).toBe(true);
+    expect(WebglAddonMock).toHaveBeenCalledTimes(2);
+  });
+
   it("stale context loss callback is a no-op after release", () => {
     let contextLossHandler: (() => void) | undefined;
     mockOnContextLoss.mockImplementation((handler: () => void) => {
@@ -603,35 +634,67 @@ describe("TerminalWebGLManager", () => {
     expect(manager.isActive("unknown")).toBe(false);
   });
 
-  describe("setMaxContexts", () => {
-    let originalMax: number;
+  describe("threshold setters", () => {
+    let originalUpper: number;
+    let originalLower: number;
 
     beforeEach(async () => {
       const mod = await import("../TerminalWebGLManager");
-      originalMax = mod.TerminalWebGLManager.MAX_CONTEXTS;
+      originalUpper = mod.TerminalWebGLManager.UPPER_THRESHOLD;
+      originalLower = mod.TerminalWebGLManager.LOWER_THRESHOLD;
     });
 
     afterEach(async () => {
       const mod = await import("../TerminalWebGLManager");
-      mod.TerminalWebGLManager.setMaxContexts(originalMax);
+      mod.TerminalWebGLManager.setWebglThresholds(originalUpper, originalLower);
     });
 
-    it("clamps zero to 1", async () => {
+    it("setWebglUpperThreshold clamps zero to 1", async () => {
       const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      TerminalWebGLManager.setMaxContexts(0);
-      expect(TerminalWebGLManager.MAX_CONTEXTS).toBe(1);
+      TerminalWebGLManager.setWebglUpperThreshold(0);
+      expect(TerminalWebGLManager.UPPER_THRESHOLD).toBe(1);
     });
 
-    it("clamps negative values to 1", async () => {
+    it("setWebglUpperThreshold clamps negative values to 1", async () => {
       const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      TerminalWebGLManager.setMaxContexts(-5);
-      expect(TerminalWebGLManager.MAX_CONTEXTS).toBe(1);
+      TerminalWebGLManager.setWebglUpperThreshold(-5);
+      expect(TerminalWebGLManager.UPPER_THRESHOLD).toBe(1);
     });
 
-    it("accepts positive values verbatim", async () => {
+    it("setWebglUpperThreshold accepts positive values verbatim", async () => {
       const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      TerminalWebGLManager.setMaxContexts(8);
-      expect(TerminalWebGLManager.MAX_CONTEXTS).toBe(8);
+      TerminalWebGLManager.setWebglUpperThreshold(8);
+      expect(TerminalWebGLManager.UPPER_THRESHOLD).toBe(8);
+    });
+
+    it("lowering upper below the current lower clamps lower down", async () => {
+      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+      TerminalWebGLManager.setWebglUpperThreshold(20);
+      TerminalWebGLManager.setWebglLowerThreshold(15);
+      TerminalWebGLManager.setWebglUpperThreshold(10);
+      expect(TerminalWebGLManager.UPPER_THRESHOLD).toBe(10);
+      expect(TerminalWebGLManager.LOWER_THRESHOLD).toBe(10);
+    });
+
+    it("raising lower above the current upper clamps lower up to upper", async () => {
+      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+      TerminalWebGLManager.setWebglUpperThreshold(5);
+      TerminalWebGLManager.setWebglLowerThreshold(100);
+      expect(TerminalWebGLManager.LOWER_THRESHOLD).toBe(5);
+    });
+
+    it("setWebglThresholds atomically sets both, applying clamps", async () => {
+      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+      TerminalWebGLManager.setWebglThresholds(12, 10);
+      expect(TerminalWebGLManager.UPPER_THRESHOLD).toBe(12);
+      expect(TerminalWebGLManager.LOWER_THRESHOLD).toBe(10);
+    });
+
+    it("setWebglLowerThreshold clamps negative values to zero", async () => {
+      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+      TerminalWebGLManager.setWebglUpperThreshold(10);
+      TerminalWebGLManager.setWebglLowerThreshold(-3);
+      expect(TerminalWebGLManager.LOWER_THRESHOLD).toBe(0);
     });
   });
 
@@ -672,13 +735,17 @@ describe("TerminalWebGLManager", () => {
       expect(manager.isActive("t1")).toBe(true);
     });
 
-    it("setting hardware unavailable does not affect already-active contexts", () => {
+    it("setting hardware unavailable releases active contexts (mode-switch model)", () => {
+      // Under the mode-switch design, hardware-unavailable is a wholesale
+      // transition — every WebGL terminal flips to DOM, not a mixed state.
+      // The previous LRU-pool implementation left existing contexts alone;
+      // the new model coordinates the change across the fleet.
       const managed = makeManagedTerminal();
       manager.ensureContext("t1", managed);
       expect(manager.isActive("t1")).toBe(true);
 
       manager.setHardwareAvailable(false);
-      expect(manager.isActive("t1")).toBe(true);
+      expect(manager.isActive("t1")).toBe(false);
     });
 
     it("logs a warning only once when skipping due to software GPU", () => {
@@ -771,7 +838,12 @@ describe("TerminalWebGLManager", () => {
       expect(manager.isActive("t4")).toBe(true);
     });
 
-    it("does not evict already-active contexts when the breaker trips", () => {
+    it("releases every active context when the breaker trips (mode-switch model)", () => {
+      // Under the mode-switch design, a breaker trip is wholesale: WebGL is
+      // declared unreliable for the session, so every active context flips to
+      // DOM together. The previous LRU implementation left them in place,
+      // betting they were still healthy — that bet stops mattering once we've
+      // already decided not to use WebGL going forward.
       const handlers = captureContextLossHandlers();
 
       const m1 = makeManagedTerminal();
@@ -787,7 +859,10 @@ describe("TerminalWebGLManager", () => {
       handlers[1]!();
       handlers[2]!();
 
-      expect(manager.isActive("t4")).toBe(true);
+      expect(manager.isActive("t1")).toBe(false);
+      expect(manager.isActive("t2")).toBe(false);
+      expect(manager.isActive("t3")).toBe(false);
+      expect(manager.isActive("t4")).toBe(false);
     });
 
     it("stale handlers from recycled ids do not contribute to the loss count", () => {
@@ -968,497 +1043,222 @@ describe("TerminalWebGLManager", () => {
     });
   });
 
-  describe("LRU eviction", () => {
-    // These tests fill the pool to MAX_CONTEXTS, past the passive gate.
-    // Pin the threshold above the pool cap so eviction — not passive-mode
-    // suppression — is what's under test here.
+  describe("mode switch", () => {
+    // Tight thresholds so the count manipulation here is small enough to
+    // follow. Real defaults are 12/10 (balanced profile); the test layer
+    // controls them directly.
     beforeEach(async () => {
       const mod = await import("../TerminalWebGLManager");
-      mod.TerminalWebGLManager.setPassiveThreshold(999);
+      mod.TerminalWebGLManager.setWebglThresholds(3, 2);
     });
 
-    it("evicts the least recently used entry when pool reaches MAX_CONTEXTS", async () => {
-      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      const maxContexts = TerminalWebGLManager.MAX_CONTEXTS;
-
-      const disposes: ReturnType<typeof vi.fn>[] = [];
-      WebglAddonMock.mockImplementation(function () {
-        const d = vi.fn();
-        disposes.push(d);
-        return { dispose: d, onContextLoss: mockOnContextLoss };
-      });
-
-      const localManager = new TerminalWebGLManager();
-
-      for (let i = 0; i < maxContexts; i++) {
-        const m = makeManagedTerminal({ lastActiveTime: i });
-        localManager.ensureContext(`t${i}`, m);
-      }
-
-      expect(disposes).toHaveLength(maxContexts);
-      disposes.forEach((d) => expect(d).not.toHaveBeenCalled());
-
-      // Add one more — should evict t0 (oldest in LRU order)
-      const extra = makeManagedTerminal({ lastActiveTime: maxContexts });
-      localManager.ensureContext(`t${maxContexts}`, extra);
-
-      expect(disposes[0]).toHaveBeenCalledTimes(1);
-      expect(localManager.isActive("t0")).toBe(false);
-      expect(localManager.isActive(`t${maxContexts}`)).toBe(true);
-
-      // t1 through t{maxContexts-1} should still be active
-      for (let i = 1; i < maxContexts; i++) {
-        expect(localManager.isActive(`t${i}`)).toBe(true);
-      }
-    });
-
-    it("touching an entry moves it to the end of LRU", async () => {
-      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      const maxContexts = TerminalWebGLManager.MAX_CONTEXTS;
-
-      const disposes: ReturnType<typeof vi.fn>[] = [];
-      WebglAddonMock.mockImplementation(function () {
-        const d = vi.fn();
-        disposes.push(d);
-        return { dispose: d, onContextLoss: mockOnContextLoss };
-      });
-
-      const localManager = new TerminalWebGLManager();
-
-      for (let i = 0; i < maxContexts; i++) {
-        const m = makeManagedTerminal({ lastActiveTime: i });
-        localManager.ensureContext(`t${i}`, m);
-      }
-
-      // Touch t0 — should move it to end of LRU
-      const m0 = makeManagedTerminal({ lastActiveTime: maxContexts + 1 });
-      localManager.ensureContext("t0", m0);
-
-      // Add one more — should evict t1 (now the oldest), not t0
-      const extra = makeManagedTerminal({ lastActiveTime: maxContexts + 2 });
-      localManager.ensureContext(`t${maxContexts}`, extra);
-
-      expect(localManager.isActive("t0")).toBe(true);
-      expect(localManager.isActive("t1")).toBe(false);
-      expect(disposes[1]).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("eviction priority", () => {
-    // Same as LRU eviction: these fill the pool past the passive gate, so the
-    // threshold is pinned above the pool cap to isolate eviction behaviour.
-    beforeEach(async () => {
-      const mod = await import("../TerminalWebGLManager");
-      mod.TerminalWebGLManager.setPassiveThreshold(999);
-    });
-
-    // Builds a fresh manager whose addons each carry an id-tagged dispose mock,
-    // so a test can assert exactly which pooled terminal lost its slot.
-    async function makePriorityManager(): Promise<{
-      localManager: import("../TerminalWebGLManager").TerminalWebGLManager;
-      disposeFor: (id: string) => ReturnType<typeof vi.fn>;
-    }> {
-      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      const disposeById = new Map<string, ReturnType<typeof vi.fn>>();
-      let pendingId: string | null = null;
-      WebglAddonMock.mockImplementation(function () {
-        const d = vi.fn();
-        if (pendingId) disposeById.set(pendingId, d);
-        return { dispose: d, onContextLoss: mockOnContextLoss };
-      });
-      const localManager = new TerminalWebGLManager();
-      const origEnsure = localManager.ensureContext.bind(localManager);
-      // Tag the next-constructed addon with the id being ensured.
-      localManager.ensureContext = (id: string, m: ManagedTerminal): void => {
-        pendingId = id;
-        origEnsure(id, m);
-        pendingId = null;
-      };
-      return {
-        localManager,
-        disposeFor: (id: string) => {
-          const d = disposeById.get(id);
-          if (!d) throw new Error(`no addon constructed for ${id}`);
-          return d;
-        },
-      };
-    }
-
-    it("evicts the idle terminal over actively-working ones regardless of LRU order", async () => {
-      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      const max = TerminalWebGLManager.MAX_CONTEXTS;
-      const { localManager, disposeFor } = await makePriorityManager();
-
-      // Oldest LRU entries are actively streaming (tier 5). Pure LRU would evict
-      // t0; the priority scorer must instead evict the idle terminal even though
-      // it is the newest entry.
-      for (let i = 0; i < max - 1; i++) {
-        localManager.ensureContext(
-          `work${i}`,
-          makeManagedTerminal({ agentState: "working", pendingWrites: 2, isFocused: false })
-        );
-      }
-      localManager.ensureContext(
-        "idle",
-        makeManagedTerminal({ agentState: "idle", pendingWrites: 0, isFocused: false })
-      );
-
-      localManager.ensureContext("extra", makeManagedTerminal({ agentState: "working" }));
-
-      expect(localManager.isActive("idle")).toBe(false);
-      expect(disposeFor("idle")).toHaveBeenCalledTimes(1);
-      expect(localManager.isActive("work0")).toBe(true);
-      expect(localManager.isActive("extra")).toBe(true);
-    });
-
-    it("treats undefined agentState as tier-0 and evicts it before a working terminal", async () => {
-      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      const max = TerminalWebGLManager.MAX_CONTEXTS;
-      const { localManager, disposeFor } = await makePriorityManager();
-
-      for (let i = 0; i < max - 1; i++) {
-        localManager.ensureContext(
-          `work${i}`,
-          makeManagedTerminal({ agentState: "working", pendingWrites: 1 })
-        );
-      }
-      // No agentState at all (non-agent terminal).
-      localManager.ensureContext("plain", makeManagedTerminal());
-
-      localManager.ensureContext("extra", makeManagedTerminal());
-
-      expect(localManager.isActive("plain")).toBe(false);
-      expect(disposeFor("plain")).toHaveBeenCalledTimes(1);
-    });
-
-    it("protects a streaming terminal (tier 5) over a focused-idle one (tier 4)", async () => {
-      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      const max = TerminalWebGLManager.MAX_CONTEXTS;
-      const { localManager, disposeFor } = await makePriorityManager();
-
-      for (let i = 0; i < max - 1; i++) {
-        localManager.ensureContext(
-          `work${i}`,
-          makeManagedTerminal({ agentState: "working", pendingWrites: 3, isFocused: false })
-        );
-      }
-      // Focused but idle — the user clicked through it but it isn't doing work.
-      localManager.ensureContext(
-        "focused",
-        makeManagedTerminal({ agentState: "waiting", pendingWrites: 0, isFocused: true })
-      );
-
-      localManager.ensureContext("extra", makeManagedTerminal({ agentState: "working" }));
-
-      expect(localManager.isActive("focused")).toBe(false);
-      expect(disposeFor("focused")).toHaveBeenCalledTimes(1);
-      for (let i = 0; i < max - 1; i++) {
-        expect(localManager.isActive(`work${i}`)).toBe(true);
-      }
-    });
-
-    it("classifies recent-write recency at the WRITE_BURST_RECENCY_MS boundary", async () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(1_000_000);
-      installRafShim();
-      try {
-        const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-        const { WRITE_BURST_RECENCY_MS } = await import("../types");
-        const max = TerminalWebGLManager.MAX_CONTEXTS;
-        const { localManager, disposeFor } = await makePriorityManager();
-
-        const now = Date.now();
-        // Filler: streaming terminals (tier 5) — never the eviction target.
-        for (let i = 0; i < max - 2; i++) {
-          localManager.ensureContext(
-            `work${i}`,
-            makeManagedTerminal({ agentState: "working", pendingWrites: 2 })
-          );
-        }
-        // A: waiting, wrote just inside the window → recently-writing → tier 3.
-        localManager.ensureContext(
-          "recent",
-          makeManagedTerminal({
-            agentState: "waiting",
-            pendingWrites: 0,
-            isFocused: false,
-            lastWriteAt: now - (WRITE_BURST_RECENCY_MS - 1),
-          })
-        );
-        // B: waiting, wrote just outside the window → not recently-writing → tier 1.
-        localManager.ensureContext(
-          "stale",
-          makeManagedTerminal({
-            agentState: "waiting",
-            pendingWrites: 0,
-            isFocused: false,
-            lastWriteAt: now - (WRITE_BURST_RECENCY_MS + 1),
-          })
-        );
-
-        localManager.ensureContext("extra", makeManagedTerminal({ agentState: "working" }));
-
-        // Tier 1 (stale) outranks tier 3 (recent) for eviction.
-        expect(localManager.isActive("stale")).toBe(false);
-        expect(disposeFor("stale")).toHaveBeenCalledTimes(1);
-        expect(localManager.isActive("recent")).toBe(true);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("falls back to LRU order to break ties within the same tier", async () => {
-      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      const max = TerminalWebGLManager.MAX_CONTEXTS;
-      const { localManager, disposeFor } = await makePriorityManager();
-
-      // Every entry is tier 0 (idle). Oldest LRU entry must lose its slot.
-      for (let i = 0; i < max; i++) {
-        localManager.ensureContext(`idle${i}`, makeManagedTerminal({ agentState: "idle" }));
-      }
-      localManager.ensureContext("extra", makeManagedTerminal({ agentState: "idle" }));
-
-      expect(localManager.isActive("idle0")).toBe(false);
-      expect(disposeFor("idle0")).toHaveBeenCalledTimes(1);
-      expect(localManager.isActive("idle1")).toBe(true);
-    });
-
-    it("evicts a recently-flushed done terminal (tier 0) before a waiting one (tier 1)", async () => {
-      // Regression: an exited/completed agent that just printed a final line
-      // has a recent lastWriteAt, but that flush is not an ongoing burst — it
-      // must stay tier 0 and be evicted before an idle "waiting" terminal.
-      vi.useFakeTimers();
-      vi.setSystemTime(1_000_000);
-      installRafShim();
-      try {
-        const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-        const max = TerminalWebGLManager.MAX_CONTEXTS;
-        const { localManager, disposeFor } = await makePriorityManager();
-
-        // Filler streaming terminals (tier 5) — never the target.
-        for (let i = 0; i < max - 2; i++) {
-          localManager.ensureContext(
-            `work${i}`,
-            makeManagedTerminal({ agentState: "working", pendingWrites: 2 })
-          );
-        }
-        // Waiting, no recent write → tier 1.
-        localManager.ensureContext(
-          "waiting",
-          makeManagedTerminal({ agentState: "waiting", pendingWrites: 0, isFocused: false })
-        );
-        // Exited, just flushed a final line → must remain tier 0, not tier 3.
-        localManager.ensureContext(
-          "exited",
-          makeManagedTerminal({
-            agentState: "exited",
-            pendingWrites: 0,
-            isFocused: false,
-            lastWriteAt: Date.now() - 1,
-          })
-        );
-
-        localManager.ensureContext("extra", makeManagedTerminal({ agentState: "working" }));
-
-        expect(localManager.isActive("exited")).toBe(false);
-        expect(disposeFor("exited")).toHaveBeenCalledTimes(1);
-        expect(localManager.isActive("waiting")).toBe(true);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("treats exactly WRITE_BURST_RECENCY_MS ago as stale (strict < boundary)", async () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(1_000_000);
-      installRafShim();
-      try {
-        const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-        const { WRITE_BURST_RECENCY_MS } = await import("../types");
-        const max = TerminalWebGLManager.MAX_CONTEXTS;
-        const { localManager, disposeFor } = await makePriorityManager();
-
-        const now = Date.now();
-        for (let i = 0; i < max - 2; i++) {
-          localManager.ensureContext(
-            `work${i}`,
-            makeManagedTerminal({ agentState: "working", pendingWrites: 2 })
-          );
-        }
-        // Exactly at the window edge → stale (tier 1), since the check is `<`.
-        localManager.ensureContext(
-          "edge",
-          makeManagedTerminal({
-            agentState: "waiting",
-            pendingWrites: 0,
-            isFocused: false,
-            lastWriteAt: now - WRITE_BURST_RECENCY_MS,
-          })
-        );
-        // One millisecond inside the window → recent (tier 3).
-        localManager.ensureContext(
-          "inside",
-          makeManagedTerminal({
-            agentState: "waiting",
-            pendingWrites: 0,
-            isFocused: false,
-            lastWriteAt: now - WRITE_BURST_RECENCY_MS + 1,
-          })
-        );
-
-        localManager.ensureContext("extra", makeManagedTerminal({ agentState: "working" }));
-
-        expect(localManager.isActive("edge")).toBe(false);
-        expect(disposeFor("edge")).toHaveBeenCalledTimes(1);
-        expect(localManager.isActive("inside")).toBe(true);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("rate-limits the pool-pressure warning to once per minute", async () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(0);
-      installRafShim();
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      try {
-        const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-        const max = TerminalWebGLManager.MAX_CONTEXTS;
-        const { localManager } = await makePriorityManager();
-
-        for (let i = 0; i < max; i++) {
-          localManager.ensureContext(`idle${i}`, makeManagedTerminal({ agentState: "idle" }));
-        }
-
-        const poolWarnings = () =>
-          warnSpy.mock.calls.filter(
-            (args) => typeof args[0] === "string" && args[0].includes("Pool pressure")
-          );
-
-        // First eviction warns immediately.
-        localManager.ensureContext("e1", makeManagedTerminal({ agentState: "idle" }));
-        expect(poolWarnings()).toHaveLength(1);
-
-        // Second eviction within the same minute is suppressed.
-        localManager.ensureContext("e2", makeManagedTerminal({ agentState: "idle" }));
-        expect(poolWarnings()).toHaveLength(1);
-
-        // After the interval elapses, the next eviction warns again.
-        vi.setSystemTime(60_001);
-        localManager.ensureContext("e3", makeManagedTerminal({ agentState: "idle" }));
-        expect(poolWarnings()).toHaveLength(2);
-      } finally {
-        warnSpy.mockRestore();
-        vi.useRealTimers();
-      }
-    });
-  });
-
-  describe("passive mode gate (#8378)", () => {
-    it("suppresses new acquisitions once pool+queue reaches the threshold", async () => {
-      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      TerminalWebGLManager.setPassiveThreshold(2);
-
-      manager.ensureContext("t1", makeManagedTerminal());
-      manager.ensureContext("t2", makeManagedTerminal());
-      expect(WebglAddonMock).toHaveBeenCalledTimes(2);
-      expect(manager.isActive("t1")).toBe(true);
-      expect(manager.isActive("t2")).toBe(true);
-
-      // 3rd request — pool is already at the threshold, so this is suppressed
-      // and the terminal stays on the DOM renderer.
-      manager.ensureContext("t3", makeManagedTerminal());
-      expect(WebglAddonMock).toHaveBeenCalledTimes(2);
-      expect(manager.isActive("t3")).toBe(false);
-    });
-
-    it("lets a re-ensure of an already-pooled terminal pass through (LRU touch)", async () => {
-      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      TerminalWebGLManager.setPassiveThreshold(2);
-
+    it("starts in webgl mode and attaches every want", () => {
       const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      const m3 = makeManagedTerminal();
       manager.ensureContext("t1", m1);
-      manager.ensureContext("t2", makeManagedTerminal());
+      manager.ensureContext("t2", m2);
+      manager.ensureContext("t3", m3);
 
-      // Pool is full at the threshold; re-ensuring a pooled terminal must not
-      // be gated (it adds no new context) and must not evict anything.
-      manager.ensureContext("t1", m1);
-      expect(WebglAddonMock).toHaveBeenCalledTimes(2);
+      expect(manager.getMode()).toBe("webgl");
       expect(manager.isActive("t1")).toBe(true);
       expect(manager.isActive("t2")).toBe(true);
+      expect(manager.isActive("t3")).toBe(true);
     });
 
-    it("resumes acquisition once a release drops the count below the threshold", async () => {
-      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      TerminalWebGLManager.setPassiveThreshold(2);
+    it("flips to dom mode and releases every context when wants exceeds upper", () => {
+      const terms = Array.from({ length: 4 }, () => makeManagedTerminal());
+      manager.ensureContext("t1", terms[0]!);
+      manager.ensureContext("t2", terms[1]!);
+      manager.ensureContext("t3", terms[2]!);
+      expect(manager.getMode()).toBe("webgl");
 
-      manager.ensureContext("t1", makeManagedTerminal());
-      manager.ensureContext("t2", makeManagedTerminal());
-      manager.ensureContext("t3", makeManagedTerminal());
-      expect(manager.isActive("t3")).toBe(false);
+      // The 4th want crosses the upper threshold (3) → flip to dom.
+      manager.ensureContext("t4", terms[3]!);
 
-      manager.releaseContext("t1");
+      expect(manager.getMode()).toBe("dom");
       expect(manager.isActive("t1")).toBe(false);
-
-      // Slot freed — a newly-visible terminal now passes the gate.
-      manager.ensureContext("t3", makeManagedTerminal());
-      expect(manager.isActive("t3")).toBe(true);
-      expect(WebglAddonMock).toHaveBeenCalledTimes(3);
-    });
-
-    it("keeps a suppressed terminal on DOM until the caller re-ensures it", async () => {
-      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      TerminalWebGLManager.setPassiveThreshold(2);
-
-      manager.ensureContext("t1", makeManagedTerminal());
-      manager.ensureContext("t2", makeManagedTerminal());
-      manager.ensureContext("t3", makeManagedTerminal());
-      expect(manager.isActive("t3")).toBe(false);
-
-      // Releasing t1 frees a slot, but t3 must NOT auto-resume — the gate only
-      // suppresses, it doesn't track suppressed terminals. The caller drives
-      // re-acquisition on the next attach/focus signal.
-      manager.releaseContext("t1");
-      expect(manager.isActive("t3")).toBe(false);
-
-      manager.ensureContext("t3", makeManagedTerminal());
-      expect(manager.isActive("t3")).toBe(true);
-    });
-
-    it("clamps the threshold to a minimum of 1", async () => {
-      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      TerminalWebGLManager.setPassiveThreshold(0);
-
-      // Clamped to 1 (not 0): the first acquisition still succeeds, the second
-      // is suppressed. A threshold of 0 would have suppressed even the first.
-      manager.ensureContext("t1", makeManagedTerminal());
-      manager.ensureContext("t2", makeManagedTerminal());
-      expect(manager.isActive("t1")).toBe(true);
       expect(manager.isActive("t2")).toBe(false);
-      expect(WebglAddonMock).toHaveBeenCalledTimes(1);
+      expect(manager.isActive("t3")).toBe(false);
+      expect(manager.isActive("t4")).toBe(false);
+      // All four still tracked as wanting WebGL — they get it back on flip.
+      expect(manager.getWantsSize()).toBe(4);
     });
 
-    it("does not evict existing pooled contexts when the threshold is crossed", async () => {
+    it("flipping to dom refreshes every visible formerly-pooled terminal", () => {
+      // Visible terminals must repaint so the renderer swap (WebGL→DOM) happens
+      // in the same frame, not deferred to the next write. A regression that
+      // drops the refresh call would leave visible panes blank until output.
+      const terms = Array.from({ length: 4 }, () =>
+        makeManagedTerminal({ isOpened: true, isVisible: true })
+      );
+      manager.ensureContext("t1", terms[0]!);
+      manager.ensureContext("t2", terms[1]!);
+      manager.ensureContext("t3", terms[2]!);
+      // Reset refresh-call history from any attach-time paints.
+      terms.forEach((t) => (t.terminal.refresh as ReturnType<typeof vi.fn>).mockClear());
+
+      manager.ensureContext("t4", terms[3]!);
+      expect(manager.getMode()).toBe("dom");
+
+      // The three previously-pooled terminals each got a refresh; t4 never
+      // entered the pool (ensureContext evaluated mode before queueAttach) so
+      // it isn't refreshed by flipToDom.
+      expect(terms[0]!.terminal.refresh).toHaveBeenCalled();
+      expect(terms[1]!.terminal.refresh).toHaveBeenCalled();
+      expect(terms[2]!.terminal.refresh).toHaveBeenCalled();
+    });
+
+    it("does not attach new wants while in dom mode", () => {
+      // Push past upper to land in dom mode.
+      for (let i = 0; i < 4; i++) {
+        manager.ensureContext(`t${i}`, makeManagedTerminal());
+      }
+      expect(manager.getMode()).toBe("dom");
+
+      const before = WebglAddonMock.mock.calls.length;
+      manager.ensureContext("t5", makeManagedTerminal());
+      expect(WebglAddonMock.mock.calls.length).toBe(before);
+      expect(manager.isActive("t5")).toBe(false);
+    });
+
+    it("flips back to webgl when wants drops to the lower threshold", () => {
+      // Push to dom mode at 4 wants.
+      for (let i = 0; i < 4; i++) {
+        manager.ensureContext(`t${i}`, makeManagedTerminal());
+      }
+      expect(manager.getMode()).toBe("dom");
+
+      // Drop two wants → at 2, which is the lower threshold → flip back.
+      manager.releaseContext("t0");
+      manager.releaseContext("t1");
+
+      expect(manager.getMode()).toBe("webgl");
+      // Surviving wants get reattached (rAF mode is sync in this suite).
+      expect(manager.isActive("t2")).toBe(true);
+      expect(manager.isActive("t3")).toBe(true);
+    });
+
+    it("hysteresis: oscillating one above/below upper does not flap", () => {
+      // Land exactly at upper (3 wants, webgl mode).
+      manager.ensureContext("a", makeManagedTerminal());
+      manager.ensureContext("b", makeManagedTerminal());
+      manager.ensureContext("c", makeManagedTerminal());
+      expect(manager.getMode()).toBe("webgl");
+
+      // 3 → 4 flips to dom.
+      manager.ensureContext("d", makeManagedTerminal());
+      expect(manager.getMode()).toBe("dom");
+
+      // 4 → 3 must NOT flip back — lower threshold is 2.
+      manager.releaseContext("d");
+      expect(manager.getMode()).toBe("dom");
+
+      // 3 → 4 again — already dom, no behavior change beyond tracking.
+      manager.ensureContext("d", makeManagedTerminal());
+      expect(manager.getMode()).toBe("dom");
+
+      // Now drop all the way to the lower band (2).
+      manager.releaseContext("d");
+      manager.releaseContext("c");
+      expect(manager.getMode()).toBe("webgl");
+    });
+
+    it("logs the downgrade warning only once per dom-mode trip", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      // First downgrade.
+      for (let i = 0; i < 4; i++) {
+        manager.ensureContext(`t${i}`, makeManagedTerminal());
+      }
+      expect(manager.getMode()).toBe("dom");
+
+      const downgradeWarnings = (): Array<unknown[]> =>
+        warnSpy.mock.calls.filter(
+          (args) => typeof args[0] === "string" && args[0].includes("Switching to DOM renderer")
+        );
+      expect(downgradeWarnings()).toHaveLength(1);
+
+      // Adding another want stays in dom — no second warning.
+      manager.ensureContext("t99", makeManagedTerminal());
+      expect(downgradeWarnings()).toHaveLength(1);
+
+      // Recover to webgl, then trip again — second downgrade IS logged.
+      manager.releaseContext("t0");
+      manager.releaseContext("t1");
+      manager.releaseContext("t2");
+      manager.releaseContext("t3");
+      manager.releaseContext("t99");
+      expect(manager.getMode()).toBe("webgl");
+
+      for (let i = 0; i < 4; i++) {
+        manager.ensureContext(`u${i}`, makeManagedTerminal());
+      }
+      expect(downgradeWarnings()).toHaveLength(2);
+
+      warnSpy.mockRestore();
+    });
+
+    it("dom→webgl flip queues every want via the rAF drain (no synchronous bulk attach)", () => {
+      // Push to dom mode at 4 wants.
+      for (let i = 0; i < 4; i++) {
+        manager.ensureContext(`t${i}`, makeManagedTerminal());
+      }
+      expect(manager.getMode()).toBe("dom");
+
+      // Switch to queued rAF so the drain steps are visible one frame at a time.
+      rafMode = "queued";
+
+      // Drop to lower threshold (2) → flip back to webgl. Two wants survive.
+      manager.releaseContext("t0");
+      manager.releaseContext("t1");
+      expect(manager.getMode()).toBe("webgl");
+
+      // Both surviving wants are queued, none attached yet.
+      expect(manager.isActive("t2")).toBe(false);
+      expect(manager.isActive("t3")).toBe(false);
+
+      flushRafFrame();
+      // Exactly one attached per frame.
+      const activeAfterFrame1 = [manager.isActive("t2"), manager.isActive("t3")].filter(Boolean);
+      expect(activeAfterFrame1).toHaveLength(1);
+
+      flushRafFrame();
+      expect(manager.isActive("t2")).toBe(true);
+      expect(manager.isActive("t3")).toBe(true);
+
+      // Queue drained.
+      expect(flushRafFrame()).toBe(false);
+    });
+
+    it("hardware-unavailable forces dom mode even when count is below lower threshold", () => {
+      manager.setHardwareAvailable(false);
+      expect(manager.getMode()).toBe("dom");
+
+      // Wants do not flip back even at zero — hardware is gone for the session.
+      manager.ensureContext("t1", makeManagedTerminal());
+      manager.releaseContext("t1");
+      expect(manager.getMode()).toBe("dom");
+    });
+
+    it("refreshMode() re-evaluates against current thresholds (profile change)", async () => {
+      // Populate to 3 wants under the (3, 2) thresholds — still in webgl.
+      manager.ensureContext("a", makeManagedTerminal());
+      manager.ensureContext("b", makeManagedTerminal());
+      manager.ensureContext("c", makeManagedTerminal());
+      expect(manager.getMode()).toBe("webgl");
+
+      // Simulate a profile downgrade narrowing the band BELOW the current
+      // wants count. Without refreshMode(), the manager would stay in webgl
+      // until the next ensure/release. With it, the mode flips on the spot.
       const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
-      TerminalWebGLManager.setPassiveThreshold(2);
+      TerminalWebGLManager.setWebglThresholds(2, 1);
+      manager.refreshMode();
 
-      const disposes: ReturnType<typeof vi.fn>[] = [];
-      WebglAddonMock.mockImplementation(function () {
-        const d = vi.fn();
-        disposes.push(d);
-        return { dispose: d, onContextLoss: mockOnContextLoss };
-      });
-      const localManager = new TerminalWebGLManager();
-
-      localManager.ensureContext("t1", makeManagedTerminal());
-      localManager.ensureContext("t2", makeManagedTerminal());
-      // Suppressed — must not trigger eviction of t1/t2 to make room.
-      localManager.ensureContext("t3", makeManagedTerminal());
-
-      expect(localManager.isActive("t1")).toBe(true);
-      expect(localManager.isActive("t2")).toBe(true);
-      expect(disposes).toHaveLength(2);
-      disposes.forEach((d) => expect(d).not.toHaveBeenCalled());
+      expect(manager.getMode()).toBe("dom");
+      expect(manager.isActive("a")).toBe(false);
+      expect(manager.isActive("b")).toBe(false);
+      expect(manager.isActive("c")).toBe(false);
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -1085,6 +1085,45 @@ describe("TerminalWebGLManager", () => {
       expect(manager.getWantsSize()).toBe(4);
     });
 
+    it("paces dom-mode release to one active context per animation frame", () => {
+      const terms = Array.from({ length: 4 }, () => makeManagedTerminal());
+      manager.ensureContext("t1", terms[0]!);
+      manager.ensureContext("t2", terms[1]!);
+      manager.ensureContext("t3", terms[2]!);
+
+      rafMode = "queued";
+      manager.ensureContext("t4", terms[3]!);
+      expect(manager.getMode()).toBe("dom");
+
+      // The downgrade is visible immediately, but expensive WebGL teardown is
+      // paced so a 16-panel fleet does not lose every context in one task.
+      expect(manager.isActive("t1")).toBe(true);
+      expect(manager.isActive("t2")).toBe(true);
+      expect(manager.isActive("t3")).toBe(true);
+
+      flushRafFrame();
+      const activeAfterFrame1 = [
+        manager.isActive("t1"),
+        manager.isActive("t2"),
+        manager.isActive("t3"),
+      ].filter(Boolean);
+      expect(activeAfterFrame1).toHaveLength(2);
+
+      flushRafFrame();
+      const activeAfterFrame2 = [
+        manager.isActive("t1"),
+        manager.isActive("t2"),
+        manager.isActive("t3"),
+      ].filter(Boolean);
+      expect(activeAfterFrame2).toHaveLength(1);
+
+      flushRafFrame();
+      expect(manager.isActive("t1")).toBe(false);
+      expect(manager.isActive("t2")).toBe(false);
+      expect(manager.isActive("t3")).toBe(false);
+      expect(flushRafFrame()).toBe(false);
+    });
+
     it("flipping to dom refreshes every visible formerly-pooled terminal", () => {
       // Visible terminals must repaint so the renderer swap (WebGL→DOM) happens
       // in the same frame, not deferred to the next write. A regression that

--- a/src/services/terminal/__tests__/optimisticPanelClose.test.ts
+++ b/src/services/terminal/__tests__/optimisticPanelClose.test.ts
@@ -46,11 +46,6 @@ describe("optimisticPanelClose", () => {
     mockState.focusedId = null;
     mockState.panelIds = [];
     mockState.panelsById = {};
-    // The real store setter updates focusedId; mirror that so the deferred
-    // focus guard (`focusedId === target`) sees the committed value.
-    setFocusedMock.mockImplementation((id: string | null) => {
-      mockState.focusedId = id;
-    });
   });
 
   afterEach(() => {

--- a/src/services/terminal/__tests__/optimisticPanelClose.test.ts
+++ b/src/services/terminal/__tests__/optimisticPanelClose.test.ts
@@ -46,6 +46,11 @@ describe("optimisticPanelClose", () => {
     mockState.focusedId = null;
     mockState.panelIds = [];
     mockState.panelsById = {};
+    // The real store setter updates focusedId; mirror that so the deferred
+    // focus guard (`focusedId === target`) sees the committed value.
+    setFocusedMock.mockImplementation((id: string | null) => {
+      mockState.focusedId = id;
+    });
   });
 
   afterEach(() => {

--- a/src/services/terminal/__tests__/optimisticPanelClose.test.ts
+++ b/src/services/terminal/__tests__/optimisticPanelClose.test.ts
@@ -145,7 +145,12 @@ describe("optimisticPanelClose", () => {
 
     requestPanelClose({ hideIds: ["p1"], commit: vi.fn() });
 
+    // The logical focus retarget is synchronous — a rapid Cmd+W stream relies
+    // on it — but the xterm DOM focus is deferred past the close paint.
     expect(setFocusedMock).toHaveBeenCalledWith("p2");
+    expect(focusMock).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
     expect(focusMock).toHaveBeenCalledWith("p2");
   });
 

--- a/src/services/terminal/__tests__/optimisticPanelClose.test.ts
+++ b/src/services/terminal/__tests__/optimisticPanelClose.test.ts
@@ -17,6 +17,12 @@ const mockState = {
   panelIds: [] as string[],
   panelsById: {} as Record<string, MockPanel>,
   setFocused: setFocusedMock,
+  getTabGroups: undefined as
+    | ((
+        location: "grid",
+        worktreeId?: string
+      ) => Array<{ panelIds: string[]; activeTabId: string }>)
+    | undefined,
 };
 
 vi.mock("@/store", () => ({
@@ -46,6 +52,8 @@ describe("optimisticPanelClose", () => {
     mockState.focusedId = null;
     mockState.panelIds = [];
     mockState.panelsById = {};
+    mockState.getTabGroups = undefined;
+    document.body.innerHTML = "";
     // The real store setter updates focusedId; mirror that so the deferred
     // focus guard (`focusedId === target`) sees the committed value.
     setFocusedMock.mockImplementation((id: string | null) => {
@@ -59,9 +67,18 @@ describe("optimisticPanelClose", () => {
 
   it("hides the panel immediately and defers the canonical commit", () => {
     const commit = vi.fn();
+    const gridCell = document.createElement("div");
+    gridCell.dataset.terminalId = "p1";
+    const panel = document.createElement("div");
+    panel.dataset.panelId = "p1";
+    gridCell.appendChild(panel);
+    document.body.appendChild(gridCell);
+
     requestPanelClose({ hideIds: ["p1"], commit });
 
     expect(isOptimisticallyClosing("p1")).toBe(true);
+    expect(gridCell.style.display).toBe("none");
+    expect(gridCell.dataset.optimisticClosing).toBe("true");
     expect(commit).not.toHaveBeenCalled();
 
     vi.runAllTimers();
@@ -126,15 +143,14 @@ describe("optimisticPanelClose", () => {
     expect(ok).toHaveBeenCalledTimes(1);
   });
 
-  it("notifies subscribers when closingIds change", () => {
+  it("does not notify React subscribers on the visual hide path", () => {
     const listener = vi.fn();
     const unsubscribe = subscribeOptimisticClose(listener);
 
     requestPanelClose({ hideIds: ["p1"], commit: vi.fn() });
-    expect(listener).toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
 
-    listener.mockClear();
-    vi.runAllTimers(); // flush clears closingIds -> another notify
+    vi.runAllTimers(); // flush clears lifecycle state after canonical commit
     expect(listener).toHaveBeenCalled();
 
     unsubscribe();
@@ -157,6 +173,46 @@ describe("optimisticPanelClose", () => {
 
     vi.runAllTimers();
     expect(focusMock).toHaveBeenCalledWith("p2");
+  });
+
+  it("advances focus to the next visual grid panel, not the first panel", () => {
+    mockState.focusedId = "p2";
+    mockState.panelIds = ["p1", "p2", "p3", "p4"];
+    mockState.panelsById = {
+      p1: { id: "p1", location: "grid", worktreeId: "w1" },
+      p2: { id: "p2", location: "grid", worktreeId: "w1" },
+      p3: { id: "p3", location: "grid", worktreeId: "w1" },
+      p4: { id: "p4", location: "grid", worktreeId: "w1" },
+    };
+    mockState.getTabGroups = () => [
+      { panelIds: ["p1"], activeTabId: "p1" },
+      { panelIds: ["p2"], activeTabId: "p2" },
+      { panelIds: ["p3"], activeTabId: "p3" },
+      { panelIds: ["p4"], activeTabId: "p4" },
+    ];
+
+    requestPanelClose({ hideIds: ["p2"], commit: vi.fn() });
+
+    expect(setFocusedMock).toHaveBeenCalledWith("p3");
+  });
+
+  it("falls back to the previous visual grid panel when closing the last panel", () => {
+    mockState.focusedId = "p3";
+    mockState.panelIds = ["p1", "p2", "p3"];
+    mockState.panelsById = {
+      p1: { id: "p1", location: "grid", worktreeId: "w1" },
+      p2: { id: "p2", location: "grid", worktreeId: "w1" },
+      p3: { id: "p3", location: "grid", worktreeId: "w1" },
+    };
+    mockState.getTabGroups = () => [
+      { panelIds: ["p1"], activeTabId: "p1" },
+      { panelIds: ["p2"], activeTabId: "p2" },
+      { panelIds: ["p3"], activeTabId: "p3" },
+    ];
+
+    requestPanelClose({ hideIds: ["p3"], commit: vi.fn() });
+
+    expect(setFocusedMock).toHaveBeenCalledWith("p2");
   });
 
   it("does not move focus when the closed panel was not focused", () => {

--- a/src/services/terminal/optimisticPanelClose.ts
+++ b/src/services/terminal/optimisticPanelClose.ts
@@ -118,14 +118,7 @@ function advanceFocusPastClosing(hideIds: string[]): void {
     // real work that must not block the close frame. The logical `setFocused`
     // above already retargets a rapid Cmd+W stream synchronously.
     const focusTarget = next;
-    requestAnimationFrame(() => {
-      // Re-check before the deferred focus lands: a rapid close burst or a
-      // click elsewhere may have moved focus on, or closed this target too.
-      const current = panelStoreApi.getState().focusedId;
-      if (current === focusTarget && !closingIds.has(focusTarget)) {
-        terminalInstanceService.focus(focusTarget);
-      }
-    });
+    requestAnimationFrame(() => terminalInstanceService.focus(focusTarget));
   }
 }
 

--- a/src/services/terminal/optimisticPanelClose.ts
+++ b/src/services/terminal/optimisticPanelClose.ts
@@ -6,9 +6,9 @@
 // rapid closes stack and feel laggy.
 //
 // This coordinator splits the close in two:
-//   1. Optimistic hide — the clicked panel id(s) land in `closingIds` and the
-//      grid filters them out immediately, so the panel disappears in the same
-//      frame with near-zero work (just a free CSS-grid reflow).
+//   1. Optimistic hide — the clicked panel id(s) land in `closingIds` for
+//      dedupe/focus and their DOM cells are hidden imperatively with
+//      `display:none`. React does not unmount xterm on the click path.
 //   2. Deferred canonical commit — the real teardown runs after the browser
 //      has painted the removal, coalesced so a burst of closes flushes once.
 //
@@ -49,6 +49,7 @@ export interface PanelCloseRequest {
 
 const EMPTY: ReadonlySet<string> = new Set<string>();
 let closingIds: ReadonlySet<string> = EMPTY;
+let renderClosingIds: ReadonlySet<string> = EMPTY;
 let pending: PanelCloseRequest[] = [];
 let flushTimer: number | undefined;
 const listeners = new Set<() => void>();
@@ -63,7 +64,7 @@ function emit(): void {
   }
 }
 
-/** Subscribe to `closingIds` changes — wired into `useSyncExternalStore`. */
+/** Subscribe to render-overlay changes — wired into `useSyncExternalStore`. */
 export function subscribeOptimisticClose(listener: () => void): () => void {
   listeners.add(listener);
   return () => {
@@ -73,7 +74,7 @@ export function subscribeOptimisticClose(listener: () => void): () => void {
 
 /** Stable snapshot for `useSyncExternalStore` — identity changes only on edit. */
 export function getClosingIdsSnapshot(): ReadonlySet<string> {
-  return closingIds;
+  return renderClosingIds;
 }
 
 export function isOptimisticallyClosing(id: string): boolean {
@@ -86,7 +87,97 @@ export function hasPendingOptimisticCloses(): boolean {
 
 function setClosingIds(next: Set<string>): void {
   closingIds = next.size === 0 ? EMPTY : next;
+  renderClosingIds = EMPTY;
   emit();
+}
+
+function setClosingIdsSilently(next: Set<string>): void {
+  closingIds = next.size === 0 ? EMPTY : next;
+}
+
+function getPanelElement(id: string): HTMLElement | null {
+  if (typeof document === "undefined") return null;
+  for (const element of document.querySelectorAll<HTMLElement>("[data-panel-id]")) {
+    if (element.dataset.panelId === id) return element;
+  }
+  for (const element of document.querySelectorAll<HTMLElement>("[data-terminal-id]")) {
+    if (element.dataset.terminalId === id) return element;
+  }
+  return null;
+}
+
+function hidePanelsImperatively(ids: string[]): void {
+  for (const id of ids) {
+    const panelElement = getPanelElement(id);
+    const element =
+      (panelElement?.closest("[data-terminal-id]") as HTMLElement | null) ?? panelElement;
+    if (!element) continue;
+    element.dataset.optimisticClosing = "true";
+    element.setAttribute("aria-hidden", "true");
+    element.style.display = "none";
+    (element as HTMLElement & { inert?: boolean }).inert = true;
+  }
+}
+
+function firstFocusablePanelInGroup(
+  panelIds: string[],
+  activeTabId: string | undefined,
+  closing: ReadonlySet<string>
+): string | null {
+  if (activeTabId && panelIds.includes(activeTabId) && !closing.has(activeTabId)) {
+    return activeTabId;
+  }
+  return panelIds.find((id) => !closing.has(id)) ?? null;
+}
+
+function findNextGridFocusTarget(hideIds: string[]): string | null {
+  const state = panelStoreApi.getState();
+  const closing = new Set(closingIds);
+  const closingWorktreeId = state.panelsById[hideIds[0] ?? ""]?.worktreeId;
+  const groups = state.getTabGroups?.("grid", closingWorktreeId);
+
+  if (groups && groups.length > 0) {
+    const closedGroupIndex = groups.findIndex((group) =>
+      group.panelIds.some((id) => hideIds.includes(id))
+    );
+
+    if (closedGroupIndex >= 0) {
+      for (let i = closedGroupIndex + 1; i < groups.length; i++) {
+        const group = groups[i]!;
+        const candidate = firstFocusablePanelInGroup(group.panelIds, group.activeTabId, closing);
+        if (candidate) return candidate;
+      }
+      for (let i = closedGroupIndex - 1; i >= 0; i--) {
+        const group = groups[i]!;
+        const candidate = firstFocusablePanelInGroup(group.panelIds, group.activeTabId, closing);
+        if (candidate) return candidate;
+      }
+      return null;
+    }
+  }
+
+  const closedIndexes = hideIds
+    .map((id) => state.panelIds.indexOf(id))
+    .filter((index) => index >= 0);
+  const startIndex = closedIndexes.length > 0 ? Math.max(...closedIndexes) + 1 : 0;
+
+  const isGridSurvivor = (id: string): boolean => {
+    if (closing.has(id)) return false;
+    const terminal = state.panelsById[id];
+    if (!terminal) return false;
+    if (terminal.location !== "grid" && terminal.location !== undefined) return false;
+    return terminal.worktreeId === closingWorktreeId;
+  };
+
+  for (let i = startIndex; i < state.panelIds.length; i++) {
+    const id = state.panelIds[i]!;
+    if (isGridSurvivor(id)) return id;
+  }
+  for (let i = startIndex - 2; i >= 0; i--) {
+    const id = state.panelIds[i]!;
+    if (isGridSurvivor(id)) return id;
+  }
+  return null;
 }
 
 // Closing the focused panel must advance `focusedId` synchronously: keybinding
@@ -99,17 +190,7 @@ function advanceFocusPastClosing(hideIds: string[]): void {
   const focusedId = state.focusedId;
   if (!focusedId || !hideIds.includes(focusedId)) return;
 
-  const closingWorktreeId = state.panelsById[hideIds[0] ?? ""]?.worktreeId;
-  let next: string | null = null;
-  for (const id of state.panelIds) {
-    if (closingIds.has(id)) continue;
-    const terminal = state.panelsById[id];
-    if (!terminal) continue;
-    if (terminal.location !== "grid" && terminal.location !== undefined) continue;
-    if (terminal.worktreeId !== closingWorktreeId) continue;
-    next = id;
-    break;
-  }
+  const next = findNextGridFocusTarget(hideIds);
   state.setFocused(next);
   if (next) {
     // Move DOM focus too — the closed pane's xterm textarea is unmounting, so
@@ -151,7 +232,7 @@ function runFlush(): void {
   }
 
   // The canonical commit moved these panels to trash, so the grid derivations
-  // exclude them on their own now — drop them from the optimistic overlay.
+  // exclude them on their own now — drop them from the lifecycle overlay.
   if (closingIds.size > 0) {
     const next = new Set(closingIds);
     for (const request of batch) {
@@ -184,7 +265,8 @@ export function requestPanelClose(request: PanelCloseRequest): void {
 
   const next = new Set(closingIds);
   for (const id of request.hideIds) next.add(id);
-  setClosingIds(next);
+  setClosingIdsSilently(next);
+  hidePanelsImperatively(request.hideIds);
 
   advanceFocusPastClosing(request.hideIds);
   pending.push(request);
@@ -198,6 +280,7 @@ export function __resetOptimisticPanelCloseForTests(): void {
   }
   pending = [];
   closingIds = EMPTY;
+  renderClosingIds = EMPTY;
   listeners.clear();
 }
 

--- a/src/services/terminal/optimisticPanelClose.ts
+++ b/src/services/terminal/optimisticPanelClose.ts
@@ -19,12 +19,26 @@ import { panelStoreApi } from "@/store";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { logError } from "@/utils/logger";
 
-// A burst of closes within this gap collapses into one deferred flush. Short
-// enough that canonical state (and undo) stays responsive, long enough that the
-// optimistic removal has reliably painted first.
-const FLUSH_DEBOUNCE_MS = 48;
-// Hard ceiling so a sustained close stream still commits promptly.
+// The canonical teardown runs in idle time — after the optimistic removal has
+// painted — so it never competes with the close interaction or a burst of
+// closes. `FLUSH_MAX_WAIT_MS` caps the wait so undo and canonical state stay
+// responsive even if the main thread never goes idle.
 const FLUSH_MAX_WAIT_MS = 160;
+
+const supportsIdleCallback =
+  typeof window !== "undefined" && typeof window.requestIdleCallback === "function";
+
+/** Schedule `cb` for the next idle slot, or `FLUSH_MAX_WAIT_MS` at the latest. */
+function scheduleIdle(cb: () => void): number {
+  return supportsIdleCallback
+    ? window.requestIdleCallback(cb, { timeout: FLUSH_MAX_WAIT_MS })
+    : window.setTimeout(cb, FLUSH_MAX_WAIT_MS);
+}
+
+function cancelIdle(handle: number): void {
+  if (supportsIdleCallback) window.cancelIdleCallback(handle);
+  else window.clearTimeout(handle);
+}
 
 export interface PanelCloseRequest {
   /** Panel ids to hide from the grid immediately. */
@@ -37,7 +51,6 @@ const EMPTY: ReadonlySet<string> = new Set<string>();
 let closingIds: ReadonlySet<string> = EMPTY;
 let pending: PanelCloseRequest[] = [];
 let flushTimer: number | undefined;
-let firstRequestAt: number | undefined;
 const listeners = new Set<() => void>();
 
 function emit(): void {
@@ -100,23 +113,24 @@ function advanceFocusPastClosing(hideIds: string[]): void {
   state.setFocused(next);
   if (next) {
     // Move DOM focus too — the closed pane's xterm textarea is unmounting, so
-    // without this keyboard focus falls to <body> until the user clicks.
-    terminalInstanceService.focus(next);
+    // without this keyboard focus falls to <body> until the user clicks. Defer
+    // it past paint: xterm `.focus()` restores the viewport scroll position,
+    // real work that must not block the close frame. The logical `setFocused`
+    // above already retargets a rapid Cmd+W stream synchronously.
+    const focusTarget = next;
+    requestAnimationFrame(() => terminalInstanceService.focus(focusTarget));
   }
 }
 
 function scheduleFlush(): void {
-  const now = Date.now();
-  if (firstRequestAt === undefined) firstRequestAt = now;
-  if (flushTimer !== undefined) clearTimeout(flushTimer);
-  const elapsed = now - firstRequestAt;
-  const delay = Math.max(0, Math.min(FLUSH_DEBOUNCE_MS, FLUSH_MAX_WAIT_MS - elapsed));
-  flushTimer = window.setTimeout(runFlush, delay);
+  // A burst of closes coalesces: the first schedules the flush, the rest just
+  // queue into `pending` — `runFlush` drains every queued request at once.
+  if (flushTimer !== undefined) return;
+  flushTimer = scheduleIdle(runFlush);
 }
 
 function runFlush(): void {
   flushTimer = undefined;
-  firstRequestAt = undefined;
   if (pending.length === 0) return;
 
   const batch = pending;
@@ -147,10 +161,9 @@ function runFlush(): void {
  */
 export function flushOptimisticCloses(): void {
   if (flushTimer !== undefined) {
-    clearTimeout(flushTimer);
+    cancelIdle(flushTimer);
     flushTimer = undefined;
   }
-  firstRequestAt = undefined;
   runFlush();
 }
 
@@ -173,10 +186,9 @@ export function requestPanelClose(request: PanelCloseRequest): void {
 
 export function __resetOptimisticPanelCloseForTests(): void {
   if (flushTimer !== undefined) {
-    clearTimeout(flushTimer);
+    cancelIdle(flushTimer);
     flushTimer = undefined;
   }
-  firstRequestAt = undefined;
   pending = [];
   closingIds = EMPTY;
   listeners.clear();

--- a/src/services/terminal/optimisticPanelClose.ts
+++ b/src/services/terminal/optimisticPanelClose.ts
@@ -118,7 +118,14 @@ function advanceFocusPastClosing(hideIds: string[]): void {
     // real work that must not block the close frame. The logical `setFocused`
     // above already retargets a rapid Cmd+W stream synchronously.
     const focusTarget = next;
-    requestAnimationFrame(() => terminalInstanceService.focus(focusTarget));
+    requestAnimationFrame(() => {
+      // Re-check before the deferred focus lands: a rapid close burst or a
+      // click elsewhere may have moved focus on, or closed this target too.
+      const current = panelStoreApi.getState().focusedId;
+      if (current === focusTarget && !closingIds.has(focusTarget)) {
+        terminalInstanceService.focus(focusTarget);
+      }
+    });
   }
 }
 

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -176,14 +176,17 @@ export interface ManagedTerminal {
   ipcListenerCount: number;
 
   // Visibility-driven WebGL restore debounce. Show path waits ~100ms before
-  // re-acquiring so rapid tab/panel toggles don't thrash addon load/unload.
+  // re-ensuring the addon, so rapid tab/panel toggles don't repeatedly
+  // construct/dispose addons even when the manager-level mode flag is stable.
   webGLRestoreTimer?: number;
 
-  // Visibility-driven WebGL release hysteresis. Hide path holds the context
-  // for ~500ms before releasing so rapid hide→show cycles (panel toggles,
-  // focus oscillation) don't churn the WebGL pool. Authoritative release
-  // paths (tier demotion, agent demotion, destroy, hibernation) cancel this
-  // timer and release immediately.
+  // Visibility-driven WebGL release hysteresis. Hide path holds eligibility
+  // for ~500ms before calling releaseContext, so rapid hide→show cycles don't
+  // repeatedly drop/re-add the terminal to the manager's `wants` set.
+  // Authoritative release paths (tier demotion, agent demotion, destroy,
+  // hibernation) cancel this timer and release immediately. Note: while the
+  // timer is armed, the terminal still counts toward the mode-switch
+  // threshold — see TerminalWebGLManager for the trade-off.
   webGLHideTimer?: number;
 
   // Timestamp of the most recent successful reduceScrollback() — gates the

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -10,7 +10,7 @@ import {
 } from "@shared/config/panelKindRegistry";
 import { getTerminalAppearanceSnapshot } from "@/hooks/useTerminalAppearance";
 import { getScrollbackForType, PERFORMANCE_MODE_SCROLLBACK } from "@/utils/scrollbackConfig";
-import { getXtermOptions } from "@/config/xtermConfig";
+import { getXtermOptions, calculateTerminalDimensions } from "@/config/xtermConfig";
 import { deriveTerminalRuntimeIdentity } from "@/utils/terminalChrome";
 import { getWorktreeSelectionSnapshot } from "@/store/storeAccessors";
 import { usePanelLimitStore, evaluatePanelLimit } from "@/store/panelLimitStore";
@@ -489,12 +489,11 @@ export const createAddPanelActions = (
 
         // For offscreen/inactive agents, prewarmTerminal's fit() already handles
         // initial PTY resize through settled strategy. Only send explicit resize
-        // for active grid spawns where fit() is skipped.
+        // for active grid spawns where fit() is skipped. Cell metrics come from
+        // calculateTerminalDimensions so the lineHeight assumption stays in sync
+        // with xtermConfig (1.0 — see BASE_TERMINAL_OPTIONS).
         if (!offscreenOrInactive) {
-          const cellWidth = Math.max(6, Math.floor(fontSize * 0.6));
-          const cellHeight = Math.max(10, Math.floor(fontSize * 1.1));
-          const cols = Math.max(20, Math.min(500, Math.floor(widthPx / cellWidth)));
-          const rows = Math.max(10, Math.min(200, Math.floor(heightPx / cellHeight)));
+          const { cols, rows } = calculateTerminalDimensions(widthPx, heightPx, fontSize);
           terminalInstanceService.sendPtyResize(id, cols, rows);
         }
       }

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -118,7 +118,7 @@ export const createTrashActions = (
     scheduleTrashExpiry(id, expiresAt);
 
     if (panelKindHasPty(terminal.kind ?? "terminal")) {
-      terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.BACKGROUND);
+      terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);
       return;
     }
   };
@@ -225,7 +225,7 @@ export const createTrashActions = (
     for (const id of trashPanelIds) {
       const terminal = state.panelsById[id];
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
-        terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.BACKGROUND);
+        terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);
       }
     }
   };
@@ -442,7 +442,7 @@ export const createTrashActions = (
       scheduleTrashExpiry(id, expiresAt);
 
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
-        terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.BACKGROUND);
+        terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);
       }
     },
 

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -118,7 +118,7 @@ export const createTrashActions = (
     scheduleTrashExpiry(id, expiresAt);
 
     if (panelKindHasPty(terminal.kind ?? "terminal")) {
-      terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);
+      terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.BACKGROUND);
       return;
     }
   };
@@ -225,7 +225,7 @@ export const createTrashActions = (
     for (const id of trashPanelIds) {
       const terminal = state.panelsById[id];
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
-        terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);
+        terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.BACKGROUND);
       }
     }
   };
@@ -442,7 +442,7 @@ export const createTrashActions = (
       scheduleTrashExpiry(id, expiresAt);
 
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
-        terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);
+        terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.BACKGROUND);
       }
     },
 


### PR DESCRIPTION
Multi-commit rework of the panel grid, the surface that hosts agent terminals.

## Sizing model

The grid was count-driven: at five or more panels it jumped into a scrollable list, regardless of how much screen the user actually had. On a wide display that meant scrolling past three perfectly good empty columns. This makes the grid size-driven instead.

Wide displays now carry 3-4 columns. The column cap stays at 4, which is the subitizing / ambient-awareness ceiling (the same number MOT and revised working-memory research independently converge on — beyond it the user isn't monitoring panes, they're checking on them after the fact). Scroll mode only activates when minimum-height rows would actually overflow the viewport, not at a fixed panel count.

The constants in `src/lib/terminalLayout.ts` are reworked into character-column terms — `GRID_MIN_PANEL_COLS`, `READABLE_GRID_MIN_COLS`, `pxForCols`, `pxForRows`, `applyHysteresis`, `gridRowsOverflow`, `computeScrollRowHeight` — so the math reads in the unit the panels actually render in. `applyHysteresis` adds a Schmitt-trigger buffer at column breakpoints to stop the grid flickering between two layouts when the window is resized near a boundary.

This is a behavioural change for anyone used to the old count-driven grid. The five-pane case in particular looks very different.

## Scrollbar

The native scrollbar is replaced with a custom `GridScrollbar` component, modelled on VS Code's (xterm's) slider. Always-visible handle, pointer-capture drag with `onLostPointerCapture` cleanup, and a reserved 22px gutter via `paddingRight` so panels never sit under the handle. The native scrollbar is hidden via `scrollbar-width: none`.

## Close-path performance

Closing a panel was the worst frame in the app at high panel counts. The click went through React state, unmounted the xterm, ran FLIP, restretched every survivor, and resized every surviving terminal — all on the click frame.

Now the click hides the grid cell via `display: none` directly. The xterm stays mounted; the canonical store commit lands one debounce later. FLIP layout projection is disabled while any optimistic close is in flight, so there's no intermediate reflow. WebGL context release is paced to one per rAF frame instead of running the whole pool synchronously, and the post-close resize pass is scheduled via `scheduler.postTask` at user-visible priority so the browser can yield between the resize and the next paint.

The LRU WebGL pool is also gone. `TerminalWebGLManager` now runs in one of two modes (WebGL or DOM) with a hysteresis band between `webglUpperThreshold` and `webglLowerThreshold`. Either every active context gets a renderer or every active context is released — no per-context flapping at the boundary when a single panel opens or closes.

The close path is noticeably snappier at high panel counts, which is the only measurement that matters here.
