### PR TITLE
fix(e2e): exact selector for voice Clear button (#8882)

### DIFF
--- a/e2e/full/platform/core-voice-input.spec.ts
+++ b/e2e/full/platform/core-voice-input.spec.ts
@@ -315,7 +315,7 @@ test.describe.serial("E2E: Voice Input — Settings UI", () => {
     const keyInput = window.locator('input[placeholder="Enter new key to replace"]');
     await expect(keyInput).toBeVisible({ timeout: T_SHORT });
     await expect(window.getByText("Configured", { exact: true })).toBeVisible();
-    const clearButton = window.locator('button:has-text("Clear")').first();
+    const clearButton = window.getByRole("button", { name: "Clear", exact: true });
     await expect(clearButton).toBeVisible();
 
     // Close + reopen — key must still be configured.


### PR DESCRIPTION
## Summary

Slimmed this PR down to one fix. The other change was an env-gate skip on `opencode-online.spec.ts`, but `OPENCODE_E2E_ENABLED` was never wired into the workflow. If we'd merged it, the test would have silently been disabled in CI.

The kept change switches `button:has-text("Clear").first()` to `getByRole("button", { name: "Clear", exact: true })` in `e2e/full/platform/core-voice-input.spec.ts:318`.

The substring match is a latent issue. It only fails if another settings tab with a "Clear log" button (MCP, Diagnostics, Daintree Assistant) has been visited earlier in the run, since those tabs are lazy-mounted via `visitedTabs` in `SettingsDialog.tsx`. The exact-name role lookup is robust against that test-order regression.

Closes #8882. #8883 will be handled separately.

## Test plan

- [ ] `npx playwright test e2e/full/platform/core-voice-input.spec.ts` — voice input API key persists test passes