### PR TITLE
fix(browser): add visible focus rings to webview and sidebar rows

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -755,6 +755,7 @@ export function BrowserPane({
                 allowpopups=""
                 className={cn(
                   "w-full h-full border-0",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
                   isDragging && "invisible pointer-events-none"
                 )}
               />

--- a/src/index.css
+++ b/src/index.css
@@ -705,7 +705,7 @@ code.hljs {
   --sidebar-accent: var(--theme-overlay-soft);
   --sidebar-accent-foreground: var(--theme-text-primary);
   --sidebar-border: var(--theme-border-default);
-  --sidebar-ring: var(--theme-focus-ring);
+  --sidebar-ring: var(--theme-accent-primary);
 }
 
 /* Compact density mode for dock - reduced padding and heights */


### PR DESCRIPTION
## Summary
Small accessibility fix that adds visible focus rings to the browser webview and sidebar rows. Clients that rely on keyboard navigation (or focus-visible heuristics) now get a clear, usable indicator.

The webview gets a `focus-visible` outline in the accent color. The sidebar had a ring CSS variable (`--sidebar-ring`) that was pulling from the `--theme-focus-ring` token, which resolves to transparent in the current theme — switching it to `--theme-accent-primary` gives sidebar rows an actual visible ring.

Resolves #8933.

## Changes
- `src/components/Browser/BrowserPane.tsx` — added `focus-visible:outline`, `outline-2`, `outline-daintree-accent`, and `outline-offset-2` classes to the webview element
- `src/index.css` — changed `--sidebar-ring` from `var(--theme-focus-ring)` to `var(--theme-accent-primary)`

## Testing
Tabbed through the browser pane and sidebar rows to confirm visible focus rings appear on both surfaces.