### PR TITLE
fix(agents): use inherited Gemini OAuth paths for Antigravity auth check

### DIFF
--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -856,6 +856,50 @@ describe("CliAvailabilityService", () => {
       const result = await service.checkAvailability();
       expect(result.copilot).toBe("ready");
     });
+
+    it("does NOT probe the bogus Antigravity path (.antigravity/oauth_creds.json)", async () => {
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+
+      // Only agy binary found; no auth files exist
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        if (cmdOf(args) === "agy") return Buffer.from("");
+        throw new Error("not found");
+      });
+      mockedAccess.mockRejectedValue(new Error("ENOENT"));
+
+      const result = await service.checkAvailability();
+
+      // Binary on PATH + no credential detected → `unauthenticated`.
+      expect(result.antigravity).toBe("unauthenticated");
+      expect(service.getDetails()!.antigravity?.authConfirmed).toBe(false);
+
+      const probedPaths = mockedAccess.mock.calls.map((call) => String(call[0]));
+      // agy stores OAuth in the OS keychain, not on disk. The old
+      // .antigravity/oauth_creds.json path never existed and must never be
+      // probed (regression guard for #8918).
+      expect(probedPaths).not.toContain(join(homedir(), ".antigravity/oauth_creds.json"));
+    });
+
+    it("reaches 'ready' for Antigravity when ~/.gemini/antigravity-cli directory exists", async () => {
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        if (cmdOf(args) === "agy") return Buffer.from("");
+        throw new Error("not found");
+      });
+
+      const antigravityDir = join(homedir(), ".gemini/antigravity-cli");
+      mockedAccess.mockImplementation(async (path) => {
+        if (String(path) === antigravityDir) return;
+        throw new Error("ENOENT");
+      });
+
+      const result = await service.checkAvailability();
+      expect(result.antigravity).toBe("ready");
+      expect(service.getDetails()!.antigravity?.authConfirmed).toBe(true);
+    });
   });
 
   describe("diagnostic logging for auth discovery", () => {

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -875,13 +875,15 @@ describe("CliAvailabilityService", () => {
       expect(service.getDetails()!.antigravity?.authConfirmed).toBe(false);
 
       const probedPaths = mockedAccess.mock.calls.map((call) => String(call[0]));
-      // agy stores OAuth in the OS keychain, not on disk. The old
-      // .antigravity/oauth_creds.json path never existed and must never be
-      // probed (regression guard for #8918).
+      // The old .antigravity/oauth_creds.json path never existed on disk and
+      // must never be probed (regression guard for #8918).
       expect(probedPaths).not.toContain(join(homedir(), ".antigravity/oauth_creds.json"));
+      // Upper-bound guard: the inherited Gemini OAuth file IS probed — proves
+      // the fix wired the real path, not just that the bogus one is gone.
+      expect(probedPaths).toContain(join(homedir(), ".gemini/oauth_creds.json"));
     });
 
-    it("reaches 'ready' for Antigravity when ~/.gemini/antigravity-cli directory exists", async () => {
+    it("reaches 'ready' for Antigravity when ~/.gemini/oauth_creds.json exists", async () => {
       const { access } = await import("fs/promises");
       const mockedAccess = vi.mocked(access);
 
@@ -890,15 +892,39 @@ describe("CliAvailabilityService", () => {
         throw new Error("not found");
       });
 
-      const antigravityDir = join(homedir(), ".gemini/antigravity-cli");
+      // agy inherits Gemini's OAuth creds; either inherited file is a match.
+      const oauthCreds = join(homedir(), ".gemini/oauth_creds.json");
       mockedAccess.mockImplementation(async (path) => {
-        if (String(path) === antigravityDir) return;
+        if (String(path) === oauthCreds) return;
         throw new Error("ENOENT");
       });
 
       const result = await service.checkAvailability();
       expect(result.antigravity).toBe("ready");
       expect(service.getDetails()!.antigravity?.authConfirmed).toBe(true);
+    });
+
+    it("reaches 'ready' for Antigravity via GOOGLE_API_KEY env var alone", async () => {
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        if (cmdOf(args) === "agy") return Buffer.from("");
+        throw new Error("not found");
+      });
+      // No credential files on disk; only the env var signals auth.
+      mockedAccess.mockRejectedValue(new Error("ENOENT"));
+
+      const prev = process.env.GOOGLE_API_KEY;
+      process.env.GOOGLE_API_KEY = "test-key";
+      try {
+        const result = await service.checkAvailability();
+        expect(result.antigravity).toBe("ready");
+        expect(service.getDetails()!.antigravity?.authConfirmed).toBe(true);
+      } finally {
+        if (prev === undefined) delete process.env.GOOGLE_API_KEY;
+        else process.env.GOOGLE_API_KEY = prev;
+      }
     });
   });
 

--- a/shared/config/agents/antigravity.ts
+++ b/shared/config/agents/antigravity.ts
@@ -59,14 +59,18 @@ export const config: AgentConfig = {
   help: {
     args: [],
   },
-  // The exact credential filename under `~/.antigravity/` isn't documented
-  // yet — `oauth_creds.json` mirrors the Gemini CLI's layout and is the
-  // most likely location given `agy` is the Gemini CLI successor. The
-  // env var fallback (`GOOGLE_API_KEY`) is a strong signal regardless of
-  // file path. Worst case the file probe misses and we rely on the env
-  // signal; the auth check never gates launch.
+  // `agy` is a compiled Go binary that stores OAuth credentials in the
+  // OS-native keychain (macOS Keychain, Linux libsecret) — there is no
+  // on-disk credential file to probe. The old `~/.antigravity/oauth_creds.json`
+  // path never existed, so authenticated users always read as
+  // unauthenticated. `~/.gemini/antigravity-cli` is the non-credential
+  // settings directory `agy` writes on first run after setup, so its
+  // presence is the best available filesystem proxy for "set up and used"
+  // (fs.access works on directories too). The `GOOGLE_API_KEY` env var
+  // fallback remains the strong positive signal. This is a best-effort
+  // indicator — the auth check never gates launch.
   authCheck: {
-    configPathsAll: [".antigravity/oauth_creds.json"],
+    configPathsAll: [".gemini/antigravity-cli"],
     envVar: "GOOGLE_API_KEY",
   },
   prerequisites: [

--- a/shared/config/agents/antigravity.ts
+++ b/shared/config/agents/antigravity.ts
@@ -59,18 +59,18 @@ export const config: AgentConfig = {
   help: {
     args: [],
   },
-  // `agy` is a compiled Go binary that stores OAuth credentials in the
-  // OS-native keychain (macOS Keychain, Linux libsecret) — there is no
-  // on-disk credential file to probe. The old `~/.antigravity/oauth_creds.json`
-  // path never existed, so authenticated users always read as
-  // unauthenticated. `~/.gemini/antigravity-cli` is the non-credential
-  // settings directory `agy` writes on first run after setup, so its
-  // presence is the best available filesystem proxy for "set up and used"
-  // (fs.access works on directories too). The `GOOGLE_API_KEY` env var
-  // fallback remains the strong positive signal. This is a best-effort
-  // indicator — the auth check never gates launch.
+  // The `agy` CLI inherits credentials from the parent Gemini CLI: on a
+  // signed-in machine the authenticated user file is `~/.gemini/oauth_creds.json`
+  // (standard Gemini OAuth JSON), with `~/.gemini/google_accounts.json`
+  // alongside as the active-account signal — the same paths Gemini CLI
+  // probes. The old `~/.antigravity/oauth_creds.json` guess never existed
+  // on disk, so authenticated users always read as unauthenticated. (The
+  // Antigravity IDE stores its own OAuth state in a SQLite db under
+  // ~/Library/Application Support — secondary, since Daintree launches the
+  // CLI, not the IDE, and a `.vscdb` file needs a probe strategy beyond
+  // `fs.access`.) The `GOOGLE_API_KEY` env var fallback remains valid.
   authCheck: {
-    configPathsAll: [".gemini/antigravity-cli"],
+    configPathsAll: [".gemini/oauth_creds.json", ".gemini/google_accounts.json"],
     envVar: "GOOGLE_API_KEY",
   },
   prerequisites: [


### PR DESCRIPTION
## Summary

- The auth check in `shared/config/agents/antigravity.ts` was probing `.antigravity/oauth_creds.json`, a path that doesn't exist on disk. Authenticated users always showed as unauthenticated in the setup UI.
- `agy` inherits credentials from the parent Gemini CLI, so the probe now targets `.gemini/oauth_creds.json` and `.gemini/google_accounts.json` -- the same paths the Gemini CLI writes.
- The `GOOGLE_API_KEY` env var fallback is unchanged. The auth check only affects the setup UI indicator; it never gates launch.

Resolves #8918

## Changes

- `shared/config/agents/antigravity.ts` -- replace the bogus `.antigravity/oauth_creds.json` path with `.gemini/oauth_creds.json` and `.gemini/google_accounts.json` in `authCheck.configPathsAll`
- `electron/services/__tests__/CliAvailabilityService.test.ts` -- four regression-guard tests: the bogus path is never probed, the real inherited path is probed, `antigravity` reaches `ready` when `~/.gemini/oauth_creds.json` exists, and `GOOGLE_API_KEY` alone yields `ready`

## Testing

Covered by the new tests in `CliAvailabilityService.test.ts`. Manually verified the setup UI no longer shows an unauthenticated indicator on a signed-in machine.