### PR TITLE
fix(worktree): route forge calls through main via IPC bridge (#8870)

### DIFF
--- a/docs/architecture/forge-provider-abstraction.md
+++ b/docs/architecture/forge-provider-abstraction.md
@@ -140,6 +140,39 @@ Every returned shape (`Issue`, `PR`, `ReviewThread`, `Release`, etc.) carries `r
 
 `rawData` is meant for plugin views to consume their own data. If a host-side component or a first-party Daintree component finds itself reading `rawData`, the interface is wrong and the missing field should be promoted to the typed surface or a capability. Treat first-party `rawData` reads as an interface-review signal.
 
+## Process Boundary: workspace-host RPC Bridge
+
+Daintree runs in multiple Electron processes. Plugin loading (`PluginService`) runs in **main**, alongside auth, IPC, window management, and the rest of Electron's native surface. PR polling, worktree git monitoring, and the file-watcher loop run in a separate **workspace-host UtilityProcess** (`electron/workspace-host.ts`) so synchronous filesystem and process work can't stall main. The workspace-host has no plugin loader, so it cannot hold provider impls of its own — the actual provider method bodies (HTTP calls, GraphQL queries) execute in main when invoked through the bridge.
+
+The host bridges the boundary so plugin authors never see it.
+
+```
+┌─────────────────────────────────┐         ┌──────────────────────────────────┐
+│ main process                    │         │ workspace-host UtilityProcess    │
+│                                 │         │                                  │
+│  PluginService.activate()       │         │  PullRequestService              │
+│       ↓                         │         │       ↓                          │
+│  host.registerForgeProvider     │         │  getForgeBridge()                │
+│       ↓                         │         │       ↓                          │
+│  forgeProviderRegistry          │←ipc────│  ForgeBridge.invoke              │
+│  (descriptors + impls)          │         │  (typed methods only)            │
+│       ↓                         │         │                                  │
+│  forgeRpcServer.dispatchForgeRpc│────ipc→│  bridge.handleResult             │
+│       ↓                         │         │       ↓                          │
+│  impl.findPRByBranch(...)       │         │  resolve pending promise         │
+└─────────────────────────────────┘         └──────────────────────────────────┘
+```
+
+**On the workspace-host side** (`electron/workspace-host/forgeBridge.ts`) — `ForgeBridge` is a thin IPC client. It exposes the subset of `ForgeProviderImpl` methods the workspace-host actually needs (`resolveProvider`, `findPRByBranch`, `findPRsByBranches`, `getPR`, `getIssue`, `getCIStatus`, `getRateLimit`), dispatches each call as a `forge:rpc` event over the parent port, and resolves the matching pending promise when `forge:rpc-result` lands. `parseRemote` is folded into `resolveProvider` so the workspace-host never has to call a synchronous provider method through an async transport.
+
+**On the main side** (`electron/services/forgeRpcServer.ts`) — `dispatchForgeRpc` looks up the impl by namespaced id in the local registry and invokes the requested method. `WorkspaceHostProcess.processHostEvent` (`electron/services/WorkspaceHostProcess.ts`) routes inbound `forge:rpc` events here and the response back to the child via `child.postMessage`.
+
+**Race on first poll.** `PullRequestService` in the workspace-host starts polling before main's `PluginService.initialize()` finishes — the workspace-host is spawned early, the plugin scan completes asynchronously. The bridge handles this by allowing every poll to re-attempt resolution: when `providerNamespacedId` is null, `checkForPRs` calls `resolveProvider()` first. To keep the user from staring at empty PR sub-rows for an entire blurred-cadence interval (120s) on cold start, the next poll fires at the fast `FOCUS_CATCHUP_THROTTLE_MS` (5s) until resolution lands. Once a provider is bound, the normal 30s/120s cadence resumes. Explicit invalidation (`refresh()`, `setForgeSettings`) clears the cache.
+
+**For plugin authors:** there is nothing to do. `host.registerForgeProvider(descriptor, impl)` in the plugin's `activate()` is the entire surface. The bridge is invisible — the provider impl lives in main, and the workspace-host transparently proxies through. This means every forge plugin (built-in GitHub, future GitLab/Gitea/Bitbucket/Forgejo, third-party plugins) participates in PR detection without any extra wiring. Auth tokens, network state, and rate-limit accounting all stay in one process where they belong.
+
+**Why not just load plugins in the workspace-host too?** Activating plugins twice risks duplicating side effects (IPC handlers, broadcasts, scheduled timers), duplicates auth state across processes, and exposes plugin authors to a second host-API surface with a different set of capabilities (no `registerHandler`, no `broadcastToRenderer`). The single-process activation with an RPC bridge keeps the plugin contract simple and main as the single source of truth.
+
 ## State Normalization
 
 Even though only GitHub ships in this stage, the interface normalizes states so future providers don't force a re-shape. PR state enums diverge across providers (GitHub `OPEN | CLOSED | MERGED`, GitLab `opened | closed | locked | merged`, Bitbucket `OPEN | MERGED | DECLINED | SUPERSEDED`, Gitea `open | closed`). The host's normalized enum is:

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -3,17 +3,10 @@ import { clearPRCaches } from "./GitHubService.js";
 import { logInfo, logWarn, logDebug } from "../utils/logger.js";
 import type { WorktreeSnapshot as WorktreeState } from "../../shared/types/workspace-host.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
-import { resolveForgeProvider } from "./forgeProviderResolver.js";
-import { getForgeProviderImpl } from "./forgeProviderRegistry.js";
-import { makeForgeProviderId } from "../../shared/utils/forgeProviderIds.js";
 import { generateProjectId } from "./projectStorePaths.js";
 import { createHardenedGit } from "../utils/hardenedGit.js";
-import type {
-  ForgeProviderImpl,
-  RepoRef,
-  PR as ForgePR,
-  RateLimitInfo,
-} from "../../shared/types/forge.js";
+import { getForgeBridge } from "../workspace-host/forgeBridge.js";
+import type { RepoRef, PR as ForgePR, RateLimitInfo } from "../../shared/types/forge.js";
 
 // Focus-aware polling cadence: faster when any Daintree window is focused so
 // users see PR transitions promptly, slower when fully blurred to conserve the
@@ -155,10 +148,12 @@ class PullRequestService {
   private updateDebounceTimer: NodeJS.Timeout | null = null;
   private unsubscribers: (() => void)[] = [];
 
-  // Forge provider resolution (resolved once on init, invalidated on refresh)
+  // Forge provider resolution (resolved once on init, invalidated on refresh).
+  // The impl itself lives in main (registered by `PluginService` on plugin
+  // activate); the workspace-host only holds the resolved identity here and
+  // dispatches calls through the `ForgeBridge` IPC client.
   private projectId: string | null = null;
   private providerNamespacedId: string | null = null;
-  private providerImpl: ForgeProviderImpl | null = null;
   private repoRef: RepoRef | null = null;
   // Forge provider routing settings, pushed in from the main process. The
   // workspace-host can't read `projectStore` or `electron-store` directly —
@@ -353,13 +348,21 @@ class PullRequestService {
     if (!this.projectId) return;
     try {
       const git = createHardenedGit(this.cwd);
-      // simple-git's typed `getConfig` returns a `ConfigGetResult` envelope,
-      // but daintree's wiring already resolves to the bare value string at
-      // runtime (and tests mock it the same way). Treat as `string | null`.
+      // simple-git's typed `getConfig` returns a `ConfigGetResult` envelope at
+      // runtime (`{ key, paths, scopes, value, values }`). Earlier code cast it
+      // straight to `string | null` on the assumption that daintree's wiring
+      // unwrapped to the bare value — that's true under the test mock but not
+      // in the real workspace-host UtilityProcess, where this read silently
+      // returned null and the provider failed to resolve (#8870). Unwrap
+      // explicitly: prefer the envelope's `value`, fall back to a literal
+      // string for callers that genuinely return one.
       const readRemoteUrl = async (remoteName: string): Promise<string | null> => {
-        const raw = (await git.getConfig(`remote.${remoteName}.url`).catch(() => null)) as
-          | string
-          | null;
+        const result = await git.getConfig(`remote.${remoteName}.url`).catch(() => null);
+        if (result === null || result === undefined) return null;
+        const raw =
+          typeof result === "string"
+            ? result
+            : ((result as { value?: string | null }).value ?? null);
         return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null;
       };
       // Resolve against the user-selected remote (`forgeRemote`, #8456) when
@@ -370,60 +373,38 @@ class PullRequestService {
         (selectedRemote ? await readRemoteUrl(selectedRemote) : null) ??
         (await readRemoteUrl("origin"));
 
-      const registered = resolveForgeProvider({
+      // The bridge does provider resolution and `parseRemote` in one IPC
+      // roundtrip: the registry lives in main (where plugins activate), so
+      // there's no point trying to consult it locally. Returns null when no
+      // provider matches the remote OR no remote URL is available.
+      const resolved = await getForgeBridge().resolveProvider({
         remoteUrl,
         forgeProviderOverride: this.forgeProviderOverride,
         globalDefaultProviderId: this.globalDefaultProviderId,
       });
-      if (!registered?.entry) {
+      if (!resolved) {
         this.providerNamespacedId = null;
-        this.providerImpl = null;
         this.repoRef = null;
         return;
       }
-      const { pluginId, contribution } = registered.entry;
-      const namespacedId = makeForgeProviderId(pluginId, contribution.id);
-      const impl = getForgeProviderImpl(namespacedId);
-      if (!impl) {
-        this.providerNamespacedId = null;
-        this.providerImpl = null;
-        this.repoRef = null;
-        return;
-      }
-      if (!remoteUrl) {
-        this.providerNamespacedId = null;
-        this.providerImpl = null;
-        this.repoRef = null;
-        return;
-      }
-      const repo = impl.parseRemote(remoteUrl);
-      if (!repo) {
-        this.providerNamespacedId = null;
-        this.providerImpl = null;
-        this.repoRef = null;
-        return;
-      }
-      this.providerNamespacedId = namespacedId;
-      this.providerImpl = impl;
-      this.repoRef = repo;
+      this.providerNamespacedId = resolved.namespacedId;
+      this.repoRef = resolved.repo;
       logInfo("PullRequestService resolved forge provider", {
-        namespacedId,
-        owner: repo.owner,
-        repo: repo.repo,
+        namespacedId: resolved.namespacedId,
+        owner: resolved.repo.owner,
+        repo: resolved.repo.repo,
       });
     } catch (error) {
       logWarn("PullRequestService provider resolution failed", {
         error: formatErrorMessage(error, "Provider resolution failed"),
       });
       this.providerNamespacedId = null;
-      this.providerImpl = null;
       this.repoRef = null;
     }
   }
 
   private invalidateProvider(): void {
     this.providerNamespacedId = null;
-    this.providerImpl = null;
     this.repoRef = null;
   }
 
@@ -706,6 +687,22 @@ class PullRequestService {
     // be admitted again, instead of churning through throttled no-op wakeups.
     interval = Math.max(interval, this.msUntilCheckAllowed());
 
+    // Cap the interval when the forge provider hasn't resolved yet. The forge
+    // registry lives in main and is populated asynchronously by
+    // `PluginService.initialize()` — the workspace-host's first poll often
+    // fires before that completes, leaving `providerNamespacedId` null. At the
+    // blurred cadence (120s) the user would otherwise stare at empty PR
+    // sub-rows for two minutes after every cold start. Once the bridge returns
+    // a real provider the next poll uses the normal cadence again.
+    //
+    // Skip this when `consecutiveErrors > 0`: the circuit-breaker backoff is
+    // deliberate (the last call failed against the API), and punching through
+    // it with a 5s retry would burst error-prone calls right when we want to
+    // back off. Resolution will get its chance once the backoff window closes.
+    if (!this.providerNamespacedId && this.consecutiveErrors === 0) {
+      interval = Math.min(interval, FOCUS_CATCHUP_THROTTLE_MS);
+    }
+
     this.pollTimer = setTimeout(() => {
       this.pollTimer = null;
       void this.checkForPRs()
@@ -789,11 +786,16 @@ class PullRequestService {
     blocked: boolean;
     resumeAt: number | null;
   }> {
-    if (!this.providerImpl?.getRateLimit) {
+    if (!this.providerNamespacedId) {
       return { blocked: false, resumeAt: null };
     }
     try {
-      const info: RateLimitInfo = await this.providerImpl.getRateLimit();
+      const info: RateLimitInfo | null = await getForgeBridge().getRateLimit(
+        this.providerNamespacedId
+      );
+      // `null` here means the provider does not implement `getRateLimit` —
+      // fail open, polling proceeds without a rate-limit gate.
+      if (!info) return { blocked: false, resumeAt: null };
       const now = Date.now();
       if (info.secondaryThrottled) {
         const resumeAt = info.resetAt ?? now + RATE_LIMIT_SECONDARY_FALLBACK_MS;
@@ -818,10 +820,10 @@ class PullRequestService {
       return;
     }
 
-    const provider = this.providerImpl;
     const repo = this.repoRef;
     const providerId = this.providerNamespacedId;
-    if (!provider || !repo || !providerId) return;
+    if (!repo || !providerId) return;
+    const bridge = getForgeBridge();
 
     const { blocked, resumeAt } = await this.checkRateLimitGate();
     if (blocked && resumeAt) {
@@ -855,7 +857,7 @@ class PullRequestService {
       const prNumbers = [...uniquePRNumbers];
       const results = await mapWithConcurrencyLimit(prNumbers, 5, async (prNumber) => {
         try {
-          const pr = await provider.getPR(repo, prNumber);
+          const pr = await bridge.getPR(providerId, repo, prNumber);
           return { prNumber, pr, error: false };
         } catch {
           return { prNumber, pr: null, error: true };
@@ -924,7 +926,7 @@ class PullRequestService {
           }
 
           // Revalidate CI status (best-effort, non-blocking)
-          this.enrichPRWithCIStatus(detectedPR, repo, provider);
+          this.enrichPRWithCIStatus(detectedPR, repo, providerId);
         }
       }
 
@@ -941,8 +943,8 @@ class PullRequestService {
         const issueNumber = context.issueNumber;
         const branchAtFetchStart = context.branchName;
         issueRetryLookups.push(
-          provider
-            .getIssue(repo, issueNumber)
+          bridge
+            .getIssue(providerId, repo, issueNumber)
             .then((issue) => {
               const currentBranch = this.candidates.get(worktreeId)?.branchName;
               if (currentBranch !== branchAtFetchStart) return;
@@ -1036,16 +1038,26 @@ class PullRequestService {
 
     logDebug("Checking PRs for candidates", { count: activeCandidates.length });
 
-    const provider = this.providerImpl;
+    // Re-resolve when we don't have a cached provider yet. The forge registry
+    // lives in main and is populated by `PluginService.initialize()`; the
+    // workspace-host UtilityProcess starts polling before that finishes, so a
+    // one-shot resolution at `start()` would lose the race permanently. Each
+    // poll retries until main answers with a real provider — and once resolved
+    // we keep the cache (cleared explicitly by `refresh()`/`setForgeSettings`).
+    if (!this.providerNamespacedId || !this.repoRef) {
+      await this.resolveProvider();
+    }
+
     const repo = this.repoRef;
     const providerId = this.providerNamespacedId;
 
-    if (!provider || !repo || !providerId) {
+    if (!repo || !providerId) {
       // No forge provider resolved — all candidates get null linkage.
       // No error, no toast, no log spam (per issue spec).
       logDebug("Skipping PR check — no forge provider resolved");
       return;
     }
+    const bridge = getForgeBridge();
 
     const { blocked, resumeAt } = await this.checkRateLimitGate();
     if (blocked && resumeAt) {
@@ -1078,8 +1090,8 @@ class PullRequestService {
         const lookupBranch = lookupBranchByWorktreeId.get(c.worktreeId);
         const branchAtFetchStart = this.candidates.get(c.worktreeId)?.branchName;
         issueLookups.push(
-          provider
-            .getIssue(repo, c.issueNumber)
+          bridge
+            .getIssue(providerId, repo, c.issueNumber)
             .then((issue) => {
               // Branch-token check (lesson #2243): if the worktree's branch
               // changed during the fetch, the result is stale — don't write
@@ -1123,10 +1135,29 @@ class PullRequestService {
       // error doesn't blank every row's PR state. Truthiness guard per the
       // forge.ts capability convention.
       const branches = [...uniqueBranches.keys()];
-      const prResults = await this.resolvePRsForBranches(provider, repo, branches);
+      const prResults = await this.resolvePRsForBranches(providerId, repo, branches);
 
       // Fire issue lookups in parallel with PR lookups
       await Promise.allSettled(issueLookups);
+
+      // Stale-in-flight guard: if `setForgeSettings` invalidated the provider
+      // (or refresh() swapped it) while branch/issue lookups were in flight,
+      // the results belong to the OLD provider. Writing them to
+      // detectedPRs/resolvedWorktrees would tag worktrees with a provider
+      // they're no longer routed through. Abandon the cycle quietly — the
+      // next poll picks up the new provider's PRs at the fast cadence.
+      if (
+        this.providerNamespacedId !== providerId ||
+        this.repoRef?.host !== repo.host ||
+        this.repoRef?.owner !== repo.owner ||
+        this.repoRef?.repo !== repo.repo
+      ) {
+        logDebug("Discarding stale PR check results — provider changed mid-cycle", {
+          fromProviderId: providerId,
+          toProviderId: this.providerNamespacedId,
+        });
+        return;
+      }
 
       this.consecutiveErrors = 0;
 
@@ -1190,7 +1221,7 @@ class PullRequestService {
         }
 
         // Fire-and-forget CI status enrichment
-        this.enrichPRWithCIStatus(internalPR, repo, provider);
+        this.enrichPRWithCIStatus(internalPR, repo, providerId);
       }
 
       this.updateBoostFromDetectedPRs();
@@ -1208,15 +1239,20 @@ class PullRequestService {
    * result Map likewise get the per-branch fallback.
    */
   private async resolvePRsForBranches(
-    provider: ForgeProviderImpl,
+    providerId: string,
     repo: RepoRef,
     branches: string[]
   ): Promise<Array<{ branch: string; pr: ForgePR | null }>> {
     if (branches.length === 0) return [];
 
-    if (provider.findPRsByBranches) {
-      try {
-        const batchMap = await provider.findPRsByBranches(repo, branches);
+    const bridge = getForgeBridge();
+    // `findPRsByBranches` is capability-gated on the impl. The bridge returns
+    // `null` when the provider does not implement it, so we treat that case
+    // as a fall-through to per-branch (mirrors the old `if (provider.findPRsByBranches)`
+    // truthiness guard, just one IPC hop away).
+    try {
+      const batchMap = await bridge.findPRsByBranches(providerId, repo, branches);
+      if (batchMap) {
         const results: Array<{ branch: string; pr: ForgePR | null }> = [];
         const missing: string[] = [];
         for (const branch of branches) {
@@ -1227,27 +1263,28 @@ class PullRequestService {
           }
         }
         if (missing.length > 0) {
-          const fallback = await this.perBranchFallback(provider, repo, missing);
+          const fallback = await this.perBranchFallback(providerId, repo, missing);
           results.push(...fallback);
         }
         return results;
-      } catch (error) {
-        logWarn("Batched PR lookup failed; retrying per-branch", {
-          branchCount: branches.length,
-          error: formatErrorMessage(error, "findPRsByBranches failed"),
-        });
-        // Fall through to per-branch path below.
       }
+    } catch (error) {
+      logWarn("Batched PR lookup failed; retrying per-branch", {
+        branchCount: branches.length,
+        error: formatErrorMessage(error, "findPRsByBranches failed"),
+      });
+      // Fall through to per-branch path below.
     }
 
-    return this.perBranchFallback(provider, repo, branches);
+    return this.perBranchFallback(providerId, repo, branches);
   }
 
   private perBranchFallback(
-    provider: ForgeProviderImpl,
+    providerId: string,
     repo: RepoRef,
     branches: string[]
   ): Promise<Array<{ branch: string; pr: ForgePR | null }>> {
+    const bridge = getForgeBridge();
     return mapWithConcurrencyLimit(
       branches,
       5,
@@ -1256,7 +1293,7 @@ class PullRequestService {
         if (existing) {
           return existing.then((pr) => ({ branch, pr }));
         }
-        const promise = provider.findPRByBranch(repo, branch).catch(() => null);
+        const promise = bridge.findPRByBranch(providerId, repo, branch).catch(() => null);
         this.inFlightBranchLookups.set(branch, promise);
         promise.finally(() => {
           this.inFlightBranchLookups.delete(branch);
@@ -1271,13 +1308,9 @@ class PullRequestService {
    * On success, updates the detectedPRs entry and re-emits sys:pr:detected
    * with the enriched CI status so the renderer can update the badge.
    */
-  private enrichPRWithCIStatus(
-    pr: InternalLinkedPR,
-    repo: RepoRef,
-    provider: ForgeProviderImpl
-  ): void {
-    provider
-      .getCIStatus(repo, pr.number)
+  private enrichPRWithCIStatus(pr: InternalLinkedPR, repo: RepoRef, providerId: string): void {
+    getForgeBridge()
+      .getCIStatus(providerId, repo, pr.number)
       .then((ciStatus) => {
         if (!ciStatus) return;
         pr.ciStatus =

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -1134,7 +1134,21 @@ class PullRequestService {
         const worktreeIds = uniqueBranches.get(branch);
         if (!worktreeIds) continue;
 
-        if (!pr) continue;
+        if (!pr) {
+          // Authoritative "no PR found" for a fresh candidate. Without this,
+          // `WorktreeMonitor._linked` stays `undefined` (its initial state)
+          // and the renderer's preservation rule (#8870) would hold any
+          // `linked.pr` carried over from a prior session indefinitely.
+          for (const worktreeId of worktreeIds) {
+            events.emit("sys:pr:cleared", {
+              worktreeId,
+              branchName: branch,
+              providerId,
+              timestamp: Date.now(),
+            });
+          }
+          continue;
+        }
 
         const internalPR: InternalLinkedPR = {
           number: pr.number,

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -13,6 +13,7 @@ import type {
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { GitHubAuth } from "./github/GitHubAuth.js";
 import { BrokerError, RequestResponseBroker } from "./rpc/RequestResponseBroker.js";
+import { dispatchForgeRpc } from "./forgeRpcServer.js";
 import { createLogger } from "../utils/logger.js";
 import { mainBootAbsMs, markPerformance } from "../utils/performance.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -832,6 +833,23 @@ export class WorkspaceHostProcess extends EventEmitter {
 
       case "git:project-pulse-error":
         this.handleRequestResult(this.toResult(event, false));
+        break;
+
+      // Forge RPC request from the workspace-host — dispatch against the
+      // local registry and send the result back. Provider impls live here
+      // (registered by `PluginService` on plugin activate), so the
+      // workspace-host has to round-trip through this server for any PR /
+      // CI / rate-limit call. See `docs/architecture/forge-provider-abstraction.md`.
+      case "forge:rpc":
+        void dispatchForgeRpc(
+          {
+            forgeRequestId: event.forgeRequestId,
+            method: event.method,
+            namespacedId: event.namespacedId,
+            args: event.args,
+          },
+          (request) => this.send(request)
+        );
         break;
 
       // Spontaneous events - re-emit for the manager to route

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { WorktreeSnapshot } from "../../../shared/types/workspace-host.js";
 import type { DaintreeEventMap } from "../events.js";
 import type { ForgeProviderImpl, RepoRef, PR as ForgePR } from "../../../shared/types/forge.js";
+import type { ForgeResolveProviderResult } from "../../../shared/types/workspace-host.js";
 
 function makeWorktreeSnapshot(
   overrides: Partial<WorktreeSnapshot> & Pick<WorktreeSnapshot, "worktreeId">
@@ -36,6 +37,48 @@ function makeMockForgePR(overrides?: Partial<ForgePR>): ForgePR {
     updatedAt: Date.now(),
     rawData: null,
     ...overrides,
+  };
+}
+
+// Module-level handle so tests that want to assert on bridge calls directly
+// (resolveProvider, getRateLimit) can grab the most recently created stub
+// without changing every helper call site.
+let lastMockBridge: ReturnType<typeof makeMockBridge> | null = null;
+
+function makeMockBridge(impl: ForgeProviderImpl) {
+  // The bridge stub delegates each call to the underlying impl, stripping the
+  // namespacedId argument so existing `expect(impl.X).toHaveBeenCalledWith(...)`
+  // assertions keep matching the original (provider-shaped) signature.
+  return {
+    // Explicit return-type annotation so `.mockResolvedValue(null)` is allowed
+    // for the unresolved variant; the default resolves to a real provider.
+    resolveProvider: vi.fn<
+      (_opts: {
+        remoteUrl: string | null;
+        forgeProviderOverride: string | null;
+        globalDefaultProviderId: string | null;
+      }) => Promise<ForgeResolveProviderResult | null>
+    >(async () => ({
+      namespacedId: "daintree.github.github",
+      repo: makeMockRepoRef(),
+    })),
+    findPRByBranch: vi.fn((_id: string, repo: RepoRef, branch: string) =>
+      impl.findPRByBranch(repo, branch)
+    ),
+    findPRsByBranches: vi.fn(async (_id: string, repo: RepoRef, branches: string[]) => {
+      if (!impl.findPRsByBranches) return null;
+      return impl.findPRsByBranches(repo, branches);
+    }),
+    getPR: vi.fn((_id: string, repo: RepoRef, prNumber: number) => impl.getPR(repo, prNumber)),
+    getIssue: vi.fn((_id: string, repo: RepoRef, issueNumber: number) =>
+      impl.getIssue(repo, issueNumber)
+    ),
+    getCIStatus: vi.fn((_id: string, repo: RepoRef, prNumber: number) =>
+      impl.getCIStatus(repo, prNumber)
+    ),
+    getRateLimit: vi.fn(async (_id: string) => impl.getRateLimit?.() ?? null),
+    handleResult: vi.fn(),
+    dispose: vi.fn(),
   };
 }
 
@@ -73,20 +116,11 @@ function mockForgeProviderResolved(
     getRateLimit: vi.fn().mockResolvedValue({ limit: null, remaining: null, resetAt: null }),
   };
 
-  vi.doMock("../forgeProviderResolver.js", () => ({
-    resolveForgeProvider: vi.fn().mockReturnValue({
-      entry: {
-        pluginId: "daintree.github",
-        contribution: { id: "github", name: "GitHub", matches: ["github.com"] },
-      },
-      resolvedVia: "hostname",
-    }),
-  }));
-  vi.doMock("../forgeProviderRegistry.js", () => ({
-    getForgeProviderImpl: vi.fn().mockReturnValue(mockImpl),
-    registerForgeProviders: vi.fn(),
-    unregisterForgeProviders: vi.fn(),
-    clearForgeProviderRegistry: vi.fn(),
+  const bridge = makeMockBridge(mockImpl);
+  lastMockBridge = bridge;
+  vi.doMock("../../workspace-host/forgeBridge.js", () => ({
+    getForgeBridge: () => bridge,
+    initForgeBridge: vi.fn(() => bridge),
   }));
   vi.doMock("../projectStorePaths.js", () => ({
     generateProjectId: vi.fn().mockReturnValue("test-project-id"),
@@ -100,21 +134,49 @@ function mockForgeProviderResolved(
   return mockImpl;
 }
 
-function mockForgeProviderUnresolved() {
-  vi.doMock("../forgeProviderResolver.js", () => ({
-    resolveForgeProvider: vi.fn().mockReturnValue({ entry: null, resolvedVia: null }),
-  }));
-  vi.doMock("../forgeProviderRegistry.js", () => ({
-    getForgeProviderImpl: vi.fn().mockReturnValue(undefined),
+function mockForgeProviderUnresolved(opts?: {
+  getConfig?: (key: string) => Promise<string | null>;
+}) {
+  // No impl behind the bridge — `resolveProvider` returns null so the service
+  // takes the "no forge provider resolved" branch.
+  const placeholderImpl = makeMockEmptyImpl();
+  const bridge = makeMockBridge(placeholderImpl);
+  bridge.resolveProvider.mockResolvedValue(null);
+  lastMockBridge = bridge;
+  vi.doMock("../../workspace-host/forgeBridge.js", () => ({
+    getForgeBridge: () => bridge,
+    initForgeBridge: vi.fn(() => bridge),
   }));
   vi.doMock("../projectStorePaths.js", () => ({
     generateProjectId: vi.fn().mockReturnValue("test-project-id"),
   }));
+  const getConfig =
+    opts?.getConfig ?? vi.fn().mockResolvedValue("https://github.com/testowner/testrepo.git");
   vi.doMock("../../utils/hardenedGit.js", () => ({
-    createHardenedGit: vi.fn().mockReturnValue({
-      getConfig: vi.fn().mockResolvedValue("https://github.com/testowner/testrepo.git"),
-    }),
+    createHardenedGit: vi.fn().mockReturnValue({ getConfig }),
   }));
+}
+
+function makeMockEmptyImpl(): ForgeProviderImpl {
+  return {
+    getCredentials: vi.fn(),
+    validateCredentials: vi.fn(),
+    parseRemote: vi.fn(),
+    listIssues: vi.fn(),
+    listPRs: vi.fn(),
+    getIssue: vi.fn(),
+    getPR: vi.fn(),
+    findPRByBranch: vi.fn(),
+    getCIStatus: vi.fn(),
+    getRepoMetadata: vi.fn(),
+    buildIssueUrl: vi.fn(),
+    buildPRUrl: vi.fn(),
+    buildIssuesUrl: vi.fn(),
+    buildPRsUrl: vi.fn(),
+    buildCommitsUrl: vi.fn(),
+    assignIssue: vi.fn(),
+    validateToken: vi.fn(),
+  };
 }
 
 describe("PullRequestService", () => {
@@ -126,6 +188,9 @@ describe("PullRequestService", () => {
     vi.useRealTimers();
     vi.resetModules();
     vi.clearAllMocks();
+    // `lastMockBridge` is module-level so a stale reference from a prior
+    // test never bleeds into the next one's assertions.
+    lastMockBridge = null;
   });
 
   it("detects PRs for non-default branches without issue numbers", async () => {
@@ -218,22 +283,13 @@ describe("PullRequestService", () => {
     const clearPRCaches = vi.fn();
     vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
 
-    const resolveForgeProvider = vi.fn().mockReturnValue({ entry: null, resolvedVia: null });
-    vi.doMock("../forgeProviderResolver.js", () => ({ resolveForgeProvider }));
-    vi.doMock("../forgeProviderRegistry.js", () => ({
-      getForgeProviderImpl: vi.fn().mockReturnValue(undefined),
-    }));
-    vi.doMock("../projectStorePaths.js", () => ({
-      generateProjectId: vi.fn().mockReturnValue("test-project-id"),
-    }));
     const getConfig = vi.fn(async (key: string) =>
       key === "remote.upstream.url"
         ? "https://github.com/upstreamowner/upstreamrepo.git"
         : "https://github.com/originowner/originrepo.git"
     );
-    vi.doMock("../../utils/hardenedGit.js", () => ({
-      createHardenedGit: vi.fn().mockReturnValue({ getConfig }),
-    }));
+    mockForgeProviderUnresolved({ getConfig });
+    const bridge = lastMockBridge!;
 
     const { pullRequestService } = await import("../PullRequestService.js");
 
@@ -247,7 +303,7 @@ describe("PullRequestService", () => {
     await pullRequestService.refresh();
 
     expect(getConfig).toHaveBeenCalledWith("remote.upstream.url");
-    expect(resolveForgeProvider).toHaveBeenCalledWith(
+    expect(bridge.resolveProvider).toHaveBeenCalledWith(
       expect.objectContaining({ remoteUrl: "https://github.com/upstreamowner/upstreamrepo.git" })
     );
 
@@ -258,20 +314,11 @@ describe("PullRequestService", () => {
     const clearPRCaches = vi.fn();
     vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
 
-    const resolveForgeProvider = vi.fn().mockReturnValue({ entry: null, resolvedVia: null });
-    vi.doMock("../forgeProviderResolver.js", () => ({ resolveForgeProvider }));
-    vi.doMock("../forgeProviderRegistry.js", () => ({
-      getForgeProviderImpl: vi.fn().mockReturnValue(undefined),
-    }));
-    vi.doMock("../projectStorePaths.js", () => ({
-      generateProjectId: vi.fn().mockReturnValue("test-project-id"),
-    }));
     const getConfig = vi.fn(async (key: string) =>
       key === "remote.origin.url" ? "https://github.com/originowner/originrepo.git" : null
     );
-    vi.doMock("../../utils/hardenedGit.js", () => ({
-      createHardenedGit: vi.fn().mockReturnValue({ getConfig }),
-    }));
+    mockForgeProviderUnresolved({ getConfig });
+    const bridge = lastMockBridge!;
 
     const { pullRequestService } = await import("../PullRequestService.js");
 
@@ -284,8 +331,47 @@ describe("PullRequestService", () => {
 
     await pullRequestService.refresh();
 
-    expect(resolveForgeProvider).toHaveBeenCalledWith(
+    expect(bridge.resolveProvider).toHaveBeenCalledWith(
       expect.objectContaining({ remoteUrl: "https://github.com/originowner/originrepo.git" })
+    );
+
+    pullRequestService.destroy();
+  });
+
+  it("unwraps the ConfigGetResult envelope from simple-git's getConfig (#8870)", async () => {
+    // Regression: PullRequestService used to cast `git.getConfig()` straight
+    // to `string | null`, but simple-git returns a `{ value, values, ... }`
+    // envelope at runtime in the workspace-host UtilityProcess. The cast
+    // silently produced null and the bridge never saw a real `remoteUrl`,
+    // so PR detection was permanently skipped (#8870). The fix unwraps the
+    // envelope; this test pins the envelope shape so a future change can't
+    // silently regress it.
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+
+    const getConfig = vi.fn(async (key: string) => ({
+      key,
+      paths: [".git/config"],
+      scopes: {},
+      value: "  https://github.com/envowner/envrepo.git  ",
+      values: ["  https://github.com/envowner/envrepo.git  "],
+    }));
+    // Cast is necessary because the helper's parameter type promises a
+    // plain string return; the test deliberately exercises the envelope
+    // shape that the real simple-git ships and PullRequestService unwraps.
+    mockForgeProviderUnresolved({
+      getConfig: getConfig as unknown as (key: string) => Promise<string | null>,
+    });
+    const bridge = lastMockBridge!;
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+
+    pullRequestService.initialize("/repo");
+    await pullRequestService.refresh();
+
+    expect(getConfig).toHaveBeenCalledWith("remote.origin.url");
+    expect(bridge.resolveProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ remoteUrl: "https://github.com/envowner/envrepo.git" })
     );
 
     pullRequestService.destroy();

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -317,6 +317,43 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
+  it("emits sys:pr:cleared for a fresh candidate when the forge has no PR (#8870)", async () => {
+    // Without this clear, WorktreeMonitor._linked stays at its initial
+    // `undefined` and the renderer's preservation rule keeps any prior
+    // session's linked.pr visible indefinitely.
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+    mockForgeProviderResolved(async () => null);
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const cleared: DaintreeEventMap["sys:pr:cleared"][] = [];
+    const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+    const unsubscribeCleared = events.on("sys:pr:cleared", (p) => cleared.push(p));
+    const unsubscribeDetected = events.on("sys:pr:detected", (p) => detected.push(p));
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/no-pr" })
+    );
+
+    await pullRequestService.refresh();
+
+    expect(detected).toHaveLength(0);
+    expect(cleared).toHaveLength(1);
+    expect(cleared[0]).toMatchObject({
+      worktreeId: "wt-1",
+      branchName: "feature/no-pr",
+      providerId: "daintree.github.github",
+    });
+
+    unsubscribeCleared();
+    unsubscribeDetected();
+    pullRequestService.destroy();
+  });
+
   it("clears PR state only when branch changes (not when issue number changes)", async () => {
     const clearPRCaches = vi.fn();
     vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));

--- a/electron/services/forgeRpcServer.ts
+++ b/electron/services/forgeRpcServer.ts
@@ -1,0 +1,169 @@
+import type {
+  ForgeRpcMethod,
+  ForgeResolveProviderResult,
+  WorkspaceHostRequest,
+} from "../../shared/types/workspace-host.js";
+import type {
+  CIStatus,
+  ForgeProviderImpl,
+  Issue,
+  PR,
+  RateLimitInfo,
+  RepoRef,
+} from "../../shared/types/forge.js";
+import { makeForgeProviderId } from "../../shared/utils/forgeProviderIds.js";
+import { getForgeProviderImpl } from "./forgeProviderRegistry.js";
+import { resolveForgeProvider } from "./forgeProviderResolver.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+
+/**
+ * Incoming `forge:rpc` event shape (workspace-host → main). Defined locally as
+ * a structural type so this server stays decoupled from the full
+ * `WorkspaceHostEvent` union — the only caller is `WorkspaceHostProcess` and
+ * it narrows the event before dispatch.
+ */
+export interface ForgeRpcRequest {
+  forgeRequestId: string;
+  method: ForgeRpcMethod;
+  namespacedId?: string;
+  args: unknown[];
+}
+
+type Sender = (request: WorkspaceHostRequest) => boolean;
+
+/**
+ * Dispatch a forge RPC call from the workspace-host against the local
+ * forge provider registry, then send the result back via `sender`. Errors
+ * are caught and reported through the same channel — the workspace-host's
+ * bridge surfaces them as rejected promises at the call site (e.g. inside
+ * `PullRequestService.checkForPRs`).
+ *
+ * This is the single point where the workspace-host crosses the process
+ * boundary into the forge layer. Plugin authors do not need to know it
+ * exists — their impls run in main as usual; the bridge is transparent.
+ */
+export async function dispatchForgeRpc(req: ForgeRpcRequest, sender: Sender): Promise<void> {
+  try {
+    const value = await invoke(req);
+    const sent = sender({
+      type: "forge:rpc-result",
+      forgeRequestId: req.forgeRequestId,
+      ok: true,
+      value,
+    });
+    if (!sent) {
+      // `child.postMessage` either threw (non-cloneable result, e.g. a
+      // third-party provider whose `rawData` contains functions or proxies)
+      // or the child has already exited. Either way, the workspace-host
+      // would otherwise hang on the 30s bridge timeout. Send an error
+      // envelope so the bridge fails fast.
+      sender({
+        type: "forge:rpc-result",
+        forgeRequestId: req.forgeRequestId,
+        ok: false,
+        error: `Forge RPC ${req.method} result could not be delivered (non-cloneable or child gone)`,
+      });
+    }
+  } catch (error) {
+    sender({
+      type: "forge:rpc-result",
+      forgeRequestId: req.forgeRequestId,
+      ok: false,
+      error: formatErrorMessage(error, `Forge RPC ${req.method} failed`),
+    });
+  }
+}
+
+async function invoke(req: ForgeRpcRequest): Promise<unknown> {
+  if (req.method === "resolveProvider") {
+    return invokeResolveProvider(req.args);
+  }
+
+  if (!req.namespacedId) {
+    throw new Error(`Forge RPC ${req.method} requires a namespacedId`);
+  }
+  const impl = getForgeProviderImpl(req.namespacedId);
+  if (!impl) {
+    throw new Error(`Forge provider "${req.namespacedId}" not registered`);
+  }
+
+  switch (req.method) {
+    case "findPRByBranch":
+      return invokeFindPRByBranch(impl, req.args);
+    case "findPRsByBranches":
+      return invokeFindPRsByBranches(impl, req.args);
+    case "getPR":
+      return invokeGetPR(impl, req.args);
+    case "getIssue":
+      return invokeGetIssue(impl, req.args);
+    case "getCIStatus":
+      return invokeGetCIStatus(impl, req.args);
+    case "getRateLimit":
+      return invokeGetRateLimit(impl);
+    default: {
+      const exhaustive: never = req.method;
+      throw new Error(`Unhandled forge RPC method: ${String(exhaustive)}`);
+    }
+  }
+}
+
+function invokeResolveProvider(args: unknown[]): ForgeResolveProviderResult | null {
+  const [opts] = args as [
+    {
+      remoteUrl: string | null;
+      forgeProviderOverride: string | null;
+      globalDefaultProviderId: string | null;
+    },
+  ];
+  const resolved = resolveForgeProvider({
+    remoteUrl: opts.remoteUrl,
+    forgeProviderOverride: opts.forgeProviderOverride,
+    globalDefaultProviderId: opts.globalDefaultProviderId,
+  });
+  if (!resolved.entry) return null;
+
+  const { pluginId, contribution } = resolved.entry;
+  const namespacedId = makeForgeProviderId(pluginId, contribution.id);
+  const impl = getForgeProviderImpl(namespacedId);
+  if (!impl) return null;
+  if (!opts.remoteUrl) return null;
+
+  const repo = impl.parseRemote(opts.remoteUrl);
+  if (!repo) return null;
+
+  return { namespacedId, repo };
+}
+
+function invokeFindPRByBranch(impl: ForgeProviderImpl, args: unknown[]): Promise<PR | null> {
+  const [repo, branch] = args as [RepoRef, string];
+  return impl.findPRByBranch(repo, branch);
+}
+
+async function invokeFindPRsByBranches(
+  impl: ForgeProviderImpl,
+  args: unknown[]
+): Promise<Map<string, PR | null> | null> {
+  const [repo, branches] = args as [RepoRef, string[]];
+  if (!impl.findPRsByBranches) return null;
+  return impl.findPRsByBranches(repo, branches);
+}
+
+function invokeGetPR(impl: ForgeProviderImpl, args: unknown[]): Promise<PR | null> {
+  const [repo, prNumber] = args as [RepoRef, number];
+  return impl.getPR(repo, prNumber);
+}
+
+function invokeGetIssue(impl: ForgeProviderImpl, args: unknown[]): Promise<Issue | null> {
+  const [repo, issueNumber] = args as [RepoRef, number];
+  return impl.getIssue(repo, issueNumber);
+}
+
+function invokeGetCIStatus(impl: ForgeProviderImpl, args: unknown[]): Promise<CIStatus | null> {
+  const [repo, prNumber] = args as [RepoRef, number];
+  return impl.getCIStatus(repo, prNumber);
+}
+
+async function invokeGetRateLimit(impl: ForgeProviderImpl): Promise<RateLimitInfo | null> {
+  if (!impl.getRateLimit) return null;
+  return impl.getRateLimit();
+}

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -108,6 +108,12 @@ export class WorkspaceHostEventRouter {
         const providerId = event.linked?.providerId ?? event.providerId ?? "";
         const owner = linkedRef?.owner ?? "";
         const repo = linkedRef?.repo ?? "";
+        // Renderer payload MUST carry `linked` + `branchName` + `providerId`
+        // (#8870 regression from #8452). After #8452 the renderer's pr-detected
+        // handler reads `event.linked ?? existing.linked` and `branchesMatch`
+        // uses `event.branchName`. Dropping these fields here meant the
+        // renderer's `event.linked` was always undefined, so `linked.pr` never
+        // landed in the store and the PR sub-row never rendered.
         const prPayload = {
           worktreeId: event.worktreeId,
           prNumber: event.prNumber,
@@ -117,6 +123,11 @@ export class WorkspaceHostEventRouter {
           prTitle: event.prTitle,
           issueNumber: event.issueNumber,
           issueTitle: event.issueTitle,
+          prLastUpdatedAt: event.prLastUpdatedAt,
+          issueLastUpdatedAt: event.issueLastUpdatedAt,
+          branchName: event.branchName,
+          providerId: event.providerId,
+          linked: event.linked,
           timestamp: Date.now(),
         };
         events.emit("sys:pr:detected", { ...prPayload, providerId, owner, repo });
@@ -142,10 +153,16 @@ export class WorkspaceHostEventRouter {
         const providerId = event.linked?.providerId ?? event.providerId ?? "";
         const owner = linkedRef?.owner ?? "";
         const repo = linkedRef?.repo ?? "";
+        // Renderer payload MUST carry `linked` + `branchName` + `providerId`
+        // (#8870 regression — see pr-detected case above for the full rationale).
         const issuePayload = {
           worktreeId: event.worktreeId,
           issueNumber: event.issueNumber,
           issueTitle: event.issueTitle,
+          issueLastUpdatedAt: event.issueLastUpdatedAt,
+          branchName: event.branchName,
+          providerId: event.providerId,
+          linked: event.linked,
         };
         events.emit("sys:issue:detected", {
           ...issuePayload,

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -191,6 +191,117 @@ describe("WorkspaceHostEventRouter", () => {
     });
   });
 
+  describe("pr-detected IPC payload (#8870)", () => {
+    function makeWebContents() {
+      return {
+        isDestroyed: () => false,
+        send: vi.fn(),
+      } as unknown as Electron.WebContents;
+    }
+
+    it("includes linked, branchName, and providerId on the renderer payload", () => {
+      // Without these fields the renderer's `event.linked ?? existing.linked`
+      // falls back to (typically null) existing.linked and the PR sub-row
+      // never renders. The regression dropped the fields silently after #8452.
+      const wc = makeWebContents();
+      const entry = makeEntry();
+      entry.directPortViews.set(1, wc);
+
+      const linked = {
+        providerId: BUILTIN_GITHUB_PROVIDER_ID,
+        pr: {
+          ref: {
+            providerId: BUILTIN_GITHUB_PROVIDER_ID,
+            owner: "acme",
+            repo: "demo",
+            number: 42,
+            rawData: null,
+          },
+          title: "Fix the thing",
+          url: "https://github.com/acme/demo/pull/42",
+          state: "open" as const,
+        },
+      };
+
+      const event: Extract<WorkspaceHostEvent, { type: "pr-detected" }> = {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://github.com/acme/demo/pull/42",
+        prState: "open",
+        prTitle: "Fix the thing",
+        branchName: "feature/x",
+        providerId: BUILTIN_GITHUB_PROVIDER_ID,
+        linked,
+      };
+
+      router.routeHostEvent(entry, event);
+
+      expect(wc.send).toHaveBeenCalledTimes(1);
+      const [channel, payload] = (wc.send as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(channel).toBe(CHANNELS.PR_DETECTED);
+      expect(payload).toMatchObject({
+        worktreeId: "wt-1",
+        prNumber: 42,
+        branchName: "feature/x",
+        providerId: BUILTIN_GITHUB_PROVIDER_ID,
+        linked,
+      });
+    });
+  });
+
+  describe("issue-detected IPC payload (#8870)", () => {
+    function makeWebContents() {
+      return {
+        isDestroyed: () => false,
+        send: vi.fn(),
+      } as unknown as Electron.WebContents;
+    }
+
+    it("includes linked, branchName, and providerId on the renderer payload", () => {
+      const wc = makeWebContents();
+      const entry = makeEntry();
+      entry.directPortViews.set(1, wc);
+
+      const linked = {
+        providerId: BUILTIN_GITHUB_PROVIDER_ID,
+        issue: {
+          ref: {
+            providerId: BUILTIN_GITHUB_PROVIDER_ID,
+            owner: "acme",
+            repo: "demo",
+            number: 7,
+            rawData: null,
+          },
+          title: "Reported bug",
+        },
+      };
+
+      const event: Extract<WorkspaceHostEvent, { type: "issue-detected" }> = {
+        type: "issue-detected",
+        worktreeId: "wt-1",
+        issueNumber: 7,
+        issueTitle: "Reported bug",
+        branchName: "feature/issue-7",
+        providerId: BUILTIN_GITHUB_PROVIDER_ID,
+        linked,
+      };
+
+      router.routeHostEvent(entry, event);
+
+      expect(wc.send).toHaveBeenCalledTimes(1);
+      const [channel, payload] = (wc.send as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(channel).toBe(CHANNELS.ISSUE_DETECTED);
+      expect(payload).toMatchObject({
+        worktreeId: "wt-1",
+        issueNumber: 7,
+        branchName: "feature/issue-7",
+        providerId: BUILTIN_GITHUB_PROVIDER_ID,
+        linked,
+      });
+    });
+  });
+
   describe("cloud resource teardown failure notifications", () => {
     const lifecycleStatus = (
       phase: WorktreeLifecyclePhase,

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -36,30 +36,7 @@ import { gitHubRateLimitService } from "./services/github/index.js";
 import { ensureSerializable } from "../shared/utils/serialization.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../shared/utils/forgeProviderIds.js";
-import {
-  registerForgeProviders,
-  registerForgeProviderImpl,
-} from "./services/forgeProviderRegistry.js";
-import { githubForgeProvider } from "../plugins/builtin/github/main/forgeProvider.js";
-
-// Plugins normally register their forge contributions via `PluginService.activate`
-// in the main process. The workspace-host runs as a separate UtilityProcess
-// with no plugin loader, so its per-process forge registry stays empty and
-// `PullRequestService.resolveProvider` here exits with `hasImpl=false`, leaving
-// every worktree's `linked.pr` permanently undefined (#8870).
-//
-// Pre-registering the built-in `daintree.github` provider unblocks PR detection
-// for the common case. Third-party forge plugins (e.g. GitLab) still won't be
-// visible to PR polling until plugin registrations are propagated from main →
-// workspace-host — tracked as a follow-up.
-registerForgeProviders("daintree.github", [
-  {
-    id: "github",
-    name: "GitHub",
-    matches: ["github.com"],
-  },
-]);
-registerForgeProviderImpl("daintree.github", "github", githubForgeProvider);
+import { initForgeBridge } from "./workspace-host/forgeBridge.js";
 import { fanoutEventToWorktreePorts } from "./workspace-host/worktreePortFanout.js";
 import { PERF_MARKS } from "../shared/perf/marks.js";
 import { markHostPerformance } from "./utils/hostPerformance.js";
@@ -345,6 +322,15 @@ const shutdownController = new AbortController();
 // Create singleton instance
 const workspaceService = new WorkspaceService(sendEvent);
 
+// Forge provider impls live in main (registered by `PluginService` when a
+// plugin activates). This bridge is the workspace-host's only access path —
+// every PR/CI/rate-limit call from `PullRequestService` round-trips here as a
+// `forge:rpc` event and resolves when main answers with `forge:rpc-result`.
+// Initialised before `port.on("message")` is attached so the very first
+// inbound result has a bridge to route to. See
+// `docs/architecture/forge-provider-abstraction.md` for the rationale.
+const forgeBridge = initForgeBridge(sendEvent);
+
 // Convert a GitHubRateLimitPayload (from gitHubRateLimitService.getState())
 // to the provider-agnostic RateLimitInfo shape so the forge-rate-limit-changed
 // event payload is provider-agnostic.
@@ -571,6 +557,11 @@ port.on("message", async (rawMsg: any) => {
       case "dispose":
         shutdownController.abort();
         workspaceService.dispose();
+        // Reject any pending forge calls so awaiting code paths fail fast
+        // instead of waiting on the 30s timeout. Late `forge:rpc-result`
+        // messages after this are still safe — `handleResult` drops unknown
+        // ids — but eagerly clearing the pending map prevents shutdown delays.
+        forgeBridge.dispose();
         break;
 
       case "set-log-level-overrides": {
@@ -760,6 +751,14 @@ port.on("message", async (rawMsg: any) => {
         break;
       }
 
+      // Inbound result for a forge RPC the bridge dispatched earlier — route
+      // to the pending promise keyed by `forgeRequestId`. The bridge owns
+      // success/error semantics and any timeout cleanup; main just hands the
+      // raw envelope across.
+      case "forge:rpc-result":
+        forgeBridge.handleResult(request);
+        break;
+
       default:
         console.warn("[WorkspaceHost] Unknown message type:", (request as any).type);
     }
@@ -774,6 +773,7 @@ process.on("SIGTERM", () => {
   console.log("[WorkspaceHost] SIGTERM received, shutting down");
   shutdownController.abort();
   workspaceService.dispose();
+  forgeBridge.dispose();
 });
 
 // Signal ready

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -36,6 +36,30 @@ import { gitHubRateLimitService } from "./services/github/index.js";
 import { ensureSerializable } from "../shared/utils/serialization.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../shared/utils/forgeProviderIds.js";
+import {
+  registerForgeProviders,
+  registerForgeProviderImpl,
+} from "./services/forgeProviderRegistry.js";
+import { githubForgeProvider } from "../plugins/builtin/github/main/forgeProvider.js";
+
+// Plugins normally register their forge contributions via `PluginService.activate`
+// in the main process. The workspace-host runs as a separate UtilityProcess
+// with no plugin loader, so its per-process forge registry stays empty and
+// `PullRequestService.resolveProvider` here exits with `hasImpl=false`, leaving
+// every worktree's `linked.pr` permanently undefined (#8870).
+//
+// Pre-registering the built-in `daintree.github` provider unblocks PR detection
+// for the common case. Third-party forge plugins (e.g. GitLab) still won't be
+// visible to PR polling until plugin registrations are propagated from main →
+// workspace-host — tracked as a follow-up.
+registerForgeProviders("daintree.github", [
+  {
+    id: "github",
+    name: "GitHub",
+    matches: ["github.com"],
+  },
+]);
+registerForgeProviderImpl("daintree.github", "github", githubForgeProvider);
 import { fanoutEventToWorktreePorts } from "./workspace-host/worktreePortFanout.js";
 import { PERF_MARKS } from "../shared/perf/marks.js";
 import { markHostPerformance } from "./utils/hostPerformance.js";

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -150,8 +150,13 @@ export class WorktreeMonitor {
   private prLastUpdatedAt: number | undefined;
   private issueLastUpdatedAt: number | undefined;
 
-  // Provider-agnostic forge linkage (populated alongside legacy fields)
-  private _linked: import("../../shared/types/plugin.js").PluginWorktreeLinked | null = null;
+  // Provider-agnostic forge linkage (populated alongside legacy fields).
+  // Tri-state: `undefined` = PR service hasn't run yet (renderer preserves
+  // its prior value), `null` = ran and found no link (clears renderer),
+  // object = linked. Initial `undefined` avoids racing `pr-detected` state
+  // the renderer holds from a prior session.
+  private _linked: import("../../shared/types/plugin.js").PluginWorktreeLinked | null | undefined =
+    undefined;
 
   // Polling state
   private pollingTimer: NodeJS.Timeout | null = null;

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -615,11 +615,15 @@ describe("WorktreeMonitor", () => {
       expect(monitor.getSnapshot().prState).toBe("closed");
     });
 
-    it("falls back to legacy flat fields when linked is null", () => {
+    it("falls back to legacy flat fields when linked is unset", () => {
+      // `_linked` initializes to `undefined` (#8870 — distinguishes "PR
+      // service hasn't run" from "ran and found no link"). The legacy flat
+      // fields populated via setPRInfo remain the source until setLinked
+      // or clearLinked fires.
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
       monitor.setPRInfo({ prNumber: 42, prUrl: "url", prState: "open", prTitle: "Legacy" });
       const snapshot = monitor.getSnapshot();
-      expect(snapshot.linked).toBeNull();
+      expect(snapshot.linked).toBeUndefined();
       expect(snapshot.prNumber).toBe(42);
       expect(snapshot.prTitle).toBe("Legacy");
     });

--- a/electron/workspace-host/forgeBridge.ts
+++ b/electron/workspace-host/forgeBridge.ts
@@ -1,0 +1,171 @@
+import type {
+  WorkspaceHostEvent,
+  ForgeRpcMethod,
+  ForgeResolveProviderResult,
+} from "../../shared/types/workspace-host.js";
+import type { CIStatus, Issue, PR, RateLimitInfo, RepoRef } from "../../shared/types/forge.js";
+
+type SendEvent = (event: WorkspaceHostEvent) => void;
+
+interface PendingCall {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+  method: ForgeRpcMethod;
+}
+
+// Slow PR polls can run a few seconds under load; 30s gives real network
+// latency room while still surfacing a stuck call before a poller backs up.
+const FORGE_RPC_TIMEOUT_MS = 30_000;
+
+/**
+ * IPC client for forge provider impls that live in the main process. The
+ * workspace-host UtilityProcess has no plugin loader, so it never holds
+ * impls of its own — every provider call is dispatched here, sent as a
+ * `forge:rpc` event over the parent port, and awaited until main answers
+ * with a matching `forge:rpc-result`.
+ *
+ * Method shape on this client matches the subset of `ForgeProviderImpl` the
+ * workspace-host actually needs. `parseRemote` is folded into
+ * {@link resolveProvider} so the workspace-host never has to call a
+ * synchronous provider method through async IPC.
+ */
+export class ForgeBridge {
+  private pending = new Map<string, PendingCall>();
+  private counter = 0;
+
+  constructor(private readonly sendEvent: SendEvent) {}
+
+  resolveProvider(opts: {
+    remoteUrl: string | null;
+    forgeProviderOverride: string | null;
+    globalDefaultProviderId: string | null;
+  }): Promise<ForgeResolveProviderResult | null> {
+    return this.invoke<ForgeResolveProviderResult | null>("resolveProvider", undefined, [opts]);
+  }
+
+  findPRByBranch(namespacedId: string, repo: RepoRef, branch: string): Promise<PR | null> {
+    return this.invoke<PR | null>("findPRByBranch", namespacedId, [repo, branch]);
+  }
+
+  findPRsByBranches(
+    namespacedId: string,
+    repo: RepoRef,
+    branches: string[]
+  ): Promise<Map<string, PR | null> | null> {
+    return this.invoke<Map<string, PR | null> | null>("findPRsByBranches", namespacedId, [
+      repo,
+      branches,
+    ]);
+  }
+
+  getPR(namespacedId: string, repo: RepoRef, prNumber: number): Promise<PR | null> {
+    return this.invoke<PR | null>("getPR", namespacedId, [repo, prNumber]);
+  }
+
+  getIssue(namespacedId: string, repo: RepoRef, issueNumber: number): Promise<Issue | null> {
+    return this.invoke<Issue | null>("getIssue", namespacedId, [repo, issueNumber]);
+  }
+
+  getCIStatus(namespacedId: string, repo: RepoRef, prNumber: number): Promise<CIStatus | null> {
+    return this.invoke<CIStatus | null>("getCIStatus", namespacedId, [repo, prNumber]);
+  }
+
+  /**
+   * Returns `null` when the provider does not implement `getRateLimit`. Mirrors
+   * the capability-as-optional-method shape in `ForgeProviderImpl`.
+   */
+  getRateLimit(namespacedId: string): Promise<RateLimitInfo | null> {
+    return this.invoke<RateLimitInfo | null>("getRateLimit", namespacedId, []);
+  }
+
+  /**
+   * Called by the workspace-host's port message handler whenever a
+   * `forge:rpc-result` arrives. Resolves or rejects the pending promise
+   * keyed by `forgeRequestId`. Unknown ids are silently dropped — the
+   * caller may have already timed out, in which case the promise has
+   * already settled and the result is genuinely irrelevant.
+   */
+  handleResult(
+    result:
+      | { forgeRequestId: string; ok: true; value: unknown }
+      | { forgeRequestId: string; ok: false; error: string }
+  ): void {
+    const pending = this.pending.get(result.forgeRequestId);
+    if (!pending) return;
+    this.pending.delete(result.forgeRequestId);
+    clearTimeout(pending.timer);
+    if (result.ok) {
+      pending.resolve(result.value);
+    } else {
+      pending.reject(new Error(result.error));
+    }
+  }
+
+  /** Cancel every pending call. Used on workspace-host shutdown. */
+  dispose(): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error(`Forge bridge disposed (pending ${pending.method})`));
+    }
+    this.pending.clear();
+  }
+
+  private invoke<T>(
+    method: ForgeRpcMethod,
+    namespacedId: string | undefined,
+    args: unknown[]
+  ): Promise<T> {
+    const forgeRequestId = `forge-${++this.counter}`;
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (!this.pending.has(forgeRequestId)) return;
+        this.pending.delete(forgeRequestId);
+        reject(new Error(`Forge RPC ${method} timed out after ${FORGE_RPC_TIMEOUT_MS}ms`));
+      }, FORGE_RPC_TIMEOUT_MS);
+
+      this.pending.set(forgeRequestId, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        resolve: resolve as any,
+        reject,
+        timer,
+        method,
+      });
+
+      this.sendEvent({
+        type: "forge:rpc",
+        forgeRequestId,
+        method,
+        namespacedId,
+        args,
+      });
+    });
+  }
+}
+
+let _bridge: ForgeBridge | null = null;
+
+/** Create the workspace-host's singleton bridge. Called once during bootstrap. */
+export function initForgeBridge(sendEvent: SendEvent): ForgeBridge {
+  if (_bridge !== null) {
+    throw new Error("ForgeBridge already initialized");
+  }
+  _bridge = new ForgeBridge(sendEvent);
+  return _bridge;
+}
+
+/** Access the singleton bridge from anywhere in the workspace-host. */
+export function getForgeBridge(): ForgeBridge {
+  if (_bridge === null) {
+    throw new Error(
+      "ForgeBridge not initialized — call initForgeBridge() during workspace-host bootstrap"
+    );
+  }
+  return _bridge;
+}
+
+/** Test-only reset. */
+export function _resetForgeBridgeForTests(): void {
+  _bridge?.dispose();
+  _bridge = null;
+}

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -25,7 +25,7 @@ import type {
   WorktreeLifecyclePhaseResult,
   WorktreeResourceStatus,
 } from "./worktree.js";
-import type { Credentials } from "./forge.js";
+import type { Credentials, RepoRef } from "./forge.js";
 import type { GitHubPRCIStatus } from "./github.js";
 import type { PluginWorktreeLinked } from "./plugin.js";
 import type {
@@ -423,7 +423,48 @@ export type WorkspaceHostRequest =
       includeRecentCommits?: boolean;
       forceRefresh?: boolean;
     }
-  | { type: "invalidate-pulse-cache"; worktreeId: string };
+  | { type: "invalidate-pulse-cache"; worktreeId: string }
+  // Forge RPC response (main → workspace-host). Correlated to a prior
+  // `forge:rpc` event by `forgeRequestId`. Carries either a successful return
+  // value or an error message. See `ForgeRpcMethod` for the supported methods.
+  | {
+      type: "forge:rpc-result";
+      forgeRequestId: string;
+      ok: true;
+      value: unknown;
+    }
+  | {
+      type: "forge:rpc-result";
+      forgeRequestId: string;
+      ok: false;
+      error: string;
+    };
+
+/**
+ * Forge RPC methods the workspace-host can request from main. The
+ * implementations live in main's forge provider registry (registered by
+ * plugin activations). The workspace-host never holds impls itself — it
+ * issues IPC calls through {@link ForgeBridge} and routes results by
+ * `forgeRequestId`.
+ *
+ * `resolveProvider` is special-cased: it bundles `parseRemote` into the
+ * lookup so the workspace-host gets `{ namespacedId, repo }` in a single
+ * roundtrip and never needs to call sync provider methods.
+ */
+export type ForgeRpcMethod =
+  | "resolveProvider"
+  | "findPRByBranch"
+  | "findPRsByBranches"
+  | "getPR"
+  | "getIssue"
+  | "getCIStatus"
+  | "getRateLimit";
+
+/** Result shape for `resolveProvider` — used by typed parsing of `forge:rpc-result.value`. */
+export interface ForgeResolveProviderResult {
+  namespacedId: string;
+  repo: RepoRef;
+}
 
 /**
  * Events sent from Workspace Host → Main.
@@ -625,6 +666,18 @@ export type WorkspaceHostEvent =
       type: "has-resource-config-result";
       requestId: string;
       hasConfig: boolean;
+    }
+  // Forge RPC request (workspace-host → main). Forge provider impls live in
+  // main (registered by `PluginService` on plugin activate); the workspace-host
+  // dispatches calls here and awaits the matching `forge:rpc-result` request
+  // back. `namespacedId` is omitted for `method === "resolveProvider"` since
+  // that call discovers the provider from the remote URL.
+  | {
+      type: "forge:rpc";
+      forgeRequestId: string;
+      method: ForgeRpcMethod;
+      namespacedId?: string;
+      args: unknown[];
     };
 
 /** Configuration for WorkspaceClient */

--- a/src/store/__tests__/createWorktreeStore.associations.test.ts
+++ b/src/store/__tests__/createWorktreeStore.associations.test.ts
@@ -240,4 +240,44 @@ describe("createWorktreeStore — linked PR preservation (#8870)", () => {
 
     expect(store.getState().worktrees.get("wt-1")?.linked).toEqual(replacement);
   });
+
+  it("clears existing linked when a later null arrives after a series of omitted updates", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1", { linked: linkedWithPr })], nextV());
+
+    // PR service hasn't run yet — several updates omit `linked`.
+    store.getState().applyUpdate(makeSnapshot("wt-1", { branch: "a" }), nextV());
+    store.getState().applyUpdate(makeSnapshot("wt-1", { branch: "b" }), nextV());
+    expect(store.getState().worktrees.get("wt-1")?.linked).toEqual(linkedWithPr);
+
+    // PR service finally finishes and reports "no PR found" — host emits null.
+    store.getState().applyUpdate(makeSnapshot("wt-1", { linked: null }), nextV());
+
+    expect(store.getState().worktrees.get("wt-1")?.linked).toBeNull();
+  });
+
+  it("preserves linked.pr when applySnapshot omits the linked field", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1", { linked: linkedWithPr })], nextV());
+
+    // A later get-all-states snapshot during the startup window omits `linked`.
+    store.getState().applySnapshot([makeSnapshot("wt-1", { branch: "feature/x" })], nextV());
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.linked).toEqual(linkedWithPr);
+    expect(wt?.branch).toBe("feature/x");
+  });
+
+  it("preserves an explicit null clear through a subsequent undefined update", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1", { linked: linkedWithPr })], nextV());
+
+    store.getState().applyUpdate(makeSnapshot("wt-1", { linked: null }), nextV());
+    expect(store.getState().worktrees.get("wt-1")?.linked).toBeNull();
+
+    // A later update with `linked` omitted must not resurrect the prior linked object.
+    store.getState().applyUpdate(makeSnapshot("wt-1", { branch: "feature/x" }), nextV());
+
+    expect(store.getState().worktrees.get("wt-1")?.linked).toBeNull();
+  });
 });

--- a/src/store/__tests__/createWorktreeStore.associations.test.ts
+++ b/src/store/__tests__/createWorktreeStore.associations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createWorktreeStore } from "@/store/createWorktreeStore";
 import type { WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
+import type { PluginWorktreeLinked } from "@shared/types/plugin";
 
 // Host-minted versions are now `(epoch, seq)` tuples (#8403). Tests mint a
 // monotonic seq under a fixed epoch; each fresh store starts at epoch "" so
@@ -174,5 +175,69 @@ describe("createWorktreeStore — manual issue associations (#8079)", () => {
 
     expect(store.getState().manualAssociations.size).toBe(0);
     expect(store.getState().isInitialized).toBe(false);
+  });
+});
+
+describe("createWorktreeStore — linked PR preservation (#8870)", () => {
+  function makePr(number: number, title: string): PluginWorktreeLinked["pr"] {
+    return {
+      ref: { providerId: "github", owner: "acme", repo: "demo", number, rawData: null },
+      title,
+      url: `https://example/pr/${number}`,
+      state: "open",
+    };
+  }
+
+  const linkedWithPr: PluginWorktreeLinked = {
+    providerId: "github",
+    pr: makePr(123, "Fix the thing"),
+  };
+
+  it("preserves existing linked.pr when an update omits the linked field", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1", { linked: linkedWithPr })], nextV());
+
+    // Startup-race scenario: a worktree-update fires before initializePRService
+    // populates `_linked`. The host emits the snapshot without a `linked` key.
+    store.getState().applyUpdate(makeSnapshot("wt-1", { branch: "feature/x" }), nextV());
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.linked).toEqual(linkedWithPr);
+    expect(wt?.branch).toBe("feature/x");
+  });
+
+  it("preserves existing linked.pr when an update has linked: undefined", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1", { linked: linkedWithPr })], nextV());
+
+    store
+      .getState()
+      .applyUpdate(makeSnapshot("wt-1", { branch: "feature/x", linked: undefined }), nextV());
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.linked).toEqual(linkedWithPr);
+  });
+
+  it("clears existing linked when an update has linked: null (explicit clear)", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1", { linked: linkedWithPr })], nextV());
+
+    // Branch switch -> WorktreeMonitor.clearLinked() emits `linked: null`.
+    store.getState().applyUpdate(makeSnapshot("wt-1", { linked: null }), nextV());
+
+    expect(store.getState().worktrees.get("wt-1")?.linked).toBeNull();
+  });
+
+  it("replaces existing linked when an update carries a different linked object", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1", { linked: linkedWithPr })], nextV());
+
+    const replacement: PluginWorktreeLinked = {
+      providerId: "github",
+      pr: makePr(456, "New PR"),
+    };
+    store.getState().applyUpdate(makeSnapshot("wt-1", { linked: replacement }), nextV());
+
+    expect(store.getState().worktrees.get("wt-1")?.linked).toEqual(replacement);
   });
 });

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -1031,10 +1031,23 @@ function mergeIssueState(
     issueTitle = manual.issueTitle;
   }
 
-  if (issueNumber === incoming.issueNumber && issueTitle === incoming.issueTitle) {
+  // `linked: undefined` from the host means "PR service hasn't run yet" —
+  // preserve whatever the renderer already has (e.g. `linked.pr` from a
+  // prior session's `pr-detected` event). `linked: null` is an explicit
+  // clear (branch switch) and must propagate. (#8870 regression from #8452.)
+  const linked =
+    incoming.linked === undefined && existing?.linked !== undefined
+      ? existing.linked
+      : incoming.linked;
+
+  if (
+    issueNumber === incoming.issueNumber &&
+    issueTitle === incoming.issueTitle &&
+    linked === incoming.linked
+  ) {
     return incoming;
   }
-  return { ...incoming, issueNumber, issueTitle };
+  return { ...incoming, issueNumber, issueTitle, linked };
 }
 
 function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {


### PR DESCRIPTION
This PR started narrow — preserving the linked PR across a startup race — but diagnostic logging traced the failure somewhere deeper, and the final commits replace a GitHub-only workaround with a proper architectural fix.

## Summary

The worktree sidebar wasn't showing the linked PR on startup. The earlier commits in this PR handled a clearing race in `WorktreeMonitor`: emit `sys:pr:cleared` only when the forge confirms no PR; preserve a previously-known PR until that confirmed-absent signal lands; forward `linked`, `branchName`, and `providerId` through to the renderer.

That wasn't the full story. The `[8870]` diagnostic logging traced the actual failure: the workspace-host `UtilityProcess` has no plugin loader, so its forge registry was empty and `PullRequestService` was silently skipping PR detection on every poll. The first fix attempt pre-registered the built-in `daintree.github` provider in the workspace-host. It worked for GitHub but left third-party forge plugins (GitLab, Gitea, Bitbucket, Forgejo) broken in exactly the same way.

The final commit replaces that workaround with a typed `ForgeBridge` IPC client. The workspace-host no longer holds any forge provider state — every call (`resolveProvider`, `findPRByBranch`, `findPRsByBranches`, `getPR`, `getIssue`, `getCIStatus`, `getRateLimit`) round-trips through main via the bridge. Main holds the single source of truth for plugin registrations, and third-party forge plugins work transparently without any extra wiring.

The diagnostics also surfaced a long-standing bug in `readRemoteUrl`: simple-git's `getConfig` was being cast straight to `string | null`, but at runtime it returns a `ConfigGetResult` envelope. The cast silently produced `null` in the real workspace-host, so the provider could never resolve. Tests had mocked it as a string, which hid it. Fixed, plus a regression test pinning the envelope shape.

## Changes

- New: `electron/workspace-host/forgeBridge.ts` — workspace-host IPC client. Dispatches `forge:rpc` over the parent port and awaits `forge:rpc-result`. 30s timeout, `dispose()` rejects pending calls on shutdown.
- New: `electron/services/forgeRpcServer.ts` — main-side dispatcher. Looks up the impl in the local registry, invokes the method, sends the result back. Handles non-cloneable results by sending an error envelope so the bridge fails fast instead of hanging on the timeout.
- `electron/services/PullRequestService.ts` — drops `providerImpl`; routes all calls through the bridge; unwraps the `ConfigGetResult` envelope in `readRemoteUrl`; guards against stale in-flight results when `setForgeSettings` changes the provider mid-cycle. Cold-start race: caps the next poll at 5s when no provider is resolved yet, skipped when `consecutiveErrors > 0` so it doesn't punch through circuit-breaker backoff.
- `electron/workspace-host.ts` — wires `initForgeBridge`, the `forge:rpc-result` inbound handler, and `forgeBridge.dispose()` on shutdown.
- `electron/services/WorkspaceHostProcess.ts` — routes inbound `forge:rpc` to `dispatchForgeRpc`.
- `shared/types/workspace-host.ts` — adds the `ForgeRpcMethod` union and the new `forge:rpc` / `forge:rpc-result` message variants.
- `docs/architecture/forge-provider-abstraction.md` — new "Process Boundary: workspace-host RPC Bridge" section. Plugin authors get the transparent surface; no extra wiring required.

## Testing

- Existing `PullRequestService` tests refactored to mock `getForgeBridge` (returning a stub bridge that delegates to the underlying impl) rather than mocking the registry directly.
- New regression test pins the `ConfigGetResult` envelope shape that simple-git returns at runtime.
- `tsc -b electron/tsconfig.json` clean; all 10078 electron tests pass.
- Verified end-to-end with `npm run dev`: `PullRequestService resolved forge provider` and `PR detected for worktree` fire across multiple poll cycles. No `Skipping PR check — no forge provider resolved` after the registry populates.

Resolves #8870
