### PR TITLE
feat(panels): per-kind dock and focus policy descriptor (#8946)

### DIFF
--- a/shared/config/__tests__/panelKindPolicy.test.ts
+++ b/shared/config/__tests__/panelKindPolicy.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_PANEL_KIND_POLICY,
+  getPanelKindConfig,
+  resolvePanelKindPolicy,
+  type PanelKindConfig,
+} from "../panelKindRegistry.js";
+
+describe("DEFAULT_PANEL_KIND_POLICY", () => {
+  it("captures today's universal behavior so the additive descriptor is a strict superset", () => {
+    expect(DEFAULT_PANEL_KIND_POLICY).toEqual({
+      dockFallbackTarget: "first-grid",
+      defaultFocusOnCreate: true,
+      dockPopoverOnSpawn: true,
+      closeBehavior: "trash",
+    });
+  });
+});
+
+describe("resolvePanelKindPolicy", () => {
+  it("returns the default policy when called with undefined", () => {
+    expect(resolvePanelKindPolicy(undefined)).toEqual(DEFAULT_PANEL_KIND_POLICY);
+  });
+
+  it("returns the default policy for a kind that omits the policy block", () => {
+    expect(resolvePanelKindPolicy("terminal")).toEqual(DEFAULT_PANEL_KIND_POLICY);
+    expect(resolvePanelKindPolicy("browser")).toEqual(DEFAULT_PANEL_KIND_POLICY);
+    expect(resolvePanelKindPolicy("dev-preview")).toEqual(DEFAULT_PANEL_KIND_POLICY);
+  });
+
+  it("layers a kind's declared policy over the default", () => {
+    const reviewConfig = getPanelKindConfig("review");
+    expect(reviewConfig).toBeDefined();
+    expect(resolvePanelKindPolicy("review")).toEqual({
+      ...DEFAULT_PANEL_KIND_POLICY,
+      dockFallbackTarget: "previous-focused",
+    });
+  });
+
+  it("accepts a PanelKindConfig directly to skip the registry lookup", () => {
+    const config: PanelKindConfig = {
+      id: "synthetic",
+      name: "Synthetic",
+      iconId: "test",
+      color: "#000",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      policy: { dockPopoverOnSpawn: false, defaultFocusOnCreate: false },
+    };
+    expect(resolvePanelKindPolicy(config)).toEqual({
+      ...DEFAULT_PANEL_KIND_POLICY,
+      dockPopoverOnSpawn: false,
+      defaultFocusOnCreate: false,
+    });
+  });
+
+  it("treats an unknown kind id as undefined (default policy)", () => {
+    expect(resolvePanelKindPolicy("does-not-exist")).toEqual(DEFAULT_PANEL_KIND_POLICY);
+  });
+
+  it("treats a config with an empty policy object as equivalent to omitting policy", () => {
+    const config: PanelKindConfig = {
+      id: "synthetic",
+      name: "Synthetic",
+      iconId: "test",
+      color: "#000",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      policy: {},
+    };
+    expect(resolvePanelKindPolicy(config)).toEqual(DEFAULT_PANEL_KIND_POLICY);
+  });
+
+  it("preserves unknown dockFallbackTarget strings on the resolved object (caller decides how to degrade)", () => {
+    // Open union — plugins may declare custom strategies. Resolver doesn't
+    // sanitize; downstream call sites silently degrade unknown values to
+    // first-grid behavior. Verify the field round-trips so a plugin can
+    // detect its own strategy.
+    const config: PanelKindConfig = {
+      id: "synthetic",
+      name: "Synthetic",
+      iconId: "test",
+      color: "#000",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      policy: { dockFallbackTarget: "plugin-custom-strategy" },
+    };
+    expect(resolvePanelKindPolicy(config).dockFallbackTarget).toBe("plugin-custom-strategy");
+  });
+});

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -15,6 +15,69 @@ export const BUILT_IN_PANEL_KINDS = ["terminal", "browser", "dev-preview", "revi
 export type BuiltInPanelKind = (typeof BUILT_IN_PANEL_KINDS)[number];
 
 /**
+ * Where the focus fallback should look when the focused panel is removed
+ * (trashed, moved to dock). `"first-grid"` is today's behavior — pick the
+ * first remaining grid panel of the active worktree. `"previous-focused"`
+ * restores focus to whatever `previousFocusedId` points at (if still a valid
+ * grid panel), falling back to first-grid otherwise.
+ *
+ * Open union — extensions may register custom fallback strategies; unknown
+ * values are treated as `"first-grid"` so a misconfigured plugin can't strand
+ * focus.
+ */
+export type PanelKindDockFallbackTarget = "first-grid" | "previous-focused" | (string & {});
+
+/**
+ * Type stub for a future field that will control what happens when a panel is
+ * closed (trashed vs. moved to dock). Wired into `PanelKindPolicy` so the
+ * shape is forward-compatible; no behavioral wiring exists yet.
+ */
+export type PanelKindCloseBehavior = "trash" | "dock" | (string & {});
+
+/**
+ * Per-kind dock/focus policy. All fields are optional — kinds that omit a
+ * field fall back to the matching `DEFAULT_PANEL_KIND_POLICY` value, which
+ * encodes today's behavior. Kinds that omit the whole `policy` block are
+ * indistinguishable from kinds that set `policy: {}`.
+ */
+export interface PanelKindPolicy {
+  /**
+   * Where focus lands when this kind's panel was focused and is then removed
+   * from the grid (trashed, moved to dock). Default: `"first-grid"`.
+   */
+  dockFallbackTarget?: PanelKindDockFallbackTarget;
+  /**
+   * Whether spawning this kind into the grid should steal keyboard focus to
+   * the new panel. Used as the default when no caller-supplied override is
+   * provided. Default: `true` (today's behavior — newly added grid panels
+   * become focused).
+   */
+  defaultFocusOnCreate?: boolean;
+  /**
+   * Whether spawning this kind into the dock with `activateDockOnCreate`
+   * should open the dock popover (mount the panel UI and steal focus to it).
+   * Mirrors the MCP suppression path. Default: `true`.
+   */
+  dockPopoverOnSpawn?: boolean;
+  /**
+   * Stubbed for forward-compatibility. Not wired yet. Default: `"trash"`.
+   */
+  closeBehavior?: PanelKindCloseBehavior;
+}
+
+/**
+ * Default policy values applied when a kind omits a `policy` field (or omits
+ * the whole `policy` block). Captures today's universal behavior so the
+ * additive policy descriptor is a strict superset.
+ */
+export const DEFAULT_PANEL_KIND_POLICY: Required<PanelKindPolicy> = {
+  dockFallbackTarget: "first-grid",
+  defaultFocusOnCreate: true,
+  dockPopoverOnSpawn: true,
+  closeBehavior: "trash",
+};
+
+/**
  * Configuration for a panel kind.
  * Extensions can register new panel kinds with custom configurations.
  */
@@ -69,6 +132,12 @@ export interface PanelKindConfig {
    * Optional: unregistered/extension kinds fall back to getExtensionFallbackDefaults.
    */
   createDefaults?: (options: AddPanelOptions) => Partial<TerminalInstance>;
+  /**
+   * Per-kind dock/focus policy. See `PanelKindPolicy` for fields. Omitting
+   * this (or setting it to `{}`) preserves the universal default behavior
+   * encoded in `DEFAULT_PANEL_KIND_POLICY`.
+   */
+  policy?: PanelKindPolicy;
 }
 
 /**
@@ -133,6 +202,10 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     searchAliases: ["diff", "commit", "stage", "git"],
     firstRenderRestore: true,
     lazyImportPath: "src/panels/review/ReviewPane.tsx",
+    // Review is a reading surface: when the user moves it to the dock or
+    // trashes it, send focus back to whatever they were last reading rather
+    // than handing focus to the first grid terminal in the worktree.
+    policy: { dockFallbackTarget: "previous-focused" },
   },
 };
 
@@ -277,6 +350,25 @@ export function unregisterPanelKind(kindId: string): boolean {
  */
 export function getPanelKindConfig(kind: PanelKind): PanelKindConfig | undefined {
   return PANEL_KIND_REGISTRY[kind];
+}
+
+/**
+ * Resolve a panel kind's policy, layering its declared `policy` block over
+ * `DEFAULT_PANEL_KIND_POLICY`. Returns a fully-populated `Required<PanelKindPolicy>`
+ * so callers can read fields without an undefined check.
+ *
+ * Pass either a `PanelKindConfig` (skip the registry lookup when the caller
+ * already has the entry) or a `PanelKind` (does the lookup). An unknown kind
+ * resolves to the default policy.
+ *
+ * Sync, side-effect free, and safe to call from inside Zustand `set()`
+ * updaters — the registry is a module-level synchronous map.
+ */
+export function resolvePanelKindPolicy(
+  source: PanelKindConfig | PanelKind | undefined
+): Required<PanelKindPolicy> {
+  const config = typeof source === "string" ? getPanelKindConfig(source) : (source ?? undefined);
+  return { ...DEFAULT_PANEL_KIND_POLICY, ...(config?.policy ?? {}) };
 }
 
 /**

--- a/src/store/__tests__/trashTerminalAgentFocus.test.ts
+++ b/src/store/__tests__/trashTerminalAgentFocus.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
     onPanelBackgrounded: vi.fn(),
+    wake: vi.fn(),
   },
 }));
 
@@ -685,6 +686,86 @@ describe("review-kind dock fallback (#8946 — previous-focused policy)", () => 
 
     // Terminal kind = default "first-grid" policy → shell-first wins, not shell-last
     expect(usePanelStore.getState().focusedId).toBe("shell-first");
+  });
+
+  it("unknown dockFallbackTarget string degrades to first-grid", async () => {
+    const { registerPanelKind, unregisterPanelKind } =
+      await import("@shared/config/panelKindRegistry");
+    registerPanelKind({
+      id: "plugin-custom-fallback",
+      name: "Plugin Custom",
+      iconId: "test",
+      color: "#000",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      usesTerminalUi: false,
+      extensionId: "test-policy-plugin",
+      policy: { dockFallbackTarget: "some-future-strategy" },
+    });
+
+    try {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+      usePanelStore.setState({
+        panelsById: {
+          "shell-first": makeTerminal("shell-first", "terminal", undefined, "wt-1"),
+          "shell-last": makeTerminal("shell-last", "terminal", undefined, "wt-1"),
+          "plugin-1": {
+            id: "plugin-1",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            kind: "plugin-custom-fallback" as any,
+            worktreeId: "wt-1",
+            title: "plugin-1",
+            location: "grid" as const,
+          },
+        },
+        panelIds: ["shell-first", "shell-last", "plugin-1"],
+        focusedId: "plugin-1",
+        // Even with a valid previous-focused, an unknown strategy must
+        // degrade to first-grid rather than guessing.
+        previousFocusedId: "shell-last",
+      });
+
+      usePanelStore.getState().trashPanel("plugin-1");
+
+      expect(usePanelStore.getState().focusedId).toBe("shell-first");
+    } finally {
+      unregisterPanelKind("plugin-custom-fallback");
+    }
+  });
+
+  it("previous-focused via real focus-navigation mechanism (no injected previousFocusedId)", () => {
+    // End-to-end check: navigate via `setFocused` (the real mechanism the
+    // store uses when the user clicks/Tab/keyboard-focuses a panel), then
+    // trash a review panel and verify focus returns to the previously-
+    // focused panel without manually seeding `previousFocusedId`.
+    usePanelStore.setState({
+      panelsById: {
+        "real-shell-a": makeTerminal("real-shell-a", "terminal"),
+        "real-shell-b": makeTerminal("real-shell-b", "terminal"),
+        "real-review": makeReviewPanel("real-review"),
+      },
+      panelIds: ["real-shell-a", "real-shell-b", "real-review"],
+      focusedId: null,
+      previousFocusedId: null,
+    });
+
+    const { setFocused } = usePanelStore.getState();
+    // Simulate a real navigation sequence — `setFocused` is what every
+    // user-driven focus change goes through (click, Tab, keyboard, etc.).
+    setFocused("real-shell-a");
+    setFocused("real-shell-b");
+    expect(usePanelStore.getState().focusedId).toBe("real-shell-b");
+    expect(usePanelStore.getState().previousFocusedId).toBe("real-shell-a");
+
+    setFocused("real-review");
+    expect(usePanelStore.getState().focusedId).toBe("real-review");
+    expect(usePanelStore.getState().previousFocusedId).toBe("real-shell-b");
+
+    // Trash the review pane. Per the previous-focused policy, focus must
+    // return to shell-b (the panel the user was reading from).
+    usePanelStore.getState().trashPanel("real-review");
+    expect(usePanelStore.getState().focusedId).toBe("real-shell-b");
   });
 
   it("trashPanel: review respects worktree scoping when reading previousFocusedId", () => {

--- a/src/store/__tests__/trashTerminalAgentFocus.test.ts
+++ b/src/store/__tests__/trashTerminalAgentFocus.test.ts
@@ -516,6 +516,199 @@ describe("worktree-scoped focus fallback (#4327)", () => {
   });
 });
 
+function makeReviewPanel(id: string, worktreeId?: string) {
+  return {
+    id,
+    kind: "review" as const,
+    worktreeId,
+    title: id,
+    location: "grid" as const,
+  };
+}
+
+describe("review-kind dock fallback (#8946 — previous-focused policy)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { reset } = usePanelStore.getState();
+    reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      previousFocusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  afterEach(() => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("trashPanel: review restores focus to previousFocusedId rather than first-grid", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: {
+        "shell-1": makeTerminal("shell-1", "terminal", undefined, "wt-1"),
+        "review-1": makeReviewPanel("review-1", "wt-1"),
+        "shell-2": makeTerminal("shell-2", "terminal", undefined, "wt-1"),
+      },
+      panelIds: ["shell-1", "review-1", "shell-2"],
+      // User was reading the review pane and previously had shell-2 focused
+      focusedId: "review-1",
+      previousFocusedId: "shell-2",
+    });
+
+    usePanelStore.getState().trashPanel("review-1");
+
+    // Review opts into "previous-focused", so focus returns to shell-2
+    // (not shell-1, which is what first-grid would pick).
+    expect(usePanelStore.getState().focusedId).toBe("shell-2");
+  });
+
+  it("trashPanel: review falls back to first-grid when previousFocusedId is stale", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: {
+        "shell-first": makeTerminal("shell-first", "terminal", undefined, "wt-1"),
+        "review-1": makeReviewPanel("review-1", "wt-1"),
+      },
+      panelIds: ["shell-first", "review-1"],
+      focusedId: "review-1",
+      // Stale pointer — panel was trashed/never existed
+      previousFocusedId: "ghost-id",
+    });
+
+    usePanelStore.getState().trashPanel("review-1");
+
+    // Stale previousFocusedId is invalid, fall through to first-grid pick
+    expect(usePanelStore.getState().focusedId).toBe("shell-first");
+  });
+
+  it("trashPanel: review falls back to first-grid when previousFocusedId points to a docked panel", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: {
+        "shell-first": makeTerminal("shell-first", "terminal", undefined, "wt-1"),
+        "docked-shell": {
+          ...makeTerminal("docked-shell", "terminal", undefined, "wt-1"),
+          location: "dock" as const,
+        },
+        "review-1": makeReviewPanel("review-1", "wt-1"),
+      },
+      panelIds: ["shell-first", "docked-shell", "review-1"],
+      focusedId: "review-1",
+      previousFocusedId: "docked-shell",
+    });
+
+    usePanelStore.getState().trashPanel("review-1");
+
+    // Previously-focused panel is no longer grid-resident → fall through.
+    expect(usePanelStore.getState().focusedId).toBe("shell-first");
+  });
+
+  it("trashPanel: review falls back to first-grid when previousFocusedId is null", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: {
+        "shell-1": makeTerminal("shell-1", "terminal", undefined, "wt-1"),
+        "review-1": makeReviewPanel("review-1", "wt-1"),
+      },
+      panelIds: ["shell-1", "review-1"],
+      focusedId: "review-1",
+      previousFocusedId: null,
+    });
+
+    usePanelStore.getState().trashPanel("review-1");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-1");
+  });
+
+  it("moveTerminalToDock: review restores focus to previousFocusedId", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: {
+        "shell-first": makeTerminal("shell-first", "terminal", undefined, "wt-1"),
+        "shell-last": makeTerminal("shell-last", "terminal", undefined, "wt-1"),
+        "review-1": makeReviewPanel("review-1", "wt-1"),
+      },
+      panelIds: ["shell-first", "shell-last", "review-1"],
+      focusedId: "review-1",
+      previousFocusedId: "shell-last",
+    });
+
+    usePanelStore.getState().moveTerminalToDock("review-1");
+
+    // Without policy: would pick shell-first. With "previous-focused":
+    // restores shell-last as the user expected.
+    expect(usePanelStore.getState().focusedId).toBe("shell-last");
+  });
+
+  it("moveTerminalToPosition to dock: review restores focus to previousFocusedId", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: {
+        "shell-first": makeTerminal("shell-first", "terminal", undefined, "wt-1"),
+        "shell-last": makeTerminal("shell-last", "terminal", undefined, "wt-1"),
+        "review-1": makeReviewPanel("review-1", "wt-1"),
+      },
+      panelIds: ["shell-first", "shell-last", "review-1"],
+      focusedId: "review-1",
+      previousFocusedId: "shell-last",
+    });
+
+    usePanelStore.getState().moveTerminalToPosition("review-1", 0, "dock");
+
+    expect(usePanelStore.getState().focusedId).toBe("shell-last");
+  });
+
+  it("terminal kind without policy still uses first-grid behavior (no regression)", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: {
+        "shell-first": makeTerminal("shell-first", "terminal", undefined, "wt-1"),
+        "shell-last": makeTerminal("shell-last", "terminal", undefined, "wt-1"),
+        "shell-focused": makeTerminal("shell-focused", "terminal", undefined, "wt-1"),
+      },
+      panelIds: ["shell-first", "shell-last", "shell-focused"],
+      focusedId: "shell-focused",
+      // Even if previousFocusedId is set, the default first-grid policy ignores it.
+      previousFocusedId: "shell-last",
+    });
+
+    usePanelStore.getState().trashPanel("shell-focused");
+
+    // Terminal kind = default "first-grid" policy → shell-first wins, not shell-last
+    expect(usePanelStore.getState().focusedId).toBe("shell-first");
+  });
+
+  it("trashPanel: review respects worktree scoping when reading previousFocusedId", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: {
+        "shell-other-wt": makeTerminal("shell-other-wt", "terminal", undefined, "wt-2"),
+        "shell-same-wt": makeTerminal("shell-same-wt", "terminal", undefined, "wt-1"),
+        "review-1": makeReviewPanel("review-1", "wt-1"),
+      },
+      panelIds: ["shell-other-wt", "shell-same-wt", "review-1"],
+      focusedId: "review-1",
+      // previousFocusedId points to a panel in a DIFFERENT worktree —
+      // restoring it would jump across worktrees. Treat as invalid.
+      previousFocusedId: "shell-other-wt",
+    });
+
+    usePanelStore.getState().trashPanel("review-1");
+
+    // Falls through to first-grid in the active worktree.
+    expect(usePanelStore.getState().focusedId).toBe("shell-same-wt");
+  });
+});
+
 describe("lastClosedConfig snapshot (#4717)", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -37,12 +37,80 @@ import { isRuntimeAgentTerminal } from "@/utils/terminalType";
 import { logInfo, logWarn, logError } from "@/utils/logger";
 import { clearTerminalRestartGuard } from "./restartExitSuppression";
 import { buildPanelSnapshotOptions } from "@/services/terminal/panelDuplicationService";
+import { resolvePanelKindPolicy, type PanelKindPolicy } from "@shared/config/panelKindRegistry";
 
 export type { TerminalInstance, AddPanelOptions, QueuedCommand, CrashType };
 export { isAgentReady };
 export type { TerminalMruSlice, WatchedPanelsSlice };
 
 const PROJECT_SWITCH_RESIZE_SUPPRESSION_MS = 10_000;
+
+/**
+ * State snapshot required by `pickFallbackFocusId` — a minimal subset of the
+ * panel store so the helper stays pure and easy to test in isolation.
+ */
+interface FallbackFocusStateSnapshot {
+  panelsById: Record<string, TerminalInstance>;
+  panelIds: string[];
+  previousFocusedId: string | null;
+}
+
+/**
+ * Pick the next `focusedId` after a panel (or group) leaves the grid.
+ *
+ * Policy-driven via `policy.dockFallbackTarget`:
+ *   - `"previous-focused"` — restore to `state.previousFocusedId` when it is
+ *     still a grid-resident panel in the active worktree and isn't being
+ *     removed by the same operation; otherwise fall through to first-grid.
+ *   - `"first-grid"` (default / unknown) — first remaining grid panel of the
+ *     active worktree. When `preferAgent` is true, prefer the first runtime
+ *     agent terminal in that set before falling back to the plain first-grid
+ *     pick (trash variants only).
+ *
+ * Pure: no `set`/`get` calls, no `getActiveWorktreeId` indirection — the
+ * caller passes the active worktree id so the helper can be exercised in
+ * unit tests without booting the store.
+ *
+ * @returns the next panel id, or `null` if no candidate exists
+ */
+function pickFallbackFocusId(
+  state: FallbackFocusStateSnapshot,
+  excludeIds: ReadonlySet<string>,
+  activeWorktreeId: string | undefined,
+  policy: Required<PanelKindPolicy>,
+  preferAgent: boolean
+): string | null {
+  if (policy.dockFallbackTarget === "previous-focused") {
+    const prevId = state.previousFocusedId;
+    if (prevId !== null && !excludeIds.has(prevId)) {
+      const prev = state.panelsById[prevId];
+      if (prev && prev.location === "grid" && (prev.worktreeId ?? undefined) === activeWorktreeId) {
+        return prevId;
+      }
+    }
+    // Stale or invalid previous focus — fall through to first-grid so the
+    // user always lands on a real panel rather than being stranded at null.
+  }
+
+  // Default "first-grid" path (also the fallback for unknown strategies).
+  const gridTerminals: TerminalInstance[] = [];
+  for (const tid of state.panelIds) {
+    const t = state.panelsById[tid];
+    if (
+      t &&
+      !excludeIds.has(t.id) &&
+      t.location === "grid" &&
+      (t.worktreeId ?? undefined) === activeWorktreeId
+    ) {
+      gridTerminals.push(t);
+    }
+  }
+  if (preferAgent) {
+    const nextAgent = gridTerminals.find((t) => isRuntimeAgentTerminal(t));
+    if (nextAgent) return nextAgent.id;
+  }
+  return gridTerminals[0]?.id ?? null;
+}
 
 function isVisibleLivePtyTerminal(terminal: TerminalInstance): boolean {
   const location = terminal.location ?? "grid";
@@ -227,6 +295,12 @@ export const usePanelStore = create<PanelGridState>()(
         // (#6959 — assistant focus theft when MCP launches an agent).
         const assistantHasFocus = isAssistantFocused();
         const suppressMcpSpawnFocus = options.spawnedBy === "mcp" || isMcpSpawnFocusSuppressed();
+        // Resolve the kind's policy synchronously — by the time `addPanel`
+        // returns, plugin teardown could have changed the registry. The MCP
+        // suppression already wins via `panelRegistry/addPanel.ts`; this
+        // additional gate lets a kind declare "never steal focus on create"
+        // without forcing every caller to pass an option.
+        const kindPolicy = resolvePanelKindPolicy(options.kind);
         const panelOptions =
           suppressMcpSpawnFocus && options.spawnedBy !== "mcp"
             ? ({ ...options, spawnedBy: "mcp" } as AddPanelOptions)
@@ -239,10 +313,11 @@ export const usePanelStore = create<PanelGridState>()(
         // focus also isn't meaningful during restore — focus is resolved elsewhere once
         // the active worktree is set.
         if ((!options.location || options.location === "grid") && !isHydrationBatchActive()) {
-          // Suppress focus capture for MCP-initiated spawns or when the
-          // Daintree Assistant currently owns keyboard focus. The new panel
-          // still lands in the grid; the user keeps typing where they were.
-          if (assistantHasFocus || suppressMcpSpawnFocus) {
+          // Suppress focus capture for MCP-initiated spawns, when the Daintree
+          // Assistant owns keyboard focus, or when the kind's policy opts out
+          // of focus-on-create. The new panel still lands in the grid; the
+          // user keeps typing where they were.
+          if (assistantHasFocus || suppressMcpSpawnFocus || !kindPolicy.defaultFocusOnCreate) {
             return id;
           }
           if (focusedBeforeCreate !== id) {
@@ -282,24 +357,24 @@ export const usePanelStore = create<PanelGridState>()(
 
       moveTerminalToDock: (id: string) => {
         const state = get();
+        // Resolve the kind's policy BEFORE the registry mutation so the
+        // pick-rule reads pre-move grid contents and a sync read can't be
+        // replayed against a partially-mutated store under React 19
+        // concurrent rendering.
+        const movingKind = state.panelsById[id]?.kind;
+        const policy = resolvePanelKindPolicy(movingKind);
         registrySlice.moveTerminalToDock(id);
 
         const updates: Partial<PanelGridState> = {};
 
         if (state.focusedId === id) {
-          const activeWt = getActiveWorktreeId() ?? undefined;
-          const gridTerminals: TerminalInstance[] = [];
-          for (const tid of state.panelIds) {
-            const t = state.panelsById[tid];
-            if (
-              t &&
-              t.id !== id &&
-              t.location === "grid" &&
-              (t.worktreeId ?? undefined) === activeWt
-            )
-              gridTerminals.push(t);
-          }
-          updates.focusedId = gridTerminals[0]?.id ?? null;
+          updates.focusedId = pickFallbackFocusId(
+            state,
+            new Set([id]),
+            getActiveWorktreeId() ?? undefined,
+            policy,
+            false
+          );
           // Auto-fallback focus from a moved-to-dock panel isn't a user
           // navigation event — clear the alternate pointer to avoid round-
           // tripping into a panel the user didn't choose.
@@ -384,6 +459,11 @@ export const usePanelStore = create<PanelGridState>()(
           }
         }
 
+        // Resolve the kind's policy and trashed-as-agent flag BEFORE the
+        // registry mutation — `state.panelsById[id]` may be gone afterward.
+        const policy = resolvePanelKindPolicy(terminalToTrash?.kind);
+        const preferAgent = Boolean(terminalToTrash && isRuntimeAgentTerminal(terminalToTrash));
+
         registrySlice.trashPanel(id);
 
         // Clear watch when panel is trashed (onTerminalRemoved only fires on full removal)
@@ -392,24 +472,13 @@ export const usePanelStore = create<PanelGridState>()(
         const updates: Partial<PanelGridState> = {};
 
         if (state.focusedId === id) {
-          const activeWt = getActiveWorktreeId() ?? undefined;
-          const gridTerminals: TerminalInstance[] = [];
-          for (const tid of state.panelIds) {
-            const t = state.panelsById[tid];
-            if (
-              t &&
-              t.id !== id &&
-              t.location === "grid" &&
-              (t.worktreeId ?? undefined) === activeWt
-            )
-              gridTerminals.push(t);
-          }
-          const trashedTerminal = state.panelsById[id];
-          const wasAgent = trashedTerminal && isRuntimeAgentTerminal(trashedTerminal);
-          const nextAgent = wasAgent
-            ? gridTerminals.find((t) => isRuntimeAgentTerminal(t))
-            : undefined;
-          updates.focusedId = nextAgent?.id ?? gridTerminals[0]?.id ?? null;
+          updates.focusedId = pickFallbackFocusId(
+            state,
+            new Set([id]),
+            getActiveWorktreeId() ?? undefined,
+            policy,
+            preferAgent
+          );
           updates.previousFocusedId = null;
         } else if (state.previousFocusedId === id) {
           updates.previousFocusedId = null;
@@ -443,30 +512,27 @@ export const usePanelStore = create<PanelGridState>()(
           }
         }
 
+        // Resolve the kind's policy from the FOCUSED panel of the group
+        // (mixed-kind groups don't exist today — only `terminal` has
+        // canConvert: true — so this matches the existing single-kind
+        // assumption while staying well-defined if that ever changes).
+        const focusedTerminal =
+          state.focusedId !== null ? state.panelsById[state.focusedId] : undefined;
+        const policy = resolvePanelKindPolicy(focusedTerminal?.kind);
+        const preferAgent = Boolean(focusedTerminal && isRuntimeAgentTerminal(focusedTerminal));
+
         registrySlice.trashPanelGroup(panelId);
 
         const updates: Partial<PanelGridState> = {};
 
         if (panelIdsInGroup.includes(state.focusedId ?? "")) {
-          const activeWt = getActiveWorktreeId() ?? undefined;
-          const groupSet = new Set(panelIdsInGroup);
-          const gridTerminals: TerminalInstance[] = [];
-          for (const tid of state.panelIds) {
-            const t = state.panelsById[tid];
-            if (
-              t &&
-              !groupSet.has(t.id) &&
-              t.location === "grid" &&
-              (t.worktreeId ?? undefined) === activeWt
-            )
-              gridTerminals.push(t);
-          }
-          const focusedTerminal = state.panelsById[state.focusedId!];
-          const wasAgent = focusedTerminal && isRuntimeAgentTerminal(focusedTerminal);
-          const nextAgent = wasAgent
-            ? gridTerminals.find((t) => isRuntimeAgentTerminal(t))
-            : undefined;
-          updates.focusedId = nextAgent?.id ?? gridTerminals[0]?.id ?? null;
+          updates.focusedId = pickFallbackFocusId(
+            state,
+            new Set(panelIdsInGroup),
+            getActiveWorktreeId() ?? undefined,
+            policy,
+            preferAgent
+          );
           updates.previousFocusedId = null;
         } else if (
           state.previousFocusedId !== null &&
@@ -556,6 +622,10 @@ export const usePanelStore = create<PanelGridState>()(
         worktreeId?: string | null
       ) => {
         const state = get();
+        // Resolve the kind's policy from the pre-move snapshot so the dock
+        // branch's pick-rule reads the moving panel's kind.
+        const movingKind = state.panelsById[id]?.kind;
+        const policy = resolvePanelKindPolicy(movingKind);
         registrySlice.moveTerminalToPosition(id, toIndex, location, worktreeId);
 
         if (location === "grid") {
@@ -566,21 +636,18 @@ export const usePanelStore = create<PanelGridState>()(
             ...(previousFocusedId !== id && { previousFocusedId }),
           });
         } else if (state.focusedId === id) {
-          const activeWt = getActiveWorktreeId() ?? undefined;
-          const gridTerminals: TerminalInstance[] = [];
-          for (const tid of state.panelIds) {
-            const t = state.panelsById[tid];
-            if (
-              t &&
-              t.id !== id &&
-              t.location === "grid" &&
-              (t.worktreeId ?? undefined) === activeWt
-            )
-              gridTerminals.push(t);
-          }
           // Auto-fallback focus when the focused panel is moved to dock —
           // not a user navigation, so the alternate pointer becomes stale.
-          set({ focusedId: gridTerminals[0]?.id ?? null, previousFocusedId: null });
+          set({
+            focusedId: pickFallbackFocusId(
+              state,
+              new Set([id]),
+              getActiveWorktreeId() ?? undefined,
+              policy,
+              false
+            ),
+            previousFocusedId: null,
+          });
         }
       },
 

--- a/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
@@ -423,6 +423,112 @@ describe("atomic dock activation on create (#6590)", () => {
   });
 });
 
+describe("dockPopoverOnSpawn policy gate (#8946)", () => {
+  beforeEach(async () => {
+    const { reset } = usePanelStore.getState();
+    await reset();
+  });
+
+  it("kind with dockPopoverOnSpawn: false skips the popover even when activateDockOnCreate is true", async () => {
+    const { registerPanelKind, unregisterPanelKind } =
+      await import("@shared/config/panelKindRegistry");
+    registerPanelKind({
+      id: "quiet-dock-kind",
+      name: "Quiet Dock",
+      iconId: "test",
+      color: "#000",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      usesTerminalUi: false,
+      extensionId: "test-policy-plugin",
+      policy: { dockPopoverOnSpawn: false },
+    });
+
+    try {
+      const { addPanel } = usePanelStore.getState();
+      // Extension kinds widen via explicit cast at the integration boundary
+      // — see ExtensionPanelOptions note in shared/types/addPanelOptions.ts.
+      const id = await addPanel({
+        kind: "quiet-dock-kind",
+        requestedId: "quiet-dock-1",
+        cwd: "/",
+        location: "dock",
+        bypassLimits: true,
+        activateDockOnCreate: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      expect(id).toBe("quiet-dock-1");
+      const state = usePanelStore.getState();
+      // Panel committed to dock but popover NOT opened — activeDockTerminalId stays null.
+      expect(state.panelsById[id!]).toBeDefined();
+      expect(state.activeDockTerminalId).toBeNull();
+      expect(state.focusedId).toBeNull();
+    } finally {
+      unregisterPanelKind("quiet-dock-kind");
+    }
+  });
+
+  it("MCP suppression still wins over kind policy (both gates lead to suppressed popover)", async () => {
+    const { registerPanelKind, unregisterPanelKind } =
+      await import("@shared/config/panelKindRegistry");
+    // Even with dockPopoverOnSpawn: true (default), MCP spawn still suppresses.
+    registerPanelKind({
+      id: "opt-in-popover-kind",
+      name: "Opt-In",
+      iconId: "test",
+      color: "#000",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      usesTerminalUi: false,
+      extensionId: "test-policy-plugin",
+      policy: { dockPopoverOnSpawn: true },
+    });
+
+    try {
+      const { addPanel } = usePanelStore.getState();
+      const id = await addPanel({
+        kind: "opt-in-popover-kind",
+        requestedId: "opt-in-1",
+        cwd: "/",
+        location: "dock",
+        bypassLimits: true,
+        activateDockOnCreate: true,
+        spawnedBy: "mcp",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      expect(id).toBe("opt-in-1");
+      const state = usePanelStore.getState();
+      expect(state.panelsById[id!]).toBeDefined();
+      // MCP still suppresses regardless of policy.
+      expect(state.activeDockTerminalId).toBeNull();
+    } finally {
+      unregisterPanelKind("opt-in-popover-kind");
+    }
+  });
+
+  it("kind without policy (default dockPopoverOnSpawn: true) still opens the popover", async () => {
+    const { addPanel } = usePanelStore.getState();
+    const id = await addPanel({
+      // browser has no policy — uses default dockPopoverOnSpawn: true.
+      kind: "browser",
+      requestedId: "browser-default-popover",
+      cwd: "/",
+      location: "dock",
+      bypassLimits: true,
+      activateDockOnCreate: true,
+    });
+
+    expect(id).toBe("browser-default-popover");
+    const state = usePanelStore.getState();
+    expect(state.panelsById[id!]).toBeDefined();
+    expect(state.activeDockTerminalId).toBe("browser-default-popover");
+  });
+});
+
 describe("dock watchdog hardening (#7278)", () => {
   beforeEach(async () => {
     const { reset } = usePanelStore.getState();

--- a/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
@@ -527,6 +527,132 @@ describe("dockPopoverOnSpawn policy gate (#8946)", () => {
     expect(state.panelsById[id!]).toBeDefined();
     expect(state.activeDockTerminalId).toBe("browser-default-popover");
   });
+
+  it("PTY extension kind honors dockPopoverOnSpawn: false (resolved from requestedKind, not collapsed kind)", async () => {
+    // Regression guard: previously the PTY path resolved policy from the
+    // collapsed `kind` ("terminal" | "dev-preview"), silently dropping any
+    // PTY extension kind's policy. Resolution now uses `requestedKind`.
+    const wake = vi.mocked(terminalInstanceService.wake);
+    wake.mockReset();
+
+    const { registerPanelKind, unregisterPanelKind } =
+      await import("@shared/config/panelKindRegistry");
+    registerPanelKind({
+      id: "pty-quiet-kind",
+      name: "PTY Quiet",
+      iconId: "test",
+      color: "#000",
+      hasPty: true,
+      canRestart: true,
+      canConvert: true,
+      usesTerminalUi: true,
+      extensionId: "test-policy-plugin",
+      policy: { dockPopoverOnSpawn: false },
+    });
+
+    try {
+      const { addPanel } = usePanelStore.getState();
+      const id = await addPanel({
+        kind: "pty-quiet-kind",
+        requestedId: "pty-quiet-1",
+        cwd: "/",
+        location: "dock",
+        bypassLimits: true,
+        activateDockOnCreate: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      expect(id).toBe("pty-quiet-1");
+      const state = usePanelStore.getState();
+      expect(state.panelsById[id!]).toBeDefined();
+      // Popover suppressed by policy.
+      expect(state.activeDockTerminalId).toBeNull();
+      // Side-effect block also suppressed.
+      expect(wake).not.toHaveBeenCalledWith("pty-quiet-1");
+    } finally {
+      unregisterPanelKind("pty-quiet-kind");
+    }
+  });
+});
+
+describe("defaultFocusOnCreate policy gate (#8946)", () => {
+  beforeEach(async () => {
+    const { reset } = usePanelStore.getState();
+    await reset();
+  });
+
+  it("kind with defaultFocusOnCreate: false does not steal focus on grid spawn", async () => {
+    const { registerPanelKind, unregisterPanelKind } =
+      await import("@shared/config/panelKindRegistry");
+    registerPanelKind({
+      id: "no-focus-steal-kind",
+      name: "No Focus Steal",
+      iconId: "test",
+      color: "#000",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      usesTerminalUi: false,
+      extensionId: "test-policy-plugin",
+      policy: { defaultFocusOnCreate: false },
+    });
+
+    try {
+      const { addPanel } = usePanelStore.getState();
+      // Seed an existing focused grid panel.
+      const firstId = await addPanel({
+        kind: "browser",
+        requestedId: "anchor-focus",
+        cwd: "/",
+        location: "grid",
+        bypassLimits: true,
+      });
+      expect(firstId).toBe("anchor-focus");
+      expect(usePanelStore.getState().focusedId).toBe("anchor-focus");
+
+      // Spawn the policy-gated kind into the grid — should NOT steal focus.
+      const id = await addPanel({
+        kind: "no-focus-steal-kind",
+        requestedId: "quiet-grid-1",
+        cwd: "/",
+        location: "grid",
+        bypassLimits: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      expect(id).toBe("quiet-grid-1");
+      const state = usePanelStore.getState();
+      expect(state.panelsById[id!]).toBeDefined();
+      // Anchor still holds focus, previousFocusedId is unchanged.
+      expect(state.focusedId).toBe("anchor-focus");
+    } finally {
+      unregisterPanelKind("no-focus-steal-kind");
+    }
+  });
+
+  it("kind without policy (default defaultFocusOnCreate: true) does steal focus on grid spawn", async () => {
+    const { addPanel } = usePanelStore.getState();
+    const firstId = await addPanel({
+      kind: "browser",
+      requestedId: "anchor-2",
+      cwd: "/",
+      location: "grid",
+      bypassLimits: true,
+    });
+    expect(firstId).toBe("anchor-2");
+    expect(usePanelStore.getState().focusedId).toBe("anchor-2");
+
+    const secondId = await addPanel({
+      // browser has no policy → default defaultFocusOnCreate: true.
+      kind: "browser",
+      requestedId: "stealer-2",
+      cwd: "/",
+      location: "grid",
+      bypassLimits: true,
+    });
+    expect(secondId).toBe("stealer-2");
+    expect(usePanelStore.getState().focusedId).toBe("stealer-2");
+  });
 });
 
 describe("dock watchdog hardening (#7278)", () => {

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -7,6 +7,7 @@ import {
   panelKindUsesTerminalUi,
   getPanelKindConfig,
   getExtensionFallbackDefaults,
+  resolvePanelKindPolicy,
 } from "@shared/config/panelKindRegistry";
 import { getTerminalAppearanceSnapshot } from "@/hooks/useTerminalAppearance";
 import { getScrollbackForType, PERFORMANCE_MODE_SCROLLBACK } from "@/utils/scrollbackConfig";
@@ -237,7 +238,11 @@ export const createAddPanelActions = (
             // popover. Opening the popover mounts Radix focus management and
             // terminal focus handlers, which is itself a keyboard-focus side
             // effect even if focusedId is preserved. See #6959.
-            if (options.spawnedBy === "mcp") {
+            // The kind's policy may also opt out (e.g., a reading-surface
+            // kind that prefers to land in the dock quietly); same mechanism,
+            // applied per-kind.
+            const policy = resolvePanelKindPolicy(requestedKind);
+            if (options.spawnedBy === "mcp" || !policy.dockPopoverOnSpawn) {
               return {
                 panelsById: newById,
                 panelIds: newIds,
@@ -451,7 +456,9 @@ export const createAddPanelActions = (
           // popover. Opening the popover mounts Radix focus management and
           // terminal focus handlers, which is itself a keyboard-focus side
           // effect even if focusedId is preserved. See #6959.
-          if (options.spawnedBy === "mcp") {
+          // The kind's policy may also opt out via `dockPopoverOnSpawn: false`.
+          const policy = resolvePanelKindPolicy(kind);
+          if (options.spawnedBy === "mcp" || !policy.dockPopoverOnSpawn) {
             return {
               panelsById: newById,
               panelIds: newIds,
@@ -555,7 +562,15 @@ export const createAddPanelActions = (
     // perform. Wrapped to mirror the prewarm block: a renderer service
     // failure should not strand the panel in `spawning` with the spawn
     // promise never started.
-    if (options.activateDockOnCreate && location === "dock" && options.spawnedBy !== "mcp") {
+    // Mirror both opt-outs from the popover gate above so this side-effect
+    // path doesn't fire when the popover was deliberately suppressed.
+    const ptyDockPolicy = resolvePanelKindPolicy(kind);
+    if (
+      options.activateDockOnCreate &&
+      location === "dock" &&
+      options.spawnedBy !== "mcp" &&
+      ptyDockPolicy.dockPopoverOnSpawn
+    ) {
       try {
         terminalInstanceService.wake(id);
         if (agentState === "waiting") {

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -207,6 +207,14 @@ export const createAddPanelActions = (
         });
         collectPanelIdForBatch(id);
       } else {
+        // Capture the kind's policy synchronously, BEFORE the `set()` updater
+        // closure. The updater can run later (or, under React 19 concurrent
+        // mode, replay), and a plugin unregister landing between this point
+        // and the commit would silently flip the popover gate. See the
+        // matching pattern in panelStore.ts where every fallback site reads
+        // policy before the registry mutation.
+        const popoverSuppressed =
+          options.spawnedBy === "mcp" || !resolvePanelKindPolicy(requestedKind).dockPopoverOnSpawn;
         set((state) => {
           const existing = state.panelsById[id];
           if (existing) {
@@ -241,8 +249,7 @@ export const createAddPanelActions = (
             // The kind's policy may also opt out (e.g., a reading-surface
             // kind that prefers to land in the dock quietly); same mechanism,
             // applied per-kind.
-            const policy = resolvePanelKindPolicy(requestedKind);
-            if (options.spawnedBy === "mcp" || !policy.dockPopoverOnSpawn) {
+            if (popoverSuppressed) {
               return {
                 panelsById: newById,
                 panelIds: newIds,
@@ -405,6 +412,13 @@ export const createAddPanelActions = (
       });
       collectPanelIdForBatch(id);
     } else {
+      // Capture popover-gate inputs synchronously, BEFORE the `set()` updater
+      // closure — same reason as the non-PTY path above. Resolve from
+      // `requestedKind` (the caller-supplied kind), not the collapsed `kind`,
+      // so a PTY extension kind's policy is honored. `kind` here is collapsed
+      // to "terminal" | "dev-preview" for storage-shape purposes only.
+      const ptyPopoverSuppressed =
+        options.spawnedBy === "mcp" || !resolvePanelKindPolicy(requestedKind).dockPopoverOnSpawn;
       set((state) => {
         const existing = state.panelsById[id];
         if (existing) {
@@ -457,8 +471,7 @@ export const createAddPanelActions = (
           // terminal focus handlers, which is itself a keyboard-focus side
           // effect even if focusedId is preserved. See #6959.
           // The kind's policy may also opt out via `dockPopoverOnSpawn: false`.
-          const policy = resolvePanelKindPolicy(kind);
-          if (options.spawnedBy === "mcp" || !policy.dockPopoverOnSpawn) {
+          if (ptyPopoverSuppressed) {
             return {
               panelsById: newById,
               panelIds: newIds,
@@ -564,7 +577,8 @@ export const createAddPanelActions = (
     // promise never started.
     // Mirror both opt-outs from the popover gate above so this side-effect
     // path doesn't fire when the popover was deliberately suppressed.
-    const ptyDockPolicy = resolvePanelKindPolicy(kind);
+    // Resolve from `requestedKind` to honor PTY extension kind policies.
+    const ptyDockPolicy = resolvePanelKindPolicy(requestedKind);
     if (
       options.activateDockOnCreate &&
       location === "dock" &&


### PR DESCRIPTION
## Summary

- Adds a `PanelKindPolicy` descriptor to the panel kind registry so each kind can specify its own dock fallback target, default focus behavior on creation, dock popover on spawn, and close behavior. `DEFAULT_PANEL_KIND_POLICY` captures today's universal behavior, so kinds without an explicit policy are unchanged.
- Wires the review kind with `dockFallbackTarget: "previous-focused"` so trashing or docking a review pane restores focus to the panel the user was reading before.
- Extracts a pure `pickFallbackFocusId()` helper in `panelStore.ts`, deduplicating four previously repeated fallback blocks across `moveTerminalToDock`, `moveTerminalToPosition`, `trashPanel`, and `trashPanelGroup`.

Resolves #8946

## Changes

- `shared/config/panelKindRegistry.ts` — `PanelKindPolicy` type, `DEFAULT_PANEL_KIND_POLICY` constant, `resolvePanelKindPolicy()` helper, review kind wired with `previous-focused` fallback
- `src/store/panelStore.ts` — extracted `pickFallbackFocusId()`, deduped four fallback blocks, validation that the `previous-focused` candidate is still grid-resident in the active worktree
- `src/store/slices/panelRegistry/addPanel.ts` — `dockPopoverOnSpawn` gate alongside MCP suppression (both PTY and non-PTY paths), `defaultFocusOnCreate` as a third focus-suppression gate, policy resolved from `requestedKind` (not collapsed kind) to honor PTY extension kinds, policy lookup hoisted out of `set()` updater closures to avoid React 19 concurrent replay races

## Testing

- New: `shared/config/__tests__/panelKindPolicy.test.ts` — 7 unit tests for `resolvePanelKindPolicy()` and `DEFAULT_PANEL_KIND_POLICY`
- Extended: `src/store/__tests__/trashTerminalAgentFocus.test.ts` — 9 review-kind divergence tests including real-navigation flow and unknown-strategy degradation
- Extended: `src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts` — 5 tests covering `dockPopoverOnSpawn` for non-PTY and PTY extension kinds, MCP precedence, and `defaultFocusOnCreate` gate
- All 2380 store-related tests pass; full verify suite (typecheck, lint, format, build, IPC checks) clean