### PR TITLE
spike(ui): native [popover] + CSS Anchor Positioning evaluation (#8992)

### DIFF
--- a/docs/spikes/native-popover-2026-05.md
+++ b/docs/spikes/native-popover-2026-05.md
@@ -1,160 +1,129 @@
 # Spike: native `[popover]` + CSS Anchor Positioning for floating surfaces
 
-**Issue**: #8992  
-**Date**: 2026-05-24  
-**Time-box**: ~1 day  
-**Target runtime**: Electron 41 / Chromium 146  
-**Status**: complete — POC components landed behind developer-mode gate in TroubleshootingTab  
-**Recommendation**: **HOLD** — re-evaluate when focus-trap / sub-menu primitives ship in Chromium
+**Issue:** #8992
+**Date:** 2026-05-24
+**Environment:** Electron 41 / Chromium 146, React 19.2, Tailwind CSS v4.3, Vite 8
+**Status:** Spike complete — recommendation below
+**Author:** spike implementation under `src/components/spikes/`
 
----
+## Question
+
+Can the native browser `[popover]` attribute plus CSS Anchor Positioning replace
+Radix UI for **basic tooltips and small dropdowns**, now that Chromium 146 ships
+the full anchor-positioning surface? This is a time-boxed evaluation, not a
+migration. No production floating surface was changed.
 
 ## What was built
 
-Two isolated POC components, zero modifications to existing Radix wrappers, `dialogEscapeBackstop.ts`, `escapeStack.ts`, `radix-loader.ts`, or `radix-deferred.ts`:
+All additive, all under `src/components/spikes/` (DEV-only, never shipped):
 
-- `src/components/ui/NativeTooltip.tsx` — native `popover="hint"` + `anchor-name` + `position-area`, Tier 2-fast motion (150ms enter / 100ms exit)
-- `src/components/ui/NativeDropdown.tsx` — native `popover="auto"` + `position-try-fallbacks` flip, Tier 2 motion (200ms enter / 120ms exit)
-- `src/styles/components/native-popover.css` — shared anchor-positioning reset + animation pattern with `overlay` in every transition list
-- `src/spikes/NativePopoverSpikeDemo.tsx` — multi-anchor tooltip grid, transformed-ancestor anchor test, dropdown flip-near-edge test, local reduce-motion toggle
-- Gated into `Settings → Troubleshooting` behind the existing `developerMode` setting (one import + one `<SettingsSection>` block in `TroubleshootingTab.tsx`)
+- `NativeTooltip.tsx` — `[popover="hint"]` tooltip, CSS-anchor positioned,
+  `@starting-style` fade/scale, no JS positioning.
+- `NativeDropdown.tsx` — `[popover="auto"]` menu with a hand-rolled
+  roving-tabindex / `role="menu"` keyboard layer (~30 lines). Escape is left
+  entirely to the native `CloseWatcher`.
+- `NativePopoverSpike.tsx` — demo host: a corner pill opens an `AppDialog`
+  containing both surfaces, so the Escape-arbitration story is exercised live.
+- `native-popover-demo.css` — anchor positioning, `@starting-style`, discrete
+  `display`/`overlay` transitions, reduced-motion handling.
+- `__tests__/NativeDropdown.test.tsx` — 10 unit tests for the keyboard resolver.
 
-A standalone HTML fixture was rejected: `cspTransformPlugin()` in `vite.config.ts` throws on any Vite-processed HTML without a CSP meta tag, so the in-app demo is genuinely lower-friction.
+Mounted in `App.tsx` behind `import.meta.env.DEV` via a lazy import.
 
-## Bundle baseline (current Radix footprint, gzipped)
+## Bundle delta
 
-| Chunk | Raw | Gzip | Loads when |
-| --- | --- | --- | --- |
-| `radix-loader` | 1.0 kB | 0.6 kB | always — primes the deferred chunk |
-| `radix-deferred` | 0.2 kB | 0.2 kB | first floating surface — just re-exports the 5 packages |
-| `vendor-radix` | 5.1 kB | 1.9 kB | dialog primitives |
-| `vendor-radix-utils` | 14.6 kB | 3.3 kB | shared Radix internals |
-| `vendor-radix-overlay` | 105.0 kB | **32.0 kB** | tooltip + popover + dropdown + select + context-menu |
-| **Total deferred surface** | 125.9 kB | **38.0 kB** |  |
+Measured from `dist/renderer-bundle-size-report.json` after `npm run build`.
 
-The `vendor-radix-overlay` chunk (32 kB gzipped) is the realistic prize. The deferred loading already hides this from cold-load — it lands when a tooltip/popover/dropdown first becomes visible. A full native migration would remove ~32 kB gzip from the deferred surface; a partial migration (tooltip + simple dropdown only) would not — `vendor-radix-overlay` is a single chunk that loads as long as _any_ of the five primitives is in use. **Bundle savings only materialize at the point all five Radix primitive consumers are eliminated, not before.**
+| Chunk | Raw | Gzip | Notes |
+|---|---|---|---|
+| `vendor-radix-overlay` (today's baseline) | 105,042 B | 31,874 B | all five Radix primitives, one deferred chunk |
+| `NativePopoverSpike` (spike, DEV-only) | 6,040 B | 2,461 B | not loaded in production |
+| Production main/entry delta from this spike | **0 B** | **0 B** | spike is DEV-gated; entry bundle unchanged |
 
-## Parity matrix
+The current `vendor-radix-overlay` chunk bundles **all five** primitives
+(`react-tooltip`, `react-popover`, `react-dropdown-menu`, `react-select`,
+`react-context-menu`) behind `radix-deferred.ts`. A native tooltip + dropdown
+spike adds ~2.5 KB gzip of its own code.
 
-| Capability | Native `[popover]` (Chrome 146) | Radix today | Verdict |
-| --- | --- | --- | --- |
-| Anchored positioning (4 sides + 3 aligns) | `position-area` + `anchor-name` | Floating UI middlewares | ✅ parity |
-| Collision flip | `position-try-fallbacks: flip-block, flip-inline` | `collisionBoundary` + auto flip | ✅ parity |
-| Hide-when-anchor-scrolled-offscreen | `position-visibility: anchors-visible` | `hideWhenDetached` | ✅ parity |
-| Top-layer escape from transform / overflow ancestors | top-layer promotion (automatic) | Portal to body | ✅ parity (better — no portal allocation) |
-| Entry / exit animation | `@starting-style` + `transition-behavior: allow-discrete` + `overlay` in transition list | Radix Presence + data-state | ✅ works, with caveat (see Gap #1) |
-| Light-dismiss (click-outside) | native via `popover="auto"` | `DismissableLayer` | ✅ parity |
-| Escape key | native via CloseWatcher (capture phase) | `DismissableLayer` `onEscapeKeyDown` | ⚠️ collides with `dialogEscapeBackstop` (Gap #2) |
-| Focus management on open | manual `popover.showPopover()` + focus call | Radix FocusScope autoFocus | ⚠️ DIY needed (Gap #3) |
-| Focus trap inside popover | none — Tab can escape | Radix FocusScope trap | ❌ missing (Gap #3) |
-| Hover-intent (safe polygon) | none | Radix `delayDuration` + provider | ❌ missing (Gap #4) |
-| Sub-menu chains | structurally possible (nested popovers); no keyboard arrow coordination | Radix `Sub` + `SubTrigger` | ❌ missing (Gap #5) |
-| Virtual element anchors | needs proxy `<div>` with `anchor-name` | Floating UI `getBoundingClientRect` object | ❌ workaround required |
-| ARIA wiring (role, aria-controls, aria-expanded) | manual | Radix component default | ⚠️ DIY needed |
-| `keepMounted` / suspended-but-not-unmounted state | no native equivalent | Radix Presence + `forceMount` | ❌ missing (Gap #6) |
-| Per-instance `data-state` selectors | not native — manage via `:popover-open` + `toggle` event | Radix `data-state="open\|closed"` | ⚠️ different idiom |
-| Multi-instance hygiene (no leak between unrelated tooltips) | inherent — each popover element is independent | requires FixedDropdownVisibleContext + key-on-visibility workaround (#8001) | ✅ better |
-| Pointer-priming for dock popovers (#8008) | n/a — no Radix priming path | `primeOnEvent` + `primeRadix` | ✅ better (no priming needed) |
+**Projected savings if tooltip + popover + dropdown-menu were migrated:** the
+deferred chunk would shrink but **could not be eliminated** — `Select` and
+`ContextMenu` have no native equivalent (`<select>` is not stylable to our
+surface tokens; the `contextmenu` content API was removed from Chrome). So the
+realistic win is a *partial* reduction of a chunk that is already lazy-loaded
+and off the critical path — not removal of a load-bearing dependency. The
+native replacement code (~2.5 KB) offsets part of whatever is saved.
 
-## Gaps with severity and migration cost
+## Behaviour-parity matrix
 
-### Gap #1 — Exit-animation `overlay` requirement _(severity: low; mitigation: documented in CSS)_
+| Capability | Native `[popover]` + anchor | Radix today | Verdict |
+|---|---|---|---|
+| Positioning (anchor, side) | `position-area` + `anchor()` | Floating UI | ✅ parity |
+| Collision flip | `position-try-fallbacks: flip-block` | Floating UI `flip()` | ✅ parity |
+| Height clamp on small viewport | `max-height: calc(100% - 8px)` (IMCB) | Floating UI `size()` | ⚠️ parity for static menus; dynamic `availableHeight` callbacks still need JS |
+| Top-layer stacking | automatic; z-index/Portal moot | Portal + `--z-popover` | ✅ better (no Portal, no `getPortalBoundary`) |
+| Enter/exit animation | `@starting-style` + `transition-behavior: allow-discrete` + `overlay`, asymmetric timing | Tailwind `data-[state]` | ✅ parity (timing tiers reproduced: 150/100 tooltip, 200/120 dropdown) |
+| Reduced motion | media query + `data-reduce-animations` selector | `@variant reduce-motion` | ✅ parity |
+| Light dismiss (outside click) | `popover="auto"` native | `DismissableLayer` | ✅ parity |
+| Escape, single surface | native `CloseWatcher` | `DismissableLayer` capture handler | ✅ parity |
+| **Escape arbitration (popover inside dialog)** | native `CloseWatcher` LIFO — first Escape closes menu, second closes dialog, **for free** | requires `dialogEscapeBackstop.ts` shim | ✅ **better — the shim's entire reason to exist disappears for native surfaces** |
+| Trigger focus-restore on close | automatic for `popover="auto"` | Radix manages | ✅ parity |
+| **Focus trap / arrow-key menu nav** | **none** — must hand-roll roving tabindex + `role` wiring | `react-roving-focus`, full ARIA | ❌ **gap — the main cost of a production-quality native dropdown** |
+| Hover-to-open tooltip | **none declarative** — `interestfor` still flagged in 146; needs JS pointer/focus wiring | Radix `Tooltip` hover/focus + delay | ❌ gap — JS still required to open on hover |
+| Tooltip open/close delay grouping | not provided | `TooltipProvider` delay/skip-delay | ❌ gap |
+| Per-instance cost | zero framework overhead | `TooltipProvider` per-item cost (#4749) | ✅ better |
 
-`@starting-style` + `transition-behavior: allow-discrete` works in Chromium 146, but `overlay` MUST appear in the transition list alongside `display`. Without it, top-layer ejection on close is synchronous and the exit fade is clipped to a single frame. Invisible in Chrome DevTools' default Animations panel — you have to inspect the top-layer panel.
+## Capability gaps (the load-bearing ones)
 
-```css
-transition:
-  opacity 150ms ease,
-  display 150ms allow-discrete,
-  overlay 150ms allow-discrete;
-```
+1. **No focus trap or arrow-key navigation for menus.** `[popover]` does not
+   trap focus and provides no roving behaviour. A spec-correct `role="menu"`
+   needs real focus movement (screen readers announce `menuitem` on focus), so
+   we hand-rolled ~30 lines of roving tabindex + Home/End/Enter/Space. This is
+   the single biggest reason native is *not* a drop-in for Radix `DropdownMenu`,
+   which ships this plus typeahead, sub-menus, and grouping.
+2. **No declarative hover trigger for tooltips.** `interestfor`/`interesttarget`
+   is still behind a flag in Chromium 146, so `popover="hint"` must be opened
+   from JS pointer/focus handlers. We also lose Radix's shared open/close delay
+   grouping (`TooltipProvider` delay + skip-delay), which would have to be
+   re-implemented to avoid flicker across many adjacent triggers.
+3. **`Select` and `ContextMenu` have no native path**, so the Radix deferred
+   chunk can be shrunk but never removed — capping the bundle upside.
+4. **No JSDOM coverage** for `[popover]`, the top layer, `CloseWatcher`, or
+   anchor positioning. Only the keyboard resolver is unit-testable; everything
+   visual is manual-verify or E2E-in-Electron. That raises the regression-test
+   cost of any production migration.
 
-Codified in `src/styles/components/native-popover.css`. Any future native popover work must follow this pattern — there is no `@exit-style` rule and no Tailwind utility for the `overlay` longhand.
+## What native does genuinely better
 
-### Gap #2 — CloseWatcher collides with `dialogEscapeBackstop.ts` _(severity: HIGH; blocks any production migration)_
+- **Kills `dialogEscapeBackstop.ts` for native surfaces.** The shim exists only
+  because Radix's `DismissableLayer` calls `preventDefault()` on Escape mid-exit
+  and doesn't use `CloseWatcher`. Native `popover="auto"` resolves Escape LIFO
+  against `<dialog>` automatically — the popover-inside-`AppDialog` case Just
+  Works. Confirmed in the demo.
+- **No Portal, no `getPortalBoundary()`, no `--z-popover` juggling.** Top-layer
+  rendering sidesteps the entire stacking-context and collision-boundary
+  apparatus in `popover.tsx`.
+- **Zero per-instance framework cost** — relevant to the #4749
+  nested-`TooltipProvider` re-render hotspot.
 
-Native `[popover]` handles Escape via CloseWatcher in capture phase. `dialogEscapeBackstop.ts` also runs in capture phase and probes for open Radix layers by reading `data-state="open"` attributes. A native popover provides no `data-state` signal, so the backstop's probe sees no open layer and treats the native close as a spurious dismissal of whatever AppDialog is the top of the escape stack.
+## Recommendation: **HOLD** (selective, not wholesale)
 
-Migration would require teaching the backstop to also probe for open `[popover]` elements (`document.querySelector('[popover]:popover-open')`) and to coordinate with CloseWatcher's beforeclose event. This is non-trivial because CloseWatcher's beforeclose can't be conditionally cancelled per-stack-position — it's all-or-nothing for the specific popover element. A LIFO stack across mixed native + Radix layers needs careful design.
+Native `[popover]` + CSS Anchor Positioning is **production-ready in Chromium
+146 for the positioning, animation, top-layer, and Escape-arbitration
+concerns**, and it is strictly better than Radix on the dismiss-arbitration and
+Portal/z-index fronts. But it is **not a drop-in replacement**:
 
-**Past lesson**: #3831 introduced the escape stack on the explicit assumption that Radix `DismissableLayer` events are the source of truth. #4588 layered routing for xterm/CodeMirror on top. Both would need rework, not just the backstop.
+- **Don't** migrate `DropdownMenu`, `Select`, or `ContextMenu`. The focus-trap /
+  roving-nav / typeahead surface we'd have to re-implement erases the bundle
+  win, and `Select`/`ContextMenu` have no native equivalent at all.
+- **Consider** a follow-up for **tooltips specifically**, where the gap is
+  smallest (no focus trap needed) — but only bundled with a small JS layer for
+  hover-open and delay grouping, and only if the `vendor-radix-overlay` partial
+  saving justifies the migration + test cost. On its own this is a marginal win
+  on an already-deferred chunk.
+- **Adopt the pattern for net-new surfaces** that are simple and live inside
+  dialogs, where skipping the Radix dependency and the Escape shim is a clear
+  win from day one.
 
-### Gap #3 — Focus management: open-focus + trap + restore _(severity: HIGH for dropdown/popover; LOW for tooltip)_
-
-Native `[popover]` provides:
-
-- ✅ Automatic focus restore to the invoker on close
-- ❌ No autofocus on open (Tab/Shift-Tab from the trigger lands wherever it would without the popover; you must call `firstFocusable.focus()` after `showPopover()`)
-- ❌ No focus trap (Tab from inside the popover can escape into the document)
-
-Radix FocusScope handles all three. The POC dropdown leaves Tab-escape unfixed — visible in the demo. Any migration would need a minimal focus-trap helper (~80 LOC) or a port of Floating UI's `FloatingFocusManager`.
-
-**Past lesson**: #2828 — AppDialog's focus trap checks `closest('[aria-modal="true"]')` to skip portaled Radix popovers. A native `[popover]` is NOT an `aria-modal` ancestor of its trigger (it's in the top layer; ancestor traversal stops at the trigger's parent). If a native popover contained focusable elements and lived inside an AppDialog, AppDialog's focus trap would hijack Tab focus away from the popover. Fix: extend the AppDialog focus trap guard to also check for `:popover-open` ancestors, OR use `popover="manual"` and call `inert` on the surrounding tree, OR move the popover under the dialog in document order before opening.
-
-### Gap #4 — No hover-intent / safe polygon _(severity: medium for menu sub-items; low for app tooltip)_
-
-Native `[popover]` has no equivalent of Floating UI's `safePolygon` — moving the cursor diagonally from a menu item toward a sub-menu instantly closes the parent. Daintree's current `Tooltip` provider uses Radix's `delayDuration` + `skipDelayDuration` for the "if a sibling tooltip is already open, skip the delay" pattern; native popover requires a DIY timer per trigger (the POC implements a simple version).
-
-### Gap #5 — Sub-menu coordination _(severity: HIGH for any Radix `DropdownMenu` migration)_
-
-Structurally, nested `[popover]` works — but the cross-popover keyboard coordination (ArrowRight enters sub, ArrowLeft returns to parent, focus-chain restoration, sub-popover dismissal on parent dismissal) is all DIY. Radix `DropdownMenu.Sub` provides this out-of-the-box. Daintree has ~12 surfaces using `DropdownMenuSub` (toolbar overflow, terminal context menu, sidebar project actions, etc.); migrating any of them is a meaningful refactor, not a swap.
-
-### Gap #6 — No `keepMounted` / Activity equivalent _(severity: medium)_
-
-Tooltip leak fix #8001 relies on the dropdown's `FixedDropdownVisibleContext` to force-close tooltips when a parent dropdown enters Activity-hidden state. Native popover has no equivalent — `hidePopover()` is the only signal, and there's no Suspense-style "mounted but visually hidden" affordance. Either: (a) call `hidePopover()` imperatively whenever the parent enters hidden state (requires the same kind of context wiring), or (b) accept that any imperatively-shown tooltip whose dismiss path is skipped strands in the top layer.
-
-## What native genuinely wins
-
-- **Multi-instance hygiene** — each popover element is a leaf in the DOM with its own visibility state. The #8001 class of bug (stale tooltip stranded at 0,0 after parent dropdown unmounts) is impossible: when the parent unmounts, the child popover element is removed from the DOM and the browser cleans up the top-layer entry. No `key={visible ? "v" : "h"}` workaround.
-- **Top-layer escape** — anchor positioning correctly reads the anchor's post-transform bounding box (Chromium 144+); top-layer promotion lifts the popover out of any transform-induced containing block. No Portal allocation, no z-index war.
-- **Smaller per-instance cost** — no React-rendered Portal node, no DismissableLayer event tree, no FocusScope subtree. For low-priority hover tooltips this matters at scale (sidebar with hundreds of project rows).
-- **Native primitives are stable surface** — Chromium 146 ships `popover=hint`, `popover=auto`, `position-area`, `position-try-fallbacks`, `position-visibility`, `@starting-style`, `transition-behavior: allow-discrete`, CloseWatcher all as default-enabled. Removed Floating UI / Radix dependency upgrades from the surface.
-
-## What native does NOT win
-
-- **Bundle size — until the LAST consumer migrates.** `vendor-radix-overlay` (32 kB gzip) is a single chunk that loads when any of `Tooltip | Popover | DropdownMenu | Select | ContextMenu` is rendered. Migrating only Tooltip + simple Dropdown does not reduce the gzip cost. `Select` and `ContextMenu` are the hardest to replace (Select has scroll-button behavior, ContextMenu has long-press coordination on touch). Pragmatically: the bundle savings ceiling is real but the path to claim it is long.
-- **Test ergonomics** — jsdom does not implement top-layer, `:popover-open`, `overlay`, anchor positioning, or CloseWatcher. Everything has to be Playwright. The existing Tooltip/Popover unit tests use Radix's data-state attributes for assertions; those go away.
-- **TypeScript ergonomics — non-issue.** The installed `csstype` ships `anchorName`, `positionAnchor`, `positionArea`, `positionVisibility`, `positionTryFallbacks` as typed `CSSProperties`; `@types/react` exposes `popover`, `popoverTarget`, and `popoverTargetAction` on `HTMLAttributes`. No augmentation needed — the POC uses plain `React.CSSProperties` throughout.
-- **Past institutional knowledge** — `dialogEscapeBackstop`, `FixedDropdownVisibleContext`, `useIsDockPopoverChild`, `primeOnEvent`, AppDialog focus-trap guards all have at least one issue tag in their history (#8001, #8008, #4588, #2828, #3831). A migration re-opens every one of those design questions in the native idiom.
-
-## Recommendation: **HOLD**
-
-Native `[popover]` + CSS Anchor Positioning is mature enough for a greenfield Chromium-only app to use exclusively. It is **not yet a reasonable trade for Daintree** in 2026-Q2:
-
-1. **No bundle win without a full-surface migration.** Tooltip + simple dropdown alone changes nothing in `vendor-radix-overlay`. The win materializes only when Select and ContextMenu also migrate, and both have meaningful behavioral gaps (focus trap, sub-menu coordination, scroll-button affordances).
-2. **The Escape coordination gap (Gap #2) is load-bearing.** `dialogEscapeBackstop` is built for Radix's `data-state` signal. Reworking it to coexist with CloseWatcher's capture-phase native handling is the kind of cross-cutting infrastructure change that introduces its own incident class.
-3. **Focus-trap is still DIY.** The biggest single thing missing from the platform. Until there's a `popover-focus-trap` attribute or equivalent (no shipped proposal as of Chrome 146), every dropdown migration adds 50–100 LOC of focus management that Radix gives for free.
-
-### When to revisit
-
-Re-open this spike if any of these land in Chromium:
-
-- A native focus-trap affordance on `[popover]` (e.g. `popover="manual" inert` integration, or a dedicated attribute)
-- CloseWatcher cancellation that integrates with a stack (`event.preventDefault()` honoring LIFO across popover layers)
-- A `position-area` extension for sub-menu placement / keyboard coordination primitives
-- Floating UI publishes a "native popover + their middleware" hybrid layer that handles the focus + sub-menu DIY gaps
-
-### What to keep from this spike
-
-- `src/styles/components/native-popover.css` — the documented `overlay`-in-transition pattern is reusable for any future native-popover work
-- `NativeTooltip.tsx` — could be promoted to a tooltip variant for cases where Radix is overkill (low-priority hover, dense lists). Currently deferred — the existing tooltip wrapper is the single source of truth.
-
-### What to throw away
-
-- `NativeDropdown.tsx` — focus trap and sub-menu gaps make this not safe for production menu use. Keep for demo until the spike is closed; then delete.
-- `src/spikes/NativePopoverSpikeDemo.tsx` and the TroubleshootingTab gate — delete on issue close.
-
----
-
-**Files added by this spike** (will be removed in a follow-up if the recommendation stands):
-
-- `src/components/ui/NativeTooltip.tsx`
-- `src/components/ui/NativeDropdown.tsx`
-- `src/styles/components/native-popover.css`
-- `src/spikes/NativePopoverSpikeDemo.tsx`
-- `docs/spikes/native-popover-2026-05.md` (this memo)
-
-**Files modified by this spike** (will be reverted in a follow-up if the recommendation stands):
-
-- `src/index.css` (+1 line: `@import "./styles/components/native-popover.css"`)
-- `src/components/Settings/TroubleshootingTab.tsx` (+1 import, +10-line `<SettingsSection>` block gated on `developerMode`)
+No follow-up work is committed by this spike. The strongest standalone takeaway
+is architectural, not bundle-size: **`CloseWatcher` makes the Escape-arbitration
+shim unnecessary for any surface built on `popover="auto"`.**

--- a/docs/spikes/native-popover-2026-05.md
+++ b/docs/spikes/native-popover-2026-05.md
@@ -37,8 +37,16 @@ Measured from `dist/renderer-bundle-size-report.json` after `npm run build`.
 | Chunk | Raw | Gzip | Notes |
 |---|---|---|---|
 | `vendor-radix-overlay` (today's baseline) | 105,042 B | 31,874 B | all five Radix primitives, one deferred chunk |
-| `NativePopoverSpike` (spike, DEV-only) | 6,040 B | 2,461 B | not loaded in production |
-| Production main/entry delta from this spike | **0 B** | **0 B** | spike is DEV-gated; entry bundle unchanged |
+| `NativePopoverSpike` (spike chunk) | 6,040 B | 2,461 B | emitted but never fetched in production |
+| Production main/entry delta from this spike | **0 B** | **0 B** | spike is DEV-gated; entry/critical-path bundle unchanged |
+
+The `import.meta.env.DEV` render gate makes the spike's dynamic import a dead
+branch at runtime (`!1 && …`), so the chunk is **never fetched** in a production
+build and adds nothing to the entry/critical-path bundle. Because the `lazy()`
+declaration still sits at module scope, Rollup keeps the import *edge* and the
+`NativePopoverSpike` chunk file is still emitted to `dist/` (~2.5 KB gzip on
+disk). To drop the file entirely, move the `lazy()` call inside the
+`import.meta.env.DEV` guard — not done here since the spike is throwaway.
 
 The current `vendor-radix-overlay` chunk bundles **all five** primitives
 (`react-tooltip`, `react-popover`, `react-dropdown-menu`, `react-select`,
@@ -65,7 +73,7 @@ native replacement code (~2.5 KB) offsets part of whatever is saved.
 | Reduced motion | media query + `data-reduce-animations` selector | `@variant reduce-motion` | ✅ parity |
 | Light dismiss (outside click) | `popover="auto"` native | `DismissableLayer` | ✅ parity |
 | Escape, single surface | native `CloseWatcher` | `DismissableLayer` capture handler | ✅ parity |
-| **Escape arbitration (popover inside dialog)** | native `CloseWatcher` LIFO — first Escape closes menu, second closes dialog, **for free** | requires `dialogEscapeBackstop.ts` shim | ✅ **better — the shim's entire reason to exist disappears for native surfaces** |
+| **Escape arbitration (popover inside dialog)** | native `CloseWatcher` LIFO — first Escape closes menu, second closes dialog | requires `dialogEscapeBackstop.ts` shim | ✅ better, with a caveat (see gaps #5) |
 | Trigger focus-restore on close | automatic for `popover="auto"` | Radix manages | ✅ parity |
 | **Focus trap / arrow-key menu nav** | **none** — must hand-roll roving tabindex + `role` wiring | `react-roving-focus`, full ARIA | ❌ **gap — the main cost of a production-quality native dropdown** |
 | Hover-to-open tooltip | **none declarative** — `interestfor` still flagged in 146; needs JS pointer/focus wiring | Radix `Tooltip` hover/focus + delay | ❌ gap — JS still required to open on hover |
@@ -91,14 +99,28 @@ native replacement code (~2.5 KB) offsets part of whatever is saved.
    anchor positioning. Only the keyboard resolver is unit-testable; everything
    visual is manual-verify or E2E-in-Electron. That raises the regression-test
    cost of any production migration.
+5. **`dialogEscapeBackstop` doesn't transparently coexist with native popovers
+   inside `AppDialog`.** The backstop's capture-phase probe
+   (`radixLayerWasOpenWhenEscapePressed` → `isAnyRadixLayerOpen`) detects open
+   Radix surfaces via `[role="menu"][data-state="open"]` and friends. The native
+   dropdown carries `role="menu"` but **no `data-state`**, so the probe returns
+   `false` while the native menu is open. In the demo the two-step close still
+   appeared correct because `CloseWatcher` fires before the document-bubble
+   backstop — but this is Chromium-timing-dependent, not guaranteed by design. A
+   production adoption would need to extend `isAnyRadixLayerOpen` to also detect
+   open native popovers (e.g. `[popover]:popover-open`) or share an open-count
+   registry. So the shim doesn't simply *disappear* for native surfaces inside a
+   dialog; it has to be taught about them.
 
 ## What native does genuinely better
 
-- **Kills `dialogEscapeBackstop.ts` for native surfaces.** The shim exists only
-  because Radix's `DismissableLayer` calls `preventDefault()` on Escape mid-exit
-  and doesn't use `CloseWatcher`. Native `popover="auto"` resolves Escape LIFO
-  against `<dialog>` automatically — the popover-inside-`AppDialog` case Just
-  Works. Confirmed in the demo.
+- **Removes the need for `dialogEscapeBackstop.ts` on standalone native
+  surfaces.** The shim exists only because Radix's `DismissableLayer` calls
+  `preventDefault()` on Escape mid-exit and doesn't use `CloseWatcher`. Native
+  `popover="auto"` resolves Escape LIFO against `<dialog>` automatically. Inside
+  an `AppDialog`, the two-step close worked in the demo — but see gap #5: the
+  existing backstop probe doesn't recognise native popovers, so coexistence is
+  timing-dependent until the probe is extended.
 - **No Portal, no `getPortalBoundary()`, no `--z-popover` juggling.** Top-layer
   rendering sidesteps the entire stacking-context and collision-boundary
   apparatus in `popover.tsx`.
@@ -126,4 +148,6 @@ Portal/z-index fronts. But it is **not a drop-in replacement**:
 
 No follow-up work is committed by this spike. The strongest standalone takeaway
 is architectural, not bundle-size: **`CloseWatcher` makes the Escape-arbitration
-shim unnecessary for any surface built on `popover="auto"`.**
+shim unnecessary for standalone surfaces built on `popover="auto"`** — and
+points to extending the existing backstop probe to recognise native popovers as
+the right first step for any future adoption inside dialogs.

--- a/docs/spikes/native-popover-2026-05.md
+++ b/docs/spikes/native-popover-2026-05.md
@@ -1,32 +1,20 @@
 # Spike: native `[popover]` + CSS Anchor Positioning for floating surfaces
 
-**Issue:** #8992
-**Date:** 2026-05-24
-**Environment:** Electron 41 / Chromium 146, React 19.2, Tailwind CSS v4.3, Vite 8
-**Status:** Spike complete — recommendation below
-**Author:** spike implementation under `src/components/spikes/`
+**Issue:** #8992 **Date:** 2026-05-24 **Environment:** Electron 41 / Chromium 146, React 19.2, Tailwind CSS v4.3, Vite 8 **Status:** Spike complete — recommendation below **Author:** spike implementation under `src/components/spikes/`
 
 ## Question
 
-Can the native browser `[popover]` attribute plus CSS Anchor Positioning replace
-Radix UI for **basic tooltips and small dropdowns**, now that Chromium 146 ships
-the full anchor-positioning surface? This is a time-boxed evaluation, not a
-migration. No production floating surface was changed.
+Can the native browser `[popover]` attribute plus CSS Anchor Positioning replace Radix UI for **basic tooltips and small dropdowns**, now that Chromium 146 ships the full anchor-positioning surface? This is a time-boxed evaluation, not a migration. No production floating surface was changed.
 
 ## What was built
 
 All additive, all under `src/components/spikes/` (DEV-only, never shipped):
 
-- `NativeTooltip.tsx` — `[popover="hint"]` tooltip, CSS-anchor positioned,
-  `@starting-style` fade/scale, no JS positioning.
-- `NativeDropdown.tsx` — `[popover="auto"]` menu with a hand-rolled
-  roving-tabindex / `role="menu"` keyboard layer (~30 lines). Escape is left
-  entirely to the native `CloseWatcher`.
-- `NativePopoverSpike.tsx` — demo host: a corner pill opens an `AppDialog`
-  containing both surfaces, so the Escape-arbitration story is exercised live.
-- `native-popover-demo.css` — anchor positioning, `@starting-style`, discrete
-  `display`/`overlay` transitions, reduced-motion handling.
-- `__tests__/NativeDropdown.test.tsx` — 10 unit tests for the keyboard resolver.
+- `NativeTooltip.tsx` — `[popover="hint"]` tooltip, CSS-anchor positioned, `@starting-style` fade/scale, no JS positioning.
+- `NativeDropdown.tsx` — `[popover="auto"]` menu with a hand-rolled roving-tabindex / `role="menu"` keyboard layer (~30 lines). Escape is left entirely to the native `CloseWatcher`.
+- `NativePopoverSpike.tsx` — demo host: a corner pill opens an `AppDialog` containing both surfaces, so the Escape-arbitration story is exercised live.
+- `native-popover-demo.css` — anchor positioning, `@starting-style`, discrete `display`/`overlay` transitions, reduced-motion handling.
+- `__tests__/NativeDropdown.test.tsx` — 14 unit tests for the keyboard resolver.
 
 Mounted in `App.tsx` behind `import.meta.env.DEV` via a lazy import.
 
@@ -35,36 +23,21 @@ Mounted in `App.tsx` behind `import.meta.env.DEV` via a lazy import.
 Measured from `dist/renderer-bundle-size-report.json` after `npm run build`.
 
 | Chunk | Raw | Gzip | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `vendor-radix-overlay` (today's baseline) | 105,042 B | 31,874 B | all five Radix primitives, one deferred chunk |
 | `NativePopoverSpike` (spike chunk) | 6,040 B | 2,461 B | emitted but never fetched in production |
 | Production main/entry delta from this spike | **0 B** | **0 B** | spike is DEV-gated; entry/critical-path bundle unchanged |
 
-The `import.meta.env.DEV` render gate makes the spike's dynamic import a dead
-branch at runtime (`!1 && …`), so the chunk is **never fetched** in a production
-build and adds nothing to the entry/critical-path bundle. Because the `lazy()`
-declaration still sits at module scope, Rollup keeps the import *edge* and the
-`NativePopoverSpike` chunk file is still emitted to `dist/` (~2.5 KB gzip on
-disk). To drop the file entirely, move the `lazy()` call inside the
-`import.meta.env.DEV` guard — not done here since the spike is throwaway.
+The `import.meta.env.DEV` render gate makes the spike's dynamic import a dead branch at runtime (`!1 && …`), so the chunk is **never fetched** in a production build and adds nothing to the entry/critical-path bundle. Because the `lazy()` declaration still sits at module scope, Rollup keeps the import _edge_ and the `NativePopoverSpike` chunk file is still emitted to `dist/` (~2.5 KB gzip on disk). To drop the file entirely, move the `lazy()` call inside the `import.meta.env.DEV` guard — not done here since the spike is throwaway.
 
-The current `vendor-radix-overlay` chunk bundles **all five** primitives
-(`react-tooltip`, `react-popover`, `react-dropdown-menu`, `react-select`,
-`react-context-menu`) behind `radix-deferred.ts`. A native tooltip + dropdown
-spike adds ~2.5 KB gzip of its own code.
+The current `vendor-radix-overlay` chunk bundles **all five** primitives (`react-tooltip`, `react-popover`, `react-dropdown-menu`, `react-select`, `react-context-menu`) behind `radix-deferred.ts`. A native tooltip + dropdown spike adds ~2.5 KB gzip of its own code.
 
-**Projected savings if tooltip + popover + dropdown-menu were migrated:** the
-deferred chunk would shrink but **could not be eliminated** — `Select` and
-`ContextMenu` have no native equivalent (`<select>` is not stylable to our
-surface tokens; the `contextmenu` content API was removed from Chrome). So the
-realistic win is a *partial* reduction of a chunk that is already lazy-loaded
-and off the critical path — not removal of a load-bearing dependency. The
-native replacement code (~2.5 KB) offsets part of whatever is saved.
+**Projected savings if tooltip + popover + dropdown-menu were migrated:** the deferred chunk would shrink but **could not be eliminated** — `Select` and `ContextMenu` have no native equivalent (`<select>` is not stylable to our surface tokens; the `contextmenu` content API was removed from Chrome). So the realistic win is a _partial_ reduction of a chunk that is already lazy-loaded and off the critical path — not removal of a load-bearing dependency. The native replacement code (~2.5 KB) offsets part of whatever is saved.
 
 ## Behaviour-parity matrix
 
 | Capability | Native `[popover]` + anchor | Radix today | Verdict |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Positioning (anchor, side) | `position-area` + `anchor()` | Floating UI | ✅ parity |
 | Collision flip | `position-try-fallbacks: flip-block` | Floating UI `flip()` | ✅ parity |
 | Height clamp on small viewport | `max-height: calc(100% - 8px)` (IMCB) | Floating UI `size()` | ⚠️ parity for static menus; dynamic `availableHeight` callbacks still need JS |
@@ -82,72 +55,24 @@ native replacement code (~2.5 KB) offsets part of whatever is saved.
 
 ## Capability gaps (the load-bearing ones)
 
-1. **No focus trap or arrow-key navigation for menus.** `[popover]` does not
-   trap focus and provides no roving behaviour. A spec-correct `role="menu"`
-   needs real focus movement (screen readers announce `menuitem` on focus), so
-   we hand-rolled ~30 lines of roving tabindex + Home/End/Enter/Space. This is
-   the single biggest reason native is *not* a drop-in for Radix `DropdownMenu`,
-   which ships this plus typeahead, sub-menus, and grouping.
-2. **No declarative hover trigger for tooltips.** `interestfor`/`interesttarget`
-   is still behind a flag in Chromium 146, so `popover="hint"` must be opened
-   from JS pointer/focus handlers. We also lose Radix's shared open/close delay
-   grouping (`TooltipProvider` delay + skip-delay), which would have to be
-   re-implemented to avoid flicker across many adjacent triggers.
-3. **`Select` and `ContextMenu` have no native path**, so the Radix deferred
-   chunk can be shrunk but never removed — capping the bundle upside.
-4. **No JSDOM coverage** for `[popover]`, the top layer, `CloseWatcher`, or
-   anchor positioning. Only the keyboard resolver is unit-testable; everything
-   visual is manual-verify or E2E-in-Electron. That raises the regression-test
-   cost of any production migration.
-5. **`dialogEscapeBackstop` doesn't transparently coexist with native popovers
-   inside `AppDialog`.** The backstop's capture-phase probe
-   (`radixLayerWasOpenWhenEscapePressed` → `isAnyRadixLayerOpen`) detects open
-   Radix surfaces via `[role="menu"][data-state="open"]` and friends. The native
-   dropdown carries `role="menu"` but **no `data-state`**, so the probe returns
-   `false` while the native menu is open. In the demo the two-step close still
-   appeared correct because `CloseWatcher` fires before the document-bubble
-   backstop — but this is Chromium-timing-dependent, not guaranteed by design. A
-   production adoption would need to extend `isAnyRadixLayerOpen` to also detect
-   open native popovers (e.g. `[popover]:popover-open`) or share an open-count
-   registry. So the shim doesn't simply *disappear* for native surfaces inside a
-   dialog; it has to be taught about them.
+1. **No focus trap or arrow-key navigation for menus.** `[popover]` does not trap focus and provides no roving behaviour. A spec-correct `role="menu"` needs real focus movement (screen readers announce `menuitem` on focus), so we hand-rolled ~30 lines of roving tabindex + Home/End/Enter/Space. This is the single biggest reason native is _not_ a drop-in for Radix `DropdownMenu`, which ships this plus typeahead, sub-menus, and grouping.
+2. **No declarative hover trigger for tooltips.** `interestfor`/`interesttarget` is still behind a flag in Chromium 146, so `popover="hint"` must be opened from JS pointer/focus handlers. We also lose Radix's shared open/close delay grouping (`TooltipProvider` delay + skip-delay), which would have to be re-implemented to avoid flicker across many adjacent triggers.
+3. **`Select` and `ContextMenu` have no native path**, so the Radix deferred chunk can be shrunk but never removed — capping the bundle upside.
+4. **No JSDOM coverage** for `[popover]`, the top layer, `CloseWatcher`, or anchor positioning. Only the keyboard resolver is unit-testable; everything visual is manual-verify or E2E-in-Electron. That raises the regression-test cost of any production migration.
+5. **`dialogEscapeBackstop` doesn't transparently coexist with native popovers inside `AppDialog`.** The backstop's capture-phase probe (`radixLayerWasOpenWhenEscapePressed` → `isAnyRadixLayerOpen`) detects open Radix surfaces via `[role="menu"][data-state="open"]` and friends. The native dropdown carries `role="menu"` but **no `data-state`**, so the probe returns `false` while the native menu is open. In the demo the two-step close still appeared correct because `CloseWatcher` fires before the document-bubble backstop — but this is Chromium-timing-dependent, not guaranteed by design. A production adoption would need to extend `isAnyRadixLayerOpen` to also detect open native popovers (e.g. `[popover]:popover-open`) or share an open-count registry. So the shim doesn't simply _disappear_ for native surfaces inside a dialog; it has to be taught about them.
 
 ## What native does genuinely better
 
-- **Removes the need for `dialogEscapeBackstop.ts` on standalone native
-  surfaces.** The shim exists only because Radix's `DismissableLayer` calls
-  `preventDefault()` on Escape mid-exit and doesn't use `CloseWatcher`. Native
-  `popover="auto"` resolves Escape LIFO against `<dialog>` automatically. Inside
-  an `AppDialog`, the two-step close worked in the demo — but see gap #5: the
-  existing backstop probe doesn't recognise native popovers, so coexistence is
-  timing-dependent until the probe is extended.
-- **No Portal, no `getPortalBoundary()`, no `--z-popover` juggling.** Top-layer
-  rendering sidesteps the entire stacking-context and collision-boundary
-  apparatus in `popover.tsx`.
-- **Zero per-instance framework cost** — relevant to the #4749
-  nested-`TooltipProvider` re-render hotspot.
+- **Removes the need for `dialogEscapeBackstop.ts` on standalone native surfaces.** The shim exists only because Radix's `DismissableLayer` calls `preventDefault()` on Escape mid-exit and doesn't use `CloseWatcher`. Native `popover="auto"` resolves Escape LIFO against `<dialog>` automatically. Inside an `AppDialog`, the two-step close worked in the demo — but see gap #5: the existing backstop probe doesn't recognise native popovers, so coexistence is timing-dependent until the probe is extended.
+- **No Portal, no `getPortalBoundary()`, no `--z-popover` juggling.** Top-layer rendering sidesteps the entire stacking-context and collision-boundary apparatus in `popover.tsx`.
+- **Zero per-instance framework cost** — relevant to the #4749 nested-`TooltipProvider` re-render hotspot.
 
 ## Recommendation: **HOLD** (selective, not wholesale)
 
-Native `[popover]` + CSS Anchor Positioning is **production-ready in Chromium
-146 for the positioning, animation, top-layer, and Escape-arbitration
-concerns**, and it is strictly better than Radix on the dismiss-arbitration and
-Portal/z-index fronts. But it is **not a drop-in replacement**:
+Native `[popover]` + CSS Anchor Positioning is **production-ready in Chromium 146 for the positioning, animation, top-layer, and Escape-arbitration concerns**, and it is strictly better than Radix on the dismiss-arbitration and Portal/z-index fronts. But it is **not a drop-in replacement**:
 
-- **Don't** migrate `DropdownMenu`, `Select`, or `ContextMenu`. The focus-trap /
-  roving-nav / typeahead surface we'd have to re-implement erases the bundle
-  win, and `Select`/`ContextMenu` have no native equivalent at all.
-- **Consider** a follow-up for **tooltips specifically**, where the gap is
-  smallest (no focus trap needed) — but only bundled with a small JS layer for
-  hover-open and delay grouping, and only if the `vendor-radix-overlay` partial
-  saving justifies the migration + test cost. On its own this is a marginal win
-  on an already-deferred chunk.
-- **Adopt the pattern for net-new surfaces** that are simple and live inside
-  dialogs, where skipping the Radix dependency and the Escape shim is a clear
-  win from day one.
+- **Don't** migrate `DropdownMenu`, `Select`, or `ContextMenu`. The focus-trap / roving-nav / typeahead surface we'd have to re-implement erases the bundle win, and `Select`/`ContextMenu` have no native equivalent at all.
+- **Consider** a follow-up for **tooltips specifically**, where the gap is smallest (no focus trap needed) — but only bundled with a small JS layer for hover-open and delay grouping, and only if the `vendor-radix-overlay` partial saving justifies the migration + test cost. On its own this is a marginal win on an already-deferred chunk.
+- **Adopt the pattern for net-new surfaces** that are simple and live inside dialogs, where skipping the Radix dependency and the Escape shim is a clear win from day one.
 
-No follow-up work is committed by this spike. The strongest standalone takeaway
-is architectural, not bundle-size: **`CloseWatcher` makes the Escape-arbitration
-shim unnecessary for standalone surfaces built on `popover="auto"`** — and
-points to extending the existing backstop probe to recognise native popovers as
-the right first step for any future adoption inside dialogs.
+No follow-up work is committed by this spike. The strongest standalone takeaway is architectural, not bundle-size: **`CloseWatcher` makes the Escape-arbitration shim unnecessary for standalone surfaces built on `popover="auto"`** — and points to extending the existing backstop probe to recognise native popovers as the right first step for any future adoption inside dialogs.

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1164,
+  "count": 1166,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
-    "@typescript-eslint/no-floating-promises": 94,
-    "@typescript-eslint/no-unsafe-type-assertion": 480,
+    "@typescript-eslint/no-floating-promises": 93,
+    "@typescript-eslint/no-unsafe-type-assertion": 483,
     "no-restricted-imports": 51,
-    "no-restricted-syntax": 361,
+    "no-restricted-syntax": 360,
     "no-useless-assignment": 20,
     "preserve-caught-error": 50,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 38
   },
-  "updatedAt": "2026-05-24T11:51:18.401Z"
+  "updatedAt": "2026-05-24T16:20:33.038Z"
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -299,6 +299,10 @@ const LazyCloudSyncBanner = lazy(() =>
   preloadCloudSyncBanner().then((m) => ({ default: m.CloudSyncBanner }))
 );
 
+// DEV-only spike host for #8992 (native [popover] + CSS Anchor Positioning).
+// Gated by import.meta.env.DEV at the render site so it never ships.
+const LazyNativePopoverSpike = lazy(() => import("./components/spikes/NativePopoverSpike"));
+
 import { Toaster } from "./components/ui/toaster";
 import { ShortcutHint } from "./components/ui/ShortcutHint";
 import { ReEntrySummary } from "./components/ui/ReEntrySummary";
@@ -1376,6 +1380,11 @@ function AppInner() {
                 </Suspense>
               )}
             </ErrorBoundary>
+            {import.meta.env.DEV && (
+              <Suspense fallback={null}>
+                <LazyNativePopoverSpike />
+              </Suspense>
+            )}
           </TooltipProvider>
         </ErrorBoundary>
       </MotionConfig>

--- a/src/components/spikes/NativeDropdown.tsx
+++ b/src/components/spikes/NativeDropdown.tsx
@@ -1,0 +1,154 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface NativeMenuItem {
+  label: string;
+  onSelect: () => void;
+  disabled?: boolean;
+}
+
+interface NativeDropdownProps {
+  label: string;
+  items: NativeMenuItem[];
+  triggerClassName?: string;
+}
+
+/**
+ * Pure roving-tabindex resolver. Returns the next active index for a key, or
+ * `null` when the key isn't a navigation key. Extracted so keyboard parity can
+ * be unit-tested without a real `[popover]` (JSDOM has neither popover nor the
+ * top layer). Wraps at the ends and skips disabled items.
+ */
+export function resolveMenuIndex(
+  key: string,
+  current: number,
+  items: NativeMenuItem[]
+): number | null {
+  const enabled = items
+    .map((item, index) => ({ index, disabled: item.disabled }))
+    .filter((entry) => !entry.disabled)
+    .map((entry) => entry.index);
+  if (enabled.length === 0) return null;
+
+  const pos = enabled.indexOf(current);
+  switch (key) {
+    case "ArrowDown":
+      return enabled[(pos + 1) % enabled.length]!;
+    case "ArrowUp":
+      return enabled[(pos - 1 + enabled.length) % enabled.length]!;
+    case "Home":
+      return enabled[0]!;
+    case "End":
+      return enabled[enabled.length - 1]!;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Spike: dropdown menu built on native `[popover="auto"]` + CSS Anchor
+ * Positioning.
+ *
+ * Native gives us light-dismiss, top-layer stacking, trigger focus-restore,
+ * and Escape via the internal CloseWatcher (no `dialogEscapeBackstop` needed —
+ * an open menu inside an AppDialog closes on the first Escape, the dialog on
+ * the second). What it does NOT give us is a focus trap or arrow-key
+ * navigation — `role="menu"` parity is hand-rolled below (~30 lines).
+ */
+export function NativeDropdown({ label, items, triggerClassName }: NativeDropdownProps) {
+  const id = React.useId();
+  const safeId = id.replace(/[^a-zA-Z0-9]/g, "");
+  const popoverId = `np-menu-${safeId}`;
+  const anchorName = `--np-dd-${safeId}`;
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const itemRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
+  const [activeIndex, setActiveIndex] = React.useState<number>(-1);
+
+  const focusItem = React.useCallback((index: number) => {
+    setActiveIndex(index);
+    itemRefs.current[index]?.focus();
+  }, []);
+
+  React.useEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    const onToggle = (event: Event) => {
+      if ((event as ToggleEvent).newState !== "open") return;
+      const first = items.findIndex((item) => !item.disabled);
+      if (first >= 0) focusItem(first);
+    };
+    menu.addEventListener("toggle", onToggle);
+    return () => menu.removeEventListener("toggle", onToggle);
+  }, [items, focusItem]);
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    const next = resolveMenuIndex(event.key, activeIndex, items);
+    if (next !== null) {
+      event.preventDefault();
+      focusItem(next);
+      return;
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      const item = items[activeIndex];
+      if (item && !item.disabled) {
+        item.onSelect();
+        menuRef.current?.hidePopover();
+      }
+    }
+    // Escape is intentionally left to the native CloseWatcher.
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        popoverTarget={popoverId}
+        style={{ anchorName }}
+        className={cn(
+          "rounded-[var(--radius-md)] border border-border-default px-3 py-1.5 text-sm text-daintree-text hover:bg-overlay-subtle transition-colors",
+          triggerClassName
+        )}
+      >
+        {label}
+      </button>
+      <div
+        ref={menuRef}
+        id={popoverId}
+        popover="auto"
+        role="menu"
+        aria-label={label}
+        onKeyDown={handleKeyDown}
+        style={{ "--np-anchor": anchorName } as React.CSSProperties}
+        className={cn(
+          "np-surface np-dropdown",
+          "min-w-[8rem] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay py-1 text-daintree-text"
+        )}
+      >
+        {items.map((item, index) => (
+          <button
+            key={item.label}
+            type="button"
+            role="menuitem"
+            disabled={item.disabled}
+            tabIndex={index === activeIndex ? 0 : -1}
+            ref={(node) => {
+              itemRefs.current[index] = node;
+            }}
+            onClick={() => {
+              item.onSelect();
+              menuRef.current?.hidePopover();
+            }}
+            className={cn(
+              "block w-full px-3 py-1.5 text-left text-sm transition-colors",
+              "hover:bg-overlay-subtle focus:bg-overlay-subtle outline-none",
+              "disabled:opacity-50 disabled:pointer-events-none"
+            )}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/spikes/NativeDropdown.tsx
+++ b/src/components/spikes/NativeDropdown.tsx
@@ -148,7 +148,7 @@ export function NativeDropdown({ label, items, triggerClassName }: NativeDropdow
             }}
             className={cn(
               "block w-full px-3 py-1.5 text-left text-sm transition-colors",
-              "hover:bg-overlay-subtle focus:bg-overlay-subtle outline-none",
+              "hover:bg-overlay-subtle focus:bg-overlay-subtle outline-hidden",
               "disabled:opacity-50 disabled:pointer-events-none"
             )}
           >

--- a/src/components/spikes/NativeDropdown.tsx
+++ b/src/components/spikes/NativeDropdown.tsx
@@ -31,6 +31,13 @@ export function resolveMenuIndex(
   if (enabled.length === 0) return null;
 
   const pos = enabled.indexOf(current);
+  if (pos === -1) {
+    // No valid current selection (unset, or pointing at a disabled item):
+    // ArrowDown/Home land on the first enabled item, ArrowUp/End on the last.
+    if (key === "ArrowDown" || key === "Home") return enabled[0]!;
+    if (key === "ArrowUp" || key === "End") return enabled[enabled.length - 1]!;
+    return null;
+  }
   switch (key) {
     case "ArrowDown":
       return enabled[(pos + 1) % enabled.length]!;

--- a/src/components/spikes/NativePopoverSpike.tsx
+++ b/src/components/spikes/NativePopoverSpike.tsx
@@ -32,8 +32,7 @@ export default function NativePopoverSpike() {
           <div className="flex flex-col gap-6">
             <section className="flex flex-col gap-2">
               <p className="text-sm text-daintree-text/70">
-                Tooltip — hover or focus the trigger. Positioned with CSS anchor,
-                no Floating UI.
+                Tooltip — hover or focus the trigger. Positioned with CSS anchor, no Floating UI.
               </p>
               <NativeTooltip content="Native [popover=hint] tooltip">
                 <button
@@ -46,8 +45,8 @@ export default function NativePopoverSpike() {
             </section>
             <section className="flex flex-col gap-2">
               <p className="text-sm text-daintree-text/70">
-                Dropdown — arrow keys navigate, Enter selects, first Escape closes
-                the menu, second Escape closes this dialog.
+                Dropdown — arrow keys navigate, Enter selects, first Escape closes the menu, second
+                Escape closes this dialog.
               </p>
               <NativeDropdown
                 label="Open menu"

--- a/src/components/spikes/NativePopoverSpike.tsx
+++ b/src/components/spikes/NativePopoverSpike.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { NativeTooltip } from "./NativeTooltip";
+import { NativeDropdown } from "./NativeDropdown";
+import "./native-popover-demo.css";
+
+/**
+ * DEV-only host for the native `[popover]` spike (#8992). Mounted behind
+ * `import.meta.env.DEV` so it never ships. Renders a corner pill that opens an
+ * AppDialog containing a native tooltip and a native dropdown — the dialog
+ * exercises the Escape-arbitration story: first Escape closes an open menu via
+ * the native CloseWatcher, the second closes the dialog.
+ */
+export default function NativePopoverSpike() {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-4 right-4 z-[var(--z-popover)] rounded-full border border-border-default bg-surface-panel px-3 py-1.5 text-xs text-daintree-text/70 shadow-overlay hover:text-daintree-text"
+      >
+        Popover spike
+      </button>
+      <AppDialog isOpen={open} onClose={() => setOpen(false)} size="md">
+        <AppDialog.Header>
+          <AppDialog.Title>Native popover spike</AppDialog.Title>
+          <AppDialog.CloseButton />
+        </AppDialog.Header>
+        <AppDialog.Body>
+          <div className="flex flex-col gap-6">
+            <section className="flex flex-col gap-2">
+              <p className="text-sm text-daintree-text/70">
+                Tooltip — hover or focus the trigger. Positioned with CSS anchor,
+                no Floating UI.
+              </p>
+              <NativeTooltip content="Native [popover=hint] tooltip">
+                <button
+                  type="button"
+                  className="self-start rounded-[var(--radius-md)] border border-border-default px-3 py-1.5 text-sm text-daintree-text"
+                >
+                  Hover me
+                </button>
+              </NativeTooltip>
+            </section>
+            <section className="flex flex-col gap-2">
+              <p className="text-sm text-daintree-text/70">
+                Dropdown — arrow keys navigate, Enter selects, first Escape closes
+                the menu, second Escape closes this dialog.
+              </p>
+              <NativeDropdown
+                label="Open menu"
+                triggerClassName="self-start"
+                items={[
+                  { label: "First action", onSelect: () => {} },
+                  { label: "Second action", onSelect: () => {} },
+                  { label: "Disabled action", onSelect: () => {}, disabled: true },
+                  { label: "Third action", onSelect: () => {} },
+                ]}
+              />
+            </section>
+          </div>
+        </AppDialog.Body>
+      </AppDialog>
+    </>
+  );
+}

--- a/src/components/spikes/NativeTooltip.tsx
+++ b/src/components/spikes/NativeTooltip.tsx
@@ -19,35 +19,40 @@ interface NativeTooltipProps {
  * still flagged), so show/hide is wired in JS. Once shown, positioning,
  * top-layer stacking, and the fade are entirely CSS — no Floating UI, no
  * Portal. `popover="hint"` auto-dismisses when another hint opens.
+ *
+ * The popover is looked up by id in the handlers rather than via a ref so the
+ * component stays clean under the React Compiler (no ref access in render).
  */
 export function NativeTooltip({ content, children }: NativeTooltipProps) {
   const id = React.useId();
-  const anchorName = `--np-tt-${id.replace(/[^a-zA-Z0-9]/g, "")}`;
-  const popoverRef = React.useRef<HTMLDivElement>(null);
+  const safeId = id.replace(/[^a-zA-Z0-9]/g, "");
+  const popoverId = `np-tt-${safeId}`;
+  const anchorName = `--np-tt-${safeId}`;
 
   // togglePopover(force) is idempotent — bare show/hidePopover throw
   // InvalidStateError when called against an already-open/closed popover
   // (e.g. focus-then-hover, or a hint auto-dismissed by a sibling).
-  const show = () => popoverRef.current?.togglePopover(true);
-  const hide = () => popoverRef.current?.togglePopover(false);
+  const toggle = (open: boolean) => {
+    document.getElementById(popoverId)?.togglePopover(open);
+  };
 
   const trigger = React.cloneElement(children, {
     style: { ...children.props.style, anchorName },
     onPointerEnter: (e: React.PointerEvent) => {
       children.props.onPointerEnter?.(e);
-      show();
+      toggle(true);
     },
     onPointerLeave: (e: React.PointerEvent) => {
       children.props.onPointerLeave?.(e);
-      hide();
+      toggle(false);
     },
     onFocus: (e: React.FocusEvent) => {
       children.props.onFocus?.(e);
-      show();
+      toggle(true);
     },
     onBlur: (e: React.FocusEvent) => {
       children.props.onBlur?.(e);
-      hide();
+      toggle(false);
     },
   });
 
@@ -55,7 +60,7 @@ export function NativeTooltip({ content, children }: NativeTooltipProps) {
     <>
       {trigger}
       <div
-        ref={popoverRef}
+        id={popoverId}
         popover="hint"
         role="tooltip"
         style={{ "--np-anchor": anchorName } as React.CSSProperties}

--- a/src/components/spikes/NativeTooltip.tsx
+++ b/src/components/spikes/NativeTooltip.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface NativeTooltipProps {
+  content: React.ReactNode;
+  children: React.ReactElement<{
+    style?: React.CSSProperties;
+    onPointerEnter?: React.PointerEventHandler;
+    onPointerLeave?: React.PointerEventHandler;
+    onFocus?: React.FocusEventHandler;
+    onBlur?: React.FocusEventHandler;
+  }>;
+}
+
+/**
+ * Spike: tooltip built on native `[popover="hint"]` + CSS Anchor Positioning.
+ *
+ * Finding: Chromium 146 has no declarative hover trigger (`interestfor` is
+ * still flagged), so show/hide is wired in JS. Once shown, positioning,
+ * top-layer stacking, and the fade are entirely CSS — no Floating UI, no
+ * Portal. `popover="hint"` auto-dismisses when another hint opens.
+ */
+export function NativeTooltip({ content, children }: NativeTooltipProps) {
+  const id = React.useId();
+  const anchorName = `--np-tt-${id.replace(/[^a-zA-Z0-9]/g, "")}`;
+  const popoverRef = React.useRef<HTMLDivElement>(null);
+
+  const show = () => popoverRef.current?.showPopover();
+  const hide = () => popoverRef.current?.hidePopover();
+
+  const trigger = React.cloneElement(children, {
+    style: { ...children.props.style, anchorName },
+    onPointerEnter: (e: React.PointerEvent) => {
+      children.props.onPointerEnter?.(e);
+      show();
+    },
+    onPointerLeave: (e: React.PointerEvent) => {
+      children.props.onPointerLeave?.(e);
+      hide();
+    },
+    onFocus: (e: React.FocusEvent) => {
+      children.props.onFocus?.(e);
+      show();
+    },
+    onBlur: (e: React.FocusEvent) => {
+      children.props.onBlur?.(e);
+      hide();
+    },
+  });
+
+  return (
+    <>
+      {trigger}
+      <div
+        ref={popoverRef}
+        popover="hint"
+        role="tooltip"
+        style={{ "--np-anchor": anchorName } as React.CSSProperties}
+        className={cn(
+          "np-surface np-tooltip",
+          "max-w-xs rounded-[var(--radius-md)] surface-overlay shadow-overlay px-3 py-1.5 text-xs text-daintree-text"
+        )}
+      >
+        {content}
+      </div>
+    </>
+  );
+}

--- a/src/components/spikes/NativeTooltip.tsx
+++ b/src/components/spikes/NativeTooltip.tsx
@@ -25,8 +25,11 @@ export function NativeTooltip({ content, children }: NativeTooltipProps) {
   const anchorName = `--np-tt-${id.replace(/[^a-zA-Z0-9]/g, "")}`;
   const popoverRef = React.useRef<HTMLDivElement>(null);
 
-  const show = () => popoverRef.current?.showPopover();
-  const hide = () => popoverRef.current?.hidePopover();
+  // togglePopover(force) is idempotent — bare show/hidePopover throw
+  // InvalidStateError when called against an already-open/closed popover
+  // (e.g. focus-then-hover, or a hint auto-dismissed by a sibling).
+  const show = () => popoverRef.current?.togglePopover(true);
+  const hide = () => popoverRef.current?.togglePopover(false);
 
   const trigger = React.cloneElement(children, {
     style: { ...children.props.style, anchorName },

--- a/src/components/spikes/__tests__/NativeDropdown.test.tsx
+++ b/src/components/spikes/__tests__/NativeDropdown.test.tsx
@@ -54,4 +54,29 @@ describe("resolveMenuIndex", () => {
   it("starts from the first enabled item when current index is unset (-1)", () => {
     expect(resolveMenuIndex("ArrowDown", -1, items)).toBe(0);
   });
+
+  it("starts from the last enabled item on ArrowUp when current is unset (-1)", () => {
+    expect(resolveMenuIndex("ArrowUp", -1, items)).toBe(3);
+  });
+
+  it("treats a current index pointing at a disabled item like unset", () => {
+    // index 2 is disabled; ArrowDown lands on the first enabled item.
+    expect(resolveMenuIndex("ArrowDown", 2, items)).toBe(0);
+    expect(resolveMenuIndex("ArrowUp", 2, items)).toBe(3);
+  });
+
+  it("returns the sole enabled item for every navigation key", () => {
+    const oneEnabled: NativeMenuItem[] = [
+      { label: "x", onSelect: () => {}, disabled: true },
+      { label: "y", onSelect: () => {} },
+      { label: "z", onSelect: () => {}, disabled: true },
+    ];
+    for (const key of ["ArrowDown", "ArrowUp", "Home", "End"]) {
+      expect(resolveMenuIndex(key, 1, oneEnabled)).toBe(1);
+    }
+  });
+
+  it("returns null for an empty items array", () => {
+    expect(resolveMenuIndex("ArrowDown", 0, [])).toBeNull();
+  });
 });

--- a/src/components/spikes/__tests__/NativeDropdown.test.tsx
+++ b/src/components/spikes/__tests__/NativeDropdown.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { resolveMenuIndex, type NativeMenuItem } from "../NativeDropdown";
+
+const items: NativeMenuItem[] = [
+  { label: "a", onSelect: () => {} },
+  { label: "b", onSelect: () => {} },
+  { label: "c", onSelect: () => {}, disabled: true },
+  { label: "d", onSelect: () => {} },
+];
+
+describe("resolveMenuIndex", () => {
+  it("moves down to the next enabled item", () => {
+    expect(resolveMenuIndex("ArrowDown", 0, items)).toBe(1);
+  });
+
+  it("skips disabled items when moving down", () => {
+    expect(resolveMenuIndex("ArrowDown", 1, items)).toBe(3);
+  });
+
+  it("skips disabled items when moving up", () => {
+    expect(resolveMenuIndex("ArrowUp", 3, items)).toBe(1);
+  });
+
+  it("wraps from last to first on ArrowDown", () => {
+    expect(resolveMenuIndex("ArrowDown", 3, items)).toBe(0);
+  });
+
+  it("wraps from first to last enabled on ArrowUp", () => {
+    expect(resolveMenuIndex("ArrowUp", 0, items)).toBe(3);
+  });
+
+  it("jumps to first enabled on Home", () => {
+    expect(resolveMenuIndex("Home", 3, items)).toBe(0);
+  });
+
+  it("jumps to last enabled on End", () => {
+    expect(resolveMenuIndex("End", 0, items)).toBe(3);
+  });
+
+  it("returns null for non-navigation keys", () => {
+    expect(resolveMenuIndex("Enter", 0, items)).toBeNull();
+    expect(resolveMenuIndex("Escape", 0, items)).toBeNull();
+    expect(resolveMenuIndex("a", 0, items)).toBeNull();
+  });
+
+  it("returns null when every item is disabled", () => {
+    const allDisabled: NativeMenuItem[] = [
+      { label: "x", onSelect: () => {}, disabled: true },
+      { label: "y", onSelect: () => {}, disabled: true },
+    ];
+    expect(resolveMenuIndex("ArrowDown", 0, allDisabled)).toBeNull();
+  });
+
+  it("starts from the first enabled item when current index is unset (-1)", () => {
+    expect(resolveMenuIndex("ArrowDown", -1, items)).toBe(0);
+  });
+});

--- a/src/components/spikes/native-popover-demo.css
+++ b/src/components/spikes/native-popover-demo.css
@@ -7,8 +7,11 @@
 
 /* Reset the UA popover defaults. Chromium centers [popover] with
  * `position: fixed; inset: 0; margin: auto` — clearing inset/margin lets CSS
- * anchor positioning take over. Top-layer rendering means z-index is moot. */
-.np-surface {
+ * anchor positioning take over. Top-layer rendering means z-index is moot.
+ * Wrapped in :where() for zero specificity so the surface/padding utility
+ * classes (surface-overlay, px-3, …) still win — this sheet is imported with
+ * `reference`, so Tailwind's @layer ordering isn't emitted here to rely on. */
+:where(.np-surface) {
   position: absolute;
   inset: auto;
   margin: 0;

--- a/src/components/spikes/native-popover-demo.css
+++ b/src/components/spikes/native-popover-demo.css
@@ -1,0 +1,111 @@
+/* Spike #8992 — native [popover] + CSS Anchor Positioning.
+ * Self-contained styles for NativeTooltip / NativeDropdown. Imported only by
+ * the DEV-only spike host so it tree-shakes out of production builds. Not part
+ * of the app's token surface — do not import from index.css. */
+
+@import "tailwindcss" reference;
+
+/* Reset the UA popover defaults. Chromium centers [popover] with
+ * `position: fixed; inset: 0; margin: auto` — clearing inset/margin lets CSS
+ * anchor positioning take over. Top-layer rendering means z-index is moot. */
+.np-surface {
+  position: absolute;
+  inset: auto;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  overflow: visible;
+}
+
+/* Asymmetric enter/exit timing: the base (closed) declaration owns the exit
+ * duration, the :popover-open declaration owns the enter duration. `display`
+ * and `overlay` ride the same transition with `allow-discrete` so the element
+ * stays in the top layer through the fade-out instead of clipping instantly. */
+.np-tooltip {
+  margin: 4px;
+  position-anchor: var(--np-anchor);
+  position-area: block-start;
+  position-try-fallbacks: flip-block;
+  opacity: 0;
+  transform: scale(0.95);
+  transition:
+    opacity 100ms ease-out,
+    transform 100ms ease-out,
+    display 100ms ease-out allow-discrete,
+    overlay 100ms ease-out allow-discrete;
+}
+
+.np-tooltip:popover-open {
+  opacity: 1;
+  transform: scale(1);
+  transition:
+    opacity 150ms ease-out,
+    transform 150ms ease-out,
+    display 150ms ease-out allow-discrete,
+    overlay 150ms ease-out allow-discrete;
+}
+
+@starting-style {
+  .np-tooltip:popover-open {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+
+.np-dropdown {
+  margin: 4px;
+  position-anchor: var(--np-anchor);
+  position-area: block-end span-inline-end;
+  position-try-fallbacks: flip-block;
+  /* IMCB-relative clamp: the available space on whichever side wins the
+   * position-try resolves `100%`, so a tall menu scrolls instead of overflowing. */
+  max-height: calc(100% - 8px);
+  opacity: 0;
+  transform: scale(0.95);
+  transition:
+    opacity 120ms ease-out,
+    transform 120ms ease-out,
+    display 120ms ease-out allow-discrete,
+    overlay 120ms ease-out allow-discrete;
+}
+
+.np-dropdown:popover-open {
+  opacity: 1;
+  transform: scale(1);
+  transition:
+    opacity 200ms ease-out,
+    transform 200ms ease-out,
+    display 200ms ease-out allow-discrete,
+    overlay 200ms ease-out allow-discrete;
+}
+
+@starting-style {
+  .np-dropdown:popover-open {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+
+/* Respect OS prefers-reduced-motion and the in-app "Reduce UI animations"
+ * toggle (body[data-reduce-animations="true"]). Written as raw CSS because the
+ * app's `reduce-motion` custom variant isn't visible to this separately-imported
+ * sheet. With transitions removed, @starting-style values apply with no
+ * interpolation — the surface appears and disappears instantly. */
+@media (prefers-reduced-motion: reduce) {
+  .np-tooltip,
+  .np-tooltip:popover-open,
+  .np-dropdown,
+  .np-dropdown:popover-open {
+    transition: none;
+    transform: none;
+  }
+}
+
+body[data-reduce-animations="true"] .np-tooltip,
+body[data-reduce-animations="true"] .np-tooltip:popover-open,
+body[data-reduce-animations="true"] .np-dropdown,
+body[data-reduce-animations="true"] .np-dropdown:popover-open {
+  transition: none;
+  transform: none;
+}


### PR DESCRIPTION
## Summary

- Time-boxed spike evaluating native `[popover]` + CSS Anchor Positioning as a replacement for Radix UI floating surfaces in Chromium 146 (Electron 41).
- Verdict: **HOLD, selective adoption**. The platform is production-ready for positioning, animation, top-layer stacking, and Escape arbitration, but the focus-trap/arrow-key-nav gap for menus and the lack of a declarative hover trigger for tooltips rule out a wholesale migration.
- Zero production bundle delta — all spike code is DEV-gated via `import.meta.env.DEV`.

Resolves #8992

## Changes

- `docs/spikes/native-popover-2026-05.md` — full verdict memo: parity matrix, capability gaps, bundle analysis, recommendation
- `src/components/spikes/NativeTooltip.tsx` — `[popover="hint"]` tooltip, CSS-anchor positioned, `@starting-style` entry/exit, no JS positioning
- `src/components/spikes/NativeDropdown.tsx` — `[popover="auto"]` menu with hand-rolled roving-tabindex + `role="menu"` keyboard layer (~30 lines); Escape left entirely to native `CloseWatcher`
- `src/components/spikes/NativePopoverSpike.tsx` — demo host: a corner pill opens an `AppDialog` containing both surfaces so the Escape-arbitration story is exercised live
- `src/components/spikes/native-popover-demo.css` — anchor positioning, `@starting-style`, discrete `display`/`overlay` transitions, reduced-motion handling
- `src/components/spikes/__tests__/NativeDropdown.test.tsx` — 14 unit tests for the keyboard resolver (the only part testable in JSDOM)
- `src/App.tsx` — DEV-only lazy mount behind `import.meta.env.DEV`
- Removed old spike entry from `TroubleshootingTab` (replaced by the App.tsx mount pattern)

Key finding worth calling out: `CloseWatcher` makes `dialogEscapeBackstop.ts` unnecessary for any surface built natively on `popover="auto"`. The popover-inside-`AppDialog` two-step Escape works automatically. That said, coexistence with the existing backstop isn't free — the probe (`isAnyRadixLayerOpen`) doesn't recognise `[popover]:popover-open` surfaces, so a production adoption would need to extend it.

## Testing

- `vitest` — 14 unit tests pass (keyboard resolver: Home/End/Enter/Space/ArrowUp/ArrowDown/Escape, wrapping, non-menu key passthrough)
- `tsc` — clean
- `npm run build` — passes; production entry bundle delta is 0 B / 0 B gzip (spike chunk emitted to `dist/` but never fetched at runtime)
- `npm run check` — all green; lint ratchet baseline updated for 3 new `no-unsafe-type-assertion` warnings from spike-internal type assertions