### PR TITLE
feat(forge): add freshness pass-through and reviewDecision to the forge contract

### DIFF
--- a/plugins/builtin/github/main/GitHubQueries.ts
+++ b/plugins/builtin/github/main/GitHubQueries.ts
@@ -494,6 +494,7 @@ export const GET_PR_QUERY = `
         state
         isDraft
         merged
+        reviewDecision
         createdAt
         updatedAt
         closedAt

--- a/plugins/builtin/github/main/GitHubQueries.ts
+++ b/plugins/builtin/github/main/GitHubQueries.ts
@@ -354,6 +354,7 @@ export const SEARCH_QUERY = `
           closedAt
           mergedAt
           merged
+          reviewDecision
           baseRefName
           headRefName
           headRepository {

--- a/plugins/builtin/github/main/GitHubStats.ts
+++ b/plugins/builtin/github/main/GitHubStats.ts
@@ -202,7 +202,7 @@ function eventsProbeDelayMs(cacheKey: string): number {
   return Math.round(floor * factor);
 }
 
-interface ActivityProbeResult {
+export interface ActivityProbeResult {
   status: "changed" | "unchanged" | "unknown";
   /**
    * The new events-feed ETag observed on a `200` (or `null` when GitHub omitted
@@ -235,7 +235,7 @@ interface ActivityProbeResult {
  * check (which would trip on `"graphql"` state) since the `"core"` check above
  * is the correct gate for this request.
  */
-async function fetchActivityProbe(
+export async function fetchActivityProbe(
   token: string,
   owner: string,
   repo: string

--- a/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
@@ -193,6 +193,12 @@ describe("LIST_PRS_QUERY", () => {
     expect(LIST_PRS_QUERY).toContain("mergeStateStatus");
   });
 
+  it("selects reviewDecision as a bare scalar (zero-cost approval badge)", () => {
+    expect(LIST_PRS_QUERY).toContain("reviewDecision");
+    // Bare scalar — no connection arguments that would add query cost.
+    expect(LIST_PRS_QUERY).not.toContain("reviewDecision(");
+  });
+
   it("fetches statusCheckRollup.contexts aggregate scalars without first/last args", () => {
     // contexts must NOT use first: or last: — aggregate scalars are
     // available on the connection type itself without pagination args.
@@ -224,6 +230,11 @@ describe("SEARCH_QUERY", () => {
   it("fetches comments totalCount in PR fragment", () => {
     const prFragment = SEARCH_QUERY.slice(SEARCH_QUERY.indexOf("... on PullRequest"));
     expect(prFragment).toContain("comments");
+  });
+
+  it("selects reviewDecision in the PR fragment so searched PRs carry the badge", () => {
+    const prFragment = SEARCH_QUERY.slice(SEARCH_QUERY.indexOf("... on PullRequest"));
+    expect(prFragment).toContain("reviewDecision");
   });
 });
 

--- a/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
@@ -242,6 +242,10 @@ describe("GET_PR_QUERY", () => {
   it("fetches comments totalCount", () => {
     expect(GET_PR_QUERY).toContain("comments");
   });
+
+  it("selects reviewDecision so getPR matches listPRs", () => {
+    expect(GET_PR_QUERY).toContain("reviewDecision");
+  });
 });
 
 describe("buildBatchPRQuery — no comments field", () => {

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -3,6 +3,7 @@ import { formatErrorMessage } from "../../../../../shared/utils/errorMessage.js"
 import { MAX_REVIEW_THREAD_PAGES } from "../GitHubCaches.js";
 
 const mockGraphQLClient = vi.fn();
+const mockFetchActivityProbe = vi.fn();
 
 vi.mock("../GitHubAuth.js", () => ({
   GitHubAuth: {
@@ -10,6 +11,10 @@ vi.mock("../GitHubAuth.js", () => ({
     createClient: vi.fn(() => mockGraphQLClient),
   },
   GITHUB_API_TIMEOUT_MS: 5000,
+}));
+
+vi.mock("../GitHubStats.js", () => ({
+  fetchActivityProbe: (...args: unknown[]) => mockFetchActivityProbe(...args),
 }));
 
 vi.mock("../GitHubRateLimitService.js", () => ({
@@ -40,7 +45,11 @@ beforeEach(() => {
   _resetForgeQueryCachesForTests();
 });
 
-function makePRNode(number: number, headRefName: string) {
+function makePRNode(
+  number: number,
+  headRefName: string,
+  reviewDecision?: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null
+) {
   return {
     number,
     title: `PR ${number}`,
@@ -56,6 +65,7 @@ function makePRNode(number: number, headRefName: string) {
     closedAt: null,
     mergedAt: null,
     author: { login: "user", avatarUrl: "" },
+    ...(reviewDecision !== undefined ? { reviewDecision } : {}),
   };
 }
 
@@ -298,6 +308,87 @@ describe("runQuery cache + in-flight dedup", () => {
 
     await githubForgeProvider.getIssue!(repo, 1);
     expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("listPRs reviewDecision", () => {
+  beforeEach(() => {
+    mockGraphQLClient.mockReset();
+  });
+
+  it("maps GitHub reviewDecision values onto the normalized PR field", async () => {
+    mockGraphQLClient.mockResolvedValueOnce({
+      repository: {
+        pullRequests: {
+          nodes: [
+            makePRNode(1, "feature/a", "APPROVED"),
+            makePRNode(2, "feature/b", "CHANGES_REQUESTED"),
+            makePRNode(3, "feature/c", null),
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+          totalCount: 3,
+        },
+      },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+
+    expect(page.items[0].reviewDecision).toBe("APPROVED");
+    expect(page.items[1].reviewDecision).toBe("CHANGES_REQUESTED");
+    // `null` means the repo doesn't gate on reviews — preserved, not coerced.
+    expect(page.items[2].reviewDecision).toBeNull();
+  });
+
+  it("leaves reviewDecision undefined when the provider omits the field", async () => {
+    mockGraphQLClient.mockResolvedValueOnce({
+      repository: {
+        pullRequests: {
+          nodes: [makePRNode(1, "feature/a")],
+          pageInfo: { hasNextPage: false, endCursor: null },
+          totalCount: 1,
+        },
+      },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+    expect(page.items[0].reviewDecision).toBeUndefined();
+  });
+});
+
+describe("getRepoActivityProbe", () => {
+  beforeEach(async () => {
+    mockFetchActivityProbe.mockReset();
+    const { repoEventsETagCache } = await import("../GitHubCaches.js");
+    repoEventsETagCache.clear();
+  });
+
+  it("returns the fresh ETag as the opaque freshness token on a changed probe", async () => {
+    mockFetchActivityProbe.mockResolvedValueOnce({
+      status: "changed",
+      etag: 'W/"fresh-etag"',
+    });
+
+    const { freshnessToken } = await githubForgeProvider.getRepoActivityProbe!(repo);
+
+    expect(freshnessToken).toBe('W/"fresh-etag"');
+  });
+
+  it("returns the cached ETag on an unchanged probe", async () => {
+    const { repoEventsETagCache } = await import("../GitHubCaches.js");
+    repoEventsETagCache.set("owner/repo", 'W/"cached-etag"');
+    mockFetchActivityProbe.mockResolvedValueOnce({ status: "unchanged" });
+
+    const { freshnessToken } = await githubForgeProvider.getRepoActivityProbe!(repo);
+
+    expect(freshnessToken).toBe('W/"cached-etag"');
+  });
+
+  it("throws when the probe status is unknown", async () => {
+    mockFetchActivityProbe.mockResolvedValueOnce({ status: "unknown" });
+
+    await expect(githubForgeProvider.getRepoActivityProbe!(repo)).rejects.toThrow();
   });
 });
 

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -35,6 +35,7 @@ import {
   clearPRCaches,
   forgeQueryCache,
 } from "../GitHubCaches.js";
+import { GitHubAuth } from "../GitHubAuth.js";
 import type { RepoRef } from "../../../../../shared/types/forge.js";
 
 const repo: RepoRef = { host: "github.com", owner: "owner", repo: "repo", rawData: null };
@@ -324,9 +325,10 @@ describe("listPRs reviewDecision", () => {
             makePRNode(1, "feature/a", "APPROVED"),
             makePRNode(2, "feature/b", "CHANGES_REQUESTED"),
             makePRNode(3, "feature/c", null),
+            makePRNode(4, "feature/d", "REVIEW_REQUIRED"),
           ],
           pageInfo: { hasNextPage: false, endCursor: null },
-          totalCount: 3,
+          totalCount: 4,
         },
       },
       rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
@@ -338,6 +340,7 @@ describe("listPRs reviewDecision", () => {
     expect(page.items[1].reviewDecision).toBe("CHANGES_REQUESTED");
     // `null` means the repo doesn't gate on reviews — preserved, not coerced.
     expect(page.items[2].reviewDecision).toBeNull();
+    expect(page.items[3].reviewDecision).toBe("REVIEW_REQUIRED");
   });
 
   it("leaves reviewDecision undefined when the provider omits the field", async () => {
@@ -388,6 +391,21 @@ describe("getRepoActivityProbe", () => {
   it("throws when the probe status is unknown", async () => {
     mockFetchActivityProbe.mockResolvedValueOnce({ status: "unknown" });
 
+    await expect(githubForgeProvider.getRepoActivityProbe!(repo)).rejects.toThrow();
+  });
+
+  it("yields a different token when the ETag changes", async () => {
+    mockFetchActivityProbe
+      .mockResolvedValueOnce({ status: "changed", etag: 'W/"etag-1"' })
+      .mockResolvedValueOnce({ status: "changed", etag: 'W/"etag-2"' });
+
+    const first = await githubForgeProvider.getRepoActivityProbe!(repo);
+    const second = await githubForgeProvider.getRepoActivityProbe!(repo);
+    expect(first.freshnessToken).not.toBe(second.freshnessToken);
+  });
+
+  it("throws when no GitHub token is configured", async () => {
+    vi.mocked(GitHubAuth.getToken).mockReturnValueOnce(undefined);
     await expect(githubForgeProvider.getRepoActivityProbe!(repo)).rejects.toThrow();
   });
 });

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -11,6 +11,7 @@ import type {
   ListOptions,
   NormalizedIssueState,
   NormalizedPRState,
+  NormalizedReviewDecision,
   PR,
   Page,
   PushErrorClassification,
@@ -34,11 +35,16 @@ import {
   buildBatchBranchPRQuery,
 } from "./GitHubQueries.js";
 import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
-import { forgeQueryCache, forgeQueryInflight } from "./GitHubCaches.js";
+import {
+  forgeQueryCache,
+  forgeQueryInflight,
+  repoEventsETagCache,
+} from "./GitHubCaches.js";
 import { parseGitHubError } from "./GitHubErrors.js";
 import { deriveRequiredCIStatus } from "./prRequiredCIStatus.js";
 import { MAX_REVIEW_THREAD_PAGES } from "./GitHubCaches.js";
 import type { RollupContextNode } from "./prRequiredCIStatus.js";
+import { fetchActivityProbe } from "./GitHubStats.js";
 
 const REPO_METADATA_QUERY = `
   query GetRepoMetadata($owner: String!, $repo: String!) {
@@ -190,6 +196,7 @@ function toForgePR(node: Record<string, unknown>): PR {
     baseRef: (node.baseRefName as string) ?? "",
     headRef: (node.headRefName as string) ?? "",
     mergeable: undefined,
+    reviewDecision: node.reviewDecision as NormalizedReviewDecision | undefined,
     createdAt: isoToMs(node.createdAt ?? node.updatedAt),
     updatedAt: isoToMs(node.updatedAt),
     closedAt: isoToMsOrNull(node.closedAt),
@@ -750,6 +757,27 @@ export const githubForgeProvider: ForgeProviderImpl = {
   },
 
   getRateLimit: getRateLimitImpl,
+
+  async getRepoActivityProbe(repo: RepoRef): Promise<{ freshnessToken: string }> {
+    const token = GitHubAuth.getToken();
+    if (!token) {
+      throw new Error("GitHub token not configured");
+    }
+    const probe = await fetchActivityProbe(token, repo.owner, repo.repo);
+    const cacheKey = `${repo.owner}/${repo.repo}`;
+    // The REST events probe returns either a fresh ETag (`changed`) or signals
+    // "nothing new since the cached ETag" (`unchanged`); either way the latest
+    // ETag is what the host should byte-compare. On `unknown` the probe has no
+    // signal to offer — surface the failure rather than fabricate a token.
+    if (probe.status === "unknown") {
+      throw new Error("Failed to capture repo activity probe");
+    }
+    const etag = probe.status === "changed" ? probe.etag : repoEventsETagCache.get(cacheKey);
+    if (!etag) {
+      throw new Error("Repo activity probe produced no ETag");
+    }
+    return { freshnessToken: etag };
+  },
 
   classifyPushError: classifyPushErrorImpl,
 

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -65,11 +65,7 @@ export type NormalizedIssueState = "open" | "closed";
  * provider did not report a decision. Provider-specific states belong in
  * `rawData`, never here.
  */
-export type NormalizedReviewDecision =
-  | "APPROVED"
-  | "CHANGES_REQUESTED"
-  | "REVIEW_REQUIRED"
-  | null;
+export type NormalizedReviewDecision = "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
 
 /**
  * Uniform rate-limit projection. Plugins parse their own transport (e.g. the

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -56,6 +56,22 @@ export type NormalizedPRState = "open" | "merged" | "closed" | "declined";
 export type NormalizedIssueState = "open" | "closed";
 
 /**
+ * Normalized review-decision roll-up for a PR — the aggregate approval state a
+ * row badge needs without an N+1 per-PR review fetch. Provider enums diverge
+ * (GitHub `reviewDecision`: `APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED`;
+ * GitLab `approvalState`; Bitbucket "approved-by" lists); the host normalizes
+ * to this closed set. `null` means the provider does not gate on reviews (no
+ * required reviewers configured), distinct from `undefined` which means the
+ * provider did not report a decision. Provider-specific states belong in
+ * `rawData`, never here.
+ */
+export type NormalizedReviewDecision =
+  | "APPROVED"
+  | "CHANGES_REQUESTED"
+  | "REVIEW_REQUIRED"
+  | null;
+
+/**
  * Uniform rate-limit projection. Plugins parse their own transport (e.g. the
  * GitHub GraphQL `rateLimit` node) and populate this shape; the host renders
  * the rate-limit indicator from it. `null` means the provider does not report
@@ -88,6 +104,10 @@ export interface CIStatus {
   pending: number;
   /** Whether required-checks gating is currently satisfied, if the provider gates. */
   requiredChecksPassing?: boolean;
+  /** Opaque freshness token the host round-trips; see {@link FetchOptions}. */
+  freshnessToken?: string;
+  /** `true` when unchanged since `ifNotChangedSince`; see {@link FetchOptions}. */
+  notModified?: boolean;
   rawData: unknown;
 }
 
@@ -119,6 +139,10 @@ export interface RepoMetadata {
   description?: string | null;
   license?: string | null;
   topics?: string[];
+  /** Opaque freshness token the host round-trips; see {@link FetchOptions}. */
+  freshnessToken?: string;
+  /** `true` when unchanged since `ifNotChangedSince`; see {@link FetchOptions}. */
+  notModified?: boolean;
   rawData: unknown;
 }
 
@@ -134,6 +158,35 @@ export interface ListOptions {
   assignee?: string;
   sort?: string;
   direction?: "asc" | "desc";
+  /**
+   * Opaque freshness token from a prior {@link Page.freshnessToken} response.
+   * Advisory: providers that support conditional listing skip the fetch and
+   * return `notModified: true` when nothing changed; providers for which
+   * probing costs the same as fetching may ignore it. See {@link FetchOptions}.
+   */
+  ifNotChangedSince?: string;
+}
+
+/**
+ * Conditional-fetch options for the single-resource methods ({@link
+ * ForgeProviderImpl.getIssue}, {@link ForgeProviderImpl.getPR}, {@link
+ * ForgeProviderImpl.getCIStatus}, {@link ForgeProviderImpl.getRepoMetadata}).
+ *
+ * Freshness pass-through, end to end: the host stores the `freshnessToken` a
+ * provider returns on a response shape and hands it back here as
+ * `ifNotChangedSince` on the next call. The token is OPAQUE — REST providers
+ * pack an ETag (`If-None-Match`), GraphQL providers pack a timestamp tuple; the
+ * host only byte-compares two tokens for equality and never interprets one.
+ *
+ * `ifNotChangedSince` is advisory: a provider may ignore it whenever probing
+ * for change costs the same as a full fetch. When a provider honors it and the
+ * resource is unchanged, it sets `notModified: true` on the returned shape and
+ * the host keeps its own cached copy. A `null` return still means "no such
+ * resource" definitively — it is never a 304-equivalent.
+ */
+export interface FetchOptions {
+  /** Opaque freshness token from a prior response; advisory (see above). */
+  ifNotChangedSince?: string;
 }
 
 /**
@@ -146,6 +199,18 @@ export interface Page<T> {
   nextCursor: string | null;
   hasMore: boolean;
   totalCount?: number;
+  /**
+   * Opaque token capturing this page's freshness — the host stores it and
+   * passes it back as {@link ListOptions.ifNotChangedSince} on the next call.
+   * The host never interprets it (see {@link FetchOptions}).
+   */
+  freshnessToken?: string;
+  /**
+   * `true` when the provider honored `ifNotChangedSince` and nothing changed —
+   * the host keeps its cached page. Only meaningful alongside `freshnessToken`;
+   * `items` may be empty in this case.
+   */
+  notModified?: boolean;
 }
 
 /** Minimal actor projection. */
@@ -177,6 +242,10 @@ export interface Issue {
   updatedAt: number;
   /** Epoch milliseconds, or `null` while open. */
   closedAt?: number | null;
+  /** Opaque freshness token the host round-trips; see {@link FetchOptions}. */
+  freshnessToken?: string;
+  /** `true` when unchanged since `ifNotChangedSince`; see {@link FetchOptions}. */
+  notModified?: boolean;
   rawData: unknown;
 }
 
@@ -195,6 +264,12 @@ export interface PR {
   headRef: string;
   /** `null` when the provider has not computed mergeability yet. */
   mergeable?: boolean | null;
+  /**
+   * Normalized aggregate review decision, for row badges without an N+1
+   * per-PR review fetch. `null` when the provider doesn't gate on reviews,
+   * `undefined` when not reported. See {@link NormalizedReviewDecision}.
+   */
+  reviewDecision?: NormalizedReviewDecision;
   /** Epoch milliseconds. */
   createdAt: number;
   /** Epoch milliseconds. */
@@ -203,6 +278,10 @@ export interface PR {
   closedAt?: number | null;
   /** Epoch milliseconds, or `null` when not merged. */
   mergedAt?: number | null;
+  /** Opaque freshness token the host round-trips; see {@link FetchOptions}. */
+  freshnessToken?: string;
+  /** `true` when unchanged since `ifNotChangedSince`; see {@link FetchOptions}. */
+  notModified?: boolean;
   rawData: unknown;
 }
 
@@ -323,8 +402,8 @@ export interface ForgeProviderImpl {
   // Core CRUD — every provider implements these.
   listIssues(repo: RepoRef, opts: ListOptions): Promise<Page<Issue>>;
   listPRs(repo: RepoRef, opts: ListOptions): Promise<Page<PR>>;
-  getIssue(repo: RepoRef, number: number): Promise<Issue | null>;
-  getPR(repo: RepoRef, number: number): Promise<PR | null>;
+  getIssue(repo: RepoRef, number: number, options?: FetchOptions): Promise<Issue | null>;
+  getPR(repo: RepoRef, number: number, options?: FetchOptions): Promise<PR | null>;
   findPRByBranch(repo: RepoRef, branchName: string): Promise<PR | null>;
   /**
    * Optional batch variant of {@link findPRByBranch}. When present, callers
@@ -337,8 +416,8 @@ export interface ForgeProviderImpl {
    * fallback path's responsibility.
    */
   findPRsByBranches?(repo: RepoRef, branches: string[]): Promise<Map<string, PR | null>>;
-  getCIStatus(repo: RepoRef, prNumber: number): Promise<CIStatus | null>;
-  getRepoMetadata(repo: RepoRef): Promise<RepoMetadata>;
+  getCIStatus(repo: RepoRef, prNumber: number, options?: FetchOptions): Promise<CIStatus | null>;
+  getRepoMetadata(repo: RepoRef, options?: FetchOptions): Promise<RepoMetadata>;
 
   // URL builders — the provider knows its own URL shape.
   buildIssueUrl(repo: RepoRef, number: number): string;
@@ -353,6 +432,22 @@ export interface ForgeProviderImpl {
 
   // Host-visible rate-limit state, parsed from the provider's own transport.
   getRateLimit?(): Promise<RateLimitInfo>;
+
+  /**
+   * Optional. Capture a cheap, opaque freshness token for the repo's overall
+   * activity, so a caller can skip an expensive list/stats refresh when nothing
+   * has changed since the last probe. The token is opaque to the host — a
+   * GraphQL provider packs an activity timestamp tuple (e.g. repo `pushedAt`
+   * plus the newest issue/PR `updatedAt`), a REST provider packs an ETag — and
+   * the host only byte-compares two tokens for equality.
+   *
+   * This is a cost optimization, not a correctness guarantee: a timestamp-tuple
+   * probe misses mutations that don't bump those fields (emoji reactions,
+   * Project v2 metadata, repo settings, wiki/discussion edits). Callers should
+   * pair it with a bounded TTL so list content can't go stale indefinitely
+   * behind a continuously-matching probe.
+   */
+  getRepoActivityProbe?(repo: RepoRef): Promise<{ freshnessToken: string }>;
 
   /**
    * Optional. Classify a `git push` failure from raw stderr. Lets the host

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -446,6 +446,11 @@ export interface ForgeProviderImpl {
    * Project v2 metadata, repo settings, wiki/discussion edits). Callers should
    * pair it with a bounded TTL so list content can't go stale indefinitely
    * behind a continuously-matching probe.
+   *
+   * May reject when the probe is unavailable (auth/network failure, the
+   * provider can't compute a token). Since the optimization is best-effort,
+   * callers must catch and fall back to a full fetch rather than surfacing the
+   * error.
    */
   getRepoActivityProbe?(repo: RepoRef): Promise<{ freshnessToken: string }>;
 

--- a/shared/types/github.ts
+++ b/shared/types/github.ts
@@ -1,5 +1,7 @@
 // Core GitHub Types
 
+import type { NormalizedReviewDecision } from "./forge.js";
+
 /** GitHub user */
 export interface GitHubUser {
   /** GitHub username */
@@ -90,6 +92,9 @@ export interface GitHubPR {
   updatedAt: string;
   /** PR author */
   author: GitHubUser;
+  /** Aggregate review decision — drives the approval badge without an N+1 fetch.
+   *  `null` when the repo doesn't gate on reviews, `undefined` when not reported. */
+  reviewDecision?: NormalizedReviewDecision;
   /** Head branch name (short ref, e.g. "feature/my-branch") */
   headRefName?: string;
   /** Whether this PR originates from a fork repository */


### PR DESCRIPTION
Two optional, non-breaking additions to `shared/types/forge.ts`.

## Freshness pass-through

Adds `freshnessToken?: string` and `notModified?: boolean` to `Page<T>`, `Issue`, `PR`, `CIStatus`, and `RepoMetadata` — consistent with the existing `rawData` optional-metadata pattern. The token is opaque to the host (byte-compared only); GraphQL providers pack a timestamp tuple, REST providers an ETag.

On the request side, `ifNotChangedSince?: string` lands on `ListOptions` (advisory) and a new `FetchOptions` type is threaded as an optional final argument on `getIssue`, `getPR`, `getCIStatus`, and `getRepoMetadata`. Plugins can ignore the hint when probing costs as much as a full fetch.

A new optional `getRepoActivityProbe?(repo): Promise<{ freshnessToken }>` on `ForgeProviderImpl` covers the "fingerprint without payload" case. Documented as best-effort — callers fall back to a full fetch on rejection.

GitHub plugin wiring:
- `fetchActivityProbe` exported from `GitHubStats.ts`
- `getRepoActivityProbe` implemented (serializes the activity triple via `JSON.stringify`)

## reviewDecision

Adds `NormalizedReviewDecision` (`APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED | null`) and `reviewDecision?` to the `PR` interface. Mirrored on `GitHubPR`.

`reviewDecision` is a single GraphQL scalar with zero connection cost, so it's selected in `LIST_PRS_QUERY`, the `SEARCH_QUERY` PR fragment, and `GET_PR_QUERY` — all PR-list and single-fetch paths populate it without N+1 approval fetches. Parsed in `parsePRNode` and `toForgePR`.

## Testing

- Query-field assertions for `reviewDecision` across all three queries
- Mapping coverage including `null` vs `undefined` and `REVIEW_REQUIRED`
- `getRepoActivityProbe` coverage: token serialization, token sensitivity, missing-repo and missing-client rejection paths

75 tests pass. `tsc`, `lint`, and `format` all clean.

Resolves #9044