### PR TITLE
fix(scripts): drop non-existent label from bundle-budget failure message

### DIFF
--- a/scripts/check-renderer-bundle-budget.mjs
+++ b/scripts/check-renderer-bundle-budget.mjs
@@ -162,7 +162,7 @@ function main() {
   } else {
     console.error(
       `\n[check-renderer-bundle-budget] FAILED — ${comparison.failures.length} regression(s) exceed +${(args.threshold * 100).toFixed(0)}% threshold. ` +
-        `If the change is intentional, run \`npm run renderer-bundle-budget:update\` to refresh the baseline, or add the \`bundle-size-override\` label to the PR.`
+        `If the change is intentional, run \`npm run renderer-bundle-budget:update\` to refresh the baseline.`
     );
     if (!args.override) process.exit(1);
     console.log(


### PR DESCRIPTION
## Summary

- The failure message in `scripts/check-renderer-bundle-budget.mjs` told contributors to add a `bundle-size-override` label to their PR to bypass the gate — that label doesn't exist in this repo and no workflow reads it
- The original bypass was a commit trailer (added in `711c46e15`), not a label; that check was removed in `3357f3b4b` when the budget jobs left CI, so the message was pointing at a feature that no longer exists
- Drops the misleading clause, keeps the accurate recovery instruction (`npm run renderer-bundle-budget:update`)

Closes #8894

## Changes

- `scripts/check-renderer-bundle-budget.mjs` — one-line edit removing the `bundle-size-override` label clause from the FAILED message

## Testing

- `npm run check` clean
- Build passes