### PR TITLE
ci(test-ratio): add PR-trigger arm for fix-with-test reminder

### DIFF
--- a/.github/workflows/test-ratio.yml
+++ b/.github/workflows/test-ratio.yml
@@ -64,7 +64,8 @@ jobs:
       - name: Classify PR for test coverage
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+        # Informational only — the script always exits 0, and a transient
+        # git-diff failure must not surface as a red check on the PR.
         run: |
-          set -euo pipefail
           git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
             | node scripts/check-pr-test-ratio.mjs

--- a/.github/workflows/test-ratio.yml
+++ b/.github/workflows/test-ratio.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: "37 6 * * *"
   workflow_dispatch:
+  pull_request:
+    branches: [main, develop]
 
 permissions:
   contents: read
@@ -14,6 +16,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -42,3 +45,26 @@ jobs:
           path: dist/test-ratio-summary.md
           retention-days: 30
           if-no-files-found: ignore
+
+  classify-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Classify PR for test coverage
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+            | node scripts/check-pr-test-ratio.mjs

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "renderer-import-budget:update": "vite build && node scripts/check-renderer-import-budget.mjs --update",
     "test-ratio:check": "node scripts/check-test-ratio.mjs",
     "test-ratio:update": "node scripts/check-test-ratio.mjs --update",
+    "test-ratio:pr": "node scripts/check-pr-test-ratio.mjs",
     "check": "npm run typecheck && npm run check:channels && npm run check:crash-loop-constants && npm run check:ipc && npm run check:ipc-renderer && npm run check:ipc-handwritten && npm run check:help && npm run lint:ratchet && npm run format:check",
     "fix": "npm run format && npm run lint:fix",
     "test:smoke": "node scripts/run-smoke.mjs",

--- a/scripts/check-pr-test-ratio.mjs
+++ b/scripts/check-pr-test-ratio.mjs
@@ -41,4 +41,7 @@ async function main() {
   }
 }
 
-main();
+// Informational only — never fail the PR. Swallow any unexpected runtime error.
+main().catch((err) => {
+  console.error(`check-pr-test-ratio: skipped due to unexpected error: ${err?.message ?? err}`);
+});

--- a/scripts/check-pr-test-ratio.mjs
+++ b/scripts/check-pr-test-ratio.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+// PR-trigger arm of the fix-with-test ratio gate. Classifies the single current
+// PR and emits a non-blocking ::notice:: when it looks like a fix but didn't
+// touch any test files. Informational only — never exits non-zero.
+//
+// Usage (in CI):
+//   git diff --name-only "origin/$BASE...HEAD" | PR_TITLE="$TITLE" node scripts/check-pr-test-ratio.mjs
+//
+// Input contract:
+//   - Changed file paths arrive on stdin, one per line.
+//   - The PR title arrives via the PR_TITLE env var (kept out of the shell line
+//     so an untrusted title can't be interpreted as a command).
+
+import { classifyPR, shouldRemindAboutTests } from "./test-ratio-lib.mjs";
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function main() {
+  const raw = await readStdin();
+  const files = raw
+    .split("\n")
+    .map((line) => line.replace(/\r$/, "").trim())
+    .filter(Boolean)
+    .map((path) => ({ path }));
+
+  const classified = classifyPR({
+    number: 0,
+    title: process.env.PR_TITLE ?? "",
+    files: { nodes: files },
+  });
+
+  if (shouldRemindAboutTests(classified)) {
+    console.log(
+      "::notice title=Test coverage reminder::This PR looks like a fix but didn't touch any test files. Consider adding a regression test."
+    );
+  }
+}
+
+main();

--- a/scripts/check-pr-test-ratio.test.ts
+++ b/scripts/check-pr-test-ratio.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "check-pr-test-ratio.mjs"
+);
+
+function run(stdin: string, env: Record<string, string> = {}) {
+  return new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+    const child = spawn("node", [SCRIPT], {
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    child.stdin.write(stdin);
+    child.stdin.end();
+  });
+}
+
+describe("check-pr-test-ratio CLI", () => {
+  it("emits a notice for a fix PR with no test files and exits 0", async () => {
+    const { code, stdout } = await run("src/foo.ts\n", { PR_TITLE: "fix: repair crash" });
+    expect(code).toBe(0);
+    expect(stdout).toContain("::notice title=Test coverage reminder::");
+  });
+
+  it("stays quiet for a fix PR that touches tests", async () => {
+    const { code, stdout } = await run("src/foo.test.ts\n", { PR_TITLE: "fix: repair crash" });
+    expect(code).toBe(0);
+    expect(stdout).toBe("");
+  });
+
+  it("stays quiet for a non-fix PR", async () => {
+    const { code, stdout } = await run("src/foo.ts\n", { PR_TITLE: "feat: add feature" });
+    expect(code).toBe(0);
+    expect(stdout).toBe("");
+  });
+
+  it("treats an unset PR_TITLE as a non-fix PR and exits 0", async () => {
+    const { code, stdout } = await run("src/foo.ts\n", { PR_TITLE: "" });
+    expect(code).toBe(0);
+    expect(stdout).toBe("");
+  });
+
+  it("handles CRLF and blank lines, emitting exactly one notice", async () => {
+    const { code, stdout } = await run("src/foo.ts\r\n\n \nsrc/bar.ts\r\n", {
+      PR_TITLE: "fix: repair crash",
+    });
+    expect(code).toBe(0);
+    expect(stdout.match(/::notice/g)).toHaveLength(1);
+  });
+});

--- a/scripts/test-ratio-lib.mjs
+++ b/scripts/test-ratio-lib.mjs
@@ -73,6 +73,17 @@ export function classifyPR(pr) {
 }
 
 /**
+ * Per-PR reminder policy for the pull_request arm: true when a PR looks like a
+ * fix but didn't touch any test files. Skipped PRs (release/version bumps) and
+ * non-fix PRs never trigger the reminder.
+ * @param {ClassifiedPR} classified — output of classifyPR
+ * @returns {boolean}
+ */
+export function shouldRemindAboutTests(classified) {
+  return classified.isFix && !classified.touchesTests && !classified.isSkipped;
+}
+
+/**
  * Aggregate classified PRs into the two ratios.
  *
  * @param {ClassifiedPR[]} classified — output of classifyPR for each PR

--- a/scripts/test-ratio-lib.mjs
+++ b/scripts/test-ratio-lib.mjs
@@ -11,7 +11,7 @@
 // - The CLI compares these against a checked-in baseline and emits GitHub
 //   workflow annotations. No PR-blocking gate.
 
-export const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|js|jsx)$/;
+export const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/;
 
 const FIX_TITLE_RE = /^fix[(:]/i;
 const RELEASE_TITLE_RE = /^chore\(release\):/;

--- a/scripts/test-ratio-lib.test.ts
+++ b/scripts/test-ratio-lib.test.ts
@@ -113,6 +113,11 @@ describe("TEST_FILE_RE", () => {
     expect(TEST_FILE_RE.test("scripts/helpers.spec.js")).toBe(true);
   });
 
+  it("matches .test.mjs and .spec.cjs files", () => {
+    expect(TEST_FILE_RE.test("scripts/lint-ratchet.test.mjs")).toBe(true);
+    expect(TEST_FILE_RE.test("scripts/helpers.spec.cjs")).toBe(true);
+  });
+
   it("rejects non-test files", () => {
     expect(TEST_FILE_RE.test("src/utils/test-utils.ts")).toBe(false);
     expect(TEST_FILE_RE.test("src/components/TestButton.tsx")).toBe(false);
@@ -223,6 +228,14 @@ describe("shouldRemindAboutTests", () => {
       pr({ title: "chore(release): v0.7.2", files: { nodes: [{ path: "package.json" }] } })
     );
     expect(shouldRemindAboutTests(r)).toBe(false);
+  });
+
+  it("respects the isSkipped guard for an otherwise-reminding shape", () => {
+    // Exercises the `!isSkipped` clause directly — a real release PR is also
+    // isFix:false, so this synthetic shape is the only way to isolate it.
+    expect(shouldRemindAboutTests({ isFix: true, touchesTests: false, isSkipped: true })).toBe(
+      false
+    );
   });
 });
 

--- a/scripts/test-ratio-lib.test.ts
+++ b/scripts/test-ratio-lib.test.ts
@@ -5,6 +5,7 @@ import {
   isReleaseOrVersionBump,
   isEligiblePR,
   classifyPR,
+  shouldRemindAboutTests,
   computeTestRatioReport,
   validateBaseline,
   compareToBaseline,
@@ -187,6 +188,41 @@ describe("classifyPR", () => {
   it("handles files passed as null (unrequested field)", () => {
     const r = classifyPR(pr({ files: null }));
     expect(r.touchesTests).toBe(false);
+  });
+});
+
+// ── shouldRemindAboutTests ───────────────────────────────────────────────
+
+describe("shouldRemindAboutTests", () => {
+  it("reminds when a fix PR touches no tests", () => {
+    const r = classifyPR(
+      pr({ title: "fix: typo in error message", files: { nodes: [{ path: "src/lib/errors.ts" }] } })
+    );
+    expect(shouldRemindAboutTests(r)).toBe(true);
+  });
+
+  it("stays quiet when a fix PR touches tests", () => {
+    const r = classifyPR(
+      pr({
+        title: "fix(auth): token refresh",
+        files: { nodes: [{ path: "src/auth/auth.test.ts" }] },
+      })
+    );
+    expect(shouldRemindAboutTests(r)).toBe(false);
+  });
+
+  it("stays quiet for non-fix PRs without tests", () => {
+    const r = classifyPR(
+      pr({ title: "feat: add dark mode", files: { nodes: [{ path: "src/theme/dark.ts" }] } })
+    );
+    expect(shouldRemindAboutTests(r)).toBe(false);
+  });
+
+  it("stays quiet for skipped release PRs without tests", () => {
+    const r = classifyPR(
+      pr({ title: "chore(release): v0.7.2", files: { nodes: [{ path: "package.json" }] } })
+    );
+    expect(shouldRemindAboutTests(r)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #8897.

Adds a `pull_request`-triggered, **informational-only** arm to `.github/workflows/test-ratio.yml`. The nightly rolling-window arm is unchanged — this adds a per-PR "patch-style" reminder alongside the existing "project-style" trend gate.

## What it does

A new `classify-pr` job classifies the single current PR and emits a non-blocking GitHub `::notice::` when the PR looks like a fix (`fix:` / `fix(` title) but touches no test files:

> This PR looks like a fix but didn't touch any test files. Consider adding a regression test.

## How

- New `classify-pr` job gated on `if: github.event_name == 'pull_request'`; the existing nightly `check` job is now gated on `schedule` / `workflow_dispatch`.
- Reads the changed-file list via `git diff --name-only "origin/<base>...HEAD"` (checkout `fetch-depth: 0`) — avoids `gh pr view`'s silent 100-file truncation and needs no extra permissions (`contents: read` suffices).
- PR title is passed via the `PR_TITLE` env var (never interpolated into the shell line) for injection safety.
- New thin script `scripts/check-pr-test-ratio.mjs` reads the file list from stdin; a pure `shouldRemindAboutTests()` helper was added to `scripts/test-ratio-lib.mjs`.
- The script always exits `0` and the step does not use `set -euo pipefail`, so a transient `git diff` failure can't surface as a red check — informational during the probation period before deciding whether to promote it to a required check on `develop`.
- Also extended `TEST_FILE_RE` to match `.test.mjs`/`.cjs` and `.spec.mjs`/`.cjs` files (the repo has many `.test.mjs` scripts), fixing a false-positive reminder on test-only `.mjs` fix PRs.

## Tests

- New unit tests: `shouldRemindAboutTests` (incl. direct `isSkipped`-guard), `.mjs`/`.cjs` recognition.
- New CLI spawn tests for `check-pr-test-ratio.mjs` (notice path, empty-title fallback, CRLF/blank-line handling).
- 56 tests pass; typecheck / lint / format / build all clean.
- Added `test-ratio:pr` npm alias for local runs.