### PR TITLE
fix(fleet-preview): keep enter cue invisible under performance-mode + add coverage

### DIFF
--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -896,5 +896,45 @@ describe("PanelHeader", () => {
       expect(header?.getAttribute("data-selected")).toBe("true");
       expect(header?.className).toContain("bg-overlay-subtle");
     });
+
+    it("still renders the overlay when the pane is focused", () => {
+      // A focused, previewed pane gets bg-overlay-subtle via the isFocused
+      // branch — the overlay must not be gated on focus/selection state.
+      const { container } = render(
+        <PanelHeader {...makeProps({ isFleetPreviewed: true, isFocused: true })} />
+      );
+      expect(container.querySelector(".fleet-preview-enter-overlay")).not.toBeNull();
+    });
+
+    it("mounts/unmounts the overlay across preview enter→exit→enter, replaying the cue", () => {
+      const { container, rerender } = render(
+        <PanelHeader {...makeProps({ isFleetPreviewed: false })} />
+      );
+      expect(container.querySelector(".fleet-preview-enter-overlay")).toBeNull();
+
+      rerender(<PanelHeader {...makeProps({ isFleetPreviewed: true })} />);
+      const first = container.querySelector(".fleet-preview-enter-overlay");
+      expect(first).not.toBeNull();
+
+      rerender(<PanelHeader {...makeProps({ isFleetPreviewed: false })} />);
+      expect(container.querySelector(".fleet-preview-enter-overlay")).toBeNull();
+
+      // Re-entering remounts a fresh node so the one-shot animation replays.
+      rerender(<PanelHeader {...makeProps({ isFleetPreviewed: true })} />);
+      const second = container.querySelector(".fleet-preview-enter-overlay");
+      expect(second).not.toBeNull();
+      expect(second).not.toBe(first);
+    });
+
+    it("syncs the data-fleet-previewed attribute with the preview state", () => {
+      const { container, rerender } = render(
+        <PanelHeader {...makeProps({ isFleetPreviewed: true })} />
+      );
+      const header = container.querySelector("[data-pane-chrome]");
+      expect(header?.getAttribute("data-fleet-previewed")).toBe("true");
+
+      rerender(<PanelHeader {...makeProps({ isFleetPreviewed: false })} />);
+      expect(header?.hasAttribute("data-fleet-previewed")).toBe(false);
+    });
   });
 });

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -868,4 +868,33 @@ describe("PanelHeader", () => {
       expect(cls).toContain("focus:outline-hidden");
     });
   });
+
+  describe("fleet preview kinetic cue", () => {
+    it("renders the preview-enter overlay when isFleetPreviewed is true", () => {
+      const { container } = render(<PanelHeader {...makeProps({ isFleetPreviewed: true })} />);
+      const overlay = container.querySelector(".fleet-preview-enter-overlay");
+      expect(overlay).not.toBeNull();
+      expect(overlay?.getAttribute("aria-hidden")).toBe("true");
+    });
+
+    it("does not render the overlay when isFleetPreviewed is false", () => {
+      const { container } = render(<PanelHeader {...makeProps({ isFleetPreviewed: false })} />);
+      expect(container.querySelector(".fleet-preview-enter-overlay")).toBeNull();
+    });
+
+    it("coexists with the selected state without replacing the selected background", () => {
+      // isFocused: false isolates the bg cascade so isSelected wins the class
+      // (bg-overlay-subtle) — the kinetic overlay is additive, not a replacement.
+      const { container } = render(
+        <PanelHeader
+          {...makeProps({ isFleetPreviewed: true, isSelected: true, isFocused: false })}
+        />
+      );
+      const overlay = container.querySelector(".fleet-preview-enter-overlay");
+      expect(overlay).not.toBeNull();
+      const header = container.querySelector("[data-pane-chrome]");
+      expect(header?.getAttribute("data-selected")).toBe("true");
+      expect(header?.className).toContain("bg-overlay-subtle");
+    });
+  });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -1575,8 +1575,13 @@ body,
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background-color: color-mix(in oklch, var(--theme-tint) 20%, transparent);
-  animation: fleet-preview-enter 150ms cubic-bezier(0.4, 0, 0.2, 1) 1 both;
+  border-radius: inherit;
+  /* opacity: 0 rest state — the keyframe drives the pulse, and this keeps the
+   * overlay invisible when the animation is killed (data-performance-mode
+   * wildcard sets `animation: none`), avoiding a frozen static tint. */
+  opacity: 0;
+  background: color-mix(in oklch, var(--theme-tint) 12%, transparent);
+  animation: fleet-preview-enter 200ms cubic-bezier(0.4, 0, 0.2, 1) 1 both;
   will-change: opacity;
   z-index: 2;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1580,8 +1580,8 @@ body,
    * overlay invisible when the animation is killed (data-performance-mode
    * wildcard sets `animation: none`), avoiding a frozen static tint. */
   opacity: 0;
-  background: color-mix(in oklch, var(--theme-tint) 12%, transparent);
-  animation: fleet-preview-enter 200ms cubic-bezier(0.4, 0, 0.2, 1) 1 both;
+  background-color: color-mix(in oklch, var(--theme-tint) 20%, transparent);
+  animation: fleet-preview-enter 150ms cubic-bezier(0.4, 0, 0.2, 1) 1 both;
   will-change: opacity;
   z-index: 2;
 }


### PR DESCRIPTION
The kinetic fleet-preview enter cue from #8995 already landed on `develop` (commit `d97774d3`). This branch was developed in parallel and rebased on top, so it's a small hardening + test follow-up rather than the feature itself.

## What this adds on top of develop

- **`opacity: 0` rest state on `.fleet-preview-enter-overlay`** — under `data-performance-mode` the global `body[data-performance-mode="true"] *` wildcard sets `animation: none`, which left the overlay's `background-color` painting as a permanently-visible static tint for as long as `isFleetPreviewed` was true. Adding an `opacity: 0` rest state keeps the overlay invisible when the keyframe is suppressed (mirrors how the reduce-motion block already nulls it), so performance-mode users see a clean header instead of a frozen tint.
- **`border-radius: inherit`** — clipping parity with the sibling `.fleet-exit-pulse-overlay`; harmless today (the header isn't rounded) and future-proof if it ever gains rounded corners.
- **6 `PanelHeader` tests** — the merged cue shipped without coverage. These assert the overlay is present when `isFleetPreviewed` is true (and `aria-hidden`), absent when false, coexists with the selected and focused background states without replacing them, remounts a fresh node across enter→exit→enter so the one-shot animation replays, and that `data-fleet-previewed` stays in sync.

Greg's merged design values (20% tint, 150ms) are preserved — this PR deliberately does not re-tune them.

Net diff vs `develop`: ~9 lines of CSS and the new test block.