### PR TITLE
refactor(ui): narrow EmptyState user-cleared scale to sidebar | canvas

### DIFF
--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -53,7 +53,7 @@ export type EmptyStateProps =
    */
   | (EmptyStateCommonProps & {
       variant: "user-cleared";
-      scale: "popover" | "sidebar" | "canvas";
+      scale: "sidebar" | "canvas";
       icon?: ReactNode;
       description?: never;
       action?: never;

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -244,6 +244,13 @@ describe("EmptyState", () => {
       );
       expect(element).toBeTruthy();
     });
+
+    it("accepts sidebar scale on user-cleared", () => {
+      const element = (
+        <EmptyState variant="user-cleared" scale="sidebar" title="You're all caught up" />
+      );
+      expect(element).toBeTruthy();
+    });
   });
 
   describe("accessibility", () => {

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -236,6 +236,14 @@ describe("EmptyState", () => {
       );
       expect(element).toBeTruthy();
     });
+
+    it("rejects popover scale on user-cleared", () => {
+      const element = (
+        // @ts-expect-error user-cleared does not allow popover scale
+        <EmptyState variant="user-cleared" scale="popover" title="You're all caught up" />
+      );
+      expect(element).toBeTruthy();
+    });
   });
 
   describe("accessibility", () => {


### PR DESCRIPTION
## Summary

- Removes \`popover\` from the \`user-cleared\` arm of the \`EmptyState\` scale union — no callers were using it at that scale and it contradicts the design rules for completed-result states
- Leaves the broader \`EmptyStateScale\` type unchanged, since \`zero-data\` and \`filtered-empty\` variants still legitimately use \`popover\` scale
- Adds two test canaries to lock the contract: a negative test confirming \`popover\` is rejected for \`user-cleared\`, and a positive test confirming \`sidebar\` still works

Resolves #8972

## Changes

- `src/components/ui/EmptyState.tsx` — tighten the \`user-cleared\` scale union to \`"sidebar" | "canvas"\`
- `src/components/ui/__tests__/EmptyState.test.tsx` — negative + positive canary tests

## Testing

45 vitest tests in `EmptyState.test.tsx` pass. \`tsc --noEmit\` clean.