### PR TITLE
fix(palette): drop aria-modal on exiting palette dialog

### DIFF
--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -193,7 +193,7 @@ export function AppPaletteDialog({
       <div
         ref={dialogRef}
         role="dialog"
-        aria-modal="true"
+        aria-modal={isOpen ? "true" : "false"}
         aria-label={ariaLabel}
         tabIndex={-1}
         className={cn(

--- a/src/components/ui/__tests__/AppPaletteDialog.exitAriaModal.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.exitAriaModal.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppPaletteDialog } from "../AppPaletteDialog";
+
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useOverlayState: () => {},
+  };
+});
+
+// Configurable presence mock: lets each test decouple `shouldRender` from
+// `isOpen` so we can exercise the exit-animation window (isOpen=false while the
+// dialog is still mounted) that the main test file intentionally collapses.
+let presence = { isVisible: false, shouldRender: false };
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: () => presence,
+}));
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+function renderPalette(isOpen: boolean) {
+  return render(
+    <AppPaletteDialog isOpen={isOpen} onClose={() => {}} ariaLabel="Test palette">
+      <input type="text" placeholder="Palette input" />
+    </AppPaletteDialog>
+  );
+}
+
+describe("AppPaletteDialog aria-modal during exit window", () => {
+  afterEach(() => {
+    presence = { isVisible: false, shouldRender: false };
+  });
+
+  it("declares aria-modal='true' while open", () => {
+    presence = { isVisible: true, shouldRender: true };
+    renderPalette(true);
+    const dialog = screen.getByRole("dialog", { name: "Test palette" });
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("drops aria-modal to 'false' during the exit animation (isOpen=false, still mounted)", () => {
+    // The exiting dialog is still rendered (shouldRender=true) but the user has
+    // dismissed it (isOpen=false). It must not declare itself the active modal,
+    // otherwise it overlaps an incoming palette's aria-modal and traps the AT
+    // virtual cursor (issue #8948).
+    presence = { isVisible: false, shouldRender: true };
+    renderPalette(false);
+    const dialog = screen.getByRole("dialog", { name: "Test palette" });
+    expect(dialog.getAttribute("aria-modal")).toBe("false");
+  });
+
+  it("renders nothing once the exit animation completes", () => {
+    presence = { isVisible: false, shouldRender: false };
+    renderPalette(false);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/src/components/ui/__tests__/AppPaletteDialog.exitAriaModal.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.exitAriaModal.test.tsx
@@ -14,9 +14,15 @@ vi.mock("@/hooks", async (importOriginal) => {
 // Configurable presence mock: lets each test decouple `shouldRender` from
 // `isOpen` so we can exercise the exit-animation window (isOpen=false while the
 // dialog is still mounted) that the main test file intentionally collapses.
-let presence = { isVisible: false, shouldRender: false };
+// Keyed off `isOpen` so a single test can mount two palettes with different
+// lifecycle states (the real #8948 handoff scenario).
+type Presence = { isVisible: boolean; shouldRender: boolean };
+let presenceFor: (isOpen: boolean) => Presence = () => ({
+  isVisible: false,
+  shouldRender: false,
+});
 vi.mock("@/hooks/useAnimatedPresence", () => ({
-  useAnimatedPresence: () => presence,
+  useAnimatedPresence: ({ isOpen }: { isOpen: boolean }) => presenceFor(isOpen),
 }));
 
 vi.stubGlobal(
@@ -28,9 +34,9 @@ vi.stubGlobal(
   }
 );
 
-function renderPalette(isOpen: boolean) {
+function renderPalette(isOpen: boolean, ariaLabel = "Test palette") {
   return render(
-    <AppPaletteDialog isOpen={isOpen} onClose={() => {}} ariaLabel="Test palette">
+    <AppPaletteDialog isOpen={isOpen} onClose={() => {}} ariaLabel={ariaLabel}>
       <input type="text" placeholder="Palette input" />
     </AppPaletteDialog>
   );
@@ -38,11 +44,11 @@ function renderPalette(isOpen: boolean) {
 
 describe("AppPaletteDialog aria-modal during exit window", () => {
   afterEach(() => {
-    presence = { isVisible: false, shouldRender: false };
+    presenceFor = () => ({ isVisible: false, shouldRender: false });
   });
 
   it("declares aria-modal='true' while open", () => {
-    presence = { isVisible: true, shouldRender: true };
+    presenceFor = () => ({ isVisible: true, shouldRender: true });
     renderPalette(true);
     const dialog = screen.getByRole("dialog", { name: "Test palette" });
     expect(dialog.getAttribute("aria-modal")).toBe("true");
@@ -53,15 +59,39 @@ describe("AppPaletteDialog aria-modal during exit window", () => {
     // dismissed it (isOpen=false). It must not declare itself the active modal,
     // otherwise it overlaps an incoming palette's aria-modal and traps the AT
     // virtual cursor (issue #8948).
-    presence = { isVisible: false, shouldRender: true };
+    presenceFor = () => ({ isVisible: false, shouldRender: true });
     renderPalette(false);
     const dialog = screen.getByRole("dialog", { name: "Test palette" });
     expect(dialog.getAttribute("aria-modal")).toBe("false");
   });
 
   it("renders nothing once the exit animation completes", () => {
-    presence = { isVisible: false, shouldRender: false };
+    presenceFor = () => ({ isVisible: false, shouldRender: false });
     renderPalette(false);
     expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("keeps exactly one active modal during a palette handoff (#8948)", () => {
+    // Both palettes are mounted at once: the outgoing one is mid-exit
+    // (isOpen=false, shouldRender=true) while the incoming one is open. Only the
+    // incoming dialog may declare aria-modal="true".
+    presenceFor = (isOpen) => ({ isVisible: isOpen, shouldRender: true });
+    render(
+      <>
+        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Outgoing palette">
+          <input type="text" placeholder="Outgoing input" />
+        </AppPaletteDialog>
+        <AppPaletteDialog isOpen={true} onClose={() => {}} ariaLabel="Incoming palette">
+          <input type="text" placeholder="Incoming input" />
+        </AppPaletteDialog>
+      </>
+    );
+
+    // Both dialogs are in the DOM during the overlap window.
+    expect(screen.getAllByRole("dialog")).toHaveLength(2);
+    // But only one declares itself the active modal.
+    const activeModals = document.querySelectorAll('[role="dialog"][aria-modal="true"]');
+    expect(activeModals).toHaveLength(1);
+    expect(activeModals[0].getAttribute("aria-label")).toBe("Incoming palette");
   });
 });

--- a/src/components/ui/__tests__/AppPaletteDialog.exitAriaModal.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.exitAriaModal.test.tsx
@@ -92,6 +92,6 @@ describe("AppPaletteDialog aria-modal during exit window", () => {
     // But only one declares itself the active modal.
     const activeModals = document.querySelectorAll('[role="dialog"][aria-modal="true"]');
     expect(activeModals).toHaveLength(1);
-    expect(activeModals[0].getAttribute("aria-label")).toBe("Incoming palette");
+    expect(activeModals[0]?.getAttribute("aria-label")).toBe("Incoming palette");
   });
 });


### PR DESCRIPTION
## Summary

- During palette-to-palette handoff, a dismissed `AppPaletteDialog` keeps `aria-modal="true"` while its 100ms exit animation finishes (`useAnimatedPresence` holds the node mounted via `shouldRender=true`). The incoming palette also declares `aria-modal="true"`, so two active modals coexist for ~100ms. Chromium 146 tracks a single active aria-modal dialog; two siblings is undefined AT behavior and can trap the NVDA/JAWS virtual cursor in the exiting dialog.
- Fix in `src/components/ui/AppPaletteDialog.tsx`: change hardcoded `aria-modal="true"` to `aria-modal={isOpen ? "true" : "false"}`. The dismissed dialog stops declaring itself the active modal immediately on close while keeping `role="dialog"`, so AT doesn't announce "dialog closed" prematurely. Declarative JSX, no `useEffect`.
- Focus-trap, Escape-stack, and `restoreFocus` already gate on `isOpen` and are unaffected.

Resolves #8948

## Changes

- `src/components/ui/AppPaletteDialog.tsx` — `aria-modal` now mirrors `isOpen`
- `src/components/ui/__tests__/AppPaletteDialog.exitAriaModal.test.tsx` (new) — 4 cases: `aria-modal="true"` while open; `aria-modal="false"` during exit (`isOpen=false`, `shouldRender=true`); nothing rendered after exit; and a two-palette handoff invariant asserting exactly one `aria-modal="true"` dialog exists at a time

## Testing

9 unit tests pass. The handoff invariant test renders two palettes simultaneously (one exiting, one entering) and asserts a single `aria-modal="true"`. Typecheck, lint, format, and build all clean.

Note: `AppDialog.tsx` has the same hardcoded attribute but is outside the palette mutex — left for a follow-up.