### PR TITLE
feat(scripts): add markdown summary emission to budget-check scripts

### DIFF
--- a/scripts/budget-summary-lib.mjs
+++ b/scripts/budget-summary-lib.mjs
@@ -80,15 +80,51 @@ export function formatBudgetSummary({
   // leaving room for an omission notice. The title line (bodyLines[0]) is
   // always retained so the collapsed block still identifies itself. The closing
   // </details> is re-appended by assemble(), so truncation never leaves the
-  // block unclosed.
+  // block unclosed. Preserve at least one body entry line when possible.
   const total = bodyLines.length;
   const noticeFor = (omitted) =>
     `_[${omitted} line(s) omitted — summary exceeded ${maxChars}-character cap]_`;
+
+  // Identify the structural prefix (title, section headings, and blank separators).
+  // A structural line is either empty, starts with ##, or is a pure markdown element.
+  // Entry lines are content lines (typically start with "- " for lists).
+  const isStructural = (line) => !line.trim() || line.startsWith("##") || line.startsWith("###");
+
+  // Find the boundary between structural lines and entries. We want to keep at least
+  // the first entry plus all structural lines before it.
+  let structuralBoundary = 0;
+  for (let i = 0; i < bodyLines.length; i++) {
+    if (!isStructural(bodyLines[i])) {
+      structuralBoundary = i;
+      break;
+    }
+  }
+
+  // First pass: try to keep as many lines as possible while staying within the soft cap,
+  // ensuring we include at least one entry (at minimum, structuralBoundary + 1 lines).
+  for (let keep = total - 1; keep >= structuralBoundary + 1; keep--) {
+    const kept = bodyLines.slice(0, keep);
+    const candidate = assemble([...kept, "", noticeFor(total - keep)]);
+    if (candidate.length <= maxChars) return candidate;
+  }
+
+  // Second pass: if the soft cap can't accommodate an entry line, find the smallest
+  // version with at least one entry, even if it exceeds the cap slightly.
+  // This ensures that even when severely over-budget, we still show at least one item.
+  for (let keep = structuralBoundary + 1; keep <= total - 1; keep++) {
+    const kept = bodyLines.slice(0, keep);
+    const candidate = assemble([...kept, "", noticeFor(total - keep)]);
+    // Return the first one that includes an entry (which this loop guarantees).
+    return candidate;
+  }
+
+  // Fallback: if we somehow have no entries at all, keep as much as fits structurally.
   for (let keep = total - 1; keep >= 1; keep--) {
     const kept = bodyLines.slice(0, keep);
     const candidate = assemble([...kept, "", noticeFor(total - keep)]);
     if (candidate.length <= maxChars) return candidate;
   }
+
   // Degenerate case: even the title + notice overflows. Return the smallest
   // valid block — title plus notice — accepting it may still nudge over the cap
   // (it never will in practice; the wrapper + one line is a few hundred bytes).

--- a/scripts/budget-summary-lib.mjs
+++ b/scripts/budget-summary-lib.mjs
@@ -1,0 +1,108 @@
+// Shared markdown-summary formatter for the performance-budget CI gates.
+//
+// Every budget-check script (compiler bailouts, eager import counts, renderer
+// bundle size, first-render chunk gzip) emits a markdown file under dist/ so a
+// downstream workflow can aggregate all of them into a single PR comment. To
+// keep that aggregation cheap and the comment under GitHub's 65,536-character
+// limit, each script produces a uniform collapsible block:
+//
+//   <details>
+//   <summary>{plain-text PASS/FAIL one-liner}</summary>
+//
+//   ## {title}
+//
+//   ### {section heading}
+//   {section body lines}
+//
+//   </details>
+//
+// The blank lines around <summary> and </details> are load-bearing: GitHub
+// Flavored Markdown only renders tables/lists inside <details> when a blank
+// line separates the HTML tags from the markdown body. The <summary> text must
+// be plain (no markdown syntax) so it renders in the collapsed state.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+// GitHub rejects PR/issue comments over 65,536 characters with a 422. Aggregating
+// five summaries into one comment means each must stay well under that ceiling;
+// 65,000 leaves headroom for the aggregator's own framing (headings, separators).
+export const DEFAULT_MAX_CHARS = 65000;
+
+// Build the collapsible body lines (everything between <summary> and the
+// trailing </details>) from the title + sections. Kept separate from the
+// wrapper so the size guard can truncate body lines without disturbing the
+// <details>/<summary>/</details> scaffolding.
+function buildBodyLines(title, sections) {
+  const lines = [`## ${title}`];
+  for (const section of sections) {
+    const body = Array.isArray(section.body) ? section.body : [];
+    // Skip empty sections entirely — an empty "### Regressions" heading is noise.
+    if (body.length === 0) continue;
+    lines.push("");
+    if (section.heading) lines.push(`### ${section.heading}`, "");
+    lines.push(...body);
+  }
+  return lines;
+}
+
+/**
+ * Format a budget result as a uniform collapsible markdown summary.
+ *
+ * @param {Object} opts
+ * @param {string} opts.title - Document heading inside the collapsible (e.g. "Compiler bailout budget").
+ * @param {"PASS"|"FAIL"} opts.status - Gate result, surfaced in the <summary> one-liner.
+ * @param {string} opts.headerLine - Plain-text one-liner for the <summary> tag (PASS/FAIL + key metric).
+ * @param {Array<{heading?: string, body: string[]}>} opts.sections - Body sections; empty-body sections are dropped.
+ * @param {number} [opts.maxChars=DEFAULT_MAX_CHARS] - Soft cap; body rows are trimmed past this length.
+ * @returns {string} Markdown collapsible block (no trailing newline).
+ */
+export function formatBudgetSummary({
+  title,
+  status,
+  headerLine,
+  sections = [],
+  maxChars = DEFAULT_MAX_CHARS,
+}) {
+  // The <summary> is plain text; prefix the status so the collapsed row reads
+  // "PASS — ..." / "FAIL — ..." even before expansion.
+  const summaryText = `${status} — ${headerLine}`;
+  const open = `<details>\n<summary>${summaryText}</summary>\n`;
+  const close = "\n</details>";
+
+  const assemble = (bodyLines) => `${open}\n${bodyLines.join("\n")}\n${close}`;
+
+  const bodyLines = buildBodyLines(title, sections);
+  let out = assemble(bodyLines);
+  if (out.length <= maxChars) return out;
+
+  // Over the cap: drop body lines from the end until the assembled block fits,
+  // leaving room for an omission notice. The title line (bodyLines[0]) is
+  // always retained so the collapsed block still identifies itself. The closing
+  // </details> is re-appended by assemble(), so truncation never leaves the
+  // block unclosed.
+  const total = bodyLines.length;
+  const noticeFor = (omitted) =>
+    `_[${omitted} line(s) omitted — summary exceeded ${maxChars}-character cap]_`;
+  for (let keep = total - 1; keep >= 1; keep--) {
+    const kept = bodyLines.slice(0, keep);
+    const candidate = assemble([...kept, "", noticeFor(total - keep)]);
+    if (candidate.length <= maxChars) return candidate;
+  }
+  // Degenerate case: even the title + notice overflows. Return the smallest
+  // valid block — title plus notice — accepting it may still nudge over the cap
+  // (it never will in practice; the wrapper + one line is a few hundred bytes).
+  return assemble([bodyLines[0] ?? `## ${title}`, "", noticeFor(Math.max(total - 1, 0))]);
+}
+
+/**
+ * Write a markdown summary to disk, creating the parent directory as needed.
+ * Separate from formatBudgetSummary so the formatter stays pure/testable.
+ *
+ * @param {string} filePath - Absolute path of the summary file (e.g. dist/compiler-budget-summary.md).
+ * @param {string} markdown - Markdown content (a trailing newline is appended).
+ */
+export function writeSummary(filePath, markdown) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, markdown.endsWith("\n") ? markdown : markdown + "\n");
+}

--- a/scripts/budget-summary-lib.test.mjs
+++ b/scripts/budget-summary-lib.test.mjs
@@ -126,6 +126,47 @@ describe("formatBudgetSummary — size guard", () => {
     expect(md).toContain("## Big report");
   });
 
+  it("reports the exact number of omitted lines in the notice", () => {
+    // 10 deterministic entry lines. Truncation drops from the end, so only
+    // entry lines (never the "## T" / "### S" structural lines) get dropped as
+    // long as at least one entry survives — making the count exactly checkable.
+    const body = Array.from({ length: 10 }, (_, i) => `- line ${i}`);
+    const opts = {
+      title: "T",
+      status: "PASS",
+      headerLine: "h",
+      sections: [{ heading: "S", body }],
+    };
+    const full = formatBudgetSummary(opts);
+    const md = formatBudgetSummary({ ...opts, maxChars: full.length - 30 });
+
+    const m = md.match(/_\[(\d+) line\(s\) omitted/);
+    expect(m).not.toBeNull();
+    const reported = Number(m[1]);
+    const present = body.filter((line) => md.includes(line)).length;
+    expect(present).toBeGreaterThan(0); // structural lines were retained
+    expect(reported).toBe(body.length - present);
+  });
+
+  it("does not truncate when output is exactly at the cap, truncates one char under", () => {
+    const body = Array.from({ length: 50 }, (_, i) => `- chunk-${i}`);
+    const opts = {
+      title: "Boundary",
+      status: "PASS",
+      headerLine: "edge",
+      sections: [{ heading: "Chunks", body }],
+    };
+    const exact = formatBudgetSummary(opts);
+    // At exactly the assembled length, the <= guard must NOT truncate.
+    const atCap = formatBudgetSummary({ ...opts, maxChars: exact.length });
+    expect(atCap).toBe(exact);
+    expect(atCap).not.toContain("omitted");
+    // One character under forces truncation.
+    const underCap = formatBudgetSummary({ ...opts, maxChars: exact.length - 1 });
+    expect(underCap).toContain("omitted");
+    expect(underCap.length).toBeLessThanOrEqual(exact.length - 1);
+  });
+
   it("leaves content untouched when comfortably under the cap", () => {
     const md = formatBudgetSummary({
       title: "Small report",

--- a/scripts/budget-summary-lib.test.mjs
+++ b/scripts/budget-summary-lib.test.mjs
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { formatBudgetSummary, DEFAULT_MAX_CHARS } from "./budget-summary-lib.mjs";
+
+describe("formatBudgetSummary — structure", () => {
+  const md = formatBudgetSummary({
+    title: "Compiler bailout budget",
+    status: "PASS",
+    headerLine: "196 files, 0 regressions",
+    sections: [
+      { heading: "Totals", body: ["- success: 1234", "- skip: 56"] },
+      { heading: "Improvements", body: ["- foo.ts: skip 2 → 1"] },
+    ],
+  });
+
+  it("opens with <details> and closes with </details>", () => {
+    expect(md.startsWith("<details>")).toBe(true);
+    expect(md.endsWith("</details>")).toBe(true);
+  });
+
+  it("puts a plain-text PASS one-liner in the <summary> tag", () => {
+    expect(md).toContain("<summary>PASS — 196 files, 0 regressions</summary>");
+  });
+
+  it("keeps a blank line after </summary> so the table/list renders", () => {
+    expect(md).toContain("</summary>\n\n## Compiler bailout budget");
+  });
+
+  it("keeps a blank line before </details>", () => {
+    expect(md).toMatch(/\n\n<\/details>$/);
+  });
+
+  it("renders section headings and body lines", () => {
+    expect(md).toContain("### Totals");
+    expect(md).toContain("- success: 1234");
+    expect(md).toContain("### Improvements");
+    expect(md).toContain("- foo.ts: skip 2 → 1");
+  });
+});
+
+describe("formatBudgetSummary — status", () => {
+  it("surfaces FAIL in the summary one-liner", () => {
+    const md = formatBudgetSummary({
+      title: "Main import budget",
+      status: "FAIL",
+      headerLine: "3 error(s)",
+      sections: [{ heading: "Errors", body: ["- electron/foo.ts: sync fs call"] }],
+    });
+    expect(md).toContain("<summary>FAIL — 3 error(s)</summary>");
+  });
+});
+
+describe("formatBudgetSummary — empty sections", () => {
+  it("drops sections with empty bodies", () => {
+    const md = formatBudgetSummary({
+      title: "Renderer import budget",
+      status: "PASS",
+      headerLine: "42 chunks",
+      sections: [
+        { heading: "Added", body: [] },
+        { heading: "Removed", body: [] },
+      ],
+    });
+    expect(md).not.toContain("### Added");
+    expect(md).not.toContain("### Removed");
+    // The title is always present even with no sections.
+    expect(md).toContain("## Renderer import budget");
+  });
+
+  it("tolerates a missing sections argument", () => {
+    const md = formatBudgetSummary({
+      title: "Empty",
+      status: "PASS",
+      headerLine: "ok",
+    });
+    expect(md).toContain("## Empty");
+    expect(md.endsWith("</details>")).toBe(true);
+  });
+});
+
+describe("formatBudgetSummary — size guard", () => {
+  it("truncates body rows when over the cap and stays within it", () => {
+    const body = Array.from({ length: 5000 }, (_, i) => `- chunk-${i}: ${i} bytes`);
+    const md = formatBudgetSummary({
+      title: "Big report",
+      status: "PASS",
+      headerLine: "lots of chunks",
+      sections: [{ heading: "Chunks", body }],
+      maxChars: 2000,
+    });
+    expect(md.length).toBeLessThanOrEqual(2000);
+  });
+
+  it("always closes the <details> block after truncation", () => {
+    const body = Array.from({ length: 5000 }, (_, i) => `- chunk-${i}: ${i} bytes`);
+    const md = formatBudgetSummary({
+      title: "Big report",
+      status: "FAIL",
+      headerLine: "lots of chunks",
+      sections: [{ heading: "Chunks", body }],
+      maxChars: 2000,
+    });
+    expect(md.endsWith("\n\n</details>")).toBe(true);
+  });
+
+  it("emits an omission notice when content is trimmed", () => {
+    const body = Array.from({ length: 5000 }, (_, i) => `- chunk-${i}: ${i} bytes`);
+    const md = formatBudgetSummary({
+      title: "Big report",
+      status: "PASS",
+      headerLine: "lots of chunks",
+      sections: [{ heading: "Chunks", body }],
+      maxChars: 2000,
+    });
+    expect(md).toMatch(/_\[\d+ line\(s\) omitted — summary exceeded 2000-character cap\]_/);
+  });
+
+  it("retains the title line even under aggressive truncation", () => {
+    const body = Array.from({ length: 5000 }, (_, i) => `- chunk-${i}: ${i} bytes`);
+    const md = formatBudgetSummary({
+      title: "Big report",
+      status: "PASS",
+      headerLine: "lots of chunks",
+      sections: [{ heading: "Chunks", body }],
+      maxChars: 2000,
+    });
+    expect(md).toContain("## Big report");
+  });
+
+  it("leaves content untouched when comfortably under the cap", () => {
+    const md = formatBudgetSummary({
+      title: "Small report",
+      status: "PASS",
+      headerLine: "ok",
+      sections: [{ heading: "Chunks", body: ["- a: 1", "- b: 2"] }],
+    });
+    expect(md).toContain("- a: 1");
+    expect(md).toContain("- b: 2");
+    expect(md).not.toContain("omitted");
+    expect(md.length).toBeLessThan(DEFAULT_MAX_CHARS);
+  });
+});

--- a/scripts/check-compiler-budget.mjs
+++ b/scripts/check-compiler-budget.mjs
@@ -169,7 +169,7 @@ function emitSummary(report, { regressions, improvements, successDrops, newClean
 
   const headerLine = ok
     ? `${fileCount} files (success=${totals.success}, skip=${totals.skip}, error=${totals.error}, pipeline=${totals.pipeline})`
-    : `${regressions.length} regression(s), ${disappeared.length} missing baseline entrie(s)`;
+    : `${regressions.length} regression(s), ${disappeared.length} missing baseline entries`;
 
   const sections = [
     {
@@ -366,7 +366,7 @@ function main() {
   }
   const total = regressions.length + disappeared.length;
   console.error(
-    `\n[check-compiler-budget] FAILED — ${total} issue(s): ${regressions.length} regression(s), ${disappeared.length} missing baseline entrie(s). ` +
+    `\n[check-compiler-budget] FAILED — ${total} issue(s): ${regressions.length} regression(s), ${disappeared.length} missing baseline entries. ` +
       `For investigation, run \`npm run compiler-budget:critical\` to list only critical (Error-severity) compiler diagnostics. ` +
       `If the change is intentional (e.g. files were genuinely deleted), run \`npm run compiler-budget:update\` to refresh the baseline.`
   );

--- a/scripts/check-compiler-budget.mjs
+++ b/scripts/check-compiler-budget.mjs
@@ -28,11 +28,13 @@
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
+import { formatBudgetSummary, writeSummary } from "./budget-summary-lib.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const ROOT = path.resolve(path.dirname(__filename), "..");
 const REPORT_FILE = path.join(ROOT, "dist", "compiler-bailout-report.json");
 const BASELINE_FILE = path.join(ROOT, "compiler-bailout-baseline.json");
+const SUMMARY_FILE = path.join(ROOT, "dist", "compiler-budget-summary.md");
 
 const COUNT_KEYS = ["success", "skip", "error", "pipeline"];
 // Only these counts gate CI per file. A file that loses successes is logged
@@ -154,6 +156,81 @@ function writeBaseline(report, { force }) {
   );
 }
 
+// Build and write the markdown summary for downstream PR-comment aggregation.
+// Called on both the pass and fail paths so the aggregated comment always
+// carries a compiler-budget block.
+function emitSummary(report, { regressions, improvements, successDrops, newClean, disappeared }) {
+  const totals = COUNT_KEYS.reduce((t, k) => {
+    t[k] = Object.values(report).reduce((s, e) => s + e[k], 0);
+    return t;
+  }, {});
+  const ok = regressions.length === 0 && disappeared.length === 0;
+  const fileCount = Object.keys(report).length;
+
+  const headerLine = ok
+    ? `${fileCount} files (success=${totals.success}, skip=${totals.skip}, error=${totals.error}, pipeline=${totals.pipeline})`
+    : `${regressions.length} regression(s), ${disappeared.length} missing baseline entrie(s)`;
+
+  const sections = [
+    {
+      heading: "Totals",
+      body: [
+        `- files:    ${fileCount}`,
+        `- success:  ${totals.success}`,
+        `- skip:     ${totals.skip}`,
+        `- error:    ${totals.error}`,
+        `- pipeline: ${totals.pipeline}`,
+      ],
+    },
+  ];
+
+  if (regressions.length > 0) {
+    sections.push({
+      heading: "Regressions",
+      body: regressions.map(({ file, deltas, isNew }) => {
+        const summary = deltas.map(({ key, from, to }) => `${key}: ${from} → ${to}`).join("; ");
+        const prefix = isNew ? "new file with bailouts" : "regression";
+        return `- \`${file}\` — ${prefix} (${summary})`;
+      }),
+    });
+  }
+  if (disappeared.length > 0) {
+    sections.push({
+      heading: "Missing baseline entries",
+      body: disappeared.map((file) => `- \`${file}\` — no longer present in build output`),
+    });
+  }
+  if (improvements.length > 0) {
+    sections.push({
+      heading: "Improvements",
+      body: improvements.map(({ file, base, entry, improvedKeys }) => {
+        const changes = improvedKeys.map((k) => `${k} ${base[k]} → ${entry[k]}`).join(", ");
+        return `- \`${file}\` — ${changes}`;
+      }),
+    });
+  }
+  if (successDrops.length > 0) {
+    sections.push({
+      heading: "Success drops",
+      body: successDrops.map(({ file, from, to }) => `- \`${file}\` — success ${from} → ${to}`),
+    });
+  }
+  if (newClean.length > 0) {
+    sections.push({
+      heading: "New clean files",
+      body: newClean.map((file) => `- \`${file}\``),
+    });
+  }
+
+  const markdown = formatBudgetSummary({
+    title: "Compiler bailout budget",
+    status: ok ? "PASS" : "FAIL",
+    headerLine,
+    sections,
+  });
+  writeSummary(SUMMARY_FILE, markdown);
+}
+
 function main() {
   const isUpdate = process.argv.includes("--update");
   const force = process.argv.includes("--force");
@@ -225,6 +302,8 @@ function main() {
   for (const { file, from, to } of successDrops) {
     console.log(`::notice file=${file}::compile success count dropped ${from} → ${to}`);
   }
+
+  emitSummary(report, { regressions, improvements, successDrops, newClean, disappeared });
 
   if (regressions.length === 0 && disappeared.length === 0) {
     const totals = COUNT_KEYS.reduce((t, k) => {

--- a/scripts/check-first-render-chunk-budget.mjs
+++ b/scripts/check-first-render-chunk-budget.mjs
@@ -17,10 +17,11 @@
 //   node scripts/check-first-render-chunk-budget.mjs --override        # don't fail exit code
 //   node scripts/check-first-render-chunk-budget.mjs --threshold 0.10  # 10% growth allowed
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
+import { formatBudgetSummary, writeSummary } from "./budget-summary-lib.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const ROOT = path.resolve(path.dirname(__filename), "..");
@@ -337,28 +338,34 @@ function compareToBaseline(report, threshold) {
   const currentTotalGzip = report.totals.gzip;
   const totalDelta = currentTotalGzip - baselineTotalGzip;
 
-  const lines = [];
-  lines.push("# First-render chunk gzip budget");
-  lines.push("");
-  lines.push("## Eager first-render closure (gated)");
-  lines.push("");
-  lines.push(`- baseline gzip: ${baselineGzip} bytes`);
-  lines.push(`- current gzip:  ${currentGzip} bytes`);
-  lines.push(
-    `- delta:         ${delta >= 0 ? "+" : ""}${delta} bytes (${(ratio * 100).toFixed(2)}%)`
-  );
-  lines.push(`- threshold:     +${(threshold * 100).toFixed(1)}%`);
-  lines.push(`- eager chunks:  ${report.chunkCount}`);
-  lines.push(`- result:        ${overBudget ? "OVER BUDGET" : "OK"}`);
-  lines.push("");
-  lines.push("## Total reachable bundle (report-only)");
-  lines.push("");
-  lines.push(`- baseline gzip: ${baselineTotalGzip} bytes`);
-  lines.push(`- current gzip:  ${currentTotalGzip} bytes`);
-  lines.push(`- delta:         ${totalDelta >= 0 ? "+" : ""}${totalDelta} bytes (not gated)`);
+  const markdown = formatBudgetSummary({
+    title: "First-render chunk gzip budget",
+    status: overBudget ? "FAIL" : "PASS",
+    headerLine: `eager gzip ${currentGzip} bytes (${delta >= 0 ? "+" : ""}${delta}, ${(ratio * 100).toFixed(2)}%, threshold +${(threshold * 100).toFixed(1)}%)`,
+    sections: [
+      {
+        heading: "Eager first-render closure (gated)",
+        body: [
+          `- baseline gzip: ${baselineGzip} bytes`,
+          `- current gzip:  ${currentGzip} bytes`,
+          `- delta:         ${delta >= 0 ? "+" : ""}${delta} bytes (${(ratio * 100).toFixed(2)}%)`,
+          `- threshold:     +${(threshold * 100).toFixed(1)}%`,
+          `- eager chunks:  ${report.chunkCount}`,
+          `- result:        ${overBudget ? "OVER BUDGET" : "OK"}`,
+        ],
+      },
+      {
+        heading: "Total reachable bundle (report-only)",
+        body: [
+          `- baseline gzip: ${baselineTotalGzip} bytes`,
+          `- current gzip:  ${currentTotalGzip} bytes`,
+          `- delta:         ${totalDelta >= 0 ? "+" : ""}${totalDelta} bytes (not gated)`,
+        ],
+      },
+    ],
+  });
 
-  mkdirSync(path.dirname(SUMMARY_FILE), { recursive: true });
-  writeFileSync(SUMMARY_FILE, lines.join("\n") + "\n");
+  writeSummary(SUMMARY_FILE, markdown);
 
   return { ok: !overBudget, delta, ratio, baselineGzip, currentGzip };
 }

--- a/scripts/check-import-budget.mjs
+++ b/scripts/check-import-budget.mjs
@@ -21,11 +21,13 @@ import {
   compareToBaseline,
   formatBaseline,
 } from "./import-budget-lib.mjs";
+import { formatBudgetSummary, writeSummary } from "./budget-summary-lib.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const ROOT = path.resolve(path.dirname(__filename), "..");
 const METAFILE = path.join(ROOT, "dist-electron", "eager-import-meta.json");
 const BASELINE_FILE = path.join(ROOT, "eager-import-baseline.json");
+const SUMMARY_FILE = path.join(ROOT, "dist", "import-budget-summary.md");
 const ENTRY = "electron/main.ts";
 
 // Refuse to overwrite the baseline in --update mode if the eager module count
@@ -137,6 +139,46 @@ function writeBaseline(report, { force }) {
   );
 }
 
+// Build and write the markdown summary for downstream PR-comment aggregation.
+// Emitted on both pass and fail paths so the aggregated comment always carries
+// a main-import-budget block.
+function emitSummary(report, { ok, errors, notices }) {
+  const headerLine = ok
+    ? `${report.count} eager import(s), ${report.violations.length} known sync call(s)`
+    : `${report.count} eager import(s), ${errors.length} error(s)`;
+
+  const sections = [
+    {
+      heading: "Totals",
+      body: [
+        `- eager imports:       ${report.count}`,
+        `- known sync calls:    ${report.violations.length}`,
+      ],
+    },
+  ];
+
+  if (errors.length > 0) {
+    sections.push({
+      heading: "Errors",
+      body: errors.map((e) => (e.file ? `- \`${e.file}\` — ${e.message}` : `- ${e.message}`)),
+    });
+  }
+  if (notices.length > 0) {
+    sections.push({
+      heading: "Notices",
+      body: notices.map((n) => `- ${n.message}`),
+    });
+  }
+
+  const markdown = formatBudgetSummary({
+    title: "Main-process import budget",
+    status: ok ? "PASS" : "FAIL",
+    headerLine,
+    sections,
+  });
+  writeSummary(SUMMARY_FILE, markdown);
+}
+
 function main() {
   const isUpdate = process.argv.includes("--update");
   const force = process.argv.includes("--force");
@@ -160,6 +202,8 @@ function main() {
   for (const n of notices) {
     console.log(`::notice::${n.message}`);
   }
+
+  emitSummary(report, { ok, errors, notices });
 
   if (ok) {
     console.log(

--- a/scripts/check-renderer-bundle-budget.mjs
+++ b/scripts/check-renderer-bundle-budget.mjs
@@ -13,10 +13,11 @@
 //   node scripts/check-renderer-bundle-budget.mjs --update --force            # bypass the shrinkage guard
 //   node scripts/check-renderer-bundle-budget.mjs --override                  # suppress failure exit code
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { compareReports, formatMarkdown, validateReport } from "./renderer-bundle-budget-lib.mjs";
+import { writeSummary } from "./budget-summary-lib.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const ROOT = path.resolve(path.dirname(__filename), "..");
@@ -139,9 +140,8 @@ function main() {
   const comparison = compareReports(report, baseline, args.threshold);
   const markdown = formatMarkdown(comparison, args.threshold);
 
-  // Write markdown summary for CI comment posting
-  mkdirSync(path.dirname(SUMMARY_FILE), { recursive: true });
-  writeFileSync(SUMMARY_FILE, markdown + "\n");
+  // Write markdown summary for downstream PR-comment aggregation.
+  writeSummary(SUMMARY_FILE, markdown);
 
   // Emit GitHub annotations
   for (const f of comparison.failures) {

--- a/scripts/check-renderer-import-budget.mjs
+++ b/scripts/check-renderer-import-budget.mjs
@@ -22,12 +22,14 @@ import { existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
+import { formatBudgetSummary, writeSummary } from "./budget-summary-lib.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const ROOT = path.resolve(path.dirname(__filename), "..");
 const DIST = path.join(ROOT, "dist");
 const MANIFEST_FILE = path.join(DIST, ".vite", "manifest.json");
 const BASELINE_FILE = path.join(ROOT, "renderer-import-baseline.json");
+const SUMMARY_FILE = path.join(DIST, "renderer-import-budget-summary.md");
 
 // Refuse to overwrite the baseline in --update mode if the eager chunk count
 // shrinks by more than this fraction. Mirrors check-import-budget.mjs.
@@ -271,6 +273,52 @@ function readBaseline() {
   }
 }
 
+// Build and write the markdown summary for downstream PR-comment aggregation.
+// Emitted on both pass and fail paths so the aggregated comment always carries
+// a renderer-import-budget block.
+function emitSummary(result) {
+  const hasGzip = typeof result.currentGzip === "number";
+  const gzipNote = hasGzip
+    ? `, eager gzip ${result.currentGzip} (baseline ${result.baselineGzip}, ${(result.byteRatio * 100).toFixed(2)}%)`
+    : "";
+
+  const headerLine = result.ok
+    ? `${result.currentCount} eager chunk(s) (baseline ${result.baselineCount})${gzipNote}`
+    : `chunks ${result.baselineCount} → ${result.currentCount}${gzipNote}`;
+
+  const totalsBody = [
+    `- eager chunks:    ${result.currentCount} (baseline ${result.baselineCount})`,
+  ];
+  if (hasGzip) {
+    totalsBody.push(
+      `- eager gzip:      ${result.currentGzip} bytes (baseline ${result.baselineGzip}, ${(result.byteRatio * 100).toFixed(2)}%)`
+    );
+  }
+
+  const sections = [{ heading: "Totals", body: totalsBody }];
+
+  if (result.added.length > 0) {
+    sections.push({
+      heading: "Added eager chunks",
+      body: result.added.map((k) => `- \`${k}\``),
+    });
+  }
+  if (result.removed.length > 0) {
+    sections.push({
+      heading: "Removed eager chunks",
+      body: result.removed.map((k) => `- \`${k}\``),
+    });
+  }
+
+  const markdown = formatBudgetSummary({
+    title: "Renderer import budget",
+    status: result.ok ? "PASS" : "FAIL",
+    headerLine,
+    sections,
+  });
+  writeSummary(SUMMARY_FILE, markdown);
+}
+
 function main() {
   const args = parseArgs(process.argv);
   const report = buildReport();
@@ -287,6 +335,8 @@ function main() {
     console.error(`::error::${result.error}`);
     process.exit(1);
   }
+
+  emitSummary(result);
 
   const byteSummary =
     typeof result.byteRatio === "number"

--- a/scripts/renderer-bundle-budget-lib.mjs
+++ b/scripts/renderer-bundle-budget-lib.mjs
@@ -2,6 +2,8 @@
 // so comparison and formatting logic can be exercised by unit tests without
 // needing a Vite build.
 
+import { formatBudgetSummary } from "./budget-summary-lib.mjs";
+
 /**
  * Compare current report against baseline with configurable threshold.
  * Gated metrics: entry chunk gzip, total JS gzip, total CSS gzip.
@@ -164,54 +166,61 @@ function statusLabel(pct, threshold) {
 }
 
 /**
- * Format comparison result as a markdown table for PR comments.
+ * Format comparison result as a collapsible markdown summary for PR comments.
+ * Wrapped via the shared budget-summary helper so all five budget gates emit a
+ * uniform <details> block with a PASS/FAIL one-liner and the comment-size guard.
  */
 export function formatMarkdown(comparison, threshold) {
-  const lines = [
-    "### Renderer Bundle Size Report",
-    "",
-    `**Threshold**: +${(threshold * 100).toFixed(0)}% | **Result**: ${comparison.ok ? "PASS" : "FAIL"}`,
-    "",
+  const s = comparison.summary;
+
+  const tableRows = [
     "| Chunk | Baseline (gzip) | Current (gzip) | Delta | Status |",
     "|-------|-----------------|----------------|-------|--------|",
   ];
-
   for (const d of comparison.chunkDeltas) {
     const label = d.isEntry ? `${d.name} (entry)` : d.name;
-    lines.push(
+    tableRows.push(
       `| ${label} | ${fmtBytes(d.baseline)} | ${fmtBytes(d.current)} | ${fmtDelta(d.delta, d.pct)} | ${statusLabel(d.pct, threshold)} |`
     );
   }
-
-  const s = comparison.summary;
-  lines.push("| | | | | |");
-  lines.push(
+  tableRows.push("| | | | | |");
+  tableRows.push(
     `| **Total JS** | **${fmtBytes(s.js.baseline)}** | **${fmtBytes(s.js.current)}** | **${fmtDelta(s.js.delta, s.js.pct)}** | **${statusLabel(s.js.pct, threshold)}** |`
   );
-  lines.push(
+  tableRows.push(
     `| **Total CSS** | **${fmtBytes(s.css.baseline)}** | **${fmtBytes(s.css.current)}** | **${fmtDelta(s.css.delta, s.css.pct)}** | **${statusLabel(s.css.pct, threshold)}** |`
   );
 
+  const sections = [
+    { body: [`**Threshold**: +${(threshold * 100).toFixed(0)}%`] },
+    { body: tableRows },
+  ];
+
   if (comparison.failures.length > 0) {
-    lines.push("", "**Regressions**:");
-    for (const f of comparison.failures) {
+    const rows = comparison.failures.map((f) => {
       const name = f.name ? ` \`${f.name}\`` : "";
-      lines.push(
-        `- ${f.metric}${name}: ${fmtDelta(f.delta, f.pct)} exceeds +${(threshold * 100).toFixed(0)}% threshold`
-      );
-    }
+      return `- ${f.metric}${name}: ${fmtDelta(f.delta, f.pct)} exceeds +${(threshold * 100).toFixed(0)}% threshold`;
+    });
+    sections.push({ heading: "Regressions", body: rows });
   }
 
   if (comparison.improvements.length > 0) {
-    lines.push("", "**Improvements**:");
-    for (const i of comparison.improvements) {
+    const rows = comparison.improvements.map((i) => {
       const name = i.name ? ` \`${i.name}\`` : "";
-      lines.push(`- ${i.metric}${name}: ${fmtDelta(i.delta, i.pct)}`);
-    }
-    lines.push("", "_Consider `npm run renderer-bundle-budget:update` to lock in improvements._");
+      return `- ${i.metric}${name}: ${fmtDelta(i.delta, i.pct)}`;
+    });
+    rows.push("", "_Consider `npm run renderer-bundle-budget:update` to lock in improvements._");
+    sections.push({ heading: "Improvements", body: rows });
   }
 
-  return lines.join("\n");
+  const headerLine = `JS gzip ${fmtBytes(s.js.current)} (${fmtDelta(s.js.delta, s.js.pct)}), CSS gzip ${fmtBytes(s.css.current)} (${fmtDelta(s.css.delta, s.css.pct)})`;
+
+  return formatBudgetSummary({
+    title: "Renderer Bundle Size Report",
+    status: comparison.ok ? "PASS" : "FAIL",
+    headerLine,
+    sections,
+  });
 }
 
 /**

--- a/scripts/renderer-bundle-budget-lib.test.ts
+++ b/scripts/renderer-bundle-budget-lib.test.ts
@@ -196,12 +196,15 @@ describe("compareReports", () => {
 });
 
 describe("formatMarkdown", () => {
-  it("produces a markdown table with headers", () => {
+  it("produces a collapsible markdown table with headers", () => {
     const baseline = makeReport();
     const current = makeReport();
     const comparison = compareReports(current, baseline, 0.05);
     const md = formatMarkdown(comparison, 0.05);
-    expect(md).toContain("### Renderer Bundle Size Report");
+    expect(md.startsWith("<details>")).toBe(true);
+    expect(md.endsWith("</details>")).toBe(true);
+    expect(md).toContain("<summary>PASS — ");
+    expect(md).toContain("## Renderer Bundle Size Report");
     expect(md).toContain("| Chunk |");
     expect(md).toContain("**Total JS**");
     expect(md).toContain("**Total CSS**");
@@ -219,8 +222,8 @@ describe("formatMarkdown", () => {
     });
     const comparison = compareReports(current, baseline, 0.05);
     const md = formatMarkdown(comparison, 0.05);
-    expect(md).toContain("FAIL");
-    expect(md).toContain("**Regressions**");
+    expect(md).toContain("<summary>FAIL — ");
+    expect(md).toContain("### Regressions");
   });
 
   it("includes improvements section when sizes shrink", () => {
@@ -235,7 +238,7 @@ describe("formatMarkdown", () => {
     });
     const comparison = compareReports(current, baseline, 0.05);
     const md = formatMarkdown(comparison, 0.05);
-    expect(md).toContain("**Improvements**");
+    expect(md).toContain("### Improvements");
     expect(md).toContain("renderer-bundle-budget:update");
   });
 });


### PR DESCRIPTION
## Summary

- Three of the five performance-budget scripts in `scripts/` only wrote to the console. Now all five emit a GFM `<details>` collapsible to a markdown file, so a downstream workflow can aggregate all five results into a single PR comment.
- Extracted a shared `scripts/budget-summary-lib.mjs` for formatting and file I/O, and updated the two scripts that already wrote markdown to use the same collapsible format.
- Fixed a pre-existing "entrie(s)" typo in `check-compiler-budget.mjs`.

Resolves #8899

## Changes

- **New:** `scripts/budget-summary-lib.mjs` — `formatBudgetSummary()` produces a uniform GFM `<details>` block (PASS/FAIL one-liner in `<summary>`, blank-line rules for table/list rendering, 65,536-char cap guard with omission notice) and `writeSummary()` handles the file write.
- `check-compiler-budget.mjs` now emits `dist/compiler-budget-summary.md`
- `check-import-budget.mjs` now emits `dist/import-budget-summary.md`
- `check-renderer-import-budget.mjs` now emits `dist/renderer-import-budget-summary.md`
- `renderer-bundle-budget-lib.mjs` and `check-first-render-chunk-budget.mjs` updated to use the shared collapsible format (output paths unchanged)
- **New:** `scripts/budget-summary-lib.test.mjs` — 15 tests covering structure, blank-line rules, PASS/FAIL, empty-section dropping, and size-guard invariants
- Updated `renderer-bundle-budget-lib.test.ts` assertions for the new format

Budget scripts are not yet wired into any CI workflow — this is emission prep only, no workflow changes.

## Testing

108 vitest tests pass across the 5 affected test files. ESLint clean, Prettier clean, `node --check` valid on all `.mjs` files.