### PR TITLE
feat(terminal): slim panel grid scrollbar and tint the gutter

### DIFF
--- a/shared/theme/__tests__/runtimeDefaults.test.ts
+++ b/shared/theme/__tests__/runtimeDefaults.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 import { PANEL_KIND_BRAND_COLORS } from "../entityColors.js";
 import type { ThemePalette } from "../palette.js";
 import { createSemanticTokens } from "../semantic.js";
-import { ANSI_CYAN_FALLBACK, ANSI_MAGENTA_FALLBACK, normalizeAppColorScheme } from "../themes.js";
+import {
+  ANSI_CYAN_FALLBACK,
+  ANSI_MAGENTA_FALLBACK,
+  BUILT_IN_APP_SCHEMES,
+  normalizeAppColorScheme,
+} from "../themes.js";
 
 function makePaletteWithoutTerminal(): ThemePalette {
   return {
@@ -122,6 +127,25 @@ describe("ANSI terminal fallbacks for plugin themes without a terminal sub-palet
     expect(tokens["terminal-cyan"]).toBe("#00ffff");
     expect(tokens["terminal-bright-magenta"]).toBe("#ff88ff");
     expect(tokens["terminal-bright-cyan"]).toBe("#88ffff");
+  });
+});
+
+describe("scrollbar-track default — subtle gutter tint", () => {
+  it("every built-in theme resolves a non-transparent, derived track tint", () => {
+    for (const scheme of BUILT_IN_APP_SCHEMES) {
+      const track = scheme.tokens["scrollbar-track"];
+      expect(track, scheme.id).not.toBe("transparent");
+      // withAlpha(text-primary, 0.03) emits an rgba() triplet at 3% opacity.
+      expect(track, scheme.id).toMatch(/^rgba\(\d+, \d+, \d+, 0\.03\)$/);
+    }
+  });
+
+  it("an explicit scrollbar-track override wins over the derived default", () => {
+    const scheme = normalizeAppColorScheme({
+      palette: makePaletteWithoutTerminal(),
+      tokens: { "scrollbar-track": "#abcdef" },
+    });
+    expect(scheme.tokens["scrollbar-track"]).toBe("#abcdef");
   });
 });
 

--- a/shared/theme/themes.ts
+++ b/shared/theme/themes.ts
@@ -245,7 +245,7 @@ export function createDaintreeTokens(
     "scrollbar-thumb-hover":
       tokens["scrollbar-thumb-hover"] ??
       `color-mix(in oklab, ${tokens["activity-idle"]} 85%, ${tokens["text-primary"]})`,
-    "scrollbar-track": tokens["scrollbar-track"] ?? "transparent",
+    "scrollbar-track": tokens["scrollbar-track"] ?? withAlpha(tokens["text-primary"], 0.03),
     "panel-state-edge-width": tokens["panel-state-edge-width"] ?? (dark ? "0px" : "2px"),
     "panel-state-edge-inset-block": tokens["panel-state-edge-inset-block"] ?? "4px",
     "panel-state-edge-radius": tokens["panel-state-edge-radius"] ?? "2px",

--- a/src/components/Terminal/GridScrollbar.tsx
+++ b/src/components/Terminal/GridScrollbar.tsx
@@ -182,7 +182,7 @@ export function GridScrollbar({
       data-no-dnd
       onPointerDown={onTrackPointerDown}
       onWheel={onWheel}
-      className="absolute z-20"
+      className="absolute z-20 rounded-[7px] bg-[var(--scrollbar-track)]"
       style={{
         right: BAR_INSET_PX,
         top: TRACK_INSET_PX,
@@ -206,7 +206,7 @@ export function GridScrollbar({
         onPointerEnter={() => setPhase((p) => (p === "drag" ? p : "hover"))}
         onPointerLeave={() => setPhase((p) => (p === "drag" ? p : "idle"))}
         className={cn(
-          "absolute inset-x-0 cursor-default rounded-[7px] transition-colors",
+          "absolute inset-x-0 cursor-default rounded-[7px] border-2 border-transparent bg-clip-padding transition-colors",
           phase === "idle" ? "bg-[var(--scrollbar-thumb)]" : "bg-[var(--scrollbar-thumb-hover)]"
         )}
         style={{ height: geometry.height, top: geometry.top }}


### PR DESCRIPTION
## Summary

- The visible scrollbar thumb in `GridScrollbar.tsx` was 14px wide, which read more like default browser chrome than a deliberate grab target. This PR slims the painted pill to ~10px using a transparent border and `background-clip: padding-box`, keeping the full 14px drag hitbox intact.
- The gutter was blank. Added a rounded tint using the `scrollbar-track` semantic token — previously defaulted to `transparent` in `shared/theme/themes.ts`, now set to 3% opacity on the primary text colour so it adapts across all 14 built-in themes without any per-theme overrides.

Resolves #8913

## Changes

- `src/components/Terminal/GridScrollbar.tsx`: thumb gains `border-2 border-transparent bg-clip-padding`; track gains `rounded-[7px] bg-[var(--scrollbar-track)]`. `BAR_WIDTH_PX`, `THUMB_MIN_PX`, and `GRID_SCROLLBAR_GUTTER_PX` are unchanged — no layout impact.
- `shared/theme/themes.ts`: `scrollbar-track` default changed from `"transparent"` to `withAlpha(text-primary, 0.03)`, following the established `withAlpha` pattern (resolves to concrete values, not CSS relative color syntax).
- `shared/theme/__tests__/runtimeDefaults.test.ts`: 2 new tests — every built-in theme resolves a non-transparent rgba track tint; explicit `scrollbar-track` overrides still win.

## Testing

- `GridScrollbar.test.ts` — 6 tests pass.
- `runtimeDefaults.test.ts` — 11 tests pass (9 existing + 2 new).
- Full `npm run check` clean: typecheck, IPC checks, lint, format.