### PR TITLE
feat(welcome): give the welcome screen one clear first step

### DIFF
--- a/e2e/full/platform/core-accessibility.spec.ts
+++ b/e2e/full/platform/core-accessibility.spec.ts
@@ -61,7 +61,7 @@ test.describe.serial("Core: Accessibility", () => {
   test.describe.serial("Axe Audits", () => {
     test("welcome screen passes WCAG 2.2 AA audit", async () => {
       const { window } = ctx;
-      await window.getByRole("button", { name: "Open Folder" }).waitFor({
+      await window.getByRole("button", { name: "Open folder" }).waitFor({
         state: "visible",
         timeout: T_MEDIUM,
       });

--- a/e2e/full/platform/core-hybrid-input-bar.spec.ts
+++ b/e2e/full/platform/core-hybrid-input-bar.spec.ts
@@ -25,7 +25,7 @@ async function ensureProjectViewOpen(): Promise<void> {
 
   if (
     await ctx.window
-      .getByRole("button", { name: "Open Folder" })
+      .getByRole("button", { name: "Open folder" })
       .isVisible({ timeout: 500 })
       .catch(() => false)
   ) {

--- a/e2e/full/platform/core-shell-settings.spec.ts
+++ b/e2e/full/platform/core-shell-settings.spec.ts
@@ -42,9 +42,9 @@ test.describe.serial("Core: Shell & Settings", () => {
       await expectToolbarButtonReachable(window, SEL.toolbar.openSettings, T_SHORT);
     });
 
-    test("welcome screen shows Open Folder button", async () => {
+    test("welcome screen shows Open folder button", async () => {
       const { window } = ctx;
-      await expect(window.getByRole("button", { name: "Open Folder" })).toBeVisible({
+      await expect(window.getByRole("button", { name: "Open folder" })).toBeVisible({
         timeout: T_MEDIUM,
       });
     });

--- a/e2e/full/platform/oauth-loopback-flow.spec.ts
+++ b/e2e/full/platform/oauth-loopback-flow.spec.ts
@@ -491,7 +491,7 @@ test.describe.serial("E2E: OAuth Loopback Flow in Dev Preview", () => {
 
       // If we're back on Welcome, explicitly reopen the fixture project instead of
       // relying only on the recent-project shortcut state.
-      const openFolder = w().getByRole("button", { name: "Open Folder" });
+      const openFolder = w().getByRole("button", { name: "Open folder" });
       if (await openFolder.isVisible({ timeout: 1000 }).catch(() => false)) {
         await openProject(ctx.app, w(), fixture);
         await w().waitForTimeout(2000);

--- a/e2e/full/terminal/core-fleet-broadcast.spec.ts
+++ b/e2e/full/terminal/core-fleet-broadcast.spec.ts
@@ -102,7 +102,7 @@ async function ensureFleetProjectOpen(): Promise<void> {
 
     if (
       await ctx.window
-        .getByRole("button", { name: "Open Folder" })
+        .getByRole("button", { name: "Open folder" })
         .isVisible({ timeout: 500 })
         .catch(() => false)
     ) {

--- a/e2e/helpers/project.ts
+++ b/e2e/helpers/project.ts
@@ -11,7 +11,7 @@ export async function openProject(
 ): Promise<void> {
   const isWindowsCI = process.env.CI && process.platform === "win32";
   await mockOpenDialog(app, projectPath);
-  const openFolder = window.getByRole("button", { name: "Open Folder" });
+  const openFolder = window.getByRole("button", { name: "Open folder" });
   await expect(openFolder).toBeVisible({ timeout: isWindowsCI ? 30_000 : 10_000 });
   await openFolder.click();
 }

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -160,7 +160,7 @@ export const SEL = {
     noUnstagedChanges: 'text="All changes staged"',
   },
   welcome: {
-    openFolder: 'button:has-text("Open Folder")',
+    openFolder: 'button:has-text("Open folder")',
   },
   firstRun: {
     welcomeTitle: 'h1:has-text("Welcome to Daintree")',

--- a/e2e/online/claude-online.spec.ts
+++ b/e2e/online/claude-online.spec.ts
@@ -119,7 +119,7 @@ test.describe("Claude Online Flow", () => {
       const { app, window } = ctx;
 
       await mockOpenDialog(app, fixtureDir);
-      await window.getByRole("button", { name: "Open Folder" }).click();
+      await window.getByRole("button", { name: "Open folder" }).click();
     });
 
     // Re-acquire window after open — ProjectViewManager creates a new

--- a/e2e/online/opencode-online.spec.ts
+++ b/e2e/online/opencode-online.spec.ts
@@ -50,7 +50,7 @@ async function openFixtureProject(): Promise<void> {
   const { app, window } = ctx;
 
   await mockOpenDialog(app, fixtureDir);
-  await window.getByRole("button", { name: "Open Folder" }).click();
+  await window.getByRole("button", { name: "Open folder" }).click();
 
   // Re-acquire window after open — ProjectViewManager creates a new
   // WebContentsView for the project — then dismiss the telemetry consent

--- a/e2e/online/terminal-identity-transitions.spec.ts
+++ b/e2e/online/terminal-identity-transitions.spec.ts
@@ -489,7 +489,7 @@ test.describe("Terminal chrome ↔ live process identity (bidirectional)", () =>
       diagnostics = createIdentityDiagnostics(ctx);
       const { app, window } = ctx;
       await mockOpenDialog(app, fixtureDir);
-      await window.getByRole("button", { name: "Open Folder" }).click();
+      await window.getByRole("button", { name: "Open folder" }).click();
     });
 
     ctx.window = await refreshActiveWindow(ctx.app, ctx.window);

--- a/e2e/screenshots/store-reel.spec.ts
+++ b/e2e/screenshots/store-reel.spec.ts
@@ -93,7 +93,7 @@ async function bootProject(
   });
 
   await mockOpenDialog(ctx.app, repo.dir);
-  await ctx.window.getByRole("button", { name: "Open Folder" }).click();
+  await ctx.window.getByRole("button", { name: "Open folder" }).click();
 
   let page = await refreshActiveWindow(ctx.app, ctx.window);
   await dismissTelemetryConsent(page);

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -67,6 +67,44 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
     []
   );
 
+  const quickActions = useMemo(
+    () => [
+      {
+        id: "open-folder",
+        icon: FolderOpen,
+        title: "Open folder",
+        description: "Open an existing project on your machine",
+        onClick: () => void addProject(),
+        primary: true,
+      },
+      {
+        id: "create-project",
+        icon: FolderPlus,
+        title: "Create project",
+        description: "Start fresh in a new folder",
+        onClick: openCreateFolderDialog,
+        primary: false,
+      },
+      {
+        id: "clone-repository",
+        icon: GitBranch,
+        title: "Clone repository",
+        description: "Pull a repo from a Git URL",
+        onClick: openCloneRepoDialog,
+        primary: false,
+      },
+      {
+        id: "launch-agent",
+        icon: Rocket,
+        title: "Launch agent",
+        description: "Open the panel palette to start an agent",
+        onClick: () => void actionService.dispatch("panel.palette", undefined, { source: "user" }),
+        primary: false,
+      },
+    ],
+    [addProject, openCreateFolderDialog, openCloneRepoDialog]
+  );
+
   const completedCount = checklist ? Object.values(checklist.items).filter(Boolean).length : 0;
   const allDone = checklist ? Object.values(checklist.items).every(Boolean) : false;
   const showChecklist = gettingStarted.visible && checklist && !checklist.dismissed && !allDone;
@@ -100,31 +138,55 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
 
         {/* Quick Actions */}
         <div className="w-full">
-          <div className="flex flex-wrap gap-3 justify-center">
-            <Button size="lg" onClick={() => void addProject()}>
-              <FolderOpen />
-              Open Folder
-            </Button>
-            <Button size="lg" variant="outline" onClick={openCreateFolderDialog}>
-              <FolderPlus />
-              Create Project
-            </Button>
-            <Button size="lg" variant="outline" onClick={openCloneRepoDialog}>
-              <GitBranch />
-              Clone Repository
-            </Button>
-            <Button
-              size="lg"
-              variant="outline"
-              onClick={() =>
-                void actionService.dispatch("panel.palette", undefined, {
-                  source: "user",
-                })
-              }
+          {hasProjects && (
+            <h3
+              id="quick-actions-heading"
+              className="text-xs font-medium text-daintree-text/50 uppercase tracking-wider mb-3"
             >
-              <Rocket />
-              Launch Agent
-            </Button>
+              Quick actions
+            </h3>
+          )}
+          <div
+            role="group"
+            aria-label={hasProjects ? undefined : "Quick actions"}
+            aria-labelledby={hasProjects ? "quick-actions-heading" : undefined}
+            data-testid="quick-actions"
+            className="grid grid-cols-2 gap-3"
+          >
+            {quickActions.map(({ id, icon: Icon, title, description, onClick, primary }) => {
+              // Subtle surface lift marks the recommended first step for new
+              // users only; once recents exist the list owns the primary path,
+              // so every card drops to equal, demoted weight. Not the accent
+              // color — that load-bearing signal is owned by the checklist.
+              const lifted = primary && !hasProjects;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={onClick}
+                  aria-describedby={`qa-desc-${id}`}
+                  className={cn(
+                    "flex flex-col items-start gap-1 rounded-[var(--radius-md)] p-3 text-left",
+                    "transition-colors duration-150",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
+                    lifted
+                      ? "ring-1 ring-border-strong bg-surface-panel-elevated/95 hover:bg-surface-panel-elevated"
+                      : "ring-1 ring-border-strong/40 hover:bg-overlay-soft"
+                  )}
+                >
+                  <span className="flex items-center gap-2 text-sm font-medium text-daintree-text">
+                    <Icon className="h-4 w-4 shrink-0 text-daintree-text/70" />
+                    {title}
+                  </span>
+                  <span
+                    id={`qa-desc-${id}`}
+                    className="text-xs text-daintree-text/50 leading-relaxed"
+                  >
+                    {description}
+                  </span>
+                </button>
+              );
+            })}
           </div>
         </div>
 

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -164,6 +164,10 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
                   key={id}
                   type="button"
                   onClick={onClick}
+                  // Title is the accessible name; the description is announced
+                  // once via aria-describedby. aria-label keeps the name clean
+                  // so the in-button description text isn't double-announced.
+                  aria-label={title}
                   aria-describedby={`qa-desc-${id}`}
                   className={cn(
                     "flex flex-col items-start gap-1 rounded-[var(--radius-md)] p-3 text-left",

--- a/src/components/Project/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/Project/__tests__/WelcomeScreen.test.tsx
@@ -708,10 +708,12 @@ describe("WelcomeScreen", () => {
 
     const openFolder = screen.getByText("Open folder").closest("button")!;
     const createProject = screen.getByText("Create project").closest("button")!;
+    const cloneRepository = screen.getByText("Clone repository").closest("button")!;
     const launchAgent = screen.getByText("Launch agent").closest("button")!;
 
     expect(openFolder.disabled).toBe(false);
     expect(createProject.disabled).toBe(false);
+    expect(cloneRepository.disabled).toBe(false);
     expect(launchAgent.disabled).toBe(false);
   });
 
@@ -734,6 +736,12 @@ describe("WelcomeScreen", () => {
 
     const openFolder = screen.getByText("Open folder").closest("button")!;
     expect(openFolder.className).toContain("bg-surface-panel-elevated/95");
+
+    // Only the primary card is lifted — the three secondary cards are not.
+    for (const label of ["Create project", "Clone repository", "Launch agent"]) {
+      const card = screen.getByText(label).closest("button")!;
+      expect(card.className).not.toContain("bg-surface-panel-elevated/95");
+    }
   });
 
   it("adds a muted heading and demotes the Open folder card for returning users", () => {

--- a/src/components/Project/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/Project/__tests__/WelcomeScreen.test.tsx
@@ -6,11 +6,13 @@ const { dispatchMock } = vi.hoisted(() => ({
   dispatchMock: vi.fn(() => Promise.resolve()),
 }));
 
-const { addProjectMock, openCreateFolderDialogMock, switchProjectMock } = vi.hoisted(() => ({
-  addProjectMock: vi.fn(() => Promise.resolve()),
-  openCreateFolderDialogMock: vi.fn(),
-  switchProjectMock: vi.fn(() => Promise.resolve()),
-}));
+const { addProjectMock, openCreateFolderDialogMock, openCloneRepoDialogMock, switchProjectMock } =
+  vi.hoisted(() => ({
+    addProjectMock: vi.fn(() => Promise.resolve()),
+    openCreateFolderDialogMock: vi.fn(),
+    openCloneRepoDialogMock: vi.fn(),
+    switchProjectMock: vi.fn(() => Promise.resolve()),
+  }));
 
 const { getDisplayComboMock } = vi.hoisted(() => ({
   getDisplayComboMock: vi.fn((actionId: string) => {
@@ -175,6 +177,7 @@ let storeState = {
   isLoading: false,
   addProject: addProjectMock,
   openCreateFolderDialog: openCreateFolderDialogMock,
+  openCloneRepoDialog: openCloneRepoDialogMock,
   switchProject: switchProjectMock,
 };
 
@@ -273,6 +276,7 @@ describe("WelcomeScreen", () => {
       isLoading: false,
       addProject: addProjectMock,
       openCreateFolderDialog: openCreateFolderDialogMock,
+      openCloneRepoDialog: openCloneRepoDialogMock,
       switchProject: switchProjectMock,
     };
     agentDiscoveryState.loaded = true;
@@ -648,46 +652,101 @@ describe("WelcomeScreen", () => {
 
   // --- Quick Actions ---
 
-  it("renders quick action buttons", () => {
+  it("renders quick action cards with sentence-case labels and descriptions", () => {
     render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
-    expect(screen.getByText("Open Folder")).toBeTruthy();
-    expect(screen.getByText("Create Project")).toBeTruthy();
-    expect(screen.getByText("Launch Agent")).toBeTruthy();
+    expect(screen.getByText("Open folder")).toBeTruthy();
+    expect(screen.getByText("Create project")).toBeTruthy();
+    expect(screen.getByText("Clone repository")).toBeTruthy();
+    expect(screen.getByText("Launch agent")).toBeTruthy();
+
+    // Each secondary action carries a short description to tell them apart.
+    expect(screen.getByText("Open an existing project on your machine")).toBeTruthy();
+    expect(screen.getByText("Start fresh in a new folder")).toBeTruthy();
+    expect(screen.getByText("Pull a repo from a Git URL")).toBeTruthy();
+    expect(screen.getByText("Open the panel palette to start an agent")).toBeTruthy();
   });
 
-  it("calls addProject when Open Folder is clicked", () => {
+  it("groups quick actions in an accessible region with described cards", () => {
     render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
-    fireEvent.click(screen.getByText("Open Folder"));
+    const group = screen.getByTestId("quick-actions");
+    expect(group.getAttribute("role")).toBe("group");
+
+    const openFolder = screen.getByText("Open folder").closest("button")!;
+    const describedBy = openFolder.getAttribute("aria-describedby");
+    expect(describedBy).toBe("qa-desc-open-folder");
+    expect(document.getElementById(describedBy!)?.textContent).toBe(
+      "Open an existing project on your machine"
+    );
+  });
+
+  it("calls addProject when Open folder is clicked", () => {
+    render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+
+    fireEvent.click(screen.getByText("Open folder"));
     expect(addProjectMock).toHaveBeenCalledTimes(1);
   });
 
-  it("calls openCreateFolderDialog when Create Project is clicked", () => {
+  it("calls openCreateFolderDialog when Create project is clicked", () => {
     render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
-    fireEvent.click(screen.getByText("Create Project"));
+    fireEvent.click(screen.getByText("Create project"));
     expect(openCreateFolderDialogMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls openCloneRepoDialog when Clone repository is clicked", () => {
+    render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+
+    fireEvent.click(screen.getByText("Clone repository"));
+    expect(openCloneRepoDialogMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not disable quick action buttons when isLoading is true", () => {
     storeState = { ...storeState, isLoading: true };
     render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
-    const openFolder = screen.getByText("Open Folder").closest("button")!;
-    const createProject = screen.getByText("Create Project").closest("button")!;
-    const launchAgent = screen.getByText("Launch Agent").closest("button")!;
+    const openFolder = screen.getByText("Open folder").closest("button")!;
+    const createProject = screen.getByText("Create project").closest("button")!;
+    const launchAgent = screen.getByText("Launch agent").closest("button")!;
 
     expect(openFolder.disabled).toBe(false);
     expect(createProject.disabled).toBe(false);
     expect(launchAgent.disabled).toBe(false);
   });
 
-  it("dispatches panel.palette when Launch Agent is clicked", () => {
+  it("dispatches panel.palette when Launch agent is clicked", () => {
     render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
-    fireEvent.click(screen.getByText("Launch Agent"));
+    fireEvent.click(screen.getByText("Launch agent"));
     expect(dispatchMock).toHaveBeenCalledWith("panel.palette", undefined, { source: "user" });
+  });
+
+  it("lifts the Open folder card and hides the heading for first-time users", () => {
+    storeState = { ...storeState, projects: [] };
+    render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+
+    // No "Quick actions" heading competes with the hero copy for new users.
+    expect(screen.queryByText("Quick actions")).toBeNull();
+
+    const group = screen.getByTestId("quick-actions");
+    expect(group.getAttribute("aria-label")).toBe("Quick actions");
+
+    const openFolder = screen.getByText("Open folder").closest("button")!;
+    expect(openFolder.className).toContain("bg-surface-panel-elevated/95");
+  });
+
+  it("adds a muted heading and demotes the Open folder card for returning users", () => {
+    render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+
+    expect(screen.getByText("Quick actions")).toBeTruthy();
+
+    const group = screen.getByTestId("quick-actions");
+    expect(group.getAttribute("aria-labelledby")).toBe("quick-actions-heading");
+
+    // With recents present the list owns the primary path — no card lift.
+    const openFolder = screen.getByText("Open folder").closest("button")!;
+    expect(openFolder.className).not.toContain("bg-surface-panel-elevated/95");
   });
 
   // --- Keyboard Shortcuts ---


### PR DESCRIPTION
## Summary

- Replaces the four equal-weight action buttons on the welcome screen with a 2x2 card grid. Each card has an icon, sentence-case title, and short description.
- For new users, the `Open folder` card gets a subtle surface lift to signal the recommended first step — no accent colour, just a slight background shift. For returning users with recent projects, all cards drop to equal weight under a muted "Quick actions" heading; the recents list owns the primary path there.
- Sweeps 11 E2E test files for the `Open Folder` → `Open folder` label rename.

Resolves #8955

## Changes

- `src/components/Project/WelcomeScreen.tsx` — new card grid layout with new/returning user states
- `src/components/Project/__tests__/WelcomeScreen.test.tsx` — updated + expanded unit tests
- `e2e/**` — 11 files updated for sentence-case label rename

## Testing

- Unit tests updated and passing
- E2E selector updates cover the label rename across all affected test files
- Verified card hierarchy visually for both new-user and returning-user states