### PR TITLE
chore(github): drop unused reviewCount from PR queries and type

### DIFF
--- a/electron/services/__tests__/GitHubService.parsePRNode.test.ts
+++ b/electron/services/__tests__/GitHubService.parsePRNode.test.ts
@@ -18,7 +18,6 @@ interface RawPRNode {
   headRepository?: { nameWithOwner?: string } | null;
   baseRepository?: { nameWithOwner?: string } | null;
   author?: { login?: string; avatarUrl?: string } | null;
-  reviews?: { totalCount?: number };
   comments?: { totalCount?: number };
   commits?: {
     nodes?: Array<{
@@ -48,7 +47,6 @@ function normalizeRawState(
 // Inline the logic from parsePRNode to keep tests self-contained
 function parsePRNode(node: RawPRNode) {
   const author = node.author;
-  const reviewsData = node.reviews;
   const commentsData = node.comments;
   const merged = node.merged;
   const rawState = node.state as string;
@@ -77,7 +75,6 @@ function parsePRNode(node: RawPRNode) {
       login: author?.login ?? "unknown",
       avatarUrl: author?.avatarUrl ?? "",
     },
-    reviewCount: reviewsData?.totalCount,
     commentCount: commentsData?.totalCount,
     headRefName: (node.headRefName as string) || undefined,
     isFork: isFork ?? undefined,
@@ -95,7 +92,6 @@ describe("parsePRNode", () => {
     updatedAt: "2025-01-01T00:00:00Z",
     merged: false,
     author: { login: "alice", avatarUrl: "https://avatars.example.com/alice" },
-    reviews: { totalCount: 2 },
   };
 
   it("extracts headRefName from node", () => {

--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -75,7 +75,6 @@ export function updateRepoStatsCount(cacheKey: string, type: "issue" | "pr", cou
 
 export function parsePRNode(node: Record<string, unknown>): GitHubPR {
   const author = node.author as { login?: string; avatarUrl?: string } | null;
-  const reviewsData = node.reviews as { totalCount?: number };
   const commentsData = node.comments as { totalCount?: number };
   const merged = node.merged as boolean;
   const rawState = node.state as string;
@@ -147,7 +146,6 @@ export function parsePRNode(node: Record<string, unknown>): GitHubPR {
       login: author?.login ?? "unknown",
       avatarUrl: author?.avatarUrl ?? "",
     },
-    reviewCount: reviewsData?.totalCount,
     commentCount: commentsData?.totalCount,
     headRefName: (node.headRefName as string) || undefined,
     isFork: isFork ?? undefined,

--- a/plugins/builtin/github/main/GitHubQueries.ts
+++ b/plugins/builtin/github/main/GitHubQueries.ts
@@ -68,7 +68,6 @@ export const REPO_STATS_AND_PAGE_QUERY = `
           headRepository { nameWithOwner }
           baseRepository { nameWithOwner }
           author { login avatarUrl }
-          reviews(first: 1) { totalCount }
           comments { totalCount }
           commits(last: 1) {
             nodes {
@@ -296,9 +295,6 @@ export const LIST_PRS_QUERY = `
             login
             avatarUrl
           }
-          reviews(first: 1) {
-            totalCount
-          }
           comments {
             totalCount
           }
@@ -396,9 +392,6 @@ export const SEARCH_QUERY = `
           author {
             login
             avatarUrl
-          }
-          reviews(first: 1) {
-            totalCount
           }
           comments {
             totalCount
@@ -554,9 +547,6 @@ export const GET_PR_QUERY = `
             name
             color
           }
-        }
-        reviews(first: 1) {
-          totalCount
         }
         comments {
           totalCount

--- a/shared/types/github.ts
+++ b/shared/types/github.ts
@@ -90,8 +90,6 @@ export interface GitHubPR {
   updatedAt: string;
   /** PR author */
   author: GitHubUser;
-  /** Number of reviews */
-  reviewCount?: number;
   /** Head branch name (short ref, e.g. "feature/my-branch") */
   headRefName?: string;
   /** Whether this PR originates from a fork repository */


### PR DESCRIPTION
## Summary
- Removes `reviewCount` from the `GitHubPR` type and drops the `reviews` GraphQL selection from four queries.
- The audit found nothing on first paint reads `reviewCount` through the typed path -- `toForgePR` doesn't map it, and `enrichPRWithCIStatus` already fetches CI status separately.
- Trims wasted GraphQL cost with no contract change.

Resolves #9045

## Changes
- `shared/types/github.ts`: removed `reviewCount` optional field from `GitHubPR`
- `plugins/builtin/github/main/GitHubPRs.ts`: removed `reviewCount` extraction in `parsePRNode`
- `plugins/builtin/github/main/GitHubQueries.ts`: dropped `reviews(first: 1) { totalCount }` from all four queries
- `electron/services/__tests__/GitHubService.parsePRNode.test.ts`: updated tests to match

## Testing
- Typecheck passes clean (renderer + electron)
- Existing `parsePRNode` tests updated and passing
- Verified no code paths read `reviewCount` through the typed interface