### PR TITLE
fix(notify): lower toast dwell defaults toward industry midpoint

### DIFF
--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -1063,7 +1063,7 @@ describe("Toast severity-based dismissal (issue #5859)", () => {
     expect(screen.getByText("Something failed")).toBeTruthy();
   });
 
-  it("error toast dismisses around the 12s severity default", async () => {
+  it("error toast dismisses around the 8s severity default", async () => {
     render(<Toaster />);
     await act(async () => {
       // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
@@ -1071,13 +1071,13 @@ describe("Toast severity-based dismissal (issue #5859)", () => {
       vi.advanceTimersByTime(16);
     });
 
-    // Just before 12s — still visible.
+    // Just before 8s — still visible.
     await act(async () => {
-      vi.advanceTimersByTime(11500);
+      vi.advanceTimersByTime(7500);
     });
     expect(screen.getByText("Failed once")).toBeTruthy();
 
-    // Past 12s + the exit fade — gone.
+    // Past 8s + the exit fade — gone.
     await act(async () => {
       vi.advanceTimersByTime(1000);
     });

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -64,7 +64,9 @@ const TYPE_ICON_CONFIG: Record<string, IconConfig> = {
 /**
  * Hard cap on total visible time for any toast, regardless of how many
  * coalesced updates restart its timer. Bounds chatty same-entity bursts
- * (e.g. agent state churn under #5863).
+ * (e.g. agent state churn under #5863). With severity defaults now at 5–8s,
+ * a single tick never approaches this ceiling — it's a safety net for
+ * coalesced bursts and over-length explicit durations, not a routine clamp.
  */
 const MAX_VISIBLE_DURATION_MS = 15000;
 const VISIBLE_DURATION_MULTIPLIER = 3;

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -684,20 +684,20 @@ describe("notify()", () => {
   });
 
   describe("default duration — severity-based defaults", () => {
-    it("applies a 12s default for error notifications", () => {
+    it("applies an 8s default for error notifications", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
       // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
       notify({ type: "error", message: "Something failed" });
       const notification = useNotificationStore.getState().notifications[0];
-      expect(notification!.duration).toBe(12000);
+      expect(notification!.duration).toBe(8000);
       expect(notification!.duration).toBe(TOAST_DURATION.error);
     });
 
-    it("applies a 12s default for warning notifications", () => {
+    it("applies an 8s default for warning notifications", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
       notify({ type: "warning", message: "Heads up" });
       const notification = useNotificationStore.getState().notifications[0];
-      expect(notification!.duration).toBe(12000);
+      expect(notification!.duration).toBe(8000);
       expect(notification!.duration).toBe(TOAST_DURATION.warning);
     });
 
@@ -709,11 +709,11 @@ describe("notify()", () => {
       expect(notification!.duration).toBe(TOAST_DURATION.success);
     });
 
-    it("applies an 8s default for info notifications", () => {
+    it("applies a 6s default for info notifications", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
       notify({ type: "info", message: "FYI" });
       const notification = useNotificationStore.getState().notifications[0];
-      expect(notification!.duration).toBe(8000);
+      expect(notification!.duration).toBe(6000);
       expect(notification!.duration).toBe(TOAST_DURATION.info);
     });
 

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -638,8 +638,8 @@ export function notify(payload: NotifyPayload): string {
 
   // Severity-based dismiss defaults. When a toast fires, the persistent inbox is
   // the WCAG 2.2.1 conforming alternative for time-limited content, so
-  // error/warning use a generous 12s instead of full sticky to keep the active
-  // stack from growing.
+  // error/warning use 8s instead of full sticky to keep the active stack from
+  // growing.
   if (payload.duration === undefined) {
     payload = { ...payload, duration: TOAST_DURATION[type] };
   }

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -42,23 +42,28 @@ export function isNotificationEventKind(v: string | undefined): v is Notificatio
 /**
  * Default auto-dismiss durations (ms) by notification type.
  *
- * Errors and warnings get a generous 12s so the user has time to read them;
- * success dismisses in 5s — Adobe Spectrum's accessibility minimum, leaving
- * room for short-sentence copy without rushing slow readers. Info gets 8s to
- * match the Atlassian accessibility minimum for sentence-length content. When
- * a toast fires, the persistent inbox is the WCAG 2.2.1 conforming alternative
- * — users who miss a toast can always recover it from the notification center.
- * When no toast is shown (priority "low"), the inbox is the primary channel and
- * carries no compliance load.
+ * Tuned toward the published industry midpoint rather than the high end.
+ * Surveyed defaults: Material Design 3 4s (short) / 10s (long), IBM Carbon 5s,
+ * Shopify Polaris 5s, Apple HIG 5s, Adobe Spectrum 5s (React) / 6s (Web
+ * Components a11y minimum), Microsoft Fluent 2 7s, Atlassian AutoDismissFlag
+ * 8s. The cluster centres on 5–8s, so:
+ *   - error/warning 8s — Atlassian's ceiling; the types where users most need
+ *     reading time, kept at the top of the range rather than above it.
+ *   - info 6s — Spectrum Web Components' accessibility minimum.
+ *   - success 5s — the cross-system consensus for confirmations.
+ * When a toast fires, the persistent inbox is the WCAG 2.2.1 conforming
+ * alternative — users who miss a toast can always recover it from the
+ * notification center. When no toast is shown (priority "low"), the inbox is
+ * the primary channel and carries no compliance load.
  *
  * Action-bearing toasts override this to `0` (sticky) so the action remains
  * available; explicit `duration` on the payload always wins.
  */
 export const TOAST_DURATION: Record<NotificationType, number> = {
-  error: 12000,
-  warning: 12000,
+  error: 8000,
+  warning: 8000,
   success: 5000,
-  info: 8000,
+  info: 6000,
 };
 
 export interface CoalesceOptions {


### PR DESCRIPTION
## Summary

- Lowered `TOAST_DURATION` defaults in `src/lib/notify.ts`: error and warning 12s → 8s, info 8s → 6s, success unchanged at 5s
- Values now match published design-system benchmarks: Atlassian `AutoDismissFlag` 8s ceiling for error/warning, Adobe Spectrum 6s a11y minimum for info, 5s cross-system consensus for success
- Rewrote the `TOAST_DURATION` JSDoc to cite those actual numbers; kept the WCAG 2.2.1 durable-inbox framing and the action-bearing-sticky note

Resolves #9009

## Changes

- `src/lib/notify.ts` — updated `TOAST_DURATION` values and rewrote the JSDoc comment to cite real design-system sources
- `src/components/ui/toaster.tsx` — reframed the `MAX_VISIBLE_DURATION_MS` (15000) comment as a safety net for coalesced bursts / over-length explicit durations, not a routine clamp
- `src/lib/__tests__/notify.test.ts` — updated literal assertions (8s error/warning, 6s info) to match new defaults
- `src/components/ui/__tests__/toaster.test.tsx` — updated error-default timing assertion (12s → 8s)
- Three explicit `duration: 12000` callers in `watchNotification.ts` and `lifecycle.ts` are out of scope — all action-bearing/sticky

## Testing

260 tests pass; typecheck, lint, and format all clean.