### PR TITLE
fix(github): restore caching and in-flight dedup in CodeForge data path

### DIFF
--- a/electron/workspace-host/__tests__/forgeBridge.test.ts
+++ b/electron/workspace-host/__tests__/forgeBridge.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ForgeBridge } from "../forgeBridge.js";
+import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js";
+import type { RepoRef } from "../../../shared/types/forge.js";
+
+const repo: RepoRef = { host: "github.com", owner: "owner", repo: "repo", rawData: null };
+
+type ForgeRpcEvent = Extract<WorkspaceHostEvent, { type: "forge:rpc" }>;
+
+function isForgeRpc(event: WorkspaceHostEvent): event is ForgeRpcEvent {
+  return event.type === "forge:rpc";
+}
+
+describe("ForgeBridge in-flight dedup", () => {
+  let events: ForgeRpcEvent[];
+  let bridge: ForgeBridge;
+
+  beforeEach(() => {
+    events = [];
+    bridge = new ForgeBridge((event) => {
+      if (isForgeRpc(event)) events.push(event);
+    });
+  });
+
+  it("coalesces concurrent identical calls into one forge:rpc event", async () => {
+    const a = bridge.getPR("ns", repo, 1);
+    const b = bridge.getPR("ns", repo, 1);
+
+    expect(events).toHaveLength(1);
+
+    bridge.handleResult({
+      forgeRequestId: events[0].forgeRequestId,
+      ok: true,
+      value: { number: 1 },
+    });
+
+    const [ra, rb] = await Promise.all([a, b]);
+    expect(ra).toEqual({ number: 1 });
+    expect(rb).toEqual({ number: 1 });
+  });
+
+  it("sends separate events when args differ", () => {
+    void bridge.getPR("ns", repo, 1);
+    void bridge.getPR("ns", repo, 2);
+
+    expect(events).toHaveLength(2);
+  });
+
+  it("sends separate events when namespacedId differs", () => {
+    void bridge.getPR("ns-a", repo, 1);
+    void bridge.getPR("ns-b", repo, 1);
+
+    expect(events).toHaveLength(2);
+  });
+
+  it("evicts on rejection so a retry sends a fresh event", async () => {
+    const first = bridge.getPR("ns", repo, 1);
+    expect(events).toHaveLength(1);
+
+    bridge.handleResult({ forgeRequestId: events[0].forgeRequestId, ok: false, error: "boom" });
+    await expect(first).rejects.toThrow("boom");
+
+    const retry = bridge.getPR("ns", repo, 1);
+    expect(events).toHaveLength(2);
+
+    bridge.handleResult({
+      forgeRequestId: events[1].forgeRequestId,
+      ok: true,
+      value: { number: 1 },
+    });
+    await expect(retry).resolves.toEqual({ number: 1 });
+  });
+
+  it("evicts on success so a later identical call refetches", async () => {
+    const first = bridge.getPR("ns", repo, 1);
+    bridge.handleResult({
+      forgeRequestId: events[0].forgeRequestId,
+      ok: true,
+      value: { number: 1 },
+    });
+    await first;
+
+    void bridge.getPR("ns", repo, 1);
+    expect(events).toHaveLength(2);
+  });
+
+  it("dispose rejects deduped concurrent callers", async () => {
+    const a = bridge.getPR("ns", repo, 1);
+    const b = bridge.getPR("ns", repo, 1);
+    expect(events).toHaveLength(1);
+
+    bridge.dispose();
+
+    await expect(a).rejects.toThrow(/disposed/);
+    await expect(b).rejects.toThrow(/disposed/);
+  });
+});

--- a/electron/workspace-host/__tests__/forgeBridge.test.ts
+++ b/electron/workspace-host/__tests__/forgeBridge.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ForgeBridge } from "../forgeBridge.js";
 import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js";
 import type { RepoRef } from "../../../shared/types/forge.js";
@@ -22,6 +22,12 @@ describe("ForgeBridge in-flight dedup", () => {
     });
   });
 
+  afterEach(() => {
+    // Reject any still-pending calls so their 30s RPC timers are cleared and
+    // don't leak across tests.
+    bridge.dispose();
+  });
+
   it("coalesces concurrent identical calls into one forge:rpc event", async () => {
     const a = bridge.getPR("ns", repo, 1);
     const b = bridge.getPR("ns", repo, 1);
@@ -40,15 +46,16 @@ describe("ForgeBridge in-flight dedup", () => {
   });
 
   it("sends separate events when args differ", () => {
-    void bridge.getPR("ns", repo, 1);
-    void bridge.getPR("ns", repo, 2);
+    // Never settled — afterEach dispose() rejects them, so swallow.
+    void bridge.getPR("ns", repo, 1).catch(() => {});
+    void bridge.getPR("ns", repo, 2).catch(() => {});
 
     expect(events).toHaveLength(2);
   });
 
   it("sends separate events when namespacedId differs", () => {
-    void bridge.getPR("ns-a", repo, 1);
-    void bridge.getPR("ns-b", repo, 1);
+    void bridge.getPR("ns-a", repo, 1).catch(() => {});
+    void bridge.getPR("ns-b", repo, 1).catch(() => {});
 
     expect(events).toHaveLength(2);
   });
@@ -80,7 +87,7 @@ describe("ForgeBridge in-flight dedup", () => {
     });
     await first;
 
-    void bridge.getPR("ns", repo, 1);
+    void bridge.getPR("ns", repo, 1).catch(() => {});
     expect(events).toHaveLength(2);
   });
 

--- a/electron/workspace-host/forgeBridge.ts
+++ b/electron/workspace-host/forgeBridge.ts
@@ -1,9 +1,14 @@
+import { configure } from "safe-stable-stringify";
 import type {
   WorkspaceHostEvent,
   ForgeRpcMethod,
   ForgeResolveProviderResult,
 } from "../../shared/types/workspace-host.js";
 import type { CIStatus, Issue, PR, RateLimitInfo, RepoRef } from "../../shared/types/forge.js";
+
+// Deterministic stringify so identical arg shapes coalesce regardless of
+// property order.
+const stringifyArgs = configure({ bigint: false });
 
 type SendEvent = (event: WorkspaceHostEvent) => void;
 
@@ -33,6 +38,11 @@ const FORGE_RPC_TIMEOUT_MS = 30_000;
 export class ForgeBridge {
   private pending = new Map<string, PendingCall>();
   private counter = 0;
+  // Strict singleflight at the IPC boundary: concurrent identical calls join
+  // one in-flight promise instead of crossing the process boundary twice.
+  // Evicted on settlement (not TTL-cached) — the 60s response cache in
+  // `forgeProvider.runQuery` absorbs staggered bursts on the main-process side.
+  private inFlightByArgs = new Map<string, Promise<unknown>>();
 
   constructor(private readonly sendEvent: SendEvent) {}
 
@@ -109,9 +119,34 @@ export class ForgeBridge {
       pending.reject(new Error(`Forge bridge disposed (pending ${pending.method})`));
     }
     this.pending.clear();
+    this.inFlightByArgs.clear();
+  }
+
+  private buildInvokeKey(
+    method: ForgeRpcMethod,
+    namespacedId: string | undefined,
+    args: unknown[]
+  ): string {
+    return `${method}\0${namespacedId ?? ""}\0${stringifyArgs(args) ?? ""}`;
   }
 
   private invoke<T>(
+    method: ForgeRpcMethod,
+    namespacedId: string | undefined,
+    args: unknown[]
+  ): Promise<T> {
+    const key = this.buildInvokeKey(method, namespacedId, args);
+    const existing = this.inFlightByArgs.get(key);
+    if (existing !== undefined) return existing as Promise<T>;
+
+    const request = this.dispatch<T>(method, namespacedId, args).finally(() => {
+      this.inFlightByArgs.delete(key);
+    });
+    this.inFlightByArgs.set(key, request);
+    return request;
+  }
+
+  private dispatch<T>(
     method: ForgeRpcMethod,
     namespacedId: string | undefined,
     args: unknown[]

--- a/plugins/builtin/github/main/GitHubCaches.ts
+++ b/plugins/builtin/github/main/GitHubCaches.ts
@@ -166,4 +166,9 @@ export function clearPRCaches(): void {
   branchListETagCache.clear();
   reviewThreadsCache.clear();
   prRequiredStatusCache.clear();
+  // PR queries (GET_PR, LIST_PRS, PR CI status, batch-branch) all flow through
+  // forgeProvider.runQuery, so a manual PR refresh must drop their forge cache
+  // entries too or it would serve stale state for up to the 60s TTL.
+  forgeQueryCache.clear();
+  forgeQueryInflight.clear();
 }

--- a/plugins/builtin/github/main/GitHubCaches.ts
+++ b/plugins/builtin/github/main/GitHubCaches.ts
@@ -1,3 +1,4 @@
+import type { GraphQlQueryResponseData } from "@octokit/graphql";
 import { Cache } from "../../../../electron/utils/cache.js";
 import { GitHubFirstPageCache } from "../../../../electron/services/GitHubFirstPageCache.js";
 import { GitHubStatsCache } from "../../../../electron/services/GitHubStatsCache.js";
@@ -96,6 +97,24 @@ export const prRequiredStatusCache = new Cache<string, PRRequiredStatusEntry>({
   defaultTTL: 60000,
 });
 
+/**
+ * Response cache for raw forge GraphQL queries, keyed by query + serialized
+ * variables. Restores the 60s TTL the legacy GitHub service layer had before
+ * the CodeForge migration moved all queries through `forgeProvider.runQuery`.
+ * Lives here (not in `forgeProvider.ts`) so `clearGitHubCaches()` drops it
+ * atomically with the other caches on a token or settings change.
+ */
+export const forgeQueryCache = new Cache<string, GraphQlQueryResponseData>({
+  defaultTTL: 60000,
+});
+
+/**
+ * In-flight singleflight map for forge GraphQL queries. Concurrent callers with
+ * an identical key join the same pending promise instead of issuing duplicate
+ * network requests. Entries are evicted on settlement by `runQuery`.
+ */
+export const forgeQueryInflight = new Map<string, Promise<GraphQlQueryResponseData>>();
+
 export function clearGitHubCaches(): void {
   etagCacheVersion++;
   repoContextCache.clear();
@@ -113,8 +132,16 @@ export function clearGitHubCaches(): void {
   branchListETagCache.clear();
   reviewThreadsCache.clear();
   prRequiredStatusCache.clear();
+  forgeQueryCache.clear();
+  forgeQueryInflight.clear();
   GitHubFirstPageCache.getInstance().clear();
   GitHubStatsCache.getInstance().clear();
+}
+
+/** Test-only reset for the forge query cache + in-flight map. */
+export function _resetForgeQueryCachesForTests(): void {
+  forgeQueryCache.clear();
+  forgeQueryInflight.clear();
 }
 
 export function truncateBody(body: string | null | undefined, maxLength = 150): string {

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -23,9 +23,20 @@ vi.mock("../GitHubErrors.js", () => ({
 }));
 
 import { githubForgeProvider } from "../forgeProvider.js";
+import {
+  _resetForgeQueryCachesForTests,
+  clearGitHubCaches,
+  forgeQueryCache,
+} from "../GitHubCaches.js";
 import type { RepoRef } from "../../../../../shared/types/forge.js";
 
 const repo: RepoRef = { host: "github.com", owner: "owner", repo: "repo", rawData: null };
+
+// runQuery caches + coalesces across all provider methods, so every suite must
+// start from a clean cache or call-count assertions become order-dependent.
+beforeEach(() => {
+  _resetForgeQueryCachesForTests();
+});
 
 function makePRNode(number: number, headRefName: string) {
   return {
@@ -177,6 +188,99 @@ describe("findPRsByBranches", () => {
     const calledQuery = mockGraphQLClient.mock.calls[0][0] as string;
     const matches = calledQuery.match(/headRefName: "shared"/g);
     expect(matches?.length).toBe(1);
+  });
+});
+
+function makeIssueResponse(number: number) {
+  return {
+    repository: {
+      issue: {
+        number,
+        title: `Issue ${number}`,
+        bodyText: "",
+        state: "OPEN",
+        url: `https://github.com/owner/repo/issues/${number}`,
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+        closedAt: null,
+        author: { login: "user", avatarUrl: "" },
+      },
+    },
+    rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+  };
+}
+
+describe("runQuery cache + in-flight dedup", () => {
+  beforeEach(() => {
+    mockGraphQLClient.mockReset();
+  });
+
+  it("coalesces concurrent identical queries into one client call", async () => {
+    let resolveClient!: (value: unknown) => void;
+    mockGraphQLClient.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveClient = resolve;
+      })
+    );
+
+    const a = githubForgeProvider.getIssue!(repo, 1);
+    const b = githubForgeProvider.getIssue!(repo, 1);
+
+    resolveClient(makeIssueResponse(1));
+    const [ra, rb] = await Promise.all([a, b]);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+    expect(ra?.number).toBe(1);
+    expect(rb?.number).toBe(1);
+  });
+
+  it("serves a cache hit for a repeat query within the TTL", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(makeIssueResponse(1));
+
+    const first = await githubForgeProvider.getIssue!(repo, 1);
+    const second = await githubForgeProvider.getIssue!(repo, 1);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+    expect(first?.number).toBe(1);
+    expect(second?.number).toBe(1);
+  });
+
+  it("issues a separate request when variables differ", async () => {
+    mockGraphQLClient
+      .mockResolvedValueOnce(makeIssueResponse(1))
+      .mockResolvedValueOnce(makeIssueResponse(2));
+
+    await githubForgeProvider.getIssue!(repo, 1);
+    await githubForgeProvider.getIssue!(repo, 2);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache errors — a retry issues a fresh request", async () => {
+    mockGraphQLClient
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce(makeIssueResponse(1));
+
+    await expect(githubForgeProvider.getIssue!(repo, 1)).rejects.toThrow();
+    const retry = await githubForgeProvider.getIssue!(repo, 1);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+    expect(retry?.number).toBe(1);
+  });
+
+  it("clearGitHubCaches() drops the forge cache so the next call refetches", async () => {
+    mockGraphQLClient
+      .mockResolvedValueOnce(makeIssueResponse(1))
+      .mockResolvedValueOnce(makeIssueResponse(1));
+
+    await githubForgeProvider.getIssue!(repo, 1);
+    expect(forgeQueryCache.size()).toBe(1);
+
+    clearGitHubCaches();
+    expect(forgeQueryCache.size()).toBe(0);
+
+    await githubForgeProvider.getIssue!(repo, 1);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -26,6 +26,7 @@ import { githubForgeProvider } from "../forgeProvider.js";
 import {
   _resetForgeQueryCachesForTests,
   clearGitHubCaches,
+  clearPRCaches,
   forgeQueryCache,
 } from "../GitHubCaches.js";
 import type { RepoRef } from "../../../../../shared/types/forge.js";
@@ -277,6 +278,21 @@ describe("runQuery cache + in-flight dedup", () => {
     expect(forgeQueryCache.size()).toBe(1);
 
     clearGitHubCaches();
+    expect(forgeQueryCache.size()).toBe(0);
+
+    await githubForgeProvider.getIssue!(repo, 1);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("clearPRCaches() drops the forge cache so a manual refresh refetches", async () => {
+    mockGraphQLClient
+      .mockResolvedValueOnce(makeIssueResponse(1))
+      .mockResolvedValueOnce(makeIssueResponse(1));
+
+    await githubForgeProvider.getIssue!(repo, 1);
+    expect(forgeQueryCache.size()).toBe(1);
+
+    clearPRCaches();
     expect(forgeQueryCache.size()).toBe(0);
 
     await githubForgeProvider.getIssue!(repo, 1);

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -1,4 +1,5 @@
 import type { GraphQlQueryResponseData } from "@octokit/graphql";
+import { configure } from "safe-stable-stringify";
 import type {
   AuthValidation,
   CIStatus,
@@ -33,6 +34,7 @@ import {
   buildBatchBranchPRQuery,
 } from "./GitHubQueries.js";
 import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
+import { forgeQueryCache, forgeQueryInflight } from "./GitHubCaches.js";
 import { parseGitHubError } from "./GitHubErrors.js";
 import { deriveRequiredCIStatus } from "./prRequiredCIStatus.js";
 import type { RollupContextNode } from "./prRequiredCIStatus.js";
@@ -213,7 +215,17 @@ function buildOrderBy(opts: ListOptions): { field: string; direction: string } {
   return { field, direction };
 }
 
-async function runQuery(
+// Deterministic stringify so equivalent variables produce one cache key
+// regardless of property insertion order across call sites.
+const stringifyVariables = configure({ bigint: false });
+
+// `\0` can't appear in a GraphQL document, so it can't be forged by a query
+// string that happens to contain the serialized variables.
+function buildCacheKey(query: string, variables: Record<string, unknown>): string {
+  return `${query}\0${stringifyVariables(variables) ?? ""}`;
+}
+
+async function dispatchQuery(
   query: string,
   variables: Record<string, unknown>
 ): Promise<GraphQlQueryResponseData> {
@@ -228,6 +240,37 @@ async function runQuery(
   } catch (error) {
     throw new Error(parseGitHubError(error), { cause: error });
   }
+}
+
+/**
+ * Sole GraphQL entry point. Serves a 60s response cache and coalesces
+ * concurrent identical queries through an in-flight singleflight map (both in
+ * `GitHubCaches.ts` so a token change clears them atomically). Errors are never
+ * cached — a transient failure must not block retries for the full TTL.
+ */
+async function runQuery(
+  query: string,
+  variables: Record<string, unknown>
+): Promise<GraphQlQueryResponseData> {
+  const key = buildCacheKey(query, variables);
+
+  const cached = forgeQueryCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const inflight = forgeQueryInflight.get(key);
+  if (inflight !== undefined) return inflight;
+
+  const request = dispatchQuery(query, variables)
+    .then((response) => {
+      forgeQueryCache.set(key, response);
+      return response;
+    })
+    .finally(() => {
+      forgeQueryInflight.delete(key);
+    });
+
+  forgeQueryInflight.set(key, request);
+  return request;
 }
 
 async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<Page<Issue>> {


### PR DESCRIPTION
## Summary

After the CodeForge migration, `runQuery` in `forgeProvider.ts` made direct GraphQL calls with **no response caching and no in-flight dedup** — the legacy GitHub service layer had per-entity 60s `Cache<>` instances that the forge path dropped entirely. This restores both mechanisms at the right layers.

## Changes

- **`GitHubCaches.ts`** — added `forgeQueryCache` (60s TTL) + `forgeQueryInflight` singleflight map. Both are cleared by `clearGitHubCaches()` (token/settings change) **and** `clearPRCaches()` (manual PR refresh) so an explicit refresh never serves stale CI/PR state.
- **`forgeProvider.runQuery`** — checks the response cache, coalesces concurrent identical queries through the in-flight map, caches successes, and **never caches errors** (a transient failure must not block retries for the full TTL). Key = query + `safe-stable-stringify(variables)`, `\0`-delimited.
- **`ForgeBridge.invoke`** — strict IPC-boundary singleflight keyed by `method + namespacedId + args`, evicted on settlement and on `dispose()`, so concurrent identical workspace-host RPCs coalesce before crossing the process boundary.
- **Tests** — new cache/dedup suite for `forgeProvider` (16 tests) and a new `forgeBridge` dedup suite (6 tests): concurrent coalescing, cache hit within TTL, distinct-variable isolation, errors-not-cached, and cache-clear invalidation on both `clearGitHubCaches()` and `clearPRCaches()`.

Closes #9053.