### PR TITLE
fix(dev-preview): stop dev server on background, matching trash behavior

### DIFF
--- a/src/store/slices/panelRegistry/__tests__/devPreviewLifecycle.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/devPreviewLifecycle.test.ts
@@ -220,4 +220,66 @@ describe("dev-preview lifecycle integration", () => {
     expect(mockStopByPanel).toHaveBeenCalledWith({ panelId: "dev-panel-b" });
     expect(mockStopByPanel).toHaveBeenCalledTimes(2);
   });
+
+  it("stops dev-preview runtime when panel is backgrounded", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "dev-panel-bg": {
+          id: "dev-panel-bg",
+          kind: "dev-preview",
+          title: "Dev Preview",
+          cwd: "/repo",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+          devCommand: "npm run dev",
+        },
+      },
+      panelIds: ["dev-panel-bg"],
+    });
+
+    usePanelStore.getState().backgroundTerminal("dev-panel-bg");
+
+    expect(mockStopByPanel).toHaveBeenCalledWith({ panelId: "dev-panel-bg" });
+  });
+
+  it("stops dev-preview runtimes when backgrounding a panel group", () => {
+    const group: TabGroup = {
+      id: "group-bg-dev-preview",
+      panelIds: ["dev-panel-bg-1", "term-bg-1"],
+      activeTabId: "dev-panel-bg-1",
+      location: "grid",
+    };
+
+    usePanelStore.setState({
+      panelsById: {
+        "dev-panel-bg-1": {
+          id: "dev-panel-bg-1",
+          kind: "dev-preview",
+          title: "Dev Preview",
+          cwd: "/repo",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+          devCommand: "npm run dev",
+        },
+        "term-bg-1": {
+          id: "term-bg-1",
+          kind: "terminal",
+          title: "Terminal",
+          cwd: "/repo",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      },
+      panelIds: ["dev-panel-bg-1", "term-bg-1"],
+      tabGroups: new Map([["group-bg-dev-preview", group]]),
+    });
+
+    usePanelStore.getState().backgroundPanelGroup("dev-panel-bg-1");
+
+    expect(mockStopByPanel).toHaveBeenCalledWith({ panelId: "dev-panel-bg-1" });
+    expect(mockStopByPanel).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/store/slices/panelRegistry/background.ts
+++ b/src/store/slices/panelRegistry/background.ts
@@ -1,5 +1,6 @@
 import type { PanelRegistryStoreApi, PanelRegistrySlice, TerminalInstance } from "./types";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { isDevPreviewPanel } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
@@ -26,7 +27,7 @@ export const createBackgroundActions = (
     if (!terminal) return;
     if (terminal.location === "trash" || terminal.location === "background") return;
 
-    if (terminal.kind === "dev-preview") {
+    if (isDevPreviewPanel(terminal)) {
       stopDevPreviewByPanelId(id);
     }
 
@@ -174,7 +175,7 @@ export const createBackgroundActions = (
 
     for (const bid of bgPanelIds) {
       const terminal = state.panelsById[bid];
-      if (terminal?.kind === "dev-preview") {
+      if (terminal && isDevPreviewPanel(terminal)) {
         stopDevPreviewByPanelId(bid);
         continue;
       }

--- a/src/store/slices/panelRegistry/background.ts
+++ b/src/store/slices/panelRegistry/background.ts
@@ -5,6 +5,7 @@ import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { transferBetweenWorktreeIndex } from "./worktreeIndex";
+import { stopDevPreviewByPanelId } from "./helpers";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
@@ -24,6 +25,10 @@ export const createBackgroundActions = (
     const terminal = get().panelsById[id];
     if (!terminal) return;
     if (terminal.location === "trash" || terminal.location === "background") return;
+
+    if (terminal.kind === "dev-preview") {
+      stopDevPreviewByPanelId(id);
+    }
 
     const originalLocation: "dock" | "grid" = terminal.location === "dock" ? "dock" : "grid";
 
@@ -169,6 +174,10 @@ export const createBackgroundActions = (
 
     for (const bid of bgPanelIds) {
       const terminal = state.panelsById[bid];
+      if (terminal?.kind === "dev-preview") {
+        stopDevPreviewByPanelId(bid);
+        continue;
+      }
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
         terminalInstanceService.applyRendererPolicy(bid, TerminalRefreshTier.BACKGROUND);
         // See backgroundTerminal: re-arm hibernation for panels already at


### PR DESCRIPTION
## Summary
- Fixes a subprocess leak where backgrounding a dev-preview panel kept its dev server running indefinitely. Trashing already stopped it; backgrounding now does the same.
- Both the single-panel and group background code paths call `stopDevPreviewByPanelId`.
- Two new tests cover the fix.

Resolves #8963

## Changes
- `src/store/slices/panelRegistry/background.ts` — import and invoke `stopDevPreviewByPanelId` before backgrounding a dev-preview panel in both `backgroundTerminal` and `backgroundPanelGroup`
- `src/store/slices/panelRegistry/__tests__/devPreviewLifecycle.test.ts` — tests for single-panel background stop and group background stop (verifies terminal panels pass through untouched)

## Testing
- `npx vitest run src/store/slices/panelRegistry/__tests__/devPreviewLifecycle.test.ts` passes
- Lint and format pass with no changes