### PR TITLE
refactor(welcome): extract shared agent welcome card eligibility check

### DIFF
--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -31,6 +31,7 @@ import { getAgentConfig } from "@/config/agents";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
 import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import { isAgentPinned } from "../../../shared/utils/agentPinned";
+import type { AgentAvailabilityState } from "../../../shared/types/ipc/system";
 import type { GettingStartedChecklistState } from "@/hooks/app/useGettingStartedChecklist";
 
 interface WelcomeScreenProps {
@@ -240,6 +241,27 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
   );
 }
 
+/* ---------- Shared helpers ---------- */
+
+export function isAgentWelcomeCardEligible({
+  agentSettings,
+  hasRealData,
+  welcomeCardDismissed,
+  availability,
+}: {
+  agentSettings: { agents?: Record<string, { pinned?: boolean }> } | null;
+  hasRealData: boolean;
+  welcomeCardDismissed: boolean;
+  availability: Record<string, AgentAvailabilityState> | null;
+}): boolean {
+  if (!agentSettings) return false;
+  if (!hasRealData || welcomeCardDismissed) return false;
+  const hasReady = BUILT_IN_AGENT_IDS.some((id) => isAgentLaunchable(availability?.[id]));
+  if (!hasReady) return false;
+  const hasPinned = BUILT_IN_AGENT_IDS.some((id) => isAgentPinned(agentSettings.agents?.[id]));
+  return !hasPinned;
+}
+
 /* ---------- Sub-sections ---------- */
 
 function NudgeSequencer({
@@ -262,12 +284,12 @@ function NudgeSequencer({
   // return null (no launchable agents, or any built-in already pinned) we
   // fall through to the checklist instead of silently suppressing it.
   const welcomeCardEligible = useMemo(() => {
-    if (!agentSettings) return false;
-    if (!hasRealData || welcomeCardDismissed) return false;
-    const hasReady = BUILT_IN_AGENT_IDS.some((id) => isAgentLaunchable(availability?.[id]));
-    if (!hasReady) return false;
-    const hasPinned = BUILT_IN_AGENT_IDS.some((id) => isAgentPinned(agentSettings?.agents?.[id]));
-    return !hasPinned;
+    return isAgentWelcomeCardEligible({
+      agentSettings,
+      hasRealData,
+      welcomeCardDismissed,
+      availability,
+    });
   }, [hasRealData, welcomeCardDismissed, availability, agentSettings]);
 
   // Wait for hydration so we don't briefly render setup banner before its
@@ -423,14 +445,11 @@ function AgentWelcomeCard() {
     return BUILT_IN_AGENT_IDS.filter((id) => isAgentLaunchable(availability?.[id]));
   }, [availability]);
 
-  const hasNoPinnedAgents = useMemo(() => {
-    if (!agentSettings?.agents) return true;
-    return !BUILT_IN_AGENT_IDS.some((id) => isAgentPinned(agentSettings.agents[id]));
-  }, [agentSettings]);
-
-  if (!hasRealData || !loaded) return null;
-  if (welcomeCardDismissed) return null;
-  if (readyAgentIds.length === 0 || !hasNoPinnedAgents) return null;
+  if (!loaded) return null;
+  if (
+    !isAgentWelcomeCardEligible({ agentSettings, hasRealData, welcomeCardDismissed, availability })
+  )
+    return null;
 
   const handlePinAll = async () => {
     if (busy) return;

--- a/src/components/Project/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/Project/__tests__/WelcomeScreen.test.tsx
@@ -193,7 +193,7 @@ Object.defineProperty(window, "electron", {
   writable: true,
 });
 
-import { WelcomeScreen } from "../WelcomeScreen";
+import { WelcomeScreen, isAgentWelcomeCardEligible } from "../WelcomeScreen";
 import type { GettingStartedChecklistState } from "@/hooks/app/useGettingStartedChecklist";
 import type { ChecklistState } from "@shared/types/ipc/maps";
 
@@ -1062,6 +1062,107 @@ describe("WelcomeScreen", () => {
       expect(screen.queryByTestId("agent-setup-banner")).toBeNull();
       expect(screen.queryByText(/Installed agents found/)).toBeNull();
       expect(screen.queryByText("Getting Started")).toBeNull();
+    });
+  });
+
+  describe("isAgentWelcomeCardEligible", () => {
+    it("returns false when agentSettings is null", () => {
+      expect(
+        isAgentWelcomeCardEligible({
+          agentSettings: null,
+          hasRealData: true,
+          welcomeCardDismissed: false,
+          availability: { claude: "ready" },
+        })
+      ).toBe(false);
+    });
+
+    it("returns false when hasRealData is false", () => {
+      expect(
+        isAgentWelcomeCardEligible({
+          agentSettings: { agents: {} },
+          hasRealData: false,
+          welcomeCardDismissed: false,
+          availability: { claude: "ready" },
+        })
+      ).toBe(false);
+    });
+
+    it("returns false when welcomeCardDismissed is true", () => {
+      expect(
+        isAgentWelcomeCardEligible({
+          agentSettings: { agents: {} },
+          hasRealData: true,
+          welcomeCardDismissed: true,
+          availability: { claude: "ready" },
+        })
+      ).toBe(false);
+    });
+
+    it("returns false when no built-in agent is launchable", () => {
+      expect(
+        isAgentWelcomeCardEligible({
+          agentSettings: { agents: {} },
+          hasRealData: true,
+          welcomeCardDismissed: false,
+          availability: { claude: "missing", codex: "missing" },
+        })
+      ).toBe(false);
+    });
+
+    it("returns false when a built-in agent is already pinned", () => {
+      expect(
+        isAgentWelcomeCardEligible({
+          agentSettings: { agents: { claude: { pinned: true } } },
+          hasRealData: true,
+          welcomeCardDismissed: false,
+          availability: { claude: "ready" },
+        })
+      ).toBe(false);
+    });
+
+    it("returns true when ready agents exist and none are pinned", () => {
+      expect(
+        isAgentWelcomeCardEligible({
+          agentSettings: { agents: {} },
+          hasRealData: true,
+          welcomeCardDismissed: false,
+          availability: { claude: "ready", codex: "ready" },
+        })
+      ).toBe(true);
+    });
+
+    it("returns true for unauthenticated agent (launchable)", () => {
+      expect(
+        isAgentWelcomeCardEligible({
+          agentSettings: { agents: {} },
+          hasRealData: true,
+          welcomeCardDismissed: false,
+          availability: { claude: "unauthenticated" },
+        })
+      ).toBe(true);
+    });
+
+    it("returns false for blocked agent (not launchable)", () => {
+      expect(
+        isAgentWelcomeCardEligible({
+          agentSettings: { agents: {} },
+          hasRealData: true,
+          welcomeCardDismissed: false,
+          availability: { claude: "blocked" },
+        })
+      ).toBe(false);
+    });
+
+    it("ignores custom agent pins when checking built-in eligibility", () => {
+      expect(
+        isAgentWelcomeCardEligible({
+          agentSettings: { agents: { "my-custom-agent": { pinned: true } } },
+          hasRealData: true,
+          welcomeCardDismissed: false,
+          availability: { claude: "ready" },
+        })
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Extracted the duplicated eligibility check into `isAgentWelcomeCardEligible`, shared between `NudgeSequencer` and `AgentWelcomeCard` in WelcomeScreen.
- Fixed a null-safety inconsistency between the two callers. One used `agentSettings.agents[id]` without optional chaining while the other used `agentSettings?.agents?.[id]`. Both now go through the shared function.
- Added 8 direct unit tests covering all branches: null settings, no real data, dismissed, no launchable agent, pinned agent, ready/unauthenticated/blocked availability, and custom agent pins.

Resolves #8952.

## Changes

- `src/components/Project/WelcomeScreen.tsx` — extracted `isAgentWelcomeCardEligible`, replaced duplicate inline logic in both call sites.
- `src/components/Project/__tests__/WelcomeScreen.test.tsx` — 8 unit tests for the exported function.

## Testing

All 69 existing WelcomeScreen tests pass, plus the 8 new tests. Full typecheck clean.