### PR TITLE
feat(setup): split first-run setup wizard into discrete steps

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -2437,11 +2437,11 @@
     "pipelineErrors": []
   },
   "src/components/Setup/AgentSetupWizard.tsx": {
-    "success": 3,
+    "success": 5,
     "skip": 0,
-    "error": 2,
+    "error": 3,
     "pipeline": 0,
-    "hintCount": 2,
+    "hintCount": 3,
     "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []

--- a/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
@@ -98,7 +98,7 @@ vi.mock("@/utils/env", () => ({
   isDaintreeEnvEnabled: (key: string) => isDaintreeEnvEnabledMock(key),
 }));
 
-type MockWizardStep = { type: "selection" | "cli" | "complete" };
+type MockWizardStep = { type: "appearance" | "agents" | "privacy" | "cli" | "complete" };
 
 vi.mock("@/components/Setup/AgentSetupWizard", () => ({
   AgentSetupWizard: vi.fn(
@@ -113,10 +113,10 @@ vi.mock("@/components/Setup/AgentSetupWizard", () => ({
             Close
           </button>
           <button
-            data-testid="emit-step-selection"
-            onClick={() => props.onStepChange?.({ type: "selection" })}
+            data-testid="emit-step-appearance"
+            onClick={() => props.onStepChange?.({ type: "appearance" })}
           >
-            selection
+            appearance
           </button>
           <button data-testid="emit-step-cli" onClick={() => props.onStepChange?.({ type: "cli" })}>
             cli
@@ -393,7 +393,7 @@ describe("OnboardingFlow telemetry tracking", () => {
 
     // Simulate the user advancing into the CLI sub-step.
     await act(async () => {
-      getByTestId("emit-step-selection").click();
+      getByTestId("emit-step-appearance").click();
       getByTestId("emit-step-cli").click();
     });
 
@@ -461,7 +461,7 @@ describe("OnboardingFlow telemetry tracking", () => {
       fireOpenWizard();
     });
     await act(async () => {
-      getByTestId("emit-step-selection").click();
+      getByTestId("emit-step-appearance").click();
       getByTestId("emit-step-cli").click();
     });
     await act(async () => {

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -173,7 +173,7 @@ function ThemeMockup({ scheme }: { scheme: AppColorScheme }) {
   );
 }
 
-// Tier arrays for the selection step — featured agents get prominent display,
+// Tier arrays for the agents step — featured agents get prominent display,
 // the rest fall into "More agents". New built-in agents automatically land in MORE_AGENT_IDS.
 export const FEATURED_AGENT_IDS: readonly string[] = ["claude", "gemini", "codex"];
 export const MORE_AGENT_IDS: readonly string[] = BUILT_IN_AGENT_IDS.filter(
@@ -223,7 +223,12 @@ const reducedStepVariants: Variants = {
 
 // --- Wizard state machine ---
 
-export type WizardStep = { type: "selection" } | { type: "cli" } | { type: "complete" };
+export type WizardStep =
+  | { type: "appearance" }
+  | { type: "agents" }
+  | { type: "privacy" }
+  | { type: "cli" }
+  | { type: "complete" };
 
 export interface WizardState {
   step: WizardStep;
@@ -231,42 +236,76 @@ export interface WizardState {
   availability: CliAvailability;
   selections: Record<string, boolean>;
   selectionsInitialized: boolean;
+  isFirstRun: boolean;
 }
 
 export type WizardAction =
-  | { type: "SELECTION_CONTINUE" }
+  | { type: "APPEARANCE_CONTINUE" }
+  | { type: "AGENTS_CONTINUE" }
+  | { type: "PRIVACY_CONTINUE" }
   | { type: "CLI_CONTINUE" }
   | { type: "BACK" }
   | { type: "SET_AVAILABILITY"; payload: CliAvailability }
   | { type: "INIT_SELECTIONS"; payload: Record<string, boolean> }
   | { type: "TOGGLE_SELECTION"; agentId: string; checked: boolean }
-  | { type: "RESET"; availability: CliAvailability };
+  | { type: "RESET"; availability: CliAvailability; isFirstRun: boolean };
 
-const TOTAL_STEPS = 3; // selection, cli, complete
+// First-run walks every step (appearance → agents → privacy → cli → complete);
+// re-runs from Settings start at `agents` and skip the first-run-only consent
+// steps. The `cli` step is conditionally skipped when all selected agents are
+// already installed, but the dot count reflects the maximum flow length —
+// mirroring the pre-split behavior where the skippable `cli` step still
+// counted toward the total.
+export function flowSteps(isFirstRun: boolean): WizardStep["type"][] {
+  return isFirstRun
+    ? ["appearance", "agents", "privacy", "cli", "complete"]
+    : ["agents", "cli", "complete"];
+}
 
-export function buildInitialState(availability: CliAvailability): WizardState {
+export function buildInitialState(availability: CliAvailability, isFirstRun = false): WizardState {
   return {
-    step: { type: "selection" },
+    step: { type: isFirstRun ? "appearance" : "agents" },
     history: [],
     availability,
     selections: {},
     selectionsInitialized: false,
+    isFirstRun,
   };
+}
+
+// The cli step is skipped when every selected agent is already launchable —
+// there is nothing left to install, so jump straight to the summary.
+function resolvePostInstallStep(state: WizardState): WizardStep {
+  const selectedIds = Object.keys(state.selections).filter((id) => state.selections[id]);
+  const allSelectedInstalled =
+    selectedIds.length > 0 && selectedIds.every((id) => isAgentLaunchable(state.availability[id]));
+  return allSelectedInstalled ? { type: "complete" } : { type: "cli" };
 }
 
 export function wizardReducer(state: WizardState, action: WizardAction): WizardState {
   switch (action.type) {
-    case "SELECTION_CONTINUE": {
-      const selectedIds = Object.keys(state.selections).filter((id) => state.selections[id]);
-      const allSelectedInstalled =
-        selectedIds.length > 0 &&
-        selectedIds.every((id) => isAgentLaunchable(state.availability[id]));
+    case "APPEARANCE_CONTINUE":
       return {
         ...state,
-        step: allSelectedInstalled ? { type: "complete" } : { type: "cli" },
+        step: { type: "agents" },
         history: [...state.history, state.step],
       };
-    }
+
+    case "AGENTS_CONTINUE":
+      // First-run users get the privacy consent step before install/summary;
+      // re-runs branch straight to cli/complete.
+      return {
+        ...state,
+        step: state.isFirstRun ? { type: "privacy" } : resolvePostInstallStep(state),
+        history: [...state.history, state.step],
+      };
+
+    case "PRIVACY_CONTINUE":
+      return {
+        ...state,
+        step: resolvePostInstallStep(state),
+        history: [...state.history, state.step],
+      };
 
     case "CLI_CONTINUE":
       return {
@@ -303,7 +342,7 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
       };
 
     case "RESET":
-      return buildInitialState(action.availability);
+      return buildInitialState(action.availability, action.isFirstRun);
 
     default:
       return state;
@@ -330,7 +369,7 @@ export function AgentSetupWizard({
   const [state, dispatch] = useReducer(
     wizardReducer,
     initialAvailability ?? ({} as CliAvailability),
-    (avail) => buildInitialState(avail)
+    (avail) => buildInitialState(avail, isFirstRun)
   );
 
   const [hasFatalHealthFailure, setHasFatalHealthFailure] = useState(false);
@@ -371,6 +410,7 @@ export function AgentSetupWizard({
       dispatch({
         type: "RESET",
         availability: initialAvailability ?? ({} as CliAvailability),
+        isFirstRun,
       });
       initRef.current = false;
       hasAutoSelected.current = false;
@@ -381,7 +421,7 @@ export function AgentSetupWizard({
       directionRef.current = 1;
     }
     prevIsOpenRef.current = isOpen;
-  }, [isOpen, initialAvailability]);
+  }, [isOpen, initialAvailability, isFirstRun]);
 
   // Poll availability — paused when document is hidden
   useAgentSetupPoll(isOpen, (result) => {
@@ -404,7 +444,7 @@ export function AgentSetupWizard({
   // Auto-select theme based on OS preference (first-run only, once)
   useEffect(() => {
     if (!isFirstRun || !isOpen || hasAutoSelected.current) return;
-    if (state.step.type !== "selection") return;
+    if (state.step.type !== "appearance") return;
     hasAutoSelected.current = true;
     const prefersLight = window.matchMedia("(prefers-color-scheme: light)").matches;
     const targetId = prefersLight ? "bondi" : "daintree";
@@ -487,35 +527,38 @@ export function AgentSetupWizard({
     [state.selections]
   );
 
-  const totalSteps = TOTAL_STEPS;
-  const stepNumber = (() => {
-    switch (state.step.type) {
-      case "selection":
-        return 0;
-      case "cli":
-        return 1;
-      case "complete":
-        return 2;
-      default:
-        return 0;
-    }
-  })();
+  const flow = useMemo(() => flowSteps(isFirstRun), [isFirstRun]);
+  const totalSteps = flow.length;
+  const stepNumber = Math.max(0, flow.indexOf(state.step.type));
 
-  const handleSelectionContinue = useCallback(async () => {
+  const handleAppearanceContinue = useCallback(() => {
+    directionRef.current = 1;
+    dispatch({ type: "APPEARANCE_CONTINUE" });
+  }, []);
+
+  const handleAgentsContinue = useCallback(async () => {
     directionRef.current = 1;
     setIsSaving(true);
     try {
-      if (isFirstRun) {
-        await commitTelemetry(telemetryEnabled ? "errors" : "off");
-      }
       for (const [agentId, pinned] of Object.entries(state.selections)) {
         await setAgentPinned(agentId, pinned);
       }
-      dispatch({ type: "SELECTION_CONTINUE" });
+      dispatch({ type: "AGENTS_CONTINUE" });
     } finally {
       setIsSaving(false);
     }
-  }, [state.selections, setAgentPinned, isFirstRun, commitTelemetry, telemetryEnabled]);
+  }, [state.selections, setAgentPinned]);
+
+  const handlePrivacyContinue = useCallback(async () => {
+    directionRef.current = 1;
+    setIsSaving(true);
+    try {
+      await commitTelemetry(telemetryEnabled ? "errors" : "off");
+      dispatch({ type: "PRIVACY_CONTINUE" });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [commitTelemetry, telemetryEnabled]);
 
   const handleCliContinue = useCallback(() => {
     directionRef.current = 1;
@@ -541,8 +584,8 @@ export function AgentSetupWizard({
     });
   }, []);
 
-  const handleSelectionSkip = useCallback(async () => {
-    // Mirror handleSelectionContinue's isSaving lock so a rapid double-click
+  const handleSkip = useCallback(async () => {
+    // Mirror the Continue handlers' isSaving lock so a rapid double-click
     // can't race two commits and two close calls through `commitTelemetry`'s
     // ref guard before it flips.
     setIsSaving(true);
@@ -563,7 +606,10 @@ export function AgentSetupWizard({
   const showLoadingSelections = !state.selectionsInitialized && isAvailabilityLoading;
 
   const handleBeforeClose = useCallback(async () => {
-    if (isFirstRun && state.step.type === "selection") {
+    // Any first-run close before the summary records telemetry off — silence is
+    // not consent. Once the user reaches `complete` they have already passed the
+    // privacy step, so their choice is committed and we must not re-commit.
+    if (isFirstRun && state.step.type !== "complete") {
       const committedNow = await commitTelemetry("off");
       if (committedNow && !telemetryToggleTouchedRef.current) {
         notifyTelemetryDefault();
@@ -582,14 +628,9 @@ export function AgentSetupWizard({
     >
       <AppDialog.Header>
         <AppDialog.Title icon={<Plug className="w-5 h-5 text-daintree-accent" />}>
-          {isFirstRun && state.step.type === "selection" ? "Welcome to Daintree" : "Agent Setup"}
+          {isFirstRun && state.step.type === "appearance" ? "Welcome to Daintree" : "Agent Setup"}
         </AppDialog.Title>
-        <div className="flex items-center gap-3">
-          <span className="text-xs text-daintree-text/40">
-            {stepNumber + 1} of {totalSteps}
-          </span>
-          <AppDialog.CloseButton />
-        </div>
+        <AppDialog.CloseButton />
       </AppDialog.Header>
 
       <AppDialog.Body>
@@ -603,8 +644,14 @@ export function AgentSetupWizard({
               animate="animate"
               exit="exit"
             >
-              {state.step.type === "selection" && (
-                <SelectionStep
+              {state.step.type === "appearance" && (
+                <AppearanceStep
+                  selectedSchemeId={selectedSchemeId}
+                  onThemeSelect={handleThemeSelect}
+                />
+              )}
+              {state.step.type === "agents" && (
+                <AgentsStep
                   availability={state.availability}
                   selections={state.selections}
                   isLoading={showLoadingSelections}
@@ -615,8 +662,10 @@ export function AgentSetupWizard({
                   onFatalFailureChange={setHasFatalHealthFailure}
                   onCheckingChange={setIsHealthChecking}
                   isFirstRun={isFirstRun}
-                  selectedSchemeId={selectedSchemeId}
-                  onThemeSelect={handleThemeSelect}
+                />
+              )}
+              {state.step.type === "privacy" && (
+                <PrivacyStep
                   telemetryEnabled={telemetryEnabled}
                   onTelemetryChange={handleTelemetryChange}
                 />
@@ -626,7 +675,7 @@ export function AgentSetupWizard({
                   availability={state.availability}
                   selections={state.selections}
                   onInstallComplete={() => {
-                    cliAvailabilityClient.refresh().then((result) => {
+                    void cliAvailabilityClient.refresh().then((result) => {
                       if (isOpenRef.current) {
                         dispatch({ type: "SET_AVAILABILITY", payload: result });
                       }
@@ -660,40 +709,52 @@ export function AgentSetupWizard({
             ))}
           </div>
           <div className="flex items-center gap-2">
-            {state.step.type !== "selection" && state.step.type !== "complete" && (
-              <Button
-                variant="ghost"
-                onClick={handleBack}
-                className="text-daintree-text/70"
-                disabled={isSaving}
-              >
-                <ChevronLeft className="w-4 h-4" />
-                Back
-              </Button>
-            )}
-            {state.step.type === "selection" && (
-              <>
+            {state.step.type !== "complete" &&
+              (state.history.length > 0 ? (
                 <Button
                   variant="ghost"
-                  onClick={handleSelectionSkip}
+                  onClick={handleBack}
+                  className="text-daintree-text/70"
+                  disabled={isSaving}
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                  Back
+                </Button>
+              ) : (
+                <Button
+                  variant="ghost"
+                  onClick={handleSkip}
                   disabled={isSaving}
                   className="text-daintree-text/60"
                 >
                   Skip
                 </Button>
-                <Button
-                  onClick={handleSelectionContinue}
-                  disabled={
-                    selectedAgentIds.length === 0 ||
-                    isSaving ||
-                    hasFatalHealthFailure ||
-                    isHealthChecking
-                  }
-                >
-                  Continue
-                  <ArrowRight className="w-4 h-4 ml-1" />
-                </Button>
-              </>
+              ))}
+            {state.step.type === "appearance" && (
+              <Button onClick={handleAppearanceContinue} disabled={isSaving}>
+                Continue
+                <ArrowRight className="w-4 h-4 ml-1" />
+              </Button>
+            )}
+            {state.step.type === "agents" && (
+              <Button
+                onClick={handleAgentsContinue}
+                disabled={
+                  selectedAgentIds.length === 0 ||
+                  isSaving ||
+                  hasFatalHealthFailure ||
+                  isHealthChecking
+                }
+              >
+                Continue
+                <ArrowRight className="w-4 h-4 ml-1" />
+              </Button>
+            )}
+            {state.step.type === "privacy" && (
+              <Button onClick={handlePrivacyContinue} disabled={isSaving}>
+                Continue
+                <ArrowRight className="w-4 h-4 ml-1" />
+              </Button>
             )}
             {state.step.type === "cli" && (
               <Button onClick={handleCliContinue}>
@@ -701,7 +762,7 @@ export function AgentSetupWizard({
                 <ChevronRight className="w-4 h-4 ml-1" />
               </Button>
             )}
-            {state.step.type === "complete" && <Button onClick={handleFinish}>Finish Setup</Button>}
+            {state.step.type === "complete" && <Button onClick={handleFinish}>Finish setup</Button>}
           </div>
         </div>
       </AppDialog.Footer>
@@ -709,9 +770,68 @@ export function AgentSetupWizard({
   );
 }
 
-// --- Selection step (merged from AgentSelectionStep) ---
+// --- Appearance step (first-run theme picker) ---
 
-function SelectionStep({
+function AppearanceStep({
+  selectedSchemeId,
+  onThemeSelect,
+}: {
+  selectedSchemeId?: string;
+  onThemeSelect: (id: string) => void;
+}) {
+  const schemes = [daintreeScheme, bondiScheme] as const;
+
+  return (
+    <section>
+      <h3 className="text-base font-semibold text-daintree-text mb-2">Appearance</h3>
+      <p className="text-sm text-daintree-text/60 mb-4">
+        Choose your preferred theme. More options available in Settings.
+      </p>
+      <div className="grid grid-cols-2 gap-4" role="listbox" aria-label="Select theme">
+        {schemes.map((scheme) => {
+          const isSelected = selectedSchemeId === scheme.id;
+          const isDark = scheme.type === "dark";
+          return (
+            <button
+              key={scheme.id}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              onClick={() => onThemeSelect(scheme.id)}
+              className={cn(
+                "flex flex-col gap-2 p-3 rounded-[var(--radius-md)] border transition-colors text-left",
+                isSelected
+                  ? "border-border-strong bg-overlay-selected"
+                  : "border-daintree-border bg-daintree-bg hover:border-daintree-text/30"
+              )}
+            >
+              <ThemeMockup scheme={scheme} />
+              <div className="flex items-center justify-between px-0.5">
+                <div className="flex items-center gap-1.5">
+                  {isDark ? (
+                    <Moon className="w-3 h-3 text-daintree-text/50" />
+                  ) : (
+                    <Sun className="w-3 h-3 text-daintree-text/50" />
+                  )}
+                  <span className="text-sm font-medium text-daintree-text">{scheme.name}</span>
+                  <span className="text-xs text-daintree-text/50">{isDark ? "Dark" : "Light"}</span>
+                </div>
+                {isSelected && <Check className="w-3.5 h-3.5 text-daintree-text shrink-0" />}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+      <p className="text-xs text-daintree-text/50 text-center mt-3">
+        More themes available in Settings → Appearance
+      </p>
+    </section>
+  );
+}
+
+// --- Agents step (system requirements + agent multi-select) ---
+
+function AgentsStep({
   availability,
   selections,
   isLoading,
@@ -720,10 +840,6 @@ function SelectionStep({
   onFatalFailureChange,
   onCheckingChange,
   isFirstRun = false,
-  selectedSchemeId,
-  onThemeSelect,
-  telemetryEnabled,
-  onTelemetryChange,
 }: {
   availability: CliAvailability;
   selections: Record<string, boolean>;
@@ -733,10 +849,6 @@ function SelectionStep({
   onFatalFailureChange: (hasFatal: boolean) => void;
   onCheckingChange: (checking: boolean) => void;
   isFirstRun?: boolean;
-  selectedSchemeId?: string;
-  onThemeSelect?: (id: string) => void;
-  telemetryEnabled?: boolean;
-  onTelemetryChange?: (enabled: boolean) => void;
 }) {
   const featuredAgents = useMemo(
     () => sortTierByInstalled(FEATURED_AGENT_IDS, availability),
@@ -747,9 +859,6 @@ function SelectionStep({
     [availability]
   );
 
-  const schemes = [daintreeScheme, bondiScheme] as const;
-  const crashReportingLabelId = useId();
-
   return (
     <div className="space-y-6">
       <SystemRequirementsSection
@@ -757,65 +866,7 @@ function SelectionStep({
         onCheckingChange={onCheckingChange}
       />
 
-      {isFirstRun && (
-        <section className="pb-6 border-b border-daintree-border">
-          <h3 className="text-base font-semibold text-daintree-text mb-2">Welcome to Daintree</h3>
-          <p className="text-sm text-daintree-text/60">
-            Pick a theme, choose your agents, and you&apos;re ready to go.
-          </p>
-        </section>
-      )}
-
-      {isFirstRun && onThemeSelect && (
-        <section className="pb-6 border-b border-daintree-border">
-          <h3 className="text-base font-semibold text-daintree-text mb-2">Appearance</h3>
-          <p className="text-sm text-daintree-text/60 mb-4">
-            Choose your preferred theme. More options available in Settings.
-          </p>
-          <div className="grid grid-cols-2 gap-4" role="listbox" aria-label="Select theme">
-            {schemes.map((scheme) => {
-              const isSelected = selectedSchemeId === scheme.id;
-              const isDark = scheme.type === "dark";
-              return (
-                <button
-                  key={scheme.id}
-                  type="button"
-                  role="option"
-                  aria-selected={isSelected}
-                  onClick={() => onThemeSelect(scheme.id)}
-                  className={cn(
-                    "flex flex-col gap-2 p-3 rounded-[var(--radius-md)] border transition-colors text-left",
-                    isSelected
-                      ? "border-border-strong bg-overlay-selected"
-                      : "border-daintree-border bg-daintree-bg hover:border-daintree-text/30"
-                  )}
-                >
-                  <ThemeMockup scheme={scheme} />
-                  <div className="flex items-center justify-between px-0.5">
-                    <div className="flex items-center gap-1.5">
-                      {isDark ? (
-                        <Moon className="w-3 h-3 text-daintree-text/50" />
-                      ) : (
-                        <Sun className="w-3 h-3 text-daintree-text/50" />
-                      )}
-                      <span className="text-sm font-medium text-daintree-text">{scheme.name}</span>
-                      <span className="text-xs text-daintree-text/50">
-                        {isDark ? "Dark" : "Light"}
-                      </span>
-                    </div>
-                    {isSelected && <Check className="w-3.5 h-3.5 text-daintree-text shrink-0" />}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-          <p className="text-xs text-daintree-text/50 text-center mt-3">
-            More themes available in Settings → Appearance
-          </p>
-        </section>
-      )}
-
-      <section className={cn(isFirstRun && "pb-6 border-b border-daintree-border")}>
+      <section>
         <h3 className="text-base font-semibold text-daintree-text mb-2">
           {isFirstRun ? "Agents" : "Choose your AI agents"}
         </h3>
@@ -882,59 +933,71 @@ function SelectionStep({
           </div>
         )}
       </section>
-
-      {isFirstRun && onTelemetryChange != null && (
-        <section>
-          <h3 className="text-base font-semibold text-daintree-text mb-2">Privacy</h3>
-          <p className="text-sm text-daintree-text/60 mb-4">
-            Help improve Daintree by sharing anonymous crash reports.
-          </p>
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-3">
-              <p id={crashReportingLabelId} className="text-sm font-medium text-daintree-text">
-                Enable crash reporting
-              </p>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={telemetryEnabled}
-                aria-labelledby={crashReportingLabelId}
-                onClick={() => onTelemetryChange(!telemetryEnabled)}
-                className={cn(
-                  "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors",
-                  telemetryEnabled ? "bg-daintree-accent" : "bg-daintree-border"
-                )}
-              >
-                <span
-                  className={cn(
-                    "pointer-events-none inline-block h-4 w-4 rounded-full shadow transform transition-transform mt-0.5",
-                    telemetryEnabled
-                      ? "translate-x-4 ml-0.5 bg-text-inverse"
-                      : "translate-x-0 ml-0.5 bg-daintree-text"
-                  )}
-                />
-              </button>
-            </div>
-            <p className="text-xs text-daintree-text/50">
-              No file contents or credentials are ever sent.
-            </p>
-            <button
-              type="button"
-              className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline focus-visible:outline-hidden focus-visible:underline"
-              onClick={() =>
-                void actionService.dispatch(
-                  "telemetry.togglePreview",
-                  { active: true },
-                  { source: "user" }
-                )
-              }
-            >
-              Preview what would be sent
-            </button>
-          </div>
-        </section>
-      )}
     </div>
+  );
+}
+
+// --- Privacy step (first-run crash-reporting consent) ---
+
+function PrivacyStep({
+  telemetryEnabled,
+  onTelemetryChange,
+}: {
+  telemetryEnabled?: boolean;
+  onTelemetryChange: (enabled: boolean) => void;
+}) {
+  const crashReportingLabelId = useId();
+
+  return (
+    <section>
+      <h3 className="text-base font-semibold text-daintree-text mb-2">Privacy</h3>
+      <p className="text-sm text-daintree-text/60 mb-4">
+        Help improve Daintree by sharing anonymous crash reports
+      </p>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <p id={crashReportingLabelId} className="text-sm font-medium text-daintree-text">
+            Enable crash reporting
+          </p>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={telemetryEnabled}
+            aria-labelledby={crashReportingLabelId}
+            onClick={() => onTelemetryChange(!telemetryEnabled)}
+            className={cn(
+              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors",
+              telemetryEnabled ? "bg-daintree-accent" : "bg-daintree-border"
+            )}
+          >
+            <span
+              className={cn(
+                "pointer-events-none inline-block h-4 w-4 rounded-full shadow transform transition-transform mt-0.5",
+                telemetryEnabled
+                  ? "translate-x-4 ml-0.5 bg-text-inverse"
+                  : "translate-x-0 ml-0.5 bg-daintree-text"
+              )}
+            />
+          </button>
+        </div>
+        <p className="text-xs text-daintree-text/50">
+          No file contents or credentials are ever sent.
+        </p>
+        <button
+          type="button"
+          className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline focus-visible:outline-hidden focus-visible:underline"
+          onClick={() =>
+            void actionService.dispatch(
+              "telemetry.togglePreview",
+              { active: true },
+              { source: "user" }
+            )
+          }
+        >
+          Preview what would be sent
+        </button>
+      </div>
+    </section>
   );
 }
 
@@ -960,7 +1023,7 @@ export function CompleteStep({
         <div className="w-12 h-12 rounded-full bg-status-success/15 flex items-center justify-center mx-auto mb-4">
           <Sparkles className="w-6 h-6 text-status-success" />
         </div>
-        <h3 className="text-base font-semibold text-daintree-text mb-2">Setup Complete</h3>
+        <h3 className="text-base font-semibold text-daintree-text mb-2">Setup complete</h3>
         <p className="text-sm text-daintree-text/60">
           {hasAgents
             ? `You have ${installedAgents.length} agent${installedAgents.length === 1 ? "" : "s"} ready to use. Launch them from the toolbar or with keyboard shortcuts.`

--- a/src/components/Setup/__tests__/AgentSetupWizard.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizard.test.ts
@@ -200,6 +200,30 @@ describe("AgentSetupWizard reducer", () => {
     expect(state.history).toEqual([]);
   });
 
+  it("routes installed-but-not-launchable agents (installed/blocked) to cli, not complete", () => {
+    // `installed` and `blocked` pass isAgentInstalled but fail isAgentLaunchable
+    // — the binary exists yet still needs setup, so the cli step must run.
+    const avail = { claude: "installed", gemini: "blocked" } as CliAvailability;
+    let state = buildInitialState(avail);
+    state = wizardReducer(state, {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true, gemini: true },
+    });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
+    expect(state.step).toEqual({ type: "cli" });
+  });
+
+  it("treats unauthenticated agents as launchable and skips to complete", () => {
+    const avail = { claude: "unauthenticated" } as CliAvailability;
+    let state = buildInitialState(avail);
+    state = wizardReducer(state, {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true },
+    });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
+    expect(state.step).toEqual({ type: "complete" });
+  });
+
   it("goes to cli when availability changes after init to mark agent uninstalled", () => {
     const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
     let state = buildInitialState(allInstalled);

--- a/src/components/Setup/__tests__/AgentSetupWizard.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizard.test.ts
@@ -91,68 +91,112 @@ describe("AgentSetupWizard reducer", () => {
     codex: "missing",
   } as CliAvailability;
 
-  it("always starts at selection step", () => {
-    const state = buildInitialState(emptyAvail);
-    expect(state.step).toEqual({ type: "selection" });
+  it("starts at the appearance step on first run", () => {
+    const state = buildInitialState(emptyAvail, true);
+    expect(state.step).toEqual({ type: "appearance" });
     expect(state.history).toEqual([]);
+    expect(state.isFirstRun).toBe(true);
   });
 
-  it("advances from selection to cli step when not all installed", () => {
+  it("starts at the agents step when not first run", () => {
+    const state = buildInitialState(emptyAvail);
+    expect(state.step).toEqual({ type: "agents" });
+    expect(state.history).toEqual([]);
+    expect(state.isFirstRun).toBe(false);
+  });
+
+  it("advances from appearance to agents on first run", () => {
+    let state = buildInitialState(emptyAvail, true);
+    state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
+    expect(state.step).toEqual({ type: "agents" });
+    expect(state.history).toEqual([{ type: "appearance" }]);
+  });
+
+  it("advances from agents to privacy on first run regardless of install state", () => {
+    const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
+    let state = buildInitialState(allInstalled, true);
+    state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
+    state = wizardReducer(state, {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true, gemini: true },
+    });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
+    expect(state.step).toEqual({ type: "privacy" });
+  });
+
+  it("advances from agents to cli (non-first-run) when not all installed", () => {
     let state = buildInitialState(partialAvail);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: true, codex: true },
     });
-    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });
   });
 
-  it("skips to complete when all selected agents are installed", () => {
+  it("skips to complete (non-first-run) when all selected agents are installed", () => {
     const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
     let state = buildInitialState(allInstalled);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: true },
     });
-    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
     expect(state.step).toEqual({ type: "complete" });
-    expect(state.history).toEqual([{ type: "selection" }]);
+    expect(state.history).toEqual([{ type: "agents" }]);
   });
 
-  it("goes to cli when at least one selected agent is not installed", () => {
+  it("privacy advances to cli when not all installed", () => {
     const partial = { claude: "ready", gemini: "missing" } as CliAvailability;
-    let state = buildInitialState(partial);
+    let state = buildInitialState(partial, true);
+    state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: true },
     });
-    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
+    state = wizardReducer(state, { type: "PRIVACY_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });
   });
 
-  it("skips to complete when only selected agents are installed (unselected missing)", () => {
+  it("privacy skips to complete when all selected agents are installed", () => {
+    const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
+    let state = buildInitialState(allInstalled, true);
+    state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
+    state = wizardReducer(state, {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true, gemini: true },
+    });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
+    state = wizardReducer(state, { type: "PRIVACY_CONTINUE" });
+    expect(state.step).toEqual({ type: "complete" });
+  });
+
+  it("privacy skips to complete when only selected agents are installed (unselected missing)", () => {
     const avail = { claude: "ready", gemini: "missing" } as CliAvailability;
-    let state = buildInitialState(avail);
+    let state = buildInitialState(avail, true);
+    state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: false },
     });
-    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
+    state = wizardReducer(state, { type: "PRIVACY_CONTINUE" });
     expect(state.step).toEqual({ type: "complete" });
   });
 
-  it("BACK from complete (after skip) returns to selection, not cli", () => {
+  it("BACK from complete returns to the prior step, preserving history", () => {
     const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
     let state = buildInitialState(allInstalled);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: true },
     });
-    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
     expect(state.step).toEqual({ type: "complete" });
 
     state = wizardReducer(state, { type: "BACK" });
-    expect(state.step).toEqual({ type: "selection" });
+    expect(state.step).toEqual({ type: "agents" });
     expect(state.history).toEqual([]);
   });
 
@@ -167,7 +211,7 @@ describe("AgentSetupWizard reducer", () => {
       type: "SET_AVAILABILITY",
       payload: { claude: "ready", gemini: "missing" } as CliAvailability,
     });
-    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });
   });
 
@@ -177,27 +221,38 @@ describe("AgentSetupWizard reducer", () => {
       type: "INIT_SELECTIONS",
       payload: { claude: true },
     });
-    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });
 
     state = wizardReducer(state, { type: "CLI_CONTINUE" });
     expect(state.step).toEqual({ type: "complete" });
   });
 
-  it("follows full wizard flow: selection -> cli -> complete", () => {
-    let state = buildInitialState(emptyAvail);
+  it("follows full first-run flow: appearance -> agents -> privacy -> cli -> complete", () => {
+    let state = buildInitialState(emptyAvail, true);
+
+    state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
+    expect(state.step).toEqual({ type: "agents" });
 
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: true },
     });
-    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
+    expect(state.step).toEqual({ type: "privacy" });
+
+    state = wizardReducer(state, { type: "PRIVACY_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });
 
     state = wizardReducer(state, { type: "CLI_CONTINUE" });
     expect(state.step).toEqual({ type: "complete" });
 
-    expect(state.history).toEqual([{ type: "selection" }, { type: "cli" }]);
+    expect(state.history).toEqual([
+      { type: "appearance" },
+      { type: "agents" },
+      { type: "privacy" },
+      { type: "cli" },
+    ]);
   });
 
   it("navigates back through history", () => {
@@ -206,15 +261,15 @@ describe("AgentSetupWizard reducer", () => {
       type: "INIT_SELECTIONS",
       payload: { claude: true },
     });
-    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });
 
     state = wizardReducer(state, { type: "BACK" });
-    expect(state.step).toEqual({ type: "selection" });
+    expect(state.step).toEqual({ type: "agents" });
 
-    // Back from selection does nothing (empty history)
+    // Back from the entry step does nothing (empty history)
     const unchanged = wizardReducer(state, { type: "BACK" });
-    expect(unchanged.step).toEqual({ type: "selection" });
+    expect(unchanged.step).toEqual({ type: "agents" });
   });
 
   it("toggles agent selection", () => {
@@ -245,35 +300,54 @@ describe("AgentSetupWizard reducer", () => {
     expect(state.selections.claude).toBe(false);
   });
 
-  it("resets to initial state", () => {
+  it("resets to the first-run entry step when isFirstRun is true", () => {
     let state = buildInitialState(emptyAvail);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true },
     });
-    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
 
-    const reset = wizardReducer(state, { type: "RESET", availability: partialAvail });
-    expect(reset.step).toEqual({ type: "selection" });
+    const reset = wizardReducer(state, {
+      type: "RESET",
+      availability: partialAvail,
+      isFirstRun: true,
+    });
+    expect(reset.step).toEqual({ type: "appearance" });
     expect(reset.history).toEqual([]);
     expect(reset.selections).toEqual({});
     expect(reset.availability).toBe(partialAvail);
+    expect(reset.isFirstRun).toBe(true);
   });
 
-  it("navigates back from cli to selection and re-confirms", () => {
+  it("resets to the agents step when isFirstRun is false", () => {
+    let state = buildInitialState(emptyAvail, true);
+    state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
+
+    const reset = wizardReducer(state, {
+      type: "RESET",
+      availability: partialAvail,
+      isFirstRun: false,
+    });
+    expect(reset.step).toEqual({ type: "agents" });
+    expect(reset.history).toEqual([]);
+    expect(reset.isFirstRun).toBe(false);
+  });
+
+  it("navigates back from cli to agents and re-confirms", () => {
     let state = buildInitialState(emptyAvail);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: true },
     });
-    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });
 
     state = wizardReducer(state, { type: "BACK" });
-    expect(state.step).toEqual({ type: "selection" });
+    expect(state.step).toEqual({ type: "agents" });
 
     state = wizardReducer(state, { type: "TOGGLE_SELECTION", agentId: "gemini", checked: false });
-    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });
     expect(state.selections.gemini).toBe(false);
   });

--- a/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
+++ b/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
@@ -271,6 +271,39 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
     expect(notifyMock).not.toHaveBeenCalled();
   });
 
+  it("commits 'errors' (not 'off') when the user enables crash reporting and clicks Continue on the privacy step", async () => {
+    const onClose = vi.fn();
+    await act(async () => {
+      render(
+        <AgentSetupWizard
+          isOpen
+          onClose={onClose}
+          isFirstRun
+          initialAvailability={{ claude: "ready" }}
+        />
+      );
+    });
+
+    // appearance -> agents -> privacy
+    await clickButton("Continue");
+    await clickButton("Continue");
+
+    const toggle = document.querySelector('button[role="switch"]') as HTMLButtonElement | null;
+    expect(toggle, "privacy toggle should be present on the privacy step").not.toBeNull();
+    await act(async () => {
+      toggle!.click(); // enable crash reporting
+    });
+
+    await clickButton("Continue");
+
+    expect(setTelemetryLevelMock).toHaveBeenCalledWith("errors");
+    expect(markPromptShownMock).toHaveBeenCalledTimes(1);
+    // Continue is an explicit, informed choice — no silent-default nag.
+    expect(notifyMock).not.toHaveBeenCalled();
+    // The wizard advances (all agents installed -> complete) rather than closing.
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it("does not fire when isFirstRun is false (commit path is bypassed entirely)", async () => {
     const onClose = vi.fn();
     await act(async () => {

--- a/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
+++ b/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
@@ -181,6 +181,18 @@ vi.stubGlobal("window", {
 
 import { AgentSetupWizard } from "../AgentSetupWizard";
 
+// Clicks the visible footer button whose label matches exactly. Only the
+// current step renders, so the match is unambiguous across the wizard flow.
+async function clickButton(label: string) {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label
+  );
+  expect(button, `expected a "${label}" button to be present`).toBeDefined();
+  await act(async () => {
+    button!.click();
+  });
+}
+
 describe("AgentSetupWizard silent-default privacy notify", () => {
   beforeEach(() => {
     notifyMock.mockClear();
@@ -194,11 +206,11 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
       render(<AgentSetupWizard isOpen onClose={onClose} isFirstRun initialAvailability={{}} />);
     });
 
-    // Click the Skip button (rendered inside the selection-step footer).
+    // Click the Skip button (rendered on the first-run entry step — appearance).
     const skipButton = Array.from(document.querySelectorAll("button")).find(
       (b) => b.textContent === "Skip"
     );
-    expect(skipButton, "Skip button should be present on selection step").toBeDefined();
+    expect(skipButton, "Skip button should be present on the entry step").toBeDefined();
 
     await act(async () => {
       skipButton!.click();
@@ -218,15 +230,28 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("does NOT fire inbox confirmation when the user touched the privacy toggle before skipping", async () => {
+  it("does NOT fire inbox confirmation when the user touched the privacy toggle before closing", async () => {
     const onClose = vi.fn();
     await act(async () => {
-      render(<AgentSetupWizard isOpen onClose={onClose} isFirstRun initialAvailability={{}} />);
+      render(
+        // A pre-installed agent keeps the agents-step Continue enabled so we
+        // can navigate forward to the privacy step where the toggle now lives.
+        <AgentSetupWizard
+          isOpen
+          onClose={onClose}
+          isFirstRun
+          initialAvailability={{ claude: "ready" }}
+        />
+      );
     });
+
+    // appearance -> agents -> privacy
+    await clickButton("Continue");
+    await clickButton("Continue");
 
     // Find the privacy toggle (role="switch", labeled "Enable crash reporting").
     const toggle = document.querySelector('button[role="switch"]') as HTMLButtonElement | null;
-    expect(toggle, "privacy toggle should be present on first-run selection step").not.toBeNull();
+    expect(toggle, "privacy toggle should be present on the privacy step").not.toBeNull();
 
     await act(async () => {
       toggle!.click();
@@ -234,11 +259,12 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
       toggle!.click();
     });
 
-    const skipButton = Array.from(document.querySelectorAll("button")).find(
-      (b) => b.textContent === "Skip"
-    );
+    // Dismiss from the privacy step — the touched toggle suppresses the nag.
+    const dismiss = document.querySelector(
+      '[data-testid="dialog-dismiss"]'
+    ) as HTMLButtonElement | null;
     await act(async () => {
-      skipButton!.click();
+      dismiss!.click();
     });
 
     expect(setTelemetryLevelMock).toHaveBeenCalledWith("off");
@@ -285,7 +311,7 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
     expect(notifyMock).toHaveBeenCalledTimes(1);
   });
 
-  it("invokes onStepChange with the initial selection step", async () => {
+  it("invokes onStepChange with the initial appearance step", async () => {
     const onStepChange = vi.fn();
     await act(async () => {
       render(
@@ -299,7 +325,7 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
       );
     });
 
-    expect(onStepChange).toHaveBeenCalledWith({ type: "selection" });
+    expect(onStepChange).toHaveBeenCalledWith({ type: "appearance" });
   });
 
   it("fires inbox confirmation when first-run user dismisses via the dialog (onBeforeClose path)", async () => {


### PR DESCRIPTION
## Summary

The first-run `AgentSetupWizard` packed five unrelated decisions onto a single tall, scrolling `selection` step — a system-requirements check, a welcome blurb, a theme picker, the agent multi-select, and a crash-reporting privacy toggle. The privacy toggle sat below the fold, so telemetry committed `off` without the user ever seeing the choice: a silent default.

This decomposes that mega-step into three discrete steps — **appearance**, **agents**, **privacy** — sequenced quick-win first and consent last, so the crash-reporting choice is a step the user lands on rather than scrolls past.

## Changes

- **Split** the monolithic `selection` step into `AppearanceStep` (theme picker), `AgentsStep` (system requirements + agent multi-select), and `PrivacyStep` (crash-reporting toggle). Dropped the now-redundant welcome blurb (the dialog title already welcomes).
- **Reducer**: expanded the `WizardStep` union (`appearance | agents | privacy | cli | complete`, removed `selection`) and stored `isFirstRun` in `WizardState` so the reducer stays pure. First-run walks every step; re-runs from Settings start at `agents`. Step routing (`cli` vs `complete` based on whether all selected agents are launchable) is preserved.
- **Privacy stays skippable** — Continue with the toggle untouched still records `off` (silence is not consent), not a hard gate. Telemetry commit/notify semantics are unchanged; only the toggle's placement moved. Closing before the summary still commits `off` (broadened `handleBeforeClose` from `step === "selection"` to `step !== "complete"`).
- **Back** now renders on every step that has somewhere to go back to, without clearing entered choices (history-driven). **Skip** renders only on the entry step.
- **Collapsed** the duplicate progress indicators: removed the header `N of 3` count, kept the footer dots driven by a per-flow step total.
- **Microcopy**: `Setup Complete` → `Setup complete`, `Finish Setup` → `Finish setup`, dropped the trailing period from the privacy subtitle.

## Out of scope (untouched)

The `cli` and `complete` steps, the telemetry commit/notify behavior itself, and the framer-motion slide.

## Testing

- Rewrote the reducer tests for the new step model and the render/telemetry tests to navigate to the privacy step; added coverage for the privacy-step `errors` path and `installed`/`blocked` agent routing.
- 57 unit tests pass; `tsc`, lint, and format are clean.

Closes #8966
