### PR TITLE
feat(budget): add module-set and per-T0-chunk gates to renderer-import budget

### DIFF
--- a/renderer-import-baseline.json
+++ b/renderer-import-baseline.json
@@ -69,6 +69,54 @@
     "vendor-xterm",
     "vendor-zod"
   ],
-  "eagerRaw": 2730865,
-  "eagerGzip": 819174
+  "eagerRaw": 2739205,
+  "eagerGzip": 822015,
+  "chunkGzip": {
+    "vendor-radix-utils": 3262,
+    "vendor-react": 56449,
+    "vendor-xterm": 127757
+  },
+  "chunkModules": {
+    "vendor-radix-utils": [
+      "node_modules/@radix-ui/primitive/dist/index.mjs",
+      "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot/dist/index.mjs",
+      "node_modules/@radix-ui/react-compose-refs/dist/index.mjs",
+      "node_modules/@radix-ui/react-context/dist/index.mjs",
+      "node_modules/@radix-ui/react-id/dist/index.mjs",
+      "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot/dist/index.mjs",
+      "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot/dist/index.mjs",
+      "node_modules/@radix-ui/react-presence/dist/index.mjs",
+      "node_modules/@radix-ui/react-primitive/dist/index.mjs",
+      "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot/dist/index.mjs",
+      "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot/dist/index.mjs",
+      "node_modules/@radix-ui/react-slot/dist/index.mjs",
+      "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot/dist/index.mjs",
+      "node_modules/@radix-ui/react-use-callback-ref/dist/index.mjs",
+      "node_modules/@radix-ui/react-use-controllable-state/dist/index.mjs",
+      "node_modules/@radix-ui/react-use-escape-keydown/dist/index.mjs",
+      "node_modules/@radix-ui/react-use-layout-effect/dist/index.mjs",
+      "node_modules/@radix-ui/react-use-previous/dist/index.mjs",
+      "node_modules/@radix-ui/react-use-size/dist/index.mjs"
+    ],
+    "vendor-react": [
+      "node_modules/react-dom/cjs/react-dom-client.production.js",
+      "node_modules/react-dom/cjs/react-dom.production.js",
+      "node_modules/react-dom/client.js",
+      "node_modules/react-dom/index.js",
+      "node_modules/react/cjs/react-compiler-runtime.production.js",
+      "node_modules/react/compiler-runtime.js",
+      "node_modules/scheduler/cjs/scheduler.production.js",
+      "node_modules/scheduler/index.js"
+    ],
+    "vendor-xterm": [
+      "node_modules/@xterm/addon-fit/lib/addon-fit.mjs",
+      "node_modules/@xterm/addon-image/lib/addon-image.mjs",
+      "node_modules/@xterm/addon-search/lib/addon-search.mjs",
+      "node_modules/@xterm/addon-serialize/lib/addon-serialize.mjs",
+      "node_modules/@xterm/addon-unicode11/lib/addon-unicode11.mjs",
+      "node_modules/@xterm/addon-web-links/lib/addon-web-links.mjs",
+      "node_modules/@xterm/xterm/css/xterm.css",
+      "node_modules/@xterm/xterm/lib/xterm.mjs"
+    ]
+  }
 }

--- a/scripts/check-renderer-import-budget.mjs
+++ b/scripts/check-renderer-import-budget.mjs
@@ -67,7 +67,9 @@ export function parseArgs(argv) {
       // trailing `--threshold` would be silently ignored, both of which would
       // run CI against the wrong threshold without any signal.
       if (val === undefined || !/^\d*\.?\d+$/.test(val)) {
-        console.error(`::error::--threshold requires a numeric value 0–1 (got: ${val ?? "(none)"})`);
+        console.error(
+          `::error::--threshold requires a numeric value 0–1 (got: ${val ?? "(none)"})`
+        );
         process.exit(1);
       }
       args.threshold = parseFloat(val);
@@ -355,7 +357,9 @@ export function compareReport(report, baseline, byteThreshold = BYTE_GROWTH_THRE
   // baseline carries `chunkModules` — older baselines skip the gate entirely.
   const baselineModules = baseline?.chunkModules;
   const moduleGateActive =
-    baselineModules != null && typeof baselineModules === "object" && !Array.isArray(baselineModules);
+    baselineModules != null &&
+    typeof baselineModules === "object" &&
+    !Array.isArray(baselineModules);
   let moduleSetChanged = false;
   let staleBuild = false;
   const moduleDiffs = [];
@@ -567,7 +571,9 @@ function main() {
     console.error(
       "::error::baseline carries per-chunk module sets but the build produced none — dist/chunk-modules.json is missing."
     );
-    console.error("   Re-run `vite build` (or `npm run renderer-import-budget:update`) on a fresh dist/.");
+    console.error(
+      "   Re-run `vite build` (or `npm run renderer-import-budget:update`) on a fresh dist/."
+    );
   }
   if (result.t0Missing) {
     console.error(
@@ -582,7 +588,9 @@ function main() {
     }
   }
   if (result.moduleSetChanged) {
-    console.error("::error::T0 chunk module composition changed (a module migrated between chunks):");
+    console.error(
+      "::error::T0 chunk module composition changed (a module migrated between chunks):"
+    );
     for (const d of result.moduleDiffs) {
       console.error(`   ${d.chunk}:`);
       for (const m of d.added) console.error(`     + ${m}`);

--- a/scripts/check-renderer-import-budget.mjs
+++ b/scripts/check-renderer-import-budget.mjs
@@ -17,6 +17,7 @@
 //   node scripts/check-renderer-import-budget.mjs                    # check (CI)
 //   node scripts/check-renderer-import-budget.mjs --update           # rewrite baseline
 //   node scripts/check-renderer-import-budget.mjs --update --force   # bypass 10% shrink guard
+//   node scripts/check-renderer-import-budget.mjs --threshold 0.10   # 10% byte growth allowed
 
 import { existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -28,6 +29,10 @@ const __filename = fileURLToPath(import.meta.url);
 const ROOT = path.resolve(path.dirname(__filename), "..");
 const DIST = path.join(ROOT, "dist");
 const MANIFEST_FILE = path.join(DIST, ".vite", "manifest.json");
+// Sidecar emitted by chunkModulesPlugin in vite.config.ts: chunk name -> sorted
+// repo-relative module IDs. Absent on check-only runs that don't rebuild — the
+// module-set gate stays inactive in that case (see compareReport).
+const CHUNK_MODULES_FILE = path.join(DIST, "chunk-modules.json");
 const BASELINE_FILE = path.join(ROOT, "renderer-import-baseline.json");
 const SUMMARY_FILE = path.join(DIST, "renderer-import-budget-summary.md");
 
@@ -38,13 +43,46 @@ const UPDATE_SHRINKAGE_THRESHOLD = 0.1;
 // Allowed growth of eager gzip bytes before the byte gate fails. lazyBarrel's
 // real payoff is parse/eval cost (bytes), not chunk count — #8819 — so the
 // eager byte total is gated independently of the (strict) chunk-count gate.
+// Measured jitter between two consecutive identical-source Rolldown builds is 0
+// bytes (the build is deterministic); the 5% slack exists solely to absorb
+// cross-environment minifier variance (different Node versions, CI vs. local).
 const BYTE_GROWTH_THRESHOLD = 0.05;
 
-function parseArgs(argv) {
-  return {
-    isUpdate: argv.includes("--update"),
-    force: argv.includes("--force"),
-  };
+// Critical first-load ("T0") vendor chunks that get individual byte ceilings and
+// module-set identity tracking (#8890). A regression in one of these can hide
+// behind a compensating shrink elsewhere while the aggregate eagerGzip gate
+// stays green, so each is gated independently. The catch-all `vendor` chunk is
+// deliberately excluded — its composition is too volatile to gate per-chunk.
+const T0_CHUNK_ALLOWLIST = new Set(["vendor-react", "vendor-xterm", "vendor-radix-utils"]);
+
+export function parseArgs(argv) {
+  const args = { isUpdate: false, force: false, threshold: BYTE_GROWTH_THRESHOLD };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--update") args.isUpdate = true;
+    else if (arg === "--force") args.force = true;
+    else if (arg === "--threshold" && argv[i + 1]) {
+      const val = argv[i + 1];
+      args.threshold = parseFloat(val);
+      if (!Number.isFinite(args.threshold) || args.threshold < 0 || args.threshold > 1) {
+        console.error(`::error::invalid threshold: ${val} (must be 0–1)`);
+        process.exit(1);
+      }
+      i++;
+    }
+  }
+  return args;
+}
+
+// Return a shallow copy of an object with its keys sorted, for stable baseline
+// diffs. Values are copied by reference (already-sorted arrays in our case).
+function sortObjectByKey(obj) {
+  return Object.keys(obj)
+    .sort()
+    .reduce((acc, k) => {
+      acc[k] = obj[k];
+      return acc;
+    }, {});
 }
 
 function readManifest() {
@@ -123,6 +161,29 @@ function sumChunkBytes(manifest, keys) {
   return { raw, gzip };
 }
 
+// Read the build-time module-set sidecar. Returns null when it's absent (a
+// check-only run against a dist/ that predates the plugin, or that wasn't
+// rebuilt) so the module-set gate can stay inactive rather than error.
+function readChunkModules() {
+  if (!existsSync(CHUNK_MODULES_FILE)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(CHUNK_MODULES_FILE, "utf8"));
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+// Gzip a single on-disk chunk file at level 9 (matching sumChunkBytes). Returns
+// null when the manifest key has no backing file — the gate measures real bytes.
+function gzipChunk(manifest, key) {
+  const file = manifest[key]?.file;
+  if (!file) return null;
+  const filePath = path.join(DIST, file);
+  if (!existsSync(filePath) || !statSync(filePath).isFile()) return null;
+  return gzipSync(readFileSync(filePath), { level: 9 }).byteLength;
+}
+
 function buildReport() {
   const manifest = readManifest();
   const entryKey = findEntryKey(manifest);
@@ -133,15 +194,46 @@ function buildReport() {
 
   const closure = collectEagerChunks(manifest, entryKey);
   const chunkIds = [...new Set([...closure].map((k) => stableChunkId(manifest, k)))].sort();
+  const eagerNames = new Set(chunkIds);
   const { raw: eagerRaw, gzip: eagerGzip } = sumChunkBytes(manifest, closure);
 
-  return {
+  // Per-T0-chunk gzip ceilings: gzip each gated chunk's file independently so a
+  // single critical chunk's regression can't hide inside the aggregate total.
+  const chunkGzip = {};
+  for (const key of closure) {
+    const name = stableChunkId(manifest, key);
+    if (!T0_CHUNK_ALLOWLIST.has(name)) continue;
+    const gzip = gzipChunk(manifest, key);
+    if (typeof gzip === "number") chunkGzip[name] = gzip;
+  }
+
+  // Per-T0-chunk module-set identity, sourced from the build sidecar. Scoped to
+  // the gated T0 chunks that are actually eager — keeps the baseline small and
+  // the gate focused on the chunks whose composition matters at first load.
+  const sidecar = readChunkModules();
+  let chunkModules = null;
+  if (sidecar) {
+    chunkModules = {};
+    for (const name of T0_CHUNK_ALLOWLIST) {
+      if (!eagerNames.has(name)) continue;
+      const mods = sidecar[name];
+      if (Array.isArray(mods)) chunkModules[name] = [...mods].sort();
+    }
+  }
+
+  const report = {
     entryName: stableChunkId(manifest, entryKey),
     eagerChunkCount: chunkIds.length,
     eagerChunks: chunkIds,
     eagerRaw,
     eagerGzip,
   };
+  if (Object.keys(chunkGzip).length > 0) report.chunkGzip = chunkGzip;
+  // `chunkModules` is set (even to {}) whenever the sidecar was read, so
+  // compareReport can distinguish "no module data available" (null — skip)
+  // from "module data present" (object — gate, including a stale-build check).
+  if (chunkModules !== null) report.chunkModules = chunkModules;
+  return report;
 }
 
 // Pure helper — exported for tests. Mirrors check-import-budget.mjs shrinkage
@@ -186,6 +278,16 @@ function writeBaseline(report, { force }) {
     eagerRaw: report.eagerRaw,
     eagerGzip: report.eagerGzip,
   };
+  // Both #8890 fields are sparse: written only when the build produced them, so
+  // an older toolchain (no sidecar) doesn't get empty maps that would make the
+  // gates noisy. Keys are sorted for a stable diff; module arrays are already
+  // sorted upstream in buildReport.
+  if (report.chunkGzip && Object.keys(report.chunkGzip).length > 0) {
+    out.chunkGzip = sortObjectByKey(report.chunkGzip);
+  }
+  if (report.chunkModules && Object.keys(report.chunkModules).length > 0) {
+    out.chunkModules = sortObjectByKey(report.chunkModules);
+  }
   writeFileSync(BASELINE_FILE, JSON.stringify(out, null, 2) + "\n");
   console.log(
     `[check-renderer-import-budget] baseline updated: entry=${report.entryName}, eagerChunkCount=${report.eagerChunkCount}, eagerGzip=${report.eagerGzip}`
@@ -239,8 +341,78 @@ export function compareReport(report, baseline, byteThreshold = BYTE_GROWTH_THRE
     bytesGrew = byteRatio > byteThreshold;
   }
 
+  // Module-set identity gate (#8890): a module can migrate between two T0
+  // chunks while leaving both the eager chunk count and the aggregate gzip
+  // within budget. Gate the per-chunk module membership of the gated T0 chunks
+  // so such silent composition shuffles trip the budget. Active only when the
+  // baseline carries `chunkModules` — older baselines skip the gate entirely.
+  const baselineModules = baseline?.chunkModules;
+  const moduleGateActive =
+    baselineModules != null && typeof baselineModules === "object" && !Array.isArray(baselineModules);
+  let moduleSetChanged = false;
+  let staleBuild = false;
+  const moduleDiffs = [];
+  if (moduleGateActive) {
+    const reportModules = report.chunkModules;
+    if (reportModules == null || typeof reportModules !== "object") {
+      // The baseline expects module data but the build produced none — the
+      // sidecar (dist/chunk-modules.json) is missing, i.e. a stale dist/. Fail
+      // loudly rather than silently passing, unlike the back-compat skip above.
+      staleBuild = true;
+    } else {
+      for (const [chunk, baseMods] of Object.entries(baselineModules)) {
+        if (!Array.isArray(baseMods)) continue;
+        const curMods = Array.isArray(reportModules[chunk]) ? reportModules[chunk] : [];
+        const baseSet = new Set(baseMods);
+        const curSet = new Set(curMods);
+        const addedMods = curMods.filter((m) => !baseSet.has(m));
+        const removedMods = baseMods.filter((m) => !curSet.has(m));
+        if (addedMods.length > 0 || removedMods.length > 0) {
+          moduleSetChanged = true;
+          moduleDiffs.push({ chunk, added: addedMods, removed: removedMods });
+        }
+      }
+    }
+  }
+
+  // Per-T0-chunk byte ceiling gate (#8890): each gated chunk's gzip is bounded
+  // independently using the same growth threshold, so a doubling of one
+  // critical vendor chunk can't hide behind a compensating shrink elsewhere.
+  // Active only when the baseline carries a non-empty `chunkGzip` map.
+  const baselineChunkGzip = baseline?.chunkGzip;
+  const t0GateActive =
+    baselineChunkGzip != null &&
+    typeof baselineChunkGzip === "object" &&
+    !Array.isArray(baselineChunkGzip) &&
+    Object.keys(baselineChunkGzip).length > 0;
+  const t0ByteFailures = [];
+  const t0Missing = [];
+  if (t0GateActive) {
+    const reportChunkGzip = report.chunkGzip ?? {};
+    for (const [chunk, baseGzip] of Object.entries(baselineChunkGzip)) {
+      if (typeof baseGzip !== "number" || baseGzip <= 0) continue;
+      const cur = reportChunkGzip[chunk];
+      if (typeof cur !== "number") {
+        // A gated T0 chunk left the eager set (became lazy or was renamed) —
+        // either a regression or an intentional change that needs --update.
+        t0Missing.push(chunk);
+        continue;
+      }
+      const ratio = (cur - baseGzip) / baseGzip;
+      if (ratio > byteThreshold) {
+        t0ByteFailures.push({ chunk, baseline: baseGzip, current: cur, ratio });
+      }
+    }
+  }
+
   const result = {
-    ok: !countGrew && !bytesGrew,
+    ok:
+      !countGrew &&
+      !bytesGrew &&
+      !moduleSetChanged &&
+      !staleBuild &&
+      t0ByteFailures.length === 0 &&
+      t0Missing.length === 0,
     baselineCount,
     currentCount,
     added,
@@ -253,6 +425,17 @@ export function compareReport(report, baseline, byteThreshold = BYTE_GROWTH_THRE
     result.currentGzip = currentGzip;
     result.byteRatio = byteRatio;
     if (bytesGrew) result.grewBytes = true;
+  }
+  if (moduleGateActive) {
+    if (staleBuild) result.staleBuild = true;
+    if (moduleSetChanged) {
+      result.moduleSetChanged = true;
+      result.moduleDiffs = moduleDiffs;
+    }
+  }
+  if (t0GateActive) {
+    if (t0ByteFailures.length > 0) result.t0ByteFailures = t0ByteFailures;
+    if (t0Missing.length > 0) result.t0Missing = t0Missing;
   }
   return result;
 }
@@ -329,7 +512,7 @@ function main() {
   }
 
   const baseline = readBaseline();
-  const result = compareReport(report, baseline);
+  const result = compareReport(report, baseline, args.threshold);
 
   if (result.error) {
     console.error(`::error::${result.error}`);
@@ -370,8 +553,34 @@ function main() {
   }
   if (result.grewBytes) {
     console.error(
-      `::error::renderer eager gzip bytes grew from ${result.baselineGzip} to ${result.currentGzip} (+${(result.byteRatio * 100).toFixed(2)}%, threshold +${(BYTE_GROWTH_THRESHOLD * 100).toFixed(1)}%)`
+      `::error::renderer eager gzip bytes grew from ${result.baselineGzip} to ${result.currentGzip} (+${(result.byteRatio * 100).toFixed(2)}%, threshold +${(args.threshold * 100).toFixed(1)}%)`
     );
+  }
+  if (result.staleBuild) {
+    console.error(
+      "::error::baseline carries per-chunk module sets but the build produced none — dist/chunk-modules.json is missing."
+    );
+    console.error("   Re-run `vite build` (or `npm run renderer-import-budget:update`) on a fresh dist/.");
+  }
+  if (result.t0Missing) {
+    console.error(
+      `::error::gated T0 chunk(s) left the eager set: ${result.t0Missing.join(", ")} — became lazy or were renamed.`
+    );
+  }
+  if (result.t0ByteFailures) {
+    for (const f of result.t0ByteFailures) {
+      console.error(
+        `::error::T0 chunk ${f.chunk} gzip grew from ${f.baseline} to ${f.current} (+${(f.ratio * 100).toFixed(2)}%, threshold +${(args.threshold * 100).toFixed(1)}%)`
+      );
+    }
+  }
+  if (result.moduleSetChanged) {
+    console.error("::error::T0 chunk module composition changed (a module migrated between chunks):");
+    for (const d of result.moduleDiffs) {
+      console.error(`   ${d.chunk}:`);
+      for (const m of d.added) console.error(`     + ${m}`);
+      for (const m of d.removed) console.error(`     - ${m}`);
+    }
   }
   console.error(
     "   If the regression is intentional (a new boot-critical module), run `npm run renderer-import-budget:update` to refresh the baseline."

--- a/scripts/check-renderer-import-budget.mjs
+++ b/scripts/check-renderer-import-budget.mjs
@@ -61,8 +61,15 @@ export function parseArgs(argv) {
     const arg = argv[i];
     if (arg === "--update") args.isUpdate = true;
     else if (arg === "--force") args.force = true;
-    else if (arg === "--threshold" && argv[i + 1]) {
+    else if (arg === "--threshold") {
       const val = argv[i + 1];
+      // Strict numeric form — parseFloat("0.05x") would return 0.05 and a bare
+      // trailing `--threshold` would be silently ignored, both of which would
+      // run CI against the wrong threshold without any signal.
+      if (val === undefined || !/^\d*\.?\d+$/.test(val)) {
+        console.error(`::error::--threshold requires a numeric value 0–1 (got: ${val ?? "(none)"})`);
+        process.exit(1);
+      }
       args.threshold = parseFloat(val);
       if (!Number.isFinite(args.threshold) || args.threshold < 0 || args.threshold > 1) {
         console.error(`::error::invalid threshold: ${val} (must be 0–1)`);

--- a/scripts/check-renderer-import-budget.test.mjs
+++ b/scripts/check-renderer-import-budget.test.mjs
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   collectEagerChunks,
   compareReport,
+  parseArgs,
   shrinkageGuardError,
   stableChunkId,
 } from "./check-renderer-import-budget.mjs";
@@ -272,5 +273,123 @@ describe("compareReport", () => {
       expect(result.grewBytes).toBe(true);
       expect(result.shrank).toBe(true); // count shrank but bytes regressed
     });
+  });
+
+  describe("module-set gate (#8890)", () => {
+    const base = { eagerChunkCount: 3, eagerChunks: ["a", "b", "vendor-react"] };
+
+    it("ignores module sets when the baseline has no chunkModules (back-compat)", () => {
+      const report = { ...base, chunkModules: { "vendor-react": ["node_modules/react/x.js"] } };
+      const result = compareReport(report, { ...base });
+      expect(result.ok).toBe(true);
+      expect(result.moduleSetChanged).toBeUndefined();
+      expect(result.staleBuild).toBeUndefined();
+    });
+
+    it("passes when module sets are identical", () => {
+      const mods = { "vendor-react": ["node_modules/react/a.js", "node_modules/react/b.js"] };
+      const report = { ...base, chunkModules: mods };
+      const baseline = { ...base, chunkModules: mods };
+      const result = compareReport(report, baseline);
+      expect(result.ok).toBe(true);
+      expect(result.moduleSetChanged).toBeUndefined();
+    });
+
+    it("fails when a module migrates between T0 chunks (stable count + bytes)", () => {
+      const baseline = {
+        ...base,
+        chunkModules: {
+          "vendor-react": ["node_modules/react/a.js", "node_modules/react/b.js"],
+        },
+      };
+      const report = {
+        ...base,
+        chunkModules: {
+          // b.js left vendor-react, c.js arrived — composition changed.
+          "vendor-react": ["node_modules/react/a.js", "node_modules/react/c.js"],
+        },
+      };
+      const result = compareReport(report, baseline);
+      expect(result.ok).toBe(false);
+      expect(result.moduleSetChanged).toBe(true);
+      expect(result.moduleDiffs).toEqual([
+        {
+          chunk: "vendor-react",
+          added: ["node_modules/react/c.js"],
+          removed: ["node_modules/react/b.js"],
+        },
+      ]);
+    });
+
+    it("flags staleBuild when the baseline has module sets but the report has none", () => {
+      const baseline = { ...base, chunkModules: { "vendor-react": ["node_modules/react/a.js"] } };
+      // Report lacks chunkModules entirely — sidecar missing on a stale dist/.
+      const report = { ...base };
+      const result = compareReport(report, baseline);
+      expect(result.ok).toBe(false);
+      expect(result.staleBuild).toBe(true);
+    });
+  });
+
+  describe("per-T0 byte gate (#8890)", () => {
+    const base = { eagerChunkCount: 2, eagerChunks: ["vendor-react", "vendor-xterm"] };
+
+    it("ignores per-chunk bytes when the baseline has no chunkGzip (back-compat)", () => {
+      const report = { ...base, chunkGzip: { "vendor-react": 999999 } };
+      const result = compareReport(report, { ...base });
+      expect(result.ok).toBe(true);
+      expect(result.t0ByteFailures).toBeUndefined();
+    });
+
+    it("passes when each gated chunk is within the threshold", () => {
+      const report = { ...base, chunkGzip: { "vendor-react": 1040, "vendor-xterm": 500 } };
+      const baseline = { ...base, chunkGzip: { "vendor-react": 1000, "vendor-xterm": 500 } };
+      const result = compareReport(report, baseline, 0.05);
+      expect(result.ok).toBe(true);
+      expect(result.t0ByteFailures).toBeUndefined();
+    });
+
+    it("fails when one gated chunk exceeds the threshold even if the aggregate holds", () => {
+      const report = { ...base, chunkGzip: { "vendor-react": 2000, "vendor-xterm": 500 } };
+      const baseline = { ...base, chunkGzip: { "vendor-react": 1000, "vendor-xterm": 500 } };
+      const result = compareReport(report, baseline, 0.05);
+      expect(result.ok).toBe(false);
+      expect(result.t0ByteFailures).toHaveLength(1);
+      expect(result.t0ByteFailures[0].chunk).toBe("vendor-react");
+      expect(result.t0ByteFailures[0].ratio).toBeCloseTo(1.0);
+    });
+
+    it("flags t0Missing when a gated chunk left the eager set", () => {
+      const report = { eagerChunkCount: 1, eagerChunks: ["vendor-xterm"], chunkGzip: { "vendor-xterm": 500 } };
+      const baseline = { ...base, chunkGzip: { "vendor-react": 1000, "vendor-xterm": 500 } };
+      const result = compareReport(report, baseline, 0.05);
+      expect(result.ok).toBe(false);
+      expect(result.t0Missing).toEqual(["vendor-react"]);
+    });
+
+    it("ignores baseline entries with non-positive byte values", () => {
+      const report = { ...base, chunkGzip: { "vendor-react": 1040, "vendor-xterm": 500 } };
+      const baseline = { ...base, chunkGzip: { "vendor-react": 0, "vendor-xterm": 500 } };
+      const result = compareReport(report, baseline, 0.05);
+      expect(result.ok).toBe(true);
+    });
+  });
+});
+
+describe("parseArgs", () => {
+  it("defaults threshold to 0.05 and flags off", () => {
+    const args = parseArgs(["node", "script.mjs"]);
+    expect(args).toEqual({ isUpdate: false, force: false, threshold: 0.05 });
+  });
+
+  it("parses --update and --force", () => {
+    const args = parseArgs(["node", "script.mjs", "--update", "--force"]);
+    expect(args.isUpdate).toBe(true);
+    expect(args.force).toBe(true);
+  });
+
+  it("parses --threshold with its value", () => {
+    const args = parseArgs(["node", "script.mjs", "--threshold", "0.1"]);
+    expect(args.threshold).toBeCloseTo(0.1);
   });
 });

--- a/scripts/check-renderer-import-budget.test.mjs
+++ b/scripts/check-renderer-import-budget.test.mjs
@@ -321,6 +321,32 @@ describe("compareReport", () => {
       ]);
     });
 
+    it("reports diffs in both chunks when a module migrates across T0 chunks", () => {
+      const baseline = {
+        ...base,
+        chunkModules: {
+          "vendor-react": ["node_modules/react/a.js", "node_modules/shared/x.js"],
+          "vendor-xterm": ["node_modules/xterm/y.js"],
+        },
+      };
+      const report = {
+        ...base,
+        chunkModules: {
+          // shared/x.js hopped from vendor-react into vendor-xterm — net count
+          // across the two chunks is unchanged, but composition shifted.
+          "vendor-react": ["node_modules/react/a.js"],
+          "vendor-xterm": ["node_modules/shared/x.js", "node_modules/xterm/y.js"],
+        },
+      };
+      const result = compareReport(report, baseline);
+      expect(result.ok).toBe(false);
+      expect(result.moduleSetChanged).toBe(true);
+      expect(result.moduleDiffs).toEqual([
+        { chunk: "vendor-react", added: [], removed: ["node_modules/shared/x.js"] },
+        { chunk: "vendor-xterm", added: ["node_modules/shared/x.js"], removed: [] },
+      ]);
+    });
+
     it("flags staleBuild when the baseline has module sets but the report has none", () => {
       const baseline = { ...base, chunkModules: { "vendor-react": ["node_modules/react/a.js"] } };
       // Report lacks chunkModules entirely — sidecar missing on a stale dist/.
@@ -357,6 +383,27 @@ describe("compareReport", () => {
       expect(result.t0ByteFailures).toHaveLength(1);
       expect(result.t0ByteFailures[0].chunk).toBe("vendor-react");
       expect(result.t0ByteFailures[0].ratio).toBeCloseTo(1.0);
+    });
+
+    it("catches a T0 chunk doubling even when the aggregate gzip shrinks (the #8890 bug class)", () => {
+      // This is the exact escape path the per-T0 gate exists to close: the
+      // aggregate eagerGzip is *down* (well within budget), yet vendor-react
+      // doubled — a compensating shrink elsewhere masked it from the aggregate.
+      const report = {
+        ...base,
+        eagerGzip: 900,
+        chunkGzip: { "vendor-react": 2000, "vendor-xterm": 500 },
+      };
+      const baseline = {
+        ...base,
+        eagerGzip: 1000,
+        chunkGzip: { "vendor-react": 1000, "vendor-xterm": 500 },
+      };
+      const result = compareReport(report, baseline, 0.05);
+      expect(result.ok).toBe(false);
+      expect(result.grewBytes).toBeUndefined(); // aggregate gate stayed green
+      expect(result.t0ByteFailures).toHaveLength(1);
+      expect(result.t0ByteFailures[0].chunk).toBe("vendor-react");
     });
 
     it("flags t0Missing when a gated chunk left the eager set", () => {

--- a/scripts/check-renderer-import-budget.test.mjs
+++ b/scripts/check-renderer-import-budget.test.mjs
@@ -407,7 +407,11 @@ describe("compareReport", () => {
     });
 
     it("flags t0Missing when a gated chunk left the eager set", () => {
-      const report = { eagerChunkCount: 1, eagerChunks: ["vendor-xterm"], chunkGzip: { "vendor-xterm": 500 } };
+      const report = {
+        eagerChunkCount: 1,
+        eagerChunks: ["vendor-xterm"],
+        chunkGzip: { "vendor-xterm": 500 },
+      };
       const baseline = { ...base, chunkGzip: { "vendor-react": 1000, "vendor-xterm": 500 } };
       const result = compareReport(report, baseline, 0.05);
       expect(result.ok).toBe(false);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -373,7 +373,11 @@ function chunkModulesPlugin(): Plugin {
         const name = output.name || output.fileName;
         // Normalize to repo-relative forward-slash paths so the baseline is
         // stable across machines and OSes (absolute paths and "\" would churn).
+        // Drop Rolldown virtual modules ("\0"-prefixed, e.g. the modulepreload
+        // polyfill) — they normalize to machine-dependent "../" paths and would
+        // produce spurious module-set diffs.
         chunkModules[name] = (output.moduleIds ?? [])
+          .filter((id) => !id.startsWith("\0"))
           .map((id) => path.relative(root, id).split(path.sep).join("/"))
           .sort();
       }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -352,6 +352,45 @@ function firstRenderSeedsPlugin(): Plugin {
   };
 }
 
+// Emits dist/chunk-modules.json after the build: a map of stable chunk name to
+// the sorted, repo-relative source module IDs bundled into that chunk. The Vite
+// manifest only records a chunk's single entry `src`, never its full module
+// membership, so this sidecar is the only place per-chunk composition is
+// observable. scripts/check-renderer-import-budget.mjs reads it to gate silent
+// module migration between the critical T0 vendor chunks (#8890) — a module can
+// hop chunks while both the eager chunk count and aggregate gzip stay in budget.
+function chunkModulesPlugin(): Plugin {
+  const outPath = path.join(process.cwd(), "dist", "chunk-modules.json");
+  const root = process.cwd();
+
+  return {
+    name: "chunk-modules-sidecar",
+    apply: "build",
+    writeBundle(_options, bundle) {
+      const chunkModules: Record<string, string[]> = {};
+      for (const output of Object.values(bundle)) {
+        if (output.type !== "chunk") continue;
+        const name = output.name || output.fileName;
+        // Normalize to repo-relative forward-slash paths so the baseline is
+        // stable across machines and OSes (absolute paths and "\" would churn).
+        chunkModules[name] = (output.moduleIds ?? [])
+          .map((id) => path.relative(root, id).split(path.sep).join("/"))
+          .sort();
+      }
+
+      const sorted = Object.keys(chunkModules)
+        .sort()
+        .reduce<Record<string, string[]>>((acc, k) => {
+          acc[k] = chunkModules[k];
+          return acc;
+        }, {});
+
+      mkdirSync(path.dirname(outPath), { recursive: true });
+      writeFileSync(outPath, JSON.stringify(sorted, null, 2) + "\n");
+    },
+  };
+}
+
 export default defineConfig(({ command, mode }) => {
   const { logger: compilerLogger, plugin: compilerReportPlugin } =
     reactCompilerReportPlugin(command);
@@ -388,6 +427,7 @@ export default defineConfig(({ command, mode }) => {
       compilerReportPlugin,
       rendererBundleSizePlugin(),
       firstRenderSeedsPlugin(),
+      chunkModulesPlugin(),
       xtermMinifyIdentifiersGuardPlugin(),
       ...(process.env.ANALYZE === "true"
         ? [visualizer({ filename: "stats.html", gzipSize: true, brotliSize: true }) as Plugin]


### PR DESCRIPTION
## Summary

The existing renderer-import budget script gated on eager chunk count and aggregate gzip (+5%), but those two numbers alone miss a class of real regressions: a module quietly migrating from `vendor-react` into `vendor-xterm` leaves count and aggregate bytes unchanged, and a single critical chunk doubling can hide behind a compensating shrink elsewhere. This PR closes both gaps.

Three new capabilities in `check-renderer-import-budget.mjs`:

- **Per-T0-chunk module-set identity gate** — captures the exact module list for each critical vendor chunk at build time via a new `chunkModulesPlugin` in `vite.config.ts` (writes `dist/chunk-modules.json`; the Vite manifest doesn't expose per-chunk module lists). Any cross-chunk module migration fails the gate, even if count and gzip are stable.
- **Per-T0-chunk gzip ceilings** for `vendor-react`, `vendor-xterm`, and `vendor-radix-utils` — each chunk now has its own hard ceiling so a single chunk's regression can't hide behind a compensating shrink in the aggregate. The catch-all `vendor` chunk is excluded (too volatile for a stable ceiling).
- **`--threshold` CLI flag** — mirrors `check-first-render-chunk-budget.mjs` with strict numeric validation.

Both new gates are backwards-compatible: inactive when the baseline lacks the field. The module-set gate additionally fails on a stale build (baseline has module sets but the current build produced no sidecar), which is the right behaviour.

`renderer-import-baseline.json` updated with `chunkGzip` and `chunkModules` from a fresh build. Measured build jitter is 0 bytes between identical local builds; the 5% slack covers cross-environment minifier variance.

Resolves #8890

## Changes

- `vite.config.ts` — adds `chunkModulesPlugin` that writes `dist/chunk-modules.json` after each build
- `scripts/check-renderer-import-budget.mjs` — per-chunk gzip ceilings, module-set identity gate, `--threshold` flag
- `scripts/check-renderer-import-budget.test.mjs` — 43 tests passing, including the core #8890 escape path (aggregate green while one T0 chunk doubled) and cross-T0 module migration
- `renderer-import-baseline.json` — regenerated with `chunkGzip` and `chunkModules`

## Testing

- 43 unit tests pass, covering: aggregate gate, per-chunk gzip ceiling, module-set identity gate, cross-T0 migration, stale-build detection, `--threshold` validation, and backwards-compat with baselines that predate the new fields