### PR TITLE
fix(a11y): add ARIA live regions and list semantics to shortcut reference dialog

### DIFF
--- a/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
+++ b/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
@@ -157,8 +157,8 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
       <AppDialog.Body>
         <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
           {searchQuery.trim()
-            ? `${filteredBindings.length} shortcuts found`
-            : `${filteredBindings.length} shortcuts`}
+            ? `${filteredBindings.length} shortcut${filteredBindings.length !== 1 ? "s" : ""} found for "${searchQuery.trim()}"`
+            : `${filteredBindings.length} shortcut${filteredBindings.length !== 1 ? "s" : ""}`}
         </div>
 
         {sortedCategories.length === 0 ? (
@@ -173,7 +173,10 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
         ) : (
           <div id={resultsId} className="space-y-8">
             {sortedCategories.map((category) => {
-              const headingId = `${headingPrefix}-${category.replace(/\s+/g, "-")}`;
+              const headingId = `${headingPrefix}-${category
+                .replace(/[^a-zA-Z0-9]/g, "-")
+                .replace(/-+/g, "-")
+                .replace(/^-|-$/g, "")}`;
               return (
                 <div key={category}>
                   <h3

--- a/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
+++ b/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, useId } from "react";
 import Fuse, { type IFuseOptions } from "fuse.js";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { useOverlayState } from "@/hooks";
@@ -35,6 +35,8 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
   const [searchQuery, setSearchQuery] = useState("");
   const [bindingsVersion, setBindingsVersion] = useState(0);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const resultsId = useId();
+  const headingPrefix = useId();
 
   useEffect(() => {
     const unsubscribe = keybindingService.subscribe(() => {
@@ -147,51 +149,72 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           aria-label="Search shortcuts"
+          aria-controls={resultsId}
           className="w-full px-4 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
         />
       </AppDialog.Header>
 
       <AppDialog.Body>
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {searchQuery.trim()
+            ? `${filteredBindings.length} shortcuts found`
+            : `${filteredBindings.length} shortcuts`}
+        </div>
+
         {sortedCategories.length === 0 ? (
-          <div className="text-center text-daintree-text/60 py-8">
+          <div
+            id={resultsId}
+            role="status"
+            aria-live="polite"
+            className="text-center text-daintree-text/60 py-8"
+          >
             No shortcuts found matching "{searchQuery}"
           </div>
         ) : (
-          <div className="space-y-8">
-            {sortedCategories.map((category) => (
-              <div key={category}>
-                <h3 className="text-lg font-semibold text-daintree-text mb-3 pb-2 border-b border-daintree-border">
-                  {category}
-                </h3>
-                <dl className="space-y-2">
-                  {groupedBindings[category]!.map((binding) => (
-                    <div
-                      key={binding.actionId}
-                      className="flex items-center justify-between py-2 px-3 rounded hover:bg-daintree-border/50"
-                    >
-                      <dt className="flex-1">
-                        <div className="text-daintree-text font-medium">{binding.description}</div>
-                        {binding.scope !== "global" && (
-                          <div className="text-xs text-daintree-text/60 mt-1">
-                            Scope: {binding.scope}
+          <div id={resultsId} className="space-y-8">
+            {sortedCategories.map((category) => {
+              const headingId = `${headingPrefix}-${category.replace(/\s+/g, "-")}`;
+              return (
+                <div key={category}>
+                  <h3
+                    id={headingId}
+                    className="text-lg font-semibold text-daintree-text mb-3 pb-2 border-b border-daintree-border"
+                  >
+                    {category}
+                  </h3>
+                  <div role="list" aria-labelledby={headingId} className="space-y-2">
+                    {groupedBindings[category]!.map((binding) => (
+                      <div
+                        key={binding.actionId}
+                        role="listitem"
+                        className="flex items-center justify-between py-2 px-3 rounded hover:bg-daintree-border/50"
+                      >
+                        <div className="flex-1">
+                          <div className="text-daintree-text font-medium">
+                            {binding.description}
                           </div>
-                        )}
-                      </dt>
-                      <dd className="ml-4">
-                        {binding.effectiveCombo ? (
-                          <KbdChord
-                            shortcut={binding.effectiveCombo}
-                            aria-label={binding.displayCombo}
-                          />
-                        ) : (
-                          <span className="text-xs text-daintree-text/60 italic">unbound</span>
-                        )}
-                      </dd>
-                    </div>
-                  ))}
-                </dl>
-              </div>
-            ))}
+                          {binding.scope !== "global" && (
+                            <div className="text-xs text-daintree-text/60 mt-1">
+                              Scope: {binding.scope}
+                            </div>
+                          )}
+                        </div>
+                        <div className="ml-4">
+                          {binding.effectiveCombo ? (
+                            <KbdChord
+                              shortcut={binding.effectiveCombo}
+                              aria-label={binding.displayCombo}
+                            />
+                          ) : (
+                            <span className="text-xs text-daintree-text/60 italic">unbound</span>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
           </div>
         )}
       </AppDialog.Body>

--- a/src/components/KeyboardShortcuts/__tests__/ShortcutReferenceDialog.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/ShortcutReferenceDialog.test.tsx
@@ -306,13 +306,84 @@ describe("ShortcutReferenceDialog", () => {
     expect(unboundCell.tagName.toLowerCase()).toBe("span");
   });
 
-  it("uses dl/dt/dd semantics for shortcut rows", () => {
+  it("uses list/listitem roles for shortcut rows", () => {
     render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
 
-    const dl = document.querySelector("dl");
-    expect(dl).toBeTruthy();
-    expect(document.querySelectorAll("dt").length).toBeGreaterThan(0);
-    expect(document.querySelectorAll("dd").length).toBeGreaterThan(0);
+    const lists = screen.getAllByRole("list");
+    expect(lists.length).toBeGreaterThan(0);
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems.length).toBeGreaterThan(0);
+  });
+
+  it("search input has aria-controls linking to results container", () => {
+    render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
+
+    const input = screen.getByLabelText("Search shortcuts");
+    const controlsId = input.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    const results = document.getElementById(controlsId!);
+    expect(results).toBeTruthy();
+  });
+
+  it("includes sr-only live region for result count announcements", () => {
+    render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
+
+    const statusRegions = screen.getAllByRole("status");
+    const countRegion = statusRegions.find((el) => el.textContent?.includes("shortcuts"));
+    expect(countRegion).toBeTruthy();
+    expect(countRegion!.getAttribute("aria-live")).toBe("polite");
+    expect(countRegion!.getAttribute("aria-atomic")).toBe("true");
+  });
+
+  it("empty state container has status role for screen reader announcement", async () => {
+    render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
+
+    const searchInput = screen.getByPlaceholderText("Search shortcuts...");
+    fireEvent.change(searchInput, { target: { value: "nonexistent" } });
+
+    await waitFor(() => {
+      const emptyDiv = screen.getByText('No shortcuts found matching "nonexistent"');
+      expect(emptyDiv.closest('[role="status"]')).toBeTruthy();
+      expect(emptyDiv.closest('[aria-live="polite"]')).toBeTruthy();
+    });
+  });
+
+  it("sr-only count updates when search filters results", async () => {
+    render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
+
+    const countRegion = screen
+      .getAllByRole("status")
+      .find((el) => el.textContent?.includes("shortcuts"));
+    expect(countRegion?.textContent).toContain("6");
+
+    const searchInput = screen.getByPlaceholderText("Search shortcuts...");
+    fireEvent.change(searchInput, { target: { value: "stash" } });
+
+    await waitFor(() => {
+      const updated = screen
+        .getAllByRole("status")
+        .find((el) => el.textContent?.includes("shortcuts"));
+      expect(updated?.textContent).toContain("1");
+    });
+  });
+
+  it("sr-only count region is always mounted", async () => {
+    render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
+
+    // Should exist when results are shown
+    let statusRegions = screen.getAllByRole("status");
+    let countRegion = statusRegions.find((el) => el.textContent?.includes("shortcuts"));
+    expect(countRegion).toBeTruthy();
+
+    // Should still exist when search yields no results
+    const searchInput = screen.getByPlaceholderText("Search shortcuts...");
+    fireEvent.change(searchInput, { target: { value: "nonexistent" } });
+
+    await waitFor(() => {
+      statusRegions = screen.getAllByRole("status");
+      countRegion = statusRegions.find((el) => el.textContent?.includes("shortcuts"));
+      expect(countRegion).toBeTruthy();
+    });
   });
 
   it("footer renders Esc inside a kbd element", () => {

--- a/src/components/KeyboardShortcuts/__tests__/ShortcutReferenceDialog.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/ShortcutReferenceDialog.test.tsx
@@ -329,7 +329,7 @@ describe("ShortcutReferenceDialog", () => {
     render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
 
     const statusRegions = screen.getAllByRole("status");
-    const countRegion = statusRegions.find((el) => el.textContent?.includes("shortcuts"));
+    const countRegion = statusRegions.find((el) => el.textContent?.includes("shortcut"));
     expect(countRegion).toBeTruthy();
     expect(countRegion!.getAttribute("aria-live")).toBe("polite");
     expect(countRegion!.getAttribute("aria-atomic")).toBe("true");
@@ -353,8 +353,8 @@ describe("ShortcutReferenceDialog", () => {
 
     const countRegion = screen
       .getAllByRole("status")
-      .find((el) => el.textContent?.includes("shortcuts"));
-    expect(countRegion?.textContent).toContain("6");
+      .find((el) => el.textContent?.includes("shortcut"));
+    expect(countRegion?.textContent).toBe("6 shortcuts");
 
     const searchInput = screen.getByPlaceholderText("Search shortcuts...");
     fireEvent.change(searchInput, { target: { value: "stash" } });
@@ -362,8 +362,8 @@ describe("ShortcutReferenceDialog", () => {
     await waitFor(() => {
       const updated = screen
         .getAllByRole("status")
-        .find((el) => el.textContent?.includes("shortcuts"));
-      expect(updated?.textContent).toContain("1");
+        .find((el) => el.textContent?.includes("shortcut"));
+      expect(updated?.textContent).toBe('1 shortcut found for "stash"');
     });
   });
 
@@ -372,7 +372,7 @@ describe("ShortcutReferenceDialog", () => {
 
     // Should exist when results are shown
     let statusRegions = screen.getAllByRole("status");
-    let countRegion = statusRegions.find((el) => el.textContent?.includes("shortcuts"));
+    let countRegion = statusRegions.find((el) => el.textContent?.includes("shortcut"));
     expect(countRegion).toBeTruthy();
 
     // Should still exist when search yields no results
@@ -381,8 +381,32 @@ describe("ShortcutReferenceDialog", () => {
 
     await waitFor(() => {
       statusRegions = screen.getAllByRole("status");
-      countRegion = statusRegions.find((el) => el.textContent?.includes("shortcuts"));
+      countRegion = statusRegions.find((el) => el.textContent?.includes("shortcut"));
       expect(countRegion).toBeTruthy();
+    });
+  });
+
+  it("sr-only announcement changes when same-count but different results", async () => {
+    render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
+
+    const searchInput = screen.getByPlaceholderText("Search shortcuts...");
+
+    // settings → 1 result
+    fireEvent.change(searchInput, { target: { value: "settings" } });
+    await waitFor(() => {
+      const region = screen
+        .getAllByRole("status")
+        .find((el) => el.textContent?.includes("shortcut"));
+      expect(region?.textContent).toBe('1 shortcut found for "settings"');
+    });
+
+    // stash → also 1 result, but different text → re-announces
+    fireEvent.change(searchInput, { target: { value: "stash" } });
+    await waitFor(() => {
+      const region = screen
+        .getAllByRole("status")
+        .find((el) => el.textContent?.includes("shortcut"));
+      expect(region?.textContent).toBe('1 shortcut found for "stash"');
     });
   });
 


### PR DESCRIPTION
## Summary
The shortcut reference dialog search results were completely silent to screen readers -- typing in the search input gave no feedback that anything changed. Added an `aria-live` region that announces result counts after each keystroke, list semantics on category groups, and `aria-controls` linking the search input to the results region.

Resolves #8943

## Changes
- `aria-live="polite"` region announces result count on search, including when the count stays the same but the search term changes
- Category groups use `role="list"` with `aria-labelledby` pointing to the sanitized category heading
- Search input uses `aria-controls` to link to the results container
- Category heading IDs are sanitized to valid HTML ID values
- Empty state announcement uses `role="status"` so screen readers pick it up
- Tests covering the new ARIA behavior and edge cases