### PR TITLE
fix(git-init): Doherty-gate the spinner and drop the silent commit default

### DIFF
--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -5,6 +5,7 @@ import { Check, AlertCircle } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { FolderGit2 } from "@/components/icons";
 import { projectClient } from "@/clients";
+import { useDohertyGate } from "@/hooks";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { GitInitOptions, GitInitProgressEvent } from "@shared/types/ipc/gitInit";
 
@@ -29,7 +30,7 @@ const TEMPLATE_OPTIONS: Array<{ value: GitignoreTemplate; label: string; descrip
 export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: GitInitDialogProps) {
   const [gitignoreTemplate, setGitignoreTemplate] = useState<GitignoreTemplate>("node");
   const [createInitialCommit, setCreateInitialCommit] = useState(true);
-  const [initialCommitMessage, setInitialCommitMessage] = useState("Initial commit");
+  const [initialCommitMessage, setInitialCommitMessage] = useState("");
   const [progressEvents, setProgressEvents] = useState<GitInitProgressEvent[]>([]);
   const [isInitializing, setIsInitializing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -51,7 +52,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
     if (!isOpen) {
       setGitignoreTemplate("node");
       setCreateInitialCommit(true);
-      setInitialCommitMessage("Initial commit");
+      setInitialCommitMessage("");
       setProgressEvents([]);
       setIsInitializing(false);
       setError(null);
@@ -105,7 +106,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
       await projectClient.initGitGuided({
         directoryPath,
         createInitialCommit,
-        initialCommitMessage: trimmedMessage || "Initial commit",
+        initialCommitMessage: trimmedMessage,
         createGitignore: gitignoreTemplate !== "none",
         gitignoreTemplate,
       });
@@ -157,7 +158,8 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
     return null;
   };
 
-  const showProgress = isInitializing || progressEvents.length > 0;
+  const showConnecting = useDohertyGate(isInitializing && progressEvents.length === 0);
+  const showProgress = showConnecting || progressEvents.length > 0;
   const configDisabled = isInitializing || isComplete;
   const trimmedMessage = initialCommitMessage.trim();
   const canStart = !createInitialCommit || trimmedMessage !== "";

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -104,7 +104,15 @@ describe("GitInitDialog", () => {
     await waitFor(() => expect(onInitGitProgressMock).toHaveBeenCalled());
     expect(initGitGuidedMock).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    const button = screen.getByRole("button", {
+      name: /initialize repository/i,
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: init" },
+    });
+    fireEvent.click(button);
 
     await waitFor(() => {
       expect(initGitGuidedMock).toHaveBeenCalledWith(
@@ -113,7 +121,7 @@ describe("GitInitDialog", () => {
           createInitialCommit: true,
           createGitignore: true,
           gitignoreTemplate: "node",
-          initialCommitMessage: "Initial commit",
+          initialCommitMessage: "feat: init",
         })
       );
     });
@@ -166,6 +174,9 @@ describe("GitInitDialog", () => {
     renderDialog();
 
     fireEvent.change(screen.getByLabelText(/gitignore template/i), { target: { value: "none" } });
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: init" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
 
     await waitFor(() => {
@@ -180,6 +191,9 @@ describe("GitInitDialog", () => {
 
     renderDialog();
 
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: init" },
+    });
     const button = screen.getByRole("button", { name: /initialize repository/i });
     fireEvent.click(button);
     fireEvent.click(button);
@@ -191,6 +205,9 @@ describe("GitInitDialog", () => {
     const onSuccess = vi.fn();
     renderDialog({ onSuccess });
 
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: init" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
     await waitFor(() => expect(progressHandler).not.toBeNull());
 
@@ -209,6 +226,9 @@ describe("GitInitDialog", () => {
   it("surfaces the git config commands and offers Try again on identity error", async () => {
     renderDialog();
 
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: init" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
     await waitFor(() => expect(progressHandler).not.toBeNull());
 


### PR DESCRIPTION
This fixes a couple of issues with `GitInitDialog`.

First, the spinner flickers because `git init` finishes in under 400ms but there was no anti-flicker gate on the progress box. The progress box rendered the moment initialization started, so the spinner flashed and was gone almost immediately. `CloneRepoDialog` already uses `useDohertyGate` for exactly this case; this wires it into `GitInitDialog` the same way.

Second, the initial commit message field was pre-filled with `Initial commit`, and the submit path silently fell back to that string when the field was empty. That's the kind of silent commit message default #7880 prohibits. The field now starts empty and the fallback is removed. The existing validation still prevents submitting with an empty message when the commit checkbox is on.

Resolves #8956

## Changes
- Added `useDohertyGate` to gate the progress box, matching the pattern from `CloneRepoDialog`
- Removed the `Initial commit` pre-fill and the silent fallback in the submit handler
- Updated tests to supply an explicit commit message and assert it reaches `initGitGuided`

## Testing
- Unit tests pass -- verified the message field starts empty, the button is disabled until a message is entered, and the explicit message flows through to `initGitGuided`