### PR TITLE
test(e2e): env-gate opencode-online suite when OpenCode absent

### DIFF
--- a/.github/workflows/e2e-single.yml
+++ b/.github/workflows/e2e-single.yml
@@ -214,6 +214,7 @@ jobs:
           E2E_WORKERS: ${{ inputs.workers }}
           E2E_RETRIES: ${{ inputs.retries }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
         run: node scripts/ci/run-single-e2e.mjs
 
       - name: Run single e2e test (Linux)
@@ -225,6 +226,7 @@ jobs:
           E2E_WORKERS: ${{ inputs.workers }}
           E2E_RETRIES: ${{ inputs.retries }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
         run: xvfb-run --auto-servernum node scripts/ci/run-single-e2e.mjs
 
       - name: Run single e2e test (Windows)
@@ -236,6 +238,7 @@ jobs:
           E2E_WORKERS: ${{ inputs.workers }}
           E2E_RETRIES: ${{ inputs.retries }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
           ELECTRON_ENABLE_LOGGING: "1"
         run: node scripts/ci/run-single-e2e.mjs
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -369,6 +369,7 @@ jobs:
           # Required for `online`; harmless empty string for other projects
           # when secrets aren't inherited.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
         run: |
           set -euo pipefail
           npx playwright test ${{ steps.test-cmd.outputs.args }} ${SHARD_ARGS:-} ${LAST_FAILED_ARGS:-}
@@ -378,6 +379,7 @@ jobs:
         shell: bash
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
         run: |
           set -euo pipefail
           xvfb-run --auto-servernum npx playwright test ${{ steps.test-cmd.outputs.args }} ${SHARD_ARGS:-} ${LAST_FAILED_ARGS:-}
@@ -394,6 +396,7 @@ jobs:
         env:
           ELECTRON_ENABLE_LOGGING: "1"
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENCODE_E2E_ENABLED: ${{ inputs.suite == 'online' && '1' || '' }}
         run: |
           set -euo pipefail
 

--- a/e2e/online/opencode-online.spec.ts
+++ b/e2e/online/opencode-online.spec.ts
@@ -143,6 +143,11 @@ test.describe("OpenCode Online Flow", () => {
   });
 
   test("full OpenCode agent interaction", async () => {
+    test.skip(
+      !process.env.OPENCODE_E2E_ENABLED,
+      "online: requires OpenCode installed and OPENCODE_E2E_ENABLED=1"
+    );
+
     await test.step("launch app", async () => {
       ctx = await launchApp();
     });


### PR DESCRIPTION
## Summary
- Skip the `full OpenCode agent interaction` test in `e2e/online/opencode-online.spec.ts` unless `OPENCODE_E2E_ENABLED` is set, so the suite skips cleanly instead of failing with a 30s `TimeoutError` on developer machines that don't have OpenCode installed.
- Set `OPENCODE_E2E_ENABLED=1` for the `online` suite in all three platform run-step env blocks of `e2e.yml` and `e2e-single.yml`, so CI continues to run the test where OpenCode is actually installed.

The skip guard is placed inside the test body (matching the `claude-online.spec.ts` convention) so `beforeAll`/`afterAll` fixture setup and cleanup still run; the skip fires before `launchApp()`, so no Electron process is spawned when skipped.

Closes #8883

## Test plan
- [x] `OPENCODE_E2E_ENABLED=` `npx playwright test e2e/online/opencode-online.spec.ts` → 1 skipped, no timeout
- [x] `npm run check` (typecheck + lint + format) clean
- [ ] CI online suite runs the test on all three OSes with `OPENCODE_E2E_ENABLED=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)