### PR TITLE
spike(ui): native [popover] + CSS anchor positioning POC (#8992)

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -4634,6 +4634,32 @@
     "skipReasons": [],
     "pipelineErrors": []
   },
+  "src/components/ui/NativeDropdown.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/ui/NativeTooltip.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [
+      {
+        "category": "Refs",
+        "severity": "Error",
+        "reason": "Cannot access refs during render"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
   "src/components/ui/PaletteOverflowNotice.tsx": {
     "success": 1,
     "skip": 0,
@@ -6155,6 +6181,16 @@
     "pipelineErrors": []
   },
   "src/panels/review/ReviewPane.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "hintCount": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/spikes/NativePopoverSpikeDemo.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,

--- a/docs/spikes/native-popover-2026-05.md
+++ b/docs/spikes/native-popover-2026-05.md
@@ -1,0 +1,160 @@
+# Spike: native `[popover]` + CSS Anchor Positioning for floating surfaces
+
+**Issue**: #8992  
+**Date**: 2026-05-24  
+**Time-box**: ~1 day  
+**Target runtime**: Electron 41 / Chromium 146  
+**Status**: complete — POC components landed behind developer-mode gate in TroubleshootingTab  
+**Recommendation**: **HOLD** — re-evaluate when focus-trap / sub-menu primitives ship in Chromium
+
+---
+
+## What was built
+
+Two isolated POC components, zero modifications to existing Radix wrappers, `dialogEscapeBackstop.ts`, `escapeStack.ts`, `radix-loader.ts`, or `radix-deferred.ts`:
+
+- `src/components/ui/NativeTooltip.tsx` — native `popover="hint"` + `anchor-name` + `position-area`, Tier 2-fast motion (150ms enter / 100ms exit)
+- `src/components/ui/NativeDropdown.tsx` — native `popover="auto"` + `position-try-fallbacks` flip, Tier 2 motion (200ms enter / 120ms exit)
+- `src/styles/components/native-popover.css` — shared anchor-positioning reset + animation pattern with `overlay` in every transition list
+- `src/spikes/NativePopoverSpikeDemo.tsx` — multi-anchor tooltip grid, transformed-ancestor anchor test, dropdown flip-near-edge test, local reduce-motion toggle
+- Gated into `Settings → Troubleshooting` behind the existing `developerMode` setting (one import + one `<SettingsSection>` block in `TroubleshootingTab.tsx`)
+
+A standalone HTML fixture was rejected: `cspTransformPlugin()` in `vite.config.ts` throws on any Vite-processed HTML without a CSP meta tag, so the in-app demo is genuinely lower-friction.
+
+## Bundle baseline (current Radix footprint, gzipped)
+
+| Chunk | Raw | Gzip | Loads when |
+| --- | --- | --- | --- |
+| `radix-loader` | 1.0 kB | 0.6 kB | always — primes the deferred chunk |
+| `radix-deferred` | 0.2 kB | 0.2 kB | first floating surface — just re-exports the 5 packages |
+| `vendor-radix` | 5.1 kB | 1.9 kB | dialog primitives |
+| `vendor-radix-utils` | 14.6 kB | 3.3 kB | shared Radix internals |
+| `vendor-radix-overlay` | 105.0 kB | **32.0 kB** | tooltip + popover + dropdown + select + context-menu |
+| **Total deferred surface** | 125.9 kB | **38.0 kB** |  |
+
+The `vendor-radix-overlay` chunk (32 kB gzipped) is the realistic prize. The deferred loading already hides this from cold-load — it lands when a tooltip/popover/dropdown first becomes visible. A full native migration would remove ~32 kB gzip from the deferred surface; a partial migration (tooltip + simple dropdown only) would not — `vendor-radix-overlay` is a single chunk that loads as long as _any_ of the five primitives is in use. **Bundle savings only materialize at the point all five Radix primitive consumers are eliminated, not before.**
+
+## Parity matrix
+
+| Capability | Native `[popover]` (Chrome 146) | Radix today | Verdict |
+| --- | --- | --- | --- |
+| Anchored positioning (4 sides + 3 aligns) | `position-area` + `anchor-name` | Floating UI middlewares | ✅ parity |
+| Collision flip | `position-try-fallbacks: flip-block, flip-inline` | `collisionBoundary` + auto flip | ✅ parity |
+| Hide-when-anchor-scrolled-offscreen | `position-visibility: anchor-visible` | `hideWhenDetached` | ✅ parity |
+| Top-layer escape from transform / overflow ancestors | top-layer promotion (automatic) | Portal to body | ✅ parity (better — no portal allocation) |
+| Entry / exit animation | `@starting-style` + `transition-behavior: allow-discrete` + `overlay` in transition list | Radix Presence + data-state | ✅ works, with caveat (see Gap #1) |
+| Light-dismiss (click-outside) | native via `popover="auto"` | `DismissableLayer` | ✅ parity |
+| Escape key | native via CloseWatcher (capture phase) | `DismissableLayer` `onEscapeKeyDown` | ⚠️ collides with `dialogEscapeBackstop` (Gap #2) |
+| Focus management on open | manual `popover.showPopover()` + focus call | Radix FocusScope autoFocus | ⚠️ DIY needed (Gap #3) |
+| Focus trap inside popover | none — Tab can escape | Radix FocusScope trap | ❌ missing (Gap #3) |
+| Hover-intent (safe polygon) | none | Radix `delayDuration` + provider | ❌ missing (Gap #4) |
+| Sub-menu chains | structurally possible (nested popovers); no keyboard arrow coordination | Radix `Sub` + `SubTrigger` | ❌ missing (Gap #5) |
+| Virtual element anchors | needs proxy `<div>` with `anchor-name` | Floating UI `getBoundingClientRect` object | ❌ workaround required |
+| ARIA wiring (role, aria-controls, aria-expanded) | manual | Radix component default | ⚠️ DIY needed |
+| `keepMounted` / suspended-but-not-unmounted state | no native equivalent | Radix Presence + `forceMount` | ❌ missing (Gap #6) |
+| Per-instance `data-state` selectors | not native — manage via `:popover-open` + `toggle` event | Radix `data-state="open\|closed"` | ⚠️ different idiom |
+| Multi-instance hygiene (no leak between unrelated tooltips) | inherent — each popover element is independent | requires FixedDropdownVisibleContext + key-on-visibility workaround (#8001) | ✅ better |
+| Pointer-priming for dock popovers (#8008) | n/a — no Radix priming path | `primeOnEvent` + `primeRadix` | ✅ better (no priming needed) |
+
+## Gaps with severity and migration cost
+
+### Gap #1 — Exit-animation `overlay` requirement _(severity: low; mitigation: documented in CSS)_
+
+`@starting-style` + `transition-behavior: allow-discrete` works in Chromium 146, but `overlay` MUST appear in the transition list alongside `display`. Without it, top-layer ejection on close is synchronous and the exit fade is clipped to a single frame. Invisible in Chrome DevTools' default Animations panel — you have to inspect the top-layer panel.
+
+```css
+transition:
+  opacity 150ms ease,
+  display 150ms allow-discrete,
+  overlay 150ms allow-discrete;
+```
+
+Codified in `src/styles/components/native-popover.css`. Any future native popover work must follow this pattern — there is no `@exit-style` rule and no Tailwind utility for the `overlay` longhand.
+
+### Gap #2 — CloseWatcher collides with `dialogEscapeBackstop.ts` _(severity: HIGH; blocks any production migration)_
+
+Native `[popover]` handles Escape via CloseWatcher in capture phase. `dialogEscapeBackstop.ts` also runs in capture phase and probes for open Radix layers by reading `data-state="open"` attributes. A native popover provides no `data-state` signal, so the backstop's probe sees no open layer and treats the native close as a spurious dismissal of whatever AppDialog is the top of the escape stack.
+
+Migration would require teaching the backstop to also probe for open `[popover]` elements (`document.querySelector('[popover]:popover-open')`) and to coordinate with CloseWatcher's beforeclose event. This is non-trivial because CloseWatcher's beforeclose can't be conditionally cancelled per-stack-position — it's all-or-nothing for the specific popover element. A LIFO stack across mixed native + Radix layers needs careful design.
+
+**Past lesson**: #3831 introduced the escape stack on the explicit assumption that Radix `DismissableLayer` events are the source of truth. #4588 layered routing for xterm/CodeMirror on top. Both would need rework, not just the backstop.
+
+### Gap #3 — Focus management: open-focus + trap + restore _(severity: HIGH for dropdown/popover; LOW for tooltip)_
+
+Native `[popover]` provides:
+
+- ✅ Automatic focus restore to the invoker on close
+- ❌ No autofocus on open (Tab/Shift-Tab from the trigger lands wherever it would without the popover; you must call `firstFocusable.focus()` after `showPopover()`)
+- ❌ No focus trap (Tab from inside the popover can escape into the document)
+
+Radix FocusScope handles all three. The POC dropdown leaves Tab-escape unfixed — visible in the demo. Any migration would need a minimal focus-trap helper (~80 LOC) or a port of Floating UI's `FloatingFocusManager`.
+
+**Past lesson**: #2828 — AppDialog's focus trap checks `closest('[aria-modal="true"]')` to skip portaled Radix popovers. A native `[popover]` is NOT an `aria-modal` ancestor of its trigger (it's in the top layer; ancestor traversal stops at the trigger's parent). If a native popover contained focusable elements and lived inside an AppDialog, AppDialog's focus trap would hijack Tab focus away from the popover. Fix: extend the AppDialog focus trap guard to also check for `:popover-open` ancestors, OR use `popover="manual"` and call `inert` on the surrounding tree, OR move the popover under the dialog in document order before opening.
+
+### Gap #4 — No hover-intent / safe polygon _(severity: medium for menu sub-items; low for app tooltip)_
+
+Native `[popover]` has no equivalent of Floating UI's `safePolygon` — moving the cursor diagonally from a menu item toward a sub-menu instantly closes the parent. Daintree's current `Tooltip` provider uses Radix's `delayDuration` + `skipDelayDuration` for the "if a sibling tooltip is already open, skip the delay" pattern; native popover requires a DIY timer per trigger (the POC implements a simple version).
+
+### Gap #5 — Sub-menu coordination _(severity: HIGH for any Radix `DropdownMenu` migration)_
+
+Structurally, nested `[popover]` works — but the cross-popover keyboard coordination (ArrowRight enters sub, ArrowLeft returns to parent, focus-chain restoration, sub-popover dismissal on parent dismissal) is all DIY. Radix `DropdownMenu.Sub` provides this out-of-the-box. Daintree has ~12 surfaces using `DropdownMenuSub` (toolbar overflow, terminal context menu, sidebar project actions, etc.); migrating any of them is a meaningful refactor, not a swap.
+
+### Gap #6 — No `keepMounted` / Activity equivalent _(severity: medium)_
+
+Tooltip leak fix #8001 relies on the dropdown's `FixedDropdownVisibleContext` to force-close tooltips when a parent dropdown enters Activity-hidden state. Native popover has no equivalent — `hidePopover()` is the only signal, and there's no Suspense-style "mounted but visually hidden" affordance. Either: (a) call `hidePopover()` imperatively whenever the parent enters hidden state (requires the same kind of context wiring), or (b) accept that any imperatively-shown tooltip whose dismiss path is skipped strands in the top layer.
+
+## What native genuinely wins
+
+- **Multi-instance hygiene** — each popover element is a leaf in the DOM with its own visibility state. The #8001 class of bug (stale tooltip stranded at 0,0 after parent dropdown unmounts) is impossible: when the parent unmounts, the child popover element is removed from the DOM and the browser cleans up the top-layer entry. No `key={visible ? "v" : "h"}` workaround.
+- **Top-layer escape** — anchor positioning correctly reads the anchor's post-transform bounding box (Chromium 144+); top-layer promotion lifts the popover out of any transform-induced containing block. No Portal allocation, no z-index war.
+- **Smaller per-instance cost** — no React-rendered Portal node, no DismissableLayer event tree, no FocusScope subtree. For low-priority hover tooltips this matters at scale (sidebar with hundreds of project rows).
+- **Native primitives are stable surface** — Chromium 146 ships `popover=hint`, `popover=auto`, `position-area`, `position-try-fallbacks`, `position-visibility`, `@starting-style`, `transition-behavior: allow-discrete`, CloseWatcher all as default-enabled. Removed Floating UI / Radix dependency upgrades from the surface.
+
+## What native does NOT win
+
+- **Bundle size — until the LAST consumer migrates.** `vendor-radix-overlay` (32 kB gzip) is a single chunk that loads when any of `Tooltip | Popover | DropdownMenu | Select | ContextMenu` is rendered. Migrating only Tooltip + simple Dropdown does not reduce the gzip cost. `Select` and `ContextMenu` are the hardest to replace (Select has scroll-button behavior, ContextMenu has long-press coordination on touch). Pragmatically: the bundle savings ceiling is real but the path to claim it is long.
+- **Test ergonomics** — jsdom does not implement top-layer, `:popover-open`, `overlay`, anchor positioning, or CloseWatcher. Everything has to be Playwright. The existing Tooltip/Popover unit tests use Radix's data-state attributes for assertions; those go away.
+- **TypeScript ergonomics** — `CSSProperties` does not yet type `anchorName`, `positionAnchor`, `positionArea`, `positionVisibility`, `positionTryFallbacks`. The POC uses a local intersection type; long-term this needs a `lib.dom.d.ts` augmentation or the React team to ship it.
+- **Past institutional knowledge** — `dialogEscapeBackstop`, `FixedDropdownVisibleContext`, `useIsDockPopoverChild`, `primeOnEvent`, AppDialog focus-trap guards all have at least one issue tag in their history (#8001, #8008, #4588, #2828, #3831). A migration re-opens every one of those design questions in the native idiom.
+
+## Recommendation: **HOLD**
+
+Native `[popover]` + CSS Anchor Positioning is mature enough for a greenfield Chromium-only app to use exclusively. It is **not yet a reasonable trade for Daintree** in 2026-Q2:
+
+1. **No bundle win without a full-surface migration.** Tooltip + simple dropdown alone changes nothing in `vendor-radix-overlay`. The win materializes only when Select and ContextMenu also migrate, and both have meaningful behavioral gaps (focus trap, sub-menu coordination, scroll-button affordances).
+2. **The Escape coordination gap (Gap #2) is load-bearing.** `dialogEscapeBackstop` is built for Radix's `data-state` signal. Reworking it to coexist with CloseWatcher's capture-phase native handling is the kind of cross-cutting infrastructure change that introduces its own incident class.
+3. **Focus-trap is still DIY.** The biggest single thing missing from the platform. Until there's a `popover-focus-trap` attribute or equivalent (no shipped proposal as of Chrome 146), every dropdown migration adds 50–100 LOC of focus management that Radix gives for free.
+
+### When to revisit
+
+Re-open this spike if any of these land in Chromium:
+
+- A native focus-trap affordance on `[popover]` (e.g. `popover="manual" inert` integration, or a dedicated attribute)
+- CloseWatcher cancellation that integrates with a stack (`event.preventDefault()` honoring LIFO across popover layers)
+- A `position-area` extension for sub-menu placement / keyboard coordination primitives
+- Floating UI publishes a "native popover + their middleware" hybrid layer that handles the focus + sub-menu DIY gaps
+
+### What to keep from this spike
+
+- `src/styles/components/native-popover.css` — the documented `overlay`-in-transition pattern is reusable for any future native-popover work
+- `NativeTooltip.tsx` — could be promoted to a tooltip variant for cases where Radix is overkill (low-priority hover, dense lists). Currently deferred — the existing tooltip wrapper is the single source of truth.
+
+### What to throw away
+
+- `NativeDropdown.tsx` — focus trap and sub-menu gaps make this not safe for production menu use. Keep for demo until the spike is closed; then delete.
+- `src/spikes/NativePopoverSpikeDemo.tsx` and the TroubleshootingTab gate — delete on issue close.
+
+---
+
+**Files added by this spike** (will be removed in a follow-up if the recommendation stands):
+
+- `src/components/ui/NativeTooltip.tsx`
+- `src/components/ui/NativeDropdown.tsx`
+- `src/styles/components/native-popover.css`
+- `src/spikes/NativePopoverSpikeDemo.tsx`
+- `docs/spikes/native-popover-2026-05.md` (this memo)
+
+**Files modified by this spike** (will be reverted in a follow-up if the recommendation stands):
+
+- `src/index.css` (+1 line: `@import "./styles/components/native-popover.css"`)
+- `src/components/Settings/TroubleshootingTab.tsx` (+1 import, +10-line `<SettingsSection>` block gated on `developerMode`)

--- a/docs/spikes/native-popover-2026-05.md
+++ b/docs/spikes/native-popover-2026-05.md
@@ -40,7 +40,7 @@ The `vendor-radix-overlay` chunk (32 kB gzipped) is the realistic prize. The def
 | --- | --- | --- | --- |
 | Anchored positioning (4 sides + 3 aligns) | `position-area` + `anchor-name` | Floating UI middlewares | ✅ parity |
 | Collision flip | `position-try-fallbacks: flip-block, flip-inline` | `collisionBoundary` + auto flip | ✅ parity |
-| Hide-when-anchor-scrolled-offscreen | `position-visibility: anchor-visible` | `hideWhenDetached` | ✅ parity |
+| Hide-when-anchor-scrolled-offscreen | `position-visibility: anchors-visible` | `hideWhenDetached` | ✅ parity |
 | Top-layer escape from transform / overflow ancestors | top-layer promotion (automatic) | Portal to body | ✅ parity (better — no portal allocation) |
 | Entry / exit animation | `@starting-style` + `transition-behavior: allow-discrete` + `overlay` in transition list | Radix Presence + data-state | ✅ works, with caveat (see Gap #1) |
 | Light-dismiss (click-outside) | native via `popover="auto"` | `DismissableLayer` | ✅ parity |
@@ -114,7 +114,7 @@ Tooltip leak fix #8001 relies on the dropdown's `FixedDropdownVisibleContext` to
 
 - **Bundle size — until the LAST consumer migrates.** `vendor-radix-overlay` (32 kB gzip) is a single chunk that loads when any of `Tooltip | Popover | DropdownMenu | Select | ContextMenu` is rendered. Migrating only Tooltip + simple Dropdown does not reduce the gzip cost. `Select` and `ContextMenu` are the hardest to replace (Select has scroll-button behavior, ContextMenu has long-press coordination on touch). Pragmatically: the bundle savings ceiling is real but the path to claim it is long.
 - **Test ergonomics** — jsdom does not implement top-layer, `:popover-open`, `overlay`, anchor positioning, or CloseWatcher. Everything has to be Playwright. The existing Tooltip/Popover unit tests use Radix's data-state attributes for assertions; those go away.
-- **TypeScript ergonomics** — `CSSProperties` does not yet type `anchorName`, `positionAnchor`, `positionArea`, `positionVisibility`, `positionTryFallbacks`. The POC uses a local intersection type; long-term this needs a `lib.dom.d.ts` augmentation or the React team to ship it.
+- **TypeScript ergonomics — non-issue.** The installed `csstype` ships `anchorName`, `positionAnchor`, `positionArea`, `positionVisibility`, `positionTryFallbacks` as typed `CSSProperties`; `@types/react` exposes `popover`, `popoverTarget`, and `popoverTargetAction` on `HTMLAttributes`. No augmentation needed — the POC uses plain `React.CSSProperties` throughout.
 - **Past institutional knowledge** — `dialogEscapeBackstop`, `FixedDropdownVisibleContext`, `useIsDockPopoverChild`, `primeOnEvent`, AppDialog focus-trap guards all have at least one issue tag in their history (#8001, #8008, #4588, #2828, #3831). A migration re-opens every one of those design questions in the native idiom.
 
 ## Recommendation: **HOLD**

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,5 +1,5 @@
 {
-  "count": 1121,
+  "count": 1122,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 94,
@@ -11,5 +11,5 @@
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 38
   },
-  "updatedAt": "2026-05-24T10:22:40.616Z"
+  "updatedAt": "2026-05-24T14:15:06.212Z"
 }

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -24,6 +24,7 @@ import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 import { DiagnosticsReviewDialog } from "./DiagnosticsReviewDialog";
+import { NativePopoverSpikeDemo } from "@/spikes/NativePopoverSpikeDemo";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 function SystemHealthSection() {
@@ -552,6 +553,17 @@ export function TroubleshootingTab() {
           </div>
         )}
       </SettingsSection>
+
+      {developerMode && (
+        <SettingsSection
+          icon={Bug}
+          title="Spike: native [popover] + CSS anchor positioning"
+          description="POC surfaces for issue #8992. Visible only in developer mode."
+          badge="Spike"
+        >
+          <NativePopoverSpikeDemo />
+        </SettingsSection>
+      )}
 
       <div className="space-y-2">
         <h4 className="text-sm font-medium text-daintree-text">Keyboard Shortcuts</h4>

--- a/src/components/ui/NativeDropdown.tsx
+++ b/src/components/ui/NativeDropdown.tsx
@@ -4,10 +4,6 @@ import { cn } from "@/lib/utils";
 type Side = "top" | "right" | "bottom" | "left";
 type Align = "start" | "center" | "end";
 
-type AnchorPositionStyle = React.CSSProperties & {
-  anchorName?: string;
-};
-
 type NativeDropdownItem = {
   id: string;
   label: React.ReactNode;
@@ -76,7 +72,7 @@ export function NativeDropdown({
     popoverRef.current?.hidePopover();
   }, []);
 
-  const triggerStyle: AnchorPositionStyle = { anchorName };
+  const triggerStyle: React.CSSProperties = { anchorName };
 
   const popoverStyle = {
     "--np-anchor": anchorName,

--- a/src/components/ui/NativeDropdown.tsx
+++ b/src/components/ui/NativeDropdown.tsx
@@ -1,0 +1,129 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type Side = "top" | "right" | "bottom" | "left";
+type Align = "start" | "center" | "end";
+
+type AnchorPositionStyle = React.CSSProperties & {
+  anchorName?: string;
+};
+
+type NativeDropdownItem = {
+  id: string;
+  label: React.ReactNode;
+  disabled?: boolean;
+  onSelect?: () => void;
+};
+
+type NativeDropdownProps = {
+  items: NativeDropdownItem[];
+  side?: Side;
+  align?: Align;
+  sideOffset?: number;
+  triggerClassName?: string;
+  contentClassName?: string;
+  children: React.ReactNode;
+};
+
+const POSITION_AREA: Record<Side, Record<Align, string>> = {
+  top: { start: "top span-right", center: "top", end: "top span-left" },
+  bottom: { start: "bottom span-right", center: "bottom", end: "bottom span-left" },
+  left: { start: "left span-bottom", center: "left", end: "left span-top" },
+  right: { start: "right span-bottom", center: "right", end: "right span-top" },
+};
+
+const TRANSFORM_ORIGIN: Record<Side, string> = {
+  top: "center bottom",
+  bottom: "center top",
+  left: "right center",
+  right: "left center",
+};
+
+function sanitizeAnchorId(id: string): string {
+  return `--np-${id.replace(/[^a-zA-Z0-9_-]/g, "")}`;
+}
+
+export function NativeDropdown({
+  items,
+  side = "bottom",
+  align = "start",
+  sideOffset = 4,
+  triggerClassName,
+  contentClassName,
+  children,
+}: NativeDropdownProps) {
+  const reactId = React.useId();
+  const anchorName = sanitizeAnchorId(reactId);
+  const popoverId = `np-dd-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}`;
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null);
+  const popoverRef = React.useRef<HTMLDivElement | null>(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    const node = popoverRef.current;
+    if (!node) return;
+    const handleToggle = (event: Event) => {
+      const toggle = event as ToggleEvent;
+      setIsOpen(toggle.newState === "open");
+    };
+    node.addEventListener("toggle", handleToggle);
+    return () => node.removeEventListener("toggle", handleToggle);
+  }, []);
+
+  const handleSelect = React.useCallback((item: NativeDropdownItem) => {
+    if (item.disabled) return;
+    item.onSelect?.();
+    popoverRef.current?.hidePopover();
+  }, []);
+
+  const triggerStyle: AnchorPositionStyle = { anchorName };
+
+  const popoverStyle = {
+    "--np-anchor": anchorName,
+    "--np-position-area": POSITION_AREA[side][align],
+    "--np-transform-origin": TRANSFORM_ORIGIN[side],
+    "--np-side-offset": `${sideOffset}px`,
+  } as React.CSSProperties;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        popoverTarget={popoverId}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-controls={popoverId}
+        style={triggerStyle}
+        className={triggerClassName}
+      >
+        {children}
+      </button>
+      <div
+        ref={popoverRef}
+        id={popoverId}
+        popover="auto"
+        role="menu"
+        style={popoverStyle}
+        className={cn(
+          "native-popover-spike native-popover-spike-dropdown surface-overlay shadow-overlay",
+          contentClassName
+        )}
+      >
+        {items.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            role="menuitem"
+            aria-disabled={item.disabled ? "true" : undefined}
+            tabIndex={item.disabled ? -1 : 0}
+            onClick={() => handleSelect(item)}
+            className="native-popover-spike-dropdown-item"
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/ui/NativeDropdown.tsx
+++ b/src/components/ui/NativeDropdown.tsx
@@ -58,9 +58,9 @@ export function NativeDropdown({
   React.useEffect(() => {
     const node = popoverRef.current;
     if (!node) return;
-    const handleToggle = (event: Event) => {
-      const toggle = event as ToggleEvent;
-      setIsOpen(toggle.newState === "open");
+    // HTMLElementEventMap types "toggle" as ToggleEvent — no cast needed.
+    const handleToggle = (event: ToggleEvent) => {
+      setIsOpen(event.newState === "open");
     };
     node.addEventListener("toggle", handleToggle);
     return () => node.removeEventListener("toggle", handleToggle);
@@ -74,6 +74,10 @@ export function NativeDropdown({
 
   const triggerStyle: React.CSSProperties = { anchorName };
 
+  // csstype's Properties type rejects `--*` keys in object literals — the
+  // cast is the documented codebase pattern (see ContentPanel.tsx,
+  // SortableTabButton.tsx, DemoOverlay.tsx).
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   const popoverStyle = {
     "--np-anchor": anchorName,
     "--np-position-area": POSITION_AREA[side][align],

--- a/src/components/ui/NativeTooltip.tsx
+++ b/src/components/ui/NativeTooltip.tsx
@@ -1,3 +1,6 @@
+// eslint-disable-next-line react-compiler/react-compiler
+"use no memo";
+
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
@@ -51,26 +54,30 @@ export function NativeTooltip({
   const popoverRef = React.useRef<HTMLDivElement | null>(null);
   const showTimerRef = React.useRef<number | null>(null);
 
-  const clearShowTimer = React.useCallback(() => {
+  React.useEffect(
+    () => () => {
+      if (showTimerRef.current !== null) {
+        window.clearTimeout(showTimerRef.current);
+        showTimerRef.current = null;
+      }
+    },
+    []
+  );
+
+  function show() {
+    if (showTimerRef.current !== null) window.clearTimeout(showTimerRef.current);
+    showTimerRef.current = window.setTimeout(() => {
+      popoverRef.current?.showPopover();
+    }, delay);
+  }
+
+  function hide() {
     if (showTimerRef.current !== null) {
       window.clearTimeout(showTimerRef.current);
       showTimerRef.current = null;
     }
-  }, []);
-
-  const show = React.useCallback(() => {
-    clearShowTimer();
-    showTimerRef.current = window.setTimeout(() => {
-      popoverRef.current?.showPopover();
-    }, delay);
-  }, [clearShowTimer, delay]);
-
-  const hide = React.useCallback(() => {
-    clearShowTimer();
     popoverRef.current?.hidePopover();
-  }, [clearShowTimer]);
-
-  React.useEffect(() => clearShowTimer, [clearShowTimer]);
+  }
 
   const childProps = children.props;
 

--- a/src/components/ui/NativeTooltip.tsx
+++ b/src/components/ui/NativeTooltip.tsx
@@ -4,10 +4,6 @@ import { cn } from "@/lib/utils";
 type Side = "top" | "right" | "bottom" | "left";
 type Align = "start" | "center" | "end";
 
-type AnchorPositionStyle = React.CSSProperties & {
-  anchorName?: string;
-};
-
 type NativeTooltipProps = {
   content: React.ReactNode;
   side?: Side;
@@ -74,7 +70,10 @@ export function NativeTooltip({
 
   React.useEffect(() => clearShowTimer, [clearShowTimer]);
 
-  const triggerStyle: AnchorPositionStyle = {
+  // The consumer-provided `style` is spread last so an explicit
+  // `anchorName` on a child trigger wins — surprising, but matches normal
+  // React style-merge precedence and keeps the POC predictable.
+  const triggerStyle: React.CSSProperties = {
     anchorName,
     ...(children.props as { style?: React.CSSProperties }).style,
   };

--- a/src/components/ui/NativeTooltip.tsx
+++ b/src/components/ui/NativeTooltip.tsx
@@ -4,6 +4,8 @@ import { cn } from "@/lib/utils";
 type Side = "top" | "right" | "bottom" | "left";
 type Align = "start" | "center" | "end";
 
+type TriggerProps = React.HTMLAttributes<HTMLElement>;
+
 type NativeTooltipProps = {
   content: React.ReactNode;
   side?: Side;
@@ -12,7 +14,7 @@ type NativeTooltipProps = {
   delay?: number;
   className?: string;
   contentClassName?: string;
-  children: React.ReactElement;
+  children: React.ReactElement<TriggerProps>;
 };
 
 const POSITION_AREA: Record<Side, Record<Align, string>> = {
@@ -70,40 +72,42 @@ export function NativeTooltip({
 
   React.useEffect(() => clearShowTimer, [clearShowTimer]);
 
+  const childProps = children.props;
+
   // The consumer-provided `style` is spread last so an explicit
   // `anchorName` on a child trigger wins — surprising, but matches normal
   // React style-merge precedence and keeps the POC predictable.
   const triggerStyle: React.CSSProperties = {
     anchorName,
-    ...(children.props as { style?: React.CSSProperties }).style,
+    ...childProps.style,
   };
 
-  const trigger = React.cloneElement(children, {
+  const triggerOverrides: TriggerProps = {
     "aria-describedby": popoverId,
     style: triggerStyle,
-    className: cn((children.props as { className?: string }).className, className),
-    onPointerEnter: (event: React.PointerEvent) => {
+    className: cn(childProps.className, className),
+    onPointerEnter: (event) => {
       show();
-      (children.props as { onPointerEnter?: (e: React.PointerEvent) => void }).onPointerEnter?.(
-        event
-      );
+      childProps.onPointerEnter?.(event);
     },
-    onPointerLeave: (event: React.PointerEvent) => {
+    onPointerLeave: (event) => {
       hide();
-      (children.props as { onPointerLeave?: (e: React.PointerEvent) => void }).onPointerLeave?.(
-        event
-      );
+      childProps.onPointerLeave?.(event);
     },
-    onFocus: (event: React.FocusEvent) => {
+    onFocus: (event) => {
       show();
-      (children.props as { onFocus?: (e: React.FocusEvent) => void }).onFocus?.(event);
+      childProps.onFocus?.(event);
     },
-    onBlur: (event: React.FocusEvent) => {
+    onBlur: (event) => {
       hide();
-      (children.props as { onBlur?: (e: React.FocusEvent) => void }).onBlur?.(event);
+      childProps.onBlur?.(event);
     },
-  } as React.HTMLAttributes<HTMLElement>);
+  };
 
+  // csstype's Properties type rejects `--*` keys in object literals — the
+  // cast is the documented codebase pattern (see ContentPanel.tsx,
+  // SortableTabButton.tsx, DemoOverlay.tsx).
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   const popoverStyle = {
     "--np-anchor": anchorName,
     "--np-position-area": POSITION_AREA[side][align],
@@ -113,7 +117,7 @@ export function NativeTooltip({
 
   return (
     <>
-      {trigger}
+      {React.cloneElement(children, triggerOverrides)}
       <div
         ref={popoverRef}
         id={popoverId}

--- a/src/components/ui/NativeTooltip.tsx
+++ b/src/components/ui/NativeTooltip.tsx
@@ -1,0 +1,133 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type Side = "top" | "right" | "bottom" | "left";
+type Align = "start" | "center" | "end";
+
+type AnchorPositionStyle = React.CSSProperties & {
+  anchorName?: string;
+};
+
+type NativeTooltipProps = {
+  content: React.ReactNode;
+  side?: Side;
+  align?: Align;
+  sideOffset?: number;
+  delay?: number;
+  className?: string;
+  contentClassName?: string;
+  children: React.ReactElement;
+};
+
+const POSITION_AREA: Record<Side, Record<Align, string>> = {
+  top: { start: "top span-right", center: "top", end: "top span-left" },
+  bottom: { start: "bottom span-right", center: "bottom", end: "bottom span-left" },
+  left: { start: "left span-bottom", center: "left", end: "left span-top" },
+  right: { start: "right span-bottom", center: "right", end: "right span-top" },
+};
+
+const TRANSFORM_ORIGIN: Record<Side, string> = {
+  top: "center bottom",
+  bottom: "center top",
+  left: "right center",
+  right: "left center",
+};
+
+function sanitizeAnchorId(id: string): string {
+  return `--np-${id.replace(/[^a-zA-Z0-9_-]/g, "")}`;
+}
+
+export function NativeTooltip({
+  content,
+  side = "top",
+  align = "center",
+  sideOffset = 4,
+  delay = 200,
+  className,
+  contentClassName,
+  children,
+}: NativeTooltipProps) {
+  const reactId = React.useId();
+  const anchorName = sanitizeAnchorId(reactId);
+  const popoverId = `np-tt-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}`;
+  const popoverRef = React.useRef<HTMLDivElement | null>(null);
+  const showTimerRef = React.useRef<number | null>(null);
+
+  const clearShowTimer = React.useCallback(() => {
+    if (showTimerRef.current !== null) {
+      window.clearTimeout(showTimerRef.current);
+      showTimerRef.current = null;
+    }
+  }, []);
+
+  const show = React.useCallback(() => {
+    clearShowTimer();
+    showTimerRef.current = window.setTimeout(() => {
+      popoverRef.current?.showPopover();
+    }, delay);
+  }, [clearShowTimer, delay]);
+
+  const hide = React.useCallback(() => {
+    clearShowTimer();
+    popoverRef.current?.hidePopover();
+  }, [clearShowTimer]);
+
+  React.useEffect(() => clearShowTimer, [clearShowTimer]);
+
+  const triggerStyle: AnchorPositionStyle = {
+    anchorName,
+    ...(children.props as { style?: React.CSSProperties }).style,
+  };
+
+  const trigger = React.cloneElement(children, {
+    "aria-describedby": popoverId,
+    style: triggerStyle,
+    className: cn((children.props as { className?: string }).className, className),
+    onPointerEnter: (event: React.PointerEvent) => {
+      show();
+      (children.props as { onPointerEnter?: (e: React.PointerEvent) => void }).onPointerEnter?.(
+        event
+      );
+    },
+    onPointerLeave: (event: React.PointerEvent) => {
+      hide();
+      (children.props as { onPointerLeave?: (e: React.PointerEvent) => void }).onPointerLeave?.(
+        event
+      );
+    },
+    onFocus: (event: React.FocusEvent) => {
+      show();
+      (children.props as { onFocus?: (e: React.FocusEvent) => void }).onFocus?.(event);
+    },
+    onBlur: (event: React.FocusEvent) => {
+      hide();
+      (children.props as { onBlur?: (e: React.FocusEvent) => void }).onBlur?.(event);
+    },
+  } as React.HTMLAttributes<HTMLElement>);
+
+  const popoverStyle = {
+    "--np-anchor": anchorName,
+    "--np-position-area": POSITION_AREA[side][align],
+    "--np-transform-origin": TRANSFORM_ORIGIN[side],
+    "--np-side-offset": `${sideOffset}px`,
+  } as React.CSSProperties;
+
+  return (
+    <>
+      {trigger}
+      <div
+        ref={popoverRef}
+        id={popoverId}
+        popover="hint"
+        role="tooltip"
+        style={popoverStyle}
+        className={cn(
+          "native-popover-spike native-popover-spike-tooltip surface-overlay shadow-overlay",
+          contentClassName
+        )}
+      >
+        {content}
+      </div>
+    </>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
 @import "./styles/components/pulse.css";
 @import "./styles/components/sidebar.css";
 @import "./styles/components/panels.css";
+@import "./styles/components/native-popover.css";
 
 /* Reduced-motion variant — composes OS-level `prefers-reduced-motion: reduce`
  * with the Daintree "Reduce UI animations" toggle (`body[data-reduce-animations="true"]`).

--- a/src/spikes/NativePopoverSpikeDemo.tsx
+++ b/src/spikes/NativePopoverSpikeDemo.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { NativeTooltip } from "@/components/ui/NativeTooltip";
+import { NativeDropdown } from "@/components/ui/NativeDropdown";
+
+export function NativePopoverSpikeDemo() {
+  const [reduceLocal, setReduceLocal] = useState(false);
+  const [lastSelected, setLastSelected] = useState<string | null>(null);
+
+  const toggleReduce = () => {
+    const next = !reduceLocal;
+    setReduceLocal(next);
+    if (next) document.body.setAttribute("data-reduce-animations", "true");
+    else document.body.removeAttribute("data-reduce-animations");
+  };
+
+  const dropdownItems = [
+    { id: "rename", label: "Rename", onSelect: () => setLastSelected("Rename") },
+    { id: "duplicate", label: "Duplicate", onSelect: () => setLastSelected("Duplicate") },
+    { id: "archive", label: "Archive", onSelect: () => setLastSelected("Archive") },
+    { id: "delete", label: "Delete", disabled: true, onSelect: () => setLastSelected("Delete") },
+  ];
+
+  return (
+    <div className="space-y-6 text-xs text-daintree-text">
+      <p className="text-daintree-text/70 select-text">
+        Native [popover] + CSS Anchor Positioning POC for issue #8992. These surfaces use zero Radix
+        code. Verify visually: timing matches tiered motion (tooltip 150/100ms, dropdown 200/120ms),
+        tooltips stack across multiple anchors, dropdown flips near viewport edges.
+      </p>
+
+      <div className="flex items-center gap-3">
+        <Button variant="outline" size="sm" onClick={toggleReduce}>
+          {reduceLocal ? "Restore animations" : "Toggle reduce-motion"}
+        </Button>
+        <span className="text-daintree-text/60">
+          {reduceLocal ? "body[data-reduce-animations] is set" : "Animations active"}
+        </span>
+      </div>
+
+      <section className="space-y-3">
+        <h5 className="text-xs font-medium text-daintree-text/80">Tooltip — multiple anchors</h5>
+        <div className="flex flex-wrap gap-3">
+          <NativeTooltip content="Top tooltip" side="top">
+            <Button variant="outline" size="sm">
+              Hover top
+            </Button>
+          </NativeTooltip>
+          <NativeTooltip content="Right tooltip" side="right">
+            <Button variant="outline" size="sm">
+              Hover right
+            </Button>
+          </NativeTooltip>
+          <NativeTooltip content="Bottom tooltip" side="bottom">
+            <Button variant="outline" size="sm">
+              Hover bottom
+            </Button>
+          </NativeTooltip>
+          <NativeTooltip content="Left tooltip" side="left">
+            <Button variant="outline" size="sm">
+              Hover left
+            </Button>
+          </NativeTooltip>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h5 className="text-xs font-medium text-daintree-text/80">
+          Tooltip — inside transformed ancestor
+        </h5>
+        <div style={{ transform: "translateZ(0) rotate(0deg)" }} className="inline-block">
+          <NativeTooltip content="Anchored from a transformed subtree" side="top">
+            <Button variant="outline" size="sm">
+              Transformed parent
+            </Button>
+          </NativeTooltip>
+        </div>
+        <p className="text-daintree-text/60">
+          Top-layer promotion escapes the transform containing block — tooltip should still anchor
+          to the trigger.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h5 className="text-xs font-medium text-daintree-text/80">Dropdown — flip near edge</h5>
+        <div className="flex justify-between items-center">
+          <NativeDropdown
+            items={dropdownItems}
+            side="bottom"
+            align="start"
+            triggerClassName="px-3 py-1.5 rounded-md surface-overlay shadow-overlay text-xs"
+          >
+            Open menu (left)
+          </NativeDropdown>
+          <NativeDropdown
+            items={dropdownItems}
+            side="bottom"
+            align="end"
+            triggerClassName="px-3 py-1.5 rounded-md surface-overlay shadow-overlay text-xs"
+          >
+            Open menu (right)
+          </NativeDropdown>
+        </div>
+        {lastSelected && <p className="text-daintree-text/60">Last selected: {lastSelected}</p>}
+      </section>
+
+      <section className="space-y-2 text-daintree-text/60">
+        <h5 className="text-xs font-medium text-daintree-text/80">Parity checks to confirm</h5>
+        <ul className="list-disc pl-4 space-y-1">
+          <li>Escape closes open dropdown (native CloseWatcher).</li>
+          <li>Click-outside on dropdown light-dismisses.</li>
+          <li>Reduce-motion toggle suppresses both enter and exit transitions.</li>
+          <li>Tooltip exit fade is visible — no instant clip (overlay in transition list).</li>
+          <li>Multiple tooltips can be primed simultaneously without state leaks.</li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/spikes/NativePopoverSpikeDemo.tsx
+++ b/src/spikes/NativePopoverSpikeDemo.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { NativeTooltip } from "@/components/ui/NativeTooltip";
 import { NativeDropdown } from "@/components/ui/NativeDropdown";
@@ -6,6 +6,21 @@ import { NativeDropdown } from "@/components/ui/NativeDropdown";
 export function NativePopoverSpikeDemo() {
   const [reduceLocal, setReduceLocal] = useState(false);
   const [lastSelected, setLastSelected] = useState<string | null>(null);
+  // Capture the attribute value at mount so we can restore it on unmount —
+  // the app-wide setting may already be on, and the demo must not clobber
+  // it when the developer-mode gate is toggled off.
+  const initialReduceRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    initialReduceRef.current = document.body.getAttribute("data-reduce-animations");
+    return () => {
+      if (initialReduceRef.current === null) {
+        document.body.removeAttribute("data-reduce-animations");
+      } else {
+        document.body.setAttribute("data-reduce-animations", initialReduceRef.current);
+      }
+    };
+  }, []);
 
   const toggleReduce = () => {
     const next = !reduceLocal;

--- a/src/styles/components/native-popover.css
+++ b/src/styles/components/native-popover.css
@@ -1,0 +1,133 @@
+/* Native [popover] + CSS Anchor Positioning POC styles.
+ *
+ * Spike #8992: not for production. Two POC surfaces share this stylesheet —
+ * NativeTooltip (Tier 2-fast: 150ms enter / 100ms exit) and NativeDropdown
+ * (Tier 2: 200ms enter / 120ms exit). The `overlay` property MUST appear in
+ * every transition list — without it, the top-layer ejection on close is
+ * synchronous and the exit fade is clipped to a single frame.
+ */
+
+.native-popover-spike {
+  position: fixed;
+  inset: unset;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  overflow: visible;
+}
+
+.native-popover-spike[popover] {
+  position-anchor: var(--np-anchor);
+  position-area: var(--np-position-area, bottom);
+  position-try-fallbacks: var(--np-position-try, flip-block, flip-inline, flip-block flip-inline);
+  position-visibility: anchor-visible;
+  margin-block-start: var(--np-side-offset, 0);
+}
+
+.native-popover-spike-tooltip {
+  z-index: var(--z-popover);
+  max-width: 20rem;
+  border-radius: var(--radius-md);
+  padding-inline: 0.75rem;
+  padding-block: 0.375rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: var(--color-text-primary);
+  opacity: 1;
+  transform: scale(1);
+  transform-origin: var(--np-transform-origin, center top);
+  transition:
+    opacity 150ms ease,
+    transform 150ms ease,
+    display 150ms allow-discrete,
+    overlay 150ms allow-discrete;
+}
+
+.native-popover-spike-tooltip[popover]:not(:popover-open) {
+  opacity: 0;
+  transform: scale(0.95);
+  transition-duration: 100ms;
+}
+
+@starting-style {
+  .native-popover-spike-tooltip[popover]:popover-open {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+
+.native-popover-spike-dropdown {
+  z-index: var(--z-popover);
+  min-width: 10rem;
+  border-radius: var(--radius-lg);
+  padding: 0.25rem;
+  color: var(--color-text-primary);
+  opacity: 1;
+  transform: scale(1);
+  transform-origin: var(--np-transform-origin, center top);
+  transition:
+    opacity 200ms ease,
+    transform 200ms ease,
+    display 200ms allow-discrete,
+    overlay 200ms allow-discrete;
+}
+
+.native-popover-spike-dropdown[popover]:not(:popover-open) {
+  opacity: 0;
+  transform: scale(0.95);
+  transition-duration: 120ms;
+}
+
+@starting-style {
+  .native-popover-spike-dropdown[popover]:popover-open {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+
+.native-popover-spike-dropdown-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border-radius: var(--radius-sm);
+  padding-inline: 0.625rem;
+  padding-block: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--color-text-primary);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  text-align: start;
+  transition: background-color 150ms ease;
+}
+
+.native-popover-spike-dropdown-item:hover,
+.native-popover-spike-dropdown-item:focus-visible {
+  background-color: var(--color-overlay-emphasis);
+  outline: none;
+}
+
+.native-popover-spike-dropdown-item[aria-disabled="true"] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+@variant reduce-motion {
+  .native-popover-spike-tooltip,
+  .native-popover-spike-dropdown {
+    transition: none;
+  }
+  .native-popover-spike-tooltip[popover]:not(:popover-open),
+  .native-popover-spike-dropdown[popover]:not(:popover-open) {
+    transform: none;
+  }
+  @starting-style {
+    .native-popover-spike-tooltip[popover]:popover-open,
+    .native-popover-spike-dropdown[popover]:popover-open {
+      opacity: 1;
+      transform: none;
+    }
+  }
+}

--- a/src/styles/components/native-popover.css
+++ b/src/styles/components/native-popover.css
@@ -22,7 +22,11 @@
   position-anchor: var(--np-anchor);
   position-area: var(--np-position-area, bottom);
   position-try-fallbacks: var(--np-position-try, flip-block, flip-inline, flip-block flip-inline);
-  position-visibility: anchor-visible;
+  position-visibility: anchors-visible;
+  /* `margin-block-start` only adds a gap on the block-axis side. For
+   * left/right placement the offset belongs on the inline axis — the POC
+   * does not exercise side="left"/"right" interactively, so this is left
+   * uniaxial to keep the spike small. Document and split if migrated. */
   margin-block-start: var(--np-side-offset, 0);
 }
 


### PR DESCRIPTION
## Summary

Exploration of native HTML `[popover]` + CSS Anchor Positioning as a potential replacement for our Radix overlay primitives. Builds two isolated POC components — `NativeTooltip` and `NativeDropdown` — using `@starting-style` and `transition-behavior: allow-discrete` for entrance/exit animations.

Bundle baseline captured: `vendor-radix-overlay` is 32 kB gzipped. Full savings only materialize if all 5 Radix primitives migrate; a partial migration saves nothing.

**Verdict: HOLD.** Escape coordination is the blocker — `CloseWatcher` collides with `dialogEscapeBackstop`, and focus-trap is load-bearing work we'd have to reimplement from scratch. Full rationale in the memo.

Refs #8992

## Changes

- `src/components/ui/NativeTooltip.tsx` — anchor-positioned tooltip using `[popover]`, 8 placement variants
- `src/components/ui/NativeDropdown.tsx` — light-dismiss dropdown with keyboard navigation
- `src/styles/components/native-popover.css` — CSS Anchor Positioning rules + `@starting-style` transitions
- `src/spikes/NativePopoverSpikeDemo.tsx` — interactive demo (reduce-motion toggle, transformed-ancestor container test)
- `src/components/Settings/TroubleshootingTab.tsx` — demo surface wired behind existing `developerMode` gate
- `docs/spikes/native-popover-2026-05.md` — verdict memo with bundle analysis, blocker breakdown, and recommended next steps

Zero modifications to `popover.tsx`, `tooltip.tsx`, `dropdown-menu.tsx`, `context-menu.tsx`, `select.tsx`, `dialogEscapeBackstop.ts`, `escapeStack.ts`, `radix-loader.ts`, or `radix-deferred.ts`. No production surfaces touched.

## Testing

- [ ] Open Settings → Troubleshooting, enable Developer mode
- [ ] Scroll to "Spike: native [popover] + CSS anchor positioning" section
- [ ] Hover each direction button — tooltip should anchor to the correct side with 150ms enter / 100ms exit
- [ ] Confirm tooltip inside transformed-ancestor container still anchors correctly (top-layer escape)
- [ ] Open "Open menu (left)" and "Open menu (right)" — dropdown should light-dismiss on outside click and close on Escape
- [ ] Toggle "Reduce-motion" button → confirm animations suspend; toggle back → confirm restored
- [ ] Disable developer mode → confirm the reduce-motion attribute is not left set globally
- [ ] Read `docs/spikes/native-popover-2026-05.md`