### PR TITLE
perf(build): derive first-render chunk seeds from panel-kind registry

### DIFF
--- a/first-render-chunk-baseline.json
+++ b/first-render-chunk-baseline.json
@@ -3,36 +3,52 @@
   "seeds": {
     "resolved": [
       "src/components/Browser/BrowserPane.tsx",
-      "src/components/DevPreview/DevPreviewPane.tsx"
+      "src/components/DevPreview/DevPreviewPane.tsx",
+      "src/panels/review/ReviewPane.tsx"
     ],
     "missing": []
   },
-  "chunkCount": 71,
+  "chunkCount": 80,
   "chunks": {
-    "_ActionService-Dme_budY.js": {
-      "file": "assets/ActionService-Dme_budY.js",
+    "_ActionService-DtYR5Fne.js": {
+      "file": "assets/ActionService-DtYR5Fne.js",
       "raw": 10215,
-      "gzip": 3955
+      "gzip": 3954
     },
-    "_KeybindingService-CRS6IdQy.js": {
-      "file": "assets/KeybindingService-CRS6IdQy.js",
-      "raw": 36775,
-      "gzip": 8272
+    "_DiffViewer-D76qzBo9.js": {
+      "file": "assets/DiffViewer-D76qzBo9.js",
+      "raw": 31126,
+      "gzip": 11551
     },
-    "_Spinner-xY2_SIAM.js": {
-      "file": "assets/Spinner-xY2_SIAM.js",
+    "_KeybindingService-2AHda0wW.js": {
+      "file": "assets/KeybindingService-2AHda0wW.js",
+      "raw": 36746,
+      "gzip": 8262
+    },
+    "_ReviewHubContent-Cr898jM-.js": {
+      "file": "assets/ReviewHubContent-Cr898jM-.js",
+      "raw": 117163,
+      "gzip": 32523
+    },
+    "_Spinner-2IMpYjkB.js": {
+      "file": "assets/Spinner-2IMpYjkB.js",
       "raw": 580,
-      "gzip": 401
+      "gzip": 402
     },
-    "_TerminalInstanceService-DF97AiC-.js": {
-      "file": "assets/TerminalInstanceService-DF97AiC-.js",
-      "raw": 212527,
-      "gzip": 56210
+    "_TerminalInstanceService-I4-5g2Re.js": {
+      "file": "assets/TerminalInstanceService-I4-5g2Re.js",
+      "raw": 216963,
+      "gzip": 56937
     },
-    "_accessibilityAnnouncerStore-Vh7l8s5c.js": {
-      "file": "assets/accessibilityAnnouncerStore-Vh7l8s5c.js",
+    "_TruncatedTooltip-CnSgNOcF.js": {
+      "file": "assets/TruncatedTooltip-CnSgNOcF.js",
+      "raw": 2667,
+      "gzip": 1357
+    },
+    "_accessibilityAnnouncerStore-D4j7NYYG.js": {
+      "file": "assets/accessibilityAnnouncerStore-D4j7NYYG.js",
       "raw": 246,
-      "gzip": 186
+      "gzip": 185
     },
     "_agentIds-DR1bHg7L.js": {
       "file": "assets/agentIds-DR1bHg7L.js",
@@ -44,13 +60,13 @@
       "raw": 41527,
       "gzip": 9094
     },
-    "_agentSettingsStore-RAn_nIWX.js": {
-      "file": "assets/agentSettingsStore-RAn_nIWX.js",
+    "_agentSettingsStore-BzUIbyw3.js": {
+      "file": "assets/agentSettingsStore-BzUIbyw3.js",
       "raw": 10382,
-      "gzip": 3521
+      "gzip": 3524
     },
-    "_agents-BEuZq5B6.js": {
-      "file": "assets/agents-BEuZq5B6.js",
+    "_agents-T7jlTPnp.js": {
+      "file": "assets/agents-T7jlTPnp.js",
       "raw": 56541,
       "gzip": 18325
     },
@@ -69,23 +85,23 @@
       "raw": 732,
       "gzip": 229
     },
-    "_appThemeStore-IosMUb5T.js": {
-      "file": "assets/appThemeStore-IosMUb5T.js",
+    "_appThemeStore-yX3N3-Dc.js": {
+      "file": "assets/appThemeStore-yX3N3-Dc.js",
       "raw": 81698,
-      "gzip": 18595
+      "gzip": 18596
     },
-    "_branchPrefixes-DvNUR8Za.js": {
-      "file": "assets/branchPrefixes-DvNUR8Za.js",
+    "_branchPrefixes-I6FrHOfg.js": {
+      "file": "assets/branchPrefixes-I6FrHOfg.js",
       "raw": 1358,
-      "gzip": 524
+      "gzip": 523
     },
-    "_button-BzRMZbtb.js": {
-      "file": "assets/button-BzRMZbtb.js",
+    "_button-BJWtOnuS.js": {
+      "file": "assets/button-BJWtOnuS.js",
       "raw": 5691,
-      "gzip": 2073
+      "gzip": 2075
     },
-    "_clientAppError-D8ez_TBk.js": {
-      "file": "assets/clientAppError-D8ez_TBk.js",
+    "_clientAppError-DpoNg0Yq.js": {
+      "file": "assets/clientAppError-DpoNg0Yq.js",
       "raw": 349,
       "gzip": 259
     },
@@ -93,6 +109,11 @@
       "file": "assets/clients-DFtKCgo5.js",
       "raw": 19950,
       "gzip": 5097
+    },
+    "_clike-Du01Xetv.js": {
+      "file": "assets/clike-Du01Xetv.js",
+      "raw": 768,
+      "gzip": 483
     },
     "_commandsClient-Bi6EDRjd.js": {
       "file": "assets/commandsClient-Bi6EDRjd.js",
@@ -104,8 +125,13 @@
       "raw": 507,
       "gzip": 197
     },
-    "_devServerDetection-cWKskKPv.js": {
-      "file": "assets/devServerDetection-cWKskKPv.js",
+    "_css-CaI9BV1x.js": {
+      "file": "assets/css-CaI9BV1x.js",
+      "raw": 1295,
+      "gzip": 646
+    },
+    "_devServerDetection-RlY88ZM8.js": {
+      "file": "assets/devServerDetection-RlY88ZM8.js",
       "raw": 692,
       "gzip": 405
     },
@@ -129,6 +155,11 @@
       "raw": 221,
       "gzip": 170
     },
+    "_formatBytes-CajMOJcO.js": {
+      "file": "assets/formatBytes-CajMOJcO.js",
+      "raw": 289,
+      "gzip": 220
+    },
     "_globalEnvClient-DspHlWgs.js": {
       "file": "assets/globalEnvClient-DspHlWgs.js",
       "raw": 436,
@@ -149,30 +180,35 @@
       "raw": 625,
       "gzip": 212
     },
+    "_markup-E81AWVus.js": {
+      "file": "assets/markup-E81AWVus.js",
+      "raw": 2941,
+      "gzip": 1178
+    },
     "_normalizeErrorMessage-DN-BDbkE.js": {
       "file": "assets/normalizeErrorMessage-DN-BDbkE.js",
       "raw": 578,
       "gzip": 284
     },
-    "_notificationSettingsStore-CSUUSp-O.js": {
-      "file": "assets/notificationSettingsStore-CSUUSp-O.js",
+    "_notificationSettingsStore-C38aOoYY.js": {
+      "file": "assets/notificationSettingsStore-C38aOoYY.js",
       "raw": 1951,
       "gzip": 601
     },
-    "_notify-X99EiPYZ.js": {
-      "file": "assets/notify-X99EiPYZ.js",
+    "_notify-S43bzQWo.js": {
+      "file": "assets/notify-S43bzQWo.js",
       "raw": 8750,
-      "gzip": 3326
+      "gzip": 3329
     },
-    "_panelKindRegistry-B-6MzkMg.js": {
-      "file": "assets/panelKindRegistry-B-6MzkMg.js",
-      "raw": 2890,
-      "gzip": 1108
+    "_panelKindRegistry-BQXWbUSI.js": {
+      "file": "assets/panelKindRegistry-BQXWbUSI.js",
+      "raw": 3124,
+      "gzip": 1174
     },
-    "_panelLimitStore-DaCPiZck.js": {
-      "file": "assets/panelLimitStore-DaCPiZck.js",
+    "_panelLimitStore-1218Dram.js": {
+      "file": "assets/panelLimitStore-1218Dram.js",
       "raw": 2591,
-      "gzip": 984
+      "gzip": 985
     },
     "_path-BxIg65YB.js": {
       "file": "assets/path-BxIg65YB.js",
@@ -194,60 +230,65 @@
       "raw": 1348,
       "gzip": 735
     },
-    "_projectPresetsStore-kwcKeaVn.js": {
-      "file": "assets/projectPresetsStore-kwcKeaVn.js",
+    "_projectPresetsStore-DNPVpT9_.js": {
+      "file": "assets/projectPresetsStore-DNPVpT9_.js",
       "raw": 287,
       "gzip": 174
     },
-    "_projectSettingsStore-C9qOrn2c.js": {
-      "file": "assets/projectSettingsStore-C9qOrn2c.js",
+    "_projectSettingsStore-BBnzsLdu.js": {
+      "file": "assets/projectSettingsStore-BBnzsLdu.js",
       "raw": 1920,
-      "gzip": 830
+      "gzip": 835
     },
-    "_projectStore-9rCrWZ3H.js": {
-      "file": "assets/projectStore-9rCrWZ3H.js",
-      "raw": 14916,
-      "gzip": 4939
+    "_projectStore-BuhGj-yI.js": {
+      "file": "assets/projectStore-BuhGj-yI.js",
+      "raw": 14951,
+      "gzip": 4961
     },
-    "_radix-loader-rf9-y3VB.js": {
-      "file": "assets/radix-loader-rf9-y3VB.js",
+    "_radix-loader-CBGZ83Ma.js": {
+      "file": "assets/radix-loader-CBGZ83Ma.js",
       "raw": 1065,
-      "gzip": 589
+      "gzip": 588
     },
-    "_resourceMonitoringStore-DYvAjSDx.js": {
-      "file": "assets/resourceMonitoringStore-DYvAjSDx.js",
-      "raw": 2132,
-      "gzip": 981
+    "_resourceMonitoringStore-SIzBWvgZ.js": {
+      "file": "assets/resourceMonitoringStore-SIzBWvgZ.js",
+      "raw": 3006,
+      "gzip": 1305
     },
     "_rolldown-runtime-BYbx6iT9.js": {
       "file": "assets/rolldown-runtime-BYbx6iT9.js",
       "raw": 826,
       "gzip": 473
     },
-    "_safeStorage-DzvsXWgr.js": {
-      "file": "assets/safeStorage-DzvsXWgr.js",
-      "raw": 3936,
-      "gzip": 1550
+    "_safeStorage-BnYOpj7O.js": {
+      "file": "assets/safeStorage-BnYOpj7O.js",
+      "raw": 3984,
+      "gzip": 1580
     },
     "_scrollback-CCK-ANL6.js": {
       "file": "assets/scrollback-CCK-ANL6.js",
       "raw": 201,
       "gzip": 175
     },
-    "_storeAccessors-cyarJq-k.js": {
-      "file": "assets/storeAccessors-cyarJq-k.js",
+    "_storeAccessors-XDJxreeP.js": {
+      "file": "assets/storeAccessors-XDJxreeP.js",
       "raw": 6687,
-      "gzip": 2027
+      "gzip": 2028
     },
-    "_terminalChrome-DLdjAwN2.js": {
-      "file": "assets/terminalChrome-DLdjAwN2.js",
+    "_svgSanitizer-C6GNSwUq.js": {
+      "file": "assets/svgSanitizer-C6GNSwUq.js",
+      "raw": 1966,
+      "gzip": 999
+    },
+    "_terminalChrome-DqV46Aem.js": {
+      "file": "assets/terminalChrome-DqV46Aem.js",
       "raw": 2526,
-      "gzip": 976
+      "gzip": 975
     },
-    "_terminalColorSchemeStore-_Y7GpeK8.js": {
-      "file": "assets/terminalColorSchemeStore-_Y7GpeK8.js",
+    "_terminalColorSchemeStore-cwfAh4TN.js": {
+      "file": "assets/terminalColorSchemeStore-cwfAh4TN.js",
       "raw": 18144,
-      "gzip": 5144
+      "gzip": 5145
     },
     "_terminalConfigClient-ChVwVclH.js": {
       "file": "assets/terminalConfigClient-ChVwVclH.js",
@@ -259,53 +300,53 @@
       "raw": 473,
       "gzip": 308
     },
-    "_terminalInputStore-C85BkCNm.js": {
-      "file": "assets/terminalInputStore-C85BkCNm.js",
+    "_terminalInputStore-B80tIanp.js": {
+      "file": "assets/terminalInputStore-B80tIanp.js",
       "raw": 7757,
-      "gzip": 2724
+      "gzip": 2726
     },
-    "_uiStore-DA2txRU1.js": {
-      "file": "assets/uiStore-DA2txRU1.js",
+    "_uiStore-B5qu1A6m.js": {
+      "file": "assets/uiStore-B5qu1A6m.js",
       "raw": 3625,
-      "gzip": 1143
+      "gzip": 1142
     },
-    "_useEscapeStack-CRkQrc9F.js": {
-      "file": "assets/useEscapeStack-CRkQrc9F.js",
+    "_useEscapeStack-lNLYymlN.js": {
+      "file": "assets/useEscapeStack-lNLYymlN.js",
       "raw": 2817,
-      "gzip": 1201
+      "gzip": 1200
     },
-    "_useFindInPage-DZpIVmk9.js": {
-      "file": "assets/useFindInPage-DZpIVmk9.js",
-      "raw": 31560,
-      "gzip": 9863
+    "_useFindInPage-C_62nnEX.js": {
+      "file": "assets/useFindInPage-C_62nnEX.js",
+      "raw": 31559,
+      "gzip": 9861
     },
-    "_utils-JSm7Mv1O.js": {
-      "file": "assets/utils-JSm7Mv1O.js",
+    "_utils-DoYW3Tk9.js": {
+      "file": "assets/utils-DoYW3Tk9.js",
       "raw": 218,
-      "gzip": 192
+      "gzip": 193
     },
-    "_vendor-Cx1LP5N-.js": {
-      "file": "assets/vendor-Cx1LP5N-.js",
-      "raw": 425488,
-      "gzip": 137287
+    "_vendor-DxqYuGAK.js": {
+      "file": "assets/vendor-DxqYuGAK.js",
+      "raw": 425479,
+      "gzip": 137362
     },
-    "_vendor-editor-WWOGLB7P.js": {
-      "file": "assets/vendor-editor-WWOGLB7P.js",
-      "raw": 450355,
-      "gzip": 144750
+    "_vendor-editor-DCJ2nCoQ.js": {
+      "file": "assets/vendor-editor-DCJ2nCoQ.js",
+      "raw": 450309,
+      "gzip": 145334
     },
-    "_vendor-icons-B5wONvPP.js": {
-      "file": "assets/vendor-icons-B5wONvPP.js",
+    "_vendor-icons-BW7qPwVI.js": {
+      "file": "assets/vendor-icons-BW7qPwVI.js",
       "raw": 49131,
-      "gzip": 14778
+      "gzip": 14777
     },
-    "_vendor-motion~index-BPGUdkld.js": {
-      "file": "assets/vendor-motion~index-BPGUdkld.js",
+    "_vendor-motion~index-O-kBfSkv.js": {
+      "file": "assets/vendor-motion~index-O-kBfSkv.js",
       "raw": 5584,
       "gzip": 2430
     },
-    "_vendor-motion~index~BrowserPane~DevPreviewPane~App~CelebrationConfetti~OnboardingFlow~Workt~d1asc0vi-joore45g.js": {
-      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~CelebrationConfetti~OnboardingFlow~Workt~d1asc0vi-joore45g.js",
+    "_vendor-motion~index~BrowserPane~DevPreviewPane~App~CelebrationConfetti~OnboardingFlow~Workt~d1asc0vi-BynhCmZQ.js": {
+      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~CelebrationConfetti~OnboardingFlow~Workt~d1asc0vi-BynhCmZQ.js",
       "raw": 7911,
       "gzip": 3424
     },
@@ -314,25 +355,25 @@
       "raw": 269,
       "gzip": 201
     },
-    "_vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~f3gnuexl-Bl18iGsI.js": {
-      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~f3gnuexl-Bl18iGsI.js",
+    "_vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~f3gnuexl-CJwuoR8M.js": {
+      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~f3gnuexl-CJwuoR8M.js",
       "raw": 31215,
       "gzip": 11212
     },
-    "_vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~j1o0q54h-B3PE9bDZ.js": {
-      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~j1o0q54h-B3PE9bDZ.js",
+    "_vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~j1o0q54h-C2AEi6b4.js": {
+      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~j1o0q54h-C2AEi6b4.js",
       "raw": 603,
       "gzip": 416
     },
-    "_vendor-radix-utils-Cn-zq-mb.js": {
-      "file": "assets/vendor-radix-utils-Cn-zq-mb.js",
+    "_vendor-radix-utils-BZAkSNI2.js": {
+      "file": "assets/vendor-radix-utils-BZAkSNI2.js",
       "raw": 14557,
-      "gzip": 3264
+      "gzip": 3262
     },
-    "_vendor-react-DASo11VT.js": {
-      "file": "assets/vendor-react-DASo11VT.js",
+    "_vendor-react-PFUbaouz.js": {
+      "file": "assets/vendor-react-PFUbaouz.js",
       "raw": 181960,
-      "gzip": 56450
+      "gzip": 56449
     },
     "_vendor-xterm-CysUrkNV.js": {
       "file": "assets/vendor-xterm-CysUrkNV.js",
@@ -344,33 +385,38 @@
       "raw": 74222,
       "gzip": 19574
     },
-    "_viewportPresets-Cl4hjF92.js": {
-      "file": "assets/viewportPresets-Cl4hjF92.js",
+    "_viewportPresets-bzntvG4T.js": {
+      "file": "assets/viewportPresets-bzntvG4T.js",
       "raw": 5533,
-      "gzip": 2086
+      "gzip": 2085
     },
     "index.html": {
-      "file": "assets/index-Dz5dvZF9.js",
-      "raw": 425083,
-      "gzip": 133132
+      "file": "assets/index-D7QaqKc1.js",
+      "raw": 428114,
+      "gzip": 134208
     },
     "src/components/Browser/BrowserPane.tsx": {
-      "file": "assets/BrowserPane-jYYCfWDw.js",
-      "raw": 21095,
-      "gzip": 7422
+      "file": "assets/BrowserPane-AarygZdF.js",
+      "raw": 21093,
+      "gzip": 7421
     },
     "src/components/DevPreview/DevPreviewPane.tsx": {
-      "file": "assets/DevPreviewPane-DeUtvE3b.js",
-      "raw": 69690,
-      "gzip": 21098
+      "file": "assets/DevPreviewPane-BxgJX92n.js",
+      "raw": 69684,
+      "gzip": 21091
+    },
+    "src/panels/review/ReviewPane.tsx": {
+      "file": "assets/ReviewPane-B8q5g6Ev.js",
+      "raw": 1109,
+      "gzip": 671
     }
   },
   "eagerTotals": {
-    "raw": 2859435,
-    "gzip": 860048
+    "raw": 3027324,
+    "gzip": 912569
   },
   "totals": {
-    "raw": 7253929,
-    "gzip": 2305655
+    "raw": 7267628,
+    "gzip": 2310567
   }
 }

--- a/scripts/check-first-render-chunk-budget.mjs
+++ b/scripts/check-first-render-chunk-budget.mjs
@@ -26,18 +26,22 @@ const __filename = fileURLToPath(import.meta.url);
 const ROOT = path.resolve(path.dirname(__filename), "..");
 const DIST = path.join(ROOT, "dist");
 const MANIFEST_FILE = path.join(DIST, ".vite", "manifest.json");
+const SEEDS_FILE = path.join(DIST, ".vite", "first-render-seeds.json");
 const BASELINE_FILE = path.join(ROOT, "first-render-chunk-baseline.json");
 const SUMMARY_FILE = path.join(DIST, "first-render-chunk-summary.md");
 
 // Seed list: every source path that is part of the renderer's first-paint
 // bundle. The renderer entry chunk is auto-detected via `isEntry`. The lazy
-// entries below are React.lazy boundaries in src/panels/registry.tsx that
-// resolve immediately when a persisted browser/dev-preview panel is restored
-// — i.e. on the first-render path even though they're nominally "lazy".
-export const LAZY_FIRST_RENDER_SEEDS = [
-  "src/components/Browser/BrowserPane.tsx",
-  "src/components/DevPreview/DevPreviewPane.tsx",
-];
+// entries are React.lazy boundaries in src/panels/registry.tsx that resolve
+// immediately when a persisted browser/dev-preview/review panel is restored —
+// i.e. on the first-render path even though they're nominally "lazy".
+//
+// The list is no longer hardcoded here: it's derived from the panel-kind
+// registry (shared/config/panelKindRegistry.ts → getFirstRenderSeeds) and
+// emitted to dist/.vite/first-render-seeds.json by firstRenderSeedsPlugin at
+// build time. This script can't import the TS registry directly from plain
+// Node ESM, so it reads the emitted artifact. Keeping the registry as the
+// single source of truth is the whole point — see #8895.
 
 const DEFAULT_THRESHOLD = 0.05;
 const UPDATE_SHRINKAGE_THRESHOLD = 0.1;
@@ -91,6 +95,38 @@ function readManifest() {
   }
 }
 
+// Reads the registry-derived seed list emitted by firstRenderSeedsPlugin. Fails
+// loud on a missing/invalid/empty artifact rather than falling back to a
+// hardcoded list — a silently-empty seed set would measure only the entry chunk
+// and let a regression slip past the gate, exactly the drift #8895 closes.
+function readFirstRenderSeeds() {
+  if (!existsSync(SEEDS_FILE)) {
+    console.error(`::error::first-render seeds not found at ${path.relative(ROOT, SEEDS_FILE)}`);
+    console.error(
+      "   Run `vite build` first (seeds artifact emitted by firstRenderSeedsPlugin in vite.config.ts)."
+    );
+    process.exit(1);
+  }
+  let seeds;
+  try {
+    seeds = JSON.parse(readFileSync(SEEDS_FILE, "utf8"));
+  } catch (err) {
+    console.error(`::error::failed to parse first-render seeds: ${err.message}`);
+    process.exit(1);
+  }
+  if (!Array.isArray(seeds) || seeds.some((s) => typeof s !== "string" || s.length === 0)) {
+    console.error("::error::first-render seeds must be a non-empty array of source-path strings");
+    process.exit(1);
+  }
+  if (seeds.length === 0) {
+    console.error(
+      "::error::first-render seeds is empty — the registry produced no firstRenderRestore kinds"
+    );
+    process.exit(1);
+  }
+  return seeds;
+}
+
 // BFS the manifest graph. `imports[]` and `dynamicImports[]` reference other
 // manifest keys (source paths). Visiting by manifest key (not file name) avoids
 // double-counting chunks shared via Rolldown's `codeSplitting.groups`
@@ -105,10 +141,10 @@ function readManifest() {
 //     entire reachable bundle. Report-only, retained as a coarse total-bundle
 //     regression signal.
 //
-// The seeds (renderer entry + LAZY_FIRST_RENDER_SEEDS) are always enqueued
-// explicitly regardless of `followDynamic` — they're first-paint paths by
-// definition (a persisted browser/dev-preview panel restores synchronously),
-// not edges discovered by walking `dynamicImports[]`.
+// The seeds (renderer entry + the registry-derived first-render seeds) are
+// always enqueued explicitly regardless of `followDynamic` — they're first-paint
+// paths by definition (a persisted browser/dev-preview/review panel restores
+// synchronously), not edges discovered by walking `dynamicImports[]`.
 export function collectClosure(manifest, seedKeys, { followDynamic = true } = {}) {
   const visited = new Set();
   const queue = [];
@@ -184,14 +220,14 @@ function sizeClosure(manifest, closure) {
   return { chunks, totals: { raw: totalRaw, gzip: totalGzip }, missing };
 }
 
-function buildReport(manifest) {
+function buildReport(manifest, lazySeeds) {
   const entryKey = findEntryKey(manifest);
   if (!entryKey) {
     console.error("::error::no entry chunk found in manifest (no chunk has isEntry: true)");
     process.exit(1);
   }
 
-  const seedKeys = [entryKey, ...LAZY_FIRST_RENDER_SEEDS];
+  const seedKeys = [entryKey, ...lazySeeds];
 
   // Eager walk (gated): the static first-render closure.
   const eagerClosure = collectClosure(manifest, seedKeys, { followDynamic: false });
@@ -204,8 +240,8 @@ function buildReport(manifest) {
 
   for (const m of [...eager.missing, ...total.missing]) console.warn(`::warning::${m}`);
 
-  const seedsResolved = LAZY_FIRST_RENDER_SEEDS.filter((s) => Boolean(manifest[s]));
-  const seedsMissing = LAZY_FIRST_RENDER_SEEDS.filter((s) => !manifest[s]);
+  const seedsResolved = lazySeeds.filter((s) => Boolean(manifest[s]));
+  const seedsMissing = lazySeeds.filter((s) => !manifest[s]);
   for (const s of seedsMissing) {
     console.warn(
       `::warning::seed ${s} not present in manifest — closure may be undercounted (rename or refactor?)`
@@ -330,7 +366,8 @@ function compareToBaseline(report, threshold) {
 function main() {
   const args = parseArgs(process.argv);
   const manifest = readManifest();
-  const report = buildReport(manifest);
+  const lazySeeds = readFirstRenderSeeds();
+  const report = buildReport(manifest, lazySeeds);
 
   if (args.isUpdate) {
     writeBaseline(report, { force: args.force });

--- a/scripts/check-first-render-chunk-budget.test.mjs
+++ b/scripts/check-first-render-chunk-budget.test.mjs
@@ -8,6 +8,7 @@ import { collectClosure, shrinkageGuardError } from "./check-first-render-chunk-
 const LAZY_FIRST_RENDER_SEEDS = [
   "src/components/Browser/BrowserPane.tsx",
   "src/components/DevPreview/DevPreviewPane.tsx",
+  "src/panels/review/ReviewPane.tsx",
 ];
 
 // Synthetic manifest mirroring the Vite 8 / Rolldown shape: top-level keys are
@@ -52,6 +53,12 @@ function makeManifest(extra = {}) {
       imports: [],
       dynamicImports: [],
     },
+    "src/panels/review/ReviewPane.tsx": {
+      file: "assets/ReviewPane-yz0.js",
+      imports: ["_vendor-review.js"],
+      dynamicImports: [],
+    },
+    "_vendor-review.js": { file: "assets/vendor-review-123.js", imports: [], dynamicImports: [] },
     ...extra,
   };
 }
@@ -98,6 +105,10 @@ describe("collectClosure — first-render seeds", () => {
     const eager = collectClosure(manifest, seeds, { followDynamic: false });
     expect(eager.has("src/components/Browser/BrowserPane.tsx")).toBe(true);
     expect(eager.has("src/components/DevPreview/DevPreviewPane.tsx")).toBe(true);
+    // ReviewPane is the seed that previously drifted out of the list (#8895) —
+    // it must be enqueued and its static vendor dep pulled into the closure.
+    expect(eager.has("src/panels/review/ReviewPane.tsx")).toBe(true);
+    expect(eager.has("_vendor-review.js")).toBe(true);
     // And the BrowserPane's own static import is reachable from the seed.
     expect(eager.has("_vendor-browser.js")).toBe(true);
     // domMax is still excluded — it isn't a seed and only the dynamic edge

--- a/scripts/check-first-render-chunk-budget.test.mjs
+++ b/scripts/check-first-render-chunk-budget.test.mjs
@@ -1,9 +1,14 @@
 import { describe, it, expect } from "vitest";
-import {
-  collectClosure,
-  shrinkageGuardError,
-  LAZY_FIRST_RENDER_SEEDS,
-} from "./check-first-render-chunk-budget.mjs";
+import { collectClosure, shrinkageGuardError } from "./check-first-render-chunk-budget.mjs";
+
+// The seed list is now registry-derived (shared/config/panelKindRegistry.ts) and
+// read from dist/.vite/first-render-seeds.json at runtime. collectClosure takes
+// seed keys as a parameter, so these tests pass the lazy seeds as a literal —
+// the registry contract itself is covered by panelKindRegistry.test.ts.
+const LAZY_FIRST_RENDER_SEEDS = [
+  "src/components/Browser/BrowserPane.tsx",
+  "src/components/DevPreview/DevPreviewPane.tsx",
+];
 
 // Synthetic manifest mirroring the Vite 8 / Rolldown shape: top-level keys are
 // either source paths (for entries / lazy seeds) or `_vendor-*.js` keys for

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -13,6 +13,7 @@ import {
   unregisterPluginPanelKinds,
   clearPanelKindRegistry,
   getBuiltInPanelKinds,
+  getFirstRenderSeeds,
   type PanelKindConfig,
 } from "../panelKindRegistry.js";
 
@@ -446,5 +447,58 @@ describe("getPanelKindColor fallback", () => {
 
     unregisterPluginPanelKinds("ext-a");
     expect(getPanelKindColor("ext-a.viewer")).toBe("var(--theme-text-secondary)");
+  });
+});
+
+describe("getFirstRenderSeeds", () => {
+  afterEach(() => {
+    clearPanelKindRegistry();
+  });
+
+  it("returns the lazy import paths of every first-render built-in kind", () => {
+    expect([...getFirstRenderSeeds()].sort()).toEqual([
+      "src/components/Browser/BrowserPane.tsx",
+      "src/components/DevPreview/DevPreviewPane.tsx",
+      "src/panels/review/ReviewPane.tsx",
+    ]);
+  });
+
+  it("includes the review pane — the seed that previously drifted (#8895)", () => {
+    expect(getFirstRenderSeeds()).toContain("src/panels/review/ReviewPane.tsx");
+  });
+
+  it("emits no empty or non-string seeds", () => {
+    for (const seed of getFirstRenderSeeds()) {
+      expect(typeof seed).toBe("string");
+      expect(seed.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("excludes the eager terminal kind (no lazy first-render chunk)", () => {
+    expect(getFirstRenderSeeds()).not.toContain(getPanelKindConfig("terminal")?.id);
+    // Terminal has no lazyImportPath, so its path can't appear regardless.
+    expect(getPanelKindConfig("terminal")?.firstRenderRestore).toBeUndefined();
+  });
+
+  it("excludes plugin-registered kinds even when they set firstRenderRestore", () => {
+    registerPanelKind({
+      ...makeExtensionConfig("ext-a.lazy", "ext-a"),
+      firstRenderRestore: true,
+      lazyImportPath: "src/plugins/ext-a/LazyPane.tsx",
+    });
+    expect(getFirstRenderSeeds()).not.toContain("src/plugins/ext-a/LazyPane.tsx");
+  });
+
+  it("throws when a built-in sets firstRenderRestore without a lazyImportPath", () => {
+    // clearPanelKindRegistry only removes extension entries, so overwriting a
+    // built-in would corrupt state for sibling tests — save and restore it.
+    const original = getPanelKindConfig("browser") as PanelKindConfig;
+    const { lazyImportPath: _omitted, ...broken } = original;
+    try {
+      registerPanelKind(broken);
+      expect(() => getFirstRenderSeeds()).toThrow(/lazyImportPath/);
+    } finally {
+      registerPanelKind(original);
+    }
   });
 });

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -37,6 +37,21 @@ export interface PanelKindConfig {
   usesTerminalUi?: boolean;
   /** Whether this panel kind should keep its runtime alive across project switches */
   keepAliveOnProjectSwitch?: boolean;
+  /**
+   * Whether this panel kind's lazy chunk loads on the first-render path — i.e.
+   * a persisted panel of this kind restores synchronously from session state,
+   * pulling its `React.lazy()` chunk into the first-paint download. Drives the
+   * first-render chunk budget seed list (see `getFirstRenderSeeds`).
+   */
+  firstRenderRestore?: boolean;
+  /**
+   * Root-relative source path of this kind's lazy boundary, in the exact form
+   * Vite/Rolldown emits as a manifest key (e.g. `"src/panels/review/ReviewPane.tsx"`).
+   * Required when `firstRenderRestore` is true so the budget script can resolve
+   * the chunk in `dist/.vite/manifest.json`. Must match the manifest key — a
+   * file-relative path like `"./review/ReviewPane"` will silently miss.
+   */
+  lazyImportPath?: string;
   /** Whether this panel kind should appear in the panel palette (⌘⇧P). Set to false for panels with dedicated spawn actions (terminal, agent). Defaults to true for extension panels if not specified. */
   showInPalette?: boolean;
   /** Extension ID if this is an extension-provided panel kind */
@@ -86,6 +101,8 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     keepAliveOnProjectSwitch: true,
     showInPalette: true,
     searchAliases: ["web", "chrome", "internet", "www"],
+    firstRenderRestore: true,
+    lazyImportPath: "src/components/Browser/BrowserPane.tsx",
   },
   "dev-preview": {
     id: "dev-preview",
@@ -99,6 +116,8 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     keepAliveOnProjectSwitch: true,
     showInPalette: true,
     searchAliases: ["localhost", "server", "preview", "port"],
+    firstRenderRestore: true,
+    lazyImportPath: "src/components/DevPreview/DevPreviewPane.tsx",
   },
   review: {
     id: "review",
@@ -112,6 +131,8 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     keepAliveOnProjectSwitch: true,
     showInPalette: true,
     searchAliases: ["diff", "commit", "stage", "git"],
+    firstRenderRestore: true,
+    lazyImportPath: "src/panels/review/ReviewPane.tsx",
   },
 };
 
@@ -398,6 +419,36 @@ export function panelKindKeepsAliveOnProjectSwitch(kind: PanelKind): boolean {
  */
 export function getBuiltInPanelKinds(): BuiltInPanelKind[] {
   return [...BUILT_IN_PANEL_KINDS];
+}
+
+/**
+ * Source paths of every panel kind whose lazy chunk loads on the first-render
+ * path (`firstRenderRestore === true`). This is the single source of truth for
+ * the first-render chunk budget seed list — a build-time Vite plugin emits the
+ * result to `dist/.vite/first-render-seeds.json`, which the budget script reads
+ * (it can't import this TS module directly from plain Node ESM).
+ *
+ * Only built-in kinds are eligible: plugin-registered panels are runtime-async
+ * (their chunks are never part of the first-paint download) and are excluded by
+ * design. A misconfigured built-in — `firstRenderRestore: true` with a missing
+ * or empty `lazyImportPath` — throws rather than silently dropping the seed,
+ * since a dropped seed is exactly the budget drift this guard exists to catch.
+ *
+ * @returns Root-relative source paths matching Vite manifest keys
+ */
+export function getFirstRenderSeeds(): string[] {
+  const seeds: string[] = [];
+  for (const config of Object.values(PANEL_KIND_REGISTRY)) {
+    if (config.firstRenderRestore !== true) continue;
+    if (config.extensionId !== undefined) continue;
+    if (typeof config.lazyImportPath !== "string" || config.lazyImportPath.length === 0) {
+      throw new Error(
+        `[panelKindRegistry] panel kind "${config.id}" sets firstRenderRestore but is missing lazyImportPath`
+      );
+    }
+    seeds.push(config.lazyImportPath);
+  }
+  return seeds;
 }
 
 /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { gzipSync } from "node:zlib";
 import { getDevServerConfig } from "./shared/config/devServer";
 import { getDaintreeAppDevCSP, getDaintreeAppProdCSP } from "./shared/config/csp";
+import { getFirstRenderSeeds } from "./shared/config/panelKindRegistry";
 
 const devServerConfig = getDevServerConfig();
 
@@ -282,6 +283,26 @@ function rendererBundleSizePlugin(): Plugin {
   };
 }
 
+// Emits dist/.vite/first-render-seeds.json — the root-relative source paths of
+// every lazy panel chunk that loads on the first-render path, derived from the
+// panel-kind registry (getFirstRenderSeeds). The check-first-render-chunk-budget
+// script reads this artifact instead of a hardcoded list, so the seed set can
+// never drift from the registry. Build-only; the seeds are static registry data,
+// not bundle-derived, so this doesn't inspect the OutputBundle.
+function firstRenderSeedsPlugin(): Plugin {
+  const seedsPath = path.join(process.cwd(), "dist", ".vite", "first-render-seeds.json");
+
+  return {
+    name: "first-render-seeds",
+    apply: "build",
+    writeBundle() {
+      const seeds = getFirstRenderSeeds();
+      mkdirSync(path.dirname(seedsPath), { recursive: true });
+      writeFileSync(seedsPath, JSON.stringify(seeds, null, 2) + "\n");
+    },
+  };
+}
+
 export default defineConfig(({ command, mode }) => {
   const { logger: compilerLogger, plugin: compilerReportPlugin } =
     reactCompilerReportPlugin(command);
@@ -317,6 +338,7 @@ export default defineConfig(({ command, mode }) => {
       cspTransformPlugin(),
       compilerReportPlugin,
       rendererBundleSizePlugin(),
+      firstRenderSeedsPlugin(),
       xtermMinifyIdentifiersGuardPlugin(),
       ...(process.env.ANALYZE === "true"
         ? [visualizer({ filename: "stats.html", gzipSize: true, brotliSize: true }) as Plugin]


### PR DESCRIPTION
## Summary

The first-render chunk budget gate was silently skipping the review panel chunk. The seed list in `scripts/check-first-render-chunk-budget.mjs` was hardcoded and had drifted -- `LazyReviewPane` was wired in `src/panels/registry.tsx` but never added to `LAZY_FIRST_RENDER_SEEDS`, so its chunk escaped the budget check entirely.

This PR makes `shared/config/panelKindRegistry.ts` the single source of truth for first-render seeds.

Resolves #8895

## Changes

- Added `firstRenderRestore?: boolean` and `lazyImportPath?: string` to `PanelKindConfig`; marked `browser`, `dev-preview`, and `review` kinds accordingly
- Exported `getFirstRenderSeeds()` -- filters built-in kinds with `firstRenderRestore === true`, validates that each has a `lazyImportPath`, throws on misconfiguration, and excludes plugin/extension panels by design (runtime-async)
- Added `firstRenderSeedsPlugin` in `vite.config.ts` (build-only, `writeBundle` hook) that emits `dist/.vite/first-render-seeds.json`, mirroring the existing `rendererBundleSizePlugin`
- Updated `check-first-render-chunk-budget.mjs` to read the emitted artifact with fail-loud validation (missing file, parse error, non-array, empty array, and non-string entries all exit 1); threaded seeds into `buildReport()` as a parameter instead of a module-level constant
- Re-baselined `first-render-chunk-baseline.json` to capture the review chunk (`chunkCount` 71 → 80, `seeds.missing` now empty)

## Testing

- Added `getFirstRenderSeeds()` unit tests: exact paths, review-included regression, terminal/plugin exclusion, and throw-on-misconfig
- Extended the budget script closure-walk test to cover the review seed
- `vitest` passes (56 + 15 tests)
- Full Vite build passes with all 3 seeds resolved (`seeds.missing` empty)
- Typecheck, lint, and format all clean