### PR TITLE
refactor(panel): remove redundant motion wrapper in SortableTabButton

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -435,6 +435,8 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     return null;
   }
 
+  const performanceMode = document.body.dataset.performanceMode === "true";
+
   const brandColor =
     panelPresetColors.get(activePanel.id) ?? deriveTerminalChrome(activePanel).color;
   const activeChrome = deriveTerminalChrome({
@@ -601,8 +603,8 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                     aria-label="Dock panel tabs"
                     onKeyDown={handleTabListKeyDown}
                   >
-                    <AnimatePresence initial={false} mode="popLayout">
-                      {panels.map((panel) => {
+                    {performanceMode ? (
+                      panels.map((panel) => {
                         const tabChrome = deriveTerminalChrome({
                           kind: panel.kind,
                           launchAgentId: panel.launchAgentId,
@@ -615,31 +617,63 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                           presetColor: panelPresetColors.get(panel.id),
                         });
                         return (
-                          <m.div
+                          <SortableTabButton
                             key={panel.id}
-                            layout="position"
-                            transition={{
-                              duration: UI_ANIMATION_DURATION / 1000,
-                              ease: EASE_OUT_EXPO_FM,
-                            }}
-                          >
-                            <SortableTabButton
-                              id={panel.id}
-                              title={getBaseTitle(panel.title)}
-                              chrome={tabChrome}
-                              kind={panel.kind ?? "terminal"}
-                              agentState={getDockDisplayAgentState(panel)}
-                              isActive={panel.id === activeTabId}
-                              presetColor={panelPresetColors.get(panel.id)}
-                              isUsingFallback={panel.isUsingFallback}
-                              onClick={() => handleTabClick(panel.id)}
-                              onClose={() => handleTabClose(panel.id)}
-                              onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
-                            />
-                          </m.div>
+                            id={panel.id}
+                            title={getBaseTitle(panel.title)}
+                            chrome={tabChrome}
+                            kind={panel.kind ?? "terminal"}
+                            agentState={getDockDisplayAgentState(panel)}
+                            isActive={panel.id === activeTabId}
+                            presetColor={panelPresetColors.get(panel.id)}
+                            isUsingFallback={panel.isUsingFallback}
+                            onClick={() => handleTabClick(panel.id)}
+                            onClose={() => handleTabClose(panel.id)}
+                            onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
+                          />
                         );
-                      })}
-                    </AnimatePresence>
+                      })
+                    ) : (
+                      <AnimatePresence initial={false} mode="popLayout">
+                        {panels.map((panel) => {
+                          const tabChrome = deriveTerminalChrome({
+                            kind: panel.kind,
+                            launchAgentId: panel.launchAgentId,
+                            runtimeIdentity: panel.runtimeIdentity,
+                            detectedAgentId: panel.detectedAgentId,
+                            detectedProcessId: panel.detectedProcessId,
+                            agentState: panel.agentState,
+                            runtimeStatus: panel.runtimeStatus,
+                            exitCode: panel.exitCode,
+                            presetColor: panelPresetColors.get(panel.id),
+                          });
+                          return (
+                            <m.div
+                              key={panel.id}
+                              layout="position"
+                              transition={{
+                                duration: UI_ANIMATION_DURATION / 1000,
+                                ease: EASE_OUT_EXPO_FM,
+                              }}
+                            >
+                              <SortableTabButton
+                                id={panel.id}
+                                title={getBaseTitle(panel.title)}
+                                chrome={tabChrome}
+                                kind={panel.kind ?? "terminal"}
+                                agentState={getDockDisplayAgentState(panel)}
+                                isActive={panel.id === activeTabId}
+                                presetColor={panelPresetColors.get(panel.id)}
+                                isUsingFallback={panel.isUsingFallback}
+                                onClick={() => handleTabClick(panel.id)}
+                                onClose={() => handleTabClose(panel.id)}
+                                onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
+                              />
+                            </m.div>
+                          );
+                        })}
+                      </AnimatePresence>
+                    )}
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <button

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -12,7 +12,7 @@ import {
 } from "@dnd-kit/core";
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
-import { LayoutGroup } from "framer-motion";
+import { LayoutGroup, AnimatePresence, m } from "framer-motion";
 import { ChevronDown, CopyPlus, SquareArrowOutUpRight } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
@@ -58,6 +58,7 @@ import type { TabGroup } from "@/types";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { handleDockInteractOutside, handleDockEscapeKeyDown } from "./dockPopoverGuard";
 import { usePreferencesStore } from "@/store";
+import { UI_ANIMATION_DURATION, EASE_OUT_EXPO_FM } from "@/lib/animationUtils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DockPopoverChildProvider } from "@/components/ui/DockPopoverChildContext";
 
@@ -600,35 +601,45 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                     aria-label="Dock panel tabs"
                     onKeyDown={handleTabListKeyDown}
                   >
-                    {panels.map((panel) => {
-                      const tabChrome = deriveTerminalChrome({
-                        kind: panel.kind,
-                        launchAgentId: panel.launchAgentId,
-                        runtimeIdentity: panel.runtimeIdentity,
-                        detectedAgentId: panel.detectedAgentId,
-                        detectedProcessId: panel.detectedProcessId,
-                        agentState: panel.agentState,
-                        runtimeStatus: panel.runtimeStatus,
-                        exitCode: panel.exitCode,
-                        presetColor: panelPresetColors.get(panel.id),
-                      });
-                      return (
-                        <SortableTabButton
-                          key={panel.id}
-                          id={panel.id}
-                          title={getBaseTitle(panel.title)}
-                          chrome={tabChrome}
-                          kind={panel.kind ?? "terminal"}
-                          agentState={getDockDisplayAgentState(panel)}
-                          isActive={panel.id === activeTabId}
-                          presetColor={panelPresetColors.get(panel.id)}
-                          isUsingFallback={panel.isUsingFallback}
-                          onClick={() => handleTabClick(panel.id)}
-                          onClose={() => handleTabClose(panel.id)}
-                          onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
-                        />
-                      );
-                    })}
+                    <AnimatePresence initial={false} mode="popLayout">
+                      {panels.map((panel) => {
+                        const tabChrome = deriveTerminalChrome({
+                          kind: panel.kind,
+                          launchAgentId: panel.launchAgentId,
+                          runtimeIdentity: panel.runtimeIdentity,
+                          detectedAgentId: panel.detectedAgentId,
+                          detectedProcessId: panel.detectedProcessId,
+                          agentState: panel.agentState,
+                          runtimeStatus: panel.runtimeStatus,
+                          exitCode: panel.exitCode,
+                          presetColor: panelPresetColors.get(panel.id),
+                        });
+                        return (
+                          <m.div
+                            key={panel.id}
+                            layout="position"
+                            transition={{
+                              duration: UI_ANIMATION_DURATION / 1000,
+                              ease: EASE_OUT_EXPO_FM,
+                            }}
+                          >
+                            <SortableTabButton
+                              id={panel.id}
+                              title={getBaseTitle(panel.title)}
+                              chrome={tabChrome}
+                              kind={panel.kind ?? "terminal"}
+                              agentState={getDockDisplayAgentState(panel)}
+                              isActive={panel.id === activeTabId}
+                              presetColor={panelPresetColors.get(panel.id)}
+                              isUsingFallback={panel.isUsingFallback}
+                              onClick={() => handleTabClick(panel.id)}
+                              onClose={() => handleTabClose(panel.id)}
+                              onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
+                            />
+                          </m.div>
+                        );
+                      })}
+                    </AnimatePresence>
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <button

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -235,6 +235,8 @@ vi.mock("@dnd-kit/modifiers", () => ({
 vi.mock("framer-motion", () => ({
   LayoutGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  m: { div: ({ children }: { children: React.ReactNode }) => <>{children}</> },
   domMax: {},
 }));
 

--- a/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
@@ -232,6 +232,8 @@ vi.mock("@dnd-kit/modifiers", () => ({
 vi.mock("framer-motion", () => ({
   LayoutGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  m: { div: ({ children }: { children: React.ReactNode }) => <>{children}</> },
   domMax: {},
 }));
 

--- a/src/components/Panel/SortableTabButton.tsx
+++ b/src/components/Panel/SortableTabButton.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { m } from "framer-motion";
 import { DRAG_GHOST_OPACITY } from "@/lib/animationUtils";
 import { TabButton, type TabButtonProps } from "./TabButton";
 
@@ -53,33 +52,17 @@ function SortableTabButtonComponent({
     [onClose]
   );
 
-  const performanceMode = document.body.dataset.performanceMode === "true";
-
   return (
     <div ref={setNodeRef} style={style}>
-      {performanceMode ? (
-        <TabButton
-          ref={setActivatorNodeRef}
-          id={id}
-          onClick={handleClick}
-          onClose={handleClose}
-          sortableListeners={listeners}
-          sortableAttributes={attributes}
-          {...tabButtonProps}
-        />
-      ) : (
-        <m.div layout="position">
-          <TabButton
-            ref={setActivatorNodeRef}
-            id={id}
-            onClick={handleClick}
-            onClose={handleClose}
-            sortableListeners={listeners}
-            sortableAttributes={attributes}
-            {...tabButtonProps}
-          />
-        </m.div>
-      )}
+      <TabButton
+        ref={setActivatorNodeRef}
+        id={id}
+        onClick={handleClick}
+        onClose={handleClose}
+        sortableListeners={listeners}
+        sortableAttributes={attributes}
+        {...tabButtonProps}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- `SortableTabButton` had a redundant inner `m.div layout="position"` wrapper. The outer `m.div` in `PanelTabList` (inside `AnimatePresence mode="popLayout"`) already owns the layout animation contract, so the inner one was doing nothing useful — and actively causing stutter during drag. dnd-kit applies a CSS transform to the isolation div; framer-motion applied its own transform on the inner wrapper, and the two counter-measured each other on drag-end.
- After removing the inner wrapper, both branches of the `SortableTabButton` ternary rendered identical output, so the ternary collapsed and the unused `m` import was removed.
- `DockedTabGroup` renders `SortableTabButton` directly with no outer motion wrapper, so removing the inner one broke tab close/reorder animation there. Fixed by mirroring the `PanelTabList` pattern: wrapped `panels.map(...)` in `AnimatePresence initial={false} mode="popLayout"` with an `m.div layout="position"` per panel using `UI_ANIMATION_DURATION`/`EASE_OUT_EXPO_FM`.

Resolves #8996

## Changes

- `src/components/Panel/SortableTabButton.tsx` — removed inner `m.div layout="position"`, collapsed ternary, removed `m` import
- `src/components/Layout/DockedTabGroup.tsx` — added `AnimatePresence`/`m.div` wrapper around `panels.map` to restore FLIP animation on tab close and reorder
- `src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx` and `DockedTabGroup.polish.test.tsx` — updated `framer-motion` vi.mock to export `AnimatePresence` and `m`

## Testing

- TypeScript clean, ESLint warnings only (baseline maintained), Prettier clean
- Vitest: DockedTabGroup tests 21/21 passing
- `format:check` and `build:full` pass