### PR TITLE
feat(recipe-runner): surface detected run commands in empty state

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -2869,9 +2869,9 @@
   "src/components/Terminal/RecipeRunner/useRecipeRunner.ts": {
     "success": 0,
     "skip": 0,
-    "error": 2,
+    "error": 3,
     "pipeline": 0,
-    "hintCount": 2,
+    "hintCount": 3,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []

--- a/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
@@ -34,7 +34,14 @@ export function RecipeRunner({ activeWorktreeId, defaultCwd }: RecipeRunnerProps
   const runner = useRecipeRunner({ activeWorktreeId, defaultCwd });
 
   if (runner.recipes.length === 0) {
-    return <RecipeRunnerEmpty onCreate={runner.handleCreate} />;
+    return (
+      <RecipeRunnerEmpty
+        onCreate={runner.handleCreate}
+        suggestions={runner.suggestions}
+        onRunSuggestion={runner.handleRunSuggestion}
+        disabled={!defaultCwd}
+      />
+    );
   }
 
   const flatRecipes = runner.getFlatRecipes();

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx
@@ -1,28 +1,70 @@
-import { Plus } from "lucide-react";
+import { Play, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { RunCommand } from "@/types";
 
 interface RecipeRunnerEmptyProps {
   onCreate: () => void;
+  suggestions: RunCommand[];
+  onRunSuggestion: (suggestion: RunCommand) => void;
+  disabled?: boolean;
 }
 
-export function RecipeRunnerEmpty({ onCreate }: RecipeRunnerEmptyProps) {
+export function RecipeRunnerEmpty({
+  onCreate,
+  suggestions,
+  onRunSuggestion,
+  disabled,
+}: RecipeRunnerEmptyProps) {
+  const hasSuggestions = suggestions.length > 0;
+
   return (
-    <div className="flex flex-col items-center gap-3 py-6">
-      <p className="text-xs text-text-muted">
-        Launch agents, dev servers, and terminals together with one click
-      </p>
-      <button
-        type="button"
-        onClick={onCreate}
-        className="group flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] hover:bg-overlay-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
-      >
-        <Plus
-          className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-text transition-colors shrink-0"
-          aria-hidden
-        />
-        <span className="text-sm text-text-muted group-hover:text-daintree-text transition-colors">
-          Create your first recipe
-        </span>
-      </button>
+    <div className="flex flex-col items-stretch gap-3 py-6 w-full max-w-md mx-auto">
+      {hasSuggestions ? (
+        <div className="flex flex-col gap-2">
+          {suggestions.map((suggestion) => (
+            <button
+              key={suggestion.id}
+              type="button"
+              onClick={() => onRunSuggestion(suggestion)}
+              disabled={disabled}
+              className="group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle"
+            >
+              <Play
+                className={cn(
+                  "h-3.5 w-3.5 text-status-success/50 transition-colors shrink-0",
+                  !disabled && "group-hover:text-status-success"
+                )}
+                aria-hidden
+              />
+              <span className="flex-1 text-sm font-medium text-daintree-text truncate">
+                {suggestion.name}
+              </span>
+              <span className="text-xs text-text-muted truncate max-w-[55%]">
+                {suggestion.command}
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-text-muted text-center">
+          Launch agents, dev servers, and terminals together with one click
+        </p>
+      )}
+      <div className="flex justify-center">
+        <button
+          type="button"
+          onClick={onCreate}
+          className="group flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] hover:bg-overlay-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+        >
+          <Plus
+            className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-text transition-colors shrink-0"
+            aria-hidden
+          />
+          <span className="text-sm text-text-muted group-hover:text-daintree-text transition-colors">
+            Create your first recipe
+          </span>
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerEmpty.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/RecipeRunnerEmpty.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { RunCommand } from "@/types";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+import { RecipeRunnerEmpty } from "../RecipeRunnerEmpty";
+
+function makeSuggestion(overrides: Partial<RunCommand> & { id: string; name: string }): RunCommand {
+  return {
+    command: `npm run ${overrides.name}`,
+    ...overrides,
+  };
+}
+
+describe("RecipeRunnerEmpty", () => {
+  it("renders the descriptive copy and create button when there are no suggestions", () => {
+    render(<RecipeRunnerEmpty onCreate={vi.fn()} suggestions={[]} onRunSuggestion={vi.fn()} />);
+
+    expect(
+      screen.getByText(/Launch agents, dev servers, and terminals together with one click/i)
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Create your first recipe/i })).toBeTruthy();
+  });
+
+  it("renders a card for each suggestion and hides the descriptive copy", () => {
+    const suggestions = [
+      makeSuggestion({ id: "1", name: "dev", command: "npm run dev" }),
+      makeSuggestion({ id: "2", name: "test", command: "npm run test" }),
+    ];
+
+    render(
+      <RecipeRunnerEmpty onCreate={vi.fn()} suggestions={suggestions} onRunSuggestion={vi.fn()} />
+    );
+
+    expect(screen.getByRole("button", { name: /dev.*npm run dev/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /test.*npm run test/i })).toBeTruthy();
+    expect(
+      screen.queryByText(/Launch agents, dev servers, and terminals together with one click/i)
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: /Create your first recipe/i })).toBeTruthy();
+  });
+
+  it("calls onRunSuggestion with the clicked suggestion", () => {
+    const onRunSuggestion = vi.fn();
+    const suggestion = makeSuggestion({ id: "1", name: "dev", command: "npm run dev" });
+
+    render(
+      <RecipeRunnerEmpty
+        onCreate={vi.fn()}
+        suggestions={[suggestion]}
+        onRunSuggestion={onRunSuggestion}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /dev.*npm run dev/i }));
+    expect(onRunSuggestion).toHaveBeenCalledWith(suggestion);
+  });
+
+  it("calls onCreate when the create button is clicked", () => {
+    const onCreate = vi.fn();
+    render(<RecipeRunnerEmpty onCreate={onCreate} suggestions={[]} onRunSuggestion={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Create your first recipe/i }));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables suggestion cards when disabled is true and skips onRunSuggestion on click", () => {
+    const onRunSuggestion = vi.fn();
+    const suggestion = makeSuggestion({ id: "1", name: "dev", command: "npm run dev" });
+
+    render(
+      <RecipeRunnerEmpty
+        onCreate={vi.fn()}
+        suggestions={[suggestion]}
+        onRunSuggestion={onRunSuggestion}
+        disabled
+      />
+    );
+
+    const button = screen.getByRole("button", { name: /dev.*npm run dev/i });
+    expect(button.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(button);
+    expect(onRunSuggestion).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Terminal/RecipeRunner/__tests__/useRecipeRunner.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/useRecipeRunner.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import type { TerminalRecipe } from "@/types";
+import type { TerminalRecipe, RunCommand } from "@/types";
 import type { RecipeSpawnResults } from "@/store/recipeStore";
 
 const recipes: TerminalRecipe[] = [];
@@ -57,11 +57,19 @@ vi.mock("@/store/createWorktreeStore", () => ({
   getCurrentViewStore: () => fakeWorktreeStore,
 }));
 
-const projectSettingsState = { allDetectedRunners: [] };
+const projectSettingsState: { allDetectedRunners: RunCommand[] } = { allDetectedRunners: [] };
 
 vi.mock("@/store/projectSettingsStore", () => ({
   useProjectSettingsStore: <T,>(selector: (state: typeof projectSettingsState) => T) =>
     selector(projectSettingsState),
+}));
+
+const addPanelMock = vi.fn<(options: unknown) => Promise<string | null>>();
+const panelStoreState = {
+  addPanel: (options: unknown) => addPanelMock(options),
+};
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: <T,>(selector: (state: typeof panelStoreState) => T) => selector(panelStoreState),
 }));
 
 vi.mock("@/services/ActionService", () => ({
@@ -96,7 +104,10 @@ function makeRecipe(
 
 beforeEach(() => {
   recipes.length = 0;
+  projectSettingsState.allDetectedRunners = [];
   runRecipeWithResultsMock.mockReset();
+  addPanelMock.mockReset();
+  addPanelMock.mockResolvedValue("panel-1");
   logErrorMock.mockReset();
 });
 
@@ -561,5 +572,151 @@ describe("useRecipeRunner — async lifecycle", () => {
     });
     await flush();
     expect(runRecipeWithResultsMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+function makeRunCommand(overrides: Partial<RunCommand> & { id: string; name: string }): RunCommand {
+  return {
+    command: `npm run ${overrides.name}`,
+    ...overrides,
+  };
+}
+
+describe("useRecipeRunner — suggestions", () => {
+  it("caps suggestions to two even when several keyword-matching runners are detected", () => {
+    projectSettingsState.allDetectedRunners = [
+      makeRunCommand({ id: "1", name: "dev" }),
+      makeRunCommand({ id: "2", name: "start" }),
+      makeRunCommand({ id: "3", name: "serve" }),
+      makeRunCommand({ id: "4", name: "test" }),
+      makeRunCommand({ id: "5", name: "build" }),
+    ];
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    expect(result.current.suggestions).toHaveLength(2);
+    expect(result.current.suggestions.map((s) => s.id)).toEqual(["1", "2"]);
+  });
+
+  it("filters out runners that do not match any keyword", () => {
+    projectSettingsState.allDetectedRunners = [
+      makeRunCommand({ id: "1", name: "lint", command: "eslint ." }),
+      makeRunCommand({ id: "2", name: "dev", command: "vite" }),
+      makeRunCommand({ id: "3", name: "format", command: "prettier ." }),
+    ];
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    expect(result.current.suggestions.map((s) => s.id)).toEqual(["2"]);
+  });
+
+  it("returns an empty array when no detected runners match", () => {
+    projectSettingsState.allDetectedRunners = [
+      makeRunCommand({ id: "1", name: "lint", command: "eslint ." }),
+    ];
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    expect(result.current.suggestions).toEqual([]);
+  });
+});
+
+describe("useRecipeRunner — handleRunSuggestion", () => {
+  it("spawns a terminal via addPanel with the suggestion command", async () => {
+    const suggestion = makeRunCommand({ id: "s-dev", name: "dev", command: "npm run dev" });
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/repo" })
+    );
+
+    act(() => {
+      result.current.handleRunSuggestion(suggestion);
+    });
+    await flush();
+
+    expect(addPanelMock).toHaveBeenCalledTimes(1);
+    expect(addPanelMock).toHaveBeenCalledWith({
+      kind: "terminal",
+      title: "dev",
+      cwd: "/repo",
+      command: "npm run dev",
+      location: "grid",
+      worktreeId: "wt-1",
+      spawnedBy: "quickrun",
+    });
+  });
+
+  it("does nothing when defaultCwd is missing", () => {
+    const suggestion = makeRunCommand({ id: "s-dev", name: "dev" });
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: undefined })
+    );
+
+    act(() => {
+      result.current.handleRunSuggestion(suggestion);
+    });
+
+    expect(addPanelMock).not.toHaveBeenCalled();
+  });
+
+  it("guards against double-click reentrancy while the spawn is in flight", async () => {
+    const suggestion = makeRunCommand({ id: "s-dev", name: "dev" });
+    let resolve: (id: string) => void = () => {};
+    addPanelMock.mockReturnValueOnce(
+      new Promise<string>((r) => {
+        resolve = r;
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/repo" })
+    );
+
+    act(() => {
+      result.current.handleRunSuggestion(suggestion);
+      result.current.handleRunSuggestion(suggestion);
+    });
+
+    expect(addPanelMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolve("panel-1");
+      await Promise.resolve();
+    });
+
+    // Guard cleared — a fresh click should fire again.
+    act(() => {
+      result.current.handleRunSuggestion(suggestion);
+    });
+    await flush();
+    expect(addPanelMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the guard when addPanel rejects", async () => {
+    const suggestion = makeRunCommand({ id: "s-dev", name: "dev" });
+    addPanelMock.mockRejectedValueOnce(new Error("Panel limit reached"));
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/repo" })
+    );
+
+    act(() => {
+      result.current.handleRunSuggestion(suggestion);
+    });
+    await flush();
+
+    addPanelMock.mockResolvedValueOnce("panel-2");
+    act(() => {
+      result.current.handleRunSuggestion(suggestion);
+    });
+    await flush();
+
+    expect(addPanelMock).toHaveBeenCalledTimes(2);
+    expect(logErrorMock).toHaveBeenCalledWith("Suggestion run failed", expect.any(Error));
   });
 });

--- a/src/components/Terminal/RecipeRunner/__tests__/useRecipeRunner.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/useRecipeRunner.test.tsx
@@ -625,6 +625,23 @@ describe("useRecipeRunner — suggestions", () => {
 
     expect(result.current.suggestions).toEqual([]);
   });
+
+  it("matches the keyword in either the name or the command field", () => {
+    projectSettingsState.allDetectedRunners = [
+      // keyword only in name
+      makeRunCommand({ id: "1", name: "dev", command: "vite" }),
+      // keyword only in command
+      makeRunCommand({ id: "2", name: "watch", command: "npm run dev" }),
+      // neither field matches
+      makeRunCommand({ id: "3", name: "lint", command: "eslint ." }),
+    ];
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    expect(result.current.suggestions.map((s) => s.id)).toEqual(["1", "2"]);
+  });
 });
 
 describe("useRecipeRunner — handleRunSuggestion", () => {
@@ -718,5 +735,47 @@ describe("useRecipeRunner — handleRunSuggestion", () => {
 
     expect(addPanelMock).toHaveBeenCalledTimes(2);
     expect(logErrorMock).toHaveBeenCalledWith("Suggestion run failed", expect.any(Error));
+  });
+
+  it("logs and releases the guard when addPanel resolves null (panel rejected)", async () => {
+    const suggestion = makeRunCommand({ id: "s-dev", name: "dev", command: "npm run dev" });
+    addPanelMock.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/repo" })
+    );
+
+    act(() => {
+      result.current.handleRunSuggestion(suggestion);
+    });
+    await flush();
+
+    expect(logErrorMock).toHaveBeenCalledWith(
+      "Suggestion run rejected by panel store",
+      "npm run dev"
+    );
+
+    // Guard released — a follow-up click fires.
+    addPanelMock.mockResolvedValueOnce("panel-2");
+    act(() => {
+      result.current.handleRunSuggestion(suggestion);
+    });
+    await flush();
+    expect(addPanelMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes worktreeId: undefined to addPanel when activeWorktreeId is null", async () => {
+    const suggestion = makeRunCommand({ id: "s-dev", name: "dev", command: "npm run dev" });
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: null, defaultCwd: "/repo" })
+    );
+
+    act(() => {
+      result.current.handleRunSuggestion(suggestion);
+    });
+    await flush();
+
+    expect(addPanelMock).toHaveBeenCalledTimes(1);
+    expect(addPanelMock.mock.calls[0]?.[0]).toMatchObject({ worktreeId: undefined });
   });
 });

--- a/src/components/Terminal/RecipeRunner/useRecipeRunner.ts
+++ b/src/components/Terminal/RecipeRunner/useRecipeRunner.ts
@@ -414,7 +414,7 @@ export function useRecipeRunner({
 
       void (async () => {
         try {
-          await addPanel({
+          const id = await addPanel({
             kind: "terminal",
             title: suggestion.name,
             cwd: defaultCwd,
@@ -423,6 +423,12 @@ export function useRecipeRunner({
             worktreeId: activeWorktreeId ?? undefined,
             spawnedBy: "quickrun",
           });
+          // addPanel resolves null when the panel is rejected (panel limit,
+          // policy gate, cancelled confirmation). Log so a silent click on a
+          // first-run discovery surface leaves a diagnostic trail.
+          if (id === null) {
+            logError("Suggestion run rejected by panel store", suggestion.command);
+          }
         } catch (error) {
           // Unhandled rejection crashes Electron 41 utility processes.
           logError("Suggestion run failed", error);

--- a/src/components/Terminal/RecipeRunner/useRecipeRunner.ts
+++ b/src/components/Terminal/RecipeRunner/useRecipeRunner.ts
@@ -6,6 +6,7 @@ import {
 } from "@/store/recipeStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import { usePanelStore } from "@/store/panelStore";
 import { actionService } from "@/services/ActionService";
 import { detectUnresolvedVariables, type RecipeContext } from "@/utils/recipeVariables";
 import { getAgentConfig } from "@/config/agents";
@@ -52,6 +53,7 @@ export interface UseRecipeRunnerResult {
   handleUnpin: (recipeId: string) => void;
   handleDelete: (recipeId: string) => void;
   handleCreate: () => void;
+  handleRunSuggestion: (suggestion: RunCommand) => void;
   handleRetryFailed: () => void;
   dismissSpawnFailures: () => void;
   dismissUnresolvedVars: () => void;
@@ -101,6 +103,7 @@ export function useRecipeRunner({
   const getRecipeById = useRecipeStore((s) => s.getRecipeById);
 
   const allDetectedRunners = useProjectSettingsStore((s) => s.allDetectedRunners);
+  const addPanel = usePanelStore((s) => s.addPanel);
 
   const [searchQuery, setSearchQuery] = useState("");
   const [focusedIndex, setFocusedIndex] = useState(0);
@@ -109,6 +112,7 @@ export function useRecipeRunner({
   const [isRetryingFailed, setIsRetryingFailed] = useState(false);
 
   const isRunningRef = useRef(false);
+  const isSpawningSuggestionRef = useRef(false);
   const lastRunRecipeIdRef = useRef<string | null>(null);
   // Generation counter: every run/retry captures the current value, then any
   // resolved async work checks the latest value before calling setState. If a
@@ -170,14 +174,18 @@ export function useRecipeRunner({
     return undefined;
   }, [focusedIndex, getFlatRecipes]);
 
-  // Suggestions from package.json
+  // Suggestions from package.json. Capped at 2 so the empty state stays a
+  // launchpad ("here's the obvious next click") rather than a gallery — the
+  // user can browse the full set after creating a recipe.
   const suggestions = useMemo(() => {
     const keywords = ["dev", "start", "serve", "test", "build"];
-    return allDetectedRunners.filter((r) =>
-      keywords.some(
-        (kw) => r.command.toLowerCase().includes(kw) || r.name.toLowerCase().includes(kw)
+    return allDetectedRunners
+      .filter((r) =>
+        keywords.some(
+          (kw) => r.command.toLowerCase().includes(kw) || r.name.toLowerCase().includes(kw)
+        )
       )
-    );
+      .slice(0, 2);
   }, [allDetectedRunners]);
 
   const buildContext = useCallback(
@@ -396,6 +404,36 @@ export function useRecipeRunner({
     );
   }, [activeWorktreeId]);
 
+  const handleRunSuggestion = useCallback(
+    (suggestion: RunCommand) => {
+      if (!defaultCwd) return;
+      // Guard with useRef (not useState) — addPanel is async and a state-based
+      // guard would batch and leave a double-fire window. See PR #4703.
+      if (isSpawningSuggestionRef.current) return;
+      isSpawningSuggestionRef.current = true;
+
+      void (async () => {
+        try {
+          await addPanel({
+            kind: "terminal",
+            title: suggestion.name,
+            cwd: defaultCwd,
+            command: suggestion.command,
+            location: "grid",
+            worktreeId: activeWorktreeId ?? undefined,
+            spawnedBy: "quickrun",
+          });
+        } catch (error) {
+          // Unhandled rejection crashes Electron 41 utility processes.
+          logError("Suggestion run failed", error);
+        } finally {
+          isSpawningSuggestionRef.current = false;
+        }
+      })();
+    },
+    [defaultCwd, activeWorktreeId, addPanel]
+  );
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "ArrowDown") {
@@ -456,6 +494,7 @@ export function useRecipeRunner({
     handleUnpin,
     handleDelete,
     handleCreate,
+    handleRunSuggestion,
     handleRetryFailed,
     dismissSpawnFailures,
     dismissUnresolvedVars,


### PR DESCRIPTION
## Summary

- `useRecipeRunner.ts` was already computing a `suggestions` array from detected run commands, but nothing consumed it. This PR wires it up.
- Caps suggestions to 2, renders them as clickable cards in `RecipeRunnerEmpty`, and spawns ad-hoc terminals via the same `addPanel` path `QuickRun` uses.
- Demotes "Create your first recipe" to a secondary action when suggestions are present; falls back to the current copy when nothing is detected.

Resolves #8947

## Changes

- `useRecipeRunner.ts` — `.slice(0, 2)` cap on suggestions; `handleRunSuggestion` with `useRef` reentrancy guard; logs rejection and null returns from `addPanel`
- `RecipeRunnerEmpty.tsx` — suggestion cards styled to match recipe grid items; create button demoted to secondary below the cards
- `RecipeRunner.tsx` — passes `suggestions` and `handleRunSuggestion` down to `RecipeRunnerEmpty`
- Tests — suggestion cap, OR-branch keyword matching, null `cwd` no-op, double-click reentrancy guard, `addPanel` rejection/null, null `activeWorktreeId`, component rendering branches

## Testing

28/28 unit tests pass. All 9 CI checks pass (typecheck, lint ratchet at 1121 baseline, format, channels, ipc, ipc-renderer, ipc-handwritten, help, build).