### PR TITLE
feat(lint): enforce property-syntax method signatures on PanelKindConfig

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -310,6 +310,17 @@ export default tseslint.config(
     },
   },
 
+  // Enforce property syntax on interface method signatures to preserve
+  // function parameter contravariance under strictFunctionTypes. Method
+  // syntax is bivariant and would silently accept unsafe widening casts.
+  // See #8961.
+  {
+    files: ["shared/config/**/*.ts"],
+    rules: {
+      "@typescript-eslint/method-signature-style": ["error", "property"],
+    },
+  },
+
   // Catch un-awaited promises in renderer code. `safeFireAndForget` is the
   // sanctioned escape hatch for fire-and-forget IPC — see issue #6029.
   {

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -142,15 +142,8 @@ const BUILT_IN_SERIALIZE_DEFAULTS = {
 export function initBuiltInPanelKinds(): void {
   for (const [kindId, hooks] of Object.entries(BUILT_IN_SERIALIZE_DEFAULTS)) {
     const existing = requirePanelKindConfig(kindId);
-    // Narrow per-kind hooks are widened to the shared PanelKindConfig contract
-    // here — this is the single seam between the typed registry map above and
-    // the extension-friendly wide interface. Function parameter contravariance
-    // makes this cast necessary; it is intentionally isolated to this function.
-    // Do NOT change PanelKindConfig.serialize / createDefaults to method syntax
-    // (`serialize(panel: …): …`). Method syntax is bivariant under
-    // strictFunctionTypes and would silently accept the unsafe widening this
-    // cast deliberately isolates — the property-syntax form is what makes the
-    // cast meaningful instead of redundant.
+    // Narrow per-kind hooks widened to PanelKindConfig — property-syntax
+    // invariant enforced by @typescript-eslint/method-signature-style.
     const serialize = hooks.serialize as PanelKindConfig["serialize"];
     const createDefaults = hooks.createDefaults as PanelKindConfig["createDefaults"];
     if (existing.serialize !== serialize || existing.createDefaults !== createDefaults) {


### PR DESCRIPTION
## Summary
This adds `@typescript-eslint/method-signature-style` scoped to `shared/config/**/*.ts`, so CI catches method-signature syntax in the panel kind registry instead of relying on a warning comment block that reviewers had to notice in PR diffs.

The old warning block in `registry.tsx` is now a one-line pointer at the lint rule.

Resolves #8961.

## Changes
- Added `@typescript-eslint/method-signature-style` rule (`["error", "property"]`) scoped to `shared/config/**/*.ts` in `eslint.config.js`
- Condensed the 6-line warning comment in `src/panels/registry.tsx` to a single line referencing the lint rule

## Testing
- `npx eslint shared/config/` -- zero errors from the new rule, only pre-existing `no-explicit-any` warnings
- `npx tsc --noEmit` -- passes cleanly
- Verified that `serialize(panel: ...)` method syntax would trigger the error by testing the rule scope