### PR TITLE
feat(worktree): capture source PR when creating from PR dropdown (#8888)

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -409,6 +409,21 @@ class PullRequestService {
   }
 
   /**
+   * Currently-resolved forge provider context, or null when no provider has
+   * resolved yet (e.g. token not connected). Read synchronously so callers can
+   * eagerly compose a `linked` projection at worktree-create time without an
+   * IPC roundtrip (#8888).
+   */
+  public getProviderContext(): { providerId: string; owner: string; repo: string } | null {
+    if (!this.providerNamespacedId || !this.repoRef) return null;
+    return {
+      providerId: this.providerNamespacedId,
+      owner: this.repoRef.owner,
+      repo: this.repoRef.repo,
+    };
+  }
+
+  /**
    * Start polling. The first check is delayed by a randomised
    * STARTUP_JITTER_MIN..MAX window so a fleet-wide host restart doesn't fire a
    * synchronised PR refetch burst. Pass `startupDelayMs = 0` to check

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -20,6 +20,7 @@ interface PullRequestServiceLike {
     isEnabled: boolean;
     detectionStateTripped: boolean;
   };
+  getProviderContext(): { providerId: string; owner: string; repo: string } | null;
 }
 
 export interface PRIntegrationCallbacks {
@@ -188,6 +189,15 @@ export class PRIntegrationService {
       // also disables polling but must not show the "detection paused" badge.
       circuitBreakerTripped: status.detectionStateTripped,
     };
+  }
+
+  /**
+   * Currently-resolved forge provider context, or null when no provider has
+   * resolved yet. Used to eagerly compose a `linked` projection at
+   * worktree-create time (#8888).
+   */
+  getProviderContext(): { providerId: string; owner: string; repo: string } | null {
+    return this.prService.getProviderContext();
   }
 
   resetPRState(projectRootPath: string | null): void {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1783,6 +1783,63 @@ export class WorkspaceService {
         }
       }
 
+      // #8888: when created from the GitHub PR dropdown, seed the source PR
+      // eagerly so the card surfaces the PR (title, linked issue) immediately
+      // instead of waiting for PullRequestService's branch-name polling. Must
+      // run before `return canonicalWorktreeId` — the initial clean snapshot
+      // already emitted from addNewWorktreeMonitor, so we mutate and emit once
+      // more. Wrapped in try/catch: a seeding failure must never fail the
+      // create (polling backfills `linked` regardless).
+      if (options.sourcePrNumber !== undefined) {
+        const m = this.monitors.get(canonicalWorktreeId);
+        if (m) {
+          try {
+            m.setSourcePrNumber(options.sourcePrNumber);
+
+            const providerCtx = this.prService.getProviderContext();
+            if (providerCtx && options.sourcePrUrl && options.sourcePrState) {
+              // Provider resolved — `linked` is the source of truth.
+              const linked = this.composeLinked({
+                providerId: providerCtx.providerId,
+                owner: providerCtx.owner,
+                repo: providerCtx.repo,
+                pr: {
+                  number: options.sourcePrNumber,
+                  title: options.sourcePrTitle,
+                  url: options.sourcePrUrl,
+                  state: options.sourcePrState,
+                },
+                issue:
+                  options.sourcePrLinkedIssueNumber !== undefined
+                    ? { number: options.sourcePrLinkedIssueNumber }
+                    : undefined,
+              });
+              m.setLinked(linked);
+            } else {
+              // No provider context yet (e.g. token not connected). Persist the
+              // legacy flat fields so the PR still shows; PullRequestService
+              // fills `linked` on its first poll.
+              m.setPRInfo({
+                prNumber: options.sourcePrNumber,
+                prUrl: options.sourcePrUrl,
+                prState: options.sourcePrState,
+                prTitle: options.sourcePrTitle,
+              });
+            }
+
+            // Keep the flat issue number in lockstep so the offline issue badge
+            // shows and the onIssueNotFound guard matches.
+            if (options.sourcePrLinkedIssueNumber !== undefined) {
+              m.setIssueNumber(options.sourcePrLinkedIssueNumber);
+            }
+
+            m.emitUpdate();
+          } catch (err) {
+            console.warn("[WorkspaceHost] failed to seed source PR on create:", err);
+          }
+        }
+      }
+
       // Fire-and-forget tail: cache invalidation, .daintree copy, and
       // lifecycle setup are non-blocking for callers of create-worktree-result.
       // Tail failures are logged but never re-emit a result event.

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -147,6 +147,7 @@ export class WorktreeMonitor {
   private prTitle: string | undefined;
   private issueTitle: string | undefined;
   private _branchDerivedTitle: string | undefined;
+  private _sourcePrNumber: number | undefined;
   private prLastUpdatedAt: number | undefined;
   private issueLastUpdatedAt: number | undefined;
 
@@ -646,6 +647,15 @@ export class WorktreeMonitor {
   }
 
   /**
+   * Mark this worktree as PR-originated by recording the source PR number (#8888).
+   * Set once at creation time from the PR-dropdown flow; immutable thereafter.
+   * Drives the inverted PR-title-as-headline display in the worktree card.
+   */
+  setSourcePrNumber(prNumber: number | undefined): void {
+    this._sourcePrNumber = prNumber;
+  }
+
+  /**
    * Update the repository's main/integration branch — the base-branch
    * divergence fallback used when this worktree has no linked PR. Called by
    * `syncMonitors` so existing monitors track a main-worktree branch switch.
@@ -1077,6 +1087,7 @@ export class WorktreeMonitor {
       prTitle: linkedPr ? linkedPr.title : this.prTitle,
       issueTitle: linkedIssue ? linkedIssue.title : this.issueTitle,
       branchDerivedTitle: this._branchDerivedTitle,
+      sourcePrNumber: this._sourcePrNumber,
       prLastUpdatedAt: this.prLastUpdatedAt,
       issueLastUpdatedAt: this.issueLastUpdatedAt,
       worktreeChanges: this.worktreeChanges,

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -640,6 +640,11 @@ export class WorktreeMonitor {
     this.prCiStatus = undefined;
     this.prTitle = undefined;
     this.prLastUpdatedAt = undefined;
+    // Drop the PR-originated discriminator too (#8888): clearing PR info means
+    // the branch no longer maps to its source PR (branch rename, or detection
+    // found no PR), so the inverted PR-title headline must not linger with a
+    // stale number and no title.
+    this._sourcePrNumber = undefined;
   }
 
   setLinked(linked: import("../../shared/types/plugin.js").PluginWorktreeLinked | null): void {

--- a/electron/workspace-host/__tests__/PRIntegrationService.test.ts
+++ b/electron/workspace-host/__tests__/PRIntegrationService.test.ts
@@ -52,6 +52,7 @@ describe("PRIntegrationService", () => {
       isEnabled: boolean;
       detectionStateTripped: boolean;
     };
+    getProviderContext(): { providerId: string; owner: string; repo: string } | null;
   }
 
   let prServiceMock: PullRequestServiceLike;
@@ -72,6 +73,7 @@ describe("PRIntegrationService", () => {
         isEnabled: true,
         detectionStateTripped: false,
       })),
+      getProviderContext: vi.fn(() => null),
     };
   });
 

--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -108,6 +108,7 @@ export function parsePRNode(node: Record<string, unknown>): GitHubPR {
     headRefName: (node.headRefName as string) || undefined,
     isFork: isFork ?? undefined,
     ciStatus,
+    bodyText: (node.bodyText as string) || undefined,
   };
 }
 

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -166,4 +166,21 @@ export interface CreateWorktreeOptions {
   provisionResource?: boolean;
   /** Worktree environment mode ("local" or an environment key from resourceEnvironments) */
   worktreeMode?: string;
+  /**
+   * Source PR number when the worktree is created from the GitHub PR dropdown.
+   * Captured eagerly so the worktree's linked PR is seeded at creation time
+   * rather than waiting for PullRequestService branch-name polling (#8888).
+   */
+  sourcePrNumber?: number;
+  /** Source PR title (for immediate headline display). */
+  sourcePrTitle?: string;
+  /** Source PR URL. */
+  sourcePrUrl?: string;
+  /** Source PR state, normalized to the workspace-host lowercase form. */
+  sourcePrState?: "open" | "closed" | "merged";
+  /**
+   * Closing issue number for the source PR, extracted from `closingIssuesReferences`
+   * or a body-parse of `Closes/Fixes/Resolves #N`. Undefined when the PR closes no issue.
+   */
+  sourcePrLinkedIssueNumber?: number;
 }

--- a/shared/types/github.ts
+++ b/shared/types/github.ts
@@ -92,6 +92,9 @@ export interface GitHubPR {
    *  was truncated, or when the repository has no required checks configured (in which case
    *  ciStatus reflects the raw rollup). */
   ciSummary?: GitHubPRCISummary;
+  /** Plain-text PR body. Used to body-parse closing-issue references (`Closes #N`)
+   *  when capturing the source PR at worktree-create time. */
+  bodyText?: string;
 }
 
 /** Issue tooltip data (subset of full issue for hover display) */

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -112,6 +112,14 @@ export interface WorktreeSnapshot {
    * fetched yet so the sidebar never shows the raw slug (#8851).
    */
   branchDerivedTitle?: string;
+  /**
+   * PR number this worktree was created from via the GitHub PR dropdown (#8888).
+   * Acts as the "PR-originated" discriminator: when set, the card surfaces the
+   * PR title as the primary headline with the linked issue underneath, inverting
+   * the default issue-first display. Persisted independently of `linked.pr`, which
+   * may lag until PullRequestService's first poll resolves.
+   */
+  sourcePrNumber?: number;
   prLastUpdatedAt?: number;
   issueLastUpdatedAt?: number;
   worktreeChanges?: WorktreeChanges | null;

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -116,8 +116,9 @@ export interface WorktreeSnapshot {
    * PR number this worktree was created from via the GitHub PR dropdown (#8888).
    * Acts as the "PR-originated" discriminator: when set, the card surfaces the
    * PR title as the primary headline with the linked issue underneath, inverting
-   * the default issue-first display. Persisted independently of `linked.pr`, which
-   * may lag until PullRequestService's first poll resolves.
+   * the default issue-first display. Held in-memory by the monitor (like
+   * `worktreeMode`); not persisted to disk, so after a host restart the PR is
+   * re-detected by polling and shown as a subordinate badge until then.
    */
   sourcePrNumber?: number;
   prLastUpdatedAt?: number;

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -193,6 +193,13 @@ export interface Worktree {
    */
   branchDerivedTitle?: string;
 
+  /**
+   * PR number this worktree was created from via the GitHub PR dropdown (#8888).
+   * When set, the card shows the PR title as the primary headline with the linked
+   * issue underneath, inverting the default issue-first display.
+   */
+  sourcePrNumber?: number;
+
   /** Timestamp when the issue title was last updated by the workspace-host */
   issueLastUpdatedAt?: number;
 

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -14,6 +14,7 @@ import { notify } from "@/lib/notify";
 import { systemClient } from "@/clients/systemClient";
 import { useRecipeStore } from "@/store/recipeStore";
 import { logError } from "@/utils/logger";
+import { extractClosingIssueNumber } from "@/utils/closingIssueRef";
 import { useProjectStore } from "@/store/projectStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
@@ -42,6 +43,18 @@ import {
 } from "./views";
 
 type BranchMode = "new" | "existing";
+
+/** Map the GitHub uppercase PR state to the workspace-host lowercase form. */
+function normalizeSourcePrState(state: GitHubPR["state"]): "open" | "closed" | "merged" {
+  switch (state) {
+    case "MERGED":
+      return "merged";
+    case "CLOSED":
+      return "closed";
+    default:
+      return "open";
+  }
+}
 
 interface NewWorktreeDialogProps {
   isOpen: boolean;
@@ -527,6 +540,18 @@ export function NewWorktreeDialog({
           useExistingBranch,
           provisionResource: snapWorktreeMode !== "local" || undefined,
           worktreeMode: snapWorktreeMode,
+          // #8888: when created from the PR dropdown, capture the source PR so
+          // the host seeds the worktree's linked PR (and closing issue) eagerly
+          // instead of waiting for branch-name polling to rediscover it.
+          ...(snapInitialPR
+            ? {
+                sourcePrNumber: snapInitialPR.number,
+                sourcePrTitle: snapInitialPR.title,
+                sourcePrUrl: snapInitialPR.url,
+                sourcePrState: normalizeSourcePrState(snapInitialPR.state),
+                sourcePrLinkedIssueNumber: extractClosingIssueNumber(snapInitialPR.bodyText),
+              }
+            : {}),
         };
 
         const actionResult = await actionService.dispatch(

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -25,6 +25,12 @@ interface NonMainSecondaryRowProps {
    * line, which surfaces below either form of title (#8851).
    */
   hasDisplayTitle: boolean;
+  /**
+   * True when the worktree was created from the PR dropdown (#8888): the PR is
+   * the headline, so suppress the subordinate PR badge here and instead surface
+   * the linked issue underneath.
+   */
+  isPrOriginated: boolean;
   hasPlanFile: boolean;
   badges: {
     onOpenIssue?: () => void;
@@ -42,6 +48,7 @@ export function NonMainSecondaryRow({
   hasUpstreamDelta,
   hasAuthFailedSignIn,
   hasDisplayTitle,
+  isPrOriginated,
   hasPlanFile,
   badges,
 }: NonMainSecondaryRowProps) {
@@ -54,7 +61,10 @@ export function NonMainSecondaryRow({
     [worktree.isCurrent, fetchIntervalActiveMs, fetchIntervalBackgroundMs]
   );
 
+  // Suppress the subordinate PR badge when the PR is already the headline
+  // (PR-originated worktrees, #8888) — the linked issue takes the secondary row.
   const showPRBadge =
+    !isPrOriginated &&
     worktree.linked?.pr &&
     worktree.linked.pr.state !== "closed" &&
     worktree.linked.pr.state !== "declined";
@@ -104,9 +114,10 @@ export function NonMainSecondaryRow({
 
   return (
     <div className="flex flex-col gap-0.5 mt-1.5">
-      {worktree.issueNumber && !hasDisplayTitle && (
+      {worktree.issueNumber && (isPrOriginated || !hasDisplayTitle) && (
         <IssueBadge
           issueNumber={worktree.issueNumber}
+          issueTitle={isPrOriginated ? worktree.issueTitle : undefined}
           worktreePath={worktree.path}
           onOpen={badges.onOpenIssue}
           isActive={isActive}

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { Clock, CloudOff, CornerDownRight, GitPullRequest } from "lucide-react";
 import type { CIStatus } from "@shared/types/forge";
 import type { NormalizedPRState } from "@shared/types/forge";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { usePRTooltip } from "@/hooks/useGitHubTooltip";
 import { useGitHubBadgeTooltip } from "./hooks/useGitHubBadgeTooltip";
@@ -23,6 +24,13 @@ interface PRBadgeProps {
   rowLastUpdatedAt?: number;
   /** Service-wide PR detection circuit breaker tripped — this rollup may be stale. */
   prDetectionPaused?: boolean;
+  /**
+   * Render as the card's primary headline (larger text, PR title shown). Used
+   * for worktrees created from the PR dropdown (#8888), mirroring IssueBadge.
+   */
+  isHeadline?: boolean;
+  /** PR title to show when `isHeadline` is set. */
+  prTitle?: string;
 }
 
 export function PRBadge({
@@ -36,11 +44,25 @@ export function PRBadge({
   underlineOnHover,
   rowLastUpdatedAt,
   prDetectionPaused,
+  isHeadline,
+  prTitle,
 }: PRBadgeProps) {
+  // Mirror IssueBadge: when a freshly-set PR number has no title yet, suppress
+  // the raw "#NNN" fallback for the first 400ms (Doherty) rather than flashing
+  // the number while the title fetch is in-flight.
+  "use no memo";
+
   const { data, loading, error, missingToken, fetchTooltip, reset } = usePRTooltip(
     worktreePath,
     prNumber
   );
+
+  const prevPrNumber = useRef<number | undefined>(undefined);
+  const isColdTitleGap = isHeadline === true && !prTitle && prNumber !== prevPrNumber.current;
+  const showColdFallback = useDohertyGate(isColdTitleGap);
+  useEffect(() => {
+    prevPrNumber.current = prNumber;
+  }, [prNumber]);
 
   const { isOpen, handleOpenChange, handleClick } = useGitHubBadgeTooltip({
     fetchTooltip,
@@ -80,9 +102,11 @@ export function PRBadge({
 
   const ariaLabel = missingToken
     ? "Configure GitHub token to see PR details"
-    : (ciVisual
-        ? `Open ${prStateLabel} pull request #${prNumber} on GitHub — ${ciVisual.ariaLabel}`
-        : `Open ${prStateLabel} pull request #${prNumber} on GitHub`) +
+    : (isHeadline && prTitle
+        ? `Open pull request #${prNumber}: ${prTitle}`
+        : ciVisual
+          ? `Open ${prStateLabel} pull request #${prNumber} on GitHub — ${ciVisual.ariaLabel}`
+          : `Open ${prStateLabel} pull request #${prNumber} on GitHub`) +
       (freshnessCause === "rate-limit"
         ? " — GitHub rate limited"
         : freshnessCause === "circuit-breaker" || (prDetectionPaused ?? false)
@@ -108,7 +132,8 @@ export function PRBadge({
           onClick={handleClick}
           data-no-dnd
           className={cn(
-            "flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0"
+            "flex items-center gap-1 text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
+            isHeadline ? "gap-1.5 text-[13px]" : "text-xs"
           )}
           aria-disabled={!isActive || undefined}
           aria-label={ariaLabel}
@@ -123,18 +148,45 @@ export function PRBadge({
             />
           )}
           <GitPullRequest
-            className={cn("w-3 h-3 shrink-0", missingToken ? "grayscale opacity-50" : prStateColor)}
+            className={cn(
+              "shrink-0",
+              isHeadline ? "w-3.5 h-3.5" : "w-3 h-3",
+              missingToken ? "grayscale opacity-50" : prStateColor
+            )}
             aria-hidden="true"
           />
-          <span
-            className={cn(
-              "font-mono",
-              underlineOnHover && "hover:underline",
-              missingToken ? "text-text-muted" : prStateColor
-            )}
-          >
-            #{prNumber}
-          </span>
+          {isHeadline ? (
+            <span
+              className={cn(
+                "truncate flex-1 min-w-0",
+                underlineOnHover && "hover:underline",
+                missingToken
+                  ? "text-text-muted"
+                  : isActive
+                    ? "text-text-primary font-medium"
+                    : "text-text-secondary font-medium"
+              )}
+            >
+              {prTitle ||
+                (isColdTitleGap && !showColdFallback ? null : (
+                  <span
+                    className={cn("font-mono", missingToken ? "text-text-muted" : prStateColor)}
+                  >
+                    #{prNumber}
+                  </span>
+                ))}
+            </span>
+          ) : (
+            <span
+              className={cn(
+                "font-mono",
+                underlineOnHover && "hover:underline",
+                missingToken ? "text-text-muted" : prStateColor
+              )}
+            >
+              #{prNumber}
+            </span>
+          )}
           {ciVisual && !missingToken && (
             <span
               className="inline-flex items-center justify-center w-3 h-3 shrink-0"

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -8,6 +8,7 @@ import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import { Sprout, Pin, BellOff, RefreshCw } from "lucide-react";
 import type { AggregateCounts } from "./MainWorktreeSummaryRows";
 import { IssueBadge } from "./IssueBadge";
+import { PRBadge } from "./PRBadge";
 import { EnvironmentPopover } from "./EnvironmentPopover";
 import { CollapsedSessionIndicators } from "./CollapsedSessionIndicators";
 import { CollapsedAlarmPill } from "./CollapsedAlarmPill";
@@ -254,8 +255,19 @@ export function WorktreeHeader({
     [menu]
   );
 
-  const displayTitle = worktree.issueTitle ?? worktree.branchDerivedTitle;
-  const hasDisplayTitle = !!(worktree.issueNumber && displayTitle);
+  // PR-originated worktrees (created from the PR dropdown, #8888) invert the
+  // default issue-first headline: the PR title leads, with the linked issue
+  // shown underneath. `sourcePrNumber` is the persisted discriminator.
+  const isPrOriginated = !!worktree.sourcePrNumber;
+  const prHeadlineTitle = worktree.linked?.pr?.title ?? worktree.prTitle;
+  const displayTitle = isPrOriginated
+    ? prHeadlineTitle
+    : (worktree.issueTitle ?? worktree.branchDerivedTitle);
+  // For PR-originated, the headline always renders (PRBadge handles the brief
+  // cold-title gap → "#NNN"); otherwise it needs both an issue number and title.
+  const hasDisplayTitle = isPrOriginated
+    ? !!worktree.sourcePrNumber
+    : !!(worktree.issueNumber && displayTitle);
   const hasPlanFile = Boolean(worktree.hasPlanFile);
   const hasFreshnessPill = !!(lastGitStatusCheckedAt && lastGitStatusCheckedAt > 0);
   const underlineOnHover = variant !== "sidebar" || isActive;
@@ -311,15 +323,31 @@ export function WorktreeHeader({
             />
           )}
           {hasDisplayTitle ? (
-            <IssueBadge
-              issueNumber={worktree.issueNumber!}
-              issueTitle={displayTitle}
-              worktreePath={worktree.path}
-              onOpen={badges.onOpenIssue}
-              isHeadline
-              isActive={isActive}
-              underlineOnHover={underlineOnHover}
-            />
+            isPrOriginated ? (
+              <PRBadge
+                prNumber={worktree.sourcePrNumber!}
+                prTitle={displayTitle}
+                prState={worktree.linked?.pr?.state}
+                prCiStatus={worktree.linked?.pr?.ciStatus}
+                isSubordinate={false}
+                worktreePath={worktree.path}
+                onOpen={badges.onOpenPR}
+                isHeadline
+                isActive={isActive}
+                underlineOnHover={underlineOnHover}
+                rowLastUpdatedAt={worktree.prLastUpdatedAt}
+              />
+            ) : (
+              <IssueBadge
+                issueNumber={worktree.issueNumber!}
+                issueTitle={displayTitle}
+                worktreePath={worktree.path}
+                onOpen={badges.onOpenIssue}
+                isHeadline
+                isActive={isActive}
+                underlineOnHover={underlineOnHover}
+              />
+            )
           ) : isMainStandardLayout ? (
             <TruncatedTooltip content={worktree.name}>
               <span
@@ -461,6 +489,7 @@ export function WorktreeHeader({
             hasUpstreamDelta={hasUpstreamDelta}
             hasAuthFailedSignIn={hasAuthFailedSignIn}
             hasDisplayTitle={hasDisplayTitle}
+            isPrOriginated={isPrOriginated}
             hasPlanFile={hasPlanFile}
             badges={badges}
           />

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -257,7 +257,8 @@ export function WorktreeHeader({
 
   // PR-originated worktrees (created from the PR dropdown, #8888) invert the
   // default issue-first headline: the PR title leads, with the linked issue
-  // shown underneath. `sourcePrNumber` is the persisted discriminator.
+  // shown underneath. `sourcePrNumber` is the in-memory discriminator seeded at
+  // creation time.
   const isPrOriginated = !!worktree.sourcePrNumber;
   const prHeadlineTitle = worktree.linked?.pr?.title ?? worktree.prTitle;
   const displayTitle = isPrOriginated

--- a/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
@@ -239,6 +239,21 @@ describe("NonMainSecondaryRow → badge ordering by alarm tier", () => {
     expect(issueBadgeProps.at(-1)?.issueNumber).toBe(123);
   });
 
+  it("PR-originated with no linked issue: renders no issue badge", () => {
+    issueBadgeProps.length = 0;
+    const { queryByTestId } = renderRow({
+      worktree: {
+        ...baseWorktree,
+        sourcePrNumber: 10,
+        issueNumber: undefined,
+      } as unknown as WorktreeState,
+      hasDisplayTitle: true,
+      isPrOriginated: true,
+    });
+    expect(queryByTestId("issue-badge")).toBeNull();
+    expect(queryByTestId("pr-badge")).toBeNull();
+  });
+
   it("CI 'pending' does not flip the order (transient — no spatial churn)", () => {
     const pendingLinked = ciFailureLinked();
     pendingLinked.pr.ciStatus.state = "pending" as never;

--- a/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
@@ -16,10 +16,19 @@ vi.mock("react-dom", async () => {
   return { ...actual, createPortal: (children: ReactNode) => children };
 });
 
+const issueBadgeProps: Array<Record<string, unknown>> = [];
+
 vi.mock("../PRBadge", () => ({
   PRBadge: (props: Record<string, unknown>) => {
     prBadgeProps.push(props);
     return <div data-testid="pr-badge" data-call-index={prBadgeProps.length - 1} />;
+  },
+}));
+
+vi.mock("../IssueBadge", () => ({
+  IssueBadge: (props: Record<string, unknown>) => {
+    issueBadgeProps.push(props);
+    return <div data-testid="issue-badge" data-call-index={issueBadgeProps.length - 1} />;
   },
 }));
 
@@ -56,6 +65,8 @@ interface RenderOverrides {
   worktree?: WorktreeState;
   hasUpstreamDelta?: boolean;
   hasAuthFailedSignIn?: boolean;
+  hasDisplayTitle?: boolean;
+  isPrOriginated?: boolean;
 }
 
 function renderRow(overrides: RenderOverrides = {}) {
@@ -68,7 +79,8 @@ function renderRow(overrides: RenderOverrides = {}) {
         underlineOnHover={false}
         hasUpstreamDelta={overrides.hasUpstreamDelta ?? false}
         hasAuthFailedSignIn={overrides.hasAuthFailedSignIn ?? false}
-        hasDisplayTitle={false}
+        hasDisplayTitle={overrides.hasDisplayTitle ?? false}
+        isPrOriginated={overrides.isPrOriginated ?? false}
         hasPlanFile={false}
         badges={{}}
       />
@@ -208,6 +220,23 @@ describe("NonMainSecondaryRow → badge ordering by alarm tier", () => {
     expect(prIdx).toBeGreaterThanOrEqual(0);
     expect(upIdx).toBeGreaterThanOrEqual(0);
     expect(prIdx).toBeLessThan(upIdx);
+  });
+
+  it("PR-originated: suppresses the subordinate PR badge and shows the linked issue", () => {
+    issueBadgeProps.length = 0;
+    const { queryByTestId } = renderRow({
+      worktree: {
+        ...baseWorktree,
+        sourcePrNumber: 42,
+        issueNumber: 123,
+      } as WorktreeState,
+      hasDisplayTitle: true,
+      isPrOriginated: true,
+    });
+    // PR is the headline above — no subordinate PR badge here.
+    expect(queryByTestId("pr-badge")).toBeNull();
+    // The linked issue surfaces in the secondary row even though hasDisplayTitle is true.
+    expect(issueBadgeProps.at(-1)?.issueNumber).toBe(123);
   });
 
   it("CI 'pending' does not flip the order (transient — no spatial churn)", () => {

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -183,6 +183,37 @@ describe("WorktreeHeader PR-originated headline (#8888)", () => {
     });
     expect(screen.getByText("Eager PR title")).toBeDefined();
   });
+
+  it("drops the PR headline once sourcePrNumber is cleared (branch rename)", () => {
+    const { rerender } = renderHeader({
+      worktree: {
+        ...baseWorktree,
+        sourcePrNumber: 314,
+        prTitle: "Eager PR title",
+      } as WorktreeState,
+      badges: { onOpenPR: noop },
+    });
+    expect(screen.getByText("Eager PR title")).toBeDefined();
+
+    // Simulate clearPRInfo() firing on a branch change: sourcePrNumber and the
+    // flat PR fields are gone, so the headline must revert to the branch label.
+    rerender(
+      <TooltipProvider>
+        <WorktreeHeader
+          worktree={{ ...baseWorktree } as WorktreeState}
+          isActive={false}
+          isMainWorktree={false}
+          isPinned={false}
+          branchLabel="feature/test"
+          badges={{}}
+          gitStateIndicator={null}
+          menu={baseMenu}
+        />
+      </TooltipProvider>
+    );
+    expect(screen.queryByText("Eager PR title")).toBeNull();
+    expect(screen.queryByRole("button", { name: /Open pull request/ })).toBeNull();
+  });
 });
 
 describe("WorktreeHeader issue title headline", () => {

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -145,6 +145,46 @@ describe("WorktreeHeader menu button", () => {
   });
 });
 
+describe("WorktreeHeader PR-originated headline (#8888)", () => {
+  it("shows the PR title as the primary headline when sourcePrNumber is set", () => {
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        sourcePrNumber: 314,
+        linked: {
+          providerId: "github",
+          pr: {
+            ref: { providerId: "github", owner: "o", repo: "r", number: 314, rawData: null },
+            title: "Fix flaky terminal search",
+            url: "https://github.com/o/r/pull/314",
+            state: "open",
+          },
+        },
+        issueNumber: 99,
+      } as WorktreeState,
+      badges: { onOpenPR: noop, onOpenIssue: noop },
+    });
+
+    const prButton = screen.getByRole("button", {
+      name: /Open pull request #314: Fix flaky terminal search/,
+    });
+    expect(prButton).toBeDefined();
+    expect(screen.getByText("Fix flaky terminal search")).toBeDefined();
+  });
+
+  it("falls back to the flat prTitle when linked.pr is not yet populated", () => {
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        sourcePrNumber: 314,
+        prTitle: "Eager PR title",
+      } as WorktreeState,
+      badges: { onOpenPR: noop },
+    });
+    expect(screen.getByText("Eager PR title")).toBeDefined();
+  });
+});
+
 describe("WorktreeHeader issue title headline", () => {
   it("shows issue title as primary headline when issueTitle is available", () => {
     renderHeader({

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -1071,6 +1071,7 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.issueNumber === b.issueNumber &&
     a.issueTitle === b.issueTitle &&
     a.branchDerivedTitle === b.branchDerivedTitle &&
+    a.sourcePrNumber === b.sourcePrNumber &&
     a.prLastUpdatedAt === b.prLastUpdatedAt &&
     a.issueLastUpdatedAt === b.issueLastUpdatedAt &&
     a.hasPlanFile === b.hasPlanFile &&

--- a/src/utils/__tests__/closingIssueRef.test.ts
+++ b/src/utils/__tests__/closingIssueRef.test.ts
@@ -43,4 +43,16 @@ describe("extractClosingIssueNumber", () => {
   it("is case-insensitive on the keyword", () => {
     expect(extractClosingIssueNumber("CLOSES #77")).toBe(77);
   });
+
+  it.each(["This hotfixes #123", "discloses #300", "prefix-fix #456", "unresolved #5"])(
+    "does not match a keyword embedded in a longer word: %s",
+    (body) => {
+      expect(extractClosingIssueNumber(body)).toBeUndefined();
+    }
+  );
+
+  it("still matches a keyword preceded by punctuation", () => {
+    expect(extractClosingIssueNumber("(closes #88)")).toBe(88);
+    expect(extractClosingIssueNumber("- Fixes #9")).toBe(9);
+  });
 });

--- a/src/utils/__tests__/closingIssueRef.test.ts
+++ b/src/utils/__tests__/closingIssueRef.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { extractClosingIssueNumber } from "../closingIssueRef";
+
+describe("extractClosingIssueNumber", () => {
+  it("returns undefined for empty / nullish input", () => {
+    expect(extractClosingIssueNumber(undefined)).toBeUndefined();
+    expect(extractClosingIssueNumber(null)).toBeUndefined();
+    expect(extractClosingIssueNumber("")).toBeUndefined();
+  });
+
+  it("returns undefined when no closing keyword is present", () => {
+    expect(extractClosingIssueNumber("See #123 for context")).toBeUndefined();
+    expect(extractClosingIssueNumber("Related to #123")).toBeUndefined();
+  });
+
+  it.each([
+    ["Closes #123", 123],
+    ["closes #7", 7],
+    ["Closed #42", 42],
+    ["Fixes #88", 88],
+    ["fixed #5", 5],
+    ["Fix #9", 9],
+    ["Resolves #100", 100],
+    ["resolved #11", 11],
+  ])("parses %s → #%i", (body, expected) => {
+    expect(extractClosingIssueNumber(body)).toBe(expected);
+  });
+
+  it("matches the keyword anywhere in a multi-line body", () => {
+    const body = "## Summary\n\nDoes some things.\n\nFixes #456\n\nMore notes.";
+    expect(extractClosingIssueNumber(body)).toBe(456);
+  });
+
+  it("parses cross-repo references (org/repo#N)", () => {
+    expect(extractClosingIssueNumber("Closes daintreehq/daintree#321")).toBe(321);
+    expect(extractClosingIssueNumber("Fixes some-org/some.repo-1#9")).toBe(9);
+  });
+
+  it("returns the first match when several closing refs exist", () => {
+    expect(extractClosingIssueNumber("Closes #1, fixes #2, resolves #3")).toBe(1);
+  });
+
+  it("is case-insensitive on the keyword", () => {
+    expect(extractClosingIssueNumber("CLOSES #77")).toBe(77);
+  });
+});

--- a/src/utils/closingIssueRef.ts
+++ b/src/utils/closingIssueRef.ts
@@ -11,8 +11,11 @@
  */
 export function extractClosingIssueNumber(bodyText?: string | null): number | undefined {
   if (!bodyText) return undefined;
+  // Negative lookbehind so the keyword isn't matched inside a longer token
+  // ("hotfixes #1", "discloses #2", "prefix-fix #3" must not match), while
+  // still allowing leading punctuation ("(closes #4)", "- Fixes #5").
   const match =
-    /(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+#|#)(\d+)/i.exec(
+    /(?<![\w-])(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+#|#)(\d+)/i.exec(
       bodyText
     );
   const captured = match?.[1];

--- a/src/utils/closingIssueRef.ts
+++ b/src/utils/closingIssueRef.ts
@@ -1,0 +1,22 @@
+/**
+ * Closing-issue reference parsed from a PR body. GitHub's `closingIssuesReferences`
+ * GraphQL field only auto-populates for PRs targeting the repository's default
+ * branch, so a body-parse of the `Closes/Fixes/Resolves #N` keywords (including
+ * cross-repo `org/repo#N`) is the reliable fallback for PRs targeting other
+ * branches (e.g. `develop`). Used to capture the source PR's linked issue at
+ * worktree-create time (#8888).
+ *
+ * Returns the first match only — a PR with multiple closing references is
+ * unusual and the worktree card surfaces a single linked issue.
+ */
+export function extractClosingIssueNumber(bodyText?: string | null): number | undefined {
+  if (!bodyText) return undefined;
+  const match =
+    /(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+(?:[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+#|#)(\d+)/i.exec(
+      bodyText
+    );
+  const captured = match?.[1];
+  if (!captured) return undefined;
+  const parsed = Number.parseInt(captured, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}


### PR DESCRIPTION
## Summary

When a user creates a worktree from the GitHub PR dropdown, the source PR is now captured **at creation time** and seeded onto the worktree's linked PR immediately — instead of waiting for `PullRequestService`'s branch-name polling to rediscover the association.

- The source PR (number / title / url / state) and its closing issue flow through `CreateWorktreeOptions` into `WorkspaceService.performCreateWorktree`, which composes the `linked` projection via the existing `composeLinked()` + `setLinked()` using the provider context now exposed by `PullRequestService.getProviderContext()`.
- **Display inversion:** PR-originated worktrees show the **PR title as the primary headline** with the linked issue underneath, inverting the default issue-first layout. `sourcePrNumber` is the in-memory discriminator (seeded at creation; cleared on branch rename / PR-clear).
- **Closing issue** is body-parsed from `Closes`/`Fixes`/`Resolves #N` (including cross-repo `org/repo#N`), since GitHub's `closingIssuesReferences` only auto-populates for PRs targeting the default branch.
- **Graceful fallback:** if the forge provider isn't resolved at create time, the flat PR fields are persisted and polling backfills `linked` on its first run.

## Changes

- `shared/types`: `GitHubPR.bodyText`, `CreateWorktreeOptions.sourcePr*`, `WorktreeSnapshot`/`Worktree.sourcePrNumber`.
- Host: `PullRequestService.getProviderContext()`, `PRIntegrationService` delegation, `WorktreeMonitor` field + setter + snapshot projection (cleared in `clearPRInfo()`), eager seeding in `performCreateWorktree`.
- Renderer: `NewWorktreeDialog` passes source-PR fields; `WorktreeHeader` + `PRBadge` headline mode; `NonMainSecondaryRow` surfaces the linked issue and suppresses the subordinate PR badge; `createWorktreeStore` equality; new `extractClosingIssueNumber` util.

## Testing

- `tsc --noEmit` clean; full verify suite (IPC maps, channels, help, lint ratchet −28, format) clean.
- Targeted vitest: `closingIssueRef`, `NonMainSecondaryRow`, `WorktreeHeader`, `PRBadge`, `PRIntegrationService` all pass.

Closes #8888

🤖 Generated with [Claude Code](https://claude.com/claude-code)