### PR TITLE
fix(assistant): visible focus state for Daintree Assistant sidebar

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -108,6 +108,11 @@ export function HelpPanel({
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const [isResizing, setIsResizing] = useState(false);
   const isMacroFocused = useMacroFocusStore((s) => s.focusedRegion === "assistant");
+  // Ordinary DOM focus (click-to-focus, programmatic) inside the aside — the
+  // macro-focus signal only fires on keyboard region cycling, so without this
+  // the panel shows no "active surface" affordance when the user clicks in.
+  const [hasDomFocus, setHasDomFocus] = useState(false);
+  const isHighlighted = isMacroFocused || hasDomFocus;
   const isVisible = isVisibleProp ?? effectiveWidth > 0;
   const [showNewSessionConfirm, setShowNewSessionConfirm] = useState(false);
   const [showAgentSwitchConfirm, setShowAgentSwitchConfirm] = useState(false);
@@ -601,6 +606,13 @@ export function HelpPanel({
       // element per ARIA 1.2 and trips axe's `aria-hidden-focus` rule).
       inert={!isVisible || undefined}
       data-macro-focus={isMacroFocused ? "true" : undefined}
+      onFocus={() => setHasDomFocus(true)}
+      onBlur={(e) => {
+        // Keep the highlight while focus moves between controls inside the
+        // aside (xterm textarea ↔ header buttons). `contains(null)` is false,
+        // so window/page blur correctly clears it.
+        if (!e.currentTarget.contains(e.relatedTarget)) setHasDomFocus(false);
+      }}
       className={cn(
         "relative shrink-0 flex flex-col h-full overflow-hidden outline-hidden",
         "bg-daintree-bg border-l border-daintree-border",
@@ -635,6 +647,7 @@ export function HelpPanel({
         onNewSession={handleNewSession}
         onOpenDocs={handleOpenAssistantDocs}
         onClose={handleClose}
+        isFocused={isHighlighted}
       />
 
       {/* Content */}

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -114,6 +114,12 @@ export function HelpPanel({
   const [hasDomFocus, setHasDomFocus] = useState(false);
   const isHighlighted = isMacroFocused || hasDomFocus;
   const isVisible = isVisibleProp ?? effectiveWidth > 0;
+  // Clear the focus highlight when the panel collapses — a width collapse can
+  // tear down the focused descendant (e.g. xterm) without firing a blur,
+  // which would otherwise leave the lift stuck on across a reopen.
+  useEffect(() => {
+    if (!isVisible) setHasDomFocus(false);
+  }, [isVisible]);
   const [showNewSessionConfirm, setShowNewSessionConfirm] = useState(false);
   const [showAgentSwitchConfirm, setShowAgentSwitchConfirm] = useState(false);
   // Tracks the last preferredAgentId the switch effect acted on so a single

--- a/src/components/HelpPanel/HelpPanelHeader.tsx
+++ b/src/components/HelpPanel/HelpPanelHeader.tsx
@@ -1,6 +1,7 @@
 import { ChevronRight, CircleHelp, Plus } from "lucide-react";
 import { SpinnerCircle, HollowCircle, InteractingCircle } from "@/components/icons";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
+import { cn } from "@/lib/utils";
 import type { AgentState } from "@/types";
 
 // Tier-1 ambient indicator (per CLAUDE.md Runtime Signals): surfaces the
@@ -60,6 +61,7 @@ interface HelpPanelHeaderProps {
   onNewSession: () => void;
   onOpenDocs: () => void;
   onClose: () => void;
+  isFocused?: boolean;
 }
 
 export function HelpPanelHeader({
@@ -68,9 +70,15 @@ export function HelpPanelHeader({
   onNewSession,
   onOpenDocs,
   onClose,
+  isFocused = false,
 }: HelpPanelHeaderProps) {
   return (
-    <div className="flex items-center gap-1 px-3 py-2 border-b border-daintree-border shrink-0">
+    <div
+      className={cn(
+        "flex items-center gap-1 px-3 py-2 border-b border-daintree-border shrink-0 transition-colors",
+        isFocused && "bg-overlay-subtle"
+      )}
+    >
       <div className="flex items-center min-w-0 flex-1">
         <DaintreeIcon className="w-4 h-4 text-daintree-text/50 shrink-0" />
         <span className="ml-1.5 text-xs font-medium text-daintree-text/70 truncate">

--- a/src/components/HelpPanel/__tests__/HelpPanelHeader.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelHeader.test.tsx
@@ -22,26 +22,26 @@ function renderHeader(isFocused?: boolean) {
 describe("HelpPanelHeader", () => {
   it("does not lift the header background when unfocused", () => {
     const { container } = renderHeader(false);
-    const root = container.firstChild as HTMLElement;
+    const root = container.firstElementChild!;
 
-    expect(root.className).not.toContain("bg-overlay-subtle");
-    expect(root.className).toContain("transition-colors");
+    expect(root.classList.contains("bg-overlay-subtle")).toBe(false);
+    expect(root.classList.contains("transition-colors")).toBe(true);
   });
 
   it("does not lift the header background when isFocused is omitted", () => {
     const { container } = renderHeader(undefined);
-    const root = container.firstChild as HTMLElement;
+    const root = container.firstElementChild!;
 
-    expect(root.className).not.toContain("bg-overlay-subtle");
+    expect(root.classList.contains("bg-overlay-subtle")).toBe(false);
   });
 
   it("lifts the header background with a neutral overlay when focused", () => {
     const { container } = renderHeader(true);
-    const root = container.firstChild as HTMLElement;
+    const root = container.firstElementChild!;
 
-    expect(root.className).toContain("bg-overlay-subtle");
-    expect(root.className).toContain("transition-colors");
+    expect(root.classList.contains("bg-overlay-subtle")).toBe(true);
+    expect(root.classList.contains("transition-colors")).toBe(true);
     // Neutral lift only — the accent ring is reserved for the macro-focus signal.
-    expect(root.className).not.toContain("accent");
+    expect([...root.classList].some((c) => c.includes("accent"))).toBe(false);
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanelHeader.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelHeader.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
+
+import { HelpPanelHeader } from "../HelpPanelHeader";
+
+function renderHeader(isFocused?: boolean) {
+  return render(
+    <HelpPanelHeader
+      agentState={null}
+      canStartNewSession={false}
+      onNewSession={vi.fn()}
+      onOpenDocs={vi.fn()}
+      onClose={vi.fn()}
+      isFocused={isFocused}
+    />
+  );
+}
+
+describe("HelpPanelHeader", () => {
+  it("does not lift the header background when unfocused", () => {
+    const { container } = renderHeader(false);
+    const root = container.firstChild as HTMLElement;
+
+    expect(root.className).not.toContain("bg-overlay-subtle");
+    expect(root.className).toContain("transition-colors");
+  });
+
+  it("does not lift the header background when isFocused is omitted", () => {
+    const { container } = renderHeader(undefined);
+    const root = container.firstChild as HTMLElement;
+
+    expect(root.className).not.toContain("bg-overlay-subtle");
+  });
+
+  it("lifts the header background with a neutral overlay when focused", () => {
+    const { container } = renderHeader(true);
+    const root = container.firstChild as HTMLElement;
+
+    expect(root.className).toContain("bg-overlay-subtle");
+    expect(root.className).toContain("transition-colors");
+    // Neutral lift only — the accent ring is reserved for the macro-focus signal.
+    expect(root.className).not.toContain("accent");
+  });
+});


### PR DESCRIPTION
## Summary

- The Daintree Assistant sidebar showed no visible focus state on an ordinary click — only the macro-focus accent ring fired during keyboard cycling, leaving normal click-to-focus invisible.
- Fix tracks ordinary DOM focus on the `<aside>` via React `onFocus`/`onBlur` with a `currentTarget.contains(relatedTarget)` containment guard so focus moves between internal controls don't flicker. Combines it with the existing macro-focus signal into `isHighlighted`, passed to `HelpPanelHeader` which applies a neutral `bg-overlay-subtle` title-bar lift (`transition-colors`, 150ms). Accent color stays reserved for the macro-focus ring only.
- Also resets the highlight on panel collapse (`isVisible false`) to avoid a stale lift surviving a width-collapse that tears down the focused descendant without firing `blur`.

Resolves #8903

## Changes

- `HelpPanel.tsx` — `onFocus`/`onBlur` handlers on the `<aside>`, `isFocused` state, combined with `macroFocus` into `isHighlighted`, passed to header.
- `HelpPanelHeader.tsx` — accepts `isHighlighted` prop, applies `bg-overlay-subtle` lift when true.
- `HelpPanel/__tests__/HelpPanelHeader.test.tsx` — 3 new tests: neutral lift present when focused, `transition-colors` always present, no accent class on focus.

Grid panels are not affected — `ContentPanel`'s `terminal-selected` class is gated on `panelStore.focusedId`, which the assistant `<aside>` never sets.

## Testing

- New `HelpPanelHeader.test.tsx` (3 tests — all green).
- `npm run check` passes clean: typecheck, lint (0 violations), format, IPC checks.