### PR TITLE
feat(forge): add host-side BatchLoader to coalesce forge provider calls

### DIFF
--- a/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
@@ -254,6 +254,40 @@ describe("registerForgeDataHandlers", () => {
     expect(fakeImpl.getIssue).toHaveBeenCalledTimes(2);
   });
 
+  it("treats list queries with embedded-comma labels as distinct (no false coalescing)", async () => {
+    fakeImpl.listIssues.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
+    registerForgeDataHandlers();
+    const handler = findHandler("forge:list-issues");
+
+    await Promise.all([
+      handler(null, { cwd: "/repo", opts: { labels: ["a,b"] } }),
+      handler(null, { cwd: "/repo", opts: { labels: ["a", "b"] } }),
+    ]);
+
+    // `["a,b"]` and `["a","b"]` are different queries — the JSON-tuple key keeps
+    // them in separate in-flight slots instead of collapsing to one call.
+    expect(fakeImpl.listIssues).toHaveBeenCalledTimes(2);
+  });
+
+  it("collapses repeat lookups within the TTL then re-runs after it elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      fakeImpl.getPR.mockResolvedValue(makePR(5));
+      registerForgeDataHandlers();
+      const handler = findHandler("forge:get-pr");
+
+      await handler(null, { cwd: "/repo", prNumber: 5 });
+      await handler(null, { cwd: "/repo", prNumber: 5 }); // within TTL → cached
+      expect(fakeImpl.getPR).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(151); // TTL eviction fires
+      await handler(null, { cwd: "/repo", prNumber: 5 }); // after TTL → re-run
+      expect(fakeImpl.getPR).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("propagates provider resolution failures (e.g. provider not activated)", async () => {
     resolveForCwdMock.mockRejectedValue(
       new Error("No forge provider registered for this repository")

--- a/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
@@ -207,6 +207,53 @@ describe("registerForgeDataHandlers", () => {
     ).rejects.toThrow("Invalid PR number");
   });
 
+  it("coalesces concurrent identical getPR calls into one provider call", async () => {
+    let resolveGetPR!: (pr: PR) => void;
+    fakeImpl.getPR.mockReturnValue(new Promise<PR>((resolve) => (resolveGetPR = resolve)));
+    registerForgeDataHandlers();
+    const handler = findHandler("forge:get-pr");
+
+    const p1 = handler(null, { cwd: "/repo", prNumber: 5 });
+    const p2 = handler(null, { cwd: "/repo", prNumber: 5 });
+    resolveGetPR(makePR(5));
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(fakeImpl.getPR).toHaveBeenCalledTimes(1);
+    expect(r1).toMatchObject({ number: 5 });
+    expect(r2).toMatchObject({ number: 5 });
+  });
+
+  it("does not coalesce calls that differ by PR number or cwd", async () => {
+    fakeImpl.getPR.mockImplementation((_repo: RepoRef, n: number) => Promise.resolve(makePR(n)));
+    registerForgeDataHandlers();
+    const handler = findHandler("forge:get-pr");
+
+    await Promise.all([
+      handler(null, { cwd: "/repo", prNumber: 5 }),
+      handler(null, { cwd: "/repo", prNumber: 6 }),
+      handler(null, { cwd: "/other", prNumber: 5 }),
+    ]);
+
+    // Distinct (cwd, prNumber) keys → three independent provider calls; the
+    // cwd dimension keeps separate projects from sharing a slot (#4832).
+    expect(fakeImpl.getPR).toHaveBeenCalledTimes(3);
+  });
+
+  it("evicts a failed lookup immediately so the next caller retries", async () => {
+    fakeImpl.getIssue
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce(makeIssue(42));
+    registerForgeDataHandlers();
+    const handler = findHandler("forge:get-issue");
+
+    await expect(handler(null, { cwd: "/repo", issueNumber: 42 })).rejects.toThrow("transient");
+    // Immediate eviction on rejection: the retry runs the provider again
+    // rather than returning the cached failed promise.
+    const result = await handler(null, { cwd: "/repo", issueNumber: 42 });
+    expect(result).toMatchObject({ number: 42 });
+    expect(fakeImpl.getIssue).toHaveBeenCalledTimes(2);
+  });
+
   it("propagates provider resolution failures (e.g. provider not activated)", async () => {
     resolveForCwdMock.mockRejectedValue(
       new Error("No forge provider registered for this repository")

--- a/electron/ipc/handlers/forgeData.ts
+++ b/electron/ipc/handlers/forgeData.ts
@@ -29,8 +29,63 @@ function requireCwd(value: unknown): string {
   return value;
 }
 
+// Brief in-flight collapse window after a read resolves. These handlers are
+// point lookups that can't be batched but get hammered by concurrent renderer
+// callers (e.g. several panels mounting against the same cwd). 150ms mirrors
+// the WorkspaceClient singleflight TTL (#4832): long enough to collapse a
+// mount burst, short enough never to serve stale read data.
+const SINGLE_FLIGHT_TTL_MS = 150;
+
+/**
+ * Closure-scoped single-flight coalescer. Concurrent callers with the same key
+ * share one in-flight promise; a key keeps collapsing for {@link
+ * SINGLE_FLIGHT_TTL_MS} after it resolves, and is evicted immediately on
+ * rejection so the next caller retries. The map is per-`registerForgeDataHandlers`
+ * call so it never leaks across project teardown.
+ */
+function createSingleFlight() {
+  const inflight = new Map<string, Promise<unknown>>();
+  return function singleFlight<T>(key: string, run: () => Promise<T>): Promise<T> {
+    const existing = inflight.get(key);
+    if (existing) return existing as Promise<T>;
+
+    const promise = run();
+    inflight.set(key, promise);
+    promise.then(
+      () => {
+        setTimeout(() => {
+          if (inflight.get(key) === promise) inflight.delete(key);
+        }, SINGLE_FLIGHT_TTL_MS);
+      },
+      () => {
+        if (inflight.get(key) === promise) inflight.delete(key);
+      }
+    );
+    return promise;
+  };
+}
+
+/**
+ * Deterministic key for a {@link ListOptions} value. Built from explicit fields
+ * in a fixed order rather than `JSON.stringify`, whose output depends on
+ * property insertion order and would split otherwise-identical queries into
+ * separate in-flight slots.
+ */
+function listOptionsKey(opts: ListOptions): string {
+  return [
+    opts.state ?? "",
+    opts.cursor ?? "",
+    opts.perPage ?? "",
+    (opts.labels ?? []).join(","),
+    opts.assignee ?? "",
+    opts.sort ?? "",
+    opts.direction ?? "",
+  ].join("|");
+}
+
 export function registerForgeDataHandlers(): () => void {
   const cleanups: Array<() => void> = [];
+  const coalesce = createSingleFlight();
 
   cleanups.push(
     typedHandle(
@@ -40,8 +95,11 @@ export function registerForgeDataHandlers(): () => void {
           throw new Error("Invalid payload");
         }
         const cwd = requireCwd(payload.cwd);
-        const { impl, repoRef } = await resolveForCwd(cwd);
-        return impl.listIssues(repoRef, payload.opts ?? {});
+        const opts = payload.opts ?? {};
+        return coalesce(`${cwd}::listIssues::${listOptionsKey(opts)}`, async () => {
+          const { impl, repoRef } = await resolveForCwd(cwd);
+          return impl.listIssues(repoRef, opts);
+        });
       }
     )
   );
@@ -52,8 +110,11 @@ export function registerForgeDataHandlers(): () => void {
         throw new Error("Invalid payload");
       }
       const cwd = requireCwd(payload.cwd);
-      const { impl, repoRef } = await resolveForCwd(cwd);
-      return impl.listPRs(repoRef, payload.opts ?? {});
+      const opts = payload.opts ?? {};
+      return coalesce(`${cwd}::listPRs::${listOptionsKey(opts)}`, async () => {
+        const { impl, repoRef } = await resolveForCwd(cwd);
+        return impl.listPRs(repoRef, opts);
+      });
     })
   );
 
@@ -64,8 +125,10 @@ export function registerForgeDataHandlers(): () => void {
       }
       const cwd = requireCwd(payload.cwd);
       const issueNumber = requirePositiveInt(payload.issueNumber, "issue number");
-      const { impl, repoRef } = await resolveForCwd(cwd);
-      return impl.getIssue(repoRef, issueNumber);
+      return coalesce(`${cwd}::getIssue::${issueNumber}`, async () => {
+        const { impl, repoRef } = await resolveForCwd(cwd);
+        return impl.getIssue(repoRef, issueNumber);
+      });
     })
   );
 
@@ -76,8 +139,10 @@ export function registerForgeDataHandlers(): () => void {
       }
       const cwd = requireCwd(payload.cwd);
       const prNumber = requirePositiveInt(payload.prNumber, "PR number");
-      const { impl, repoRef } = await resolveForCwd(cwd);
-      return impl.getPR(repoRef, prNumber);
+      return coalesce(`${cwd}::getPR::${prNumber}`, async () => {
+        const { impl, repoRef } = await resolveForCwd(cwd);
+        return impl.getPR(repoRef, prNumber);
+      });
     })
   );
 

--- a/electron/ipc/handlers/forgeData.ts
+++ b/electron/ipc/handlers/forgeData.ts
@@ -72,15 +72,18 @@ function createSingleFlight() {
  * separate in-flight slots.
  */
 function listOptionsKey(opts: ListOptions): string {
-  return [
-    opts.state ?? "",
-    opts.cursor ?? "",
-    opts.perPage ?? "",
-    (opts.labels ?? []).join(","),
-    opts.assignee ?? "",
-    opts.sort ?? "",
-    opts.direction ?? "",
-  ].join("|");
+  // JSON-encode a fixed-order tuple so each field is unambiguously delimited:
+  // a string separator would let a `|` inside a value (or `["a,b"]` vs
+  // `["a","b"]` labels) collide two distinct queries into one in-flight slot.
+  return JSON.stringify([
+    opts.state ?? null,
+    opts.cursor ?? null,
+    opts.perPage ?? null,
+    opts.labels ?? null,
+    opts.assignee ?? null,
+    opts.sort ?? null,
+    opts.direction ?? null,
+  ]);
 }
 
 export function registerForgeDataHandlers(): () => void {

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -1093,7 +1093,7 @@ class PullRequestService {
           // and redundant API calls.
           if (!enrichedPRNumbers.has(prNumber)) {
             enrichedPRNumbers.add(prNumber);
-            this.enrichPRWithCIStatus(detectedPR, repo, providerId);
+            this.enrichPRWithCIStatus(detectedPR, repo);
           }
         }
       }
@@ -1390,7 +1390,7 @@ class PullRequestService {
         }
 
         // Fire-and-forget CI status enrichment
-        this.enrichPRWithCIStatus(internalPR, repo, providerId);
+        this.enrichPRWithCIStatus(internalPR, repo);
       }
 
       this.updateBoostFromDetectedPRs();
@@ -1443,7 +1443,7 @@ class PullRequestService {
    * On success, updates the detectedPRs entry and re-emits sys:pr:detected
    * with the enriched CI status so the renderer can update the badge.
    */
-  private enrichPRWithCIStatus(pr: InternalLinkedPR, repo: RepoRef, providerId: string): void {
+  private enrichPRWithCIStatus(pr: InternalLinkedPR, repo: RepoRef): void {
     const loader = this.ciStatusLoader;
     if (!loader) return;
     // Synchronous `load()` here: enrichPRWithCIStatus is called fire-and-forget

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -489,7 +489,15 @@ class PullRequestService {
         batchMap = null; // fall through to per-number lookups
       }
       if (batchMap) {
-        return list.map((prNumber) => batchMap.get(prNumber) ?? null);
+        // A present key (even null-valued) is authoritative; an omitted key is
+        // a transient miss per the BatchLookupCapability contract — surface it
+        // as a per-key Error so it rejects (enrich drops it) and stays eligible
+        // for retry rather than being written as a confirmed "no CI status".
+        return list.map((prNumber) =>
+          batchMap.has(prNumber)
+            ? (batchMap.get(prNumber) ?? null)
+            : new Error(`CI status for PR #${prNumber} omitted from getCIStatuses batch`)
+        );
       }
       // CI status is best-effort: a transient failure resolves to null rather
       // than rejecting, so it never invalidates an already-detected PR.
@@ -1413,8 +1421,20 @@ class PullRequestService {
       return [];
     }
 
+    // Absorb a per-load rejection as `null` ("no PR found"). The only source of
+    // rejection here is the loader being disposed by a mid-cycle provider swap
+    // (`invalidateProvider()` from refresh()/setForgeSettings()); propagating it
+    // would land in checkForPRs's catch and wrongly bump `consecutiveErrors`
+    // toward the circuit breaker. The downstream stale-provider guard discards
+    // the whole cycle once it sees the provider changed, so the null is never
+    // written as a spurious `sys:pr:cleared`.
     return Promise.all(
-      branches.map((branch) => loader.load(branch).then((pr) => ({ branch, pr })))
+      branches.map((branch) =>
+        loader.load(branch).then(
+          (pr) => ({ branch, pr }),
+          () => ({ branch, pr: null as ForgePR | null })
+        )
+      )
     );
   }
 

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -6,7 +6,8 @@ import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { generateProjectId } from "./projectStorePaths.js";
 import { createHardenedGit } from "../utils/hardenedGit.js";
 import { getForgeBridge } from "../workspace-host/forgeBridge.js";
-import type { RepoRef, PR as ForgePR, RateLimitInfo } from "../../shared/types/forge.js";
+import { BatchLoader } from "../workspace-host/batchLoader.js";
+import type { RepoRef, PR as ForgePR, RateLimitInfo, CIStatus } from "../../shared/types/forge.js";
 
 // Focus-aware polling cadence: faster when any Daintree window is focused so
 // users see PR transitions promptly, slower when fully blurred to conserve the
@@ -102,23 +103,6 @@ export interface PRDetectionResult {
   prState: "open" | "merged" | "closed";
 }
 
-async function mapWithConcurrencyLimit<T, R>(
-  items: T[],
-  limit: number,
-  fn: (item: T) => Promise<R>
-): Promise<R[]> {
-  const results = new Array<R>(items.length);
-  let index = 0;
-  async function worker(): Promise<void> {
-    while (index < items.length) {
-      const i = index++;
-      results[i] = await fn(items[i]);
-    }
-  }
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
-  return results;
-}
-
 function isCandidateBranch(branchName: string | undefined): boolean {
   if (!branchName) return false;
   const normalized = branchName.trim();
@@ -177,8 +161,16 @@ class PullRequestService {
   // Selected git remote name (`forgeRemote`, #8456). When set, the provider is
   // resolved against this remote's URL instead of `origin`.
   private forgeRemote: string | null = null;
-  // In-flight dedup: keyed by branch name
-  private inFlightBranchLookups = new Map<string, Promise<ForgePR | null>>();
+  // Host-side request coalescers, scoped to the resolved provider. Created in
+  // `resolveProvider()`, disposed in `invalidateProvider()` — a fresh instance
+  // per provider so a swap can never bind the old provider's in-flight results
+  // (the dispose rejects them). They replace the hand-rolled per-branch
+  // in-flight dedup map and collapse same-tick fan-out (branch → PR, PR-number
+  // → PR, PR-number → CI status) into one batch call when the provider
+  // implements the matching `batchLookups` capability.
+  private prByBranchLoader: BatchLoader<string, ForgePR | null> | null = null;
+  private prByNumberLoader: BatchLoader<number, ForgePR | null> | null = null;
+  private ciStatusLoader: BatchLoader<number, CIStatus | null> | null = null;
 
   constructor() {
     this.unsubscribers.push(events.on("sys:worktree:update", this.handleWorktreeUpdate.bind(this)));
@@ -396,10 +388,12 @@ class PullRequestService {
       if (!resolved) {
         this.providerNamespacedId = null;
         this.repoRef = null;
+        this.disposeLoaders();
         return;
       }
       this.providerNamespacedId = resolved.namespacedId;
       this.repoRef = resolved.repo;
+      this.createLoaders(resolved.namespacedId, resolved.repo);
       logInfo("PullRequestService resolved forge provider", {
         namespacedId: resolved.namespacedId,
         owner: resolved.repo.owner,
@@ -411,12 +405,107 @@ class PullRequestService {
       });
       this.providerNamespacedId = null;
       this.repoRef = null;
+      this.disposeLoaders();
     }
   }
 
   private invalidateProvider(): void {
     this.providerNamespacedId = null;
     this.repoRef = null;
+    this.disposeLoaders();
+  }
+
+  /**
+   * Build the provider-scoped coalescers. Each loader's batch function prefers
+   * the optional `batchLookups` capability (one round-trip for many keys) and
+   * falls back to per-key bridge calls when the provider doesn't implement it,
+   * mirroring the truthiness-guarded capability convention. `providerId`/`repo`
+   * are captured here so the loader always calls the provider it was minted
+   * for; a swap disposes it before a new one is created.
+   */
+  private createLoaders(providerId: string, repo: RepoRef): void {
+    this.disposeLoaders();
+    const bridge = getForgeBridge();
+
+    this.prByBranchLoader = new BatchLoader<string, ForgePR | null>(async (branches) => {
+      const list = [...branches];
+      let batchMap: Map<string, ForgePR | null> | null = null;
+      try {
+        batchMap = await bridge.findPRsByBranches(providerId, repo, list);
+      } catch (error) {
+        logWarn("Batched PR-by-branch lookup failed; retrying per-branch", {
+          branchCount: list.length,
+          error: formatErrorMessage(error, "findPRsByBranches failed"),
+        });
+      }
+      // A branch missing from the batch map falls back to a per-branch call,
+      // matching the old `perBranchFallback`. A transient per-branch error
+      // resolves to null (treated as "no PR"), as the prior path did.
+      return Promise.all(
+        list.map((branch) => {
+          if (batchMap?.has(branch)) return batchMap.get(branch) ?? null;
+          return bridge.findPRByBranch(providerId, repo, branch).catch(() => null);
+        })
+      );
+    });
+
+    this.prByNumberLoader = new BatchLoader<number, ForgePR | null>(async (prNumbers) => {
+      const list = [...prNumbers];
+      let batchMap: Map<number, ForgePR | null> | null = null;
+      try {
+        batchMap = await bridge.findPRsByNumbers(providerId, repo, list);
+      } catch {
+        batchMap = null; // fall through to per-number lookups
+      }
+      if (batchMap) {
+        // A present key (even with a null value) is authoritative "found / not
+        // found"; an omitted key is a transient miss → surface as a per-key
+        // Error so the loader rejects it and the caller skips (never wipes) it.
+        return list.map((prNumber) =>
+          batchMap.has(prNumber)
+            ? (batchMap.get(prNumber) ?? null)
+            : new Error(`PR #${prNumber} omitted from findPRsByNumbers batch`)
+        );
+      }
+      // Per-number fallback preserves the transient-vs-not-found distinction:
+      // getPR resolves null for a confirmed missing PR but throws on transient
+      // failure, which we surface as a per-key Error.
+      return Promise.all(
+        list.map((prNumber) =>
+          bridge.getPR(providerId, repo, prNumber).then(
+            (pr) => pr,
+            (error: unknown) => (error instanceof Error ? error : new Error(String(error)))
+          )
+        )
+      );
+    });
+
+    this.ciStatusLoader = new BatchLoader<number, CIStatus | null>(async (prNumbers) => {
+      const list = [...prNumbers];
+      let batchMap: Map<number, CIStatus | null> | null = null;
+      try {
+        batchMap = await bridge.getCIStatuses(providerId, repo, list);
+      } catch {
+        batchMap = null; // fall through to per-number lookups
+      }
+      if (batchMap) {
+        return list.map((prNumber) => batchMap.get(prNumber) ?? null);
+      }
+      // CI status is best-effort: a transient failure resolves to null rather
+      // than rejecting, so it never invalidates an already-detected PR.
+      return Promise.all(
+        list.map((prNumber) => bridge.getCIStatus(providerId, repo, prNumber).catch(() => null))
+      );
+    });
+  }
+
+  private disposeLoaders(): void {
+    this.prByBranchLoader?.dispose();
+    this.prByNumberLoader?.dispose();
+    this.ciStatusLoader?.dispose();
+    this.prByBranchLoader = null;
+    this.prByNumberLoader = null;
+    this.ciStatusLoader = null;
   }
 
   /**
@@ -551,10 +640,10 @@ class PullRequestService {
     this.resolvedWorktrees.clear();
     this.issueTitleFetchedWorktrees.clear();
     // Re-resolve the forge provider on manual refresh so token changes
-    // and provider installs/uninstalls take effect immediately. Clear the
-    // in-flight branch-lookup dedup so a stale promise from the previous
-    // provider can't bind a wrong-repo PR to a worktree after refresh.
-    this.inFlightBranchLookups.clear();
+    // and provider installs/uninstalls take effect immediately.
+    // `invalidateProvider()` disposes the request coalescers, rejecting any
+    // in-flight lookup so a stale promise from the previous provider can't bind
+    // a wrong-repo PR to a worktree after refresh.
     this.invalidateProvider();
     await this.resolveProvider();
     // Manual refresh is an explicit "I want fresh data now" — bypass the 5s
@@ -588,7 +677,6 @@ class PullRequestService {
     this.boostExpiresAt = null;
     this.clearStagnantPollCounts();
     this.lastCheckAt = Number.NEGATIVE_INFINITY;
-    this.inFlightBranchLookups.clear();
     this.invalidateProvider();
   }
 
@@ -901,19 +989,32 @@ class PullRequestService {
     if (uniquePRNumbers.size === 0) return;
     logDebug("Revalidating resolved PRs", { count: uniquePRNumbers.size });
 
+    const prByNumberLoader = this.prByNumberLoader;
+    if (!prByNumberLoader) return;
+
     try {
-      // Revalidate each known PR by number via provider.getPR.
-      // Transient errors (network, 5xx) are captured as `error: true` and
-      // skipped so a flaky API call doesn't clear valid PR state.
+      // Revalidate each known PR by number through the provider-scoped loader,
+      // coalescing the fan-out into one `findPRsByNumbers` batch when supported.
+      // The loader resolves null for a confirmed-missing PR but rejects on a
+      // transient error, which we map to `error: true` and skip so a flaky API
+      // call doesn't clear valid PR state.
       const prNumbers = [...uniquePRNumbers];
-      const results = await mapWithConcurrencyLimit(prNumbers, 5, async (prNumber) => {
-        try {
-          const pr = await bridge.getPR(providerId, repo, prNumber);
-          return { prNumber, pr, error: false };
-        } catch {
-          return { prNumber, pr: null, error: true };
-        }
-      });
+      const results = await Promise.all(
+        prNumbers.map((prNumber) =>
+          prByNumberLoader.load(prNumber).then(
+            (pr): { prNumber: number; pr: ForgePR | null; error: boolean } => ({
+              prNumber,
+              pr,
+              error: false,
+            }),
+            (): { prNumber: number; pr: ForgePR | null; error: boolean } => ({
+              prNumber,
+              pr: null,
+              error: true,
+            })
+          )
+        )
+      );
 
       const enrichedPRNumbers = new Set<number>();
 
@@ -1194,7 +1295,7 @@ class PullRequestService {
       // error doesn't blank every row's PR state. Truthiness guard per the
       // forge.ts capability convention.
       const branches = [...uniqueBranches.keys()];
-      const prResults = await this.resolvePRsForBranches(providerId, repo, branches);
+      const prResults = await this.resolvePRsForBranches(branches);
 
       // Fire issue lookups in parallel with PR lookups
       await Promise.allSettled(issueLookups);
@@ -1291,75 +1392,29 @@ class PullRequestService {
   }
 
   /**
-   * Resolve a list of unique branches to PRs. Prefers the optional batch
-   * capability `findPRsByBranches` to collapse N round-trips into ceil(N/chunk)
-   * GraphQL requests. If the batch call throws — single transient error from
-   * one chunk shouldn't blank every row's PR state — falls back to the
-   * existing per-branch concurrency-5 path; branches missing from the batch
-   * result Map likewise get the per-branch fallback.
+   * Resolve a list of unique branches to PRs through the provider-scoped
+   * `prByBranchLoader`. All `load()` calls here enqueue synchronously, so the
+   * loader coalesces them into a single `findPRsByBranches` batch (or per-branch
+   * fallback) and dedups any branch already in flight from an overlapping
+   * cycle. The loader resolves a transient error to `null` ("no PR"), matching
+   * the prior `perBranchFallback` behavior.
    */
   private async resolvePRsForBranches(
-    providerId: string,
-    repo: RepoRef,
     branches: string[]
   ): Promise<Array<{ branch: string; pr: ForgePR | null }>> {
     if (branches.length === 0) return [];
 
-    const bridge = getForgeBridge();
-    // `findPRsByBranches` is capability-gated on the impl. The bridge returns
-    // `null` when the provider does not implement it, so we treat that case
-    // as a fall-through to per-branch (mirrors the old `if (provider.findPRsByBranches)`
-    // truthiness guard, just one IPC hop away).
-    try {
-      const batchMap = await bridge.findPRsByBranches(providerId, repo, branches);
-      if (batchMap) {
-        const results: Array<{ branch: string; pr: ForgePR | null }> = [];
-        const missing: string[] = [];
-        for (const branch of branches) {
-          if (batchMap.has(branch)) {
-            results.push({ branch, pr: batchMap.get(branch) ?? null });
-          } else {
-            missing.push(branch);
-          }
-        }
-        if (missing.length > 0) {
-          const fallback = await this.perBranchFallback(providerId, repo, missing);
-          results.push(...fallback);
-        }
-        return results;
-      }
-    } catch (error) {
-      logWarn("Batched PR lookup failed; retrying per-branch", {
-        branchCount: branches.length,
-        error: formatErrorMessage(error, "findPRsByBranches failed"),
-      });
-      // Fall through to per-branch path below.
+    const loader = this.prByBranchLoader;
+    if (!loader) {
+      // Unreachable in practice — checkForPRs() resolves the provider (which
+      // creates the loaders) before calling here. Guard defensively without
+      // wiping state: leave every branch unresolved for the next cycle.
+      logWarn("resolvePRsForBranches called with no provider loader; skipping");
+      return [];
     }
 
-    return this.perBranchFallback(providerId, repo, branches);
-  }
-
-  private perBranchFallback(
-    providerId: string,
-    repo: RepoRef,
-    branches: string[]
-  ): Promise<Array<{ branch: string; pr: ForgePR | null }>> {
-    const bridge = getForgeBridge();
-    return mapWithConcurrencyLimit(
-      branches,
-      5,
-      (branch): Promise<{ branch: string; pr: ForgePR | null }> => {
-        const existing = this.inFlightBranchLookups.get(branch);
-        if (existing) {
-          return existing.then((pr) => ({ branch, pr }));
-        }
-        const promise = bridge.findPRByBranch(providerId, repo, branch).catch(() => null);
-        this.inFlightBranchLookups.set(branch, promise);
-        promise.finally(() => {
-          this.inFlightBranchLookups.delete(branch);
-        });
-        return promise.then((pr) => ({ branch, pr }));
-      }
+    return Promise.all(
+      branches.map((branch) => loader.load(branch).then((pr) => ({ branch, pr })))
     );
   }
 
@@ -1369,8 +1424,14 @@ class PullRequestService {
    * with the enriched CI status so the renderer can update the badge.
    */
   private enrichPRWithCIStatus(pr: InternalLinkedPR, repo: RepoRef, providerId: string): void {
-    getForgeBridge()
-      .getCIStatus(providerId, repo, pr.number)
+    const loader = this.ciStatusLoader;
+    if (!loader) return;
+    // Synchronous `load()` here: enrichPRWithCIStatus is called fire-and-forget
+    // in a `for` loop per detected PR, so all loads enqueue in the same tick and
+    // coalesce into one `getCIStatuses` batch. Do NOT add an `await` before this
+    // call — it would drain the microtask queue and defeat the coalescing.
+    loader
+      .load(pr.number)
       .then((ciStatus) => {
         if (!ciStatus) return;
         const prevCiStatus = pr.ciStatus;

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -642,6 +642,9 @@ describe("PullRequestService", () => {
     const { pullRequestService } = await import("../PullRequestService.js");
     const { events } = await import("../events.js");
 
+    const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+    const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
     pullRequestService.initialize("/repo");
     events.emit(
       "sys:worktree:update",
@@ -663,6 +666,69 @@ describe("PullRequestService", () => {
       expect.arrayContaining([1, 2])
     );
     expect(mockImpl.getCIStatus).not.toHaveBeenCalled();
+
+    // The batched CI result is applied: each worktree gets a re-emit carrying
+    // its enriched status, proving the coalesced data flows back through.
+    const ciByWorktree = new Map(
+      detected.filter((d) => d.prCiStatus).map((d) => [d.worktreeId, d.prCiStatus])
+    );
+    expect(ciByWorktree.get("wt-1")).toBe("SUCCESS");
+    expect(ciByWorktree.get("wt-2")).toBe("SUCCESS");
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
+  it("does not bump consecutiveErrors when the provider is invalidated mid-check", async () => {
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+
+    let releaseBatch: (() => void) | null = null;
+    const batchSpy = vi.fn(
+      (_repo: RepoRef, branches: string[]) =>
+        new Promise<Map<string, ForgePR | null>>((resolve) => {
+          releaseBatch = () => {
+            const map = new Map<string, ForgePR | null>();
+            for (const branch of branches) map.set(branch, makeMockForgePR({ number: 1, headRef: branch }));
+            resolve(map);
+          };
+        })
+    );
+    mockForgeProviderResolved(undefined, batchSpy);
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+    );
+
+    const svc = pullRequestService as unknown as {
+      checkForPRs: () => Promise<void>;
+      resolveProvider: () => Promise<void>;
+      invalidateProvider: () => void;
+      consecutiveErrors: number;
+      lastCheckAt: number;
+    };
+
+    await svc.resolveProvider();
+    svc.lastCheckAt = Number.NEGATIVE_INFINITY;
+
+    // Start a check that blocks inside the branch loader's batch function.
+    const checkPromise = svc.checkForPRs();
+    await flushLoaders();
+    expect(batchSpy).toHaveBeenCalledTimes(1);
+
+    // Swap the provider mid-flight (refresh()/setForgeSettings() do this): the
+    // loader is disposed, rejecting the in-flight load. The cycle must be
+    // discarded by the stale-provider guard, NOT counted as an error.
+    svc.invalidateProvider();
+    releaseBatch?.(); // late batch result must be dropped silently
+    await checkPromise;
+    await flushLoaders();
+
+    expect(svc.consecutiveErrors).toBe(0);
 
     pullRequestService.destroy();
   });

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -624,7 +624,10 @@ describe("PullRequestService", () => {
     const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
       const map = new Map<string, ForgePR | null>();
       for (const branch of branches) {
-        map.set(branch, makeMockForgePR({ number: branch === "feature/a" ? 1 : 2, headRef: branch }));
+        map.set(
+          branch,
+          makeMockForgePR({ number: branch === "feature/a" ? 1 : 2, headRef: branch })
+        );
       }
       return map;
     });
@@ -661,10 +664,7 @@ describe("PullRequestService", () => {
     // Two PRs detected in one cycle → a single coalesced batch call, never the
     // per-PR path.
     expect(getCIStatuses).toHaveBeenCalledTimes(1);
-    expect(getCIStatuses).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.arrayContaining([1, 2])
-    );
+    expect(getCIStatuses).toHaveBeenCalledWith(expect.anything(), expect.arrayContaining([1, 2]));
     expect(mockImpl.getCIStatus).not.toHaveBeenCalled();
 
     // The batched CI result is applied: each worktree gets a re-emit carrying
@@ -682,13 +682,14 @@ describe("PullRequestService", () => {
   it("does not bump consecutiveErrors when the provider is invalidated mid-check", async () => {
     vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
 
-    let releaseBatch: (() => void) | null = null;
+    let releaseBatch: (() => void) | undefined;
     const batchSpy = vi.fn(
       (_repo: RepoRef, branches: string[]) =>
         new Promise<Map<string, ForgePR | null>>((resolve) => {
           releaseBatch = () => {
             const map = new Map<string, ForgePR | null>();
-            for (const branch of branches) map.set(branch, makeMockForgePR({ number: 1, headRef: branch }));
+            for (const branch of branches)
+              map.set(branch, makeMockForgePR({ number: 1, headRef: branch }));
             resolve(map);
           };
         })
@@ -739,7 +740,10 @@ describe("PullRequestService", () => {
     const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
       const map = new Map<string, ForgePR | null>();
       for (const branch of branches) {
-        map.set(branch, makeMockForgePR({ number: branch === "feature/a" ? 1 : 2, headRef: branch }));
+        map.set(
+          branch,
+          makeMockForgePR({ number: branch === "feature/a" ? 1 : 2, headRef: branch })
+        );
       }
       return map;
     });
@@ -774,7 +778,10 @@ describe("PullRequestService", () => {
     const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
       const map = new Map<string, ForgePR | null>();
       for (const branch of branches) {
-        map.set(branch, makeMockForgePR({ number: branch === "feature/a" ? 1 : 2, headRef: branch }));
+        map.set(
+          branch,
+          makeMockForgePR({ number: branch === "feature/a" ? 1 : 2, headRef: branch })
+        );
       }
       return map;
     });
@@ -801,7 +808,9 @@ describe("PullRequestService", () => {
     );
 
     await pullRequestService.refresh();
-    await (pullRequestService as unknown as { revalidateResolvedPRs: () => Promise<void> }).revalidateResolvedPRs();
+    await (
+      pullRequestService as unknown as { revalidateResolvedPRs: () => Promise<void> }
+    ).revalidateResolvedPRs();
 
     // Both resolved PRs revalidate through one batch call, not per-number getPR.
     expect(findPRsByNumbers).toHaveBeenCalledTimes(1);

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import type { WorktreeSnapshot } from "../../../shared/types/workspace-host.js";
 import type { DaintreeEventMap } from "../events.js";
-import type { ForgeProviderImpl, RepoRef, PR as ForgePR } from "../../../shared/types/forge.js";
+import type {
+  ForgeProviderImpl,
+  RepoRef,
+  PR as ForgePR,
+  CIStatus,
+} from "../../../shared/types/forge.js";
 import type { ForgeResolveProviderResult } from "../../../shared/types/workspace-host.js";
 
 function makeWorktreeSnapshot(
@@ -69,6 +74,10 @@ function makeMockBridge(impl: ForgeProviderImpl) {
       if (!impl.findPRsByBranches) return null;
       return impl.findPRsByBranches(repo, branches);
     }),
+    findPRsByNumbers: vi.fn(async (_id: string, repo: RepoRef, prNumbers: number[]) => {
+      if (!impl.batchLookups?.findPRsByNumbers) return null;
+      return impl.batchLookups.findPRsByNumbers(repo, prNumbers);
+    }),
     getPR: vi.fn((_id: string, repo: RepoRef, prNumber: number) => impl.getPR(repo, prNumber)),
     getIssue: vi.fn((_id: string, repo: RepoRef, issueNumber: number) =>
       impl.getIssue(repo, issueNumber)
@@ -76,6 +85,10 @@ function makeMockBridge(impl: ForgeProviderImpl) {
     getCIStatus: vi.fn((_id: string, repo: RepoRef, prNumber: number) =>
       impl.getCIStatus(repo, prNumber)
     ),
+    getCIStatuses: vi.fn(async (_id: string, repo: RepoRef, prNumbers: number[]) => {
+      if (!impl.batchLookups?.getCIStatuses) return null;
+      return impl.batchLookups.getCIStatuses(repo, prNumbers);
+    }),
     getRateLimit: vi.fn(async (_id: string) => impl.getRateLimit?.() ?? null),
     handleResult: vi.fn(),
     dispose: vi.fn(),
@@ -155,6 +168,20 @@ function mockForgeProviderUnresolved(opts?: {
   vi.doMock("../../utils/hardenedGit.js", () => ({
     createHardenedGit: vi.fn().mockReturnValue({ getConfig }),
   }));
+}
+
+function makeMockCIStatus(): CIStatus {
+  return { state: "success", total: 1, passed: 1, failed: 0, pending: 0, rawData: null };
+}
+
+// Drain microtasks + process.nextTick so the host-side BatchLoader's
+// fire-and-forget CI enrichment dispatches under fake timers (which fake
+// setTimeout but not nextTick/microtasks).
+async function flushLoaders(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+    await new Promise<void>((resolve) => process.nextTick(resolve));
+  }
 }
 
 function makeMockEmptyImpl(): ForgeProviderImpl {
@@ -588,6 +615,136 @@ describe("PullRequestService", () => {
     expect(detected.every((d) => d.prNumber === 99)).toBe(true);
 
     unsubscribe();
+    pullRequestService.destroy();
+  });
+
+  it("coalesces CI-status enrichment into one getCIStatuses batch when the capability is present", async () => {
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+
+    const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+      const map = new Map<string, ForgePR | null>();
+      for (const branch of branches) {
+        map.set(branch, makeMockForgePR({ number: branch === "feature/a" ? 1 : 2, headRef: branch }));
+      }
+      return map;
+    });
+    const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+
+    const getCIStatuses = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+      const map = new Map<number, CIStatus | null>();
+      for (const n of prNumbers) map.set(n, makeMockCIStatus());
+      return map;
+    });
+    // The bridge stub reads `batchLookups` lazily at call time, so attaching it
+    // after the resolved-provider setup is enough to advertise the capability.
+    mockImpl.batchLookups = { getCIStatuses };
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+    );
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/b" })
+    );
+
+    await pullRequestService.refresh();
+    await flushLoaders();
+
+    // Two PRs detected in one cycle → a single coalesced batch call, never the
+    // per-PR path.
+    expect(getCIStatuses).toHaveBeenCalledTimes(1);
+    expect(getCIStatuses).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.arrayContaining([1, 2])
+    );
+    expect(mockImpl.getCIStatus).not.toHaveBeenCalled();
+
+    pullRequestService.destroy();
+  });
+
+  it("falls back to per-PR getCIStatus when the batch CI capability is absent", async () => {
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+
+    const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+      const map = new Map<string, ForgePR | null>();
+      for (const branch of branches) {
+        map.set(branch, makeMockForgePR({ number: branch === "feature/a" ? 1 : 2, headRef: branch }));
+      }
+      return map;
+    });
+    const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+    mockImpl.getCIStatus = vi.fn().mockResolvedValue(makeMockCIStatus());
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+    );
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/b" })
+    );
+
+    await pullRequestService.refresh();
+    await flushLoaders();
+
+    // No batch capability → loader falls back to one getCIStatus per PR.
+    expect(mockImpl.getCIStatus).toHaveBeenCalledTimes(2);
+
+    pullRequestService.destroy();
+  });
+
+  it("coalesces revalidation getPR fan-out into one findPRsByNumbers batch when present", async () => {
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+
+    const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+      const map = new Map<string, ForgePR | null>();
+      for (const branch of branches) {
+        map.set(branch, makeMockForgePR({ number: branch === "feature/a" ? 1 : 2, headRef: branch }));
+      }
+      return map;
+    });
+    const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+
+    const findPRsByNumbers = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+      const map = new Map<number, ForgePR | null>();
+      for (const n of prNumbers) map.set(n, makeMockForgePR({ number: n }));
+      return map;
+    });
+    mockImpl.batchLookups = { findPRsByNumbers };
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+    );
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/b" })
+    );
+
+    await pullRequestService.refresh();
+    await (pullRequestService as unknown as { revalidateResolvedPRs: () => Promise<void> }).revalidateResolvedPRs();
+
+    // Both resolved PRs revalidate through one batch call, not per-number getPR.
+    expect(findPRsByNumbers).toHaveBeenCalledTimes(1);
+    expect(findPRsByNumbers).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.arrayContaining([1, 2])
+    );
+    expect(mockImpl.getPR).not.toHaveBeenCalled();
+
     pullRequestService.destroy();
   });
 

--- a/electron/services/forgeRpcServer.ts
+++ b/electron/services/forgeRpcServer.ts
@@ -92,12 +92,16 @@ async function invoke(req: ForgeRpcRequest): Promise<unknown> {
       return invokeFindPRByBranch(impl, req.args);
     case "findPRsByBranches":
       return invokeFindPRsByBranches(impl, req.args);
+    case "findPRsByNumbers":
+      return invokeFindPRsByNumbers(impl, req.args);
     case "getPR":
       return invokeGetPR(impl, req.args);
     case "getIssue":
       return invokeGetIssue(impl, req.args);
     case "getCIStatus":
       return invokeGetCIStatus(impl, req.args);
+    case "getCIStatuses":
+      return invokeGetCIStatuses(impl, req.args);
     case "getRateLimit":
       return invokeGetRateLimit(impl);
     default: {
@@ -148,6 +152,15 @@ async function invokeFindPRsByBranches(
   return impl.findPRsByBranches(repo, branches);
 }
 
+async function invokeFindPRsByNumbers(
+  impl: ForgeProviderImpl,
+  args: unknown[]
+): Promise<Map<number, PR | null> | null> {
+  const [repo, prNumbers] = args as [RepoRef, number[]];
+  if (!impl.batchLookups?.findPRsByNumbers) return null;
+  return impl.batchLookups.findPRsByNumbers(repo, prNumbers);
+}
+
 function invokeGetPR(impl: ForgeProviderImpl, args: unknown[]): Promise<PR | null> {
   const [repo, prNumber] = args as [RepoRef, number];
   return impl.getPR(repo, prNumber);
@@ -161,6 +174,15 @@ function invokeGetIssue(impl: ForgeProviderImpl, args: unknown[]): Promise<Issue
 function invokeGetCIStatus(impl: ForgeProviderImpl, args: unknown[]): Promise<CIStatus | null> {
   const [repo, prNumber] = args as [RepoRef, number];
   return impl.getCIStatus(repo, prNumber);
+}
+
+async function invokeGetCIStatuses(
+  impl: ForgeProviderImpl,
+  args: unknown[]
+): Promise<Map<number, CIStatus | null> | null> {
+  const [repo, prNumbers] = args as [RepoRef, number[]];
+  if (!impl.batchLookups?.getCIStatuses) return null;
+  return impl.batchLookups.getCIStatuses(repo, prNumbers);
 }
 
 async function invokeGetRateLimit(impl: ForgeProviderImpl): Promise<RateLimitInfo | null> {

--- a/electron/workspace-host/__tests__/batchLoader.test.ts
+++ b/electron/workspace-host/__tests__/batchLoader.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { BatchLoader, type BatchLoadFn } from "../batchLoader.js";
+
+/**
+ * Drain microtasks + nextTick + any timers. The loader schedules via
+ * `Promise.resolve().then(() => process.nextTick(dispatch))`, and a batch
+ * function may itself await, so a single macrotask hop after the current jobs
+ * settle everything pending.
+ */
+const flush = (): Promise<void> => new Promise<void>((resolve) => setTimeout(resolve, 5));
+
+describe("BatchLoader", () => {
+  it("coalesces synchronously-enqueued loads into one batch call and dedups repeats", async () => {
+    const batchFn = vi.fn<BatchLoadFn<string, string>>(async (keys) => keys.map((k) => `v:${k}`));
+    const loader = new BatchLoader(batchFn);
+
+    const a = loader.load("a");
+    const b = loader.load("b");
+    const aAgain = loader.load("a");
+
+    await expect(a).resolves.toBe("v:a");
+    await expect(b).resolves.toBe("v:b");
+    await expect(aAgain).resolves.toBe("v:a");
+
+    expect(batchFn).toHaveBeenCalledTimes(1);
+    expect(batchFn).toHaveBeenCalledWith(["a", "b"]);
+  });
+
+  it("does NOT coalesce across awaits (documents the caller trap)", async () => {
+    const batchFn = vi.fn<BatchLoadFn<string, string>>(async (keys) => keys.map((k) => `v:${k}`));
+    const loader = new BatchLoader(batchFn);
+
+    await loader.load("a");
+    await loader.load("b");
+
+    expect(batchFn).toHaveBeenCalledTimes(2);
+    expect(batchFn).toHaveBeenNthCalledWith(1, ["a"]);
+    expect(batchFn).toHaveBeenNthCalledWith(2, ["b"]);
+  });
+
+  it("isolates per-key errors: an Error in a slot rejects only that key", async () => {
+    const loader = new BatchLoader<string, string>(async (keys) =>
+      keys.map((k) => (k === "bad" ? new Error("boom") : `v:${k}`))
+    );
+
+    const ok = loader.load("good");
+    const bad = loader.load("bad");
+
+    await expect(ok).resolves.toBe("v:good");
+    await expect(bad).rejects.toThrow("boom");
+  });
+
+  it("rejects every pending key when the batch function throws", async () => {
+    const loader = new BatchLoader<string, string>(async () => {
+      throw new Error("whole batch failed");
+    });
+
+    const a = loader.load("a");
+    const b = loader.load("b");
+
+    await expect(a).rejects.toThrow("whole batch failed");
+    await expect(b).rejects.toThrow("whole batch failed");
+  });
+
+  it("rejects every pending key when the result array length mismatches", async () => {
+    const loader = new BatchLoader<string, string>(async () => ["only-one"]);
+
+    const a = loader.load("a");
+    const b = loader.load("b");
+
+    await expect(a).rejects.toThrow(/returned 1 results for 2 keys/);
+    await expect(b).rejects.toThrow(/returned 1 results for 2 keys/);
+  });
+
+  it("chunks at maxBatchSize, firing concurrent batch calls", async () => {
+    const batchFn = vi.fn<BatchLoadFn<number, number>>(async (keys) => keys.map((k) => k * 10));
+    const loader = new BatchLoader(batchFn, { maxBatchSize: 2 });
+
+    const results = await Promise.all([loader.load(1), loader.load(2), loader.load(3)]);
+
+    expect(results).toEqual([10, 20, 30]);
+    expect(batchFn).toHaveBeenCalledTimes(2);
+    expect(batchFn).toHaveBeenNthCalledWith(1, [1, 2]);
+    expect(batchFn).toHaveBeenNthCalledWith(2, [3]);
+  });
+
+  it("re-fetches a settled key on the next tick (no persistent cache)", async () => {
+    const batchFn = vi.fn<BatchLoadFn<string, string>>(async (keys) => keys.map((k) => `v:${k}`));
+    const loader = new BatchLoader(batchFn);
+
+    await loader.load("a");
+    await loader.load("a");
+
+    expect(batchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("dispose() rejects all pending loads", async () => {
+    let resolveBatch!: (values: string[]) => void;
+    const loader = new BatchLoader<string, string>(
+      () => new Promise<string[]>((resolve) => (resolveBatch = resolve))
+    );
+
+    const a = loader.load("a");
+    const b = loader.load("b");
+    await flush(); // let dispatch fire so the batch fn is in flight
+
+    loader.dispose();
+
+    await expect(a).rejects.toThrow("BatchLoader disposed");
+    await expect(b).rejects.toThrow("BatchLoader disposed");
+
+    // A late-arriving batch result after dispose must not throw or re-settle.
+    resolveBatch(["v:a", "v:b"]);
+    await flush();
+  });
+
+  it("rejects synchronously when load() is called after dispose", async () => {
+    const loader = new BatchLoader<string, string>(async (keys) => keys.map((k) => k));
+    loader.dispose();
+
+    await expect(loader.load("a")).rejects.toThrow("BatchLoader disposed");
+  });
+
+  it("never calls the batch function when nothing is loaded", async () => {
+    const batchFn = vi.fn<BatchLoadFn<string, string>>(async (keys) => keys.map((k) => k));
+    new BatchLoader(batchFn);
+
+    await flush();
+
+    expect(batchFn).not.toHaveBeenCalled();
+  });
+
+  it("supports a custom cacheKeyFn for object keys", async () => {
+    const batchFn = vi.fn<BatchLoadFn<{ id: number }, number>>(async (keys) =>
+      keys.map((k) => k.id)
+    );
+    const loader = new BatchLoader(batchFn, { cacheKeyFn: (k) => String(k.id) });
+
+    const [a, b] = await Promise.all([loader.load({ id: 1 }), loader.load({ id: 1 })]);
+
+    expect(a).toBe(1);
+    expect(b).toBe(1);
+    expect(batchFn).toHaveBeenCalledTimes(1);
+    expect(batchFn).toHaveBeenCalledWith([{ id: 1 }]);
+  });
+});

--- a/electron/workspace-host/batchLoader.ts
+++ b/electron/workspace-host/batchLoader.ts
@@ -1,0 +1,181 @@
+/**
+ * Host-side request coalescer for the workspace-host UtilityProcess.
+ *
+ * The CodeForge migration routed every provider call through {@link
+ * ForgeBridge}, which removed the per-call dedup the old single-file GitHub
+ * path had. `BatchLoader` restores it: `load(key)` calls made within one
+ * event-loop tick are gathered into a single `batchLoadFn` invocation, and a
+ * key already in flight from a prior tick shares the pending promise rather
+ * than firing a second call (single-flight). There is no persistent value
+ * cache — `PullRequestService` is a polling service, so a settled key is
+ * evicted immediately and the next poll re-fetches.
+ *
+ * Scheduling uses a microtask → `process.nextTick` hybrid: the microtask
+ * drains every synchronously-enqueued `load()` (and any awaited siblings in
+ * the same chain) before the batch dispatches on the nextTick phase. Bare
+ * `process.nextTick` fires before sibling promises resolve and would fragment
+ * a fan-out across async chains; `queueMicrotask` alone fires too eagerly.
+ *
+ * Caller trap: `await load(a); await load(b)` never coalesces — the first
+ * await drains the microtask queue and dispatches before `b` is enqueued.
+ * Callers that want coalescing must enqueue synchronously (a fire-and-forget
+ * `for` loop) or use `Promise.all([load(a), load(b)])`.
+ */
+
+const DEFAULT_MAX_BATCH_SIZE = 100;
+
+/**
+ * Resolves a batch of keys to a 1:1 result array. The function must always
+ * resolve, never reject as a whole — return an `Error` in a slot to reject
+ * just that key while the others resolve. A thrown/rejected batch function is
+ * treated as a failure of every key in the chunk.
+ */
+export type BatchLoadFn<K, V> = (keys: readonly K[]) => Promise<ReadonlyArray<V | Error>>;
+
+export interface BatchLoaderOptions<K> {
+  /**
+   * Maps a key to its dedup string. Defaults to `String(key)`, which is
+   * correct for primitive keys (numbers, strings). Object keys need an
+   * explicit deterministic builder — never `JSON.stringify` (property order
+   * is not guaranteed).
+   */
+  cacheKeyFn?: (key: K) => string;
+  /** Maximum keys per `batchLoadFn` call. Larger batches chunk into concurrent calls. Default 100. */
+  maxBatchSize?: number;
+}
+
+interface Deferred<V> {
+  resolve: (value: V) => void;
+  reject: (error: Error) => void;
+}
+
+interface QueueEntry<K> {
+  key: K;
+  cacheKey: string;
+}
+
+export class BatchLoader<K, V> {
+  private readonly cacheKeyFn: (key: K) => string;
+  private readonly maxBatchSize: number;
+  private queue: QueueEntry<K>[] = [];
+  // In-flight single-flight map: a key present here has a pending promise that
+  // later `load()` calls reuse. Evicted on settle so the next poll re-fetches.
+  private readonly inFlight = new Map<string, Promise<V>>();
+  private readonly pending = new Map<string, Deferred<V>>();
+  private dispatchQueued = false;
+  private isDisposed = false;
+
+  constructor(
+    private readonly batchLoadFn: BatchLoadFn<K, V>,
+    options: BatchLoaderOptions<K> = {}
+  ) {
+    this.cacheKeyFn = options.cacheKeyFn ?? ((key) => String(key));
+    const size = options.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE;
+    this.maxBatchSize = size > 0 ? size : DEFAULT_MAX_BATCH_SIZE;
+  }
+
+  load(key: K): Promise<V> {
+    if (this.isDisposed) {
+      return Promise.reject(new Error("BatchLoader disposed"));
+    }
+
+    const cacheKey = this.cacheKeyFn(key);
+    const existing = this.inFlight.get(cacheKey);
+    if (existing) return existing;
+
+    let resolveFn!: (value: V) => void;
+    let rejectFn!: (error: Error) => void;
+    const promise = new Promise<V>((resolve, reject) => {
+      resolveFn = resolve;
+      rejectFn = reject;
+    });
+
+    this.inFlight.set(cacheKey, promise);
+    this.pending.set(cacheKey, { resolve: resolveFn, reject: rejectFn });
+    this.queue.push({ key, cacheKey });
+    // Set the reentrancy guard synchronously (lesson #4703) so a second load()
+    // in the same stack frame doesn't schedule a duplicate dispatch.
+    this.scheduleDispatch();
+    return promise;
+  }
+
+  /** Cancel everything. Pending loads reject; later loads reject synchronously. */
+  dispose(): void {
+    if (this.isDisposed) return;
+    this.isDisposed = true;
+    const error = new Error("BatchLoader disposed");
+    for (const deferred of this.pending.values()) {
+      deferred.reject(error);
+    }
+    this.pending.clear();
+    this.inFlight.clear();
+    this.queue = [];
+  }
+
+  private scheduleDispatch(): void {
+    if (this.dispatchQueued) return;
+    this.dispatchQueued = true;
+    void Promise.resolve().then(() => {
+      process.nextTick(() => this.dispatch());
+    });
+  }
+
+  private dispatch(): void {
+    this.dispatchQueued = false;
+    if (this.isDisposed || this.queue.length === 0) return;
+
+    const batch = this.queue;
+    this.queue = [];
+
+    // Chunk synchronously at dispatch time: an over-sized batch fans out into
+    // concurrent batchLoadFn calls rather than deferring the overflow.
+    for (let i = 0; i < batch.length; i += this.maxBatchSize) {
+      this.dispatchChunk(batch.slice(i, i + this.maxBatchSize));
+    }
+  }
+
+  private dispatchChunk(chunk: QueueEntry<K>[]): void {
+    const keys = chunk.map((entry) => entry.key);
+    this.batchLoadFn(keys).then(
+      (results) => {
+        if (this.isDisposed) return;
+        if (results.length !== chunk.length) {
+          const error = new Error(
+            `BatchLoader batch function returned ${results.length} results for ${chunk.length} keys`
+          );
+          for (const entry of chunk) this.settleReject(entry.cacheKey, error);
+          return;
+        }
+        for (let i = 0; i < chunk.length; i++) {
+          const result = results[i];
+          if (result instanceof Error) {
+            this.settleReject(chunk[i].cacheKey, result);
+          } else {
+            this.settleResolve(chunk[i].cacheKey, result as V);
+          }
+        }
+      },
+      (error: unknown) => {
+        if (this.isDisposed) return;
+        const wrapped = error instanceof Error ? error : new Error(String(error));
+        for (const entry of chunk) this.settleReject(entry.cacheKey, wrapped);
+      }
+    );
+  }
+
+  private settleResolve(cacheKey: string, value: V): void {
+    this.inFlight.delete(cacheKey);
+    const deferred = this.pending.get(cacheKey);
+    if (!deferred) return;
+    this.pending.delete(cacheKey);
+    deferred.resolve(value);
+  }
+
+  private settleReject(cacheKey: string, error: Error): void {
+    this.inFlight.delete(cacheKey);
+    const deferred = this.pending.get(cacheKey);
+    if (!deferred) return;
+    this.pending.delete(cacheKey);
+    deferred.reject(error);
+  }
+}

--- a/electron/workspace-host/forgeBridge.ts
+++ b/electron/workspace-host/forgeBridge.ts
@@ -69,6 +69,25 @@ export class ForgeBridge {
     ]);
   }
 
+  /**
+   * Optional batch variant of {@link getPR}. Returns `null` when the provider
+   * does not implement `batchLookups.findPRsByNumbers`; the host-side
+   * `BatchLoader` then falls back to per-number {@link getPR} calls. A returned
+   * `Map` is keyed by PR number — an omitted key means the provider could not
+   * resolve that number in the batch (transient), distinct from an explicit
+   * `null` value (confirmed not found).
+   */
+  findPRsByNumbers(
+    namespacedId: string,
+    repo: RepoRef,
+    prNumbers: number[]
+  ): Promise<Map<number, PR | null> | null> {
+    return this.invoke<Map<number, PR | null> | null>("findPRsByNumbers", namespacedId, [
+      repo,
+      prNumbers,
+    ]);
+  }
+
   getPR(namespacedId: string, repo: RepoRef, prNumber: number): Promise<PR | null> {
     return this.invoke<PR | null>("getPR", namespacedId, [repo, prNumber]);
   }
@@ -79,6 +98,23 @@ export class ForgeBridge {
 
   getCIStatus(namespacedId: string, repo: RepoRef, prNumber: number): Promise<CIStatus | null> {
     return this.invoke<CIStatus | null>("getCIStatus", namespacedId, [repo, prNumber]);
+  }
+
+  /**
+   * Optional batch variant of {@link getCIStatus}. Returns `null` when the
+   * provider does not implement `batchLookups.getCIStatuses`; the host-side
+   * `BatchLoader` then falls back to per-number {@link getCIStatus} calls. A
+   * returned `Map` is keyed by PR number.
+   */
+  getCIStatuses(
+    namespacedId: string,
+    repo: RepoRef,
+    prNumbers: number[]
+  ): Promise<Map<number, CIStatus | null> | null> {
+    return this.invoke<Map<number, CIStatus | null> | null>("getCIStatuses", namespacedId, [
+      repo,
+      prNumbers,
+    ]);
   }
 
   /**

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -283,6 +283,23 @@ export interface MilestoneCapability {
 }
 
 /**
+ * Optional multi-key batch lookups. The host's host-side `BatchLoader`
+ * coalesces same-tick `getCIStatus`/`getPR` fan-out into one of these calls
+ * when the provider implements them, collapsing N round-trips into ceil(N/100)
+ * requests. Each method returns a `Map` keyed by the input number; an explicit
+ * `null` value means the lookup confirmed "not found", while a key *omitted*
+ * from the map means the implementation could not resolve it in this batch
+ * (transient error) and the caller should retry it — mirroring the
+ * {@link ForgeProviderImpl.findPRsByBranches} omission convention. Providers
+ * that don't batch simply omit the capability; the host falls back to per-key
+ * calls transparently.
+ */
+export interface BatchLookupCapability {
+  getCIStatuses?(repo: RepoRef, prNumbers: number[]): Promise<Map<number, CIStatus | null>>;
+  findPRsByNumbers?(repo: RepoRef, prNumbers: number[]): Promise<Map<number, PR | null>>;
+}
+
+/**
  * Runtime contract a forge plugin implements and registers via
  * `host.registerForgeProvider`. Every provider implements the base methods;
  * optional capabilities are sibling fields the host probes at runtime.
@@ -353,6 +370,7 @@ export interface ForgeProviderImpl {
   releases?: ReleaseCapability;
   projectBoards?: ProjectBoardCapability;
   milestones?: MilestoneCapability;
+  batchLookups?: BatchLookupCapability;
 }
 
 /**

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -464,9 +464,11 @@ export type ForgeRpcMethod =
   | "resolveProvider"
   | "findPRByBranch"
   | "findPRsByBranches"
+  | "findPRsByNumbers"
   | "getPR"
   | "getIssue"
   | "getCIStatus"
+  | "getCIStatuses"
   | "getRateLimit";
 
 /** Result shape for `resolveProvider` — used by typed parsing of `forge:rpc-result.value`. */


### PR DESCRIPTION
## Summary

- Adds `BatchLoader<K,V>` (`electron/workspace-host/batchLoader.ts`) — coalesces forge provider calls within one event-loop tick via microtask→`process.nextTick` scheduling, with single-flight dedup, per-key error isolation, `maxBatchSize` chunking, and provider-swap disposal. Restores the call coalescing lost in the CodeForge migration.
- Adds a `batchLookups` capability umbrella (`getCIStatuses`, `findPRsByNumbers`) on `ForgeProviderImpl`, wired through `ForgeBridge` and `forgeRpcServer`. Returns `null` when the provider lacks the capability, triggering per-key fallback.
- Migrates `PullRequestService` to three provider-scoped loaders — retires `inFlightBranchLookups`/`perBranchFallback`, coalesces `enrichPRWithCIStatus` CI fanout and `revalidateResolvedPRs` getPR fanout. Loaders disposed on provider swap so a stale provider can never bind results.
- Adds a closure-scoped single-flight coalescer to `forgeData.ts` read handlers (`getIssue`, `getPR`, `listIssues`, `listPRs`) — cwd-scoped key, 150ms TTL, immediate eviction on error.

Resolves #9043

## Changes

- `electron/workspace-host/batchLoader.ts` — new `BatchLoader` class
- `shared/types/forge.ts`, `shared/types/workspace-host.ts` — `batchLookups` capability types
- `electron/workspace-host/forgeBridge.ts` — capability wiring
- `electron/services/forgeRpcServer.ts` — RPC surface for batch lookups
- `electron/services/PullRequestService.ts` — migrated to three batch loaders
- `electron/ipc/handlers/forgeData.ts` — single-flight coalescer on all four read handlers

## Testing

- `BatchLoader` unit suite: 12 cases covering coalescing, dedup, error isolation, chunking, and disposal
- `PullRequestService` tests: coalescing, fallback, revalidation, and provider-swap scenarios
- `forgeData` tests: single-flight dedup, per-key error isolation, TTL expiry

53 tests pass. Full project check (typecheck, lint, format, IPC guards) clean.