### PR TITLE
refactor(palette): derive EmptyState fade-suppression from query staleness

### DIFF
--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -486,6 +486,11 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
   // the immediate `trimmedQuery` so clearing the input flips back to
   // zero-data without a stale "No matches for ..." flash.
   const deferredTrimmedQuery = useDeferredValue(trimmedQuery);
+  // When the urgent query is ahead of the deferred one, the user is mid-keystroke
+  // and the empty state is churning — suppress the fade so it doesn't strobe. The
+  // length guard keeps the crossfade when the input is cleared back to empty (the
+  // deferred value briefly lags behind "", which would otherwise read as stale).
+  const isStale = trimmedQuery !== deferredTrimmedQuery && trimmedQuery.length > 0;
   if (trimmedQuery) {
     const displayQuery = deferredTrimmedQuery || trimmedQuery;
     return (
@@ -495,6 +500,7 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
         title={noMatchMessage ?? defaultNoMatchTitle(displayQuery)}
         action={noMatchContent}
         className="px-3 py-8"
+        instant={isStale}
       />
     );
   }
@@ -505,6 +511,7 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
       title={emptyMessage}
       action={children}
       className="px-3 py-8"
+      instant={isStale}
     />
   );
 };

--- a/src/components/ui/__tests__/AppPaletteEmptyInstant.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteEmptyInstant.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Lets each test dictate what the deferred query lags behind, so we can
@@ -15,12 +16,18 @@ vi.mock("react", async () => {
   };
 });
 
-const emptyStateProps: Array<Record<string, unknown>> = [];
+interface CapturedEmptyStateProps {
+  instant?: boolean;
+  variant?: string;
+  title?: ReactNode;
+}
+
+const emptyStateProps: CapturedEmptyStateProps[] = [];
 
 vi.mock("@/components/ui/EmptyState", () => ({
-  EmptyState: (props: Record<string, unknown>) => {
+  EmptyState: (props: CapturedEmptyStateProps) => {
     emptyStateProps.push(props);
-    return <div data-instant={String(props.instant)}>{props.title as string}</div>;
+    return <div data-instant={String(props.instant)}>{props.title}</div>;
   },
 }));
 
@@ -38,7 +45,11 @@ vi.mock("@/store/paletteStore", () => ({
 
 import { AppPaletteDialog } from "../AppPaletteDialog";
 
-const lastProps = () => emptyStateProps[emptyStateProps.length - 1];
+const lastProps = (): CapturedEmptyStateProps => {
+  const props = emptyStateProps.at(-1);
+  if (!props) throw new Error("EmptyState was not rendered");
+  return props;
+};
 
 describe("AppPaletteDialog.Empty instant derivation", () => {
   beforeEach(() => {

--- a/src/components/ui/__tests__/AppPaletteEmptyInstant.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteEmptyInstant.test.tsx
@@ -80,4 +80,13 @@ describe("AppPaletteDialog.Empty instant derivation", () => {
     expect(lastProps().instant).toBe(false);
     expect(lastProps().variant).toBe("zero-data");
   });
+
+  it("treats a whitespace-only query as zero-data with the fade intact", () => {
+    // trim() collapses "   " to "" -> zero-data branch, and the length guard
+    // keeps instant false even while the deferred value lags on "foo".
+    deferQuery = () => "foo";
+    render(<AppPaletteDialog.Empty query="   " emptyMessage="No items available" />);
+    expect(lastProps().instant).toBe(false);
+    expect(lastProps().variant).toBe("zero-data");
+  });
 });

--- a/src/components/ui/__tests__/AppPaletteEmptyInstant.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteEmptyInstant.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Lets each test dictate what the deferred query lags behind, so we can
+// deterministically exercise the `trimmedQuery !== deferredTrimmedQuery`
+// staleness branch without depending on the concurrent scheduler's timing.
+let deferQuery: (value: string) => string = (value) => value;
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useDeferredValue: (value: string) => deferQuery(value),
+  };
+});
+
+const emptyStateProps: Array<Record<string, unknown>> = [];
+
+vi.mock("@/components/ui/EmptyState", () => ({
+  EmptyState: (props: Record<string, unknown>) => {
+    emptyStateProps.push(props);
+    return <div data-instant={String(props.instant)}>{props.title as string}</div>;
+  },
+}));
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/hooks", () => ({
+  useOverlayState: () => {},
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ activePaletteId: null }) },
+}));
+
+import { AppPaletteDialog } from "../AppPaletteDialog";
+
+const lastProps = () => emptyStateProps[emptyStateProps.length - 1];
+
+describe("AppPaletteDialog.Empty instant derivation", () => {
+  beforeEach(() => {
+    emptyStateProps.length = 0;
+    deferQuery = (value) => value;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("suppresses the fade (instant) when the query is mid-keystroke stale", () => {
+    // Deferred value lags behind the urgent query -> the user is still typing.
+    deferQuery = (value) => (value === "foo" ? "fo" : value);
+    render(<AppPaletteDialog.Empty query="foo" emptyMessage="No items available" />);
+    expect(lastProps().instant).toBe(true);
+    expect(lastProps().variant).toBe("filtered-empty");
+  });
+
+  it("keeps the fade when the deferred query has caught up to the urgent query", () => {
+    // deferQuery is identity -> deferred === urgent -> not stale.
+    render(<AppPaletteDialog.Empty query="foo" emptyMessage="No items available" />);
+    expect(lastProps().instant).toBe(false);
+    expect(lastProps().variant).toBe("filtered-empty");
+  });
+
+  it("keeps the fade on the zero-data branch when the input is cleared (length guard)", () => {
+    // Input cleared to "" while the deferred value still lags on "foo": stale by
+    // string comparison, but the length guard must keep instant false so the
+    // crossfade back to the zero-data state still plays.
+    deferQuery = () => "foo";
+    render(<AppPaletteDialog.Empty query="" emptyMessage="No items available" />);
+    expect(lastProps().instant).toBe(false);
+    expect(lastProps().variant).toBe("zero-data");
+  });
+
+  it("keeps the fade on the steady zero-data state", () => {
+    render(<AppPaletteDialog.Empty query="" emptyMessage="No items available" />);
+    expect(lastProps().instant).toBe(false);
+    expect(lastProps().variant).toBe("zero-data");
+  });
+});


### PR DESCRIPTION
## Summary

- `AppPaletteDialog.Empty` already computed `useDeferredValue(trimmedQuery)` but threw away the staleness signal instead of using it to suppress the `EmptyState` fade during fast typing
- Derives `isStale` by comparing `trimmedQuery !== deferredTrimmedQuery` with a length guard (so clearing the input back to zero-data still crossfades), then passes it as `instant` to both `EmptyState` renders
- Fixes all palette consumers (`SearchablePalette`, `PanelPalette`, `NewTerminalPalette`) in one place without touching `SidebarContent.tsx`'s toggle-driven flags or `EmptyState.tsx` itself

Resolves #8909

## Changes

- `src/components/ui/AppPaletteDialog.tsx`: inline `isStale` derivation, `instant={isStale}` on both `EmptyState` renders
- `src/components/ui/__tests__/AppPaletteEmptyInstant.test.tsx` (new): 5 cases covering stale mid-keystroke, deferred caught up, cleared input with lagging deferred, steady zero-data, and whitespace-only query

## Testing

- 62 vitest tests pass across the 3 affected test files
- `npm run check` clean: typecheck, lint, format, channel/IPC checks all pass