### PR TITLE
fix(ui): tighten floating-UI entry motion

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -341,7 +341,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
         </TerminalContextMenu>
 
         <PopoverContent
-          className="w-[700px] max-w-[90vw] h-[500px] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
+          className="w-[700px] max-w-[90vw] h-[500px] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1"
           side="top"
           align="start"
           sideOffset={10}

--- a/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
@@ -18,12 +18,12 @@ describe("DockedTerminalItem", () => {
     expect(content).toContain("data-[state=closed]:duration-[120ms]");
     expect(content).toContain("data-[state=open]:fade-in-0");
     expect(content).toContain("data-[state=closed]:fade-out-0");
-    expect(content).toContain("data-[state=open]:zoom-in-95");
-    expect(content).toContain("data-[state=closed]:zoom-out-95");
-    expect(content).toContain("data-[side=bottom]:slide-in-from-top-2");
-    expect(content).toContain("data-[side=left]:slide-in-from-right-2");
-    expect(content).toContain("data-[side=right]:slide-in-from-left-2");
-    expect(content).toContain("data-[side=top]:slide-in-from-bottom-2");
+    expect(content).toContain("data-[state=open]:zoom-in-97");
+    expect(content).toContain("data-[state=closed]:zoom-out-97");
+    expect(content).toContain("data-[side=bottom]:slide-in-from-top-1");
+    expect(content).toContain("data-[side=left]:slide-in-from-right-1");
+    expect(content).toContain("data-[side=right]:slide-in-from-left-1");
+    expect(content).toContain("data-[side=top]:slide-in-from-bottom-1");
   });
 
   it("keeps existing dock popover guards intact", () => {

--- a/src/components/ui/__tests__/radix-animation-classes.test.tsx
+++ b/src/components/ui/__tests__/radix-animation-classes.test.tsx
@@ -5,8 +5,10 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import * as SelectPrimitive from "@radix-ui/react-select";
 import { PopoverContent } from "../popover";
 import { DropdownMenuContent, DropdownMenuSubContent } from "../dropdown-menu";
+import { SelectContent } from "../select";
 import { primeRadix } from "../radix-loader";
 
 beforeAll(async () => {
@@ -20,17 +22,30 @@ const ENTER_EXIT_CLASSES = [
   "data-[state=closed]:animate-out",
   "data-[state=open]:fade-in-0",
   "data-[state=closed]:fade-out-0",
-  "data-[state=open]:zoom-in-95",
-  "data-[state=closed]:zoom-out-95",
-  "data-[side=bottom]:slide-in-from-top-2",
-  "data-[side=left]:slide-in-from-right-2",
-  "data-[side=right]:slide-in-from-left-2",
-  "data-[side=top]:slide-in-from-bottom-2",
+  "data-[state=open]:zoom-in-97",
+  "data-[state=closed]:zoom-out-97",
+  "data-[side=bottom]:slide-in-from-top-1",
+  "data-[side=left]:slide-in-from-right-1",
+  "data-[side=right]:slide-in-from-left-1",
+  "data-[side=top]:slide-in-from-bottom-1",
 ];
 
 const UI_DURATION_CLASSES = [
   "data-[state=open]:duration-200",
   "data-[state=closed]:duration-[120ms]",
+];
+
+const SELECT_CLASSES = [
+  "data-[state=open]:animate-in",
+  "data-[state=closed]:animate-out",
+  "data-[state=open]:fade-in-0",
+  "data-[state=closed]:fade-out-0",
+  "data-[state=open]:zoom-in-98",
+  "data-[state=closed]:zoom-out-98",
+  "data-[side=bottom]:slide-in-from-top-1",
+  "data-[side=left]:slide-in-from-right-1",
+  "data-[side=right]:slide-in-from-left-1",
+  "data-[side=top]:slide-in-from-bottom-1",
 ];
 
 const TRANSFORM_ORIGIN_VARS: Record<string, string> = {
@@ -45,12 +60,10 @@ const TRANSFORM_ORIGIN_VARS: Record<string, string> = {
 const TOOLTIP_CLASSES = [
   "animate-in",
   "fade-in-0",
-  "zoom-in-95",
   "duration-150",
   "data-[state=closed]:animate-out",
   "data-[state=closed]:duration-[100ms]",
   "data-[state=closed]:fade-out-0",
-  "data-[state=closed]:zoom-out-95",
   "data-[side=bottom]:slide-in-from-top-1",
   "data-[side=left]:slide-in-from-right-1",
   "data-[side=right]:slide-in-from-left-1",
@@ -176,9 +189,27 @@ describe("Radix overlay animation classes — wrapper source", () => {
 
   it("select.tsx contains the full enter/exit set and UI durations", () => {
     const src = readWrapperSource("select.tsx");
-    expectAllInString(src, ENTER_EXIT_CLASSES, "select.tsx");
+    expectAllInString(src, SELECT_CLASSES, "select.tsx");
     expectAllInString(src, UI_DURATION_CLASSES, "select.tsx");
     expect(src).toContain("var(--radix-select-content-transform-origin)");
+  });
+
+  it("SelectContent renders with select-specific enter/exit class set and UI durations", () => {
+    render(
+      <SelectPrimitive.Root open>
+        <SelectPrimitive.Trigger>trigger</SelectPrimitive.Trigger>
+        <SelectContent forceMount>
+          <SelectPrimitive.Item value="a">a</SelectPrimitive.Item>
+        </SelectContent>
+      </SelectPrimitive.Root>
+    );
+    const el = assertHTMLElement(
+      document.querySelector("[data-radix-popper-content-wrapper] > *"),
+      "SelectContent"
+    );
+    expectAllInString(el.className, SELECT_CLASSES, "SelectContent");
+    expectAllInString(el.className, UI_DURATION_CLASSES, "SelectContent");
+    expect(el.style.transformOrigin).toBe(TRANSFORM_ORIGIN_VARS.select);
   });
 
   it("tooltip.tsx contains palette enter/exit set with palette durations", () => {

--- a/src/components/ui/__tests__/radix-animation-classes.test.tsx
+++ b/src/components/ui/__tests__/radix-animation-classes.test.tsx
@@ -235,4 +235,14 @@ describe("Radix overlay animation classes — wrapper source", () => {
     // until the next pointer move.
     expect(src).toMatch(/if \(pointerActiveRef\.current\) return/);
   });
+
+  it("DockedTerminalItem.tsx does not contain stale animation classes", () => {
+    const src = readWrapperSource("../Layout/DockedTerminalItem.tsx");
+    expect(src).not.toContain("slide-in-from-top-2");
+    expect(src).not.toContain("slide-in-from-right-2");
+    expect(src).not.toContain("slide-in-from-left-2");
+    expect(src).not.toContain("slide-in-from-bottom-2");
+    expect(src).not.toContain("zoom-in-95");
+    expect(src).not.toContain("zoom-out-95");
+  });
 });

--- a/src/components/ui/__tests__/radix-animation-classes.test.tsx
+++ b/src/components/ui/__tests__/radix-animation-classes.test.tsx
@@ -198,7 +198,7 @@ describe("Radix overlay animation classes — wrapper source", () => {
     render(
       <SelectPrimitive.Root open>
         <SelectPrimitive.Trigger>trigger</SelectPrimitive.Trigger>
-        <SelectContent forceMount>
+        <SelectContent>
           <SelectPrimitive.Item value="a">a</SelectPrimitive.Item>
         </SelectContent>
       </SelectPrimitive.Root>

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -195,7 +195,7 @@ const ContextMenuSubContent = React.forwardRef<
         style={{ transformOrigin: "var(--radix-context-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
           className
         )}
         {...props}
@@ -232,7 +232,7 @@ const ContextMenuContent = React.forwardRef<
         style={{ transformOrigin: "var(--radix-context-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
           className
         )}
         {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -234,7 +234,7 @@ const DropdownMenuSubContent = React.forwardRef<
         style={{ transformOrigin: "var(--radix-dropdown-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
           className
         )}
         {...props}
@@ -271,7 +271,7 @@ const DropdownMenuContent = React.forwardRef<
         style={{ transformOrigin: "var(--radix-dropdown-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
           className
         )}
         {...props}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -233,7 +233,7 @@ const PopoverContent = React.forwardRef<
         style={{ transformOrigin: "var(--radix-popover-content-transform-origin)", ...style }}
         className={cn(
           "z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-daintree-text",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
           className
         )}
         {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -217,7 +217,7 @@ const SelectContent = React.forwardRef<
           style={{ transformOrigin: "var(--radix-select-content-transform-origin)", ...style }}
           className={cn(
             "relative z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-daintree-text",
-            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-98 data-[state=open]:zoom-in-98 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
             position === "popper" &&
               "min-w-[var(--radix-select-trigger-width)] max-h-[var(--radix-select-content-available-height)]",
             className

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -176,7 +176,7 @@ const TooltipContent = React.forwardRef<
           style={{ transformOrigin: "var(--radix-tooltip-content-transform-origin)", ...style }}
           className={cn(
             "z-[var(--z-popover)] max-w-xs overflow-hidden rounded-[var(--radius-md)] surface-overlay shadow-overlay px-3 py-1.5 text-xs text-daintree-text",
-            "animate-in fade-in-0 zoom-in-95 duration-150 data-[state=closed]:animate-out data-[state=closed]:duration-[100ms] data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+            "animate-in fade-in-0 duration-150 data-[state=closed]:animate-out data-[state=closed]:duration-[100ms] data-[state=closed]:fade-out-0 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
             className
           )}
           {...props}


### PR DESCRIPTION
## Summary
Tightens floating-UI entry motion across the five Radix surfaces. The shadcn defaults (8px slide, 0.95 scale) feel loose at IDE density. Slide moves from 8px to 4px and scale tightens across the board, with tooltip dropping scale entirely.

## Changes
- `Popover` / `DropdownMenu` / `ContextMenu`: slide `top-2` to `top-1` (4px), zoom `95` to `97`
- `Select`: slide `top-2` to `top-1`, zoom `95` to `98` (tighter still -- smaller, denser surface)
- `Tooltip`: scale removed entirely -- fade plus 4px slide only
- `DockedTerminalItem.tsx`: updated to match the new popover classes
- Contract test in `radix-animation-classes.test.tsx` moves in lockstep, with a new Select render test and a stale-class guard for `DockedTerminalItem`

Resolves #8968

## Testing
- All animation-class contract tests pass
- Reduced-motion path unaffected (global CSS zeros `--tw-enter-scale` / `--tw-enter-translate` on `[data-state][data-side]`)