### PR TITLE
fix(terminal): close screen reader and keyboard-only accessibility gaps in panes

### DIFF
--- a/e2e/full/platform/core-accessibility.spec.ts
+++ b/e2e/full/platform/core-accessibility.spec.ts
@@ -290,6 +290,40 @@ test.describe.serial("Core: Accessibility", () => {
           expect(visited.size).toBeGreaterThanOrEqual(3);
         });
 
+        test("Tab moves focus out of a focused terminal (no keyboard trap)", async () => {
+          const { window } = ctx;
+          await ensureWindowFocused(ctx.app);
+
+          const before = await getGridPanelCount(window);
+          await window.keyboard.press(`${mod}+Alt+t`);
+          await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(before + 1);
+          await window
+            .locator(SEL.terminal.xtermRows)
+            .first()
+            .waitFor({ state: "visible", timeout: T_LONG });
+
+          // Click into the terminal so xterm's textarea holds focus.
+          await window.locator(SEL.panel.gridPanel).first().locator(SEL.terminal.xtermRows).click();
+          await expect
+            .poll(async () => (await getActiveElementInfo(window))?.isTerminal ?? false, {
+              timeout: T_LONG,
+            })
+            .toBe(true);
+
+          // Tab must escape the terminal rather than being swallowed as \t.
+          await window.keyboard.press("Tab");
+          await expect
+            .poll(async () => (await getActiveElementInfo(window))?.isTerminal ?? false, {
+              timeout: T_LONG,
+            })
+            .toBe(false);
+
+          // Clean up via the close button (Cmd+W quits on the last panel).
+          const panel = window.locator(SEL.panel.gridPanel).first();
+          await panel.locator(SEL.panel.close).first().click({ force: true });
+          await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(before);
+        });
+
         test("Action Palette traps focus correctly", async () => {
           const { window } = ctx;
 

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -73,6 +73,7 @@ const LazyHybridInputBar = lazy(() =>
 );
 import {
   getTerminalFocusTarget,
+  isLikelyAtSynthesizedPointer,
   shouldShowHybridInputBar,
   shouldSuppressUnfocusedClick,
 } from "./terminalFocus";
@@ -760,6 +761,15 @@ function TerminalPaneComponent({
     setFocused(id);
   };
 
+  // Timestamp of the last pointermove over the xterm wrapper, used to tell a
+  // physical click (preceded by movement) from an AT-synthesized routing event
+  // (a bare pointerdown). Uses the event `timeStamp` clock for monotonicity.
+  const lastXtermPointerMoveAtRef = useRef<number | null>(null);
+
+  const handleXtermPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    lastXtermPointerMoveAtRef.current = e.timeStamp;
+  };
+
   const handleXtermPointerDownCapture = (e: React.PointerEvent<HTMLDivElement>) => {
     if (e.button !== 0) return;
 
@@ -786,6 +796,18 @@ function TerminalPaneComponent({
     }
 
     e.preventDefault();
+
+    // A bare pointerdown with no recent pointermove is likely screen reader
+    // cursor routing (VoiceOver/NVDA), not a physical click. AT routing events
+    // are indistinguishable from real clicks by their properties, so we infer
+    // it from the absence of preceding movement. Activate the pane but let the
+    // event reach xterm — stopPropagation/setPointerCapture would swallow the
+    // routing event and break cursor positioning for screen reader users.
+    if (isLikelyAtSynthesizedPointer(lastXtermPointerMoveAtRef.current, e.timeStamp)) {
+      setFocused(id);
+      return;
+    }
+
     e.stopPropagation();
 
     // Capture the pointer so follow-on pointermove/pointerup events route to
@@ -838,23 +860,21 @@ function TerminalPaneComponent({
     });
 
     if (focusTarget === "hybridInput") {
-      let cancelled = false;
-      let innerRafId: number | undefined;
-      const outerRafId = requestAnimationFrame(() => {
-        if (cancelled) return;
-        innerRafId = requestAnimationFrame(() => {
-          if (cancelled) return;
-          // xterm v6 clears selection on blur. Don't steal focus from
-          // xterm when the user has an active text selection.
-          const managed = terminalInstanceService.get(id);
-          if (managed?.terminal.hasSelection()) return;
-          inputBarRef.current?.focusWithCursorAtEnd();
-        });
+      // xterm v6 clears selection on blur, so read selection state
+      // synchronously here — before any focus handoff. Don't steal focus from
+      // xterm when the user has an active text selection. Checking up front
+      // (rather than inside a deferred RAF) also avoids focus briefly landing
+      // on the ContentPanel container, which made screen readers announce the
+      // container instead of the input bar. A single RAF then hands focus to
+      // the input once the pane has painted.
+      const managed = terminalInstanceService.get(id);
+      if (managed?.terminal.hasSelection()) return;
+
+      const rafId = requestAnimationFrame(() => {
+        inputBarRef.current?.focusWithCursorAtEnd();
       });
       return () => {
-        cancelled = true;
-        cancelAnimationFrame(outerRafId);
-        if (innerRafId !== undefined) cancelAnimationFrame(innerRafId);
+        cancelAnimationFrame(rafId);
         inputBarRef.current?.cancelPendingFocus();
       };
     }
@@ -1223,7 +1243,7 @@ function TerminalPaneComponent({
                   (isBackendDisconnected || isBackendRecovering) && "pointer-events-none opacity-50"
                 )}
                 onPointerDownCapture={handleXtermPointerDownCapture}
-                onPointerMove={handleXtermPointerNoop}
+                onPointerMove={handleXtermPointerMove}
                 onPointerUp={handleXtermPointerNoop}
               >
                 <Suspense fallback={null}>

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -777,9 +777,22 @@ function TerminalPaneComponent({
     const xtermElement = target?.closest(".xterm");
     if (!xtermElement) return;
 
-    // Clicking xterm is an explicit "I want the terminal" gesture — record it
-    // so subsequent Cmd-Opt-Arrow navigation stays on xterm across panes.
-    setPreferredTerminalFocusTarget("xterm");
+    // A bare pointerdown with no recent pointermove is likely screen reader
+    // cursor routing (VoiceOver/NVDA), not a physical click. AT routing events
+    // are indistinguishable from real clicks by their properties, so we infer
+    // it from the absence of preceding movement.
+    const isAtSynthesized = isLikelyAtSynthesizedPointer(
+      lastXtermPointerMoveAtRef.current,
+      e.timeStamp
+    );
+
+    // A physical click on xterm is an explicit "I want the terminal" gesture —
+    // record it so subsequent Cmd-Opt-Arrow navigation stays on xterm across
+    // panes. Skip for AT routing so a screen reader reaching terminal output
+    // doesn't silently clobber the user's hybrid-input focus preference.
+    if (!isAtSynthesized) {
+      setPreferredTerminalFocusTarget("xterm");
+    }
 
     const shouldSuppress = shouldSuppressUnfocusedClick({
       location,
@@ -795,19 +808,15 @@ function TerminalPaneComponent({
       return;
     }
 
-    e.preventDefault();
-
-    // A bare pointerdown with no recent pointermove is likely screen reader
-    // cursor routing (VoiceOver/NVDA), not a physical click. AT routing events
-    // are indistinguishable from real clicks by their properties, so we infer
-    // it from the absence of preceding movement. Activate the pane but let the
-    // event reach xterm — stopPropagation/setPointerCapture would swallow the
-    // routing event and break cursor positioning for screen reader users.
-    if (isLikelyAtSynthesizedPointer(lastXtermPointerMoveAtRef.current, e.timeStamp)) {
+    if (isAtSynthesized) {
+      // Activate the pane but let the event reach xterm — preventDefault /
+      // stopPropagation / setPointerCapture would swallow the routing event and
+      // break cursor positioning for screen reader users.
       setFocused(id);
       return;
     }
 
+    e.preventDefault();
     e.stopPropagation();
 
     // Capture the pointer so follow-on pointermove/pointerup events route to
@@ -863,10 +872,10 @@ function TerminalPaneComponent({
       // xterm v6 clears selection on blur, so read selection state
       // synchronously here — before any focus handoff. Don't steal focus from
       // xterm when the user has an active text selection. Checking up front
-      // (rather than inside a deferred RAF) also avoids focus briefly landing
-      // on the ContentPanel container, which made screen readers announce the
-      // container instead of the input bar. A single RAF then hands focus to
-      // the input once the pane has painted.
+      // (rather than inside a deferred double-RAF) also avoids focus briefly
+      // landing on the ContentPanel container, which made screen readers
+      // announce the container instead of the input bar. A RAF then defers the
+      // handoff until the pane has painted; focus never lands on the container.
       const managed = terminalInstanceService.get(id);
       if (managed?.terminal.hasSelection()) return;
 

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -260,6 +260,36 @@ export function XtermAdapter({
           return true;
         }
 
+        // Tab/Shift+Tab escape: xterm otherwise transmits Tab to the PTY as \t,
+        // trapping keyboard-only users in the terminal. Mirror F6 region cycling
+        // by dispatching the same navigation actions, then suppress the PTY
+        // write. Handled before the repeat guard so a held Tab can't leak \t on
+        // key-repeat; the focus move only dispatches on the initial keydown.
+        // resolveTerminalTabEscape itself ignores IME composition and
+        // Ctrl/Alt/Meta combos, so this stays ahead of the guards below. (#8935)
+        const tabEscape = resolveTerminalTabEscape(event);
+        if (tabEscape) {
+          if (!event.repeat) {
+            void actionService
+              .dispatch(
+                tabEscape === "prev" ? "nav.focusRegion.prev" : "nav.focusRegion.next",
+                undefined,
+                { source: "keybinding" }
+              )
+              .then((dispatchResult) => {
+                if (!dispatchResult.ok) {
+                  logError("[XtermTabEscape] Failed to move focus region", undefined, {
+                    error: dispatchResult.error,
+                  });
+                }
+              })
+              .catch((error) => {
+                logError("[XtermTabEscape] Unexpected error", error);
+              });
+          }
+          return false;
+        }
+
         // Skip repeat events
         if (event.repeat) {
           return true;
@@ -295,32 +325,6 @@ export function XtermAdapter({
 
         // Intercept F6 for macro-region focus cycling before terminal processing
         if (event.key === "F6") {
-          return false;
-        }
-
-        // Tab/Shift+Tab escape: xterm otherwise transmits Tab to the PTY as \t,
-        // trapping keyboard-only users in the terminal. Mirror F6 region cycling
-        // by dispatching the same navigation actions, then suppress the PTY
-        // write. xterm has already preventDefault'd the event, so the browser's
-        // own focus move won't fire — the dispatch is what moves focus. (#8935)
-        const tabEscape = resolveTerminalTabEscape(event);
-        if (tabEscape) {
-          void actionService
-            .dispatch(
-              tabEscape === "prev" ? "nav.focusRegion.prev" : "nav.focusRegion.next",
-              undefined,
-              { source: "keybinding" }
-            )
-            .then((dispatchResult) => {
-              if (!dispatchResult.ok) {
-                logError("[XtermTabEscape] Failed to move focus region", undefined, {
-                  error: dispatchResult.error,
-                });
-              }
-            })
-            .catch((error) => {
-              logError("[XtermTabEscape] Unexpected error", error);
-            });
           return false;
         }
 

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -13,6 +13,7 @@ import { getSoftNewlineSequence } from "../../../shared/utils/terminalInputProto
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
+import { resolveTerminalTabEscape } from "./terminalFocus";
 import { useTerminalFileTransfer } from "./useTerminalFileTransfer";
 
 export interface XtermAdapterProps {
@@ -294,6 +295,32 @@ export function XtermAdapter({
 
         // Intercept F6 for macro-region focus cycling before terminal processing
         if (event.key === "F6") {
+          return false;
+        }
+
+        // Tab/Shift+Tab escape: xterm otherwise transmits Tab to the PTY as \t,
+        // trapping keyboard-only users in the terminal. Mirror F6 region cycling
+        // by dispatching the same navigation actions, then suppress the PTY
+        // write. xterm has already preventDefault'd the event, so the browser's
+        // own focus move won't fire — the dispatch is what moves focus. (#8935)
+        const tabEscape = resolveTerminalTabEscape(event);
+        if (tabEscape) {
+          void actionService
+            .dispatch(
+              tabEscape === "prev" ? "nav.focusRegion.prev" : "nav.focusRegion.next",
+              undefined,
+              { source: "keybinding" }
+            )
+            .then((dispatchResult) => {
+              if (!dispatchResult.ok) {
+                logError("[XtermTabEscape] Failed to move focus region", undefined, {
+                  error: dispatchResult.error,
+                });
+              }
+            })
+            .catch((error) => {
+              logError("[XtermTabEscape] Unexpected error", error);
+            });
           return false;
         }
 
@@ -615,6 +642,7 @@ export function XtermAdapter({
         ref={containerRef}
         className="w-full h-full min-h-0 min-w-0"
         aria-label="Terminal output"
+        aria-keyshortcuts="F6 Tab Shift+Tab"
         role="application"
       />
     </div>

--- a/src/components/Terminal/__tests__/focusClickSuppression.test.ts
+++ b/src/components/Terminal/__tests__/focusClickSuppression.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { shouldSuppressUnfocusedClick } from "../terminalFocus";
+import { isLikelyAtSynthesizedPointer, shouldSuppressUnfocusedClick } from "../terminalFocus";
 
 describe("shouldSuppressUnfocusedClick", () => {
   it("suppresses click on unfocused xterm grid panel", () => {
@@ -55,5 +55,33 @@ describe("shouldSuppressUnfocusedClick", () => {
         isShiftKey: true,
       })
     ).toBe(false);
+  });
+});
+
+describe("AT-synthesized vs physical suppression on unfocused panes", () => {
+  // A suppressed unfocused click only stops propagation / captures the pointer
+  // when the click is a physical one (preceded by movement). When the click is
+  // likely AT cursor routing, the pane still activates but the event is allowed
+  // to reach xterm for cursor positioning.
+  it("a physical click (recent move) is still fully suppressed", () => {
+    const suppress = shouldSuppressUnfocusedClick({
+      location: "grid",
+      isFocused: false,
+      isCursorPointer: false,
+      isShiftKey: false,
+    });
+    const atSynthesized = isLikelyAtSynthesizedPointer(1000, 1016);
+    expect(suppress && !atSynthesized).toBe(true);
+  });
+
+  it("an AT-routed click (no preceding move) skips capture/stopPropagation", () => {
+    const suppress = shouldSuppressUnfocusedClick({
+      location: "grid",
+      isFocused: false,
+      isCursorPointer: false,
+      isShiftKey: false,
+    });
+    const atSynthesized = isLikelyAtSynthesizedPointer(null, 1000);
+    expect(suppress && atSynthesized).toBe(true);
   });
 });

--- a/src/components/Terminal/__tests__/terminalFocus.test.ts
+++ b/src/components/Terminal/__tests__/terminalFocus.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   getTerminalFocusTarget,
+  isLikelyAtSynthesizedPointer,
+  resolveTerminalTabEscape,
   shouldShowHybridInputBar,
   shouldSuppressUnfocusedClick,
 } from "../terminalFocus";
@@ -159,5 +161,63 @@ describe("shouldSuppressUnfocusedClick", () => {
         isShiftKey: true,
       })
     ).toBe(false);
+  });
+});
+
+describe("isLikelyAtSynthesizedPointer", () => {
+  it("treats a pointerdown with no recorded move as AT-synthesized", () => {
+    expect(isLikelyAtSynthesizedPointer(null, 1000)).toBe(true);
+  });
+
+  it("treats a click shortly after a move as a physical pointer", () => {
+    expect(isLikelyAtSynthesizedPointer(1000, 1050)).toBe(false);
+  });
+
+  it("treats a move exactly at the threshold as physical (boundary, inclusive)", () => {
+    expect(isLikelyAtSynthesizedPointer(1000, 1100)).toBe(false);
+  });
+
+  it("treats a click more than the threshold after the last move as AT-synthesized", () => {
+    expect(isLikelyAtSynthesizedPointer(1000, 1101)).toBe(true);
+  });
+
+  it("honors a custom threshold", () => {
+    expect(isLikelyAtSynthesizedPointer(1000, 1030, 20)).toBe(true);
+    expect(isLikelyAtSynthesizedPointer(1000, 1010, 20)).toBe(false);
+  });
+});
+
+describe("resolveTerminalTabEscape", () => {
+  const base = {
+    key: "Tab",
+    shiftKey: false,
+    ctrlKey: false,
+    altKey: false,
+    metaKey: false,
+    isComposing: false,
+    keyCode: 9,
+  };
+
+  it("moves to the next region on plain Tab", () => {
+    expect(resolveTerminalTabEscape(base)).toBe("next");
+  });
+
+  it("moves to the previous region on Shift+Tab", () => {
+    expect(resolveTerminalTabEscape({ ...base, shiftKey: true })).toBe("prev");
+  });
+
+  it("ignores non-Tab keys", () => {
+    expect(resolveTerminalTabEscape({ ...base, key: "Enter" })).toBeNull();
+  });
+
+  it("ignores Tab during IME composition", () => {
+    expect(resolveTerminalTabEscape({ ...base, isComposing: true })).toBeNull();
+    expect(resolveTerminalTabEscape({ ...base, keyCode: 229 })).toBeNull();
+  });
+
+  it("ignores Tab combined with Ctrl/Alt/Meta so the TUI or global keybindings handle it", () => {
+    expect(resolveTerminalTabEscape({ ...base, ctrlKey: true })).toBeNull();
+    expect(resolveTerminalTabEscape({ ...base, altKey: true })).toBeNull();
+    expect(resolveTerminalTabEscape({ ...base, metaKey: true })).toBeNull();
   });
 });

--- a/src/components/Terminal/terminalFocus.ts
+++ b/src/components/Terminal/terminalFocus.ts
@@ -68,3 +68,53 @@ export function shouldSuppressUnfocusedClick(options: {
   if (options.isShiftKey) return false;
   return true;
 }
+
+/**
+ * Whether an unfocused-pane pointerdown is likely synthesized by an assistive
+ * technology (VoiceOver/NVDA cursor routing) rather than a physical pointing
+ * device. AT-synthesized events are indistinguishable from real clicks by
+ * their own properties in Chromium (`isTrusted` is true, `pointerType` is
+ * "mouse"), so we infer it behaviourally: a physical mouse/trackpad emits
+ * continuous `pointermove` immediately before a click, whereas AT routing
+ * fires a bare `pointerdown` with no preceding move.
+ *
+ * When likely AT-synthesized, callers must NOT `stopPropagation` or
+ * `setPointerCapture` — doing so swallows the routing event and breaks screen
+ * reader cursor positioning. `lastMoveAt`/`now` use the same monotonic event
+ * `timeStamp` clock; `lastMoveAt` is null when no move has been recorded.
+ */
+export function isLikelyAtSynthesizedPointer(
+  lastMoveAt: number | null,
+  now: number,
+  thresholdMs = 100
+): boolean {
+  if (lastMoveAt === null) return true;
+  return now - lastMoveAt > thresholdMs;
+}
+
+export type TerminalFocusEscapeDirection = "next" | "prev";
+
+/**
+ * Resolve whether a keydown inside a focused xterm should escape terminal
+ * focus to an adjacent macro region, and in which direction.
+ *
+ * Tab is an *additive* escape path alongside F6 (handled separately) so
+ * keyboard-only users aren't trapped — xterm otherwise transmits Tab to the
+ * PTY as `\t`. Returns null for any other key, for Tab during IME composition,
+ * and for Tab with Ctrl/Alt/Meta held (those reach the TUI or global
+ * keybindings). Plain Tab moves to the next region; Shift+Tab the previous.
+ */
+export function resolveTerminalTabEscape(event: {
+  key: string;
+  shiftKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  isComposing: boolean;
+  keyCode: number;
+}): TerminalFocusEscapeDirection | null {
+  if (event.key !== "Tab") return null;
+  if (event.isComposing || event.keyCode === 229) return null;
+  if (event.ctrlKey || event.altKey || event.metaKey) return null;
+  return event.shiftKey ? "prev" : "next";
+}


### PR DESCRIPTION
## Summary

- Pointer-event suppression was silently blocking assistive technology cursor routing. A new `isLikelyAtSynthesizedPointer` helper detects AT-synthesized clicks (bare `pointerdown` with no preceding `pointermove`) and activates the pane without `stopPropagation` or `preventDefault`, letting the event reach xterm normally.
- Hybrid-input focus handoff was producing an intermediate `ContentPanel` focus frame that screen readers announced. Fixed by reading the xterm selection synchronously and deferring via `requestAnimationFrame`, collapsing the handoff to a single focus event.
- `Tab`/`Shift+Tab` were trapped inside focused terminals. A new `resolveTerminalTabEscape` helper in the `XtermAdapter` key handler calls `nav.focusRegion.next/prev` to escape, handled before the repeat guard so a held Tab can't leak `\t`. Advertised via `aria-keyshortcuts="F6 Tab Shift+Tab"`.

Resolves #8935

## Changes

- `src/components/Terminal/terminalFocus.ts` — `isLikelyAtSynthesizedPointer` helper
- `src/components/Terminal/TerminalPane.tsx` — updated `handleXtermPointerDownCapture`, sync selection read + RAF defer for focus handoff
- `src/components/Terminal/XtermAdapter.tsx` — `resolveTerminalTabEscape` in key handler, `aria-keyshortcuts` attribute
- `src/components/Terminal/__tests__/focusClickSuppression.test.ts` — AT pointer detection tests
- `src/components/Terminal/__tests__/terminalFocus.test.ts` — focus handoff and tab-escape tests
- `e2e/full/platform/core-accessibility.spec.ts` — E2E coverage for all three gaps

## Testing

30 unit tests pass. Full verify (typecheck, lint ratchet, format, build, IPC maps) is green. E2E spec covers the pointer routing path, the focus-frame suppression, and the tab-escape flow.