### PR TITLE
fix(github): prewarm tooltip cache from list queries, dedup in-flight

### DIFF
--- a/plugins/builtin/github/main/GitHubCaches.ts
+++ b/plugins/builtin/github/main/GitHubCaches.ts
@@ -25,7 +25,13 @@ export const issueListCache = new Cache<string, GitHubListResponse<GitHubIssue>>
 });
 export const prListCache = new Cache<string, GitHubListResponse<GitHubPR>>({ defaultTTL: 60000 });
 export const projectHealthCache = new Cache<string, unknown>({ defaultTTL: 60000 });
-export const issueTooltipCache = new Cache<string, IssueTooltipData>({ defaultTTL: 300000 });
+export const issueTooltipWrittenAt = new Map<string, number>();
+export const issueTooltipCache = new Cache<string, IssueTooltipData>({
+  defaultTTL: 300000,
+  onEvict: (key) => {
+    issueTooltipWrittenAt.delete(key as string);
+  },
+});
 
 const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
 const TEN_MINUTES_MS = 10 * 60 * 1000;
@@ -138,6 +144,7 @@ export function clearGitHubCaches(): void {
   issueListCache.clear();
   prListCache.clear();
   issueTooltipCache.clear();
+  issueTooltipWrittenAt.clear();
   prTooltipCache.clear();
   prTooltipWrittenAt.clear();
   prETagCache.clear();

--- a/plugins/builtin/github/main/GitHubIssues.ts
+++ b/plugins/builtin/github/main/GitHubIssues.ts
@@ -337,9 +337,14 @@ export async function getIssueTooltip(
       })();
 
       inFlightIssueTooltips.set(cacheKey, promise);
-      promise.finally(() => {
-        inFlightIssueTooltips.delete(cacheKey);
-      });
+      promise.then(
+        () => {
+          inFlightIssueTooltips.delete(cacheKey);
+        },
+        () => {
+          inFlightIssueTooltips.delete(cacheKey);
+        }
+      );
 
       return promise;
     });

--- a/plugins/builtin/github/main/GitHubIssues.ts
+++ b/plugins/builtin/github/main/GitHubIssues.ts
@@ -10,7 +10,12 @@ import {
 import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
 import { parseGitHubError } from "./GitHubErrors.js";
 import { withRepoContextRetry } from "./GitHubRepoContext.js";
-import { repoStatsCache, issueListCache, issueTooltipCache } from "./GitHubCaches.js";
+import {
+  repoStatsCache,
+  issueListCache,
+  issueTooltipCache,
+  issueTooltipWrittenAt,
+} from "./GitHubCaches.js";
 import { GitHubStatsCache } from "../../../../electron/services/GitHubStatsCache.js";
 import { buildListCacheKey, updateRepoStatsCount } from "./GitHubPRs.js";
 import { truncateBody } from "./GitHubCaches.js";
@@ -259,6 +264,8 @@ function updateIssueAssigneeInCache(
   issueTooltipCache.invalidate(`${owner}/${repo}:${issueNumber}`);
 }
 
+const inFlightIssueTooltips = new Map<string, Promise<IssueTooltipData | null>>();
+
 export async function getIssueTooltip(
   cwd: string,
   issueNumber: number
@@ -276,51 +283,108 @@ export async function getIssueTooltip(
         return cached;
       }
 
-      const response = (await client(GET_ISSUE_QUERY, {
-        owner: context.owner,
-        repo: context.repo,
-        number: issueNumber,
-        request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
-      })) as GraphQlQueryResponseData;
+      const inFlight = inFlightIssueTooltips.get(cacheKey);
+      if (inFlight) return inFlight;
 
-      gitHubRateLimitService.updateFromGraphQL(response, "GET_ISSUE_QUERY");
+      const requestedAt = Date.now();
+      const promise = (async () => {
+        const response = (await client(GET_ISSUE_QUERY, {
+          owner: context.owner,
+          repo: context.repo,
+          number: issueNumber,
+          request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
+        })) as GraphQlQueryResponseData;
 
-      const issue = response?.repository?.issue;
-      if (!issue) {
-        return null;
-      }
+        gitHubRateLimitService.updateFromGraphQL(response, "GET_ISSUE_QUERY");
 
-      const author = issue.author as { login?: string; avatarUrl?: string } | null;
-      const assigneesData = issue.assignees as {
-        nodes?: Array<{ login?: string; avatarUrl?: string }>;
-      };
-      const labelsData = issue.labels as { nodes?: Array<{ name?: string; color?: string }> };
+        const issue = response?.repository?.issue;
+        if (!issue) {
+          return null;
+        }
 
-      const tooltipData: IssueTooltipData = {
-        number: issue.number as number,
-        title: issue.title as string,
-        bodyExcerpt: truncateBody(issue.bodyText as string | null),
-        state: issue.state as "OPEN" | "CLOSED",
-        createdAt: issue.createdAt as string,
-        author: {
-          login: author?.login ?? "unknown",
-          avatarUrl: author?.avatarUrl ?? "",
-        },
-        assignees: (assigneesData?.nodes ?? []).filter(Boolean).map((a) => ({
-          login: a.login ?? "unknown",
-          avatarUrl: a.avatarUrl ?? "",
-        })),
-        labels: (labelsData?.nodes ?? []).filter(Boolean).map((l) => ({
-          name: l.name ?? "",
-          color: l.color ?? "",
-        })),
-      };
+        const author = issue.author as { login?: string; avatarUrl?: string } | null;
+        const assigneesData = issue.assignees as {
+          nodes?: Array<{ login?: string; avatarUrl?: string }>;
+        };
+        const labelsData = issue.labels as { nodes?: Array<{ name?: string; color?: string }> };
 
-      issueTooltipCache.set(cacheKey, tooltipData);
-      return tooltipData;
+        const tooltipData: IssueTooltipData = {
+          number: issue.number as number,
+          title: issue.title as string,
+          bodyExcerpt: truncateBody(issue.bodyText as string | null),
+          state: issue.state as "OPEN" | "CLOSED",
+          createdAt: issue.createdAt as string,
+          author: {
+            login: author?.login ?? "unknown",
+            avatarUrl: author?.avatarUrl ?? "",
+          },
+          assignees: (assigneesData?.nodes ?? []).filter(Boolean).map((a) => ({
+            login: a.login ?? "unknown",
+            avatarUrl: a.avatarUrl ?? "",
+          })),
+          labels: (labelsData?.nodes ?? []).filter(Boolean).map((l) => ({
+            name: l.name ?? "",
+            color: l.color ?? "",
+          })),
+        };
+
+        const existing = issueTooltipWrittenAt.get(cacheKey);
+        if (existing === undefined || requestedAt >= existing) {
+          issueTooltipCache.set(cacheKey, tooltipData);
+          issueTooltipWrittenAt.set(cacheKey, requestedAt);
+        }
+        return tooltipData;
+      })();
+
+      inFlightIssueTooltips.set(cacheKey, promise);
+      promise.finally(() => {
+        inFlightIssueTooltips.delete(cacheKey);
+      });
+
+      return promise;
     });
   } catch {
     return null;
+  }
+}
+
+function prewarmIssueTooltips(
+  owner: string,
+  repo: string,
+  nodes: Array<Record<string, unknown>>
+): void {
+  const requestedAt = Date.now();
+  for (const node of nodes) {
+    const num = node.number as number;
+    if (!num) continue;
+    const cacheKey = `${owner}/${repo}:${num}`;
+    const existing = issueTooltipWrittenAt.get(cacheKey);
+    if (existing !== undefined && requestedAt < existing) continue;
+    const author = node.author as { login?: string; avatarUrl?: string } | null;
+    const assigneesData = node.assignees as {
+      nodes?: Array<{ login?: string; avatarUrl?: string }>;
+    };
+    const labelsData = node.labels as { nodes?: Array<{ name?: string; color?: string }> };
+    issueTooltipCache.set(cacheKey, {
+      number: num,
+      title: node.title as string,
+      bodyExcerpt: truncateBody(node.bodyText as string | null),
+      state: node.state as "OPEN" | "CLOSED",
+      createdAt: node.createdAt as string,
+      author: {
+        login: author?.login ?? "unknown",
+        avatarUrl: author?.avatarUrl ?? "",
+      },
+      assignees: (assigneesData?.nodes ?? []).filter(Boolean).map((a) => ({
+        login: a.login ?? "unknown",
+        avatarUrl: a.avatarUrl ?? "",
+      })),
+      labels: (labelsData?.nodes ?? []).filter(Boolean).map((l) => ({
+        name: l.name ?? "",
+        color: l.color ?? "",
+      })),
+    });
+    issueTooltipWrittenAt.set(cacheKey, requestedAt);
   }
 }
 
@@ -379,9 +443,12 @@ export async function listIssues(
 
         const search = response?.search;
         const nodes = (search?.nodes ?? []) as Array<Record<string, unknown>>;
+        const filteredNodes = nodes.filter(Boolean);
+
+        prewarmIssueTooltips(context.owner, context.repo, filteredNodes);
 
         result = {
-          items: nodes.filter(Boolean).map(parseIssueNode),
+          items: filteredNodes.map(parseIssueNode),
           pageInfo: {
             hasNextPage: search?.pageInfo?.hasNextPage ?? false,
             endCursor: search?.pageInfo?.endCursor ?? null,
@@ -405,9 +472,12 @@ export async function listIssues(
         const issues = response?.repository?.issues;
         const nodes = (issues?.nodes ?? []) as Array<Record<string, unknown>>;
         const totalCount = (issues?.totalCount as number) ?? undefined;
+        const filteredNodes = nodes.filter(Boolean);
+
+        prewarmIssueTooltips(context.owner, context.repo, filteredNodes);
 
         result = {
-          items: nodes.filter(Boolean).map(parseIssueNode),
+          items: filteredNodes.map(parseIssueNode),
           pageInfo: {
             hasNextPage: issues?.pageInfo?.hasNextPage ?? false,
             endCursor: issues?.pageInfo?.endCursor ?? null,

--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -246,9 +246,14 @@ export async function getPRTooltip(cwd: string, prNumber: number): Promise<PRToo
       })();
 
       inFlightPRTooltips.set(cacheKey, promise);
-      promise.finally(() => {
-        inFlightPRTooltips.delete(cacheKey);
-      });
+      promise.then(
+        () => {
+          inFlightPRTooltips.delete(cacheKey);
+        },
+        () => {
+          inFlightPRTooltips.delete(cacheKey);
+        }
+      );
 
       return promise;
     });

--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -168,6 +168,8 @@ export function mapPRStates(state?: string): string[] {
   return ["OPEN"];
 }
 
+const inFlightPRTooltips = new Map<string, Promise<PRTooltipData | null>>();
+
 export async function getPRTooltip(cwd: string, prNumber: number): Promise<PRTooltipData | null> {
   const client = GitHubAuth.createClient();
   if (!client) {
@@ -182,61 +184,73 @@ export async function getPRTooltip(cwd: string, prNumber: number): Promise<PRToo
         return cached;
       }
 
+      const inFlight = inFlightPRTooltips.get(cacheKey);
+      if (inFlight) return inFlight;
+
       const requestedAt = Date.now();
-      const response = (await client(GET_PR_QUERY, {
-        owner: context.owner,
-        repo: context.repo,
-        number: prNumber,
-        request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
-      })) as GraphQlQueryResponseData;
+      const promise = (async () => {
+        const response = (await client(GET_PR_QUERY, {
+          owner: context.owner,
+          repo: context.repo,
+          number: prNumber,
+          request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
+        })) as GraphQlQueryResponseData;
 
-      gitHubRateLimitService.updateFromGraphQL(response, "GET_PR_QUERY");
+        gitHubRateLimitService.updateFromGraphQL(response, "GET_PR_QUERY");
 
-      const pr = response?.repository?.pullRequest;
-      if (!pr) {
-        return null;
-      }
+        const pr = response?.repository?.pullRequest;
+        if (!pr) {
+          return null;
+        }
 
-      const author = pr.author as { login?: string; avatarUrl?: string } | null;
-      const assigneesData = pr.assignees as {
-        nodes?: Array<{ login?: string; avatarUrl?: string }>;
-      };
-      const labelsData = pr.labels as { nodes?: Array<{ name?: string; color?: string }> };
-      const merged = pr.merged as boolean;
-      const rawState = pr.state as string;
+        const author = pr.author as { login?: string; avatarUrl?: string } | null;
+        const assigneesData = pr.assignees as {
+          nodes?: Array<{ login?: string; avatarUrl?: string }>;
+        };
+        const labelsData = pr.labels as { nodes?: Array<{ name?: string; color?: string }> };
+        const merged = pr.merged as boolean;
+        const rawState = pr.state as string;
 
-      let state: "OPEN" | "CLOSED" | "MERGED" = rawState as "OPEN" | "CLOSED" | "MERGED";
-      if (merged) {
-        state = "MERGED";
-      }
+        let state: "OPEN" | "CLOSED" | "MERGED" = rawState as "OPEN" | "CLOSED" | "MERGED";
+        if (merged) {
+          state = "MERGED";
+        }
 
-      const tooltipData: PRTooltipData = {
-        number: pr.number as number,
-        title: pr.title as string,
-        bodyExcerpt: truncateBody(pr.bodyText as string | null),
-        state,
-        isDraft: (pr.isDraft as boolean) ?? false,
-        createdAt: pr.createdAt as string,
-        author: {
-          login: author?.login ?? "unknown",
-          avatarUrl: author?.avatarUrl ?? "",
-        },
-        assignees: (assigneesData?.nodes ?? []).filter(Boolean).map((a) => ({
-          login: a.login ?? "unknown",
-          avatarUrl: a.avatarUrl ?? "",
-        })),
-        labels: (labelsData?.nodes ?? []).filter(Boolean).map((l) => ({
-          name: l.name ?? "",
-          color: l.color ?? "",
-        })),
-      };
+        const tooltipData: PRTooltipData = {
+          number: pr.number as number,
+          title: pr.title as string,
+          bodyExcerpt: truncateBody(pr.bodyText as string | null),
+          state,
+          isDraft: (pr.isDraft as boolean) ?? false,
+          createdAt: pr.createdAt as string,
+          author: {
+            login: author?.login ?? "unknown",
+            avatarUrl: author?.avatarUrl ?? "",
+          },
+          assignees: (assigneesData?.nodes ?? []).filter(Boolean).map((a) => ({
+            login: a.login ?? "unknown",
+            avatarUrl: a.avatarUrl ?? "",
+          })),
+          labels: (labelsData?.nodes ?? []).filter(Boolean).map((l) => ({
+            name: l.name ?? "",
+            color: l.color ?? "",
+          })),
+        };
 
-      const existing = prTooltipWrittenAt.get(cacheKey);
-      if (existing === undefined || requestedAt >= existing) {
-        prTooltipCache.set(cacheKey, tooltipData);
-        prTooltipWrittenAt.set(cacheKey, requestedAt);
-      }
-      return tooltipData;
+        const existing = prTooltipWrittenAt.get(cacheKey);
+        if (existing === undefined || requestedAt >= existing) {
+          prTooltipCache.set(cacheKey, tooltipData);
+          prTooltipWrittenAt.set(cacheKey, requestedAt);
+        }
+        return tooltipData;
+      })();
+
+      inFlightPRTooltips.set(cacheKey, promise);
+      promise.finally(() => {
+        inFlightPRTooltips.delete(cacheKey);
+      });
+
+      return promise;
     });
   } catch {
     return null;
@@ -335,6 +349,51 @@ function parseBatchRequiredChecksResponse(
   return out;
 }
 
+function prewarmPRTooltips(
+  owner: string,
+  repo: string,
+  nodes: Array<Record<string, unknown>>
+): void {
+  const requestedAt = Date.now();
+  for (const node of nodes) {
+    const num = node.number as number;
+    if (!num) continue;
+    const cacheKey = `${owner}/${repo}:${num}`;
+    const existing = prTooltipWrittenAt.get(cacheKey);
+    if (existing !== undefined && requestedAt < existing) continue;
+    const author = node.author as { login?: string; avatarUrl?: string } | null;
+    const assigneesData = node.assignees as {
+      nodes?: Array<{ login?: string; avatarUrl?: string }>;
+    };
+    const labelsData = node.labels as { nodes?: Array<{ name?: string; color?: string }> };
+    const merged = node.merged as boolean;
+    const rawState = node.state as string;
+    let state: "OPEN" | "CLOSED" | "MERGED" = rawState as "OPEN" | "CLOSED" | "MERGED";
+    if (merged) state = "MERGED";
+    prTooltipCache.set(cacheKey, {
+      number: num,
+      title: node.title as string,
+      bodyExcerpt: truncateBody(node.bodyText as string | null),
+      state,
+      isDraft: (node.isDraft as boolean) ?? false,
+      createdAt: node.createdAt as string,
+      author: {
+        login: author?.login ?? "unknown",
+        avatarUrl: author?.avatarUrl ?? "",
+      },
+      assignees: (assigneesData?.nodes ?? []).filter(Boolean).map((a) => ({
+        login: a.login ?? "unknown",
+        avatarUrl: a.avatarUrl ?? "",
+      })),
+      labels: (labelsData?.nodes ?? []).filter(Boolean).map((l) => ({
+        name: l.name ?? "",
+        color: l.color ?? "",
+      })),
+    });
+    prTooltipWrittenAt.set(cacheKey, requestedAt);
+  }
+}
+
 export async function listPullRequests(
   options: GitHubListOptions
 ): Promise<GitHubListResponse<GitHubPR>> {
@@ -391,8 +450,11 @@ export async function listPullRequests(
 
         const search = response?.search;
         const nodes = (search?.nodes ?? []) as Array<Record<string, unknown>>;
+        const filteredNodes = nodes.filter(Boolean);
 
-        const parsedItems = nodes.filter(Boolean).map(parsePRNode);
+        prewarmPRTooltips(context.owner, context.repo, filteredNodes);
+
+        const parsedItems = filteredNodes.map(parsePRNode);
         const enrichedItems = await enrichPRsWithRequiredStatus(
           context,
           parsedItems,
@@ -428,8 +490,11 @@ export async function listPullRequests(
         const pullRequests = response?.repository?.pullRequests;
         const nodes = (pullRequests?.nodes ?? []) as Array<Record<string, unknown>>;
         const totalCount = (pullRequests?.totalCount as number) ?? undefined;
+        const filteredNodes = nodes.filter(Boolean);
 
-        const parsedItems = nodes.filter(Boolean).map(parsePRNode);
+        prewarmPRTooltips(context.owner, context.repo, filteredNodes);
+
+        const parsedItems = filteredNodes.map(parsePRNode);
         const enrichedItems = await enrichPRsWithRequiredStatus(
           context,
           parsedItems,

--- a/plugins/builtin/github/main/GitHubQueries.ts
+++ b/plugins/builtin/github/main/GitHubQueries.ts
@@ -295,6 +295,18 @@ export const LIST_PRS_QUERY = `
             login
             avatarUrl
           }
+          assignees(first: 10) {
+            nodes {
+              login
+              avatarUrl
+            }
+          }
+          labels(first: 10) {
+            nodes {
+              name
+              color
+            }
+          }
           comments {
             totalCount
           }
@@ -392,6 +404,18 @@ export const SEARCH_QUERY = `
           author {
             login
             avatarUrl
+          }
+          assignees(first: 10) {
+            nodes {
+              login
+              avatarUrl
+            }
+          }
+          labels(first: 10) {
+            nodes {
+              name
+              color
+            }
           }
           comments {
             totalCount

--- a/src/components/Worktree/WorktreeCard/IssueBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/IssueBadge.tsx
@@ -58,6 +58,7 @@ export function IssueBadge({
   const prevIssueNumber = useRef<number | undefined>(undefined);
   const isColdTitleGap = !issueTitle && issueNumber !== prevIssueNumber.current;
   const showColdFallback = useDohertyGate(isColdTitleGap);
+  const showTooltipLoading = useDohertyGate(loading);
   useEffect(() => {
     prevIssueNumber.current = issueNumber;
   }, [issueNumber]);
@@ -145,7 +146,7 @@ export function IssueBadge({
       <TooltipContent side="right" align="start" className="p-3">
         {missingToken ? (
           <TokenMissingTooltip type="issue" />
-        ) : loading ? (
+        ) : showTooltipLoading ? (
           <TooltipLoading />
         ) : data ? (
           <IssueTooltipContent data={data} />

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -60,6 +60,7 @@ export function PRBadge({
   const prevPrNumber = useRef<number | undefined>(undefined);
   const isColdTitleGap = isHeadline === true && !prTitle && prNumber !== prevPrNumber.current;
   const showColdFallback = useDohertyGate(isColdTitleGap);
+  const showTooltipLoading = useDohertyGate(loading);
   useEffect(() => {
     prevPrNumber.current = prNumber;
   }, [prNumber]);
@@ -214,7 +215,7 @@ export function PRBadge({
       <TooltipContent side="right" align="start" className="p-3">
         {missingToken ? (
           <TokenMissingTooltip type="pr" />
-        ) : loading ? (
+        ) : showTooltipLoading ? (
           <TooltipLoading />
         ) : data ? (
           <PRTooltipContent data={data} />

--- a/src/hooks/useGitHubTooltip.ts
+++ b/src/hooks/useGitHubTooltip.ts
@@ -78,9 +78,14 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
     })();
 
     inFlightIssues.set(cacheKey, promise);
-    promise.finally(() => {
-      inFlightIssues.delete(cacheKey);
-    });
+    promise.then(
+      () => {
+        inFlightIssues.delete(cacheKey);
+      },
+      () => {
+        inFlightIssues.delete(cacheKey);
+      }
+    );
 
     try {
       const data = await promise;
@@ -166,9 +171,14 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
     })();
 
     inFlightPRs.set(cacheKey, promise);
-    promise.finally(() => {
-      inFlightPRs.delete(cacheKey);
-    });
+    promise.then(
+      () => {
+        inFlightPRs.delete(cacheKey);
+      },
+      () => {
+        inFlightPRs.delete(cacheKey);
+      }
+    );
 
     try {
       const data = await promise;

--- a/src/hooks/useGitHubTooltip.ts
+++ b/src/hooks/useGitHubTooltip.ts
@@ -15,13 +15,14 @@ const TOOLTIP_CACHE_TTL = 300_000; // 5 minutes, matching backend TTL
 const issueCache = new TtlCache<string, IssueTooltipData>(TOOLTIP_CACHE_MAX, TOOLTIP_CACHE_TTL);
 const prCache = new TtlCache<string, PRTooltipData>(TOOLTIP_CACHE_MAX, TOOLTIP_CACHE_TTL);
 
+const inFlightIssues = new Map<string, Promise<IssueTooltipData | null>>();
+
 export function useIssueTooltip(cwd: string | undefined, issueNumber: number | undefined) {
   const [state, setState] = useState<TooltipState<IssueTooltipData>>({
     data: null,
     loading: false,
     error: false,
   });
-  const fetchingKeyRef = useRef<string | null>(null);
   const mountedRef = useRef(true);
   const hasToken = useGitHubConfigStore((s) => s.config?.hasToken);
   const storeInitialized = useGitHubConfigStore((s) => s.isInitialized);
@@ -48,39 +49,61 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
       return;
     }
 
-    if (fetchingKeyRef.current === cacheKey) return;
+    const inFlight = inFlightIssues.get(cacheKey);
+    if (inFlight) {
+      setState((prev) => ({ ...prev, loading: true, error: false }));
+      try {
+        const data = await inFlight;
+        if (!mountedRef.current) return;
+        if (data) {
+          setState({ data, loading: false, error: false });
+        } else {
+          setState({ data: null, loading: false, error: true });
+        }
+      } catch {
+        if (!mountedRef.current) return;
+        setState({ data: null, loading: false, error: true });
+      }
+      return;
+    }
 
-    fetchingKeyRef.current = cacheKey;
     setState((prev) => ({ ...prev, loading: true, error: false }));
 
-    try {
+    const promise = (async () => {
       const data = await window.electron.github.getIssueTooltip(cwd, issueNumber);
-      if (!mountedRef.current || fetchingKeyRef.current !== cacheKey) return;
-
       if (data) {
         issueCache.set(cacheKey, data);
+      }
+      return data;
+    })();
+
+    inFlightIssues.set(cacheKey, promise);
+    promise.finally(() => {
+      inFlightIssues.delete(cacheKey);
+    });
+
+    try {
+      const data = await promise;
+      if (!mountedRef.current) return;
+      if (data) {
         setState({ data, loading: false, error: false });
       } else {
         setState({ data: null, loading: false, error: true });
       }
     } catch {
-      if (!mountedRef.current || fetchingKeyRef.current !== cacheKey) return;
+      if (!mountedRef.current) return;
       setState({ data: null, loading: false, error: true });
-    } finally {
-      if (fetchingKeyRef.current === cacheKey) {
-        fetchingKeyRef.current = null;
-      }
     }
   }, [cwd, issueNumber, missingToken]);
 
   const reset = useCallback(() => {
-    if (!fetchingKeyRef.current) {
-      setState({ data: null, loading: false, error: false });
-    }
+    setState({ data: null, loading: false, error: false });
   }, []);
 
   return { ...state, missingToken, fetchTooltip, reset };
 }
+
+const inFlightPRs = new Map<string, Promise<PRTooltipData | null>>();
 
 export function usePRTooltip(cwd: string | undefined, prNumber: number | undefined) {
   const [state, setState] = useState<TooltipState<PRTooltipData>>({
@@ -88,7 +111,6 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
     loading: false,
     error: false,
   });
-  const fetchingKeyRef = useRef<string | null>(null);
   const mountedRef = useRef(true);
   const hasToken = useGitHubConfigStore((s) => s.config?.hasToken);
   const storeInitialized = useGitHubConfigStore((s) => s.isInitialized);
@@ -115,35 +137,55 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
       return;
     }
 
-    if (fetchingKeyRef.current === cacheKey) return;
+    const inFlight = inFlightPRs.get(cacheKey);
+    if (inFlight) {
+      setState((prev) => ({ ...prev, loading: true, error: false }));
+      try {
+        const data = await inFlight;
+        if (!mountedRef.current) return;
+        if (data) {
+          setState({ data, loading: false, error: false });
+        } else {
+          setState({ data: null, loading: false, error: true });
+        }
+      } catch {
+        if (!mountedRef.current) return;
+        setState({ data: null, loading: false, error: true });
+      }
+      return;
+    }
 
-    fetchingKeyRef.current = cacheKey;
     setState((prev) => ({ ...prev, loading: true, error: false }));
 
-    try {
+    const promise = (async () => {
       const data = await window.electron.github.getPRTooltip(cwd, prNumber);
-      if (!mountedRef.current || fetchingKeyRef.current !== cacheKey) return;
-
       if (data) {
         prCache.set(cacheKey, data);
+      }
+      return data;
+    })();
+
+    inFlightPRs.set(cacheKey, promise);
+    promise.finally(() => {
+      inFlightPRs.delete(cacheKey);
+    });
+
+    try {
+      const data = await promise;
+      if (!mountedRef.current) return;
+      if (data) {
         setState({ data, loading: false, error: false });
       } else {
         setState({ data: null, loading: false, error: true });
       }
     } catch {
-      if (!mountedRef.current || fetchingKeyRef.current !== cacheKey) return;
+      if (!mountedRef.current) return;
       setState({ data: null, loading: false, error: true });
-    } finally {
-      if (fetchingKeyRef.current === cacheKey) {
-        fetchingKeyRef.current = null;
-      }
     }
   }, [cwd, prNumber, missingToken]);
 
   const reset = useCallback(() => {
-    if (!fetchingKeyRef.current) {
-      setState({ data: null, loading: false, error: false });
-    }
+    setState({ data: null, loading: false, error: false });
   }, []);
 
   return { ...state, missingToken, fetchTooltip, reset };


### PR DESCRIPTION
## Summary

Every issue or PR hover on the legacy `github.*` path was a cold round-trip to GitHub's GraphQL API, even when the row was already on screen. List queries were parsing `bodyText` from the response but then throwing it away. This prewarms the tooltip cache from data we already have, cuts about half the remaining misses with module-level in-flight dedup, and cleans up a loading flicker that shouldn't fire.

Resolves #9058.

## Changes

- **Tooltip cache prewarming** — `listIssues` and `listPullRequests` now call `prewarmIssueTooltips` / `prewarmPRTooltips` after list queries resolve, projecting `bodyText`, `assignees`, and `labels` into the tooltip cache. Added `issueTooltipWrittenAt` map for write-protection parity with `prTooltipWrittenAt`.
- **Single-flight dedup in main and renderer** — Module-level `inFlightIssueTooltips` / `inFlightPRTooltips` maps in the IPC handlers coalesce concurrent fetches for the same key across windows. Renderer-side `inFlightIssues` / `inFlightPRs` maps (replacing per-hook `fetchingKeyRef`) do the same across hook instances within a window. Cleanup uses `promise.then(success, failure)` instead of `.finally()` to avoid silently swallowing rejected maps.
- **Extended list queries** — `LIST_PRS_QUERY` and `SEARCH_QUERY` now request `assignees(first:10)` and `labels(first:10)` for prewarm parity with `LIST_ISSUES_QUERY`.
- **Doherty gate on tooltip loading** — `IssueBadge` and `PRBadge` wrap the `TooltipLoading` component in `useDohertyGate`, suppressing the loading indicator for sub-400ms cache hits.

## Testing

Manual verification: hover tooltips on the worktree dashboard issue/PR badges. Cold misses still fetch and render; second hover uses the cache. Concurrent hovers from different badge components share one request. Loading state does not flash on fast cache hits.