### PR TITLE
fix(ci): replace silent budget-override flag with linked-issue gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Fast-fail before the slow check: a budget `*-override` label must be
+      # backed by a linked tracking issue in the PR body. PR-only — push and
+      # workflow_dispatch have no PR context, so the step is skipped there.
+      # PR body and label names are injected via env (never the shell) so PR
+      # body metacharacters can't reach a command line.
+      - name: Budget override gate
+        if: github.event_name == 'pull_request'
+        run: node scripts/check-budget-override-gate.mjs
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+
       - name: Check (typecheck + lint + format)
         run: npm run check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+    # labeled/unlabeled/edited are needed so the budget override gate
+    # re-evaluates when a `*-override` label or the PR body changes without a
+    # new commit — otherwise a label added after a green run would never be
+    # re-checked. The heavyweight build job skips those label/edit-only events
+    # (see the build job `if:`).
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
   workflow_dispatch:
     inputs:
       os:
@@ -80,6 +86,13 @@ jobs:
         run: npm run test
 
   build:
+    # Skip the full build on label/description-only PR events — those only need
+    # the budget override gate (in the check job) to re-evaluate, not a fresh
+    # electron build. ci-ok treats a skipped build as non-failing.
+    if: >-
+      !(github.event_name == 'pull_request' && contains(fromJSON('["labeled","unlabeled","edited"]'), github.event.action))
+
+
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/scripts/check-budget-override-gate.mjs
+++ b/scripts/check-budget-override-gate.mjs
@@ -47,9 +47,12 @@ export function hasLinkedIssueReference(body) {
 }
 
 // Parse the JSON array of label names. toJson() on an empty label set yields
-// "[]"; a truly empty PR body field can surface as the string "null". Anything
-// that isn't a JSON array of strings is treated as a hard parse failure so the
-// caller can fail closed rather than silently waving the gate through.
+// "[]"; an empty/absent label field can surface as the string "null". Anything
+// that isn't a JSON array of strings — non-JSON, a non-array, or an array with
+// a non-string member — returns { error } so the caller fails closed rather
+// than silently waving the gate through. The non-string-member guard matters
+// if the workflow expression ever drifts from `labels.*.name` (string names) to
+// the full label-object array: that would otherwise parse to [] and pass.
 export function parseLabels(raw) {
   if (raw === undefined || raw === null || raw === "") return [];
   let parsed;
@@ -62,7 +65,10 @@ export function parseLabels(raw) {
   if (!Array.isArray(parsed)) {
     return { error: `PR_LABELS is not a JSON array: ${raw}` };
   }
-  return parsed.filter((l) => typeof l === "string");
+  if (!parsed.every((l) => typeof l === "string")) {
+    return { error: `PR_LABELS is not an array of strings: ${raw}` };
+  }
+  return parsed;
 }
 
 // Pure gate decision. Returns { skipped } when there's no PR context, otherwise
@@ -115,6 +121,6 @@ function main() {
   process.exit(1);
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main();
 }

--- a/scripts/check-budget-override-gate.mjs
+++ b/scripts/check-budget-override-gate.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+// Linked-issue gate for the budget override labels. Each budget category has a
+// dedicated `*-override` label that lets a PR intentionally accept a regression
+// instead of refreshing the baseline. To keep that escape hatch auditable, this
+// gate fails CI when any override label is applied without a tracking issue
+// referenced in the PR body (`Fixes #N` / `Resolves #N` / `Closes #N`).
+//
+// Reads the PR body and label names from the environment (injected by the CI
+// workflow) rather than the shell, so PR-body metacharacters never reach a
+// command line:
+//   PR_BODY   — github.event.pull_request.body
+//   PR_LABELS — toJson(github.event.pull_request.labels.*.name) (a JSON array)
+//
+// When PR_BODY is unset (push / workflow_dispatch — no PR context) the gate
+// skips cleanly, since there's no body to validate. Mirrors the standalone
+// ESM ratchet style of lint-ratchet.mjs / ipc-handwritten-ratchet.mjs.
+//
+// Usage (CI only):
+//   PR_BODY="$BODY" PR_LABELS='["renderer-bundle-override"]' \
+//     node scripts/check-budget-override-gate.mjs
+
+import { pathToFileURL } from "node:url";
+
+// One label per budget category. The slug matches the npm `*:check` script name
+// (renderer-bundle-budget:check → renderer-bundle-override) so the label-to-gate
+// mapping is grep-able. Only renderer-bundle and first-render-chunk have a
+// regression path wired today; the rest are reserved so the gate stays uniform
+// as the remaining budgets gain override support.
+export const BUDGET_OVERRIDE_LABELS = [
+  "renderer-bundle-override",
+  "first-render-chunk-override",
+  "compiler-budget-override",
+  "import-budget-override",
+  "renderer-import-budget-override",
+];
+
+// Matches a GitHub closing keyword followed by an issue number anywhere in the
+// body. Deliberately narrow: only `fixes`/`resolves`/`closes` (the keywords the
+// issue spec names) and a bare `#N` — `Fixed #1`, `see #1`, or `#abc` don't
+// count, so the reference is an explicit, intentional link.
+const ISSUE_REF_RE = /\b(?:fixes|resolves|closes)\s+#\d+\b/i;
+
+export function hasLinkedIssueReference(body) {
+  if (typeof body !== "string") return false;
+  return ISSUE_REF_RE.test(body);
+}
+
+// Parse the JSON array of label names. toJson() on an empty label set yields
+// "[]"; a truly empty PR body field can surface as the string "null". Anything
+// that isn't a JSON array of strings is treated as a hard parse failure so the
+// caller can fail closed rather than silently waving the gate through.
+export function parseLabels(raw) {
+  if (raw === undefined || raw === null || raw === "") return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { error: `PR_LABELS is not valid JSON: ${raw}` };
+  }
+  if (parsed === null) return [];
+  if (!Array.isArray(parsed)) {
+    return { error: `PR_LABELS is not a JSON array: ${raw}` };
+  }
+  return parsed.filter((l) => typeof l === "string");
+}
+
+// Pure gate decision. Returns { skipped } when there's no PR context, otherwise
+// { ok, matchedLabels } — ok is false only when an override label is present
+// without a linked issue. `parseError` fails closed.
+export function validateBudgetOverrideGate({ body, labels }) {
+  if (body === undefined || body === null) return { skipped: true };
+
+  const parsed = parseLabels(labels);
+  if (parsed && parsed.error) return { ok: false, parseError: parsed.error };
+
+  const matchedLabels = BUDGET_OVERRIDE_LABELS.filter((l) => parsed.includes(l));
+  if (matchedLabels.length === 0) return { ok: true, matchedLabels };
+
+  return { ok: hasLinkedIssueReference(body), matchedLabels };
+}
+
+function main() {
+  const result = validateBudgetOverrideGate({
+    body: process.env.PR_BODY,
+    labels: process.env.PR_LABELS,
+  });
+
+  if (result.skipped) {
+    console.log("[check-budget-override-gate] no PR context — skipping.");
+    return;
+  }
+
+  if (result.parseError) {
+    console.error(`::error::${result.parseError}`);
+    process.exit(1);
+  }
+
+  if (result.matchedLabels.length === 0) {
+    console.log("[check-budget-override-gate] OK — no budget override labels applied.");
+    return;
+  }
+
+  if (result.ok) {
+    console.log(
+      `[check-budget-override-gate] OK — override label(s) ${result.matchedLabels.join(", ")} backed by a linked issue.`
+    );
+    return;
+  }
+
+  console.error(
+    `::error::Budget override label(s) ${result.matchedLabels.join(", ")} require a tracking issue. ` +
+      "Add `Fixes #N`, `Resolves #N`, or `Closes #N` to the PR body, or remove the label and refresh the baseline instead."
+  );
+  process.exit(1);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-budget-override-gate.test.mjs
+++ b/scripts/check-budget-override-gate.test.mjs
@@ -1,3 +1,5 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import {
   BUDGET_OVERRIDE_LABELS,
@@ -5,6 +7,16 @@ import {
   parseLabels,
   validateBudgetOverrideGate,
 } from "./check-budget-override-gate.mjs";
+
+const GATE_SCRIPT = fileURLToPath(new URL("./check-budget-override-gate.mjs", import.meta.url));
+
+function runGate(env) {
+  return spawnSync(process.execPath, [GATE_SCRIPT], {
+    encoding: "utf8",
+    // Clear PR_* from the ambient env so the test controls them fully.
+    env: { ...process.env, PR_BODY: undefined, PR_LABELS: undefined, ...env },
+  });
+}
 
 describe("hasLinkedIssueReference", () => {
   it.each(["Fixes #123", "resolves #1", "CLOSES #42", "see also Fixes #7 thanks"])(
@@ -14,12 +26,17 @@ describe("hasLinkedIssueReference", () => {
     }
   );
 
-  it.each(["Fixed #123", "fix #123", "Fixes #abc", "bare #123", "fixes#123", "fixes 123"])(
-    "rejects %j",
-    (body) => {
-      expect(hasLinkedIssueReference(body)).toBe(false);
-    }
-  );
+  it.each([
+    "Fixed #123",
+    "fix #123",
+    "Fixes #abc",
+    "bare #123",
+    "fixes#123",
+    "fixes 123",
+    "Fixes daintreehq/daintree#123",
+  ])("rejects %j", (body) => {
+    expect(hasLinkedIssueReference(body)).toBe(false);
+  });
 
   it("rejects non-string bodies", () => {
     expect(hasLinkedIssueReference(undefined)).toBe(false);
@@ -44,8 +61,14 @@ describe("parseLabels", () => {
     ]);
   });
 
-  it("drops non-string array members", () => {
-    expect(parseLabels('["a",1,null,"b"]')).toEqual(["a", "b"]);
+  it("fails closed on a non-string array member (expression drift guard)", () => {
+    const result = parseLabels('["a",1,null,"b"]');
+    expect(result.error).toMatch(/not an array of strings/);
+  });
+
+  it("fails closed on an array of label objects", () => {
+    const result = parseLabels('[{"name":"renderer-bundle-override"}]');
+    expect(result.error).toMatch(/not an array of strings/);
   });
 
   it("fails closed on malformed JSON", () => {
@@ -132,5 +155,42 @@ describe("validateBudgetOverrideGate", () => {
     const result = validateBudgetOverrideGate({ body: "Fixes #1", labels: "[broken" });
     expect(result.ok).toBe(false);
     expect(result.parseError).toMatch(/not valid JSON/);
+  });
+});
+
+describe("CLI (main)", () => {
+  it("exits 0 and skips when PR_BODY is unset (non-PR context)", () => {
+    const r = runGate({ PR_LABELS: '["renderer-bundle-override"]' });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/no PR context/);
+  });
+
+  it("exits 0 when no override labels are applied", () => {
+    const r = runGate({ PR_BODY: "no link here", PR_LABELS: '["enhancement"]' });
+    expect(r.status).toBe(0);
+  });
+
+  it("exits 1 with an annotation when an override label lacks a linked issue", () => {
+    const r = runGate({ PR_BODY: "just bumping it", PR_LABELS: '["renderer-bundle-override"]' });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/::error::/);
+    expect(r.stderr).toMatch(/renderer-bundle-override/);
+  });
+
+  it("exits 1 for an empty-string body with an override label (not coerced to skip)", () => {
+    const r = runGate({ PR_BODY: "", PR_LABELS: '["first-render-chunk-override"]' });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/::error::/);
+  });
+
+  it("exits 0 when the override label is backed by a linked issue", () => {
+    const r = runGate({ PR_BODY: "Fixes #8902", PR_LABELS: '["renderer-bundle-override"]' });
+    expect(r.status).toBe(0);
+  });
+
+  it("exits 1 (fails closed) when PR_LABELS is malformed JSON", () => {
+    const r = runGate({ PR_BODY: "Fixes #1", PR_LABELS: "not-json" });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/::error::/);
   });
 });

--- a/scripts/check-budget-override-gate.test.mjs
+++ b/scripts/check-budget-override-gate.test.mjs
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import {
+  BUDGET_OVERRIDE_LABELS,
+  hasLinkedIssueReference,
+  parseLabels,
+  validateBudgetOverrideGate,
+} from "./check-budget-override-gate.mjs";
+
+describe("hasLinkedIssueReference", () => {
+  it.each(["Fixes #123", "resolves #1", "CLOSES #42", "see also Fixes #7 thanks"])(
+    "accepts %j",
+    (body) => {
+      expect(hasLinkedIssueReference(body)).toBe(true);
+    }
+  );
+
+  it.each(["Fixed #123", "fix #123", "Fixes #abc", "bare #123", "fixes#123", "fixes 123"])(
+    "rejects %j",
+    (body) => {
+      expect(hasLinkedIssueReference(body)).toBe(false);
+    }
+  );
+
+  it("rejects non-string bodies", () => {
+    expect(hasLinkedIssueReference(undefined)).toBe(false);
+    expect(hasLinkedIssueReference(null)).toBe(false);
+    expect(hasLinkedIssueReference("")).toBe(false);
+  });
+});
+
+describe("parseLabels", () => {
+  it("returns [] for empty / null / undefined input", () => {
+    expect(parseLabels(undefined)).toEqual([]);
+    expect(parseLabels(null)).toEqual([]);
+    expect(parseLabels("")).toEqual([]);
+    expect(parseLabels("[]")).toEqual([]);
+    expect(parseLabels("null")).toEqual([]);
+  });
+
+  it("parses a JSON array of label names", () => {
+    expect(parseLabels('["renderer-bundle-override","enhancement"]')).toEqual([
+      "renderer-bundle-override",
+      "enhancement",
+    ]);
+  });
+
+  it("drops non-string array members", () => {
+    expect(parseLabels('["a",1,null,"b"]')).toEqual(["a", "b"]);
+  });
+
+  it("fails closed on malformed JSON", () => {
+    const result = parseLabels("[not json");
+    expect(result.error).toMatch(/not valid JSON/);
+  });
+
+  it("fails closed on non-array JSON", () => {
+    const result = parseLabels('{"name":"x"}');
+    expect(result.error).toMatch(/not a JSON array/);
+  });
+});
+
+describe("validateBudgetOverrideGate", () => {
+  it("skips when there is no PR body (push / workflow_dispatch)", () => {
+    expect(validateBudgetOverrideGate({ body: undefined, labels: "[]" })).toEqual({
+      skipped: true,
+    });
+    expect(validateBudgetOverrideGate({ body: null, labels: undefined })).toEqual({
+      skipped: true,
+    });
+  });
+
+  it("passes when no override labels are applied, regardless of body", () => {
+    const result = validateBudgetOverrideGate({
+      body: "no issue reference here",
+      labels: '["enhancement","infrastructure"]',
+    });
+    expect(result).toEqual({ ok: true, matchedLabels: [] });
+  });
+
+  it("passes when an override label is backed by a linked issue", () => {
+    const result = validateBudgetOverrideGate({
+      body: "Intentional growth. Fixes #8902",
+      labels: '["renderer-bundle-override"]',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.matchedLabels).toEqual(["renderer-bundle-override"]);
+  });
+
+  it("fails when an override label has no linked issue", () => {
+    const result = validateBudgetOverrideGate({
+      body: "just bumping the budget",
+      labels: '["first-render-chunk-override"]',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.matchedLabels).toEqual(["first-render-chunk-override"]);
+  });
+
+  it("fails when body is an empty string and an override label is present", () => {
+    const result = validateBudgetOverrideGate({
+      body: "",
+      labels: '["compiler-budget-override"]',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.matchedLabels).toEqual(["compiler-budget-override"]);
+  });
+
+  it.each(BUDGET_OVERRIDE_LABELS)("recognizes each override label: %s", (label) => {
+    const failing = validateBudgetOverrideGate({ body: "nope", labels: JSON.stringify([label]) });
+    expect(failing.ok).toBe(false);
+    expect(failing.matchedLabels).toEqual([label]);
+
+    const passing = validateBudgetOverrideGate({
+      body: "Closes #1",
+      labels: JSON.stringify([label]),
+    });
+    expect(passing.ok).toBe(true);
+  });
+
+  it("reports all matched override labels when multiple are applied", () => {
+    const result = validateBudgetOverrideGate({
+      body: "no link",
+      labels: '["renderer-bundle-override","first-render-chunk-override","enhancement"]',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.matchedLabels).toEqual([
+      "renderer-bundle-override",
+      "first-render-chunk-override",
+    ]);
+  });
+
+  it("fails closed when PR_LABELS is malformed JSON", () => {
+    const result = validateBudgetOverrideGate({ body: "Fixes #1", labels: "[broken" });
+    expect(result.ok).toBe(false);
+    expect(result.parseError).toMatch(/not valid JSON/);
+  });
+});

--- a/scripts/check-first-render-chunk-budget.mjs
+++ b/scripts/check-first-render-chunk-budget.mjs
@@ -6,15 +6,16 @@
 // "what the user actually downloads before they can interact" — eager imports
 // plus the lazy chunks for any panel restored from the previous session.
 //
-// Compares against the checked-in first-render-chunk-baseline.json. Warn-only
-// for the first nightly week per #7576 — use --override in CI until the
-// staged-rollout window expires.
+// Compares against the checked-in first-render-chunk-baseline.json.
+//
+// There is no override flag: an intentional regression is accepted by applying
+// the `first-render-chunk-override` label to the PR with a linked tracking
+// issue (enforced by scripts/check-budget-override-gate.mjs in CI).
 //
 // Usage:
 //   node scripts/check-first-render-chunk-budget.mjs                   # check (CI)
 //   node scripts/check-first-render-chunk-budget.mjs --update          # write baseline
 //   node scripts/check-first-render-chunk-budget.mjs --update --force  # bypass shrink guard
-//   node scripts/check-first-render-chunk-budget.mjs --override        # don't fail exit code
 //   node scripts/check-first-render-chunk-budget.mjs --threshold 0.10  # 10% growth allowed
 
 import { existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
@@ -59,12 +60,11 @@ export function shrinkageGuardError(priorGzip, nextGzip, threshold) {
 }
 
 function parseArgs(argv) {
-  const args = { isUpdate: false, force: false, override: false, threshold: DEFAULT_THRESHOLD };
+  const args = { isUpdate: false, force: false, threshold: DEFAULT_THRESHOLD };
   for (let i = 2; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--update") args.isUpdate = true;
     else if (arg === "--force") args.force = true;
-    else if (arg === "--override") args.override = true;
     else if (arg === "--threshold" && argv[i + 1]) {
       const val = argv[i + 1];
       args.threshold = parseFloat(val);
@@ -394,14 +394,9 @@ function main() {
     `::error::first-render chunk gzip grew from ${result.baselineGzip} to ${result.currentGzip} (+${result.delta}, ${(result.ratio * 100).toFixed(2)}%, threshold +${(args.threshold * 100).toFixed(1)}%)`
   );
   console.error(
-    `   If the change is intentional, run \`npm run first-render-chunk-budget:update\` to refresh the baseline.`
+    `   If the change is intentional, run \`npm run first-render-chunk-budget:update\` to refresh the baseline, ` +
+      `or apply the \`first-render-chunk-override\` label to the PR with a linked tracking issue (\`Fixes #N\`, \`Resolves #N\`, or \`Closes #N\` in the PR body).`
   );
-  if (args.override) {
-    console.log(
-      "[check-first-render-chunk-budget] override active — exiting successfully despite regression"
-    );
-    return;
-  }
   process.exit(1);
 }
 

--- a/scripts/check-renderer-bundle-budget.mjs
+++ b/scripts/check-renderer-bundle-budget.mjs
@@ -11,7 +11,10 @@
 //   node scripts/check-renderer-bundle-budget.mjs --threshold 0.10            # allow 10% growth
 //   node scripts/check-renderer-bundle-budget.mjs --update                    # write current report as new baseline
 //   node scripts/check-renderer-bundle-budget.mjs --update --force            # bypass the shrinkage guard
-//   node scripts/check-renderer-bundle-budget.mjs --override                  # suppress failure exit code
+//
+// There is no override flag: an intentional regression is accepted by applying
+// the `renderer-bundle-override` label to the PR with a linked tracking issue
+// (enforced by scripts/check-budget-override-gate.mjs in CI).
 
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -94,12 +97,11 @@ function writeBaseline(report, { force }) {
 }
 
 function parseArgs(argv) {
-  const args = { isUpdate: false, force: false, override: false, threshold: DEFAULT_THRESHOLD };
+  const args = { isUpdate: false, force: false, threshold: DEFAULT_THRESHOLD };
   for (let i = 2; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--update") args.isUpdate = true;
     else if (arg === "--force") args.force = true;
-    else if (arg === "--override") args.override = true;
     else if (arg === "--threshold" && argv[i + 1]) {
       const val = argv[i + 1];
       args.threshold = parseFloat(val);
@@ -162,12 +164,9 @@ function main() {
   } else {
     console.error(
       `\n[check-renderer-bundle-budget] FAILED — ${comparison.failures.length} regression(s) exceed +${(args.threshold * 100).toFixed(0)}% threshold. ` +
-        `If the change is intentional, run \`npm run renderer-bundle-budget:update\` to refresh the baseline.`
+        `If the change is intentional, run \`npm run renderer-bundle-budget:update\` to refresh the baseline, or apply the \`renderer-bundle-override\` label to the PR with a linked tracking issue (\`Fixes #N\`, \`Resolves #N\`, or \`Closes #N\` in the PR body).`
     );
-    if (!args.override) process.exit(1);
-    console.log(
-      "[check-renderer-bundle-budget] override active — exiting successfully despite regressions"
-    );
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Summary

- The old `--override` CLI flag silently suppressed budget failures with no audit trail, and the `bundle-size-override` label it pointed contributors to didn't exist on the repo.
- Replaces both with five granular per-budget-category override labels gated on a `Fixes`/`Resolves`/`Closes #N` reference in the PR body — matching the project's existing ratchet style.
- Adds `scripts/check-budget-override-gate.mjs` (the gate script) and 36 unit + CLI tests; updates CI to re-evaluate the gate on label and edit events.

Closes #8902

## Changes

- **NEW** `scripts/check-budget-override-gate.mjs` — fails CI when any `*-override` label is applied without a linked issue reference in the PR body; skips outside PR context; fails closed on malformed `PR_LABELS`
- **NEW** `scripts/check-budget-override-gate.test.mjs` — 36 unit + CLI tests covering all five labels, edge cases, and the CLI exit codes
- `.github/workflows/ci.yml` — added PR-only "Budget override gate" step; added `pull_request` trigger types `[opened, synchronize, reopened, labeled, unlabeled, edited]` so the gate re-evaluates on label/body changes; build job skips on label/edit-only events to avoid wasteful Electron rebuilds
- `scripts/check-renderer-bundle-budget.mjs` and `scripts/check-first-render-chunk-budget.mjs` — removed the silent `--override` flag; fixed the erroneous `bundle-size-override` label name; error messages now point at the real override labels and the linked-issue requirement

## Testing

- 36 unit + CLI tests in `check-budget-override-gate.test.mjs` covering valid/invalid PR bodies, all five label names, missing `PR_BODY`/`PR_LABELS` env vars, non-PR context (skips cleanly), and malformed input (fails closed)
- Five GitHub labels (`renderer-bundle-override`, `first-render-chunk-override`, `compiler-budget-override`, `import-budget-override`, `renderer-import-budget-override`) created on the repo via `gh label create`