### PR TITLE
fix(a11y): announce key state transitions to screen readers

### DIFF
--- a/src/components/ErrorBoundary/ErrorFallback.tsx
+++ b/src/components/ErrorBoundary/ErrorFallback.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
@@ -59,17 +59,19 @@ export function ErrorFallback({
     announcement: "Error ID copied",
   });
 
+  const announcedRef = useRef(false);
+
   // Fullscreen carries role="alertdialog" + autoFocus on its primary button —
   // AT already gets a focus shift + accessible-name read, so a duplicate
   // announce() would over-narrate. Section/component variants are inline and
   // need an explicit live-region message.
   useEffect(() => {
-    if (variant === "fullscreen") return;
+    if (variant === "fullscreen" || announcedRef.current) return;
+    announcedRef.current = true;
     const name = componentName || (variant === "section" ? "Section" : "Component");
     const msg = variant === "section" ? `${name} stopped working` : `${name} error`;
     useAnnouncerStore.getState().announce(msg, variant === "section" ? "assertive" : "polite");
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only announcement
-  }, []);
+  }, [variant, componentName]);
 
   const handleOpenLogs = () => {
     void actionService.dispatch("logs.openFile", undefined, { source: "user" });

--- a/src/components/ErrorBoundary/ErrorFallback.tsx
+++ b/src/components/ErrorBoundary/ErrorFallback.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { TriangleAlert } from "lucide-react";
 
 export interface ErrorFallbackProps {
@@ -56,6 +58,18 @@ export function ErrorFallback({
   const { copied: incidentIdCopied, copy: copyIncidentId } = useCopyWithFeedback({
     announcement: "Error ID copied",
   });
+
+  // Fullscreen carries role="alertdialog" + autoFocus on its primary button —
+  // AT already gets a focus shift + accessible-name read, so a duplicate
+  // announce() would over-narrate. Section/component variants are inline and
+  // need an explicit live-region message.
+  useEffect(() => {
+    if (variant === "fullscreen") return;
+    const name = componentName || (variant === "section" ? "Section" : "Component");
+    const msg = variant === "section" ? `${name} stopped working` : `${name} error`;
+    useAnnouncerStore.getState().announce(msg, variant === "section" ? "assertive" : "polite");
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only announcement
+  }, []);
 
   const handleOpenLogs = () => {
     void actionService.dispatch("logs.openFile", undefined, { source: "user" });

--- a/src/components/ErrorBoundary/__tests__/ErrorFallback.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorFallback.test.tsx
@@ -307,6 +307,38 @@ describe("ErrorFallback", () => {
     });
   });
 
+  describe("screen-reader announcements (#8937)", () => {
+    beforeEach(() => {
+      vi.stubEnv("DEV", false);
+    });
+
+    it("announces section variant assertively on mount with stopped-working phrasing", () => {
+      render(<ErrorFallback {...baseProps} variant="section" componentName="Git panel" />);
+      const { assertive, polite } = useAnnouncerStore.getState();
+      expect(assertive?.msg).toBe("Git panel stopped working");
+      expect(polite).toBeNull();
+    });
+
+    it("announces component variant politely on mount with error phrasing", () => {
+      render(<ErrorFallback {...baseProps} variant="component" componentName="Recipe runner" />);
+      const { polite, assertive } = useAnnouncerStore.getState();
+      expect(polite?.msg).toBe("Recipe runner error");
+      expect(assertive).toBeNull();
+    });
+
+    it("falls back to a generic name when componentName is missing", () => {
+      render(<ErrorFallback {...baseProps} variant="section" />);
+      expect(useAnnouncerStore.getState().assertive?.msg).toBe("Section stopped working");
+    });
+
+    it("does not announce for fullscreen variant (covered by role=alertdialog + autoFocus)", () => {
+      render(<ErrorFallback {...baseProps} variant="fullscreen" componentName="App" />);
+      const { polite, assertive } = useAnnouncerStore.getState();
+      expect(polite).toBeNull();
+      expect(assertive).toBeNull();
+    });
+  });
+
   describe("incident ID edge cases", () => {
     it("does not render Error ID when incidentId is null", () => {
       vi.stubEnv("DEV", false);

--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -221,9 +221,14 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
     if (killConfirmId) {
       const target = terminals.find((t) => t.id === killConfirmId);
       removePanel(killConfirmId);
+      // Close the confirm dialog first so the announce reaches AT after focus
+      // returns to the main tree (VoiceOver suppresses live-region updates
+      // from outside the active modal subtree).
+      setKillConfirmId(null);
       useAnnouncerStore
         .getState()
         .announce(target?.title ? `${target.title} killed` : "Terminal killed");
+      return;
     }
     setKillConfirmId(null);
   }, [killConfirmId, removePanel, terminals]);

--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -7,6 +7,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/utils";
 import { usePanelStore, type TerminalInstance } from "@/store";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import type { TrashedTerminalGroupMetadata } from "@/store/slices";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useBackgroundedTerminals } from "@/hooks/useTerminalSelectors";
@@ -218,10 +219,14 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
 
   const handleKillConfirm = useCallback(() => {
     if (killConfirmId) {
+      const target = terminals.find((t) => t.id === killConfirmId);
       removePanel(killConfirmId);
+      useAnnouncerStore
+        .getState()
+        .announce(target?.title ? `${target.title} killed` : "Terminal killed");
     }
     setKillConfirmId(null);
-  }, [killConfirmId, removePanel]);
+  }, [killConfirmId, removePanel, terminals]);
 
   if (terminals.length === 0) return null;
 

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -7,6 +7,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/utils";
 import { usePanelStore, type TerminalInstance } from "@/store";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWaitingTerminals } from "@/hooks/useTerminalSelectors";
 import { useWorktrees } from "@/hooks/useWorktrees";
@@ -140,10 +141,14 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
 
   const handleKillConfirm = useCallback(() => {
     if (killConfirmId) {
+      const target = terminals.find((t) => t.id === killConfirmId);
       removePanel(killConfirmId);
+      useAnnouncerStore
+        .getState()
+        .announce(target?.title ? `${target.title} killed` : "Terminal killed");
     }
     setKillConfirmId(null);
-  }, [killConfirmId, removePanel]);
+  }, [killConfirmId, removePanel, terminals]);
 
   if (terminals.length === 0) return null;
 

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -143,9 +143,14 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
     if (killConfirmId) {
       const target = terminals.find((t) => t.id === killConfirmId);
       removePanel(killConfirmId);
+      // Close the confirm dialog first so the announce reaches AT after focus
+      // returns to the main tree (VoiceOver suppresses live-region updates
+      // from outside the active modal subtree).
+      setKillConfirmId(null);
       useAnnouncerStore
         .getState()
         .announce(target?.title ? `${target.title} killed` : "Terminal killed");
+      return;
     }
     setKillConfirmId(null);
   }, [killConfirmId, removePanel, terminals]);

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -13,6 +13,7 @@ import { isBrowserPanel, isDevPreviewPanel, isReviewPanel } from "@shared/types/
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useIsHibernated } from "@/hooks/useIsHibernated";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { terminalHasRunningAgentSession } from "@/utils/destructiveSessionConfirm";
 import {
   ArrowDownFromLine,
@@ -371,6 +372,9 @@ export function TerminalContextMenu({
       { terminalId, confirmed: true },
       { source: sourceRef.current }
     );
+    useAnnouncerStore
+      .getState()
+      .announce(destructiveConfirm.kind === "kill" ? "Terminal killed" : "Terminal restarted");
     setDestructiveConfirm(null);
   }, [destructiveConfirm, terminalId]);
 

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -367,15 +367,18 @@ export function TerminalContextMenu({
   const handleDestructiveConfirm = useCallback(() => {
     if (!destructiveConfirm) return;
     const actionId = destructiveConfirm.kind === "kill" ? "terminal.kill" : "terminal.restart";
+    const announcement =
+      destructiveConfirm.kind === "kill" ? "Terminal killed" : "Terminal restarted";
     void actionService.dispatch(
       actionId,
       { terminalId, confirmed: true },
       { source: sourceRef.current }
     );
-    useAnnouncerStore
-      .getState()
-      .announce(destructiveConfirm.kind === "kill" ? "Terminal killed" : "Terminal restarted");
+    // Close the dialog first so the announce fires after focus returns to the
+    // main tree — VoiceOver suppresses live-region updates from outside the
+    // current modal subtree while focus is trapped.
     setDestructiveConfirm(null);
+    useAnnouncerStore.getState().announce(announcement);
   }, [destructiveConfirm, terminalId]);
 
   const closeDestructiveConfirm = useCallback(() => {

--- a/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
+++ b/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement, useCallback } from "react";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { actionService } from "@/services/ActionService";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import {
   useTerminalPendingDestructiveActionStore,
   type TerminalPendingDestructiveActionSnapshot,
@@ -95,6 +96,7 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
 
   const handleConfirm = useCallback(() => {
     if (pending === null) return;
+    const announce = useAnnouncerStore.getState().announce;
     switch (pending.kind) {
       case "kill":
         // Defensive: refuse to dispatch when the snapshot lost the target.
@@ -106,6 +108,7 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
           { terminalId: pending.terminalId, confirmed: true },
           { source: "user" }
         );
+        announce("Terminal killed");
         break;
       case "restart":
         if (!pending.terminalId) break;
@@ -114,29 +117,42 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
           { terminalId: pending.terminalId, confirmed: true },
           { source: "user" }
         );
+        announce("Terminal restarted");
         break;
-      case "killAll":
+      case "killAll": {
         void actionService.dispatch("terminal.killAll", { confirmed: true }, { source: "user" });
+        const noun = pending.targetCount === 1 ? "terminal" : "terminals";
+        announce(`Killed ${pending.targetCount} ${noun}`);
         break;
-      case "restartAll":
+      }
+      case "restartAll": {
         void actionService.dispatch("terminal.restartAll", { confirmed: true }, { source: "user" });
+        const noun = pending.targetCount === 1 ? "terminal" : "terminals";
+        announce(`Restarted ${pending.targetCount} ${noun}`);
         break;
-      case "worktreeRestartAll":
+      }
+      case "worktreeRestartAll": {
         if (!pending.worktreeId) break;
         void actionService.dispatch(
           "worktree.sessions.restartAll",
           { worktreeId: pending.worktreeId, confirmed: true },
           { source: "user" }
         );
+        const noun = pending.targetCount === 1 ? "session" : "sessions";
+        announce(`Restarted ${pending.targetCount} ${noun}`);
         break;
-      case "worktreeTrashAll":
+      }
+      case "worktreeTrashAll": {
         if (!pending.worktreeId) break;
         void actionService.dispatch(
           "worktree.sessions.trashAll",
           { worktreeId: pending.worktreeId, confirmed: true },
           { source: "user" }
         );
+        const noun = pending.targetCount === 1 ? "session" : "sessions";
+        announce(`Trashed ${pending.targetCount} ${noun}`);
         break;
+      }
     }
     clear();
   }, [pending, clear]);

--- a/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
+++ b/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
@@ -96,7 +96,7 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
 
   const handleConfirm = useCallback(() => {
     if (pending === null) return;
-    const announce = useAnnouncerStore.getState().announce;
+    let announcement: string | null = null;
     switch (pending.kind) {
       case "kill":
         // Defensive: refuse to dispatch when the snapshot lost the target.
@@ -108,7 +108,7 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
           { terminalId: pending.terminalId, confirmed: true },
           { source: "user" }
         );
-        announce("Terminal killed");
+        announcement = "Terminal killed";
         break;
       case "restart":
         if (!pending.terminalId) break;
@@ -117,18 +117,18 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
           { terminalId: pending.terminalId, confirmed: true },
           { source: "user" }
         );
-        announce("Terminal restarted");
+        announcement = "Terminal restarted";
         break;
       case "killAll": {
         void actionService.dispatch("terminal.killAll", { confirmed: true }, { source: "user" });
         const noun = pending.targetCount === 1 ? "terminal" : "terminals";
-        announce(`Killed ${pending.targetCount} ${noun}`);
+        announcement = `Killed ${pending.targetCount} ${noun}`;
         break;
       }
       case "restartAll": {
         void actionService.dispatch("terminal.restartAll", { confirmed: true }, { source: "user" });
         const noun = pending.targetCount === 1 ? "terminal" : "terminals";
-        announce(`Restarted ${pending.targetCount} ${noun}`);
+        announcement = `Restarted ${pending.targetCount} ${noun}`;
         break;
       }
       case "worktreeRestartAll": {
@@ -139,7 +139,7 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
           { source: "user" }
         );
         const noun = pending.targetCount === 1 ? "session" : "sessions";
-        announce(`Restarted ${pending.targetCount} ${noun}`);
+        announcement = `Restarted ${pending.targetCount} ${noun}`;
         break;
       }
       case "worktreeTrashAll": {
@@ -150,11 +150,17 @@ export function TerminalDestructiveActionConfirmDialog(): ReactElement | null {
           { source: "user" }
         );
         const noun = pending.targetCount === 1 ? "session" : "sessions";
-        announce(`Trashed ${pending.targetCount} ${noun}`);
+        announcement = `Trashed ${pending.targetCount} ${noun}`;
         break;
       }
     }
+    // Close the dialog first so the announce fires after focus returns to
+    // the main tree — VoiceOver suppresses live-region updates from outside
+    // the current modal subtree while focus is trapped.
     clear();
+    if (announcement) {
+      useAnnouncerStore.getState().announce(announcement);
+    }
   }, [pending, clear]);
 
   if (pending === null) return null;

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -13,6 +13,7 @@ import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore"
 import { notify } from "@/lib/notify";
 import { systemClient } from "@/clients/systemClient";
 import { useRecipeStore } from "@/store/recipeStore";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { logError } from "@/utils/logger";
 import { extractClosingIssueNumber } from "@/utils/closingIssueRef";
 import { useProjectStore } from "@/store/projectStore";
@@ -641,6 +642,7 @@ export function NewWorktreeDialog({
         }
 
         onWorktreeCreated?.(worktreeId);
+        useAnnouncerStore.getState().announce(`Created worktree ${fullBranchName}`);
       } catch (err: unknown) {
         const message = formatErrorMessage(err, "Failed to create worktree");
         if (placeholderPath) {
@@ -657,6 +659,7 @@ export function NewWorktreeDialog({
             message,
           });
         }
+        useAnnouncerStore.getState().announce("Couldn't create worktree", "assertive");
       } finally {
         isCreatingRef.current = false;
       }

--- a/src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx
+++ b/src/components/Worktree/ReviewHub/ForcePushConfirmDialog.tsx
@@ -4,6 +4,7 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { Spinner } from "@/components/ui/Spinner";
 import { AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 
 interface RemoteCommit {
@@ -91,8 +92,10 @@ export function ForcePushConfirmDialog({
     try {
       await window.electron.git.forcePushWithLease(cwd, branchName, leaseSha);
       onSuccess();
+      useAnnouncerStore.getState().announce(`Force pushed ${branchName}`);
     } catch (err) {
       onError(err);
+      useAnnouncerStore.getState().announce(`Couldn't force push ${branchName}`, "assertive");
     } finally {
       isExecutingRef.current = false;
       setIsPushing(false);

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -5,6 +5,7 @@ import { actionService } from "@/services/ActionService";
 import { useMenuActionSource } from "@/components/ui/menu-source";
 import { useRecipeStore } from "@/store/recipeStore";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
 export type ConfirmDialogState =
@@ -244,6 +245,7 @@ export function useWorktreeActions({
           { worktreeId: worktree.id, confirmed: true },
           { source: "user" }
         );
+        useAnnouncerStore.getState().announce("Trashed all sessions");
         setConfirmDialog({ isOpen: false });
       },
     });
@@ -264,6 +266,7 @@ export function useWorktreeActions({
           { worktreeId: worktree.id },
           { source: "user" }
         );
+        useAnnouncerStore.getState().announce("Terminated all sessions");
         setConfirmDialog({ isOpen: false });
       },
     });

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -245,8 +245,10 @@ export function useWorktreeActions({
           { worktreeId: worktree.id, confirmed: true },
           { source: "user" }
         );
-        useAnnouncerStore.getState().announce("Trashed all sessions");
+        // Close before announce — see VoiceOver modal-scoping note in
+        // TerminalContextMenu.handleDestructiveConfirm.
         setConfirmDialog({ isOpen: false });
+        useAnnouncerStore.getState().announce("Trashed all sessions");
       },
     });
   }, [worktree.id, worktree.issueTitle, worktree.branch]);
@@ -266,8 +268,10 @@ export function useWorktreeActions({
           { worktreeId: worktree.id },
           { source: "user" }
         );
-        useAnnouncerStore.getState().announce("Terminated all sessions");
+        // Close before announce — see VoiceOver modal-scoping note in
+        // TerminalContextMenu.handleDestructiveConfirm.
         setConfirmDialog({ isOpen: false });
+        useAnnouncerStore.getState().announce("Terminated all sessions");
       },
     });
   }, [worktree.id, worktree.issueTitle, worktree.branch]);

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle, Trash2 } from "lucide-react";
 import { FolderGit2 } from "@/components/icons";
 import { useWorktreeTerminals } from "@/hooks/useWorktreeTerminals";
 import { deriveEffectiveTier } from "@/services/actions/deriveEffectiveTier";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import type { WorktreeState } from "@/types";
 import { cn } from "@/lib/utils";
@@ -89,6 +90,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     // Fire-and-forget — progress and any failure surface on the card, not the
     // modal (#8417). The dialog closes immediately so the user keeps flow.
     getCurrentViewStore().getState().startDelete(worktree.id, options);
+    useAnnouncerStore.getState().announce("Deleting worktree");
     onClose();
   };
 

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -15,6 +15,7 @@ import {
 import type { WorktreeState, WorktreeSnapshot } from "@/types";
 import type { UseAgentLauncherReturn } from "@/hooks/useAgentLauncher";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -608,12 +609,18 @@ export function WorktreeOverviewModal({
 
   const handleCloseSessionsConfirm = useCallback(() => {
     const state = usePanelStore.getState();
+    const count = closeSessionsIdsRef.current.length;
     for (const id of closeSessionsIdsRef.current) {
       state.bulkCloseByWorktree(id);
     }
     closeSessionsIdsRef.current = [];
     setIsCloseSessionsConfirmOpen(false);
     clearSelection();
+    useAnnouncerStore
+      .getState()
+      .announce(
+        count === 1 ? "Closed sessions for 1 worktree" : `Closed sessions for ${count} worktrees`
+      );
   }, [clearSelection]);
 
   const handleCloseSessionsCancel = useCallback(() => {

--- a/src/components/Worktree/useWorktreeBulkRemove.ts
+++ b/src/components/Worktree/useWorktreeBulkRemove.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import PQueue from "p-queue";
 import { worktreeClient } from "@/clients/worktreeClient";
 import { notify } from "@/lib/notify";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { logError } from "@/utils/logger";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { WorktreeState } from "@/types";
@@ -184,30 +185,35 @@ export function useWorktreeBulkRemove({
         })
       );
 
+      const announce = useAnnouncerStore.getState().announce;
       if (failures.length === 0) {
         // Transient: the overview grid already reflects the removed
         // worktrees disappearing — the toast is a one-shot confirmation,
         // not something the user needs to revisit from the notification
         // inbox (#8249).
+        const successTitle = total === 1 ? "Removed 1 worktree" : `Removed ${total} worktrees`;
         notify({
           type: "success",
-          title: total === 1 ? "Removed 1 worktree" : `Removed ${total} worktrees`,
+          title: successTitle,
           message:
             total === 1
               ? "The worktree directory was deleted from disk."
               : `${total} worktree directories were deleted from disk.`,
           transient: true,
         });
+        announce(successTitle);
       } else if (successCount === 0) {
         // Total failure — no recovery action attached because the modal
         // itself is the retry surface (the user can re-select and retry).
         const firstFailure = failures[0];
+        const failureTitle = total === 1 ? "Couldn't remove worktree" : "Couldn't remove worktrees";
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
         notify({
           type: "error",
-          title: total === 1 ? "Couldn't remove worktree" : "Couldn't remove worktrees",
+          title: failureTitle,
           message: firstFailure ? firstFailure.reason : "All removals failed.",
         });
+        announce(failureTitle, "assertive");
       } else {
         // Partial — warning type so the success half isn't lost in red.
         // Warning toasts aren't gated by the success-toast rule, so no
@@ -218,11 +224,13 @@ export function useWorktreeBulkRemove({
           failures.length === 1 && firstFailure
             ? `${firstFailure.name} failed: ${firstFailure.reason}`
             : `${failures.length} failed.`;
+        const partialTitle = `Removed ${successCount} of ${total} worktrees`;
         notify({
           type: "warning",
-          title: `Removed ${successCount} of ${total} worktrees`,
+          title: partialTitle,
           message: partialMessage,
         });
+        announce(partialTitle);
       }
     } catch (err) {
       // p-queue timeout escape hatch. Underlying IPC calls may still
@@ -239,6 +247,7 @@ export function useWorktreeBulkRemove({
             ? "A removal exceeded the timeout — re-open the overview to check which worktrees remain."
             : "The removal run failed before completing.",
       });
+      useAnnouncerStore.getState().announce("Bulk remove aborted", "assertive");
     } finally {
       isExecutingRef.current = false;
       setIsExecuting(false);

--- a/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
+++ b/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
@@ -81,6 +81,43 @@ describe("useAccessibilityAnnouncements — agent-state announcements (#8937)", 
     expect(assertive).toBeNull();
   });
 
+  it("cancels pending debounce timer when panel is removed before fire (#8937)", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Agent A", agentState: "working" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    // Transition triggers a 300ms debounce timer
+    act(() => {
+      setPanels([{ id: "t1", title: "Agent A", agentState: "exited" }]);
+    });
+    rerender();
+
+    // Remove the panel before the timer fires
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      setPanels([]);
+    });
+    rerender();
+
+    // Past the original debounce window — stale timer should have been cancelled
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    const { polite, assertive } = useAnnouncerStore.getState();
+    expect(polite).toBeNull();
+    expect(assertive).toBeNull();
+  });
+
   it("announces 'completed' (unchanged behavior — regression guard)", () => {
     const { rerender } = renderHook(() => useAccessibilityAnnouncements());
 

--- a/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
+++ b/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { AgentState } from "@shared/types/agent";
+
+interface Terminal {
+  id: string;
+  title: string;
+  agentState?: AgentState;
+  stateChangeConfidence?: number;
+}
+
+const { panelMockStore } = vi.hoisted(() => {
+  // Lazy require zustand inside the hoisted block so it runs before mocks.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { create } = require("zustand") as typeof import("zustand");
+  return {
+    panelMockStore: create<{
+      focusedId: string | null;
+      panelsById: Record<
+        string,
+        { id: string; title: string; agentState?: AgentState; stateChangeConfidence?: number }
+      >;
+      panelIds: string[];
+    }>(() => ({
+      focusedId: null,
+      panelsById: {},
+      panelIds: [],
+    })),
+  };
+});
+
+vi.mock("@/store", () => ({
+  usePanelStore: panelMockStore,
+}));
+
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { useAccessibilityAnnouncements } from "../useAccessibilityAnnouncements";
+
+function setPanels(panels: Terminal[]) {
+  panelMockStore.setState({
+    focusedId: null,
+    panelsById: Object.fromEntries(panels.map((p) => [p.id, p])),
+    panelIds: panels.map((p) => p.id),
+  });
+}
+
+describe("useAccessibilityAnnouncements — agent-state announcements (#8937)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
+    panelMockStore.setState({ focusedId: null, panelsById: {}, panelIds: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("announces 'exited' state politely after the debounce window", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Agent A", agentState: "working" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Agent A", agentState: "exited" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    const { polite, assertive } = useAnnouncerStore.getState();
+    expect(polite?.msg).toBe("Agent A exited");
+    expect(assertive).toBeNull();
+  });
+
+  it("announces 'completed' (unchanged behavior — regression guard)", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Agent A", agentState: "working" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Agent A", agentState: "completed" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Agent A finished");
+  });
+});

--- a/src/hooks/app/useAccessibilityAnnouncements.ts
+++ b/src/hooks/app/useAccessibilityAnnouncements.ts
@@ -99,6 +99,17 @@ export function useAccessibilityAnnouncements() {
       debounceTimersRef.current.set(terminal.id, timer);
     }
 
+    // Cancel pending debounce timers for panels that have left panelIds.
+    // Without this, a state-change timer scheduled just before removal would
+    // fire 300ms later and announce "${title} exited" for a panel that is
+    // no longer in the store.
+    for (const [id, timer] of debounceTimersRef.current) {
+      if (!newStates.has(id)) {
+        clearTimeout(timer);
+        debounceTimersRef.current.delete(id);
+      }
+    }
+
     previousStatesRef.current = newStates;
   }, [panelsById, panelIds]);
 

--- a/src/hooks/app/useAccessibilityAnnouncements.ts
+++ b/src/hooks/app/useAccessibilityAnnouncements.ts
@@ -19,6 +19,8 @@ function getAgentStateMessage(
       return { msg: `${title} is waiting for input`, priority: "polite" };
     case "completed":
       return { msg: `${title} finished`, priority: "polite" };
+    case "exited":
+      return { msg: `${title} exited`, priority: "polite" };
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

- The accessibility announcer infrastructure was already wired, but five state transitions were completely silent for screen-reader users
- Added `announce()` calls to existing callbacks in each affected component -- destructive action confirmations, agent exit, error surfacing, panel close, and worktree creation
- Added unit tests for `useAccessibilityAnnouncements`

Resolves #8937

## Changes

- `ErrorFallback`: announce error state on mount
- `BackgroundContainer` / `WaitingContainer`: announce agent `exited` state (was silently falling through)
- `TerminalContextMenu` / `TerminalDestructiveActionConfirmDialog`: announce destructive action completion
- `NewWorktreeDialog`: announce creation success and failure
- `ForcePushConfirmDialog`: announce force-push confirmation
- `WorktreeDeleteDialog` / `WorktreeOverviewModal` / `useWorktreeBulkRemove`: announce worktree deletion
- `useWorktreeActions`: announce panel close
- `useAccessibilityAnnouncements`: unit tests covering all announcement paths

## Testing

- Unit tests added for `useAccessibilityAnnouncements` covering agent state changes, panel events, and the new paths
- Manually verified announcements fire in VoiceOver for each gap