### PR TITLE
feat(lint-ratchet): track per-rule warning counts

### DIFF
--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,4 +1,15 @@
 {
-  "count": 1149,
-  "updatedAt": "2026-05-20T16:26:28.716Z"
+  "count": 1120,
+  "byRule": {
+    "@typescript-eslint/no-explicit-any": 54,
+    "@typescript-eslint/no-floating-promises": 94,
+    "@typescript-eslint/no-unsafe-type-assertion": 480,
+    "no-restricted-imports": 8,
+    "no-restricted-syntax": 361,
+    "no-useless-assignment": 20,
+    "preserve-caught-error": 50,
+    "react-compiler/react-compiler": 15,
+    "react-hooks/exhaustive-deps": 38
+  },
+  "updatedAt": "2026-05-24T08:10:23.250Z"
 }

--- a/scripts/lint-ratchet.mjs
+++ b/scripts/lint-ratchet.mjs
@@ -5,6 +5,20 @@
  *
  * Fails the build if ESLint warnings increase beyond the baseline.
  * This allows gradual reduction of warnings without introducing new ones.
+ *
+ * Two tiers of enforcement:
+ *   - Total count: `baseline.count` — the canonical aggregate gate.
+ *   - Per-rule: `baseline.byRule` — a `{ ruleId: count }` map that catches
+ *     "warning-shifting" (fixing one rule while introducing another keeps the
+ *     total flat). Any single rule's count increasing fails the build with the
+ *     named rule and delta. A rule disappearing from live output while still in
+ *     the baseline is a hard failure too — silencing a rule in config would
+ *     otherwise drop the total and sneak past the count gate.
+ *
+ * Usage:
+ *   node scripts/lint-ratchet.mjs                   # check mode (CI)
+ *   node scripts/lint-ratchet.mjs --update          # write current counts as new baseline
+ *   node scripts/lint-ratchet.mjs --update --force  # bypass the shrinkage / disappeared guards
  */
 
 import { execSync } from "child_process";
@@ -22,6 +36,87 @@ const UPDATE_SHRINKAGE_THRESHOLD = 0.1;
 // don't count toward the ratchet — test patterns like `as Foo` partial mocks
 // aren't product debt. Errors are still counted for all files below.
 const TEST_FILE_PATTERN = /[/\\](__tests__|e2e)[/\\]|\.(?:test|spec)\.[^.]+$/;
+
+/**
+ * Core shrinkage guard. Returns `{ blocked: true, message }` when the count
+ * would drop by more than `threshold` (proportionally), else `{ blocked: false }`.
+ * `force` bypasses the guard entirely. Used for both the total count and, in
+ * --update mode, each individual rule's count.
+ */
+export function checkShrinkageGuard(
+  priorCount,
+  newCount,
+  force,
+  threshold = UPDATE_SHRINKAGE_THRESHOLD
+) {
+  if (force) return { blocked: false };
+
+  if (priorCount > 0 && Number.isFinite(priorCount)) {
+    const drop = (priorCount - newCount) / priorCount;
+    if (drop > threshold) {
+      return {
+        blocked: true,
+        message: `::error::refusing to update baseline — warning count would drop from ${priorCount} to ${newCount} (${(drop * 100).toFixed(1)}% shrinkage > ${(threshold * 100).toFixed(0)}% threshold).`,
+      };
+    }
+  }
+
+  return { blocked: false };
+}
+
+/**
+ * Tally severity-1 (warning) messages per rule across the already-filtered
+ * production results. Messages with a null `ruleId` (parse/syntax errors) are
+ * always severity 2, so the `msg.ruleId` guard naturally excludes them.
+ * Returns a `{ ruleId: count }` object with keys sorted for deterministic diffs.
+ */
+export function aggregateByRule(productionResults) {
+  const tally = {};
+  for (const file of productionResults) {
+    for (const msg of file.messages) {
+      if (msg.severity === 1 && msg.ruleId) {
+        tally[msg.ruleId] = (tally[msg.ruleId] ?? 0) + 1;
+      }
+    }
+  }
+  return Object.fromEntries(Object.entries(tally).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+/**
+ * Compare a baseline `byRule` map against the live one. Pure — returns
+ * structured findings; the caller formats and decides exit status.
+ *   - disappeared: rules in the baseline absent from live output (hard failure;
+ *     someone silenced the rule, masking the loss behind the flat total).
+ *   - regressed: rules whose live count exceeds the baseline (the warning-shift).
+ *   - newRules: rules present in live output but not the baseline (a new class
+ *     of violation that wasn't previously tracked).
+ */
+export function checkByRule(baselineByRule, liveByRule) {
+  const disappeared = [];
+  const regressed = [];
+  const newRules = [];
+
+  for (const [rule, from] of Object.entries(baselineByRule)) {
+    const to = liveByRule[rule];
+    if (to === undefined) {
+      disappeared.push(rule);
+    } else if (to > from) {
+      regressed.push({ rule, from, to, delta: to - from });
+    }
+  }
+
+  for (const [rule, to] of Object.entries(liveByRule)) {
+    if (!(rule in baselineByRule)) {
+      newRules.push({ rule, to });
+    }
+  }
+
+  return { disappeared, regressed, newRules };
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
 
 function main() {
   const isUpdate = process.argv.includes("--update");
@@ -81,6 +176,8 @@ function main() {
     return sum + file.messages.filter((msg) => msg.severity === 2).length;
   }, 0);
 
+  const byRule = aggregateByRule(productionResults);
+
   console.log(`📊 Current ESLint warnings: ${warningCount}`);
 
   // Always fail if there are errors
@@ -90,31 +187,67 @@ function main() {
     process.exit(1);
   }
 
-  // Update mode: save current count as new baseline
+  // Update mode: save current counts as new baseline
   if (isUpdate) {
-    // Shrinkage guard: if the warning count drops by more than the threshold
-    // compared to the prior baseline, refuse to update. This prevents a config
-    // bug (e.g. .eslintignore expansion, file-pattern narrowing) from silently
-    // locking in undercounting as the new baseline.
+    // Total shrinkage guard: if the warning count drops by more than the
+    // threshold compared to the prior baseline, refuse to update. This prevents
+    // a config bug (e.g. .eslintignore expansion, file-pattern narrowing) from
+    // silently locking in undercounting as the new baseline.
     if (existsSync(BASELINE_FILE) && !force) {
-      let priorCount = 0;
+      let prior = null;
       try {
-        const prior = JSON.parse(readFileSync(BASELINE_FILE, "utf8"));
-        if (prior && typeof prior.count === "number" && Number.isFinite(prior.count)) {
-          priorCount = prior.count;
-        }
+        prior = JSON.parse(readFileSync(BASELINE_FILE, "utf8"));
       } catch {
         // Unparseable prior baseline — let the update proceed; the previous
         // baseline is unusable anyway.
       }
-      if (priorCount > 0) {
-        const drop = (priorCount - warningCount) / priorCount;
-        if (drop > UPDATE_SHRINKAGE_THRESHOLD) {
+
+      const priorCount =
+        prior && typeof prior.count === "number" && Number.isFinite(prior.count) ? prior.count : 0;
+
+      const totalGuard = checkShrinkageGuard(priorCount, warningCount, force);
+      if (totalGuard.blocked) {
+        console.error(totalGuard.message);
+        console.error(
+          "   This usually means ESLint coverage shrank (config change, .eslintignore expansion, or file-pattern narrowing)."
+        );
+        console.error("   If the shrinkage is intentional, re-run with --force.");
+        process.exit(1);
+      }
+
+      // Per-rule guards: a rule disappearing entirely, or shrinking by more than
+      // the threshold, is treated the same as the total — refuse the update so
+      // an accidental config change can't bake in a coverage loss. --force is
+      // the deliberate escape hatch (it skips this whole block).
+      if (prior && isPlainObject(prior.byRule)) {
+        const disappeared = [];
+        const shrunk = [];
+        for (const [rule, priorRuleCount] of Object.entries(prior.byRule)) {
+          const liveRuleCount = byRule[rule];
+          if (liveRuleCount === undefined) {
+            disappeared.push({ rule, from: priorRuleCount });
+            continue;
+          }
+          const guard = checkShrinkageGuard(priorRuleCount, liveRuleCount, force);
+          if (guard.blocked) {
+            shrunk.push({ rule, from: priorRuleCount, to: liveRuleCount });
+          }
+        }
+
+        if (disappeared.length > 0 || shrunk.length > 0) {
+          for (const { rule, from } of disappeared) {
+            console.error(
+              `::error::refusing to update baseline — rule "${rule}" disappeared from live output (baseline: ${from}). A silenced or removed rule must not be dropped silently.`
+            );
+          }
+          for (const { rule, from, to } of shrunk) {
+            const drop = (((from - to) / from) * 100).toFixed(1);
+            console.error(
+              `::error::refusing to update baseline — rule "${rule}" would drop from ${from} to ${to} (${drop}% shrinkage > ${(UPDATE_SHRINKAGE_THRESHOLD * 100).toFixed(0)}% threshold).`
+            );
+          }
           console.error(
-            `::error::refusing to update baseline — warning count would drop from ${priorCount} to ${warningCount} (${(drop * 100).toFixed(1)}% shrinkage > ${(UPDATE_SHRINKAGE_THRESHOLD * 100).toFixed(0)}% threshold).`
-          );
-          console.error(
-            "   This usually means ESLint coverage shrank (config change, .eslintignore expansion, or file-pattern narrowing)."
+            "   This usually means ESLint coverage shrank (a rule was disabled, or file patterns narrowed)."
           );
           console.error("   If the shrinkage is intentional, re-run with --force.");
           process.exit(1);
@@ -122,9 +255,11 @@ function main() {
       }
     }
 
-    const baseline = { count: warningCount, updatedAt: new Date().toISOString() };
+    const baseline = { count: warningCount, byRule, updatedAt: new Date().toISOString() };
     writeFileSync(BASELINE_FILE, JSON.stringify(baseline, null, 2) + "\n");
-    console.log(`✅ Baseline updated: ${warningCount} warnings`);
+    console.log(
+      `✅ Baseline updated: ${warningCount} warnings across ${Object.keys(byRule).length} rules`
+    );
     return;
   }
 
@@ -154,16 +289,56 @@ function main() {
   const baselineCount = baseline.count;
   const diff = warningCount - baselineCount;
 
+  let failed = false;
+
   if (diff > 0) {
     console.error(`❌ ESLint warnings increased by ${diff} (baseline: ${baselineCount})`);
     console.error(`   Fix the new warnings or run: npm run lint:ratchet -- --update`);
-    process.exit(1);
+    failed = true;
   } else if (diff < 0) {
     console.log(`🎉 ESLint warnings decreased by ${Math.abs(diff)}! (baseline: ${baselineCount})`);
     console.log(`   Update baseline: npm run lint:ratchet -- --update`);
   } else {
     console.log(`✅ No new warnings introduced (baseline: ${baselineCount})`);
   }
+
+  // Per-rule check: catches warning-shifting that the flat total can't see.
+  if (isPlainObject(baseline.byRule)) {
+    const { disappeared, regressed, newRules } = checkByRule(baseline.byRule, byRule);
+
+    if (disappeared.length > 0 || regressed.length > 0 || newRules.length > 0) {
+      for (const { rule, from, to, delta } of regressed) {
+        console.error(
+          `::error::rule "${rule}" increased by ${delta} (baseline: ${from}, live: ${to})`
+        );
+      }
+      for (const { rule, to } of newRules) {
+        console.error(
+          `::error::new rule "${rule}" introduced ${to} warning(s) not present in the baseline`
+        );
+      }
+      for (const rule of disappeared) {
+        console.error(
+          `::error::rule "${rule}" disappeared from live output (baseline: ${baseline.byRule[rule]}). A silenced or removed rule must not drop silently — restore it or run: npm run lint:ratchet -- --update`
+        );
+      }
+      console.error(
+        `   Per-rule ratchet failed. Fix the regressing rule(s) or run: npm run lint:ratchet -- --update`
+      );
+      failed = true;
+    }
+  } else {
+    console.warn(
+      `⚠️  Baseline has no per-rule data. Run: npm run lint:ratchet -- --update to enable per-rule tracking.`
+    );
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
 }
 
-main();
+const invokedDirectly = process.argv[1] && process.argv[1] === __filename;
+if (invokedDirectly) {
+  main();
+}

--- a/scripts/lint-ratchet.mjs
+++ b/scripts/lint-ratchet.mjs
@@ -71,7 +71,9 @@ export function checkShrinkageGuard(
  * Returns a `{ ruleId: count }` object with keys sorted for deterministic diffs.
  */
 export function aggregateByRule(productionResults) {
-  const tally = {};
+  // Null-prototype object so a rule named "constructor"/"toString" can't collide
+  // with an inherited member (the `?? 0` guard wouldn't fire on a real function).
+  const tally = Object.create(null);
   for (const file of productionResults) {
     for (const msg of file.messages) {
       if (msg.severity === 1 && msg.ruleId) {
@@ -97,16 +99,20 @@ export function checkByRule(baselineByRule, liveByRule) {
   const newRules = [];
 
   for (const [rule, from] of Object.entries(baselineByRule)) {
-    const to = liveByRule[rule];
-    if (to === undefined) {
+    // Object.hasOwn (not `in` / direct lookup) so prototype members like
+    // "toString" don't masquerade as present rules.
+    if (!Object.hasOwn(liveByRule, rule)) {
       disappeared.push(rule);
-    } else if (to > from) {
+      continue;
+    }
+    const to = liveByRule[rule];
+    if (to > from) {
       regressed.push({ rule, from, to, delta: to - from });
     }
   }
 
   for (const [rule, to] of Object.entries(liveByRule)) {
-    if (!(rule in baselineByRule)) {
+    if (!Object.hasOwn(baselineByRule, rule)) {
       newRules.push({ rule, to });
     }
   }
@@ -135,7 +141,7 @@ function main() {
     // ESLint exits with code 1 when there are warnings/errors
     // The output is still valid JSON in stdout
     if (error.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") {
-      console.error("❌ ESLint output exceeded buffer size (25MB)");
+      console.error("❌ ESLint output exceeded buffer size (50MB)");
       console.error("   Try reducing the number of files or increasing maxBuffer");
       process.exit(1);
     }
@@ -168,6 +174,12 @@ function main() {
   // test-file errors must still block the build.
   const productionResults = results.filter((file) => !TEST_FILE_PATTERN.test(file.filePath));
 
+  // `warningCount` counts every severity-1 message; `byRule` (below) only counts
+  // those with a non-null ruleId. They stay in sync because ESLint emits
+  // null-ruleId messages as severity 2 (parse errors) under the current
+  // invocation — this divergence assumption only breaks if a flag like
+  // --report-unused-disable-directives is added, which would emit severity-1
+  // null-ruleId messages. `count` remains the canonical total either way.
   const warningCount = productionResults.reduce((sum, file) => {
     return sum + file.messages.filter((msg) => msg.severity === 1).length;
   }, 0);
@@ -223,11 +235,11 @@ function main() {
         const disappeared = [];
         const shrunk = [];
         for (const [rule, priorRuleCount] of Object.entries(prior.byRule)) {
-          const liveRuleCount = byRule[rule];
-          if (liveRuleCount === undefined) {
+          if (!Object.hasOwn(byRule, rule)) {
             disappeared.push({ rule, from: priorRuleCount });
             continue;
           }
+          const liveRuleCount = byRule[rule];
           const guard = checkShrinkageGuard(priorRuleCount, liveRuleCount, force);
           if (guard.blocked) {
             shrunk.push({ rule, from: priorRuleCount, to: liveRuleCount });

--- a/scripts/lint-ratchet.test.mjs
+++ b/scripts/lint-ratchet.test.mjs
@@ -164,6 +164,17 @@ describe("aggregateByRule", () => {
     const results = [mkFile("/src/a.ts", [{ severity: 2, ruleId: "no-debugger" }])];
     expect(aggregateByRule(results)).toEqual({});
   });
+
+  it("counts a ruleId that collides with an Object prototype member", () => {
+    const results = [
+      mkFile("/src/a.ts", [
+        { severity: 1, ruleId: "constructor" },
+        { severity: 1, ruleId: "toString" },
+        { severity: 1, ruleId: "constructor" },
+      ]),
+    ];
+    expect(aggregateByRule(results)).toEqual({ constructor: 2, toString: 1 });
+  });
 });
 
 describe("checkByRule", () => {
@@ -220,5 +231,18 @@ describe("checkByRule", () => {
       { rule: "a", from: 1, to: 2, delta: 1 },
       { rule: "b", from: 2, to: 5, delta: 3 },
     ]);
+  });
+
+  it("treats a prototype-named rule as a real new rule, not an inherited member", () => {
+    // `"toString" in {}` is true — using Object.hasOwn avoids the false positive.
+    const { newRules, disappeared } = checkByRule({}, { toString: 1 });
+    expect(newRules).toEqual([{ rule: "toString", to: 1 }]);
+    expect(disappeared).toEqual([]);
+  });
+
+  it("flags a prototype-named baseline rule as disappeared when absent from live", () => {
+    const { disappeared, regressed } = checkByRule({ toString: 3 }, { "no-console": 1 });
+    expect(disappeared).toEqual(["toString"]);
+    expect(regressed).toEqual([]);
   });
 });

--- a/scripts/lint-ratchet.test.mjs
+++ b/scripts/lint-ratchet.test.mjs
@@ -1,29 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
+import { checkShrinkageGuard, aggregateByRule, checkByRule } from "./lint-ratchet.mjs";
 
-// Test the lint-ratchet shrinkage guard logic in isolation. We don't shell out
-// to eslint; we test the guard that fires inside the --update path.
+// These import the pure helpers directly from the script — the `invokedDirectly`
+// guard means importing the module does not spawn ESLint or touch the baseline.
 
 const UPDATE_SHRINKAGE_THRESHOLD = 0.1;
-
-/**
- * Core guard logic extracted from lint-ratchet.mjs for testability.
- * Returns `{ blocked: true, message: string }` or `{ blocked: false }`.
- */
-function checkShrinkageGuard(priorCount, newCount, force, threshold = UPDATE_SHRINKAGE_THRESHOLD) {
-  if (force) return { blocked: false };
-
-  if (priorCount > 0) {
-    const drop = (priorCount - newCount) / priorCount;
-    if (drop > threshold) {
-      return {
-        blocked: true,
-        message: `::error::refusing to update baseline — warning count would drop from ${priorCount} to ${newCount} (${(drop * 100).toFixed(1)}% shrinkage > ${(threshold * 100).toFixed(0)}% threshold).`,
-      };
-    }
-  }
-
-  return { blocked: false };
-}
 
 describe("lint-ratchet shrinkage guard", () => {
   describe("UPDATE_SHRINKAGE_THRESHOLD = 0.1", () => {
@@ -124,5 +105,120 @@ describe("lint-ratchet shrinkage guard", () => {
       const result = checkShrinkageGuard(10, 9, false);
       expect(result.blocked).toBe(false);
     });
+  });
+});
+
+describe("aggregateByRule", () => {
+  const mkFile = (filePath, messages) => ({ filePath, messages });
+
+  it("tallies severity-1 warnings per rule across files", () => {
+    const results = [
+      mkFile("/src/a.ts", [
+        { severity: 1, ruleId: "@typescript-eslint/no-explicit-any" },
+        { severity: 1, ruleId: "no-console" },
+      ]),
+      mkFile("/src/b.ts", [{ severity: 1, ruleId: "@typescript-eslint/no-explicit-any" }]),
+    ];
+    expect(aggregateByRule(results)).toEqual({
+      "@typescript-eslint/no-explicit-any": 2,
+      "no-console": 1,
+    });
+  });
+
+  it("excludes severity-2 (error) messages", () => {
+    const results = [
+      mkFile("/src/a.ts", [
+        { severity: 2, ruleId: "no-debugger" },
+        { severity: 1, ruleId: "no-console" },
+      ]),
+    ];
+    expect(aggregateByRule(results)).toEqual({ "no-console": 1 });
+  });
+
+  it("excludes messages with null ruleId (parse/syntax errors)", () => {
+    const results = [
+      mkFile("/src/a.ts", [
+        { severity: 1, ruleId: null },
+        { severity: 1, ruleId: "no-console" },
+      ]),
+    ];
+    expect(aggregateByRule(results)).toEqual({ "no-console": 1 });
+  });
+
+  it("returns keys sorted for deterministic diffs", () => {
+    const results = [
+      mkFile("/src/a.ts", [
+        { severity: 1, ruleId: "zebra-rule" },
+        { severity: 1, ruleId: "alpha-rule" },
+        { severity: 1, ruleId: "@scope/mid-rule" },
+      ]),
+    ];
+    expect(Object.keys(aggregateByRule(results))).toEqual([
+      "@scope/mid-rule",
+      "alpha-rule",
+      "zebra-rule",
+    ]);
+  });
+
+  it("returns an empty object when there are no warnings", () => {
+    const results = [mkFile("/src/a.ts", [{ severity: 2, ruleId: "no-debugger" }])];
+    expect(aggregateByRule(results)).toEqual({});
+  });
+});
+
+describe("checkByRule", () => {
+  it("flags a rule whose live count exceeds the baseline (warning-shift)", () => {
+    const baseline = { "no-console": 5, "no-explicit-any": 10 };
+    const live = { "no-console": 7, "no-explicit-any": 10 };
+    const { regressed, disappeared, newRules } = checkByRule(baseline, live);
+    expect(regressed).toEqual([{ rule: "no-console", from: 5, to: 7, delta: 2 }]);
+    expect(disappeared).toEqual([]);
+    expect(newRules).toEqual([]);
+  });
+
+  it("flags a rule present in the baseline but absent from live as disappeared", () => {
+    const baseline = { "no-console": 5, "no-explicit-any": 10 };
+    const live = { "no-explicit-any": 10 };
+    const { disappeared, regressed, newRules } = checkByRule(baseline, live);
+    expect(disappeared).toEqual(["no-console"]);
+    expect(regressed).toEqual([]);
+    expect(newRules).toEqual([]);
+  });
+
+  it("flags a rule present in live but absent from baseline as new", () => {
+    const baseline = { "no-console": 5 };
+    const live = { "no-console": 5, "new-rule": 3 };
+    const { newRules, regressed, disappeared } = checkByRule(baseline, live);
+    expect(newRules).toEqual([{ rule: "new-rule", to: 3 }]);
+    expect(regressed).toEqual([]);
+    expect(disappeared).toEqual([]);
+  });
+
+  it("passes cleanly when every rule's live count is <= baseline and present", () => {
+    const baseline = { "no-console": 5, "no-explicit-any": 10 };
+    const live = { "no-console": 4, "no-explicit-any": 10 };
+    const { disappeared, regressed, newRules } = checkByRule(baseline, live);
+    expect(disappeared).toEqual([]);
+    expect(regressed).toEqual([]);
+    expect(newRules).toEqual([]);
+  });
+
+  it("detects the canonical warning-shift: total flat, one rule up, one rule down", () => {
+    // Total is 15 in both, but no-console rose while no-explicit-any fell —
+    // the flat total can't see this; the per-rule check must.
+    const baseline = { "no-console": 5, "no-explicit-any": 10 };
+    const live = { "no-console": 8, "no-explicit-any": 7 };
+    const { regressed } = checkByRule(baseline, live);
+    expect(regressed).toEqual([{ rule: "no-console", from: 5, to: 8, delta: 3 }]);
+  });
+
+  it("reports multiple simultaneous regressions", () => {
+    const baseline = { a: 1, b: 2, c: 3 };
+    const live = { a: 2, b: 5, c: 3 };
+    const { regressed } = checkByRule(baseline, live);
+    expect(regressed).toEqual([
+      { rule: "a", from: 1, to: 2, delta: 1 },
+      { rule: "b", from: 2, to: 5, delta: 3 },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Extends `scripts/lint-ratchet.mjs` to track warning counts per rule using a `byRule` map in `eslint-warnings-baseline.json`, alongside the existing `count` field
- Check mode now fails when any individual rule's count increases, naming the rule and the delta — catches warning-shifting that the single-integer total can't see
- Update mode applies the 10% shrinkage guard per-rule; a disappeared or over-shrunk rule blocks the update unless `--force`

Resolves #8891

## Changes

- `scripts/lint-ratchet.mjs` — exports three pure helpers (`aggregateByRule`, `checkByRule`, `checkShrinkageGuard`); added an `invokedDirectly` guard so tests import without spawning ESLint; hardened against prototype-named rule IDs (`Object.create(null)` + `Object.hasOwn`)
- `eslint-warnings-baseline.json` — added `byRule` map alongside the canonical `count` (count drifted 1149→1120 on the fresh run; per-rule sum matches the total)
- `scripts/lint-ratchet.test.mjs` — rewritten to import the exported helpers; 30 tests covering warning-shift, disappeared rules, new rules, and prototype keys

Old baselines without `byRule` skip per-rule enforcement and hint the user to run `--update`.

## Testing

30 unit tests pass. `npm run check` runs clean against the updated baseline.