### PR TITLE
fix(e2e): poll buffer API directly in waitForTerminalReady, skip DOM fallback after WebGL swap

### DIFF
--- a/e2e/helpers/terminal.ts
+++ b/e2e/helpers/terminal.ts
@@ -105,15 +105,22 @@ export async function waitForTerminalReady(
 ): Promise<void> {
   await waitForTerminalPty(page, panelLocator, timeout);
 
+  // Bypass getTerminalText's DOM fallback: after DOM→WebGL swap the rows element
+  // is empty, so null (reader not yet registered) must mean "keep polling", not
+  // "fall through to DOM text".
+  const panelId = await getPanelId(panelLocator);
   await expect
     .poll(
-      async () => {
-        const text = await getTerminalText(panelLocator);
-        return text.trim().length > 0;
-      },
+      () =>
+        page.evaluate((id) => {
+          const reader = (window as unknown as Record<string, unknown>)
+            .__daintreeReadTerminalBuffer;
+          if (typeof reader !== "function") return null;
+          return reader(id) as string | null;
+        }, panelId),
       { timeout, intervals: [100, 250, 500] }
     )
-    .toBe(true);
+    .toSatisfy((text: string | null) => typeof text === "string" && text.trim().length > 0);
 }
 
 async function activateTerminal(page: Page, panelId: string): Promise<void> {


### PR DESCRIPTION
Fixes #8881

## Summary

`waitForTerminalReady` was calling `getTerminalText`, which falls back to
`xtermRows.innerText()` when `__daintreeReadTerminalBuffer` is not yet registered.
After the DOM→WebGL renderer swap (`7b0d1e312`, `bae8344c1`), the DOM rows element
exists but xterm.js no longer writes text into it — so the fallback always returns `""`
and the text-present poll times out.

The root race: `hasPty === true` (PTY attached) can be true before
`__daintreeReadTerminalBuffer` is registered on the window. In that window every
call to `getTerminalText` silently returns empty DOM text.

## Change

In `waitForTerminalReady`, replaced the `getTerminalText`-based text-present check
with a direct inline buffer-API poll:

- Returns `null` when the reader is not yet registered → `toSatisfy` keeps polling
- Returns the buffer string once registered → poll resolves when non-empty
- `getTerminalText`'s DOM fallback is left intact for non-WebGL environments

**File:** `e2e/helpers/terminal.ts`

## Test plan

- [ ] `npx playwright test e2e/core/core-process-badge.spec.ts` passes
- [ ] `npx playwright test e2e/full/resilience/core-concurrent-operations.spec.ts` passes
- [ ] `npx playwright test e2e/full/platform/core-multi-window.spec.ts` passes
- [ ] `npx playwright test e2e/full/worktree/core-worktree-cross-boundary.spec.ts` passes