### PR TITLE
feat(hibernation): wire backgrounded panels into hibernation eligibility

### DIFF
--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -94,6 +94,7 @@ const mocks = vi.hoisted(() => {
     resetRenderer: vi.fn(),
     destroy: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     resize: vi.fn(),
     prewarmTerminal: vi.fn(),
     sendPtyResize: vi.fn(),

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     destroy: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     resize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
   },
 }));

--- a/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
@@ -36,6 +36,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     destroy: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     resize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
   },
 }));

--- a/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
@@ -6,6 +6,7 @@ const terminalInstanceServiceMock = vi.hoisted(() => ({
   focus: vi.fn(),
   cleanup: vi.fn(),
   applyRendererPolicy: vi.fn(),
+  onPanelBackgrounded: vi.fn(),
   resetRenderer: vi.fn(),
   hibernate: vi.fn(),
 }));

--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -21,6 +21,13 @@ export interface HibernationManagerDeps extends TerminalListenerInstallDeps {
   openLink: (url: string, id: string, event?: MouseEvent) => void;
   getCwdProvider: (id: string) => (() => string) | undefined;
   onHibernationChanged: (id: string) => void;
+  /**
+   * Live lookup for "has the user explicitly backgrounded this panel?" —
+   * reads the renderer-side `backgroundedTerminals` map. Evaluated at every
+   * eligibility check (never captured into a timer closure) so a restore
+   * between schedule and fire correctly drops the bypass.
+   */
+  getIsBackgrounded: (id: string) => boolean;
 }
 
 export class TerminalHibernationManager {
@@ -39,7 +46,7 @@ export class TerminalHibernationManager {
     // lockstep. The predicate adds a tier check on top; hibernate() itself
     // is permissive about tier because callers (memory-pressure accelerator)
     // may want to force teardown regardless of the renderer-policy tier.
-    if (!this.isSafeToHibernate(managed)) return;
+    if (!this.isSafeToHibernate(managed, id)) return;
 
     logDebug(`[TIS.hibernate] Hibernating terminal ${id}`);
 
@@ -226,12 +233,23 @@ export class TerminalHibernationManager {
    *   either non-existent or at least AGENT_IDLE_SILENCE_MS old. The
    *   "never wrote" case is treated as safe because silence is by
    *   definition infinite if no write has ever been recorded.
+   * - User-backgrounded panels: the silence window is bypassed — the user
+   *   explicitly hid the panel, so an active agent is no objection to
+   *   reclaiming its memory under pressure. The `pendingWrites === 0` burst
+   *   guard still holds unconditionally so we never tear down mid-write.
+   *   Read live via `getIsBackgrounded` so a restore between schedule and
+   *   fire drops the bypass.
    */
-  private isSafeToHibernate(managed: ManagedTerminal, now: number = Date.now()): boolean {
+  private isSafeToHibernate(
+    managed: ManagedTerminal,
+    id: string,
+    now: number = Date.now()
+  ): boolean {
     if (!managed.runtimeAgentId) return true;
     const state = managed.canonicalAgentState;
     if (state === undefined || !ACTIVE_AGENT_STATES.has(state)) return true;
     if ((managed.pendingWrites ?? 0) > 0) return false;
+    if (this.deps.getIsBackgrounded(id)) return true;
     if (managed.lastWriteAt === undefined) return true;
     return now - managed.lastWriteAt >= AGENT_IDLE_SILENCE_MS;
   }
@@ -242,14 +260,17 @@ export class TerminalHibernationManager {
    * (working/waiting/directing) becomes eligible after AGENT_IDLE_SILENCE_MS
    * of output silence so a long-parked agent doesn't permanently strand
    * memory the way the original "active agent → never hibernate" rule did.
+   * A user-backgrounded panel skips that silence window entirely (see
+   * `isSafeToHibernate`).
    */
   isHibernationEligible(
     tier: TerminalRefreshTier,
     managed: ManagedTerminal,
+    id: string,
     now: number = Date.now()
   ): boolean {
     if (tier !== TerminalRefreshTier.BACKGROUND) return false;
-    return this.isSafeToHibernate(managed, now);
+    return this.isSafeToHibernate(managed, id, now);
   }
 
   /**
@@ -281,12 +302,16 @@ export class TerminalHibernationManager {
     // every write, since that would create unbounded deferral. The next
     // write will naturally re-trigger scheduleHibernation via the renderer
     // policy if the tier is still BACKGROUND.
+    // A user-backgrounded panel skips the eligibility re-check entirely and
+    // falls through to the normal hibernation timer — the silence window
+    // does not apply when the user has explicitly hidden the panel.
     if (
       managed.runtimeAgentId &&
       managed.canonicalAgentState !== undefined &&
       ACTIVE_AGENT_STATES.has(managed.canonicalAgentState) &&
       (managed.pendingWrites ?? 0) === 0 &&
-      managed.lastWriteAt !== undefined
+      managed.lastWriteAt !== undefined &&
+      !this.deps.getIsBackgrounded(id)
     ) {
       const now = Date.now();
       const elapsed = now - managed.lastWriteAt;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -152,6 +152,7 @@ class TerminalInstanceService {
       openLink: (url, id, event) => this.linkHandler.openLink(url, id, event),
       getCwdProvider: (id) => this.cwdProviders.get(id),
       onHibernationChanged: (id) => this.notifyHibernationListeners(id),
+      getIsBackgrounded: (id) => usePanelStore.getState().backgroundedTerminals.has(id),
       ...this.makeListenerInstallDeps(),
     });
 

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -2316,6 +2316,27 @@ class TerminalInstanceService {
     }
   }
 
+  /**
+   * Called when the user explicitly backgrounds a panel. A terminal that was
+   * already offscreen at BACKGROUND tier had its hibernation timer armed by
+   * the earlier tier drop — and for a still-active agent inside the silence
+   * window that means a one-shot eligibility re-check that waits out the full
+   * AGENT_IDLE_SILENCE_MS. That re-check predates the backgrounded bypass, so
+   * without this nudge the bypass wouldn't take effect until the window
+   * expired anyway. Cancel the pending timer and reschedule so the bypass
+   * (`getIsBackgrounded` is now true) arms the normal hibernation timer
+   * immediately. Visible panels are skipped — backgrounding unmounts them,
+   * and the resulting detach → setVisible(false) → onTierApplied path arms
+   * the timer with the bypass already in effect.
+   */
+  onPanelBackgrounded(id: string): void {
+    const managed = this.instances.get(id);
+    if (!managed || managed.isHibernated || managed.isVisible) return;
+    if (managed.lastAppliedTier !== TerminalRefreshTier.BACKGROUND) return;
+    this.cancelHibernation(managed);
+    this.scheduleHibernation(id, managed);
+  }
+
   destroy(id: string): void {
     const managed = this.instances.get(id);
     if (!managed) return;

--- a/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
@@ -388,7 +388,13 @@ describe("TerminalHibernationManager adversarial", () => {
 
       vi.advanceTimersByTime(30_000);
 
+      // hibernate() must not have been attempted — assert the teardown side
+      // effects never fired, not just the isHibernated flag (which alone
+      // could pass vacuously if hibernate() was never called for any reason).
       expect(managed.isHibernated).toBe(false);
+      expect(deps.destroyRestoreState).not.toHaveBeenCalled();
+      expect(deps.resetBufferedOutput).not.toHaveBeenCalled();
+      expect(managed.terminal.dispose).not.toHaveBeenCalled();
     } finally {
       vi.setSystemTime(new Date());
       vi.useRealTimers();

--- a/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
@@ -4,7 +4,7 @@ import {
   TerminalHibernationManager,
   type HibernationManagerDeps,
 } from "../TerminalHibernationManager";
-import { AGENT_IDLE_SILENCE_MS, type ManagedTerminal } from "../types";
+import { type ManagedTerminal } from "../types";
 import { TerminalRefreshTier } from "../../../../shared/types/panel";
 
 const {

--- a/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
@@ -4,7 +4,7 @@ import {
   TerminalHibernationManager,
   type HibernationManagerDeps,
 } from "../TerminalHibernationManager";
-import type { ManagedTerminal } from "../types";
+import { AGENT_IDLE_SILENCE_MS, type ManagedTerminal } from "../types";
 import { TerminalRefreshTier } from "../../../../shared/types/panel";
 
 const {
@@ -178,6 +178,7 @@ function makeMockDeps(managed?: ManagedTerminal): HibernationManagerDeps {
     openLink: vi.fn(),
     getCwdProvider: vi.fn(() => undefined),
     onHibernationChanged: vi.fn(),
+    getIsBackgrounded: vi.fn(() => false),
     onBufferModeChange: vi.fn(),
     notifyParsed: vi.fn(),
     scrollToBottomSafe: vi.fn(),
@@ -357,5 +358,40 @@ describe("TerminalHibernationManager adversarial", () => {
     expect(managed.isDetached).toBe(true);
     expect(managed.restoreGeneration).toBe(8);
     expect(managed.lastReflowAt).toBe(0);
+  });
+
+  it("BACKGROUNDED_BYPASS_DROPPED_WHEN_RESTORED_BETWEEN_SCHEDULE_AND_FIRE", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      managed = makeMockManaged({
+        runtimeAgentId: "claude",
+        canonicalAgentState: "working",
+        isVisible: false,
+        pendingWrites: 0,
+        lastWriteAt: 0, // recent — well inside the silence window
+      });
+      deps = makeMockDeps(managed);
+      // Backgrounded at schedule time → bypass active, normal timer armed.
+      (deps.getIsBackgrounded as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      manager = new TerminalHibernationManager(deps);
+
+      manager.scheduleHibernation("t1", managed);
+      expect(managed.hibernationEligibilityTimer).toBeUndefined();
+      expect(managed.hibernationTimer).toBeDefined();
+
+      // User restores the panel before the timer fires: the backgrounded
+      // map is cleared, so getIsBackgrounded now reads false live. The agent
+      // is still active and within the silence window, so hibernate() must
+      // bail rather than tear down a live agent.
+      (deps.getIsBackgrounded as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+      vi.advanceTimersByTime(30_000);
+
+      expect(managed.isHibernated).toBe(false);
+    } finally {
+      vi.setSystemTime(new Date());
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -526,7 +526,9 @@ describe("TerminalHibernationManager", () => {
 
     it("accepts BACKGROUND for non-agent terminals", () => {
       managed.runtimeAgentId = undefined;
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(true);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(
+        true
+      );
     });
 
     it("rejects BACKGROUND while a recently-active agent is still working/waiting/directing", () => {
@@ -535,28 +537,32 @@ describe("TerminalHibernationManager", () => {
       managed.lastWriteAt = now - 1000;
 
       managed.canonicalAgentState = "working";
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
-        false
-      );
+      expect(
+        manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)
+      ).toBe(false);
 
       managed.canonicalAgentState = "waiting";
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
-        false
-      );
+      expect(
+        manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)
+      ).toBe(false);
 
       managed.canonicalAgentState = "directing";
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
-        false
-      );
+      expect(
+        manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)
+      ).toBe(false);
     });
 
     it("accepts BACKGROUND once an agent has completed or exited", () => {
       managed.runtimeAgentId = "claude";
       managed.canonicalAgentState = "completed";
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(true);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(
+        true
+      );
 
       managed.canonicalAgentState = "exited";
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(true);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(
+        true
+      );
     });
 
     it("treats `idle` as immediately eligible — no silence window required", () => {
@@ -564,7 +570,9 @@ describe("TerminalHibernationManager", () => {
       managed.canonicalAgentState = "idle";
       // No lastWriteAt: `idle` is a resting state, not in ACTIVE_AGENT_STATES,
       // so the silence guard doesn't apply.
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(true);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(
+        true
+      );
     });
 
     it("accepts BACKGROUND for a working agent that has been silent past AGENT_IDLE_SILENCE_MS", () => {
@@ -573,9 +581,9 @@ describe("TerminalHibernationManager", () => {
       managed.canonicalAgentState = "working";
       managed.lastWriteAt = now - AGENT_IDLE_SILENCE_MS;
       managed.pendingWrites = 0;
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
-        true
-      );
+      expect(
+        manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)
+      ).toBe(true);
     });
 
     it("rejects BACKGROUND one millisecond shy of the silence boundary", () => {
@@ -584,9 +592,9 @@ describe("TerminalHibernationManager", () => {
       managed.canonicalAgentState = "waiting";
       managed.lastWriteAt = now - AGENT_IDLE_SILENCE_MS + 1;
       managed.pendingWrites = 0;
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
-        false
-      );
+      expect(
+        manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)
+      ).toBe(false);
     });
 
     it("rejects BACKGROUND when an idle-eligible active agent still has pending writes", () => {
@@ -595,9 +603,9 @@ describe("TerminalHibernationManager", () => {
       managed.canonicalAgentState = "working";
       managed.lastWriteAt = now - AGENT_IDLE_SILENCE_MS - 10_000;
       managed.pendingWrites = 1;
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
-        false
-      );
+      expect(
+        manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)
+      ).toBe(false);
     });
 
     it("accepts BACKGROUND for an active agent that has no recorded lastWriteAt", () => {
@@ -608,7 +616,9 @@ describe("TerminalHibernationManager", () => {
       managed.canonicalAgentState = "waiting";
       managed.pendingWrites = 0;
       managed.lastWriteAt = undefined;
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(true);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(
+        true
+      );
     });
 
     it("bypasses the silence window for a user-backgrounded active agent with no pending writes", () => {
@@ -618,9 +628,9 @@ describe("TerminalHibernationManager", () => {
       managed.lastWriteAt = now - 1000; // well inside the 5-min silence window
       managed.pendingWrites = 0;
       (deps.getIsBackgrounded as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
-        true
-      );
+      expect(
+        manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)
+      ).toBe(true);
     });
 
     it("still rejects a user-backgrounded terminal that has pending writes (burst guard holds)", () => {
@@ -630,9 +640,9 @@ describe("TerminalHibernationManager", () => {
       managed.lastWriteAt = now - 1000;
       managed.pendingWrites = 1;
       (deps.getIsBackgrounded as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
-        false
-      );
+      expect(
+        manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)
+      ).toBe(false);
     });
 
     it("preserves the silence window for a non-backgrounded active agent (no bypass)", () => {
@@ -642,9 +652,9 @@ describe("TerminalHibernationManager", () => {
       managed.lastWriteAt = now - 1000;
       managed.pendingWrites = 0;
       // getIsBackgrounded defaults to false — silence window must still apply.
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
-        false
-      );
+      expect(
+        manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)
+      ).toBe(false);
     });
 
     it("scopes the bypass to the queried id — backgrounding another panel doesn't leak", () => {
@@ -657,12 +667,12 @@ describe("TerminalHibernationManager", () => {
       (deps.getIsBackgrounded as ReturnType<typeof vi.fn>).mockImplementation(
         (queriedId: string) => queriedId === "t2"
       );
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
-        false
-      );
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t2", now)).toBe(
-        true
-      );
+      expect(
+        manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)
+      ).toBe(false);
+      expect(
+        manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t2", now)
+      ).toBe(true);
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -160,6 +160,7 @@ function makeMockDeps(managed?: ManagedTerminal): HibernationManagerDeps {
     openLink: vi.fn(),
     getCwdProvider: vi.fn(() => undefined),
     onHibernationChanged: vi.fn(),
+    getIsBackgrounded: vi.fn(() => false),
     onBufferModeChange: vi.fn(),
     notifyParsed: vi.fn(),
     scrollToBottomSafe: vi.fn(),
@@ -518,14 +519,14 @@ describe("TerminalHibernationManager", () => {
   describe("isHibernationEligible()", () => {
     it("rejects non-BACKGROUND tiers regardless of agent state", () => {
       managed.runtimeAgentId = undefined;
-      expect(manager.isHibernationEligible(TerminalRefreshTier.FOCUSED, managed)).toBe(false);
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BURST, managed)).toBe(false);
-      expect(manager.isHibernationEligible(TerminalRefreshTier.VISIBLE, managed)).toBe(false);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.FOCUSED, managed, "t1")).toBe(false);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BURST, managed, "t1")).toBe(false);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.VISIBLE, managed, "t1")).toBe(false);
     });
 
     it("accepts BACKGROUND for non-agent terminals", () => {
       managed.runtimeAgentId = undefined;
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed)).toBe(true);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(true);
     });
 
     it("rejects BACKGROUND while a recently-active agent is still working/waiting/directing", () => {
@@ -534,17 +535,17 @@ describe("TerminalHibernationManager", () => {
       managed.lastWriteAt = now - 1000;
 
       managed.canonicalAgentState = "working";
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, now)).toBe(
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
         false
       );
 
       managed.canonicalAgentState = "waiting";
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, now)).toBe(
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
         false
       );
 
       managed.canonicalAgentState = "directing";
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, now)).toBe(
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
         false
       );
     });
@@ -552,10 +553,10 @@ describe("TerminalHibernationManager", () => {
     it("accepts BACKGROUND once an agent has completed or exited", () => {
       managed.runtimeAgentId = "claude";
       managed.canonicalAgentState = "completed";
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed)).toBe(true);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(true);
 
       managed.canonicalAgentState = "exited";
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed)).toBe(true);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(true);
     });
 
     it("treats `idle` as immediately eligible — no silence window required", () => {
@@ -563,7 +564,7 @@ describe("TerminalHibernationManager", () => {
       managed.canonicalAgentState = "idle";
       // No lastWriteAt: `idle` is a resting state, not in ACTIVE_AGENT_STATES,
       // so the silence guard doesn't apply.
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed)).toBe(true);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(true);
     });
 
     it("accepts BACKGROUND for a working agent that has been silent past AGENT_IDLE_SILENCE_MS", () => {
@@ -572,7 +573,7 @@ describe("TerminalHibernationManager", () => {
       managed.canonicalAgentState = "working";
       managed.lastWriteAt = now - AGENT_IDLE_SILENCE_MS;
       managed.pendingWrites = 0;
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, now)).toBe(
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
         true
       );
     });
@@ -583,7 +584,7 @@ describe("TerminalHibernationManager", () => {
       managed.canonicalAgentState = "waiting";
       managed.lastWriteAt = now - AGENT_IDLE_SILENCE_MS + 1;
       managed.pendingWrites = 0;
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, now)).toBe(
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
         false
       );
     });
@@ -594,7 +595,7 @@ describe("TerminalHibernationManager", () => {
       managed.canonicalAgentState = "working";
       managed.lastWriteAt = now - AGENT_IDLE_SILENCE_MS - 10_000;
       managed.pendingWrites = 1;
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, now)).toBe(
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
         false
       );
     });
@@ -607,7 +608,43 @@ describe("TerminalHibernationManager", () => {
       managed.canonicalAgentState = "waiting";
       managed.pendingWrites = 0;
       managed.lastWriteAt = undefined;
-      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed)).toBe(true);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(true);
+    });
+
+    it("bypasses the silence window for a user-backgrounded active agent with no pending writes", () => {
+      const now = Date.now();
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.lastWriteAt = now - 1000; // well inside the 5-min silence window
+      managed.pendingWrites = 0;
+      (deps.getIsBackgrounded as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
+        true
+      );
+    });
+
+    it("still rejects a user-backgrounded terminal that has pending writes (burst guard holds)", () => {
+      const now = Date.now();
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.lastWriteAt = now - 1000;
+      managed.pendingWrites = 1;
+      (deps.getIsBackgrounded as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
+        false
+      );
+    });
+
+    it("preserves the silence window for a non-backgrounded active agent (no bypass)", () => {
+      const now = Date.now();
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.lastWriteAt = now - 1000;
+      managed.pendingWrites = 0;
+      // getIsBackgrounded defaults to false — silence window must still apply.
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
+        false
+      );
     });
   });
 
@@ -713,6 +750,27 @@ describe("TerminalHibernationManager", () => {
       // Cross the silence boundary — re-check fires, schedules the
       // normal 30s timer, then advance through that to hibernate.
       vi.advanceTimersByTime(1);
+      expect(managed.hibernationEligibilityTimer).toBeUndefined();
+      expect(managed.hibernationTimer).toBeDefined();
+
+      vi.advanceTimersByTime(30_000);
+      expect(managed.isHibernated).toBe(true);
+
+      vi.setSystemTime(new Date());
+    });
+
+    it("skips the eligibility re-check and arms the hibernation timer for a backgrounded active agent", () => {
+      vi.setSystemTime(0);
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.isVisible = false;
+      managed.pendingWrites = 0;
+      managed.lastWriteAt = 0; // would normally arm the re-check timer
+      (deps.getIsBackgrounded as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      manager.scheduleHibernation("t1", managed);
+
+      // Backgrounded: re-check timer skipped, normal hibernation timer armed.
       expect(managed.hibernationEligibilityTimer).toBeUndefined();
       expect(managed.hibernationTimer).toBeDefined();
 

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -646,6 +646,24 @@ describe("TerminalHibernationManager", () => {
         false
       );
     });
+
+    it("scopes the bypass to the queried id — backgrounding another panel doesn't leak", () => {
+      const now = Date.now();
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.lastWriteAt = now - 1000;
+      managed.pendingWrites = 0;
+      // Only "t2" is backgrounded; "t1" must keep its silence window.
+      (deps.getIsBackgrounded as ReturnType<typeof vi.fn>).mockImplementation(
+        (queriedId: string) => queriedId === "t2"
+      );
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1", now)).toBe(
+        false
+      );
+      expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t2", now)).toBe(
+        true
+      );
+    });
   });
 
   describe("scheduleHibernation() / cancelHibernation()", () => {
@@ -771,6 +789,35 @@ describe("TerminalHibernationManager", () => {
       manager.scheduleHibernation("t1", managed);
 
       // Backgrounded: re-check timer skipped, normal hibernation timer armed.
+      expect(managed.hibernationEligibilityTimer).toBeUndefined();
+      expect(managed.hibernationTimer).toBeDefined();
+
+      vi.advanceTimersByTime(30_000);
+      expect(managed.isHibernated).toBe(true);
+
+      vi.setSystemTime(new Date());
+    });
+
+    it("cancel + reschedule swaps a pending eligibility timer for the normal timer once backgrounded", () => {
+      vi.setSystemTime(0);
+      managed.runtimeAgentId = "claude";
+      managed.canonicalAgentState = "working";
+      managed.isVisible = false;
+      managed.pendingWrites = 0;
+      managed.lastWriteAt = 0;
+
+      // Active agent inside the silence window → eligibility re-check armed.
+      manager.scheduleHibernation("t1", managed);
+      expect(managed.hibernationEligibilityTimer).toBeDefined();
+      expect(managed.hibernationTimer).toBeUndefined();
+
+      // User backgrounds the panel — the onPanelBackgrounded path cancels the
+      // pending timer and reschedules. With the bypass now live, the normal
+      // hibernation timer is armed instead of waiting out the silence window.
+      (deps.getIsBackgrounded as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      manager.cancelHibernation(managed);
+      manager.scheduleHibernation("t1", managed);
+
       expect(managed.hibernationEligibilityTimer).toBeUndefined();
       expect(managed.hibernationTimer).toBeDefined();
 

--- a/src/store/__tests__/atomicStateSwap.test.ts
+++ b/src/store/__tests__/atomicStateSwap.test.ts
@@ -38,6 +38,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
     setVisible: vi.fn(),
     suppressResizesDuringProjectSwitch: vi.fn(),

--- a/src/store/__tests__/layoutUndoStore.test.ts
+++ b/src/store/__tests__/layoutUndoStore.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     destroy: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     lockResize: vi.fn(),
     optimizeForDock: vi.fn(),
     suppressResizesDuringProjectSwitch: vi.fn(),

--- a/src/store/__tests__/panelStore.adversarial.test.ts
+++ b/src/store/__tests__/panelStore.adversarial.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     detachForProjectSwitch: vi.fn(),
     suppressResizesDuringProjectSwitch: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
   },
 }));
 

--- a/src/store/__tests__/panelStore.assistantFocusGuard.test.ts
+++ b/src/store/__tests__/panelStore.assistantFocusGuard.test.ts
@@ -44,6 +44,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     detachForProjectSwitch: vi.fn(),
     suppressResizesDuringProjectSwitch: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     prewarmTerminal: vi.fn(),
     sendPtyResize: vi.fn(),
     setInputLocked: vi.fn(),

--- a/src/store/__tests__/panelStore.processDetectionListeners.test.ts
+++ b/src/store/__tests__/panelStore.processDetectionListeners.test.ts
@@ -184,6 +184,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     prewarmTerminal: vi.fn(),
     sendPtyResize: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     setInputLocked: vi.fn(),
     destroy: vi.fn(),
     suppressNextExit: vi.fn(),

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
     setInputLocked: vi.fn(),
     wake: vi.fn(),

--- a/src/store/__tests__/resetWithoutKilling.test.ts
+++ b/src/store/__tests__/resetWithoutKilling.test.ts
@@ -36,6 +36,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
     setVisible: vi.fn(),
     suppressResizesDuringProjectSwitch: vi.fn(),

--- a/src/store/__tests__/trashTerminalAgentFocus.test.ts
+++ b/src/store/__tests__/trashTerminalAgentFocus.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
   },
 }));
 

--- a/src/store/__tests__/worktreeStore.circularInit.test.ts
+++ b/src/store/__tests__/worktreeStore.circularInit.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     detachForProjectSwitch: vi.fn(),
     suppressResizesDuringProjectSwitch: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     wake: vi.fn(),
   },
 }));

--- a/src/store/__tests__/worktreeStore.onCreated.test.ts
+++ b/src/store/__tests__/worktreeStore.onCreated.test.ts
@@ -12,6 +12,7 @@ const focusStateGetterMock = vi.hoisted(() =>
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
   },
 }));
 

--- a/src/store/slices/__tests__/fleetBulkActions.test.ts
+++ b/src/store/slices/__tests__/fleetBulkActions.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     destroy: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     resize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
   },
 }));

--- a/src/store/slices/__tests__/gridCapacity.test.ts
+++ b/src/store/slices/__tests__/gridCapacity.test.ts
@@ -34,6 +34,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     destroy: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     wake: vi.fn(),
   },
 }));

--- a/src/store/slices/__tests__/moveTerminalToWorktree.test.ts
+++ b/src/store/slices/__tests__/moveTerminalToWorktree.test.ts
@@ -15,6 +15,7 @@ vi.mock("@/clients", () => ({
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     resize: vi.fn().mockReturnValue(null),
   },
 }));

--- a/src/store/slices/__tests__/worktreeBulkActions.test.ts
+++ b/src/store/slices/__tests__/worktreeBulkActions.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     destroy: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     resize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
     wake: vi.fn(),
   },

--- a/src/store/slices/panelRegistry/__tests__/activeTabTracking.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/activeTabTracking.test.ts
@@ -37,6 +37,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
   },
 }));

--- a/src/store/slices/panelRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
   },
 }));
 

--- a/src/store/slices/panelRegistry/__tests__/consoleCaptureCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/consoleCaptureCleanup.test.ts
@@ -33,6 +33,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
     setInputLocked: vi.fn(),
   },

--- a/src/store/slices/panelRegistry/__tests__/devPreviewLifecycle.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/devPreviewLifecycle.test.ts
@@ -32,6 +32,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
   },
 }));

--- a/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
@@ -78,6 +78,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
     prewarmTerminal: vi.fn(),
     setInputLocked: vi.fn(),

--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -15,6 +15,7 @@ vi.mock("@/clients", () => ({
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     resize: vi.fn().mockReturnValue(null),
   },
 }));

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -48,6 +48,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
     prewarmTerminal: vi.fn(),
     setInputLocked: vi.fn(),

--- a/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
@@ -47,6 +47,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
     suppressNextExit: vi.fn(),
     get: vi.fn().mockReturnValue({ terminal: { cols: 80, rows: 24 } }),

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -47,6 +47,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
     prewarmTerminal: vi.fn(),
     setInputLocked: vi.fn(),

--- a/src/store/slices/panelRegistry/__tests__/reconnectErrorDebounce.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/reconnectErrorDebounce.test.ts
@@ -41,6 +41,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
   },
 }));

--- a/src/store/slices/panelRegistry/__tests__/removePanelFromGroup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/removePanelFromGroup.test.ts
@@ -37,6 +37,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
   },
 }));

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -49,6 +49,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
     suppressNextExit: vi.fn(),
     get: vi.fn().mockReturnValue({ terminal: { cols: 80, rows: 24 } }),

--- a/src/store/slices/panelRegistry/__tests__/restoreTerminalOrder.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restoreTerminalOrder.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
   },
 }));

--- a/src/store/slices/panelRegistry/__tests__/setDevPreviewScrollPosition.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/setDevPreviewScrollPosition.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
   },
 }));

--- a/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/clients", () => ({
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     resize: vi.fn().mockReturnValue(null),
   },
 }));

--- a/src/store/slices/panelRegistry/__tests__/trashTerminalGroupCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/trashTerminalGroupCleanup.test.ts
@@ -37,6 +37,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     cleanup: vi.fn(),
     destroy: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
   },
 }));
 

--- a/src/store/slices/panelRegistry/__tests__/updateActivityEarlyExit.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/updateActivityEarlyExit.test.ts
@@ -37,6 +37,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
   },
 }));

--- a/src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
   },
 }));

--- a/src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
     destroy: vi.fn(),
   },
 }));

--- a/src/store/slices/panelRegistry/background.ts
+++ b/src/store/slices/panelRegistry/background.ts
@@ -89,6 +89,11 @@ export const createBackgroundActions = (
 
     if (panelKindHasPty(terminal.kind ?? "terminal")) {
       terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.BACKGROUND);
+      // Re-arm hibernation now that the panel is user-backgrounded: a panel
+      // already at BACKGROUND tier gets a no-op above, so without this the
+      // backgrounded bypass wouldn't take effect until the silence window
+      // expired.
+      terminalInstanceService.onPanelBackgrounded(id);
     }
   },
 
@@ -166,6 +171,9 @@ export const createBackgroundActions = (
       const terminal = state.panelsById[bid];
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
         terminalInstanceService.applyRendererPolicy(bid, TerminalRefreshTier.BACKGROUND);
+        // See backgroundTerminal: re-arm hibernation for panels already at
+        // BACKGROUND tier (non-active group tabs) so the bypass applies now.
+        terminalInstanceService.onPanelBackgrounded(bid);
       }
     }
   },


### PR DESCRIPTION
## Summary

- Adds `backgroundedTerminals.has(id)` as an input to `isSafeToHibernate` so user-backgrounded panels bypass the `AGENT_IDLE_SILENCE_MS` silence window. The pending-writes burst guard still applies; only the agent-activity exemption is relaxed.
- Threads `getIsBackgrounded` through `HibernationManagerDeps`, wired in `TerminalInstanceService` via `usePanelStore.getState()`. No new IPC — `backgroundedTerminals` and the hibernation manager both live in the renderer.
- Adds `onPanelBackgrounded(id)` to `TerminalInstanceService` to cancel and reschedule hibernation when a panel that's already at the `BACKGROUND` tier is backgrounded again (since `applyRendererPolicy(BACKGROUND)` is a same-tier no-op and wouldn't trigger the normal eligibility path). Wired into the `backgroundTerminal` and `backgroundPanelGroup` store actions.

Resolves #8965

## Changes

- `TerminalHibernationManager`: added `getIsBackgrounded` dep; `isSafeToHibernate` bypasses the agent-idle silence check for backgrounded panels; `scheduleHibernation` skips the eligibility re-check for backgrounded panels
- `TerminalInstanceService`: added `onPanelBackgrounded(id)` for same-tier re-arm; wired `getIsBackgrounded` from `usePanelStore`
- `background.ts`: call `onPanelBackgrounded` from `backgroundTerminal` and `backgroundPanelGroup` store actions
- 37 test mocks updated with `onPanelBackgrounded` stub

## Testing

101 tests pass across the hibernation and background store suites. Added tests for cancel-and-reschedule, multi-id isolation, and a strengthened adversarial restore-race scenario. All 9 verify checks pass (typecheck, lint:ratchet, format:check, IPC checks).