### PR TITLE
chore(import-budget): tighten allowlist hygiene

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1359,
-  "moduleCount": 1359,
+  "count": 1361,
+  "moduleCount": 1361,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -89,327 +89,322 @@
   "syncViolations": [
     {
       "file": "electron/ipc/errorHandlers.ts",
-      "line": 34,
+      "line": 35,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/errorHandlers.ts",
-      "line": 298,
+      "line": 299,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/agentCapabilities.ts",
-      "line": 84,
+      "line": 85,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/agentCli.ts",
-      "line": 112,
+      "line": 113,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/ai.ts",
-      "line": 61,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/ai.ts",
-      "line": 79,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/ai.ts",
-      "line": 117,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/ai.ts",
-      "line": 134,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/app/state.ts",
-      "line": 58,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/app/state.ts",
-      "line": 357,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/app/state.ts",
-      "line": 359,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/app/state.ts",
-      "line": 413,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/appTheme.ts",
-      "line": 23,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/demo.ts",
-      "line": 233,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/ipc/handlers/diagnostics.ts",
-      "line": 54,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/ipc/handlers/diagnostics.ts",
-      "line": 61,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/ipc/handlers/forge.ts",
-      "line": 136,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeResolution.ts",
-      "line": 44,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 23,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 188,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 203,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 213,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 191,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 277,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 281,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 324,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 328,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 366,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 370,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/globalEnv.ts",
-      "line": 6,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/helpAssistant.ts",
-      "line": 98,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/helpAssistant.ts",
-      "line": 137,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/keybinding.ts",
-      "line": 12,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/logs.ts",
-      "line": 133,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/logs.ts",
-      "line": 228,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/milestones.ts",
-      "line": 9,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/milestones.ts",
-      "line": 13,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/notifications.ts",
       "line": 62,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/notifications.ts",
-      "line": 152,
+      "file": "electron/ipc/handlers/ai.ts",
+      "line": 80,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/onboarding.ts",
-      "line": 64,
+      "file": "electron/ipc/handlers/ai.ts",
+      "line": 118,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/privacy.ts",
-      "line": 29,
+      "file": "electron/ipc/handlers/ai.ts",
+      "line": 135,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/shortcutHints.ts",
-      "line": 9,
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 61,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/shortcutHints.ts",
-      "line": 13,
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 360,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/terminalConfig.ts",
-      "line": 17,
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 362,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/voiceInput.ts",
-      "line": 43,
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 416,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
-      "line": 87,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
-      "line": 188,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
-      "line": 192,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 57,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 72,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 84,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 91,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktreeConfig.ts",
-      "line": 12,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktreeConfig.ts",
-      "line": 25,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/pendingErrorsStore.ts",
-      "line": 7,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/main.ts",
-      "line": 151,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/main.ts",
-      "line": 232,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AppAgentService.ts",
-      "line": 34,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AppAgentService.ts",
-      "line": 48,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AppAgentService.ts",
-      "line": 53,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AppAgentService.ts",
-      "line": 123,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AppHydrationService.ts",
+      "file": "electron/ipc/handlers/appTheme.ts",
       "line": 24,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/AppHydrationService.ts",
-      "line": 82,
+      "file": "electron/ipc/handlers/demo.ts",
+      "line": 234,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/ipc/handlers/diagnostics.ts",
+      "line": 55,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/ipc/handlers/diagnostics.ts",
+      "line": 62,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/ipc/handlers/forge.ts",
+      "line": 137,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/forgeResolution.ts",
+      "line": 45,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/forgeSettings.ts",
+      "line": 24,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/forgeSettings.ts",
+      "line": 189,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/forgeSettings.ts",
+      "line": 204,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/forgeSettings.ts",
+      "line": 214,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 192,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 278,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 282,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 325,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 329,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 367,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 371,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/globalEnv.ts",
+      "line": 7,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/helpAssistant.ts",
+      "line": 99,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/helpAssistant.ts",
+      "line": 138,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/keybinding.ts",
+      "line": 13,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/logs.ts",
+      "line": 134,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/logs.ts",
+      "line": 229,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/milestones.ts",
+      "line": 10,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/milestones.ts",
+      "line": 14,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/notifications.ts",
+      "line": 63,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/notifications.ts",
+      "line": 153,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/onboarding.ts",
+      "line": 65,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/privacy.ts",
+      "line": 30,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/shortcutHints.ts",
+      "line": 10,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/shortcutHints.ts",
+      "line": 14,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/terminalConfig.ts",
+      "line": 18,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/voiceInput.ts",
+      "line": 44,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
+      "line": 88,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
+      "line": 189,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
+      "line": 193,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 58,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 73,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 85,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 92,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktreeConfig.ts",
+      "line": 13,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktreeConfig.ts",
+      "line": 26,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/pendingErrorsStore.ts",
+      "line": 8,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/main.ts",
+      "line": 152,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/main.ts",
+      "line": 233,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppAgentService.ts",
+      "line": 35,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppAgentService.ts",
+      "line": 49,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppAgentService.ts",
+      "line": 54,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppAgentService.ts",
+      "line": 124,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AppHydrationService.ts",
-      "line": 84,
+      "line": 25,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 275,
+      "file": "electron/services/AppHydrationService.ts",
+      "line": 83,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppHydrationService.ts",
+      "line": 85,
       "pattern": "sync-store-get"
     },
     {
@@ -419,62 +414,62 @@
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 396,
+      "line": 277,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 405,
+      "line": 397,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 435,
+      "line": 406,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 474,
+      "line": 436,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AutoUpdaterService.ts",
+      "line": 475,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 474,
+      "line": 475,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 491,
+      "line": 492,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CliAvailabilityService.ts",
-      "line": 807,
+      "line": 808,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 56,
+      "line": 57,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 81,
+      "line": 82,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 89,
+      "line": 90,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 111,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CliInstallService.ts",
-      "line": 126,
+      "line": 112,
       "pattern": "sync-fs"
     },
     {
@@ -484,12 +479,12 @@
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 130,
+      "line": 128,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 144,
+      "line": 131,
       "pattern": "sync-fs"
     },
     {
@@ -499,12 +494,12 @@
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 155,
+      "line": 146,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 159,
+      "line": 156,
       "pattern": "sync-fs"
     },
     {
@@ -514,7 +509,7 @@
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 168,
+      "line": 161,
       "pattern": "sync-fs"
     },
     {
@@ -524,52 +519,52 @@
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 182,
+      "line": 170,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 212,
+      "line": 183,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CliInstallService.ts",
+      "line": 213,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 190,
+      "line": 191,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 194,
+      "line": 195,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 229,
+      "line": 230,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 251,
+      "line": 252,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 264,
+      "line": 265,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 283,
+      "line": 284,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 300,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 316,
+      "line": 301,
       "pattern": "sync-fs"
     },
     {
@@ -579,7 +574,7 @@
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 329,
+      "line": 318,
       "pattern": "sync-fs"
     },
     {
@@ -588,103 +583,103 @@
       "pattern": "sync-fs"
     },
     {
+      "file": "electron/services/CrashLoopGuardService.ts",
+      "line": 331,
+      "pattern": "sync-fs"
+    },
+    {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 112,
+      "line": 113,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 137,
+      "line": 138,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 273,
+      "line": 274,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 290,
+      "line": 291,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 399,
+      "line": 400,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 402,
+      "line": 403,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 466,
+      "line": 467,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 532,
+      "line": 533,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 534,
+      "line": 535,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 541,
+      "line": 542,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 544,
+      "line": 545,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 571,
+      "line": 572,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 573,
+      "line": 574,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 577,
+      "line": 578,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 594,
+      "line": 595,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 610,
+      "line": 611,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 614,
+      "line": 615,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 617,
+      "line": 618,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 646,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 662,
+      "line": 647,
       "pattern": "sync-fs"
     },
     {
@@ -694,7 +689,7 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 729,
+      "line": 664,
       "pattern": "sync-fs"
     },
     {
@@ -704,7 +699,7 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 760,
+      "line": 731,
       "pattern": "sync-fs"
     },
     {
@@ -714,13 +709,13 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 788,
-      "pattern": "sync-store-get"
+      "line": 762,
+      "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 815,
-      "pattern": "sync-fs"
+      "line": 789,
+      "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
@@ -729,7 +724,7 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 863,
+      "line": 817,
       "pattern": "sync-fs"
     },
     {
@@ -739,27 +734,27 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 868,
+      "line": 865,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 983,
+      "line": 869,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1007,
+      "line": 984,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1016,
+      "line": 1008,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1027,
+      "line": 1017,
       "pattern": "sync-fs"
     },
     {
@@ -769,57 +764,57 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1040,
+      "line": 1029,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 1041,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1056,
+      "line": 1057,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1058,
+      "line": 1059,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1064,
+      "line": 1065,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1074,
+      "line": 1075,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/DatabaseMaintenanceService.ts",
-      "line": 145,
+      "line": 146,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/DatabaseMaintenanceService.ts",
-      "line": 149,
+      "line": 150,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/DatabaseMaintenanceService.ts",
-      "line": 149,
+      "line": 150,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitHubFirstPageCache.ts",
-      "line": 195,
+      "line": 196,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitHubFirstPageCache.ts",
-      "line": 201,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/GitHubFirstPageCache.ts",
-      "line": 231,
+      "line": 202,
       "pattern": "sync-fs"
     },
     {
@@ -828,18 +823,18 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/GitHubStatsCache.ts",
-      "line": 154,
+      "file": "electron/services/GitHubFirstPageCache.ts",
+      "line": 233,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitHubStatsCache.ts",
-      "line": 160,
+      "line": 155,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitHubStatsCache.ts",
-      "line": 192,
+      "line": 161,
       "pattern": "sync-fs"
     },
     {
@@ -848,33 +843,33 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/GitService.ts",
-      "line": 59,
+      "file": "electron/services/GitHubStatsCache.ts",
+      "line": 194,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 110,
+      "line": 60,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 527,
+      "line": 111,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 533,
+      "line": 528,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/GitService.ts",
+      "line": 534,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 24,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 39,
+      "line": 25,
       "pattern": "sync-fs"
     },
     {
@@ -884,12 +879,12 @@
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 45,
+      "line": 41,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 75,
+      "line": 46,
       "pattern": "sync-fs"
     },
     {
@@ -898,78 +893,78 @@
       "pattern": "sync-fs"
     },
     {
+      "file": "electron/services/GpuCrashMonitorService.ts",
+      "line": 77,
+      "pattern": "sync-fs"
+    },
+    {
       "file": "electron/services/HelpService.ts",
-      "line": 16,
+      "line": 17,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/HelpSessionService.ts",
-      "line": 1089,
+      "line": 1090,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/HibernationService.ts",
-      "line": 372,
+      "line": 373,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/IdleTerminalNotificationService.ts",
-      "line": 90,
+      "line": 91,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/IdleTerminalNotificationService.ts",
-      "line": 260,
+      "line": 261,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/mcp-server/httpLifecycle.ts",
-      "line": 364,
+      "line": 365,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/McpServerService.ts",
-      "line": 273,
+      "line": 274,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 297,
+      "line": 298,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 301,
+      "line": 302,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 335,
+      "line": 336,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 350,
+      "line": 351,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 363,
+      "line": 364,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 376,
+      "line": 377,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 393,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 406,
+      "line": 394,
       "pattern": "sync-fs"
     },
     {
@@ -978,24 +973,24 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/persistence/db.ts",
-      "line": 83,
-      "pattern": "sync-sqlite"
-    },
-    {
-      "file": "electron/services/persistence/db.ts",
-      "line": 118,
+      "file": "electron/services/PanelSuspectLedgerService.ts",
+      "line": 408,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 121,
+      "line": 84,
       "pattern": "sync-sqlite"
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 156,
+      "line": 119,
       "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/persistence/db.ts",
+      "line": 122,
+      "pattern": "sync-sqlite"
     },
     {
       "file": "electron/services/persistence/db.ts",
@@ -1004,162 +999,162 @@
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 162,
+      "line": 158,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 165,
+      "line": 163,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 171,
+      "line": 166,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/persistence/db.ts",
+      "line": 172,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/readLastProjectId.ts",
-      "line": 20,
+      "line": 21,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/readLastProjectId.ts",
-      "line": 24,
+      "line": 25,
       "pattern": "sync-sqlite"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 263,
+      "line": 264,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/ProcessMemoryMonitor.ts",
-      "line": 425,
+      "line": 426,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectEnvSecureStorage.ts",
-      "line": 13,
+      "line": 14,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/ProjectFileStore.ts",
+      "line": 64,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/ProjectSettingsManager.ts",
+      "line": 30,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/ProjectSettingsManager.ts",
       "line": 63,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectSettingsManager.ts",
-      "line": 29,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/ProjectSettingsManager.ts",
-      "line": 62,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/ProjectSettingsManager.ts",
-      "line": 176,
+      "line": 177,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStateManager.ts",
-      "line": 156,
+      "line": 157,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 88,
+      "line": 89,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 258,
+      "line": 259,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 441,
+      "line": 442,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 448,
+      "line": 449,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 502,
+      "line": 503,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 508,
+      "line": 509,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectSwitchService.ts",
-      "line": 163,
+      "line": 164,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/pty/agentSessionHistory.ts",
-      "line": 56,
+      "line": 57,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 257,
+      "line": 258,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 270,
+      "line": 271,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 282,
+      "line": 283,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 297,
+      "line": 298,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 310,
+      "line": 311,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 325,
+      "line": 326,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 330,
+      "line": 331,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 119,
+      "line": 120,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 130,
+      "line": 131,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 193,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 245,
+      "line": 194,
       "pattern": "sync-fs"
     },
     {
@@ -1169,37 +1164,37 @@
     },
     {
       "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 256,
+      "line": 247,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/pty/terminalSessionPersistence.ts",
+      "line": 257,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/terminalShell.ts",
-      "line": 42,
+      "line": 43,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PtyClient.ts",
-      "line": 155,
+      "line": 166,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/SecureStorage.ts",
-      "line": 22,
+      "line": 23,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 95,
+      "line": 96,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 101,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/StoreMigrations.ts",
-      "line": 134,
+      "line": 102,
       "pattern": "sync-fs"
     },
     {
@@ -1209,47 +1204,47 @@
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 149,
+      "line": 136,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 171,
+      "line": 150,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/StoreMigrations.ts",
+      "line": 172,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 255,
+      "line": 256,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 270,
+      "line": 271,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 296,
+      "line": 297,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 303,
+      "line": 304,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 426,
+      "line": 427,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TrashedPidTracker.ts",
-      "line": 212,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/TrashedPidTracker.ts",
-      "line": 217,
+      "line": 213,
       "pattern": "sync-fs"
     },
     {
@@ -1259,7 +1254,7 @@
     },
     {
       "file": "electron/services/TrashedPidTracker.ts",
-      "line": 245,
+      "line": 219,
       "pattern": "sync-fs"
     },
     {
@@ -1268,23 +1263,23 @@
       "pattern": "sync-fs"
     },
     {
+      "file": "electron/services/TrashedPidTracker.ts",
+      "line": 247,
+      "pattern": "sync-fs"
+    },
+    {
       "file": "electron/services/UserAgentRegistryService.ts",
-      "line": 27,
+      "line": 28,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 38,
+      "line": 39,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 44,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 200,
+      "line": 45,
       "pattern": "sync-store-get"
     },
     {
@@ -1294,7 +1289,7 @@
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 258,
+      "line": 202,
       "pattern": "sync-store-get"
     },
     {
@@ -1304,7 +1299,7 @@
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 440,
+      "line": 260,
       "pattern": "sync-store-get"
     },
     {
@@ -1313,13 +1308,13 @@
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/setup/devDiagnostics.ts",
-      "line": 40,
-      "pattern": "sync-fs"
+      "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
+      "line": 442,
+      "pattern": "sync-store-get"
     },
     {
-      "file": "electron/setup/environment.ts",
-      "line": 59,
+      "file": "electron/setup/devDiagnostics.ts",
+      "line": 41,
       "pattern": "sync-fs"
     },
     {
@@ -1329,62 +1324,57 @@
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 62,
+      "line": 61,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 73,
+      "line": 63,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 85,
+      "line": 74,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 154,
+      "line": 86,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 250,
+      "line": 155,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 328,
+      "line": 251,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 642,
+      "line": 329,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/setup/environment.ts",
+      "line": 643,
       "pattern": "sync-sqlite"
     },
     {
       "file": "electron/store.ts",
-      "line": 490,
+      "line": 493,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 492,
+      "line": 495,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 507,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/store.ts",
-      "line": 522,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/store.ts",
-      "line": 523,
+      "line": 510,
       "pattern": "sync-fs"
     },
     {
@@ -1394,92 +1384,97 @@
     },
     {
       "file": "electron/store.ts",
-      "line": 540,
+      "line": 526,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 542,
+      "line": 528,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 559,
+      "line": 543,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 568,
+      "line": 545,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 569,
+      "line": 562,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 571,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 572,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/emergencyLog.ts",
-      "line": 23,
+      "line": 24,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/emergencyLog.ts",
-      "line": 26,
+      "line": 27,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/emergencyLog.ts",
-      "line": 28,
+      "line": 29,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/emergencyLog.ts",
+      "line": 36,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/fs.ts",
+      "line": 27,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/fs.ts",
+      "line": 84,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/fs.ts",
+      "line": 148,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/fs.ts",
+      "line": 156,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/git.ts",
+      "line": 131,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/git.ts",
+      "line": 380,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/git.ts",
+      "line": 688,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/gitRepoOperationState.ts",
       "line": 35,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/fs.ts",
-      "line": 26,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/fs.ts",
-      "line": 83,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/fs.ts",
-      "line": 147,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/fs.ts",
-      "line": 155,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/git.ts",
-      "line": 130,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/git.ts",
-      "line": 379,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/git.ts",
-      "line": 687,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 34,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 58,
       "pattern": "sync-fs"
     },
     {
@@ -1489,107 +1484,107 @@
     },
     {
       "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 67,
+      "line": 60,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 74,
+      "line": 68,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 81,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gpuDetection.ts",
-      "line": 32,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gpuDetection.ts",
-      "line": 41,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gpuDetection.ts",
-      "line": 50,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/logger.ts",
-      "line": 71,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/logger.ts",
       "line": 75,
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/utils/logger.ts",
-      "line": 81,
+      "file": "electron/utils/gitRepoOperationState.ts",
+      "line": 82,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/gpuDetection.ts",
+      "line": 33,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/gpuDetection.ts",
+      "line": 42,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/gpuDetection.ts",
+      "line": 51,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 137,
+      "line": 72,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 139,
+      "line": 76,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 151,
+      "line": 82,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 154,
+      "line": 138,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 184,
+      "line": 140,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 187,
+      "line": 152,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 191,
+      "line": 155,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 228,
+      "line": 185,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 230,
+      "line": 188,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 234,
+      "line": 192,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 236,
+      "line": 229,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 521,
+      "line": 231,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/logger.ts",
+      "line": 235,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/logger.ts",
+      "line": 237,
       "pattern": "sync-fs"
     },
     {
@@ -1599,12 +1594,12 @@
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 528,
+      "line": 523,
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/utils/performance.ts",
-      "line": 64,
+      "file": "electron/utils/logger.ts",
+      "line": 529,
       "pattern": "sync-fs"
     },
     {
@@ -1613,48 +1608,53 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/utils/worktreePattern.ts",
-      "line": 19,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/watchdog-host-core.ts",
-      "line": 181,
+      "file": "electron/utils/performance.ts",
+      "line": 66,
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/window/createWindow.ts",
-      "line": 145,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/window/globalServicesInit.ts",
-      "line": 85,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/window/globalServicesInit.ts",
-      "line": 168,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/window/globalServicesInit.ts",
-      "line": 576,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/window/globalServicesInit.ts",
-      "line": 722,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/window/skeletonCss.ts",
+      "file": "electron/utils/worktreePattern.ts",
       "line": 20,
       "pattern": "sync-store-get"
     },
     {
+      "file": "electron/watchdog-host-core.ts",
+      "line": 182,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/window/createWindow.ts",
+      "line": 146,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/globalServicesInit.ts",
+      "line": 86,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/globalServicesInit.ts",
+      "line": 169,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/globalServicesInit.ts",
+      "line": 577,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/globalServicesInit.ts",
+      "line": 723,
+      "pattern": "sync-store-get"
+    },
+    {
       "file": "electron/window/skeletonCss.ts",
-      "line": 25,
+      "line": 21,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/skeletonCss.ts",
+      "line": 26,
       "pattern": "sync-store-get"
     }
   ]

--- a/electron/ipc/errorHandlers.ts
+++ b/electron/ipc/errorHandlers.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads error-reporting config via store.get synchronously while handling IPC errors
 import { randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
 import { ipcMain, BrowserWindow, shell } from "electron";

--- a/electron/ipc/handlers/agentCapabilities.ts
+++ b/electron/ipc/handlers/agentCapabilities.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads agent-capability settings via store.get synchronously in the IPC handler
 import { store } from "../../store.js";
 import { CcrConfigService } from "../../services/CcrConfigService.js";
 import {

--- a/electron/ipc/handlers/agentCli.ts
+++ b/electron/ipc/handlers/agentCli.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads agent CLI config via store.get synchronously in the IPC handler
 import { CHANNELS } from "../channels.js";
 import { getAgentIds } from "../../../shared/config/agentRegistry.js";
 import type {

--- a/electron/ipc/handlers/ai.ts
+++ b/electron/ipc/handlers/ai.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads AI provider settings via store.get synchronously in the IPC handler
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import type { HandlerDependencies } from "../types.js";

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads persisted app state via store.get synchronously in the IPC handler
 import { app } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { store, type StoreSchema, consumePendingSettingsRecovery } from "../../../store.js";

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads the persisted theme via store.get synchronously so the IPC reply is immediate
 import { dialog, BrowserWindow, nativeTheme } from "electron";
 import { promises as fs } from "node:fs";
 import { CHANNELS } from "../channels.js";

--- a/electron/ipc/handlers/demo.ts
+++ b/electron/ipc/handlers/demo.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads demo fixture files via sync fs while servicing the IPC request
 import { ipcMain, session } from "electron";
 import { randomBytes } from "crypto";
 import * as fs from "fs";

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads diagnostics files via sync fs in the IPC handler
 import { app, dialog, shell } from "electron";
 import os from "node:os";
 import v8 from "node:v8";

--- a/electron/ipc/handlers/forge.ts
+++ b/electron/ipc/handlers/forge.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads forge config via store.get synchronously in the IPC handler
 import { shell } from "electron";
 import { CHANNELS } from "../channels.js";
 import { typedHandle } from "../utils.js";

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads forge-resolution config via store.get synchronously in the IPC handler
 import { store } from "../../store.js";
 import { getForgeProviderImpl } from "../../services/forgeProviderRegistry.js";
 import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads forge settings via store.get synchronously in the IPC handler
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import { typedHandle } from "../utils.js";

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads git config via store.get synchronously while servicing git-write IPC
 import { execFile } from "node:child_process";
 import fs from "node:fs";
 import { realpath } from "node:fs/promises";

--- a/electron/ipc/handlers/globalEnv.ts
+++ b/electron/ipc/handlers/globalEnv.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads the persisted global env via store.get synchronously at module scope
 import { defineIpcNamespace, op } from "../define.js";
 import { GLOBAL_ENV_METHOD_CHANNELS } from "./globalEnv.preload.js";
 import { store } from "../../store.js";

--- a/electron/ipc/handlers/helpAssistant.ts
+++ b/electron/ipc/handlers/helpAssistant.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads help-assistant settings via store.get synchronously in the IPC handler
 import { store } from "../../store.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { HELP_ASSISTANT_METHOD_CHANNELS } from "./helpAssistant.preload.js";

--- a/electron/ipc/handlers/keybinding.ts
+++ b/electron/ipc/handlers/keybinding.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads persisted keybindings via store.get synchronously at module scope
 import { dialog } from "electron";
 import { promises as fs } from "node:fs";
 import { CHANNELS } from "../channels.js";

--- a/electron/ipc/handlers/logs.ts
+++ b/electron/ipc/handlers/logs.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads logging config via store.get synchronously in the IPC handler
 import { shell } from "electron";
 import { CHANNELS } from "../channels.js";
 import { logBuffer } from "../../services/LogBuffer.js";

--- a/electron/ipc/handlers/milestones.ts
+++ b/electron/ipc/handlers/milestones.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads milestone state via store.get synchronously at module scope
 import { store } from "../../store.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { MILESTONES_METHOD_CHANNELS } from "./milestones.preload.js";

--- a/electron/ipc/handlers/notifications.ts
+++ b/electron/ipc/handlers/notifications.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads notification settings via store.get synchronously in the IPC handler
 import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import {

--- a/electron/ipc/handlers/onboarding.ts
+++ b/electron/ipc/handlers/onboarding.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads onboarding state via store.get synchronously in the IPC handler
 import { store } from "../../store.js";
 import type { StoreSchema } from "../../store.js";
 import { defineIpcNamespace, op } from "../define.js";

--- a/electron/ipc/handlers/privacy.ts
+++ b/electron/ipc/handlers/privacy.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads privacy settings via store.get synchronously in the IPC handler
 import { app, shell, session } from "electron";
 import { store } from "../../store.js";
 import {

--- a/electron/ipc/handlers/shortcutHints.ts
+++ b/electron/ipc/handlers/shortcutHints.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads shortcut-hint state via store.get synchronously at module scope
 import { store } from "../../store.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { SHORTCUT_HINTS_METHOD_CHANNELS } from "./shortcutHints.preload.js";

--- a/electron/ipc/handlers/terminalConfig.ts
+++ b/electron/ipc/handlers/terminalConfig.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads terminal config via store.get synchronously at module scope
 import { dialog, BrowserWindow } from "electron";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads voice-input settings via store.get synchronously in the IPC handler
 import { ipcMain, systemPreferences, shell } from "electron";
 import { spawn } from "child_process";
 import { CHANNELS } from "../channels.js";

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads worktree settings via store.get synchronously in the IPC handler
 import { CHANNELS } from "../../channels.js";
 import { store } from "../../../store.js";
 import { projectStore } from "../../../services/ProjectStore.js";

--- a/electron/ipc/handlers/worktree/pull-requests.ts
+++ b/electron/ipc/handlers/worktree/pull-requests.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads PR/auth settings via store.get synchronously in the IPC handler
 import { CHANNELS } from "../../channels.js";
 import { store } from "../../../store.js";
 import type { HandlerDependencies } from "../../types.js";

--- a/electron/ipc/handlers/worktreeConfig.ts
+++ b/electron/ipc/handlers/worktreeConfig.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads worktree config via store.get synchronously at module scope
 import { store } from "../../store.js";
 import type { HandlerDependencies } from "../types.js";
 import type { WorktreeConfig } from "../../../shared/types/index.js";

--- a/electron/ipc/pendingErrorsStore.ts
+++ b/electron/ipc/pendingErrorsStore.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads the pending-errors queue via store.get synchronously at module scope
 import { store } from "../store.js";
 import type { ErrorRecord } from "../../shared/types/ipc/errors.js";
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads boot-critical config via store.get synchronously during main-process startup
 // Environment setup must run first (GC exposure, userData, flags, sandbox)
 import "./setup/environment.js";
 

--- a/electron/services/AppAgentService.ts
+++ b/electron/services/AppAgentService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads app-agent config via store.get synchronously during service init
 import { store } from "../store.js";
 import type { AppAgentConfig } from "../../shared/types/appAgent.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads persisted hydration state via store.get synchronously during startup
 import { app } from "electron";
 import { store } from "../store.js";
 import { projectStore } from "./ProjectStore.js";

--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads updater config via store.get and the staged installer via sync fs
 import { existsSync, readFileSync } from "fs";
 import path from "path";
 import { app, ipcMain } from "electron";

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads the CLI-availability cache via store.get synchronously
 import { execFile, execFileSync } from "child_process";
 import { access, constants } from "fs/promises";
 import { delimiter, dirname, join, win32 as pathWin32 } from "path";

--- a/electron/services/CliInstallService.ts
+++ b/electron/services/CliInstallService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: performs sync fs checks while detecting and installing the agent CLI
 import fs from "fs";
 import path from "path";
 import os from "os";

--- a/electron/services/CrashLoopGuardService.ts
+++ b/electron/services/CrashLoopGuardService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes the crash-loop sentinel via sync fs before async IO is safe
 import { app } from "electron";
 import fs from "node:fs";
 import path from "node:path";

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes crash-recovery state via sync fs and store.get during early startup
 import { app, BrowserWindow } from "electron";
 import fs from "node:fs";
 import path from "node:path";

--- a/electron/services/DatabaseMaintenanceService.ts
+++ b/electron/services/DatabaseMaintenanceService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: performs sync fs checks during database maintenance
 import { powerMonitor } from "electron";
 import fs from "node:fs";
 import {

--- a/electron/services/GitHubFirstPageCache.ts
+++ b/electron/services/GitHubFirstPageCache.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes the GitHub first-page cache via sync fs
 import { readFileSync, existsSync, mkdirSync } from "fs";
 import { resilientAtomicWriteFileSync } from "../utils/fs.js";
 import { getWritesSuppressed } from "./diskPressureState.js";

--- a/electron/services/GitHubStatsCache.ts
+++ b/electron/services/GitHubStatsCache.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes the GitHub stats cache via sync fs
 import { readFileSync, existsSync, mkdirSync } from "fs";
 import { resilientAtomicWriteFileSync } from "../utils/fs.js";
 import { getWritesSuppressed } from "./diskPressureState.js";

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: performs sync fs existence checks while resolving git paths
 import type { SimpleGit, BranchSummary } from "simple-git";
 import { resolve, dirname, normalize, sep, isAbsolute } from "path";
 import { existsSync } from "fs";

--- a/electron/services/GpuCrashMonitorService.ts
+++ b/electron/services/GpuCrashMonitorService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes the GPU-crash sentinel via sync fs
 import { app } from "electron";
 import fs from "node:fs";
 import path from "node:path";

--- a/electron/services/HelpService.ts
+++ b/electron/services/HelpService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads bundled help content via sync fs at module scope
 import fs from "fs";
 import path from "path";
 import { app } from "electron";

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads help-session state via store.get synchronously
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";

--- a/electron/services/HibernationService.ts
+++ b/electron/services/HibernationService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads hibernation settings via store.get synchronously
 import { readdir, stat } from "fs/promises";
 import path from "path";
 import { ACTIVE_AGENT_STATES } from "../../shared/types/agent.js";

--- a/electron/services/IdleTerminalNotificationService.ts
+++ b/electron/services/IdleTerminalNotificationService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads idle-notification settings via store.get synchronously
 import type { AgentState } from "../../shared/types/agent.js";
 import type {
   IdleTerminalNotifyConfig,

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads MCP server settings via store.get synchronously during service init
 import { randomUUID } from "node:crypto";
 import { webContents as webContentsModule } from "electron";
 import { store } from "../store.js";

--- a/electron/services/PanelSuspectLedgerService.ts
+++ b/electron/services/PanelSuspectLedgerService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes the panel-suspect ledger via sync fs
 import { app } from "electron";
 import fs from "node:fs";
 import path from "node:path";

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads plugin settings via store.get synchronously during service init
 import fs from "fs/promises";
 import path from "path";
 import os from "os";

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads process memory stats via sync fs
 import os from "os";
 import v8 from "node:v8";
 import path from "node:path";

--- a/electron/services/ProjectEnvSecureStorage.ts
+++ b/electron/services/ProjectEnvSecureStorage.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads the secure-storage key map via store.get synchronously at module scope
 import { store } from "../store.js";
 
 /**

--- a/electron/services/ProjectFileStore.ts
+++ b/electron/services/ProjectFileStore.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes the project file store via sync fs
 import type { TerminalRecipe } from "../types/index.js";
 import fs from "fs/promises";
 import { existsSync } from "fs";

--- a/electron/services/ProjectSettingsManager.ts
+++ b/electron/services/ProjectSettingsManager.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads project settings via store.get and settings files via sync fs
 import type { ProjectSettings } from "../types/index.js";
 import type { NotificationSettings } from "../../shared/types/ipc/api.js";
 import type Store from "electron-store";

--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes project state via sync fs
 import type { ProjectState } from "../types/index.js";
 import fs from "fs/promises";
 import { existsSync } from "fs";

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes the project list via sync fs during startup
 import type {
   Project,
   ProjectState,

--- a/electron/services/ProjectSwitchService.ts
+++ b/electron/services/ProjectSwitchService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads last-project state via store.get synchronously during project switching
 import path from "path";
 import type { Project } from "../types/index.js";
 import type { HandlerDependencies } from "../ipc/types.js";

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads pty config via store.get synchronously during client init
 /**
  * PtyClient - Main process orchestrator for terminal management.
  *

--- a/electron/services/SecureStorage.ts
+++ b/electron/services/SecureStorage.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads the secure-storage map via store.get synchronously at module scope
 import { store, type StoreSchema } from "../store.js";
 
 export type SecureKey = "userConfig.githubToken";

--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes store data via sync fs and store.get while migrating the store
 import Store from "electron-store";
 import type { StoreSchema } from "../store.js";
 import { tightenFilePermissions } from "../store.js";

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads telemetry consent/config via store.get synchronously
 import { randomUUID } from "node:crypto";
 import { app } from "electron";
 import { store } from "../store.js";

--- a/electron/services/TrashedPidTracker.ts
+++ b/electron/services/TrashedPidTracker.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes the trashed-PID ledger via sync fs
 import { app } from "electron";
 import fs from "node:fs";
 import path from "node:path";

--- a/electron/services/UserAgentRegistryService.ts
+++ b/electron/services/UserAgentRegistryService.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads the user-agent registry via store.get synchronously during init
 import { store } from "../store.js";
 import type { UserAgentRegistry, UserAgentConfig } from "../../shared/types/index.js";
 import { UserAgentConfigSchema, SAFE_AGENT_ID_PATTERN } from "../../shared/types/index.js";

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads MCP server config via store.get synchronously during lifecycle setup
 import http from "node:http";
 import { createHash, randomUUID } from "node:crypto";
 import type { AddressInfo } from "node:net";

--- a/electron/services/persistence/db.ts
+++ b/electron/services/persistence/db.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: opens the SQLite store and reads its file synchronously at bootstrap (sync is the storage contract)
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";

--- a/electron/services/persistence/readLastProjectId.ts
+++ b/electron/services/persistence/readLastProjectId.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads the last-active project id from SQLite synchronously before the window opens
 /**
  * Synchronous, standalone reader for the last-active projectId.
  *

--- a/electron/services/pty/TerminalRegistry.ts
+++ b/electron/services/pty/TerminalRegistry.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes the terminal registry via sync fs
 import { createHash } from "crypto";
 import fs from "node:fs";
 import path from "node:path";

--- a/electron/services/pty/agentSessionHistory.ts
+++ b/electron/services/pty/agentSessionHistory.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes agent session history via sync fs
 import { readFileSync } from "fs";
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";

--- a/electron/services/pty/terminalSessionPersistence.ts
+++ b/electron/services/pty/terminalSessionPersistence.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes terminal session snapshots via sync fs
 import { readFileSync, statSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
 import { mkdir, readdir, stat, unlink } from "node:fs/promises";
 import { resilientAtomicWriteFile, resilientAtomicWriteFileSync } from "../../utils/fs.js";

--- a/electron/services/pty/terminalShell.ts
+++ b/electron/services/pty/terminalShell.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: resolves the login shell via a sync fs check
 import { existsSync } from "fs";
 import { execFileSync } from "child_process";
 import { isPowerShellShell } from "../../../shared/utils/shellEscape.js";

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads workspace-host config via store.get synchronously during pool setup
 import { type WebContents } from "electron";
 import path from "path";
 import { WorkspaceHostProcess } from "../WorkspaceHostProcess.js";

--- a/electron/setup/devDiagnostics.ts
+++ b/electron/setup/devDiagnostics.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: writes dev diagnostics via sync fs during setup
 import { app, ipcMain } from "electron";
 import fs from "node:fs";
 

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: performs sync fs and SQLite setup while preparing the runtime environment
 // Dead-fd errnos that must not propagate on GUI launch (AppImage/Wayland, no
 // terminal). EPIPE is a closed pipe (e.g. user quits Terminal.app while
 // Daintree runs); EIO is a disconnected pty (the primary errno for AppImage

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes the electron-store JSON file via sync fs (it is the synchronous store itself)
 import Store from "electron-store";
 import fs from "fs";
 import path from "path";

--- a/electron/utils/emergencyLog.ts
+++ b/electron/utils/emergencyLog.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: writes emergency logs via sync fs so they survive a crash before async transports exist
 import { appendFileSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { app } from "electron";

--- a/electron/utils/fs.ts
+++ b/electron/utils/fs.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: wraps the sync fs primitives used across the main process
 import { dirname } from "path";
 import { access, chmod as fsChmod, open, unlink as fsUnlink } from "fs/promises";
 import { chmodSync, closeSync, fsyncSync, openSync, unlinkSync, writeFileSync } from "fs";

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: performs sync fs checks while resolving git metadata
 import { dirname, resolve } from "path";
 import { realpathSync, promises as fs } from "fs";
 import type { SimpleGit, StatusResult } from "simple-git";

--- a/electron/utils/gitRepoOperationState.ts
+++ b/electron/utils/gitRepoOperationState.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes the git-operation lock via sync fs
 import { existsSync } from "fs";
 import { join as pathJoin } from "path";
 import type { RepoState } from "../../shared/types/git.js";

--- a/electron/utils/gpuDetection.ts
+++ b/electron/utils/gpuDetection.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads GPU info files via sync fs during detection
 import { app } from "electron";
 import fs from "node:fs";
 

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: writes logs via sync fs so early-boot logs survive a crash before async transports exist
 import { configure } from "safe-stable-stringify";
 import { getErrorDetails } from "./errorTypes.js";
 import {

--- a/electron/utils/performance.ts
+++ b/electron/utils/performance.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads performance markers via sync fs
 import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";

--- a/electron/utils/worktreePattern.ts
+++ b/electron/utils/worktreePattern.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads the worktree-path pattern via store.get synchronously at module scope
 import { store } from "../store.js";
 import { projectStore } from "../services/ProjectStore.js";
 import {

--- a/electron/watchdog-host-core.ts
+++ b/electron/watchdog-host-core.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads/writes the watchdog heartbeat via sync fs in the host process
 /**
  * Pure watchdog logic, extracted for testability. The runtime entry point
  * (watchdog-host.ts) is a thin wrapper that injects the real ping/timer/

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads persisted window state via store.get synchronously when creating the window
 import {
   app,
   BrowserWindow,

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads boot config via store.get synchronously while wiring global services
 import { app, dialog, session } from "electron";
 import {
   LATEST_SCHEMA_VERSION,

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: reads theme tokens via store.get synchronously to inline first-paint skeleton CSS
 /**
  * Injects CSS custom properties into a WebContents so the HTML skeleton
  * in index.html renders with the correct theme and layout dimensions

--- a/scripts/check-import-budget.mjs
+++ b/scripts/check-import-budget.mjs
@@ -18,6 +18,7 @@ import { fileURLToPath } from "node:url";
 import {
   walkEagerGraph,
   scanSyncViolations,
+  scanAllowlistMarkers,
   compareToBaseline,
   formatBaseline,
 } from "./import-budget-lib.mjs";
@@ -197,7 +198,8 @@ function main() {
   );
   validateBaseline(baseline);
 
-  const { ok, errors, notices } = compareToBaseline(report, baseline);
+  const markedFiles = scanAllowlistMarkers(baseline.allowlist, ROOT);
+  const { ok, errors, notices } = compareToBaseline(report, baseline, { markedFiles });
 
   for (const n of notices) {
     console.log(`::notice::${n.message}`);

--- a/scripts/check-import-budget.mjs
+++ b/scripts/check-import-budget.mjs
@@ -138,6 +138,19 @@ function writeBaseline(report, { force }) {
   console.log(
     `[check-import-budget] baseline updated: count=${formatted.count}, allowlist=${formatted.allowlist.length} file(s), syncViolations=${formatted.syncViolations.length}`
   );
+
+  // Remind the developer to justify any allowlisted file that lacks the
+  // `// eager-import-allow:` header — otherwise the next `check` run fails with
+  // missing-allow-comment. The update path itself doesn't fail on this; it only
+  // captures current state.
+  const marked = scanAllowlistMarkers(formatted.allowlist, ROOT);
+  const unmarked = formatted.allowlist.filter((file) => !marked.has(file));
+  if (unmarked.length > 0) {
+    console.warn(
+      `[check-import-budget] ${unmarked.length} allowlisted file(s) lack a \`// eager-import-allow: <reason>\` header. Add one near the top of each before committing, or \`check\` will fail:`
+    );
+    for (const file of unmarked) console.warn(`   - ${file}`);
+  }
 }
 
 // Build and write the markdown summary for downstream PR-comment aggregation.

--- a/scripts/import-budget-lib.mjs
+++ b/scripts/import-budget-lib.mjs
@@ -29,6 +29,57 @@ const SYNC_PATTERNS = [
   { name: "sync-sqlite", re: SYNC_SQLITE_RE },
 ];
 
+// Each allowlisted file must carry a one-line header marker naming why the sync
+// exception is permitted, so the justification lives next to the code it covers
+// instead of in `git blame`. Shape mirrors `// biome-ignore <rule>: <reason>`:
+// a `// eager-import-allow:` prefix followed by a non-empty reason. Presence is
+// enforced; the reason text is for humans and is not validated.
+export const ALLOWLIST_MARKER_RE = /^\s*\/\/\s*eager-import-allow\s*:\s*\S/m;
+
+// How many leading lines of a file are scanned for the marker. Keeps the
+// convention "near the top" (after a shebang / license banner) without matching
+// an incidental occurrence deep in the file (e.g. inside a string literal).
+const ALLOWLIST_MARKER_HEADER_LINES = 20;
+
+/**
+ * True if `source` contains a `// eager-import-allow: <reason>` marker.
+ * @param {string} source
+ * @returns {boolean}
+ */
+export function hasAllowlistMarker(source) {
+  return ALLOWLIST_MARKER_RE.test(source);
+}
+
+/**
+ * Read each allowlisted file and return the set of files whose header carries
+ * the `// eager-import-allow:` marker. Only the first
+ * `ALLOWLIST_MARKER_HEADER_LINES` lines are inspected. Unreadable files are
+ * warned about and treated as unmarked, mirroring `scanSyncViolations`.
+ *
+ * @param {Iterable<string>} allowlistFiles — repo-relative paths
+ * @param {string} root — absolute repo root
+ * @param {(file: string) => string} [readFile] — override for tests
+ * @returns {Set<string>}
+ */
+export function scanAllowlistMarkers(allowlistFiles, root, readFile) {
+  const reader = readFile ?? ((f) => fs.readFileSync(f, "utf8"));
+  const marked = new Set();
+  for (const file of allowlistFiles) {
+    let source;
+    try {
+      source = reader(`${root}/${file}`);
+    } catch (err) {
+      console.warn(
+        `[import-budget] could not read ${file} for allowlist-marker scan: ${err?.message ?? err}`
+      );
+      continue;
+    }
+    const header = source.split(/\r?\n/).slice(0, ALLOWLIST_MARKER_HEADER_LINES).join("\n");
+    if (hasAllowlistMarker(header)) marked.add(file);
+  }
+  return marked;
+}
+
 /**
  * Walk the eager (statically-imported) subgraph of an esbuild metafile, rooted
  * at `entry`. Follows only `import-statement` / `require-call` edges; stops at
@@ -115,10 +166,20 @@ export function scanSyncViolations(files, root, readFile) {
  * for humans to diff — it does NOT gate CI. The allowlist is the sole gate.
  * This keeps line-number refactors from churning the baseline.
  *
+ * Allowlist hygiene (hard errors, not notices):
+ * - An allowlist entry with no matching current violation is stale and fails —
+ *   the PR that removes a sync call must remove its allowlist entry in the same
+ *   change (same shape as ESLint `reportUnusedDisableDirectives: "error"`).
+ * - A still-used allowlist entry whose file lacks the
+ *   `// eager-import-allow: <reason>` header marker fails, when marker data is
+ *   supplied via `opts.markedFiles`. Omitting `markedFiles` skips that check so
+ *   the comparison stays pure and unit-testable without filesystem access.
+ *
  * @param {{ count: number, violations: {file:string, line:number, pattern:string}[], moduleCount: number }} current
  * @param {{ count: number, allowlist: string[], syncViolations: {file:string, line:number, pattern:string}[] }} baseline
+ * @param {{ markedFiles?: Set<string> }} [opts] — set of allowlisted files that carry the header marker
  */
-export function compareToBaseline(current, baseline) {
+export function compareToBaseline(current, baseline, opts = {}) {
   const errors = [];
   const notices = [];
 
@@ -154,17 +215,24 @@ export function compareToBaseline(current, baseline) {
     });
   }
 
-  const unusedAllowlist = [];
+  const { markedFiles } = opts;
   for (const file of allowlist) {
-    if (!current.violations.some((v) => v.file === file)) {
-      unusedAllowlist.push(file);
+    const isUsed = current.violations.some((v) => v.file === file);
+    if (!isUsed) {
+      errors.push({
+        kind: "unused-allowlist",
+        file,
+        message: `allowlist entry no longer has sync calls (or is no longer on the eager path). Remove it from the \`allowlist\` in eager-import-baseline.json, or run \`npm run import-budget:update\` to tidy.`,
+      });
+      continue;
     }
-  }
-  if (unusedAllowlist.length > 0) {
-    notices.push({
-      kind: "unused-allowlist",
-      message: `allowlist entries no longer have sync calls (or no longer on eager path): ${unusedAllowlist.join(", ")}. Consider \`npm run import-budget:update\` to tidy.`,
-    });
+    if (markedFiles !== undefined && !markedFiles.has(file)) {
+      errors.push({
+        kind: "missing-allow-comment",
+        file,
+        message: `on the eager-import allowlist but missing a \`// eager-import-allow: <reason>\` header comment. Add one near the top of the file naming why the sync exception is permitted.`,
+      });
+    }
   }
 
   return { ok: errors.length === 0, errors, notices };

--- a/scripts/import-budget-lib.test.ts
+++ b/scripts/import-budget-lib.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect, vi } from "vitest";
 import {
   walkEagerGraph,
@@ -401,6 +404,38 @@ describe("compareToBaseline", () => {
     expect(r.errors.some((e) => e.kind === "missing-allow-comment")).toBe(false);
   });
 
+  it("reports every allowlist-hygiene problem in one pass", () => {
+    const r = compareToBaseline(
+      {
+        count: 10,
+        moduleCount: 10,
+        violations: [
+          { file: "electron/marked.ts", line: 1, pattern: "sync-fs" },
+          { file: "electron/unmarked.ts", line: 1, pattern: "sync-fs" },
+          { file: "electron/new.ts", line: 2, pattern: "sync-fs" },
+        ],
+      },
+      {
+        count: 10,
+        allowlist: ["electron/marked.ts", "electron/unmarked.ts", "electron/stale.ts"],
+        syncViolations: [],
+      },
+      { markedFiles: new Set(["electron/marked.ts"]) }
+    );
+    expect(r.ok).toBe(false);
+    expect(r.errors.filter((e) => e.kind === "new-sync-violation").map((e) => e.file)).toEqual([
+      "electron/new.ts",
+    ]);
+    expect(r.errors.filter((e) => e.kind === "missing-allow-comment").map((e) => e.file)).toEqual([
+      "electron/unmarked.ts",
+    ]);
+    expect(r.errors.filter((e) => e.kind === "unused-allowlist").map((e) => e.file)).toEqual([
+      "electron/stale.ts",
+    ]);
+    // The marked, still-used entry produces no error.
+    expect(r.errors.some((e) => e.file === "electron/marked.ts")).toBe(false);
+  });
+
   it("ignores baseline.syncViolations — allowlist is the sole gate", () => {
     // A file that's in syncViolations but NOT in allowlist must still fail.
     // This pins the policy: the snapshot is informational, enforcement is
@@ -495,9 +530,16 @@ describe("allowlist markers", () => {
     expect(result.has("electron/b.ts")).toBe(false);
   });
 
-  it("scanAllowlistMarkers ignores a marker past the header window", () => {
-    const lines = Array.from({ length: 21 }, (_, i) => `// line ${i + 1}`);
-    lines[20] = "// eager-import-allow: too far down";
+  it("scanAllowlistMarkers accepts a marker exactly on the last header line (20)", () => {
+    const lines = Array.from({ length: 25 }, (_, i) => `// line ${i + 1}`);
+    lines[19] = "// eager-import-allow: just in time"; // 20th line (0-indexed 19)
+    const result = scanAllowlistMarkers(["electron/a.ts"], "/root", () => lines.join("\n"));
+    expect(result.has("electron/a.ts")).toBe(true);
+  });
+
+  it("scanAllowlistMarkers ignores a marker past the header window (line 21)", () => {
+    const lines = Array.from({ length: 25 }, (_, i) => `// line ${i + 1}`);
+    lines[20] = "// eager-import-allow: too far down"; // 21st line (0-indexed 20)
     const result = scanAllowlistMarkers(["electron/a.ts"], "/root", () => lines.join("\n"));
     expect(result.has("electron/a.ts")).toBe(false);
   });
@@ -519,5 +561,19 @@ describe("allowlist markers", () => {
     expect(result.size).toBe(0);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("missing.ts"));
     warnSpy.mockRestore();
+  });
+});
+
+describe("eager-import-baseline.json hygiene (live canary)", () => {
+  // Catches baseline drift: any allowlisted file that loses its
+  // `// eager-import-allow:` header (rename, file move, accidental deletion,
+  // or a fresh `--update` that adds an unmarked entry) fails here.
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const baseline = JSON.parse(readFileSync(path.join(root, "eager-import-baseline.json"), "utf8"));
+
+  it("every allowlisted file carries the eager-import-allow header", () => {
+    const marked = scanAllowlistMarkers(baseline.allowlist, root);
+    const unmarked = baseline.allowlist.filter((file: string) => !marked.has(file));
+    expect(unmarked).toEqual([]);
   });
 });

--- a/scripts/import-budget-lib.test.ts
+++ b/scripts/import-budget-lib.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect, vi } from "vitest";
 import {
   walkEagerGraph,
   scanSyncViolations,
+  scanAllowlistMarkers,
+  hasAllowlistMarker,
   compareToBaseline,
   formatBaseline,
+  ALLOWLIST_MARKER_RE,
   SYNC_FS_RE,
   SYNC_STORE_RE,
   SYNC_SQLITE_RE,
@@ -335,13 +338,67 @@ describe("compareToBaseline", () => {
     expect(r.errors[0].message).toMatch(/line 4/);
   });
 
-  it("flags unused allowlist entries as a notice", () => {
+  it("flags unused allowlist entries as an error", () => {
     const r = compareToBaseline(
       { count: 10, moduleCount: 10, violations: [] },
       { count: 10, allowlist: ["electron/old.ts"], syncViolations: [] }
     );
+    expect(r.ok).toBe(false);
+    expect(
+      r.errors.some((e) => e.kind === "unused-allowlist" && e.file === "electron/old.ts")
+    ).toBe(true);
+    expect(r.notices.some((n) => n.kind === "unused-allowlist")).toBe(false);
+  });
+
+  it("skips the marker check when markedFiles is not provided", () => {
+    const r = compareToBaseline(
+      {
+        count: 10,
+        moduleCount: 10,
+        violations: [{ file: "electron/a.ts", line: 1, pattern: "sync-fs" }],
+      },
+      { count: 10, allowlist: ["electron/a.ts"], syncViolations: [] }
+    );
     expect(r.ok).toBe(true);
-    expect(r.notices.some((n) => n.kind === "unused-allowlist")).toBe(true);
+    expect(r.errors.some((e) => e.kind === "missing-allow-comment")).toBe(false);
+  });
+
+  it("passes when a used allowlisted file carries the allow comment", () => {
+    const r = compareToBaseline(
+      {
+        count: 10,
+        moduleCount: 10,
+        violations: [{ file: "electron/a.ts", line: 1, pattern: "sync-fs" }],
+      },
+      { count: 10, allowlist: ["electron/a.ts"], syncViolations: [] },
+      { markedFiles: new Set(["electron/a.ts"]) }
+    );
+    expect(r.ok).toBe(true);
+    expect(r.errors.some((e) => e.kind === "missing-allow-comment")).toBe(false);
+  });
+
+  it("fails when a used allowlisted file lacks the allow comment", () => {
+    const r = compareToBaseline(
+      {
+        count: 10,
+        moduleCount: 10,
+        violations: [{ file: "electron/a.ts", line: 1, pattern: "sync-fs" }],
+      },
+      { count: 10, allowlist: ["electron/a.ts"], syncViolations: [] },
+      { markedFiles: new Set() }
+    );
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toMatchObject({ kind: "missing-allow-comment", file: "electron/a.ts" });
+  });
+
+  it("stale allowlist entry emits only unused-allowlist, not missing-allow-comment", () => {
+    const r = compareToBaseline(
+      { count: 10, moduleCount: 10, violations: [] },
+      { count: 10, allowlist: ["electron/stale.ts"], syncViolations: [] },
+      { markedFiles: new Set() }
+    );
+    expect(r.errors.some((e) => e.kind === "unused-allowlist")).toBe(true);
+    expect(r.errors.some((e) => e.kind === "missing-allow-comment")).toBe(false);
   });
 
   it("ignores baseline.syncViolations — allowlist is the sole gate", () => {
@@ -406,5 +463,61 @@ describe("formatBaseline", () => {
       ],
     });
     expect(result.syncViolations.map((v) => v.pattern)).toEqual(["sync-fs", "sync-store-get"]);
+  });
+});
+
+describe("allowlist markers", () => {
+  it("matches a valid marker with a reason", () => {
+    expect(ALLOWLIST_MARKER_RE.test("// eager-import-allow: boot-critical sync")).toBe(true);
+    expect(ALLOWLIST_MARKER_RE.test("  // eager-import-allow: indented reason")).toBe(true);
+    expect(ALLOWLIST_MARKER_RE.test("//eager-import-allow:tight")).toBe(true);
+  });
+
+  it("rejects a marker with an empty reason", () => {
+    expect(ALLOWLIST_MARKER_RE.test("// eager-import-allow:")).toBe(false);
+    expect(ALLOWLIST_MARKER_RE.test("// eager-import-allow: ")).toBe(false);
+  });
+
+  it("rejects block-comment markers", () => {
+    expect(ALLOWLIST_MARKER_RE.test("/* eager-import-allow: reason */")).toBe(false);
+  });
+
+  it("hasAllowlistMarker finds a marker among other header lines", () => {
+    const source = "#!/usr/bin/env node\n// eager-import-allow: boot sync\nimport x from 'x';\n";
+    expect(hasAllowlistMarker(source)).toBe(true);
+  });
+
+  it("scanAllowlistMarkers returns the set of files carrying a marker", () => {
+    const reader = (absPath: string) =>
+      absPath.endsWith("a.ts") ? "// eager-import-allow: reason\n" : "no marker here\n";
+    const result = scanAllowlistMarkers(["electron/a.ts", "electron/b.ts"], "/root", reader);
+    expect(result.has("electron/a.ts")).toBe(true);
+    expect(result.has("electron/b.ts")).toBe(false);
+  });
+
+  it("scanAllowlistMarkers ignores a marker past the header window", () => {
+    const lines = Array.from({ length: 21 }, (_, i) => `// line ${i + 1}`);
+    lines[20] = "// eager-import-allow: too far down";
+    const result = scanAllowlistMarkers(["electron/a.ts"], "/root", () => lines.join("\n"));
+    expect(result.has("electron/a.ts")).toBe(false);
+  });
+
+  it("scanAllowlistMarkers handles CRLF line endings", () => {
+    const result = scanAllowlistMarkers(
+      ["electron/a.ts"],
+      "/root",
+      () => "// eager-import-allow: reason\r\nimport x from 'x';\r\n"
+    );
+    expect(result.has("electron/a.ts")).toBe(true);
+  });
+
+  it("scanAllowlistMarkers warns and skips unreadable files", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = scanAllowlistMarkers(["electron/missing.ts"], "/root", () => {
+      throw new Error("ENOENT");
+    });
+    expect(result.size).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("missing.ts"));
+    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
This PR tightens up hygiene for the import-budget allowlist in two ways.

**Hard error on stale entries.** `compareToBaseline` now throws a hard `::error::` annotation for every stale allowlist entry instead of a non-failing `::notice::`. Same shape as ESLint's `reportUnusedDisableDirectives:"error"` — a PR that removes a sync call must drop its allowlist entry in the same change.

**Mandatory `// eager-import-allow: <reason>` header.** The gate enforces marker presence on every still-used allowlisted file via a new `missing-allow-comment` error. `scanAllowlistMarkers` reads the first 20 lines of each file; `compareToBaseline` stays a pure function (marker data injected via `opts.markedFiles`, so unit tests need no fs). All 83 allowlisted `electron/*` files have been stamped with a tailored justification.

**DX:** `npm run import-budget:update` now lists any allowlisted file missing the header so it gets stamped before `check` fails.

**Baseline refresh:** running the mandated `npm run import-budget:update` (the issue's prerequisite) refreshed `eager-import-baseline.json` — count moved 1359 → 1361 from pre-existing develop drift. This PR adds zero imports; prepending comments can't add eager modules. `syncViolations` line numbers shifted +1 in stamped files. Allowlist stays at 83 entries (none were stale).

The import-budget gate runs via `npm run import-budget` and is not wired into any GitHub workflow. The vitest suite (`import-budget-lib.test.ts`, 44 tests) runs in PR CI and covers the new severity, marker helpers, and a live canary asserting every baseline allowlist entry carries the marker.

## Testing

- 44 unit tests pass
- `npm run import-budget` exits 0
- Typecheck, lint, format, and build all clean

Resolves #8889