### PR TITLE
fix(palette): polish command palette accessibility

### DIFF
--- a/src/components/ActionPalette/ActionPalette.test.tsx
+++ b/src/components/ActionPalette/ActionPalette.test.tsx
@@ -17,13 +17,20 @@ const lastSearchablePaletteProps: { current: MockSearchablePaletteProps | null }
 // Capture the props passed to SearchablePalette and mirror its empty-state
 // gating (only render `emptyContent` when the user hasn't typed a query, same
 // as AppPaletteDialog.Empty's zero-data branch). Avoids dragging the full
-// dialog/animation stack into a renderer-only unit test.
+// dialog/animation stack into a renderer-only unit test. Footer resolution
+// mirrors SearchablePalette: getFooter > footer.
 vi.mock("@/components/ui/SearchablePalette", () => ({
   SearchablePalette: (props: MockSearchablePaletteProps) => {
     lastSearchablePaletteProps.current = props;
     const query = props.query ?? "";
     const results = props.results ?? [];
     const showEmptyContent = results.length === 0 && query.trim() === "";
+    const getFooter = props.getFooter as ((selected: unknown) => React.ReactNode) | undefined;
+    const selectedIndex = (props.selectedIndex as number) ?? 0;
+    const selectedItem = results[selectedIndex] ?? null;
+    const footerNode = getFooter
+      ? getFooter(selectedItem)
+      : ((props.footer as React.ReactNode) ?? null);
     return (
       <div data-testid="searchable-palette">
         {(props.inputPrefix as React.ReactNode) ?? null}
@@ -35,7 +42,7 @@ vi.mock("@/components/ui/SearchablePalette", () => ({
             (props.emptyContent ?? null)
           )
         ) : null}
-        {(props.footer as React.ReactNode) ?? null}
+        {footerNode}
       </div>
     );
   },
@@ -326,5 +333,64 @@ describe("ActionPalette", () => {
     } else {
       expect(screen.queryByText("search projects")).toBeNull();
     }
+  });
+
+  describe("prefix discoverability footer", () => {
+    it("renders the prefix table in the default empty-query footer", () => {
+      render(<ActionPalette {...baseProps} />);
+      // One chip per prefix — labels are lowercased for mid-sentence rendering.
+      expect(screen.getByText("commands")).toBeTruthy();
+      expect(screen.getByText("worktrees")).toBeTruthy();
+      expect(screen.getByText("panels")).toBeTruthy();
+      expect(screen.getByText("prompt history")).toBeTruthy();
+      expect(screen.getByText("projects")).toBeTruthy();
+    });
+
+    it("hides the prefix table once a query is typed", () => {
+      render(
+        <ActionPalette
+          {...baseProps}
+          query="al"
+          results={[makeItem("a.action", "Alpha")]}
+          totalResults={1}
+        />
+      );
+      expect(screen.queryByText("worktrees")).toBeNull();
+    });
+
+    it("hides the prefix table while a mode chip is active", () => {
+      render(<ActionPalette {...baseProps} />);
+      // Sanity: prefix row visible before any prefix is typed.
+      expect(screen.getByText("worktrees")).toBeTruthy();
+      fireKey(">");
+      // Activating commands mode replaces the row with the mode-scoped hint.
+      expect(screen.queryByText("worktrees")).toBeNull();
+    });
+  });
+
+  describe("section header listbox separators", () => {
+    it("renders section headers as aria-disabled options so AT announces them", () => {
+      render(
+        <ActionPalette
+          {...baseProps}
+          pinnedCount={1}
+          results={[makeItem("pinned.alpha", "Alpha"), makeItem("recent.beta", "Beta")]}
+          totalResults={2}
+        />
+      );
+      const renderBody = lastSearchablePaletteProps.current?.renderBody as
+        | (() => React.ReactNode)
+        | undefined;
+      expect(typeof renderBody).toBe("function");
+      const { container } = render(<>{renderBody!()}</>);
+
+      const favorites = container.querySelector('[aria-label="Favorites"]');
+      const recent = container.querySelector('[aria-label="Recently used"]');
+      expect(favorites?.getAttribute("role")).toBe("option");
+      expect(favorites?.getAttribute("aria-disabled")).toBe("true");
+      expect(favorites?.getAttribute("aria-selected")).toBe("false");
+      expect(recent?.getAttribute("role")).toBe("option");
+      expect(recent?.getAttribute("aria-disabled")).toBe("true");
+    });
   });
 });

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -380,7 +380,10 @@ export function ActionPalette({
         );
       }
 
-      const showPrefixHints = activeMode === null && query === "";
+      // Mirror showSections (`!query.trim()`) so a whitespace-only buffer
+      // collapses to the same default state instead of diverging between the
+      // sectioned MRU body and the prefix-hint footer.
+      const showPrefixHints = activeMode === null && !query.trim();
       return (
         <div
           id={footerHintId}

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -385,10 +385,7 @@ export function ActionPalette({
       // sectioned MRU body and the prefix-hint footer.
       const showPrefixHints = activeMode === null && !query.trim();
       return (
-        <div
-          id={footerHintId}
-          className="@container/palette-footer w-full flex flex-col gap-1.5"
-        >
+        <div id={footerHintId} className="@container/palette-footer w-full flex flex-col gap-1.5">
           {body}
           {showPrefixHints && <PrefixDiscoverabilityRow />}
         </div>

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
 import { PaletteOverflowNotice } from "@/components/ui/PaletteOverflowNotice";
-import { PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
+import { KBD_CLASS, PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
 import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
 import { useEffectiveCombo } from "@/hooks/useKeybinding";
 import { useActionPrefsStore } from "@/store/actionPrefsStore";
@@ -25,10 +25,6 @@ const SECTION_HEADER_CLASS =
 // Module-level so SearchablePalette receives a stable reference and skips
 // re-renders driven only by a freshly-created callback identity.
 const getActionItemId = (item: ActionPaletteItemType): string => item.id;
-
-// Verb-noun derived from the highlighted action's title — empty selection
-// falls back to a generic "run action" so the chip never goes blank.
-const getActionLabel = (item: ActionPaletteItemType | null): string => item?.title ?? "Run action";
 
 type ActionPaletteMode = "commands";
 
@@ -57,6 +53,32 @@ const COMMANDS_LABEL = PREFIX_MAP[">"]!.label;
 function looksLikePath(query: string): boolean {
   if (!query) return false;
   return /[/\\]/.test(query) || /^[.~]/.test(query);
+}
+
+// Compact prefix table surfaced in the default empty-query footer so users can
+// discover the mode-routing characters without having to type one first. Drops
+// out as soon as a query or mode is active so it never competes with the
+// primary "↵ to {action}" hint.
+function PrefixDiscoverabilityRow() {
+  return (
+    <div
+      className="@max-[420px]/palette-footer:hidden flex items-center gap-2 flex-wrap text-[11px] text-daintree-text/45"
+      aria-label="Prefix shortcuts"
+    >
+      <span className="text-daintree-text/40">Type</span>
+      {Object.entries(PREFIX_MAP).map(([prefix, route], i) => (
+        <span key={prefix} className="inline-flex items-baseline">
+          <kbd className={KBD_CLASS}>{prefix}</kbd>
+          <span className="ml-1.5">{route.label.toLowerCase()}</span>
+          {i < Object.entries(PREFIX_MAP).length - 1 && (
+            <span aria-hidden="true" className="ml-2 text-daintree-text/25">
+              ·
+            </span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
 }
 
 type ModeChipProps = {
@@ -138,6 +160,10 @@ export function ActionPalette({
 
   const actionPaletteShortcut = useEffectiveCombo("action.palette.open");
   const pinnedActionIds = useActionPrefsStore((state) => state.pinnedActionIds);
+  // Stable id wraps the rendered footer hint and gets pointed at by every
+  // option's aria-describedby — mirrors QuickSwitcher.tsx so screen readers
+  // announce what Enter does for each row.
+  const footerHintId = useId();
 
   // The sectioned empty-query body renders headers as siblings of the row list,
   // so the listbox children stay 1:1 with `results` for the parent's
@@ -172,6 +198,7 @@ export function ActionPalette({
             onPin={pinAction}
             onUnpin={unpinAction}
             onHide={hideAction}
+            footerHintId={footerHintId}
           />
         </div>
       );
@@ -184,6 +211,7 @@ export function ActionPalette({
       pinAction,
       unpinAction,
       hideAction,
+      footerHintId,
     ]
   );
 
@@ -203,7 +231,21 @@ export function ActionPalette({
         >
           {pinnedRows.length > 0 && (
             <>
-              <div className={SECTION_HEADER_CLASS} role="presentation">
+              {/*
+                Listbox children must be role="option" or role="group" per ARIA.
+                role="group" inside role="listbox" is broken under Chromium 146 +
+                VoiceOver (label is dropped, "empty group" is announced), so the
+                separator masquerades as a non-interactive option instead — AT
+                announces the section name, arrow keys still skip it because it
+                isn't in `results`.
+              */}
+              <div
+                className={SECTION_HEADER_CLASS}
+                role="option"
+                aria-disabled="true"
+                aria-selected="false"
+                aria-label="Favorites"
+              >
                 Favorites
               </div>
               {pinnedRows.map((item, idx) => renderActionRow(item, idx))}
@@ -211,7 +253,13 @@ export function ActionPalette({
           )}
           {recentRows.length > 0 && (
             <>
-              <div className={SECTION_HEADER_CLASS} role="presentation">
+              <div
+                className={SECTION_HEADER_CLASS}
+                role="option"
+                aria-disabled="true"
+                aria-selected="false"
+                aria-label="Recently used"
+              >
                 Recently used
               </div>
               {recentRows.map((item, idx) => renderActionRow(item, pinnedCount + idx))}
@@ -288,37 +336,63 @@ export function ActionPalette({
     [activeMode, query]
   );
 
-  const footer = useMemo<React.ReactNode>(() => {
-    // Mode-active footer: name what Enter does in the current scope so the
-    // user can't accidentally fire the wrong primary action.
-    if (activeMode === "commands") {
-      return (
-        <PaletteFooterHints
-          primaryHint={{ keys: ["↵"], label: "to run command" }}
-          hints={[
-            { keys: ["⌫"], label: "exit scope" },
-            { keys: ["Esc"], label: "close" },
-          ]}
-        />
-      );
-    }
+  const getFooter = useCallback(
+    (selectedItem: ActionPaletteItemType | null): React.ReactNode => {
+      let body: React.ReactNode;
 
-    // Default empty-mode hint: surface the projects prefix when the query
-    // resembles a path or filename. Per-query-shape only — no auto-routing.
-    if (results.length === 0 && looksLikePath(query)) {
-      return (
-        <PaletteFooterHints
-          primaryHint={{ keys: ["/"], label: "search projects" }}
-          hints={[
-            { keys: ["↑", "↓"], label: "navigate" },
-            { keys: ["Esc"], label: "close" },
-          ]}
-        />
-      );
-    }
+      // Mode-active footer: name what Enter does in the current scope so the
+      // user can't accidentally fire the wrong primary action.
+      if (activeMode === "commands") {
+        body = (
+          <PaletteFooterHints
+            primaryHint={{ keys: ["↵"], label: "to run command" }}
+            hints={[
+              { keys: ["⌫"], label: "exit scope" },
+              { keys: ["Esc"], label: "close" },
+            ]}
+          />
+        );
+      } else if (results.length === 0 && looksLikePath(query)) {
+        // Default empty-mode hint: surface the projects prefix when the query
+        // resembles a path or filename. Per-query-shape only — no auto-routing.
+        body = (
+          <PaletteFooterHints
+            primaryHint={{ keys: ["/"], label: "search projects" }}
+            hints={[
+              { keys: ["↑", "↓"], label: "navigate" },
+              { keys: ["Esc"], label: "close" },
+            ]}
+          />
+        );
+      } else {
+        // Default footer mirrors SearchablePalette's getActionLabel composition
+        // so we keep that affordance while still owning the wrapper id used by
+        // aria-describedby.
+        const phrase = `to ${(selectedItem?.title ?? "Run action").trim().toLowerCase()}`;
+        body = (
+          <PaletteFooterHints
+            primaryHint={{ keys: ["↵"], label: phrase }}
+            hints={[
+              { keys: ["↑", "↓"], label: "navigate" },
+              { keys: ["Esc"], label: "close" },
+            ]}
+          />
+        );
+      }
 
-    return undefined;
-  }, [activeMode, query, results.length]);
+      const showPrefixHints = activeMode === null && query === "";
+      return (
+        <div
+          id={footerHintId}
+          className="@container/palette-footer w-full flex flex-col gap-1.5"
+        >
+          {body}
+          {showPrefixHints && <PrefixDiscoverabilityRow />}
+        </div>
+      );
+    },
+    [activeMode, query, results.length, footerHintId]
+  );
 
   const chipNode = chipShouldRender ? <ModeChip label={chipLabel} isVisible={chipVisible} /> : null;
 
@@ -336,9 +410,8 @@ export function ActionPalette({
       onHoverIndex={setSelectedIndex}
       onKeyDown={handleKeyDown}
       inputPrefix={chipNode}
-      footer={footer}
+      getFooter={getFooter}
       getItemId={getActionItemId}
-      getActionLabel={activeMode === null && footer === undefined ? getActionLabel : undefined}
       isFiltering={isStale}
       renderItem={(item, index, isSelected, onHoverIndex) => {
         const isPinned = pinnedActionIds.includes(item.id);
@@ -354,6 +427,7 @@ export function ActionPalette({
             onPin={pinAction}
             onUnpin={unpinAction}
             onHide={hideAction}
+            footerHintId={footerHintId}
           />
         );
       }}

--- a/src/components/ActionPalette/ActionPaletteItem.test.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.test.tsx
@@ -441,4 +441,49 @@ describe("ActionPaletteItem", () => {
       expect(container.querySelector('svg[aria-hidden="true"]')).toBeTruthy();
     });
   });
+
+  describe("footerHintId aria-describedby", () => {
+    it("points aria-describedby at the supplied footerHintId", () => {
+      const { container } = render(
+        <ActionPaletteItem
+          item={makeItem()}
+          index={0}
+          isSelected={false}
+          onSelect={onSelect}
+          footerHintId="palette-footer-hint"
+        />
+      );
+      expect(container.querySelector("button")?.getAttribute("aria-describedby")).toBe(
+        "palette-footer-hint"
+      );
+    });
+
+    it("appends the rationale id when selected on a confirm-tier row", () => {
+      const item = {
+        ...makeItem(),
+        id: "delete-worktree",
+        danger: "confirm" as const,
+        dangerRationale: "Removes the working tree",
+      };
+      const { container } = render(
+        <ActionPaletteItem
+          item={item}
+          index={0}
+          isSelected={true}
+          onSelect={onSelect}
+          footerHintId="palette-footer-hint"
+        />
+      );
+      expect(container.querySelector("button")?.getAttribute("aria-describedby")).toBe(
+        "palette-footer-hint delete-worktree-danger-rationale"
+      );
+    });
+
+    it("omits aria-describedby entirely when no footerHintId and no selected rationale", () => {
+      const { container } = render(
+        <ActionPaletteItem item={makeItem()} index={0} isSelected={false} onSelect={onSelect} />
+      );
+      expect(container.querySelector("button")?.getAttribute("aria-describedby")).toBeNull();
+    });
+  });
 });

--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -23,6 +23,13 @@ interface ActionPaletteItemProps {
    * hide button is hidden.
    */
   onHide?: (item: ActionPaletteItemType) => void;
+  /**
+   * Stable id of the footer-hint node. When provided it is announced via
+   * aria-describedby alongside the optional rationale id, so screen readers
+   * hear what Enter does for each option. Mirrors the QuickSwitcherItem
+   * pattern.
+   */
+  footerHintId?: string;
 }
 
 function ActionPaletteItemInner({
@@ -35,6 +42,7 @@ function ActionPaletteItemInner({
   onPin,
   onUnpin,
   onHide,
+  footerHintId,
 }: ActionPaletteItemProps) {
   const categoryColor = ACTION_CATEGORY_COLORS[item.category] ?? ACTION_CATEGORY_DEFAULT_COLOR;
   const [pinRejected, setPinRejected] = useState(false);
@@ -108,6 +116,11 @@ function ActionPaletteItemInner({
   const isConfirmTier = item.danger === "confirm";
   const hasRationale = isConfirmTier && Boolean(item.dangerRationale);
   const rationaleId = hasRationale ? `${item.id}-danger-rationale` : undefined;
+  // Rationale node is CSS-hidden on unselected rows but stays in the DOM, so we
+  // only point aria-describedby at it while selected. The footer hint is always
+  // visible, so it's announced for every option.
+  const describedBy =
+    [footerHintId, isSelected ? rationaleId : undefined].filter(Boolean).join(" ") || undefined;
   // HIG ellipsis (U+2026) signals "activation requires further input or confirmation".
   // Appended at render time; the action definition's title is never mutated.
   const displayTitle = isConfirmTier ? `${item.title} …` : item.title;
@@ -135,7 +148,7 @@ function ActionPaletteItemInner({
         tabIndex={-1}
         aria-label={item.title}
         aria-haspopup={isConfirmTier ? "dialog" : undefined}
-        aria-describedby={isSelected && rationaleId ? rationaleId : undefined}
+        aria-describedby={describedBy}
         onClick={handleSelectClick}
         className={cn(
           "flex-1 min-w-0 flex items-center gap-3 text-left bg-transparent border-0 p-0",

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useRef, useCallback } from "react";
 import { AppPaletteDialog, KBD_CLASS, PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
 import { PaletteOverflowNotice } from "@/components/ui/PaletteOverflowNotice";
 import { useEscapeStack } from "@/hooks";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import type { FuseResultMatch } from "@/hooks/useSearchablePalette";
 
 const noopHoverIndex = () => {};
@@ -199,6 +201,25 @@ export function SearchablePalette<T>({
     }
   }, [selectedIndex, results]);
 
+  // Announce the result count to screen readers on the trailing edge of a
+  // filter pass. Gated on the `isFiltering` true→false transition (mirrors the
+  // visual stale-dim signal) and debounced 400ms so fast typists don't chatter
+  // the live region. Empty-query passes are skipped — the listbox already
+  // reflects the no-input state and an "N results" announcement there is noise.
+  const prevIsFilteringRef = useRef(isFiltering);
+  useEffect(() => {
+    const wasFiltering = prevIsFilteringRef.current;
+    prevIsFilteringRef.current = isFiltering;
+    if (!wasFiltering || isFiltering) return;
+    if (!query.trim()) return;
+    const count = results.length;
+    const timer = window.setTimeout(() => {
+      const message = count === 1 ? "1 result" : `${count} results`;
+      useAnnouncerStore.getState().announce(message, "polite");
+    }, UI_DOHERTY_THRESHOLD);
+    return () => window.clearTimeout(timer);
+  }, [isFiltering, query, results.length]);
+
   useEscapeStack(isOpen, () => {
     if (query !== "") {
       onQueryChange("");
@@ -206,6 +227,8 @@ export function SearchablePalette<T>({
       onClose();
     }
   });
+
+  const hoverIndexHandler = onHoverIndex ?? noopHoverIndex;
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -227,6 +250,23 @@ export function SearchablePalette<T>({
           e.stopPropagation();
           onSelectNext();
           break;
+        case "Home":
+          // Override native caret-to-start so the listbox jumps to the first
+          // result. The palette input is single-line, the caret rarely needs
+          // explicit movement, and matching VS Code / Linear / Raycast keeps
+          // the muscle memory consistent. No-op when there's nothing to jump
+          // to so empty-state typing isn't intercepted.
+          if (results.length === 0) break;
+          e.preventDefault();
+          e.stopPropagation();
+          hoverIndexHandler(0);
+          break;
+        case "End":
+          if (results.length === 0) break;
+          e.preventDefault();
+          e.stopPropagation();
+          hoverIndexHandler(results.length - 1);
+          break;
         case "Enter":
           e.preventDefault();
           e.stopPropagation();
@@ -243,15 +283,13 @@ export function SearchablePalette<T>({
           break;
       }
     },
-    [onKeyDown, onSelectPrevious, onSelectNext, onConfirm]
+    [onKeyDown, onSelectPrevious, onSelectNext, onConfirm, results.length, hoverIndexHandler]
   );
 
   const activeDescendant =
     results.length > 0 && selectedIndex >= 0 && selectedIndex < results.length
       ? `${itemIdPrefix}-${getItemId(results[selectedIndex]!)}`
       : undefined;
-
-  const hoverIndexHandler = onHoverIndex ?? noopHoverIndex;
 
   const selectedItem = results[selectedIndex] ?? null;
 

--- a/src/components/ui/__tests__/SearchablePalette.announce.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.announce.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
+  }
+});
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/hooks", () => ({
+  useEscapeStack: () => {},
+  useOverlayState: () => {},
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ activePaletteId: null }) },
+}));
+
+const announceMock = vi.fn();
+vi.mock("@/store/accessibilityAnnouncerStore", () => ({
+  useAnnouncerStore: { getState: () => ({ announce: announceMock }) },
+}));
+
+import { SearchablePalette } from "../SearchablePalette";
+
+interface Item {
+  id: string;
+}
+
+function renderPalette(initial: { query: string; results: Item[]; isFiltering: boolean }) {
+  const props = {
+    isOpen: true,
+    query: initial.query,
+    results: initial.results,
+    selectedIndex: 0,
+    onQueryChange: () => {},
+    onSelectPrevious: () => {},
+    onSelectNext: () => {},
+    onConfirm: () => {},
+    onClose: () => {},
+    getItemId: (item: Item) => item.id,
+    renderItem: (item: Item) => <div key={item.id}>{item.id}</div>,
+    label: "Test",
+    ariaLabel: "Test palette",
+    isFiltering: initial.isFiltering,
+  };
+  return render(<SearchablePalette<Item> {...props} />);
+}
+
+describe("SearchablePalette filter-result live announcement", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    announceMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("announces the result count after isFiltering transitions to false", () => {
+    const items = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const { rerender } = renderPalette({ query: "x", results: items, isFiltering: true });
+
+    rerender(
+      <SearchablePalette<Item>
+        isOpen
+        query="x"
+        results={items}
+        selectedIndex={0}
+        onQueryChange={() => {}}
+        onSelectPrevious={() => {}}
+        onSelectNext={() => {}}
+        onConfirm={() => {}}
+        onClose={() => {}}
+        getItemId={(item) => item.id}
+        renderItem={(item) => <div key={item.id}>{item.id}</div>}
+        label="Test"
+        ariaLabel="Test palette"
+        isFiltering={false}
+      />
+    );
+
+    expect(announceMock).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(400);
+    expect(announceMock).toHaveBeenCalledTimes(1);
+    expect(announceMock).toHaveBeenCalledWith("3 results", "polite");
+  });
+
+  it("uses singular phrasing for exactly one result", () => {
+    const items = [{ id: "a" }];
+    const { rerender } = renderPalette({ query: "x", results: items, isFiltering: true });
+
+    rerender(
+      <SearchablePalette<Item>
+        isOpen
+        query="x"
+        results={items}
+        selectedIndex={0}
+        onQueryChange={() => {}}
+        onSelectPrevious={() => {}}
+        onSelectNext={() => {}}
+        onConfirm={() => {}}
+        onClose={() => {}}
+        getItemId={(item) => item.id}
+        renderItem={(item) => <div key={item.id}>{item.id}</div>}
+        label="Test"
+        ariaLabel="Test palette"
+        isFiltering={false}
+      />
+    );
+
+    vi.advanceTimersByTime(400);
+    expect(announceMock).toHaveBeenCalledWith("1 result", "polite");
+  });
+
+  it("skips the announcement when the query is empty", () => {
+    const items = [{ id: "a" }];
+    const { rerender } = renderPalette({ query: "", results: items, isFiltering: true });
+
+    rerender(
+      <SearchablePalette<Item>
+        isOpen
+        query=""
+        results={items}
+        selectedIndex={0}
+        onQueryChange={() => {}}
+        onSelectPrevious={() => {}}
+        onSelectNext={() => {}}
+        onConfirm={() => {}}
+        onClose={() => {}}
+        getItemId={(item) => item.id}
+        renderItem={(item) => <div key={item.id}>{item.id}</div>}
+        label="Test"
+        ariaLabel="Test palette"
+        isFiltering={false}
+      />
+    );
+
+    vi.advanceTimersByTime(400);
+    expect(announceMock).not.toHaveBeenCalled();
+  });
+
+  it("cancels the pending announcement if isFiltering flips back to true", () => {
+    const items = [{ id: "a" }, { id: "b" }];
+    const { rerender } = renderPalette({ query: "x", results: items, isFiltering: true });
+
+    const renderProps = (isFiltering: boolean, query: string) => (
+      <SearchablePalette<Item>
+        isOpen
+        query={query}
+        results={items}
+        selectedIndex={0}
+        onQueryChange={() => {}}
+        onSelectPrevious={() => {}}
+        onSelectNext={() => {}}
+        onConfirm={() => {}}
+        onClose={() => {}}
+        getItemId={(item) => item.id}
+        renderItem={(item) => <div key={item.id}>{item.id}</div>}
+        label="Test"
+        ariaLabel="Test palette"
+        isFiltering={isFiltering}
+      />
+    );
+
+    rerender(renderProps(false, "x"));
+    vi.advanceTimersByTime(100);
+    rerender(renderProps(true, "xy"));
+    vi.advanceTimersByTime(500);
+
+    expect(announceMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/__tests__/SearchablePalette.keyboard.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.keyboard.test.tsx
@@ -146,4 +146,34 @@ describe("SearchablePalette keyboard navigation (non-composing)", () => {
     input.dispatchEvent(event);
     expect(onConfirm).not.toHaveBeenCalled();
   });
+
+  it("jumps to the first row on Home", () => {
+    const onHoverIndex = vi.fn();
+    renderPalette({ onHoverIndex, selectedIndex: 1 });
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "Home", keyCode: 36 });
+    expect(onHoverIndex).toHaveBeenCalledWith(0);
+  });
+
+  it("jumps to the last row on End", () => {
+    const onHoverIndex = vi.fn();
+    renderPalette({ onHoverIndex, selectedIndex: 0 });
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "End", keyCode: 35 });
+    expect(onHoverIndex).toHaveBeenCalledWith(items.length - 1);
+  });
+
+  it("does not intercept Home when the result list is empty", () => {
+    const onHoverIndex = vi.fn();
+    renderPalette({ onHoverIndex, results: [] });
+    const input = screen.getByRole("combobox");
+    const event = new window.KeyboardEvent("keydown", { key: "Home", keyCode: 36, bubbles: true });
+    let prevented = false;
+    event.preventDefault = () => {
+      prevented = true;
+    };
+    input.dispatchEvent(event);
+    expect(onHoverIndex).not.toHaveBeenCalled();
+    expect(prevented).toBe(false);
+  });
 });

--- a/src/components/ui/__tests__/SearchablePalette.keyboard.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.keyboard.test.tsx
@@ -176,4 +176,18 @@ describe("SearchablePalette keyboard navigation (non-composing)", () => {
     expect(onHoverIndex).not.toHaveBeenCalled();
     expect(prevented).toBe(false);
   });
+
+  it("does not intercept End when the result list is empty", () => {
+    const onHoverIndex = vi.fn();
+    renderPalette({ onHoverIndex, results: [] });
+    const input = screen.getByRole("combobox");
+    const event = new window.KeyboardEvent("keydown", { key: "End", keyCode: 35, bubbles: true });
+    let prevented = false;
+    event.preventDefault = () => {
+      prevented = true;
+    };
+    input.dispatchEvent(event);
+    expect(onHoverIndex).not.toHaveBeenCalled();
+    expect(prevented).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Five ARIA / keyboard fixes to the command palette so it works for screen-reader users and matches the keyboard conventions other palette-driven apps already use. Closes #8929.

- `ActionPaletteItem` rows now carry `aria-describedby` pointing at the rendered footer hint (mirrors `QuickSwitcherItem`) so AT users hear what Enter does on each option, alongside the existing danger-rationale link.
- The `Favorites` / `Recently used` section headers in the empty-query rail are no longer `role="presentation"` siblings of `role="option"` — they're now `role="option" aria-disabled="true" aria-selected="false"` separators with `aria-label`. ARIA spec recommends `role="group"` here but it is broken under Chromium 146 + VoiceOver (label dropped, "empty group" announced), so the flat-listbox separator is the practical workaround.
- The five mode-routing characters (`>`, `@`, `#`, `:`, `/`) now appear in a compact discoverability row in the default footer instead of only appearing reactively after typing a prefix.
- `SearchablePalette` handles `Home` / `End` to jump to the first / last result, with `preventDefault` matching the other navigation keys. Per WAI-APG these belong to caret movement in an editable combobox, but the issue is explicit and palette UIs (VS Code, Linear, Raycast) routinely override that — kept caret movement only when the result list is empty.
- When `isFiltering` transitions true → false with a non-empty query, the polite live region announces "N result(s)" 400ms later via the existing `useAnnouncerStore`. Debounced so fast typists don't chatter the region; cancelled if filtering flips back on within the window.

## Test plan

- [ ] Open the action palette on an empty query — "Favorites" / "Recently used" announce as separators; section structure is audible
- [ ] Verify each option's Enter affordance ("to {action}") is announced as the row's description
- [ ] Type `>` / `@` / `#` / `:` / `/` from the empty state — the prefix table in the footer matches the routes
- [ ] Press Home / End while results are visible — selection jumps to first / last; empty result list leaves caret behavior intact
- [ ] Type a query and let it settle — VoiceOver announces "N results" once
- [ ] Confirm-tier action (e.g. Delete worktree) still announces its danger rationale when selected
