### PR TITLE
fix(activity): suppress idle→busy flip on focus repaint

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -863,6 +863,10 @@ export class ActivityMonitor {
     this.lastActivityTimestamp = now;
     this.lastDataTimestamp = now;
     if (this.state !== "busy") {
+      // Skip idle→busy on OSC progress while focus suppression is active —
+      // a focus-triggered repaint that also emits OSC 9;4 must not bypass
+      // the suppression window (#8865).
+      if (this.isFocusSuppressed(now)) return;
       this.becomeBusy({ trigger: "output" }, now);
       return;
     }
@@ -925,7 +929,7 @@ export class ActivityMonitor {
     this.simpleOutputTemperature.reset();
   }
 
-  private isFocusSuppressed(now: number): boolean {
+  isFocusSuppressed(now: number = Date.now()): boolean {
     return this.focusSuppressUntil > 0 && now < this.focusSuppressUntil;
   }
 

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -184,6 +184,12 @@ export class ActivityMonitor {
   // Resize suppression
   private resizeSuppressUntil = 0;
 
+  // Focus suppression (#8865). xterm emits CSI I / CSI O on focus changes when
+  // the TUI has enabled DEC mode ?1004; the agent's repaint can arrive after
+  // the 1s echo window closes, so a dedicated longer window is required to
+  // suppress the idle→busy promotion that the repaint would otherwise cause.
+  private focusSuppressUntil = 0;
+
   private readonly onWaitingTimeout?: (id: string, spawnedAt: number) => void;
   private readonly onBootComplete?: (bootCompleteAt: number) => void;
   private bootCompleteCallbackFired = false;
@@ -483,6 +489,7 @@ export class ActivityMonitor {
       if (
         isWorking &&
         !this.isResizeSuppressed(now) &&
+        !this.isFocusSuppressed(now) &&
         (this.state === "busy" ||
           this.inputTracker.pendingInputUntil > 0 ||
           !this.inputTracker.isRecentUserInput(now))
@@ -529,6 +536,7 @@ export class ActivityMonitor {
       this.state === "idle" &&
       hasOutputActivity &&
       !this.isResizeSuppressed(now) &&
+      !this.isFocusSuppressed(now) &&
       !this.inputTracker.isRecentUserInput(now) &&
       this.bootDetector.hasExitedBootState
     ) {
@@ -560,6 +568,7 @@ export class ActivityMonitor {
         this.getVisibleLines &&
         this.state === "idle" &&
         !this.isResizeSuppressed(now) &&
+        !this.isFocusSuppressed(now) &&
         !this.inputTracker.isRecentUserInput(now) &&
         this.bootDetector.hasExitedBootState
       ) {
@@ -582,12 +591,16 @@ export class ActivityMonitor {
         this.lastWorkingIndicatorTimestamp = now;
       }
 
-      if (patternResult.isWorking && !this.isResizeSuppressed(now)) {
+      if (
+        patternResult.isWorking &&
+        !this.isResizeSuppressed(now) &&
+        !this.isFocusSuppressed(now)
+      ) {
         this.becomeBusyFromPattern(patternResult.confidence, now);
       }
     }
 
-    if (this.isResizeSuppressed(now)) {
+    if (this.isResizeSuppressed(now) || this.isFocusSuppressed(now)) {
       return;
     }
 
@@ -636,6 +649,7 @@ export class ActivityMonitor {
       return;
     }
     if (this.isResizeSuppressed(now)) return;
+    if (this.isFocusSuppressed(now)) return;
     // Pre-boot frames are part of the agent's startup chrome — let the boot
     // detector handle them via the regular onData path.
     if (!this.bootDetector.hasExitedBootState) return;
@@ -660,6 +674,12 @@ export class ActivityMonitor {
 
   private noteStructuralWorkingSignal(now: number, confidence: number): void {
     this.lastActivityTimestamp = now;
+    if (this.isFocusSuppressed(now)) {
+      // Focus-triggered repaint is not a structural working signal (#8865).
+      // Reset the debouncer so a single post-focus blip can't accumulate.
+      this.structuralRecoveryDebouncer.reset();
+      return;
+    }
     if (this.inputTracker.isRecentUserInput(now)) {
       // The user just typed; require sustained signal across user input
       // before recovering (matches the regex tier's behavior).
@@ -718,7 +738,10 @@ export class ActivityMonitor {
       return;
     }
 
-    if (this.state !== "busy" && result.stateHint === "busy") {
+    // Focus-triggered TUI redrawn during a suppression window is not new work
+    // (#8865). Skip idle→busy promotion until the window expires; lastActivity
+    // is still refreshed above so the idle timer doesn't drift.
+    if (this.state !== "busy" && result.stateHint === "busy" && !this.isFocusSuppressed(now)) {
       this.becomeBusy({ trigger: "output" }, now);
       return;
     }
@@ -776,6 +799,7 @@ export class ActivityMonitor {
     this.patternBuf.reset();
     this.bootDetector.reset();
     this.resizeSuppressUntil = 0;
+    this.focusSuppressUntil = 0;
     this.lastPatternResult = undefined;
     this.lastPatternResultAt = 0;
     this.cpuTracker.reset();
@@ -882,6 +906,27 @@ export class ActivityMonitor {
 
   private isResizeSuppressed(now: number): boolean {
     return this.resizeSuppressUntil > 0 && now < this.resizeSuppressUntil;
+  }
+
+  // Called by `TerminalProcess.write`/`tryWrite` when the renderer forwards a
+  // focus-in or focus-out report to the PTY. Opens a 2s window during which
+  // output cannot promote idle→busy: agent TUIs respond to focus changes by
+  // repainting their prompt, and that repaint frequently arrives after the
+  // 1s INPUT_ECHO_WINDOW_MS expires. Window is bounded — same lesson as
+  // PR #4974: never let a suppression mechanism stick indefinitely.
+  notifyFocus(suppressionMs = 2000): void {
+    this.focusSuppressUntil = Date.now() + suppressionMs;
+    this.workingSignalDebouncer.reset();
+    this.cosmeticRecoveryDebouncer.reset();
+    this.structuralRecoveryDebouncer.reset();
+    // Discard accumulated temperature snapshot so the post-focus redraw gets a
+    // fresh baseline. Unlike resize, focus does not invalidate cell ring-buffer
+    // history or the high-output window — those stay intact.
+    this.simpleOutputTemperature.reset();
+  }
+
+  private isFocusSuppressed(now: number): boolean {
+    return this.focusSuppressUntil > 0 && now < this.focusSuppressUntil;
   }
 
   getState(): "busy" | "idle" {

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -3353,6 +3353,152 @@ describe("ActivityMonitor", () => {
     });
   });
 
+  describe("Focus suppression (Issue #8865)", () => {
+    it("does NOT promote idle→busy from agent redraw inside the focus suppression window", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("focus-test", 1000, onStateChange, {
+        highOutputThreshold: {
+          enabled: true,
+          windowMs: 500,
+          bytesPerSecond: 2048,
+          recoveryEnabled: true,
+          recoveryDelayMs: 500,
+        },
+      });
+
+      monitor.notifyFocus();
+
+      // Simulate a slow agent redraw arriving 1.5s after focus (past the 1s
+      // INPUT_ECHO_WINDOW_MS but within the 2s notifyFocus window).
+      vi.advanceTimersByTime(1500);
+      for (let i = 0; i < 30; i++) {
+        monitor.onData("x".repeat(500));
+        vi.advanceTimersByTime(10);
+      }
+
+      expect(monitor.getState()).toBe("idle");
+      const busyCalls = onStateChange.mock.calls.filter((call) => call[2] === "busy");
+      expect(busyCalls.length).toBe(0);
+
+      monitor.dispose();
+    });
+
+    it("promotes idle→busy from output AFTER the focus suppression window expires", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("focus-test-2", 1000, onStateChange, {
+        highOutputThreshold: {
+          enabled: true,
+          windowMs: 500,
+          bytesPerSecond: 2048,
+          recoveryEnabled: true,
+          recoveryDelayMs: 500,
+        },
+      });
+
+      monitor.notifyFocus(200);
+      vi.advanceTimersByTime(250);
+
+      for (let i = 0; i < 30; i++) {
+        monitor.onData("x".repeat(500));
+        vi.advanceTimersByTime(20);
+      }
+
+      expect(monitor.getState()).toBe("busy");
+
+      monitor.dispose();
+    });
+
+    it("rapid successive focus events extend the suppression window", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("focus-test-3", 1000, onStateChange, {
+        highOutputThreshold: {
+          enabled: true,
+          windowMs: 500,
+          bytesPerSecond: 2048,
+          recoveryEnabled: true,
+          recoveryDelayMs: 500,
+        },
+      });
+
+      monitor.notifyFocus(500);
+      vi.advanceTimersByTime(400);
+      monitor.notifyFocus(500);
+      vi.advanceTimersByTime(400);
+
+      // Still within the second window — bytes should be suppressed
+      for (let i = 0; i < 20; i++) {
+        monitor.onData("x".repeat(500));
+        vi.advanceTimersByTime(5);
+      }
+
+      expect(monitor.getState()).toBe("idle");
+
+      monitor.dispose();
+    });
+
+    it("suppresses pattern-based busy promotion during the focus window", () => {
+      const onStateChange = vi.fn();
+      const getVisibleLines = vi.fn(() => ["> "]);
+      const monitor = new ActivityMonitor("focus-test-4", 1000, onStateChange, {
+        getVisibleLines,
+        getCursorLine: () => "> ",
+        pollingIntervalMs: 50,
+        idleDebounceMs: 200,
+        bootCompletePatterns: [/ready/i],
+        pollingMaxBootMs: 100,
+        workingRecoveryDelayMs: 200,
+      });
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(150);
+      onStateChange.mockClear();
+
+      // Transition to idle
+      vi.advanceTimersByTime(3000);
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      // Focus event, then agent redraws working pattern content
+      monitor.notifyFocus(2000);
+      getVisibleLines.mockReturnValue(["  esc to interrupt  "]);
+
+      vi.advanceTimersByTime(1500);
+
+      // Should remain idle — pattern recovery suppressed during focus window
+      expect(monitor.getState()).toBe("idle");
+
+      monitor.dispose();
+    });
+
+    it("dispose() clears the focus suppression window", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("focus-test-5", 1000, onStateChange);
+
+      monitor.notifyFocus(5000);
+      monitor.dispose();
+
+      // After dispose, internal state is reset. Creating a new monitor with
+      // a fresh ID should behave normally — the disposed monitor's focus
+      // window must not bleed across instances (it can't via shared state,
+      // but we still assert dispose() doesn't throw with a pending window).
+      expect(monitor.getState()).toBe("idle");
+    });
+
+    it("does not affect an already-busy terminal — focus does not flip busy→idle", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("focus-test-6", 1000, onStateChange);
+
+      monitor.onInput("hello\r");
+      expect(monitor.getState()).toBe("busy");
+      onStateChange.mockClear();
+
+      monitor.notifyFocus(2000);
+      expect(monitor.getState()).toBe("busy");
+
+      monitor.dispose();
+    });
+  });
+
   describe("Working silence timeout", () => {
     it("should transition polling terminal to idle after silence exceeds maxWorkingSilenceMs", () => {
       const onStateChange = vi.fn();

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -3497,6 +3497,33 @@ describe("ActivityMonitor", () => {
 
       monitor.dispose();
     });
+
+    it("suppresses idle→busy from OSC 9;4 progress during the focus window (#8865)", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("focus-test-7", 1000, onStateChange);
+
+      monitor.notifyFocus(2000);
+      monitor.onOscProgressWorking();
+
+      expect(monitor.getState()).toBe("idle");
+      const busyCalls = onStateChange.mock.calls.filter((call) => call[2] === "busy");
+      expect(busyCalls.length).toBe(0);
+
+      monitor.dispose();
+    });
+
+    it("isFocusSuppressed() reflects window state and clears after expiry", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("focus-test-8", 1000, onStateChange);
+
+      expect(monitor.isFocusSuppressed()).toBe(false);
+      monitor.notifyFocus(500);
+      expect(monitor.isFocusSuppressed()).toBe(true);
+      vi.advanceTimersByTime(600);
+      expect(monitor.isFocusSuppressed()).toBe(false);
+
+      monitor.dispose();
+    });
   });
 
   describe("Working silence timeout", () => {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -741,7 +741,11 @@ export class TerminalProcess {
       terminal.traceId = traceId || undefined;
     }
     if (this.activityMonitor) {
-      this.activityMonitor.onInput(data);
+      if (data === "\x1b[I" || data === "\x1b[O") {
+        this.activityMonitor.notifyFocus();
+      } else {
+        this.activityMonitor.onInput(data);
+      }
     }
 
     try {
@@ -770,7 +774,11 @@ export class TerminalProcess {
     }
 
     if (this.activityMonitor) {
-      this.activityMonitor.onInput(data);
+      if (data === "\x1b[I" || data === "\x1b[O") {
+        this.activityMonitor.notifyFocus();
+      } else {
+        this.activityMonitor.onInput(data);
+      }
     }
 
     const bracketedPaste = isBracketedPaste(data);

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -41,6 +41,7 @@ import {
   getSoftNewlineSequence,
   getSubmitEnterDelay,
   isBracketedPaste,
+  isFocusReport,
   delay,
   BRACKETED_PASTE_START,
   BRACKETED_PASTE_END,
@@ -741,8 +742,8 @@ export class TerminalProcess {
       terminal.traceId = traceId || undefined;
     }
     if (this.activityMonitor) {
-      if (data === "\x1b[I" || data === "\x1b[O") {
-        this.activityMonitor.notifyFocus();
+      if (isFocusReport(data)) {
+        this.handleFocusInput();
       } else {
         this.activityMonitor.onInput(data);
       }
@@ -774,8 +775,8 @@ export class TerminalProcess {
     }
 
     if (this.activityMonitor) {
-      if (data === "\x1b[I" || data === "\x1b[O") {
-        this.activityMonitor.notifyFocus();
+      if (isFocusReport(data)) {
+        this.handleFocusInput();
       } else {
         this.activityMonitor.onInput(data);
       }
@@ -1457,11 +1458,29 @@ export class TerminalProcess {
     const result = this.agentOutputTemperature.observeDelta(Date.now(), {
       changedChars: delta.changedChars,
     });
+    // ActivityMonitor.notifyFocus suppresses its own idle→busy paths, but this
+    // direct call into agentStateService is a parallel promotion path; gate it
+    // on the same window so a focus-triggered TUI repaint can't flip an idle
+    // agent to busy (#8865).
+    if (this.activityMonitor?.isFocusSuppressed()) {
+      return;
+    }
     if (result.stateHint === "busy" && this.terminalInfo.agentState === state) {
       this.deps.agentStateService.handleActivityState(this.terminalInfo, "busy", {
         trigger: "output",
       });
     }
+  }
+
+  // Side-effects shared by both PTY write paths when xterm forwards a CSI I/O
+  // focus report. Mirrors the resize handler's pattern (notifyResize +
+  // agentOutputTemperature.noteResize): open the ActivityMonitor suppression
+  // window AND invalidate the agentOutputTemperature baseline so the redraw
+  // that follows the focus event is treated as a fresh comparison point.
+  private handleFocusInput(): void {
+    this.activityMonitor?.notifyFocus();
+    this.agentOutputTemperature.reset();
+    this.agentOutputContentSnapshot = undefined;
   }
 
   /**

--- a/electron/services/pty/__tests__/InputTracker.test.ts
+++ b/electron/services/pty/__tests__/InputTracker.test.ts
@@ -14,6 +14,33 @@ describe("InputTracker", () => {
       expect(result.kind).toBe("ignored");
     });
 
+    it("ignores focus-in (CSI I) when configured (#8865)", () => {
+      const focusTracker = new InputTracker({
+        ignoredInputSequences: ["\x1b\r", "\x1b[I", "\x1b[O"],
+      });
+      const result = focusTracker.process("\x1b[I", 1000);
+      expect(result.kind).toBe("ignored");
+      expect(focusTracker.lastUserInputAt).toBe(0);
+    });
+
+    it("ignores focus-out (CSI O) when configured (#8865)", () => {
+      const focusTracker = new InputTracker({
+        ignoredInputSequences: ["\x1b\r", "\x1b[I", "\x1b[O"],
+      });
+      const result = focusTracker.process("\x1b[O", 1000);
+      expect(result.kind).toBe("ignored");
+      expect(focusTracker.lastUserInputAt).toBe(0);
+    });
+
+    it("still stamps lastUserInputAt for normal keystrokes after focus events (#8865)", () => {
+      const focusTracker = new InputTracker({
+        ignoredInputSequences: ["\x1b\r", "\x1b[I", "\x1b[O"],
+      });
+      focusTracker.process("\x1b[I", 1000);
+      focusTracker.process("a", 2000);
+      expect(focusTracker.lastUserInputAt).toBe(2000);
+    });
+
     it("returns no-enter for non-enter input", () => {
       const result = tracker.process("abc", 1000);
       expect(result.kind).toBe("no-enter");

--- a/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
@@ -174,6 +174,70 @@ describe("TerminalProcess.submit", () => {
     expect(notifyFocusSpy).not.toHaveBeenCalled();
   });
 
+  it("focus event resets the agentOutputTemperature baseline (#8865)", () => {
+    const terminal = createTerminal({ kind: "terminal", launchAgentId: "claude" });
+    const internals = terminal as unknown as {
+      agentOutputTemperature: { reset: () => void };
+      agentOutputContentSnapshot: unknown;
+    };
+    const tempResetSpy = vi.spyOn(internals.agentOutputTemperature, "reset");
+
+    terminal.tryWrite("\x1b[I");
+
+    expect(tempResetSpy).toHaveBeenCalledTimes(1);
+    expect(internals.agentOutputContentSnapshot).toBeUndefined();
+  });
+
+  it("noteAgentOutputActivity respects ActivityMonitor focus suppression (#8865)", () => {
+    const handleActivityState = vi.fn();
+    const ctx = defaultSpawnContext();
+    const terminal = new TerminalProcess(
+      "t-focus-bypass",
+      {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        kind: "terminal",
+        launchAgentId: "claude",
+      },
+      { emitData: () => {}, onExit: () => {} },
+      {
+        agentStateService: { handleActivityState } as any,
+        ptyPool: null,
+        processTreeCache: null,
+      },
+      ctx,
+      createMockPty()
+    );
+
+    const internals = terminal as unknown as {
+      isAgentLive: boolean;
+      terminalInfo: { agentState: string };
+      activityMonitor: { notifyFocus: (ms?: number) => void };
+      agentOutputContentSnapshot: unknown;
+      noteAgentOutputActivity: (before: unknown) => void;
+      getAgentOutputContentSnapshot: () => unknown;
+    };
+
+    // Force a busy-promoting condition: agent live, state idle, baseline set,
+    // visible delta after focus is non-trivial.
+    Object.defineProperty(terminal, "isAgentLive", { value: true, configurable: true });
+    internals.terminalInfo.agentState = "idle";
+    // Seed the snapshot baseline so the activity check has something to diff
+    // against in the noteAgentOutputActivity call below.
+    internals.agentOutputContentSnapshot = { lines: ["before"] };
+    internals.getAgentOutputContentSnapshot = () => ({ lines: ["after redraw with lots of new"] });
+
+    internals.activityMonitor.notifyFocus(2000);
+    // Clear any busy emissions from startPolling()'s initial state — we only
+    // care about whether noteAgentOutputActivity promotes during the window.
+    handleActivityState.mockClear();
+    internals.noteAgentOutputActivity({ lines: ["before"] });
+
+    const busyCalls = handleActivityState.mock.calls.filter((call) => call[1] === "busy");
+    expect(busyCalls.length).toBe(0);
+  });
+
   it("delays Enter for Copilot (submitEnterDelayMs: 200) so Ink TUI registers input", async () => {
     vi.useFakeTimers();
     const terminal = createTerminal({ kind: "terminal", launchAgentId: "copilot" });

--- a/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
@@ -127,6 +127,53 @@ describe("TerminalProcess.submit", () => {
     vi.useRealTimers();
   });
 
+  it("routes focus-in (CSI I) to activityMonitor.notifyFocus instead of onInput (#8865)", () => {
+    const terminal = createTerminal({ kind: "terminal", launchAgentId: "claude" });
+    const monitor = (
+      terminal as unknown as { activityMonitor: { notifyFocus: () => void; onInput: () => void } }
+    ).activityMonitor;
+    expect(monitor).toBeTruthy();
+    const notifyFocusSpy = vi.spyOn(monitor, "notifyFocus");
+    const onInputSpy = vi.spyOn(monitor, "onInput");
+
+    const result = terminal.tryWrite("\x1b[I");
+
+    expect(result.ok).toBe(true);
+    expect(notifyFocusSpy).toHaveBeenCalledTimes(1);
+    expect(onInputSpy).not.toHaveBeenCalled();
+    // Focus bytes still reach the PTY (vim's FocusGained etc. must keep working).
+    expect(ptyWriteMock).toHaveBeenCalledWith("\x1b[I");
+  });
+
+  it("routes focus-out (CSI O) to activityMonitor.notifyFocus on write() too (#8865)", () => {
+    const terminal = createTerminal({ kind: "terminal", launchAgentId: "claude" });
+    const monitor = (
+      terminal as unknown as { activityMonitor: { notifyFocus: () => void; onInput: () => void } }
+    ).activityMonitor;
+    const notifyFocusSpy = vi.spyOn(monitor, "notifyFocus");
+    const onInputSpy = vi.spyOn(monitor, "onInput");
+
+    terminal.write("\x1b[O");
+
+    expect(notifyFocusSpy).toHaveBeenCalledTimes(1);
+    expect(onInputSpy).not.toHaveBeenCalled();
+    expect(ptyWriteMock).toHaveBeenCalledWith("\x1b[O");
+  });
+
+  it("normal keystrokes still go through onInput, not notifyFocus (#8865)", () => {
+    const terminal = createTerminal({ kind: "terminal", launchAgentId: "claude" });
+    const monitor = (
+      terminal as unknown as { activityMonitor: { notifyFocus: () => void; onInput: () => void } }
+    ).activityMonitor;
+    const notifyFocusSpy = vi.spyOn(monitor, "notifyFocus");
+    const onInputSpy = vi.spyOn(monitor, "onInput");
+
+    terminal.tryWrite("a");
+
+    expect(onInputSpy).toHaveBeenCalledWith("a");
+    expect(notifyFocusSpy).not.toHaveBeenCalled();
+  });
+
   it("delays Enter for Copilot (submitEnterDelayMs: 200) so Ink TUI registers input", async () => {
     vi.useFakeTimers();
     const terminal = createTerminal({ kind: "terminal", launchAgentId: "copilot" });

--- a/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
+++ b/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
@@ -182,9 +182,18 @@ describe("buildActivityMonitorOptions", () => {
     expect(result.agentId).toBe("claude");
   });
 
-  it("defaults ignoredInputSequences to escape-return", () => {
+  it("defaults ignoredInputSequences to escape-return plus focus reports (#8865)", () => {
     const result = buildActivityMonitorOptions(undefined, {});
-    expect(result.ignoredInputSequences).toEqual(["\x1b\r"]);
+    expect(result.ignoredInputSequences).toEqual(["\x1b\r", "\x1b[I", "\x1b[O"]);
+  });
+
+  it("merges focus reports into agent-defined ignoredInputSequences (#8865)", () => {
+    // Every named agent overrides ignoredInputSequences; merging unconditionally
+    // guarantees focus filtering is present without each config re-listing it.
+    const result = buildActivityMonitorOptions("claude", {});
+    expect(result.ignoredInputSequences).toContain("\x1b\r");
+    expect(result.ignoredInputSequences).toContain("\x1b[I");
+    expect(result.ignoredInputSequences).toContain("\x1b[O");
   });
 
   it("sets idle debounce for agent terminals", () => {

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -176,7 +176,12 @@ export function buildActivityMonitorOptions(
   }
 ): ActivityMonitorOptions {
   const agentConfig = effectiveAgentId ? getEffectiveAgentConfig(effectiveAgentId) : undefined;
-  const ignoredInputSequences = agentConfig?.capabilities?.ignoredInputSequences ?? ["\x1b\r"];
+  // Focus-in/out (CSI I/O) must not stamp lastUserInputAt: a focus click would
+  // open the 1s echo window, expire before a slow TUI redraw, and the redraw
+  // then flips idle→busy (#8865). Forwarding to the PTY still happens — only
+  // the input-tracking side ignores it.
+  const ignoredInputSequences =
+    agentConfig?.capabilities?.ignoredInputSequences ?? ["\x1b\r", "\x1b[I", "\x1b[O"];
 
   const detection = effectiveAgentId
     ? getEffectiveAgentConfig(effectiveAgentId)?.detection

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -179,9 +179,10 @@ export function buildActivityMonitorOptions(
   // Focus-in/out (CSI I/O) must not stamp lastUserInputAt: a focus click would
   // open the 1s echo window, expire before a slow TUI redraw, and the redraw
   // then flips idle→busy (#8865). Forwarding to the PTY still happens — only
-  // the input-tracking side ignores it.
-  const ignoredInputSequences =
-    agentConfig?.capabilities?.ignoredInputSequences ?? ["\x1b\r", "\x1b[I", "\x1b[O"];
+  // the input-tracking side ignores it. Merged unconditionally so every named
+  // agent inherits the focus filter without re-listing it in its config.
+  const baseIgnored = agentConfig?.capabilities?.ignoredInputSequences ?? ["\x1b\r"];
+  const ignoredInputSequences = Array.from(new Set([...baseIgnored, "\x1b[I", "\x1b[O"]));
 
   const detection = effectiveAgentId
     ? getEffectiveAgentConfig(effectiveAgentId)?.detection

--- a/electron/services/pty/terminalInput.ts
+++ b/electron/services/pty/terminalInput.ts
@@ -74,6 +74,14 @@ export function isBracketedPaste(data: string): boolean {
   return containsFullBracketedPaste(data);
 }
 
+// xterm.js 6.0 dispatches DEC ?1004 focus reports as isolated 3-byte writes
+// when the textarea gains/loses focus and the TUI has enabled focus tracking.
+// Tests `=== "\x1b[I"` rather than substring to avoid false positives on the
+// occasional sequence whose payload happens to contain CSI I/O (#8865).
+export function isFocusReport(data: string): boolean {
+  return data === "\x1b[I" || data === "\x1b[O";
+}
+
 export function chunkInput(data: string): string[] {
   if (data.length === 0) {
     return [];


### PR DESCRIPTION
## Summary

Clicking between agent terminals would flip an idle agent to `working` even though nothing was happening. The cause: xterm.js sends `CSI I`/`CSI O` focus reports to the PTY when the TUI has enabled DEC mode `?1004` (Claude Code and Codex both do). `InputTracker` was stamping `lastUserInputAt` on those sequences, and when the agent's redraw arrived after the 1-second echo window, `ActivityMonitor` read it as new output and promoted the state.

The fix is three-layered:

- **`InputTracker`** — merge `\x1b[I`/`\x1b[O` into the default `ignoredInputSequences` so focus events never stamp `lastUserInputAt`.
- **`ActivityMonitor`** — add `notifyFocus(2000ms)` with a bounded suppression window that gates all five output-driven busy-promotion paths (simple output, structural signal, output temperature, OSC progress, and `noteAgentOutputActivity`).
- **`TerminalProcess`** — detect focus report bytes in both `tryWrite` and `write`, route through `handleFocusInput` which calls `notifyFocus` and resets `agentOutputTemperature` (the parallel path that would otherwise bypass `ActivityMonitor`).

PTY forwarding is preserved — vim `FocusGained` and similar still work.

Resolves #8865

## Changes

- `electron/services/ActivityMonitor.ts` — `notifyFocus` method + suppression window gating all five promotion paths
- `electron/services/pty/TerminalProcess.ts` — `handleFocusInput` routing for `CSI I`/`CSI O` bytes
- `electron/services/pty/terminalActivityPatterns.ts` + `terminalInput.ts` — focus sequences added to `ignoredInputSequences`
- Tests across `ActivityMonitor`, `InputTracker`, `TerminalProcess`, and `terminalActivityPatterns`

## Testing

- `InputTracker` ignore semantics for focus sequences
- `ActivityMonitor` suppression across all five gated paths, plus dispose cleanup
- `TerminalProcess` routing of focus bytes and `agentOutputTemperature` reset
- `noteAgentOutputActivity` gate
- `ignoredInputSequences` merge for agent configs
- 1361 tests passing on touched and adjacent modules