### PR TITLE
feat(compiler-budget): make bailout ratchet severity-aware

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -4,6 +4,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -13,32 +14,8 @@
     "skip": 0,
     "error": 6,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 6,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -47,16 +24,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -65,6 +34,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -74,6 +44,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -83,6 +54,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -92,6 +64,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -101,6 +74,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -110,34 +84,18 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/App.tsx": {
-    "success": 0,
+    "success": 1,
     "skip": 0,
-    "error": 2,
+    "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle Import expressions"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle Import expressions"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -146,15 +104,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/ActionPalette/ActionPalette.tsx": {
-    "success": 1,
+    "success": 2,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -164,6 +124,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -173,6 +134,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -182,6 +144,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -191,6 +154,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -200,12 +164,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -214,6 +174,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -223,6 +184,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -232,6 +194,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -241,15 +204,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "errorBailouts": [],
-    "skipReasons": [],
-    "pipelineErrors": []
-  },
-  "src/components/Commands/CommandPickerButton.tsx": {
-    "success": 1,
-    "skip": 0,
-    "error": 0,
-    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -259,6 +214,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -268,12 +224,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -282,12 +234,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -296,20 +244,53 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
+    "hintCount": 1,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/DevPreview/BlockedNavBanner.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [
       {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+        "category": "Refs",
+        "severity": "Error",
+        "reason": "Cannot access refs during render"
       }
     ],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/DevPreview/ConsoleDrawer.tsx": {
-    "success": 1,
+    "success": 2,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/DevPreview/ConsolePanel.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0,
+    "hintCount": 1,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/DevPreview/DevPreviewLoadingState.tsx": {
+    "success": 4,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -319,27 +300,66 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/DevPreview/ObjectInspector.tsx": {
+    "success": 2,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0,
+    "hintCount": 1,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/DevPreview/StackTrace.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/DevPreview/useDevPreviewConsoleCapture.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/DevPreview/useDevPreviewLoadLifecycle.ts": {
     "success": 0,
     "skip": 0,
-    "error": 1,
+    "error": 4,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [
       {
         "category": "Refs",
+        "severity": "Error",
+        "reason": "Cannot access refs during render"
+      },
+      {
+        "category": "Refs",
+        "severity": "Error",
+        "reason": "Cannot access refs during render"
+      },
+      {
+        "category": "Refs",
+        "severity": "Error",
+        "reason": "Cannot access refs during render"
+      },
+      {
+        "category": "Refs",
+        "severity": "Error",
         "reason": "Cannot access refs during render"
       }
     ],
@@ -351,6 +371,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -360,12 +381,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -374,6 +391,7 @@
     "skip": 1,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": ["Skipped due to '[object Object]' directive."],
     "pipelineErrors": []
@@ -383,6 +401,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -392,6 +411,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -401,6 +421,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -410,12 +431,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -424,6 +441,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -433,6 +451,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -442,6 +461,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -451,6 +471,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -460,6 +481,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -469,6 +491,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -478,6 +501,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -487,6 +511,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -496,6 +521,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -505,6 +531,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -514,6 +541,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -523,6 +551,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -532,6 +561,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -541,6 +571,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -550,6 +581,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -559,6 +591,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -568,12 +601,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -582,6 +611,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -591,6 +621,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -600,6 +631,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -609,6 +641,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -618,6 +651,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -627,6 +661,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Fleet/FleetFailureBanner.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -636,6 +681,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -645,6 +691,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -654,6 +701,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -663,6 +711,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -672,6 +721,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -681,6 +731,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -690,6 +741,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -699,6 +751,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -708,6 +761,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -717,6 +771,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -726,6 +781,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -735,6 +791,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/HelpPanel/HelpLaunchingState.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -744,6 +811,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -753,6 +821,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -762,6 +831,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -771,6 +841,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -780,6 +851,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -789,28 +861,8 @@
     "skip": 0,
     "error": 5,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 5,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -819,6 +871,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -828,6 +881,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -837,6 +891,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -846,6 +901,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -855,6 +911,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -864,6 +921,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -873,6 +931,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -882,6 +941,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -891,6 +951,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -900,12 +961,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -914,6 +971,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -923,6 +981,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -932,15 +991,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "errorBailouts": [],
-    "skipReasons": [],
-    "pipelineErrors": []
-  },
-  "src/components/Layout/FreshnessUtils.tsx": {
-    "success": 1,
-    "skip": 0,
-    "error": 0,
-    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -950,6 +1001,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -959,12 +1011,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Expected Identifier, got TSAsExpression key in ObjectExpression"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -973,6 +1021,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -982,15 +1031,27 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Layout/PRDetectionPausedIndicator.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/Layout/RateLimitDetails.tsx": {
-    "success": 2,
+    "success": 3,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1000,6 +1061,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1009,6 +1071,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1018,6 +1081,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1027,12 +1091,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1041,6 +1101,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Layout/ToolbarCommandPaletteButton.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1050,6 +1121,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1059,6 +1131,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1068,6 +1141,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1077,6 +1151,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1086,6 +1161,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1095,6 +1171,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1104,6 +1181,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1113,6 +1191,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1122,6 +1201,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1131,6 +1211,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1140,6 +1221,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1149,6 +1231,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1158,6 +1241,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1167,6 +1251,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1176,6 +1261,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1185,6 +1271,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1194,6 +1281,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1203,6 +1291,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1212,6 +1301,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1221,6 +1311,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1230,6 +1321,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1239,6 +1331,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1248,6 +1341,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1257,6 +1351,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1266,6 +1361,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1275,6 +1371,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1284,6 +1381,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1293,6 +1391,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1302,6 +1401,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1311,6 +1411,27 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Plugin/PluginConfirmDialog.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Portal/PortalCloseConfirmDialog.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1320,12 +1441,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1334,6 +1451,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1343,12 +1461,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1357,6 +1471,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1366,12 +1481,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1380,6 +1491,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1389,12 +1501,18 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Project/CodeForgeTab.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1403,12 +1521,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1417,12 +1531,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1431,20 +1541,7 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
-    "skipReasons": [],
-    "pipelineErrors": []
-  },
-  "src/components/Project/ForgeProviderTab.tsx": {
-    "success": 1,
-    "skip": 0,
-    "error": 0,
-    "pipeline": 0,
+    "hintCount": 1,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1454,16 +1551,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1472,12 +1561,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1486,6 +1571,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1495,20 +1581,7 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
-    "skipReasons": [],
-    "pipelineErrors": []
-  },
-  "src/components/Project/ProjectSwitcher.tsx": {
-    "success": 1,
-    "skip": 0,
-    "error": 0,
-    "pipeline": 0,
+    "hintCount": 1,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1518,6 +1591,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1527,12 +1601,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1541,6 +1611,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1550,6 +1621,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1559,12 +1631,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1573,6 +1641,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1582,6 +1651,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1591,6 +1661,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1600,6 +1671,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1609,6 +1681,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1618,6 +1691,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1627,6 +1701,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1636,12 +1711,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1650,6 +1721,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1659,6 +1731,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Recovery/RecoveryBannerCoordinator.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1668,6 +1751,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1675,8 +1759,29 @@
   "src/components/Recovery/SafeModeBanner.tsx": {
     "success": 1,
     "skip": 0,
+    "error": 1,
+    "pipeline": 0,
+    "hintCount": 1,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Recovery/WatchdogDisabledBanner.tsx": {
+    "success": 1,
+    "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Recovery/useRecoveryPriority.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1686,6 +1791,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1695,12 +1801,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1709,6 +1811,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1718,6 +1821,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1727,6 +1831,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1736,6 +1841,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1745,6 +1851,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1754,6 +1861,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1763,6 +1871,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1772,12 +1881,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1786,6 +1891,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1795,12 +1901,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1809,12 +1911,18 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Settings/CodeForgeSettingsTab.tsx": {
+    "success": 3,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0,
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1823,6 +1931,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1832,6 +1941,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1841,30 +1951,18 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/Settings/DaintreeAssistantSettingsTab.tsx": {
     "success": 1,
     "skip": 0,
-    "error": 2,
+    "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1873,6 +1971,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1882,6 +1981,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1891,20 +1991,8 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1913,6 +2001,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -1922,12 +2011,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1936,12 +2021,18 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Settings/ForgeProviderSelectorDropdown.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1950,86 +2041,18 @@
     "skip": 0,
     "error": 10,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 10,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/Settings/GitHubSettingsTab.tsx": {
-    "success": 0,
+    "success": 1,
     "skip": 0,
     "error": 7,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 7,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2038,12 +2061,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2052,6 +2071,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2061,6 +2081,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2070,16 +2091,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2088,12 +2101,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2102,6 +2111,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2111,6 +2121,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2118,18 +2129,10 @@
   "src/components/Settings/McpServerSettingsTab.tsx": {
     "success": 0,
     "skip": 0,
-    "error": 2,
+    "error": 5,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 5,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2138,6 +2141,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2147,6 +2151,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2156,6 +2161,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2165,6 +2171,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2174,6 +2181,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2183,12 +2191,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2197,6 +2201,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2206,6 +2211,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2215,20 +2221,17 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Unexpected terminal kind `ternary` for logical test block"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/Settings/SettingsDialog.tsx": {
-    "success": 11,
+    "success": 12,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2238,6 +2241,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2247,12 +2251,18 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Unexpected terminal kind `ternary` for logical test block"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Settings/SettingsLoadErrorBanner.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2261,6 +2271,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2270,6 +2281,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2279,12 +2291,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Unexpected terminal kind `ternary` for logical test block"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2293,6 +2301,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2302,6 +2311,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2311,6 +2321,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2320,12 +2331,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Unexpected terminal kind `ternary` for logical test block"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2334,6 +2341,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2343,16 +2351,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2361,32 +2361,8 @@
     "skip": 0,
     "error": 6,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 6,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2395,6 +2371,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2404,32 +2381,18 @@
     "skip": 0,
     "error": 6,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 6,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Settings/TurnOutcomeDiagnostics.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 2,
+    "pipeline": 0,
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2438,16 +2401,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2456,16 +2411,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2474,6 +2421,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2483,12 +2431,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2497,16 +2441,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2515,6 +2451,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2524,6 +2461,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2533,6 +2471,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2542,6 +2481,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2551,6 +2491,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2560,12 +2501,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2574,25 +2511,18 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/Sidebar/SidebarContent.tsx": {
-    "success": 0,
+    "success": 4,
     "skip": 0,
-    "error": 2,
+    "error": 0,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      }
-    ],
+    "hintCount": 0,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2601,6 +2531,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2610,6 +2541,27 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Sidebar/WorktreeCardPlaceholder.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Sidebar/WorktreeLoadErrorBanner.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0,
+    "hintCount": 1,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2619,6 +2571,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2628,15 +2581,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
-  "src/components/Sidebar/useWorktreeGridRovingFocus.ts": {
+  "src/components/Sidebar/useWorktreeSidebarKeyboard.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2646,6 +2601,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2655,6 +2611,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2664,6 +2621,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2673,6 +2631,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2682,6 +2641,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2691,6 +2651,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2700,6 +2661,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2709,6 +2671,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2718,6 +2681,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2727,6 +2691,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2736,15 +2701,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "errorBailouts": [],
-    "skipReasons": [],
-    "pipelineErrors": []
-  },
-  "src/components/Terminal/GridFullOverlay.tsx": {
-    "success": 1,
-    "skip": 0,
-    "error": 0,
-    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2754,6 +2711,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2763,6 +2721,27 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Terminal/GridScrollRootContext.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Terminal/GridScrollbar.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2772,6 +2751,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2781,6 +2761,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2790,6 +2771,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2799,6 +2781,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2808,6 +2791,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2817,6 +2801,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2826,6 +2811,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2835,6 +2821,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2844,6 +2831,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2853,6 +2841,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2862,6 +2851,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2871,12 +2861,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2885,16 +2871,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -2903,6 +2881,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Terminal/ScrollbackRestoreErrorBanner.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2912,6 +2901,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2921,6 +2911,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2930,6 +2921,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2939,6 +2931,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2948,6 +2941,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2957,6 +2951,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2966,6 +2961,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2975,6 +2971,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -2984,16 +2981,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3002,15 +2991,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/Terminal/TerminalPane.tsx": {
-    "success": 2,
+    "success": 3,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3020,6 +3011,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3029,6 +3021,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3038,6 +3031,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3047,12 +3041,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3061,6 +3051,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3070,6 +3061,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3079,12 +3071,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3093,6 +3081,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3102,6 +3091,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3111,6 +3101,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3120,6 +3111,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3129,6 +3121,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3138,6 +3131,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3147,6 +3141,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3156,6 +3151,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3165,6 +3161,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3174,6 +3171,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3183,12 +3181,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3197,6 +3191,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3206,9 +3201,11 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [
       {
         "category": "Refs",
+        "severity": "Error",
         "reason": "Cannot access refs during render"
       }
     ],
@@ -3220,6 +3217,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3229,6 +3227,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3238,6 +3237,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3247,6 +3247,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3256,6 +3257,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3265,12 +3267,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3279,6 +3277,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3288,30 +3287,18 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/Terminal/useContentGridContext.tsx": {
     "success": 0,
     "skip": 0,
-    "error": 2,
+    "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3320,12 +3307,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3334,6 +3317,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3343,16 +3327,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3361,12 +3337,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3375,6 +3347,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3384,6 +3357,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3393,6 +3367,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3402,6 +3377,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3411,6 +3387,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3420,16 +3397,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3438,12 +3407,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3452,21 +3417,18 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/Worktree/FileDiffModal.tsx": {
-    "success": 0,
+    "success": 1,
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3475,12 +3437,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3489,6 +3447,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3498,16 +3457,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3516,6 +3467,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3525,6 +3477,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3534,12 +3487,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3548,20 +3497,8 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3570,24 +3507,8 @@
     "skip": 0,
     "error": 4,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 4,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3596,6 +3517,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3605,12 +3527,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3619,6 +3537,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3628,44 +3547,8 @@
     "skip": 0,
     "error": 9,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 9,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3674,6 +3557,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3683,6 +3567,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Worktree/WorktreeCard/CollapsedAlarmPill.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3692,6 +3587,37 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Worktree/WorktreeCard/CommitAuthorAvatar.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Worktree/WorktreeCard/CommitChip.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Worktree/WorktreeCard/CommitInfoTooltip.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3701,6 +3627,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3710,6 +3637,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3719,6 +3647,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3728,9 +3657,11 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [
       {
         "category": "Refs",
+        "severity": "Error",
         "reason": "Cannot access refs during render"
       }
     ],
@@ -3742,6 +3673,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3751,6 +3683,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3760,6 +3693,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3769,6 +3703,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3778,6 +3713,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3787,6 +3723,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3794,8 +3731,9 @@
   "src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx": {
     "success": 1,
     "skip": 0,
-    "error": 0,
+    "error": 1,
     "pipeline": 0,
+    "hintCount": 1,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3805,15 +3743,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/WorktreeHeader.tsx": {
-    "success": 1,
+    "success": 2,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3823,6 +3763,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3832,16 +3773,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3850,6 +3783,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3859,6 +3793,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3868,6 +3803,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3877,12 +3813,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3891,6 +3823,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3900,25 +3833,18 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeDeleteDialog.tsx": {
-    "success": 0,
+    "success": 1,
     "skip": 0,
-    "error": 2,
+    "error": 0,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 0,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3927,6 +3853,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3936,6 +3863,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3945,6 +3873,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3954,6 +3883,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3963,6 +3893,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3972,6 +3903,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3981,6 +3913,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3990,6 +3923,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -3999,6 +3933,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4008,6 +3943,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4017,6 +3953,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4026,6 +3963,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4035,6 +3973,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4044,6 +3983,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4053,6 +3993,27 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Worktree/useWorktreeBulkRemove.ts": {
+    "success": 0,
+    "skip": 0,
+    "error": 2,
+    "pipeline": 0,
+    "hintCount": 2,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Worktree/useWorktreeOverviewKeyboard.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4062,12 +4023,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4076,6 +4033,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4085,6 +4043,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4094,6 +4053,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4103,6 +4063,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4112,6 +4073,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4121,12 +4083,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Unexpected terminal kind `ternary` for logical test block"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4135,6 +4093,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4144,6 +4103,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4153,6 +4113,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4162,6 +4123,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4171,6 +4133,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4180,6 +4143,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4189,6 +4153,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4198,6 +4163,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4207,6 +4173,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4216,6 +4183,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/icons/brands/AntigravityIcon.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4225,6 +4203,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4234,6 +4213,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4243,6 +4223,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4252,6 +4233,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4261,6 +4243,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4270,6 +4253,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4279,6 +4263,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4288,6 +4273,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4297,6 +4283,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4306,6 +4293,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4315,6 +4303,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4324,6 +4313,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4333,6 +4323,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4342,6 +4333,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4351,6 +4343,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4360,6 +4353,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4369,6 +4363,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4378,6 +4373,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4387,6 +4383,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4396,6 +4393,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4405,6 +4403,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4414,6 +4413,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4423,6 +4423,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4432,6 +4433,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4441,6 +4443,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4450,6 +4453,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4459,6 +4463,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4468,6 +4473,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4477,6 +4483,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4486,6 +4493,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4495,6 +4503,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4504,6 +4513,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4513,6 +4523,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4522,6 +4533,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4531,12 +4543,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4545,6 +4553,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4554,6 +4563,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4563,6 +4573,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4572,6 +4583,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4581,6 +4593,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4590,6 +4603,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4599,6 +4613,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4608,6 +4623,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4617,6 +4633,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4626,6 +4643,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4635,6 +4653,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4644,6 +4663,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4653,6 +4673,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4662,6 +4683,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4671,6 +4693,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4680,6 +4703,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4689,6 +4713,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4698,6 +4723,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4707,6 +4733,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4716,6 +4743,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4725,24 +4753,27 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/ui/context-menu.tsx": {
-    "success": 15,
+    "success": 16,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/components/ui/dropdown-menu.tsx": {
-    "success": 15,
+    "success": 16,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4752,6 +4783,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4761,6 +4793,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/ui/menu-source.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4770,6 +4813,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4779,6 +4823,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4788,6 +4833,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4797,12 +4843,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4811,6 +4853,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4820,16 +4863,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4838,6 +4873,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4847,6 +4883,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4856,6 +4893,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4865,12 +4903,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4879,6 +4913,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4888,12 +4923,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4902,15 +4933,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/hooks/app/useCrashRecoveryGate.ts": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 0,
+    "error": 1,
     "pipeline": 0,
+    "hintCount": 1,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4920,12 +4953,18 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/hooks/app/useFocusOnActivateIntent.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -4934,6 +4973,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4943,6 +4983,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4952,6 +4993,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4961,6 +5003,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4970,6 +5013,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4979,6 +5023,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4988,6 +5033,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -4997,6 +5043,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5006,6 +5053,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5015,6 +5063,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5024,15 +5073,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/hooks/useActionRegistry.ts": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 0,
+    "error": 1,
     "pipeline": 0,
+    "hintCount": 1,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5042,6 +5093,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5051,12 +5103,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5065,6 +5113,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5074,6 +5123,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5083,40 +5133,8 @@
     "skip": 0,
     "error": 8,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 8,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5125,6 +5143,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5134,6 +5153,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5143,6 +5163,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5152,20 +5173,7 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
-    "skipReasons": [],
-    "pipelineErrors": []
-  },
-  "src/hooks/useConnectivity.ts": {
-    "success": 2,
-    "skip": 0,
-    "error": 0,
-    "pipeline": 0,
+    "hintCount": 1,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5175,20 +5183,8 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5197,6 +5193,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5206,15 +5203,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/hooks/useDeferredLoading.ts": {
-    "success": 1,
+    "success": 3,
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5224,12 +5223,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5238,6 +5233,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5247,6 +5243,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5256,6 +5253,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5265,12 +5263,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5279,6 +5273,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5288,6 +5283,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/hooks/useFileDecorations.ts": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0,
+    "hintCount": 1,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5297,6 +5303,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5306,6 +5313,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5313,26 +5321,10 @@
   "src/hooks/useFleetPicker.ts": {
     "success": 0,
     "skip": 0,
-    "error": 4,
+    "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5341,6 +5333,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/hooks/useForgeAuthorAvatar.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5350,6 +5353,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5359,6 +5363,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5368,6 +5373,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5377,16 +5383,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5395,6 +5393,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5404,6 +5403,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5413,22 +5413,19 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/hooks/useGridNavigation.ts": {
     "success": 0,
-    "skip": 0,
-    "error": 1,
+    "skip": 1,
+    "error": 0,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Refs",
-        "reason": "Cannot access refs during render"
-      }
-    ],
-    "skipReasons": [],
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": ["Skipped due to '[object Object]' directive."],
     "pipelineErrors": []
   },
   "src/hooks/useHasBeenVisible.ts": {
@@ -5436,6 +5433,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5445,6 +5443,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5454,6 +5453,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5463,6 +5463,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5472,6 +5473,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5481,6 +5483,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/hooks/useIsHibernated.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5490,6 +5503,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5499,6 +5513,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5508,6 +5523,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5517,6 +5533,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5526,12 +5543,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5540,6 +5553,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5549,15 +5563,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/hooks/useMenuActions.ts": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 0,
+    "error": 1,
     "pipeline": 0,
+    "hintCount": 1,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5567,6 +5583,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5576,12 +5593,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5590,21 +5603,18 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
   "src/hooks/usePanelHandlers.ts": {
-    "success": 0,
+    "success": 1,
     "skip": 0,
-    "error": 1,
+    "error": 0,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 0,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5613,6 +5623,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5622,12 +5633,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5636,6 +5643,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5645,6 +5653,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5654,6 +5663,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5663,16 +5673,8 @@
     "skip": 0,
     "error": 2,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "Unsupported declaration type for hoisting"
-      }
-    ],
+    "hintCount": 2,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5681,6 +5683,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5690,12 +5693,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5704,6 +5703,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5713,6 +5713,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5722,12 +5723,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5736,12 +5733,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5750,20 +5743,8 @@
     "skip": 0,
     "error": 3,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      },
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 3,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5772,6 +5753,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5781,12 +5763,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5795,6 +5773,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5804,6 +5783,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5813,12 +5793,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5827,6 +5803,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5836,6 +5813,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5845,6 +5823,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5854,6 +5833,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5863,6 +5843,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5872,6 +5853,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5881,15 +5863,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
-    "errorBailouts": [],
-    "skipReasons": [],
-    "pipelineErrors": []
-  },
-  "src/hooks/useSlowCall.ts": {
-    "success": 1,
-    "skip": 0,
-    "error": 0,
-    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5899,6 +5873,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5908,6 +5883,17 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/hooks/useTabLoad.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5917,6 +5903,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5926,6 +5913,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5935,6 +5923,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5944,12 +5933,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -5958,6 +5943,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5967,6 +5953,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5976,6 +5963,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5985,6 +5973,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -5994,6 +5983,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6003,6 +5993,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6012,6 +6003,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6021,6 +6013,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6030,6 +6023,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6039,6 +6033,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6048,12 +6043,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6062,6 +6053,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6071,6 +6063,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6080,6 +6073,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6089,12 +6083,8 @@
     "skip": 0,
     "error": 1,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
-      }
-    ],
+    "hintCount": 1,
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -6103,6 +6093,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6112,6 +6103,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6121,6 +6113,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6130,6 +6123,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6139,6 +6133,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6148,6 +6143,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6157,6 +6153,27 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/store/githubRateLimitStore.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/store/githubTokenHealthStore.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6166,6 +6183,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
@@ -6175,6 +6193,7 @@
     "skip": 0,
     "error": 0,
     "pipeline": 0,
+    "hintCount": 0,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []

--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -3699,12 +3699,18 @@
     "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/PRBadge.tsx": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 0,
+    "error": 1,
     "pipeline": 0,
     "hintCount": 0,
-    "errorBailouts": [],
+    "errorBailouts": [
+      {
+        "category": "Refs",
+        "severity": "Error",
+        "reason": "Cannot access refs during render"
+      }
+    ],
     "skipReasons": [],
     "pipelineErrors": []
   },

--- a/docs/development.md
+++ b/docs/development.md
@@ -163,9 +163,16 @@ npm run compiler-budget:critical  # Triage: re-runs compiler with severity:"Erro
 npm run compiler-budget:update    # Accept: refreshes baseline after intentional regressions
 ```
 
-The **budget gate** (`compiler-budget:check`) records every `CompileError` event in `compiler-bailout-baseline.json` — cosmetic `Todo` diagnostics and load-bearing `Error` diagnostics alike — so no bailout can sneak past code review. The **critical-errors script** (`compiler-budget:critical`) re-runs the React Compiler directly on `src/` and filters to `severity: "Error"`, isolating the small subset of diagnostics that actually affect optimization. Run it when the budget gate fires to determine whether the new bailout is cosmetic noise or needs attention.
+The **budget gate** (`compiler-budget:check`) is severity-aware. Severity is derived dynamically from the plugin's exported `LintRules` registry (1 `Hint` category `Todo`, 2 `Warning`, 23 `Error` as of `babel-plugin-react-compiler` 1.0.0), so a plugin upgrade that recategorizes a rule reflows the gate automatically. Per `CompileError` event, the gate buckets by severity:
+
+- **`Hint` (cosmetic `Todo` noise — try/catch lowering, dynamic-import arrows):** collapsed to a single per-file `hintCount`, not stored verbatim. This keeps `compiler-bailout-baseline.json` compact — a shifting Todo count is a one-line diff instead of dozens of repeated reason strings. Gated only by a **global Hint budget**: per-file churn moves freely (a refactor shifting noise between files nets to zero), but the whole-repo total may not grow.
+- **`Error` + `Warning` (load-bearing rule-of-React violations):** tracked verbatim in `errorBailouts` (with `category`, `severity`, `reason`) and protected by a **strict zero-regression gate** — any per-file increase, any new file with a strict bailout, or any growth in the whole-repo strict total fails CI.
+
+The raw `error` count is kept per file for diagnostics but no longer gates directly. The **critical-errors script** (`compiler-budget:critical`) re-runs the React Compiler directly on `src/` and filters to `severity: "Error"`, isolating the small subset of diagnostics that actually affect optimization. Run it when the budget gate fires to determine whether the new bailout is cosmetic noise or needs attention.
 
 Both tools use `panicThreshold: "none"` — the signal lives in the report and the triage script, never in build crashes.
+
+Refresh the baseline with `npm run compiler-budget:update` when a regression is intentional. The 10% shrinkage guard counts file keys (not entry shape), so the one-time severity-aware reformat doesn't trip it; `--force` is only needed if the file count genuinely drops by more than 10%.
 
 ## Code Patterns
 

--- a/scripts/check-compiler-budget.mjs
+++ b/scripts/check-compiler-budget.mjs
@@ -308,16 +308,18 @@ function emitSummary(
   if (improvements.length > 0) {
     sections.push({
       heading: "Improvements",
-      body: improvements.map(({ file, base, entry, improvedKeys, baseStrictCount, strictCount }) => {
-        const changes = improvedKeys
-          .map((k) =>
-            k === "strictErrors"
-              ? `strictErrors ${baseStrictCount} → ${strictCount}`
-              : `${k} ${base[k]} → ${entry[k]}`
-          )
-          .join(", ");
-        return `- \`${file}\` — ${changes}`;
-      }),
+      body: improvements.map(
+        ({ file, base, entry, improvedKeys, baseStrictCount, strictCount }) => {
+          const changes = improvedKeys
+            .map((k) =>
+              k === "strictErrors"
+                ? `strictErrors ${baseStrictCount} → ${strictCount}`
+                : `${k} ${base[k]} → ${entry[k]}`
+            )
+            .join(", ");
+          return `- \`${file}\` — ${changes}`;
+        }
+      ),
     });
   }
   if (successDrops.length > 0) {

--- a/scripts/check-compiler-budget.mjs
+++ b/scripts/check-compiler-budget.mjs
@@ -28,6 +28,7 @@
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
+import { LintRules } from "babel-plugin-react-compiler";
 import { formatBudgetSummary, writeSummary } from "./budget-summary-lib.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -37,12 +38,43 @@ const BASELINE_FILE = path.join(ROOT, "compiler-bailout-baseline.json");
 const SUMMARY_FILE = path.join(ROOT, "dist", "compiler-budget-summary.md");
 
 const COUNT_KEYS = ["success", "skip", "error", "pipeline"];
-// Only these counts gate CI per file. A file that loses successes is logged
-// but doesn't fail by itself (could be a deleted function or a removed
-// component). However, a file *disappearing entirely* from the report after
-// being in the baseline IS a hard failure — that's how silent coverage loss
-// (path-normalization bug, upstream taxonomy change) sneaks past CI.
-const REGRESSION_KEYS = ["skip", "error", "pipeline"];
+// Per-file count keys that gate CI directly. `error` is deliberately NOT here:
+// it's the raw CompileError event count (cosmetic Hints + real Errors lumped
+// together), kept for diagnostics only. Hints gate via the global hintCount
+// budget; Error+Warning bailouts gate via the per-file/global strict check
+// below. A file that loses successes is logged but doesn't fail by itself.
+// A file *disappearing entirely* from the report after being in the baseline
+// IS a hard failure — that's how silent coverage loss (path-normalization bug,
+// upstream taxonomy change) sneaks past CI.
+const REGRESSION_KEYS = ["skip", "pipeline"];
+
+// Severity bucketing derived from the live plugin's LintRules registry — the
+// same source vite.config.ts uses, so the reporter and gate never drift. As of
+// babel-plugin-react-compiler 1.0.0: 1 Hint (Todo), 2 Warning, 23 Error.
+const SEVERITY_BY_CATEGORY = Object.fromEntries(LintRules.map((r) => [r.category, r.severity]));
+const HINT_CATEGORIES = new Set(
+  LintRules.filter((r) => r.severity === "Hint").map((r) => r.category)
+);
+
+// Hint-severity count for an entry. New (severity-aware) reports/baselines
+// carry an explicit `hintCount`; legacy ones don't, so default to 0.
+function getHintCount(entry) {
+  return typeof entry?.hintCount === "number" && Number.isFinite(entry.hintCount)
+    ? entry.hintCount
+    : 0;
+}
+
+// Strict (Error+Warning) bailouts for an entry. The filter is belt-and-braces:
+// a correctly-built report never puts Hint categories in errorBailouts, but a
+// legacy baseline (pre-severity-split) lumped Todo entries in here, so we strip
+// them at read time to keep the strict gate honest against old baselines.
+function getStrictBailouts(entry) {
+  return Array.isArray(entry?.errorBailouts)
+    ? entry.errorBailouts.filter(
+        (b) => b && typeof b === "object" && !HINT_CATEGORIES.has(b.category)
+      )
+    : [];
+}
 
 // Refuse to overwrite the baseline in --update mode if the report shrinks by
 // more than this fraction. Catches the case where a developer reflexively
@@ -91,6 +123,19 @@ function validateShape(data, label, file) {
         process.exit(1);
       }
     }
+    // hintCount is optional for backward-compat with pre-severity baselines,
+    // but when present it must be a valid non-negative finite number.
+    if (
+      "hintCount" in entry &&
+      (typeof entry.hintCount !== "number" ||
+        entry.hintCount < 0 ||
+        !Number.isFinite(entry.hintCount))
+    ) {
+      console.error(
+        `::error file=${path.relative(ROOT, file)}::${label} entry for "${filename}" has invalid hintCount: ${JSON.stringify(entry.hintCount)}`
+      );
+      process.exit(1);
+    }
   }
 }
 
@@ -108,6 +153,7 @@ function writeBaseline(report, { force }) {
         skip: e.skip,
         error: e.error,
         pipeline: e.pipeline,
+        hintCount: getHintCount(e),
         errorBailouts: Array.isArray(e.errorBailouts) ? e.errorBailouts : [],
         skipReasons: Array.isArray(e.skipReasons) ? e.skipReasons : [],
         pipelineErrors: Array.isArray(e.pipelineErrors) ? e.pipelineErrors : [],
@@ -151,35 +197,56 @@ function writeBaseline(report, { force }) {
     t[k] = Object.values(sorted).reduce((s, e) => s + e[k], 0);
     return t;
   }, {});
+  const hintTotal = Object.values(sorted).reduce((s, e) => s + getHintCount(e), 0);
+  const strictTotal = Object.values(sorted).reduce((s, e) => s + getStrictBailouts(e).length, 0);
   console.log(
-    `[check-compiler-budget] baseline updated: ${Object.keys(sorted).length} files (success=${totals.success}, skip=${totals.skip}, error=${totals.error}, pipeline=${totals.pipeline})`
+    `[check-compiler-budget] baseline updated: ${Object.keys(sorted).length} files (success=${totals.success}, skip=${totals.skip}, hints=${hintTotal}, strictErrors=${strictTotal}, pipeline=${totals.pipeline})`
   );
 }
 
 // Build and write the markdown summary for downstream PR-comment aggregation.
 // Called on both the pass and fail paths so the aggregated comment always
 // carries a compiler-budget block.
-function emitSummary(report, { regressions, improvements, successDrops, newClean, disappeared }) {
+function emitSummary(
+  report,
+  {
+    regressions,
+    improvements,
+    successDrops,
+    newClean,
+    disappeared,
+    hintBudgetExceeded,
+    reportHintTotal,
+    baselineHintTotal,
+    reportStrictTotal,
+  }
+) {
   const totals = COUNT_KEYS.reduce((t, k) => {
     t[k] = Object.values(report).reduce((s, e) => s + e[k], 0);
     return t;
   }, {});
-  const ok = regressions.length === 0 && disappeared.length === 0;
+  const ok = regressions.length === 0 && disappeared.length === 0 && !hintBudgetExceeded;
   const fileCount = Object.keys(report).length;
 
+  const failParts = [];
+  if (regressions.length > 0) failParts.push(`${regressions.length} regression(s)`);
+  if (disappeared.length > 0) failParts.push(`${disappeared.length} missing baseline entries`);
+  if (hintBudgetExceeded) failParts.push("Hint budget exceeded");
+
   const headerLine = ok
-    ? `${fileCount} files (success=${totals.success}, skip=${totals.skip}, error=${totals.error}, pipeline=${totals.pipeline})`
-    : `${regressions.length} regression(s), ${disappeared.length} missing baseline entries`;
+    ? `${fileCount} files (success=${totals.success}, skip=${totals.skip}, hints=${reportHintTotal}, strictErrors=${reportStrictTotal}, pipeline=${totals.pipeline})`
+    : failParts.join(", ");
 
   const sections = [
     {
       heading: "Totals",
       body: [
-        `- files:    ${fileCount}`,
-        `- success:  ${totals.success}`,
-        `- skip:     ${totals.skip}`,
-        `- error:    ${totals.error}`,
-        `- pipeline: ${totals.pipeline}`,
+        `- files:        ${fileCount}`,
+        `- success:      ${totals.success}`,
+        `- skip:         ${totals.skip}`,
+        `- hints:        ${reportHintTotal} (baseline ${baselineHintTotal})`,
+        `- strictErrors: ${reportStrictTotal}`,
+        `- pipeline:     ${totals.pipeline}`,
       ],
     },
   ];
@@ -200,11 +267,26 @@ function emitSummary(report, { regressions, improvements, successDrops, newClean
       body: disappeared.map((file) => `- \`${file}\` — no longer present in build output`),
     });
   }
+  if (hintBudgetExceeded) {
+    sections.push({
+      heading: "Hint budget",
+      body: [
+        `- global Hint total grew: ${baselineHintTotal} → ${reportHintTotal}`,
+        `- Hint-severity bailouts are cosmetic, but new un-optimizable code likely landed.`,
+      ],
+    });
+  }
   if (improvements.length > 0) {
     sections.push({
       heading: "Improvements",
-      body: improvements.map(({ file, base, entry, improvedKeys }) => {
-        const changes = improvedKeys.map((k) => `${k} ${base[k]} → ${entry[k]}`).join(", ");
+      body: improvements.map(({ file, base, entry, improvedKeys, baseStrictCount, strictCount }) => {
+        const changes = improvedKeys
+          .map((k) =>
+            k === "strictErrors"
+              ? `strictErrors ${baseStrictCount} → ${strictCount}`
+              : `${k} ${base[k]} → ${entry[k]}`
+          )
+          .join(", ");
         return `- \`${file}\` — ${changes}`;
       }),
     });
@@ -253,36 +335,56 @@ function main() {
 
   for (const [file, entry] of Object.entries(report)) {
     const base = baseline[file];
+    const strictCount = getStrictBailouts(entry).length;
     if (!base) {
-      // New file in the report. Allowed only if it has zero bailouts.
-      const bailouts = REGRESSION_KEYS.reduce((s, k) => s + entry[k], 0);
-      if (bailouts > 0) {
-        regressions.push({
-          file,
-          deltas: REGRESSION_KEYS.filter((k) => entry[k] > 0).map((k) => ({
-            key: k,
-            from: 0,
-            to: entry[k],
-          })),
-          isNew: true,
-        });
+      // New file in the report. Allowed only if it has zero gating bailouts —
+      // that means zero skip/pipeline AND zero strict (Error+Warning) bailouts.
+      // New-file Hints are absorbed by the global Hint budget below, not gated
+      // per-file (a brand-new component with cosmetic Todo noise shouldn't fail
+      // CI unless it pushes the whole-repo Hint total over its ceiling).
+      const deltas = REGRESSION_KEYS.filter((k) => entry[k] > 0).map((k) => ({
+        key: k,
+        from: 0,
+        to: entry[k],
+      }));
+      if (strictCount > 0) {
+        deltas.push({ key: "strictErrors", from: 0, to: strictCount });
+      }
+      if (deltas.length > 0) {
+        regressions.push({ file, deltas, isNew: true });
       } else {
         newClean.push(file);
       }
       continue;
     }
+    const baseStrictCount = getStrictBailouts(base).length;
     const deltas = REGRESSION_KEYS.filter((k) => entry[k] > base[k]).map((k) => ({
       key: k,
       from: base[k],
       to: entry[k],
     }));
+    if (strictCount > baseStrictCount) {
+      deltas.push({ key: "strictErrors", from: baseStrictCount, to: strictCount });
+    }
     if (deltas.length > 0) regressions.push({ file, deltas, isNew: false });
     const improvedKeys = REGRESSION_KEYS.filter((k) => entry[k] < base[k]);
-    if (improvedKeys.length > 0) improvements.push({ file, base, entry, improvedKeys });
+    if (strictCount < baseStrictCount) improvedKeys.push("strictErrors");
+    if (improvedKeys.length > 0) {
+      improvements.push({ file, base, entry, improvedKeys, baseStrictCount, strictCount });
+    }
     if (entry.success < base.success) {
       successDrops.push({ file, from: base.success, to: entry.success });
     }
   }
+
+  // Global Hint budget: the implicit sum of per-file hintCount across the
+  // baseline is the ceiling. Per-file Hint churn is allowed to move freely (a
+  // refactor that shifts Todo noise between files nets to zero), but the
+  // whole-repo total may not grow — that's the signal that genuinely new
+  // un-optimizable code landed. Refresh with `npm run compiler-budget:update`.
+  const reportHintTotal = Object.values(report).reduce((s, e) => s + getHintCount(e), 0);
+  const baselineHintTotal = Object.values(baseline).reduce((s, e) => s + getHintCount(e), 0);
+  const hintBudgetExceeded = reportHintTotal > baselineHintTotal;
 
   // Files that vanished from the report ARE failures: the most likely cause
   // is a path-normalization regression or an upstream React Compiler taxonomy
@@ -295,28 +397,51 @@ function main() {
   for (const file of newClean) {
     console.log(`::notice file=${file}::compiled cleanly (new file in report)`);
   }
-  for (const { file, base, entry, improvedKeys } of improvements) {
-    const changes = improvedKeys.map((k) => `${k} ${base[k]} → ${entry[k]}`).join(", ");
+  for (const { file, base, entry, improvedKeys, baseStrictCount, strictCount } of improvements) {
+    const changes = improvedKeys
+      .map((k) =>
+        k === "strictErrors"
+          ? `strictErrors ${baseStrictCount} → ${strictCount}`
+          : `${k} ${base[k]} → ${entry[k]}`
+      )
+      .join(", ");
     console.log(`::notice file=${file}::compiler bailouts decreased (${changes})`);
   }
   for (const { file, from, to } of successDrops) {
     console.log(`::notice file=${file}::compile success count dropped ${from} → ${to}`);
   }
 
-  emitSummary(report, { regressions, improvements, successDrops, newClean, disappeared });
+  const reportStrictTotal = Object.values(report).reduce(
+    (s, e) => s + getStrictBailouts(e).length,
+    0
+  );
 
-  if (regressions.length === 0 && disappeared.length === 0) {
+  emitSummary(report, {
+    regressions,
+    improvements,
+    successDrops,
+    newClean,
+    disappeared,
+    hintBudgetExceeded,
+    reportHintTotal,
+    baselineHintTotal,
+    reportStrictTotal,
+  });
+
+  if (regressions.length === 0 && disappeared.length === 0 && !hintBudgetExceeded) {
     const totals = COUNT_KEYS.reduce((t, k) => {
       t[k] = Object.values(report).reduce((s, e) => s + e[k], 0);
       return t;
     }, {});
+    // A drop in the global Hint total is an improvement worth capturing too.
     const improvedCount = improvements.length;
+    const hintImproved = reportHintTotal < baselineHintTotal;
     const refreshHint =
-      improvedCount > 0 || newClean.length > 0
+      improvedCount > 0 || newClean.length > 0 || hintImproved
         ? "  (consider `npm run compiler-budget:update` to capture improvements)"
         : "";
     console.log(
-      `[check-compiler-budget] OK — ${Object.keys(report).length} files, success=${totals.success}, skip=${totals.skip}, error=${totals.error}, pipeline=${totals.pipeline}${refreshHint}`
+      `[check-compiler-budget] OK — ${Object.keys(report).length} files, success=${totals.success}, skip=${totals.skip}, hints=${reportHintTotal}, strictErrors=${reportStrictTotal}, pipeline=${totals.pipeline}${refreshHint}`
     );
     return;
   }
@@ -364,11 +489,22 @@ function main() {
       `::error file=${file}::baseline entry no longer present in build output (deleted file? path-normalization regression? upstream React Compiler change?)`
     );
   }
-  const total = regressions.length + disappeared.length;
+  if (hintBudgetExceeded) {
+    console.error(
+      `::error::global Hint compiler bailout budget exceeded (was ${baselineHintTotal}, now ${reportHintTotal}). ` +
+        `Hint-severity bailouts are cosmetic, but the whole-repo total grew — new un-optimizable code likely landed.`
+    );
+  }
+  const total = regressions.length + disappeared.length + (hintBudgetExceeded ? 1 : 0);
+  const parts = [
+    `${regressions.length} regression(s)`,
+    `${disappeared.length} missing baseline entrie(s)`,
+  ];
+  if (hintBudgetExceeded) parts.push("Hint budget exceeded");
   console.error(
-    `\n[check-compiler-budget] FAILED — ${total} issue(s): ${regressions.length} regression(s), ${disappeared.length} missing baseline entries. ` +
+    `\n[check-compiler-budget] FAILED — ${total} issue(s): ${parts.join(", ")}. ` +
       `For investigation, run \`npm run compiler-budget:critical\` to list only critical (Error-severity) compiler diagnostics. ` +
-      `If the change is intentional (e.g. files were genuinely deleted), run \`npm run compiler-budget:update\` to refresh the baseline.`
+      `If the change is intentional (e.g. files were genuinely deleted, or new cosmetic Hint noise is unavoidable), run \`npm run compiler-budget:update\` to refresh the baseline.`
   );
   process.exit(1);
 }

--- a/scripts/check-compiler-budget.mjs
+++ b/scripts/check-compiler-budget.mjs
@@ -4,17 +4,20 @@
 // ──────────────────────────────────────
 // Tier 1 — Budget gate (this script): diffs dist/compiler-bailout-report.json
 //   against compiler-bailout-baseline.json and fails on any per-file regression.
-//   The baseline records ALL CompileError events (cosmetic + critical) so
-//   nothing slips past code review. Most entries are cosmetic "Todo" noise
-//   (e.g. `Todo: (BuildHIR::lowerExpression) Handle Import expressions` on
-//   anonymous arrows inside `React.lazy(() => import(...))`).
+//   Severity-aware (#8892): Hint-severity "Todo" noise collapses to a per-file
+//   hintCount gated by a global budget; Error+Warning bailouts are tracked
+//   verbatim in errorBailouts and gated strictly (any per-file/global increase
+//   or new strict category fails). The Hint noise is the bulk of events (e.g.
+//   `Todo: (BuildHIR::lowerExpression) Handle Import expressions` on anonymous
+//   arrows inside `React.lazy(() => import(...))`).
 //
 // Tier 2 — Critical-errors triage: `npm run compiler-budget:critical` runs
 //   scripts/find-critical-compiler-errors.mjs, which re-runs the React Compiler
 //   across src/ with a severity: "Error" filter. It surfaces only the
-//   load-bearing bailouts (the 2 out of ~196 that actually matter). Use it
-//   when the budget gate fires to triage whether the new bailout is cosmetic
-//   or needs attention.
+//   load-bearing Error-severity bailouts. NOTE: it does NOT surface
+//   Warning-severity bailouts (IncompatibleLibrary, UnsupportedSyntax), which
+//   also trip the strict gate — for those, read the errorBailouts detail
+//   printed by this script on failure.
 //
 // Update the baseline when the regression is intentional (genuine new code
 // that can't be optimized, or the React Compiler adds new categories):
@@ -74,6 +77,32 @@ function getStrictBailouts(entry) {
         (b) => b && typeof b === "object" && !HINT_CATEGORIES.has(b.category)
       )
     : [];
+}
+
+// Per-category counts of strict (Error+Warning) bailouts. The gate diffs these
+// rather than the raw length so a count-neutral category swap (e.g. a file's
+// lone Refs violation becoming a Hooks violation) still fails — that's a new
+// strict violation, not a wash, and "verbatim tracking" means the taxonomy is
+// load-bearing, not just the total.
+function strictCategoryCounts(entry) {
+  const counts = new Map();
+  for (const b of getStrictBailouts(entry)) {
+    counts.set(b.category, (counts.get(b.category) ?? 0) + 1);
+  }
+  return counts;
+}
+
+// Returns the strict categories whose per-file count increased (or newly
+// appeared) in `entry` relative to `base`. Empty array = no strict regression.
+function regressedStrictCategories(entry, base) {
+  const current = strictCategoryCounts(entry);
+  const prior = strictCategoryCounts(base);
+  const regressed = [];
+  for (const [category, count] of current) {
+    if (count > (prior.get(category) ?? 0))
+      regressed.push({ category, from: prior.get(category) ?? 0, to: count });
+  }
+  return regressed;
 }
 
 // Refuse to overwrite the baseline in --update mode if the report shrinks by
@@ -347,8 +376,8 @@ function main() {
         from: 0,
         to: entry[k],
       }));
-      if (strictCount > 0) {
-        deltas.push({ key: "strictErrors", from: 0, to: strictCount });
+      for (const { category, from, to } of regressedStrictCategories(entry, undefined)) {
+        deltas.push({ key: `strictErrors[${category}]`, from, to });
       }
       if (deltas.length > 0) {
         regressions.push({ file, deltas, isNew: true });
@@ -363,8 +392,10 @@ function main() {
       from: base[k],
       to: entry[k],
     }));
-    if (strictCount > baseStrictCount) {
-      deltas.push({ key: "strictErrors", from: baseStrictCount, to: strictCount });
+    // Category-aware: catches both a count increase and a count-neutral swap
+    // to a different strict category.
+    for (const { category, from, to } of regressedStrictCategories(entry, base)) {
+      deltas.push({ key: `strictErrors[${category}]`, from, to });
     }
     if (deltas.length > 0) regressions.push({ file, deltas, isNew: false });
     const improvedKeys = REGRESSION_KEYS.filter((k) => entry[k] < base[k]);
@@ -503,7 +534,7 @@ function main() {
   if (hintBudgetExceeded) parts.push("Hint budget exceeded");
   console.error(
     `\n[check-compiler-budget] FAILED — ${total} issue(s): ${parts.join(", ")}. ` +
-      `For investigation, run \`npm run compiler-budget:critical\` to list only critical (Error-severity) compiler diagnostics. ` +
+      `For Error-severity diagnostics, run \`npm run compiler-budget:critical\`; Warning-severity bailouts (which also trip the strict gate) appear only in the errorBailouts detail printed above. ` +
       `If the change is intentional (e.g. files were genuinely deleted, or new cosmetic Hint noise is unavoidable), run \`npm run compiler-budget:update\` to refresh the baseline.`
   );
   process.exit(1);

--- a/scripts/check-compiler-budget.test.mjs
+++ b/scripts/check-compiler-budget.test.mjs
@@ -33,18 +33,35 @@ function getStrictBailouts(entry) {
     : [];
 }
 
+function strictCategoryCounts(entry) {
+  const counts = new Map();
+  for (const b of getStrictBailouts(entry)) {
+    counts.set(b.category, (counts.get(b.category) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function regressedStrictCategories(entry, base) {
+  const current = strictCategoryCounts(entry);
+  const prior = strictCategoryCounts(base);
+  const regressed = [];
+  for (const [category, count] of current) {
+    if (count > (prior.get(category) ?? 0)) regressed.push(category);
+  }
+  return regressed;
+}
+
 // Mirror the per-file regression decision: returns the delta keys that would
-// fail CI for a single file given its baseline (or null baseline = new file).
+// fail CI for a single file given its baseline (or null/undefined baseline =
+// new file). Strict-error keys are category-aware (`strictErrors[Category]`).
 function fileRegressionKeys(entry, base) {
   const REGRESSION_KEYS = ["skip", "pipeline"];
-  const strictCount = getStrictBailouts(entry).length;
-  if (!base) {
-    const keys = REGRESSION_KEYS.filter((k) => entry[k] > 0);
-    if (strictCount > 0) keys.push("strictErrors");
-    return keys;
+  const keys = base
+    ? REGRESSION_KEYS.filter((k) => entry[k] > base[k])
+    : REGRESSION_KEYS.filter((k) => entry[k] > 0);
+  for (const category of regressedStrictCategories(entry, base)) {
+    keys.push(`strictErrors[${category}]`);
   }
-  const keys = REGRESSION_KEYS.filter((k) => entry[k] > base[k]);
-  if (strictCount > getStrictBailouts(base).length) keys.push("strictErrors");
   return keys;
 }
 
@@ -441,7 +458,7 @@ describe("strict Error per-file gate (#8892)", () => {
       hintCount: 0,
       errorBailouts: [{ category: "Hooks", severity: "Error", reason: "x" }],
     };
-    expect(fileRegressionKeys(entry, null)).toContain("strictErrors");
+    expect(fileRegressionKeys(entry, null)).toEqual(["strictErrors[Hooks]"]);
   });
 
   it("passes a new file with only Hint noise (Hints gate globally, not per-file)", () => {
@@ -457,10 +474,39 @@ describe("strict Error per-file gate (#8892)", () => {
       hintCount: 0,
       errorBailouts: [{ category: "Refs", severity: "Error", reason: "x" }],
     };
-    expect(fileRegressionKeys(entry, base)).toEqual(["strictErrors"]);
+    expect(fileRegressionKeys(entry, base)).toEqual(["strictErrors[Refs]"]);
   });
 
-  it("passes when a file's strict count is unchanged but Hint count grows", () => {
+  it("fails a count-neutral category swap (Refs → Hooks, count stays 1)", () => {
+    // The taxonomy is load-bearing: a different strict violation is a new
+    // violation even if the total count is unchanged.
+    const base = {
+      skip: 0,
+      pipeline: 0,
+      hintCount: 0,
+      errorBailouts: [{ category: "Refs", severity: "Error", reason: "x" }],
+    };
+    const entry = {
+      skip: 0,
+      pipeline: 0,
+      hintCount: 0,
+      errorBailouts: [{ category: "Hooks", severity: "Error", reason: "y" }],
+    };
+    expect(fileRegressionKeys(entry, base)).toEqual(["strictErrors[Hooks]"]);
+  });
+
+  it("fails a Warning-severity bailout against a clean baseline (Warning folds into the strict gate)", () => {
+    const base = { skip: 0, pipeline: 0, hintCount: 0, errorBailouts: [] };
+    const entry = {
+      skip: 0,
+      pipeline: 0,
+      hintCount: 0,
+      errorBailouts: [{ category: "IncompatibleLibrary", severity: "Warning", reason: "x" }],
+    };
+    expect(fileRegressionKeys(entry, base)).toEqual(["strictErrors[IncompatibleLibrary]"]);
+  });
+
+  it("passes when a file's strict categories are unchanged but Hint count grows", () => {
     const base = {
       skip: 0,
       pipeline: 0,
@@ -482,6 +528,30 @@ describe("strict Error per-file gate (#8892)", () => {
     const base = { skip: 0, pipeline: 0, error: 0, hintCount: 0, errorBailouts: [] };
     const entry = { skip: 0, pipeline: 0, error: 6, hintCount: 6, errorBailouts: [] };
     expect(fileRegressionKeys(entry, base)).toEqual([]);
+  });
+
+  it("KNOWN GAP: a malformed CompileError with no detail is invisible if it never reaches errorBailouts", () => {
+    // The vite reporter lands malformed details under category "(unknown)" so
+    // they DO gate. But a hypothetical report that recorded only the raw error
+    // count (error: 1, empty errorBailouts) would slip through — documents that
+    // the gate trusts errorBailouts, not the raw error count.
+    const base = { skip: 0, pipeline: 0, error: 0, hintCount: 0, errorBailouts: [] };
+    const entry = { skip: 0, pipeline: 0, error: 1, hintCount: 0, errorBailouts: [] };
+    expect(fileRegressionKeys(entry, base)).toEqual([]);
+  });
+
+  it("gates a malformed CompileError once the reporter lands it under (unknown)", () => {
+    const base = { skip: 0, pipeline: 0, error: 0, hintCount: 0, errorBailouts: [] };
+    const entry = {
+      skip: 0,
+      pipeline: 0,
+      error: 1,
+      hintCount: 0,
+      errorBailouts: [
+        { category: "(unknown)", severity: "Error", reason: "malformed CompileError event" },
+      ],
+    };
+    expect(fileRegressionKeys(entry, base)).toEqual(["strictErrors[(unknown)]"]);
   });
 });
 

--- a/scripts/check-compiler-budget.test.mjs
+++ b/scripts/check-compiler-budget.test.mjs
@@ -1,8 +1,59 @@
 import { describe, it, expect } from "vitest";
+import { LintRules } from "babel-plugin-react-compiler";
 
 // Tests the pure logic introduced in #7454 — capturing compiler bailout
-// reasons and categories. Mirrors the lint-ratchet.test.mjs pattern: extract
-// the logic under test inline, no shell-out, no script import.
+// reasons and categories — plus the severity-aware ratchet from #8892. Mirrors
+// the lint-ratchet.test.mjs pattern: extract the logic under test inline, no
+// shell-out, no script import.
+
+// ── Severity-aware mirrors (#8892) ───────────────────────────────────────────
+// Mirror the SEVERITY_BY_CATEGORY / severityForCategory / getHintCount /
+// getStrictBailouts helpers from check-compiler-budget.mjs (and the matching
+// severityForCategory in vite.config.ts).
+const SEVERITY_BY_CATEGORY = Object.fromEntries(LintRules.map((r) => [r.category, r.severity]));
+const HINT_CATEGORIES = new Set(
+  LintRules.filter((r) => r.severity === "Hint").map((r) => r.category)
+);
+
+function severityForCategory(category) {
+  return SEVERITY_BY_CATEGORY[category] ?? "Error";
+}
+
+function getHintCount(entry) {
+  return typeof entry?.hintCount === "number" && Number.isFinite(entry.hintCount)
+    ? entry.hintCount
+    : 0;
+}
+
+function getStrictBailouts(entry) {
+  return Array.isArray(entry?.errorBailouts)
+    ? entry.errorBailouts.filter(
+        (b) => b && typeof b === "object" && !HINT_CATEGORIES.has(b.category)
+      )
+    : [];
+}
+
+// Mirror the per-file regression decision: returns the delta keys that would
+// fail CI for a single file given its baseline (or null baseline = new file).
+function fileRegressionKeys(entry, base) {
+  const REGRESSION_KEYS = ["skip", "pipeline"];
+  const strictCount = getStrictBailouts(entry).length;
+  if (!base) {
+    const keys = REGRESSION_KEYS.filter((k) => entry[k] > 0);
+    if (strictCount > 0) keys.push("strictErrors");
+    return keys;
+  }
+  const keys = REGRESSION_KEYS.filter((k) => entry[k] > base[k]);
+  if (strictCount > getStrictBailouts(base).length) keys.push("strictErrors");
+  return keys;
+}
+
+// Mirror the global Hint budget gate: report total may not exceed baseline.
+function hintBudgetExceeded(report, baseline) {
+  const reportTotal = Object.values(report).reduce((s, e) => s + getHintCount(e), 0);
+  const baselineTotal = Object.values(baseline).reduce((s, e) => s + getHintCount(e), 0);
+  return reportTotal > baselineTotal;
+}
 
 /**
  * Mirrors `summarizePipelineError` in vite.config.ts. Trims to first line,
@@ -25,6 +76,7 @@ function reconstructBaselineEntry(e) {
     skip: e.skip,
     error: e.error,
     pipeline: e.pipeline,
+    hintCount: getHintCount(e),
     errorBailouts: Array.isArray(e.errorBailouts) ? e.errorBailouts : [],
     skipReasons: Array.isArray(e.skipReasons) ? e.skipReasons : [],
     pipelineErrors: Array.isArray(e.pipelineErrors) ? e.pipelineErrors : [],
@@ -34,6 +86,8 @@ function reconstructBaselineEntry(e) {
 /**
  * Mirrors the validateShape COUNT_KEYS check — extra fields are tolerated;
  * only the four counts must be present and valid non-negative finite numbers.
+ * hintCount is optional (legacy baselines lack it) but, when present, must be
+ * a valid non-negative finite number.
  */
 const COUNT_KEYS = ["success", "skip", "error", "pipeline"];
 function entryShapeError(entry) {
@@ -41,6 +95,14 @@ function entryShapeError(entry) {
   for (const key of COUNT_KEYS) {
     const v = entry[key];
     if (typeof v !== "number" || v < 0 || !Number.isFinite(v)) return `invalid-${key}`;
+  }
+  if (
+    "hintCount" in entry &&
+    (typeof entry.hintCount !== "number" ||
+      entry.hintCount < 0 ||
+      !Number.isFinite(entry.hintCount))
+  ) {
+    return "invalid-hintCount";
   }
   return null;
 }
@@ -297,5 +359,148 @@ describe("regression diagnostic display", () => {
       pipelineErrors: ["p"],
     });
     expect(lines).toEqual(["   error[Refs]: r", "   skip: s", "   pipeline: p"]);
+  });
+});
+
+describe("severity bucketing (#8892)", () => {
+  it("derives severity from the live LintRules registry", () => {
+    // Cosmetic try/catch lowering noise — the category that dominated the
+    // pre-#8892 baseline.
+    expect(severityForCategory("Todo")).toBe("Hint");
+    // Rule-of-React violations — the load-bearing ones.
+    expect(severityForCategory("Hooks")).toBe("Error");
+    expect(severityForCategory("Refs")).toBe("Error");
+    // Warnings fold into the strict gate (treated like Error).
+    expect(severityForCategory("IncompatibleLibrary")).toBe("Warning");
+    expect(severityForCategory("UnsupportedSyntax")).toBe("Warning");
+  });
+
+  it("defaults unknown/future categories to Error (fail loud, never silently Hint)", () => {
+    expect(severityForCategory("SomeFutureCategoryNotInRegistry")).toBe("Error");
+    expect(severityForCategory("")).toBe("Error");
+  });
+
+  it("classifies exactly one Hint category (Todo)", () => {
+    expect([...HINT_CATEGORIES]).toEqual(["Todo"]);
+  });
+});
+
+describe("getHintCount (#8892)", () => {
+  it("reads an explicit hintCount", () => {
+    expect(getHintCount({ hintCount: 7 })).toBe(7);
+  });
+
+  it("defaults missing hintCount to 0 (legacy baseline)", () => {
+    expect(getHintCount({ success: 1, skip: 0, error: 0, pipeline: 0 })).toBe(0);
+    expect(getHintCount(undefined)).toBe(0);
+  });
+
+  it("treats non-numeric / non-finite hintCount as 0", () => {
+    expect(getHintCount({ hintCount: "9" })).toBe(0);
+    expect(getHintCount({ hintCount: Infinity })).toBe(0);
+    expect(getHintCount({ hintCount: NaN })).toBe(0);
+  });
+});
+
+describe("getStrictBailouts (#8892)", () => {
+  it("returns Error and Warning entries verbatim", () => {
+    const entry = {
+      errorBailouts: [
+        { category: "Refs", severity: "Error", reason: "r" },
+        { category: "IncompatibleLibrary", severity: "Warning", reason: "w" },
+      ],
+    };
+    expect(getStrictBailouts(entry)).toHaveLength(2);
+  });
+
+  it("strips Hint (Todo) entries from a legacy baseline that lumped them in", () => {
+    // Pre-#8892 baselines stored Todo verbatim in errorBailouts. The strict
+    // gate must ignore them so it stays honest against old baselines.
+    const entry = {
+      errorBailouts: [
+        { category: "Todo", reason: "cosmetic" },
+        { category: "Todo", reason: "cosmetic" },
+        { category: "Hooks", reason: "real" },
+      ],
+    };
+    expect(getStrictBailouts(entry).map((b) => b.category)).toEqual(["Hooks"]);
+  });
+
+  it("tolerates a missing or malformed errorBailouts array", () => {
+    expect(getStrictBailouts({})).toEqual([]);
+    expect(getStrictBailouts({ errorBailouts: "nope" })).toEqual([]);
+    expect(getStrictBailouts({ errorBailouts: [null, 42, "x"] })).toEqual([]);
+  });
+});
+
+describe("strict Error per-file gate (#8892)", () => {
+  it("fails a new file that introduces a strict bailout", () => {
+    const entry = {
+      skip: 0,
+      pipeline: 0,
+      hintCount: 0,
+      errorBailouts: [{ category: "Hooks", severity: "Error", reason: "x" }],
+    };
+    expect(fileRegressionKeys(entry, null)).toContain("strictErrors");
+  });
+
+  it("passes a new file with only Hint noise (Hints gate globally, not per-file)", () => {
+    const entry = { skip: 0, pipeline: 0, hintCount: 12, errorBailouts: [] };
+    expect(fileRegressionKeys(entry, null)).toEqual([]);
+  });
+
+  it("fails when a file's strict bailout count increases against baseline", () => {
+    const base = { skip: 0, pipeline: 0, hintCount: 0, errorBailouts: [] };
+    const entry = {
+      skip: 0,
+      pipeline: 0,
+      hintCount: 0,
+      errorBailouts: [{ category: "Refs", severity: "Error", reason: "x" }],
+    };
+    expect(fileRegressionKeys(entry, base)).toEqual(["strictErrors"]);
+  });
+
+  it("passes when a file's strict count is unchanged but Hint count grows", () => {
+    const base = {
+      skip: 0,
+      pipeline: 0,
+      hintCount: 2,
+      errorBailouts: [{ category: "Refs", severity: "Error", reason: "x" }],
+    };
+    const entry = {
+      skip: 0,
+      pipeline: 0,
+      hintCount: 5,
+      errorBailouts: [{ category: "Refs", severity: "Error", reason: "x" }],
+    };
+    expect(fileRegressionKeys(entry, base)).toEqual([]);
+  });
+
+  it("does NOT gate on the raw error count (Hint-only error inflation is allowed)", () => {
+    // error went 0 → 6 but it's all Hint noise — no strict bailouts, so no
+    // per-file failure. This is the core #8892 behavior change.
+    const base = { skip: 0, pipeline: 0, error: 0, hintCount: 0, errorBailouts: [] };
+    const entry = { skip: 0, pipeline: 0, error: 6, hintCount: 6, errorBailouts: [] };
+    expect(fileRegressionKeys(entry, base)).toEqual([]);
+  });
+});
+
+describe("global Hint budget gate (#8892)", () => {
+  it("fails when the whole-repo Hint total grows", () => {
+    const baseline = { "a.tsx": { hintCount: 3 }, "b.tsx": { hintCount: 2 } };
+    const report = { "a.tsx": { hintCount: 3 }, "b.tsx": { hintCount: 4 } };
+    expect(hintBudgetExceeded(report, baseline)).toBe(true);
+  });
+
+  it("passes when Hint noise shifts between files but the total is unchanged", () => {
+    const baseline = { "a.tsx": { hintCount: 3 }, "b.tsx": { hintCount: 2 } };
+    const report = { "a.tsx": { hintCount: 1 }, "b.tsx": { hintCount: 4 } };
+    expect(hintBudgetExceeded(report, baseline)).toBe(false);
+  });
+
+  it("passes when the total drops (improvement)", () => {
+    const baseline = { "a.tsx": { hintCount: 3 }, "b.tsx": { hintCount: 2 } };
+    const report = { "a.tsx": { hintCount: 1 }, "b.tsx": { hintCount: 1 } };
+    expect(hintBudgetExceeded(report, baseline)).toBe(false);
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -160,6 +160,17 @@ function reactCompilerReportPlugin(command: "build" | "serve"): {
                   typeof detail.reason === "string" ? detail.reason : String(detail.reason ?? ""),
               });
             }
+          } else {
+            // Malformed CompileError (absent/non-object detail). The raw
+            // entry.error count no longer gates CI, so a silent drop here would
+            // be invisible coverage loss. Land it in the strict gate under an
+            // unknown category so it fails loud rather than vanishing — most
+            // likely an upstream plugin event-shape change.
+            entry.errorBailouts.push({
+              category: "(unknown)",
+              severity: "Error",
+              reason: "malformed CompileError event (no detail object)",
+            });
           }
           break;
         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, type Plugin } from "vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
+import { LintRules } from "babel-plugin-react-compiler";
 import babel from "@rolldown/plugin-babel";
 import tailwindcss from "@tailwindcss/vite";
 import { visualizer } from "rollup-plugin-visualizer";
@@ -19,25 +20,48 @@ const devServerConfig = getDevServerConfig();
 const DEV_CSP = getDaintreeAppDevCSP();
 const PROD_CSP = getDaintreeAppProdCSP();
 
+// Severity bucketing derived from the live plugin's LintRules registry rather
+// than hard-coded, so a plugin upgrade that recategorizes a rule reflows the
+// gate automatically. As of babel-plugin-react-compiler 1.0.0: 1 Hint (Todo),
+// 2 Warning (IncompatibleLibrary, UnsupportedSyntax), 23 Error categories.
+const SEVERITY_BY_CATEGORY: Record<string, string> = Object.fromEntries(
+  LintRules.map((rule) => [rule.category, rule.severity])
+);
+
+// Look up a category's severity WITHOUT touching detail.severity — that getter
+// throws ("Unsupported category X") for any ErrorCategory not in the plugin's
+// internal switch, which would crash the build the first time a future plugin
+// version emits a new category. Unknown categories default to "Error" so they
+// land in the strict gate (fail loud) rather than the silent Hint count.
+function severityForCategory(category: string): string {
+  return SEVERITY_BY_CATEGORY[category] ?? "Error";
+}
+
 // Per-file accumulator written to dist/compiler-bailout-report.json after the
 // build completes. Counts come from babel-plugin-react-compiler's logger:
 // CompileSuccess, CompileSkip, CompileError, PipelineError. Other event kinds
 // (Timing, CompileDiagnostic, AutoDeps*) are ignored — they aren't regression
-// signals. Diagnostic arrays (errorBailouts, skipReasons, pipelineErrors)
-// preserve the human-readable reason and ErrorCategory for each bailout so
-// CI failures point at the actual cause without rebuilding locally. The
-// accumulator Map and the logger object MUST be created in the same factory
-// call so they share state via closure; threading either through module scope
-// would silently produce an empty report.
+// signals. CompileError events are bucketed by severity: Hint-severity bailouts
+// (the cosmetic "Todo" try/catch-lowering noise that dominates the report)
+// collapse to a single `hintCount`, while Error+Warning bailouts are tracked
+// verbatim in `errorBailouts` so the strict gate can point at the actual cause
+// without rebuilding locally. The accumulator Map and the logger object MUST be
+// created in the same factory call so they share state via closure; threading
+// either through module scope would silently produce an empty report.
 type CompilerBailoutEntry = {
   success: number;
   skip: number;
   error: number;
   pipeline: number;
-  // Source type is `ErrorCategory` from babel-plugin-react-compiler — kept as
-  // string at this boundary to avoid cross-package type coupling that would
-  // break silently on a plugin upgrade.
-  errorBailouts: Array<{ category: string; reason: string }>;
+  // Hint-severity CompileError count (cosmetic "Todo" bailouts). Collapsed to a
+  // number so a shifting count produces a one-line diff instead of N lines of
+  // repeated reason-string churn.
+  hintCount: number;
+  // Error+Warning-severity bailouts only — Hint entries are counted in
+  // hintCount, not pushed here. Source type is `ErrorCategory` from
+  // babel-plugin-react-compiler — kept as string at this boundary to avoid
+  // cross-package type coupling that would break silently on a plugin upgrade.
+  errorBailouts: Array<{ category: string; severity: string; reason: string }>;
   skipReasons: string[];
   pipelineErrors: string[];
 };
@@ -78,6 +102,7 @@ function reactCompilerReportPlugin(command: "build" | "serve"): {
         skip: 0,
         error: 0,
         pipeline: 0,
+        hintCount: 0,
         errorBailouts: [],
         skipReasons: [],
         pipelineErrors: [],
@@ -111,17 +136,30 @@ function reactCompilerReportPlugin(command: "build" | "serve"): {
           break;
         }
         case "CompileError": {
+          // Raw event count, kept for diagnostics — it is NOT a gate key (the
+          // strict gate counts errorBailouts; Hints gate via hintCount).
           entry.error++;
           // detail is CompilerErrorDetail | CompilerDiagnostic — both expose
           // .category (ErrorCategory enum) and .reason (string) via getters
-          // backed by required Zod-validated options. Cast is safe.
+          // backed by required Zod-validated options. Cast is safe. We resolve
+          // severity from the category via the prebuilt map rather than the
+          // detail.severity getter, which throws on unknown categories.
           const detail = (event as { detail?: { category?: unknown; reason?: unknown } }).detail;
           if (detail && typeof detail === "object") {
-            entry.errorBailouts.push({
-              category: String(detail.category ?? ""),
-              reason:
-                typeof detail.reason === "string" ? detail.reason : String(detail.reason ?? ""),
-            });
+            const category = String(detail.category ?? "");
+            const severity = severityForCategory(category);
+            if (severity === "Hint") {
+              // Cosmetic Todo-style bailout — collapse to a count, don't store
+              // the verbose reason string.
+              entry.hintCount++;
+            } else {
+              entry.errorBailouts.push({
+                category,
+                severity,
+                reason:
+                  typeof detail.reason === "string" ? detail.reason : String(detail.reason ?? ""),
+              });
+            }
           }
           break;
         }


### PR DESCRIPTION
## Summary

The 144KB `compiler-bailout-baseline.json` was dominated by ~200 verbose `Todo` reason strings, all at `Hint` severity. That made the baseline noisy and the gate blind to what actually matters. This PR splits bailout tracking by severity so the ratchet only enforces strict zero-regression on bailouts that warrant it.

- `Hint`-severity bailouts (1 rule: `Todo`) collapse to a per-file `hintCount`, gated by a global budget. Per-file churn is free; the whole-repo total may not grow.
- `Error`+`Warning` bailouts are tracked verbatim in `errorBailouts` as `{category, severity, reason}`, protected by a category-aware strict gate that catches count increases, new files, and count-neutral category swaps.
- Severity buckets are derived from `babel-plugin-react-compiler`'s exported `LintRules` registry, so `vite.config.ts` and `scripts/check-compiler-budget.mjs` share the same source and can't drift.
- Malformed `CompileError` events (no `detail` object) land under category `(unknown)` so silent coverage loss can't sneak through.
- Fully backward-compatible: legacy baselines with missing `hintCount` are treated as 0; legacy `Todo` entries in `errorBailouts` are stripped from the strict count at read time.

Baseline regenerated via `npm run compiler-budget:update`: 616 files, `hintTotal=212`, `strictTotal=7`, file shrank from 144KB to 131KB.

Resolves #8892.

## Changes

- `vite.config.ts` — severity-aware `CompileError` handler; resolves severity via prebuilt map with `"Error"` fallback
- `scripts/check-compiler-budget.mjs` — `hintCount` per file, `getStrictBailouts()`, category-aware strict gate, malformed-detail handling, global hint budget check
- `compiler-bailout-baseline.json` — regenerated with new schema (every entry has `hintCount`, no `Todo` in `errorBailouts`)
- `docs/development.md` — updated tooling notes

## Testing

49 tests in `scripts/check-compiler-budget.test.mjs` — severity bucketing, `hintCount`, `getStrictBailouts`, category-aware strict gate (including category swap and Warning), malformed-detail, and global hint budget cases. `npm run check` (typecheck + lint + format) clean.