### PR TITLE
fix(a11y): add forced-colors fallbacks for chrome selection states

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2604,6 +2604,21 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     outline-offset: -2px;
   }
 
+  /* The active panel tab marks itself with a background tint plus a
+     framer-motion underline (both background-color based, stripped here).
+     Fall back to a system-color bottom border so the active tab stays visible. */
+  [role="tab"][aria-selected="true"] {
+    border-bottom: 2px solid SelectedItem;
+  }
+
+  /* Radix submenu triggers signal their open state with a background tint via
+     data-state="open"; that is stripped here. Scope to [role="menuitem"] so the
+     fallback doesn't collide with dialog/popover/combobox open states. */
+  [role="menuitem"][data-state="open"] {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+
   button,
   [role="button"],
   [type="button"],

--- a/src/index.css
+++ b/src/index.css
@@ -2606,8 +2606,11 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
 
   /* The active panel tab marks itself with a background tint plus a
      framer-motion underline (both background-color based, stripped here).
-     Fall back to a system-color bottom border so the active tab stays visible. */
-  [role="tab"][aria-selected="true"] {
+     Fall back to a system-color bottom border so the active tab stays visible.
+     Scoped to [data-tab-id] (the panel TabButton) so the rule doesn't add a
+     directionally-wrong bottom border to the vertical Settings nav or the
+     rounded-pill Portal tabs, which use different selectors. */
+  [role="tab"][aria-selected="true"][data-tab-id] {
     border-bottom: 2px solid SelectedItem;
   }
 

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -95,4 +95,11 @@ html[data-dragging="true"] .sidebar-worktree-card[data-hovered="true"] {
     outline: 2px solid Highlight;
     outline-offset: -2px;
   }
+
+  /* The active row's left-edge indicator is an inset box-shadow, which is
+     stripped here. Fall back to a system-color left border so the selected
+     worktree stays distinguishable from idle rows. */
+  .sidebar-worktree-card[data-active="true"] {
+    border-left: 2px solid SelectedItem;
+  }
 }

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -392,3 +392,19 @@ html[data-shortcut-reveal] .shortcut-reveal-chip {
       opacity 200ms ease;
   }
 }
+
+/* The armed/pressed control state relies on a background tint plus an inset
+   box-shadow ring, both stripped in forced-colors mode. Fall back to a
+   ButtonText border so armed buttons stay distinguishable from idle ones.
+   Selectors mirror the armed-state rule above (including the sidebar-toggle
+   opt-out) to keep the same scope. */
+@media (forced-colors: active) {
+  .toolbar-icon-button[aria-pressed="true"]:where(:not([data-sidebar-toggle])),
+  .toolbar-icon-button[aria-expanded="true"],
+  .toolbar-icon-button[data-state="open"],
+  .toolbar-agent-button[aria-pressed="true"],
+  .toolbar-agent-button[aria-expanded="true"],
+  .toolbar-agent-button[data-state="open"] {
+    border: 2px solid ButtonText;
+  }
+}


### PR DESCRIPTION
## Summary

- Four app-chrome selection states were invisible in Windows High Contrast Mode — the UA strips `background-color` and `box-shadow`, so anything relying on those alone disappeared
- Adds `@media (forced-colors: active)` fallbacks using system colors only; no layout shift in normal mode
- Closes #8932

## Changes

- **Sidebar active worktree row** (`src/styles/components/sidebar.css`) — `border-left: 2px solid SelectedItem` replaces the stripped inset `box-shadow`
- **Active panel tab indicator** (`src/index.css`) — `border-bottom: 2px solid SelectedItem` on `[role=tab][aria-selected=true][data-tab-id]`; scoped to `[data-tab-id]` so it doesn't add a wrong-direction border to the vertical Settings nav or the rounded-pill Portal tabs
- **Armed/pressed toolbar buttons** (`src/styles/components/toolbar.css`) — `border: 2px solid ButtonText` on the armed state selectors (`[aria-pressed=true]`, `[aria-expanded=true]`, `[data-state=open]`)
- **Open Radix submenu triggers** (`src/index.css`) — `outline: 2px solid Highlight` scoped to `[role=menuitem][data-state=open]` to avoid collisions with dialog and popover roles

## Testing

Verified with forced-colors emulation in Chrome DevTools (Rendering panel → Emulate CSS media feature `forced-colors: active`). All four states now show a visible structural indicator in High Contrast Mode. `npm run check` passes clean.