### PR TITLE
feat(github): capture per-query GraphQL rateLimit.cost for quota diagnostics

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -84,332 +84,328 @@
     "electron/watchdog-host-core.ts",
     "electron/window/createWindow.ts",
     "electron/window/globalServicesInit.ts",
-    "electron/window/skeletonCss.ts"
+    "electron/window/skeletonCss.ts",
+    "plugins/builtin/github/main/GitHubRateLimitService.ts"
   ],
   "syncViolations": [
     {
       "file": "electron/ipc/errorHandlers.ts",
-      "line": 34,
+      "line": 35,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/errorHandlers.ts",
-      "line": 298,
+      "line": 299,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/agentCapabilities.ts",
-      "line": 84,
+      "line": 85,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/agentCli.ts",
-      "line": 112,
+      "line": 113,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/ai.ts",
-      "line": 61,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/ai.ts",
-      "line": 79,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/ai.ts",
-      "line": 117,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/ai.ts",
-      "line": 134,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/app/state.ts",
-      "line": 60,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/app/state.ts",
-      "line": 359,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/app/state.ts",
-      "line": 361,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/app/state.ts",
-      "line": 415,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/appTheme.ts",
-      "line": 23,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/demo.ts",
-      "line": 233,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/ipc/handlers/diagnostics.ts",
-      "line": 54,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/ipc/handlers/diagnostics.ts",
-      "line": 61,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/ipc/handlers/forge.ts",
-      "line": 136,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeResolution.ts",
-      "line": 44,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 23,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 188,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 203,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 213,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 191,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 277,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 281,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 324,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 328,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 366,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/git-write.ts",
-      "line": 370,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/globalEnv.ts",
-      "line": 6,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/helpAssistant.ts",
-      "line": 98,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/helpAssistant.ts",
-      "line": 137,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/keybinding.ts",
-      "line": 12,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/logs.ts",
-      "line": 133,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/logs.ts",
-      "line": 228,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/milestones.ts",
-      "line": 9,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/milestones.ts",
-      "line": 13,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/notifications.ts",
       "line": 62,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/notifications.ts",
-      "line": 152,
+      "file": "electron/ipc/handlers/ai.ts",
+      "line": 80,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/onboarding.ts",
-      "line": 64,
+      "file": "electron/ipc/handlers/ai.ts",
+      "line": 118,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/privacy.ts",
-      "line": 29,
+      "file": "electron/ipc/handlers/ai.ts",
+      "line": 135,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/shortcutHints.ts",
-      "line": 9,
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 61,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/shortcutHints.ts",
-      "line": 13,
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 360,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/terminalConfig.ts",
-      "line": 17,
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 362,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/voiceInput.ts",
-      "line": 43,
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 416,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
-      "line": 87,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
-      "line": 188,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
-      "line": 192,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 57,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 72,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 84,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 91,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktreeConfig.ts",
-      "line": 12,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktreeConfig.ts",
-      "line": 25,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/pendingErrorsStore.ts",
-      "line": 7,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/main.ts",
-      "line": 151,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/main.ts",
-      "line": 232,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AppAgentService.ts",
-      "line": 34,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AppAgentService.ts",
-      "line": 48,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AppAgentService.ts",
-      "line": 53,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AppAgentService.ts",
-      "line": 123,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AppHydrationService.ts",
+      "file": "electron/ipc/handlers/appTheme.ts",
       "line": 24,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/AppHydrationService.ts",
-      "line": 82,
+      "file": "electron/ipc/handlers/demo.ts",
+      "line": 234,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/ipc/handlers/diagnostics.ts",
+      "line": 55,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/ipc/handlers/diagnostics.ts",
+      "line": 62,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/ipc/handlers/forge.ts",
+      "line": 137,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/forgeResolution.ts",
+      "line": 45,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/forgeSettings.ts",
+      "line": 24,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/forgeSettings.ts",
+      "line": 189,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/forgeSettings.ts",
+      "line": 204,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/forgeSettings.ts",
+      "line": 214,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 192,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 278,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 282,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 325,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 329,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 367,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/git-write.ts",
+      "line": 371,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/globalEnv.ts",
+      "line": 7,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/helpAssistant.ts",
+      "line": 99,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/helpAssistant.ts",
+      "line": 138,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/keybinding.ts",
+      "line": 13,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/logs.ts",
+      "line": 134,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/logs.ts",
+      "line": 229,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/milestones.ts",
+      "line": 10,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/milestones.ts",
+      "line": 14,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/notifications.ts",
+      "line": 63,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/notifications.ts",
+      "line": 153,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/onboarding.ts",
+      "line": 65,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/privacy.ts",
+      "line": 30,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/shortcutHints.ts",
+      "line": 10,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/shortcutHints.ts",
+      "line": 14,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/terminalConfig.ts",
+      "line": 18,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/voiceInput.ts",
+      "line": 44,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
+      "line": 88,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
+      "line": 189,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/lifecycle.ts",
+      "line": 193,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 58,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 73,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 85,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 92,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktreeConfig.ts",
+      "line": 13,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktreeConfig.ts",
+      "line": 26,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/pendingErrorsStore.ts",
+      "line": 8,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/main.ts",
+      "line": 152,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/main.ts",
+      "line": 233,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppAgentService.ts",
+      "line": 35,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppAgentService.ts",
+      "line": 49,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppAgentService.ts",
+      "line": 54,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppAgentService.ts",
+      "line": 124,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AppHydrationService.ts",
-      "line": 84,
+      "line": 25,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 275,
+      "file": "electron/services/AppHydrationService.ts",
+      "line": 83,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AppHydrationService.ts",
+      "line": 85,
       "pattern": "sync-store-get"
     },
     {
@@ -419,62 +415,62 @@
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 396,
+      "line": 277,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 405,
+      "line": 397,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 435,
+      "line": 406,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 474,
+      "line": 436,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/AutoUpdaterService.ts",
+      "line": 475,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 474,
+      "line": 475,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/AutoUpdaterService.ts",
-      "line": 491,
+      "line": 492,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CliAvailabilityService.ts",
-      "line": 807,
+      "line": 808,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 56,
+      "line": 57,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 81,
+      "line": 82,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 89,
+      "line": 90,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 111,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CliInstallService.ts",
-      "line": 126,
+      "line": 112,
       "pattern": "sync-fs"
     },
     {
@@ -484,12 +480,12 @@
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 130,
+      "line": 128,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 144,
+      "line": 131,
       "pattern": "sync-fs"
     },
     {
@@ -499,12 +495,12 @@
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 155,
+      "line": 146,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 159,
+      "line": 156,
       "pattern": "sync-fs"
     },
     {
@@ -514,7 +510,7 @@
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 168,
+      "line": 161,
       "pattern": "sync-fs"
     },
     {
@@ -524,52 +520,52 @@
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 182,
+      "line": 170,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CliInstallService.ts",
-      "line": 212,
+      "line": 183,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CliInstallService.ts",
+      "line": 213,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 190,
+      "line": 191,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 194,
+      "line": 195,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 229,
+      "line": 230,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 251,
+      "line": 252,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 264,
+      "line": 265,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 283,
+      "line": 284,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 300,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 316,
+      "line": 301,
       "pattern": "sync-fs"
     },
     {
@@ -579,7 +575,7 @@
     },
     {
       "file": "electron/services/CrashLoopGuardService.ts",
-      "line": 329,
+      "line": 318,
       "pattern": "sync-fs"
     },
     {
@@ -588,103 +584,103 @@
       "pattern": "sync-fs"
     },
     {
+      "file": "electron/services/CrashLoopGuardService.ts",
+      "line": 331,
+      "pattern": "sync-fs"
+    },
+    {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 112,
+      "line": 113,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 137,
+      "line": 138,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 273,
+      "line": 274,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 290,
+      "line": 291,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 399,
+      "line": 400,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 402,
+      "line": 403,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 466,
+      "line": 467,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 532,
+      "line": 533,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 534,
+      "line": 535,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 541,
+      "line": 542,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 544,
+      "line": 545,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 571,
+      "line": 572,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 573,
+      "line": 574,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 577,
+      "line": 578,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 594,
+      "line": 595,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 610,
+      "line": 611,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 614,
+      "line": 615,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 617,
+      "line": 618,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 646,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 662,
+      "line": 647,
       "pattern": "sync-fs"
     },
     {
@@ -694,7 +690,7 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 729,
+      "line": 664,
       "pattern": "sync-fs"
     },
     {
@@ -704,7 +700,7 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 760,
+      "line": 731,
       "pattern": "sync-fs"
     },
     {
@@ -714,13 +710,13 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 788,
-      "pattern": "sync-store-get"
+      "line": 762,
+      "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 815,
-      "pattern": "sync-fs"
+      "line": 789,
+      "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
@@ -729,7 +725,7 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 863,
+      "line": 817,
       "pattern": "sync-fs"
     },
     {
@@ -739,27 +735,27 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 868,
+      "line": 865,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 983,
+      "line": 869,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1007,
+      "line": 984,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1016,
+      "line": 1008,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1027,
+      "line": 1017,
       "pattern": "sync-fs"
     },
     {
@@ -769,57 +765,57 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1040,
+      "line": 1029,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 1041,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1056,
+      "line": 1057,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1058,
+      "line": 1059,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1064,
+      "line": 1065,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1074,
+      "line": 1075,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/DatabaseMaintenanceService.ts",
-      "line": 145,
+      "line": 146,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/DatabaseMaintenanceService.ts",
-      "line": 149,
+      "line": 150,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/DatabaseMaintenanceService.ts",
-      "line": 149,
+      "line": 150,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitHubFirstPageCache.ts",
-      "line": 195,
+      "line": 196,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitHubFirstPageCache.ts",
-      "line": 201,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/GitHubFirstPageCache.ts",
-      "line": 231,
+      "line": 202,
       "pattern": "sync-fs"
     },
     {
@@ -828,18 +824,18 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/GitHubStatsCache.ts",
-      "line": 154,
+      "file": "electron/services/GitHubFirstPageCache.ts",
+      "line": 233,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitHubStatsCache.ts",
-      "line": 160,
+      "line": 155,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitHubStatsCache.ts",
-      "line": 192,
+      "line": 161,
       "pattern": "sync-fs"
     },
     {
@@ -848,33 +844,33 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/GitService.ts",
-      "line": 59,
+      "file": "electron/services/GitHubStatsCache.ts",
+      "line": 194,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 110,
+      "line": 60,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 527,
+      "line": 111,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 533,
+      "line": 528,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/GitService.ts",
+      "line": 534,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 24,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 39,
+      "line": 25,
       "pattern": "sync-fs"
     },
     {
@@ -884,12 +880,12 @@
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 45,
+      "line": 41,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 75,
+      "line": 46,
       "pattern": "sync-fs"
     },
     {
@@ -898,78 +894,78 @@
       "pattern": "sync-fs"
     },
     {
+      "file": "electron/services/GpuCrashMonitorService.ts",
+      "line": 77,
+      "pattern": "sync-fs"
+    },
+    {
       "file": "electron/services/HelpService.ts",
-      "line": 16,
+      "line": 17,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/HelpSessionService.ts",
-      "line": 1089,
+      "line": 1090,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/HibernationService.ts",
-      "line": 372,
+      "line": 373,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/IdleTerminalNotificationService.ts",
-      "line": 90,
+      "line": 91,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/IdleTerminalNotificationService.ts",
-      "line": 260,
+      "line": 261,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/mcp-server/httpLifecycle.ts",
-      "line": 364,
+      "line": 365,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/McpServerService.ts",
-      "line": 273,
+      "line": 274,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 297,
+      "line": 298,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 301,
+      "line": 302,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 335,
+      "line": 336,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 350,
+      "line": 351,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 363,
+      "line": 364,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 376,
+      "line": 377,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 393,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/PanelSuspectLedgerService.ts",
-      "line": 406,
+      "line": 394,
       "pattern": "sync-fs"
     },
     {
@@ -978,24 +974,24 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/services/persistence/db.ts",
-      "line": 83,
-      "pattern": "sync-sqlite"
-    },
-    {
-      "file": "electron/services/persistence/db.ts",
-      "line": 118,
+      "file": "electron/services/PanelSuspectLedgerService.ts",
+      "line": 408,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 121,
+      "line": 84,
       "pattern": "sync-sqlite"
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 156,
+      "line": 119,
       "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/persistence/db.ts",
+      "line": 122,
+      "pattern": "sync-sqlite"
     },
     {
       "file": "electron/services/persistence/db.ts",
@@ -1004,162 +1000,162 @@
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 162,
+      "line": 158,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 165,
+      "line": 163,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/db.ts",
-      "line": 171,
+      "line": 166,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/persistence/db.ts",
+      "line": 172,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/readLastProjectId.ts",
-      "line": 20,
+      "line": 21,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/persistence/readLastProjectId.ts",
-      "line": 24,
+      "line": 25,
       "pattern": "sync-sqlite"
     },
     {
       "file": "electron/services/PluginService.ts",
-      "line": 263,
+      "line": 264,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/ProcessMemoryMonitor.ts",
-      "line": 425,
+      "line": 426,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectEnvSecureStorage.ts",
-      "line": 13,
+      "line": 14,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/ProjectFileStore.ts",
+      "line": 64,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/ProjectSettingsManager.ts",
+      "line": 30,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/ProjectSettingsManager.ts",
       "line": 63,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectSettingsManager.ts",
-      "line": 29,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/ProjectSettingsManager.ts",
-      "line": 62,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/ProjectSettingsManager.ts",
-      "line": 176,
+      "line": 177,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStateManager.ts",
-      "line": 156,
+      "line": 157,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 88,
+      "line": 89,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 258,
+      "line": 259,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 441,
+      "line": 442,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 448,
+      "line": 449,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 502,
+      "line": 503,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 508,
+      "line": 509,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectSwitchService.ts",
-      "line": 163,
+      "line": 164,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/pty/agentSessionHistory.ts",
-      "line": 56,
+      "line": 57,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 257,
+      "line": 258,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 270,
+      "line": 271,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 282,
+      "line": 283,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 297,
+      "line": 298,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 310,
+      "line": 311,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 325,
+      "line": 326,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 330,
+      "line": 331,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 119,
+      "line": 120,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 130,
+      "line": 131,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 193,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 245,
+      "line": 194,
       "pattern": "sync-fs"
     },
     {
@@ -1169,37 +1165,37 @@
     },
     {
       "file": "electron/services/pty/terminalSessionPersistence.ts",
-      "line": 256,
+      "line": 247,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/pty/terminalSessionPersistence.ts",
+      "line": 257,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/pty/terminalShell.ts",
-      "line": 42,
+      "line": 43,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/PtyClient.ts",
-      "line": 165,
+      "line": 166,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/SecureStorage.ts",
-      "line": 22,
+      "line": 23,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 95,
+      "line": 96,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 101,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/StoreMigrations.ts",
-      "line": 134,
+      "line": 102,
       "pattern": "sync-fs"
     },
     {
@@ -1209,47 +1205,47 @@
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 149,
+      "line": 136,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 171,
+      "line": 150,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/StoreMigrations.ts",
+      "line": 172,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 255,
+      "line": 256,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 270,
+      "line": 271,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 296,
+      "line": 297,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 303,
+      "line": 304,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 426,
+      "line": 427,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TrashedPidTracker.ts",
-      "line": 212,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/TrashedPidTracker.ts",
-      "line": 217,
+      "line": 213,
       "pattern": "sync-fs"
     },
     {
@@ -1259,7 +1255,7 @@
     },
     {
       "file": "electron/services/TrashedPidTracker.ts",
-      "line": 245,
+      "line": 219,
       "pattern": "sync-fs"
     },
     {
@@ -1268,23 +1264,23 @@
       "pattern": "sync-fs"
     },
     {
+      "file": "electron/services/TrashedPidTracker.ts",
+      "line": 247,
+      "pattern": "sync-fs"
+    },
+    {
       "file": "electron/services/UserAgentRegistryService.ts",
-      "line": 27,
+      "line": 28,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 38,
+      "line": 39,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 44,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 200,
+      "line": 45,
       "pattern": "sync-store-get"
     },
     {
@@ -1294,7 +1290,7 @@
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 258,
+      "line": 202,
       "pattern": "sync-store-get"
     },
     {
@@ -1304,7 +1300,7 @@
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 440,
+      "line": 260,
       "pattern": "sync-store-get"
     },
     {
@@ -1313,13 +1309,13 @@
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/setup/devDiagnostics.ts",
-      "line": 40,
-      "pattern": "sync-fs"
+      "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
+      "line": 442,
+      "pattern": "sync-store-get"
     },
     {
-      "file": "electron/setup/environment.ts",
-      "line": 59,
+      "file": "electron/setup/devDiagnostics.ts",
+      "line": 41,
       "pattern": "sync-fs"
     },
     {
@@ -1329,57 +1325,57 @@
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 62,
+      "line": 61,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 73,
+      "line": 63,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 85,
+      "line": 74,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 154,
+      "line": 86,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 250,
+      "line": 155,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 328,
+      "line": 251,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 642,
+      "line": 329,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/setup/environment.ts",
+      "line": 643,
       "pattern": "sync-sqlite"
     },
     {
       "file": "electron/store.ts",
-      "line": 492,
+      "line": 493,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 494,
+      "line": 495,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 509,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/store.ts",
-      "line": 524,
+      "line": 510,
       "pattern": "sync-fs"
     },
     {
@@ -1389,27 +1385,27 @@
     },
     {
       "file": "electron/store.ts",
-      "line": 527,
+      "line": 526,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 542,
+      "line": 528,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 544,
+      "line": 543,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 561,
+      "line": 545,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 570,
+      "line": 562,
       "pattern": "sync-fs"
     },
     {
@@ -1418,68 +1414,68 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/utils/emergencyLog.ts",
-      "line": 23,
+      "file": "electron/store.ts",
+      "line": 572,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/emergencyLog.ts",
-      "line": 26,
+      "line": 24,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/emergencyLog.ts",
-      "line": 28,
+      "line": 27,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/emergencyLog.ts",
+      "line": 29,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/emergencyLog.ts",
+      "line": 36,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/fs.ts",
+      "line": 27,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/fs.ts",
+      "line": 84,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/fs.ts",
+      "line": 148,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/fs.ts",
+      "line": 156,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/git.ts",
+      "line": 131,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/git.ts",
+      "line": 380,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/git.ts",
+      "line": 688,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/gitRepoOperationState.ts",
       "line": 35,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/fs.ts",
-      "line": 26,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/fs.ts",
-      "line": 83,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/fs.ts",
-      "line": 147,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/fs.ts",
-      "line": 155,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/git.ts",
-      "line": 130,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/git.ts",
-      "line": 379,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/git.ts",
-      "line": 687,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 34,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 58,
       "pattern": "sync-fs"
     },
     {
@@ -1489,107 +1485,107 @@
     },
     {
       "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 67,
+      "line": 60,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 74,
+      "line": 68,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/gitRepoOperationState.ts",
-      "line": 81,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gpuDetection.ts",
-      "line": 32,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gpuDetection.ts",
-      "line": 41,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/gpuDetection.ts",
-      "line": 50,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/logger.ts",
-      "line": 71,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/logger.ts",
       "line": 75,
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/utils/logger.ts",
-      "line": 81,
+      "file": "electron/utils/gitRepoOperationState.ts",
+      "line": 82,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/gpuDetection.ts",
+      "line": 33,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/gpuDetection.ts",
+      "line": 42,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/gpuDetection.ts",
+      "line": 51,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 137,
+      "line": 72,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 139,
+      "line": 76,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 151,
+      "line": 82,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 154,
+      "line": 138,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 184,
+      "line": 140,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 187,
+      "line": 152,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 191,
+      "line": 155,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 228,
+      "line": 185,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 230,
+      "line": 188,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 234,
+      "line": 192,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 236,
+      "line": 229,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 521,
+      "line": 231,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/logger.ts",
+      "line": 235,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/logger.ts",
+      "line": 237,
       "pattern": "sync-fs"
     },
     {
@@ -1599,12 +1595,12 @@
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 528,
+      "line": 523,
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/utils/performance.ts",
-      "line": 64,
+      "file": "electron/utils/logger.ts",
+      "line": 529,
       "pattern": "sync-fs"
     },
     {
@@ -1613,49 +1609,69 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/utils/worktreePattern.ts",
-      "line": 19,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/watchdog-host-core.ts",
-      "line": 181,
+      "file": "electron/utils/performance.ts",
+      "line": 66,
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/window/createWindow.ts",
-      "line": 145,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/window/globalServicesInit.ts",
-      "line": 85,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/window/globalServicesInit.ts",
-      "line": 168,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/window/globalServicesInit.ts",
-      "line": 576,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/window/globalServicesInit.ts",
-      "line": 722,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/window/skeletonCss.ts",
+      "file": "electron/utils/worktreePattern.ts",
       "line": 20,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/window/skeletonCss.ts",
-      "line": 25,
+      "file": "electron/watchdog-host-core.ts",
+      "line": 182,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/window/createWindow.ts",
+      "line": 146,
       "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/globalServicesInit.ts",
+      "line": 86,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/globalServicesInit.ts",
+      "line": 169,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/globalServicesInit.ts",
+      "line": 577,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/globalServicesInit.ts",
+      "line": 723,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/skeletonCss.ts",
+      "line": 21,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/skeletonCss.ts",
+      "line": 26,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "plugins/builtin/github/main/GitHubRateLimitService.ts",
+      "line": 373,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "plugins/builtin/github/main/GitHubRateLimitService.ts",
+      "line": 374,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "plugins/builtin/github/main/GitHubRateLimitService.ts",
+      "line": 378,
+      "pattern": "sync-fs"
     }
   ]
 }

--- a/plugins/builtin/github/main/GitHubHealth.ts
+++ b/plugins/builtin/github/main/GitHubHealth.ts
@@ -119,7 +119,7 @@ async function fetchMergeVelocity(
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as GraphQlQueryResponseData;
 
-    gitHubRateLimitService.updateFromGraphQL(result);
+    gitHubRateLimitService.updateFromGraphQL(result, "MERGE_VELOCITY_QUERY");
     return extractMergedCounts(result);
   } catch (error) {
     console.warn("[github] merged-PR velocity fetch failed:", error);
@@ -245,7 +245,7 @@ export async function getProjectHealth(
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as GraphQlQueryResponseData;
 
-    gitHubRateLimitService.updateFromGraphQL(result);
+    gitHubRateLimitService.updateFromGraphQL(result, "PROJECT_HEALTH_QUERY");
 
     const repository = result?.repository;
     if (!repository) {

--- a/plugins/builtin/github/main/GitHubIssues.ts
+++ b/plugins/builtin/github/main/GitHubIssues.ts
@@ -277,7 +277,7 @@ export async function getIssueTooltip(
         request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
       })) as GraphQlQueryResponseData;
 
-      gitHubRateLimitService.updateFromGraphQL(response);
+      gitHubRateLimitService.updateFromGraphQL(response, "GET_ISSUE_QUERY");
 
       const issue = response?.repository?.issue;
       if (!issue) {
@@ -369,7 +369,7 @@ export async function listIssues(
           request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
         })) as GraphQlQueryResponseData;
 
-        gitHubRateLimitService.updateFromGraphQL(response);
+        gitHubRateLimitService.updateFromGraphQL(response, "SEARCH_ISSUES_QUERY");
 
         const search = response?.search;
         const nodes = (search?.nodes ?? []) as Array<Record<string, unknown>>;
@@ -394,7 +394,7 @@ export async function listIssues(
           request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
         })) as GraphQlQueryResponseData;
 
-        gitHubRateLimitService.updateFromGraphQL(response);
+        gitHubRateLimitService.updateFromGraphQL(response, "LIST_ISSUES_QUERY");
 
         const issues = response?.repository?.issues;
         const nodes = (issues?.nodes ?? []) as Array<Record<string, unknown>>;
@@ -458,7 +458,7 @@ export async function getIssueByNumber(
         request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
       })) as GraphQlQueryResponseData;
 
-      gitHubRateLimitService.updateFromGraphQL(response);
+      gitHubRateLimitService.updateFromGraphQL(response, "GET_ISSUE_QUERY");
 
       const issue = response?.repository?.issue;
       if (!issue) {

--- a/plugins/builtin/github/main/GitHubPRDiscovery.ts
+++ b/plugins/builtin/github/main/GitHubPRDiscovery.ts
@@ -459,7 +459,7 @@ export async function batchCheckLinkedPRs(
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as Record<string, unknown>;
 
-    gitHubRateLimitService.updateFromGraphQL(response);
+    gitHubRateLimitService.updateFromGraphQL(response, "BATCH_DISCOVERY_PR_QUERY");
 
     const results = parseBatchPRResponse(response, candidatesForGraphQL);
     prewarmPRTooltipCache(context.owner, context.repo, results, requestedAt);
@@ -482,7 +482,7 @@ export async function batchCheckLinkedPRs(
           const retryResponse = (await client(retryQuery, {
             request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
           })) as Record<string, unknown>;
-          gitHubRateLimitService.updateFromGraphQL(retryResponse);
+          gitHubRateLimitService.updateFromGraphQL(retryResponse, "BATCH_DISCOVERY_PR_RETRY");
           const retryResults = parseBatchPRResponse(retryResponse, candidatesForGraphQL);
           prewarmPRTooltipCache(
             freshContext.owner,

--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -190,7 +190,7 @@ export async function getPRTooltip(cwd: string, prNumber: number): Promise<PRToo
         request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
       })) as GraphQlQueryResponseData;
 
-      gitHubRateLimitService.updateFromGraphQL(response);
+      gitHubRateLimitService.updateFromGraphQL(response, "GET_PR_QUERY");
 
       const pr = response?.repository?.pullRequest;
       if (!pr) {
@@ -275,7 +275,7 @@ async function enrichPRsWithRequiredStatus(
         const response = (await client(query, {
           request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
         })) as Record<string, unknown>;
-        gitHubRateLimitService.updateFromGraphQL(response);
+        gitHubRateLimitService.updateFromGraphQL(response, "BATCH_REQUIRED_CHECKS_QUERY");
         fetched = parseBatchRequiredChecksResponse(response, numbersToFetch);
         for (const [num, entry] of fetched) {
           prRequiredStatusCache.set(cacheKeyFor(num), entry);
@@ -387,7 +387,7 @@ export async function listPullRequests(
           request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
         })) as GraphQlQueryResponseData;
 
-        gitHubRateLimitService.updateFromGraphQL(response);
+        gitHubRateLimitService.updateFromGraphQL(response, "SEARCH_PRS_QUERY");
 
         const search = response?.search;
         const nodes = (search?.nodes ?? []) as Array<Record<string, unknown>>;
@@ -419,7 +419,7 @@ export async function listPullRequests(
           request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
         })) as GraphQlQueryResponseData;
 
-        gitHubRateLimitService.updateFromGraphQL(response);
+        gitHubRateLimitService.updateFromGraphQL(response, "LIST_PRS_QUERY");
 
         if (!response?.repository) {
           throw new Error("Repository not found or token lacks access.");
@@ -491,7 +491,7 @@ export async function getPRByNumber(cwd: string, prNumber: number): Promise<GitH
         request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
       })) as GraphQlQueryResponseData;
 
-      gitHubRateLimitService.updateFromGraphQL(response);
+      gitHubRateLimitService.updateFromGraphQL(response, "GET_PR_QUERY");
 
       const pr = response?.repository?.pullRequest;
       if (!pr) {
@@ -542,7 +542,7 @@ export async function getPRReviewThreads(
           request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
         })) as GraphQlQueryResponseData;
 
-        gitHubRateLimitService.updateFromGraphQL(response);
+        gitHubRateLimitService.updateFromGraphQL(response, "GET_PR_REVIEW_THREADS_QUERY");
 
         const threads = response?.repository?.pullRequest?.reviewThreads;
         const nodes = (threads?.nodes ?? []) as Array<{

--- a/plugins/builtin/github/main/GitHubRateLimitService.ts
+++ b/plugins/builtin/github/main/GitHubRateLimitService.ts
@@ -1,6 +1,10 @@
 import { appendFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import { app } from "electron";
+// eager-import-allow: sync-fs calls (appendFileSync, existsSync, mkdirSync)
+// are gated behind DAINTREE_DEBUG_GITHUB_GRAPHQL=1 — never executed at import
+// time. The imports resolve three symbols that are only dereferenced inside
+// _logGraphQLCost(), which returns immediately when the env var is absent.
 import type {
   GitHubRateLimitKind,
   GitHubRateLimitPayload,

--- a/plugins/builtin/github/main/GitHubRateLimitService.ts
+++ b/plugins/builtin/github/main/GitHubRateLimitService.ts
@@ -1,3 +1,6 @@
+import { appendFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { app } from "electron";
 import type {
   GitHubRateLimitKind,
   GitHubRateLimitPayload,
@@ -314,7 +317,7 @@ class GitHubRateLimitServiceImpl {
    *
    * Ignores missing or malformed rateLimit objects silently.
    */
-  updateFromGraphQL(data: Record<string, unknown>): void {
+  updateFromGraphQL(data: Record<string, unknown>, queryLabel?: string): void {
     const rateLimit = data?.rateLimit as
       | { cost?: number; remaining?: number; resetAt?: string; limit?: number }
       | undefined;
@@ -327,7 +330,12 @@ class GitHubRateLimitServiceImpl {
     const resetMs = Date.parse(resetAt);
     if (!Number.isFinite(resetMs)) return;
 
+    const cost = typeof rateLimit.cost === "number" ? rateLimit.cost : null;
     const limit = typeof rateLimit.limit === "number" ? rateLimit.limit : null;
+
+    if (queryLabel && cost !== null) {
+      this._logGraphQLCost(queryLabel, cost, remaining, limit);
+    }
 
     // Budget exhausted (or within the hard-stop band): hard-block GraphQL
     // until the window resets, exactly as the legacy `remaining === 0` path.
@@ -351,6 +359,26 @@ class GitHubRateLimitServiceImpl {
     if (limit === null || limit <= 0) return;
 
     this.recordBudgetReading(remaining, limit, resetMs);
+  }
+
+  private _logGraphQLCost(
+    queryLabel: string,
+    cost: number,
+    remaining: number,
+    limit: number | null
+  ): void {
+    if (process.env.DAINTREE_DEBUG_GITHUB_GRAPHQL !== "1") return;
+    try {
+      const dir = join(app.getPath("userData"), "debug");
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+      const escaped = queryLabel.replace(/["\n\r]/g, "");
+      const line = `[${new Date().toISOString()}] label="${escaped}" cost=${cost} remaining=${remaining} limit=${limit ?? "null"}\n`;
+      appendFileSync(join(dir, "github-graphql-costs.log"), line, "utf-8");
+    } catch {
+      // Must never throw — diagnostic logging is best-effort.
+    }
   }
 
   /**

--- a/plugins/builtin/github/main/GitHubStats.ts
+++ b/plugins/builtin/github/main/GitHubStats.ts
@@ -92,7 +92,7 @@ export async function getRepoStats(
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as GraphQlQueryResponseData;
 
-    gitHubRateLimitService.updateFromGraphQL(result);
+    gitHubRateLimitService.updateFromGraphQL(result, "REPO_STATS_QUERY");
 
     const repository = result?.repository;
     if (!repository) {
@@ -185,7 +185,7 @@ async function fetchActivityProbe(
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as GraphQlQueryResponseData;
 
-    gitHubRateLimitService.updateFromGraphQL(result);
+    gitHubRateLimitService.updateFromGraphQL(result, "REPO_ACTIVITY_PROBE_QUERY");
 
     const repository = result?.repository;
     if (!repository) return null;
@@ -370,7 +370,7 @@ export async function getRepoStatsAndPage(
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as GraphQlQueryResponseData;
 
-    gitHubRateLimitService.updateFromGraphQL(result);
+    gitHubRateLimitService.updateFromGraphQL(result, "REPO_STATS_AND_PAGE_QUERY");
 
     const repository = result?.repository;
     if (!repository) {

--- a/plugins/builtin/github/main/__tests__/GitHubRateLimitService.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubRateLimitService.test.ts
@@ -1,3 +1,5 @@
+import { appendFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -7,6 +9,25 @@ import {
   MAX_THROTTLE_MULTIPLIER,
 } from "../GitHubRateLimitService.js";
 import type { GitHubRateLimitPayload } from "../../../../../shared/types/ipc/github.js";
+
+vi.mock("fs", () => ({
+  appendFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn((name: string) => {
+      if (name === "userData") return "/mock/user/data";
+      throw new Error(`Unexpected getPath arg: ${name}`);
+    }),
+  },
+}));
+
+const mockedAppendFileSync = vi.mocked(appendFileSync);
+const mockedExistsSync = vi.mocked(existsSync);
+const mockedMkdirSync = vi.mocked(mkdirSync);
 
 function makeHeaders(entries: Record<string, string>): Headers {
   return new Headers(entries);
@@ -606,6 +627,101 @@ describe("GitHubRateLimitService", () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    describe("per-query cost logging (DAINTREE_DEBUG_GITHUB_GRAPHQL)", () => {
+      const label = "TEST_QUERY";
+      const debugDir = "/mock/user/data/debug";
+      const logPath = join(debugDir, "github-graphql-costs.log");
+
+      function setDebugEnv(value: string) {
+        process.env.DAINTREE_DEBUG_GITHUB_GRAPHQL = value;
+      }
+
+      beforeEach(() => {
+        delete process.env.DAINTREE_DEBUG_GITHUB_GRAPHQL;
+        mockedAppendFileSync.mockReset();
+        mockedExistsSync.mockReset();
+        mockedMkdirSync.mockReset();
+        mockedExistsSync.mockReturnValue(true);
+      });
+
+      afterEach(() => {
+        delete process.env.DAINTREE_DEBUG_GITHUB_GRAPHQL;
+      });
+
+      it("does not write when env var is unset", () => {
+        gitHubRateLimitService.updateFromGraphQL(graphQLData(4995, 5000), label);
+        expect(mockedAppendFileSync).not.toHaveBeenCalled();
+      });
+
+      it("writes one log line when env var is set and label and cost are present", () => {
+        setDebugEnv("1");
+        const data = graphQLData(4995, 5000);
+        gitHubRateLimitService.updateFromGraphQL(data, label);
+
+        expect(mockedAppendFileSync).toHaveBeenCalledTimes(1);
+        const call = mockedAppendFileSync.mock.calls[0];
+        expect(call[0]).toBe(logPath);
+        const line = call[1] as string;
+        expect(line).toContain(`label="${label}"`);
+        expect(line).toContain("cost=1");
+        expect(line).toContain("remaining=4995");
+        expect(line).toContain("limit=5000");
+        expect(line).toMatch(/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]/);
+      });
+
+      it("does not write when label is missing", () => {
+        setDebugEnv("1");
+        gitHubRateLimitService.updateFromGraphQL(graphQLData(4995, 5000));
+        expect(mockedAppendFileSync).not.toHaveBeenCalled();
+      });
+
+      it("does not write when rateLimit.cost is missing", () => {
+        setDebugEnv("1");
+        const data = {
+          rateLimit: {
+            remaining: 4995,
+            resetAt: new Date(Date.now() + ONE_HOUR_MS).toISOString(),
+            limit: 5000,
+          },
+        };
+        gitHubRateLimitService.updateFromGraphQL(data, label);
+        expect(mockedAppendFileSync).not.toHaveBeenCalled();
+        expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+      });
+
+      it("creates the debug directory if it does not exist", () => {
+        setDebugEnv("1");
+        mockedAppendFileSync.mockClear();
+        mockedExistsSync.mockReturnValue(false);
+        gitHubRateLimitService.updateFromGraphQL(graphQLData(4995, 5000), label);
+
+        expect(mockedMkdirSync).toHaveBeenCalledWith(debugDir, { recursive: true });
+        expect(mockedAppendFileSync).toHaveBeenCalled();
+      });
+
+      it("does not throw when appendFileSync throws", () => {
+        setDebugEnv("1");
+        mockedAppendFileSync.mockImplementation(() => {
+          throw new Error("disk full");
+        });
+
+        expect(() =>
+          gitHubRateLimitService.updateFromGraphQL(graphQLData(4995, 5000), label)
+        ).not.toThrow();
+        expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+      });
+
+      it("strips quotes and newlines from the label", () => {
+        setDebugEnv("1");
+        mockedAppendFileSync.mockClear();
+        gitHubRateLimitService.updateFromGraphQL(graphQLData(4995, 5000), 'label"with\nquotes"');
+
+        expect(mockedAppendFileSync).toHaveBeenCalled();
+        const line = mockedAppendFileSync.mock.calls[0][1] as string;
+        expect(line).toContain('label="labelwithquotes"');
+      });
     });
   });
 

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -215,7 +215,8 @@ function buildOrderBy(opts: ListOptions): { field: string; direction: string } {
 
 async function runQuery(
   query: string,
-  variables: Record<string, unknown>
+  variables: Record<string, unknown>,
+  queryLabel: string
 ): Promise<GraphQlQueryResponseData> {
   const client = requireClient();
   try {
@@ -223,7 +224,7 @@ async function runQuery(
       ...variables,
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as GraphQlQueryResponseData;
-    gitHubRateLimitService.updateFromGraphQL(response);
+    gitHubRateLimitService.updateFromGraphQL(response, queryLabel);
     return response;
   } catch (error) {
     throw new Error(parseGitHubError(error), { cause: error });
@@ -234,14 +235,18 @@ async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<Page<Is
   const limit = opts.perPage ?? 20;
   const orderBy = buildOrderBy(opts);
 
-  const response = await runQuery(LIST_ISSUES_QUERY, {
-    owner: repo.owner,
-    repo: repo.repo,
-    states: mapIssueGraphQLStates(opts.state),
-    cursor: opts.cursor ?? null,
-    limit,
-    orderBy,
-  });
+  const response = await runQuery(
+    LIST_ISSUES_QUERY,
+    {
+      owner: repo.owner,
+      repo: repo.repo,
+      states: mapIssueGraphQLStates(opts.state),
+      cursor: opts.cursor ?? null,
+      limit,
+      orderBy,
+    },
+    "LIST_ISSUES_QUERY"
+  );
 
   const issues = (response?.repository as Record<string, unknown> | undefined)?.issues as
     | {
@@ -263,14 +268,18 @@ async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Page<PR>> 
   const limit = opts.perPage ?? 20;
   const orderBy = buildOrderBy(opts);
 
-  const response = await runQuery(LIST_PRS_QUERY, {
-    owner: repo.owner,
-    repo: repo.repo,
-    states: mapPRGraphQLStates(opts.state),
-    cursor: opts.cursor ?? null,
-    limit,
-    orderBy,
-  });
+  const response = await runQuery(
+    LIST_PRS_QUERY,
+    {
+      owner: repo.owner,
+      repo: repo.repo,
+      states: mapPRGraphQLStates(opts.state),
+      cursor: opts.cursor ?? null,
+      limit,
+      orderBy,
+    },
+    "LIST_PRS_QUERY"
+  );
 
   const prs = (response?.repository as Record<string, unknown> | undefined)?.pullRequests as
     | {
@@ -289,11 +298,15 @@ async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Page<PR>> 
 }
 
 async function getIssueImpl(repo: RepoRef, number: number): Promise<Issue | null> {
-  const response = await runQuery(GET_ISSUE_QUERY, {
-    owner: repo.owner,
-    repo: repo.repo,
-    number,
-  });
+  const response = await runQuery(
+    GET_ISSUE_QUERY,
+    {
+      owner: repo.owner,
+      repo: repo.repo,
+      number,
+    },
+    "GET_ISSUE_QUERY"
+  );
   const issue = (response?.repository as Record<string, unknown> | undefined)?.issue as
     | Record<string, unknown>
     | null
@@ -302,11 +315,15 @@ async function getIssueImpl(repo: RepoRef, number: number): Promise<Issue | null
 }
 
 async function getPRImpl(repo: RepoRef, number: number): Promise<PR | null> {
-  const response = await runQuery(GET_PR_QUERY, {
-    owner: repo.owner,
-    repo: repo.repo,
-    number,
-  });
+  const response = await runQuery(
+    GET_PR_QUERY,
+    {
+      owner: repo.owner,
+      repo: repo.repo,
+      number,
+    },
+    "GET_PR_QUERY"
+  );
   const pr = (response?.repository as Record<string, unknown> | undefined)?.pullRequest as
     | Record<string, unknown>
     | null
@@ -341,7 +358,7 @@ async function findPRsByBranchesImpl(
     const query = buildBatchBranchPRQuery(repo.owner, repo.repo, chunk);
     let response: Record<string, unknown>;
     try {
-      response = (await runQuery(query, {})) as Record<string, unknown>;
+      response = (await runQuery(query, {}, "BATCH_BRANCH_PR_QUERY")) as Record<string, unknown>;
     } catch {
       // Omit this chunk's branches from the result — caller's missing-key
       // fallback path handles them.
@@ -374,12 +391,16 @@ async function findPRByBranchImpl(repo: RepoRef, branchName: string): Promise<PR
   // `is:`) don't override the intended search semantics.
   const escapedBranch = branchName.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   const searchQuery = `repo:${repo.owner}/${repo.repo} is:pr head:"${escapedBranch}" sort:created-desc`;
-  const response = await runQuery(SEARCH_QUERY, {
-    searchQuery,
-    type: "ISSUE",
-    cursor: null,
-    limit: 1,
-  });
+  const response = await runQuery(
+    SEARCH_QUERY,
+    {
+      searchQuery,
+      type: "ISSUE",
+      cursor: null,
+      limit: 1,
+    },
+    "SEARCH_QUERY"
+  );
   const nodes = ((response?.search as { nodes?: unknown[] } | undefined)?.nodes ?? []) as Array<
     Record<string, unknown>
   >;
@@ -388,11 +409,15 @@ async function findPRByBranchImpl(repo: RepoRef, branchName: string): Promise<PR
 }
 
 async function getCIStatusImpl(repo: RepoRef, prNumber: number): Promise<CIStatus | null> {
-  const response = await runQuery(PR_CI_STATUS_QUERY, {
-    owner: repo.owner,
-    repo: repo.repo,
-    number: prNumber,
-  });
+  const response = await runQuery(
+    PR_CI_STATUS_QUERY,
+    {
+      owner: repo.owner,
+      repo: repo.repo,
+      number: prNumber,
+    },
+    "PR_CI_STATUS_QUERY"
+  );
 
   const pr = (response?.repository as Record<string, unknown> | undefined)?.pullRequest as
     | Record<string, unknown>
@@ -445,10 +470,14 @@ async function getCIStatusImpl(repo: RepoRef, prNumber: number): Promise<CIStatu
 }
 
 async function getRepoMetadataImpl(repo: RepoRef): Promise<RepoMetadata> {
-  const response = await runQuery(REPO_METADATA_QUERY, {
-    owner: repo.owner,
-    repo: repo.repo,
-  });
+  const response = await runQuery(
+    REPO_METADATA_QUERY,
+    {
+      owner: repo.owner,
+      repo: repo.repo,
+    },
+    "REPO_METADATA_QUERY"
+  );
 
   const repository = (response?.repository as Record<string, unknown> | undefined) ?? {};
   const defaultBranch =
@@ -481,12 +510,16 @@ async function getReviewThreadsImpl(repo: RepoRef, prNumber: number): Promise<Re
   const threads: ReviewThread[] = [];
   let cursor: string | null = null;
   while (true) {
-    const response = await runQuery(GET_PR_REVIEW_THREADS_QUERY, {
-      owner: repo.owner,
-      repo: repo.repo,
-      number: prNumber,
-      cursor,
-    });
+    const response = await runQuery(
+      GET_PR_REVIEW_THREADS_QUERY,
+      {
+        owner: repo.owner,
+        repo: repo.repo,
+        number: prNumber,
+        cursor,
+      },
+      "GET_PR_REVIEW_THREADS_QUERY"
+    );
     const reviewThreads = (
       (response?.repository as Record<string, unknown> | undefined)?.pullRequest as
         | {


### PR DESCRIPTION
## Summary

Every GraphQL response already returns `rateLimit.cost` alongside `remaining`, `resetAt`, and `limit`. We were destructuring it and throwing it away. This PR stops discarding that data so we can see which queries actually burn the rate-limit budget.

This is diagnostic infrastructure. No user-facing behavior changes.

Resolves #9052.

## Changes

- Added an optional `queryLabel` parameter to `updateFromGraphQL` so each call can tag the response with a human-readable query name.
- Tagged all 21 call sites (including the `forgeProvider` path) with query labels.
- Added `DAINTREE_DEBUG_GITHUB_GRAPHQL`-gated file logger that writes one JSON-lines entry per query to `userData/debug/github-graphql-costs.log`. Surfaces cost, remaining, limit, and a timestamp alongside the label. The env var gate means zero overhead unless you opt in.
- Added 7 unit tests covering the logging path: env-var gating, cost extraction, directory creation, error resilience, and label sanitization.

## Testing

Ran the full typecheck, lint, and format pass clean. All 67 existing unit tests pass, plus the 7 new ones.