### PR TITLE
feat(notify): centralize routing in EventKind policy manifest

### DIFF
--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1166,
+  "count": 1224,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
-    "@typescript-eslint/no-unsafe-type-assertion": 483,
+    "@typescript-eslint/no-unsafe-type-assertion": 484,
     "no-restricted-imports": 51,
-    "no-restricted-syntax": 360,
+    "no-restricted-syntax": 418,
     "no-useless-assignment": 20,
     "preserve-caught-error": 50,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 38
   },
-  "updatedAt": "2026-05-24T16:20:33.038Z"
+  "updatedAt": "2026-05-24T19:10:49.597Z"
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -453,6 +453,26 @@ export default tseslint.config(
             'Unprotected success toast. Success is over-used — fires on routine in-place state changes users can already see. Add one of: `transient: true` (one-shot, no inbox row), `priority: "low"` (history-only), or a `correlationId` (threads into an existing notification group). Or annotate with `// eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok` when the call is deliberate. See #8249.',
         },
         {
+          // why: routing each notify() through the EVENT_POLICY manifest needs a
+          // `context.eventKind` so the dispatcher can resolve priority/placement/
+          // duration centrally instead of re-deriving them per call site. Flags
+          // inline-literal notify()/addNotification() calls missing
+          // context.eventKind. Skips spread-bearing payloads (`notify({
+          // ...payload })`) and variable-reference contexts (`context: ctxVar`)
+          // since neither can be statically verified — those plus the ~74 legacy
+          // sites annotate with `// eslint-disable-next-line no-restricted-syntax
+          // -- notify-event-kind: ok` until migrated. See #9007.
+          // NOTE: the eventKind `:has()` clause intentionally omits the leading
+          // `>` before the `context` property — esquery in this version
+          // mishandles a child combinator followed by a descendant chain inside
+          // `:has(> A > B > C)`, silently matching nothing. The SpreadElement and
+          // Identifier-context guards keep their `>` since they're single-level.
+          selector:
+            "CallExpression:matches([callee.name=/^(notify|addNotification)$/], [callee.property.name=/^(notify|addNotification)$/]) > ObjectExpression:not(:has(> SpreadElement)):not(:has(Property[key.name='context'] > ObjectExpression > Property[key.name='eventKind'])):not(:has(> Property[key.name='context'][value.type='Identifier']))",
+          message:
+            'notify() call missing context.eventKind — add `context: { eventKind: "<kind>" }` so EVENT_POLICY can route it, or annotate with `// eslint-disable-next-line no-restricted-syntax -- notify-event-kind: ok` for legacy sites. See #9007.',
+        },
+        {
           selector:
             "JSXAttribute[name.name='dangerouslySetInnerHTML'] > JSXExpressionContainer > ObjectExpression > Property[key.name='__html']:not(:has(CallExpression))",
           message:

--- a/src/hooks/useDiskSpaceWarnings.ts
+++ b/src/hooks/useDiskSpaceWarnings.ts
@@ -27,6 +27,7 @@ export function useDiskSpaceWarnings(): void {
           supersedeKey: DISK_SPACE_SUPERSEDE_KEY,
           title: "Disk space restored",
           message: "Disk space is back to normal.",
+          context: { eventKind: "host" },
         });
         return;
       }
@@ -50,6 +51,7 @@ export function useDiskSpaceWarnings(): void {
           title: "Critical: Disk space very low",
           message: `Only ${mb} MB remaining. Session backups and terminal snapshots have been paused. Free disk space immediately.`,
           inboxMessage: `Critical disk space: ${mb} MB remaining. Writes paused.`,
+          context: { eventKind: "host" },
         });
       } else {
         notify({
@@ -62,6 +64,7 @@ export function useDiskSpaceWarnings(): void {
           title: "Low disk space",
           message: `${mb} MB remaining on the application data volume. Free disk space to avoid data loss.`,
           inboxMessage: `Low disk space: ${mb} MB remaining.`,
+          context: { eventKind: "host" },
         });
       }
     });

--- a/src/hooks/useGitHubTokenExpiryNotification.ts
+++ b/src/hooks/useGitHubTokenExpiryNotification.ts
@@ -33,6 +33,7 @@ export function useGitHubTokenExpiryNotification(isTokenError: boolean): void {
           "Your GitHub token isn't working. Reconnect in settings to restore issues, PRs, and stats.",
         correlationId: "github:token-expiry",
         supersedeKey: GITHUB_TOKEN_SUPERSEDE_KEY,
+        context: { eventKind: "connectivity" },
         coalesce: {
           key: "github:token-expiry",
           windowMs: 30000,
@@ -68,6 +69,7 @@ export function useGitHubTokenExpiryNotification(isTokenError: boolean): void {
           supersedeKey: GITHUB_TOKEN_SUPERSEDE_KEY,
           title: "GitHub token validated",
           message: "Your GitHub token is working again.",
+          context: { eventKind: "connectivity" },
         });
       }
     }

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -4,6 +4,10 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import {
   notify,
   TOAST_DURATION,
+  EVENT_POLICY,
+  EVENT_KIND_LABEL,
+  EVENT_KIND_TO_SETTING_KEY,
+  type NotificationEventKind,
   _resetCoalesceMap,
   _resetEscalationTrackers,
   _resetRateLimitBuckets,
@@ -2768,5 +2772,160 @@ describe("notify() — thread re-promotion (#9008)", () => {
     // The bucket is exhausted, so the re-promoted toast is suppressed (routed
     // to the summary row) rather than bypassing the rate limiter.
     expect(useNotificationStore.getState().notifications.length).toBe(toastsBefore);
+  });
+});
+
+describe("EVENT_POLICY manifest routing", () => {
+  const ALL_EVENT_KINDS: NotificationEventKind[] = [
+    "completed",
+    "waiting",
+    "workingPulse",
+    "uiFeedback",
+    "agent",
+    "git",
+    "host",
+    "recovery",
+    "settings",
+    "connectivity",
+  ];
+
+  beforeEach(() => {
+    useNotificationStore.setState({ notifications: [] });
+    useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
+    useNotificationSettingsStore.setState({
+      enabled: true,
+      hydrated: true,
+      quietHoursEnabled: false,
+      quietHoursStartMin: 22 * 60,
+      quietHoursEndMin: 8 * 60,
+      quietHoursWeekdays: [],
+    });
+    _resetCoalesceMap();
+    _resetRateLimitBuckets();
+    _setQuietUntil(0);
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("completeness", () => {
+    it("defines a policy and label for every event kind", () => {
+      for (const kind of ALL_EVENT_KINDS) {
+        expect(EVENT_POLICY[kind]).toBeDefined();
+        expect(EVENT_KIND_LABEL[kind]).toBeTruthy();
+      }
+    });
+
+    it("maps only the silenceable kinds to a settings key", () => {
+      expect(EVENT_KIND_TO_SETTING_KEY.completed).toBe("completedEnabled");
+      expect(EVENT_KIND_TO_SETTING_KEY.waiting).toBe("waitingEnabled");
+      expect(EVENT_KIND_TO_SETTING_KEY.workingPulse).toBe("workingPulseEnabled");
+      expect(EVENT_KIND_TO_SETTING_KEY.uiFeedback).toBe("uiFeedbackSoundEnabled");
+      // Routing-only kinds have no persisted silence toggle.
+      expect(EVENT_KIND_TO_SETTING_KEY.host).toBeUndefined();
+      expect(EVENT_KIND_TO_SETTING_KEY.git).toBeUndefined();
+      expect(EVENT_KIND_TO_SETTING_KEY.recovery).toBeUndefined();
+      expect(EVENT_KIND_TO_SETTING_KEY.connectivity).toBeUndefined();
+    });
+  });
+
+  describe("priority resolution", () => {
+    it("resolves an active kind to a high-priority toast when none supplied", () => {
+      notify({ type: "info", message: "Git push done", context: { eventKind: "git" } });
+      const active = useNotificationStore.getState().notifications;
+      expect(active).toHaveLength(1);
+      expect(active[0]!.priority).toBe("high");
+    });
+
+    it("resolves a passive kind to inbox-only (low priority)", () => {
+      notify({ type: "info", message: "Setting saved", context: { eventKind: "settings" } });
+      // Low priority routes to the inbox only — no active toast.
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(1);
+    });
+
+    it("lets an explicit caller priority win over the policy default", () => {
+      // git policy → high, but the caller pins low, so it must route to inbox only.
+      notify({
+        type: "info",
+        message: "Quiet git note",
+        priority: "low",
+        context: { eventKind: "git" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(1);
+    });
+  });
+
+  describe("urgent / quiet-gate resolution", () => {
+    it("bypasses the quiet gate for a time-sensitive kind", () => {
+      _setQuietUntil(Date.now() + 60_000);
+      notify({ type: "warning", message: "Disk low", context: { eventKind: "host" } });
+      // host → time-sensitive → urgent, so the toast fires despite quiet.
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+
+    it("suppresses a non-time-sensitive kind during quiet", () => {
+      _setQuietUntil(Date.now() + 60_000);
+      notify({ type: "info", message: "Git note", context: { eventKind: "git" } });
+      // git → active (no urgent), so quiet suppresses the toast.
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    });
+  });
+
+  describe("duration resolution", () => {
+    it("applies a policy defaultDurationMs when the caller omits duration", () => {
+      notify({ type: "info", message: "Git push done", context: { eventKind: "git" } });
+      const active = useNotificationStore.getState().notifications;
+      expect(active[0]!.duration).toBe(EVENT_POLICY.git.defaultDurationMs);
+    });
+
+    it("lets an explicit caller duration win over the policy default", () => {
+      notify({
+        type: "info",
+        message: "Git push done",
+        duration: 9999,
+        context: { eventKind: "git" },
+      });
+      expect(useNotificationStore.getState().notifications[0]!.duration).toBe(9999);
+    });
+
+    it("keeps action-bearing toasts sticky over the policy default", () => {
+      notify({
+        type: "info",
+        message: "Git push done",
+        context: { eventKind: "git" },
+        action: { label: "View", onClick: () => {} },
+      });
+      // Sticky-action default (0) must win over git's defaultDurationMs.
+      expect(useNotificationStore.getState().notifications[0]!.duration).toBe(0);
+    });
+
+    it("falls through to the per-type default for kinds without a policy duration", () => {
+      // recovery has no defaultDurationMs → per-type warning default applies.
+      notify({ type: "warning", message: "Settings reset", context: { eventKind: "recovery" } });
+      expect(useNotificationStore.getState().notifications[0]!.duration).toBe(
+        TOAST_DURATION.warning
+      );
+    });
+  });
+
+  describe("placement resolution", () => {
+    it("leaves placement unset for auto-surface kinds", () => {
+      notify({ type: "info", message: "Git push done", context: { eventKind: "git" } });
+      expect(useNotificationStore.getState().notifications[0]!.placement).toBeUndefined();
+    });
+  });
+
+  describe("no eventKind is unchanged", () => {
+    it("uses the legacy defaults when no eventKind is present", () => {
+      notify({ type: "info", message: "Plain note" });
+      const active = useNotificationStore.getState().notifications;
+      expect(active).toHaveLength(1);
+      expect(active[0]!.priority).toBe("high");
+      expect(active[0]!.duration).toBe(TOAST_DURATION.info);
+    });
   });
 });

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -2846,6 +2846,16 @@ describe("EVENT_POLICY manifest routing", () => {
       expect(useNotificationHistoryStore.getState().entries).toHaveLength(1);
     });
 
+    it.each(["workingPulse", "uiFeedback"] as const)(
+      "keeps passive sound kind %s inbox-only when no priority supplied",
+      (eventKind) => {
+        // Guards against a passive→active regression that would start toasting.
+        notify({ type: "info", message: "x", context: { eventKind } });
+        expect(useNotificationStore.getState().notifications).toHaveLength(0);
+        expect(useNotificationHistoryStore.getState().entries).toHaveLength(1);
+      }
+    );
+
     it("lets an explicit caller priority win over the policy default", () => {
       // git policy → high, but the caller pins low, so it must route to inbox only.
       notify({

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -18,27 +18,183 @@ import { normalizeForDedup } from "@shared/utils/normalizeErrorMessage";
 import type { ErrorRetryability, ErrorType } from "@/store/errorStore";
 import type { NotificationSettings } from "@shared/types/ipc/api";
 
-export type NotificationEventKind = "completed" | "waiting" | "workingPulse" | "uiFeedback";
+/**
+ * Closed union of routing-relevant notification domains. Kept closed (not
+ * widened with `(string & {})`) on purpose: this is an internal taxonomy, not a
+ * plugin extension point, so the closed union buys compile-time completeness
+ * checks on `EVENT_POLICY` and `EVENT_KIND_LABEL`. The first four are the
+ * historical sound/silence kinds; the rest classify the higher-traffic
+ * notification sources so `notify()` can resolve routing defaults centrally.
+ */
+export type NotificationEventKind =
+  | "completed"
+  | "waiting"
+  | "workingPulse"
+  | "uiFeedback"
+  | "agent"
+  | "git"
+  | "host"
+  | "recovery"
+  | "settings"
+  | "connectivity";
 
-export const EVENT_KIND_TO_SETTING_KEY: Record<NotificationEventKind, keyof NotificationSettings> =
-  {
-    completed: "completedEnabled",
-    waiting: "waitingEnabled",
-    workingPulse: "workingPulseEnabled",
-    uiFeedback: "uiFeedbackSoundEnabled",
-  };
+/**
+ * Baseline interruption level a kind warrants, independent of the per-call
+ * `type`. Maps to a default `priority` (see `INTERRUPTION_TO_PRIORITY`):
+ * `passive` → inbox-only, `active` → toast-when-focused, `time-sensitive` →
+ * toast + bypass the startup quiet gate, `critical` → toast + OS-native banner.
+ */
+export type EventInterruption = "passive" | "active" | "time-sensitive" | "critical";
+
+/**
+ * Declarative routing policy for a notification kind. `notify()` consults this
+ * manifest at dispatch time to fill routing defaults the caller didn't set —
+ * explicit fields on the payload always win. Replaces the per-call-site
+ * four-question checklist with a single typed source of truth.
+ */
+export interface EventPolicy {
+  /** Baseline interruption level → resolved `priority` (+ `urgent` when time-sensitive). */
+  baseInterruption: EventInterruption;
+  /**
+   * Preferred delivery surface. `"auto"` keeps the default priority routing;
+   * `"grid-bar"` pins the signal inline. Limited to real `NotificationPlacement`
+   * values — `"toast"`/`"inbox"`/`"frame"` are not standalone placements.
+   */
+  preferredSurface: "grid-bar" | "auto";
+  /**
+   * Declarative hint: this kind should re-surface as a toast when its severity
+   * escalates. Reserved for future escalation wiring — not behavioral yet.
+   */
+  reToastOnSeverityEscalation: boolean;
+  /** Default auto-dismiss (ms) when the caller omits `duration`; falls through to `TOAST_DURATION[type]`. */
+  defaultDurationMs?: number;
+  /** Persisted user-facing toggle that silences this kind, when one exists. */
+  userOverrideKey?: keyof NotificationSettings;
+}
+
+export const EVENT_POLICY: Record<NotificationEventKind, EventPolicy> = {
+  completed: {
+    baseInterruption: "active",
+    preferredSurface: "auto",
+    reToastOnSeverityEscalation: false,
+    userOverrideKey: "completedEnabled",
+  },
+  waiting: {
+    baseInterruption: "active",
+    preferredSurface: "auto",
+    reToastOnSeverityEscalation: false,
+    userOverrideKey: "waitingEnabled",
+  },
+  workingPulse: {
+    baseInterruption: "passive",
+    preferredSurface: "auto",
+    reToastOnSeverityEscalation: false,
+    userOverrideKey: "workingPulseEnabled",
+  },
+  uiFeedback: {
+    baseInterruption: "passive",
+    preferredSurface: "auto",
+    reToastOnSeverityEscalation: false,
+    userOverrideKey: "uiFeedbackSoundEnabled",
+  },
+  agent: {
+    baseInterruption: "active",
+    preferredSurface: "auto",
+    reToastOnSeverityEscalation: false,
+  },
+  git: {
+    baseInterruption: "active",
+    preferredSurface: "auto",
+    reToastOnSeverityEscalation: false,
+    // Git operation confirmations are brief — shorter than the per-type default.
+    defaultDurationMs: 6000,
+  },
+  host: {
+    baseInterruption: "time-sensitive",
+    preferredSurface: "auto",
+    reToastOnSeverityEscalation: true,
+  },
+  recovery: {
+    baseInterruption: "active",
+    preferredSurface: "auto",
+    reToastOnSeverityEscalation: true,
+  },
+  settings: {
+    baseInterruption: "passive",
+    preferredSurface: "auto",
+    reToastOnSeverityEscalation: false,
+  },
+  connectivity: {
+    baseInterruption: "active",
+    preferredSurface: "auto",
+    reToastOnSeverityEscalation: false,
+  },
+};
+
+/**
+ * Per-kind persisted silence toggle, derived from `EVENT_POLICY` so the
+ * manifest stays the single source of truth. Partial: kinds without a
+ * user-facing setting (the routing-only domains) are absent — consumers must
+ * guard for `undefined`.
+ */
+export const EVENT_KIND_TO_SETTING_KEY: Partial<
+  Record<NotificationEventKind, keyof NotificationSettings>
+> = Object.fromEntries(
+  (Object.entries(EVENT_POLICY) as [NotificationEventKind, EventPolicy][])
+    .filter((entry) => entry[1].userOverrideKey !== undefined)
+    .map(([kind, policy]) => [kind, policy.userOverrideKey])
+) as Partial<Record<NotificationEventKind, keyof NotificationSettings>>;
 
 export const EVENT_KIND_LABEL: Record<NotificationEventKind, string> = {
   completed: "completed notifications",
   waiting: "waiting notifications",
   workingPulse: "working pulse sound",
   uiFeedback: "UI feedback sounds",
+  agent: "agent notifications",
+  git: "git notifications",
+  host: "system notifications",
+  recovery: "recovery notifications",
+  settings: "settings notifications",
+  connectivity: "connection notifications",
 };
 
 const EVENT_KIND_VALUES: ReadonlySet<string> = new Set(Object.keys(EVENT_KIND_LABEL));
 
 export function isNotificationEventKind(v: string | undefined): v is NotificationEventKind {
   return v !== undefined && EVENT_KIND_VALUES.has(v);
+}
+
+const INTERRUPTION_TO_PRIORITY: Record<EventInterruption, NotificationPriority> = {
+  passive: "low",
+  active: "high",
+  "time-sensitive": "high",
+  critical: "watch",
+};
+
+/**
+ * Fills routing defaults (priority, urgent, placement) from `EVENT_POLICY` for
+ * the payload's `context.eventKind`. Only gaps are filled — any field the
+ * caller set explicitly is preserved. Returns a new object; never mutates.
+ * `duration` is resolved separately in `notify()` so the sticky-action default
+ * can still win over a policy's `defaultDurationMs`.
+ */
+function resolveEventPolicyDefaults(payload: NotifyPayload): NotifyPayload {
+  const eventKind = payload.context?.eventKind;
+  if (!eventKind) return payload;
+  const policy = EVENT_POLICY[eventKind];
+  if (!policy) return payload;
+
+  let next = payload;
+  if (next.priority === undefined) {
+    next = { ...next, priority: INTERRUPTION_TO_PRIORITY[policy.baseInterruption] };
+  }
+  if (next.urgent === undefined && policy.baseInterruption === "time-sensitive") {
+    next = { ...next, urgent: true };
+  }
+  if (next.placement === undefined && policy.preferredSurface !== "auto") {
+    next = { ...next, placement: policy.preferredSurface };
+  }
+  return next;
 }
 
 /**
@@ -600,6 +756,10 @@ export function notify(
   }
 ): string;
 export function notify(payload: NotifyPayload): string {
+  // Resolve routing defaults from the EVENT_POLICY manifest before reading any
+  // routing fields — explicit caller fields are preserved, only gaps are filled.
+  payload = resolveEventPolicyDefaults(payload);
+
   const priority = payload.priority ?? "high";
   const { placement, correlationId, type, title, message, inboxMessage, context } = payload;
 
@@ -636,6 +796,16 @@ export function notify(payload: NotifyPayload): string {
   // Action-bearing toasts persist by default so users can act; toaster's 3s fallback would otherwise dismiss them.
   if (payload.duration === undefined && allActions.length > 0) {
     payload = { ...payload, duration: 0 };
+  }
+
+  // Policy-declared default duration fills the gap after the sticky-action
+  // default (so action-bearing toasts stay sticky) but before the per-type
+  // fallback. Caller-supplied `duration` still wins over both.
+  if (payload.duration === undefined && context?.eventKind) {
+    const policyDuration = EVENT_POLICY[context.eventKind]?.defaultDurationMs;
+    if (policyDuration !== undefined) {
+      payload = { ...payload, duration: policyDuration };
+    }
   }
 
   // Severity-based dismiss defaults. When a toast fires, the persistent inbox is

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -188,7 +188,10 @@ function resolveEventPolicyDefaults(payload: NotifyPayload): NotifyPayload {
   if (next.priority === undefined) {
     next = { ...next, priority: INTERRUPTION_TO_PRIORITY[policy.baseInterruption] };
   }
-  if (next.urgent === undefined && policy.baseInterruption === "time-sensitive") {
+  if (
+    next.urgent === undefined &&
+    (policy.baseInterruption === "time-sensitive" || policy.baseInterruption === "critical")
+  ) {
     next = { ...next, urgent: true };
   }
   if (next.placement === undefined && policy.preferredSurface !== "auto") {
@@ -974,9 +977,16 @@ export function notify(payload: NotifyPayload): string {
         // type default — that signals an intentional UX choice.
         const resultingActionsCount =
           (patchAction ? 1 : 0) + (coalesce.buildAction ? 0 : (notification.actions?.length ?? 0));
+        // A duration is "default" if it's the per-type fallback, the policy's
+        // defaultDurationMs for the kind, or unset — any of these means the
+        // caller didn't pin a duration, so the sticky promotion is safe.
+        const policyDefaultDuration = notification.context?.eventKind
+          ? EVENT_POLICY[notification.context.eventKind]?.defaultDurationMs
+          : undefined;
         const storedDurationIsDefault =
           notification.duration === undefined ||
-          notification.duration === TOAST_DURATION[notification.type];
+          notification.duration === TOAST_DURATION[notification.type] ||
+          notification.duration === policyDefaultDuration;
         if (resultingActionsCount > 0 && storedDurationIsDefault) {
           patch.duration = 0;
         }

--- a/src/lib/watchNotification.ts
+++ b/src/lib/watchNotification.ts
@@ -17,6 +17,7 @@ export function fireWatchNotification(
       message: `${label} process has exited`,
       duration: 5000,
       correlationId: panelId,
+      context: { eventKind: "agent", panelId },
       action: {
         label: "Go to terminal",
         successLabel: "Opened",
@@ -38,6 +39,7 @@ export function fireWatchNotification(
       message: `${label} is waiting for your input`,
       duration: 12000,
       correlationId: panelId,
+      context: { eventKind: "agent", panelId },
       action: {
         label: "Go to terminal",
         successLabel: "Opened",

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -343,6 +343,10 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
       const { kind, projectId } = args as { kind: NotificationEventKind; projectId?: string };
       const label = EVENT_KIND_LABEL[kind] ?? kind;
       const settingKey = EVENT_KIND_TO_SETTING_KEY[kind];
+      // Routing-only kinds (e.g. "host", "git") have no persisted silence
+      // toggle. The Zod enum below only admits the four silenceable kinds, so
+      // this is a type-narrowing guard rather than a reachable runtime path.
+      if (!settingKey) return;
 
       try {
         const isGlobalOnly = kind === "uiFeedback";

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -295,6 +295,7 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
           message: "Project notifications muted",
           priority: "high",
           duration: 5000,
+          context: { eventKind: "settings" },
           // One-shot Undo confirmation; mute is reversible from the project's
           // notification settings tab, so the 5s Undo window plus the settings
           // surface make inbox persistence redundant.
@@ -391,6 +392,7 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
           message: `Silenced ${label}${scopeSuffix}`,
           priority: "high",
           duration: 5000,
+          context: { eventKind: "settings" },
           // One-shot Undo confirmation; silenced kinds are reversible from
           // notification settings, so the 5s Undo plus the settings surface
           // make inbox persistence redundant.

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { ReactNode } from "react";
 import type { ActionId } from "@shared/types/actions";
+import type { NotificationEventKind } from "@/lib/notify";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useUIStore } from "@/store/uiStore";
 
@@ -58,7 +59,7 @@ export interface Notification {
     projectId?: string;
     worktreeId?: string;
     panelId?: string;
-    eventKind?: "completed" | "waiting" | "workingPulse" | "uiFeedback";
+    eventKind?: NotificationEventKind;
   };
   /**
    * Number of events collapsed into this toast. `undefined` means a single

--- a/src/store/slices/notificationHistorySlice.ts
+++ b/src/store/slices/notificationHistorySlice.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { ActionId } from "@shared/types/actions";
 import type { NotificationActionVariant } from "@/store/notificationStore";
+import type { NotificationEventKind } from "@/lib/notify";
 
 export interface NotificationHistoryAction {
   label: string;
@@ -39,7 +40,7 @@ export interface NotificationHistoryEntry {
     projectId?: string;
     worktreeId?: string;
     panelId?: string;
-    eventKind?: "completed" | "waiting" | "workingPulse" | "uiFeedback";
+    eventKind?: NotificationEventKind;
   };
   actions?: NotificationHistoryAction[];
 }

--- a/src/utils/stateHydration/recoveryNotifications.ts
+++ b/src/utils/stateHydration/recoveryNotifications.ts
@@ -19,6 +19,7 @@ export function dispatchRecoveryNotifications(hydrateResult: HydrateResult): voi
         "Daintree disabled GPU acceleration after repeated GPU crashes. Performance may be reduced — re-enable it in Settings > Troubleshooting.",
       priority: "watch",
       duration: 0,
+      context: { eventKind: "recovery" },
     });
   }
 
@@ -35,6 +36,7 @@ export function dispatchRecoveryNotifications(hydrateResult: HydrateResult): voi
         message: `Your settings file was corrupted and has been restored from a backup. Some recent changes may have been lost.${pathNote}`,
         priority: "high",
         duration: 8000,
+        context: { eventKind: "recovery" },
       });
     } else {
       notify({
@@ -43,6 +45,7 @@ export function dispatchRecoveryNotifications(hydrateResult: HydrateResult): voi
         message: `Your settings file was corrupted and no backup was available. Settings have been reset to defaults.${pathNote}`,
         priority: "high",
         duration: 0,
+        context: { eventKind: "recovery" },
       });
     }
   }
@@ -55,6 +58,7 @@ export function dispatchRecoveryNotifications(hydrateResult: HydrateResult): voi
       message: `Your project state was corrupted and has been reset. The corrupt file is preserved at: ${quarantinedPath}`,
       priority: "high",
       duration: 0,
+      context: { eventKind: "recovery" },
     });
   }
 
@@ -66,6 +70,7 @@ export function dispatchRecoveryNotifications(hydrateResult: HydrateResult): voi
       message: `The crash-loop tracker file was corrupted and has been reset. The corrupt file is preserved at: ${quarantinedPath}`,
       priority: "high",
       duration: 0,
+      context: { eventKind: "recovery" },
     });
   }
 }


### PR DESCRIPTION
## Summary

- Extends `NotificationEventKind` in `src/lib/notify.ts` with routing-relevant kinds (`agent`, `git`, `host`, `recovery`, `settings`, `connectivity`) and adds an `EVENT_POLICY` manifest mapping each kind to a full routing policy (`baseInterruption`, `preferredSurface`, `reToastOnSeverityEscalation`, `defaultDurationMs`)
- Updates `notify()` dispatch to resolve `type`, `priority`, `placement`, and `duration` defaults from the manifest when `eventKind` is supplied — explicit caller fields still win
- Adds a new ESLint rule that requires `eventKind` or a `// eslint-disable-next-line no-restricted-syntax -- notify-event-kind: ok` annotation on every `notify()` call, with a passive-mode regression guard to cover the unmigrated long tail

Resolves #9007

## Changes

- `src/lib/notify.ts` — extended `NotificationEventKind` union, `EVENT_POLICY` table, manifest-aware dispatch
- `eslint.config.js` — new `notify-event-kind` rule with passive mode and opt-out annotation
- `src/lib/__tests__/notify.test.ts` — 169 unit tests covering the policy table, dispatch integration, and edge cases
- Five migrated call sites: `useDiskSpaceWarnings.ts`, `useGitHubTokenExpiryNotification.ts`, `watchNotification.ts`, `recoveryNotifications.ts`, `projectActions.ts`
- `eslint-warnings-baseline.json` — updated to reflect new rule coverage

## Testing

196 unit tests pass. Typecheck, lint, and format all clean. The five migrated call sites exercise `eventKind` end-to-end; the remaining long tail is held behind the `notify-event-kind: ok` escape hatch pending a follow-up migration pass.