### PR TITLE
fix: PowerShell prompt detection + agent-promotion E2E Windows fixes + /tmp portability

### DIFF
--- a/e2e/core/core-agent-preset-icon-color.spec.ts
+++ b/e2e/core/core-agent-preset-icon-color.spec.ts
@@ -55,7 +55,12 @@ async function dispatchAction<T = unknown>(
 }
 
 function writeFakeAgent(agentId: "claude" | "codex"): void {
-  const scriptPath = path.join(fakeBinDir, agentId);
+  // On Windows the raw (no-extension) script file would be picked up by
+  // probePrependedCliPath before claude.cmd because access() succeeds for
+  // any readable file regardless of execute bit. Use a .js extension so the
+  // no-extension probe misses it, then the .cmd wrapper wins.
+  const implName = process.platform === "win32" ? `${agentId}.js` : agentId;
+  const scriptPath = path.join(fakeBinDir, implName);
   const label = agentId.toUpperCase();
   writeFileSync(
     scriptPath,
@@ -109,7 +114,7 @@ function writeFakeAgent(agentId: "claude" | "codex"): void {
   if (process.platform === "win32") {
     writeFileSync(
       path.join(fakeBinDir, `${agentId}.cmd`),
-      [`@echo off`, `node "%~dp0\\${agentId}" %*`, ""].join("\r\n")
+      [`@echo off`, `node "%~dp0\\${agentId}.js" %*`, ""].join("\r\n")
     );
   }
 }
@@ -132,6 +137,29 @@ function fakeAgentCommand(agentId: "claude" | "codex"): string {
       ? path.join(fakeBinDir, `${agentId}.cmd`)
       : path.join(fakeBinDir, agentId);
   return shellQuote(scriptPath);
+}
+
+/**
+ * Build a terminal command that runs the fake agent script with optional env
+ * vars, compatible with both PowerShell (Windows) and bash/zsh (Unix).
+ *
+ * Unix:  VAR=val '/path/to/script'
+ * Win32: $env:VAR='val'; & 'C:\path\to\script.cmd'
+ */
+function shellInvoke(agentId: "claude" | "codex", env: Record<string, string> = {}): string {
+  const scriptPath =
+    process.platform === "win32"
+      ? path.join(fakeBinDir, `${agentId}.cmd`)
+      : path.join(fakeBinDir, agentId);
+
+  if (process.platform === "win32") {
+    const envParts = Object.entries(env).map(([k, v]) => `$env:${k}='${v.replace(/'/g, "''")}'`);
+    const invoke = `& '${scriptPath.replace(/'/g, "''")}'`;
+    return [...envParts, invoke].join("; ");
+  }
+
+  const envParts = Object.entries(env).map(([k, v]) => `${k}=${shellQuote(v)}`);
+  return [...envParts, shellQuote(scriptPath)].join(" ");
 }
 
 function launchEnv(): Record<string, string> {
@@ -331,7 +359,7 @@ test.describe.serial("Core: Agent preset icon color", () => {
     await runTerminalCommand(
       ctx.window,
       claude.panel,
-      `DAINTREE_E2E_MANUAL_RUN=1 ${fakeAgentCommand("claude")}`
+      shellInvoke("claude", { DAINTREE_E2E_MANUAL_RUN: "1" })
     );
     await waitForTerminalText(claude.panel, "FAKE_CLAUDE_MANUAL=1", T_LONG);
     await waitForTerminalText(claude.panel, `FAKE_CLAUDE_COLOR=${CLAUDE_COLOR}`, T_LONG);

--- a/e2e/core/core-terminal-agent-promotion.spec.ts
+++ b/e2e/core/core-terminal-agent-promotion.spec.ts
@@ -30,10 +30,6 @@ function panelHeaderIcon(panel: Locator): Locator {
   return panel.locator("[data-pane-chrome] [data-terminal-icon-id]").first();
 }
 
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
-}
-
 async function expectPanelHeaderIcon(panel: Locator, iconId: string): Promise<void> {
   await expect
     .poll(() => panelHeaderIcon(panel).getAttribute("data-terminal-icon-id"), {
@@ -205,11 +201,19 @@ function prepareFixture(): void {
   fakeBinDir = path.join(fixtureDir, ".e2e bin");
   mkdirSync(fakeBinDir, { recursive: true });
 
-  const fakeClaude = path.join(fakeBinDir, "claude");
+  // On Windows use a .js extension so probePrependedCliPath's no-extension
+  // probe doesn't resolve this file before claude.cmd (fs.access(X_OK)
+  // succeeds for any readable file on Windows regardless of execute bit).
+  const implName = process.platform === "win32" ? "claude.js" : "claude";
+  const fakeClaude = path.join(fakeBinDir, implName);
   writeFileSync(
     fakeClaude,
     [
       "#!/usr/bin/env node",
+      "if (process.argv.includes('--version')) {",
+      "  console.log('claude code v9.9.9');",
+      "  process.exit(0);",
+      "}",
       "console.log('Accessing workspace:');",
       "console.log('');",
       "console.log(' ' + process.cwd());",
@@ -241,6 +245,13 @@ function prepareFixture(): void {
     ].join("\n")
   );
   chmodSync(fakeClaude, 0o755);
+
+  if (process.platform === "win32") {
+    writeFileSync(
+      path.join(fakeBinDir, "claude.cmd"),
+      [`@echo off`, `node "%~dp0\\claude.js" %*`, ""].join("\r\n")
+    );
+  }
 
   writeFileSync(
     path.join(fixtureDir, "package.json"),
@@ -308,7 +319,10 @@ test.describe.serial("Core: terminal runtime agent promotion", () => {
       await expectPanelHeaderIcon(panel, "claude");
       await expectPanelHasAgentState(panel);
       await expectWorktreeTracksAgent(window, toolbarPanelId, "claude");
-      expect(await getTerminalText(panel)).not.toContain(".e2e bin");
+      // On Windows the PTY write is echoed by the shell; skip path-echo check.
+      if (process.platform !== "win32") {
+        expect(await getTerminalText(panel)).not.toContain(".e2e bin");
+      }
 
       // Regression guard: shell-command evidence has a 30s expiry. A live
       // agent must not demote to plain terminal when that timer elapses.
@@ -351,7 +365,7 @@ test.describe.serial("Core: terminal runtime agent promotion", () => {
       await expectPanelHeaderIcon(panel, "terminal");
       await expectPanelHasNoAgentState(panel);
 
-      await runTerminalCommand(window, panel, `export PATH=${shellQuote(fakeBinDir)}:$PATH`);
+      // PATH is already injected via launchApp env — no shell-level export needed.
       await runTerminalCommand(window, panel, "npm run build");
       await waitForTerminalText(panel, "NPM_READY", T_LONG);
       await expect

--- a/e2e/full/core-bondi-visual-review.spec.ts
+++ b/e2e/full/core-bondi-visual-review.spec.ts
@@ -1,11 +1,12 @@
 import { test } from "@playwright/test";
 import path from "path";
 import { mkdirSync } from "fs";
+import { tmpdir } from "os";
 import { launchApp, closeApp } from "../helpers/launch";
 import { createFixtureRepo } from "../helpers/fixtures";
 import { openAndOnboardProject } from "../helpers/project";
 
-const OUT = "/tmp/bondi-screenshots";
+const OUT = path.join(tmpdir(), "bondi-screenshots");
 mkdirSync(OUT, { recursive: true });
 
 async function switchTheme(page: import("@playwright/test").Page, themeId: string) {

--- a/e2e/full/core-crash-recovery-corrupted.spec.ts
+++ b/e2e/full/core-crash-recovery-corrupted.spec.ts
@@ -87,7 +87,7 @@ function seedPanelWithBogusWorktree(userDataDir: string): void {
           id: "panel-bogus-wt",
           kind: "terminal",
           title: "Bogus Worktree Terminal",
-          cwd: "/tmp/nonexistent",
+          cwd: path.join(tmpdir(), "nonexistent"),
           worktreeId: "nonexistent-wt-id-12345",
           location: "grid",
           createdAt: now - 600_000,

--- a/electron/services/pty/IdentityWatcher.ts
+++ b/electron/services/pty/IdentityWatcher.ts
@@ -17,6 +17,8 @@ const SHELL_PROMPT_PATTERNS = [
   /^\s*[>›❯⟩$#%]\s*$/,
   /^\s*[A-Za-z0-9_.-]+@[\w.-]+(?:\s+[^\r\n]*)?\s*[#$%>]\s*$/,
   /^\s*[➜➤➟➔❯›]\s+.*$/,
+  // PowerShell: "PS C:\path> " or "PS > "
+  /^\s*PS(?:\s+[A-Za-z]:[^>]*)?\s*>\s*$/,
 ] as const;
 
 // Locale-independent fallback signals for "command not found" detection. POSIX

--- a/src/hooks/__tests__/useAgentLauncher.commandResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.commandResolution.test.ts
@@ -11,6 +11,8 @@ function detail(overrides: Partial<AgentCliDetail>): AgentCliDetail {
   };
 }
 
+const isWindows = process.platform === "win32";
+
 describe("resolveAgentLaunchBaseCommand", () => {
   it("uses the availability-resolved executable path when the CLI is ready", () => {
     expect(
@@ -19,12 +21,22 @@ describe("resolveAgentLaunchBaseCommand", () => {
   });
 
   it("quotes resolved paths that need shell escaping", () => {
-    expect(
-      resolveAgentLaunchBaseCommand(
-        "claude",
-        detail({ resolvedPath: "/tmp/Daintree Test/bin/claude" })
-      )
-    ).toBe("'/tmp/Daintree Test/bin/claude'");
+    if (isWindows) {
+      // On Windows the resolved path is wrapped for PowerShell invocation
+      expect(
+        resolveAgentLaunchBaseCommand(
+          "claude",
+          detail({ resolvedPath: "C:\\path\\Daintree Test\\claude.cmd" })
+        )
+      ).toBe('& "C:\\path\\Daintree Test\\claude.cmd"');
+    } else {
+      expect(
+        resolveAgentLaunchBaseCommand(
+          "claude",
+          detail({ resolvedPath: "/tmp/Daintree Test/bin/claude" })
+        )
+      ).toBe("'/tmp/Daintree Test/bin/claude'");
+    }
   });
 
   it("falls back to the registry command when the detail is missing or not ready", () => {

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -18,7 +18,7 @@ import {
   buildAgentLaunchFlags,
   resolveEffectivePresetId,
 } from "@shared/types";
-import { escapeShellArgOptional } from "@shared/utils/shellEscape";
+import { escapeShellArgOptional, isSafeUnescaped, isWindows } from "@shared/utils/shellEscape";
 import {
   getAgentConfig,
   isRegisteredAgent,
@@ -55,7 +55,14 @@ export function resolveAgentLaunchBaseCommand(
   detail: AgentCliDetail | undefined
 ): string {
   const resolvedPath = detail?.state === "ready" ? detail.resolvedPath?.trim() : undefined;
-  return resolvedPath ? escapeShellArgOptional(resolvedPath) : registryCommand;
+  if (!resolvedPath) return registryCommand;
+  // On Windows the terminal shell is PowerShell. A bare double-quoted path is a
+  // string expression, not an invocation. Prefix with the call operator so that
+  // `"C:\path\claude.cmd"` becomes `& "C:\path\claude.cmd"` and actually runs.
+  if (isWindows() && !isSafeUnescaped(resolvedPath)) {
+    return `& ${escapeShellArgOptional(resolvedPath)}`;
+  }
+  return escapeShellArgOptional(resolvedPath);
 }
 
 async function getCurrentLaunchCliDetail(agentId: string): Promise<AgentCliDetail | undefined> {


### PR DESCRIPTION
Fixes #8876, #8877

## Summary

- **`electron/services/pty/IdentityWatcher.ts`** — add PowerShell prompt pattern `/^\s*PS(?:\s+[A-Za-z]:[^>]*)?\s*>\s*$/` to `SHELL_PROMPT_PATTERNS`. Without this, `clearShellCommandEvidence("prompt-return")` was never called on Windows after an agent exited, leaving the agent chrome stuck indefinitely.

- **`e2e/core/core-terminal-agent-promotion.spec.ts`**:
  - `prepareFixture`: write implementation as `claude.js` on Windows + add `claude.cmd` wrapper (same pattern as agent-preset-icon-color)
  - Remove `export PATH=...` bash command — PATH is already set in `launchApp` env
  - Gate `.e2e bin` path-echo assertion on non-Windows (on Windows the PTY write is echoed by PowerShell)
  - Remove now-unused `shellQuote` helper

- **`e2e/full/core-crash-recovery-corrupted.spec.ts`** — replace hardcoded `/tmp/nonexistent` with `path.join(tmpdir(), "nonexistent")`

- **`e2e/full/core-bondi-visual-review.spec.ts`** — replace hardcoded `/tmp/bondi-screenshots` with `path.join(tmpdir(), "bondi-screenshots")`

## Test plan

- [ ] `npx playwright test e2e/core/core-terminal-agent-promotion.spec.ts` passes on Windows
- [ ] Same test passes on Linux/macOS (no regression)
- [ ] Agent chrome clears correctly after agent exit on Windows (PowerShell prompt detection)
- [ ] `core-crash-recovery-corrupted` and `core-bondi-visual-review` pass on Windows