### PR TITLE
fix: PowerShell call operator for CLI path invocation + agent-preset-icon-color E2E Windows fixes

### DIFF
--- a/e2e/core/core-agent-preset-icon-color.spec.ts
+++ b/e2e/core/core-agent-preset-icon-color.spec.ts
@@ -55,7 +55,12 @@ async function dispatchAction<T = unknown>(
 }
 
 function writeFakeAgent(agentId: "claude" | "codex"): void {
-  const scriptPath = path.join(fakeBinDir, agentId);
+  // On Windows the raw (no-extension) script file would be picked up by
+  // probePrependedCliPath before claude.cmd because access() succeeds for
+  // any readable file regardless of execute bit. Use a .js extension so the
+  // no-extension probe misses it, then the .cmd wrapper wins.
+  const implName = process.platform === "win32" ? `${agentId}.js` : agentId;
+  const scriptPath = path.join(fakeBinDir, implName);
   const label = agentId.toUpperCase();
   writeFileSync(
     scriptPath,
@@ -109,7 +114,7 @@ function writeFakeAgent(agentId: "claude" | "codex"): void {
   if (process.platform === "win32") {
     writeFileSync(
       path.join(fakeBinDir, `${agentId}.cmd`),
-      [`@echo off`, `node "%~dp0\\${agentId}" %*`, ""].join("\r\n")
+      [`@echo off`, `node "%~dp0\\${agentId}.js" %*`, ""].join("\r\n")
     );
   }
 }
@@ -132,6 +137,29 @@ function fakeAgentCommand(agentId: "claude" | "codex"): string {
       ? path.join(fakeBinDir, `${agentId}.cmd`)
       : path.join(fakeBinDir, agentId);
   return shellQuote(scriptPath);
+}
+
+/**
+ * Build a terminal command that runs the fake agent script with optional env
+ * vars, compatible with both PowerShell (Windows) and bash/zsh (Unix).
+ *
+ * Unix:  VAR=val '/path/to/script'
+ * Win32: $env:VAR='val'; & 'C:\path\to\script.cmd'
+ */
+function shellInvoke(agentId: "claude" | "codex", env: Record<string, string> = {}): string {
+  const scriptPath =
+    process.platform === "win32"
+      ? path.join(fakeBinDir, `${agentId}.cmd`)
+      : path.join(fakeBinDir, agentId);
+
+  if (process.platform === "win32") {
+    const envParts = Object.entries(env).map(([k, v]) => `$env:${k}='${v.replace(/'/g, "''")}'`);
+    const invoke = `& '${scriptPath.replace(/'/g, "''")}'`;
+    return [...envParts, invoke].join("; ");
+  }
+
+  const envParts = Object.entries(env).map(([k, v]) => `${k}=${shellQuote(v)}`);
+  return [...envParts, shellQuote(scriptPath)].join(" ");
 }
 
 function launchEnv(): Record<string, string> {
@@ -331,7 +359,7 @@ test.describe.serial("Core: Agent preset icon color", () => {
     await runTerminalCommand(
       ctx.window,
       claude.panel,
-      `DAINTREE_E2E_MANUAL_RUN=1 ${fakeAgentCommand("claude")}`
+      shellInvoke("claude", { DAINTREE_E2E_MANUAL_RUN: "1" })
     );
     await waitForTerminalText(claude.panel, "FAKE_CLAUDE_MANUAL=1", T_LONG);
     await waitForTerminalText(claude.panel, `FAKE_CLAUDE_COLOR=${CLAUDE_COLOR}`, T_LONG);

--- a/src/hooks/__tests__/useAgentLauncher.commandResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.commandResolution.test.ts
@@ -11,6 +11,8 @@ function detail(overrides: Partial<AgentCliDetail>): AgentCliDetail {
   };
 }
 
+const isWindows = process.platform === "win32";
+
 describe("resolveAgentLaunchBaseCommand", () => {
   it("uses the availability-resolved executable path when the CLI is ready", () => {
     expect(
@@ -19,12 +21,22 @@ describe("resolveAgentLaunchBaseCommand", () => {
   });
 
   it("quotes resolved paths that need shell escaping", () => {
-    expect(
-      resolveAgentLaunchBaseCommand(
-        "claude",
-        detail({ resolvedPath: "/tmp/Daintree Test/bin/claude" })
-      )
-    ).toBe("'/tmp/Daintree Test/bin/claude'");
+    if (isWindows) {
+      // On Windows the resolved path is wrapped for PowerShell invocation
+      expect(
+        resolveAgentLaunchBaseCommand(
+          "claude",
+          detail({ resolvedPath: "C:\\path\\Daintree Test\\claude.cmd" })
+        )
+      ).toBe('& "C:\\path\\Daintree Test\\claude.cmd"');
+    } else {
+      expect(
+        resolveAgentLaunchBaseCommand(
+          "claude",
+          detail({ resolvedPath: "/tmp/Daintree Test/bin/claude" })
+        )
+      ).toBe("'/tmp/Daintree Test/bin/claude'");
+    }
   });
 
   it("falls back to the registry command when the detail is missing or not ready", () => {

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -18,7 +18,7 @@ import {
   buildAgentLaunchFlags,
   resolveEffectivePresetId,
 } from "@shared/types";
-import { escapeShellArgOptional } from "@shared/utils/shellEscape";
+import { escapeShellArgOptional, isSafeUnescaped, isWindows } from "@shared/utils/shellEscape";
 import {
   getAgentConfig,
   isRegisteredAgent,
@@ -55,7 +55,14 @@ export function resolveAgentLaunchBaseCommand(
   detail: AgentCliDetail | undefined
 ): string {
   const resolvedPath = detail?.state === "ready" ? detail.resolvedPath?.trim() : undefined;
-  return resolvedPath ? escapeShellArgOptional(resolvedPath) : registryCommand;
+  if (!resolvedPath) return registryCommand;
+  // On Windows the terminal shell is PowerShell. A bare double-quoted path is a
+  // string expression, not an invocation. Prefix with the call operator so that
+  // `"C:\path\claude.cmd"` becomes `& "C:\path\claude.cmd"` and actually runs.
+  if (isWindows() && !isSafeUnescaped(resolvedPath)) {
+    return `& ${escapeShellArgOptional(resolvedPath)}`;
+  }
+  return escapeShellArgOptional(resolvedPath);
 }
 
 async function getCurrentLaunchCliDetail(agentId: string): Promise<AgentCliDetail | undefined> {


### PR DESCRIPTION
Fixes #8873

## Summary

- **`src/hooks/useAgentLauncher.ts`** — `resolveAgentLaunchBaseCommand`: on Windows, prefix double-quoted resolved CLI paths with `& ` so PowerShell treats them as invocations (`& "C:\path\claude.cmd"`) rather than string expressions. Without this, `agent.launch` wrote the path to the PTY but PowerShell just echoed it and returned to the prompt.

- **`e2e/core/core-agent-preset-icon-color.spec.ts`**:
  - `writeFakeAgent`: write implementation as `claude.js` on Windows so the no-extension probe in `probePrependedCliPath` misses it and `claude.cmd` wins (on Windows `fs.access(X_OK)` succeeds for any readable file, so the no-extension probe was resolving the raw shebang script before the `.cmd` wrapper)
  - Added `shellInvoke(agentId, env)` cross-platform helper: emits `$env:K='V'; & 'path.cmd'` on Windows and `K=val 'path'` on POSIX
  - Replaced the old `DAINTREE_E2E_MANUAL_RUN=1 fakeAgentCommand(...)` call (bash inline-env + single-quote syntax) with `shellInvoke`

- **`src/hooks/__tests__/useAgentLauncher.commandResolution.test.ts`**: updated the "quotes resolved paths" test case to be platform-aware (Windows expects `& "..."`, POSIX expects `'...'`)

## Test plan

- [ ] `npx vitest run src/hooks/__tests__/useAgentLauncher.commandResolution.test.ts` passes on Windows and Linux
- [ ] `npx playwright test e2e/core/core-agent-preset-icon-color.spec.ts` passes on Windows
- [ ] Same E2E test passes on Linux/macOS (no regression)