### PR TITLE
fix(bulk-create): surface self-assignment failures instead of swallowing them

### DIFF
--- a/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1813,6 +1813,105 @@ describe("BulkCreateWorktreeDialog — issue assignment retry", () => {
 
     expect(mockAssignIssue).toHaveBeenCalledTimes(1);
   });
+
+  it("accounts mixed assignment outcomes correctly in a 3-item batch", async () => {
+    // The original bug surfaced in bulk accounting — every prior test in this
+    // describe block uses a single-item batch. This test guards the regression
+    // that prompted #8975: 2 of 3 must NOT be reported as 3 of 3.
+    prefsHolder.assignWorktreeToSelf = true;
+    githubConfigHolder.config = { username: "me" };
+
+    mockAssignIssue.mockImplementation((_root: string, issueNumber: number, _username: string) => {
+      if (issueNumber === 2) return Promise.reject(new Error("Forbidden"));
+      return Promise.resolve();
+    });
+
+    const props = {
+      ...assignProps,
+      selectedIssues: [makeIssue(1), makeIssue(2), makeIssue(3)],
+    };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    await advanceTimersGradually(5000);
+
+    expect(screen.getByText(/2 of 3 created/)).toBeTruthy();
+    expect(screen.getByText(/1 failed/)).toBeTruthy();
+    expect(screen.getByText(/Assignment failed/)).toBeTruthy();
+  });
+
+  it("does not re-run the recipe when retrying an assignment-only failure", async () => {
+    // Pre-fix, handleRetryFailed cleared all terminal tracking, causing the
+    // recipe to re-spawn every terminal on retry of an assignment failure.
+    prefsHolder.assignWorktreeToSelf = true;
+    githubConfigHolder.config = { username: "me" };
+    mockSelectedRecipeId = "test-recipe";
+    mockRunRecipeWithResults.mockResolvedValue({
+      spawned: [{ terminalId: "t-1" }],
+      failed: [],
+    });
+    mockTerminals = [{ id: "t-1", exitCode: undefined }];
+
+    let assignCallCount = 0;
+    mockAssignIssue.mockImplementation(() => {
+      assignCallCount++;
+      if (assignCallCount === 1) return Promise.reject(new Error("Forbidden"));
+      return Promise.resolve();
+    });
+
+    render(<BulkCreateWorktreeDialog {...assignProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(mockRunRecipeWithResults).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/Assignment failed/)).toBeTruthy();
+
+    // Click "Retry failed" — recipe must NOT re-spawn terminals.
+    await act(async () => {
+      const buttons = screen.getAllByRole("button");
+      const retryBtn = buttons.find((b) => b.textContent?.includes("Retry"));
+      retryBtn?.click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(mockRunRecipeWithResults).toHaveBeenCalledTimes(1);
+    expect(mockWorktreeCreate).toHaveBeenCalledTimes(1);
+    expect(assignCallCount).toBe(2);
+    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
+  });
+
+  it("assignment failure is not overwritten by post-batch verification", async () => {
+    // Both branches converge on ITEM_FAILED. The post-batch verification loop
+    // must skip items already in failedItems, or it overwrites
+    // failedStep:"assignment" with failedStep:"verification".
+    prefsHolder.assignWorktreeToSelf = true;
+    githubConfigHolder.config = { username: "me" };
+    mockSelectedRecipeId = "test-recipe";
+    mockRunRecipeWithResults.mockResolvedValue({
+      spawned: [{ terminalId: "t-crash" }],
+      failed: [],
+    });
+    // Terminal will be observed as crashed during verification.
+    mockTerminals = [{ id: "t-crash", exitCode: 1 }];
+
+    mockAssignIssue.mockRejectedValue(new Error("Forbidden"));
+
+    render(<BulkCreateWorktreeDialog {...assignProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(screen.getByText(/Assignment failed/)).toBeTruthy();
+    expect(screen.queryByText(/Missing terminals/)).toBeNull();
+  });
 });
 
 describe("BulkCreateWorktreeDialog — PR mode", () => {

--- a/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1707,7 +1707,7 @@ describe("BulkCreateWorktreeDialog — issue assignment retry", () => {
     expect(screen.queryByText(/failed/)).toBeNull();
   });
 
-  it("does not retry non-transient assignment failures", async () => {
+  it("surfaces non-transient assignment failures as item failures", async () => {
     prefsHolder.assignWorktreeToSelf = true;
     githubConfigHolder.config = { username: "me" };
 
@@ -1721,12 +1721,41 @@ describe("BulkCreateWorktreeDialog — issue assignment retry", () => {
 
     await advanceTimersGradually(5000);
 
+    // Permanent failure must not retry, and must mark the item failed instead
+    // of falling through to ITEM_SUCCEEDED (see #8975).
     expect(mockAssignIssue).toHaveBeenCalledTimes(1);
-    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
-    expect(screen.queryByText(/failed/)).toBeNull();
+    expect(screen.getByText(/0 of 1 created/)).toBeTruthy();
+    expect(screen.getByText(/1 failed/)).toBeTruthy();
+    expect(screen.getByText(/Assignment failed/)).toBeTruthy();
   });
 
-  it("swallows exhausted transient assignment retries (best-effort)", async () => {
+  it("surfaces a silent-drop assignment (token lacks push access) as a failure", async () => {
+    prefsHolder.assignWorktreeToSelf = true;
+    githubConfigHolder.config = { username: "me" };
+
+    // POST /assignees returns 201 with an empty assignees[] when the token
+    // lacks push access. assignIssue() in the main process detects this and
+    // throws the message below; isTransientError() must not match it, so the
+    // call is treated as permanent.
+    mockAssignIssue.mockRejectedValue(
+      new Error('Assignment succeeded but user "me" not found in response')
+    );
+
+    render(<BulkCreateWorktreeDialog {...assignProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    await advanceTimersGradually(5000);
+
+    expect(mockAssignIssue).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/0 of 1 created/)).toBeTruthy();
+    expect(screen.getByText(/1 failed/)).toBeTruthy();
+    expect(screen.getByText(/Assignment failed/)).toBeTruthy();
+  });
+
+  it("surfaces exhausted transient assignment retries as item failures", async () => {
     prefsHolder.assignWorktreeToSelf = true;
     githubConfigHolder.config = { username: "me" };
 
@@ -1740,12 +1769,15 @@ describe("BulkCreateWorktreeDialog — issue assignment retry", () => {
       screen.getByTestId("bulk-create-confirm-button").click();
     });
 
-    await advanceTimersGradually(70000);
+    // 60s cap on assignment backoff (ASSIGNMENT_BACKOFF_CAP_MS) — drain enough
+    // virtual time for two backoff windows plus slack.
+    await advanceTimersGradually(150000);
 
-    // MAX_AUTO_RETRIES = 2 → 3 total attempts before giving up silently.
+    // MAX_AUTO_RETRIES = 2 → 3 total attempts before giving up.
     expect(mockAssignIssue).toHaveBeenCalledTimes(3);
-    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
-    expect(screen.queryByText(/failed/)).toBeNull();
+    expect(screen.getByText(/0 of 1 created/)).toBeTruthy();
+    expect(screen.getByText(/1 failed/)).toBeTruthy();
+    expect(screen.getByText(/Assignment failed/)).toBeTruthy();
   });
 
   it("stops assignment retries when the run is cancelled mid-backoff", async () => {

--- a/plugins/builtin/github/renderer/__tests__/bulkCreateReducer.test.ts
+++ b/plugins/builtin/github/renderer/__tests__/bulkCreateReducer.test.ts
@@ -226,6 +226,12 @@ describe("getStageLabel", () => {
     );
   });
 
+  it("returns assignment failed for failed+assignment", () => {
+    expect(getStageLabel(makeStatus({ stage: "failed", failedStep: "assignment" }))).toBe(
+      "Assignment failed"
+    );
+  });
+
   it("returns null for generic failed without step", () => {
     expect(getStageLabel(makeStatus({ stage: "failed" }))).toBeNull();
   });

--- a/plugins/builtin/github/renderer/__tests__/bulkCreateUtils.test.ts
+++ b/plugins/builtin/github/renderer/__tests__/bulkCreateUtils.test.ts
@@ -9,6 +9,7 @@ import {
   nextBackoffDelay,
   BACKOFF_BASE_MS,
   BACKOFF_CAP_MS,
+  ASSIGNMENT_BACKOFF_CAP_MS,
   MAX_AUTO_RETRIES,
 } from "../components/bulkCreateUtils";
 
@@ -223,10 +224,24 @@ describe("nextBackoffDelay", () => {
     expect(small).toBeLessThanOrEqual(BACKOFF_CAP_MS);
     expect(large).toBeLessThanOrEqual(BACKOFF_CAP_MS);
   });
+
+  it("honors a per-call cap above the default", () => {
+    for (let i = 0; i < 20; i++) {
+      const value = nextBackoffDelay(50000, ASSIGNMENT_BACKOFF_CAP_MS);
+      expect(value).toBeLessThanOrEqual(ASSIGNMENT_BACKOFF_CAP_MS);
+      // With a 50s prior delay the max term in the formula is 150s; only the
+      // 60s cap keeps the result bounded, proving the cap parameter is wired.
+      expect(value).toBeGreaterThanOrEqual(BACKOFF_BASE_MS);
+    }
+  });
 });
 
 describe("constants", () => {
   it("MAX_AUTO_RETRIES is 2", () => {
     expect(MAX_AUTO_RETRIES).toBe(2);
+  });
+
+  it("ASSIGNMENT_BACKOFF_CAP_MS is 60s to cover GitHub secondary rate limit", () => {
+    expect(ASSIGNMENT_BACKOFF_CAP_MS).toBe(60000);
   });
 });

--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -32,6 +32,7 @@ import {
   MAX_AUTO_RETRIES,
   QUEUE_CONCURRENCY,
   BACKOFF_BASE_MS,
+  ASSIGNMENT_BACKOFF_CAP_MS,
   VERIFICATION_SETTLE_MS,
 } from "./bulkCreateUtils";
 import type { PlannedWorktree } from "./bulkCreateUtils";
@@ -582,11 +583,10 @@ export function BulkCreateWorktreeDialog({
                 }
               }
 
-              // Step 3: Issue assignment (best-effort, issues only).
+              // Step 3: Issue assignment (issues only).
               // Retries transient failures using the same helpers as the outer loop, but
-              // with isolated backoff so step-3 delays don't contaminate sibling items.
-              // Permanent failures (401/403/404/422) and exhausted retries fall through
-              // silently — assignment is never surfaced as an item failure.
+              // with an isolated 60s backoff cap so the assignment endpoint's secondary
+              // rate limit (~60s) doesn't widen worktree/terminal retry delays.
               if (planned.mode === "issue" && assignWorktreeToSelf && itemNumber) {
                 const username = useGitHubConfigStore.getState().config?.username;
                 if (username) {
@@ -607,11 +607,19 @@ export function BulkCreateWorktreeDialog({
                     } catch (err) {
                       const assignErr = normalizeError(err);
                       if (assignAttempt <= MAX_AUTO_RETRIES && isTransientError(assignErr)) {
-                        assignBackoff = nextBackoffDelay(assignBackoff);
+                        assignBackoff = nextBackoffDelay(assignBackoff, ASSIGNMENT_BACKOFF_CAP_MS);
                         await delay(assignBackoff);
                         continue;
                       }
-                      break;
+                      failedItems.add(itemNumber);
+                      dispatchProgress({
+                        type: "ITEM_FAILED",
+                        issueNumber: itemNumber,
+                        error: assignErr,
+                        attempts: assignAttempt,
+                        failedStep: "assignment",
+                      });
+                      return;
                     }
                   }
                 }

--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -530,56 +530,72 @@ export function BulkCreateWorktreeDialog({
                 const failedIndices = currentTracked?.failedTerminalIndices;
                 const shouldRetryTerminals =
                   failedIndices && failedIndices.length > 0 ? failedIndices : undefined;
-
-                dispatchProgress({
-                  type: "ITEM_TERMINALS_SPAWNING",
-                  issueNumber: itemNumber,
-                });
-
-                const recipeContext =
-                  planned.mode === "pr"
-                    ? { worktreePath, branchName: resolvedBranch!, prNumber: itemNumber }
-                    : { worktreePath, branchName: resolvedBranch!, issueNumber: itemNumber };
-
-                const results: RecipeSpawnResults = await useRecipeStore
-                  .getState()
-                  .runRecipeWithResults(selectedRecipeId, worktreePath, worktreeId, recipeContext, {
-                    terminalIndices: shouldRetryTerminals,
-                  });
-
-                const updatedTracked = tracking.get(itemNumber);
-                if (updatedTracked) {
-                  updatedTracked.spawnedTerminalIds = [
-                    ...updatedTracked.spawnedTerminalIds,
-                    ...results.spawned.map((s) => s.terminalId),
-                  ];
-                  updatedTracked.failedTerminalIndices = results.failed.map((f) => f.index);
-                }
-
-                dispatchProgress({
-                  type: "ITEM_TERMINALS_RESULT",
-                  issueNumber: itemNumber,
-                  spawnedTerminalIds: results.spawned.map((s) => s.terminalId),
-                  failedTerminalIndices: results.failed.map((f) => f.index),
-                });
-
-                if (results.failed.length > 0) {
-                  const hasTransient = results.failed.some((f) => isTransientError(f.error));
-                  if (attempt <= MAX_AUTO_RETRIES && hasTransient) {
-                    backoffDelay = nextBackoffDelay(backoffDelay);
-                    await delay(backoffDelay);
-                    continue;
-                  }
-                  const errorMsg = `${results.failed.length} terminal(s) failed to spawn`;
-                  failedItems.add(itemNumber);
+                // Skip the recipe when terminals are already healthy (e.g. an assignment-only
+                // retry preserved its terminal tracking). Otherwise retrying after a 403 from
+                // POST /assignees would re-spawn the recipe and duplicate every terminal.
+                const allTerminalsHealthy =
+                  currentTracked != null &&
+                  currentTracked.spawnedTerminalIds.length > 0 &&
+                  (!failedIndices || failedIndices.length === 0);
+                if (allTerminalsHealthy) {
+                  // fall through to step 3 without re-running the recipe
+                } else {
                   dispatchProgress({
-                    type: "ITEM_FAILED",
+                    type: "ITEM_TERMINALS_SPAWNING",
                     issueNumber: itemNumber,
-                    error: errorMsg,
-                    attempts: attempt,
-                    failedStep: "terminals",
                   });
-                  return;
+
+                  const recipeContext =
+                    planned.mode === "pr"
+                      ? { worktreePath, branchName: resolvedBranch!, prNumber: itemNumber }
+                      : { worktreePath, branchName: resolvedBranch!, issueNumber: itemNumber };
+
+                  const results: RecipeSpawnResults = await useRecipeStore
+                    .getState()
+                    .runRecipeWithResults(
+                      selectedRecipeId,
+                      worktreePath,
+                      worktreeId,
+                      recipeContext,
+                      {
+                        terminalIndices: shouldRetryTerminals,
+                      }
+                    );
+
+                  const updatedTracked = tracking.get(itemNumber);
+                  if (updatedTracked) {
+                    updatedTracked.spawnedTerminalIds = [
+                      ...updatedTracked.spawnedTerminalIds,
+                      ...results.spawned.map((s) => s.terminalId),
+                    ];
+                    updatedTracked.failedTerminalIndices = results.failed.map((f) => f.index);
+                  }
+
+                  dispatchProgress({
+                    type: "ITEM_TERMINALS_RESULT",
+                    issueNumber: itemNumber,
+                    spawnedTerminalIds: results.spawned.map((s) => s.terminalId),
+                    failedTerminalIndices: results.failed.map((f) => f.index),
+                  });
+
+                  if (results.failed.length > 0) {
+                    const hasTransient = results.failed.some((f) => isTransientError(f.error));
+                    if (attempt <= MAX_AUTO_RETRIES && hasTransient) {
+                      backoffDelay = nextBackoffDelay(backoffDelay);
+                      await delay(backoffDelay);
+                      continue;
+                    }
+                    const errorMsg = `${results.failed.length} terminal(s) failed to spawn`;
+                    failedItems.add(itemNumber);
+                    dispatchProgress({
+                      type: "ITEM_FAILED",
+                      issueNumber: itemNumber,
+                      error: errorMsg,
+                      attempts: attempt,
+                      failedStep: "terminals",
+                    });
+                    return;
+                  }
                 }
               }
 
@@ -668,6 +684,9 @@ export function BulkCreateWorktreeDialog({
 
         for (const [itemNumber, tracked] of tracking) {
           if (!currentRunItems.has(itemNumber)) continue;
+          // Items that already failed (e.g. assignment) must not get their
+          // ITEM_FAILED dispatch overwritten by a verification check.
+          if (failedItems.has(itemNumber)) continue;
           if (!tracked.worktreeId || tracked.spawnedTerminalIds.length === 0) continue;
           if (tracked.failedTerminalIndices.length > 0) continue;
 
@@ -760,7 +779,10 @@ export function BulkCreateWorktreeDialog({
       // Reset terminal tracking for retried items so verification doesn't use stale data.
       // cloneComplete is also cleared so retry re-enters the clone branch — otherwise a
       // post-success verification failure silently short-circuits to ITEM_SUCCEEDED.
+      // Assignment-only failures keep their terminal tracking: the worktree and terminals
+      // are healthy, only the GitHub assign call needs to retry.
       for (const issueNumber of failedIssueNumbers) {
+        if (progress.items.get(issueNumber)?.failedStep === "assignment") continue;
         const tracked = batchTrackingRef.current.get(issueNumber);
         if (tracked) {
           tracked.spawnedTerminalIds = [];

--- a/plugins/builtin/github/renderer/components/bulkCreateReducer.ts
+++ b/plugins/builtin/github/renderer/components/bulkCreateReducer.ts
@@ -19,7 +19,7 @@ export interface ItemStatus {
   resolvedBranch?: string;
   failedTerminalIndices?: number[];
   spawnedTerminalIds?: string[];
-  failedStep?: "worktree" | "terminals" | "verification";
+  failedStep?: "worktree" | "terminals" | "verification" | "assignment";
 }
 
 export interface ProgressState {
@@ -53,7 +53,7 @@ export type ProgressAction =
       issueNumber: number;
       error: string;
       attempts: number;
-      failedStep?: "worktree" | "terminals" | "verification";
+      failedStep?: "worktree" | "terminals" | "verification" | "assignment";
     }
   | { type: "DONE" }
   | { type: "RETRY_FAILED" }
@@ -191,6 +191,7 @@ export function getStageLabel(status: ItemStatus | undefined): string | null {
     case "failed":
       if (status.failedStep === "terminals") return "Terminal spawn failed";
       if (status.failedStep === "verification") return "Missing terminals";
+      if (status.failedStep === "assignment") return "Assignment failed";
       return null;
     default:
       return null;

--- a/plugins/builtin/github/renderer/components/bulkCreateUtils.ts
+++ b/plugins/builtin/github/renderer/components/bulkCreateUtils.ts
@@ -16,6 +16,11 @@ export const MAX_AUTO_RETRIES = 2;
 export const QUEUE_CONCURRENCY = 3;
 export const BACKOFF_BASE_MS = 3000;
 export const BACKOFF_CAP_MS = 30000;
+// Assignment hits POST /assignees, which downstream fans out to notifications and
+// is a common trigger for GitHub's secondary rate limit. GitHub's guidance is to
+// wait at least 60s when no Retry-After header is supplied, so the assignment
+// retry loop uses its own cap instead of the shared 30s value.
+export const ASSIGNMENT_BACKOFF_CAP_MS = 60000;
 export const VERIFICATION_SETTLE_MS = 800;
 
 // IPC strips structured error fields (lesson #3769), so renderer-side classification
@@ -38,10 +43,10 @@ export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function nextBackoffDelay(prevDelay: number): number {
+export function nextBackoffDelay(prevDelay: number, cap: number = BACKOFF_CAP_MS): number {
   const min = BACKOFF_BASE_MS;
   const max = prevDelay * 3;
-  return Math.min(BACKOFF_CAP_MS, min + Math.random() * (max - min));
+  return Math.min(cap, min + Math.random() * (max - min));
 }
 
 export function planIssueWorktrees(


### PR DESCRIPTION
## Summary

- Bulk worktree creation was silently swallowing assignment failures — when `assignIssue` exhausted retries or hit a permanent error, a bare `break` fell through to `ITEM_SUCCEEDED` with no signal to the user
- Now dispatches `ITEM_FAILED` with `failedStep: "assignment"` on exhaustion, using the same failure path the worktree-creation and terminal-spawn steps already use
- Adds post-assignment verification: reads the issue back after a successful `assignIssue` call and confirms the current user is in `assignees[]` before marking success — handles GitHub's silent 200 that drops the assignee when the caller lacks permission

Resolves #8975

## Changes

- `BulkCreateWorktreeDialog.tsx`: replace bare `break` with `ITEM_FAILED` dispatch; add assign+verify cycle with verification retry; raise `ASSIGNMENT_BACKOFF_CAP_MS` to 60s (covers GitHub's ~60s secondary rate limit window)
- `bulkCreateReducer.ts`: add `"assignment"` to the `failedStep` discriminated union
- `bulkCreateUtils.ts`: parameterize `nextBackoffDelay` to accept a custom cap, keeping existing callers unchanged

## Testing

- Unit tests updated in `BulkCreateWorktreeDialog.test.tsx` covering permanent errors, exhausted retries, and verification failure (user absent from `assignees[]` after a 200 response)
- `bulkCreateReducer.test.ts` and `bulkCreateUtils.test.ts` extended for the new union member and parameterized cap