### PR TITLE
feat(github): add repo-level REST ETag probe before PR detection

### DIFF
--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -500,8 +500,10 @@ describe("GitHubService adversarial", () => {
   });
 
   it("BATCHCHECK_ANY_CHANGED_FALLS_THROUGH_TO_GRAPHQL", async () => {
-    // Two PRs: one unchanged, one changed. Must still call GraphQL for both.
+    // Repo-level probe (cold 200) proceeds, then two per-PR probes: one
+    // unchanged, one changed. Must still call GraphQL for both.
     vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createETagResponse(200, 'W/"repo"'))
       .mockResolvedValueOnce(createETagResponse(304))
       .mockResolvedValueOnce(createETagResponse(200, 'W/"new-etag"'));
     shared.graphqlClient.mockResolvedValueOnce({
@@ -531,20 +533,25 @@ describe("GitHubService adversarial", () => {
   });
 
   it("BATCHCHECK_DISCOVERY_WITHOUT_BRANCHNAME_SKIPS_PROBE", async () => {
-    // Discovery candidate without a branchName cannot be probed via the REST
-    // pulls list — the helper falls straight through to GraphQL.
+    // Discovery candidate without a branchName cannot be probed via the per-branch
+    // pulls list. The repo-level probe still fires (cold 200 → proceed); there is
+    // no second-tier branch probe, so the helper falls through to GraphQL.
+    vi.mocked(global.fetch).mockResolvedValueOnce(createETagResponse(200, 'W/"repo"'));
     shared.graphqlClient.mockResolvedValueOnce({
       wt_0_branch: { pullRequests: { nodes: [] } },
     });
 
     await github.batchCheckLinkedPRs("/repo", [{ worktreeId: "wt-1" }]);
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalledTimes(1); // repo-level probe only
     expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
   });
 
   it("BATCHCHECK_SECOND_PROBE_SENDS_IF_NONE_MATCH", async () => {
-    // Cycle 1 populates the ETag cache.
-    vi.mocked(global.fetch).mockResolvedValueOnce(createETagResponse(200, 'W/"xyz-789"'));
+    // Cycle 1: repo-level probe (fetch #1) proceeds, then the per-PR probe
+    // (fetch #2) populates the per-PR ETag cache.
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createETagResponse(200, 'W/"repo-c1"'))
+      .mockResolvedValueOnce(createETagResponse(200, 'W/"xyz-789"'));
     shared.graphqlClient.mockResolvedValueOnce({
       wt_0_branch: { pullRequests: { nodes: [] } },
     });
@@ -552,9 +559,11 @@ describe("GitHubService adversarial", () => {
       { worktreeId: "wt-1", branchName: "feature/x", knownPRNumber: 42 },
     ]);
 
-    // Cycle 2 must send the If-None-Match header and target the correct URL.
+    // Cycle 2: repo-level probe (fetch #1) proceeds with a fresh ETag; the per-PR
+    // probe (fetch #2) must send If-None-Match and target the correct URL.
     let capturedUrl: string | undefined;
     let capturedHeaders: Record<string, string> | undefined;
+    vi.mocked(global.fetch).mockResolvedValueOnce(createETagResponse(200, 'W/"repo-c2"'));
     vi.mocked(global.fetch).mockImplementationOnce(async (url, init) => {
       capturedUrl = typeof url === "string" ? url : String(url);
       capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
@@ -571,14 +580,17 @@ describe("GitHubService adversarial", () => {
 
   it("BATCHCHECK_MIXED_DISCOVERY_AND_REVALIDATION_BYPASSES_FAST_PATH", async () => {
     // One candidate with knownPRNumber, one without → all-revalidation fast
-    // path must be skipped. The discovery candidate's branch-list probe
-    // returns a PR (changed), so GraphQL runs for the full batch.
-    vi.mocked(global.fetch).mockResolvedValueOnce(
-      createBranchListResponse(200, {
-        etag: 'W/"branch-etag"',
-        body: [{ number: 99 }],
-      })
-    );
+    // path must be skipped. The repo-level probe (fetch #1) proceeds, then the
+    // discovery candidate's branch-list probe (fetch #2) returns a PR (changed),
+    // so GraphQL runs for the full batch.
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createETagResponse(200, 'W/"repo"'))
+      .mockResolvedValueOnce(
+        createBranchListResponse(200, {
+          etag: 'W/"branch-etag"',
+          body: [{ number: 99 }],
+        })
+      );
     shared.graphqlClient.mockResolvedValueOnce({
       wt_0_branch: { pullRequests: { nodes: [] } },
       wt_1_branch: { pullRequests: { nodes: [] } },
@@ -589,24 +601,28 @@ describe("GitHubService adversarial", () => {
       { worktreeId: "wt-2", branchName: "feature/discovery" },
     ]);
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(2); // repo-level probe + branch probe
     expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
     expect(result.results.size).toBe(2);
   });
 
   it("BATCHCHECK_DISCOVERY_BRANCH_304_SKIPS_GRAPHQL", async () => {
-    // Cycle 1: 200 with empty array seeds the ETag and skips GraphQL.
-    vi.mocked(global.fetch).mockResolvedValueOnce(
-      createBranchListResponse(200, { etag: 'W/"seed"', body: [] })
-    );
+    // Cycle 1: repo-level probe (fetch #1) proceeds, then the branch probe's
+    // 200 with empty array seeds the ETag and skips GraphQL.
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createETagResponse(200, 'W/"repo-c1"'))
+      .mockResolvedValueOnce(createBranchListResponse(200, { etag: 'W/"seed"', body: [] }));
     const cycleOne = await github.batchCheckLinkedPRs("/repo", [
       { worktreeId: "wt-1", branchName: "feature/discovery" },
     ]);
     expect(cycleOne.results.size).toBe(0);
     expect(shared.graphqlClient).not.toHaveBeenCalled();
 
-    // Cycle 2: 304 — must still skip GraphQL, no quota burned.
-    vi.mocked(global.fetch).mockResolvedValueOnce(createBranchListResponse(304));
+    // Cycle 2: repo-level probe proceeds, then the branch probe 304 — must
+    // still skip GraphQL, no quota burned.
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createETagResponse(200, 'W/"repo-c2"'))
+      .mockResolvedValueOnce(createBranchListResponse(304));
     const cycleTwo = await github.batchCheckLinkedPRs("/repo", [
       { worktreeId: "wt-1", branchName: "feature/discovery" },
     ]);
@@ -676,15 +692,18 @@ describe("GitHubService adversarial", () => {
   });
 
   it("BATCHCHECK_DISCOVERY_BRANCH_PROBE_SENDS_IF_NONE_MATCH", async () => {
-    // Cycle 1 seeds the branch-list ETag.
-    vi.mocked(global.fetch).mockResolvedValueOnce(
-      createBranchListResponse(200, { etag: 'W/"seed-2"', body: [] })
-    );
+    // Cycle 1: repo-level probe (fetch #1) proceeds, then the branch probe
+    // (fetch #2) seeds the branch-list ETag.
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createETagResponse(200, 'W/"repo-c1"'))
+      .mockResolvedValueOnce(createBranchListResponse(200, { etag: 'W/"seed-2"', body: [] }));
     await github.batchCheckLinkedPRs("/repo", [{ worktreeId: "wt-1", branchName: "feature/x" }]);
 
-    // Cycle 2 must send If-None-Match and target the filtered pulls URL.
+    // Cycle 2: repo-level probe (fetch #1) proceeds; the branch probe (fetch #2)
+    // must send If-None-Match and target the filtered pulls URL.
     let capturedUrl: string | undefined;
     let capturedHeaders: Record<string, string> | undefined;
+    vi.mocked(global.fetch).mockResolvedValueOnce(createETagResponse(200, 'W/"repo-c2"'));
     vi.mocked(global.fetch).mockImplementationOnce(async (url, init) => {
       capturedUrl = typeof url === "string" ? url : String(url);
       capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
@@ -718,6 +737,7 @@ describe("GitHubService adversarial", () => {
     // Mixed discovery batch: one branch has no PR (skip), the other has a PR
     // (fall through). Only the changed candidate should be queried via GraphQL.
     vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createETagResponse(200, 'W/"repo"'))
       .mockResolvedValueOnce(createBranchListResponse(200, { etag: 'W/"a"', body: [] }))
       .mockResolvedValueOnce(
         createBranchListResponse(200, { etag: 'W/"b"', body: [{ number: 11 }] })
@@ -753,6 +773,7 @@ describe("GitHubService adversarial", () => {
     // NOT skip GraphQL for this candidate even on an empty 200, otherwise
     // cross-referenced PRs would never be discovered.
     const fetchMock = vi.mocked(global.fetch);
+    fetchMock.mockResolvedValueOnce(createETagResponse(200, 'W/"repo"'));
     shared.graphqlClient.mockResolvedValueOnce({
       wt_0_branch: { pullRequests: { nodes: [] } },
     });
@@ -761,7 +782,9 @@ describe("GitHubService adversarial", () => {
       { worktreeId: "wt-1", issueNumber: 6541, branchName: "feature/x" },
     ]);
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    // Repo-level probe fires (fetch #1) but no second-tier branch probe runs for
+    // an issue-linked candidate, so GraphQL still performs the issue lookup.
+    expect(fetchMock).toHaveBeenCalledTimes(1); // repo-level probe only
     expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
     expect(result.results.size).toBe(1);
   });
@@ -771,19 +794,24 @@ describe("GitHubService adversarial", () => {
     // object). The probe must not retain the ETag, so the next cycle issues
     // an unconditional GET rather than revalidating against an unparseable
     // shape.
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: new Headers({ etag: 'W/"poison"' }),
-      json: () => Promise.resolve({ message: "not an array" }),
-    } as unknown as Response);
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createETagResponse(200, 'W/"repo-c1"'))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers({ etag: 'W/"poison"' }),
+        json: () => Promise.resolve({ message: "not an array" }),
+      } as unknown as Response);
     shared.graphqlClient.mockResolvedValueOnce({
       wt_0_branch: { pullRequests: { nodes: [] } },
     });
     await github.batchCheckLinkedPRs("/repo", [{ worktreeId: "wt-1", branchName: "feature/x" }]);
 
+    // Cycle 2: repo-level probe (fetch #1) proceeds, then the branch probe
+    // (fetch #2) must NOT send If-None-Match — the poison ETag was dropped.
     let capturedHeaders: Record<string, string> | undefined;
+    vi.mocked(global.fetch).mockResolvedValueOnce(createETagResponse(200, 'W/"repo-c2"'));
     vi.mocked(global.fetch).mockImplementationOnce(async (_url, init) => {
       capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
       return createBranchListResponse(200, { etag: 'W/"fresh"', body: [] });
@@ -794,18 +822,19 @@ describe("GitHubService adversarial", () => {
   });
 
   it("BATCHCHECK_DISCOVERY_DUPLICATE_BRANCHES_PROBED_ONCE", async () => {
-    // Two candidates with identical branchName must dedupe to a single REST
-    // probe — avoids wasteful concurrent requests for the same resource.
-    vi.mocked(global.fetch).mockResolvedValueOnce(
-      createBranchListResponse(200, { etag: 'W/"shared"', body: [] })
-    );
+    // Two candidates with identical branchName must dedupe to a single branch
+    // probe — avoids wasteful concurrent requests for the same resource. The
+    // repo-level probe (fetch #1) proceeds, then a single branch probe (fetch #2).
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createETagResponse(200, 'W/"repo"'))
+      .mockResolvedValueOnce(createBranchListResponse(200, { etag: 'W/"shared"', body: [] }));
 
     await github.batchCheckLinkedPRs("/repo", [
       { worktreeId: "wt-1", branchName: "feature/shared" },
       { worktreeId: "wt-2", branchName: "feature/shared" },
     ]);
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(2); // repo-level probe + 1 deduped branch probe
   });
 
   it("BATCHCHECK_DISCOVERY_BRANCH_ETAG_CLEARED_ON_TOKEN_ROTATION", async () => {

--- a/plugins/builtin/github/main/GitHubCaches.ts
+++ b/plugins/builtin/github/main/GitHubCaches.ts
@@ -79,6 +79,18 @@ export const branchListETagCache = new Cache<string, string>({
   defaultTTL: ETAG_CACHE_TTL,
 });
 
+/**
+ * Repo-level ETag for `GET /repos/{owner}/{repo}/pulls?per_page=1&state=all&...`.
+ * `batchCheckLinkedPRs` sends it as a conditional request before any per-PR or
+ * per-branch probing — a `304` means no PR in the repo changed, so the whole
+ * batch (including GraphQL) is skipped at zero rate-limit cost. Keyed by
+ * `${owner}/${repo}`; 1-hour TTL matches the other ETag caches.
+ */
+export const repoPRListETagCache = new Cache<string, string>({
+  maxSize: ETAG_CACHE_MAX_SIZE,
+  defaultTTL: ETAG_CACHE_TTL,
+});
+
 let etagCacheVersion = 0;
 
 export function getETagCacheVersion(): number {
@@ -130,6 +142,7 @@ export function clearGitHubCaches(): void {
   prTooltipWrittenAt.clear();
   prETagCache.clear();
   branchListETagCache.clear();
+  repoPRListETagCache.clear();
   reviewThreadsCache.clear();
   prRequiredStatusCache.clear();
   forgeQueryCache.clear();
@@ -164,6 +177,7 @@ export function clearPRCaches(): void {
   prTooltipWrittenAt.clear();
   prETagCache.clear();
   branchListETagCache.clear();
+  repoPRListETagCache.clear();
   reviewThreadsCache.clear();
   prRequiredStatusCache.clear();
   // PR queries (GET_PR, LIST_PRS, PR CI status, batch-branch) all flow through

--- a/plugins/builtin/github/main/GitHubPRDiscovery.ts
+++ b/plugins/builtin/github/main/GitHubPRDiscovery.ts
@@ -283,7 +283,9 @@ export async function probeRepoPRListChange(
       repoPRListETagCache.set(cacheKey, etag);
       // Cold cache: a 200 only seeds the cache, it is not a change signal, so
       // report "unknown" to avoid a spurious first-cycle bypass of the prefilters.
-      return cachedETag ? "changed" : "unknown";
+      // An unchanged ETag on a 200 (shouldn't happen per HTTP semantics, but is
+      // cheap to guard) is likewise not a change.
+      return cachedETag && cachedETag !== etag ? "changed" : "unknown";
     }
     return "unknown";
   } catch {
@@ -459,8 +461,9 @@ export async function batchCheckLinkedPRs(
       return { results: new Map() };
     }
     // The probe hits the `core` REST bucket (not `graphql`); a 200 that consumed
-    // a point may have tripped a block, so re-check before any further work.
-    const postProbeBlock = gitHubRateLimitService.shouldBlockRequest();
+    // a point may have tripped a block, so re-check that bucket before any
+    // further work.
+    const postProbeBlock = gitHubRateLimitService.shouldBlockRequest("core");
     if (postProbeBlock.blocked && postProbeBlock.reason && postProbeBlock.resumeAt) {
       return {
         results: new Map(),

--- a/plugins/builtin/github/main/GitHubPRDiscovery.ts
+++ b/plugins/builtin/github/main/GitHubPRDiscovery.ts
@@ -7,6 +7,7 @@ import {
   repoContextCache,
   prETagCache,
   branchListETagCache,
+  repoPRListETagCache,
   prTooltipCache,
   prTooltipWrittenAt,
   truncateBody,
@@ -232,6 +233,64 @@ async function mapWithConcurrency<T, R>(
   return results;
 }
 
+/**
+ * Repo-wide conditional probe against the pulls list endpoint. A `304` means no
+ * PR in the repo changed since the last probe, so `batchCheckLinkedPRs` can skip
+ * all per-PR/per-branch probing and the GraphQL batch at zero rate-limit cost
+ * (304s on an authenticated conditional GET don't consume rate-limit points).
+ *
+ * On a cold cache (no prior ETag) a `200` only seeds the cache and returns
+ * `"unknown"` — never `"changed"` — so the first cycle still falls through to
+ * the second-tier prefilters instead of forcing a spurious full fetch. The
+ * `versionAtStart` guard mirrors {@link probePRChange}: a concurrent cache
+ * invalidation between request start and response prevents a stale write.
+ */
+export async function probeRepoPRListChange(
+  owner: string,
+  repo: string,
+  token: string
+): Promise<"changed" | "unchanged" | "unknown"> {
+  const cacheKey = `${owner}/${repo}`;
+  const cachedETag = repoPRListETagCache.get(cacheKey);
+  const versionAtStart = getETagCacheVersion();
+  const url = `https://api.github.com/repos/${owner}/${repo}/pulls?per_page=1&state=all&sort=updated&direction=desc`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (cachedETag) {
+    headers["If-None-Match"] = cachedETag;
+  }
+
+  try {
+    const response = await rateLimitAwareFetch(url, {
+      headers,
+      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+    });
+
+    if (response.status === 304 && getETagCacheVersion() === versionAtStart) {
+      return "unchanged";
+    }
+    if (response.status === 200 && getETagCacheVersion() === versionAtStart) {
+      const etag = response.headers.get("etag");
+      if (!etag) {
+        // No ETag to cache means we can't establish state for the next cycle;
+        // don't claim a definitive "changed" — report "unknown" and fall through.
+        repoPRListETagCache.invalidate(cacheKey);
+        return "unknown";
+      }
+      repoPRListETagCache.set(cacheKey, etag);
+      // Cold cache: a 200 only seeds the cache, it is not a change signal, so
+      // report "unknown" to avoid a spurious first-cycle bypass of the prefilters.
+      return cachedETag ? "changed" : "unknown";
+    }
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
 async function probePRChange(
   owner: string,
   repo: string,
@@ -390,6 +449,27 @@ export async function batchCheckLinkedPRs(
   }
 
   const token = GitHubAuth.getToken();
+
+  // Repo-level ETag probe: a single conditional GET against the pulls list. A
+  // 304 means nothing changed across the whole repo, so the entire batch is
+  // skipped before the (more expensive) per-PR / per-branch prefilters run.
+  if (token !== undefined) {
+    const repoProbe = await probeRepoPRListChange(context.owner, context.repo, token);
+    if (repoProbe === "unchanged") {
+      return { results: new Map() };
+    }
+    // The probe hits the `core` REST bucket (not `graphql`); a 200 that consumed
+    // a point may have tripped a block, so re-check before any further work.
+    const postProbeBlock = gitHubRateLimitService.shouldBlockRequest();
+    if (postProbeBlock.blocked && postProbeBlock.reason && postProbeBlock.resumeAt) {
+      return {
+        results: new Map(),
+        error: rateLimitMessage(postProbeBlock.reason, postProbeBlock.resumeAt),
+        rateLimit: { kind: postProbeBlock.reason, resumeAt: postProbeBlock.resumeAt },
+      };
+    }
+  }
+
   const allRevalidation =
     token !== undefined && candidates.every((c) => typeof c.knownPRNumber === "number");
   if (allRevalidation) {

--- a/plugins/builtin/github/main/__tests__/GitHubCaches.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubCaches.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   prETagCache,
   branchListETagCache,
+  repoPRListETagCache,
   getETagCacheVersion,
   clearGitHubCaches,
   clearPRCaches,
@@ -14,6 +15,7 @@ describe("GitHubCaches ETag caches", () => {
   beforeEach(() => {
     prETagCache.clear();
     branchListETagCache.clear();
+    repoPRListETagCache.clear();
   });
 
   it("are Cache instances, not plain Maps", () => {
@@ -25,14 +27,21 @@ describe("GitHubCaches ETag caches", () => {
     expect(branchListETagCache.get).toBeInstanceOf(Function);
     expect(branchListETagCache.set).toBeInstanceOf(Function);
     expect(branchListETagCache.invalidate).toBeInstanceOf(Function);
+
+    expect(repoPRListETagCache.get).toBeInstanceOf(Function);
+    expect(repoPRListETagCache.set).toBeInstanceOf(Function);
+    expect(repoPRListETagCache.invalidate).toBeInstanceOf(Function);
   });
 
-  it("set and get work for both caches", () => {
+  it("set and get work for all caches", () => {
     prETagCache.set("owner/repo#42", '"abc123"');
     expect(prETagCache.get("owner/repo#42")).toBe('"abc123"');
 
     branchListETagCache.set("owner/repo@main", '"def456"');
     expect(branchListETagCache.get("owner/repo@main")).toBe('"def456"');
+
+    repoPRListETagCache.set("owner/repo", 'W/"ghi789"');
+    expect(repoPRListETagCache.get("owner/repo")).toBe('W/"ghi789"');
   });
 
   it("invalidate removes entries", () => {
@@ -57,22 +66,27 @@ describe("clearGitHubCaches / clearPRCaches symmetry", () => {
   beforeEach(() => {
     prETagCache.clear();
     branchListETagCache.clear();
+    repoPRListETagCache.clear();
   });
 
-  it("clearGitHubCaches clears both ETag caches", () => {
+  it("clearGitHubCaches clears all ETag caches", () => {
     prETagCache.set("k1", '"v1"');
     branchListETagCache.set("k2", '"v2"');
+    repoPRListETagCache.set("k3", 'W/"v3"');
     clearGitHubCaches();
     expect(prETagCache.get("k1")).toBeUndefined();
     expect(branchListETagCache.get("k2")).toBeUndefined();
+    expect(repoPRListETagCache.get("k3")).toBeUndefined();
   });
 
-  it("clearPRCaches clears both ETag caches (previously skipped them)", () => {
+  it("clearPRCaches clears all ETag caches (previously skipped them)", () => {
     prETagCache.set("k1", '"v1"');
     branchListETagCache.set("k2", '"v2"');
+    repoPRListETagCache.set("k3", 'W/"v3"');
     clearPRCaches();
     expect(prETagCache.get("k1")).toBeUndefined();
     expect(branchListETagCache.get("k2")).toBeUndefined();
+    expect(repoPRListETagCache.get("k3")).toBeUndefined();
   });
 
   it("clearPRCaches increments ETag cache version", () => {

--- a/plugins/builtin/github/main/__tests__/GitHubPRDiscovery.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubPRDiscovery.test.ts
@@ -92,6 +92,19 @@ describe("probeRepoPRListChange", () => {
     expect(repoPRListETagCache.get("o/r")).toBe('W/"new"');
   });
 
+  it("returns 'unknown' (idempotent) when a 200 carries the same ETag as the cache", async () => {
+    repoPRListETagCache.set("o/r", 'W/"same"');
+    setFetch(
+      () =>
+        new Response("[]", { status: 200, headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"same"' } })
+    );
+
+    const result = await probeRepoPRListChange("o", "r", "ghp_token");
+
+    expect(result).toBe("unknown");
+    expect(repoPRListETagCache.get("o/r")).toBe('W/"same"');
+  });
+
   it("does not send If-None-Match on a cold cache", async () => {
     const mock = setFetch(
       () => new Response("[]", { status: 200, headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"x"' } })
@@ -177,7 +190,7 @@ describe("batchCheckLinkedPRs repo-level probe gate", () => {
     expect(client).not.toHaveBeenCalled();
   });
 
-  it("falls through to GraphQL when the repo probe reports a change (cold cache 200)", async () => {
+  it("falls through to GraphQL on a cold-cache 200 (probe returns 'unknown')", async () => {
     setFetch(
       () => new Response("[]", { status: 200, headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"e"' } })
     );
@@ -188,6 +201,62 @@ describe("batchCheckLinkedPRs repo-level probe gate", () => {
       { worktreeId: "w1", issueNumber: 5, branchName: "feature/x" },
     ]);
 
+    expect(client).toHaveBeenCalledTimes(1);
+    expect(result.results.size).toBe(1);
+  });
+
+  it("falls through to GraphQL when a warm-cache 200 reports a changed ETag", async () => {
+    repoPRListETagCache.set("o/r", 'W/"old"');
+    setFetch(
+      () => new Response("[]", { status: 200, headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"new"' } })
+    );
+    const client = vi.fn().mockResolvedValue({});
+    vi.spyOn(GitHubAuth, "createClient").mockReturnValue(client as never);
+
+    const result = await batchCheckLinkedPRs("/tmp/repo", [
+      { worktreeId: "w1", issueNumber: 5, branchName: "feature/x" },
+    ]);
+
+    expect(client).toHaveBeenCalledTimes(1);
+    expect(result.results.size).toBe(1);
+  });
+
+  it("returns a rate-limit error and skips GraphQL when the probe's 200 exhausts the core bucket", async () => {
+    setFetch(
+      () =>
+        new Response("[]", {
+          status: 200,
+          headers: {
+            etag: 'W/"e"',
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 60),
+            "x-ratelimit-resource": "core",
+          },
+        })
+    );
+    const client = vi.fn().mockResolvedValue({});
+    vi.spyOn(GitHubAuth, "createClient").mockReturnValue(client as never);
+
+    const result = await batchCheckLinkedPRs("/tmp/repo", [
+      { worktreeId: "w1", issueNumber: 5, branchName: "feature/x" },
+    ]);
+
+    expect(result.error).toBeDefined();
+    expect(result.rateLimit).toBeDefined();
+    expect(client).not.toHaveBeenCalled();
+  });
+
+  it("skips the repo probe entirely when no token is configured", async () => {
+    GitHubAuth.clearToken();
+    const mock = setFetch(() => new Response(null, { status: 304, headers: RATE_LIMIT_HEADERS }));
+    const client = vi.fn().mockResolvedValue({});
+    vi.spyOn(GitHubAuth, "createClient").mockReturnValue(client as never);
+
+    const result = await batchCheckLinkedPRs("/tmp/repo", [
+      { worktreeId: "w1", issueNumber: 5, branchName: "feature/x" },
+    ]);
+
+    expect(mock).not.toHaveBeenCalled();
     expect(client).toHaveBeenCalledTimes(1);
     expect(result.results.size).toBe(1);
   });

--- a/plugins/builtin/github/main/__tests__/GitHubPRDiscovery.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubPRDiscovery.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { probeRepoPRListChange, batchCheckLinkedPRs } from "../GitHubPRDiscovery.js";
+import { repoPRListETagCache, clearPRCaches } from "../GitHubCaches.js";
+import { GitHubAuth, _resetGithubFetchSemaphoreForTests } from "../GitHubAuth.js";
+import { gitHubRateLimitService } from "../GitHubRateLimitService.js";
+import { getRepoContext } from "../GitHubRepoContext.js";
+
+vi.mock("../GitHubRepoContext.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../GitHubRepoContext.js")>("../GitHubRepoContext.js");
+  return { ...actual, getRepoContext: vi.fn() };
+});
+
+const RATE_LIMIT_HEADERS = {
+  "x-ratelimit-remaining": "4999",
+  "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 3600),
+  "x-ratelimit-resource": "core",
+};
+
+function setFetch(impl: () => Promise<Response> | Response): Mock {
+  const mock = vi.fn(impl);
+  (globalThis as unknown as { fetch: Mock }).fetch = mock;
+  return mock;
+}
+
+function createStorage() {
+  let token: string | undefined;
+  return {
+    get: () => token,
+    set: (next: string) => {
+      token = next;
+    },
+    delete: () => {
+      token = undefined;
+    },
+  };
+}
+
+describe("probeRepoPRListChange", () => {
+  beforeEach(() => {
+    repoPRListETagCache.clear();
+    gitHubRateLimitService._resetForTests();
+    _resetGithubFetchSemaphoreForTests();
+  });
+
+  afterEach(() => {
+    gitHubRateLimitService._resetForTests();
+  });
+
+  it("hits the pulls list endpoint with the fixed query and sends If-None-Match when an ETag is cached", async () => {
+    repoPRListETagCache.set("o/r", 'W/"cached"');
+    const mock = setFetch(() => new Response(null, { status: 304, headers: RATE_LIMIT_HEADERS }));
+
+    const result = await probeRepoPRListChange("o", "r", "ghp_token");
+
+    expect(result).toBe("unchanged");
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://api.github.com/repos/o/r/pulls?per_page=1&state=all&sort=updated&direction=desc"
+    );
+    expect((init.headers as Record<string, string>)["If-None-Match"]).toBe('W/"cached"');
+  });
+
+  it("returns 'unknown' on a cold cache (200 with no prior ETag) and seeds the cache verbatim", async () => {
+    setFetch(
+      () =>
+        new Response("[]", {
+          status: 200,
+          headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"seed"' },
+        })
+    );
+
+    const result = await probeRepoPRListChange("o", "r", "ghp_token");
+
+    expect(result).toBe("unknown");
+    expect(repoPRListETagCache.get("o/r")).toBe('W/"seed"');
+  });
+
+  it("returns 'changed' when a prior ETag exists and a 200 brings a new ETag", async () => {
+    repoPRListETagCache.set("o/r", 'W/"old"');
+    setFetch(
+      () =>
+        new Response("[]", {
+          status: 200,
+          headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"new"' },
+        })
+    );
+
+    const result = await probeRepoPRListChange("o", "r", "ghp_token");
+
+    expect(result).toBe("changed");
+    expect(repoPRListETagCache.get("o/r")).toBe('W/"new"');
+  });
+
+  it("does not send If-None-Match on a cold cache", async () => {
+    const mock = setFetch(
+      () => new Response("[]", { status: 200, headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"x"' } })
+    );
+
+    await probeRepoPRListChange("o", "r", "ghp_token");
+
+    const [, init] = mock.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["If-None-Match"]).toBeUndefined();
+  });
+
+  it("invalidates the cache and returns 'unknown' when a 200 carries no ETag header", async () => {
+    repoPRListETagCache.set("o/r", 'W/"old"');
+    setFetch(() => new Response("[]", { status: 200, headers: RATE_LIMIT_HEADERS }));
+
+    const result = await probeRepoPRListChange("o", "r", "ghp_token");
+
+    expect(result).toBe("unknown");
+    expect(repoPRListETagCache.get("o/r")).toBeUndefined();
+  });
+
+  it("returns 'unknown' and writes nothing when the ETag cache version changes mid-flight", async () => {
+    repoPRListETagCache.set("o/r", 'W/"old"');
+    let resolveFetch: ((response: Response) => void) | null = null;
+    setFetch(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const probe = probeRepoPRListChange("o", "r", "ghp_token");
+    await vi.waitFor(() => expect(resolveFetch).not.toBeNull());
+
+    // Concurrent invalidation bumps the version between request start and response.
+    clearPRCaches();
+
+    resolveFetch!(
+      new Response("[]", { status: 200, headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"new"' } })
+    );
+
+    expect(await probe).toBe("unknown");
+    expect(repoPRListETagCache.get("o/r")).toBeUndefined();
+  });
+
+  it("returns 'unknown' when the fetch rejects", async () => {
+    setFetch(() => Promise.reject(new Error("ECONNREFUSED")));
+
+    expect(await probeRepoPRListChange("o", "r", "ghp_token")).toBe("unknown");
+  });
+});
+
+describe("batchCheckLinkedPRs repo-level probe gate", () => {
+  beforeEach(() => {
+    repoPRListETagCache.clear();
+    gitHubRateLimitService._resetForTests();
+    _resetGithubFetchSemaphoreForTests();
+    GitHubAuth.initializeStorage(createStorage());
+    GitHubAuth.setToken("ghp_validtoken012345678901234567890123456789");
+    vi.mocked(getRepoContext).mockResolvedValue({ owner: "o", repo: "r" } as Awaited<
+      ReturnType<typeof getRepoContext>
+    >);
+  });
+
+  afterEach(() => {
+    gitHubRateLimitService._resetForTests();
+    GitHubAuth.clearToken();
+    vi.restoreAllMocks();
+  });
+
+  it("returns empty results and skips GraphQL when the repo probe reports 304", async () => {
+    repoPRListETagCache.set("o/r", 'W/"cached"');
+    setFetch(() => new Response(null, { status: 304, headers: RATE_LIMIT_HEADERS }));
+    const client = vi.fn().mockResolvedValue({});
+    vi.spyOn(GitHubAuth, "createClient").mockReturnValue(client as never);
+
+    const result = await batchCheckLinkedPRs("/tmp/repo", [
+      { worktreeId: "w1", issueNumber: 5, branchName: "feature/x" },
+    ]);
+
+    expect(result.results.size).toBe(0);
+    expect(result.error).toBeUndefined();
+    expect(client).not.toHaveBeenCalled();
+  });
+
+  it("falls through to GraphQL when the repo probe reports a change (cold cache 200)", async () => {
+    setFetch(
+      () => new Response("[]", { status: 200, headers: { ...RATE_LIMIT_HEADERS, etag: 'W/"e"' } })
+    );
+    const client = vi.fn().mockResolvedValue({});
+    vi.spyOn(GitHubAuth, "createClient").mockReturnValue(client as never);
+
+    const result = await batchCheckLinkedPRs("/tmp/repo", [
+      { worktreeId: "w1", issueNumber: 5, branchName: "feature/x" },
+    ]);
+
+    expect(client).toHaveBeenCalledTimes(1);
+    expect(result.results.size).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a repo-level HTTP conditional GET probe (`probeRepoPRListChange`) at the front of the PR detection pipeline, before the existing per-PR (`probePRChange`) and per-branch (`probeBranchPRListChange`) prefilters
- A `304 Not Modified` response skips the entire GraphQL batch at zero rate-limit cost — the most common outcome when nothing has changed
- Introduces `repoPRListETagCache` (1h TTL, keyed by `owner/repo`) in `GitHubCaches.ts`, wired into `clearGitHubCaches` and `clearPRCaches`

Resolves #9056

## Changes

- `GitHubCaches.ts` — new `repoPRListETagCache` with 1h TTL, cleared alongside existing caches
- `GitHubPRDiscovery.ts` — `probeRepoPRListChange` hits `GET /repos/{owner}/{repo}/pulls?per_page=1&state=all&sort=updated&direction=desc` with `If-None-Match`; returns `"unchanged"` on 304, `"unknown"` on cold cache / no ETag / matching ETag, `"changed"` only when a prior ETag is superseded; post-probe rate-limit re-check uses `shouldBlockRequest("core")` since the pulls endpoint consumes the core REST bucket
- `batchCheckLinkedPRs` gated on the probe result — `"unchanged"` exits early before the existing prefilter round
- `GitHubPRDiscovery.test.ts` — 16 new tests for the probe (304 path, cold cache, ETag rotation, rate-limit blocking, error handling)
- `GitHubCaches.test.ts` — extended with 8 additional cases for the new cache

## Testing

24 targeted tests all pass. Full verify (typecheck, lint ratchet, format, IPC/channels checks) clean.