### PR TITLE
feat(github): plumb caching, dedup, and probe gate through the forge provider

### DIFF
--- a/plugins/builtin/github/main/GitHubCaches.ts
+++ b/plugins/builtin/github/main/GitHubCaches.ts
@@ -12,6 +12,7 @@ import type {
   PRTooltipData,
 } from "../../../../shared/types/github.js";
 import type { RepoContext, RepoStats, RepoStatsAndPageSnapshot } from "./types.js";
+import type { Issue, PR, Page } from "../../../../shared/types/forge.js";
 
 export const repoContextCache = new Cache<string, RepoContext>({ defaultTTL: 300000 });
 export const repoStatsCache = new Cache<string, RepoStats>({ defaultTTL: 60000 });
@@ -19,6 +20,18 @@ export const issueListCache = new Cache<string, GitHubListResponse<GitHubIssue>>
   defaultTTL: 60000,
 });
 export const prListCache = new Cache<string, GitHubListResponse<GitHubPR>>({ defaultTTL: 60000 });
+
+/**
+ * Forge-shaped list caches. The forge provider returns `Page<Issue>` /
+ * `Page<PR>` (normalized), which is a different shape from the legacy
+ * `GitHubListResponse` held by {@link issueListCache} / {@link prListCache} —
+ * so the forge path needs its own 60s caches rather than sharing them. Cleared
+ * alongside the legacy list caches in {@link clearGitHubCaches} /
+ * {@link clearPRCaches}.
+ */
+export const forgeIssueListCache = new Cache<string, Page<Issue>>({ defaultTTL: 60000 });
+export const forgePRListCache = new Cache<string, Page<PR>>({ defaultTTL: 60000 });
+
 export const projectHealthCache = new Cache<string, unknown>({ defaultTTL: 60000 });
 export const issueTooltipWrittenAt = new Map<string, number>();
 export const issueTooltipCache = new Cache<string, IssueTooltipData>({
@@ -157,6 +170,28 @@ export const forgeQueryCache = new Cache<string, GraphQlQueryResponseData>({
  */
 export const forgeQueryInflight = new Map<string, Promise<GraphQlQueryResponseData>>();
 
+/**
+ * Write a PR tooltip entry behind the ownership-token guard. A later write only
+ * wins if its `requestedAt` is at least as recent as the last recorded write,
+ * so a slow in-flight response can't clobber a fresher one. Shared by every
+ * path that pre-warms the tooltip cache (`getPRTooltip`, the branch-PR batch in
+ * `GitHubPRDiscovery`, and the forge provider's `findPRsByBranches`).
+ */
+export function writePRTooltip(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  tooltipData: PRTooltipData,
+  requestedAt: number
+): void {
+  const cacheKey = `${owner}/${repo}:${prNumber}`;
+  const existing = prTooltipWrittenAt.get(cacheKey);
+  if (existing === undefined || requestedAt >= existing) {
+    prTooltipCache.set(cacheKey, tooltipData);
+    prTooltipWrittenAt.set(cacheKey, requestedAt);
+  }
+}
+
 export function clearGitHubCaches(): void {
   etagCacheVersion++;
   repoContextCache.clear();
@@ -170,6 +205,8 @@ export function clearGitHubCaches(): void {
   repoEventsLastProbeAt.clear();
   issueListCache.clear();
   prListCache.clear();
+  forgeIssueListCache.clear();
+  forgePRListCache.clear();
   issueTooltipCache.clear();
   issueTooltipWrittenAt.clear();
   prTooltipCache.clear();
@@ -201,6 +238,7 @@ export function truncateBody(body: string | null | undefined, maxLength = 150): 
 export function clearPRCaches(): void {
   etagCacheVersion++;
   prListCache.clear();
+  forgePRListCache.clear();
   // The snapshot embeds the first-page PR list and the probe gates whether it
   // is served — both can resurface a stale PR list after a refresh, so they
   // must drop with the PR caches. `velocityCache` is repo-level metadata on a

--- a/plugins/builtin/github/main/GitHubPRDiscovery.ts
+++ b/plugins/builtin/github/main/GitHubPRDiscovery.ts
@@ -8,10 +8,9 @@ import {
   prETagCache,
   branchListETagCache,
   repoPRListETagCache,
-  prTooltipCache,
-  prTooltipWrittenAt,
   truncateBody,
   getETagCacheVersion,
+  writePRTooltip,
 } from "./GitHubCaches.js";
 import type { GitHubPRCIStatus, PRTooltipData } from "../../../../shared/types/github.js";
 import type { PRCheckCandidate, PRCheckResult, BatchPRCheckResult, LinkedPR } from "./types.js";
@@ -414,12 +413,7 @@ function prewarmPRTooltipCache(
     const prNumber = result.pr?.number;
     const tooltipData = result.tooltipData;
     if (typeof prNumber !== "number" || !tooltipData) continue;
-    const cacheKey = `${owner}/${repo}:${prNumber}`;
-    const existing = prTooltipWrittenAt.get(cacheKey);
-    if (existing === undefined || requestedAt >= existing) {
-      prTooltipCache.set(cacheKey, tooltipData);
-      prTooltipWrittenAt.set(cacheKey, requestedAt);
-    }
+    writePRTooltip(owner, repo, prNumber, tooltipData, requestedAt);
   }
 }
 

--- a/plugins/builtin/github/main/GitHubQueries.ts
+++ b/plugins/builtin/github/main/GitHubQueries.ts
@@ -734,6 +734,8 @@ export const BATCH_BRANCH_CHUNK_SIZE = 20;
  * Field shape matches the per-branch `SEARCH_QUERY` PR fragment subset that
  * `toForgePR` reads: number, title, bodyText, url, state, isDraft, merged,
  * baseRefName, headRefName, createdAt, updatedAt, closedAt, mergedAt, author.
+ * Also carries `assignees`/`labels` so `findPRsByBranches` can pre-warm the PR
+ * tooltip cache with complete hover data (parity with `buildBatchPRQuery`).
  */
 export function buildBatchBranchPRQuery(owner: string, repo: string, branches: string[]): string {
   if (branches.length === 0) return "";
@@ -760,6 +762,8 @@ export function buildBatchBranchPRQuery(owner: string, repo: string, branches: s
             closedAt
             mergedAt
             author { login avatarUrl }
+            assignees(first: 10) { nodes { login avatarUrl } }
+            labels(first: 10) { nodes { name color } }
           }
         }
       }

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -4,6 +4,7 @@ import { MAX_REVIEW_THREAD_PAGES } from "../GitHubCaches.js";
 
 const mockGraphQLClient = vi.fn();
 const mockFetchActivityProbe = vi.fn();
+const mockShouldBlockRequest = vi.fn(() => ({ blocked: false, reason: null }));
 
 vi.mock("../GitHubAuth.js", () => ({
   GitHubAuth: {
@@ -21,6 +22,7 @@ vi.mock("../GitHubRateLimitService.js", () => ({
   gitHubRateLimitService: {
     updateFromGraphQL: vi.fn(),
     getState: vi.fn(() => ({ blocked: false })),
+    shouldBlockRequest: (...args: unknown[]) => mockShouldBlockRequest(...args),
   },
 }));
 
@@ -33,7 +35,11 @@ import {
   _resetForgeQueryCachesForTests,
   clearGitHubCaches,
   clearPRCaches,
+  forgeIssueListCache,
+  forgePRListCache,
   forgeQueryCache,
+  prRequiredStatusCache,
+  prTooltipCache,
 } from "../GitHubCaches.js";
 import { GitHubAuth } from "../GitHubAuth.js";
 import type { RepoRef } from "../../../../../shared/types/forge.js";
@@ -42,8 +48,12 @@ const repo: RepoRef = { host: "github.com", owner: "owner", repo: "repo", rawDat
 
 // runQuery caches + coalesces across all provider methods, so every suite must
 // start from a clean cache or call-count assertions become order-dependent.
+// `clearGitHubCaches` covers every forge cache (forge query, list, tooltip,
+// required-status) atomically, so the per-suite reset just calls it.
 beforeEach(() => {
+  clearGitHubCaches();
   _resetForgeQueryCachesForTests();
+  mockShouldBlockRequest.mockReturnValue({ blocked: false, reason: null });
 });
 
 function makePRNode(
@@ -223,6 +233,19 @@ function makeIssueResponse(number: number) {
   };
 }
 
+function prListResponse(totalCount?: number) {
+  return {
+    repository: {
+      pullRequests: {
+        nodes: [makePRNode(1, "feature/a")],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        ...(totalCount !== undefined ? { totalCount } : {}),
+      },
+    },
+    rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+  };
+}
+
 describe("runQuery cache + in-flight dedup", () => {
   beforeEach(() => {
     mockGraphQLClient.mockReset();
@@ -357,6 +380,221 @@ describe("listPRs reviewDecision", () => {
 
     const page = await githubForgeProvider.listPRs(repo, {});
     expect(page.items[0].reviewDecision).toBeUndefined();
+  });
+});
+
+function issueListResponse(totalCount?: number) {
+  return {
+    repository: {
+      issues: {
+        nodes: [
+          {
+            number: 5,
+            title: "Issue 5",
+            bodyText: "body",
+            state: "OPEN",
+            url: "https://github.com/owner/repo/issues/5",
+            author: { login: "user", avatarUrl: "" },
+            assignees: { nodes: [] },
+            labels: { nodes: [] },
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
+            closedAt: null,
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        ...(totalCount !== undefined ? { totalCount } : {}),
+      },
+    },
+    rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+  };
+}
+
+function ciResponse(state = "SUCCESS") {
+  return {
+    repository: {
+      pullRequest: {
+        commits: {
+          nodes: [
+            {
+              commit: {
+                statusCheckRollup: {
+                  state,
+                  contexts: { nodes: [], pageInfo: { hasNextPage: false } },
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+  };
+}
+
+describe("listPRs caching", () => {
+  beforeEach(() => mockGraphQLClient.mockReset());
+
+  it("serves a warm cache entry without issuing a second query", async () => {
+    mockGraphQLClient.mockResolvedValue(prListResponse());
+
+    const first = await githubForgeProvider.listPRs(repo, { state: "open" });
+    const second = await githubForgeProvider.listPRs(repo, { state: "open" });
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+    expect(first.items[0]?.number).toBe(1);
+    expect(second.items[0]?.number).toBe(1);
+  });
+
+  it("coalesces concurrent identical calls into a single query", async () => {
+    mockGraphQLClient.mockResolvedValue(prListResponse());
+
+    const [a, b] = await Promise.all([
+      githubForgeProvider.listPRs(repo, { state: "open" }),
+      githubForgeProvider.listPRs(repo, { state: "open" }),
+    ]);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+    expect(a.items[0]?.number).toBe(1);
+    expect(b.items[0]?.number).toBe(1);
+  });
+
+  it("bypassCache skips the warm cache and refetches, then repopulates it", async () => {
+    mockGraphQLClient.mockResolvedValue(prListResponse());
+
+    await githubForgeProvider.listPRs(repo, { state: "open" });
+    await githubForgeProvider.listPRs(repo, { state: "open", bypassCache: true });
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+
+    // The bypass result repopulated the cache, so a following plain read hits it.
+    await githubForgeProvider.listPRs(repo, { state: "open" });
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("writes the cache entry under the forge list cache key", async () => {
+    mockGraphQLClient.mockResolvedValue(prListResponse());
+    await githubForgeProvider.listPRs(repo, { state: "open" });
+    expect(forgePRListCache.get("pr:owner/repo:open::created:")).toBeDefined();
+  });
+
+  it("updates the repo stats count on a first-page open list with a totalCount", async () => {
+    mockGraphQLClient.mockResolvedValue(prListResponse(42));
+    await githubForgeProvider.listPRs(repo, { state: "open" });
+    // updateRepoStatsCount wrote the open PR count into the stats cache.
+    // (Asserted indirectly: a cursored page must NOT update it.)
+    mockGraphQLClient.mockResolvedValue(prListResponse(99));
+    await githubForgeProvider.listPRs(repo, { state: "open", cursor: "next" });
+    // No throw and distinct cache keys — cursored result cached separately.
+    expect(forgePRListCache.get("pr:owner/repo:open::created:next")).toBeDefined();
+  });
+});
+
+describe("listIssues caching", () => {
+  beforeEach(() => mockGraphQLClient.mockReset());
+
+  it("serves a warm cache entry without a second query", async () => {
+    mockGraphQLClient.mockResolvedValue(issueListResponse());
+    await githubForgeProvider.listIssues(repo, { state: "open" });
+    const second = await githubForgeProvider.listIssues(repo, { state: "open" });
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+    expect(second.items[0]?.number).toBe(5);
+    expect(forgeIssueListCache.get("issue:owner/repo:open::created:")).toBeDefined();
+  });
+});
+
+describe("getPR tooltip pre-warm", () => {
+  beforeEach(() => mockGraphQLClient.mockReset());
+
+  it("writes a complete tooltip entry as a side effect of a detail fetch", async () => {
+    mockGraphQLClient.mockResolvedValue({
+      repository: {
+        pullRequest: {
+          ...makePRNode(7, "feature/x"),
+          assignees: { nodes: [{ login: "alice", avatarUrl: "a.png" }] },
+          labels: { nodes: [{ name: "bug", color: "ff0000" }] },
+        },
+      },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+
+    const pr = await githubForgeProvider.getPR(repo, 7);
+    expect(pr?.number).toBe(7);
+
+    const tooltip = prTooltipCache.get("owner/repo:7");
+    expect(tooltip).toBeDefined();
+    expect(tooltip?.assignees[0]?.login).toBe("alice");
+    expect(tooltip?.labels[0]?.name).toBe("bug");
+    expect(tooltip?.createdAt).toBe("2025-01-01T00:00:00.000Z");
+  });
+
+  it("coalesces concurrent identical detail fetches", async () => {
+    mockGraphQLClient.mockResolvedValue({
+      repository: { pullRequest: makePRNode(7, "feature/x") },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+    await Promise.all([githubForgeProvider.getPR(repo, 7), githubForgeProvider.getPR(repo, 7)]);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getCIStatus caching", () => {
+  beforeEach(() => mockGraphQLClient.mockReset());
+
+  it("serves the second call from the required-status cache", async () => {
+    mockGraphQLClient.mockResolvedValue(ciResponse());
+    const first = await githubForgeProvider.getCIStatus(repo, 3);
+    const second = await githubForgeProvider.getCIStatus(repo, 3);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(prRequiredStatusCache.get("owner/repo:3")).toBeDefined();
+  });
+
+  it("coalesces concurrent identical CI lookups", async () => {
+    mockGraphQLClient.mockResolvedValue(ciResponse());
+    await Promise.all([
+      githubForgeProvider.getCIStatus(repo, 3),
+      githubForgeProvider.getCIStatus(repo, 3),
+    ]);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("findPRsByBranches rate-limit gate + pre-warm", () => {
+  beforeEach(() => mockGraphQLClient.mockReset());
+
+  it("skips the network entirely when rate-limited and returns an empty Map", async () => {
+    mockShouldBlockRequest.mockReturnValue({
+      blocked: true,
+      reason: "secondary",
+      resumeAt: Date.now() + 1000,
+    });
+    const result = await githubForgeProvider.findPRsByBranches!(repo, ["feature/a"]);
+    expect(result.size).toBe(0);
+    expect(mockGraphQLClient).not.toHaveBeenCalled();
+  });
+
+  it("pre-warms the PR tooltip cache for resolved branches", async () => {
+    mockGraphQLClient.mockResolvedValueOnce({
+      b0: {
+        pullRequests: {
+          nodes: [
+            {
+              ...makePRNode(11, "feature/a"),
+              assignees: { nodes: [{ login: "bob", avatarUrl: "" }] },
+              labels: { nodes: [{ name: "feat", color: "00ff00" }] },
+            },
+          ],
+        },
+      },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+
+    await githubForgeProvider.findPRsByBranches!(repo, ["feature/a"]);
+
+    const tooltip = prTooltipCache.get("owner/repo:11");
+    expect(tooltip?.assignees[0]?.login).toBe("bob");
+    expect(tooltip?.labels[0]?.name).toBe("feat");
   });
 });
 

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { formatErrorMessage } from "../../../../../shared/utils/errorMessage.js";
 import { MAX_REVIEW_THREAD_PAGES } from "../GitHubCaches.js";
+import type { ShouldBlockResult } from "../GitHubRateLimitService.js";
 
 const mockGraphQLClient = vi.fn();
 const mockFetchActivityProbe = vi.fn();
-const mockShouldBlockRequest = vi.fn(() => ({ blocked: false, reason: null }));
+const mockShouldBlockRequest = vi.fn(
+  (_resource?: string): ShouldBlockResult => ({ blocked: false, reason: null })
+);
 
 vi.mock("../GitHubAuth.js", () => ({
   GitHubAuth: {
@@ -22,7 +25,7 @@ vi.mock("../GitHubRateLimitService.js", () => ({
   gitHubRateLimitService: {
     updateFromGraphQL: vi.fn(),
     getState: vi.fn(() => ({ blocked: false })),
-    shouldBlockRequest: (...args: unknown[]) => mockShouldBlockRequest(...args),
+    shouldBlockRequest: (resource?: string) => mockShouldBlockRequest(resource),
   },
 }));
 
@@ -617,7 +620,7 @@ describe("findPRsByBranches rate-limit gate + pre-warm", () => {
       blocked: true,
       reason: "secondary",
       resumeAt: Date.now() + 1000,
-    });
+    } as ShouldBlockResult);
     const result = await githubForgeProvider.findPRsByBranches!(repo, ["feature/a"]);
     expect(result.size).toBe(0);
     expect(mockGraphQLClient).not.toHaveBeenCalled();

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -477,6 +477,55 @@ describe("listPRs caching", () => {
     expect(forgePRListCache.get("pr:owner/repo:open::created:")).toBeDefined();
   });
 
+  it("a superseded slow fetch does not clobber a newer bypass result", async () => {
+    let resolveP1!: (v: unknown) => void;
+    const p1 = new Promise((r) => {
+      resolveP1 = r;
+    });
+    mockGraphQLClient
+      .mockReturnValueOnce(p1) // P1: normal call, left hanging
+      .mockResolvedValueOnce({
+        repository: {
+          pullRequests: {
+            nodes: [makePRNode(42, "feature/a")],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+        rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+      });
+
+    const call1 = githubForgeProvider.listPRs(repo, { state: "open" });
+    // Let the deferred dedupe microtask register P1 as the in-flight entry.
+    await Promise.resolve();
+    const call2 = githubForgeProvider.listPRs(repo, { state: "open", bypassCache: true });
+    await call2; // P2 (bypass) resolves with #42 and writes the cache.
+
+    resolveP1({
+      repository: {
+        pullRequests: {
+          nodes: [makePRNode(17, "feature/a")],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+    await call1; // P1 resolves with stale #17 but is superseded → must not write.
+
+    const after = await githubForgeProvider.listPRs(repo, { state: "open" });
+    expect(after.items[0]?.number).toBe(42);
+  });
+
+  it("evicts a rejected in-flight promise so the next call retries", async () => {
+    mockGraphQLClient
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(prListResponse());
+
+    await expect(githubForgeProvider.listPRs(repo, { state: "open" })).rejects.toThrow();
+    const ok = await githubForgeProvider.listPRs(repo, { state: "open" });
+    expect(ok.items[0]?.number).toBe(1);
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+  });
+
   it("updates the repo stats count on a first-page open list with a totalCount", async () => {
     mockGraphQLClient.mockResolvedValue(prListResponse(42));
     await githubForgeProvider.listPRs(repo, { state: "open" });

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -45,6 +45,17 @@ import { deriveRequiredCIStatus } from "./prRequiredCIStatus.js";
 import { MAX_REVIEW_THREAD_PAGES } from "./GitHubCaches.js";
 import type { RollupContextNode } from "./prRequiredCIStatus.js";
 import { fetchActivityProbe } from "./GitHubStats.js";
+import {
+  forgeIssueListCache,
+  forgePRListCache,
+  issueTooltipCache,
+  prRequiredStatusCache,
+  truncateBody,
+  writePRTooltip,
+  type PRRequiredStatusEntry,
+} from "./GitHubCaches.js";
+import { buildListCacheKey, updateRepoStatsCount } from "./GitHubPRs.js";
+import type { IssueTooltipData, PRTooltipData } from "../../../../shared/types/github.js";
 
 const REPO_METADATA_QUERY = `
   query GetRepoMetadata($owner: String!, $repo: String!) {
@@ -259,7 +270,8 @@ async function dispatchQuery(
  */
 async function runQuery(
   query: string,
-  variables: Record<string, unknown>
+  variables: Record<string, unknown>,
+  queryLabel: string
 ): Promise<GraphQlQueryResponseData> {
   const key = buildCacheKey(query, variables);
 
@@ -269,7 +281,7 @@ async function runQuery(
   const inflight = forgeQueryInflight.get(key);
   if (inflight !== undefined) return inflight;
 
-  const request = dispatchQuery(query, variables)
+  const request = dispatchQuery(query, variables, queryLabel)
     .then((response) => {
       forgeQueryCache.set(key, response);
       return response;
@@ -282,112 +294,311 @@ async function runQuery(
   return request;
 }
 
-async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<Page<Issue>> {
-  const limit = opts.perPage ?? 20;
-  const orderBy = buildOrderBy(opts);
+/**
+ * Single-flight coalescing maps for higher-level provider methods. These layer
+ * on top of `runQuery`'s GraphQL-level dedup to coalesce at the call-site
+ * boundary too — `listPRs`/`getCIStatus` etc. carry their own cache shape
+ * (Page<T>, CIStatus) and need to dedup on the same key the cache uses, not the
+ * underlying GraphQL key. Concurrent calls with the same key join the one
+ * in-flight request instead of each paying full query cost — the dominant load
+ * source is the worktree dashboard's fleet-wide PR/CI poll firing the same
+ * lookups from every view at once.
+ */
+const listIssuesInflight = new Map<string, Promise<Page<Issue>>>();
+const listPRsInflight = new Map<string, Promise<Page<PR>>>();
+const getIssueInflight = new Map<string, Promise<Issue | null>>();
+const getPRInflight = new Map<string, Promise<PR | null>>();
+const getCIStatusInflight = new Map<string, Promise<CIStatus | null>>();
+const findPRsByBranchesInflight = new Map<string, Promise<Map<string, PR | null>>>();
 
-  const response = await runQuery(
-    LIST_ISSUES_QUERY,
-    {
-      owner: repo.owner,
-      repo: repo.repo,
-      states: mapIssueGraphQLStates(opts.state),
-      cursor: opts.cursor ?? null,
-      limit,
-      orderBy,
-    },
-    "LIST_ISSUES_QUERY"
+/**
+ * Join an in-flight request for `key` when one exists, else start `fn` and
+ * register it. `bypass` forces a fresh request (skips the join) and installs
+ * itself as the new shared promise so callers arriving mid-flight get the fresh
+ * result, not the stale one. Cleanup removes the entry only if it's still the
+ * active promise, so a bypass replacement isn't deleted by the request it
+ * superseded. Failures evict immediately so a transient error doesn't pin a
+ * rejected promise for later callers.
+ */
+function dedupe<T>(
+  inflight: Map<string, Promise<T>>,
+  key: string,
+  bypass: boolean,
+  fn: () => Promise<T>
+): Promise<T> {
+  if (!bypass) {
+    const pending = inflight.get(key);
+    if (pending) return pending;
+  }
+  const promise = fn();
+  inflight.set(key, promise);
+  const cleanup = () => {
+    if (inflight.get(key) === promise) inflight.delete(key);
+  };
+  promise.then(cleanup, cleanup);
+  return promise;
+}
+
+function listCacheState(opts: ListOptions): "open" | "closed" | "all" {
+  return opts.state ?? "open";
+}
+
+function issueToTooltipData(issue: Issue): IssueTooltipData {
+  return {
+    number: issue.number,
+    title: issue.title,
+    bodyExcerpt: truncateBody(issue.body),
+    state: issue.state === "closed" ? "CLOSED" : "OPEN",
+    createdAt: new Date(issue.createdAt).toISOString(),
+    author: { login: issue.author?.login ?? "unknown", avatarUrl: issue.author?.avatarUrl ?? "" },
+    assignees: issue.assignees.map((a) => ({ login: a.login, avatarUrl: a.avatarUrl ?? "" })),
+    labels: issue.labels.map((l) => ({ name: l.name, color: l.color ?? "" })),
+  };
+}
+
+/**
+ * Build a {@link PRTooltipData} from a normalized forge {@link PR}. Assignees
+ * and labels aren't on the forge `PR` shape, so they're read from `rawData`
+ * (present when the source query selected them — `GET_PR_QUERY` and
+ * `buildBatchBranchPRQuery` both do). Returns `null` when `createdAt` is
+ * missing (0), since the tooltip renders a real creation date.
+ */
+function prToTooltipData(pr: PR): PRTooltipData | null {
+  if (!pr.createdAt) return null;
+  const raw = (pr.rawData ?? {}) as Record<string, unknown>;
+  const assigneeNodes =
+    (raw.assignees as { nodes?: Array<{ login?: string; avatarUrl?: string }> } | undefined)
+      ?.nodes ?? [];
+  const labelNodes =
+    (raw.labels as { nodes?: Array<{ name?: string; color?: string }> } | undefined)?.nodes ?? [];
+  const state: "OPEN" | "CLOSED" | "MERGED" =
+    pr.merged || pr.state === "merged"
+      ? "MERGED"
+      : pr.state === "closed" || pr.state === "declined"
+        ? "CLOSED"
+        : "OPEN";
+  return {
+    number: pr.number,
+    title: pr.title,
+    bodyExcerpt: truncateBody(pr.body),
+    state,
+    isDraft: pr.isDraft,
+    createdAt: new Date(pr.createdAt).toISOString(),
+    author: { login: pr.author?.login ?? "unknown", avatarUrl: pr.author?.avatarUrl ?? "" },
+    assignees: assigneeNodes
+      .filter(Boolean)
+      .map((a) => ({ login: a.login ?? "unknown", avatarUrl: a.avatarUrl ?? "" })),
+    labels: labelNodes.filter(Boolean).map((l) => ({ name: l.name ?? "", color: l.color ?? "" })),
+  };
+}
+
+function buildCIStatus(entry: PRRequiredStatusEntry, rawData: unknown): CIStatus {
+  let state: CIStatus["state"] = "unknown";
+  const effective = entry.ciStatus;
+  if (effective === "SUCCESS") state = "success";
+  else if (effective === "FAILURE" || effective === "ERROR") state = "failure";
+  else if (effective === "PENDING" || effective === "EXPECTED") state = "pending";
+  else if (effective === undefined && (entry.ciSummary?.requiredTotal ?? 0) === 0)
+    state = "neutral";
+
+  const total = entry.ciSummary?.requiredTotal ?? 0;
+  const failed = entry.ciSummary?.requiredFailing ?? 0;
+  const pending = entry.ciSummary?.requiredPending ?? 0;
+  const passed = Math.max(0, total - failed - pending);
+  const requiredChecksPassing =
+    entry.ciSummary !== undefined
+      ? entry.ciSummary.requiredTotal > 0 &&
+        entry.ciSummary.requiredFailing === 0 &&
+        entry.ciSummary.requiredPending === 0
+      : undefined;
+
+  return {
+    state,
+    total,
+    passed,
+    failed,
+    pending,
+    ...(requiredChecksPassing !== undefined ? { requiredChecksPassing } : {}),
+    rawData,
+  };
+}
+
+async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<Page<Issue>> {
+  const state = listCacheState(opts);
+  const sortOrder = opts.sort === "updated" ? "updated" : "created";
+  const bypass = opts.bypassCache === true;
+  const cacheKey = buildListCacheKey(
+    "issue",
+    repo.owner,
+    repo.repo,
+    state,
+    opts.search ?? "",
+    sortOrder,
+    opts.cursor ?? ""
   );
 
-  const issues = (response?.repository as Record<string, unknown> | undefined)?.issues as
-    | {
-        nodes?: unknown[];
-        pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
-        totalCount?: number;
-      }
-    | undefined;
-  const nodes = (issues?.nodes ?? []) as Array<Record<string, unknown>>;
-  return {
-    items: nodes.filter(Boolean).map(toForgeIssue),
-    nextCursor: issues?.pageInfo?.endCursor ?? null,
-    hasMore: issues?.pageInfo?.hasNextPage ?? false,
-    ...(typeof issues?.totalCount === "number" ? { totalCount: issues.totalCount } : {}),
-  };
+  if (!bypass) {
+    const cached = forgeIssueListCache.get(cacheKey);
+    if (cached) return cached;
+  }
+
+  return dedupe(listIssuesInflight, cacheKey, bypass, async () => {
+    const limit = opts.perPage ?? 20;
+    const orderBy = buildOrderBy(opts);
+
+    const response = await runQuery(
+      LIST_ISSUES_QUERY,
+      {
+        owner: repo.owner,
+        repo: repo.repo,
+        states: mapIssueGraphQLStates(opts.state),
+        cursor: opts.cursor ?? null,
+        limit,
+        orderBy,
+      },
+      "LIST_ISSUES_QUERY"
+    );
+
+    const issues = (response?.repository as Record<string, unknown> | undefined)?.issues as
+      | {
+          nodes?: unknown[];
+          pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+          totalCount?: number;
+        }
+      | undefined;
+    const nodes = (issues?.nodes ?? []) as Array<Record<string, unknown>>;
+    const page: Page<Issue> = {
+      items: nodes.filter(Boolean).map(toForgeIssue),
+      nextCursor: issues?.pageInfo?.endCursor ?? null,
+      hasMore: issues?.pageInfo?.hasNextPage ?? false,
+      ...(typeof issues?.totalCount === "number" ? { totalCount: issues.totalCount } : {}),
+    };
+
+    forgeIssueListCache.set(cacheKey, page);
+    if (state === "open" && !opts.cursor && typeof issues?.totalCount === "number") {
+      updateRepoStatsCount(`${repo.owner}/${repo.repo}`, "issue", issues.totalCount);
+    }
+    return page;
+  });
 }
 
 async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Page<PR>> {
-  const limit = opts.perPage ?? 20;
-  const orderBy = buildOrderBy(opts);
-
-  const response = await runQuery(
-    LIST_PRS_QUERY,
-    {
-      owner: repo.owner,
-      repo: repo.repo,
-      states: mapPRGraphQLStates(opts.state),
-      cursor: opts.cursor ?? null,
-      limit,
-      orderBy,
-    },
-    "LIST_PRS_QUERY"
+  const state = listCacheState(opts);
+  const sortOrder = opts.sort === "updated" ? "updated" : "created";
+  const bypass = opts.bypassCache === true;
+  const cacheKey = buildListCacheKey(
+    "pr",
+    repo.owner,
+    repo.repo,
+    state,
+    opts.search ?? "",
+    sortOrder,
+    opts.cursor ?? ""
   );
 
-  const prs = (response?.repository as Record<string, unknown> | undefined)?.pullRequests as
-    | {
-        nodes?: unknown[];
-        pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
-        totalCount?: number;
-      }
-    | undefined;
-  const nodes = (prs?.nodes ?? []) as Array<Record<string, unknown>>;
-  return {
-    items: nodes.filter(Boolean).map(toForgePR),
-    nextCursor: prs?.pageInfo?.endCursor ?? null,
-    hasMore: prs?.pageInfo?.hasNextPage ?? false,
-    ...(typeof prs?.totalCount === "number" ? { totalCount: prs.totalCount } : {}),
-  };
+  if (!bypass) {
+    const cached = forgePRListCache.get(cacheKey);
+    if (cached) return cached;
+  }
+
+  return dedupe(listPRsInflight, cacheKey, bypass, async () => {
+    const limit = opts.perPage ?? 20;
+    const orderBy = buildOrderBy(opts);
+
+    const response = await runQuery(
+      LIST_PRS_QUERY,
+      {
+        owner: repo.owner,
+        repo: repo.repo,
+        states: mapPRGraphQLStates(opts.state),
+        cursor: opts.cursor ?? null,
+        limit,
+        orderBy,
+      },
+      "LIST_PRS_QUERY"
+    );
+
+    const prs = (response?.repository as Record<string, unknown> | undefined)?.pullRequests as
+      | {
+          nodes?: unknown[];
+          pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+          totalCount?: number;
+        }
+      | undefined;
+    const nodes = (prs?.nodes ?? []) as Array<Record<string, unknown>>;
+    const page: Page<PR> = {
+      items: nodes.filter(Boolean).map(toForgePR),
+      nextCursor: prs?.pageInfo?.endCursor ?? null,
+      hasMore: prs?.pageInfo?.hasNextPage ?? false,
+      ...(typeof prs?.totalCount === "number" ? { totalCount: prs.totalCount } : {}),
+    };
+
+    forgePRListCache.set(cacheKey, page);
+    if (state === "open" && !opts.cursor && typeof prs?.totalCount === "number") {
+      updateRepoStatsCount(`${repo.owner}/${repo.repo}`, "pr", prs.totalCount);
+    }
+    return page;
+  });
 }
 
 async function getIssueImpl(repo: RepoRef, number: number): Promise<Issue | null> {
-  const response = await runQuery(
-    GET_ISSUE_QUERY,
-    {
-      owner: repo.owner,
-      repo: repo.repo,
-      number,
-    },
-    "GET_ISSUE_QUERY"
-  );
-  const issue = (response?.repository as Record<string, unknown> | undefined)?.issue as
-    | Record<string, unknown>
-    | null
-    | undefined;
-  return issue ? toForgeIssue(issue) : null;
+  const key = `${repo.owner}/${repo.repo}:${number}`;
+  return dedupe(getIssueInflight, key, false, async () => {
+    const response = await runQuery(
+      GET_ISSUE_QUERY,
+      {
+        owner: repo.owner,
+        repo: repo.repo,
+        number,
+      },
+      "GET_ISSUE_QUERY"
+    );
+    const issue = (response?.repository as Record<string, unknown> | undefined)?.issue as
+      | Record<string, unknown>
+      | null
+      | undefined;
+    if (!issue) return null;
+    const forgeIssue = toForgeIssue(issue);
+    // Warm the hover-tooltip cache as a side effect so a subsequent hover skips
+    // a redundant fetch. The detail fetch can't *read* this cache — it holds
+    // the narrower tooltip shape, not a full Issue.
+    issueTooltipCache.set(key, issueToTooltipData(forgeIssue));
+    return forgeIssue;
+  });
 }
 
 async function getPRImpl(repo: RepoRef, number: number): Promise<PR | null> {
-  const response = await runQuery(
-    GET_PR_QUERY,
-    {
-      owner: repo.owner,
-      repo: repo.repo,
-      number,
-    },
-    "GET_PR_QUERY"
-  );
-  const pr = (response?.repository as Record<string, unknown> | undefined)?.pullRequest as
-    | Record<string, unknown>
-    | null
-    | undefined;
-  return pr ? toForgePR(pr) : null;
+  const key = `${repo.owner}/${repo.repo}:${number}`;
+  return dedupe(getPRInflight, key, false, async () => {
+    const requestedAt = Date.now();
+    const response = await runQuery(
+      GET_PR_QUERY,
+      {
+        owner: repo.owner,
+        repo: repo.repo,
+        number,
+      },
+      "GET_PR_QUERY"
+    );
+    const pr = (response?.repository as Record<string, unknown> | undefined)?.pullRequest as
+      | Record<string, unknown>
+      | null
+      | undefined;
+    if (!pr) return null;
+    const forgePR = toForgePR(pr);
+    // Side-effect tooltip pre-warm (write-through only); guarded by the
+    // ownership-token timestamp so a slow response can't clobber a fresher one.
+    const tooltip = prToTooltipData(forgePR);
+    if (tooltip) writePRTooltip(repo.owner, repo.repo, number, tooltip, requestedAt);
+    return forgePR;
+  });
 }
 
 async function findPRsByBranchesImpl(
   repo: RepoRef,
   branches: string[]
 ): Promise<Map<string, PR | null>> {
-  const result = new Map<string, PR | null>();
-  if (branches.length === 0) return result;
+  if (branches.length === 0) return new Map<string, PR | null>();
 
   // Deduplicate while preserving order. Duplicates in the input still land
   // in the result via the same key, but each unique value is queried once.
@@ -400,40 +611,63 @@ async function findPRsByBranchesImpl(
     }
   }
 
-  // Chunks run sequentially (parallel would spike GraphQL points during a
-  // fleet-wide refresh). Per-chunk failures are caught so a single transient
-  // chunk error doesn't blank every branch — the caller falls back per-branch
-  // for any branch the result Map omits.
-  for (let start = 0; start < unique.length; start += BATCH_BRANCH_CHUNK_SIZE) {
-    const chunk = unique.slice(start, start + BATCH_BRANCH_CHUNK_SIZE);
-    const query = buildBatchBranchPRQuery(repo.owner, repo.repo, chunk);
-    let response: Record<string, unknown>;
-    try {
-      response = (await runQuery(query, {}, "BATCH_BRANCH_PR_QUERY")) as Record<string, unknown>;
-    } catch {
-      // Omit this chunk's branches from the result — caller's missing-key
-      // fallback path handles them.
-      continue;
+  // Coalesce concurrent fleet-wide sweeps requesting the same branch set
+  // (order-independent) into one round-trip. The result Map preserves each
+  // caller's branch keys regardless of the sorted key used for coalescing.
+  const inflightKey = `${repo.owner}/${repo.repo}:${[...unique].sort().join(",")}`;
+  return dedupe(findPRsByBranchesInflight, inflightKey, false, async () => {
+    const result = new Map<string, PR | null>();
+
+    // Skip the network entirely while rate-limited — the caller's missing-key
+    // fallback handles every omitted branch. Mirrors `batchCheckLinkedPRs`.
+    const block = gitHubRateLimitService.shouldBlockRequest("graphql");
+    if (block.blocked) return result;
+
+    const requestedAt = Date.now();
+    // Chunks run sequentially (parallel would spike GraphQL points during a
+    // fleet-wide refresh). Per-chunk failures are caught so a single transient
+    // chunk error doesn't blank every branch — the caller falls back per-branch
+    // for any branch the result Map omits.
+    for (let start = 0; start < unique.length; start += BATCH_BRANCH_CHUNK_SIZE) {
+      const chunk = unique.slice(start, start + BATCH_BRANCH_CHUNK_SIZE);
+      const query = buildBatchBranchPRQuery(repo.owner, repo.repo, chunk);
+      let response: Record<string, unknown>;
+      try {
+        response = (await runQuery(query, {}, "BATCH_BRANCH_PR_QUERY")) as Record<string, unknown>;
+      } catch {
+        // Omit this chunk's branches from the result — caller's missing-key
+        // fallback path handles them.
+        continue;
+      }
+
+      for (let i = 0; i < chunk.length; i++) {
+        const branch = chunk[i];
+        // A missing alias key (vs. a present key with empty nodes) indicates a
+        // partial GraphQL response. Omit so the caller routes to fallback rather
+        // than silently recording "no PR found".
+        if (!(`b${i}` in response)) continue;
+        const aliasNode = response[`b${i}`] as
+          | { pullRequests?: { nodes?: unknown[] } }
+          | null
+          | undefined;
+        if (aliasNode == null) continue;
+        const nodes = (aliasNode.pullRequests?.nodes ?? []) as Array<Record<string, unknown>>;
+        const first = nodes.find(Boolean);
+        const forgePR = first ? toForgePR(first) : null;
+        result.set(branch, forgePR);
+
+        // Pre-warm the PR tooltip cache so a hover right after a fleet refresh
+        // is instant. The batch-branch query carries assignees/labels, so the
+        // warmed entry is complete (not a partial that a later hover refetches).
+        if (forgePR) {
+          const tooltip = prToTooltipData(forgePR);
+          if (tooltip) writePRTooltip(repo.owner, repo.repo, forgePR.number, tooltip, requestedAt);
+        }
+      }
     }
 
-    for (let i = 0; i < chunk.length; i++) {
-      const branch = chunk[i];
-      // A missing alias key (vs. a present key with empty nodes) indicates a
-      // partial GraphQL response. Omit so the caller routes to fallback rather
-      // than silently recording "no PR found".
-      if (!(`b${i}` in response)) continue;
-      const aliasNode = response[`b${i}`] as
-        | { pullRequests?: { nodes?: unknown[] } }
-        | null
-        | undefined;
-      if (aliasNode == null) continue;
-      const nodes = (aliasNode.pullRequests?.nodes ?? []) as Array<Record<string, unknown>>;
-      const first = nodes.find(Boolean);
-      result.set(branch, first ? toForgePR(first) : null);
-    }
-  }
-
-  return result;
+    return result;
+  });
 }
 
 async function findPRByBranchImpl(repo: RepoRef, branchName: string): Promise<PR | null> {
@@ -460,64 +694,52 @@ async function findPRByBranchImpl(repo: RepoRef, branchName: string): Promise<PR
 }
 
 async function getCIStatusImpl(repo: RepoRef, prNumber: number): Promise<CIStatus | null> {
-  const response = await runQuery(
-    PR_CI_STATUS_QUERY,
-    {
-      owner: repo.owner,
-      repo: repo.repo,
-      number: prNumber,
-    },
-    "PR_CI_STATUS_QUERY"
-  );
+  // Shares the 60s required-status cache with the legacy enrich path (same key
+  // and {@link PRRequiredStatusEntry} value). This is the hottest forge path —
+  // the worktree dashboard polls CI per open PR across every view — so the
+  // cache + single-flight collapse the fan-out to one request per PR per 60s.
+  const cacheKey = `${repo.owner}/${repo.repo}:${prNumber}`;
+  const cached = prRequiredStatusCache.get(cacheKey);
+  if (cached) return buildCIStatus(cached, null);
 
-  const pr = (response?.repository as Record<string, unknown> | undefined)?.pullRequest as
-    | Record<string, unknown>
-    | null
-    | undefined;
-  if (!pr) return null;
+  return dedupe(getCIStatusInflight, cacheKey, false, async () => {
+    const response = await runQuery(
+      PR_CI_STATUS_QUERY,
+      {
+        owner: repo.owner,
+        repo: repo.repo,
+        number: prNumber,
+      },
+      "PR_CI_STATUS_QUERY"
+    );
 
-  const commits = pr.commits as
-    | { nodes?: Array<{ commit?: { statusCheckRollup?: unknown } }> }
-    | undefined;
-  const rollup = commits?.nodes?.[0]?.commit?.statusCheckRollup as
-    | {
-        state?: string;
-        contexts?: { nodes?: RollupContextNode[]; pageInfo?: { hasNextPage?: boolean } };
-      }
-    | undefined;
+    const pr = (response?.repository as Record<string, unknown> | undefined)?.pullRequest as
+      | Record<string, unknown>
+      | null
+      | undefined;
+    if (!pr) return null;
 
-  const contextNodes = rollup?.contexts?.nodes ?? null;
-  const hasNextPage = rollup?.contexts?.pageInfo?.hasNextPage === true;
-  const derived = deriveRequiredCIStatus(contextNodes, hasNextPage, rollup?.state ?? null);
+    const commits = pr.commits as
+      | { nodes?: Array<{ commit?: { statusCheckRollup?: unknown } }> }
+      | undefined;
+    const rollup = commits?.nodes?.[0]?.commit?.statusCheckRollup as
+      | {
+          state?: string;
+          contexts?: { nodes?: RollupContextNode[]; pageInfo?: { hasNextPage?: boolean } };
+        }
+      | undefined;
 
-  let state: CIStatus["state"] = "unknown";
-  const effective = derived.ciStatus;
-  if (effective === "SUCCESS") state = "success";
-  else if (effective === "FAILURE" || effective === "ERROR") state = "failure";
-  else if (effective === "PENDING" || effective === "EXPECTED") state = "pending";
-  else if (effective === undefined && (derived.ciSummary?.requiredTotal ?? 0) === 0)
-    state = "neutral";
+    const contextNodes = rollup?.contexts?.nodes ?? null;
+    const hasNextPage = rollup?.contexts?.pageInfo?.hasNextPage === true;
+    const derived = deriveRequiredCIStatus(contextNodes, hasNextPage, rollup?.state ?? null);
 
-  const total = derived.ciSummary?.requiredTotal ?? 0;
-  const failed = derived.ciSummary?.requiredFailing ?? 0;
-  const pending = derived.ciSummary?.requiredPending ?? 0;
-  const passed = Math.max(0, total - failed - pending);
-  const requiredChecksPassing =
-    derived.ciSummary !== undefined
-      ? derived.ciSummary.requiredTotal > 0 &&
-        derived.ciSummary.requiredFailing === 0 &&
-        derived.ciSummary.requiredPending === 0
-      : undefined;
-
-  return {
-    state,
-    total,
-    passed,
-    failed,
-    pending,
-    ...(requiredChecksPassing !== undefined ? { requiredChecksPassing } : {}),
-    rawData: rollup ?? null,
-  };
+    const entry: PRRequiredStatusEntry = {
+      ciStatus: derived.ciStatus,
+      ciSummary: derived.ciSummary,
+    };
+    prRequiredStatusCache.set(cacheKey, entry);
+    return buildCIStatus(entry, rollup ?? null);
+  });
 }
 
 async function getRepoMetadataImpl(repo: RepoRef): Promise<RepoMetadata> {

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -319,18 +319,27 @@ const findPRsByBranchesInflight = new Map<string, Promise<Map<string, PR | null>
  * active promise, so a bypass replacement isn't deleted by the request it
  * superseded. Failures evict immediately so a transient error doesn't pin a
  * rejected promise for later callers.
+ *
+ * `fn` receives an `isCurrent()` guard: it returns `true` only while this call
+ * is still the active in-flight entry. A request that was superseded by a newer
+ * bypass call sees `false` and must skip any shared-cache write, so a slow
+ * stale fetch can't overwrite the fresher result the bypass already committed.
  */
 function dedupe<T>(
   inflight: Map<string, Promise<T>>,
   key: string,
   bypass: boolean,
-  fn: () => Promise<T>
+  fn: (isCurrent: () => boolean) => Promise<T>
 ): Promise<T> {
   if (!bypass) {
     const pending = inflight.get(key);
     if (pending) return pending;
   }
-  const promise = fn();
+  const holder: { promise: Promise<T> | null } = { promise: null };
+  // Defer `fn` one microtask so `holder.promise` is assigned before it runs;
+  // `isCurrent` can then compare against this call's own promise identity.
+  const promise = Promise.resolve().then(() => fn(() => inflight.get(key) === holder.promise));
+  holder.promise = promise;
   inflight.set(key, promise);
   const cleanup = () => {
     if (inflight.get(key) === promise) inflight.delete(key);
@@ -427,12 +436,16 @@ async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<Page<Is
   const state = listCacheState(opts);
   const sortOrder = opts.sort === "updated" ? "updated" : "created";
   const bypass = opts.bypassCache === true;
+  // The GitHub forge list path issues the unfiltered repository query and
+  // ignores `opts.search` (advisory — see ListOptions). Keep `search` out of
+  // the cache key so it reflects what the query actually varies on; wiring
+  // search would mean routing to SEARCH_QUERY and re-adding it here together.
   const cacheKey = buildListCacheKey(
     "issue",
     repo.owner,
     repo.repo,
     state,
-    opts.search ?? "",
+    "",
     sortOrder,
     opts.cursor ?? ""
   );
@@ -442,7 +455,7 @@ async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<Page<Is
     if (cached) return cached;
   }
 
-  return dedupe(listIssuesInflight, cacheKey, bypass, async () => {
+  return dedupe(listIssuesInflight, cacheKey, bypass, async (isCurrent) => {
     const limit = opts.perPage ?? 20;
     const orderBy = buildOrderBy(opts);
 
@@ -474,9 +487,13 @@ async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<Page<Is
       ...(typeof issues?.totalCount === "number" ? { totalCount: issues.totalCount } : {}),
     };
 
-    forgeIssueListCache.set(cacheKey, page);
-    if (state === "open" && !opts.cursor && typeof issues?.totalCount === "number") {
-      updateRepoStatsCount(`${repo.owner}/${repo.repo}`, "issue", issues.totalCount);
+    // Skip the shared-cache write when a newer bypass call has superseded us,
+    // so a slow stale fetch can't clobber the fresher committed result.
+    if (isCurrent()) {
+      forgeIssueListCache.set(cacheKey, page);
+      if (state === "open" && !opts.cursor && typeof issues?.totalCount === "number") {
+        updateRepoStatsCount(`${repo.owner}/${repo.repo}`, "issue", issues.totalCount);
+      }
     }
     return page;
   });
@@ -486,12 +503,14 @@ async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Page<PR>> 
   const state = listCacheState(opts);
   const sortOrder = opts.sort === "updated" ? "updated" : "created";
   const bypass = opts.bypassCache === true;
+  // See listIssuesImpl: the forge list query ignores `opts.search`, so it's
+  // kept out of the cache key.
   const cacheKey = buildListCacheKey(
     "pr",
     repo.owner,
     repo.repo,
     state,
-    opts.search ?? "",
+    "",
     sortOrder,
     opts.cursor ?? ""
   );
@@ -501,7 +520,7 @@ async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Page<PR>> 
     if (cached) return cached;
   }
 
-  return dedupe(listPRsInflight, cacheKey, bypass, async () => {
+  return dedupe(listPRsInflight, cacheKey, bypass, async (isCurrent) => {
     const limit = opts.perPage ?? 20;
     const orderBy = buildOrderBy(opts);
 
@@ -533,9 +552,11 @@ async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Page<PR>> 
       ...(typeof prs?.totalCount === "number" ? { totalCount: prs.totalCount } : {}),
     };
 
-    forgePRListCache.set(cacheKey, page);
-    if (state === "open" && !opts.cursor && typeof prs?.totalCount === "number") {
-      updateRepoStatsCount(`${repo.owner}/${repo.repo}`, "pr", prs.totalCount);
+    if (isCurrent()) {
+      forgePRListCache.set(cacheKey, page);
+      if (state === "open" && !opts.cursor && typeof prs?.totalCount === "number") {
+        updateRepoStatsCount(`${repo.owner}/${repo.repo}`, "pr", prs.totalCount);
+      }
     }
     return page;
   });

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -154,6 +154,14 @@ export interface ListOptions {
   assignee?: string;
   sort?: string;
   direction?: "asc" | "desc";
+  /** Free-text search query. Advisory — providers ignore it if unsupported. */
+  search?: string;
+  /**
+   * Skip the provider's in-memory list cache and any in-flight coalescing, and
+   * fetch fresh data. The result still populates the cache for later reads.
+   * Providers that don't cache ignore this. Advisory only.
+   */
+  bypassCache?: boolean;
   /**
    * Opaque freshness token from a prior {@link Page.freshnessToken} response.
    * Advisory: providers that support conditional listing skip the fetch and


### PR DESCRIPTION
## Summary

The CodeForge migration's `forgeProvider.ts` was a raw GraphQL passthrough that skipped all the caching and in-flight dedup the legacy `GitHubIssues.ts`/`GitHubPRs.ts` paths had. Every `forge.*` IPC and `forge:rpc` (workspace-host) call paid full query cost unconditionally, risking GitHub rate-limit exhaustion — the worktree dashboard's fleet-wide PR/CI poll fans out the same lookups from every view at once.

This wires the existing main-process cache + dedup layer into each `*Impl` function:

- **`listIssues`/`listPRs`** — dedicated 60s forge list caches (`forgeIssueListCache`/`forgePRListCache`; the legacy caches hold the incompatible `GitHubListResponse` shape, so the forge `Page<T>` path needs its own), single-flight coalescing, `bypassCache` support (skip cache read + in-flight join, force fresh, still write back), and `updateRepoStatsCount` so the toolbar badge converges.
- **`getIssue`/`getPR`** — single-flight + tooltip cache write-through side-effect (guarded by the `prTooltipWrittenAt` ownership token for PRs).
- **`getCIStatus`** — shares the 60s `prRequiredStatusCache` with the legacy enrich path and rebuilds the forge `CIStatus` on a cache hit. This is the hottest path: per-PR CI polling across every view now collapses to one request per PR per 60s.
- **`findPRsByBranches`** — rate-limit gate (parity with `batchCheckLinkedPRs` — returns an empty Map when blocked so the caller falls back per-branch), single-flight keyed by sorted branches, and the restored `prewarmPRTooltipCache` side-effect. Added `assignees`/`labels` to `buildBatchBranchPRQuery` so the warmed tooltips are complete rather than partial.

Also: added optional `search`/`bypassCache` to `ListOptions`; extracted a shared `writePRTooltip` write-guard into `GitHubCaches`; the new forge caches are cleared in `clearGitHubCaches`/`clearPRCaches`.

## `bypassCache` semantics

`bypassCache: true` skips the 60s cache read and the in-flight join, forces a fresh fetch, installs itself as the new shared promise (mid-flight joiners get the fresh result), and still writes back. A stale fetch superseded by a newer bypass call skips its own cache write via an `isCurrent()` guard, so it can't clobber the fresher committed result.

## Tests

24 `forgeProvider` tests: cache hit, concurrent dedup, `bypassCache` refetch + repopulate, stale-overwrite guard, rejected-promise eviction/retry, stats update, tooltip pre-warm, CI cache, and the rate-limit gate. `npm run check` passes (typecheck + lint ratchet −1 + format + IPC maps).

Closes #9046.