### PR TITLE
fix(github-rate-limit): proactively clear REST blocks via timer

### DIFF
--- a/plugins/builtin/github/main/GitHubRateLimitService.ts
+++ b/plugins/builtin/github/main/GitHubRateLimitService.ts
@@ -153,6 +153,10 @@ class GitHubRateLimitServiceImpl {
   // One-shot timer that sweeps stale budget state just after the window
   // resets, so a stretched cadence doesn't defer throttle recovery.
   private _budgetResetTimer: ReturnType<typeof setTimeout> | null = null;
+  // One-shot timer that sweeps the soonest-expiring REST/secondary block.
+  // Without it, a renderer that short-circuits while blocked never triggers
+  // the lazy `autoClearExpired` poll, so the block lingers until app restart.
+  private _blockResetTimer: ReturnType<typeof setTimeout> | null = null;
 
   /**
    * Register a subscriber that fires on every state transition (entering a
@@ -426,6 +430,36 @@ class GitHubRateLimitServiceImpl {
     }
   }
 
+  /**
+   * Arm a one-shot timer that runs {@link autoClearExpired} just after the
+   * soonest active block's `resumeAt`. Re-arms itself from the callback so
+   * stacked blocks across multiple resources each clear on time even when
+   * the renderer's blocked-state short-circuit suppresses lazy sweeps.
+   */
+  private scheduleBlockResetSweep(): void {
+    this.clearBlockResetTimer();
+    if (this.states.size === 0) return;
+    let minResumeAt = Number.POSITIVE_INFINITY;
+    for (const state of this.states.values()) {
+      if (state.resumeAt < minResumeAt) minResumeAt = state.resumeAt;
+    }
+    const delay = Math.max(0, minResumeAt - Date.now());
+    const timer = setTimeout(() => {
+      this._blockResetTimer = null;
+      this.autoClearExpired();
+      this.scheduleBlockResetSweep();
+    }, delay);
+    timer.unref?.();
+    this._blockResetTimer = timer;
+  }
+
+  private clearBlockResetTimer(): void {
+    if (this._blockResetTimer) {
+      clearTimeout(this._blockResetTimer);
+      this._blockResetTimer = null;
+    }
+  }
+
   /** Snapshot for push/pull consumers. Collapses multi-resource state to a single payload. */
   getState(): GitHubRateLimitPayload {
     this.autoClearExpired();
@@ -483,6 +517,7 @@ class GitHubRateLimitServiceImpl {
     this._lastNotifiedMultiplier = 1;
     this._hasNotifiedBudget = false;
     this.clearBudgetResetTimer();
+    this.clearBlockResetTimer();
     if (this.states.size === 0) {
       // Still surface the cleared budget so consumers snap back to baseline.
       if (hadBudget) this.notifyListeners();
@@ -501,6 +536,7 @@ class GitHubRateLimitServiceImpl {
     this._lastNotifiedMultiplier = 1;
     this._hasNotifiedBudget = false;
     this.clearBudgetResetTimer();
+    this.clearBlockResetTimer();
   }
 
   /** Test-only inspector. */
@@ -518,6 +554,7 @@ class GitHubRateLimitServiceImpl {
     this.states.delete(resource);
     logInfo("GitHub rate limit cleared for resource", { resource });
     this.notifyListeners();
+    this.scheduleBlockResetSweep();
   }
 
   private markBlocked(
@@ -548,6 +585,7 @@ class GitHubRateLimitServiceImpl {
     } else {
       logDebug("GitHub rate limit refreshed", { kind, resumeAt, resource });
     }
+    this.scheduleBlockResetSweep();
   }
 
   private autoClearExpired(): void {

--- a/plugins/builtin/github/main/GitHubRateLimitService.ts
+++ b/plugins/builtin/github/main/GitHubRateLimitService.ts
@@ -443,7 +443,9 @@ class GitHubRateLimitServiceImpl {
     for (const state of this.states.values()) {
       if (state.resumeAt < minResumeAt) minResumeAt = state.resumeAt;
     }
-    const delay = Math.max(0, minResumeAt - Date.now());
+    // Cap at the Node setTimeout int32 ceiling — without this a malformed
+    // far-future resumeAt wraps to a 1ms delay and the self-rearm spins.
+    const delay = Math.min(Math.max(0, minResumeAt - Date.now()), 2_147_483_647);
     const timer = setTimeout(() => {
       this._blockResetTimer = null;
       this.autoClearExpired();

--- a/plugins/builtin/github/main/__tests__/GitHubRateLimitService.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubRateLimitService.test.ts
@@ -148,6 +148,122 @@ describe("GitHubRateLimitService", () => {
     });
   });
 
+  describe("proactive block expiry timer", () => {
+    it("clears the block on its own when the reset elapses without any lazy call", () => {
+      vi.useFakeTimers();
+      try {
+        const resetSeconds = Math.floor(Date.now() / 1000) + 60;
+        gitHubRateLimitService.update(
+          makeHeaders({
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(resetSeconds),
+            "x-ratelimit-resource": "core",
+          }),
+          200
+        );
+        listener.mockClear();
+
+        vi.advanceTimersByTime(60_000 + 7_500);
+
+        expect(listener).toHaveBeenCalledWith(
+          expect.objectContaining({ blocked: false, kind: null })
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("re-arms to the next-soonest expiry after the first block clears", () => {
+      vi.useFakeTimers();
+      try {
+        const nowSec = Math.floor(Date.now() / 1000);
+        gitHubRateLimitService.update(
+          makeHeaders({
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(nowSec + 60),
+            "x-ratelimit-resource": "core",
+          }),
+          200
+        );
+        gitHubRateLimitService.update(
+          makeHeaders({
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(nowSec + 600),
+            "x-ratelimit-resource": "graphql",
+          }),
+          200
+        );
+        listener.mockClear();
+
+        vi.advanceTimersByTime(60_000 + 7_500);
+
+        expect(gitHubRateLimitService.shouldBlockRequest("core").blocked).toBe(false);
+        expect(gitHubRateLimitService.shouldBlockRequest("graphql").blocked).toBe(true);
+
+        listener.mockClear();
+        vi.advanceTimersByTime(540_000);
+
+        expect(gitHubRateLimitService.shouldBlockRequest("graphql").blocked).toBe(false);
+        expect(listener).toHaveBeenCalledWith(
+          expect.objectContaining({ blocked: false, kind: null })
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not fire stale callbacks after clear()", () => {
+      vi.useFakeTimers();
+      try {
+        gitHubRateLimitService.update(
+          makeHeaders({
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 60),
+            "x-ratelimit-resource": "core",
+          }),
+          200
+        );
+        gitHubRateLimitService.clear();
+        listener.mockClear();
+
+        vi.advanceTimersByTime(120_000);
+
+        expect(listener).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("a later block does not delay an earlier block's timer", () => {
+      vi.useFakeTimers();
+      try {
+        const nowSec = Math.floor(Date.now() / 1000);
+        gitHubRateLimitService.update(
+          makeHeaders({
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(nowSec + 60),
+            "x-ratelimit-resource": "core",
+          }),
+          200
+        );
+        gitHubRateLimitService.update(
+          makeHeaders({
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(nowSec + 600),
+            "x-ratelimit-resource": "graphql",
+          }),
+          200
+        );
+
+        vi.advanceTimersByTime(60_000 + 7_500);
+
+        expect(gitHubRateLimitService.shouldBlockRequest("core").blocked).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("onStateChange listeners", () => {
     it("notifies on transition into blocked state", () => {
       gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);

--- a/plugins/builtin/github/main/__tests__/GitHubRateLimitService.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubRateLimitService.test.ts
@@ -234,6 +234,94 @@ describe("GitHubRateLimitService", () => {
       }
     });
 
+    it("re-arms to an earlier time when the same resource is re-blocked sooner", () => {
+      vi.useFakeTimers();
+      try {
+        const nowSec = Math.floor(Date.now() / 1000);
+        gitHubRateLimitService.update(
+          makeHeaders({
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(nowSec + 600),
+            "x-ratelimit-resource": "core",
+          }),
+          200
+        );
+        gitHubRateLimitService.update(
+          makeHeaders({
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(nowSec + 60),
+            "x-ratelimit-resource": "core",
+          }),
+          200
+        );
+
+        vi.advanceTimersByTime(60_000 + 7_500);
+
+        expect(gitHubRateLimitService.shouldBlockRequest("core").blocked).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not clear early when the same resource is re-blocked later", () => {
+      vi.useFakeTimers();
+      try {
+        const nowSec = Math.floor(Date.now() / 1000);
+        gitHubRateLimitService.update(
+          makeHeaders({
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(nowSec + 60),
+            "x-ratelimit-resource": "core",
+          }),
+          200
+        );
+        gitHubRateLimitService.update(
+          makeHeaders({
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(nowSec + 600),
+            "x-ratelimit-resource": "core",
+          }),
+          200
+        );
+
+        vi.advanceTimersByTime(60_000 + 7_500);
+
+        expect(gitHubRateLimitService.shouldBlockRequest("core").blocked).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("clearResource() cancels the pending block timer", () => {
+      vi.useFakeTimers();
+      try {
+        const nowSec = Math.floor(Date.now() / 1000);
+        gitHubRateLimitService.update(
+          makeHeaders({
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(nowSec + 60),
+            "x-ratelimit-resource": "core",
+          }),
+          200
+        );
+        gitHubRateLimitService.update(
+          makeHeaders({
+            "x-ratelimit-remaining": "4999",
+            "x-ratelimit-reset": String(nowSec + 3600),
+            "x-ratelimit-resource": "core",
+          }),
+          200
+        );
+        listener.mockClear();
+
+        vi.advanceTimersByTime(120_000);
+
+        expect(listener).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("a later block does not delay an earlier block's timer", () => {
       vi.useFakeTimers();
       try {


### PR DESCRIPTION
## Summary

- The GitHub rate-limit blocked indicator was sticking around indefinitely after the reset window passed, only clearing on app restart
- Root cause: REST blocks raised by `update()` had no recovery timer, so `autoClearExpired()` never fired and the block lived in the store until the process restarted
- Fix: `markBlocked()` now schedules a per-resource timer that fires when `resumeAt` passes, calling `clearResource()` proactively; `clearResource()` cancels the timer to prevent double-clear

Resolves #8974

## Changes

- `GitHubRateLimitService.markBlocked()` — arms a `setTimeout` keyed per resource using the `resumeAt` delta; clears on expiry
- `GitHubRateLimitService.clearResource()` — cancels the pending timer if one exists before clearing state
- New tests: re-block after clear resets the timer correctly; calling `clearResource()` before expiry cancels the timer

## Testing

60 unit tests pass. New cases cover the same-resource re-block path (timer reset) and the `clearResource()` cancellation path (no double-clear after manual clear).