### PR TITLE
fix(a11y): restore status indicators and toggles in forced-colors mode

### DIFF
--- a/src/components/Worktree/ActivityLight.tsx
+++ b/src/components/Worktree/ActivityLight.tsx
@@ -54,6 +54,7 @@ export function ActivityLight({ lastActivityTimestamp, className }: ActivityLigh
   return (
     <div
       aria-hidden="true"
+      data-activity-active={active ? "true" : "false"}
       className={cn(
         "w-2.5 h-2.5 rounded-full transition-colors duration-1000 ease-linear",
         active ? "" : "border bg-transparent",

--- a/src/components/Worktree/__tests__/ActivityLight.test.tsx
+++ b/src/components/Worktree/__tests__/ActivityLight.test.tsx
@@ -48,6 +48,8 @@ describe("ActivityLight", () => {
     expect(dot.style.backgroundColor).not.toBe("");
     expect(dot.style.borderColor).toBe("");
     expect(dot.className).not.toMatch(/\bborder\b/);
+    // Stable hook the forced-colors CSS repaints the otherwise-stripped fill from.
+    expect(dot.getAttribute("data-activity-active")).toBe("true");
   });
 
   it("renders a hollow ring when idle (elapsed >= DECAY_DURATION)", () => {
@@ -59,6 +61,7 @@ describe("ActivityLight", () => {
     expect(dot.className).toMatch(/\bborder\b/);
     expect(dot.className).toMatch(/bg-transparent/);
     expect(dot.style.borderColor).not.toBe("");
+    expect(dot.getAttribute("data-activity-active")).toBe("false");
   });
 
   it("renders nothing when timestamp is null (never recorded)", () => {
@@ -103,6 +106,7 @@ describe("ActivityLight", () => {
 
     // Starts active (filled).
     expect(getDot(container).className).not.toMatch(/\bborder\b/);
+    expect(getDot(container).getAttribute("data-activity-active")).toBe("true");
 
     // Jump wall-clock past the decay window and let the next scheduled
     // flip fire — the component recomputes from Date.now().
@@ -113,6 +117,7 @@ describe("ActivityLight", () => {
 
     expect(getDot(container).className).toMatch(/\bborder\b/);
     expect(getDot(container).className).toMatch(/bg-transparent/);
+    expect(getDot(container).getAttribute("data-activity-active")).toBe("false");
   });
 
   it("schedules no timer when mounted already idle (past the decay window)", () => {

--- a/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
+++ b/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
+const INDEX_CSS = path.join(REPO_ROOT, "src/index.css");
+const TOOLBAR_CSS = path.join(REPO_ROOT, "src/styles/components/toolbar.css");
+
+// Issue #8936: status indicators (toolbar pips, ActivityLight) and the
+// SettingsSwitch toggle lose all state in forced-colors / Windows High Contrast
+// mode because the UA strips background-color and box-shadow. The fix lives in
+// `@media (forced-colors: active)` blocks using system-color keywords. These
+// rules are invisible to jsdom rendering, so we guard them by asserting their
+// presence (scoped to the forced-colors block) in CSS source — a regression in
+// the cascade would silently re-break HC users otherwise.
+
+function readForcedColorsBlocks(file: string): string {
+  const content = fs.readFileSync(file, "utf8");
+  const blocks: string[] = [];
+  const marker = "@media (forced-colors: active)";
+
+  let searchFrom = 0;
+  for (;;) {
+    const start = content.indexOf(marker, searchFrom);
+    if (start === -1) break;
+
+    // Walk braces from the block's opening `{` to its matching close so we only
+    // assert on rules that actually live inside the forced-colors media query.
+    const open = content.indexOf("{", start);
+    if (open === -1) break;
+    let depth = 0;
+    let end = open;
+    for (let i = open; i < content.length; i++) {
+      if (content[i] === "{") depth++;
+      else if (content[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    blocks.push(content.slice(open, end + 1));
+    searchFrom = end + 1;
+  }
+
+  return blocks.join("\n");
+}
+
+describe("forced-colors status-indicator contract (#8936)", () => {
+  it("index.css repaints the ActivityLight active dot with CanvasText", () => {
+    const block = readForcedColorsBlocks(INDEX_CSS);
+    expect(block).toContain('[data-activity-active="true"]');
+    expect(block).toMatch(/\[data-activity-active="true"\]\s*\{[^}]*CanvasText/);
+  });
+
+  it("index.css gives the checked SettingsSwitch track a Highlight fill", () => {
+    const block = readForcedColorsBlocks(INDEX_CSS);
+    expect(block).toContain('[role="switch"][data-state="checked"]');
+    expect(block).toMatch(/\[role="switch"\]\[data-state="checked"\]\s*\{[^}]*Highlight/);
+  });
+
+  it("index.css contrasts the switch thumb in both states", () => {
+    const block = readForcedColorsBlocks(INDEX_CSS);
+    expect(block).toMatch(/span\[data-state="checked"\]\s*\{[^}]*HighlightText/);
+    expect(block).toMatch(/span\[data-state="unchecked"\]\s*\{[^}]*ButtonText/);
+  });
+
+  it("toolbar.css repaints badge pips with CanvasText", () => {
+    const block = readForcedColorsBlocks(TOOLBAR_CSS);
+    expect(block).toContain(".toolbar-badge");
+    expect(block).toContain(".toolbar-overflow-badge");
+    expect(block).toContain(".toolbar-problems-badge");
+    expect(block).toContain("CanvasText");
+  });
+
+  it("toolbar.css replaces the stripped overflow ring with an outline", () => {
+    const block = readForcedColorsBlocks(TOOLBAR_CSS);
+    expect(block).toContain('[data-severity="warning"]');
+    expect(block).toContain('[data-severity="info"]');
+    expect(block).toMatch(/outline:\s*1px solid CanvasText/);
+    expect(block).toMatch(/outline-offset:\s*-1px/);
+  });
+});

--- a/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
+++ b/src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts
@@ -50,10 +50,14 @@ function readForcedColorsBlocks(file: string): string {
 }
 
 describe("forced-colors status-indicator contract (#8936)", () => {
-  it("index.css repaints the ActivityLight active dot with CanvasText", () => {
+  it("index.css repaints the ActivityLight active dot with CanvasText !important", () => {
     const block = readForcedColorsBlocks(INDEX_CSS);
     expect(block).toContain('[data-activity-active="true"]');
-    expect(block).toMatch(/\[data-activity-active="true"\]\s*\{[^}]*CanvasText/);
+    // !important is load-bearing: it must beat the inline author background-color
+    // the UA otherwise forces to Canvas. Removing it silently re-breaks the fix.
+    expect(block).toMatch(
+      /\[data-activity-active="true"\]\s*\{[^}]*background-color:\s*CanvasText[^}]*!important/
+    );
   });
 
   it("index.css gives the checked SettingsSwitch track a Highlight fill", () => {
@@ -68,19 +72,11 @@ describe("forced-colors status-indicator contract (#8936)", () => {
     expect(block).toMatch(/span\[data-state="unchecked"\]\s*\{[^}]*ButtonText/);
   });
 
-  it("toolbar.css repaints badge pips with CanvasText", () => {
+  it("toolbar.css repaints every pip type with CanvasText", () => {
     const block = readForcedColorsBlocks(TOOLBAR_CSS);
-    expect(block).toContain(".toolbar-badge");
-    expect(block).toContain(".toolbar-overflow-badge");
-    expect(block).toContain(".toolbar-problems-badge");
-    expect(block).toContain("CanvasText");
-  });
-
-  it("toolbar.css replaces the stripped overflow ring with an outline", () => {
-    const block = readForcedColorsBlocks(TOOLBAR_CSS);
-    expect(block).toContain('[data-severity="warning"]');
-    expect(block).toContain('[data-severity="info"]');
-    expect(block).toMatch(/outline:\s*1px solid CanvasText/);
-    expect(block).toMatch(/outline-offset:\s*-1px/);
+    // All pip selectors must share a rule whose body sets background-color.
+    expect(block).toMatch(
+      /\.toolbar-badge\b[\s\S]*\.toolbar-badge-chip\b[\s\S]*\.toolbar-overflow-badge\b[\s\S]*\.toolbar-problems-badge\b\s*\{[^}]*background-color:\s*CanvasText/
+    );
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -2654,6 +2654,33 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
   textarea {
     border: 1px solid FieldText;
   }
+
+  /* ActivityLight: the active state paints via an inline background-color the
+     UA forces to Canvas (invisible), while the idle ring's border survives as
+     ButtonText — inverting the meaning. Repaint the active dot with CanvasText.
+     !important is required to beat the inline author style under forced colors;
+     this is the only place in this block that needs it. */
+  [data-activity-active="true"] {
+    background-color: CanvasText !important;
+  }
+
+  /* SettingsSwitch (Radix Switch). The track's unchecked border is already
+     covered by the global button/[role="button"] rule above. Add the checked
+     fill plus thumb contrast so on/off is distinguishable beyond thumb position.
+     Scoped to a [data-state] parent so the two non-Radix custom role="switch"
+     buttons (plain <span> children, no data-state) are not matched. */
+  [role="switch"][data-state="checked"] {
+    background-color: Highlight;
+    border-color: Highlight;
+  }
+
+  [role="switch"][data-state] span[data-state="checked"] {
+    background-color: HighlightText;
+  }
+
+  [role="switch"][data-state] span[data-state="unchecked"] {
+    background-color: ButtonText;
+  }
 }
 
 /* Increased contrast mode — heavier borders for visibility.

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -416,3 +416,24 @@ html[data-shortcut-reveal] .shortcut-reveal-chip {
     border: 2px solid ButtonText;
   }
 }
+
+/* ── Forced colors / Windows High Contrast ──
+ * Every pip paints state via background-color, which the UA forces to Canvas
+ * (invisible). Repaint with CanvasText so the dot stays visible; shape tiers
+ * (border-radius) already survive and keep carrying the non-color WCAG 1.4.1
+ * cue. The overflow ring uses box-shadow, which is stripped entirely — swap it
+ * for an inset outline so warning/info still read as ringed. */
+@media (forced-colors: active) {
+  .toolbar-badge,
+  .toolbar-overflow-badge,
+  .toolbar-problems-badge {
+    background-color: CanvasText;
+  }
+
+  .toolbar-overflow-badge[data-severity="warning"],
+  .toolbar-overflow-badge[data-severity="info"] {
+    box-shadow: none;
+    outline: 1px solid CanvasText;
+    outline-offset: -1px;
+  }
+}

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -418,22 +418,19 @@ html[data-shortcut-reveal] .shortcut-reveal-chip {
 }
 
 /* ── Forced colors / Windows High Contrast ──
- * Every pip paints state via background-color, which the UA forces to Canvas
- * (invisible). Repaint with CanvasText so the dot stays visible; shape tiers
- * (border-radius) already survive and keep carrying the non-color WCAG 1.4.1
- * cue. The overflow ring uses box-shadow, which is stripped entirely — swap it
- * for an inset outline so warning/info still read as ringed. */
+ * Every pip — including the GitHub activity corner chips — paints state via
+ * background-color, which the UA forces to Canvas (invisible). Repaint with
+ * CanvasText so the dot stays visible. The overflow severity ring (box-shadow)
+ * is stripped, but it only carved a background-colored moat to separate the pip
+ * from overlapping chrome; against the high-contrast Canvas/CanvasText palette
+ * the filled pip already separates cleanly, so no replacement is needed. The
+ * per-severity shape tiers (border-radius — not a color property) survive and
+ * remain the non-color WCAG 1.4.1 cue. */
 @media (forced-colors: active) {
   .toolbar-badge,
+  .toolbar-badge-chip,
   .toolbar-overflow-badge,
   .toolbar-problems-badge {
     background-color: CanvasText;
-  }
-
-  .toolbar-overflow-badge[data-severity="warning"],
-  .toolbar-overflow-badge[data-severity="info"] {
-    box-shadow: none;
-    outline: 1px solid CanvasText;
-    outline-offset: -1px;
   }
 }


### PR DESCRIPTION
## Summary

In Windows High Contrast / forced-colors mode the UA strips `background-color`, `border-color`, and `box-shadow`, which made three families of UI elements invisible or semantically inverted. This adds `@media (forced-colors: active)` fallbacks using CSS system-color keywords — no `forced-color-adjust: none`, no inline-style changes, no new dependencies.

Resolves #8936

## Changes

- **Toolbar badge pips** (`src/styles/components/toolbar.css`) — `.toolbar-badge`, `.toolbar-badge-chip`, `.toolbar-overflow-badge`, `.toolbar-problems-badge` repainted with `CanvasText`. Per-severity border-radius tiers already survive as the WCAG 1.4.1 non-color cue; the stripped `box-shadow` ring doesn't need replacing.
- **`ActivityLight`** (`src/components/Worktree/ActivityLight.tsx` + `src/index.css`) — added a stable `data-activity-active` hook; the active dot's inline `background-color` (forced to `Canvas` by the UA, inverting it against the idle `ButtonText` ring) is repainted with `CanvasText !important`. The 1000ms semantic decay transition is untouched.
- **`SettingsSwitch`** (`src/index.css`) — checked track gets a `Highlight` fill; the Radix thumb gets `HighlightText` (checked) / `ButtonText` (unchecked). Thumb selector scoped to `[role=switch][data-state]` so the two non-Radix custom switches aren't matched. Asymmetric transitions untouched.

## Testing

- Extended `ActivityLight.test.tsx` with `data-activity-active` assertions.
- New `src/config/__tests__/forcedColorsStatusIndicators.contract.test.ts` — brace-scoped scan of the forced-colors blocks for required selectors and system-color keywords, including a load-bearing `!important` check.
- `vitest` passes (20 tests). Full `npm run check` suite (typecheck, lint ratchet, format, IPC codegen) passes.

Note: forced-colors rendering can't be asserted in jsdom — the contract test guards the CSS source. Manual or Playwright forced-colors emulation is the true acceptance path.