### PR TITLE
fix(reduced-motion): add missing data-reduce-animations gate to JS animation guards

### DIFF
--- a/src/components/AllClearOverlay/AllClearOverlay.tsx
+++ b/src/components/AllClearOverlay/AllClearOverlay.tsx
@@ -8,6 +8,7 @@ export function AllClearOverlay() {
   useEffect(() => {
     const cleanup = window.electron.terminal.onAllAgentsClear(() => {
       if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+      if (document.body.getAttribute("data-reduce-animations") === "true") return;
       if (document.body.getAttribute("data-performance-mode") === "true") return;
 
       setVisible(true);

--- a/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
+++ b/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
@@ -64,6 +64,18 @@ describe("AllClearOverlay", () => {
     expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
   });
 
+  it("suppresses the overlay when data-reduce-animations is true", () => {
+    document.body.setAttribute("data-reduce-animations", "true");
+    render(<AllClearOverlay />);
+
+    act(() => {
+      onAllAgentsClearCb?.({ timestamp: Date.now() });
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+    document.body.removeAttribute("data-reduce-animations");
+  });
+
   it("suppresses the overlay when data-performance-mode is true", () => {
     document.body.setAttribute("data-performance-mode", "true");
     render(<AllClearOverlay />);

--- a/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
+++ b/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
@@ -66,26 +66,32 @@ describe("AllClearOverlay", () => {
 
   it("suppresses the overlay when data-reduce-animations is true", () => {
     document.body.setAttribute("data-reduce-animations", "true");
-    render(<AllClearOverlay />);
+    try {
+      render(<AllClearOverlay />);
 
-    act(() => {
-      onAllAgentsClearCb?.({ timestamp: Date.now() });
-    });
+      act(() => {
+        onAllAgentsClearCb?.({ timestamp: Date.now() });
+      });
 
-    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
-    document.body.removeAttribute("data-reduce-animations");
+      expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+    } finally {
+      document.body.removeAttribute("data-reduce-animations");
+    }
   });
 
   it("suppresses the overlay when data-performance-mode is true", () => {
     document.body.setAttribute("data-performance-mode", "true");
-    render(<AllClearOverlay />);
+    try {
+      render(<AllClearOverlay />);
 
-    act(() => {
-      onAllAgentsClearCb?.({ timestamp: Date.now() });
-    });
+      act(() => {
+        onAllAgentsClearCb?.({ timestamp: Date.now() });
+      });
 
-    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
-    document.body.removeAttribute("data-performance-mode");
+      expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+    } finally {
+      document.body.removeAttribute("data-performance-mode");
+    }
   });
 
   it("hides via safety timeout when animationend never fires", () => {

--- a/src/components/Panel/PanelTransitionOverlay.tsx
+++ b/src/components/Panel/PanelTransitionOverlay.tsx
@@ -43,6 +43,11 @@ export function triggerPanelTransition(
     return;
   }
 
+  // Check for app-level reduce-animations toggle
+  if (document.body.getAttribute("data-reduce-animations") === "true") {
+    return;
+  }
+
   // Check for performance mode
   if (document.body.getAttribute("data-performance-mode") === "true") {
     return;

--- a/src/components/Panel/__tests__/PanelTransitionOverlay.test.tsx
+++ b/src/components/Panel/__tests__/PanelTransitionOverlay.test.tsx
@@ -16,6 +16,7 @@ describe("PanelTransitionOverlay", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+    document.body.removeAttribute("data-reduce-animations");
     document.body.removeAttribute("data-performance-mode");
 
     vi.spyOn(performance, "now").mockReturnValue(1000);
@@ -30,6 +31,18 @@ describe("PanelTransitionOverlay", () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it("suppresses ghost render when data-reduce-animations is true", () => {
+    document.body.setAttribute("data-reduce-animations", "true");
+    const onComplete = vi.fn();
+    const { container } = render(<PanelTransitionOverlay onTransitionComplete={onComplete} />);
+
+    act(() => {
+      triggerPanelTransition("panel-1", "minimize", sourceRect, targetRect);
+    });
+
+    expect(container.querySelector("[class*='absolute']")).toBeNull();
   });
 
   it("applies minimize duration and easing to ghost element", () => {

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -113,7 +113,11 @@ export function InlineStatusBanner({
   autoDismissAfter,
 }: InlineStatusBannerProps) {
   const prefersReducedMotion =
-    typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    typeof window !== "undefined" &&
+    (window.matchMedia("(prefers-reduced-motion: reduce)").matches ||
+      (typeof document !== "undefined" &&
+        (document.body.getAttribute("data-reduce-animations") === "true" ||
+          document.body.getAttribute("data-performance-mode") === "true")));
   const shouldAnimate = animated && !prefersReducedMotion;
 
   const [isVisible, setIsVisible] = useState(!shouldAnimate);

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -449,4 +449,42 @@ describe("InlineStatusBanner", () => {
     expect(root.className).toContain("duration-250");
     expect(root.className).not.toContain("duration-150");
   });
+
+  it("suppresses the 250ms entrance class when data-reduce-animations is true", () => {
+    document.body.setAttribute("data-reduce-animations", "true");
+    try {
+      const { container } = render(
+        <InlineStatusBanner
+          icon={Info}
+          title="Animated"
+          severity="info"
+          animated={true}
+          actions={[]}
+        />
+      );
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).not.toContain("duration-250");
+    } finally {
+      document.body.removeAttribute("data-reduce-animations");
+    }
+  });
+
+  it("suppresses the 250ms entrance class when data-performance-mode is true", () => {
+    document.body.setAttribute("data-performance-mode", "true");
+    try {
+      const { container } = render(
+        <InlineStatusBanner
+          icon={Info}
+          title="Animated"
+          severity="info"
+          animated={true}
+          actions={[]}
+        />
+      );
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).not.toContain("duration-250");
+    } finally {
+      document.body.removeAttribute("data-performance-mode");
+    }
+  });
 });

--- a/src/lib/__tests__/appThemeViewTransition.test.ts
+++ b/src/lib/__tests__/appThemeViewTransition.test.ts
@@ -57,6 +57,7 @@ describe("appThemeViewTransition", () => {
   beforeEach(() => {
     setReducedMotion(false);
     setVisibility("visible");
+    document.body.dataset.reduceAnimations = "false";
     document.body.dataset.performanceMode = "false";
     Object.defineProperty(window, "innerWidth", { configurable: true, value: 1000 });
     Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
@@ -65,6 +66,7 @@ describe("appThemeViewTransition", () => {
   afterEach(() => {
     delete (document as unknown as { startViewTransition?: unknown }).startViewTransition;
     delete (document as unknown as { activeViewTransition?: unknown }).activeViewTransition;
+    delete document.body.dataset.reduceAnimations;
     delete document.body.dataset.performanceMode;
     vi.restoreAllMocks();
   });
@@ -77,6 +79,11 @@ describe("appThemeViewTransition", () => {
 
     it("returns true when performance mode is enabled", () => {
       document.body.dataset.performanceMode = "true";
+      expect(prefersReducedMotion()).toBe(true);
+    });
+
+    it("returns true when reduce-animations is enabled", () => {
+      document.body.dataset.reduceAnimations = "true";
       expect(prefersReducedMotion()).toBe(true);
     });
 

--- a/src/lib/appThemeViewTransition.ts
+++ b/src/lib/appThemeViewTransition.ts
@@ -13,6 +13,7 @@ export function prefersReducedMotion(): boolean {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") return true;
   return (
     window.matchMedia("(prefers-reduced-motion: reduce)").matches ||
+    document.body.dataset.reduceAnimations === "true" ||
     document.body.dataset.performanceMode === "true"
   );
 }


### PR DESCRIPTION
## Summary

There were four JS animation guards checking `prefers-reduced-motion` and `data-performance-mode` but not the app-level `data-reduce-animations` toggle. If someone turned off animations in settings, those paths would still animate.

Added the missing `data-reduce-animations` gate to all of them.

## Changes

- **`AllClearOverlay`** -- gate the all-clear flash behind `data-reduce-animations`
- **`PanelTransitionOverlay`** -- gate the minimize/restore ghost render
- **`appThemeViewTransition`** -- gate theme-change view transitions in `prefersReducedMotion()`
- **`InlineStatusBanner`** -- gate the 250ms entrance animation

Also wrapped `data-*` attribute cleanup in `try/finally` blocks in the tests so a failed assertion doesn't pollute the next test.

Resolves #8930

## Testing

Ran the relevant unit test suites -- `AllClearOverlay`, `PanelTransitionOverlay`, `appThemeViewTransition`, and `InlineStatusBanner`. All passing.