### PR TITLE
feat(panels): TerminalInstance drain infrastructure for the renderer store carrier (#8957)

### DIFF
--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1122,
+  "count": 1164,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 94,
     "@typescript-eslint/no-unsafe-type-assertion": 480,
-    "no-restricted-imports": 8,
+    "no-restricted-imports": 51,
     "no-restricted-syntax": 361,
     "no-useless-assignment": 20,
     "preserve-caught-error": 50,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 38
   },
-  "updatedAt": "2026-05-24T14:15:06.212Z"
+  "updatedAt": "2026-05-24T11:51:18.401Z"
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -563,6 +563,44 @@ export default tseslint.config(
               message:
                 "Importing githubClient from the barrel is restricted. If this file is in the allowlist, import from @/clients/githubClient directly. Otherwise use forgeClient or dispatch forge.* actions. See #8460.",
             },
+            // TerminalInstance is the legacy kitchen-sink carrier interface being
+            // drained from the renderer store (#8957). New code should read the
+            // PanelInstance discriminated union via the getNarrowPanel/getNarrowPanels
+            // adapter selectors in src/store/slices/panelRegistry/selectors.ts.
+            // Restriction is a warning so the existing ~50 call sites are ratcheted
+            // down domain-by-domain in follow-up PRs rather than blocked all at once.
+            // Note: relative imports (e.g. `./types` inside panelRegistry/) are not
+            // matched by these alias entries — a known gap for slice-internal files.
+            {
+              name: "@shared/types",
+              importNames: ["TerminalInstance"],
+              message:
+                "TerminalInstance is the legacy carrier interface. Use PanelInstance from @shared/types/panel plus the getNarrowPanel/getNarrowPanels adapter selectors. See #8957.",
+            },
+            {
+              name: "@shared/types/panel",
+              importNames: ["TerminalInstance"],
+              message:
+                "TerminalInstance is the legacy carrier interface. Use PanelInstance from @shared/types/panel plus the getNarrowPanel/getNarrowPanels adapter selectors. See #8957.",
+            },
+            {
+              name: "@/types",
+              importNames: ["TerminalInstance"],
+              message:
+                "TerminalInstance is the legacy carrier interface. Use PanelInstance from @shared/types/panel plus the getNarrowPanel/getNarrowPanels adapter selectors. See #8957.",
+            },
+            {
+              name: "@/store",
+              importNames: ["TerminalInstance"],
+              message:
+                "TerminalInstance is the legacy carrier interface. Use PanelInstance from @shared/types/panel plus the getNarrowPanel/getNarrowPanels adapter selectors. See #8957.",
+            },
+            {
+              name: "@/store/panelStore",
+              importNames: ["TerminalInstance"],
+              message:
+                "TerminalInstance is the legacy carrier interface. Use PanelInstance from @shared/types/panel plus the getNarrowPanel/getNarrowPanels adapter selectors. See #8957.",
+            },
           ],
           patterns: [
             {

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -233,6 +233,10 @@ export interface PtyPanelData extends BasePanelData {
   cwd: string;
   /** Process ID of the underlying PTY process */
   pid?: number;
+  /** Whether this terminal has an active PTY process (false for orphaned terminals that exited) */
+  hasPty?: boolean;
+  /** Last meaningful OSC title observed from the running agent — survives the trash window for display. */
+  lastObservedTitle?: string;
   /** Number of columns in the terminal */
   cols: number;
   /** Number of rows in the terminal */
@@ -245,6 +249,14 @@ export interface PtyPanelData extends BasePanelData {
   stateChangeTrigger?: AgentStateChangeTrigger;
   /** Confidence in the most recent state detection (0.0-1.0) */
   stateChangeConfidence?: number;
+  /** Why the agent is waiting (only meaningful while agentState is "waiting") */
+  waitingReason?: WaitingReason;
+  /** Error code or message from agent state transitions (e.g., "ECONNRESET", "EPIPE") */
+  error?: string;
+  /** Extracted session cost in dollars from the last completed agent run */
+  sessionCost?: number;
+  /** Extracted session token count from the last completed agent run */
+  sessionTokens?: number;
   /** AI-generated activity headline (e.g., "Installing dependencies") */
   activityHeadline?: string;
   /** Semantic activity status (working, waiting, success, failure) */
@@ -267,6 +279,8 @@ export interface PtyPanelData extends BasePanelData {
   reconnectError?: TerminalReconnectError;
   /** Scrollback restore failure - set when deferred scrollback replay fails */
   scrollbackRestoreError?: TerminalScrollbackRestoreError;
+  /** Error that occurred when spawning the PTY process */
+  spawnError?: import("./pty-host.js").SpawnError;
   /** Flow control status - indicates if terminal is paused/suspended due to backpressure or safety policy.
    *  Excludes `data-loss` (transient pulse only — never persisted as state). */
   flowStatus?: PersistableFlowStatus;
@@ -347,6 +361,13 @@ export interface PtyPanelData extends BasePanelData {
   startedAt?: number;
   /** Exit code from the last process exit */
   exitCode?: number;
+  /**
+   * Live-only spawn lifecycle state. "spawning" from the moment the optimistic
+   * placeholder lands in `panelsById` until the PTY IPC round-trip resolves;
+   * then "ready". Absent (undefined) on hydrated panels — treat as "ready".
+   * Never serialized — see `serializePtyPanel`.
+   */
+  spawnStatus?: "spawning" | "ready" | "missing-cli";
   /**
    * Original user-selected preset ID. Set on first spawn, never overwritten
    * when a fallback activates. Used to display "was {original} → {active}".

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -188,6 +188,22 @@ function persistedKeys<T extends Record<string, boolean>>(map: T): (keyof T)[] {
   return (Object.keys(map) as (keyof T)[]).filter((k) => map[k]);
 }
 
+// Compile-time carrier-boundary pin (#8957). The renderer store carrier is being
+// drained from `TerminalInstance` (kitchen-sink) to the `PanelInstance` union.
+// Every key on `TerminalInstance` must be coverable by some `PanelInstance`
+// variant plus the two carrier-only timestamps (`createdAt`/`lastActiveAt`,
+// which live on `TerminalInstance` but not `BasePanelData`). If a new field is
+// added to `TerminalInstance` without a home in the union, this assignment
+// fails with a message naming the orphaned key — forcing it onto the proper
+// variant before the carrier flip lands.
+type _KeysOfUnion<T> = T extends unknown ? keyof T : never;
+type _AllowedPanelCarrierKeys = _KeysOfUnion<PanelInstance> | "createdAt" | "lastActiveAt";
+type _OrphanedTerminalInstanceKeys = Exclude<keyof TerminalInstance, _AllowedPanelCarrierKeys>;
+const _terminalInstanceKeysCovered: [_OrphanedTerminalInstanceKeys] extends [never]
+  ? true
+  : _OrphanedTerminalInstanceKeys = true;
+void _terminalInstanceKeysCovered;
+
 const browserHistoryFixture: BrowserHistory = {
   past: ["https://prev.example"],
   present: "https://example.com",

--- a/src/store/slices/panelRegistry/__tests__/selectors.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/selectors.test.ts
@@ -33,11 +33,23 @@ describe("getNarrowPanel", () => {
     expect(p?.kind).toBe("terminal");
   });
 
-  it("treats a record with no kind as a PTY panel", () => {
+  it("backfills the terminal discriminant for a no-kind legacy record", () => {
     const noKind = panel("t", { kind: undefined });
     const p = getNarrowPanel({ t: noKind }, "t");
-    expect(p?.kind).toBeUndefined();
-    expect(p).toBe(noKind);
+    expect(p?.kind).toBe("terminal");
+    // A fresh object so the union's literal `kind: "terminal"` holds at runtime.
+    expect(p).not.toBe(noKind);
+  });
+
+  it("preserves identity for a record that already carries kind: terminal", () => {
+    const withKind = panel("t");
+    const p = getNarrowPanel({ t: withKind }, "t");
+    expect(p).toBe(withKind);
+  });
+
+  it("returns undefined for an extension/unknown kind", () => {
+    const ext = panel("x", { kind: "acme.tool" as TerminalInstance["kind"] });
+    expect(getNarrowPanel({ x: ext }, "x")).toBeUndefined();
   });
 
   it("narrows a browser panel", () => {
@@ -66,6 +78,15 @@ describe("getNarrowPanels", () => {
     const result = getNarrowPanels(byId, ["b", "missing", "a"]);
     expect(result.map((p) => p.id)).toEqual(["b", "a"]);
     expect(result.map((p) => p.kind)).toEqual(["browser", "terminal"]);
+  });
+
+  it("drops extension/unknown-kind panels from the result", () => {
+    const byId = {
+      a: panel("a"),
+      x: panel("x", { kind: "acme.tool" as TerminalInstance["kind"] }),
+    };
+    const result = getNarrowPanels(byId, ["a", "x"]);
+    expect(result.map((p) => p.id)).toEqual(["a"]);
   });
 
   it("returns a stable reference when inputs are identity-equal", () => {

--- a/src/store/slices/panelRegistry/__tests__/selectors.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/selectors.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { TerminalInstance } from "@shared/types";
+import { _resetSelectorCacheForTests, getNarrowPanel, getNarrowPanels } from "../selectors";
+
+// Adapter selectors that narrow the legacy `TerminalInstance` carrier to the
+// `PanelInstance` union via the kind type guards (#8957). A missing `kind`
+// defaults to "terminal", matching the guard convention.
+
+function panel(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    kind: "terminal",
+    title: id,
+    cwd: "/test",
+    cols: 80,
+    rows: 24,
+    location: "grid",
+    ...overrides,
+  } as TerminalInstance;
+}
+
+beforeEach(() => {
+  _resetSelectorCacheForTests();
+});
+
+describe("getNarrowPanel", () => {
+  it("returns undefined for an unknown id", () => {
+    expect(getNarrowPanel({}, "missing")).toBeUndefined();
+  });
+
+  it("narrows a terminal panel to the PTY variant", () => {
+    const p = getNarrowPanel({ t: panel("t") }, "t");
+    expect(p?.kind).toBe("terminal");
+  });
+
+  it("treats a record with no kind as a PTY panel", () => {
+    const noKind = panel("t", { kind: undefined });
+    const p = getNarrowPanel({ t: noKind }, "t");
+    expect(p?.kind).toBeUndefined();
+    expect(p).toBe(noKind);
+  });
+
+  it("narrows a browser panel", () => {
+    const p = getNarrowPanel({ b: panel("b", { kind: "browser" }) }, "b");
+    expect(p?.kind).toBe("browser");
+  });
+
+  it("narrows a dev-preview panel", () => {
+    const p = getNarrowPanel({ d: panel("d", { kind: "dev-preview" }) }, "d");
+    expect(p?.kind).toBe("dev-preview");
+  });
+
+  it("narrows a review panel", () => {
+    const p = getNarrowPanel({ r: panel("r", { kind: "review" }) }, "r");
+    expect(p?.kind).toBe("review");
+  });
+});
+
+describe("getNarrowPanels", () => {
+  it("returns an empty array for empty ids", () => {
+    expect(getNarrowPanels({}, [])).toEqual([]);
+  });
+
+  it("preserves order and skips absent ids", () => {
+    const byId = { a: panel("a"), b: panel("b", { kind: "browser" }) };
+    const result = getNarrowPanels(byId, ["b", "missing", "a"]);
+    expect(result.map((p) => p.id)).toEqual(["b", "a"]);
+    expect(result.map((p) => p.kind)).toEqual(["browser", "terminal"]);
+  });
+
+  it("returns a stable reference when inputs are identity-equal", () => {
+    const byId = { a: panel("a") };
+    const ids = ["a"];
+    const first = getNarrowPanels(byId, ids);
+    const second = getNarrowPanels(byId, ids);
+    expect(second).toBe(first);
+  });
+
+  it("recomputes when panelsById identity changes", () => {
+    const ids = ["a"];
+    const first = getNarrowPanels({ a: panel("a") }, ids);
+    const second = getNarrowPanels({ a: panel("a") }, ids);
+    expect(second).not.toBe(first);
+    expect(second.map((p) => p.id)).toEqual(["a"]);
+  });
+});

--- a/src/store/slices/panelRegistry/selectors.ts
+++ b/src/store/slices/panelRegistry/selectors.ts
@@ -54,7 +54,10 @@ export function getNarrowPanel(
     // record lands here. Backfill the literal discriminant when it's missing so
     // the returned `PtyPanelData` is sound for downstream `switch (kind)`;
     // preserve object identity when the panel already carries it.
-    return panel.kind === "terminal" ? panel : { ...panel, kind: "terminal" };
+    if ("kind" in panel && panel.kind) {
+      return panel;
+    }
+    return { ...panel, kind: "terminal" };
   }
   return undefined;
 }

--- a/src/store/slices/panelRegistry/selectors.ts
+++ b/src/store/slices/panelRegistry/selectors.ts
@@ -35,6 +35,10 @@ export function selectOrderedTerminals(
  * Uses the existing kind type guards (which default a missing `kind` to
  * "terminal"), so a no-`kind` legacy record narrows to `PtyPanelData` — no
  * blanket `as unknown as PanelInstance` cast.
+ *
+ * Returns `undefined` for an absent id and for any panel whose `kind` is
+ * outside the built-in union (e.g. an extension/plugin kind); such panels are
+ * intentionally not representable by `PanelInstance` and are dropped here.
  */
 export function getNarrowPanel(
   panelsById: Record<string, TerminalInstance>,
@@ -45,7 +49,13 @@ export function getNarrowPanel(
   if (isBrowserPanel(panel)) return panel;
   if (isDevPreviewPanel(panel)) return panel;
   if (isReviewPanel(panel)) return panel;
-  if (isPtyPanel(panel)) return panel;
+  if (isPtyPanel(panel)) {
+    // The guard defaults an absent `kind` to "terminal", so a legacy no-`kind`
+    // record lands here. Backfill the literal discriminant when it's missing so
+    // the returned `PtyPanelData` is sound for downstream `switch (kind)`;
+    // preserve object identity when the panel already carries it.
+    return panel.kind === "terminal" ? panel : { ...panel, kind: "terminal" };
+  }
   return undefined;
 }
 

--- a/src/store/slices/panelRegistry/selectors.ts
+++ b/src/store/slices/panelRegistry/selectors.ts
@@ -1,3 +1,10 @@
+import {
+  isBrowserPanel,
+  isDevPreviewPanel,
+  isPtyPanel,
+  isReviewPanel,
+  type PanelInstance,
+} from "@shared/types/panel";
 import type { TerminalInstance } from "./types";
 
 let _prevById: Record<string, TerminalInstance> | null = null;
@@ -19,8 +26,59 @@ export function selectOrderedTerminals(
   return _prevResult;
 }
 
+/**
+ * Adapter selector: narrow a single carrier entry to the `PanelInstance`
+ * discriminated union. The carrier is still typed `Record<string, TerminalInstance>`
+ * (#8957 drains that incrementally); this is the sanctioned read path for new
+ * code that wants the narrow union instead of the kitchen-sink interface.
+ *
+ * Uses the existing kind type guards (which default a missing `kind` to
+ * "terminal"), so a no-`kind` legacy record narrows to `PtyPanelData` — no
+ * blanket `as unknown as PanelInstance` cast.
+ */
+export function getNarrowPanel(
+  panelsById: Record<string, TerminalInstance>,
+  id: string
+): PanelInstance | undefined {
+  const panel = panelsById[id];
+  if (!panel) return undefined;
+  if (isBrowserPanel(panel)) return panel;
+  if (isDevPreviewPanel(panel)) return panel;
+  if (isReviewPanel(panel)) return panel;
+  if (isPtyPanel(panel)) return panel;
+  return undefined;
+}
+
+let _prevNarrowById: Record<string, TerminalInstance> | null = null;
+let _prevNarrowIds: string[] | null = null;
+let _prevNarrowResult: PanelInstance[] | null = null;
+
+/**
+ * Adapter selector: narrow an ordered list of carrier entries to
+ * `PanelInstance[]`, preserving order and skipping absent ids. Memoized on the
+ * `panelsById`/`panelIds` identities (same pattern as `selectOrderedTerminals`)
+ * so repeated calls in React render paths return a stable array reference.
+ */
+export function getNarrowPanels(
+  panelsById: Record<string, TerminalInstance>,
+  panelIds: string[]
+): PanelInstance[] {
+  if (panelsById === _prevNarrowById && panelIds === _prevNarrowIds && _prevNarrowResult) {
+    return _prevNarrowResult;
+  }
+  _prevNarrowById = panelsById;
+  _prevNarrowIds = panelIds;
+  _prevNarrowResult = panelIds
+    .map((id) => getNarrowPanel(panelsById, id))
+    .filter((p): p is PanelInstance => p !== undefined);
+  return _prevNarrowResult;
+}
+
 export function _resetSelectorCacheForTests(): void {
   _prevById = null;
   _prevIds = null;
   _prevResult = null;
+  _prevNarrowById = null;
+  _prevNarrowIds = null;
+  _prevNarrowResult = null;
 }


### PR DESCRIPTION
## Summary

First PR of a multi-PR migration to drain the legacy kitchen-sink `TerminalInstance` interface from the renderer Zustand store `panelsById` carrier toward the `PanelInstance` discriminated union. This PR lands **steps 1–3** of the issue; it lays the migration infrastructure without flipping the carrier.

## What changed

**1. Adapter selectors** (`src/store/slices/panelRegistry/selectors.ts`)
- `getNarrowPanel(panelsById, id): PanelInstance | undefined` — narrows a single carrier entry via the existing kind type guards (no `as unknown as PanelInstance` casts). Backfills the `terminal` discriminant for legacy no-`kind` records so the returned `PtyPanelData` is sound; preserves object identity when the discriminant is already present. Extension/unknown kinds return `undefined` (documented).
- `getNarrowPanels(panelsById, panelIds): PanelInstance[]` — memoized on `panelsById`/`panelIds` identity (same pattern as `selectOrderedTerminals`) for stable references in React render paths.
- These are the sanctioned read path for new code that wants the narrow union instead of the kitchen-sink interface.

**2. `no-restricted-imports` lint ratchet** (`eslint.config.js`, `eslint-warnings-baseline.json`)
- Warns on new `TerminalInstance` imports from `@shared/types`, `@shared/types/panel`, `@/types`, `@/store`, `@/store/panelStore` within `src/**`.
- Baseline regenerated: total `1121 → 1164`, `no-restricted-imports` `8 → 51`. The existing call sites are ratcheted down domain-by-domain in follow-up PRs rather than blocked all at once.

**3. Compile-time boundary pin** (`src/panels/__tests__/registry.fieldcoverage.test.ts`)
- Asserts `keyof TerminalInstance ⊆ keyof (PanelInstance & { createdAt; lastActiveAt })`. If a field is added to `TerminalInstance` without a home in the union, the build fails naming the orphaned key.

**Union completion** (`shared/types/panel.ts`)
- To make the pin pass, 8 orphaned PTY/agent-runtime fields were migrated onto `PtyPanelData`: `hasPty`, `lastObservedTitle`, `waitingReason`, `error`, `sessionCost`, `sessionTokens`, `spawnError`, `spawnStatus`. All optional, none in `PERSISTED_PTY_FIELDS` / the serializer — **backward-compatible, no `PanelSnapshot` wire-format change**.

## Out of scope (follow-up PRs)
- The carrier flip at `types.ts:72` (`Record<string, TerminalInstance>` → `Record<string, PanelInstance>`).
- Domain-by-domain consumer migration and cleanup.

## Known gaps (documented in code)
- Relative imports (e.g. `./types` inside `panelRegistry/`) aren't matched by the alias-based lint rule.
- The `src/components/DragDrop/**` allowlist disables `no-restricted-imports` entirely, masking the new guard for those files.

## Testing
- 13 new selector unit tests (narrowing, no-kind backfill, identity preservation, extension-kind drop, memoization).
- `tsc --noEmit` clean (boundary pin compiles), full `npm run check` suite green, ratchet passes.

Part of #8957.