### PR TITLE
docs(forge): correct matches contract to exact-hostname only

### DIFF
--- a/docs/architecture/forge-provider-abstraction.md
+++ b/docs/architecture/forge-provider-abstraction.md
@@ -223,7 +223,7 @@ Settings UI for auth is contributed by each plugin's own `settings` contribution
 
 ## Branch → PR Linkage
 
-`PRIntegrationService` (the worktree-PR linker) becomes provider-routed. The active provider for a worktree is determined by matching the worktree's remote URL against registered providers' `matches` patterns.
+`PRIntegrationService` (the worktree-PR linker) becomes provider-routed. The active provider for a worktree is determined by matching the worktree's remote URL hostname against registered providers' `matches` entries.
 
 The shared interface delegates to each provider's native query. Client-side filtering across paged results is forbidden — GitHub uses GraphQL `pullRequests(headRefName: $branch)`, future GitLab plugins will use REST `/projects/:id/merge_requests?source_branch=`, etc.
 

--- a/docs/architecture/forge-provider-abstraction.md
+++ b/docs/architecture/forge-provider-abstraction.md
@@ -66,7 +66,7 @@ Added to `plugin.json`'s `contributes` field. Status: **Planned**, ships in this
 | --- | --- | --- |
 | `id` | yes | Namespaced at runtime as `{pluginId}.{id}`. The built-in GitHub plugin uses bare `github`. |
 | `name` | yes | Display label in Preferences → Forge Integrations. |
-| `matches` | yes | Hostname or glob patterns for git remote URLs. The first registered provider whose pattern matches a project's remote wins. |
+| `matches` | yes | Exact hostnames for git remote URLs; first matching provider wins. Matching is case-insensitive and strips a leading `www.` from both the remote URL hostname and each entry. Glob, wildcard, suffix, and regular-expression patterns are not supported. |
 | `capabilities` | no | Free-form strings the host does not interpret. UI consumers query them to decide what affordances to surface. Suggested vocabulary: `issues`, `pulls`, `reviews`, `approvals`, `merge-trains`, `required-checks`, `draft-prs`, `assignees`, `releases`, `project-boards`, `milestones`. |
 | `settingsScopeRef` | no | ID prefix in this plugin's `settings` contributions—used to group provider settings under one heading. |
 | `viewRefs` | no | IDs of `views` contributions that should appear under this provider's panel section. |

--- a/electron/services/__tests__/forgeProviderRegistry.test.ts
+++ b/electron/services/__tests__/forgeProviderRegistry.test.ts
@@ -292,6 +292,11 @@ describe("forgeProviderRegistry — listMatchingProviders", () => {
     expect(listMatchingProviders("https://secondary.example.com/x")).toHaveLength(1);
     expect(listMatchingProviders("https://other.example.com/x")).toHaveLength(0);
   });
+
+  it("does not treat a glob-like pattern as a wildcard", () => {
+    registerForgeProviders("acme.glob", [makeContribution("glob", ["*.example.com"])]);
+    expect(listMatchingProviders("https://sub.example.com/org/repo.git")).toEqual([]);
+  });
 });
 
 describe("forgeProviderRegistry — getActiveProvider", () => {

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -417,7 +417,14 @@ export interface ForgeProviderContribution {
   id: string;
   /** Display label in Preferences → Forge Integrations. */
   name: string;
-  /** Hostname or glob patterns for git remote URLs; first matching provider wins. */
+  /**
+   * Exact hostnames for git remote URLs; first matching provider wins.
+   *
+   * Matching is case-insensitive and strips a leading `www.` from both the
+   * remote URL hostname and each pattern. Glob, wildcard, suffix, and
+   * regular-expression patterns are not supported — list every distinct
+   * hostname your forge serves as a separate entry.
+   */
   matches: string[];
   /** Informational capability hints; the host does not interpret these. */
   capabilities?: ForgeCapabilityHint[];


### PR DESCRIPTION
## Summary

- The JSDoc on `ForgeProviderContribution.matches` and the table row in the forge provider design doc both claimed glob/wildcard support that the implementation never had
- The actual implementation in `hostnameMatchesAny` does exact-hostname matching only, after lowercasing and stripping `www.` from both sides
- This corrects the docs and type contract to match reality, and adds a regression test to lock the behavior

Resolves #8949

## Changes

- `shared/types/forge.ts` — rewrites the `matches` JSDoc to state exact-hostname semantics explicitly (case-insensitive, `www.`-stripped on both sides; no glob, wildcard, suffix, or regex support)
- `docs/architecture/forge-provider-abstraction.md` — fixes the `matches` table row to match the new JSDoc; updates "Branch → PR Linkage" prose to say "matches entries" instead of "matches patterns"
- `electron/services/__tests__/forgeProviderRegistry.test.ts` — adds a negative regression test asserting that a glob-shaped value (`*.example.com`) does NOT match `sub.example.com`

No runtime behavior changes. The implementation was already correct; only the contract was stale.

## Testing

`npm run check` clean (typecheck, lint, format, build). Targeted vitest run of `forgeProviderRegistry.test.ts`: 47 tests pass, including the new regression case.