### PR TITLE
feat(ui): redesign SkeletonHint long-wait escalation

### DIFF
--- a/src/components/Browser/BrowserPaneSkeleton.tsx
+++ b/src/components/Browser/BrowserPaneSkeleton.tsx
@@ -53,7 +53,7 @@ export function BrowserPaneSkeleton({ label = "Loading browser panel" }: Browser
       </div>
 
       {/* Long-tail loading hint — sibling of role="status" so the live region
-       * isn't silenced by aria-busy. Stays invisible until 5s, then fades in. */}
+       * isn't silenced by aria-busy. Stays invisible until 8s, then fades in. */}
       <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
     </div>
   );

--- a/src/components/DevPreview/DevPreviewLoadingState.tsx
+++ b/src/components/DevPreview/DevPreviewLoadingState.tsx
@@ -9,7 +9,17 @@ interface DevPreviewLoadingStateProps {
   className?: string;
 }
 
-function FullSkeleton({ phaseLabel }: { phaseLabel: string }) {
+function FullSkeleton({
+  phaseLabel,
+  isLoading,
+  onCancel,
+}: {
+  phaseLabel: string;
+  isLoading: boolean;
+  onCancel?: () => void;
+}) {
+  const showPhaseLabel = useDohertyGate(isLoading);
+
   return (
     <div className="relative flex flex-col items-center justify-center h-full bg-daintree-bg px-6">
       <div
@@ -33,14 +43,21 @@ function FullSkeleton({ phaseLabel }: { phaseLabel: string }) {
             <SkeletonBone className="h-2.5 w-3/5" />
           </div>
         </div>
+
+        {/* Visible caption only — the role=status wrapper above owns the AT
+            announcement, and an aria-live here would be silenced by its
+            aria-busy="true" anyway. The phase also flows through the hint. */}
+        {showPhaseLabel && (
+          <p aria-hidden="true" className="mt-6 text-xs text-daintree-text/60">
+            {phaseLabel}
+          </p>
+        )}
       </div>
 
-      {/* The phase label flows through the hint's message rather than a separate
-          live region — the wrapper's aria-busy="true" would silence an inner
-          aria-live anyway. The role=status wrapper still announces it on mount. */}
       <SkeletonHint
         className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto"
         message={phaseLabel}
+        onCancel={onCancel}
       />
     </div>
   );
@@ -61,8 +78,19 @@ function OverlaySkeleton({
 
   return (
     <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg">
-      <div role="status" aria-busy="true" aria-label={phaseLabel}>
+      <div
+        className="flex flex-col items-center gap-3"
+        role="status"
+        aria-busy="true"
+        aria-label={phaseLabel}
+      >
         <span className="sr-only">{phaseLabel}</span>
+
+        {/* Visible caption only (aria-hidden) — the wrapper owns the AT
+            announcement; the phase also flows through the hint. */}
+        <p aria-hidden="true" className="text-xs text-daintree-text/60">
+          {phaseLabel}
+        </p>
       </div>
 
       <SkeletonHint
@@ -87,7 +115,7 @@ export function DevPreviewLoadingState({
 
   return (
     <div className={className}>
-      <FullSkeleton phaseLabel={phaseLabel} />
+      <FullSkeleton phaseLabel={phaseLabel} isLoading={isLoading} onCancel={onCancel} />
     </div>
   );
 }

--- a/src/components/DevPreview/DevPreviewLoadingState.tsx
+++ b/src/components/DevPreview/DevPreviewLoadingState.tsx
@@ -1,5 +1,5 @@
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
-import { SkeletonHint } from "@/components/ui/Skeleton";
+import { SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
 
 interface DevPreviewLoadingStateProps {
   variant: "full" | "overlay";
@@ -9,18 +9,7 @@ interface DevPreviewLoadingStateProps {
   className?: string;
 }
 
-function SkeletonBone({ className }: { className?: string }) {
-  return (
-    <div
-      aria-hidden="true"
-      className={`bg-muted rounded animate-pulse-delayed ${className ?? ""}`}
-    />
-  );
-}
-
-function FullSkeleton({ phaseLabel, isLoading }: { phaseLabel: string; isLoading: boolean }) {
-  const showPhaseLabel = useDohertyGate(isLoading);
-
+function FullSkeleton({ phaseLabel }: { phaseLabel: string }) {
   return (
     <div className="relative flex flex-col items-center justify-center h-full bg-daintree-bg px-6">
       <div
@@ -44,15 +33,15 @@ function FullSkeleton({ phaseLabel, isLoading }: { phaseLabel: string; isLoading
             <SkeletonBone className="h-2.5 w-3/5" />
           </div>
         </div>
-
-        {showPhaseLabel && (
-          <p aria-live="polite" className="mt-6 text-xs text-daintree-text/60">
-            {phaseLabel}
-          </p>
-        )}
       </div>
 
-      <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
+      {/* The phase label flows through the hint's message rather than a separate
+          live region — the wrapper's aria-busy="true" would silence an inner
+          aria-live anyway. The role=status wrapper still announces it on mount. */}
+      <SkeletonHint
+        className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto"
+        message={phaseLabel}
+      />
     </div>
   );
 }
@@ -72,21 +61,13 @@ function OverlaySkeleton({
 
   return (
     <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg">
-      <div
-        className="flex flex-col items-center gap-3"
-        role="status"
-        aria-busy="true"
-        aria-label={phaseLabel}
-      >
+      <div role="status" aria-busy="true" aria-label={phaseLabel}>
         <span className="sr-only">{phaseLabel}</span>
-
-        <p aria-live="polite" className="text-xs text-daintree-text/60">
-          {phaseLabel}
-        </p>
       </div>
 
       <SkeletonHint
         className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto"
+        message={phaseLabel}
         onCancel={onCancel}
       />
     </div>
@@ -106,7 +87,7 @@ export function DevPreviewLoadingState({
 
   return (
     <div className={className}>
-      <FullSkeleton phaseLabel={phaseLabel} isLoading={isLoading} />
+      <FullSkeleton phaseLabel={phaseLabel} />
     </div>
   );
 }

--- a/src/components/DevPreview/__tests__/DevPreviewLoadingState.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewLoadingState.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DevPreviewLoadingState } from "../DevPreviewLoadingState";
+
+describe("DevPreviewLoadingState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function advance(ms: number) {
+    act(() => {
+      vi.advanceTimersByTime(ms);
+    });
+  }
+
+  it("uses the shared SkeletonBone (animate-pulse-delayed) in the full variant", () => {
+    const { container } = render(
+      <DevPreviewLoadingState variant="full" isLoading phaseLabel="Installing dependencies" />
+    );
+    expect(container.querySelectorAll(".animate-pulse-delayed").length).toBeGreaterThan(0);
+  });
+
+  it("renders the SkeletonHint live region as a sibling, not nested in role=status", () => {
+    const { container } = render(
+      <DevPreviewLoadingState variant="full" isLoading phaseLabel="Installing dependencies" />
+    );
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live).toBeTruthy();
+    expect(live!.closest('[role="status"]')).toBeNull();
+  });
+
+  it("shows a visible (aria-hidden) phase caption once the overlay clears the Doherty gate", () => {
+    const { container } = render(
+      <DevPreviewLoadingState variant="overlay" isLoading phaseLabel="Rehydrating preview" />
+    );
+    // Sub-400ms: nothing rendered (Doherty gate).
+    expect(container.querySelector("p")).toBeNull();
+    advance(400);
+    const caption = container.querySelector("p[aria-hidden='true']");
+    expect(caption?.textContent).toBe("Rehydrating preview");
+  });
+
+  it("does not place a second live region inside the aria-busy status wrapper", () => {
+    const { container } = render(
+      <DevPreviewLoadingState variant="overlay" isLoading phaseLabel="Rehydrating preview" />
+    );
+    advance(400);
+    // The only aria-live region is the SkeletonHint sibling, outside role=status.
+    const liveRegions = container.querySelectorAll("[aria-live]");
+    expect(liveRegions.length).toBe(1);
+    expect(liveRegions[0]!.closest('[role="status"]')).toBeNull();
+  });
+});

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -1215,7 +1215,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
   });
 
   describe("slow-load and timeout escalation", () => {
-    it("shows phase label and Still working hint after loading threshold", () => {
+    it("shows the phase label and escalation hint after the loading threshold", () => {
       const { container } = render(<DevPreviewPane {...baseProps} />);
       const webview = getWebviewElement(container);
 
@@ -1231,12 +1231,18 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       });
 
       expect(container.textContent).toContain("Loading preview");
+      // The escalation hint stays hidden until the first threshold (8s).
+      expect(container.querySelector(".animate-hint-fade-in")).toBeNull();
 
       act(() => {
-        vi.advanceTimersByTime(6000);
+        vi.advanceTimersByTime(8000);
       });
 
-      expect(container.textContent).toContain("Still working");
+      // The hint surfaces and names the current phase via its message prop,
+      // rather than the generic "Still working…" copy.
+      const hint = container.querySelector(".animate-hint-fade-in");
+      expect(hint).not.toBeNull();
+      expect(hint?.textContent).toContain("Loading preview");
     });
 
     it("Cancel appears after action threshold and stops the webview", () => {

--- a/src/components/HelpPanel/HelpLaunchingState.tsx
+++ b/src/components/HelpPanel/HelpLaunchingState.tsx
@@ -7,7 +7,7 @@ interface HelpLaunchingStateProps {
   phase: HelpSessionPhase;
   /** Drives the 400ms Doherty gate — keep true while the launch is in flight. */
   isLoading: boolean;
-  /** Aborts the in-flight launch. Surfaced as a Cancel button by `SkeletonHint` at 15s. */
+  /** Aborts the in-flight launch. Surfaced as a Cancel button by `SkeletonHint` with the first hint. */
   onCancel: () => void;
 }
 
@@ -34,8 +34,8 @@ function phaseLabel(phase: HelpSessionPhase): string {
  * Phase-labeled loading skeleton for the assistant launch sequence. Replaces
  * the static empty state while auto-launch / select-agent runs (6–45s), so the
  * panel proves it's working instead of looking idle. Gated behind the 400ms
- * Doherty threshold to avoid flicker on fast launches; `SkeletonHint` escalates
- * copy at 5s/10s and surfaces Cancel at 15s for the long tail.
+ * Doherty threshold to avoid flicker on fast launches; `SkeletonHint` surfaces
+ * Cancel with the first hint (8s) and escalates copy for the long tail.
  */
 export function HelpLaunchingState({ phase, isLoading, onCancel }: HelpLaunchingStateProps) {
   const show = useDohertyGate(isLoading);

--- a/src/components/HelpPanel/HelpLaunchingState.tsx
+++ b/src/components/HelpPanel/HelpLaunchingState.tsx
@@ -58,6 +58,7 @@ export function HelpLaunchingState({ phase, isLoading, onCancel }: HelpLaunching
 
       <SkeletonHint
         className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto"
+        message={label}
         onCancel={onCancel}
       />
     </div>

--- a/src/components/HelpPanel/__tests__/HelpLaunchingState.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpLaunchingState.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HelpLaunchingState } from "../HelpLaunchingState";
+
+describe("HelpLaunchingState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function advance(ms: number) {
+    act(() => {
+      vi.advanceTimersByTime(ms);
+    });
+  }
+
+  it("stays hidden until the Doherty gate elapses", () => {
+    const { container } = render(
+      <HelpLaunchingState phase="provisioning" isLoading onCancel={() => {}} />
+    );
+    expect(container.firstChild).toBeNull();
+    advance(400);
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  it("threads the phase label through the hint so AT hears it (not the generic copy)", () => {
+    const { container } = render(
+      <HelpLaunchingState phase="provisioning" isLoading onCancel={() => {}} />
+    );
+    advance(400); // clear Doherty gate; hint mounts and starts its timers
+    advance(8_000); // reach the first hint threshold
+    // The Skeleton wrapper is itself a role=status / aria-live region; the hint's
+    // live region is the sibling one, outside any role=status subtree.
+    const live = Array.from(container.querySelectorAll('[aria-live="polite"]')).find(
+      (el) => el.closest('[role="status"]') === null
+    )!;
+    expect(live.textContent).toBe("Provisioning session… Cancel option available.");
+  });
+});

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -188,8 +188,12 @@ function safeThreshold(value: number | undefined, fallback: number): number {
 // generic "Taking longer than usual…" — past the stall threshold that signal is
 // accurate regardless of where the operation's own progress string sits.
 function hintCopy(phase: HintPhase, message?: string): string {
-  if (phase === "first") return message || FIRST_HINT_COPY;
-  if (phase === "second") return message || SECOND_HINT_COPY;
+  // Use the caller copy only when it carries non-whitespace content; a blank or
+  // whitespace-only string falls back to the generic copy rather than rendering
+  // an empty hint.
+  const custom = message?.trim() ? message : undefined;
+  if (phase === "first") return custom ?? FIRST_HINT_COPY;
+  if (phase === "second") return custom ?? SECOND_HINT_COPY;
   if (phase === "action") return SECOND_HINT_COPY;
   return "";
 }

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -162,9 +162,13 @@ export function SkeletonText({
   );
 }
 
-const DEFAULT_FIRST_THRESHOLD_MS = 5_000;
-const DEFAULT_SECOND_THRESHOLD_MS = 10_000;
-const DEFAULT_ACTION_THRESHOLD_MS = 15_000;
+// First hint lands at 8s — NN/g's research puts the attention-break boundary at
+// ~10s, so 8s preempts it with headroom while staying late enough not to draw
+// attention to a delay the user would otherwise tolerate. Second and action
+// thresholds keep a ~5s/~7s spacing above it so the ladder doesn't compress.
+const DEFAULT_FIRST_THRESHOLD_MS = 8_000;
+const DEFAULT_SECOND_THRESHOLD_MS = 13_000;
+const DEFAULT_ACTION_THRESHOLD_MS = 20_000;
 
 const FIRST_HINT_COPY = "Still working…";
 const SECOND_HINT_COPY = "Taking longer than usual…";
@@ -179,23 +183,37 @@ function safeThreshold(value: number | undefined, fallback: number): number {
   return value;
 }
 
-function hintCopy(phase: HintPhase): string {
-  if (phase === "first") return FIRST_HINT_COPY;
-  if (phase === "second" || phase === "action") return SECOND_HINT_COPY;
+// A caller-supplied `message` (e.g. "Fetching 3 of 12 files…") replaces the
+// generic copy at the first/second phases. The action phase always keeps the
+// generic "Taking longer than usual…" — past the stall threshold that signal is
+// accurate regardless of where the operation's own progress string sits.
+function hintCopy(phase: HintPhase, message?: string): string {
+  if (phase === "first") return message || FIRST_HINT_COPY;
+  if (phase === "second") return message || SECOND_HINT_COPY;
+  if (phase === "action") return SECOND_HINT_COPY;
   return "";
 }
 
-function actionAffordanceCopy(hasCancel: boolean, hasRetry: boolean): string {
-  if (hasCancel && hasRetry) return "Cancel and retry options available.";
-  if (hasCancel) return "Cancel option available.";
-  if (hasRetry) return "Retry option available.";
+function actionAffordanceCopy(showCancel: boolean, showRetry: boolean): string {
+  if (showCancel && showRetry) return "Cancel and retry options available.";
+  if (showCancel) return "Cancel option available.";
+  if (showRetry) return "Retry option available.";
   return "";
 }
 
-function liveRegionCopy(phase: HintPhase, hasCancel: boolean, hasRetry: boolean): string {
-  const base = hintCopy(phase);
-  if (phase !== "action") return base;
-  const action = actionAffordanceCopy(hasCancel, hasRetry);
+// Announces the visible copy plus whichever affordances are currently surfaced.
+// Receives the computed `showCancel`/`showRetry` flags (not raw handler
+// presence) so Retry is never announced before it actually appears — Cancel
+// surfaces at the first phase, Retry only at the action phase.
+function liveRegionCopy(
+  phase: HintPhase,
+  showCancel: boolean,
+  showRetry: boolean,
+  message?: string
+): string {
+  const base = hintCopy(phase, message);
+  if (phase === "hidden") return base;
+  const action = actionAffordanceCopy(showCancel, showRetry);
   return action ? `${base} ${action}` : base;
 }
 
@@ -203,24 +221,32 @@ export interface SkeletonHintProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   "role" | "aria-live" | "children"
 > {
-  /** Delay before "Still working…" appears. Default 5000ms. */
+  /** Delay before the first hint appears. Default 8000ms. */
   firstThreshold?: number;
-  /** Delay before copy escalates to "Taking longer than usual…". Default 10000ms. */
+  /** Delay before copy escalates to "Taking longer than usual…". Default 13000ms. */
   secondThreshold?: number;
-  /** Delay before Cancel/Retry buttons surface (only when handlers are passed). Default 15000ms. */
+  /** Delay before the Retry button surfaces (only when onRetry is passed). Default 20000ms. */
   actionThreshold?: number;
-  /** When provided, a Cancel button appears at actionThreshold and fires this handler. */
+  /**
+   * Caller-supplied status copy (e.g. "Fetching 3 of 12 files…"). When set, it
+   * replaces the generic first/second-phase copy. The action phase still shows
+   * the generic stall copy.
+   */
+  message?: string;
+  /** When provided, a Cancel button surfaces with the first hint and fires this handler. */
   onCancel?: () => void;
   /** When provided, a Retry button appears at actionThreshold and fires this handler. */
   onRetry?: () => void;
 }
 
 /**
- * Companion to `<Skeleton>` for long-tail loads (>5s). Stays invisible until the
- * first threshold, then fades in escalating copy and surfaces a Cancel/Retry
- * affordance at the action threshold. Place as a sibling to the `<Skeleton>`
- * wrapper — never nested inside, because the wrapper's `aria-busy="true"`
- * silences mutations within its subtree on modern screen readers.
+ * Companion to `<Skeleton>` for long-tail loads (>8s). Stays invisible until the
+ * first threshold, then fades in escalating copy. A Cancel affordance surfaces
+ * with the first hint (so the user can bail as soon as the wait registers);
+ * Retry waits for the later action threshold, where "try again" is the
+ * meaningful recovery. Place as a sibling to the `<Skeleton>` wrapper — never
+ * nested inside, because the wrapper's `aria-busy="true"` silences mutations
+ * within its subtree on modern screen readers.
  *
  * The sr-only span is always rendered so screen readers register the live
  * region up front; only its text content updates on phase change.
@@ -229,6 +255,7 @@ export function SkeletonHint({
   firstThreshold,
   secondThreshold,
   actionThreshold,
+  message,
   onCancel,
   onRetry,
   className,
@@ -256,20 +283,24 @@ export function SkeletonHint({
 
   const hasCancel = onCancel !== undefined;
   const hasRetry = onRetry !== undefined;
-  const visibleCopy = hintCopy(phase);
-  const showActions = phase === "action" && (hasCancel || hasRetry);
+  // Cancel surfaces as soon as the hint is visible; Retry stays gated to the
+  // action threshold where re-trying is the meaningful recovery.
+  const showCancel = phase !== "hidden" && hasCancel;
+  const showRetry = phase === "action" && hasRetry;
+  const visibleCopy = hintCopy(phase, message);
 
   // Key the visible row on its rendered state, not the raw phase. When phase
   // moves "second" → "action" with no handlers, the visible content is
   // identical, so React preserves the DOM node and the fade-in does NOT
   // re-fire. The key only changes when the user-visible content actually
-  // changes (copy escalation, or buttons appearing).
-  const visibleKey = `${visibleCopy}|${showActions ? "actions" : "noactions"}`;
+  // changes (copy escalation, or a button surfacing). Cancel and Retry are
+  // tracked independently so each one's appearance re-fires the fade.
+  const visibleKey = `${visibleCopy}|${showCancel ? "cancel" : ""}|${showRetry ? "retry" : ""}`;
 
   return (
     <div {...rest} className={className}>
       <span className="sr-only" aria-live="polite" aria-atomic="true">
-        {liveRegionCopy(phase, hasCancel, hasRetry)}
+        {liveRegionCopy(phase, showCancel, showRetry, message)}
       </span>
       {phase !== "hidden" && (
         <div
@@ -277,12 +308,12 @@ export function SkeletonHint({
           className="animate-hint-fade-in flex items-center gap-2 text-text-secondary text-xs"
         >
           <span aria-hidden="true">{visibleCopy}</span>
-          {showActions && hasCancel && (
+          {showCancel && (
             <Button variant="ghost" size="sm" onClick={onCancel} type="button">
               {CANCEL_LABEL}
             </Button>
           )}
-          {showActions && hasRetry && (
+          {showRetry && (
             <Button variant="ghost" size="sm" onClick={onRetry} type="button">
               {RETRY_LABEL}
             </Button>

--- a/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/src/components/ui/__tests__/Skeleton.test.tsx
@@ -273,17 +273,17 @@ describe("SkeletonHint", () => {
     expect(live?.textContent).toBe("");
   });
 
-  it('shows "Still working…" at exactly 5000ms', () => {
+  it('shows "Still working…" at exactly 8000ms', () => {
     render(<SkeletonHint />);
-    advance(4_999);
+    advance(7_999);
     expect(screen.queryByText("Still working…")).toBeNull();
     advance(1);
     expect(screen.getAllByText("Still working…").length).toBeGreaterThan(0);
   });
 
-  it('escalates to "Taking longer than usual…" at 10000ms', () => {
+  it('escalates to "Taking longer than usual…" at 13000ms', () => {
     render(<SkeletonHint />);
-    advance(10_000);
+    advance(13_000);
     expect(screen.getAllByText("Taking longer than usual…").length).toBeGreaterThan(0);
     expect(screen.queryByText("Still working…")).toBeNull();
   });
@@ -293,7 +293,7 @@ describe("SkeletonHint", () => {
     const live = container.querySelector('[aria-live="polite"]')!;
     expect(live.textContent).toBe("");
 
-    advance(5_000);
+    advance(8_000);
     expect(live.textContent).toBe("Still working…");
 
     advance(5_000);
@@ -303,63 +303,86 @@ describe("SkeletonHint", () => {
   it("appends an action affordance announcement to the live region at the action phase", () => {
     const { container } = render(<SkeletonHint onCancel={() => {}} onRetry={() => {}} />);
     const live = container.querySelector('[aria-live="polite"]')!;
-    advance(15_000);
+    advance(20_000);
     expect(live.textContent).toBe("Taking longer than usual… Cancel and retry options available.");
+  });
+
+  it("announces the Cancel affordance at the first phase, before Retry exists", () => {
+    const { container } = render(<SkeletonHint onCancel={() => {}} onRetry={() => {}} />);
+    const live = container.querySelector('[aria-live="polite"]')!;
+    advance(8_000);
+    // Cancel surfaces with the first hint; Retry is still gated to the action
+    // phase, so only Cancel is announced here.
+    expect(live.textContent).toBe("Still working… Cancel option available.");
   });
 
   it("scopes the action affordance announcement to the handlers actually passed", () => {
     const { container, rerender } = render(<SkeletonHint onCancel={() => {}} />);
     const live = container.querySelector('[aria-live="polite"]')!;
-    advance(15_000);
+    advance(20_000);
     expect(live.textContent).toBe("Taking longer than usual… Cancel option available.");
     rerender(<SkeletonHint onRetry={() => {}} />);
-    advance(15_000);
+    advance(20_000);
     expect(live.textContent).toBe("Taking longer than usual… Retry option available.");
   });
 
   it("does not append an action affordance announcement when no handlers are passed", () => {
     const { container } = render(<SkeletonHint />);
     const live = container.querySelector('[aria-live="polite"]')!;
-    advance(15_000);
+    advance(20_000);
     expect(live.textContent).toBe("Taking longer than usual…");
   });
 
-  it("does not show action buttons at 15000ms when no handlers are passed", () => {
+  it("does not show action buttons at the action threshold when no handlers are passed", () => {
     render(<SkeletonHint />);
-    advance(15_000);
+    advance(20_000);
     expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
   });
 
-  it("renders Cancel at 15000ms and fires the handler when clicked", () => {
+  it("renders Cancel at the first threshold and fires the handler when clicked", () => {
     const onCancel = vi.fn();
     render(<SkeletonHint onCancel={onCancel} />);
-    advance(15_000);
+    advance(7_999);
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    advance(1);
     const button = screen.getByRole("button", { name: "Cancel" });
     fireEvent.click(button);
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
-  it("renders Retry at 15000ms and fires the handler when clicked", () => {
+  it("keeps Cancel visible as the copy escalates through later phases", () => {
+    render(<SkeletonHint onCancel={() => {}} />);
+    advance(8_000);
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    advance(5_000); // second phase
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    advance(7_000); // action phase
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+  });
+
+  it("renders Retry only at the action threshold and fires the handler when clicked", () => {
     const onRetry = vi.fn();
     render(<SkeletonHint onRetry={onRetry} />);
-    advance(15_000);
+    advance(13_000);
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    advance(7_000);
     const button = screen.getByRole("button", { name: "Retry" });
     fireEvent.click(button);
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
-  it("renders both Cancel and Retry when both handlers are passed", () => {
+  it("renders both Cancel and Retry at the action threshold when both handlers are passed", () => {
     render(<SkeletonHint onCancel={() => {}} onRetry={() => {}} />);
-    advance(15_000);
+    advance(20_000);
     expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
   });
 
-  it("does not show buttons before the action threshold even with handlers", () => {
+  it("shows Cancel but withholds Retry before the action threshold", () => {
     render(<SkeletonHint onCancel={() => {}} onRetry={() => {}} />);
-    advance(10_000);
-    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    advance(13_000); // second phase — past first, before action
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
   });
 
@@ -378,16 +401,23 @@ describe("SkeletonHint", () => {
     expect(screen.getAllByText("Taking longer than usual…").length).toBeGreaterThan(0);
   });
 
-  it("clamps out-of-order thresholds to monotonic ascending so phase can't regress", () => {
-    // actionThreshold is intentionally smaller than secondThreshold's default —
-    // without clamping, buttons would flash at 6s then disappear at 10s when
+  it("clamps out-of-order actionThreshold to monotonic ascending so Retry can't flash early", () => {
+    // actionThreshold is intentionally smaller than secondThreshold —
+    // without clamping, Retry would flash at 2s then disappear at 3s when
     // setPhase("second") fires. With clamping, action is held to >= second.
-    render(<SkeletonHint actionThreshold={6_000} onCancel={() => {}} />);
-    advance(6_000);
-    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
-    advance(4_000);
-    // At 10s the clamped action threshold finally fires alongside second.
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    render(
+      <SkeletonHint
+        firstThreshold={1_000}
+        secondThreshold={3_000}
+        actionThreshold={2_000}
+        onRetry={() => {}}
+      />
+    );
+    advance(2_000);
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    advance(1_000);
+    // At 3s the clamped action threshold finally fires alongside second.
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
   });
 
   it("clamps secondThreshold below firstThreshold to firstThreshold (no backward jump)", () => {
@@ -407,7 +437,7 @@ describe("SkeletonHint", () => {
         actionThreshold={Number.POSITIVE_INFINITY}
       />
     );
-    advance(4_999);
+    advance(7_999);
     expect(screen.queryByText("Still working…")).toBeNull();
     advance(1);
     expect(screen.getAllByText("Still working…").length).toBeGreaterThan(0);
@@ -415,7 +445,7 @@ describe("SkeletonHint", () => {
 
   it("marks the visible copy span as aria-hidden so AT only hears the live region", () => {
     const { container } = render(<SkeletonHint />);
-    advance(5_000);
+    advance(8_000);
     const visible = container.querySelector(".animate-hint-fade-in > span[aria-hidden='true']");
     expect(visible).toBeTruthy();
     expect(visible?.textContent).toBe("Still working…");
@@ -440,7 +470,7 @@ describe("SkeletonHint", () => {
 
   it("re-keys the visible row when copy escalates so the fade-in re-fires", () => {
     const { container } = render(<SkeletonHint />);
-    advance(5_000);
+    advance(8_000);
     const first = container.querySelector(".animate-hint-fade-in");
     expect(first).toBeTruthy();
     advance(5_000);
@@ -453,25 +483,25 @@ describe("SkeletonHint", () => {
 
   it("preserves the visible node at action phase when no handlers are passed (no spurious re-fade)", () => {
     const { container } = render(<SkeletonHint />);
-    advance(10_000);
+    advance(13_000);
     const before = container.querySelector(".animate-hint-fade-in");
     expect(before).toBeTruthy();
     // Crossing the action threshold with no handlers must NOT remount the node:
     // visible content is identical, key is stable, fade-in does not re-fire.
-    advance(5_000);
+    advance(7_000);
     const after = container.querySelector(".animate-hint-fade-in");
     expect(after).toBe(before);
   });
 
-  it("re-keys at action phase when handlers appear so the fade-in re-fires", () => {
-    const { container } = render(<SkeletonHint onCancel={() => {}} />);
-    advance(10_000);
+  it("re-keys at the action phase when Retry surfaces so the fade-in re-fires", () => {
+    const { container } = render(<SkeletonHint onRetry={() => {}} />);
+    advance(13_000);
     const before = container.querySelector(".animate-hint-fade-in");
     expect(before).toBeTruthy();
-    advance(5_000);
+    advance(7_000);
     const after = container.querySelector(".animate-hint-fade-in");
     expect(after).toBeTruthy();
-    // Buttons appearing is a meaningful visual change — re-fade is desired.
+    // Retry appearing is a meaningful visual change — re-fade is desired.
     expect(after).not.toBe(before);
   });
 
@@ -483,7 +513,7 @@ describe("SkeletonHint", () => {
 
   it("Cancel/Retry buttons use the ghost variant (no accent color)", () => {
     render(<SkeletonHint onCancel={() => {}} onRetry={() => {}} />);
-    advance(15_000);
+    advance(20_000);
     const cancel = screen.getByRole("button", { name: "Cancel" });
     const retry = screen.getByRole("button", { name: "Retry" });
     // Ghost variant uses text-text-secondary, not text-accent-* / bg-primary
@@ -498,6 +528,53 @@ describe("SkeletonHint", () => {
     const { container } = render(<SkeletonHint className="my-hint" data-testid="hint" />);
     const hint = container.querySelector('[data-testid="hint"]')!;
     expect(hint.className).toContain("my-hint");
+  });
+
+  it("prefers a custom message over the generic first-phase copy", () => {
+    const { container } = render(<SkeletonHint message="Fetching 3 of 12 files…" />);
+    const live = container.querySelector('[aria-live="polite"]')!;
+    advance(8_000);
+    expect(screen.getAllByText("Fetching 3 of 12 files…").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Still working…")).toBeNull();
+    expect(live.textContent).toBe("Fetching 3 of 12 files…");
+  });
+
+  it("keeps the custom message through the second phase", () => {
+    render(<SkeletonHint message="Fetching 3 of 12 files…" />);
+    advance(13_000);
+    expect(screen.getAllByText("Fetching 3 of 12 files…").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Taking longer than usual…")).toBeNull();
+  });
+
+  it("falls back to the generic stall copy at the action phase even with a message", () => {
+    render(<SkeletonHint message="Fetching 3 of 12 files…" />);
+    advance(20_000);
+    expect(screen.getAllByText("Taking longer than usual…").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Fetching 3 of 12 files…")).toBeNull();
+  });
+
+  it("includes the Cancel affordance after a custom message in the live region", () => {
+    const { container } = render(
+      <SkeletonHint message="Fetching 3 of 12 files…" onCancel={() => {}} />
+    );
+    const live = container.querySelector('[aria-live="polite"]')!;
+    advance(8_000);
+    expect(live.textContent).toBe("Fetching 3 of 12 files… Cancel option available.");
+  });
+
+  it("falls back to the generic copy when message is an empty string", () => {
+    render(<SkeletonHint message="" />);
+    advance(8_000);
+    expect(screen.getAllByText("Still working…").length).toBeGreaterThan(0);
+  });
+
+  it("reflects a changed message immediately while visible", () => {
+    const { rerender } = render(<SkeletonHint message="Fetching 1 of 12 files…" />);
+    advance(8_000);
+    expect(screen.getAllByText("Fetching 1 of 12 files…").length).toBeGreaterThan(0);
+    rerender(<SkeletonHint message="Fetching 7 of 12 files…" />);
+    expect(screen.getAllByText("Fetching 7 of 12 files…").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Fetching 1 of 12 files…")).toBeNull();
   });
 });
 

--- a/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/src/components/ui/__tests__/Skeleton.test.tsx
@@ -576,6 +576,32 @@ describe("SkeletonHint", () => {
     expect(screen.getAllByText("Fetching 7 of 12 files…").length).toBeGreaterThan(0);
     expect(screen.queryByText("Fetching 1 of 12 files…")).toBeNull();
   });
+
+  it("renders the copy in the visible (aria-hidden) row, not only the live region", () => {
+    const { container } = render(<SkeletonHint message="Fetching 3 of 12 files…" />);
+    advance(8_000);
+    const visible = container.querySelector('.animate-hint-fade-in > span[aria-hidden="true"]');
+    expect(visible?.textContent).toBe("Fetching 3 of 12 files…");
+  });
+
+  it("withholds Retry one tick before the action threshold and shows it exactly at it", () => {
+    render(<SkeletonHint onRetry={() => {}} />);
+    advance(19_999);
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    advance(1);
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  });
+
+  it("drops Cancel and its announcement when the handler is removed while visible", () => {
+    const { container, rerender } = render(<SkeletonHint onCancel={() => {}} />);
+    const live = container.querySelector('[aria-live="polite"]')!;
+    advance(8_000);
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    expect(live.textContent).toBe("Still working… Cancel option available.");
+    rerender(<SkeletonHint />);
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    expect(live.textContent).toBe("Still working…");
+  });
 });
 
 describe("animate-hint-fade-in CSS contract", () => {


### PR DESCRIPTION
## Summary

- Cancel now surfaces with the first hint phase (when `onCancel` is provided) rather than being gated to 15s alongside Retry. Retry stays gated to the action threshold — it only makes sense once a wait is genuinely perceived as stalled.
- Added an optional `message` prop to `SkeletonHint`, preferred over generic copy at the first and second phases. Whitespace-only values fall back gracefully. `DevPreviewLoadingState` and `HelpLaunchingState` both thread their phase label through it so AT users hear what's actually happening.
- Raised default thresholds from 5/10/15s to 8/13/20s, closer to NN/g's 10s attention-break boundary. The per-call override already exists for sites that run long.

Resolves #8910

## Changes

- `SkeletonHint` (`src/components/ui/Skeleton.tsx`): `message` prop, Cancel at phase one, `visibleKey` re-keys independently on Cancel and Retry appearance, live region announces Cancel affordance at first phase, threshold defaults raised.
- `DevPreviewLoadingState`: swapped local `SkeletonBone` duplicate for the shared export; threads `phaseLabel` through `SkeletonHint`'s `message` prop; removed inner `aria-live` caption that was sitting inside the `aria-busy` wrapper (which silenced it on modern AT) — kept a visible `aria-hidden` caption for sighted feedback and a `role=status` wrapper for the AT announcement; `onCancel` forwarded to both variants.
- `HelpLaunchingState`: passes `message={label}` so AT hears the current phase.

## Testing

Updated and extended unit tests: threshold/behavior assertions, `message` prop + regression coverage (visible-row copy, Retry boundary, handler removal, DevPreview overlay caption, `HelpLaunchingState` message threading). 86 unit tests pass. Typecheck, lint, format, and build all clean.