### PR TITLE
fix(popover): reposition open popovers when right panel toggles

### DIFF
--- a/src/components/ui/__tests__/popover.test.tsx
+++ b/src/components/ui/__tests__/popover.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { cleanup, render, act } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { PopoverContent } from "../popover";
+import { primeRadix } from "../radix-loader";
+
+// Radix/Floating UI installs its own ResizeObservers on the reference/floating
+// elements, so global counters would catch those too. Track per-instance targets
+// to attribute observers to the portal boundary specifically.
+let instances: MockResizeObserver[] = [];
+let resizeCallbacks: ResizeObserverCallback[] = [];
+
+class MockResizeObserver implements ResizeObserver {
+  callback: ResizeObserverCallback;
+  targets: Element[] = [];
+  disconnected = false;
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    instances.push(this);
+    resizeCallbacks.push(callback);
+  }
+  observe(target: Element) {
+    this.targets.push(target);
+  }
+  unobserve() {}
+  disconnect() {
+    this.disconnected = true;
+  }
+}
+
+function isPortalBoundary(el: Element): boolean {
+  return el instanceof HTMLElement && el.dataset.portalBoundary === "true";
+}
+
+function portalBoundaryObserver(): MockResizeObserver | undefined {
+  return instances.find((o) => o.targets.some(isPortalBoundary));
+}
+
+beforeAll(async () => {
+  await primeRadix();
+});
+
+beforeEach(() => {
+  instances = [];
+  resizeCallbacks = [];
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function getContentEl(): HTMLElement {
+  const el = document.querySelector("[data-radix-popper-content-wrapper] > *");
+  if (!(el instanceof HTMLElement)) {
+    throw new Error(`Expected PopoverContent HTMLElement, got ${el === null ? "null" : typeof el}`);
+  }
+  return el;
+}
+
+function fireResize() {
+  act(() => {
+    for (const cb of resizeCallbacks) {
+      cb([], {} as ResizeObserver);
+    }
+  });
+}
+
+describe("PopoverContent reposition on boundary resize (issue #8969)", () => {
+  it("starts at data-reposition-tick='0'", () => {
+    render(
+      <PopoverPrimitive.Root open>
+        <PopoverPrimitive.Trigger>trigger</PopoverPrimitive.Trigger>
+        <PopoverContent forceMount>content</PopoverContent>
+      </PopoverPrimitive.Root>
+    );
+    expect(getContentEl().getAttribute("data-reposition-tick")).toBe("0");
+  });
+
+  it("increments the tick when the boundary resize callback fires", () => {
+    render(
+      <PopoverPrimitive.Root open>
+        <PopoverPrimitive.Trigger>trigger</PopoverPrimitive.Trigger>
+        <PopoverContent forceMount>content</PopoverContent>
+      </PopoverPrimitive.Root>
+    );
+    fireResize();
+    expect(getContentEl().getAttribute("data-reposition-tick")).toBe("1");
+  });
+
+  it("increments monotonically across repeated resize callbacks", () => {
+    render(
+      <PopoverPrimitive.Root open>
+        <PopoverPrimitive.Trigger>trigger</PopoverPrimitive.Trigger>
+        <PopoverContent forceMount>content</PopoverContent>
+      </PopoverPrimitive.Root>
+    );
+    fireResize();
+    fireResize();
+    fireResize();
+    expect(getContentEl().getAttribute("data-reposition-tick")).toBe("3");
+  });
+
+  it("observes the portal boundary element", () => {
+    render(
+      <PopoverPrimitive.Root open>
+        <PopoverPrimitive.Trigger>trigger</PopoverPrimitive.Trigger>
+        <PopoverContent forceMount>content</PopoverContent>
+      </PopoverPrimitive.Root>
+    );
+    expect(portalBoundaryObserver()).toBeDefined();
+  });
+
+  it("does not observe the portal boundary when a caller-supplied collisionBoundary is provided", () => {
+    const callerBoundary = document.createElement("div");
+    document.body.appendChild(callerBoundary);
+    render(
+      <PopoverPrimitive.Root open>
+        <PopoverPrimitive.Trigger>trigger</PopoverPrimitive.Trigger>
+        <PopoverContent forceMount collisionBoundary={callerBoundary}>
+          content
+        </PopoverContent>
+      </PopoverPrimitive.Root>
+    );
+    expect(portalBoundaryObserver()).toBeUndefined();
+    callerBoundary.remove();
+  });
+
+  it("disconnects the boundary observer on unmount", () => {
+    const { unmount } = render(
+      <PopoverPrimitive.Root open>
+        <PopoverPrimitive.Trigger>trigger</PopoverPrimitive.Trigger>
+        <PopoverContent forceMount>content</PopoverContent>
+      </PopoverPrimitive.Root>
+    );
+    const observer = portalBoundaryObserver();
+    expect(observer).toBeDefined();
+    expect(observer!.disconnected).toBe(false);
+    unmount();
+    expect(observer!.disconnected).toBe(true);
+  });
+});

--- a/src/components/ui/__tests__/popover.test.tsx
+++ b/src/components/ui/__tests__/popover.test.tsx
@@ -103,6 +103,20 @@ describe("PopoverContent reposition on boundary resize (issue #8969)", () => {
     expect(getContentEl().getAttribute("data-reposition-tick")).toBe("3");
   });
 
+  it("internal tick wins over a caller-supplied data-reposition-tick prop", () => {
+    render(
+      <PopoverPrimitive.Root open>
+        <PopoverPrimitive.Trigger>trigger</PopoverPrimitive.Trigger>
+        <PopoverContent forceMount data-reposition-tick={99}>
+          content
+        </PopoverContent>
+      </PopoverPrimitive.Root>
+    );
+    expect(getContentEl().getAttribute("data-reposition-tick")).toBe("0");
+    fireResize();
+    expect(getContentEl().getAttribute("data-reposition-tick")).toBe("1");
+  });
+
   it("observes the portal boundary element", () => {
     render(
       <PopoverPrimitive.Root open>

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -230,7 +230,6 @@ const PopoverContent = React.forwardRef<
         align={align}
         sideOffset={sideOffset}
         collisionBoundary={collisionBoundary ?? boundary ?? undefined}
-        data-reposition-tick={repositionTick}
         style={{ transformOrigin: "var(--radix-popover-content-transform-origin)", ...style }}
         className={cn(
           "z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-daintree-text",
@@ -238,6 +237,8 @@ const PopoverContent = React.forwardRef<
           className
         )}
         {...props}
+        // Internal reposition trigger must win over any caller-supplied value.
+        data-reposition-tick={repositionTick}
       />
     </Portal>
   );

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -201,10 +201,24 @@ const PopoverContent = React.forwardRef<
 >(({ className, align = "center", sideOffset = 4, collisionBoundary, style, ...props }, ref) => {
   const radix = useRadixPrimitives();
   const [boundary, setBoundary] = React.useState<HTMLElement | null>(null);
+  // Floating UI's autoUpdate observes the reference/floating elements but not the
+  // collision boundary. The portal boundary's width tracks --right-obstruction-offset,
+  // which changes when the right native panel toggles — so an open popover would keep a
+  // stale position. Observe the boundary and bump a tick to re-run Radix's positioning.
+  const [repositionTick, setRepositionTick] = React.useState(0);
 
   React.useEffect(() => {
-    setBoundary(getPortalBoundary());
-  }, []);
+    const element = getPortalBoundary();
+    setBoundary(element);
+
+    // When a caller supplies their own boundary the portal boundary is unused, so there
+    // is nothing to observe.
+    if (collisionBoundary || !element || typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(() => setRepositionTick((tick) => tick + 1));
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [collisionBoundary]);
 
   if (!radix) return null;
   const Portal = radix.PopoverPrimitive.Portal;
@@ -216,6 +230,7 @@ const PopoverContent = React.forwardRef<
         align={align}
         sideOffset={sideOffset}
         collisionBoundary={collisionBoundary ?? boundary ?? undefined}
+        data-reposition-tick={repositionTick}
         style={{ transformOrigin: "var(--radix-popover-content-transform-origin)", ...style }}
         className={cn(
           "z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-daintree-text",


### PR DESCRIPTION
## Summary

- Open popovers weren't repositioning when the right-side native panel (chat/dev-preview WebContentsView) toggled. `AppLayout` publishes `--right-obstruction-offset` on toggle, which resizes the collision-boundary div in `popover.tsx`, but Floating UI's `autoUpdate` only observes the reference/floating elements and scroll ancestors -- never the boundary -- so open popovers kept a stale position.
- Fix attaches a `ResizeObserver` to the portal boundary in `popover.tsx` and increments a `repositionTick` state on resize, passed as `data-reposition-tick` to Radix `Content`. This attribute change re-runs Floating UI's positioning layout effect against the updated boundary.
- Uses `data-*` rather than `key=` to avoid unmount/focus-loss/exit-animation breakage. Observer only installed when no caller-supplied `collisionBoundary`; guarded on `typeof ResizeObserver`.

Resolves #8969

## Changes

- `src/components/ui/popover.tsx` -- `ResizeObserver` on portal boundary, `repositionTick` state, `data-reposition-tick` prop on `PopoverContent`
- `src/components/ui/__tests__/popover.test.tsx` -- 7 new unit tests

## Testing

New unit tests cover: tick initialisation, increment on resize, monotonic growth, boundary observation, caller-boundary opt-out (observer skipped when caller supplies `collisionBoundary`), unmount disconnect, and internal tick winning over any caller-supplied prop.

`npm run check` passes clean.