### PR TITLE
fix(toolbar): close shortcut discoverability gaps

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils";
 import { getBrandColorHex } from "@/lib/colorUtils";
 import { BrandMark } from "@/components/icons";
 import { getAgentConfig, getMergedPresets } from "@/config/agents";
-import { useAriaKeyshortcuts, useKeybindingDisplay } from "@/hooks";
+import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { actionService } from "@/services/ActionService";
@@ -155,6 +155,7 @@ export function AgentButton({
   const { worktrees } = useWorktrees();
   const displayCombo = useKeybindingDisplay(`agent.${type}`);
   const ariaShortcut = useAriaKeyshortcuts(`agent.${type}`);
+  const hover = useShortcutHintHover(`agent.${type}`);
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
   const ccrPresets = useCcrPresetsStore((s) => s.ccrPresetsByAgent[type]);
@@ -369,7 +370,14 @@ export function AgentButton({
                   onClick={handleClick}
                   aria-disabled={isLoading || undefined}
                   data-toolbar-item={dataToolbarItem}
-                  onPointerEnter={clearFocusRestoreSuppression}
+                  onPointerEnter={(e) => {
+                    clearFocusRestoreSuppression();
+                    hover.onPointerEnter(e);
+                  }}
+                  onPointerLeave={hover.onPointerLeave}
+                  onPointerDown={hover.onPointerDown}
+                  onFocus={hover.onFocus}
+                  onBlur={hover.onBlur}
                   className={cn(
                     "toolbar-agent-button text-daintree-text relative",
                     needsSetup && "opacity-70",
@@ -447,7 +455,14 @@ export function AgentButton({
                 onClick={handleClick}
                 aria-disabled={isLoading || undefined}
                 data-toolbar-item={dataToolbarItem}
-                onPointerEnter={clearFocusRestoreSuppression}
+                onPointerEnter={(e) => {
+                  clearFocusRestoreSuppression();
+                  hover.onPointerEnter(e);
+                }}
+                onPointerLeave={hover.onPointerLeave}
+                onPointerDown={hover.onPointerDown}
+                onFocus={hover.onFocus}
+                onBlur={hover.onBlur}
                 className={cn(
                   "toolbar-agent-button text-daintree-text rounded-r-none border-r border-transparent relative",
                   needsSetup && "opacity-70",

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -141,7 +141,8 @@ export function PluginToolbarButton({
   config: NonNullable<ReturnType<ReturnType<typeof usePluginToolbarButtons>["configs"]["get"]>>;
   "data-toolbar-item"?: string;
 }) {
-  const hover = useShortcutHintHover(config.actionId as string);
+  const hover = useShortcutHintHover(config.actionId);
+  const ariaShortcut = useAriaKeyshortcuts(config.actionId);
   const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   return (
@@ -163,6 +164,7 @@ export function PluginToolbarButton({
               }}
               className={toolbarIconButtonClass}
               aria-label={config?.label ?? pluginId}
+              aria-keyshortcuts={ariaShortcut}
             >
               <McpServerIcon />
             </Button>

--- a/src/components/Layout/VoiceRecordingToolbarButton.tsx
+++ b/src/components/Layout/VoiceRecordingToolbarButton.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/context-menu";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import { cn } from "@/lib/utils";
-import { useAriaKeyshortcuts, useKeybindingDisplay } from "@/hooks";
+import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 import { useVoiceRecordingStore } from "@/store/voiceRecordingStore";
@@ -56,6 +56,7 @@ export function VoiceRecordingToolbarButton({
   const audioLevel = useVoiceRecordingStore((state) => state.audioLevel);
   const shortcut = useKeybindingDisplay("voiceInput.toggle");
   const ariaShortcut = useAriaKeyshortcuts("voiceInput.toggle");
+  const hover = useShortcutHintHover("voiceInput.toggle");
   const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   const isConnecting = status === "connecting";
@@ -187,6 +188,7 @@ export function VoiceRecordingToolbarButton({
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              {...hover}
               variant="ghost"
               size="icon"
               data-toolbar-item={dataToolbarItem}

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -109,6 +109,13 @@ vi.mock("@/hooks/useWorktrees", () => ({
 vi.mock("@/hooks", () => ({
   useKeybindingDisplay: () => null,
   useAriaKeyshortcuts: () => undefined,
+  useShortcutHintHover: () => ({
+    onPointerEnter: () => {},
+    onPointerLeave: () => {},
+    onPointerDown: () => {},
+    onFocus: () => {},
+    onBlur: () => {},
+  }),
 }));
 
 vi.mock("@/config/agents", () => ({

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -8,6 +8,8 @@ const PORTAL_BUTTON_PATH = path.resolve(__dirname, "../ToolbarPortalButton.tsx")
 const SETTINGS_BUTTON_PATH = path.resolve(__dirname, "../ToolbarSettingsButton.tsx");
 const LAUNCHER_BUTTON_PATH = path.resolve(__dirname, "../ToolbarLauncherButton.tsx");
 const AGENT_BUTTON_PATH = path.resolve(__dirname, "../AgentButton.tsx");
+const VOICE_RECORDING_PATH = path.resolve(__dirname, "../VoiceRecordingToolbarButton.tsx");
+const SHORTCUT_REVEAL_CHIP_PATH = path.resolve(__dirname, "../../ui/ShortcutRevealChip.tsx");
 const TOOLBAR_CSS_PATH = path.resolve(__dirname, "../../../styles/components/toolbar.css");
 
 describe("Toolbar shortcut tooltips — issue #3443", () => {
@@ -17,17 +19,29 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
   let settingsSource: string;
   let launcherSource: string;
   let agentSource: string;
+  let voiceSource: string;
+  let chipSource: string;
 
   beforeEach(async () => {
-    [source, problemsSource, portalSource, settingsSource, launcherSource, agentSource] =
-      await Promise.all([
-        fs.readFile(TOOLBAR_PATH, "utf-8"),
-        fs.readFile(PROBLEMS_BUTTON_PATH, "utf-8"),
-        fs.readFile(PORTAL_BUTTON_PATH, "utf-8"),
-        fs.readFile(SETTINGS_BUTTON_PATH, "utf-8"),
-        fs.readFile(LAUNCHER_BUTTON_PATH, "utf-8"),
-        fs.readFile(AGENT_BUTTON_PATH, "utf-8"),
-      ]);
+    [
+      source,
+      problemsSource,
+      portalSource,
+      settingsSource,
+      launcherSource,
+      agentSource,
+      voiceSource,
+      chipSource,
+    ] = await Promise.all([
+      fs.readFile(TOOLBAR_PATH, "utf-8"),
+      fs.readFile(PROBLEMS_BUTTON_PATH, "utf-8"),
+      fs.readFile(PORTAL_BUTTON_PATH, "utf-8"),
+      fs.readFile(SETTINGS_BUTTON_PATH, "utf-8"),
+      fs.readFile(LAUNCHER_BUTTON_PATH, "utf-8"),
+      fs.readFile(AGENT_BUTTON_PATH, "utf-8"),
+      fs.readFile(VOICE_RECORDING_PATH, "utf-8"),
+      fs.readFile(SHORTCUT_REVEAL_CHIP_PATH, "utf-8"),
+    ]);
   });
 
   describe("useKeybindingDisplay hooks", () => {
@@ -246,6 +260,79 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
 
     it("settingsShortcut is in ToolbarSettingsButton", () => {
       expect(settingsSource).toContain('useKeybindingDisplay("app.settings")');
+    });
+  });
+
+  describe("ShortcutRevealChip global gate removed — issue #8938", () => {
+    it("does not gate chip rendering behind a RENDER_CHIPS flag", () => {
+      expect(chipSource).not.toContain("RENDER_CHIPS");
+    });
+
+    it("returns null only when the keybinding display is empty", () => {
+      expect(chipSource).toContain("if (!display) return null;");
+    });
+  });
+
+  describe("PluginToolbarButton aria-keyshortcuts — issue #8938", () => {
+    it("calls useAriaKeyshortcuts with the plugin actionId", () => {
+      expect(source).toContain("useAriaKeyshortcuts(config.actionId)");
+    });
+
+    it("renders aria-keyshortcuts on the plugin Button", () => {
+      // Other aria-keyshortcuts spreads in Toolbar.tsx use named locals
+      // (sidebarAriaShortcut, copyTreeAriaShortcut). Only PluginToolbarButton
+      // uses the plain `ariaShortcut` identifier, so this assertion is
+      // unambiguous without a function-block carve-out.
+      expect(source).toContain("aria-keyshortcuts={ariaShortcut}");
+    });
+
+    it("drops the redundant `as string` cast on the hover hook", () => {
+      expect(source).not.toContain("useShortcutHintHover(config.actionId as string)");
+    });
+  });
+
+  describe("VoiceRecordingToolbarButton hint-hover — issue #8938", () => {
+    it("imports useShortcutHintHover", () => {
+      expect(voiceSource).toContain("useShortcutHintHover");
+    });
+
+    it("calls useShortcutHintHover with the voice-input actionId", () => {
+      expect(voiceSource).toContain('useShortcutHintHover("voiceInput.toggle")');
+    });
+
+    it("spreads hover handlers onto the Button", () => {
+      expect(voiceSource).toContain("{...hover}");
+    });
+  });
+
+  describe("AgentButton hint-hover — issue #8938", () => {
+    it("calls useShortcutHintHover keyed off the agent type", () => {
+      expect(agentSource).toContain("useShortcutHintHover(`agent.${type}`)");
+    });
+
+    it("composes hover.onPointerEnter alongside clearFocusRestoreSuppression", () => {
+      const composed = agentSource.match(
+        /onPointerEnter=\{\(e\) => \{\s*clearFocusRestoreSuppression\(\);\s*hover\.onPointerEnter\(e\);\s*\}\}/g
+      );
+      expect(composed).not.toBeNull();
+      expect(composed!.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("wires the remaining hover handlers explicitly on the primary Button(s)", () => {
+      const leaveMatches = agentSource.match(/onPointerLeave=\{hover\.onPointerLeave\}/g) ?? [];
+      const downMatches = agentSource.match(/onPointerDown=\{hover\.onPointerDown\}/g) ?? [];
+      const focusMatches = agentSource.match(/onFocus=\{hover\.onFocus\}/g) ?? [];
+      const blurMatches = agentSource.match(/onBlur=\{hover\.onBlur\}/g) ?? [];
+      expect(leaveMatches.length).toBeGreaterThanOrEqual(2);
+      expect(downMatches.length).toBeGreaterThanOrEqual(2);
+      expect(focusMatches.length).toBeGreaterThanOrEqual(2);
+      expect(blurMatches.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("leaves the chevron DropdownMenuTrigger Button without hover hint wiring", () => {
+      // Chevron has no ShortcutRevealChip, so it must keep the lone
+      // onPointerEnter={clearFocusRestoreSuppression} form (no hover spread).
+      expect(agentSource).toContain("onPointerEnter={clearFocusRestoreSuppression}");
     });
   });
 });

--- a/src/components/ui/ShortcutRevealChip.tsx
+++ b/src/components/ui/ShortcutRevealChip.tsx
@@ -4,14 +4,8 @@ interface ShortcutRevealChipProps {
   actionId: string;
 }
 
-// TEMPORARY (README screenshots): chip rendering disabled so Cmd+Shift+4
-// screenshots don't capture the keyboard-hint overlay. Revert this stub by
-// removing the early `return null` below once the README captures are done.
-const RENDER_CHIPS = false;
-
 export function ShortcutRevealChip({ actionId }: ShortcutRevealChipProps) {
   const display = useKeybindingDisplay(actionId);
-  if (!RENDER_CHIPS) return null;
   if (!display) return null;
   return (
     <span aria-hidden="true" className="shortcut-reveal-chip">

--- a/src/components/ui/__tests__/ShortcutRevealChip.test.tsx
+++ b/src/components/ui/__tests__/ShortcutRevealChip.test.tsx
@@ -10,8 +10,7 @@ vi.mock("@/hooks", () => ({
 
 import { ShortcutRevealChip } from "../ShortcutRevealChip";
 
-// Skipped while RENDER_CHIPS=false in ShortcutRevealChip.tsx (README screenshot toggle). Revert with the component stub.
-describe.skip("ShortcutRevealChip", () => {
+describe("ShortcutRevealChip", () => {
   it("renders nothing when display is empty", () => {
     displayMock.mockReturnValue("");
     const { container } = render(<ShortcutRevealChip actionId="x.y" />);


### PR DESCRIPTION
## Summary

- Removes the `RENDER_CHIPS=false` gate from `ShortcutRevealChip` — this was a temporary flag added for README screenshots that was accidentally left in, silently killing the held-modifier shortcut discovery path for the entire toolbar.
- Adds `useShortcutHintHover` to `VoiceRecordingToolbarButton` and `AgentButton` so keyboard users tabbing to those buttons get the same visual shortcut hint every other toolbar button already shows.
- Adds `useAriaKeyshortcuts` + `aria-keyshortcuts` to `PluginToolbarButton`, which had the visual hover hint but was missing the screen-reader side of the contract.

Resolves #8938

## Changes

- `src/components/ui/ShortcutRevealChip.tsx` — remove `RENDER_CHIPS` gate, unskip test suite
- `src/components/Layout/VoiceRecordingToolbarButton.tsx` — add `useShortcutHintHover`
- `src/components/Layout/AgentButton.tsx` — add `useShortcutHintHover`
- `src/components/Layout/Toolbar.tsx` — add `useAriaKeyshortcuts` + `aria-keyshortcuts` to `PluginToolbarButton`
- `src/components/Layout/__tests__/Toolbar.shortcuts.test.ts` — source-scan coverage for all four fixes

## Testing

55 tests pass across the targeted suites (`Toolbar.shortcuts`, `ShortcutRevealChip`). All four gaps have corresponding test coverage — chip rendering, hover hint presence on Voice and Agent buttons, and `aria-keyshortcuts` on the plugin button.