### PR TITLE
fix(worktree): UpstreamSyncBadge — delta-flash + base-divergence spacing (#8872)

### DIFF
--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { actionService } from "@/services/ActionService";
-import { useSkeletonGate } from "@/hooks/useDeferredLoading";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
 
 interface UpstreamSyncBadgeProps {
@@ -40,7 +39,23 @@ export function UpstreamSyncBadge({
 }: UpstreamSyncBadgeProps) {
   const hasAhead = aheadCount !== undefined && aheadCount > 0;
   const hasBehind = behindCount !== undefined && behindCount > 0;
-  const showPulse = useSkeletonGate(isFetchInFlight);
+
+  const prevCountsRef = useRef({ aheadCount, behindCount, baseAheadCount, baseBehindCount });
+  const [isFlashing, setIsFlashing] = useState(false);
+
+  useEffect(() => {
+    const prev = prevCountsRef.current;
+    const changed =
+      prev.aheadCount !== aheadCount ||
+      prev.behindCount !== behindCount ||
+      prev.baseAheadCount !== baseAheadCount ||
+      prev.baseBehindCount !== baseBehindCount;
+    prevCountsRef.current = { aheadCount, behindCount, baseAheadCount, baseBehindCount };
+    if (!changed) return;
+    setIsFlashing(true);
+    const safetyTimer = window.setTimeout(() => setIsFlashing(false), 250);
+    return () => window.clearTimeout(safetyTimer);
+  }, [aheadCount, behindCount, baseAheadCount, baseBehindCount]);
 
   const isStale = useMemo(() => {
     if (lastFetchedAt == null || fetchIntervalMs == null) return false;
@@ -105,7 +120,7 @@ export function UpstreamSyncBadge({
           className={cn(
             "flex items-center text-[10px] font-mono tabular-nums",
             containerGapClass,
-            isFetchInFlight && showPulse && "animate-pulse-immediate",
+            isFlashing && "animate-upstream-badge-flash",
             fetchNetworkFailed && "opacity-75",
             isStale && !isFetchInFlight && "opacity-50 transition-opacity duration-150"
           )}
@@ -113,15 +128,20 @@ export function UpstreamSyncBadge({
           data-fetch-in-flight={isFetchInFlight ? "true" : undefined}
           data-fetch-network-failed={fetchNetworkFailed ? "true" : undefined}
           data-stale={isStale ? "true" : undefined}
+          onAnimationEnd={() => setIsFlashing(false)}
         >
           {hasAhead && <span className="text-status-success">↑{aheadCount}</span>}
           {hasBehind && <span className="text-status-warning">↓{behindCount}</span>}
           {showBaseDivergence && (
-            <span className="text-text-muted/60">
-              &Delta; {baseBranchName}{" "}
-              {baseAheadCount != null && baseAheadCount > 0 && <>↑{baseAheadCount}</>}
-              {baseBehindCount != null && baseBehindCount > 0 && <>↓{baseBehindCount}</>}
-            </span>
+            <>
+              <span className="text-text-muted/60">&Delta; {baseBranchName}</span>
+              {baseAheadCount != null && baseAheadCount > 0 && (
+                <span className="text-status-success">↑{baseAheadCount}</span>
+              )}
+              {baseBehindCount != null && baseBehindCount > 0 && (
+                <span className="text-status-warning">↓{baseBehindCount}</span>
+              )}
+            </>
           )}
         </span>
       </TooltipTrigger>

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -40,33 +40,53 @@ export function UpstreamSyncBadge({
   const hasAhead = aheadCount !== undefined && aheadCount > 0;
   const hasBehind = behindCount !== undefined && behindCount > 0;
 
-  const prevCountsRef = useRef({ aheadCount, behindCount, baseAheadCount, baseBehindCount });
-  const [isFlashing, setIsFlashing] = useState(false);
-
-  useEffect(() => {
-    const prev = prevCountsRef.current;
-    const changed =
-      prev.aheadCount !== aheadCount ||
-      prev.behindCount !== behindCount ||
-      prev.baseAheadCount !== baseAheadCount ||
-      prev.baseBehindCount !== baseBehindCount;
-    prevCountsRef.current = { aheadCount, behindCount, baseAheadCount, baseBehindCount };
-    if (!changed) return;
-    setIsFlashing(true);
-    const safetyTimer = window.setTimeout(() => setIsFlashing(false), 250);
-    return () => window.clearTimeout(safetyTimer);
-  }, [aheadCount, behindCount, baseAheadCount, baseBehindCount]);
-
-  const isStale = useMemo(() => {
-    if (lastFetchedAt == null || fetchIntervalMs == null) return false;
-    return Date.now() - lastFetchedAt > fetchIntervalMs * STALENESS_MULTIPLIER;
-  }, [lastFetchedAt, fetchIntervalMs]);
-
   const showBaseDivergence =
     baseBranchName != null &&
     !baseMatchesUpstream &&
     ((baseAheadCount != null && baseAheadCount > 0) ||
       (baseBehindCount != null && baseBehindCount > 0));
+
+  // Flash only on changes the user can actually see — track display-gated
+  // values so a null→0 transition on hidden base counts doesn't flash, and
+  // a baseMatchesUpstream flip that reveals existing counts does.
+  const displayedAhead = hasAhead ? aheadCount : null;
+  const displayedBehind = hasBehind ? behindCount : null;
+  const displayedBaseAhead =
+    showBaseDivergence && baseAheadCount != null && baseAheadCount > 0 ? baseAheadCount : null;
+  const displayedBaseBehind =
+    showBaseDivergence && baseBehindCount != null && baseBehindCount > 0 ? baseBehindCount : null;
+
+  const prevDisplayedRef = useRef({
+    displayedAhead,
+    displayedBehind,
+    displayedBaseAhead,
+    displayedBaseBehind,
+  });
+  const [isFlashing, setIsFlashing] = useState(false);
+
+  useEffect(() => {
+    const prev = prevDisplayedRef.current;
+    const changed =
+      prev.displayedAhead !== displayedAhead ||
+      prev.displayedBehind !== displayedBehind ||
+      prev.displayedBaseAhead !== displayedBaseAhead ||
+      prev.displayedBaseBehind !== displayedBaseBehind;
+    prevDisplayedRef.current = {
+      displayedAhead,
+      displayedBehind,
+      displayedBaseAhead,
+      displayedBaseBehind,
+    };
+    if (!changed) return;
+    setIsFlashing(true);
+    const safetyTimer = window.setTimeout(() => setIsFlashing(false), 250);
+    return () => window.clearTimeout(safetyTimer);
+  }, [displayedAhead, displayedBehind, displayedBaseAhead, displayedBaseBehind]);
+
+  const isStale = useMemo(() => {
+    if (lastFetchedAt == null || fetchIntervalMs == null) return false;
+    return Date.now() - lastFetchedAt > fetchIntervalMs * STALENESS_MULTIPLIER;
+  }, [lastFetchedAt, fetchIntervalMs]);
 
   const handleSignInClick = useCallback((event: React.MouseEvent) => {
     event.stopPropagation();

--- a/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: ReactNode) => children };
+});
+
+vi.mock("@/lib/formatRelativeTime", () => ({
+  formatRelativeTime: () => "just now",
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+import { UpstreamSyncBadge } from "../UpstreamSyncBadge";
+
+type Props = Parameters<typeof UpstreamSyncBadge>[0];
+
+const baseProps: Props = {
+  aheadCount: 2,
+  behindCount: 0,
+  isFetchInFlight: false,
+  lastFetchedAt: Date.now(),
+  fetchAuthFailed: false,
+  fetchNetworkFailed: false,
+  isGitHubProvider: true,
+  containerGapClass: "gap-1.5",
+  baseBranchName: null,
+  baseAheadCount: null,
+  baseBehindCount: null,
+  baseMatchesUpstream: true,
+};
+
+function renderBadge(extra: Partial<Props> = {}) {
+  return render(
+    <TooltipProvider>
+      <UpstreamSyncBadge {...baseProps} {...extra} />
+    </TooltipProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("UpstreamSyncBadge — base-divergence layout", () => {
+  it("renders base-divergence arrows as separate flex children so the parent gap applies", () => {
+    renderBadge({
+      aheadCount: 0,
+      behindCount: 0,
+      baseBranchName: "develop",
+      baseAheadCount: 2,
+      baseBehindCount: 1,
+      baseMatchesUpstream: false,
+    });
+
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    const childSpans = Array.from(indicator.children) as HTMLElement[];
+
+    const aheadSpan = childSpans.find((el) => el.textContent === "↑2");
+    const behindSpan = childSpans.find((el) => el.textContent === "↓1");
+
+    expect(aheadSpan).toBeDefined();
+    expect(behindSpan).toBeDefined();
+    expect(aheadSpan).not.toBe(behindSpan);
+
+    // Counts must not be merged into a single text run.
+    const mergedSpan = childSpans.find((el) => /↑2\s*↓1/.test(el.textContent ?? ""));
+    expect(mergedSpan).toBeUndefined();
+  });
+
+  it("uses the upstream colour palette for base-divergence arrows", () => {
+    renderBadge({
+      aheadCount: 0,
+      behindCount: 0,
+      baseBranchName: "develop",
+      baseAheadCount: 2,
+      baseBehindCount: 1,
+      baseMatchesUpstream: false,
+    });
+
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    const childSpans = Array.from(indicator.children) as HTMLElement[];
+    const aheadSpan = childSpans.find((el) => el.textContent === "↑2");
+    const behindSpan = childSpans.find((el) => el.textContent === "↓1");
+
+    expect(aheadSpan?.className).toContain("text-status-success");
+    expect(behindSpan?.className).toContain("text-status-warning");
+  });
+});
+
+describe("UpstreamSyncBadge — value-change flash", () => {
+  it("does not flash on initial render", () => {
+    renderBadge();
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.className).not.toContain("animate-upstream-badge-flash");
+  });
+
+  it("does not apply the legacy pulse class for in-flight fetches", () => {
+    renderBadge({ isFetchInFlight: true });
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.className).not.toContain("animate-pulse-immediate");
+  });
+
+  it("does not flash when fetch is in-flight without count change", () => {
+    const { rerender } = renderBadge({ isFetchInFlight: false });
+    rerender(
+      <TooltipProvider>
+        <UpstreamSyncBadge {...baseProps} isFetchInFlight={true} />
+      </TooltipProvider>
+    );
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.className).not.toContain("animate-upstream-badge-flash");
+  });
+
+  it("flashes when ahead count changes between renders", () => {
+    const { rerender } = renderBadge({ aheadCount: 2 });
+    rerender(
+      <TooltipProvider>
+        <UpstreamSyncBadge {...baseProps} aheadCount={3} />
+      </TooltipProvider>
+    );
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.className).toContain("animate-upstream-badge-flash");
+  });
+
+  it("flashes when behind count changes between renders", () => {
+    const { rerender } = renderBadge({ behindCount: 0 });
+    rerender(
+      <TooltipProvider>
+        <UpstreamSyncBadge {...baseProps} behindCount={1} />
+      </TooltipProvider>
+    );
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.className).toContain("animate-upstream-badge-flash");
+  });
+
+  it("flashes when base divergence counts change between renders", () => {
+    const { rerender } = renderBadge({
+      baseBranchName: "develop",
+      baseAheadCount: 1,
+      baseBehindCount: 0,
+      baseMatchesUpstream: false,
+    });
+    rerender(
+      <TooltipProvider>
+        <UpstreamSyncBadge
+          {...baseProps}
+          baseBranchName="develop"
+          baseAheadCount={2}
+          baseBehindCount={0}
+          baseMatchesUpstream={false}
+        />
+      </TooltipProvider>
+    );
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.className).toContain("animate-upstream-badge-flash");
+  });
+
+  it("clears the flash class via the 250ms safety timer when animationend never fires", () => {
+    vi.useFakeTimers();
+    try {
+      const { rerender } = renderBadge({ aheadCount: 2 });
+      rerender(
+        <TooltipProvider>
+          <UpstreamSyncBadge {...baseProps} aheadCount={3} />
+        </TooltipProvider>
+      );
+      const indicator = screen.getByTestId("upstream-sync-indicator");
+      expect(indicator.className).toContain("animate-upstream-badge-flash");
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+      expect(indicator.className).not.toContain("animate-upstream-badge-flash");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
@@ -109,6 +109,54 @@ describe("UpstreamSyncBadge — value-change flash", () => {
     expect(indicator.className).not.toContain("animate-pulse-immediate");
   });
 
+  it("does not flash across repeated polls with stable counts (issue #8872 regression)", () => {
+    // Simulates the polling loop: lastFetchedAt advances each tick but the
+    // counts are unchanged. The badge must stay still — that was the bug.
+    const { rerender } = renderBadge({ aheadCount: 2, behindCount: 1, lastFetchedAt: 1000 });
+    for (const t of [2000, 3000, 4000, 5000]) {
+      rerender(
+        <TooltipProvider>
+          <UpstreamSyncBadge
+            {...baseProps}
+            aheadCount={2}
+            behindCount={1}
+            lastFetchedAt={t}
+            isFetchInFlight={t % 2000 === 0}
+          />
+        </TooltipProvider>
+      );
+    }
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.className).not.toContain("animate-upstream-badge-flash");
+    expect(indicator.className).not.toContain("animate-pulse-immediate");
+  });
+
+  it("does not flash when hidden base counts churn between null and 0", () => {
+    // baseMatchesUpstream=true hides base counts entirely. Backend transitions
+    // null→0 on base counts must not cause a phantom flash on the visible badge.
+    const { rerender } = renderBadge({
+      aheadCount: 2,
+      behindCount: 0,
+      baseAheadCount: null,
+      baseBehindCount: null,
+      baseMatchesUpstream: true,
+    });
+    rerender(
+      <TooltipProvider>
+        <UpstreamSyncBadge
+          {...baseProps}
+          aheadCount={2}
+          behindCount={0}
+          baseAheadCount={0}
+          baseBehindCount={0}
+          baseMatchesUpstream={true}
+        />
+      </TooltipProvider>
+    );
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.className).not.toContain("animate-upstream-badge-flash");
+  });
+
   it("does not flash when fetch is in-flight without count change", () => {
     const { rerender } = renderBadge({ isFetchInFlight: false });
     rerender(

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { WorktreeHeader, type WorktreeHeaderProps } from "../WorktreeHeader";
 import type { WorktreeState } from "@shared/types";
@@ -1240,36 +1240,16 @@ describe("WorktreeHeader upstream sync indicator", () => {
     expect(indicator.textContent).toContain("↓1");
   });
 
-  it("defers animate-pulse-immediate until 200ms gate elapses", () => {
-    vi.useFakeTimers();
+  it("does not flash on initial render", () => {
     renderHeader({
-      worktree: {
-        ...baseWorktree,
-        aheadCount: 2,
-        behindCount: 0,
-        isFetchInFlight: true,
-      },
+      worktree: { ...baseWorktree, aheadCount: 2, behindCount: 0 },
     });
     const indicator = screen.getByTestId("upstream-sync-indicator");
-    // data-fetch-in-flight reflects raw state immediately (not deferred)
-    expect(indicator.getAttribute("data-fetch-in-flight")).toBe("true");
-    // Pulse class absent before the gate elapses
+    expect(indicator.className).not.toContain("animate-upstream-badge-flash");
     expect(indicator.className).not.toContain("animate-pulse-immediate");
-
-    act(() => {
-      vi.advanceTimersByTime(199);
-    });
-    expect(indicator.className).not.toContain("animate-pulse-immediate");
-
-    act(() => {
-      vi.advanceTimersByTime(1);
-    });
-    expect(indicator.className).toContain("animate-pulse-immediate");
-    vi.useRealTimers();
   });
 
-  it("never pulses when fetch completes before 200ms gate", () => {
-    vi.useFakeTimers();
+  it("does not flash when fetch is in-flight without count change", () => {
     renderHeader({
       worktree: {
         ...baseWorktree,
@@ -1278,26 +1258,10 @@ describe("WorktreeHeader upstream sync indicator", () => {
         isFetchInFlight: true,
       },
     });
-    // Fetch completes at 150ms — rerender with isFetchInFlight: false
-    act(() => {
-      vi.advanceTimersByTime(150);
-    });
-    cleanup();
-    renderHeader({
-      worktree: {
-        ...baseWorktree,
-        aheadCount: 2,
-        behindCount: 0,
-        isFetchInFlight: false,
-      },
-    });
-    // Advance past the 200ms gate to confirm no lingering pulse
-    act(() => {
-      vi.advanceTimersByTime(100);
-    });
     const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.getAttribute("data-fetch-in-flight")).toBe("true");
+    expect(indicator.className).not.toContain("animate-upstream-badge-flash");
     expect(indicator.className).not.toContain("animate-pulse-immediate");
-    vi.useRealTimers();
   });
 
   it("does not pulse when no fetch is in-flight", () => {

--- a/src/index.css
+++ b/src/index.css
@@ -1298,6 +1298,26 @@ body,
   animation: diagnostics-state-flash 200ms cubic-bezier(0.4, 0, 0.2, 1) both;
 }
 
+/* Upstream sync badge value-change flash — one-shot opacity dip when the
+ * displayed ahead/behind counts actually change, not while a poll is in flight.
+ * Issue #8872: fetch-in-flight pulse was firing on every poll cycle. */
+@keyframes upstream-badge-update-flash {
+  0% {
+    opacity: 1;
+  }
+  40% {
+    opacity: 0.4;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.animate-upstream-badge-flash {
+  animation: upstream-badge-update-flash 200ms cubic-bezier(0.4, 0, 0.2, 1) both;
+  will-change: opacity;
+}
+
 /* Activity blip animation - for new activity signals */
 @keyframes activity-blip {
   0% {
@@ -1594,6 +1614,7 @@ body,
   .animate-trash-pulse,
   .animate-all-clear-flash,
   .animate-diagnostics-flash,
+  .animate-upstream-badge-flash,
   .animate-border-flash {
     animation: none;
     opacity: 1;


### PR DESCRIPTION
## Summary

- **Spacing defect:** In the base-divergence span, `↑ahead` and `↓behind` were both inline text inside a single `<span>`, so the parent flex `gap` never applied between them. Counts visually merged. Fix: split into separate inline elements so spacing matches the upstream `↑/↓` path.
- **Pulse-on-poll defect:** The badge ran `animate-pulse-immediate` on every fetch cycle — gated on `isFetchInFlight`, which nearly always exceeds the 200ms anti-flicker delay. It flashed even when counts were identical to the previous poll. Fix: replace the infinite skeleton pulse with a one-shot opacity flash that only fires when ahead/behind values actually change, tracked via a ref against the previous render.
- Added a regression test in `UpstreamSyncBadge.test.tsx` confirming the badge stays visually stable across polls when counts don't change.

Resolves #8872

## Changes

- `src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx` — split base-divergence counts into separate inline elements; swap poll-pulse for delta-flash using a `useRef` to track previous values
- `src/index.css` — one-shot flash keyframe utility
- `src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx` — poll-stability regression test

## Testing

- Unit test added: badge renders stable across repeated polls with unchanged counts, and triggers the flash class exactly once on a value change
- Typecheck, lint, and format all pass