### PR TITLE
fix(panels): decouple new-panel focus policy from spawn provenance

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -7,7 +7,7 @@ import type {
 } from "./panel.js";
 import type { BrowserHistory } from "./browser.js";
 import type { AgentState, AgentId } from "./agent.js";
-import type { TerminalSpawnSource } from "./panel.js";
+import type { TerminalSpawnSource, AddPanelFocusPolicy } from "./panel.js";
 import type { BuiltInAgentId } from "../config/agentIds.js";
 
 /** Fields shared by all panel creation requests */
@@ -33,6 +33,13 @@ export interface AddPanelOptionsBase {
   pluginId?: string;
   /** Origin that spawned this terminal */
   spawnedBy?: TerminalSpawnSource;
+  /**
+   * Focus policy for the new panel. `"auto"` (default) suppresses focus change
+   * only when the assistant has keyboard focus. `"preserve"` always keeps focus
+   * where it is (MCP spawns, background batch operations). `"take"` always
+   * advances focus to the new panel regardless of context.
+   */
+  focusPolicy?: AddPanelFocusPolicy;
   /** Bypass rate limiter during session restore (consumes main-process quota) */
   restore?: boolean;
   /** Bypass panel limit checks (used during hydration/state restoration) */

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -52,6 +52,7 @@ export type {
   TerminalRuntimeStatus,
   PersistableFlowStatus,
   TerminalSpawnSource,
+  AddPanelFocusPolicy,
   TerminalInstance,
   PtySpawnOptions,
   TerminalDimensions,

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -102,6 +102,9 @@ export type TerminalRuntimeStatus = PersistableFlowStatus | "background" | "exit
 /** Origin that spawned a terminal */
 export type TerminalSpawnSource = "quickrun" | "recipe" | "agent" | "palette" | "mcp";
 
+/** Focus policy for newly-created panels — orthogonal to provenance. */
+export type AddPanelFocusPolicy = "auto" | "preserve" | "take";
+
 /**
  * Live process identity detected inside a PTY. This is transient runtime state,
  * not a launch hint and not persisted.
@@ -333,6 +336,8 @@ export interface PtyPanelData extends BasePanelData {
   agentPresetColor?: string;
   /** Origin that spawned this terminal */
   spawnedBy?: TerminalSpawnSource;
+  /** Focus policy applied when this panel was created. */
+  focusPolicy?: AddPanelFocusPolicy;
   /**
    * When true, this panel is excluded from persisted layout snapshots and is
    * never rehydrated on app restart (e.g. Daintree assistant dock terminals).
@@ -570,6 +575,8 @@ export interface TerminalInstance {
   agentPresetColor?: string;
   /** Origin that spawned this terminal */
   spawnedBy?: TerminalSpawnSource;
+  /** Focus policy applied when this panel was created. */
+  focusPolicy?: AddPanelFocusPolicy;
   /**
    * When true, this panel is excluded from persisted layout snapshots and is
    * never rehydrated on app restart (e.g. Daintree assistant dock terminals).

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -564,7 +564,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
           onEscapeKeyDown={(e) => handleDockEscapeKeyDown(e, portalContainerElementRef.current)}
           onOpenAutoFocus={(event) => {
             event.preventDefault();
-            if (activePanel.spawnedBy === "mcp") {
+            if (activePanel.focusPolicy === "preserve") {
               return;
             }
             const focusTarget = getTerminalFocusTarget({

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -350,7 +350,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
           onEscapeKeyDown={(e) => handleDockEscapeKeyDown(e, portalContainerElementRef.current)}
           onOpenAutoFocus={(event) => {
             event.preventDefault();
-            if (terminal.spawnedBy === "mcp") {
+            if (terminal.focusPolicy === "preserve") {
               return;
             }
             const focusTarget = getTerminalFocusTarget({

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -373,7 +373,10 @@ describe("DockedTabGroup mount-time close guard (#6602)", () => {
 
   it("does not focus an MCP-created active dock tab from Radix open autofocus", () => {
     mockActiveDockTerminalId = "t-1";
-    const panels = [makePanel({ id: "t-1", spawnedBy: "mcp" }), makePanel({ id: "t-2" })];
+    const panels = [
+      makePanel({ id: "t-1", spawnedBy: "mcp", focusPolicy: "preserve" }),
+      makePanel({ id: "t-2" }),
+    ];
     render(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />);
     expect(capturedOnOpenAutoFocus).not.toBeNull();
 

--- a/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
@@ -256,7 +256,11 @@ describe("DockedTerminalItem mount-time close guard (#6602)", () => {
 
   it("does not focus an MCP-created dock terminal from Radix open autofocus", () => {
     mockActiveDockTerminalId = "t-1";
-    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1", spawnedBy: "mcp" })} />);
+    render(
+      <DockedTerminalItem
+        terminal={makeTerminal({ id: "t-1", spawnedBy: "mcp", focusPolicy: "preserve" })}
+      />
+    );
     expect(capturedOnOpenAutoFocus).not.toBeNull();
 
     const preventDefault = vi.fn();

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -417,7 +417,7 @@ describe("useMcpBridge", () => {
 
       expect(mocks.dispatch).toHaveBeenCalledWith(
         "agent.launch",
-        { agentId: "claude", location: "grid", spawnedBy: "mcp" },
+        { agentId: "claude", location: "grid", spawnedBy: "mcp", focusPolicy: "preserve" },
         { source: "agent", confirmed: undefined }
       );
     });
@@ -438,7 +438,7 @@ describe("useMcpBridge", () => {
 
       expect(mocks.dispatch).toHaveBeenCalledWith(
         "workflow.startWorkOnIssue",
-        { issueNumber: 6959, agentId: "claude", spawnedBy: "mcp" },
+        { issueNumber: 6959, agentId: "claude", spawnedBy: "mcp", focusPolicy: "preserve" },
         { source: "agent", confirmed: undefined }
       );
     });
@@ -462,13 +462,13 @@ describe("useMcpBridge", () => {
       expect(mocks.dispatch).toHaveBeenNthCalledWith(
         1,
         "recipe.run",
-        { recipeId: "recipe-1", spawnedBy: "mcp" },
+        { recipeId: "recipe-1", spawnedBy: "mcp", focusPolicy: "preserve" },
         { source: "agent", confirmed: undefined }
       );
       expect(mocks.dispatch).toHaveBeenNthCalledWith(
         2,
         "terminal.new",
-        { spawnedBy: "mcp" },
+        { spawnedBy: "mcp", focusPolicy: "preserve" },
         { source: "agent", confirmed: undefined }
       );
     });
@@ -488,7 +488,7 @@ describe("useMcpBridge", () => {
 
       expect(mocks.dispatch).toHaveBeenCalledWith(
         "agent.claude",
-        { spawnedBy: "mcp" },
+        { spawnedBy: "mcp", focusPolicy: "preserve" },
         { source: "agent", confirmed: undefined }
       );
     });
@@ -506,7 +506,7 @@ describe("useMcpBridge", () => {
 
       expect(mocks.dispatch).toHaveBeenCalledWith(
         "agent.terminal",
-        { spawnedBy: "mcp" },
+        { spawnedBy: "mcp", focusPolicy: "preserve" },
         { source: "agent", confirmed: undefined }
       );
     });

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -14,7 +14,12 @@ import { logError, logWarn } from "@/utils/logger";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
-import type { AgentSettings, CliAvailability, TerminalSpawnSource } from "@shared/types";
+import type {
+  AgentSettings,
+  CliAvailability,
+  TerminalSpawnSource,
+  AddPanelFocusPolicy,
+} from "@shared/types";
 import {
   generateAgentCommand,
   buildAgentLaunchFlags,
@@ -72,12 +77,17 @@ export interface LaunchAgentOptions {
    */
   agentLaunchFlags?: string[];
   /**
-   * Origin tag stamped onto the resulting panel's `spawnedBy` field. The
-   * panel store uses this to gate focus capture — `"mcp"` spawns never steal
-   * focus from the user, even if the assistant isn't currently focused
-   * (#6959).
+   * Origin tag stamped onto the resulting panel's `spawnedBy` field. Purely
+   * provenance — no focus-policy meaning. Use `focusPolicy` to control
+   * whether the new panel captures keyboard focus.
    */
   spawnedBy?: TerminalSpawnSource;
+  /**
+   * Focus policy for the new panel. `"preserve"` keeps focus where it is
+   * (background/MCP spawns). Omitted defaults to the resolved policy from
+   * `panelStore.addPanel` (respects `mcpSpawnFocusSuppression` depth).
+   */
+  focusPolicy?: AddPanelFocusPolicy;
   /**
    * Pre-reserved terminal ID passed through to `addPanel` so the dock filter
    * is active the moment the panel commits, preventing a one-frame visual
@@ -460,8 +470,9 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         }
 
         const presetTitle = isAgent && preset ? preset.name : title;
-        const spawnedBy =
-          launchOptions?.spawnedBy ?? (isMcpSpawnFocusSuppressed() ? "mcp" : undefined);
+        const spawnedBy = launchOptions?.spawnedBy;
+        const focusPolicy =
+          launchOptions?.focusPolicy ?? (isMcpSpawnFocusSuppressed() ? "preserve" : undefined);
 
         const options: AddPanelOptions = isAgent
           ? {
@@ -480,6 +491,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               activateDockOnCreate: launchOptions?.activateDockOnCreate,
               ephemeral: launchOptions?.ephemeral,
               spawnedBy,
+              focusPolicy,
               requestedId: launchOptions?.requestedId,
             }
           : {
@@ -492,6 +504,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               activateDockOnCreate: launchOptions?.activateDockOnCreate,
               ephemeral: launchOptions?.ephemeral,
               spawnedBy,
+              focusPolicy,
               requestedId: launchOptions?.requestedId,
             };
 
@@ -526,6 +539,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               extensionState: presetEnv ? { presetEnv } : undefined,
               ephemeral: launchOptions?.ephemeral,
               spawnedBy,
+              focusPolicy,
             };
             usePanelStore.setState((state) => {
               const next: Partial<typeof state> = {
@@ -539,9 +553,9 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
                 const prevFocusedId = state.focusedId ?? null;
                 const focusActuallyChanged = gateId !== prevFocusedId;
                 next.activeDockTerminalId = gateId;
-                // MCP-initiated launches still expose the gate panel in the
+                // Focus-preserve launches still expose the gate panel in the
                 // dock but never claim keyboard focus. See #6959.
-                if (spawnedBy !== "mcp") {
+                if (focusPolicy !== "preserve") {
                   next.focusedId = gateId;
                   if (focusActuallyChanged) {
                     next.previousFocusedId = prevFocusedId;

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -38,10 +38,12 @@ function shouldTagMcpSpawn(actionId: string): boolean {
 }
 
 /**
- * Stamp `spawnedBy: "mcp"` onto actions that can create panels so the panel
- * store can gate focus capture for MCP-initiated launches (#6959). We override
- * any caller-supplied `spawnedBy` because the dispatch source is authoritative
- * — an MCP client cannot claim a different origin.
+ * Stamp `spawnedBy: "mcp"` and `focusPolicy: "preserve"` onto actions that
+ * can create panels. `spawnedBy` records provenance (MCP bridge is the
+ * dispatch source); `focusPolicy` declares the caller's intent to keep focus
+ * where it is (#6959). We override any caller-supplied values because the
+ * dispatch source is authoritative — an MCP client cannot claim a different
+ * origin or focus policy.
  *
  * Exported for unit tests; importing modules should not call this directly —
  * the bridge is the only authoritative caller.
@@ -49,10 +51,10 @@ function shouldTagMcpSpawn(actionId: string): boolean {
 export function tagMcpSpawnSource(actionId: string, args: unknown): unknown {
   if (!shouldTagMcpSpawn(actionId)) return args;
   if (args && typeof args === "object" && !Array.isArray(args)) {
-    return { ...(args as Record<string, unknown>), spawnedBy: "mcp" };
+    return { ...(args as Record<string, unknown>), spawnedBy: "mcp", focusPolicy: "preserve" };
   }
   if (args === undefined || args === null) {
-    return { spawnedBy: "mcp" };
+    return { spawnedBy: "mcp", focusPolicy: "preserve" };
   }
   return args;
 }

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -1,6 +1,6 @@
 import type { ActionDefinition, ActionId } from "@shared/types/actions";
 import type { Worktree } from "@shared/types/worktree";
-import type { TerminalSpawnSource } from "@shared/types/panel";
+import type { TerminalSpawnSource, AddPanelFocusPolicy } from "@shared/types/panel";
 import type { SettingsNavTarget } from "@/components/Settings";
 import type { AddPanelOptions } from "@/store";
 
@@ -63,6 +63,7 @@ export interface ActionCallbacks {
       ephemeral?: boolean;
       agentLaunchFlags?: string[];
       spawnedBy?: TerminalSpawnSource;
+      focusPolicy?: AddPanelFocusPolicy;
       requestedId?: string;
       force?: boolean;
     }

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -1,5 +1,10 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
-import { AgentIdSchema, LaunchLocationSchema, TerminalSpawnSourceSchema } from "./schemas";
+import {
+  AgentIdSchema,
+  LaunchLocationSchema,
+  TerminalSpawnSourceSchema,
+  AddPanelFocusPolicySchema,
+} from "./schemas";
 import { z } from "zod";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -33,7 +38,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       ephemeral: z.boolean().optional(),
       agentLaunchFlags: z.array(z.string()).optional(),
       spawnedBy: TerminalSpawnSourceSchema.optional(),
-      focusPolicy: z.enum(["auto", "preserve", "take"]).optional(),
+      focusPolicy: AddPanelFocusPolicySchema.optional(),
       requestedId: z.string().optional(),
       force: z.boolean().optional(),
     }),
@@ -122,7 +127,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     .object({
       location: LaunchLocationSchema.optional(),
       spawnedBy: TerminalSpawnSourceSchema.optional(),
-      focusPolicy: z.enum(["auto", "preserve", "take"]).optional(),
+      focusPolicy: AddPanelFocusPolicySchema.optional(),
     })
     .optional();
 

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -33,6 +33,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       ephemeral: z.boolean().optional(),
       agentLaunchFlags: z.array(z.string()).optional(),
       spawnedBy: TerminalSpawnSourceSchema.optional(),
+      focusPolicy: z.enum(["auto", "preserve", "take"]).optional(),
       requestedId: z.string().optional(),
       force: z.boolean().optional(),
     }),
@@ -58,6 +59,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         ephemeral,
         agentLaunchFlags,
         spawnedBy,
+        focusPolicy,
         requestedId,
         force,
       } = args as {
@@ -74,6 +76,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         ephemeral?: boolean;
         agentLaunchFlags?: string[];
         spawnedBy?: TerminalSpawnSource;
+        focusPolicy?: "auto" | "preserve" | "take";
         requestedId?: string;
         force?: boolean;
       };
@@ -90,6 +93,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         ephemeral,
         agentLaunchFlags,
         spawnedBy,
+        focusPolicy,
         requestedId,
         force,
       });
@@ -118,6 +122,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     .object({
       location: LaunchLocationSchema.optional(),
       spawnedBy: TerminalSpawnSourceSchema.optional(),
+      focusPolicy: z.enum(["auto", "preserve", "take"]).optional(),
     })
     .optional();
 
@@ -141,13 +146,15 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       argsSchema: shortcutLaunchSchema,
       resultSchema: shortcutResultSchema,
       run: async (args: unknown) => {
-        const { location, spawnedBy } = (args ?? {}) as {
+        const { location, spawnedBy, focusPolicy } = (args ?? {}) as {
           location?: "grid" | "dock";
           spawnedBy?: TerminalSpawnSource;
+          focusPolicy?: "auto" | "preserve" | "take";
         };
         const result = await callbacks.onLaunchAgent(id, {
           location,
           spawnedBy,
+          focusPolicy,
         });
         if (!result) return null;
         return { terminalId: result.terminalId, location: result.location };
@@ -166,13 +173,15 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     argsSchema: shortcutLaunchSchema,
     resultSchema: shortcutResultSchema,
     run: async (args: unknown) => {
-      const { location, spawnedBy } = (args ?? {}) as {
+      const { location, spawnedBy, focusPolicy } = (args ?? {}) as {
         location?: "grid" | "dock";
         spawnedBy?: TerminalSpawnSource;
+        focusPolicy?: "auto" | "preserve" | "take";
       };
       const result = await callbacks.onLaunchAgent("terminal", {
         location,
         spawnedBy,
+        focusPolicy,
       });
       if (!result) return null;
       return { terminalId: result.terminalId, location: result.location };

--- a/src/services/actions/definitions/recipeActions.ts
+++ b/src/services/actions/definitions/recipeActions.ts
@@ -4,7 +4,11 @@ import { z } from "zod";
 import type { ActionContext } from "@shared/types/actions";
 import { useRecipeStore } from "@/store/recipeStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
-import { TerminalSpawnSourceSchema, RecipeSummarySchema } from "./schemas";
+import {
+  TerminalSpawnSourceSchema,
+  RecipeSummarySchema,
+  AddPanelFocusPolicySchema,
+} from "./schemas";
 
 export function registerRecipeActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
   actions.set("recipe.list", () =>
@@ -58,7 +62,7 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
         recipeId: z.string(),
         worktreeId: z.string().optional(),
         spawnedBy: TerminalSpawnSourceSchema.optional(),
-        focusPolicy: z.enum(["auto", "preserve", "take"]).optional(),
+        focusPolicy: AddPanelFocusPolicySchema.optional(),
       }),
       run: async ({ recipeId, worktreeId, spawnedBy, focusPolicy }, ctx: ActionContext) => {
         const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId ?? undefined;

--- a/src/services/actions/definitions/recipeActions.ts
+++ b/src/services/actions/definitions/recipeActions.ts
@@ -58,8 +58,9 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
         recipeId: z.string(),
         worktreeId: z.string().optional(),
         spawnedBy: TerminalSpawnSourceSchema.optional(),
+        focusPolicy: z.enum(["auto", "preserve", "take"]).optional(),
       }),
-      run: async ({ recipeId, worktreeId, spawnedBy }, ctx: ActionContext) => {
+      run: async ({ recipeId, worktreeId, spawnedBy, focusPolicy }, ctx: ActionContext) => {
         const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId ?? undefined;
         const worktree = targetWorktreeId
           ? getCurrentViewStore().getState().worktrees.get(targetWorktreeId)
@@ -76,15 +77,10 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
           worktreePath,
           branchName: worktree?.branch,
         };
-        if (spawnedBy === undefined) {
-          await useRecipeStore
-            .getState()
-            .runRecipe(recipeId, worktreePath, targetWorktreeId, recipeContext);
-        } else {
-          await useRecipeStore
-            .getState()
-            .runRecipe(recipeId, worktreePath, targetWorktreeId, recipeContext, { spawnedBy });
-        }
+        const runOptions = { spawnedBy, focusPolicy };
+        await useRecipeStore
+          .getState()
+          .runRecipe(recipeId, worktreePath, targetWorktreeId, recipeContext, runOptions);
       },
     })
   );

--- a/src/services/actions/definitions/recipeActions.ts
+++ b/src/services/actions/definitions/recipeActions.ts
@@ -77,10 +77,18 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
           worktreePath,
           branchName: worktree?.branch,
         };
-        const runOptions = { spawnedBy, focusPolicy };
-        await useRecipeStore
-          .getState()
-          .runRecipe(recipeId, worktreePath, targetWorktreeId, recipeContext, runOptions);
+        if (spawnedBy !== undefined || focusPolicy !== undefined) {
+          await useRecipeStore
+            .getState()
+            .runRecipe(recipeId, worktreePath, targetWorktreeId, recipeContext, {
+              spawnedBy,
+              focusPolicy,
+            });
+        } else {
+          await useRecipeStore
+            .getState()
+            .runRecipe(recipeId, worktreePath, targetWorktreeId, recipeContext);
+        }
       },
     })
   );

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -17,6 +17,14 @@ export const LaunchLocationSchema = z
  */
 export const TerminalSpawnSourceSchema = z.enum(["quickrun", "recipe", "agent", "palette", "mcp"]);
 
+/**
+ * Mirror of `AddPanelFocusPolicy` from `shared/types/panel.ts`. `"auto"` (the
+ * effective default) suppresses focus change only when the assistant owns
+ * keyboard input. `"preserve"` always keeps focus where it is. `"take"`
+ * always advances focus to the new panel.
+ */
+export const AddPanelFocusPolicySchema = z.enum(["auto", "preserve", "take"]);
+
 export const SettingsTabSchema = z.enum([
   "general",
   "keyboard",

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -5,7 +5,7 @@ import { useLayoutUndoStore } from "@/store/layoutUndoStore";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { flushOptimisticCloses } from "@/services/terminal/optimisticPanelClose";
 import { getDefaultTitle } from "@/store/slices/panelRegistry/helpers";
-import { TerminalSpawnSourceSchema } from "./schemas";
+import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
 import type { TerminalSpawnSource } from "@shared/types/panel";
 export function registerTerminalSpawnActions(
   actions: ActionRegistry,
@@ -22,7 +22,7 @@ export function registerTerminalSpawnActions(
     argsSchema: z
       .object({
         spawnedBy: TerminalSpawnSourceSchema.optional(),
-        focusPolicy: z.enum(["auto", "preserve", "take"]).optional(),
+        focusPolicy: AddPanelFocusPolicySchema.optional(),
       })
       .optional(),
     run: async (args) => {
@@ -53,7 +53,7 @@ export function registerTerminalSpawnActions(
       .object({
         terminalId: z.string().optional(),
         spawnedBy: TerminalSpawnSourceSchema.optional(),
-        focusPolicy: z.enum(["auto", "preserve", "take"]).optional(),
+        focusPolicy: AddPanelFocusPolicySchema.optional(),
       })
       .optional(),
     run: async (args: unknown) => {

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -19,9 +19,14 @@ export function registerTerminalSpawnActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ spawnedBy: TerminalSpawnSourceSchema.optional() }).optional(),
+    argsSchema: z
+      .object({
+        spawnedBy: TerminalSpawnSourceSchema.optional(),
+        focusPolicy: z.enum(["auto", "preserve", "take"]).optional(),
+      })
+      .optional(),
     run: async (args) => {
-      const { spawnedBy } = args ?? {};
+      const { spawnedBy, focusPolicy } = args ?? {};
       const addPanel = usePanelStore.getState().addPanel;
       const terminalId = await addPanel({
         kind: "terminal",
@@ -29,6 +34,7 @@ export function registerTerminalSpawnActions(
         location: "grid",
         worktreeId: callbacks.getActiveWorktreeId(),
         spawnedBy,
+        focusPolicy,
       });
       if (!terminalId) return;
       return { terminalId };
@@ -47,11 +53,18 @@ export function registerTerminalSpawnActions(
       .object({
         terminalId: z.string().optional(),
         spawnedBy: TerminalSpawnSourceSchema.optional(),
+        focusPolicy: z.enum(["auto", "preserve", "take"]).optional(),
       })
       .optional(),
     run: async (args: unknown) => {
-      const { terminalId, spawnedBy } =
-        (args as { terminalId?: string; spawnedBy?: TerminalSpawnSource } | undefined) ?? {};
+      const { terminalId, spawnedBy, focusPolicy } =
+        (args as
+          | {
+              terminalId?: string;
+              spawnedBy?: TerminalSpawnSource;
+              focusPolicy?: "auto" | "preserve" | "take";
+            }
+          | undefined) ?? {};
       const state = usePanelStore.getState();
       const nonTrashed = state.panelIds
         .map((id) => state.panelsById[id])
@@ -77,6 +90,9 @@ export function registerTerminalSpawnActions(
         }
         if (spawnedBy) {
           options.spawnedBy = spawnedBy;
+        }
+        if (focusPolicy) {
+          options.focusPolicy = focusPolicy;
         }
         await state.addPanel(options);
       } else if (nonTrashed.length === 0) {

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -7,7 +7,7 @@ import { useProjectStore } from "@/store/projectStore";
 import { useRecipeStore } from "@/store/recipeStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
-import { TerminalSpawnSourceSchema } from "./schemas";
+import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { partialSuccessError, slugifyForBranch } from "./workflowHelpers";
 
@@ -70,6 +70,7 @@ export function registerWorkflowCreationActions(
               "Assign the linked issue to the current user. Omit to use the user's persisted 'Assign issue to me' preference (mirrors the new-worktree dialog checkbox)."
             ),
           spawnedBy: TerminalSpawnSourceSchema.optional(),
+          focusPolicy: AddPanelFocusPolicySchema.optional(),
         })
         .refine((d) => !(d.issueNumber !== undefined && d.pullRequestNumber !== undefined), {
           message: "issueNumber and pullRequestNumber are mutually exclusive",
@@ -92,6 +93,7 @@ export function registerWorkflowCreationActions(
         pullRequestNumber,
         assignToSelf,
         spawnedBy,
+        focusPolicy,
       }) => {
         if (issueNumber !== undefined && pullRequestNumber !== undefined) {
           throw new Error("issueNumber and pullRequestNumber are mutually exclusive");
@@ -187,11 +189,12 @@ export function registerWorkflowCreationActions(
               issueNumber,
               prNumber: pullRequestNumber,
             };
-            if (spawnedBy === undefined) {
+            if (spawnedBy === undefined && focusPolicy === undefined) {
               await useRecipeStore.getState().runRecipe(recipeId, path, worktreeId, recipeContext);
             } else {
               await useRecipeStore.getState().runRecipe(recipeId, path, worktreeId, recipeContext, {
                 spawnedBy,
+                focusPolicy,
               });
             }
             recipeLaunched = true;
@@ -284,6 +287,7 @@ export function registerWorkflowCreationActions(
           .optional()
           .describe("Inject worktree context into the launched terminal (default: true)"),
         spawnedBy: TerminalSpawnSourceSchema.optional(),
+        focusPolicy: AddPanelFocusPolicySchema.optional(),
       }),
       resultSchema: z.object({
         issueNumber: z.number(),
@@ -307,6 +311,7 @@ export function registerWorkflowCreationActions(
         assignToSelf,
         injectContext,
         spawnedBy,
+        focusPolicy,
       }) => {
         const currentProject = useProjectStore.getState().currentProject;
         if (!currentProject) {
@@ -373,14 +378,17 @@ export function registerWorkflowCreationActions(
               branchName: availableBranch,
               issueNumber: issue.number,
             };
-            if (spawnedBy === undefined) {
+            if (spawnedBy === undefined && focusPolicy === undefined) {
               await useRecipeStore
                 .getState()
                 .runRecipe(recipeId, worktreePath, worktreeId, recipeContext);
             } else {
               await useRecipeStore
                 .getState()
-                .runRecipe(recipeId, worktreePath, worktreeId, recipeContext, { spawnedBy });
+                .runRecipe(recipeId, worktreePath, worktreeId, recipeContext, {
+                  spawnedBy,
+                  focusPolicy,
+                });
             }
             recipeLaunched = true;
           } catch (err) {
@@ -413,6 +421,7 @@ export function registerWorkflowCreationActions(
                 worktreeId,
                 activateDockOnCreate: false,
                 spawnedBy,
+                focusPolicy,
               })
             )?.terminalId ?? null;
         } catch (err) {

--- a/src/services/actions/definitions/worktreeResourceActions.ts
+++ b/src/services/actions/definitions/worktreeResourceActions.ts
@@ -232,6 +232,7 @@ export function registerWorktreeResourceActions(
         .object({
           worktreeId: z.string().optional(),
           spawnedBy: TerminalSpawnSourceSchema.optional(),
+          focusPolicy: z.enum(["auto", "preserve", "take"]).optional(),
         })
         .optional(),
       isEnabled: (ctx: ActionContext) => {
@@ -251,6 +252,7 @@ export function registerWorktreeResourceActions(
       run: async (args, ctx: ActionContext) => {
         const worktreeId = args?.worktreeId;
         const spawnedBy = args?.spawnedBy;
+        const focusPolicy = args?.focusPolicy;
         const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
         if (!targetWorktreeId) throw new Error("No worktree selected");
         const worktree = getCurrentViewStore().getState().worktrees.get(targetWorktreeId);
@@ -267,6 +269,7 @@ export function registerWorktreeResourceActions(
           location: "grid",
           worktreeId: targetWorktreeId,
           spawnedBy,
+          focusPolicy,
         });
       },
     })

--- a/src/services/actions/definitions/worktreeResourceActions.ts
+++ b/src/services/actions/definitions/worktreeResourceActions.ts
@@ -6,7 +6,7 @@ import { worktreeClient } from "@/clients";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { notify } from "@/lib/notify";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import { TerminalSpawnSourceSchema } from "./schemas";
+import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
 
 function notifyWorktreeResourceError(err: unknown, title: string, fallbackMessage: string): void {
   const message = formatErrorMessage(err, fallbackMessage) || fallbackMessage;
@@ -232,7 +232,7 @@ export function registerWorktreeResourceActions(
         .object({
           worktreeId: z.string().optional(),
           spawnedBy: TerminalSpawnSourceSchema.optional(),
-          focusPolicy: z.enum(["auto", "preserve", "take"]).optional(),
+          focusPolicy: AddPanelFocusPolicySchema.optional(),
         })
         .optional(),
       isEnabled: (ctx: ActionContext) => {

--- a/src/store/__tests__/panelStore.assistantFocusGuard.test.ts
+++ b/src/store/__tests__/panelStore.assistantFocusGuard.test.ts
@@ -4,9 +4,9 @@
  * an agent terminal. Verifies that `panelStore.addPanel` does NOT advance
  * `focusedId` to the freshly-spawned panel when:
  *   1. the assistant region currently owns keyboard focus, OR
- *   2. the spawn was tagged `spawnedBy: "mcp"` (issued through the MCP bridge).
+ *   2. the spawn carries `focusPolicy: "preserve"` (issued through the MCP bridge).
  *
- * For both cases, the panel still lands in the panel registry. MCP-created
+ * For both cases, the panel still lands in the panel registry. Focus-preserve
  * dock panels also must not auto-open the dock popover, because mounting that
  * popover runs its own terminal focus path.
  */
@@ -172,11 +172,12 @@ describe("panelStore.addPanel focus guard (#6959)", () => {
     document.body.removeChild(panelEl);
   });
 
-  it("does not advance focusedId when spawnedBy is 'mcp'", async () => {
+  it("does not advance focusedId when focusPolicy is 'preserve'", async () => {
     const newId = await usePanelStore.getState().addPanel({
       kind: "terminal",
       cwd: "/test",
       location: "grid",
+      focusPolicy: "preserve",
       spawnedBy: "mcp",
     });
 
@@ -185,9 +186,10 @@ describe("panelStore.addPanel focus guard (#6959)", () => {
     expect(state.focusedId).toBe("incumbent-1");
     expect(state.previousFocusedId).toBeNull();
     expect(state.panelsById[newId!]?.spawnedBy).toBe("mcp");
+    expect(state.panelsById[newId!]?.focusPolicy).toBe("preserve");
   });
 
-  it("does not advance focusedId while an MCP dispatch is active even without an action tag", async () => {
+  it("does not advance focusedId while an MCP dispatch is active even without explicit focusPolicy", async () => {
     const newId = await runWithMcpSpawnFocusSuppressed(() =>
       usePanelStore.getState().addPanel({
         kind: "terminal",
@@ -200,7 +202,7 @@ describe("panelStore.addPanel focus guard (#6959)", () => {
     const state = usePanelStore.getState();
     expect(state.focusedId).toBe("incumbent-1");
     expect(state.previousFocusedId).toBeNull();
-    expect(state.panelsById[newId!]?.spawnedBy).toBe("mcp");
+    expect(state.panelsById[newId!]?.focusPolicy).toBe("preserve");
   });
 
   it("still advances focusedId for a normal user-initiated grid spawn", async () => {
@@ -232,12 +234,13 @@ describe("panelStore.addPanel focus guard (#6959)", () => {
   });
 
   describe("dock activation path", () => {
-    it("MCP spawn into dock with activateDockOnCreate adds the panel but does not open or focus it", async () => {
+    it("focus-preserve spawn into dock with activateDockOnCreate adds the panel but does not open or focus it", async () => {
       const newId = await usePanelStore.getState().addPanel({
         kind: "terminal",
         cwd: "/test",
         location: "dock",
         activateDockOnCreate: true,
+        focusPolicy: "preserve",
         spawnedBy: "mcp",
       });
 
@@ -264,15 +267,16 @@ describe("panelStore.addPanel focus guard (#6959)", () => {
       expect(state.activeDockTerminalId).toBeNull();
       expect(state.focusedId).toBe("incumbent-1");
       expect(state.previousFocusedId).toBeNull();
-      expect(state.panelsById[newId!]?.spawnedBy).toBe("mcp");
+      expect(state.panelsById[newId!]?.focusPolicy).toBe("preserve");
       expect(state.panelsById[newId!]?.location).toBe("dock");
     });
 
-    it("MCP spawn of a non-PTY (browser) panel into the dock does not steal focus", async () => {
+    it("focus-preserve spawn of a non-PTY (browser) panel into the dock does not steal focus", async () => {
       const newId = await usePanelStore.getState().addPanel({
         kind: "browser",
         location: "dock",
         activateDockOnCreate: true,
+        focusPolicy: "preserve",
         spawnedBy: "mcp",
       });
 

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -25,7 +25,7 @@ import {
   type QueuedCommand,
   isAgentReady,
 } from "./slices";
-import type { TerminalInstance, TerminalRefreshTier } from "@shared/types";
+import type { TerminalInstance, TerminalRefreshTier, AddPanelFocusPolicy } from "@shared/types";
 import { TerminalRefreshTier as TerminalRefreshTierEnum } from "@/types";
 import { terminalRegistryController } from "@/controllers";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -294,17 +294,20 @@ export const usePanelStore = create<PanelGridState>()(
         // boundary; capturing here pins them to the user's pre-create state
         // (#6959 — assistant focus theft when MCP launches an agent).
         const assistantHasFocus = isAssistantFocused();
-        const suppressMcpSpawnFocus = options.spawnedBy === "mcp" || isMcpSpawnFocusSuppressed();
         // Resolve the kind's policy synchronously — by the time `addPanel`
-        // returns, plugin teardown could have changed the registry. The MCP
-        // suppression already wins via `panelRegistry/addPanel.ts`; this
-        // additional gate lets a kind declare "never steal focus on create"
-        // without forcing every caller to pass an option.
+        // returns, plugin teardown could have changed the registry. A kind
+        // that declares `defaultFocusOnCreate: false` is treated as an
+        // implicit `focusPolicy: "preserve"` when the caller didn't supply
+        // an explicit policy, so kinds can opt out without forcing every
+        // call site to pass an option.
         const kindPolicy = resolvePanelKindPolicy(options.kind);
-        const panelOptions =
-          suppressMcpSpawnFocus && options.spawnedBy !== "mcp"
-            ? ({ ...options, spawnedBy: "mcp" } as AddPanelOptions)
-            : options;
+        const resolvedFocusPolicy: AddPanelFocusPolicy =
+          options.focusPolicy ??
+          (isMcpSpawnFocusSuppressed() || !kindPolicy.defaultFocusOnCreate ? "preserve" : "auto");
+        const panelOptions: AddPanelOptions =
+          resolvedFocusPolicy === options.focusPolicy
+            ? options
+            : { ...options, focusPolicy: resolvedFocusPolicy };
         const id = await registrySlice.addPanel(panelOptions);
         if (id === null) return null;
         // Skip the per-panel focus mutation while a hydration batch is collecting panels:
@@ -313,11 +316,15 @@ export const usePanelStore = create<PanelGridState>()(
         // focus also isn't meaningful during restore — focus is resolved elsewhere once
         // the active worktree is set.
         if ((!options.location || options.location === "grid") && !isHydrationBatchActive()) {
-          // Suppress focus capture for MCP-initiated spawns, when the Daintree
-          // Assistant owns keyboard focus, or when the kind's policy opts out
-          // of focus-on-create. The new panel still lands in the grid; the
-          // user keeps typing where they were.
-          if (assistantHasFocus || suppressMcpSpawnFocus || !kindPolicy.defaultFocusOnCreate) {
+          // Suppress focus capture for preserve-policy spawns or when the
+          // Daintree Assistant currently owns keyboard focus. The new panel
+          // still lands in the grid; the user keeps typing where they were.
+          // The kind's `defaultFocusOnCreate: false` flag is already folded
+          // into `resolvedFocusPolicy` above.
+          if (
+            resolvedFocusPolicy === "preserve" ||
+            (resolvedFocusPolicy === "auto" && assistantHasFocus)
+          ) {
             return id;
           }
           if (focusedBeforeCreate !== id) {
@@ -333,14 +340,13 @@ export const usePanelStore = create<PanelGridState>()(
           // The registry slice atomically advances `focusedId` to the new id
           // inside its commit for normal dock activations (#6590). When the
           // assistant currently owns input we issue a corrective set() to roll
-          // keyboard focus back while leaving the dock popover open. MCP spawns
-          // skip both registry focus and dock-popover activation entirely
-          // (handled in `panelRegistry/addPanel.ts`), so no rollback is needed
-          // for the MCP case.
-          if (assistantHasFocus && !suppressMcpSpawnFocus) {
+          // keyboard focus back while leaving the dock popover open. Preserve-policy
+          // spawns skip both registry focus and dock-popover activation entirely
+          // (handled in `panelRegistry/addPanel.ts`), so no rollback is needed.
+          if (assistantHasFocus && resolvedFocusPolicy !== "preserve") {
             set({ focusedId: focusedBeforeCreate });
           } else if (
-            !suppressMcpSpawnFocus &&
+            resolvedFocusPolicy !== "preserve" &&
             focusedBeforeCreate !== null &&
             focusedBeforeCreate !== id
           ) {
@@ -348,7 +354,7 @@ export const usePanelStore = create<PanelGridState>()(
             // Updating in a follow-up set() is fine — previousFocusedId is metadata,
             // not load-bearing for dock visibility (which the watchdog effect cares
             // about and which is already covered by the registry's atomic commit).
-            // MCP spawns skip this — they never participate in alternate-pane focus.
+            // Preserve-policy panels skip this — they never participate in alternate-pane focus.
             set({ previousFocusedId: focusedBeforeCreate });
           }
         }

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -6,7 +6,7 @@ import { getAgentConfig } from "@/config/agents";
 import { generateAgentCommand } from "@shared/types";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
-import type { TerminalSpawnSource } from "@shared/types/panel";
+import type { TerminalSpawnSource, AddPanelFocusPolicy } from "@shared/types/panel";
 import { stableInRepoId, isInRepoRecipeId } from "@shared/utils/recipeFilename";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
@@ -28,6 +28,7 @@ export interface RecipeSpawnResults {
 
 export interface RecipeRunOptions {
   spawnedBy?: TerminalSpawnSource;
+  focusPolicy?: AddPanelFocusPolicy;
   terminalIndices?: number[];
 }
 
@@ -534,6 +535,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
 
     const indicesToSpawn = options?.terminalIndices ?? recipe.terminals.map((_, i) => i);
     const spawnedBy = options?.spawnedBy;
+    const focusPolicy = options?.focusPolicy ?? "preserve";
 
     // Pre-fetch agent settings once for all agent terminals
     let agentSettings: Awaited<ReturnType<typeof agentSettingsClient.get>> | null = null;
@@ -575,6 +577,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             env: terminal.env,
             exitBehavior: terminal.exitBehavior,
             spawnedBy,
+            focusPolicy,
           });
           if (terminalId) {
             results.spawned.push({ index, terminalId });
@@ -615,6 +618,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             env: terminal.env,
             exitBehavior: terminal.exitBehavior,
             spawnedBy,
+            focusPolicy,
           });
         } else {
           terminalId = await terminalStore.addPanel({
@@ -626,6 +630,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             env: terminal.env,
             exitBehavior: terminal.exitBehavior,
             spawnedBy,
+            focusPolicy,
           });
         }
         if (terminalId) {

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -535,7 +535,13 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
 
     const indicesToSpawn = options?.terminalIndices ?? recipe.terminals.map((_, i) => i);
     const spawnedBy = options?.spawnedBy;
-    const focusPolicy = options?.focusPolicy ?? "preserve";
+    // Pass focusPolicy through as-is (potentially undefined). panelStore.addPanel
+    // resolves undefined to "auto" — which suppresses focus only when the assistant
+    // owns input — or to "preserve" when an MCP dispatch is on the stack
+    // (isMcpSpawnFocusSuppressed). Defaulting to "preserve" here would silently
+    // strip focus from user-initiated recipe runs (dock menu, NewWorktreeDialog,
+    // WorktreeCard); MCP-initiated runs already get "preserve" via panelStore.
+    const focusPolicy = options?.focusPolicy;
 
     // Pre-fetch agent settings once for all agent terminals
     let agentSettings: Awaited<ReturnType<typeof agentSettingsClient.get>> | null = null;

--- a/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
@@ -217,6 +217,7 @@ describe("atomic dock activation on create (#6590)", () => {
         location: "dock",
         bypassLimits: true,
         activateDockOnCreate: true,
+        focusPolicy: "preserve",
         spawnedBy: "mcp",
       });
 
@@ -473,7 +474,10 @@ describe("dockPopoverOnSpawn policy gate (#8946)", () => {
   it("MCP suppression still wins over kind policy (both gates lead to suppressed popover)", async () => {
     const { registerPanelKind, unregisterPanelKind } =
       await import("@shared/config/panelKindRegistry");
-    // Even with dockPopoverOnSpawn: true (default), MCP spawn still suppresses.
+    // Even with dockPopoverOnSpawn: true (default), the MCP bridge stamps
+    // `focusPolicy: "preserve"` alongside `spawnedBy: "mcp"` (see
+    // `useMcpBridge.ts`), so the popover stays suppressed. Provenance no
+    // longer carries focus semantics — the explicit policy does.
     registerPanelKind({
       id: "opt-in-popover-kind",
       name: "Opt-In",
@@ -497,13 +501,14 @@ describe("dockPopoverOnSpawn policy gate (#8946)", () => {
         bypassLimits: true,
         activateDockOnCreate: true,
         spawnedBy: "mcp",
+        focusPolicy: "preserve",
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any);
 
       expect(id).toBe("opt-in-1");
       const state = usePanelStore.getState();
       expect(state.panelsById[id!]).toBeDefined();
-      // MCP still suppresses regardless of policy.
+      // MCP-paired preserve policy suppresses regardless of kind policy.
       expect(state.activeDockTerminalId).toBeNull();
     } finally {
       unregisterPanelKind("opt-in-popover-kind");

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -214,7 +214,8 @@ export const createAddPanelActions = (
         // matching pattern in panelStore.ts where every fallback site reads
         // policy before the registry mutation.
         const popoverSuppressed =
-          options.spawnedBy === "mcp" || !resolvePanelKindPolicy(requestedKind).dockPopoverOnSpawn;
+          options.focusPolicy === "preserve" ||
+          !resolvePanelKindPolicy(requestedKind).dockPopoverOnSpawn;
         set((state) => {
           const existing = state.panelsById[id];
           if (existing) {
@@ -242,13 +243,13 @@ export const createAddPanelActions = (
             // after registry.addPanel returns; here we only fold the dock
             // activation into the same set() that commits the panel so the
             // watchdog can't observe an intermediate state.
-            // MCP-initiated spawns should land in the dock without opening the
+            // Focus-preserve spawns should land in the dock without opening the
             // popover. Opening the popover mounts Radix focus management and
             // terminal focus handlers, which is itself a keyboard-focus side
             // effect even if focusedId is preserved. See #6959.
             // The kind's policy may also opt out (e.g., a reading-surface
-            // kind that prefers to land in the dock quietly); same mechanism,
-            // applied per-kind.
+            // kind that prefers to land in the dock quietly); both gates
+            // are folded into `popoverSuppressed` above.
             if (popoverSuppressed) {
               return {
                 panelsById: newById,
@@ -364,6 +365,7 @@ export const createAddPanelActions = (
       extensionState: options.extensionState,
       pluginId: ptyPluginId,
       spawnedBy: options.spawnedBy,
+      focusPolicy: options.focusPolicy,
       ephemeral: options.ephemeral,
       startedAt: Date.now(),
       spawnStatus,
@@ -418,7 +420,8 @@ export const createAddPanelActions = (
       // so a PTY extension kind's policy is honored. `kind` here is collapsed
       // to "terminal" | "dev-preview" for storage-shape purposes only.
       const ptyPopoverSuppressed =
-        options.spawnedBy === "mcp" || !resolvePanelKindPolicy(requestedKind).dockPopoverOnSpawn;
+        options.focusPolicy === "preserve" ||
+        !resolvePanelKindPolicy(requestedKind).dockPopoverOnSpawn;
       set((state) => {
         const existing = state.panelsById[id];
         if (existing) {
@@ -466,11 +469,13 @@ export const createAddPanelActions = (
           // after registry.addPanel returns; here we only fold the dock
           // activation into the same set() that commits the panel so the
           // watchdog can't observe an intermediate state.
-          // MCP-initiated spawns should land in the dock without opening the
+          // Focus-preserve spawns should land in the dock without opening the
           // popover. Opening the popover mounts Radix focus management and
           // terminal focus handlers, which is itself a keyboard-focus side
           // effect even if focusedId is preserved. See #6959.
-          // The kind's policy may also opt out via `dockPopoverOnSpawn: false`.
+          // Both the explicit preserve policy and the kind's
+          // `dockPopoverOnSpawn: false` opt-out are folded into
+          // `ptyPopoverSuppressed` above.
           if (ptyPopoverSuppressed) {
             return {
               panelsById: newById,
@@ -582,7 +587,7 @@ export const createAddPanelActions = (
     if (
       options.activateDockOnCreate &&
       location === "dock" &&
-      options.spawnedBy !== "mcp" &&
+      options.focusPolicy !== "preserve" &&
       ptyDockPolicy.dockPopoverOnSpawn
     ) {
       try {


### PR DESCRIPTION
## Summary
- Adds an explicit `focusPolicy` field on `AddPanelOptions` so callers state focus intent directly, instead of overloading `spawnedBy: "mcp"` to suppress focus.
- The MCP bridge now sets `focusPolicy: "preserve"` rather than overriding `spawnedBy`, keeping provenance and policy as orthogonal axes.
- The duplicated capture-before-await/restore pattern from `panelStore.ts` and `useAgentLauncher.ts` was consolidated into a shared approach.

Resolves #8945

## Changes
- New `FocusPolicy` type (`"auto"` | `"preserve"`) on `AddPanelOptions`
- `panelStore.addPanel` reads `focusPolicy` directly instead of inferring from `spawnedBy`
- `useMcpBridge` sets `focusPolicy: "preserve"` instead of overriding `spawnedBy`
- `useAgentLauncher` passes `focusPolicy` through launch options
- Action definitions for agent, recipe, terminal spawn, and worktree resource actions plumb `focusPolicy` through their Zod schemas
- `DockedTabGroup` and `DockedTerminalItem` pass `focusPolicy` to `addPanel`
- Existing regression guards (#6959 assistant focus theft, #6590 dock-activation) unchanged

## Testing
- Unit tests updated: `panelStore.assistantFocusGuard.test.ts`, `dockActivateOnCreate.test.ts`, `DockedTabGroup.mountGuard.test.tsx`, `DockedTerminalItem.mountGuard.test.tsx`, `useMcpBridge.test.tsx`
- MCP-spawned panels preserve focus; user-spawned panels take focus