### PR TITLE
ci(budgets): gate five performance budgets on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,63 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Build import budget metadata
+        run: npm run import-budget:build
+
+      - name: Check renderer bundle budget
+        id: renderer_bundle_budget
+        continue-on-error: true
+        run: npm run renderer-bundle-budget:check
+
+      - name: Check first render chunk budget
+        id: first_render_chunk_budget
+        continue-on-error: true
+        run: npm run first-render-chunk-budget:check
+
+      - name: Check renderer import budget
+        id: renderer_import_budget
+        continue-on-error: true
+        run: npm run renderer-import-budget:check
+
+      - name: Check import budget
+        id: import_budget
+        continue-on-error: true
+        run: npm run import-budget:check
+
+      - name: Check compiler budget
+        id: compiler_budget
+        continue-on-error: true
+        run: npm run compiler-budget:check
+
+      - name: Budget summaries
+        if: always()
+        run: |
+          if [ -f dist/renderer-bundle-size-summary.md ]; then
+            cat dist/renderer-bundle-size-summary.md >> "$GITHUB_STEP_SUMMARY"
+            printf '\n\n' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -f dist/first-render-chunk-summary.md ]; then
+            cat dist/first-render-chunk-summary.md >> "$GITHUB_STEP_SUMMARY"
+            printf '\n\n' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Gate performance budgets
+        if: always()
+        env:
+          RENDERER_BUNDLE: ${{ steps.renderer_bundle_budget.outcome }}
+          FIRST_RENDER: ${{ steps.first_render_chunk_budget.outcome }}
+          RENDERER_IMPORT: ${{ steps.renderer_import_budget.outcome }}
+          IMPORT_BUDGET: ${{ steps.import_budget.outcome }}
+          COMPILER_BUDGET: ${{ steps.compiler_budget.outcome }}
+        run: |
+          failed=0
+          [ "$RENDERER_BUNDLE" = "failure" ] && echo "::error::renderer-bundle-budget failed" && failed=1
+          [ "$FIRST_RENDER" = "failure" ] && echo "::error::first-render-chunk-budget failed" && failed=1
+          [ "$RENDERER_IMPORT" = "failure" ] && echo "::error::renderer-import-budget failed" && failed=1
+          [ "$IMPORT_BUDGET" = "failure" ] && echo "::error::import-budget failed" && failed=1
+          [ "$COMPILER_BUDGET" = "failure" ] && echo "::error::compiler-budget failed" && failed=1
+          exit $failed
+
       - name: Smoke test
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: xvfb-run --auto-servernum npm run test:smoke

--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -4,7 +4,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -14,8 +13,32 @@
     "skip": 0,
     "error": 6,
     "pipeline": 0,
-    "hintCount": 6,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -24,8 +47,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -34,7 +65,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -44,7 +74,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -54,7 +83,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -64,7 +92,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -74,7 +101,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -84,8 +110,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -94,8 +128,20 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "hintCount": 3,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle Import expressions"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle Import expressions"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle Import expressions"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -104,7 +150,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -114,7 +159,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -124,7 +168,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -134,7 +177,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -144,7 +186,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -154,7 +195,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -164,8 +204,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -174,7 +218,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -184,7 +227,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -194,7 +236,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -204,7 +245,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -214,7 +254,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -224,8 +263,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -234,8 +277,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -244,8 +291,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -254,11 +305,9 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [
       {
         "category": "Refs",
-        "severity": "Error",
         "reason": "Cannot access refs during render"
       }
     ],
@@ -270,7 +319,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -280,8 +328,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle ??= operators in AssignmentExpression"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -290,7 +342,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -300,8 +351,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -310,8 +369,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -320,7 +383,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -330,7 +392,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -340,26 +401,21 @@
     "skip": 0,
     "error": 4,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [
       {
         "category": "Refs",
-        "severity": "Error",
         "reason": "Cannot access refs during render"
       },
       {
         "category": "Refs",
-        "severity": "Error",
         "reason": "Cannot access refs during render"
       },
       {
         "category": "Refs",
-        "severity": "Error",
         "reason": "Cannot access refs during render"
       },
       {
         "category": "Refs",
-        "severity": "Error",
         "reason": "Cannot access refs during render"
       }
     ],
@@ -371,7 +427,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -381,8 +436,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -391,7 +450,6 @@
     "skip": 1,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": ["Skipped due to '[object Object]' directive."],
     "pipelineErrors": []
@@ -401,7 +459,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -411,7 +468,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -421,7 +477,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -431,8 +486,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -441,7 +500,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -451,7 +509,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -461,7 +518,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -471,7 +527,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -481,7 +536,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -491,7 +545,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -501,7 +554,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -511,7 +563,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -521,7 +572,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -531,7 +581,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -541,7 +590,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -551,7 +599,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -561,7 +608,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -571,7 +617,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -581,7 +626,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -591,7 +635,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -601,8 +644,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -611,7 +658,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -621,7 +667,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -631,7 +676,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -641,7 +685,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -651,7 +694,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -661,7 +703,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -671,7 +712,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -681,7 +721,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -691,7 +730,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -701,7 +739,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -711,7 +748,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -721,7 +757,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -731,7 +766,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -741,7 +775,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -751,7 +784,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -761,7 +793,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -771,7 +802,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -781,7 +811,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -791,7 +820,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -801,7 +829,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -811,7 +838,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -821,7 +847,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -831,7 +856,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -841,7 +865,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -851,7 +874,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -861,8 +883,28 @@
     "skip": 0,
     "error": 5,
     "pipeline": 0,
-    "hintCount": 5,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -871,7 +913,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -881,7 +922,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -891,7 +931,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -901,7 +940,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -911,7 +949,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -921,7 +958,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -931,7 +967,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -941,7 +976,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -951,7 +985,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -961,8 +994,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -971,7 +1008,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -981,7 +1017,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -991,7 +1026,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1001,7 +1035,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1011,8 +1044,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Expected Identifier, got TSAsExpression key in ObjectExpression"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1021,7 +1058,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1031,7 +1067,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1041,7 +1076,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1051,7 +1085,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1061,7 +1094,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1071,7 +1103,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1081,7 +1112,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1091,8 +1121,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1101,7 +1135,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1111,7 +1144,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1121,7 +1153,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1131,7 +1162,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1141,7 +1171,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1151,7 +1180,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1161,7 +1189,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1171,7 +1198,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1181,7 +1207,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1191,7 +1216,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1201,7 +1225,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1211,7 +1234,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1221,7 +1243,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1231,7 +1252,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1241,7 +1261,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1251,7 +1270,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1261,7 +1279,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1271,7 +1288,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1281,7 +1297,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1291,7 +1306,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1301,7 +1315,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1311,7 +1324,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1321,7 +1333,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1331,7 +1342,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1341,7 +1351,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1351,7 +1360,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1361,7 +1369,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1371,7 +1378,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1381,7 +1387,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1391,7 +1396,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1401,7 +1405,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1411,7 +1414,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1421,7 +1423,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1431,7 +1432,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1441,8 +1441,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1451,7 +1455,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1461,8 +1464,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1471,7 +1478,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1481,8 +1487,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1491,7 +1501,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1501,8 +1510,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1511,7 +1524,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1521,8 +1533,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1531,8 +1547,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1541,8 +1561,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1551,8 +1575,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1561,8 +1593,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1571,7 +1607,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1581,8 +1616,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1591,7 +1630,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1601,8 +1639,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1611,7 +1653,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1621,7 +1662,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1631,8 +1671,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1641,7 +1685,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1651,7 +1694,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1661,7 +1703,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1671,7 +1712,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1681,7 +1721,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1691,7 +1730,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1701,7 +1739,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1711,8 +1748,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1721,7 +1762,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1731,7 +1771,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1741,7 +1780,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1751,7 +1789,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1761,8 +1798,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1771,7 +1812,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1781,7 +1821,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1791,7 +1830,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1801,8 +1839,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1811,7 +1853,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1821,7 +1862,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1831,7 +1871,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1841,7 +1880,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1851,7 +1889,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1861,7 +1898,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1871,7 +1907,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1881,8 +1916,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1891,7 +1930,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1901,8 +1939,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1911,8 +1953,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1921,8 +1967,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1931,7 +1981,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1941,7 +1990,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1951,8 +1999,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1961,8 +2013,20 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "hintCount": 3,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1971,7 +2035,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1981,7 +2044,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1991,8 +2053,20 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "hintCount": 3,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2001,7 +2075,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2011,8 +2084,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2021,8 +2098,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2031,7 +2112,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2041,8 +2121,48 @@
     "skip": 0,
     "error": 10,
     "pipeline": 0,
-    "hintCount": 10,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2051,8 +2171,36 @@
     "skip": 0,
     "error": 7,
     "pipeline": 0,
-    "hintCount": 7,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2061,8 +2209,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2071,7 +2223,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2081,7 +2232,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2091,8 +2241,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2101,8 +2259,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2111,7 +2273,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2121,7 +2282,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2131,8 +2291,28 @@
     "skip": 0,
     "error": 5,
     "pipeline": 0,
-    "hintCount": 5,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2141,7 +2321,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2151,7 +2330,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2161,7 +2339,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2171,7 +2348,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2181,7 +2357,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2191,8 +2366,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2201,7 +2380,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2211,7 +2389,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2221,8 +2398,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Unexpected terminal kind `ternary` for logical test block"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2231,7 +2412,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2241,7 +2421,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2251,8 +2430,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Unexpected terminal kind `ternary` for logical test block"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2261,7 +2444,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2271,7 +2453,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2281,7 +2462,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2291,8 +2471,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Unexpected terminal kind `ternary` for logical test block"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2301,7 +2485,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2311,7 +2494,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2321,7 +2503,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2331,8 +2512,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Unexpected terminal kind `ternary` for logical test block"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2341,7 +2526,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2351,8 +2535,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2361,8 +2553,32 @@
     "skip": 0,
     "error": 6,
     "pipeline": 0,
-    "hintCount": 6,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2371,7 +2587,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2381,8 +2596,32 @@
     "skip": 0,
     "error": 6,
     "pipeline": 0,
-    "hintCount": 6,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2391,8 +2630,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2401,8 +2648,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2411,8 +2666,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2421,7 +2684,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2431,8 +2693,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2441,8 +2707,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2451,7 +2725,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2461,7 +2734,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2471,7 +2743,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2481,7 +2752,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2491,7 +2761,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2501,8 +2770,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2511,7 +2784,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2521,7 +2793,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2531,7 +2802,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2541,7 +2811,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2551,7 +2820,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2561,8 +2829,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2571,7 +2843,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2581,7 +2852,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2591,7 +2861,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2601,7 +2870,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2611,7 +2879,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2621,7 +2888,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2631,7 +2897,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2641,7 +2906,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2651,7 +2915,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2661,7 +2924,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2671,7 +2933,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2681,7 +2942,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2691,7 +2951,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2701,7 +2960,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2711,7 +2969,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2721,7 +2978,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2731,7 +2987,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2741,7 +2996,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2751,7 +3005,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2761,7 +3014,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2771,7 +3023,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2781,7 +3032,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2791,7 +3041,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2801,7 +3050,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2811,7 +3059,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2821,7 +3068,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2831,7 +3077,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2841,7 +3086,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2851,7 +3095,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2861,8 +3104,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2871,8 +3118,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2881,7 +3136,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2891,7 +3145,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2901,7 +3154,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2911,7 +3163,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2921,7 +3172,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2931,7 +3181,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2941,7 +3190,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2951,7 +3199,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2961,7 +3208,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2971,7 +3217,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2981,8 +3226,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2991,7 +3244,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3001,7 +3253,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3011,7 +3262,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3021,7 +3271,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3031,7 +3280,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3041,8 +3289,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3051,7 +3303,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3061,7 +3312,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3071,8 +3321,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3081,7 +3335,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3091,7 +3344,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3101,7 +3353,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3111,7 +3362,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3121,7 +3371,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3131,7 +3380,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3141,7 +3389,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3151,7 +3398,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3161,7 +3407,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3171,7 +3416,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3181,8 +3425,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3191,7 +3439,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3201,11 +3448,9 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [
       {
         "category": "Refs",
-        "severity": "Error",
         "reason": "Cannot access refs during render"
       }
     ],
@@ -3217,7 +3462,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3227,7 +3471,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3237,7 +3480,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3247,7 +3489,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3257,7 +3498,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3267,8 +3507,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3277,7 +3521,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3287,8 +3530,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3297,8 +3544,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3307,8 +3558,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3317,7 +3572,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3327,8 +3581,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3337,8 +3599,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3347,7 +3613,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3357,7 +3622,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3367,7 +3631,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3377,7 +3640,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3387,7 +3649,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3397,8 +3658,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3407,8 +3676,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3417,7 +3690,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3427,8 +3699,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3437,8 +3713,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3447,7 +3727,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3457,8 +3736,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3467,7 +3754,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3477,7 +3763,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3487,8 +3772,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3497,8 +3786,20 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "hintCount": 3,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3507,8 +3808,24 @@
     "skip": 0,
     "error": 4,
     "pipeline": 0,
-    "hintCount": 4,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3517,7 +3834,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3527,8 +3843,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3537,7 +3857,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3547,8 +3866,44 @@
     "skip": 0,
     "error": 9,
     "pipeline": 0,
-    "hintCount": 9,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3557,7 +3912,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3567,7 +3921,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3577,7 +3930,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3587,7 +3939,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3597,7 +3948,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3607,7 +3957,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3617,7 +3966,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3627,7 +3975,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3637,7 +3984,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3647,7 +3993,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3657,11 +4002,9 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [
       {
         "category": "Refs",
-        "severity": "Error",
         "reason": "Cannot access refs during render"
       }
     ],
@@ -3673,7 +4016,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3683,7 +4025,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3693,24 +4034,16 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/PRBadge.tsx": {
-    "success": 0,
+    "success": 1,
     "skip": 0,
-    "error": 1,
+    "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
-    "errorBailouts": [
-      {
-        "category": "Refs",
-        "severity": "Error",
-        "reason": "Cannot access refs during render"
-      }
-    ],
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3719,7 +4052,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3729,7 +4061,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3739,8 +4070,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3749,7 +4084,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3759,7 +4093,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3769,7 +4102,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3779,8 +4111,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3789,7 +4129,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3799,7 +4138,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3809,7 +4147,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3819,8 +4156,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3829,7 +4170,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3839,7 +4179,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3849,7 +4188,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3859,7 +4197,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3869,7 +4206,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3879,7 +4215,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3889,7 +4224,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3899,7 +4233,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3909,7 +4242,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3919,7 +4251,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3929,7 +4260,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3939,7 +4269,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3949,7 +4278,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3959,7 +4287,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3969,7 +4296,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3979,7 +4305,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3989,7 +4314,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3999,7 +4323,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4009,8 +4332,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4019,7 +4350,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4029,8 +4359,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4039,7 +4373,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4049,7 +4382,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4059,7 +4391,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4069,7 +4400,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4079,7 +4409,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4089,8 +4418,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Unexpected terminal kind `ternary` for logical test block"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4099,7 +4432,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4109,7 +4441,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4119,7 +4450,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4129,7 +4459,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4139,7 +4468,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4149,7 +4477,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4159,7 +4486,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4169,7 +4495,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4179,7 +4504,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4189,7 +4513,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4199,7 +4522,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4209,7 +4531,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4219,7 +4540,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4229,7 +4549,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4239,7 +4558,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4249,7 +4567,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4259,7 +4576,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4269,7 +4585,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4279,7 +4594,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4289,7 +4603,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4299,7 +4612,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4309,7 +4621,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4319,7 +4630,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4329,7 +4639,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4339,7 +4648,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4349,7 +4657,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4359,7 +4666,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4369,7 +4675,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4379,7 +4684,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4389,7 +4693,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4399,7 +4702,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4409,7 +4711,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4419,7 +4720,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4429,7 +4729,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4439,7 +4738,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4449,7 +4747,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4459,7 +4756,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4469,7 +4765,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4479,7 +4774,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4489,7 +4783,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4499,7 +4792,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4509,7 +4801,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4519,7 +4810,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4529,7 +4819,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4539,7 +4828,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4549,8 +4837,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4559,7 +4851,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4569,7 +4860,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4579,7 +4869,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4589,7 +4878,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4599,7 +4887,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4609,7 +4896,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4619,7 +4905,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4629,7 +4914,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4639,7 +4923,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4649,7 +4932,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4659,7 +4941,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4669,7 +4950,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4679,7 +4959,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4689,7 +4968,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4699,7 +4977,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4709,7 +4986,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4719,7 +4995,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4729,7 +5004,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4739,7 +5013,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4749,7 +5022,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4759,7 +5031,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4769,7 +5040,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4779,7 +5049,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4789,7 +5058,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4799,7 +5067,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4809,7 +5076,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4819,7 +5085,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4829,7 +5094,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4839,7 +5103,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4849,8 +5112,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4859,7 +5126,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4869,8 +5135,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4879,7 +5153,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4889,7 +5162,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4899,7 +5171,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4909,8 +5180,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4919,7 +5194,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4929,8 +5203,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4939,7 +5217,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4949,8 +5226,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle Import expressions"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4959,8 +5240,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4969,7 +5254,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4979,7 +5263,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4989,7 +5272,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4999,7 +5281,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5009,7 +5290,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5019,7 +5299,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5029,7 +5308,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5039,7 +5317,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5049,7 +5326,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5059,7 +5335,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5069,7 +5344,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5079,7 +5353,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5089,8 +5362,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5099,7 +5376,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5109,8 +5385,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5119,7 +5399,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5129,7 +5408,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5139,8 +5417,40 @@
     "skip": 0,
     "error": 8,
     "pipeline": 0,
-    "hintCount": 8,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5149,7 +5459,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5159,7 +5468,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5169,7 +5477,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5179,8 +5486,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5189,8 +5500,20 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "hintCount": 3,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5199,7 +5522,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5209,7 +5531,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5219,7 +5540,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5229,8 +5549,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5239,7 +5563,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5249,7 +5572,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5259,7 +5581,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5269,8 +5590,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5279,7 +5604,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5289,7 +5613,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5299,8 +5622,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5309,7 +5636,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5319,7 +5645,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5329,8 +5654,20 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "hintCount": 3,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5339,7 +5676,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5349,7 +5685,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5359,7 +5694,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5369,7 +5703,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5379,7 +5712,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5389,8 +5721,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5399,7 +5739,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5409,7 +5748,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5419,7 +5757,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5429,7 +5766,6 @@
     "skip": 1,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": ["Skipped due to '[object Object]' directive."],
     "pipelineErrors": []
@@ -5439,7 +5775,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5449,7 +5784,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5459,7 +5793,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5469,7 +5802,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5479,7 +5811,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5489,7 +5820,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5499,7 +5829,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5509,7 +5838,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5519,7 +5847,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5529,7 +5856,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5539,7 +5865,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5549,8 +5874,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5559,7 +5888,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5569,7 +5897,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5579,8 +5906,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5589,7 +5920,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5599,8 +5929,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5609,7 +5943,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5619,7 +5952,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5629,7 +5961,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5639,8 +5970,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5649,7 +5984,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5659,7 +5993,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5669,7 +6002,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5679,8 +6011,16 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "hintCount": 2,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "Unsupported declaration type for hoisting"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5689,7 +6029,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5699,8 +6038,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5709,7 +6052,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5719,7 +6061,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5729,8 +6070,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5739,8 +6084,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5749,8 +6098,20 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "hintCount": 3,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5759,7 +6120,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5769,8 +6129,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5779,7 +6143,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5789,7 +6152,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5799,8 +6161,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5809,7 +6175,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5819,7 +6184,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5829,7 +6193,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5839,7 +6202,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5849,7 +6211,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5859,7 +6220,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5869,7 +6229,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5879,7 +6238,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5889,7 +6247,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5899,7 +6256,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5909,7 +6265,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5919,7 +6274,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5929,7 +6283,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5939,8 +6292,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5949,7 +6306,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5959,7 +6315,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5969,7 +6324,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5979,7 +6333,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5989,7 +6342,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5999,7 +6351,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6009,7 +6360,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6019,7 +6369,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6029,7 +6378,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6039,7 +6387,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6049,8 +6396,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6059,7 +6410,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6069,7 +6419,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6079,7 +6428,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6089,8 +6437,12 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "hintCount": 1,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6099,7 +6451,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6109,7 +6460,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6119,7 +6469,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6129,7 +6478,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6139,7 +6487,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6149,7 +6496,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6159,7 +6505,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6169,7 +6514,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6179,7 +6523,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6189,7 +6532,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6199,7 +6541,6 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []

--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -4,6 +4,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -13,32 +14,8 @@
     "skip": 0,
     "error": 6,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 6,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -47,16 +24,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -65,6 +34,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -74,6 +44,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -83,6 +54,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -92,6 +64,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -101,6 +74,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -110,16 +84,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -128,20 +94,8 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle Import expressions"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle Import expressions"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle Import expressions"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -150,6 +104,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -159,6 +114,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -168,6 +124,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -177,6 +134,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -186,6 +144,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -195,6 +154,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -204,12 +164,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -218,6 +174,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -227,6 +184,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -236,6 +194,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -245,6 +204,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -254,6 +214,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -263,12 +224,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -277,12 +234,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -291,12 +244,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -305,9 +254,11 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [
       {
         "category": "Refs",
+        "severity": "Error",
         "reason": "Cannot access refs during render"
       }
     ],
@@ -319,6 +270,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -328,20 +280,17 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle ??= operators in AssignmentExpression"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/DevPreview/DevPreviewLoadingState.tsx": {
-    "success": 4,
+    "success": 3,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -351,16 +300,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -369,12 +310,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -383,6 +320,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -392,6 +330,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -401,21 +340,26 @@
     "skip": 0,
     "error": 4,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [
       {
         "category": "Refs",
+        "severity": "Error",
         "reason": "Cannot access refs during render"
       },
       {
         "category": "Refs",
+        "severity": "Error",
         "reason": "Cannot access refs during render"
       },
       {
         "category": "Refs",
+        "severity": "Error",
         "reason": "Cannot access refs during render"
       },
       {
         "category": "Refs",
+        "severity": "Error",
         "reason": "Cannot access refs during render"
       }
     ],
@@ -427,6 +371,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -436,12 +381,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -450,6 +391,7 @@
     "skip": 1,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": ["Skipped due to '[object Object]' directive."],
     "pipelineErrors": []
@@ -459,6 +401,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -468,6 +411,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -477,6 +421,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -486,12 +431,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -500,6 +441,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -509,6 +451,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -518,6 +461,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -527,6 +471,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -536,6 +481,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -545,6 +491,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -554,6 +501,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -563,6 +511,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -572,6 +521,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -581,6 +531,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -590,6 +541,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -599,6 +551,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -608,6 +561,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -617,6 +571,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -626,6 +581,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -635,6 +591,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -644,12 +601,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -658,6 +611,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -667,6 +621,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -676,6 +631,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -685,6 +641,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -694,6 +651,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -703,6 +661,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -712,6 +671,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -721,6 +681,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -730,6 +691,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -739,6 +701,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -748,6 +711,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -757,6 +721,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -766,6 +731,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -775,6 +741,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -784,6 +751,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -793,6 +761,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -802,6 +771,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -811,6 +781,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -820,6 +791,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -829,6 +801,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -838,6 +811,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -847,6 +821,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -856,6 +831,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -865,6 +841,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -874,6 +851,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -883,28 +861,8 @@
     "skip": 0,
     "error": 5,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 5,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -913,6 +871,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -922,6 +881,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -931,6 +891,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -940,6 +901,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -949,6 +911,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -958,6 +921,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -967,6 +931,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -976,6 +941,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -985,6 +951,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -994,12 +961,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1008,6 +971,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1017,6 +981,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1026,6 +991,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1035,6 +1001,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1044,12 +1011,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Expected Identifier, got TSAsExpression key in ObjectExpression"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1058,6 +1021,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1067,6 +1031,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1076,6 +1041,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1085,6 +1051,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1094,6 +1061,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1103,6 +1071,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1112,6 +1081,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1121,12 +1091,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1135,6 +1101,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1144,6 +1111,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1153,6 +1121,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1162,6 +1131,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1171,6 +1141,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1180,6 +1151,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1189,6 +1161,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1198,6 +1171,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1207,6 +1181,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1216,6 +1191,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1225,6 +1201,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1234,6 +1211,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1243,6 +1221,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1252,6 +1231,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1261,6 +1241,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1270,6 +1251,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1279,6 +1261,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1288,6 +1271,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1297,6 +1281,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1306,6 +1291,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1315,6 +1301,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1324,6 +1311,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1333,6 +1321,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1342,6 +1331,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1351,6 +1341,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1360,6 +1351,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1369,6 +1361,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1378,6 +1371,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1387,6 +1381,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1396,6 +1391,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1405,6 +1401,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1414,6 +1411,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1423,6 +1421,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1432,6 +1431,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1441,12 +1441,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1455,6 +1451,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1464,12 +1461,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1478,6 +1471,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1487,12 +1481,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1501,6 +1491,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1510,12 +1501,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1524,6 +1511,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1533,12 +1521,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1547,12 +1531,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1561,12 +1541,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1575,16 +1551,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1593,12 +1561,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1607,6 +1571,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1616,12 +1581,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1630,6 +1591,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1639,12 +1601,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1653,6 +1611,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1662,6 +1621,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1671,12 +1631,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1685,6 +1641,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1694,6 +1651,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1703,6 +1661,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1712,6 +1671,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1721,6 +1681,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1730,6 +1691,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1739,6 +1701,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1748,12 +1711,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1762,6 +1721,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1771,6 +1731,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1780,6 +1741,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1789,6 +1751,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1798,12 +1761,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1812,6 +1771,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1821,6 +1781,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1830,6 +1791,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1839,12 +1801,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1853,6 +1811,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1862,6 +1821,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1871,6 +1831,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1880,6 +1841,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1889,6 +1851,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1898,6 +1861,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1907,6 +1871,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1916,12 +1881,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1930,6 +1891,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1939,12 +1901,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1953,12 +1911,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1967,12 +1921,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1981,6 +1931,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1990,6 +1941,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1999,12 +1951,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2013,20 +1961,8 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2035,6 +1971,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2044,6 +1981,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2053,20 +1991,8 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2075,6 +2001,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2084,12 +2011,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2098,12 +2021,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2112,6 +2031,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2121,48 +2041,8 @@
     "skip": 0,
     "error": 10,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 10,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2171,36 +2051,8 @@
     "skip": 0,
     "error": 7,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 7,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2209,12 +2061,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2223,6 +2071,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2232,6 +2081,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2241,16 +2091,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2259,12 +2101,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2273,6 +2111,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2282,6 +2121,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2291,28 +2131,8 @@
     "skip": 0,
     "error": 5,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 5,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2321,6 +2141,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2330,6 +2151,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2339,6 +2161,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2348,6 +2171,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2357,6 +2181,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2366,12 +2191,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2380,6 +2201,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2389,6 +2211,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2398,12 +2221,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Unexpected terminal kind `ternary` for logical test block"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2412,6 +2231,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2421,6 +2241,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2430,12 +2251,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Unexpected terminal kind `ternary` for logical test block"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2444,6 +2261,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2453,6 +2271,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2462,6 +2281,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2471,12 +2291,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Unexpected terminal kind `ternary` for logical test block"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2485,6 +2301,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2494,6 +2311,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2503,6 +2321,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2512,12 +2331,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Unexpected terminal kind `ternary` for logical test block"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2526,6 +2341,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2535,16 +2351,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2553,32 +2361,8 @@
     "skip": 0,
     "error": 6,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 6,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2587,6 +2371,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2596,32 +2381,8 @@
     "skip": 0,
     "error": 6,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 6,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2630,16 +2391,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2648,16 +2401,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2666,16 +2411,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2684,6 +2421,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2693,12 +2431,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2707,16 +2441,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2725,6 +2451,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2734,6 +2461,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2743,6 +2471,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2752,6 +2481,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2761,6 +2491,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2770,12 +2501,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2784,6 +2511,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2793,6 +2521,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2802,6 +2531,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2811,6 +2541,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2820,6 +2551,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2829,12 +2561,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2843,6 +2571,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2852,6 +2581,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2861,6 +2591,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2870,6 +2601,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2879,6 +2611,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2888,6 +2621,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2897,6 +2631,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2906,6 +2641,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2915,6 +2651,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2924,6 +2661,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2933,6 +2671,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2942,6 +2681,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2951,6 +2691,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2960,6 +2701,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2969,6 +2711,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2978,6 +2721,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2987,6 +2731,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2996,6 +2741,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3005,6 +2751,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3014,6 +2761,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3023,6 +2771,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3032,6 +2781,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3041,6 +2791,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3050,6 +2801,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3059,6 +2811,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3068,6 +2821,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3077,6 +2831,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3086,6 +2841,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3095,6 +2851,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3104,12 +2861,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3118,16 +2871,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3136,6 +2881,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3145,6 +2891,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3154,6 +2901,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3163,6 +2911,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3172,6 +2921,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3181,6 +2931,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3190,6 +2941,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3199,6 +2951,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3208,6 +2961,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3217,6 +2971,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3226,16 +2981,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3244,6 +2991,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3253,6 +3001,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3262,6 +3011,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3271,6 +3021,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3280,6 +3031,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3289,12 +3041,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3303,6 +3051,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3312,6 +3061,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3321,12 +3071,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3335,6 +3081,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3344,6 +3091,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3353,6 +3101,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3362,6 +3111,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3371,6 +3121,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3380,6 +3131,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3389,6 +3141,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3398,6 +3151,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3407,6 +3161,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3416,6 +3171,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3425,12 +3181,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3439,6 +3191,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3448,9 +3201,11 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [
       {
         "category": "Refs",
+        "severity": "Error",
         "reason": "Cannot access refs during render"
       }
     ],
@@ -3462,6 +3217,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3471,6 +3227,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3480,6 +3237,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3489,6 +3247,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3498,6 +3257,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3507,12 +3267,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3521,6 +3277,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3530,12 +3287,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3544,12 +3297,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3558,12 +3307,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3572,6 +3317,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3581,16 +3327,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3599,12 +3337,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3613,6 +3347,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3622,6 +3357,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3631,6 +3367,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3640,6 +3377,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3649,6 +3387,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3658,16 +3397,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3676,12 +3407,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3690,6 +3417,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3699,12 +3427,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3713,12 +3437,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3727,6 +3447,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3736,16 +3457,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3754,6 +3467,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3763,6 +3477,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3772,12 +3487,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3786,20 +3497,8 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3808,24 +3507,8 @@
     "skip": 0,
     "error": 4,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 4,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3834,6 +3517,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3843,12 +3527,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3857,6 +3537,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3866,44 +3547,8 @@
     "skip": 0,
     "error": 9,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 9,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3912,6 +3557,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3921,6 +3567,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3930,6 +3577,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3939,6 +3587,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3948,6 +3597,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3957,6 +3607,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3966,6 +3617,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3975,6 +3627,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3984,6 +3637,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3993,6 +3647,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4002,9 +3657,11 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [
       {
         "category": "Refs",
+        "severity": "Error",
         "reason": "Cannot access refs during render"
       }
     ],
@@ -4016,6 +3673,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4025,6 +3683,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4034,16 +3693,24 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/PRBadge.tsx": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 0,
+    "error": 1,
     "pipeline": 0,
-    "errorBailouts": [],
+    "hintCount": 0,
+    "errorBailouts": [
+      {
+        "category": "Refs",
+        "severity": "Error",
+        "reason": "Cannot access refs during render"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4052,6 +3719,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4061,6 +3729,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4070,12 +3739,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4084,6 +3749,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4093,6 +3759,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4102,6 +3769,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4111,16 +3779,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4129,6 +3789,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4138,6 +3799,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4147,6 +3809,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4156,12 +3819,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4170,6 +3829,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4179,6 +3839,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4188,6 +3849,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4197,6 +3859,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4206,6 +3869,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4215,6 +3879,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4224,6 +3889,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4233,6 +3899,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4242,6 +3909,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4251,6 +3919,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4260,6 +3929,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4269,6 +3939,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4278,6 +3949,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4287,6 +3959,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4296,6 +3969,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4305,6 +3979,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4314,6 +3989,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4323,6 +3999,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4332,16 +4009,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4350,6 +4019,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4359,12 +4029,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4373,6 +4039,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4382,6 +4049,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4391,6 +4059,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4400,6 +4069,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4409,6 +4079,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4418,12 +4089,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Unexpected terminal kind `ternary` for logical test block"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4432,6 +4099,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4441,6 +4109,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4450,6 +4119,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4459,6 +4129,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4468,6 +4139,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4477,6 +4149,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4486,6 +4159,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4495,6 +4169,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4504,6 +4179,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4513,6 +4189,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4522,6 +4199,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4531,6 +4209,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4540,6 +4219,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4549,6 +4229,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4558,6 +4239,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4567,6 +4249,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4576,6 +4259,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4585,6 +4269,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4594,6 +4279,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4603,6 +4289,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4612,6 +4299,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4621,6 +4309,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4630,6 +4319,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4639,6 +4329,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4648,6 +4339,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4657,6 +4349,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4666,6 +4359,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4675,6 +4369,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4684,6 +4379,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4693,6 +4389,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4702,6 +4399,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4711,6 +4409,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4720,6 +4419,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4729,6 +4429,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4738,6 +4439,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4747,6 +4449,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4756,6 +4459,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4765,6 +4469,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4774,6 +4479,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4783,6 +4489,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4792,6 +4499,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4801,6 +4509,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4810,6 +4519,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4819,6 +4529,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4828,6 +4539,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4837,12 +4549,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4851,6 +4559,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4860,6 +4569,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4869,6 +4579,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4878,6 +4589,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4887,6 +4599,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4896,6 +4609,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4905,6 +4619,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4914,6 +4629,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4923,6 +4639,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4932,6 +4649,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4941,6 +4659,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4950,6 +4669,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4959,6 +4679,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4968,6 +4689,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4977,6 +4699,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4986,6 +4709,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4995,6 +4719,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5004,6 +4729,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5013,6 +4739,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5022,6 +4749,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5031,6 +4759,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5040,6 +4769,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5049,6 +4779,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5058,6 +4789,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5067,6 +4799,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5076,6 +4809,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5085,6 +4819,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5094,6 +4829,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5103,6 +4839,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5112,12 +4849,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5126,6 +4859,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5135,16 +4869,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5153,6 +4879,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5162,6 +4889,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5171,6 +4899,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5180,12 +4909,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5194,6 +4919,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5203,12 +4929,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5217,6 +4939,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5226,12 +4949,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle Import expressions"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5240,12 +4959,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5254,6 +4969,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5263,6 +4979,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5272,6 +4989,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5281,6 +4999,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5290,6 +5009,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5299,6 +5019,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5308,6 +5029,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5317,6 +5039,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5326,6 +5049,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5335,6 +5059,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5344,6 +5069,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5353,6 +5079,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5362,12 +5089,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5376,6 +5099,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5385,12 +5109,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5399,6 +5119,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5408,6 +5129,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5417,40 +5139,8 @@
     "skip": 0,
     "error": 8,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 8,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5459,6 +5149,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5468,6 +5159,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5477,6 +5169,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5486,12 +5179,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5500,20 +5189,8 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5522,6 +5199,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5531,6 +5209,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5540,6 +5219,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5549,12 +5229,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5563,6 +5239,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5572,6 +5249,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5581,6 +5259,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5590,12 +5269,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5604,6 +5279,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5613,6 +5289,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5622,12 +5299,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5636,6 +5309,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5645,6 +5319,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5654,20 +5329,8 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5676,6 +5339,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5685,6 +5349,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5694,6 +5359,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5703,6 +5369,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5712,6 +5379,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5721,16 +5389,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5739,6 +5399,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5748,6 +5409,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5757,6 +5419,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5766,6 +5429,7 @@
     "skip": 1,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": ["Skipped due to '[object Object]' directive."],
     "pipelineErrors": []
@@ -5775,6 +5439,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5784,6 +5449,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5793,6 +5459,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5802,6 +5469,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5811,6 +5479,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5820,6 +5489,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5829,6 +5499,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5838,6 +5509,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5847,6 +5519,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5856,6 +5529,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5865,6 +5539,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5874,12 +5549,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5888,6 +5559,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5897,6 +5569,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5906,12 +5579,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5920,6 +5589,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5929,12 +5599,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5943,6 +5609,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5952,6 +5619,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5961,6 +5629,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5970,12 +5639,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5984,6 +5649,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5993,6 +5659,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6002,6 +5669,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6011,16 +5679,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "Unsupported declaration type for hoisting"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6029,6 +5689,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6038,12 +5699,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6052,6 +5709,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6061,6 +5719,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6070,12 +5729,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6084,12 +5739,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6098,20 +5749,8 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6120,6 +5759,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6129,12 +5769,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6143,6 +5779,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6152,6 +5789,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6161,12 +5799,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6175,6 +5809,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6184,6 +5819,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6193,6 +5829,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6202,6 +5839,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6211,6 +5849,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6220,6 +5859,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6229,6 +5869,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6238,6 +5879,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6247,6 +5889,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6256,6 +5899,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6265,6 +5909,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6274,6 +5919,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6283,6 +5929,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6292,12 +5939,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6306,6 +5949,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6315,6 +5959,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6324,6 +5969,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6333,6 +5979,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6342,6 +5989,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6351,6 +5999,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6360,6 +6009,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6369,6 +6019,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6378,6 +6029,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6387,6 +6039,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6396,12 +6049,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6410,6 +6059,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6419,6 +6069,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6428,6 +6079,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6437,12 +6089,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6451,6 +6099,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6460,6 +6109,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6469,6 +6119,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6478,6 +6129,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6487,6 +6139,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6496,6 +6149,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6505,6 +6159,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6514,6 +6169,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6523,6 +6179,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6532,6 +6189,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6541,6 +6199,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []

--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -89,322 +89,327 @@
   "syncViolations": [
     {
       "file": "electron/ipc/errorHandlers.ts",
-      "line": 35,
+      "line": 34,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/errorHandlers.ts",
-      "line": 299,
+      "line": 298,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/agentCapabilities.ts",
-      "line": 85,
+      "line": 84,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/agentCli.ts",
-      "line": 113,
+      "line": 112,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/ai.ts",
-      "line": 62,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/ai.ts",
-      "line": 80,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/ai.ts",
-      "line": 118,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/ai.ts",
-      "line": 135,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/app/state.ts",
       "line": 61,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/app/state.ts",
-      "line": 360,
+      "file": "electron/ipc/handlers/ai.ts",
+      "line": 79,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/app/state.ts",
-      "line": 362,
+      "file": "electron/ipc/handlers/ai.ts",
+      "line": 117,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/app/state.ts",
-      "line": 416,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/appTheme.ts",
-      "line": 24,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/demo.ts",
-      "line": 234,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/ipc/handlers/diagnostics.ts",
-      "line": 55,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/ipc/handlers/diagnostics.ts",
-      "line": 62,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/ipc/handlers/forge.ts",
-      "line": 137,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeResolution.ts",
-      "line": 45,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 24,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 189,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 204,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 214,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 192,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 278,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 282,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 325,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 329,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 367,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 371,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/globalEnv.ts",
-      "line": 7,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/helpAssistant.ts",
-      "line": 99,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/helpAssistant.ts",
-      "line": 138,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/keybinding.ts",
-      "line": 13,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/logs.ts",
+      "file": "electron/ipc/handlers/ai.ts",
       "line": 134,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/logs.ts",
-      "line": 229,
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 60,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/milestones.ts",
-      "line": 10,
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 359,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/milestones.ts",
-      "line": 14,
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 361,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/notifications.ts",
-      "line": 63,
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 415,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/notifications.ts",
-      "line": 153,
+      "file": "electron/ipc/handlers/appTheme.ts",
+      "line": 23,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/onboarding.ts",
-      "line": 65,
+      "file": "electron/ipc/handlers/demo.ts",
+      "line": 233,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/ipc/handlers/diagnostics.ts",
+      "line": 54,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/ipc/handlers/diagnostics.ts",
+      "line": 61,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/ipc/handlers/forge.ts",
+      "line": 136,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/privacy.ts",
-      "line": 30,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/shortcutHints.ts",
-      "line": 10,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/shortcutHints.ts",
-      "line": 14,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/terminalConfig.ts",
-      "line": 18,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/voiceInput.ts",
+      "file": "electron/ipc/handlers/forgeResolution.ts",
       "line": 44,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
-      "line": 88,
+      "file": "electron/ipc/handlers/forgeSettings.ts",
+      "line": 23,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
-      "line": 189,
+      "file": "electron/ipc/handlers/forgeSettings.ts",
+      "line": 188,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
-      "line": 193,
+      "file": "electron/ipc/handlers/forgeSettings.ts",
+      "line": 203,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 58,
+      "file": "electron/ipc/handlers/forgeSettings.ts",
+      "line": 213,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 73,
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 191,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 85,
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 277,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 92,
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 281,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/worktreeConfig.ts",
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 324,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 328,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 366,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 370,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/globalEnv.ts",
+      "line": 6,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/helpAssistant.ts",
+      "line": 98,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/helpAssistant.ts",
+      "line": 137,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/keybinding.ts",
+      "line": 12,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/logs.ts",
+      "line": 133,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/logs.ts",
+      "line": 228,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/milestones.ts",
+      "line": 9,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/milestones.ts",
       "line": 13,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/worktreeConfig.ts",
-      "line": 26,
+      "file": "electron/ipc/handlers/notifications.ts",
+      "line": 62,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/pendingErrorsStore.ts",
-      "line": 8,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/main.ts",
+      "file": "electron/ipc/handlers/notifications.ts",
       "line": 152,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/main.ts",
-      "line": 233,
+      "file": "electron/ipc/handlers/onboarding.ts",
+      "line": 64,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/AppAgentService.ts",
-      "line": 35,
+      "file": "electron/ipc/handlers/privacy.ts",
+      "line": 29,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/AppAgentService.ts",
-      "line": 49,
+      "file": "electron/ipc/handlers/shortcutHints.ts",
+      "line": 9,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/AppAgentService.ts",
-      "line": 54,
+      "file": "electron/ipc/handlers/shortcutHints.ts",
+      "line": 13,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/AppAgentService.ts",
-      "line": 124,
+      "file": "electron/ipc/handlers/terminalConfig.ts",
+      "line": 17,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/AppHydrationService.ts",
+      "file": "electron/ipc/handlers/voiceInput.ts",
+      "line": 43,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
+      "line": 87,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
+      "line": 188,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
+      "line": 192,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 57,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 72,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 84,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 91,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktreeConfig.ts",
+      "line": 12,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktreeConfig.ts",
       "line": 25,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/AppHydrationService.ts",
-      "line": 83,
+      "file": "electron/ipc/pendingErrorsStore.ts",
+      "line": 7,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/main.ts",
+      "line": 151,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/main.ts",
+      "line": 232,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppAgentService.ts",
+      "line": 34,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppAgentService.ts",
+      "line": 48,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppAgentService.ts",
+      "line": 53,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppAgentService.ts",
+      "line": 123,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AppHydrationService.ts",
-      "line": 85,
+      "line": 24,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppHydrationService.ts",
+      "line": 82,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppHydrationService.ts",
+      "line": 84,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AutoUpdaterService.ts",
+      "line": 275,
       "pattern": "sync-store-get"
     },
     {
@@ -414,62 +419,62 @@
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 277,
+      "line": 396,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 397,
+      "line": 405,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 406,
+      "line": 435,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 436,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 475,
+      "line": 474,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 475,
+      "line": 474,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 492,
+      "line": 491,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CliAvailabilityService.ts",
-      "line": 808,
+      "line": 807,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 57,
+      "line": 56,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 82,
+      "line": 81,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 90,
+      "line": 89,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 112,
+      "line": 111,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CliInstallService.ts",
+      "line": 126,
       "pattern": "sync-fs"
     },
     {
@@ -479,12 +484,12 @@
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 128,
+      "line": 130,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 131,
+      "line": 144,
       "pattern": "sync-fs"
     },
     {
@@ -494,12 +499,12 @@
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 146,
+      "line": 155,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 156,
+      "line": 159,
       "pattern": "sync-fs"
     },
     {
@@ -509,7 +514,7 @@
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 161,
+      "line": 168,
       "pattern": "sync-fs"
     },
     {
@@ -519,52 +524,52 @@
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 170,
+      "line": 182,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 183,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CliInstallService.ts",
-      "line": 213,
+      "line": 212,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 191,
+      "line": 190,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 195,
+      "line": 194,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 230,
+      "line": 229,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 252,
+      "line": 251,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 265,
+      "line": 264,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 284,
+      "line": 283,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 301,
+      "line": 300,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashLoopGuardService.ts",
+      "line": 316,
       "pattern": "sync-fs"
     },
     {
@@ -574,7 +579,7 @@
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 318,
+      "line": 329,
       "pattern": "sync-fs"
     },
     {
@@ -583,103 +588,103 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 331,
-      "pattern": "sync-fs"
-    },
-    {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 113,
+      "line": 112,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 138,
+      "line": 137,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 274,
+      "line": 273,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 291,
+      "line": 290,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 400,
+      "line": 399,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 403,
+      "line": 402,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 467,
+      "line": 466,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 533,
+      "line": 532,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 535,
+      "line": 534,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 542,
+      "line": 541,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 545,
+      "line": 544,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 572,
+      "line": 571,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 574,
+      "line": 573,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 578,
+      "line": 577,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 595,
+      "line": 594,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 611,
+      "line": 610,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 615,
+      "line": 614,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 618,
+      "line": 617,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 647,
+      "line": 646,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 662,
       "pattern": "sync-fs"
     },
     {
@@ -689,7 +694,7 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 664,
+      "line": 729,
       "pattern": "sync-fs"
     },
     {
@@ -699,7 +704,7 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 731,
+      "line": 760,
       "pattern": "sync-fs"
     },
     {
@@ -709,13 +714,13 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 762,
-      "pattern": "sync-fs"
+      "line": 788,
+      "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 789,
-      "pattern": "sync-store-get"
+      "line": 815,
+      "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
@@ -724,7 +729,7 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 817,
+      "line": 863,
       "pattern": "sync-fs"
     },
     {
@@ -734,27 +739,27 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 865,
+      "line": 868,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 869,
+      "line": 983,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 984,
+      "line": 1007,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1008,
+      "line": 1016,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1017,
+      "line": 1027,
       "pattern": "sync-fs"
     },
     {
@@ -764,57 +769,57 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1029,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1041,
+      "line": 1040,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1057,
+      "line": 1056,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1059,
+      "line": 1058,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1065,
+      "line": 1064,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1075,
+      "line": 1074,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/DatabaseMaintenanceService.ts",
-      "line": 146,
+      "line": 145,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/DatabaseMaintenanceService.ts",
-      "line": 150,
+      "line": 149,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/DatabaseMaintenanceService.ts",
-      "line": 150,
+      "line": 149,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitHubFirstPageCache.ts",
-      "line": 196,
+      "line": 195,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitHubFirstPageCache.ts",
-      "line": 202,
+      "line": 201,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/GitHubFirstPageCache.ts",
+      "line": 231,
       "pattern": "sync-fs"
     },
     {
@@ -823,18 +828,18 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/GitHubFirstPageCache.ts",
-      "line": 233,
+      "file": "electron/services/GitHubStatsCache.ts",
+      "line": 154,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitHubStatsCache.ts",
-      "line": 155,
+      "line": 160,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitHubStatsCache.ts",
-      "line": 161,
+      "line": 192,
       "pattern": "sync-fs"
     },
     {
@@ -843,33 +848,33 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/GitHubStatsCache.ts",
-      "line": 194,
+      "file": "electron/services/GitService.ts",
+      "line": 59,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 60,
+      "line": 110,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 111,
+      "line": 527,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 528,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/GitService.ts",
-      "line": 534,
+      "line": 533,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 25,
+      "line": 24,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/GpuCrashMonitorService.ts",
+      "line": 39,
       "pattern": "sync-fs"
     },
     {
@@ -879,12 +884,12 @@
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 41,
+      "line": 45,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 46,
+      "line": 75,
       "pattern": "sync-fs"
     },
     {
@@ -893,78 +898,78 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 77,
-      "pattern": "sync-fs"
-    },
-    {
       "file": "electron/services/HelpService.ts",
-      "line": 17,
+      "line": 16,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/HelpSessionService.ts",
-      "line": 1090,
+      "line": 1089,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/HibernationService.ts",
-      "line": 373,
+      "line": 372,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/IdleTerminalNotificationService.ts",
-      "line": 91,
+      "line": 90,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/IdleTerminalNotificationService.ts",
-      "line": 261,
+      "line": 260,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/mcp-server/httpLifecycle.ts",
-      "line": 365,
+      "line": 364,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/McpServerService.ts",
-      "line": 274,
+      "line": 273,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 298,
+      "line": 297,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 302,
+      "line": 301,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 336,
+      "line": 335,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 351,
+      "line": 350,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 364,
+      "line": 363,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 377,
+      "line": 376,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 394,
+      "line": 393,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/PanelSuspectLedgerService.ts",
+      "line": 406,
       "pattern": "sync-fs"
     },
     {
@@ -973,24 +978,24 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 408,
-      "pattern": "sync-fs"
-    },
-    {
       "file": "electron/services/persistence/db.ts",
-      "line": 84,
+      "line": 83,
       "pattern": "sync-sqlite"
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 119,
+      "line": 118,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 122,
+      "line": 121,
       "pattern": "sync-sqlite"
+    },
+    {
+      "file": "electron/services/persistence/db.ts",
+      "line": 156,
+      "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/db.ts",
@@ -999,162 +1004,162 @@
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 158,
+      "line": 162,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 163,
+      "line": 165,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 166,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/persistence/db.ts",
-      "line": 172,
+      "line": 171,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/readLastProjectId.ts",
-      "line": 21,
+      "line": 20,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/readLastProjectId.ts",
-      "line": 25,
+      "line": 24,
       "pattern": "sync-sqlite"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 264,
+      "line": 263,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/ProcessMemoryMonitor.ts",
-      "line": 426,
+      "line": 425,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectEnvSecureStorage.ts",
-      "line": 14,
+      "line": 13,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/ProjectFileStore.ts",
-      "line": 64,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/ProjectSettingsManager.ts",
-      "line": 30,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/ProjectSettingsManager.ts",
       "line": 63,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectSettingsManager.ts",
-      "line": 177,
+      "line": 29,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/ProjectSettingsManager.ts",
+      "line": 62,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/ProjectSettingsManager.ts",
+      "line": 176,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStateManager.ts",
-      "line": 157,
+      "line": 156,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 89,
+      "line": 88,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 259,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/ProjectStore.ts",
-      "line": 442,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/ProjectStore.ts",
-      "line": 449,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/ProjectStore.ts",
-      "line": 503,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/ProjectStore.ts",
-      "line": 509,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/ProjectSwitchService.ts",
-      "line": 164,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/pty/agentSessionHistory.ts",
-      "line": 57,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/pty/TerminalRegistry.ts",
       "line": 258,
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 271,
+      "file": "electron/services/ProjectStore.ts",
+      "line": 441,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/ProjectStore.ts",
+      "line": 448,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/ProjectStore.ts",
+      "line": 502,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/ProjectStore.ts",
+      "line": 508,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/ProjectSwitchService.ts",
+      "line": 163,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/pty/agentSessionHistory.ts",
+      "line": 56,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 283,
+      "line": 257,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 298,
+      "line": 270,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 311,
+      "line": 282,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 326,
+      "line": 297,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 331,
+      "line": 310,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/pty/TerminalRegistry.ts",
+      "line": 325,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/pty/TerminalRegistry.ts",
+      "line": 330,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 120,
+      "line": 119,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 131,
+      "line": 130,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 194,
+      "line": 193,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/pty/terminalSessionPersistence.ts",
+      "line": 245,
       "pattern": "sync-fs"
     },
     {
@@ -1164,37 +1169,37 @@
     },
     {
       "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 247,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 257,
+      "line": 256,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/terminalShell.ts",
-      "line": 43,
+      "line": 42,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PtyClient.ts",
-      "line": 166,
+      "line": 165,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/SecureStorage.ts",
-      "line": 23,
+      "line": 22,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 96,
+      "line": 95,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 102,
+      "line": 101,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/StoreMigrations.ts",
+      "line": 134,
       "pattern": "sync-fs"
     },
     {
@@ -1204,47 +1209,47 @@
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 136,
+      "line": 149,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 150,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/StoreMigrations.ts",
-      "line": 172,
+      "line": 171,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 256,
+      "line": 255,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 271,
+      "line": 270,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 297,
+      "line": 296,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 304,
+      "line": 303,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 427,
+      "line": 426,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TrashedPidTracker.ts",
-      "line": 213,
+      "line": 212,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/TrashedPidTracker.ts",
+      "line": 217,
       "pattern": "sync-fs"
     },
     {
@@ -1254,7 +1259,7 @@
     },
     {
       "file": "electron/services/TrashedPidTracker.ts",
-      "line": 219,
+      "line": 245,
       "pattern": "sync-fs"
     },
     {
@@ -1263,23 +1268,23 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/TrashedPidTracker.ts",
-      "line": 247,
-      "pattern": "sync-fs"
-    },
-    {
       "file": "electron/services/UserAgentRegistryService.ts",
-      "line": 28,
+      "line": 27,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 39,
+      "line": 38,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 45,
+      "line": 44,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
+      "line": 200,
       "pattern": "sync-store-get"
     },
     {
@@ -1289,7 +1294,7 @@
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 202,
+      "line": 258,
       "pattern": "sync-store-get"
     },
     {
@@ -1299,7 +1304,7 @@
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 260,
+      "line": 440,
       "pattern": "sync-store-get"
     },
     {
@@ -1308,13 +1313,13 @@
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 442,
-      "pattern": "sync-store-get"
+      "file": "electron/setup/devDiagnostics.ts",
+      "line": 40,
+      "pattern": "sync-fs"
     },
     {
-      "file": "electron/setup/devDiagnostics.ts",
-      "line": 41,
+      "file": "electron/setup/environment.ts",
+      "line": 59,
       "pattern": "sync-fs"
     },
     {
@@ -1324,57 +1329,57 @@
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 61,
+      "line": 62,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 63,
+      "line": 73,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 74,
+      "line": 85,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 86,
+      "line": 154,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 155,
+      "line": 250,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 251,
+      "line": 328,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 329,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/setup/environment.ts",
-      "line": 643,
+      "line": 642,
       "pattern": "sync-sqlite"
     },
     {
       "file": "electron/store.ts",
-      "line": 493,
+      "line": 492,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 495,
+      "line": 494,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 510,
+      "line": 509,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 524,
       "pattern": "sync-fs"
     },
     {
@@ -1384,27 +1389,27 @@
     },
     {
       "file": "electron/store.ts",
-      "line": 526,
+      "line": 527,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 528,
+      "line": 542,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 543,
+      "line": 544,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 545,
+      "line": 561,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 562,
+      "line": 570,
       "pattern": "sync-fs"
     },
     {
@@ -1413,68 +1418,68 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/store.ts",
-      "line": 572,
+      "file": "electron/utils/emergencyLog.ts",
+      "line": 23,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/emergencyLog.ts",
-      "line": 24,
+      "line": 26,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/emergencyLog.ts",
-      "line": 27,
+      "line": 28,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/emergencyLog.ts",
-      "line": 29,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/emergencyLog.ts",
-      "line": 36,
+      "line": 35,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/fs.ts",
-      "line": 27,
+      "line": 26,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/fs.ts",
-      "line": 84,
+      "line": 83,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/fs.ts",
-      "line": 148,
+      "line": 147,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/fs.ts",
-      "line": 156,
+      "line": 155,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/git.ts",
-      "line": 131,
+      "line": 130,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/git.ts",
-      "line": 380,
+      "line": 379,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/git.ts",
-      "line": 688,
+      "line": 687,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 35,
+      "line": 34,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/gitRepoOperationState.ts",
+      "line": 58,
       "pattern": "sync-fs"
     },
     {
@@ -1484,107 +1489,107 @@
     },
     {
       "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 60,
+      "line": 67,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 68,
+      "line": 74,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/gitRepoOperationState.ts",
+      "line": 81,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/gpuDetection.ts",
+      "line": 32,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/gpuDetection.ts",
+      "line": 41,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/gpuDetection.ts",
+      "line": 50,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/logger.ts",
+      "line": 71,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/logger.ts",
       "line": 75,
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 82,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gpuDetection.ts",
-      "line": 33,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gpuDetection.ts",
-      "line": 42,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gpuDetection.ts",
-      "line": 51,
+      "file": "electron/utils/logger.ts",
+      "line": 81,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 72,
+      "line": 137,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 76,
+      "line": 139,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 82,
+      "line": 151,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 138,
+      "line": 154,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 140,
+      "line": 184,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 152,
+      "line": 187,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 155,
+      "line": 191,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 185,
+      "line": 228,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 188,
+      "line": 230,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 192,
+      "line": 234,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 229,
+      "line": 236,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 231,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/logger.ts",
-      "line": 235,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/logger.ts",
-      "line": 237,
+      "line": 521,
       "pattern": "sync-fs"
     },
     {
@@ -1594,12 +1599,12 @@
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 523,
+      "line": 528,
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/utils/logger.ts",
-      "line": 529,
+      "file": "electron/utils/performance.ts",
+      "line": 64,
       "pattern": "sync-fs"
     },
     {
@@ -1608,53 +1613,48 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/utils/performance.ts",
-      "line": 66,
-      "pattern": "sync-fs"
-    },
-    {
       "file": "electron/utils/worktreePattern.ts",
-      "line": 20,
+      "line": 19,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/watchdog-host-core.ts",
-      "line": 182,
+      "line": 181,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/window/createWindow.ts",
-      "line": 146,
+      "line": 145,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 86,
+      "line": 85,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 169,
+      "line": 168,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 577,
+      "line": 576,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 723,
+      "line": 722,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/skeletonCss.ts",
-      "line": 21,
+      "line": 20,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/skeletonCss.ts",
-      "line": 26,
+      "line": 25,
       "pattern": "sync-store-get"
     }
   ]

--- a/renderer-bundle-size-baseline.json
+++ b/renderer-bundle-size-baseline.json
@@ -2,352 +2,404 @@
   "entryChunk": "index",
   "chunks": {
     "ActionPalette": {
-      "raw": 4074,
-      "gzip": 1861
+      "raw": 12886,
+      "gzip": 5164
     },
     "ActionService": {
-      "raw": 33788,
-      "gzip": 8179
+      "raw": 10215,
+      "gzip": 3954
     },
     "AgentCard": {
-      "raw": 12508,
-      "gzip": 4632
+      "raw": 12536,
+      "gzip": 4636
     },
     "AgentSettings": {
-      "raw": 90266,
-      "gzip": 26427
+      "raw": 89325,
+      "gzip": 26436
+    },
+    "AgentShortcutCapture": {
+      "raw": 1685,
+      "gzip": 895
     },
     "App": {
-      "raw": 1340851,
-      "gzip": 373543
+      "raw": 1289431,
+      "gzip": 361571
     },
     "AutomationTab": {
-      "raw": 33273,
-      "gzip": 9480
+      "raw": 33329,
+      "gzip": 9489
     },
     "BrowserPane": {
-      "raw": 21026,
-      "gzip": 7392
+      "raw": 21093,
+      "gzip": 7422
     },
     "CelebrationConfetti": {
-      "raw": 2922,
-      "gzip": 1475
+      "raw": 3056,
+      "gzip": 1547
     },
     "CloneRepoDialog": {
-      "raw": 67,
-      "gzip": 82
+      "raw": 7737,
+      "gzip": 2862
+    },
+    "CloudSyncBanner": {
+      "raw": 1658,
+      "gzip": 899
+    },
+    "CodeForgeSettingsTab": {
+      "raw": 28189,
+      "gzip": 8845
+    },
+    "CodeForgeTab": {
+      "raw": 4015,
+      "gzip": 1579
     },
     "CommandOverridesTab": {
-      "raw": 13004,
-      "gzip": 4242
+      "raw": 13039,
+      "gzip": 4258
     },
     "CommitList": {
-      "raw": 12656,
-      "gzip": 4866
+      "raw": 12903,
+      "gzip": 4992
     },
     "ContextTab": {
       "raw": 11734,
-      "gzip": 2700
+      "gzip": 2698
+    },
+    "CrashRecoveryDialog": {
+      "raw": 16231,
+      "gzip": 5277
     },
     "CreateProjectFolderDialog": {
-      "raw": 3555,
-      "gzip": 1508
+      "raw": 3588,
+      "gzip": 1523
     },
     "CrossWorktreeDiff": {
-      "raw": 8263,
-      "gzip": 3166
+      "raw": 8261,
+      "gzip": 3159
     },
     "DaintreeAssistantSettingsTab": {
-      "raw": 21693,
-      "gzip": 7466
+      "raw": 24073,
+      "gzip": 7697
+    },
+    "DaintreeIcon": {
+      "raw": 1858,
+      "gzip": 945
     },
     "DevPreviewPane": {
-      "raw": 37511,
-      "gzip": 11670
+      "raw": 69684,
+      "gzip": 21093
     },
     "DiffViewer": {
-      "raw": 31121,
-      "gzip": 11552
-    },
-    "DockPopoverChildContext": {
-      "raw": 392,
-      "gzip": 281
+      "raw": 31126,
+      "gzip": 11551
     },
     "EnvironmentSettingsTab": {
       "raw": 6394,
-      "gzip": 2536
+      "gzip": 2532
     },
     "EnvironmentVariablesEditor": {
       "raw": 7365,
       "gzip": 2642
     },
     "FileViewerModalHost": {
-      "raw": 3727,
-      "gzip": 1904
-    },
-    "ForgeIntegrationsTab": {
-      "raw": 7577,
-      "gzip": 2813
-    },
-    "ForgeProviderTab": {
-      "raw": 3949,
-      "gzip": 1554
+      "raw": 5014,
+      "gzip": 2466
     },
     "GeneralTab": {
-      "raw": 20606,
-      "gzip": 5930
+      "raw": 20715,
+      "gzip": 5978
     },
     "GettingStartedChecklist": {
-      "raw": 8255,
-      "gzip": 3498
+      "raw": 8304,
+      "gzip": 3521
     },
     "GitHubDropdownSkeletons": {
-      "raw": 6507,
-      "gzip": 1998
+      "raw": 6508,
+      "gzip": 2004
     },
     "GitHubResourceList": {
-      "raw": 50049,
-      "gzip": 16597
+      "raw": 51305,
+      "gzip": 17044
     },
-    "GitHubSettingsTab": {
-      "raw": 6788,
-      "gzip": 2106
+    "GitHubTokenBanner": {
+      "raw": 818,
+      "gzip": 529
     },
     "GitInitDialog": {
-      "raw": 65,
-      "gzip": 80
+      "raw": 6273,
+      "gzip": 2230
     },
     "GitPullRebaseConfirmDialog": {
-      "raw": 4919,
-      "gzip": 2150
+      "raw": 4925,
+      "gzip": 2153
     },
     "GitPushConfirmDialog": {
-      "raw": 4843,
-      "gzip": 2134
+      "raw": 4849,
+      "gzip": 2138
     },
     "HybridInputBar": {
-      "raw": 126266,
-      "gzip": 37895
+      "raw": 131378,
+      "gzip": 39221
     },
     "IntegrationsTab": {
-      "raw": 10868,
-      "gzip": 3095
+      "raw": 11145,
+      "gzip": 3162
     },
-    "KeyboardShortcuts": {
-      "raw": 7194,
-      "gzip": 2699
+    "KeybindingService": {
+      "raw": 36746,
+      "gzip": 8262
     },
     "KeyboardShortcutsTab": {
-      "raw": 8895,
-      "gzip": 3116
+      "raw": 8946,
+      "gzip": 3136
     },
     "LiveTimeAgo": {
-      "raw": 2478,
-      "gzip": 1265
+      "raw": 3263,
+      "gzip": 1610
     },
     "LogLevelPalette": {
-      "raw": 5364,
-      "gzip": 2277
+      "raw": 5367,
+      "gzip": 2275
     },
     "McpAuditLogViewer": {
-      "raw": 8439,
-      "gzip": 3068
+      "raw": 18407,
+      "gzip": 5365
     },
     "McpConfirmDialog": {
-      "raw": 2521,
-      "gzip": 1266
+      "raw": 2679,
+      "gzip": 1337
+    },
+    "McpServerIcon": {
+      "raw": 1048,
+      "gzip": 639
     },
     "McpServerSettingsTab": {
-      "raw": 14109,
-      "gzip": 4336
+      "raw": 31390,
+      "gzip": 7458
     },
     "NewTerminalPalette": {
-      "raw": 4466,
-      "gzip": 2180
+      "raw": 4505,
+      "gzip": 2194
     },
     "NewWorktreeDialog": {
-      "raw": 50160,
-      "gzip": 14914
+      "raw": 48225,
+      "gzip": 14448
     },
     "NotificationSettingsTab": {
-      "raw": 15666,
-      "gzip": 4964
+      "raw": 15661,
+      "gzip": 4960
     },
     "OnboardingFlow": {
-      "raw": 48891,
-      "gzip": 15296
+      "raw": 49118,
+      "gzip": 15411
+    },
+    "PaletteOverflowNotice": {
+      "raw": 523,
+      "gzip": 381
     },
     "PaletteStrip": {
-      "raw": 632,
-      "gzip": 432
+      "raw": 640,
+      "gzip": 440
     },
     "PanelLimitConfirmDialog": {
-      "raw": 1536,
-      "gzip": 897
+      "raw": 1529,
+      "gzip": 888
     },
     "PanelPalette": {
-      "raw": 7677,
-      "gzip": 3666
+      "raw": 7811,
+      "gzip": 3731
+    },
+    "PluginConfirmDialog": {
+      "raw": 1756,
+      "gzip": 899
     },
     "PortalSettingsTab": {
-      "raw": 14641,
-      "gzip": 5113
+      "raw": 14642,
+      "gzip": 5120
     },
     "PrivacyDataTab": {
-      "raw": 11843,
-      "gzip": 3596
+      "raw": 12586,
+      "gzip": 3827
     },
     "ProjectNotificationsTab": {
       "raw": 9914,
-      "gzip": 3580
+      "gzip": 3582
     },
     "ProjectSwitcherPalette": {
-      "raw": 116,
-      "gzip": 124
+      "raw": 111,
+      "gzip": 120
     },
     "QuickCreatePalette": {
-      "raw": 70,
-      "gzip": 85
+      "raw": 6640,
+      "gzip": 2655
     },
     "QuickSwitcher": {
-      "raw": 5190,
-      "gzip": 2327
+      "raw": 5238,
+      "gzip": 2354
     },
     "RecipeEditor": {
-      "raw": 14426,
-      "gzip": 3518
+      "raw": 14855,
+      "gzip": 3731
     },
     "RecipesTab": {
-      "raw": 12480,
-      "gzip": 4398
+      "raw": 12550,
+      "gzip": 4429
+    },
+    "RecoveryBannerCoordinator": {
+      "raw": 9873,
+      "gzip": 3792
     },
     "ReviewHubContent": {
-      "raw": 115320,
-      "gzip": 30609
+      "raw": 117163,
+      "gzip": 32522
     },
     "ReviewPane": {
       "raw": 1109,
-      "gzip": 667
+      "gzip": 670
     },
     "SearchablePalette": {
-      "raw": 32713,
-      "gzip": 11405
+      "raw": 5304,
+      "gzip": 2707
     },
     "SendToAgentPalette": {
-      "raw": 4065,
-      "gzip": 1816
+      "raw": 4113,
+      "gzip": 1843
     },
     "SettingsCheckbox": {
       "raw": 3332,
-      "gzip": 1577
+      "gzip": 1578
     },
     "SettingsChoicebox": {
       "raw": 4140,
-      "gzip": 1623
+      "gzip": 1624
     },
     "SettingsDialog": {
-      "raw": 37026,
-      "gzip": 12676
+      "raw": 50809,
+      "gzip": 16673
     },
     "SettingsFlushRegistry": {
       "raw": 1314,
-      "gzip": 710
+      "gzip": 709
     },
     "SettingsInput": {
       "raw": 2123,
-      "gzip": 975
+      "gzip": 976
+    },
+    "SettingsLoadErrorBanner": {
+      "raw": 2400,
+      "gzip": 1192
     },
     "SettingsSection": {
       "raw": 1570,
-      "gzip": 881
+      "gzip": 880
     },
     "SettingsSelect": {
       "raw": 2179,
-      "gzip": 1007
+      "gzip": 1009
+    },
+    "SettingsShortcutCapture": {
+      "raw": 6557,
+      "gzip": 2374
     },
     "SettingsSubtabBar": {
       "raw": 1815,
-      "gzip": 962
+      "gzip": 961
     },
     "SettingsSwitch": {
-      "raw": 1972,
-      "gzip": 861
+      "raw": 2023,
+      "gzip": 876
     },
     "SettingsSwitchCard": {
       "raw": 4134,
-      "gzip": 1958
+      "gzip": 1963
     },
     "SettingsValidationRegistry": {
       "raw": 1239,
       "gzip": 688
     },
     "ShortcutReferenceDialog": {
-      "raw": 4682,
-      "gzip": 2088
+      "raw": 4695,
+      "gzip": 2092
     },
     "Spinner": {
       "raw": 580,
-      "gzip": 396
+      "gzip": 402
     },
     "TerminalAppearanceTab": {
-      "raw": 23985,
-      "gzip": 8023
+      "raw": 24435,
+      "gzip": 8118
     },
     "TerminalInstanceService": {
-      "raw": 221599,
-      "gzip": 59341
+      "raw": 216963,
+      "gzip": 56940
     },
     "TerminalSettingsTab": {
-      "raw": 19877,
-      "gzip": 5652
+      "raw": 20075,
+      "gzip": 5731
     },
     "ThemePalette": {
-      "raw": 5309,
-      "gzip": 2536
+      "raw": 5283,
+      "gzip": 2523
     },
     "ToolbarSettingsTab": {
-      "raw": 13428,
-      "gzip": 4945
+      "raw": 13472,
+      "gzip": 4949
     },
     "TroubleshootingTab": {
-      "raw": 18157,
-      "gzip": 6153
+      "raw": 18781,
+      "gzip": 6373
     },
     "TruncatedTooltip": {
-      "raw": 1324,
-      "gzip": 808
+      "raw": 2667,
+      "gzip": 1357
     },
     "VoiceInputSettingsTab": {
-      "raw": 23521,
+      "raw": 23144,
       "gzip": 8201
     },
     "WorktreeOverviewModal": {
-      "raw": 73,
-      "gzip": 88
+      "raw": 32497,
+      "gzip": 11298
     },
     "WorktreePalette": {
-      "raw": 67,
-      "gzip": 82
+      "raw": 4008,
+      "gzip": 1836
     },
     "WorktreeSettingsTab": {
-      "raw": 8152,
-      "gzip": 2354
+      "raw": 8188,
+      "gzip": 2365
     },
-    "YarnIcon": {
-      "raw": 50371,
-      "gzip": 15759
+    "WorktreeSidebarSearchBar": {
+      "raw": 213161,
+      "gzip": 66729
+    },
+    "accessibilityAnnouncerStore": {
+      "raw": 246,
+      "gzip": 185
+    },
+    "actionPrefsStore": {
+      "raw": 2198,
+      "gzip": 893
+    },
+    "agentIds": {
+      "raw": 284,
+      "gzip": 212
     },
     "agentRegistry": {
-      "raw": 40410,
-      "gzip": 8946
+      "raw": 41527,
+      "gzip": 9094
     },
     "agentSettingsStore": {
-      "raw": 16468,
-      "gzip": 5397
+      "raw": 10382,
+      "gzip": 3524
     },
     "agents": {
-      "raw": 5687,
-      "gzip": 2329
+      "raw": 56541,
+      "gzip": 18325
+    },
+    "animationUtils": {
+      "raw": 986,
+      "gzip": 453
     },
     "apl": {
       "raw": 2292,
@@ -357,13 +409,17 @@
       "raw": 364,
       "gzip": 197
     },
+    "appThemeClient": {
+      "raw": 732,
+      "gzip": 229
+    },
     "appThemeStore": {
-      "raw": 4145,
-      "gzip": 1397
+      "raw": 81698,
+      "gzip": 18596
     },
     "appThemeViewTransition": {
-      "raw": 735,
-      "gzip": 438
+      "raw": 1349,
+      "gzip": 770
     },
     "asciiarmor": {
       "raw": 792,
@@ -381,29 +437,45 @@
       "raw": 599,
       "gzip": 318
     },
+    "branchPrefixes": {
+      "raw": 1358,
+      "gzip": 524
+    },
+    "button": {
+      "raw": 5691,
+      "gzip": 2075
+    },
     "c": {
       "raw": 1973,
       "gzip": 1029
     },
     "categoryColors": {
-      "raw": 1371,
-      "gzip": 486
+      "raw": 1776,
+      "gzip": 525
     },
     "checklistItems": {
-      "raw": 827,
-      "gzip": 473
+      "raw": 799,
+      "gzip": 455
+    },
+    "clientAppError": {
+      "raw": 349,
+      "gzip": 259
     },
     "clients": {
-      "raw": 20668,
-      "gzip": 5168
+      "raw": 19950,
+      "gzip": 5097
     },
     "clike": {
-      "raw": 22061,
-      "gzip": 7643
+      "raw": 768,
+      "gzip": 483
     },
     "clojure": {
       "raw": 9406,
       "gzip": 3961
+    },
+    "cloudSyncBannerStore": {
+      "raw": 160,
+      "gzip": 132
     },
     "cmake": {
       "raw": 780,
@@ -416,6 +488,10 @@
     "coffeescript": {
       "raw": 3855,
       "gzip": 1678
+    },
+    "colorUtils": {
+      "raw": 386,
+      "gzip": 257
     },
     "commandsClient": {
       "raw": 203,
@@ -439,11 +515,11 @@
     },
     "csharp": {
       "raw": 6491,
-      "gzip": 2542
+      "gzip": 2541
     },
     "css": {
-      "raw": 1295,
-      "gzip": 646
+      "raw": 24708,
+      "gzip": 8241
     },
     "cypher": {
       "raw": 3182,
@@ -454,16 +530,16 @@
       "gzip": 1651
     },
     "devServerDetection": {
-      "raw": 432,
-      "gzip": 296
+      "raw": 692,
+      "gzip": 405
     },
     "diff": {
       "raw": 302,
       "gzip": 233
     },
     "dist": {
-      "raw": 100552,
-      "gzip": 32451
+      "raw": 14348,
+      "gzip": 5701
     },
     "docker": {
       "raw": 1629,
@@ -471,7 +547,7 @@
     },
     "dockerfile": {
       "raw": 1906,
-      "gzip": 651
+      "gzip": 649
     },
     "dtd": {
       "raw": 2092,
@@ -501,17 +577,41 @@
       "raw": 7846,
       "gzip": 2859
     },
+    "errorContext": {
+      "raw": 2165,
+      "gzip": 910
+    },
     "errorMessage": {
-      "raw": 5868,
-      "gzip": 2329
+      "raw": 3457,
+      "gzip": 1390
     },
     "factor": {
       "raw": 1669,
       "gzip": 608
     },
+    "filesClient": {
+      "raw": 445,
+      "gzip": 301
+    },
     "folderName": {
-      "raw": 803,
-      "gzip": 428
+      "raw": 808,
+      "gzip": 431
+    },
+    "forgeProviderHealthStore": {
+      "raw": 551,
+      "gzip": 291
+    },
+    "forgeProviderIds": {
+      "raw": 221,
+      "gzip": 170
+    },
+    "formatBytes": {
+      "raw": 289,
+      "gzip": 220
+    },
+    "formatRelativeTime": {
+      "raw": 352,
+      "gzip": 218
     },
     "forth": {
       "raw": 2541,
@@ -531,23 +631,23 @@
     },
     "gitPullRebaseConfirmStore": {
       "raw": 317,
-      "gzip": 201
+      "gzip": 202
     },
     "gitPushConfirmStore": {
       "raw": 317,
-      "gzip": 201
+      "gzip": 202
     },
     "githubConfigStore": {
-      "raw": 659,
+      "raw": 654,
       "gzip": 335
     },
-    "githubFilterStore": {
-      "raw": 886,
-      "gzip": 402
-    },
     "githubRateLimitStore": {
-      "raw": 215,
-      "gzip": 156
+      "raw": 743,
+      "gzip": 370
+    },
+    "githubTokenHealthStore": {
+      "raw": 549,
+      "gzip": 310
     },
     "globalEnvClient": {
       "raw": 436,
@@ -555,7 +655,7 @@
     },
     "go": {
       "raw": 1075,
-      "gzip": 682
+      "gzip": 679
     },
     "graphql": {
       "raw": 2592,
@@ -578,12 +678,12 @@
       "gzip": 4390
     },
     "index": {
-      "raw": 543704,
-      "gzip": 169743
+      "raw": 428114,
+      "gzip": 134212
     },
     "java": {
       "raw": 2888,
-      "gzip": 1296
+      "gzip": 1292
     },
     "javascript": {
       "raw": 17020,
@@ -593,9 +693,13 @@
       "raw": 5263,
       "gzip": 2144
     },
+    "kbdShortcut": {
+      "raw": 2893,
+      "gzip": 1123
+    },
     "kotlin": {
       "raw": 2053,
-      "gzip": 1018
+      "gzip": 1015
     },
     "less": {
       "raw": 793,
@@ -608,6 +712,10 @@
     "logger": {
       "raw": 597,
       "gzip": 305
+    },
+    "logsClient": {
+      "raw": 625,
+      "gzip": 212
     },
     "lua": {
       "raw": 3130,
@@ -631,11 +739,11 @@
     },
     "mcpConfirmStore": {
       "raw": 806,
-      "gzip": 433
+      "gzip": 429
     },
     "memoryLeakConfigStore": {
       "raw": 304,
-      "gzip": 199
+      "gzip": 200
     },
     "mirc": {
       "raw": 5917,
@@ -650,8 +758,8 @@
       "gzip": 1276
     },
     "motionFeatures": {
-      "raw": 69,
-      "gzip": 84
+      "raw": 84,
+      "gzip": 94
     },
     "mscgen": {
       "raw": 3499,
@@ -665,17 +773,21 @@
       "raw": 7409,
       "gzip": 2726
     },
+    "normalizeErrorMessage": {
+      "raw": 578,
+      "gzip": 284
+    },
     "notificationSettingsStore": {
       "raw": 1951,
       "gzip": 601
     },
     "notify": {
-      "raw": 9274,
-      "gzip": 3540
+      "raw": 8750,
+      "gzip": 3329
     },
     "nsis": {
       "raw": 6804,
-      "gzip": 2948
+      "gzip": 2949
     },
     "ntriples": {
       "raw": 2077,
@@ -689,9 +801,17 @@
       "raw": 2881,
       "gzip": 1260
     },
+    "panelKindRegistry": {
+      "raw": 2890,
+      "gzip": 1108
+    },
+    "panelLimitStore": {
+      "raw": 2591,
+      "gzip": 985
+    },
     "panelSpawning": {
-      "raw": 11728,
-      "gzip": 4473
+      "raw": 11844,
+      "gzip": 4520
     },
     "pascal": {
       "raw": 2256,
@@ -701,13 +821,17 @@
       "raw": 1234,
       "gzip": 605
     },
+    "pathPattern": {
+      "raw": 3186,
+      "gzip": 1195
+    },
     "perl": {
       "raw": 9750,
       "gzip": 3385
     },
     "persistedStoreRegistry": {
-      "raw": 9248,
-      "gzip": 2946
+      "raw": 547,
+      "gzip": 300
     },
     "php": {
       "raw": 7581,
@@ -717,6 +841,14 @@
       "raw": 2513,
       "gzip": 1343
     },
+    "platform": {
+      "raw": 587,
+      "gzip": 263
+    },
+    "pluginConfirmStore": {
+      "raw": 833,
+      "gzip": 438
+    },
     "powershell": {
       "raw": 7699,
       "gzip": 3257
@@ -725,13 +857,21 @@
       "raw": 1348,
       "gzip": 735
     },
+    "project": {
+      "raw": 224,
+      "gzip": 170
+    },
+    "projectPresetsStore": {
+      "raw": 287,
+      "gzip": 174
+    },
     "projectSettingsStore": {
-      "raw": 1915,
-      "gzip": 837
+      "raw": 1920,
+      "gzip": 835
     },
     "projectStore": {
-      "raw": 13955,
-      "gzip": 4681
+      "raw": 14951,
+      "gzip": 4965
     },
     "properties": {
       "raw": 664,
@@ -743,7 +883,7 @@
     },
     "pug": {
       "raw": 6670,
-      "gzip": 1959
+      "gzip": 1957
     },
     "puppet": {
       "raw": 2540,
@@ -763,11 +903,23 @@
     },
     "radix-deferred": {
       "raw": 199,
-      "gzip": 153
+      "gzip": 152
     },
     "radix-loader": {
       "raw": 1065,
       "gzip": 588
+    },
+    "recipeStore": {
+      "raw": 11506,
+      "gzip": 3658
+    },
+    "recoveryCopy": {
+      "raw": 1658,
+      "gzip": 682
+    },
+    "resourceMonitoringStore": {
+      "raw": 3006,
+      "gzip": 1305
     },
     "rolldown-runtime": {
       "raw": 826,
@@ -785,9 +937,17 @@
       "raw": 2542,
       "gzip": 1213
     },
+    "safeModeStore": {
+      "raw": 760,
+      "gzip": 314
+    },
     "safeStorage": {
-      "raw": 6331,
-      "gzip": 2422
+      "raw": 3986,
+      "gzip": 1582
+    },
+    "safeStringify": {
+      "raw": 403,
+      "gzip": 277
     },
     "sas": {
       "raw": 9331,
@@ -795,23 +955,27 @@
     },
     "sass": {
       "raw": 1203,
-      "gzip": 537
+      "gzip": 536
     },
     "scheme": {
       "raw": 6363,
       "gzip": 2377
     },
+    "scrollback": {
+      "raw": 201,
+      "gzip": 175
+    },
     "scss": {
       "raw": 1429,
-      "gzip": 697
+      "gzip": 695
     },
     "select": {
-      "raw": 9641,
-      "gzip": 3406
+      "raw": 9624,
+      "gzip": 3399
     },
     "settingsTabRegistry": {
-      "raw": 65161,
-      "gzip": 16817
+      "raw": 67773,
+      "gzip": 17785
     },
     "shell": {
       "raw": 2449,
@@ -830,8 +994,8 @@
       "gzip": 849
     },
     "sortableAnnouncements": {
-      "raw": 3407,
-      "gzip": 1700
+      "raw": 7327,
+      "gzip": 2872
     },
     "sparql": {
       "raw": 3331,
@@ -844,6 +1008,10 @@
     "stex": {
       "raw": 3121,
       "gzip": 1172
+    },
+    "storeAccessors": {
+      "raw": 6687,
+      "gzip": 2027
     },
     "stylus": {
       "raw": 23526,
@@ -858,32 +1026,44 @@
       "gzip": 999
     },
     "swift": {
-      "raw": 3762,
-      "gzip": 1802
+      "raw": 3005,
+      "gzip": 1330
     },
     "systemWakeStore": {
-      "raw": 4126,
-      "gzip": 1515
+      "raw": 5371,
+      "gzip": 2425
     },
     "tcl": {
       "raw": 2353,
       "gzip": 1211
     },
+    "terminalChrome": {
+      "raw": 2526,
+      "gzip": 975
+    },
+    "terminalColorSchemeStore": {
+      "raw": 18144,
+      "gzip": 5145
+    },
+    "terminalConfigClient": {
+      "raw": 944,
+      "gzip": 268
+    },
+    "terminalFont": {
+      "raw": 473,
+      "gzip": 308
+    },
     "terminalInputStore": {
-      "raw": 7145,
-      "gzip": 2412
+      "raw": 7757,
+      "gzip": 2725
     },
     "textile": {
       "raw": 6772,
       "gzip": 2429
     },
-    "theme": {
-      "raw": 80929,
-      "gzip": 18128
-    },
     "toml": {
-      "raw": 1190,
-      "gzip": 534
+      "raw": 1031,
+      "gzip": 541
     },
     "troff": {
       "raw": 957,
@@ -901,21 +1081,41 @@
       "raw": 1957,
       "gzip": 882
     },
+    "twoPaneSplitStore": {
+      "raw": 2153,
+      "gzip": 955
+    },
     "uiStore": {
       "raw": 3625,
-      "gzip": 1144
+      "gzip": 1142
     },
     "useAgentDiscoveryOnboarding": {
-      "raw": 2773,
-      "gzip": 1050
+      "raw": 2768,
+      "gzip": 1047
+    },
+    "useDebounce": {
+      "raw": 410,
+      "gzip": 288
+    },
+    "useEscapeStack": {
+      "raw": 2817,
+      "gzip": 1200
     },
     "useFindInPage": {
-      "raw": 31560,
-      "gzip": 9848
+      "raw": 31559,
+      "gzip": 9862
+    },
+    "useMcpReadiness": {
+      "raw": 698,
+      "gzip": 453
+    },
+    "useResizeObserverRaf": {
+      "raw": 30008,
+      "gzip": 9989
     },
     "utils": {
       "raw": 218,
-      "gzip": 192
+      "gzip": 193
     },
     "vb": {
       "raw": 3650,
@@ -930,28 +1130,60 @@
       "gzip": 1100
     },
     "vendor": {
-      "raw": 425474,
-      "gzip": 137259
+      "raw": 425479,
+      "gzip": 137362
     },
     "vendor-editor": {
       "raw": 450309,
       "gzip": 145334
     },
     "vendor-icons": {
-      "raw": 48585,
-      "gzip": 14660
+      "raw": 49131,
+      "gzip": 14777
     },
-    "vendor-motion": {
-      "raw": 133079,
-      "gzip": 43154
+    "vendor-motion~App": {
+      "raw": 1075,
+      "gzip": 604
+    },
+    "vendor-motion~App~WorktreeOverviewModal": {
+      "raw": 7612,
+      "gzip": 3356
+    },
+    "vendor-motion~App~motionFeatures~WorktreeOverviewModal": {
+      "raw": 28065,
+      "gzip": 11040
+    },
+    "vendor-motion~index": {
+      "raw": 5584,
+      "gzip": 2430
+    },
+    "vendor-motion~index~BrowserPane~DevPreviewPane~App~CelebrationConfetti~OnboardingFlow~Workt~d1asc0vi": {
+      "raw": 7911,
+      "gzip": 3424
+    },
+    "vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Getti~bfe2l8g2": {
+      "raw": 269,
+      "gzip": 201
+    },
+    "vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~f3gnuexl": {
+      "raw": 31215,
+      "gzip": 11212
+    },
+    "vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~j1o0q54h": {
+      "raw": 603,
+      "gzip": 416
+    },
+    "vendor-motion~motionFeatures": {
+      "raw": 56617,
+      "gzip": 17173
     },
     "vendor-radix": {
       "raw": 5056,
-      "gzip": 1920
+      "gzip": 1921
     },
     "vendor-radix-overlay": {
       "raw": 105042,
-      "gzip": 31873
+      "gzip": 31874
     },
     "vendor-radix-utils": {
       "raw": 14557,
@@ -970,8 +1202,8 @@
       "gzip": 33517
     },
     "vendor-zod": {
-      "raw": 73735,
-      "gzip": 19421
+      "raw": 74222,
+      "gzip": 19574
     },
     "verilog": {
       "raw": 8435,
@@ -982,8 +1214,8 @@
       "gzip": 1498
     },
     "viewportPresets": {
-      "raw": 1062,
-      "gzip": 484
+      "raw": 5533,
+      "gzip": 2086
     },
     "webidl": {
       "raw": 2449,
@@ -1008,12 +1240,12 @@
   },
   "totals": {
     "js": {
-      "raw": 6922290,
-      "gzip": 2183381
+      "raw": 7267507,
+      "gzip": 2310640
     },
     "css": {
-      "raw": 285984,
-      "gzip": 37685
+      "raw": 291942,
+      "gzip": 38355
     }
   }
 }


### PR DESCRIPTION
## Summary

Wires all five existing performance budget check scripts into the build job in `ci.yml` so they gate every PR after `npm run build`.

Resolves #8900

## Changes

- Adds `import-budget:build` as a pre-step before the main build, because `check-import-budget.mjs` consumes `dist-electron/eager-import-meta.json` which `npm run build` doesn't emit on its own.
- Runs all five checks with `continue-on-error` so every check gets a chance to emit GitHub annotations before the gate fires:
  - `check-renderer-bundle-size.mjs`
  - `check-first-render-chunk.mjs`
  - `check-renderer-imports.mjs`
  - `check-import-budget.mjs`
  - `check-compiler-budget.mjs`
- Adds a final gate step that fails the build (and therefore `ci-ok`) if any check's outcome is `failure`.
- Appends `renderer-bundle-size-summary.md` and `first-render-chunk-summary.md` to `$GITHUB_STEP_SUMMARY`.

## Notes

`check-first-render-chunk.mjs` ships hard-failing (no `--override`) since its baseline is fresh and the warn-only window from #7576 never started. The remaining three checks don't have markdown summaries yet -- richer PR-comment summaries are tracked in #8899.

## Testing

Verified the workflow YAML parses correctly and the step ordering is right. CI will exercise the full path on this PR.