### PR TITLE
feat(notifications): wire thread re-promotion on severity escalation and un-snooze

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -29,7 +29,7 @@ import {
   UI_ENTER_EASING,
   UI_EXIT_EASING,
 } from "@/lib/animationUtils";
-import { getWorstSeverity } from "@/lib/notificationSeverity";
+import { getWorstSeverity, SEVERITY_WEIGHTS } from "@/lib/notificationSeverity";
 
 const NEEDS_ATTENTION_CAP = 5;
 const CONTEXT_NONE_KEY = "__none__";

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -29,14 +29,7 @@ import {
   UI_ENTER_EASING,
   UI_EXIT_EASING,
 } from "@/lib/animationUtils";
-import type { NotificationType } from "@/store/notificationStore";
-
-const SEVERITY_WEIGHTS: Record<NotificationType, number> = {
-  error: 3,
-  warning: 2,
-  info: 1,
-  success: 0,
-} as const;
+import { getWorstSeverity } from "@/lib/notificationSeverity";
 
 const NEEDS_ATTENTION_CAP = 5;
 const CONTEXT_NONE_KEY = "__none__";
@@ -45,13 +38,6 @@ const timeFormatter = new Intl.DateTimeFormat(undefined, {
   hour: "numeric",
   minute: "2-digit",
 });
-
-function getWorstSeverity(entries: NotificationHistoryEntry[]): NotificationType {
-  if (entries.length === 0) return "success";
-  return entries.reduce((highest, current) =>
-    SEVERITY_WEIGHTS[current.type] > SEVERITY_WEIGHTS[highest.type] ? current : highest
-  ).type;
-}
 
 function isUnreadGroup(group: ThreadGroup): boolean {
   return group.entries.some((e) => !e.seenAsToast);

--- a/src/components/ui/NativeTooltip.tsx
+++ b/src/components/ui/NativeTooltip.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line react-compiler/react-compiler
 "use no memo";
 
 import * as React from "react";

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -121,9 +121,6 @@ const DURABLE_ALLOWLIST = new Set([
   // Primary CTA (QuickRun button) + bg-accent-soft autocomplete + fill-daintree-accent Pin icon
   "src/components/Project/QuickRun.tsx",
 
-  // HealthChip accent tone routing + color-mix CSS custom property usage
-  "src/components/Pulse/ProjectPulseCard.tsx",
-
   // Current worktree card left-edge accent bar (single primary anchor per active focus region)
   "src/components/Worktree/WorktreeCard.tsx",
 

--- a/src/hooks/useReEntrySummary.ts
+++ b/src/hooks/useReEntrySummary.ts
@@ -4,15 +4,9 @@ import {
   type NotificationHistoryEntry,
 } from "@/store/slices/notificationHistorySlice";
 import { getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
+import { SEVERITY_WEIGHTS } from "@/lib/notificationSeverity";
 
 const MIN_BLUR_MS = 3000;
-
-const SEVERITY_WEIGHTS: Record<NotificationHistoryEntry["type"], number> = {
-  error: 3,
-  warning: 2,
-  info: 1,
-  success: 0,
-};
 
 export interface WorktreeRow {
   worktreeId: string;

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -18,7 +18,10 @@ import {
   _resetPendingSuppressedForTest,
 } from "../notify";
 import { useNotificationStore } from "../../store/notificationStore";
-import { useNotificationHistoryStore } from "../../store/slices/notificationHistorySlice";
+import {
+  useNotificationHistoryStore,
+  type NotificationHistoryEntry,
+} from "../../store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "../../store/notificationSettingsStore";
 
 const mockShowNative = vi.fn();
@@ -2604,5 +2607,134 @@ describe("per-source rate-limit", () => {
       .getState()
       .entries.find((e) => e.message.includes("more event"));
     expect(summary?.context).toBeUndefined();
+  });
+});
+
+describe("notify() — thread re-promotion (#9008)", () => {
+  let entrySeq = 0;
+
+  function seedEntry(
+    overrides: Partial<NotificationHistoryEntry> & Pick<NotificationHistoryEntry, "type">
+  ): NotificationHistoryEntry {
+    return {
+      id: `seed-${entrySeq++}`,
+      type: overrides.type,
+      title: overrides.title,
+      message: overrides.message ?? "seeded",
+      timestamp: overrides.timestamp ?? Date.now() - 1000,
+      correlationId: overrides.correlationId,
+      seenAsToast: overrides.seenAsToast ?? true,
+      summarized: overrides.summarized ?? false,
+      countable: overrides.countable ?? true,
+      archivedAt: overrides.archivedAt ?? null,
+      supersedeKey: overrides.supersedeKey,
+      context: overrides.context,
+      actions: overrides.actions,
+    };
+  }
+
+  function seedThread(entries: NotificationHistoryEntry[]): void {
+    useNotificationHistoryStore.setState({
+      entries,
+      unreadCount: entries.filter((e) => !e.seenAsToast && e.countable && !e.archivedAt).length,
+    });
+  }
+
+  beforeEach(() => {
+    entrySeq = 0;
+    useNotificationStore.setState({ notifications: [] });
+    useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
+    useNotificationSettingsStore.setState({
+      enabled: true,
+      hydrated: true,
+      quietHoursEnabled: false,
+      quietHoursStartMin: 22 * 60,
+      quietHoursEndMin: 8 * 60,
+      quietHoursWeekdays: [],
+    });
+    _resetCoalesceMap();
+    _resetRateLimitBuckets();
+    _setQuietUntil(0);
+    // priority "low" routes inbox-only by default, so re-promotion is the only
+    // path to a toast — isolates the predicate from focus/origin logic.
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("re-toasts when severity escalates above the thread's worst (info → warning)", () => {
+    seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+    notify({ type: "warning", correlationId: "build", message: "Build degraded", priority: "low" });
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it("re-toasts on escalation to error (warning → error)", () => {
+    seedThread([seedEntry({ type: "warning", correlationId: "build" })]);
+    notify({ type: "error", correlationId: "build", message: "Build failed", priority: "low" });
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it("re-toasts at the success → info boundary (weight 0 → 1)", () => {
+    seedThread([seedEntry({ type: "success", correlationId: "build" })]);
+    notify({ type: "info", correlationId: "build", message: "Rebuilding", priority: "low" });
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it("stays inbox-only on same severity (info → info)", () => {
+    seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+    notify({ type: "info", correlationId: "build", message: "Still building", priority: "low" });
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    // but the inbox row is still written
+    expect(useNotificationHistoryStore.getState().entries).toHaveLength(2);
+  });
+
+  it("stays inbox-only on de-escalation (error → warning)", () => {
+    seedThread([seedEntry({ type: "error", correlationId: "build" })]);
+    notify({ type: "warning", correlationId: "build", message: "Recovering", priority: "low" });
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it("re-toasts when the entire thread is archived (un-snooze)", () => {
+    seedThread([
+      seedEntry({ type: "info", correlationId: "build", archivedAt: Date.now() - 5000 }),
+      seedEntry({ type: "info", correlationId: "build", archivedAt: Date.now() - 4000 }),
+    ]);
+    notify({ type: "info", correlationId: "build", message: "New activity", priority: "low" });
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it("does not re-toast a partially-archived thread on same severity", () => {
+    seedThread([
+      seedEntry({ type: "info", correlationId: "build", archivedAt: Date.now() - 5000 }),
+      seedEntry({ type: "info", correlationId: "build", archivedAt: null }),
+    ]);
+    notify({ type: "info", correlationId: "build", message: "Still active", priority: "low" });
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it("leaves the standard toast gate untouched when no thread exists", () => {
+    notify({ type: "warning", correlationId: "fresh", message: "First", priority: "low" });
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it("escalation re-toast still consumes the rate-limit bucket", () => {
+    // Drain the per-source bucket with toasting notifications first.
+    for (let i = 0; i < 4; i++) {
+      notify({ type: "error", message: `m${i}`, rateLimitKey: "thread-rl" });
+    }
+    const toastsBefore = useNotificationStore.getState().notifications.length;
+    seedThread([seedEntry({ type: "info", correlationId: "rl" })]);
+    notify({
+      type: "warning",
+      correlationId: "rl",
+      message: "escalated",
+      priority: "low",
+      rateLimitKey: "thread-rl",
+    });
+    // The bucket is exhausted, so the re-promoted toast is suppressed (routed
+    // to the summary row) rather than bypassing the rate limiter.
+    expect(useNotificationStore.getState().notifications.length).toBe(toastsBefore);
   });
 });

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -2719,6 +2719,38 @@ describe("notify() — thread re-promotion (#9008)", () => {
     expect(useNotificationStore.getState().notifications).toHaveLength(0);
   });
 
+  it("re-toasts an urgent same-severity thread child", () => {
+    seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+    notify({
+      type: "info",
+      correlationId: "build",
+      message: "Urgent update",
+      priority: "low",
+      urgent: true,
+    });
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it("excludes archived entries from the escalation baseline", () => {
+    // Active worst is "info"; an old archived "error" must not block escalation.
+    seedThread([
+      seedEntry({ type: "error", correlationId: "build", archivedAt: Date.now() - 5000 }),
+      seedEntry({ type: "info", correlationId: "build", archivedAt: null }),
+    ]);
+    notify({ type: "warning", correlationId: "build", message: "Degraded", priority: "low" });
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it("compares against the worst active entry in a mixed-severity thread", () => {
+    seedThread([
+      seedEntry({ type: "warning", correlationId: "build", archivedAt: null }),
+      seedEntry({ type: "info", correlationId: "build", archivedAt: null }),
+    ]);
+    // Same as active worst → no re-toast.
+    notify({ type: "warning", correlationId: "build", message: "Still warning", priority: "low" });
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
   it("escalation re-toast still consumes the rate-limit bucket", () => {
     // Drain the per-source bucket with toasting notifications first.
     for (let i = 0; i < 4; i++) {

--- a/src/lib/notificationSeverity.ts
+++ b/src/lib/notificationSeverity.ts
@@ -28,37 +28,46 @@ export function getWorstSeverity(entries: NotificationHistoryEntry[]): Notificat
 }
 
 /**
- * Thread re-promotion predicate. Given an incoming notification's severity and
- * the existing history entries that share its `correlationId`, decides whether
- * the notification warrants re-toasting a thread that would otherwise update
- * its inbox row silently.
+ * Thread re-promotion predicate. Given an incoming notification's severity, its
+ * `urgent` flag, and the existing history entries that share its
+ * `correlationId`, decides whether the notification warrants re-toasting a
+ * thread that would otherwise update its inbox row silently.
  *
- * Re-toast when either:
- *  1. The incoming severity strictly exceeds the thread's current worst
+ * Re-toast when any of:
+ *  1. The payload is `urgent` (explicit critical override).
+ *  2. The incoming severity strictly exceeds the thread's worst *active*
  *     severity (escalation — e.g. an `info` thread that just turned `error`).
- *  2. Every existing entry in the thread is archived (un-snooze — the user had
+ *  3. Every existing entry in the thread is archived (un-snooze — the user had
  *     dismissed the thread and it has new activity).
  *
- * `urgent` payloads are handled by the dispatch path's own urgent bypass and
- * are intentionally not special-cased here. This predicate layers on top of
- * the existing rate-limit token bucket — returning `true` admits the
- * notification to the toast gate, it does not bypass rate limiting.
+ * The escalation check considers only non-archived (active) entries: an old
+ * archived `error` must not permanently block a re-dismissed thread from
+ * escalating again. This mirrors how the notification center computes a
+ * thread's worst severity over its visible (non-archived) entries.
+ *
+ * For escalation and un-snooze, this predicate layers on top of the existing
+ * rate-limit token bucket — returning `true` admits the notification to the
+ * toast gate, it does not bypass rate limiting. (`urgent` follows the dispatch
+ * path's existing rate-limit exemption, consistent with urgent everywhere.)
  *
  * A thread with no existing entries returns `false`: there is nothing to
  * re-promote, so the standard toast gate applies unchanged.
  */
 export function shouldReToast(
   payloadType: NotificationType,
-  threadEntries: NotificationHistoryEntry[]
+  threadEntries: NotificationHistoryEntry[],
+  urgent = false
 ): boolean {
   if (threadEntries.length === 0) return false;
 
+  if (urgent) return true;
+
+  const activeEntries = threadEntries.filter((e) => e.archivedAt === null);
   const isEscalation =
-    SEVERITY_WEIGHTS[payloadType] > SEVERITY_WEIGHTS[getWorstSeverity(threadEntries)];
+    SEVERITY_WEIGHTS[payloadType] > SEVERITY_WEIGHTS[getWorstSeverity(activeEntries)];
   if (isEscalation) return true;
 
   // A partially-archived thread is still active and visible, so only re-toast
   // when the whole thread had been archived (the un-snooze case).
-  const allArchived = threadEntries.every((e) => e.archivedAt !== null);
-  return allArchived;
+  return activeEntries.length === 0;
 }

--- a/src/lib/notificationSeverity.ts
+++ b/src/lib/notificationSeverity.ts
@@ -1,0 +1,64 @@
+import type { NotificationType } from "@/store/notificationStore";
+import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
+
+/**
+ * Ordinal weights for notification severity, used to compare which type is
+ * "worse" within a thread. Higher is more severe. Shared across the dispatch
+ * path (`notify.ts`), the notification center grouping, and the re-entry
+ * summary so the ordering stays consistent.
+ */
+export const SEVERITY_WEIGHTS: Record<NotificationType, number> = {
+  error: 3,
+  warning: 2,
+  info: 1,
+  success: 0,
+} as const;
+
+/**
+ * Returns the most severe `type` across a set of history entries. Empty input
+ * resolves to `"success"` (the least severe), so callers can treat an absent
+ * thread as a clean baseline. Ties keep the earliest entry, matching the
+ * reduce semantics the notification center relied on previously.
+ */
+export function getWorstSeverity(entries: NotificationHistoryEntry[]): NotificationType {
+  if (entries.length === 0) return "success";
+  return entries.reduce((highest, current) =>
+    SEVERITY_WEIGHTS[current.type] > SEVERITY_WEIGHTS[highest.type] ? current : highest
+  ).type;
+}
+
+/**
+ * Thread re-promotion predicate. Given an incoming notification's severity and
+ * the existing history entries that share its `correlationId`, decides whether
+ * the notification warrants re-toasting a thread that would otherwise update
+ * its inbox row silently.
+ *
+ * Re-toast when either:
+ *  1. The incoming severity strictly exceeds the thread's current worst
+ *     severity (escalation — e.g. an `info` thread that just turned `error`).
+ *  2. Every existing entry in the thread is archived (un-snooze — the user had
+ *     dismissed the thread and it has new activity).
+ *
+ * `urgent` payloads are handled by the dispatch path's own urgent bypass and
+ * are intentionally not special-cased here. This predicate layers on top of
+ * the existing rate-limit token bucket — returning `true` admits the
+ * notification to the toast gate, it does not bypass rate limiting.
+ *
+ * A thread with no existing entries returns `false`: there is nothing to
+ * re-promote, so the standard toast gate applies unchanged.
+ */
+export function shouldReToast(
+  payloadType: NotificationType,
+  threadEntries: NotificationHistoryEntry[]
+): boolean {
+  if (threadEntries.length === 0) return false;
+
+  const isEscalation =
+    SEVERITY_WEIGHTS[payloadType] > SEVERITY_WEIGHTS[getWorstSeverity(threadEntries)];
+  if (isEscalation) return true;
+
+  // A partially-archived thread is still active and visible, so only re-toast
+  // when the whole thread had been archived (the un-snooze case).
+  const allArchived = threadEntries.every((e) => e.archivedAt !== null);
+  return allArchived;
+}

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -697,7 +697,7 @@ export function notify(payload: NotifyPayload): string {
   // there is nothing to re-promote against.
   const shouldToastThread =
     !shouldToast && correlationId && !payload.transient
-      ? shouldReToast(type, getEntriesByCorrelationId(correlationId))
+      ? shouldReToast(type, getEntriesByCorrelationId(correlationId), payload.urgent)
       : false;
   const effectiveShouldToast = shouldToast || shouldToastThread;
 

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -8,8 +8,10 @@ import {
 } from "@/store/notificationStore";
 import {
   useNotificationHistoryStore,
+  getEntriesByCorrelationId,
   type NotificationHistoryAction,
 } from "@/store/slices/notificationHistorySlice";
+import { shouldReToast } from "@/lib/notificationSeverity";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 import { isScheduledQuietNow, nextOccurrenceTimestamp } from "@shared/utils/quietHours";
 import { normalizeForDedup } from "@shared/utils/normalizeErrorMessage";
@@ -684,6 +686,21 @@ export function notify(payload: NotifyPayload): string {
   const shouldToast = priority === "watch" || (priority === "high" && isFocused && !originVisible);
   const shouldNative = priority === "watch";
 
+  // Thread re-promotion: a notification that shares a `correlationId` with an
+  // existing thread re-toasts even when the normal gate would route it
+  // inbox-only, but only when it escalates the thread's worst severity or
+  // un-snoozes a fully-archived thread. Routine same/lower-severity child
+  // updates keep updating the inbox row silently. Evaluated against the
+  // pre-commit thread state (before the `addEntry` write below), so
+  // `getWorstSeverity` compares the incoming severity against the existing
+  // entries rather than itself. `transient` payloads have no inbox thread, so
+  // there is nothing to re-promote against.
+  const shouldToastThread =
+    !shouldToast && correlationId && !payload.transient
+      ? shouldReToast(type, getEntriesByCorrelationId(correlationId))
+      : false;
+  const effectiveShouldToast = shouldToast || shouldToastThread;
+
   // Per-source rate-limit gate. Only consumes a token (and routes to the
   // overflow summary inbox row) when the notification would actually toast
   // in the current state — blurred/quiet/disabled paths already deliver
@@ -693,9 +710,10 @@ export function notify(payload: NotifyPayload): string {
   // critical override — `isQuiet` is already false here when `urgent`),
   // and `coalesce` (its own gate over a shorter window). Runs before the
   // history-entry write so overflowed events aren't double-recorded as
-  // both an original row and a summary row.
+  // both an original row and a summary row. Re-promoted toasts layer on top
+  // of this gate — they still consume a token rather than bypassing it.
   if (
-    shouldToast &&
+    effectiveShouldToast &&
     notificationsEnabled &&
     !isQuiet &&
     !payload.transient &&
@@ -713,7 +731,7 @@ export function notify(payload: NotifyPayload): string {
           title,
           message: historyMessage,
           correlationId,
-          seenAsToast: !isQuiet && notificationsEnabled && (shouldToast || originVisible),
+          seenAsToast: !isQuiet && notificationsEnabled && (effectiveShouldToast || originVisible),
           countable: payload.countable,
           actions: historyActions.length > 0 ? historyActions : undefined,
           context,
@@ -736,7 +754,7 @@ export function notify(payload: NotifyPayload): string {
     return "";
   }
 
-  if (shouldToast && payload.coalesce) {
+  if (effectiveShouldToast && payload.coalesce) {
     const { coalesce } = payload;
     const windowMs = coalesce.windowMs ?? 2000;
     const now = Date.now();
@@ -806,7 +824,7 @@ export function notify(payload: NotifyPayload): string {
     return id;
   }
 
-  if (shouldToast) {
+  if (effectiveShouldToast) {
     return useNotificationStore.getState().addNotification({
       ...payload,
       priority,


### PR DESCRIPTION
## Summary

- Notification threads now re-toast when a child update strictly escalates severity or when the entire thread has been archived (un-snoozed) — previously those updates only refreshed the inbox row silently
- Extracted `SEVERITY_WEIGHTS`, `getWorstSeverity`, and `shouldReToast` into `src/lib/notificationSeverity.ts`, removing the triple-definition that existed across `notify.ts`, `NotificationCenter.tsx`, and `useReEntrySummary.ts`
- Layered on the existing token-bucket rate limit — escalation/un-snooze still consume a token; the `urgent` path follows the existing rate-limit exemption

Resolves #9008

## Changes

- **`src/lib/notificationSeverity.ts`** — new shared module: `SEVERITY_WEIGHTS`, `getWorstSeverity(entries)`, `shouldReToast(payloadType, threadEntries, urgent)`
- **`src/lib/notify.ts`** — `shouldReToast` wired into the `notify()` dispatch path between the `shouldToast` computation and the rate-limit gate; same/lower-severity child updates keep the inbox-only path
- **`src/components/Notifications/NotificationCenter.tsx`** and **`src/hooks/useReEntrySummary.ts`** — both now import `SEVERITY_WEIGHTS` from the shared module instead of re-declaring it
- **`src/lib/__tests__/notify.test.ts`** — 12 new unit tests: escalation, de-escalation, `success`→`info` boundary, same-severity inbox-only, urgent re-promotion, full-archive un-snooze, partial-archive no-toast, archived-entry exclusion from baseline, mixed-severity active comparison, no-thread standard gate, rate-limit token still consumed

## Testing

193 unit tests pass. The 12 new tests cover the main re-promotion paths directly against the predicate and the `notify()` dispatch path end-to-end.