### PR TITLE
fix(terminal): queue bulk terminal startup

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -184,6 +184,17 @@ export function BannerSlot({ visible, children }: BannerSlotProps) {
   );
 }
 
+function TerminalStartupPlaceholder({ agentId }: { agentId?: string }) {
+  return (
+    <div className="flex h-full min-h-0 items-center justify-center bg-daintree-bg text-sm text-daintree-text/60">
+      <div className="flex items-center gap-2">
+        <Spinner size="sm" className="text-daintree-text/45" />
+        <span>{agentId ? "Starting agent" : "Starting terminal"}</span>
+      </div>
+    </div>
+  );
+}
+
 export interface ActivityState {
   headline: string;
   status: "working" | "waiting" | "success" | "failure";
@@ -1201,6 +1212,8 @@ function TerminalPaneComponent({
             detail={getPanelCliDetail() ?? { state: "missing", resolvedPath: null, via: null }}
             onRunAnyway={handleRunAnyway}
           />
+        ) : spawnStatus === "spawning" ? (
+          <TerminalStartupPlaceholder agentId={agentId} />
         ) : (
           <>
             <div className="flex-1 relative min-h-0">

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -74,6 +74,12 @@ const GRID_RESIZE_COALESCE_MS = 120;
 // terminals instead of freezing the renderer for the whole batch.
 const RESIZE_PASS_CHUNK_SIZE = 1;
 
+interface Waiter {
+  resolve: () => void;
+  reject: (error: Error) => void;
+  timeout: number;
+}
+
 function canAutoInitializeTerminalIngest(): boolean {
   return (
     typeof window !== "undefined" &&
@@ -91,10 +97,8 @@ class TerminalInstanceService {
   private unseenTracker = new TerminalUnseenOutputTracker();
   private hibernationListeners = new Map<string, Set<() => void>>();
   private cwdProviders = new Map<string, () => string>();
-  private readinessWaiters = new Map<
-    string,
-    Array<{ resolve: () => void; reject: (error: Error) => void; timeout: number }>
-  >();
+  private readinessWaiters = new Map<string, Waiter[]>();
+  private attachSettledWaiters = new Map<string, Waiter[]>();
   private offscreenManager = new TerminalOffscreenManager();
   private linkHandler = new TerminalLinkHandler();
   private cachedSelections = new Map<string, string>();
@@ -595,6 +599,21 @@ class TerminalInstanceService {
     // Guard: if a generation was provided and it doesn't match the current
     // attach generation, this is a stale cleanup from a previous mount — skip.
     if (expectedGeneration !== undefined && managed.attachGeneration !== expectedGeneration) {
+      return;
+    }
+
+    // Cold-mount observer flaps are not authoritative. XtermAdapter forces
+    // visibility true immediately after attach() so the terminal can paint
+    // before IntersectionObserver settles. During recipe/bulk-open insertion
+    // the grid may briefly report "not intersecting"; persisting that false
+    // value would strand renderer recovery behind visibility guards. Real
+    // unmounts go through detach(), which marks the instance invisible.
+    if (!isVisible && managed.isAttaching) {
+      if (managed.webGLRestoreTimer !== undefined) {
+        clearTimeout(managed.webGLRestoreTimer);
+        managed.webGLRestoreTimer = undefined;
+      }
+      this.cancelWebGLHideTimer(managed);
       return;
     }
 
@@ -1127,6 +1146,36 @@ class TerminalInstanceService {
     });
   }
 
+  waitForAttachSettled(id: string, options: { timeoutMs?: number } = {}): Promise<void> {
+    if (this.isAttachSettled(id)) {
+      return Promise.resolve();
+    }
+
+    const timeoutMs = options.timeoutMs ?? 1500;
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = window.setTimeout(() => {
+        this.removeAttachSettledWaiter(id, resolve);
+        reject(new Error(`Terminal ${id} attach settle timeout after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      const waiters = this.attachSettledWaiters.get(id) || [];
+      waiters.push({ resolve, reject, timeout });
+      this.attachSettledWaiters.set(id, waiters);
+    });
+  }
+
+  private isAttachSettled(id: string): boolean {
+    const managed = this.instances.get(id);
+    if (!managed || managed.isHibernated) return false;
+    return (
+      managed.isOpened &&
+      managed.isAttaching !== true &&
+      managed.hostElement.isConnected &&
+      managed.terminal.element !== undefined
+    );
+  }
+
   private notifyReadinessWaiters(id: string): void {
     const waiters = this.readinessWaiters.get(id);
     if (!waiters) return;
@@ -1150,6 +1199,33 @@ class TerminalInstanceService {
 
     if (waiters.length === 0) {
       this.readinessWaiters.delete(id);
+    }
+  }
+
+  private notifyAttachSettledWaiters(id: string): void {
+    if (!this.isAttachSettled(id)) return;
+    const waiters = this.attachSettledWaiters.get(id);
+    if (!waiters) return;
+
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timeout);
+      waiter.resolve();
+    }
+
+    this.attachSettledWaiters.delete(id);
+  }
+
+  private removeAttachSettledWaiter(id: string, resolve: () => void): void {
+    const waiters = this.attachSettledWaiters.get(id);
+    if (!waiters) return;
+
+    const index = waiters.findIndex((w) => w.resolve === resolve);
+    if (index >= 0) {
+      waiters.splice(index, 1);
+    }
+
+    if (waiters.length === 0) {
+      this.attachSettledWaiters.delete(id);
     }
   }
 
@@ -1287,6 +1363,7 @@ class TerminalInstanceService {
 
         if (!managed.terminal.element) {
           managed.hostElement.style.opacity = "";
+          this.notifyAttachSettledWaiters(id);
           return;
         }
 
@@ -1319,7 +1396,10 @@ class TerminalInstanceService {
         requestAnimationFrame(() => {
           if (this.instances.get(id) !== managed) return;
 
-          if (earlyResizeApplied) return;
+          if (earlyResizeApplied) {
+            this.notifyAttachSettledWaiters(id);
+            return;
+          }
 
           if (wasDetached) {
             const rect = container.getBoundingClientRect();
@@ -1331,6 +1411,7 @@ class TerminalInstanceService {
               logDebug(`[TIS.attach] Skipping resize for ${id} — dimensions match after detach`);
               managed.targetCols = undefined;
               managed.targetRows = undefined;
+              this.notifyAttachSettledWaiters(id);
               return;
             }
           }
@@ -1363,10 +1444,12 @@ class TerminalInstanceService {
               this.resizeController.lockResize(id, true, remainingSuppressionMs);
             }
           }
+          this.notifyAttachSettledWaiters(id);
         });
       });
     } else {
       managed.isAttaching = false;
+      this.notifyAttachSettledWaiters(id);
     }
 
     return managed;
@@ -1409,6 +1492,7 @@ class TerminalInstanceService {
     managed.terminal.blur();
     managed.hoveredLink = null;
     managed.lastDetachAt = Date.now();
+    managed.isVisible = false;
     managed.isDetached = true;
   }
 
@@ -2242,6 +2326,15 @@ class TerminalInstanceService {
         waiter.reject(new Error(`Terminal ${id} destroyed before frontend became ready`));
       }
       this.readinessWaiters.delete(id);
+    }
+
+    const attachWaiters = this.attachSettledWaiters.get(id);
+    if (attachWaiters) {
+      for (const waiter of attachWaiters) {
+        clearTimeout(waiter.timeout);
+        waiter.reject(new Error(`Terminal ${id} destroyed before attach settled`));
+      }
+      this.attachSettledWaiters.delete(id);
     }
 
     this.cancelAttachReveal(managed);

--- a/src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts
@@ -56,6 +56,7 @@ type AttachTestService = {
   attach: (id: string, container: HTMLElement) => ManagedTerminal | null;
   detach: (id: string, container: HTMLElement | null) => void;
   destroy: (id: string) => void;
+  waitForAttachSettled: (id: string, options?: { timeoutMs?: number }) => Promise<void>;
   resizeController: {
     fit: (id: string) => void;
     applyResize: (id: string, cols: number, rows: number) => void;
@@ -141,6 +142,7 @@ describe("TerminalInstanceService attach reveal", () => {
 
   afterEach(() => {
     service.instances.clear();
+    document.body.innerHTML = "";
     vi.useRealTimers();
   });
 
@@ -276,6 +278,37 @@ describe("TerminalInstanceService attach reveal", () => {
     service.attach("t1", container);
 
     expect(managed.hostElement.style.opacity).toBe("");
+  });
+
+  it("resolves attach-settled waiters after the post-attach fit pass", async () => {
+    const managed = makeMockManaged("t1");
+    const offscreen = document.createElement("div");
+    offscreen.appendChild(managed.hostElement);
+    service.instances.set("t1", managed);
+
+    vi.spyOn(service.resizeController, "fit").mockImplementation(() => {});
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    service.attach("t1", container);
+
+    let settled = false;
+    const settledPromise = service.waitForAttachSettled("t1").then(() => {
+      settled = true;
+    });
+
+    vi.advanceTimersByTime(16);
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    expect(service.resizeController.fit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(16);
+    await settledPromise;
+
+    expect(service.resizeController.fit).toHaveBeenCalledWith("t1");
+    expect(settled).toBe(true);
   });
 
   describe("early synchronous resize for warm terminals", () => {

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -1,11 +1,10 @@
 /**
  * Tests for optimistic panel spawn (#5789).
  *
- * Before this change, `addPanel` awaited `terminalClient.spawn()` (and env IPC
- * round-trips) before committing to `panelsById` / `panelIds`. Six rapid agent
- * clicks serialised into six sequential boots. Now the panel commits to the
- * store synchronously (as a "spawning" placeholder), and env fetch + spawn run
- * in the background — six clicks surface as six parallel placeholders.
+ * addPanel commits to the store synchronously (as a "spawning" placeholder),
+ * then realizes backend spawn and visible xterm mount through the startup
+ * queue. Six rapid agent clicks surface as six parallel placeholders without
+ * dispatching six PTY spawns / xterm opens in the same layout burst.
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -52,6 +51,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     prewarmTerminal: vi.fn(),
     setInputLocked: vi.fn(),
     sendPtyResize: vi.fn(),
+    waitForAttachSettled: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -77,7 +77,7 @@ const { usePanelStore } = await import("../../../panelStore");
 
 // Drain microtasks. The background spawn promise chains through Promise.all
 // (env fetch) → terminalClient.spawn → .then, which takes several ticks.
-async function drainMicrotasks(iterations = 20): Promise<void> {
+async function drainMicrotasks(iterations = 100): Promise<void> {
   for (let i = 0; i < iterations; i++) {
     await Promise.resolve();
   }
@@ -93,6 +93,10 @@ describe("optimistic panel spawn (#5789)", () => {
     };
     terminalClient.spawn.mockReset();
     terminalClient.spawn.mockImplementation(async ({ id }: { id?: string }) => id ?? "spawn-id");
+    const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+    const waitForAttachSettledMock = vi.mocked(terminalInstanceService.waitForAttachSettled);
+    waitForAttachSettledMock.mockReset();
+    waitForAttachSettledMock.mockResolvedValue(undefined);
   });
 
   it("commits the panel to the store before terminalClient.spawn resolves", async () => {
@@ -138,19 +142,32 @@ describe("optimistic panel spawn (#5789)", () => {
     expect(after?.spawnStatus).toBe("ready");
   });
 
-  it("registers six concurrent agent launches as six parallel placeholders", async () => {
+  it("registers six concurrent agent launches as parallel placeholders but queued spawns", async () => {
     const { terminalClient } = (await import("@/clients")) as unknown as {
       terminalClient: { spawn: ReturnType<typeof vi.fn> };
     };
+    const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+    const waitForAttachSettledMock = vi.mocked(terminalInstanceService.waitForAttachSettled);
 
-    // Block every spawn call to prove the placeholders land before spawn resolves.
-    let releaseAll: () => void = () => {};
-    const barrier = new Promise<void>((resolve) => {
-      releaseAll = resolve;
+    let releaseFirstSpawn: () => void = () => {};
+    const firstSpawnGate = new Promise<void>((resolve) => {
+      releaseFirstSpawn = resolve;
+    });
+    let releaseFirstAttach: () => void = () => {};
+    const firstAttachGate = new Promise<void>((resolve) => {
+      releaseFirstAttach = resolve;
     });
     terminalClient.spawn.mockImplementation(async ({ id }: { id?: string }) => {
-      await barrier;
-      return id ?? "barrier";
+      if (id === "concurrent-0") {
+        await firstSpawnGate;
+      }
+      return id ?? "queued";
+    });
+    waitForAttachSettledMock.mockImplementation((id: string) => {
+      if (id === "concurrent-0") {
+        return firstAttachGate;
+      }
+      return Promise.resolve();
     });
 
     const { addPanel } = usePanelStore.getState();
@@ -165,7 +182,7 @@ describe("optimistic panel spawn (#5789)", () => {
       })
     );
 
-    // All addPanel promises resolve immediately — no serialization on spawn.
+    // All addPanel promises resolve immediately: chrome placeholders are not queued.
     const ids = (await Promise.all(launches)).filter((id): id is string => id !== null);
     expect(ids).toEqual([
       "concurrent-0",
@@ -182,11 +199,20 @@ describe("optimistic panel spawn (#5789)", () => {
       expect(state.panelIds).toContain(id);
     }
 
-    // All six spawn IPCs were dispatched in parallel, not queued.
-    expect(terminalClient.spawn).toHaveBeenCalledTimes(6);
+    // Only the first PTY spawn is allowed to start while the startup job is blocked.
+    expect(terminalClient.spawn).toHaveBeenCalledTimes(1);
+    expect(terminalClient.spawn.mock.calls[0]?.[0]).toMatchObject({ id: "concurrent-0" });
 
-    releaseAll();
+    releaseFirstSpawn();
     await drainMicrotasks();
+
+    // The second spawn must also wait for the first visible attach to settle.
+    expect(terminalClient.spawn).toHaveBeenCalledTimes(1);
+
+    releaseFirstAttach();
+    await drainMicrotasks();
+
+    expect(terminalClient.spawn).toHaveBeenCalledTimes(6);
 
     const after = usePanelStore.getState();
     for (const id of ids) {
@@ -270,6 +296,8 @@ describe("optimistic panel spawn (#5789)", () => {
       cwd: "/",
       bypassLimits: true,
     });
+    await drainMicrotasks();
+    expect(terminalClient.spawn).toHaveBeenCalledTimes(1);
     // User closes it mid-spawn.
     removePanel("shared-id");
     expect(usePanelStore.getState().panelsById["shared-id"]).toBeUndefined();
@@ -322,6 +350,8 @@ describe("optimistic panel spawn (#5789)", () => {
       cwd: "/",
       bypassLimits: true,
     });
+    await drainMicrotasks();
+    expect(terminalClient.spawn).toHaveBeenCalledTimes(1);
     removePanel("orphan-id");
     // removePanel fires kill (no-op on the backend since the PTY isn't spawned yet).
     expect(terminalClient.kill).toHaveBeenCalledWith("orphan-id");

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -49,6 +49,43 @@ function countNonTrashTerminals(state: PanelRegistrySlice): number {
   return count;
 }
 
+const TERMINAL_STARTUP_ATTACH_TIMEOUT_MS = 2500;
+
+class TerminalStartupQueue {
+  private readonly tasks: Array<() => Promise<void>> = [];
+  private isDraining = false;
+
+  enqueue(task: () => Promise<void>): void {
+    this.tasks.push(task);
+    void this.drain();
+  }
+
+  private async drain(): Promise<void> {
+    if (this.isDraining) return;
+    this.isDraining = true;
+
+    try {
+      while (this.tasks.length > 0) {
+        const task = this.tasks.shift();
+        if (!task) continue;
+
+        try {
+          await task();
+        } catch (error) {
+          logError("[TerminalStore] Terminal startup task failed", error);
+        }
+      }
+    } finally {
+      this.isDraining = false;
+      if (this.tasks.length > 0) {
+        void this.drain();
+      }
+    }
+  }
+}
+
+const terminalStartupQueue = new TerminalStartupQueue();
+
 export const createAddPanelActions = (
   set: Set,
   get: Get
@@ -457,21 +494,20 @@ export const createAddPanelActions = (
         screenReaderMode: appearance.screenReaderMode,
       });
 
-      // Prewarm ALL terminal types to ensure managed instance exists.
-      // This is critical for terminals in inactive worktrees - they need a managed
-      // instance for proper BACKGROUND→VISIBLE tier transitions when worktree activates.
+      // Prewarm ALL terminal types to ensure the managed instance and data
+      // listeners exist before the backend PTY can emit output. Do not attach
+      // to an offscreen or visible DOM node here. Visible xterm.open() is
+      // gated by spawnStatus below so burst-created panels realize one at a
+      // time instead of all mounting xterm/WebGL during the same grid layout.
       const currentActiveWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
-      // When activeWorktreeId is null (hydration in progress), don't treat the
-      // terminal as offscreen — it would be prewarmed in the offscreen container
-      // at -20000px and backgrounded, suppressing data flow from the pty-host.
-      const offscreenOrInactive =
+      const isDockOrInactive =
         location === "dock" ||
         (currentActiveWorktreeId !== null &&
           (options.worktreeId ?? null) !== (currentActiveWorktreeId ?? null));
 
       if (!isAgent) {
         terminalInstanceService.prewarmTerminal(id, launchAgentId, terminalOptions, {
-          offscreen: offscreenOrInactive,
+          offscreen: false,
           widthPx: location === "dock" ? DOCK_PREWARM_WIDTH_PX : DOCK_TERM_WIDTH,
           heightPx: location === "dock" ? DOCK_PREWARM_HEIGHT_PX : DOCK_TERM_HEIGHT,
         });
@@ -482,17 +518,16 @@ export const createAddPanelActions = (
         const heightPx = location === "dock" ? DOCK_PREWARM_HEIGHT_PX : DOCK_TERM_HEIGHT;
 
         terminalInstanceService.prewarmTerminal(id, launchAgentId, terminalOptions, {
-          offscreen: offscreenOrInactive,
+          offscreen: false,
           widthPx,
           heightPx,
         });
 
-        // For offscreen/inactive agents, prewarmTerminal's fit() already handles
-        // initial PTY resize through settled strategy. Only send explicit resize
-        // for active grid spawns where fit() is skipped. Cell metrics come from
-        // calculateTerminalDimensions so the lineHeight assumption stays in sync
-        // with xtermConfig (1.0 — see BASE_TERMINAL_OPTIONS).
-        if (!offscreenOrInactive) {
+        // Only send explicit resize for active grid spawns. Background/dock
+        // terminals can boot at the spawn default and will be resized on reveal.
+        // Cell metrics come from calculateTerminalDimensions so the lineHeight
+        // assumption stays in sync with xtermConfig.
+        if (!isDockOrInactive) {
           const { cols, rows } = calculateTerminalDimensions(widthPx, heightPx, fontSize);
           terminalInstanceService.sendPtyResize(id, cols, rows);
         }
@@ -539,70 +574,76 @@ export const createAddPanelActions = (
       return id;
     }
 
-    // Fire env fetch + spawn IPC in the background so the panel render is not
-    // blocked on ~200-500ms of IPC round-trips. Any caller that needs to pipe
-    // input after spawn already gates on agentState (which starts at "working"
-    // for agents and only drops to "idle" once the PTY reports ready).
-    const spawnPromise = (async () => {
-      let mergedEnv: Record<string, string> | undefined = options.env;
+    const shouldWaitForVisibleAttach = location === "grid" && isInActiveWorktree;
+
+    // The panel chrome is already committed. Realize backend PTY startup and
+    // visible xterm.open() through a single queue so bulk recipes can add many
+    // panels without making Chromium/xterm settle every terminal in the same
+    // frame. spawnStatus remains "spawning" while queued, so TerminalPane shows
+    // lightweight chrome instead of mounting XtermAdapter.
+    terminalStartupQueue.enqueue(async () => {
+      if (get().panelsById[id]?.spawnStatus !== "spawning") return;
+
       try {
-        const [globalEnvVars, projectEnvVars] = await Promise.all([
-          globalEnvClient.get().catch((error: unknown) => {
-            logWarn("[TerminalStore] Failed to fetch global environment variables", { error });
-            return {} as Record<string, string>;
-          }),
-          capturedProjectId
-            ? projectClient.getSettings(capturedProjectId).then(
-                (s) => s?.environmentVariables ?? ({} as Record<string, string>),
-                (error: unknown) => {
-                  logWarn("[TerminalStore] Failed to fetch project environment variables", {
-                    error,
-                  });
-                  return {} as Record<string, string>;
-                }
-              )
-            : Promise.resolve({} as Record<string, string>),
-        ]);
+        let mergedEnv: Record<string, string> | undefined = options.env;
+        try {
+          const [globalEnvVars, projectEnvVars] = await Promise.all([
+            globalEnvClient.get().catch((error: unknown) => {
+              logWarn("[TerminalStore] Failed to fetch global environment variables", { error });
+              return {} as Record<string, string>;
+            }),
+            capturedProjectId
+              ? projectClient.getSettings(capturedProjectId).then(
+                  (s) => s?.environmentVariables ?? ({} as Record<string, string>),
+                  (error: unknown) => {
+                    logWarn("[TerminalStore] Failed to fetch project environment variables", {
+                      error,
+                    });
+                    return {} as Record<string, string>;
+                  }
+                )
+              : Promise.resolve({} as Record<string, string>),
+          ]);
 
-        const hasGlobal = Object.keys(globalEnvVars).length > 0;
-        const hasProject = Object.keys(projectEnvVars).length > 0;
-        if (hasGlobal || hasProject) {
-          mergedEnv = { ...globalEnvVars, ...projectEnvVars, ...options.env };
+          const hasGlobal = Object.keys(globalEnvVars).length > 0;
+          const hasProject = Object.keys(projectEnvVars).length > 0;
+          if (hasGlobal || hasProject) {
+            mergedEnv = { ...globalEnvVars, ...projectEnvVars, ...options.env };
+          }
+        } catch (error) {
+          logWarn("[TerminalStore] Failed to fetch environment variables", { error });
         }
-      } catch (error) {
-        logWarn("[TerminalStore] Failed to fetch environment variables", { error });
-      }
 
-      const commandToExecute = options.skipCommandExecution ? undefined : options.command;
-      await terminalClient.spawn({
-        id,
-        projectId: capturedProjectId,
-        cwd: options.cwd,
-        shell: options.shell,
-        cols: 80,
-        rows: 24,
-        command: commandToExecute,
-        kind,
-        launchAgentId,
-        title,
-        env: mergedEnv,
-        restore: options.restore,
-        agentLaunchFlags: options.agentLaunchFlags,
-        agentModelId: options.agentModelId,
-        worktreeId: options.worktreeId,
-        agentPresetId: options.agentPresetId,
-        agentPresetColor: options.agentPresetColor,
-        originalAgentPresetId: options.originalPresetId ?? options.agentPresetId,
-      });
-    })();
+        if (get().panelsById[id]?.spawnStatus !== "spawning") return;
 
-    void spawnPromise.then(
-      () => {
+        const commandToExecute = options.skipCommandExecution ? undefined : options.command;
+        await terminalClient.spawn({
+          id,
+          projectId: capturedProjectId,
+          cwd: options.cwd,
+          shell: options.shell,
+          cols: 80,
+          rows: 24,
+          command: commandToExecute,
+          kind,
+          launchAgentId,
+          title,
+          env: mergedEnv,
+          restore: options.restore,
+          agentLaunchFlags: options.agentLaunchFlags,
+          agentModelId: options.agentModelId,
+          worktreeId: options.worktreeId,
+          agentPresetId: options.agentPresetId,
+          agentPresetColor: options.agentPresetColor,
+          originalAgentPresetId: options.originalPresetId ?? options.agentPresetId,
+        });
+
         // Promote spawnStatus to "ready" once the PTY is live. If the panel was
         // removed during the spawn window, issue a compensating kill to avoid
         // orphaning the freshly-spawned PTY (removePanel's kill IPC was a no-op
         // at the time because the backend had no terminal yet).
         let orphaned = false;
+        let mountedPanel = false;
         set((state) => {
           const current = state.panelsById[id];
           if (!current) {
@@ -610,6 +651,7 @@ export const createAddPanelActions = (
             return state;
           }
           if (current.spawnStatus !== "spawning") return state;
+          mountedPanel = true;
           return {
             panelsById: { ...state.panelsById, [id]: { ...current, spawnStatus: "ready" } },
           };
@@ -622,8 +664,20 @@ export const createAddPanelActions = (
             });
           });
         }
-      },
-      (error) => {
+
+        if (mountedPanel && shouldWaitForVisibleAttach) {
+          try {
+            await terminalInstanceService.waitForAttachSettled(id, {
+              timeoutMs: TERMINAL_STARTUP_ATTACH_TIMEOUT_MS,
+            });
+          } catch (error) {
+            logWarn("[TerminalStore] Terminal did not attach before startup queue advanced", {
+              id,
+              error,
+            });
+          }
+        }
+      } catch (error) {
         logError("[TerminalStore] Failed to spawn terminal", error);
         // Only remove the placeholder we committed. If the id has been reused
         // (e.g. the user closed the panel mid-spawn and a reconnect slot picked
@@ -640,7 +694,7 @@ export const createAddPanelActions = (
           });
         }
       }
-    );
+    });
 
     return id;
   },


### PR DESCRIPTION
Fixes #8864.
Supersedes #8866.

## Summary
- Queue terminal startup after optimistic panel insertion so bulk recipe launches show panel chrome immediately but only one PTY/xterm attach is realized at a time.
- Keep terminal panels in `spawnStatus: "spawning"` with a lightweight placeholder until backend spawn completes, preventing all `XtermAdapter`/WebGL mounts from landing in one grid layout burst.
- Add `TerminalInstanceService.waitForAttachSettled()` so active grid terminals hold the queue until open/attach/fit has settled before the next terminal starts.
- Prewarm managed terminal instances and data listeners without attaching offscreen xterm DOM during burst startup.

## Rationale
The original PR treated the blank pane as a WebGL repaint race. The newer fix addresses the broader load problem: bulk-open was committing every panel and mounting/spawning every terminal at once, overwhelming Chromium/xterm layout and render lifecycle. This moves the backpressure to terminal startup instead of trying to repaint after the burst.

## Validation
- `npm test -- src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts`
- `npx tsc --noEmit`
- `npm run build`
