### PR TITLE
fix(drag-preview): match canonical agent state icon and color (#8973)

### DIFF
--- a/src/components/DragDrop/TerminalDragPreview.tsx
+++ b/src/components/DragDrop/TerminalDragPreview.tsx
@@ -112,7 +112,7 @@ export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPre
         {StateIcon && displayAgentState && (
           <StateIcon
             className={cn(
-              "w-3 h-3",
+              "w-3 h-3 shrink-0",
               getEffectiveStateColor(displayAgentState),
               displayAgentState === "working" && "animate-spin-slow",
               "motion-reduce:animate-none"

--- a/src/components/DragDrop/TerminalDragPreview.tsx
+++ b/src/components/DragDrop/TerminalDragPreview.tsx
@@ -1,7 +1,13 @@
-import { Loader2, Layers } from "lucide-react";
+import { Layers } from "lucide-react";
 import type { TerminalInstance } from "@/store";
 import { PlaceholderContent } from "./PlaceholderContent";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
+import {
+  getEffectiveStateIcon,
+  getEffectiveStateColor,
+} from "@/components/Worktree/terminalStateConfig";
+import { cn } from "@/lib/utils";
 
 interface TerminalDragPreviewProps {
   terminal: TerminalInstance;
@@ -19,7 +25,8 @@ export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPre
   // Drag visual color mirrors the same chrome descriptor used by tabs/panels.
   const chrome = deriveTerminalChrome(terminal);
   const brandColor = chrome.color;
-  const isWorking = terminal.agentState === "working";
+  const displayAgentState = getTerminalAgentDisplayState(chrome, terminal.agentState);
+  const StateIcon = displayAgentState ? getEffectiveStateIcon(displayAgentState) : null;
   const isGroupDrag = (groupTabCount ?? 0) > 1;
 
   return (
@@ -102,11 +109,14 @@ export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPre
           {terminal.title}
         </span>
 
-        {/* Working indicator */}
-        {isWorking && (
-          <Loader2
-            className="w-3 h-3 animate-spin motion-reduce:animate-none"
-            style={{ color: brandColor }}
+        {StateIcon && displayAgentState && (
+          <StateIcon
+            className={cn(
+              "w-3 h-3",
+              getEffectiveStateColor(displayAgentState),
+              displayAgentState === "working" && "animate-spin-slow",
+              "motion-reduce:animate-none"
+            )}
             aria-hidden="true"
           />
         )}


### PR DESCRIPTION
## Summary
- Replace the ad-hoc `Loader2` + `brandColor` working-only indicator in `TerminalDragPreview` with the canonical `getTerminalAgentDisplayState` + `getEffectiveStateIcon` + `getEffectiveStateColor` pattern (same as `TabButton`).
- Drag ghost now shows the correct semantic icon and color for `working` / `waiting` / `directing`; coerces `idle`/`completed` to `waiting` for live agents; hides the indicator on exit or for non-agent terminals — agent state reads identically on the tab, panel header, and the cursor-following ghost.
- Keep the title-bar color dot using `brandColor` (unchanged); skip motion wrappers since the drag ghost is a static snapshot.

Closes #8973

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/components/DragDrop/TerminalDragPreview.tsx` — clean
- [x] `npx prettier --check src/components/DragDrop/TerminalDragPreview.tsx` — clean
- [x] `vitest run src/components/DragDrop` — 14 files / 147 tests pass
- [x] `npm run check` (verify suite) — all 9 checks pass
- [ ] Manual: drag an agent terminal in each state (`working` / `waiting` / `directing` / exited) and confirm the ghost icon matches the tab indicator