### PR TITLE
fix(persistence): compile-time enforce BASE_PANEL_FIELDS lockstep

### DIFF
--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -535,6 +535,34 @@ describe("PanelPersistence", () => {
       });
     });
 
+    it("overwrites base fields from live terminal but preserves kind-specific fragment", () => {
+      // Round-trip test for #8960. Base fields (recognized by the compile-time
+      // allowlist) must be overwritten by the live terminal, while kind-specific
+      // fields from a previous snapshot must survive the save cycle.
+      const previous: TerminalSnapshot = {
+        id: "ext-roundtrip",
+        kind: "custom-widget",
+        title: "Stale Title",
+        worktreeId: "wt-stale",
+        location: "grid",
+        browserUrl: "https://example.com",
+      };
+
+      const panel = createMockTerminal({
+        id: "ext-roundtrip",
+        kind: "custom-widget",
+        title: "Live Title",
+        worktreeId: "wt-live",
+        location: "grid",
+      });
+
+      const snapshot = panelToSnapshot(panel, previous);
+
+      expect(snapshot.title).toBe("Live Title");
+      expect(snapshot.worktreeId).toBe("wt-live");
+      expect(snapshot.browserUrl).toBe("https://example.com");
+    });
+
     it("preserves previously-persisted kind-specific fields across save cycles", async () => {
       // Regression test for #5201. A panel whose kind has no registered
       // serializer (extension disabled mid-session, plugin not yet loaded,

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -16,10 +16,12 @@ export interface PanelPersistenceOptions {
 }
 
 // Base fields that panelToSnapshot always writes. Used to isolate kind-specific
-// fields when preserving a previous snapshot for an unregistered kind. If new
-// base fields are added to the `base` object below, they MUST be added here too,
-// or unknown-kind snapshots will silently carry stale copies of the new field.
-const BASE_PANEL_FIELDS = new Set<string>([
+// fields when preserving a previous snapshot for an unregistered kind. The
+// `satisfies` binding catches key deletions at compile time — removing a key
+// from PanelSnapshot without removing it here is a type error. The ratchet
+// does NOT catch new keys added to PanelSnapshot; a reviewer must ensure new
+// base fields in the `base` object below are listed here.
+const BASE_PANEL_FIELDS = [
   "id",
   "kind",
   "title",
@@ -27,7 +29,8 @@ const BASE_PANEL_FIELDS = new Set<string>([
   "location",
   "extensionState",
   "pluginId",
-]);
+] as const satisfies readonly (keyof PanelSnapshot)[];
+const BASE_PANEL_FIELD_SET: ReadonlySet<string> = new Set(BASE_PANEL_FIELDS);
 
 export function panelToSnapshot(
   t: TerminalInstance,
@@ -53,7 +56,7 @@ export function panelToSnapshot(
       const preserved: Record<string, unknown> = {};
       const prev = previousSnapshot as unknown as Record<string, unknown>;
       for (const key of Object.keys(prev)) {
-        if (!BASE_PANEL_FIELDS.has(key) && prev[key] !== undefined) {
+        if (!BASE_PANEL_FIELD_SET.has(key) && prev[key] !== undefined) {
           preserved[key] = prev[key];
         }
       }


### PR DESCRIPTION
## Summary

- Replaces the Set-based BASE_PANEL_FIELDS allowlist in src/store/persistence/panelPersistence.ts with a satisfies readonly (keyof PanelSnapshot)[] binding. Removing a key from PanelSnapshot without updating the allowlist is now a compile error instead of a silent staleness bug.
- Adds a round-trip test for unknown-kind panel persistence: base fields get overwritten from the live panel while kind-specific fragments survive the save cycle.

Resolves #8960.

## Changes

- src/store/persistence/panelPersistence.ts: BASE_PANEL_FIELDS converted from a plain Set to as const satisfies readonly (keyof PanelSnapshot)[]. A separate BASE_PANEL_FIELD_SET carries the ReadonlySet for the runtime lookup.
- src/store/persistence/__tests__/panelPersistence.test.ts: round-trip test asserting that live base fields overwrite stale prior-snapshot values, while kind-specific fragment fields are preserved.

## Testing

- 34 persistence tests pass
- Typecheck clean (tsc --noEmit)
- The ratchet is directional: it catches key deletions from PanelSnapshot but not additions (documented in the code comment)