### PR TITLE
ci(budgets): post all five budget summaries as one sticky PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,14 +168,31 @@ jobs:
       - name: Budget summaries
         if: always()
         run: |
-          if [ -f dist/renderer-bundle-size-summary.md ]; then
-            cat dist/renderer-bundle-size-summary.md >> "$GITHUB_STEP_SUMMARY"
-            printf '\n\n' >> "$GITHUB_STEP_SUMMARY"
-          fi
-          if [ -f dist/first-render-chunk-summary.md ]; then
-            cat dist/first-render-chunk-summary.md >> "$GITHUB_STEP_SUMMARY"
-            printf '\n\n' >> "$GITHUB_STEP_SUMMARY"
-          fi
+          for f in \
+            dist/renderer-bundle-size-summary.md \
+            dist/first-render-chunk-summary.md \
+            dist/renderer-import-budget-summary.md \
+            dist/import-budget-summary.md \
+            dist/compiler-budget-summary.md; do
+            if [ -f "$f" ]; then
+              cat "$f" >> "$GITHUB_STEP_SUMMARY"
+              printf '\n\n' >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+      - name: Upload budget summaries
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: budget-summaries
+          path: |
+            dist/renderer-bundle-size-summary.md
+            dist/first-render-chunk-summary.md
+            dist/renderer-import-budget-summary.md
+            dist/import-budget-summary.md
+            dist/compiler-budget-summary.md
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Gate performance budgets
         if: always()

--- a/.github/workflows/pr-budget-comment.yml
+++ b/.github/workflows/pr-budget-comment.yml
@@ -21,6 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled'
 
+
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -32,6 +33,9 @@ jobs:
         id: pr
         uses: actions/github-script@v8
         with:
+          # Default encoding is JSON, which would turn `return ''` into `""`
+          # (a two-character string) and break the empty-PR guard below.
+          result-encoding: string
           script: |
             const fromEvent = context.payload.workflow_run.pull_requests?.[0]?.number;
             if (fromEvent) return fromEvent;

--- a/.github/workflows/pr-budget-comment.yml
+++ b/.github/workflows/pr-budget-comment.yml
@@ -1,0 +1,100 @@
+name: PR Budget Comment
+
+# Triggered after the CI workflow completes. Runs in the base-repo context so
+# it can safely post a comment for fork PRs without exposing fork-controlled
+# code to write permissions (Pwn Request mitigation — never use
+# `pull_request_target` for this).
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    # Only react to PR-event CI runs that actually produced an artifact; push
+    # runs to develop/main have no PR to comment on, and cancelled runs may
+    # have skipped the upload step entirely.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled'
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      # `workflow_run.pull_requests` is populated for same-repo PRs but always
+      # empty for forks. Fall back to the commit→PR lookup so fork PRs still
+      # get a comment.
+      - name: Resolve PR number
+        id: pr
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fromEvent = context.payload.workflow_run.pull_requests?.[0]?.number;
+            if (fromEvent) return fromEvent;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.payload.workflow_run.head_sha,
+            });
+            const open = prs.find((pr) => pr.state === 'open') ?? prs[0];
+            if (!open) {
+              core.info('No PR associated with this commit; skipping comment.');
+              return '';
+            }
+            return open.number;
+
+      - name: Download budget summaries
+        if: steps.pr.outputs.result != ''
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: budget-summaries
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: summaries
+
+      - name: Assemble comment body
+        if: steps.pr.outputs.result != '' && steps.download.outcome == 'success'
+        id: assemble
+        run: |
+          set -euo pipefail
+          body=comment-body.md
+          : > "$body"
+          appended=0
+          for f in \
+            renderer-bundle-size-summary.md \
+            first-render-chunk-summary.md \
+            renderer-import-budget-summary.md \
+            import-budget-summary.md \
+            compiler-budget-summary.md; do
+            if [ -f "summaries/$f" ]; then
+              cat "summaries/$f" >> "$body"
+              printf '\n\n' >> "$body"
+              appended=$((appended + 1))
+            fi
+          done
+          if [ "$appended" -eq 0 ]; then
+            echo "No budget summaries downloaded; skipping comment."
+            echo "has_content=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "## Performance budget summaries"
+            echo ""
+            cat "$body"
+          } > comment-body.final.md
+          mv comment-body.final.md "$body"
+          echo "has_content=true" >> "$GITHUB_OUTPUT"
+
+      - name: Post sticky comment
+        if: steps.pr.outputs.result != '' && steps.assemble.outputs.has_content == 'true'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: budget-summaries
+          number: ${{ steps.pr.outputs.result }}
+          path: comment-body.md


### PR DESCRIPTION
## Summary

- Adds `pr-budget-comment.yml`, a new `workflow_run`-triggered workflow that downloads the `budget-summaries` artifact from the triggering run and posts all five `dist/*-summary.md` files as a single sticky PR comment via `marocchino/sticky-pull-request-comment@v3`
- Uses a hidden HTML marker so subsequent pushes update the comment in place rather than appending new ones
- Handles fork PRs via a REST fallback using `listPullRequestsAssociatedWithCommit` — `pull_request_target` was ruled out (Pwn Request class); the `workflow_run` + `actions: read` + `pull-requests: write` pattern is the safe canonical approach
- Updates `ci.yml` to upload the five `dist/*-summary.md` files as a `budget-summaries` artifact using `upload-artifact@v7` (the version used uniformly across the repo)

Resolves #8901

## Changes

- `.github/workflows/pr-budget-comment.yml` — new workflow (~100 lines): `workflow_run` trigger, `actions: read` + `pull-requests: write` permissions, PR-number resolution with fork fallback, artifact download via `download-artifact@v8` with `run-id` + `github-token`, sticky comment assembly
- `.github/workflows/ci.yml` — extends the "Budget summaries" step to write all five MDs to `GITHUB_STEP_SUMMARY` and adds an `upload-artifact@v7` step uploading `dist/*-summary.md` as the `budget-summaries` artifact

## Testing

CI green on this branch (typecheck, lint, format, build all pass). The `workflow_run` path will exercise on the first PR that goes through after merge.