### PR TITLE
fix(toolbar): snap armed-state ring on toolbar buttons

### DIFF
--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -231,8 +231,23 @@ describe("Toolbar responsive design — issue #4133", () => {
       expect(baseBlock).toMatch(/transition:[\s\S]*?;/);
       const transitionMatch = baseBlock!.match(/transition:[\s\S]*?;/)![0];
       expect(transitionMatch).not.toContain("box-shadow");
-      expect(transitionMatch).toContain("color");
+      expect(transitionMatch).not.toContain("all");
+      expect(transitionMatch).toMatch(/\bcolor\b/);
       expect(transitionMatch).toContain("background-color");
+
+      // Guard: no later rule in the same file reintroduces box-shadow or
+      // transition:all on these classes.
+      for (const block of css.match(/\.toolbar-(?:icon|agent)-button[\s\S]*?\{[\s\S]*?\}/g) ?? []) {
+        const t = block.match(/transition:[\s\S]*?;/)?.[0];
+        if (!t) continue;
+        if (block.includes("box-shadow") && t.includes("box-shadow")) {
+          // Armed-state block sets box-shadow but not in a transition list —
+          // only flag it if box-shadow appears inside the transition value.
+        }
+        expect(t).not.toContain("all");
+        if (block === baseBlock) continue; // already checked above
+        expect(t).not.toMatch(/box-shadow\s+150ms/);
+      }
     });
 
     it("overflow severity dot uses a non-color shape differentiator per tier — WCAG 1.4.1", () => {

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -219,6 +219,22 @@ describe("Toolbar responsive design — issue #4133", () => {
       expect(activeBlock).not.toMatch(/transform\s*:\s*scale/);
     });
 
+    it("armed-state ring is excluded from toolbar transition list so it snaps — same pattern as press transform", () => {
+      // The .toolbar-icon-button transition list must NOT include `box-shadow` —
+      // arming is the result of an intentional click/keypress; the ring should snap,
+      // not crossfade over 150ms. `color` and `background-color` remain at 150ms
+      // for visual cohesion with hover.
+      const baseBlock = css.match(
+        /\.toolbar-icon-button,\s*\n\s*\.toolbar-agent-button\s*\{[\s\S]*?\}/
+      )?.[0];
+      expect(baseBlock).toBeDefined();
+      expect(baseBlock).toMatch(/transition:[\s\S]*?;/);
+      const transitionMatch = baseBlock!.match(/transition:[\s\S]*?;/)![0];
+      expect(transitionMatch).not.toContain("box-shadow");
+      expect(transitionMatch).toContain("color");
+      expect(transitionMatch).toContain("background-color");
+    });
+
     it("overflow severity dot uses a non-color shape differentiator per tier — WCAG 1.4.1", () => {
       // Tier 1 evidence: each severity owns its own border-radius in CSS, so
       // critical/warning/info are distinguishable without relying on color.

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -52,11 +52,11 @@
   --_hover-shadow: var(--toolbar-control-hover-shadow, none);
   /* Press-scale is owned by the base Button cva (`active:scale-[0.98] active:duration-[1ms]`),
    * so transform is intentionally absent from this transition list — adding it would slow
-   * the snap to 150ms and override the cva's intent. */
+   * the snap to 150ms and override the cva's intent. Same for box-shadow: the armed-state
+   * inset ring is the result of an intentional click or keypress and should snap too. */
   transition:
     color 150ms ease,
-    background-color 150ms ease,
-    box-shadow 150ms ease;
+    background-color 150ms ease;
 }
 
 .toolbar-icon-button:hover {


### PR DESCRIPTION
## Summary
- The 150ms box-shadow transition was causing the armed-state ring to fade in. An intentional click or keypress should show the ring immediately.
- Removed `box-shadow` from the toolbar button transition list. The 150ms crossfade on `color` and `background-color` stays for hover cohesion.
- Added a CSS unit test that verifies the transition list and guards against accidentally reintroducing `box-shadow` in later rules.

Resolves #8967

## Changes
- `src/styles/components/toolbar.css` -- drop `box-shadow` from the `.toolbar-icon-button` / `.toolbar-agent-button` transition shorthand, keeping only `color` and `background-color`
- `src/components/Layout/__tests__/Toolbar.responsive.test.ts` -- test that the transition list excludes `box-shadow` and `all`, and that no other rule block reintroduces `box-shadow 150ms`

## Testing
- Unit test (`Toolbar.responsive.test.ts`) verifies the transition list is correct and runs guard assertions on every toolbar button rule block in the compiled CSS