### PR TITLE
fix(panel-registry): de-anchor trash and background group restore metadata

### DIFF
--- a/src/store/slices/panelRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
@@ -583,4 +583,85 @@ describe("backgroundPanelGroup anchor-removal regression (#8944)", () => {
     // Active tab t1 is gone, falls back to first surviving panel in original order
     expect(restored.activeTabId).toBe("t2");
   });
+
+  it("preserves dock location and worktreeId when the anchor is removed before restore", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["t1", "t2", "t3"],
+      activeTabId: "t2",
+      location: "dock",
+      worktreeId: "wt-1",
+    };
+    setTerminals([
+      { ...makeTerminal("t1", "dock"), worktreeId: "wt-1" },
+      { ...makeTerminal("t2", "dock"), worktreeId: "wt-1" },
+      { ...makeTerminal("t3", "dock"), worktreeId: "wt-1" },
+    ]);
+    usePanelStore.setState({ tabGroups: new Map([["group-1", group]]) });
+
+    usePanelStore.getState().backgroundPanelGroup("t1");
+
+    const groupRestoreId = usePanelStore.getState().backgroundedTerminals.get("t1")!.groupRestoreId!;
+
+    usePanelStore.setState((state) => {
+      const backgroundedTerminals = new Map(state.backgroundedTerminals);
+      backgroundedTerminals.delete("t1");
+      const panelsById = { ...state.panelsById };
+      delete panelsById["t1"];
+      return {
+        backgroundedTerminals,
+        panelsById,
+        panelIds: state.panelIds.filter((id) => id !== "t1"),
+      };
+    });
+
+    usePanelStore.getState().restoreBackgroundGroup(groupRestoreId);
+
+    const state = usePanelStore.getState();
+    const restored = [...state.tabGroups.values()][0]!;
+    expect(restored.panelIds).toEqual(["t2", "t3"]);
+    expect(restored.location).toBe("dock");
+    expect(restored.worktreeId).toBe("wt-1");
+    for (const id of ["t2", "t3"]) {
+      expect(state.panelsById[id]!.location).toBe("dock");
+      expect(state.panelsById[id]!.worktreeId).toBe("wt-1");
+    }
+  });
+
+  it("restores a single survivor without recreating a tab group", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["t1", "t2", "t3"],
+      activeTabId: "t2",
+      location: "grid",
+    };
+    setTerminals([makeTerminal("t1"), makeTerminal("t2"), makeTerminal("t3")]);
+    usePanelStore.setState({ tabGroups: new Map([["group-1", group]]) });
+
+    usePanelStore.getState().backgroundPanelGroup("t1");
+
+    const groupRestoreId = usePanelStore.getState().backgroundedTerminals.get("t1")!.groupRestoreId!;
+
+    // Remove two members including the anchor — only t3 survives.
+    usePanelStore.setState((state) => {
+      const backgroundedTerminals = new Map(state.backgroundedTerminals);
+      backgroundedTerminals.delete("t1");
+      backgroundedTerminals.delete("t2");
+      const panelsById = { ...state.panelsById };
+      delete panelsById["t1"];
+      delete panelsById["t2"];
+      return {
+        backgroundedTerminals,
+        panelsById,
+        panelIds: state.panelIds.filter((id) => id === "t3"),
+      };
+    });
+
+    usePanelStore.getState().restoreBackgroundGroup(groupRestoreId);
+
+    const state = usePanelStore.getState();
+    expect(state.backgroundedTerminals.size).toBe(0);
+    expect(state.tabGroups.size).toBe(0);
+    expect(state.panelsById["t3"]!.location).toBe("grid");
+  });
 });

--- a/src/store/slices/panelRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
@@ -519,7 +519,9 @@ describe("backgroundPanelGroup anchor-removal regression (#8944)", () => {
 
     usePanelStore.getState().backgroundPanelGroup("t1");
 
-    const groupRestoreId = usePanelStore.getState().backgroundedTerminals.get("t1")!.groupRestoreId!;
+    const groupRestoreId = usePanelStore
+      .getState()
+      .backgroundedTerminals.get("t1")!.groupRestoreId!;
 
     // Remove the original anchor (first member) from the backgrounded collection
     // and from panelsById, simulating individual deletion / hydration loss.
@@ -561,7 +563,9 @@ describe("backgroundPanelGroup anchor-removal regression (#8944)", () => {
 
     usePanelStore.getState().backgroundPanelGroup("t1");
 
-    const groupRestoreId = usePanelStore.getState().backgroundedTerminals.get("t1")!.groupRestoreId!;
+    const groupRestoreId = usePanelStore
+      .getState()
+      .backgroundedTerminals.get("t1")!.groupRestoreId!;
 
     // Remove t1 — which was both the anchor and the active tab.
     usePanelStore.setState((state) => {
@@ -601,7 +605,9 @@ describe("backgroundPanelGroup anchor-removal regression (#8944)", () => {
 
     usePanelStore.getState().backgroundPanelGroup("t1");
 
-    const groupRestoreId = usePanelStore.getState().backgroundedTerminals.get("t1")!.groupRestoreId!;
+    const groupRestoreId = usePanelStore
+      .getState()
+      .backgroundedTerminals.get("t1")!.groupRestoreId!;
 
     usePanelStore.setState((state) => {
       const backgroundedTerminals = new Map(state.backgroundedTerminals);
@@ -640,7 +646,9 @@ describe("backgroundPanelGroup anchor-removal regression (#8944)", () => {
 
     usePanelStore.getState().backgroundPanelGroup("t1");
 
-    const groupRestoreId = usePanelStore.getState().backgroundedTerminals.get("t1")!.groupRestoreId!;
+    const groupRestoreId = usePanelStore
+      .getState()
+      .backgroundedTerminals.get("t1")!.groupRestoreId!;
 
     // Remove two members including the anchor — only t3 survives.
     usePanelStore.setState((state) => {

--- a/src/store/slices/panelRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
@@ -193,12 +193,14 @@ describe("backgroundPanelGroup", () => {
     expect(bg1.groupRestoreId).toBe(bg2.groupRestoreId);
     expect(bg2.groupRestoreId).toBe(bg3.groupRestoreId);
 
-    // Only anchor (first) gets groupMetadata
-    expect(bg1.groupMetadata).toBeDefined();
-    expect(bg1.groupMetadata!.panelIds).toEqual(["t1", "t2", "t3"]);
-    expect(bg1.groupMetadata!.activeTabId).toBe("t2");
-    expect(bg2.groupMetadata).toBeUndefined();
-    expect(bg3.groupMetadata).toBeUndefined();
+    // Every member carries the full groupMetadata (issue #8944) so the group
+    // survives removal of any single member before restore.
+    for (const bg of [bg1, bg2, bg3]) {
+      expect(bg.groupMetadata).toBeDefined();
+      expect(bg.groupMetadata!.panelIds).toEqual(["t1", "t2", "t3"]);
+      expect(bg.groupMetadata!.activeTabId).toBe("t2");
+      expect(bg.groupMetadata!.location).toBe("grid");
+    }
 
     // Tab group should be deleted
     expect(state.tabGroups.has("group-1")).toBe(false);
@@ -479,5 +481,106 @@ describe("round-trip: backgroundPanelGroup → restoreBackgroundGroup", () => {
       expect(t.location).toBe("dock");
       expect(t.worktreeId).toBe("wt-1");
     }
+  });
+});
+
+describe("backgroundPanelGroup anchor-removal regression (#8944)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { reset } = usePanelStore.getState();
+    reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("preserves order and active tab when the original anchor member is removed before restore", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["t1", "t2", "t3"],
+      activeTabId: "t2",
+      location: "grid",
+    };
+
+    setTerminals([makeTerminal("t1"), makeTerminal("t2"), makeTerminal("t3")]);
+    usePanelStore.setState({ tabGroups: new Map([["group-1", group]]) });
+
+    usePanelStore.getState().backgroundPanelGroup("t1");
+
+    const groupRestoreId = usePanelStore.getState().backgroundedTerminals.get("t1")!.groupRestoreId!;
+
+    // Remove the original anchor (first member) from the backgrounded collection
+    // and from panelsById, simulating individual deletion / hydration loss.
+    usePanelStore.setState((state) => {
+      const backgroundedTerminals = new Map(state.backgroundedTerminals);
+      backgroundedTerminals.delete("t1");
+      const panelsById = { ...state.panelsById };
+      delete panelsById["t1"];
+      return {
+        backgroundedTerminals,
+        panelsById,
+        panelIds: state.panelIds.filter((id) => id !== "t1"),
+      };
+    });
+
+    usePanelStore.getState().restoreBackgroundGroup(groupRestoreId);
+
+    const state = usePanelStore.getState();
+    expect(state.backgroundedTerminals.size).toBe(0);
+    expect(state.tabGroups.size).toBe(1);
+
+    const restored = [...state.tabGroups.values()][0]!;
+    // Order from the surviving members preserved (anchor t1 dropped)
+    expect(restored.panelIds).toEqual(["t2", "t3"]);
+    // Originally-active tab (t2) survived and is still active
+    expect(restored.activeTabId).toBe("t2");
+  });
+
+  it("falls back to first surviving panel when the active tab was the removed anchor", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["t1", "t2", "t3"],
+      activeTabId: "t1",
+      location: "grid",
+    };
+
+    setTerminals([makeTerminal("t1"), makeTerminal("t2"), makeTerminal("t3")]);
+    usePanelStore.setState({ tabGroups: new Map([["group-1", group]]) });
+
+    usePanelStore.getState().backgroundPanelGroup("t1");
+
+    const groupRestoreId = usePanelStore.getState().backgroundedTerminals.get("t1")!.groupRestoreId!;
+
+    // Remove t1 — which was both the anchor and the active tab.
+    usePanelStore.setState((state) => {
+      const backgroundedTerminals = new Map(state.backgroundedTerminals);
+      backgroundedTerminals.delete("t1");
+      const panelsById = { ...state.panelsById };
+      delete panelsById["t1"];
+      return {
+        backgroundedTerminals,
+        panelsById,
+        panelIds: state.panelIds.filter((id) => id !== "t1"),
+      };
+    });
+
+    usePanelStore.getState().restoreBackgroundGroup(groupRestoreId);
+
+    const restored = [...usePanelStore.getState().tabGroups.values()][0]!;
+    expect(restored.panelIds).toEqual(["t2", "t3"]);
+    // Active tab t1 is gone, falls back to first surviving panel in original order
+    expect(restored.activeTabId).toBe("t2");
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/trashTerminalGroupCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/trashTerminalGroupCleanup.test.ts
@@ -795,4 +795,85 @@ describe("trashPanelGroup anchor-removal regression (#8944)", () => {
     // Active tab term-1 is gone, falls back to first surviving panel in original order
     expect(restored.activeTabId).toBe("term-2");
   });
+
+  it("preserves dock location and worktreeId when the anchor is removed before restore", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-2",
+      location: "dock",
+      worktreeId: "wt-1",
+    };
+    setTerminals([
+      { ...makeTerm("term-1", "dock"), worktreeId: "wt-1" },
+      { ...makeTerm("term-2", "dock"), worktreeId: "wt-1" },
+      { ...makeTerm("term-3", "dock"), worktreeId: "wt-1" },
+    ]);
+    usePanelStore.setState({ tabGroups: new Map([["group-1", group]]) });
+
+    usePanelStore.getState().trashPanelGroup("term-1");
+
+    const groupRestoreId = usePanelStore.getState().trashedTerminals.get("term-1")!.groupRestoreId!;
+
+    usePanelStore.setState((state) => {
+      const trashedTerminals = new Map(state.trashedTerminals);
+      trashedTerminals.delete("term-1");
+      const panelsById = { ...state.panelsById };
+      delete panelsById["term-1"];
+      return {
+        trashedTerminals,
+        panelsById,
+        panelIds: state.panelIds.filter((id) => id !== "term-1"),
+      };
+    });
+
+    usePanelStore.getState().restoreTrashedGroup(groupRestoreId);
+
+    const state = usePanelStore.getState();
+    const restored = [...state.tabGroups.values()][0]!;
+    expect(restored.panelIds).toEqual(["term-2", "term-3"]);
+    expect(restored.location).toBe("dock");
+    expect(restored.worktreeId).toBe("wt-1");
+    for (const id of ["term-2", "term-3"]) {
+      expect(state.panelsById[id]!.location).toBe("dock");
+      expect(state.panelsById[id]!.worktreeId).toBe("wt-1");
+    }
+  });
+
+  it("restores a single survivor without recreating a tab group", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-2",
+      location: "grid",
+    };
+    setTerminals([makeTerm("term-1"), makeTerm("term-2"), makeTerm("term-3")]);
+    usePanelStore.setState({ tabGroups: new Map([["group-1", group]]) });
+
+    usePanelStore.getState().trashPanelGroup("term-1");
+
+    const groupRestoreId = usePanelStore.getState().trashedTerminals.get("term-1")!.groupRestoreId!;
+
+    // Remove two members including the anchor — only term-3 survives.
+    usePanelStore.setState((state) => {
+      const trashedTerminals = new Map(state.trashedTerminals);
+      trashedTerminals.delete("term-1");
+      trashedTerminals.delete("term-2");
+      const panelsById = { ...state.panelsById };
+      delete panelsById["term-1"];
+      delete panelsById["term-2"];
+      return {
+        trashedTerminals,
+        panelsById,
+        panelIds: state.panelIds.filter((id) => id === "term-3"),
+      };
+    });
+
+    usePanelStore.getState().restoreTrashedGroup(groupRestoreId);
+
+    const state = usePanelStore.getState();
+    expect(state.trashedTerminals.size).toBe(0);
+    expect(state.tabGroups.size).toBe(0);
+    expect(state.panelsById["term-3"]!.location).toBe("grid");
+  });
 });

--- a/src/store/slices/panelRegistry/__tests__/trashTerminalGroupCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/trashTerminalGroupCleanup.test.ts
@@ -672,3 +672,127 @@ describe("trash expiry visibility sweep", () => {
     expect(afterState.panelsById["term-3"]?.location).toBe("trash");
   });
 });
+
+describe("trashPanelGroup anchor-removal regression (#8944)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { reset } = usePanelStore.getState();
+    reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  function makeTerm(id: string, location: "grid" | "dock" = "grid"): MockTerminal {
+    return { id, title: `Shell ${id}`, cwd: "/test", cols: 80, rows: 24, location };
+  }
+
+  it("replicates groupMetadata onto every trashed member", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-2",
+      location: "grid",
+    };
+    setTerminals([makeTerm("term-1"), makeTerm("term-2"), makeTerm("term-3")]);
+    usePanelStore.setState({ tabGroups: new Map([["group-1", group]]) });
+
+    usePanelStore.getState().trashPanelGroup("term-1");
+
+    const state = usePanelStore.getState();
+    for (const id of ["term-1", "term-2", "term-3"]) {
+      const trashed = state.trashedTerminals.get(id)!;
+      expect(trashed.groupMetadata).toBeDefined();
+      expect(trashed.groupMetadata!.panelIds).toEqual(["term-1", "term-2", "term-3"]);
+      expect(trashed.groupMetadata!.activeTabId).toBe("term-2");
+    }
+  });
+
+  it("preserves order and active tab when the original anchor member is removed before restore", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-2",
+      location: "grid",
+    };
+    setTerminals([makeTerm("term-1"), makeTerm("term-2"), makeTerm("term-3")]);
+    usePanelStore.setState({ tabGroups: new Map([["group-1", group]]) });
+
+    usePanelStore.getState().trashPanelGroup("term-1");
+
+    const groupRestoreId = usePanelStore.getState().trashedTerminals.get("term-1")!.groupRestoreId!;
+
+    // Remove the original anchor (first member) from trash + panelsById,
+    // simulating expiry / individual deletion / hydration loss.
+    usePanelStore.setState((state) => {
+      const trashedTerminals = new Map(state.trashedTerminals);
+      trashedTerminals.delete("term-1");
+      const panelsById = { ...state.panelsById };
+      delete panelsById["term-1"];
+      return {
+        trashedTerminals,
+        panelsById,
+        panelIds: state.panelIds.filter((id) => id !== "term-1"),
+      };
+    });
+
+    usePanelStore.getState().restoreTrashedGroup(groupRestoreId);
+
+    const state = usePanelStore.getState();
+    expect(state.trashedTerminals.size).toBe(0);
+    expect(state.tabGroups.size).toBe(1);
+
+    const restored = [...state.tabGroups.values()][0]!;
+    // Order from surviving members preserved (anchor term-1 dropped)
+    expect(restored.panelIds).toEqual(["term-2", "term-3"]);
+    // Originally-active tab (term-2) survived and is still active
+    expect(restored.activeTabId).toBe("term-2");
+  });
+
+  it("falls back to first surviving panel when the active tab was the removed anchor", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-1",
+      location: "grid",
+    };
+    setTerminals([makeTerm("term-1"), makeTerm("term-2"), makeTerm("term-3")]);
+    usePanelStore.setState({ tabGroups: new Map([["group-1", group]]) });
+
+    usePanelStore.getState().trashPanelGroup("term-1");
+
+    const groupRestoreId = usePanelStore.getState().trashedTerminals.get("term-1")!.groupRestoreId!;
+
+    // Remove term-1 — both the anchor and the active tab.
+    usePanelStore.setState((state) => {
+      const trashedTerminals = new Map(state.trashedTerminals);
+      trashedTerminals.delete("term-1");
+      const panelsById = { ...state.panelsById };
+      delete panelsById["term-1"];
+      return {
+        trashedTerminals,
+        panelsById,
+        panelIds: state.panelIds.filter((id) => id !== "term-1"),
+      };
+    });
+
+    usePanelStore.getState().restoreTrashedGroup(groupRestoreId);
+
+    const restored = [...usePanelStore.getState().tabGroups.values()][0]!;
+    expect(restored.panelIds).toEqual(["term-2", "term-3"]);
+    // Active tab term-1 is gone, falls back to first surviving panel in original order
+    expect(restored.activeTabId).toBe("term-2");
+  });
+});

--- a/src/store/slices/panelRegistry/background.ts
+++ b/src/store/slices/panelRegistry/background.ts
@@ -142,22 +142,22 @@ export const createBackgroundActions = (
         }
       }
 
+      // Store groupMetadata on every member, not just an anchor. If any single
+      // member is removed before restore (individual deletion, hydration loss),
+      // the surviving members still carry the full restore metadata so ordering
+      // and the active tab are preserved. See issue #8944.
       const newBackgrounded = new Map(s.backgroundedTerminals);
-      for (let i = 0; i < bgPanelIds.length; i++) {
-        const bid = bgPanelIds[i]!;
-        const isAnchor = i === 0;
+      for (const bid of bgPanelIds) {
         newBackgrounded.set(bid, {
           id: bid,
           originalLocation,
           groupRestoreId,
-          ...(isAnchor && {
-            groupMetadata: {
-              panelIds: bgPanelIds,
-              activeTabId: resolvedActiveTabId,
-              location: group.location,
-              worktreeId,
-            },
-          }),
+          groupMetadata: {
+            panelIds: bgPanelIds,
+            activeTabId: resolvedActiveTabId,
+            location: group.location,
+            worktreeId,
+          },
         });
       }
 

--- a/src/store/slices/panelRegistry/background.ts
+++ b/src/store/slices/panelRegistry/background.ts
@@ -153,7 +153,7 @@ export const createBackgroundActions = (
           originalLocation,
           groupRestoreId,
           groupMetadata: {
-            panelIds: bgPanelIds,
+            panelIds: [...bgPanelIds],
             activeTabId: resolvedActiveTabId,
             location: group.location,
             worktreeId,
@@ -249,7 +249,9 @@ export const createBackgroundActions = (
     for (const [id, backgrounded] of backgroundedTerminals.entries()) {
       if (backgrounded.groupRestoreId === groupRestoreId) {
         groupPanels.push({ id, backgrounded });
-        if (backgrounded.groupMetadata) {
+        // Metadata is replicated identically across all members (#8944); take
+        // the first one found so the restore source is deterministic.
+        if (!anchorPanel && backgrounded.groupMetadata) {
           anchorPanel = backgrounded;
         }
       }

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -192,21 +192,22 @@ export const createTrashActions = (
 
       const newTrashed = new Map(state.trashedTerminals);
 
-      for (const [i, id] of trashPanelIds.entries()) {
-        const isAnchor = i === 0;
+      // Store groupMetadata on every member, not just an anchor. If any single
+      // member is removed before restore (expiry, individual deletion, hydration
+      // loss), the surviving members still carry the full restore metadata so
+      // ordering and the active tab are preserved. See issue #8944.
+      for (const id of trashPanelIds) {
         newTrashed.set(id, {
           id,
           expiresAt,
           originalLocation,
           groupRestoreId,
-          ...(isAnchor && {
-            groupMetadata: {
-              panelIds: trashPanelIds,
-              activeTabId: resolvedActiveTabId,
-              location: group.location,
-              worktreeId,
-            },
-          }),
+          groupMetadata: {
+            panelIds: trashPanelIds,
+            activeTabId: resolvedActiveTabId,
+            location: group.location,
+            worktreeId,
+          },
         });
       }
 

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -203,7 +203,7 @@ export const createTrashActions = (
           originalLocation,
           groupRestoreId,
           groupMetadata: {
-            panelIds: trashPanelIds,
+            panelIds: [...trashPanelIds],
             activeTabId: resolvedActiveTabId,
             location: group.location,
             worktreeId,
@@ -296,7 +296,9 @@ export const createTrashActions = (
       for (const [id, trashed] of trashedTerminals.entries()) {
         if (trashed.groupRestoreId === groupRestoreId) {
           groupPanels.push({ id, trashed });
-          if (trashed.groupMetadata) {
+          // Metadata is replicated identically across all members (#8944); take
+          // the first one found so the restore source is deterministic.
+          if (!anchorPanel && trashed.groupMetadata) {
             anchorPanel = trashed;
           }
         }

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -48,7 +48,7 @@ export interface TrashedTerminal {
   originalLocation: "dock" | "grid";
   /** Shared ID for panels trashed together as a group */
   groupRestoreId?: string;
-  /** Present on the "anchor" panel of a trashed group, holds metadata for recreation */
+  /** Replicated on every member of a trashed group, holds metadata for recreation */
   groupMetadata?: TrashedTerminalGroupMetadata;
 }
 
@@ -57,7 +57,7 @@ export interface BackgroundedTerminal {
   originalLocation: "dock" | "grid";
   /** Shared ID for panels backgrounded together as a group */
   groupRestoreId?: string;
-  /** Present on the "anchor" panel of a backgrounded group, holds metadata for recreation */
+  /** Replicated on every member of a backgrounded group, holds metadata for recreation */
   groupMetadata?: TrashedTerminalGroupMetadata;
 }
 


### PR DESCRIPTION
## Summary

- Group restore metadata (`panelIds` order, `activeTabId`, `location`, `worktreeId`) was stored only on the first member of a trashed/backgrounded group. If that anchor was removed before restore, the metadata was lost silently and the group reconstructed with default ordering and no active tab.
- Fix replicates `groupMetadata` onto every member in `trashPanelGroup` and `backgroundPanelGroup` so any surviving member carries the full restore data. Anchor scan made deterministic (first-wins).
- In-memory only, no on-disk shape change, no migration needed.

Resolves #8944

## Changes

- `trashActions.ts` — replicate `groupMetadata` onto all members of a trashed group; deterministic anchor scan in `restoreTrashedGroup`
- `background.ts` — same treatment for backgrounded groups; deterministic anchor scan in `restoreBackgroundGroup`
- `types.ts` — dropped the `isAnchor` flag from `TrashedTerminalGroupMetadata` and `BackgroundedTerminalGroupMetadata`; every member now carries the full metadata
- `trashTerminalGroupCleanup.test.ts` — regression tests: replication, anchor-removal preserves order and `activeTabId`, dock + `worktreeId` pass-through, single-survivor
- `backgroundTerminalGroupCleanup.test.ts` — parallel regression suite for the background path

## Testing

All 37 targeted tests pass. Typecheck, lint, and format clean.