### PR TITLE
fix(dialog): add restoreFocusTo prop for logical-successor focus on unmount

### DIFF
--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -37,6 +37,20 @@ type DialogInitialFocus = "first" | "cancel" | "confirm" | "none";
  */
 type RestoreFocusTarget = React.RefObject<HTMLElement | null> | (() => HTMLElement | null);
 
+/**
+ * Resolve a {@link RestoreFocusTarget} to an element. Tolerates a throwing
+ * resolver so the caller can still fall through to the app-shell fallback.
+ */
+function resolveRestoreFocusTarget(target: RestoreFocusTarget | undefined): HTMLElement | null {
+  if (!target) return null;
+  try {
+    const resolved = typeof target === "function" ? target() : target.current;
+    return resolved instanceof HTMLElement ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
 interface AppDialogContextValue {
   onClose: () => void;
   titleId: string;
@@ -103,6 +117,15 @@ export function AppDialog({
   );
   const portalOffset = portalOpen ? portalWidth : 0;
 
+  // Hold the latest `restoreFocusTo` in a ref so `restoreFocus` stays
+  // identity-stable. It feeds the unmount-cleanup effect's dep array; if it
+  // changed identity (e.g. a caller passing an inline function), the cleanup
+  // would fire mid-open and restore focus prematurely.
+  const restoreFocusToRef = useRef(restoreFocusTo);
+  useEffect(() => {
+    restoreFocusToRef.current = restoreFocusTo;
+  }, [restoreFocusTo]);
+
   const restoreFocus = useCallback(() => {
     const el = previousActiveElement.current;
     previousActiveElement.current = null;
@@ -112,21 +135,19 @@ export function AppDialog({
       return;
     }
     // Trigger was unmounted before close. Prefer a caller-supplied logical
-    // successor (e.g. the next row after a delete) when one is still connected.
-    if (restoreFocusTo) {
-      const target =
-        typeof restoreFocusTo === "function" ? restoreFocusTo() : restoreFocusTo.current;
-      if (target instanceof HTMLElement && target.isConnected) {
-        target.focus();
-        return;
-      }
+    // successor (e.g. the next row after a delete) when one is still connected
+    // and actually accepts focus.
+    const target = resolveRestoreFocusTarget(restoreFocusToRef.current);
+    if (target?.isConnected) {
+      target.focus();
+      if (document.activeElement === target) return;
     }
     // Otherwise hand focus to the first tabbable child of the app shell rather
     // than letting it silently fall to <body>.
     const root = document.getElementById("root");
     const fallback = root ? getVisibleTabbableElements(root)[0] : undefined;
     fallback?.focus();
-  }, [restoreFocusTo]);
+  }, []);
 
   const { isVisible, shouldRender } = useAnimatedPresence({
     isOpen,

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -29,6 +29,14 @@ type DialogVariant = "default" | "destructive" | "info";
 type DialogZIndex = "modal" | "nested";
 type DialogInitialFocus = "first" | "cancel" | "confirm" | "none";
 
+/**
+ * A caller-supplied "logical successor" to receive focus when the dialog's
+ * trigger has been unmounted before close. Either a ref to a stable element or
+ * a function resolving the target at restoration time (for targets whose
+ * identity changes while the dialog is open, e.g. the next row after a delete).
+ */
+type RestoreFocusTarget = React.RefObject<HTMLElement | null> | (() => HTMLElement | null);
+
 interface AppDialogContextValue {
   onClose: () => void;
   titleId: string;
@@ -50,10 +58,11 @@ export interface AppDialogProps {
   maxHeight?: string;
   zIndex?: DialogZIndex;
   initialFocus?: DialogInitialFocus;
+  restoreFocusTo?: RestoreFocusTarget;
   "data-testid"?: string;
 }
 
-export type { DialogSize, DialogVariant, DialogZIndex, DialogInitialFocus };
+export type { DialogSize, DialogVariant, DialogZIndex, DialogInitialFocus, RestoreFocusTarget };
 
 const sizeClasses: Record<DialogSize, string> = {
   sm: "max-w-md",
@@ -77,6 +86,7 @@ export function AppDialog({
   maxHeight = "max-h-[80vh]",
   zIndex = "modal",
   initialFocus,
+  restoreFocusTo,
   "data-testid": dataTestId,
 }: AppDialogProps) {
   const effectiveInitialFocus: DialogInitialFocus =
@@ -101,14 +111,22 @@ export function AppDialog({
       el.focus();
       return;
     }
-    // Trigger was unmounted before close (e.g., the row that opened
-    // a destructive confirm dialog was removed by the action itself).
-    // Hand focus to the first tabbable child of the app shell rather
+    // Trigger was unmounted before close. Prefer a caller-supplied logical
+    // successor (e.g. the next row after a delete) when one is still connected.
+    if (restoreFocusTo) {
+      const target =
+        typeof restoreFocusTo === "function" ? restoreFocusTo() : restoreFocusTo.current;
+      if (target instanceof HTMLElement && target.isConnected) {
+        target.focus();
+        return;
+      }
+    }
+    // Otherwise hand focus to the first tabbable child of the app shell rather
     // than letting it silently fall to <body>.
     const root = document.getElementById("root");
     const fallback = root ? getVisibleTabbableElements(root)[0] : undefined;
     fallback?.focus();
-  }, []);
+  }, [restoreFocusTo]);
 
   const { isVisible, shouldRender } = useAnimatedPresence({
     isOpen,

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,6 +1,11 @@
 import type React from "react";
 import { useEffect, useLayoutEffect, useState } from "react";
-import { AppDialog, type DialogInitialFocus, type DialogZIndex } from "@/components/ui/AppDialog";
+import {
+  AppDialog,
+  type DialogInitialFocus,
+  type DialogZIndex,
+  type RestoreFocusTarget,
+} from "@/components/ui/AppDialog";
 import { TypedNameConfirmInput } from "@/components/ui/TypedNameConfirmInput";
 
 const DESTRUCTIVE_CONFIRM_LABEL_RE =
@@ -64,6 +69,13 @@ type ConfirmDialogBaseProps = {
   cooldownKey?: string | number;
   zIndex?: DialogZIndex;
   initialFocus?: DialogInitialFocus;
+  /**
+   * Forwarded to {@link AppDialog.restoreFocusTo}: a logical successor to
+   * receive focus when the trigger has unmounted before close (e.g. the row a
+   * destructive confirm just deleted). Falls back to the app shell when absent
+   * or disconnected.
+   */
+  restoreFocusTo?: RestoreFocusTarget;
 };
 
 export type ConfirmDialogProps =
@@ -93,6 +105,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
     variant,
     zIndex,
     initialFocus,
+    restoreFocusTo,
   } = props;
   const rawTypedNameTarget = (props as { typedNameTarget?: string }).typedNameTarget;
   const typedNameTarget = variant === "destructive" ? rawTypedNameTarget : undefined;
@@ -184,6 +197,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
       variant={variant}
       zIndex={zIndex}
       initialFocus={initialFocus}
+      restoreFocusTo={restoreFocusTo}
     >
       <AppDialog.Header>
         <AppDialog.Title>{title}</AppDialog.Title>

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -307,6 +307,103 @@ describe("AppDialog focus trapping", () => {
     document.body.removeChild(root);
   });
 
+  describe("restoreFocusTo logical successor", () => {
+    type FocusTarget = React.RefObject<HTMLElement | null> | (() => HTMLElement | null);
+
+    function setupTriggerAndRoot() {
+      const root = document.createElement("div");
+      root.id = "root";
+      const fallbackButton = document.createElement("button");
+      fallbackButton.textContent = "Fallback";
+      root.appendChild(fallbackButton);
+      document.body.appendChild(root);
+
+      const trigger = document.createElement("button");
+      trigger.textContent = "Trigger";
+      document.body.appendChild(trigger);
+      trigger.focus();
+
+      return { root, fallbackButton, trigger };
+    }
+
+    async function openCloseWith(restoreFocusTo: FocusTarget, trigger: HTMLButtonElement) {
+      const { rerender } = render(
+        <>
+          <Dispatcher />
+          <AppDialog isOpen={true} onClose={() => {}} restoreFocusTo={restoreFocusTo}>
+            <AppDialog.Body>
+              <button type="button">Inner</button>
+            </AppDialog.Body>
+          </AppDialog>
+        </>
+      );
+      await act(() => vi.runAllTimersAsync());
+
+      // The trigger is removed by the action that ran inside the dialog.
+      document.body.removeChild(trigger);
+
+      rerender(
+        <>
+          <Dispatcher />
+          <AppDialog isOpen={false} onClose={() => {}} restoreFocusTo={restoreFocusTo}>
+            <AppDialog.Body>
+              <button type="button">Inner</button>
+            </AppDialog.Body>
+          </AppDialog>
+        </>
+      );
+    }
+
+    it("focuses a connected ref target instead of the #root fallback", async () => {
+      const { root, fallbackButton, trigger } = setupTriggerAndRoot();
+      const successor = document.createElement("button");
+      successor.textContent = "Successor";
+      document.body.appendChild(successor);
+
+      await openCloseWith({ current: successor }, trigger);
+
+      expect(document.activeElement).toBe(successor);
+      expect(document.activeElement).not.toBe(fallbackButton);
+      document.body.removeChild(successor);
+      document.body.removeChild(root);
+    });
+
+    it("falls through to the #root fallback when the ref target is disconnected", async () => {
+      const { root, fallbackButton, trigger } = setupTriggerAndRoot();
+      // Never appended to the document — disconnected.
+      const successor = document.createElement("button");
+      successor.textContent = "Successor";
+
+      await openCloseWith({ current: successor }, trigger);
+
+      expect(document.activeElement).toBe(fallbackButton);
+      document.body.removeChild(root);
+    });
+
+    it("focuses the element returned by a function target", async () => {
+      const { root, fallbackButton, trigger } = setupTriggerAndRoot();
+      const successor = document.createElement("button");
+      successor.textContent = "Successor";
+      document.body.appendChild(successor);
+
+      await openCloseWith(() => successor, trigger);
+
+      expect(document.activeElement).toBe(successor);
+      expect(document.activeElement).not.toBe(fallbackButton);
+      document.body.removeChild(successor);
+      document.body.removeChild(root);
+    });
+
+    it("falls through to the #root fallback when the function returns null", async () => {
+      const { root, fallbackButton, trigger } = setupTriggerAndRoot();
+
+      await openCloseWith(() => null, trigger);
+
+      expect(document.activeElement).toBe(fallbackButton);
+      document.body.removeChild(root);
+    });
+  });
+
   describe("AppDialog Footer a11y", () => {
     it("sets aria-busy on primary button when loading", async () => {
       render(

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -402,6 +402,120 @@ describe("AppDialog focus trapping", () => {
       expect(document.activeElement).toBe(fallbackButton);
       document.body.removeChild(root);
     });
+
+    it("ignores restoreFocusTo when the trigger is still connected", async () => {
+      const { root, trigger } = setupTriggerAndRoot();
+      const successor = document.createElement("button");
+      successor.textContent = "Successor";
+      document.body.appendChild(successor);
+
+      const { rerender } = render(
+        <>
+          <Dispatcher />
+          <AppDialog isOpen={true} onClose={() => {}} restoreFocusTo={{ current: successor }}>
+            <AppDialog.Body>
+              <button type="button">Inner</button>
+            </AppDialog.Body>
+          </AppDialog>
+        </>
+      );
+      await act(() => vi.runAllTimersAsync());
+
+      // Trigger stays mounted — focus must return to it, not the successor.
+      rerender(
+        <>
+          <Dispatcher />
+          <AppDialog isOpen={false} onClose={() => {}} restoreFocusTo={{ current: successor }}>
+            <AppDialog.Body>
+              <button type="button">Inner</button>
+            </AppDialog.Body>
+          </AppDialog>
+        </>
+      );
+
+      expect(document.activeElement).toBe(trigger);
+      expect(document.activeElement).not.toBe(successor);
+      document.body.removeChild(successor);
+      document.body.removeChild(trigger);
+      document.body.removeChild(root);
+    });
+
+    it("falls through to #root when the connected target cannot take focus", async () => {
+      const { root, fallbackButton, trigger } = setupTriggerAndRoot();
+      // A connected but non-focusable element: focus() is a no-op.
+      const successor = document.createElement("div");
+      successor.textContent = "Successor";
+      document.body.appendChild(successor);
+
+      await openCloseWith({ current: successor }, trigger);
+
+      expect(document.activeElement).toBe(fallbackButton);
+      expect(document.activeElement).not.toBe(successor);
+      document.body.removeChild(successor);
+      document.body.removeChild(root);
+    });
+
+    it("falls through to #root when the function target throws", async () => {
+      const { root, fallbackButton, trigger } = setupTriggerAndRoot();
+
+      await openCloseWith(() => {
+        throw new Error("boom");
+      }, trigger);
+
+      expect(document.activeElement).toBe(fallbackButton);
+      document.body.removeChild(root);
+    });
+
+    it("does not restore focus prematurely when restoreFocusTo identity changes while open", async () => {
+      const { root, trigger } = setupTriggerAndRoot();
+      const successor = document.createElement("button");
+      successor.textContent = "Successor";
+      document.body.appendChild(successor);
+
+      const { rerender } = render(
+        <>
+          <Dispatcher />
+          <AppDialog isOpen={true} onClose={() => {}} restoreFocusTo={() => successor}>
+            <AppDialog.Body>
+              <button type="button">Inner</button>
+            </AppDialog.Body>
+          </AppDialog>
+        </>
+      );
+      await act(() => vi.runAllTimersAsync());
+      const innerButton = screen.getByText("Inner");
+      expect(document.activeElement).toBe(innerButton);
+
+      // Parent re-renders while the dialog is open, passing a fresh inline
+      // function. Focus must stay inside the dialog — no premature restore.
+      rerender(
+        <>
+          <Dispatcher />
+          <AppDialog isOpen={true} onClose={() => {}} restoreFocusTo={() => successor}>
+            <AppDialog.Body>
+              <button type="button">Inner</button>
+            </AppDialog.Body>
+          </AppDialog>
+        </>
+      );
+      expect(document.activeElement).toBe(innerButton);
+
+      // The real close still restores to the successor once the trigger is gone.
+      document.body.removeChild(trigger);
+      rerender(
+        <>
+          <Dispatcher />
+          <AppDialog isOpen={false} onClose={() => {}} restoreFocusTo={() => successor}>
+            <AppDialog.Body>
+              <button type="button">Inner</button>
+            </AppDialog.Body>
+          </AppDialog>
+        </>
+      );
+      expect(document.activeElement).toBe(successor);
+      document.body.removeChild(successor);
+      document.body.removeChild(root);
+    });
   });
 
   describe("AppDialog Footer a11y", () => {


### PR DESCRIPTION
## Summary

- Adds a `restoreFocusTo` prop to `AppDialog` so callers can name a logical-successor focus target for when the trigger element unmounts before the dialog closes (the delete-a-row pattern)
- Slots the resolved target into `restoreFocus` between the existing `document.contains(trigger)` check and the `#root` fallback, guarded with `isConnected` matching the pattern in `toaster.tsx`
- Threads the prop through `ConfirmDialogBaseProps` as a plain pass-through; held in a ref for identity stability so the cleanup effect doesn't fire mid-open when callers pass inline functions

Resolves #8970

## Changes

- `src/components/ui/AppDialog.tsx` — new `restoreFocusTo` prop (`React.RefObject<HTMLElement | null>` or `() => HTMLElement | null`); ref-wrapped for identity stability; target resolution hardened against throwing resolvers and connected-but-unfocusable elements, both falling through to the existing `#root` fallback
- `src/components/ui/ConfirmDialog.tsx` — `restoreFocusTo` added to `ConfirmDialogBaseProps` and passed through to `AppDialog`
- `src/components/ui/__tests__/AppDialog.test.tsx` — 8 new unit tests covering the prop variants, `isConnected` guard, throw recovery, and unfocusable-element fallback

Call-site wiring for worktree, recipe, and project deletes is out of scope per the issue — deferred to per-surface follow-ups.

## Testing

- 92 vitest tests pass, including the 8 new `restoreFocusTo` cases
- `npm run check` clean (typecheck, lint ratchet, format, IPC codegen)