### PR TITLE
perf(github): fold required-checks CI signal into LIST_PRS_QUERY

### DIFF
--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -21,8 +21,12 @@ import {
   type PRRequiredStatusEntry,
 } from "./GitHubCaches.js";
 import { GitHubStatsCache } from "../../../../electron/services/GitHubStatsCache.js";
-import { deriveRequiredCIStatus, normalizeRawState } from "./prRequiredCIStatus.js";
-import type { RollupContextNode } from "./prRequiredCIStatus.js";
+import {
+  deriveRequiredCIStatus,
+  deriveGlobalCIStatus,
+  normalizeRawState,
+} from "./prRequiredCIStatus.js";
+import type { RollupContextNode, GlobalCIDeriveInput } from "./prRequiredCIStatus.js";
 import type {
   GitHubPR,
   GitHubListOptions,
@@ -88,9 +92,39 @@ export function parsePRNode(node: Record<string, unknown>): GitHubPR {
   const isFork = headName && baseName ? headName !== baseName : undefined;
 
   const commitsData = node.commits as
-    | { nodes?: Array<{ commit?: { statusCheckRollup?: { state?: string } | null } | null }> }
+    | {
+        nodes?: Array<{
+          commit?: {
+            statusCheckRollup?: { state?: string; contexts?: Record<string, unknown> } | null;
+          } | null;
+        }>;
+      }
     | undefined;
   const ciStatus = normalizeRawState(commitsData?.nodes?.[0]?.commit?.statusCheckRollup?.state);
+
+  const reviewDecisionRaw = node.reviewDecision as string | null | undefined;
+  const reviewDecision =
+    reviewDecisionRaw === "APPROVED" ||
+    reviewDecisionRaw === "CHANGES_REQUESTED" ||
+    reviewDecisionRaw === "REVIEW_REQUIRED"
+      ? reviewDecisionRaw
+      : undefined;
+
+  const mergeStateStatusRaw = node.mergeStateStatus as string | null | undefined;
+  const mergeStateStatus = mergeStateStatusRaw
+    ? (mergeStateStatusRaw.toUpperCase() as GitHubPR["mergeStateStatus"])
+    : undefined;
+
+  const rollupContexts = commitsData?.nodes?.[0]?.commit?.statusCheckRollup?.contexts as
+    | GlobalCIDeriveInput
+    | undefined;
+  const globalDerived = deriveGlobalCIStatus({
+    checkRunCountsByState: rollupContexts?.checkRunCountsByState,
+    statusContextCountsByState: rollupContexts?.statusContextCountsByState,
+    checkRunCount: rollupContexts?.checkRunCount,
+    statusContextCount: rollupContexts?.statusContextCount,
+    mergeStateStatus,
+  });
 
   return {
     number: node.number as number,
@@ -108,6 +142,10 @@ export function parsePRNode(node: Record<string, unknown>): GitHubPR {
     headRefName: (node.headRefName as string) || undefined,
     isFork: isFork ?? undefined,
     ciStatus,
+    reviewDecision,
+    mergeStateStatus,
+    globalCIStatus: globalDerived.ciStatus,
+    globalCISummary: globalDerived.ciSummary,
     bodyText: (node.bodyText as string) || undefined,
   };
 }

--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -111,9 +111,19 @@ export function parsePRNode(node: Record<string, unknown>): GitHubPR {
       : undefined;
 
   const mergeStateStatusRaw = node.mergeStateStatus as string | null | undefined;
-  const mergeStateStatus = mergeStateStatusRaw
-    ? (mergeStateStatusRaw.toUpperCase() as GitHubPR["mergeStateStatus"])
-    : undefined;
+  const validMergeStates = new Set([
+    "BEHIND",
+    "BLOCKED",
+    "CLEAN",
+    "DIRTY",
+    "HAS_HOOKS",
+    "UNKNOWN",
+    "UNSTABLE",
+  ]);
+  const mergeStateStatus =
+    mergeStateStatusRaw && validMergeStates.has(mergeStateStatusRaw.toUpperCase())
+      ? (mergeStateStatusRaw.toUpperCase() as GitHubPR["mergeStateStatus"])
+      : undefined;
 
   const rollupContexts = commitsData?.nodes?.[0]?.commit?.statusCheckRollup?.contexts as
     | GlobalCIDeriveInput

--- a/plugins/builtin/github/main/GitHubQueries.ts
+++ b/plugins/builtin/github/main/GitHubQueries.ts
@@ -268,6 +268,8 @@ export const LIST_PRS_QUERY = `
           merged
           baseRefName
           headRefName
+          reviewDecision
+          mergeStateStatus
           headRepository {
             nameWithOwner
           }
@@ -289,6 +291,18 @@ export const LIST_PRS_QUERY = `
               commit {
                 statusCheckRollup {
                   state
+                  contexts {
+                    checkRunCount
+                    statusContextCount
+                    checkRunCountsByState {
+                      state
+                      count
+                    }
+                    statusContextCountsByState {
+                      state
+                      count
+                    }
+                  }
                 }
               }
             }

--- a/plugins/builtin/github/main/GitHubQueries.ts
+++ b/plugins/builtin/github/main/GitHubQueries.ts
@@ -63,6 +63,8 @@ export const REPO_STATS_AND_PAGE_QUERY = `
           updatedAt
           merged
           headRefName
+          reviewDecision
+          mergeStateStatus
           headRepository { nameWithOwner }
           baseRepository { nameWithOwner }
           author { login avatarUrl }
@@ -71,7 +73,21 @@ export const REPO_STATS_AND_PAGE_QUERY = `
           commits(last: 1) {
             nodes {
               commit {
-                statusCheckRollup { state }
+                statusCheckRollup {
+                  state
+                  contexts {
+                    checkRunCount
+                    statusContextCount
+                    checkRunCountsByState {
+                      state
+                      count
+                    }
+                    statusContextCountsByState {
+                      state
+                      count
+                    }
+                  }
+                }
               }
             }
           }

--- a/plugins/builtin/github/main/__tests__/GitHubPRs.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubPRs.test.ts
@@ -187,4 +187,29 @@ describe("parsePRNode — global CI aggregates", () => {
     // Required-only ciStatus still comes from raw rollup
     expect(pr.ciStatus).toBe("FAILURE");
   });
+
+  it("validates mergeStateStatus against known set, maps unknown to undefined", () => {
+    const pr = parsePRNode(makeBaseNode({ mergeStateStatus: "DRAFT" }));
+    expect(pr.mergeStateStatus).toBeUndefined();
+  });
+
+  it("accepts all valid mergeStateStatus values", () => {
+    for (const state of [
+      "BEHIND",
+      "BLOCKED",
+      "CLEAN",
+      "DIRTY",
+      "HAS_HOOKS",
+      "UNKNOWN",
+      "UNSTABLE",
+    ]) {
+      const pr = parsePRNode(makeBaseNode({ mergeStateStatus: state }));
+      expect(pr.mergeStateStatus).toBe(state);
+    }
+  });
+
+  it("normalises lowercase mergeStateStatus to uppercase", () => {
+    const pr = parsePRNode(makeBaseNode({ mergeStateStatus: "clean" }));
+    expect(pr.mergeStateStatus).toBe("CLEAN");
+  });
 });

--- a/plugins/builtin/github/main/__tests__/GitHubPRs.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubPRs.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { parsePRNode } from "../GitHubPRs.js";
+
+function makeBaseNode(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    number: 42,
+    title: "Test PR",
+    url: "https://github.com/owner/repo/pull/42",
+    state: "OPEN",
+    isDraft: false,
+    updatedAt: "2025-01-01T00:00:00Z",
+    author: { login: "testuser", avatarUrl: "https://example.com/avatar.png" },
+    reviews: { totalCount: 3 },
+    comments: { totalCount: 5 },
+    headRefName: "feature/test",
+    headRepository: { nameWithOwner: "fork/repo" },
+    baseRepository: { nameWithOwner: "owner/repo" },
+    ...overrides,
+  };
+}
+
+describe("parsePRNode — global CI aggregates", () => {
+  it("populates reviewDecision and mergeStateStatus from the node", () => {
+    const pr = parsePRNode(
+      makeBaseNode({
+        reviewDecision: "APPROVED",
+        mergeStateStatus: "CLEAN",
+      })
+    );
+    expect(pr.reviewDecision).toBe("APPROVED");
+    expect(pr.mergeStateStatus).toBe("CLEAN");
+  });
+
+  it("normalises reviewDecision to undefined for unrecognised values", () => {
+    const pr = parsePRNode(makeBaseNode({ reviewDecision: "COMMENTED" }));
+    expect(pr.reviewDecision).toBeUndefined();
+  });
+
+  it("normalises reviewDecision to undefined when absent", () => {
+    const pr = parsePRNode(makeBaseNode());
+    expect(pr.reviewDecision).toBeUndefined();
+  });
+
+  it("derives globalCIStatus and globalCISummary from statusCheckRollup.contexts aggregates", () => {
+    const pr = parsePRNode(
+      makeBaseNode({
+        mergeStateStatus: "CLEAN",
+        commits: {
+          nodes: [
+            {
+              commit: {
+                statusCheckRollup: {
+                  state: "SUCCESS",
+                  contexts: {
+                    checkRunCount: 3,
+                    statusContextCount: 2,
+                    checkRunCountsByState: [{ state: "SUCCESS", count: 3 }],
+                    statusContextCountsByState: [{ state: "SUCCESS", count: 2 }],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      })
+    );
+    expect(pr.globalCIStatus).toBe("SUCCESS");
+    expect(pr.globalCISummary).toEqual({
+      checkRunCount: 3,
+      statusContextCount: 2,
+      failingCount: 0,
+      pendingCount: 0,
+    });
+  });
+
+  it("returns undefined globalCIStatus when mergeStateStatus is UNKNOWN", () => {
+    const pr = parsePRNode(
+      makeBaseNode({
+        mergeStateStatus: "UNKNOWN",
+        commits: {
+          nodes: [
+            {
+              commit: {
+                statusCheckRollup: {
+                  state: "PENDING",
+                  contexts: {
+                    checkRunCount: 5,
+                    checkRunCountsByState: [{ state: "SUCCESS", count: 5 }],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      })
+    );
+    expect(pr.globalCIStatus).toBeUndefined();
+    expect(pr.globalCISummary).toBeUndefined();
+    // Required-only fields are untouched
+    expect(pr.ciStatus).toBe("PENDING");
+    expect(pr.ciSummary).toBeUndefined();
+  });
+
+  it("leaves global fields absent when statusCheckRollup is missing", () => {
+    const pr = parsePRNode(makeBaseNode());
+    expect(pr.globalCIStatus).toBeUndefined();
+    expect(pr.globalCISummary).toBeUndefined();
+    expect(pr.ciStatus).toBeUndefined();
+  });
+
+  it("leaves global fields absent when contexts is null", () => {
+    const pr = parsePRNode(
+      makeBaseNode({
+        commits: {
+          nodes: [
+            {
+              commit: {
+                statusCheckRollup: {
+                  state: "SUCCESS",
+                  contexts: null,
+                },
+              },
+            },
+          ],
+        },
+      })
+    );
+    expect(pr.globalCIStatus).toBeUndefined();
+    expect(pr.globalCISummary).toBeUndefined();
+    expect(pr.ciStatus).toBe("SUCCESS");
+  });
+
+  it("handles missing checkRunCountsByState gracefully", () => {
+    const pr = parsePRNode(
+      makeBaseNode({
+        mergeStateStatus: "CLEAN",
+        commits: {
+          nodes: [
+            {
+              commit: {
+                statusCheckRollup: {
+                  state: "SUCCESS",
+                  contexts: {
+                    checkRunCount: 0,
+                    statusContextCount: 1,
+                    statusContextCountsByState: [{ state: "SUCCESS", count: 1 }],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      })
+    );
+    expect(pr.globalCIStatus).toBe("SUCCESS");
+    expect(pr.globalCISummary?.checkRunCount).toBe(0);
+  });
+
+  it("does not populate required-only ciSummary from global aggregates", () => {
+    const pr = parsePRNode(
+      makeBaseNode({
+        mergeStateStatus: "CLEAN",
+        commits: {
+          nodes: [
+            {
+              commit: {
+                statusCheckRollup: {
+                  state: "FAILURE",
+                  contexts: {
+                    checkRunCount: 2,
+                    checkRunCountsByState: [
+                      { state: "SUCCESS", count: 1 },
+                      { state: "FAILURE", count: 1 },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      })
+    );
+    // Global CI reflects the aggregate
+    expect(pr.globalCIStatus).toBe("FAILURE");
+    // Required-only ciSummary is NOT populated — enrichment handles that
+    expect(pr.ciSummary).toBeUndefined();
+    // Required-only ciStatus still comes from raw rollup
+    expect(pr.ciStatus).toBe("FAILURE");
+  });
+});

--- a/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
@@ -185,6 +185,37 @@ describe("LIST_PRS_QUERY", () => {
     expect(LIST_PRS_QUERY).toContain("comments");
     expect(LIST_PRS_QUERY).toContain("totalCount");
   });
+
+  it("fetches reviewDecision and mergeStateStatus at the PR node level", () => {
+    expect(LIST_PRS_QUERY).toContain("reviewDecision");
+    expect(LIST_PRS_QUERY).toContain("mergeStateStatus");
+  });
+
+  it("fetches statusCheckRollup.contexts aggregate scalars without first/last args", () => {
+    // contexts must NOT use first: or last: — aggregate scalars are
+    // available on the connection type itself without pagination args.
+    const rollupSection = LIST_PRS_QUERY.slice(LIST_PRS_QUERY.indexOf("statusCheckRollup {"));
+    expect(rollupSection).toContain("contexts {");
+    expect(rollupSection).toContain("checkRunCount");
+    expect(rollupSection).toContain("statusContextCount");
+    expect(rollupSection).toContain("checkRunCountsByState {");
+    expect(rollupSection).toContain("statusContextCountsByState {");
+    expect(rollupSection).toContain("state");
+    expect(rollupSection).toContain("count");
+
+    // Must not include first: or last: on the contexts connection
+    const contextsLine = rollupSection.slice(
+      rollupSection.indexOf("contexts {"),
+      rollupSection.indexOf("contexts {") + 50
+    );
+    expect(contextsLine).not.toMatch(/\bfirst\b/);
+    expect(contextsLine).not.toMatch(/\blast\b/);
+  });
+
+  it("retains the raw statusCheckRollup.state field", () => {
+    expect(LIST_PRS_QUERY).toContain("statusCheckRollup {");
+    expect(LIST_PRS_QUERY).toContain("state");
+  });
 });
 
 describe("SEARCH_QUERY", () => {

--- a/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
@@ -152,6 +152,32 @@ describe("REPO_STATS_AND_PAGE_QUERY", () => {
     expect(REPO_STATS_AND_PAGE_QUERY).toContain("statusCheckRollup");
   });
 
+  it("includes reviewDecision and mergeStateStatus on the PR fragment", () => {
+    const prsBlock = REPO_STATS_AND_PAGE_QUERY.slice(
+      REPO_STATS_AND_PAGE_QUERY.indexOf("pullRequests(first: 20")
+    );
+    expect(prsBlock).toContain("reviewDecision");
+    expect(prsBlock).toContain("mergeStateStatus");
+  });
+
+  it("includes statusCheckRollup.contexts aggregate scalars on the PR fragment", () => {
+    const prsBlock = REPO_STATS_AND_PAGE_QUERY.slice(
+      REPO_STATS_AND_PAGE_QUERY.indexOf("pullRequests(first: 20")
+    );
+    expect(prsBlock).toContain("contexts {");
+    expect(prsBlock).toContain("checkRunCount");
+    expect(prsBlock).toContain("statusContextCount");
+    expect(prsBlock).toContain("checkRunCountsByState {");
+    expect(prsBlock).toContain("statusContextCountsByState {");
+    // Must not include first: or last: on the contexts connection
+    const contextsLine = prsBlock.slice(
+      prsBlock.indexOf("contexts {"),
+      prsBlock.indexOf("contexts {") + 50
+    );
+    expect(contextsLine).not.toMatch(/\bfirst\b/);
+    expect(contextsLine).not.toMatch(/\blast\b/);
+  });
+
   it("returns the issue fields the disk-cache validator (isIssueLike) requires", () => {
     // GitHubFirstPageCache.isIssueLike rejects items missing author{login,
     // avatarUrl} or assignees. Drop one of these from the query and the

--- a/plugins/builtin/github/main/__tests__/prRequiredCIStatus.test.ts
+++ b/plugins/builtin/github/main/__tests__/prRequiredCIStatus.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { deriveRequiredCIStatus, normalizeRawState } from "../prRequiredCIStatus.js";
+import {
+  deriveRequiredCIStatus,
+  deriveGlobalCIStatus,
+  normalizeRawState,
+} from "../prRequiredCIStatus.js";
 
 describe("deriveRequiredCIStatus", () => {
   it("returns raw status and no summary when contexts is null", () => {
@@ -237,5 +241,180 @@ describe("normalizeRawState", () => {
     expect(normalizeRawState("SKIPPED")).toBeUndefined();
     expect(normalizeRawState("STALE")).toBeUndefined();
     expect(normalizeRawState("IN_PROGRESS")).toBeUndefined();
+  });
+});
+
+describe("deriveGlobalCIStatus", () => {
+  it("returns undefined ciStatus when mergeStateStatus is UNKNOWN", () => {
+    const r = deriveGlobalCIStatus({
+      mergeStateStatus: "UNKNOWN",
+      checkRunCount: 5,
+      checkRunCountsByState: [{ state: "SUCCESS", count: 5 }],
+    });
+    expect(r.ciStatus).toBeUndefined();
+    expect(r.ciSummary).toBeUndefined();
+  });
+
+  it("returns FAILURE when mergeStateStatus is BLOCKED", () => {
+    const r = deriveGlobalCIStatus({
+      mergeStateStatus: "BLOCKED",
+      checkRunCount: 3,
+      checkRunCountsByState: [{ state: "SUCCESS", count: 3 }],
+    });
+    expect(r.ciStatus).toBe("FAILURE");
+    expect(r.ciSummary).toEqual({
+      checkRunCount: 3,
+      statusContextCount: 0,
+      failingCount: 0,
+      pendingCount: 0,
+    });
+  });
+
+  it("returns FAILURE when check runs have failing conclusions", () => {
+    const r = deriveGlobalCIStatus({
+      mergeStateStatus: "CLEAN",
+      checkRunCount: 5,
+      checkRunCountsByState: [
+        { state: "SUCCESS", count: 3 },
+        { state: "FAILURE", count: 2 },
+      ],
+    });
+    expect(r.ciStatus).toBe("FAILURE");
+    expect(r.ciSummary?.failingCount).toBe(2);
+  });
+
+  it("returns FAILURE when status contexts have ERROR/FAILURE states", () => {
+    const r = deriveGlobalCIStatus({
+      mergeStateStatus: "CLEAN",
+      statusContextCount: 4,
+      statusContextCountsByState: [
+        { state: "SUCCESS", count: 2 },
+        { state: "ERROR", count: 2 },
+      ],
+    });
+    expect(r.ciStatus).toBe("FAILURE");
+    expect(r.ciSummary?.failingCount).toBe(2);
+  });
+
+  it("treats TIMED_OUT, ACTION_REQUIRED, CANCELLED, STARTUP_FAILURE, STALE as failing", () => {
+    for (const state of ["TIMED_OUT", "ACTION_REQUIRED", "CANCELLED", "STARTUP_FAILURE", "STALE"]) {
+      const r = deriveGlobalCIStatus({
+        mergeStateStatus: "CLEAN",
+        checkRunCount: 1,
+        checkRunCountsByState: [{ state, count: 1 }],
+      });
+      expect(r.ciStatus).toBe("FAILURE");
+      expect(r.ciSummary?.failingCount).toBe(1);
+    }
+  });
+
+  it("returns PENDING when only pending check runs exist", () => {
+    const r = deriveGlobalCIStatus({
+      mergeStateStatus: "CLEAN",
+      checkRunCount: 2,
+      checkRunCountsByState: [
+        { state: "SUCCESS", count: 1 },
+        { state: "IN_PROGRESS", count: 1 },
+      ],
+    });
+    expect(r.ciStatus).toBe("PENDING");
+    expect(r.ciSummary).toEqual({
+      checkRunCount: 2,
+      statusContextCount: 0,
+      failingCount: 0,
+      pendingCount: 1,
+    });
+  });
+
+  it("returns PENDING when only pending status contexts exist", () => {
+    const r = deriveGlobalCIStatus({
+      mergeStateStatus: "CLEAN",
+      statusContextCount: 3,
+      statusContextCountsByState: [
+        { state: "PENDING", count: 2 },
+        { state: "SUCCESS", count: 1 },
+      ],
+    });
+    expect(r.ciStatus).toBe("PENDING");
+    expect(r.ciSummary?.pendingCount).toBe(2);
+  });
+
+  it("returns SUCCESS when all checks are successful", () => {
+    const r = deriveGlobalCIStatus({
+      mergeStateStatus: "CLEAN",
+      checkRunCount: 3,
+      statusContextCount: 2,
+      checkRunCountsByState: [{ state: "SUCCESS", count: 3 }],
+      statusContextCountsByState: [{ state: "SUCCESS", count: 2 }],
+    });
+    expect(r.ciStatus).toBe("SUCCESS");
+    expect(r.ciSummary).toEqual({
+      checkRunCount: 3,
+      statusContextCount: 2,
+      failingCount: 0,
+      pendingCount: 0,
+    });
+  });
+
+  it("returns undefined ciStatus when there are no checks at all", () => {
+    const r = deriveGlobalCIStatus({
+      mergeStateStatus: "CLEAN",
+      checkRunCount: 0,
+      statusContextCount: 0,
+    });
+    expect(r.ciStatus).toBeUndefined();
+  });
+
+  it("prioritises FAILURE over PENDING when both are present", () => {
+    const r = deriveGlobalCIStatus({
+      mergeStateStatus: "CLEAN",
+      checkRunCount: 3,
+      checkRunCountsByState: [
+        { state: "FAILURE", count: 1 },
+        { state: "IN_PROGRESS", count: 2 },
+      ],
+    });
+    expect(r.ciStatus).toBe("FAILURE");
+  });
+
+  it("handles null/undefined buckets gracefully", () => {
+    const r = deriveGlobalCIStatus({
+      mergeStateStatus: "CLEAN",
+      checkRunCount: 1,
+      checkRunCountsByState: null,
+      statusContextCountsByState: undefined,
+      statusContextCount: 1,
+    });
+    expect(r.ciStatus).toBeUndefined();
+  });
+
+  it("handles unknown bucket state strings gracefully", () => {
+    const r = deriveGlobalCIStatus({
+      mergeStateStatus: "CLEAN",
+      checkRunCount: 2,
+      checkRunCountsByState: [{ state: "SOME_FUTURE_STATE", count: 2 }],
+    });
+    // Unknown states contribute 0 to failing/pending — treated as success
+    expect(r.ciStatus).toBe("SUCCESS");
+    expect(r.ciSummary?.failingCount).toBe(0);
+    expect(r.ciSummary?.pendingCount).toBe(0);
+  });
+
+  it("handles missing mergeStateStatus (treat as non-UNKNOWN/non-BLOCKED)", () => {
+    const r = deriveGlobalCIStatus({
+      checkRunCount: 1,
+      checkRunCountsByState: [{ state: "SUCCESS", count: 1 }],
+    });
+    expect(r.ciStatus).toBe("SUCCESS");
+  });
+
+  it("defaults null counts to 0 and returns no summary when total is zero", () => {
+    const r = deriveGlobalCIStatus({
+      mergeStateStatus: "CLEAN",
+      checkRunCount: null,
+      statusContextCount: null,
+    });
+    expect(r.ciStatus).toBeUndefined();
+    expect(r.ciSummary).toBeUndefined();
   });
 });

--- a/plugins/builtin/github/main/__tests__/prRequiredCIStatus.test.ts
+++ b/plugins/builtin/github/main/__tests__/prRequiredCIStatus.test.ts
@@ -388,16 +388,15 @@ describe("deriveGlobalCIStatus", () => {
     expect(r.ciStatus).toBeUndefined();
   });
 
-  it("handles unknown bucket state strings gracefully", () => {
+  it("treats unknown bucket state strings conservatively (not SUCCESS)", () => {
     const r = deriveGlobalCIStatus({
       mergeStateStatus: "CLEAN",
       checkRunCount: 2,
       checkRunCountsByState: [{ state: "SOME_FUTURE_STATE", count: 2 }],
     });
-    // Unknown states contribute 0 to failing/pending — treated as success
-    expect(r.ciStatus).toBe("SUCCESS");
-    expect(r.ciSummary?.failingCount).toBe(0);
-    expect(r.ciSummary?.pendingCount).toBe(0);
+    // Unknown states prevent SUCCESS — treat as unclassifiable
+    expect(r.ciStatus).toBeUndefined();
+    expect(r.ciSummary).toBeUndefined();
   });
 
   it("handles missing mergeStateStatus (treat as non-UNKNOWN/non-BLOCKED)", () => {

--- a/plugins/builtin/github/main/prRequiredCIStatus.ts
+++ b/plugins/builtin/github/main/prRequiredCIStatus.ts
@@ -1,4 +1,8 @@
-import type { GitHubPRCIStatus, GitHubPRCISummary } from "../../../../shared/types/github.js";
+import type {
+  GitHubPRCIStatus,
+  GitHubPRCISummary,
+  GitHubPRGlobalCISummary,
+} from "../../../../shared/types/github.js";
 
 // Failing CheckRun conclusions per GitHub schema. STALE is included because a stale required
 // run has not resolved to a passing state and must not be silently treated as success.
@@ -140,4 +144,83 @@ export function deriveRequiredCIStatus(
   }
 
   return { ciStatus, ciSummary: summary };
+}
+
+export interface GlobalCIDeriveInput {
+  checkRunCountsByState?: Array<{ state?: string | null; count?: number | null }> | null;
+  statusContextCountsByState?: Array<{ state?: string | null; count?: number | null }> | null;
+  checkRunCount?: number | null;
+  statusContextCount?: number | null;
+  mergeStateStatus?: string | null;
+}
+
+/**
+ * Derive a global (non-required-filtered) CI status from the in-band aggregate
+ * scalars on {@code statusCheckRollup.contexts}. Returns {@code ciStatus: undefined}
+ * when the merge state is UNKNOWN (transient state on freshly-opened PRs).
+ */
+export function deriveGlobalCIStatus(input: GlobalCIDeriveInput): {
+  ciStatus: GitHubPRCIStatus | undefined;
+  ciSummary: GitHubPRGlobalCISummary | undefined;
+} {
+  if (input.mergeStateStatus === "UNKNOWN") {
+    return { ciStatus: undefined, ciSummary: undefined };
+  }
+
+  const checkRunCount = input.checkRunCount ?? 0;
+  const statusContextCount = input.statusContextCount ?? 0;
+
+  let failingCount = 0;
+  let pendingCount = 0;
+
+  for (const bucket of input.checkRunCountsByState ?? []) {
+    const state = bucket?.state?.toUpperCase();
+    const count = bucket?.count ?? 0;
+    if (state && FAILING_CHECK_CONCLUSIONS.has(state)) {
+      failingCount += count;
+    } else if (state && PENDING_CHECK_STATUSES.has(state)) {
+      pendingCount += count;
+    }
+  }
+
+  for (const bucket of input.statusContextCountsByState ?? []) {
+    const state = bucket?.state?.toUpperCase();
+    const count = bucket?.count ?? 0;
+    if (state && FAILING_STATUS_STATES.has(state)) {
+      failingCount += count;
+    } else if (state && PENDING_STATUS_STATES.has(state)) {
+      pendingCount += count;
+    }
+  }
+
+  if (input.mergeStateStatus === "BLOCKED") {
+    return {
+      ciStatus: "FAILURE",
+      ciSummary: { checkRunCount, statusContextCount, failingCount, pendingCount },
+    };
+  }
+
+  const hasCounts = checkRunCount + statusContextCount > 0;
+  const hasBuckets =
+    (input.checkRunCountsByState?.length ?? 0) > 0 ||
+    (input.statusContextCountsByState?.length ?? 0) > 0;
+
+  let ciStatus: GitHubPRCIStatus | undefined;
+  if (failingCount > 0) {
+    ciStatus = "FAILURE";
+  } else if (pendingCount > 0) {
+    ciStatus = "PENDING";
+  } else if (hasCounts && hasBuckets) {
+    // Only declare SUCCESS when bucket data backs the classification.
+    // Counts without bucket breakdowns mean we can't verify what state
+    // the checks are in — treat as unclassifiable.
+    ciStatus = "SUCCESS";
+  }
+
+  const ciSummary: GitHubPRGlobalCISummary | undefined =
+    ciStatus !== undefined
+      ? { checkRunCount, statusContextCount, failingCount, pendingCount }
+      : undefined;
+
+  return { ciStatus, ciSummary };
 }

--- a/plugins/builtin/github/main/prRequiredCIStatus.ts
+++ b/plugins/builtin/github/main/prRequiredCIStatus.ts
@@ -30,6 +30,12 @@ const PENDING_CHECK_STATUSES = new Set([
 // Pending StatusContext states
 const PENDING_STATUS_STATES = new Set(["PENDING", "EXPECTED"]);
 
+// Known non-failing, non-pending bucket states for check runs and status contexts.
+// Any state not in these sets or the failing/pending sets above is treated as
+// unclassifiable (conservative against future GitHub enum additions).
+const NON_FAILING_CHECK_STATES = new Set(["SUCCESS", "NEUTRAL", "SKIPPED", "COMPLETED"]);
+const NON_FAILING_STATUS_STATES = new Set(["SUCCESS"]);
+
 export interface RollupContextNode {
   __typename?: string;
   // CheckRun fields
@@ -172,6 +178,7 @@ export function deriveGlobalCIStatus(input: GlobalCIDeriveInput): {
 
   let failingCount = 0;
   let pendingCount = 0;
+  let unknownCount = 0;
 
   for (const bucket of input.checkRunCountsByState ?? []) {
     const state = bucket?.state?.toUpperCase();
@@ -180,6 +187,8 @@ export function deriveGlobalCIStatus(input: GlobalCIDeriveInput): {
       failingCount += count;
     } else if (state && PENDING_CHECK_STATUSES.has(state)) {
       pendingCount += count;
+    } else if (state && !NON_FAILING_CHECK_STATES.has(state)) {
+      unknownCount += count;
     }
   }
 
@@ -190,9 +199,16 @@ export function deriveGlobalCIStatus(input: GlobalCIDeriveInput): {
       failingCount += count;
     } else if (state && PENDING_STATUS_STATES.has(state)) {
       pendingCount += count;
+    } else if (state && !NON_FAILING_STATUS_STATES.has(state)) {
+      unknownCount += count;
     }
   }
 
+  // BLOCKED is broader than CI — it can be triggered by required reviews,
+  // stale branches, or other branch-protection rules with zero CI failures.
+  // Treating it as FAILURE is a conservative signal that "something is wrong";
+  // consumers should inspect failingCount to distinguish CI blocks from
+  // non-CI blocks (failingCount === 0 means the block is not from CI).
   if (input.mergeStateStatus === "BLOCKED") {
     return {
       ciStatus: "FAILURE",
@@ -210,10 +226,10 @@ export function deriveGlobalCIStatus(input: GlobalCIDeriveInput): {
     ciStatus = "FAILURE";
   } else if (pendingCount > 0) {
     ciStatus = "PENDING";
-  } else if (hasCounts && hasBuckets) {
-    // Only declare SUCCESS when bucket data backs the classification.
-    // Counts without bucket breakdowns mean we can't verify what state
-    // the checks are in — treat as unclassifiable.
+  } else if (hasCounts && hasBuckets && unknownCount === 0) {
+    // Only declare SUCCESS when all buckets are classified — unknown
+    // bucket states from future GitHub enum additions must not produce
+    // a false-green. Counts without bucket breakdowns are also unclassifiable.
     ciStatus = "SUCCESS";
   }
 

--- a/shared/types/github.ts
+++ b/shared/types/github.ts
@@ -62,6 +62,18 @@ export interface GitHubPRCISummary {
   requiredPending: number;
 }
 
+/** Global (non-required-filtered) CI aggregate summary from in-band statusCheckRollup.contexts */
+export interface GitHubPRGlobalCISummary {
+  /** Total check runs across all states */
+  checkRunCount: number;
+  /** Total status contexts across all states */
+  statusContextCount: number;
+  /** Failing check runs + status contexts (global, not required-filtered) */
+  failingCount: number;
+  /** Pending check runs + status contexts (global, not required-filtered) */
+  pendingCount: number;
+}
+
 /** GitHub pull request representation */
 export interface GitHubPR {
   /** PR number */
@@ -92,6 +104,21 @@ export interface GitHubPR {
    *  was truncated, or when the repository has no required checks configured (in which case
    *  ciStatus reflects the raw rollup). */
   ciSummary?: GitHubPRCISummary;
+  /** Review decision from the PR (APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or absent) */
+  reviewDecision?: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED";
+  /** Merge state status from the PR. UNKNOWN on freshly-opened PRs that GitHub hasn't backgrounded yet. */
+  mergeStateStatus?:
+    | "BEHIND"
+    | "BLOCKED"
+    | "CLEAN"
+    | "DIRTY"
+    | "HAS_HOOKS"
+    | "UNKNOWN"
+    | "UNSTABLE";
+  /** Global CI status derived from in-band statusCheckRollup.contexts aggregates (not required-filtered) */
+  globalCIStatus?: GitHubPRCIStatus;
+  /** Global CI aggregate counts from in-band statusCheckRollup.contexts (not required-filtered) */
+  globalCISummary?: GitHubPRGlobalCISummary;
   /** Plain-text PR body. Used to body-parse closing-issue references (`Closes #N`)
    *  when capturing the source PR at worktree-create time. */
   bodyText?: string;


### PR DESCRIPTION
## Summary
- Eliminates the second enrichment round-trip on every PR list refresh by folding CI aggregates directly into `LIST_PRS_QUERY`. Same 1-point cost for 20 PRs.
- Adds a global-aggregate CI summary path alongside the existing required-only path, giving us both views without extra network cost.
- Guards `mergeStateStatus = UNKNOWN` on fresh PRs as a transient checking state so the badge doesn't flash green prematurely.

The query now requests `contexts(first: 0)` with `checkRunCount`, `statusContextCount`, `checkRunCountsByState`, and `statusContextCountsByState`, plus `reviewDecision`, `mergeStateStatus`, and `totalCommentsCount` as direct scalars. `first: 0` means zero node cost for the context list — the aggregates resolve on the connection itself.

Resolves #9060.

## Changes
- **`GitHubQueries.ts`** — extended `LIST_PRS_QUERY` and `REPO_STATS_AND_PAGE_QUERY` with in-band CI aggregates and status scalars
- **`GitHubPRs.ts`** — parsed new aggregate fields onto `GitHubPR`, added `deriveGlobalCIStatus()` for the global-aggregate summary, bounced `UNKNOWN` merge state to neutral
- **`prRequiredCIStatus.ts`** — added `deriveGlobalCIStatus()` and `GlobalCIStatus` type, normalized classification across required and global paths
- **`shared/types/github.ts`** — added optional fields for `checkRunCount`, `statusContextCount`, `checkRunCountsByState`, `statusContextCountsByState`, `reviewDecision`, `mergeStateStatus`, `totalCommentsCount`
- **Tests** — expanded `GitHubPRs.test.ts`, `GitHubQueries.test.ts`, and `prRequiredCIStatus.test.ts` covering in-band parse, global derivation, `UNKNOWN` guard, and edge cases

## Testing
- Unit tests pass for query construction, response parsing, global CI derivation, and merge state classification.
- Verified against live `daintreehq/daintree` PR list — the extended query costs the same 1 point as the bare list.