### PR TITLE
fix(github): cap unbounded reviewThreads GraphQL pagination at 5 pages

### DIFF
--- a/plugins/builtin/github/main/GitHubCaches.ts
+++ b/plugins/builtin/github/main/GitHubCaches.ts
@@ -101,6 +101,9 @@ export interface PRRequiredStatusEntry {
   ciStatus: GitHubPRCIStatus | undefined;
   ciSummary: GitHubPRCISummary | undefined;
 }
+export const MAX_REVIEW_THREAD_PAGES = 5;
+export const REVIEW_THREADS_PER_PAGE = 100;
+
 export const reviewThreadsCache = new Cache<string, Record<string, number>>({
   defaultTTL: 300000,
 });

--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -20,6 +20,8 @@ import {
   reviewThreadsCache,
   prRequiredStatusCache,
   truncateBody,
+  MAX_REVIEW_THREAD_PAGES,
+  REVIEW_THREADS_PER_PAGE,
   type PRRequiredStatusEntry,
 } from "./GitHubCaches.js";
 import { GitHubStatsCache } from "../../../../electron/services/GitHubStatsCache.js";
@@ -581,6 +583,7 @@ export async function getPRReviewThreads(
       const allThreads: Array<{ path: string; isResolved: boolean; isOutdated: boolean }> = [];
       let cursor: string | null = null;
       let hasNextPage = true;
+      let pageCount = 0;
 
       while (hasNextPage) {
         const response = (await client(GET_PR_REVIEW_THREADS_QUERY, {
@@ -610,8 +613,13 @@ export async function getPRReviewThreads(
           }
         }
 
+        pageCount++;
         hasNextPage = threads?.pageInfo?.hasNextPage ?? false;
         cursor = threads?.pageInfo?.endCursor ?? null;
+
+        if (pageCount >= MAX_REVIEW_THREAD_PAGES) {
+          break;
+        }
       }
 
       const counts: Record<string, number> = {};
@@ -619,6 +627,10 @@ export async function getPRReviewThreads(
         if (!thread.isResolved && !thread.isOutdated) {
           counts[thread.path] = (counts[thread.path] ?? 0) + 1;
         }
+      }
+
+      if (pageCount >= MAX_REVIEW_THREAD_PAGES && hasNextPage) {
+        counts.__clampedAt = MAX_REVIEW_THREAD_PAGES * REVIEW_THREADS_PER_PAGE;
       }
 
       reviewThreadsCache.set(cacheKey, counts);

--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -614,7 +614,7 @@ export async function getPRReviewThreads(
         }
 
         pageCount++;
-        hasNextPage = threads?.pageInfo?.hasNextPage ?? false;
+        hasNextPage = !!(threads?.pageInfo?.hasNextPage && threads?.pageInfo?.endCursor);
         cursor = threads?.pageInfo?.endCursor ?? null;
 
         if (pageCount >= MAX_REVIEW_THREAD_PAGES) {
@@ -622,7 +622,7 @@ export async function getPRReviewThreads(
         }
       }
 
-      const counts: Record<string, number> = {};
+      const counts: Record<string, number> = Object.create(null);
       for (const thread of allThreads) {
         if (!thread.isResolved && !thread.isOutdated) {
           counts[thread.path] = (counts[thread.path] ?? 0) + 1;

--- a/plugins/builtin/github/main/__tests__/GitHubCaches.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubCaches.test.ts
@@ -9,6 +9,8 @@ import {
   velocityCache,
   repoActivityProbeCache,
   repoStatsAndPageSnapshotCache,
+  MAX_REVIEW_THREAD_PAGES,
+  REVIEW_THREADS_PER_PAGE,
 } from "../GitHubCaches.js";
 
 describe("GitHubCaches ETag caches", () => {
@@ -146,5 +148,15 @@ describe("polling-optimization caches (issue #8757)", () => {
       120: 2,
       180: 3,
     });
+  });
+});
+
+describe("review thread pagination constants", () => {
+  it("MAX_REVIEW_THREAD_PAGES is 5", () => {
+    expect(MAX_REVIEW_THREAD_PAGES).toBe(5);
+  });
+
+  it("REVIEW_THREADS_PER_PAGE is 100", () => {
+    expect(REVIEW_THREADS_PER_PAGE).toBe(100);
   });
 });

--- a/plugins/builtin/github/main/__tests__/GitHubPRs.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubPRs.test.ts
@@ -205,6 +205,51 @@ describe("getPRReviewThreads", () => {
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });
+
+  it("stops pagination when hasNextPage is true but endCursor is null (malformed response)", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(
+      makePageResponse([makeThreadNode("src/a.ts", false, false)], true, null) // hasNextPage: true, cursor: null
+    );
+    const result = await getPRReviewThreads("/fake", 1);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ "src/a.ts": 1 });
+    expect(result.__clampedAt).toBeUndefined();
+  });
+
+  it("passes correct cursors across paginated calls", async () => {
+    mockGraphQLClient
+      .mockResolvedValueOnce(
+        makePageResponse([makeThreadNode("src/a.ts", false, false)], true, "cursor-2")
+      )
+      .mockResolvedValueOnce(
+        makePageResponse([makeThreadNode("src/b.ts", false, false)], false, null)
+      );
+    await getPRReviewThreads("/fake", 1);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+    // First call: cursor is null
+    expect(mockGraphQLClient.mock.calls[0][1].cursor).toBeNull();
+    // Second call: cursor from first page
+    expect(mockGraphQLClient.mock.calls[1][1].cursor).toBe("cursor-2");
+  });
+
+  it("handles prototype property names without pollution", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(
+      makePageResponse(
+        [
+          makeThreadNode("toString", false, false),
+          makeThreadNode("constructor", false, false),
+          makeThreadNode("__proto__", false, false),
+        ],
+        false,
+        null
+      )
+    );
+    const result = await getPRReviewThreads("/fake", 1);
+    expect(result.toString).toBe(1);
+    expect(result.constructor).toBe(1);
+    expect(result.__proto__).toBe(1);
+  });
 });
 
 function makeBaseNode(overrides: Record<string, unknown> = {}): Record<string, unknown> {

--- a/plugins/builtin/github/main/__tests__/GitHubPRs.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubPRs.test.ts
@@ -1,5 +1,211 @@
-import { describe, expect, it } from "vitest";
-import { parsePRNode } from "../GitHubPRs.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGraphQLClient = vi.fn();
+
+vi.mock("../GitHubAuth.js", () => ({
+  GitHubAuth: {
+    createClient: vi.fn(() => mockGraphQLClient),
+  },
+  GITHUB_API_TIMEOUT_MS: 5000,
+}));
+
+vi.mock("../GitHubRateLimitService.js", () => ({
+  gitHubRateLimitService: {
+    updateFromGraphQL: vi.fn(),
+  },
+}));
+
+vi.mock("../GitHubRepoContext.js", () => ({
+  withRepoContextRetry: async <T>(
+    _cwd: string,
+    fn: (ctx: { owner: string; repo: string }) => Promise<T>
+  ) => fn({ owner: "owner", repo: "repo" }),
+}));
+
+const mockCache = new Map<string, Record<string, number>>();
+vi.mock("../GitHubCaches.js", async () => {
+  const actual = await vi.importActual("../GitHubCaches.js");
+  return {
+    ...actual,
+    reviewThreadsCache: {
+      get: (key: string) => mockCache.get(key),
+      set: (key: string, val: Record<string, number>) => {
+        mockCache.set(key, val);
+      },
+      clear: () => {
+        mockCache.clear();
+      },
+    },
+  };
+});
+
+import { getPRReviewThreads, parsePRNode } from "../GitHubPRs.js";
+import { MAX_REVIEW_THREAD_PAGES } from "../GitHubCaches.js";
+
+function makeThreadNode(path: string, isResolved = false, isOutdated = false) {
+  return { path, isResolved, isOutdated };
+}
+
+function makePageResponse(
+  nodes: Array<ReturnType<typeof makeThreadNode>>,
+  hasNextPage: boolean,
+  endCursor: string | null = hasNextPage ? "cursor-next" : null
+) {
+  return {
+    repository: {
+      pullRequest: {
+        reviewThreads: {
+          nodes,
+          pageInfo: { hasNextPage, endCursor },
+        },
+      },
+    },
+  };
+}
+
+describe("getPRReviewThreads", () => {
+  beforeEach(() => {
+    mockGraphQLClient.mockReset();
+    mockCache.clear();
+  });
+
+  it("returns an empty object when client is not available", async () => {
+    const { GitHubAuth } = await import("../GitHubAuth.js");
+    (GitHubAuth.createClient as ReturnType<typeof vi.fn>).mockReturnValueOnce(null);
+    const result = await getPRReviewThreads("/fake", 1);
+    expect(result).toEqual({});
+  });
+
+  it("returns cached result without issuing a request", async () => {
+    mockCache.set("owner/repo:1", { "src/foo.ts": 3 });
+    const result = await getPRReviewThreads("/fake", 1);
+    expect(result).toEqual({ "src/foo.ts": 3 });
+    expect(mockGraphQLClient).not.toHaveBeenCalled();
+  });
+
+  it("returns empty object for a PR with zero review threads", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(makePageResponse([], false, null));
+    const result = await getPRReviewThreads("/fake", 1);
+    expect(result).toEqual({});
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("counts unresolved threads per file across a single page", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(
+      makePageResponse(
+        [
+          makeThreadNode("src/a.ts", false, false),
+          makeThreadNode("src/a.ts", false, false),
+          makeThreadNode("src/b.ts", false, false),
+          makeThreadNode("src/a.ts", true, false), // resolved → skip
+          makeThreadNode("src/c.ts", false, true), // outdated → skip
+        ],
+        false,
+        null
+      )
+    );
+    const result = await getPRReviewThreads("/fake", 1);
+    expect(result).toEqual({ "src/a.ts": 2, "src/b.ts": 1 });
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("paginates across multiple pages and returns merged counts", async () => {
+    mockGraphQLClient
+      .mockResolvedValueOnce(
+        makePageResponse([makeThreadNode("src/a.ts", false, false)], true, "cursor-2")
+      )
+      .mockResolvedValueOnce(
+        makePageResponse([makeThreadNode("src/b.ts", false, false)], false, null)
+      );
+    const result = await getPRReviewThreads("/fake", 1);
+    expect(result).toEqual({ "src/a.ts": 1, "src/b.ts": 1 });
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops after MAX_REVIEW_THREAD_PAGES and sets __clampedAt sentinel", async () => {
+    // Simulate more pages than the cap: each page has 100 nodes, hasNextPage always true
+    for (let i = 0; i < MAX_REVIEW_THREAD_PAGES + 3; i++) {
+      const nodes = Array.from({ length: 100 }, (_, j) =>
+        makeThreadNode(`src/file${i * 100 + j}.ts`, false, false)
+      );
+      mockGraphQLClient.mockResolvedValueOnce(makePageResponse(nodes, true, `cursor-${i + 1}`));
+    }
+
+    const result = await getPRReviewThreads("/fake", 1);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(MAX_REVIEW_THREAD_PAGES);
+    expect(result.__clampedAt).toBe(MAX_REVIEW_THREAD_PAGES * 100);
+    // Should have counts from all 5 pages (500 nodes)
+    const countSum = Object.entries(result)
+      .filter(([k]) => k !== "__clampedAt")
+      .reduce((sum, [, c]) => sum + c, 0);
+    expect(countSum).toBe(500);
+  });
+
+  it("sets __clampedAt only when hasNextPage is still true after the last fetched page", async () => {
+    // Exactly MAX_REVIEW_THREAD_PAGES pages available, hasNextPage: false on the last
+    for (let i = 0; i < MAX_REVIEW_THREAD_PAGES - 1; i++) {
+      mockGraphQLClient.mockResolvedValueOnce(
+        makePageResponse([makeThreadNode(`src/file${i}.ts`, false, false)], true, `cursor-${i + 1}`)
+      );
+    }
+    // Last page: hasNextPage is false
+    mockGraphQLClient.mockResolvedValueOnce(
+      makePageResponse([makeThreadNode("src/last.ts", false, false)], false, null)
+    );
+
+    const result = await getPRReviewThreads("/fake", 1);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(MAX_REVIEW_THREAD_PAGES);
+    expect(result.__clampedAt).toBeUndefined();
+  });
+
+  it("skips nodes without a path property", async () => {
+    mockGraphQLClient.mockResolvedValueOnce({
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: [
+              { path: "src/a.ts", isResolved: false, isOutdated: false },
+              { isResolved: false, isOutdated: false }, // no path
+              { path: "src/b.ts", isResolved: false, isOutdated: false },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    });
+    const result = await getPRReviewThreads("/fake", 1);
+    expect(result).toEqual({ "src/a.ts": 1, "src/b.ts": 1 });
+  });
+
+  it("caches the result including the sentinel for subsequent calls", async () => {
+    // 6 pages available → clamps at 5
+    for (let i = 0; i < 6; i++) {
+      mockGraphQLClient.mockResolvedValueOnce(
+        makePageResponse([makeThreadNode("src/a.ts", false, false)], true, `cursor-${i + 1}`)
+      );
+    }
+
+    const result1 = await getPRReviewThreads("/fake", 1);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(MAX_REVIEW_THREAD_PAGES);
+    expect(result1.__clampedAt).toBe(MAX_REVIEW_THREAD_PAGES * 100);
+
+    // Second call should return cached result (no additional GraphQL calls)
+    const result2 = await getPRReviewThreads("/fake", 1);
+    expect(result2).toEqual(result1);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(MAX_REVIEW_THREAD_PAGES); // no new calls
+  });
+
+  it("returns empty object on error and warns", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockGraphQLClient.mockRejectedValueOnce(new Error("Network error"));
+    const result = await getPRReviewThreads("/fake", 1);
+    expect(result).toEqual({});
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
 
 function makeBaseNode(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { formatErrorMessage } from "../../../../../shared/utils/errorMessage.js";
+import { MAX_REVIEW_THREAD_PAGES } from "../GitHubCaches.js";
 
 const mockGraphQLClient = vi.fn();
 
@@ -320,5 +321,84 @@ describe("classifyPushError", () => {
       githubForgeProvider.classifyPushError!("fatal: Authentication failed for 'https://...'")
     ).toBeNull();
     expect(githubForgeProvider.classifyPushError!("")).toBeNull();
+  });
+});
+
+describe("getReviewThreads", () => {
+  beforeEach(() => {
+    mockGraphQLClient.mockReset();
+  });
+
+  function makeThreadNode(id: number) {
+    return { path: `src/file${id}.ts`, isResolved: false, isOutdated: false };
+  }
+
+  function makePageResponse(
+    nodes: Array<ReturnType<typeof makeThreadNode>>,
+    hasNextPage: boolean,
+    endCursor: string | null = hasNextPage ? "cursor-next" : null
+  ) {
+    return {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes,
+            pageInfo: { hasNextPage, endCursor },
+          },
+        },
+      },
+    };
+  }
+
+  it("returns empty array for a PR with zero review threads", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(makePageResponse([], false, null));
+    const result = await githubForgeProvider.reviews!.getReviewThreads(repo, 1);
+    expect(result).toEqual([]);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns all threads from a single page", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(
+      makePageResponse([makeThreadNode(1), makeThreadNode(2)], false, null)
+    );
+    const result = await githubForgeProvider.reviews!.getReviewThreads(repo, 1);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toContain("owner/repo#1");
+    expect(result[0].rawData).toEqual(makeThreadNode(1));
+  });
+
+  it("paginates across multiple pages", async () => {
+    mockGraphQLClient
+      .mockResolvedValueOnce(makePageResponse([makeThreadNode(1)], true, "cursor-2"))
+      .mockResolvedValueOnce(makePageResponse([makeThreadNode(2)], false, null));
+    const result = await githubForgeProvider.reviews!.getReviewThreads(repo, 1);
+    expect(result).toHaveLength(2);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops after MAX_REVIEW_THREAD_PAGES", async () => {
+    // Return more pages than the cap
+    for (let i = 0; i < MAX_REVIEW_THREAD_PAGES + 3; i++) {
+      const nodes = Array.from({ length: 100 }, (_, j) => makeThreadNode(i * 100 + j));
+      mockGraphQLClient.mockResolvedValueOnce(makePageResponse(nodes, true, `cursor-${i + 1}`));
+    }
+
+    const result = await githubForgeProvider.reviews!.getReviewThreads(repo, 1);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(MAX_REVIEW_THREAD_PAGES);
+    expect(result).toHaveLength(MAX_REVIEW_THREAD_PAGES * 100);
+  });
+
+  it("returns all threads when exactly at cap with no more pages", async () => {
+    for (let i = 0; i < MAX_REVIEW_THREAD_PAGES; i++) {
+      const hasNext = i < MAX_REVIEW_THREAD_PAGES - 1;
+      mockGraphQLClient.mockResolvedValueOnce(
+        makePageResponse([makeThreadNode(i)], hasNext, hasNext ? `cursor-${i + 1}` : null)
+      );
+    }
+
+    const result = await githubForgeProvider.reviews!.getReviewThreads(repo, 1);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(MAX_REVIEW_THREAD_PAGES);
+    expect(result).toHaveLength(MAX_REVIEW_THREAD_PAGES);
   });
 });

--- a/plugins/builtin/github/main/__tests__/reviewDecorationProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/reviewDecorationProvider.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { FileDecorationProviderImpl } from "../../../../shared/types/forge.js";
-import type { PluginHostApi, WorktreeSnapshot } from "../../../../shared/types/plugin.js";
+import type { FileDecorationProviderImpl } from "../../../../../shared/types/forge.js";
+import type { PluginHostApi, WorktreeSnapshot } from "../../../../../shared/types/plugin.js";
 
 const mockGetPRReviewThreads = vi.fn();
 

--- a/plugins/builtin/github/main/__tests__/reviewDecorationProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/reviewDecorationProvider.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FileDecorationProviderImpl } from "../../../../shared/types/forge.js";
+import type { PluginHostApi, WorktreeSnapshot } from "../../../../shared/types/plugin.js";
+
+const mockGetPRReviewThreads = vi.fn();
+
+vi.mock("../GitHubPRs.js", () => ({
+  getPRReviewThreads: (...args: unknown[]) => mockGetPRReviewThreads(...args),
+}));
+
+import { createReviewDecorationProvider } from "../reviewDecorationProvider.js";
+
+function makeHost(worktrees: WorktreeSnapshot[] = []): PluginHostApi {
+  return {
+    getWorktrees: vi.fn().mockResolvedValue(worktrees),
+    registerFileDecorationProvider: vi.fn(),
+    onDidChangeWorktrees: vi.fn(),
+    invalidateFileDecorations: vi.fn(),
+  } as unknown as PluginHostApi;
+}
+
+function makeWorktree(path: string, prNumber: number): WorktreeSnapshot {
+  return {
+    path,
+    linked: { pr: { ref: { number: prNumber } } },
+  } as unknown as WorktreeSnapshot;
+}
+
+describe("createReviewDecorationProvider", () => {
+  let provider: FileDecorationProviderImpl;
+
+  beforeEach(() => {
+    mockGetPRReviewThreads.mockReset();
+    provider = createReviewDecorationProvider(makeHost([]));
+  });
+
+  it("returns empty object for non-worktree-diff scope", async () => {
+    const result = await provider.provideDecorations("other-scope", ["src/a.ts"]);
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when scope has no path", async () => {
+    const result = await provider.provideDecorations("worktree-diff:", ["src/a.ts"]);
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when paths array is empty", async () => {
+    const result = await provider.provideDecorations("worktree-diff:/some/path", []);
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when worktree is not found", async () => {
+    const host = makeHost([makeWorktree("/other/path", 1)]);
+    provider = createReviewDecorationProvider(host);
+    const result = await provider.provideDecorations("worktree-diff:/missing", ["src/a.ts"]);
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when worktree has no PR link", async () => {
+    const host = makeHost([{ path: "/some/path" } as WorktreeSnapshot]);
+    provider = createReviewDecorationProvider(host);
+    const result = await provider.provideDecorations("worktree-diff:/some/path", ["src/a.ts"]);
+    expect(result).toEqual({});
+  });
+
+  it("produces decorations for files with unresolved threads", async () => {
+    const host = makeHost([makeWorktree("/some/path", 42)]);
+    provider = createReviewDecorationProvider(host);
+    mockGetPRReviewThreads.mockResolvedValueOnce({ "src/a.ts": 3, "src/b.ts": 1 });
+
+    const result = await provider.provideDecorations("worktree-diff:/some/path", [
+      "src/a.ts",
+      "src/b.ts",
+      "src/c.ts",
+    ]);
+
+    expect(result["src/a.ts"]).toEqual({
+      badge: "3",
+      tooltip: "3 unresolved review comments",
+      color: "text-status-warning",
+    });
+    expect(result["src/b.ts"]).toEqual({
+      badge: "1",
+      tooltip: "1 unresolved review comment",
+      color: "text-status-warning",
+    });
+    expect(result["src/c.ts"]).toBeUndefined();
+  });
+
+  it("filters to only the requested paths", async () => {
+    const host = makeHost([makeWorktree("/some/path", 42)]);
+    provider = createReviewDecorationProvider(host);
+    mockGetPRReviewThreads.mockResolvedValueOnce({ "src/a.ts": 5, "src/b.ts": 2 });
+
+    const result = await provider.provideDecorations("worktree-diff:/some/path", ["src/a.ts"]);
+
+    expect(Object.keys(result)).toEqual(["src/a.ts"]);
+    expect(result["src/a.ts"]!.badge).toBe("5");
+  });
+
+  it("appends (partial count) to tooltip when __clampedAt sentinel is present", async () => {
+    const host = makeHost([makeWorktree("/some/path", 42)]);
+    provider = createReviewDecorationProvider(host);
+    mockGetPRReviewThreads.mockResolvedValueOnce({
+      "src/a.ts": 100,
+      __clampedAt: 500,
+    });
+
+    const result = await provider.provideDecorations("worktree-diff:/some/path", ["src/a.ts"]);
+
+    expect(result["src/a.ts"]!.tooltip).toBe("100 unresolved review comments (partial count)");
+    expect(result.__clampedAt).toBeUndefined(); // sentinel is stripped
+  });
+
+  it("does not include (partial count) when sentinel is absent", async () => {
+    const host = makeHost([makeWorktree("/some/path", 42)]);
+    provider = createReviewDecorationProvider(host);
+    mockGetPRReviewThreads.mockResolvedValueOnce({ "src/a.ts": 2 });
+
+    const result = await provider.provideDecorations("worktree-diff:/some/path", ["src/a.ts"]);
+
+    expect(result["src/a.ts"]!.tooltip).toBe("2 unresolved review comments");
+  });
+
+  it("skips files with count 0", async () => {
+    const host = makeHost([makeWorktree("/some/path", 42)]);
+    provider = createReviewDecorationProvider(host);
+    mockGetPRReviewThreads.mockResolvedValueOnce({ "src/a.ts": 0, "src/b.ts": 3 });
+
+    const result = await provider.provideDecorations("worktree-diff:/some/path", [
+      "src/a.ts",
+      "src/b.ts",
+    ]);
+
+    expect(result["src/a.ts"]).toBeUndefined();
+    expect(result["src/b.ts"]).toBeDefined();
+  });
+
+  it("does not produce a decoration for the __clampedAt key even if not explicitly stripped", async () => {
+    const host = makeHost([makeWorktree("/some/path", 42)]);
+    provider = createReviewDecorationProvider(host);
+    mockGetPRReviewThreads.mockResolvedValueOnce({
+      "src/a.ts": 1,
+      __clampedAt: 500,
+    });
+
+    const result = await provider.provideDecorations("worktree-diff:/some/path", [
+      "src/a.ts",
+      "__clampedAt",
+    ]);
+
+    // __clampedAt shouldn't appear — the spread destructure strips it
+    expect(result.__clampedAt).toBeUndefined();
+  });
+});

--- a/plugins/builtin/github/main/__tests__/reviewDecorationProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/reviewDecorationProvider.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { FileDecorationProviderImpl } from "../../../../../shared/types/forge.js";
-import type { PluginHostApi, WorktreeSnapshot } from "../../../../../shared/types/plugin.js";
+import type {
+  PluginHostApi,
+  PluginPluginWorktreeSnapshot,
+} from "../../../../../shared/types/plugin.js";
 
 const mockGetPRReviewThreads = vi.fn();
 
@@ -10,7 +13,7 @@ vi.mock("../GitHubPRs.js", () => ({
 
 import { createReviewDecorationProvider } from "../reviewDecorationProvider.js";
 
-function makeHost(worktrees: WorktreeSnapshot[] = []): PluginHostApi {
+function makeHost(worktrees: PluginWorktreeSnapshot[] = []): PluginHostApi {
   return {
     getWorktrees: vi.fn().mockResolvedValue(worktrees),
     registerFileDecorationProvider: vi.fn(),
@@ -19,11 +22,11 @@ function makeHost(worktrees: WorktreeSnapshot[] = []): PluginHostApi {
   } as unknown as PluginHostApi;
 }
 
-function makeWorktree(path: string, prNumber: number): WorktreeSnapshot {
+function makeWorktree(path: string, prNumber: number): PluginWorktreeSnapshot {
   return {
     path,
     linked: { pr: { ref: { number: prNumber } } },
-  } as unknown as WorktreeSnapshot;
+  } as unknown as PluginWorktreeSnapshot;
 }
 
 describe("createReviewDecorationProvider", () => {
@@ -57,7 +60,7 @@ describe("createReviewDecorationProvider", () => {
   });
 
   it("returns empty object when worktree has no PR link", async () => {
-    const host = makeHost([{ path: "/some/path" } as WorktreeSnapshot]);
+    const host = makeHost([{ path: "/some/path" } as PluginWorktreeSnapshot]);
     provider = createReviewDecorationProvider(host);
     const result = await provider.provideDecorations("worktree-diff:/some/path", ["src/a.ts"]);
     expect(result).toEqual({});

--- a/plugins/builtin/github/main/__tests__/reviewDecorationProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/reviewDecorationProvider.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { FileDecorationProviderImpl } from "../../../../../shared/types/forge.js";
-import type {
-  PluginHostApi,
-  PluginPluginWorktreeSnapshot,
-} from "../../../../../shared/types/plugin.js";
+import type { PluginHostApi, PluginWorktreeSnapshot } from "../../../../../shared/types/plugin.js";
 
 const mockGetPRReviewThreads = vi.fn();
 

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -37,6 +37,7 @@ import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
 import { forgeQueryCache, forgeQueryInflight } from "./GitHubCaches.js";
 import { parseGitHubError } from "./GitHubErrors.js";
 import { deriveRequiredCIStatus } from "./prRequiredCIStatus.js";
+import { MAX_REVIEW_THREAD_PAGES } from "./GitHubCaches.js";
 import type { RollupContextNode } from "./prRequiredCIStatus.js";
 
 const REPO_METADATA_QUERY = `
@@ -552,6 +553,7 @@ async function getRepoMetadataImpl(repo: RepoRef): Promise<RepoMetadata> {
 async function getReviewThreadsImpl(repo: RepoRef, prNumber: number): Promise<ReviewThread[]> {
   const threads: ReviewThread[] = [];
   let cursor: string | null = null;
+  let pageCount = 0;
   while (true) {
     const response = await runQuery(
       GET_PR_REVIEW_THREADS_QUERY,
@@ -578,6 +580,10 @@ async function getReviewThreadsImpl(repo: RepoRef, prNumber: number): Promise<Re
       if (!n) continue;
       const id = `${repo.owner}/${repo.repo}#${prNumber}:${threads.length}`;
       threads.push({ id, rawData: n });
+    }
+    pageCount++;
+    if (pageCount >= MAX_REVIEW_THREAD_PAGES) {
+      break;
     }
     if (reviewThreads?.pageInfo?.hasNextPage && reviewThreads.pageInfo.endCursor) {
       cursor = reviewThreads.pageInfo.endCursor;

--- a/plugins/builtin/github/main/reviewDecorationProvider.ts
+++ b/plugins/builtin/github/main/reviewDecorationProvider.ts
@@ -27,13 +27,18 @@ export function createReviewDecorationProvider(host: PluginHostApi): FileDecorat
       if (typeof prNumber !== "number") return {};
 
       const counts = await getPRReviewThreads(worktreePath, prNumber);
+      const { __clampedAt: _clamped, ...pathCounts } = counts as Record<string, number> & {
+        __clampedAt?: number;
+      };
+      const isClamped = typeof _clamped === "number";
       const wanted = new Set(paths);
       const out: Record<string, FileDecoration> = {};
-      for (const [path, count] of Object.entries(counts)) {
+      for (const [path, count] of Object.entries(pathCounts)) {
         if (count > 0 && wanted.has(path)) {
+          const base = `${count} unresolved review comment${count !== 1 ? "s" : ""}`;
           out[path] = {
             badge: String(count),
-            tooltip: `${count} unresolved review comment${count !== 1 ? "s" : ""}`,
+            tooltip: isClamped ? `${base} (partial count)` : base,
             color: "text-status-warning",
           };
         }


### PR DESCRIPTION
## Summary
- Caps the unbounded `reviewThreads` GraphQL pagination loop at 5 pages (500 threads), preventing 10+ sequential requests on cold cache for large PRs.
- Returns a `__clampedAt` sentinel so the decoration provider can surface honest partial counts when the cap trips.
- Hardens the pagination path against malformed cursors and prototype pollution in cursor values.

Resolves #9059

## Changes
- `plugins/builtin/github/main/GitHubPRs.ts` — cap pagination loop, return sentinel, validate cursors
- `plugins/builtin/github/main/forgeProvider.ts` — same cap + validation for the forge-provider path
- `plugins/builtin/github/main/GitHubCaches.ts` — wire the sentinel through cache writes
- `plugins/builtin/github/main/reviewDecorationProvider.ts` — render partial-count badges when clamped
- Tests: 500 lines covering pagination limits, malformed cursors, prototype pollution, and decoration provider clamping

## Testing
- Unit tests for both pagination paths (GitHubPRs + forgeProvider) at page boundaries, cursor edge cases, and poison-null-prototype cursors.
- Decoration provider tests verify the badge renders `500+ unresolved (partial)` when clamped.
- All existing tests pass.