### PR TITLE
feat(github): wire budget throttle into renderer polls

### DIFF
--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -36,6 +36,7 @@ function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
       limit: payload.limit ?? null,
       remaining: payload.remaining ?? null,
       resetAt: null,
+      throttleMultiplier: payload.throttleMultiplier,
     };
   }
   // When blocked, force `remaining: 0` — the renderer's GitHub-flavored
@@ -46,6 +47,7 @@ function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
     remaining: 0,
     resetAt: payload.resetAt ?? null,
     ...(payload.kind === "secondary" ? { secondaryThrottled: true } : {}),
+    throttleMultiplier: payload.throttleMultiplier,
   };
 }
 

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -342,6 +342,7 @@ function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
       limit: payload.limit ?? null,
       remaining: payload.remaining ?? null,
       resetAt: null,
+      throttleMultiplier: payload.throttleMultiplier,
     };
   }
   // When blocked, force `remaining: 0` — the renderer's GitHub-flavored
@@ -352,6 +353,7 @@ function toRateLimitInfo(payload: GitHubRateLimitPayload): RateLimitInfo {
     remaining: 0,
     resetAt: payload.resetAt ?? null,
     ...(payload.kind === "secondary" ? { secondaryThrottled: true } : {}),
+    throttleMultiplier: payload.throttleMultiplier,
   };
 }
 

--- a/plugins/builtin/github/main/GitHubTokenHealthService.ts
+++ b/plugins/builtin/github/main/GitHubTokenHealthService.ts
@@ -47,7 +47,6 @@ class GitHubTokenHealthServiceImpl {
   private status: GitHubTokenHealthStatus = "unknown";
   private lastCheckedAt = 0;
   private tokenVersionAtLastCheck = -1;
-  private pollTimer: ReturnType<typeof setInterval> | null = null;
   private pendingCheck: Promise<void> | null = null;
   private readonly listeners = new Set<StateChangeListener>();
 
@@ -85,22 +84,19 @@ class GitHubTokenHealthServiceImpl {
    * Begin polling. Safe to call multiple times — subsequent calls are no-ops.
    * Fires an immediate probe asynchronously so the first result is available
    * soon after startup without blocking the caller.
+   *
+   * The recurring interval timer previously installed here was removed (#9054):
+   * cold-start, focus, and wake probes cover token-revocation detection, and
+   * GitHub guidance is to use response headers rather than polling `/rate_limit`.
    */
   start(): void {
-    if (this.pollTimer) return;
-    this.pollTimer = setInterval(() => {
-      void this.runCheck({ reason: "interval" });
-    }, HEALTH_CHECK_INTERVAL_MS);
-    this.pollTimer?.unref?.();
     void this.runCheck({ reason: "start" });
   }
 
   /** Stop polling and tear down listeners. Safe to call multiple times. */
   stop(): void {
-    if (this.pollTimer) {
-      clearInterval(this.pollTimer);
-      this.pollTimer = null;
-    }
+    // No recurring timer to clear; kept for API compatibility. The `dispose()`
+    // alias still clears listeners and resets state.
   }
 
   /** Alias for {@link stop} — matches the lifecycle naming used elsewhere. */

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -67,6 +67,14 @@ export interface RateLimitInfo {
   /** Epoch milliseconds. */
   resetAt: number | null;
   secondaryThrottled?: boolean;
+  /**
+   * Background-poll cadence multiplier derived from the remaining rate-limit
+   * budget. `1` at full speed; values above `1` stretch background fetch
+   * intervals so multiple instances drawing on the same token budget back off
+   * in step. Only the idle (background) branch is scaled; the active/focused
+   * poll cadence is unaffected.
+   */
+  throttleMultiplier?: number;
 }
 
 /** Boolean-ish CI roll-up. The host renders a summary; it does not graph checks. */

--- a/src/clients/githubClient.ts
+++ b/src/clients/githubClient.ts
@@ -31,11 +31,12 @@ import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
  */
 function toGitHubRateLimitPayload(info: RateLimitInfo): GitHubRateLimitPayload {
   const blocked = info.remaining === 0 || info.secondaryThrottled === true;
-  if (!blocked) return { blocked: false, kind: null };
+  if (!blocked) return { blocked: false, kind: null, throttleMultiplier: info.throttleMultiplier };
   return {
     blocked: true,
     kind: info.secondaryThrottled ? "secondary" : "primary",
     ...(info.resetAt != null ? { resetAt: info.resetAt } : {}),
+    throttleMultiplier: info.throttleMultiplier,
   };
 }
 

--- a/src/hooks/useProjectHealth.ts
+++ b/src/hooks/useProjectHealth.ts
@@ -5,6 +5,7 @@ import { githubClient, projectClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { usePollingLifecycle } from "@/hooks/usePollingLifecycle";
 import { useSystemWakeStore } from "@/store/systemWakeStore";
+import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
 
 const ACTIVE_POLL_INTERVAL = 30 * 1000;
 const IDLE_POLL_INTERVAL = 5 * 60 * 1000;
@@ -107,7 +108,9 @@ export function useProjectHealth(): UseProjectHealthReturn {
     },
     calculateNextInterval: ({ isVisible }) => {
       if (lastErrorRef.current) return ERROR_BACKOFF_INTERVAL;
-      return isVisible ? ACTIVE_POLL_INTERVAL : IDLE_POLL_INTERVAL;
+      if (isVisible) return ACTIVE_POLL_INTERVAL;
+      const multiplier = useGitHubRateLimitStore.getState().throttleMultiplier ?? 1;
+      return IDLE_POLL_INTERVAL * multiplier;
     },
     onProjectSwitch: () => {
       if (!mountedRef.current) return;

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -8,6 +8,7 @@ import { buildCacheKey, getCache, setCache } from "@/lib/githubResourceCache";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { usePollingLifecycle } from "@/hooks/usePollingLifecycle";
 import { useSystemWakeStore } from "@/store/systemWakeStore";
+import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
 
 function isValidPagePayload(page: unknown): page is {
   items: unknown[];
@@ -268,7 +269,9 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
         return resetAt - Date.now() + RATE_LIMIT_RESUME_BUFFER_MS;
       }
       if (lastErrorRef.current) return ERROR_BACKOFF_INTERVAL;
-      return isVisible ? ACTIVE_POLL_INTERVAL : IDLE_POLL_INTERVAL;
+      if (isVisible) return ACTIVE_POLL_INTERVAL;
+      const multiplier = useGitHubRateLimitStore.getState().throttleMultiplier ?? 1;
+      return IDLE_POLL_INTERVAL * multiplier;
     },
     onProjectSwitch: () => {
       if (!mountedRef.current) return;

--- a/src/store/__tests__/forgeProviderHealthStore.test.ts
+++ b/src/store/__tests__/forgeProviderHealthStore.test.ts
@@ -33,6 +33,7 @@ describe("forgeProviderHealthStore", () => {
       rateLimitBlocked: true,
       rateLimitKind: "primary",
       rateLimitResetAt: resetAt,
+      rateLimitMultiplier: 1,
       tokenUnhealthy: false,
     });
   });
@@ -59,12 +60,14 @@ describe("forgeProviderHealthStore", () => {
       rateLimitBlocked: true,
       rateLimitKind: "primary",
       rateLimitResetAt: 1_700_000_000_000,
+      rateLimitMultiplier: 1,
       tokenUnhealthy: false,
     });
     expect(fake).toEqual({
       rateLimitBlocked: true,
       rateLimitKind: "secondary",
       rateLimitResetAt: 1_700_000_500_000,
+      rateLimitMultiplier: 1,
       tokenUnhealthy: true,
     });
   });
@@ -139,5 +142,45 @@ describe("forgeProviderHealthStore", () => {
       .applyRateLimit(FAKE, { blocked: true, kind: "primary", resetAt: 1 });
     const after = useForgeProviderHealthStore.getState().providers;
     expect(after).not.toBe(before);
+  });
+
+  it("stores rateLimitMultiplier even when not blocked", () => {
+    useForgeProviderHealthStore.getState().applyRateLimit(BUILTIN_GITHUB_PROVIDER_ID, {
+      blocked: false,
+      kind: null,
+      throttleMultiplier: 5,
+    });
+
+    const gh = selectForgeProviderHealth(BUILTIN_GITHUB_PROVIDER_ID)(
+      useForgeProviderHealthStore.getState()
+    );
+    expect(gh.rateLimitBlocked).toBe(false);
+    expect(gh.rateLimitMultiplier).toBe(5);
+  });
+
+  it("clamps non-finite throttleMultiplier to 1", () => {
+    useForgeProviderHealthStore.getState().applyRateLimit(BUILTIN_GITHUB_PROVIDER_ID, {
+      blocked: false,
+      kind: null,
+      throttleMultiplier: Infinity,
+    });
+
+    const gh = selectForgeProviderHealth(BUILTIN_GITHUB_PROVIDER_ID)(
+      useForgeProviderHealthStore.getState()
+    );
+    expect(gh.rateLimitMultiplier).toBe(1);
+  });
+
+  it("clamps throttleMultiplier below 1 to 1", () => {
+    useForgeProviderHealthStore.getState().applyRateLimit(BUILTIN_GITHUB_PROVIDER_ID, {
+      blocked: false,
+      kind: null,
+      throttleMultiplier: 0.5,
+    });
+
+    const gh = selectForgeProviderHealth(BUILTIN_GITHUB_PROVIDER_ID)(
+      useForgeProviderHealthStore.getState()
+    );
+    expect(gh.rateLimitMultiplier).toBe(1);
   });
 });

--- a/src/store/__tests__/githubRateLimitStore.test.ts
+++ b/src/store/__tests__/githubRateLimitStore.test.ts
@@ -14,6 +14,7 @@ describe("githubRateLimitStore", () => {
     expect(state.blocked).toBe(false);
     expect(state.kind).toBeNull();
     expect(state.resetAt).toBeNull();
+    expect(state.throttleMultiplier).toBe(1);
   });
 
   it("applies a primary-block payload with all fields", () => {
@@ -49,18 +50,20 @@ describe("githubRateLimitStore", () => {
     expect(useGitHubRateLimitStore.getState().resetAt).toBeNull();
   });
 
-  it("clears kind and resetAt when an unblocked payload arrives", () => {
+  it("clears kind and resetAt but preserves throttleMultiplier when an unblocked payload arrives", () => {
     useGitHubRateLimitStore.getState().apply({
       blocked: true,
       kind: "primary",
       resetAt: 1_700_000_000_000,
+      throttleMultiplier: 5,
     });
-    useGitHubRateLimitStore.getState().apply({ blocked: false, kind: null });
+    useGitHubRateLimitStore.getState().apply({ blocked: false, kind: null, throttleMultiplier: 3 });
 
     const state = useGitHubRateLimitStore.getState();
     expect(state.blocked).toBe(false);
     expect(state.kind).toBeNull();
     expect(state.resetAt).toBeNull();
+    expect(state.throttleMultiplier).toBe(3);
   });
 
   it("delegates .setState through to the backing keyed store", () => {
@@ -94,5 +97,47 @@ describe("githubRateLimitStore", () => {
     const state = useGitHubRateLimitStore.getState();
     expect(state.kind).toBe("secondary");
     expect(state.resetAt).toBe(1_700_000_500_000);
+  });
+
+  it("forwards throttleMultiplier through apply() to the backing forge store", () => {
+    useGitHubRateLimitStore.getState().apply({
+      blocked: false,
+      kind: null,
+      throttleMultiplier: 7,
+    });
+
+    const state = useGitHubRateLimitStore.getState();
+    expect(state.throttleMultiplier).toBe(7);
+    expect(state.blocked).toBe(false);
+
+    const slice = useForgeProviderHealthStore.getState().providers["daintree.github.github"];
+    expect(slice?.rateLimitMultiplier).toBe(7);
+  });
+
+  it("defaults throttleMultiplier to 1 when payload omits it", () => {
+    useGitHubRateLimitStore.getState().apply({ blocked: false, kind: null });
+
+    const state = useGitHubRateLimitStore.getState();
+    expect(state.throttleMultiplier).toBe(1);
+  });
+
+  it("clamps non-finite throttleMultiplier to 1", () => {
+    useGitHubRateLimitStore.getState().apply({
+      blocked: false,
+      kind: null,
+      throttleMultiplier: NaN,
+    });
+
+    expect(useGitHubRateLimitStore.getState().throttleMultiplier).toBe(1);
+  });
+
+  it("clamps throttleMultiplier below 1 to 1", () => {
+    useGitHubRateLimitStore.getState().apply({
+      blocked: false,
+      kind: null,
+      throttleMultiplier: 0,
+    });
+
+    expect(useGitHubRateLimitStore.getState().throttleMultiplier).toBe(1);
   });
 });

--- a/src/store/forgeProviderHealthStore.ts
+++ b/src/store/forgeProviderHealthStore.ts
@@ -20,6 +20,7 @@ export interface ForgeProviderHealth {
   rateLimitBlocked: boolean;
   rateLimitKind: ForgeRateLimitKind | null;
   rateLimitResetAt: number | null;
+  rateLimitMultiplier: number;
   tokenUnhealthy: boolean;
 }
 
@@ -29,6 +30,7 @@ export const DEFAULT_PROVIDER_HEALTH: ForgeProviderHealth = Object.freeze({
   rateLimitBlocked: false,
   rateLimitKind: null,
   rateLimitResetAt: null,
+  rateLimitMultiplier: 1,
   tokenUnhealthy: false,
 });
 
@@ -37,6 +39,7 @@ export interface ForgeRateLimitState {
   blocked: boolean;
   kind: ForgeRateLimitKind | null;
   resetAt?: number | null;
+  throttleMultiplier?: number;
 }
 
 interface ForgeProviderHealthStore {
@@ -59,7 +62,11 @@ function mergeProvider(
 
 export const useForgeProviderHealthStore = create<ForgeProviderHealthStore>((set) => ({
   providers: {},
-  applyRateLimit: (providerId, state) =>
+  applyRateLimit: (providerId, state) => {
+    const multiplier =
+      Number.isFinite(state.throttleMultiplier ?? 1) && (state.throttleMultiplier ?? 1) >= 1
+        ? (state.throttleMultiplier ?? 1)
+        : 1;
     set((s) => ({
       providers: mergeProvider(
         s,
@@ -69,14 +76,17 @@ export const useForgeProviderHealthStore = create<ForgeProviderHealthStore>((set
               rateLimitBlocked: true,
               rateLimitKind: state.kind ?? null,
               rateLimitResetAt: state.resetAt ?? null,
+              rateLimitMultiplier: multiplier,
             }
           : {
               rateLimitBlocked: false,
               rateLimitKind: null,
               rateLimitResetAt: null,
+              rateLimitMultiplier: multiplier,
             }
       ),
-    })),
+    }));
+  },
   setTokenUnhealthy: (providerId, value) =>
     set((s) => ({
       providers: mergeProvider(s, providerId, { tokenUnhealthy: value }),

--- a/src/store/githubRateLimitStore.ts
+++ b/src/store/githubRateLimitStore.ts
@@ -16,6 +16,7 @@ export interface GitHubRateLimitState {
   blocked: boolean;
   kind: GitHubRateLimitKind | null;
   resetAt: number | null;
+  throttleMultiplier: number;
   apply: (payload: GitHubRateLimitPayload) => void;
 }
 
@@ -24,6 +25,7 @@ const apply = (payload: GitHubRateLimitPayload): void =>
     blocked: payload.blocked,
     kind: payload.kind,
     resetAt: payload.resetAt ?? null,
+    throttleMultiplier: payload.throttleMultiplier,
   });
 
 function gitHubView(): GitHubRateLimitState {
@@ -34,6 +36,7 @@ function gitHubView(): GitHubRateLimitState {
     blocked: p.rateLimitBlocked,
     kind: p.rateLimitKind,
     resetAt: p.rateLimitResetAt,
+    throttleMultiplier: p.rateLimitMultiplier,
     apply,
   };
 }
@@ -45,6 +48,7 @@ export function useGitHubRateLimitStore<T>(selector: (state: GitHubRateLimitStat
       blocked: p.rateLimitBlocked,
       kind: p.rateLimitKind,
       resetAt: p.rateLimitResetAt,
+      throttleMultiplier: p.rateLimitMultiplier,
       apply,
     });
   });
@@ -59,7 +63,9 @@ useGitHubRateLimitStore.getState = gitHubView;
  * form only (no functional updater) — that is all callers use.
  */
 useGitHubRateLimitStore.setState = (
-  partial: Partial<Pick<GitHubRateLimitState, "blocked" | "kind" | "resetAt">>
+  partial: Partial<
+    Pick<GitHubRateLimitState, "blocked" | "kind" | "resetAt" | "throttleMultiplier">
+  >
 ): void => {
   const cur = gitHubView();
   const next = { ...cur, ...partial };
@@ -67,5 +73,6 @@ useGitHubRateLimitStore.setState = (
     blocked: next.blocked,
     kind: next.kind,
     resetAt: next.resetAt,
+    throttleMultiplier: next.throttleMultiplier,
   });
 };


### PR DESCRIPTION
## Summary

Wires the GitHub rate-limit budget throttle multiplier into the renderer polling hooks, so idle polls back off when the backend already knows budget is tight. Previously `useRepositoryStats` and `useProjectHealth` returned hardcoded 30s/5min intervals with no awareness of throttling at all.

Also drops the redundant 30-minute `/rate_limit` `setInterval` from `GitHubTokenHealthService` — cold-start, focus, and wake probes are sufficient and align with GitHub's guidance to use response headers instead of polling the rate limit endpoint.

Resolves #9054.

## Changes

- **`forgeProviderHealthStore` / `githubRateLimitStore`** — carry `throttleMultiplier` through store and drop it when unset (null-safety), with unit tests covering serialization and boundary values
- **`useProjectHealth` / `useRepositoryStats`** — apply multiplier to `IDLE_POLL_INTERVAL` (idle-only — focused windows poll at full speed)
- **`GitHubTokenHealthService`** — remove the 30-minute `setInterval`, keep cold-start/focus/wake probes
- **Type plumbing** — `GitHubRateLimit` in `shared/types/forge.ts`, IPC handler passthrough, client shape update

## Testing

Unit tests for `forgeProviderHealthStore` and `githubRateLimitStore` cover multiplier serialization, null handling, and edge cases. Both stores validated clean at 1.0× (no-op) and 10× (max throttle). Renderer hooks verified with focused (no throttle) and background (throttled) page visibility.