### PR TITLE
refactor(fleet): drain TerminalInstance from fleet predicates (#8957 batch A)

### DIFF
--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { broadcastFleetLiteralPaste, executeFleetBroadcast } from "../fleetExecution";
+import {
+  broadcastFleetLiteralPaste,
+  buildFleetTargetPreviews,
+  executeFleetBroadcast,
+} from "../fleetExecution";
 import { FLEET_LARGE_PASTE_BATCH_SIZE } from "../fleetBroadcast";
 import { terminalClient } from "@/clients";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
@@ -558,5 +562,43 @@ describe("executeFleetBroadcast", () => {
       expect(notifyEnterPressedMock).not.toHaveBeenCalled();
       expect(clearDirectingStateMock).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("buildFleetTargetPreviews", () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it("marks non-PTY armed panels as excluded but preserves their title", () => {
+    // Documents #8957 batch A: the carrier surfaces non-PTY kinds via the
+    // PanelInstance union, and `buildFleetTargetPreviews` must drop them
+    // through the eligibility check rather than the prior (panel as TerminalInstance)
+    // cast which silently coerced any shape into the eligible branch.
+    seedPanels([
+      makeAgent("terminal-1"),
+      makeAgent("browser-1", { kind: "browser", title: "Browser pane", hasPty: undefined }),
+    ]);
+    useFleetArmingStore.getState().armIds(["terminal-1", "browser-1"]);
+    const previews = buildFleetTargetPreviews("hi");
+    expect(previews).toHaveLength(2);
+    const terminal = previews.find((p) => p.terminalId === "terminal-1");
+    const browser = previews.find((p) => p.terminalId === "browser-1");
+    expect(terminal?.excluded).toBe(false);
+    expect(browser?.excluded).toBe(true);
+    expect(browser?.title).toBe("Browser pane");
+    expect(browser?.exclusionReason).toBe("Panel no longer eligible");
+  });
+
+  it("falls back to 'Unknown' title when an armed id is no longer in the carrier", () => {
+    // Mirrors the user opening the broadcast preview after a terminal has
+    // been torn down — `panelsById[id]` is undefined, so getNarrowPanel
+    // returns undefined and the preview falls back to a neutral label.
+    seedPanels([makeAgent("alive")]);
+    useFleetArmingStore.getState().armIds(["alive", "ghost"]);
+    const previews = buildFleetTargetPreviews("hi");
+    const ghost = previews.find((p) => p.terminalId === "ghost");
+    expect(ghost?.excluded).toBe(true);
+    expect(ghost?.title).toBe("Unknown");
   });
 });

--- a/src/components/Fleet/fleetExecution.ts
+++ b/src/components/Fleet/fleetExecution.ts
@@ -4,8 +4,8 @@ import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressSt
 import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { isTerminalFleetEligible } from "@/store/fleetEligibility";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
-import type { TerminalInstance } from "@shared/types";
 import {
   buildFleetBroadcastRecipeContext,
   classifyFleetRejectionReason,
@@ -60,8 +60,7 @@ export function buildFleetTargetPreviews(draft: string): FleetTargetPreview[] {
 
   for (const id of armOrder) {
     if (!armedIds.has(id)) continue;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const panel: any = panelsById[id];
+    const panel = getNarrowPanel(panelsById, id);
 
     if (isTerminalFleetEligible(panel)) {
       const ctx = buildFleetBroadcastRecipeContext(id) ?? {};
@@ -70,7 +69,7 @@ export function buildFleetTargetPreviews(draft: string): FleetTargetPreview[] {
 
       previews.push({
         terminalId: id,
-        title: (panel as TerminalInstance).title ?? "Agent",
+        title: panel.title ?? "Agent",
         resolvedPayload: resolved,
         unresolvedVars,
         excluded: false,
@@ -114,7 +113,7 @@ function detectUnresolved(text: string, ctx: RecipeContext): string[] {
  */
 export function filterEligibleIds(ids: string[]): string[] {
   const { panelsById } = usePanelStore.getState();
-  return ids.filter((id) => isTerminalFleetEligible(panelsById[id]));
+  return ids.filter((id) => isTerminalFleetEligible(getNarrowPanel(panelsById, id)));
 }
 
 function resolveVariable(name: string, ctx: RecipeContext): string {

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -22,15 +22,17 @@ import { useProjectStore } from "@/store/projectStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { projectClient, terminalClient } from "@/clients";
 import { broadcastFleetLiteralPaste } from "@/components/Fleet/fleetExecution";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { notify } from "@/lib/notify";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import type { FleetSavedScope, TerminalInstance } from "@shared/types";
+import type { FleetSavedScope } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 interface ArmedSnapshot {
-  terminalTargets: TerminalInstance[];
-  waitingAgentTargets: TerminalInstance[];
-  interruptAgentTargets: TerminalInstance[];
-  restartAgentTargets: TerminalInstance[];
+  terminalTargets: PtyPanelData[];
+  waitingAgentTargets: PtyPanelData[];
+  interruptAgentTargets: PtyPanelData[];
+  restartAgentTargets: PtyPanelData[];
 }
 
 /**
@@ -42,16 +44,16 @@ interface ArmedSnapshot {
  */
 function snapshotArmed(): ArmedSnapshot {
   const armedIds = useFleetArmingStore.getState().armedIds;
-  const terminalTargets: TerminalInstance[] = [];
-  const waitingAgentTargets: TerminalInstance[] = [];
-  const interruptAgentTargets: TerminalInstance[] = [];
-  const restartAgentTargets: TerminalInstance[] = [];
+  const terminalTargets: PtyPanelData[] = [];
+  const waitingAgentTargets: PtyPanelData[] = [];
+  const interruptAgentTargets: PtyPanelData[] = [];
+  const restartAgentTargets: PtyPanelData[] = [];
   if (armedIds.size === 0) {
     return { terminalTargets, waitingAgentTargets, interruptAgentTargets, restartAgentTargets };
   }
   const { panelsById } = usePanelStore.getState();
   for (const id of armedIds) {
-    const t = panelsById[id];
+    const t = getNarrowPanel(panelsById, id);
     if (!isFleetArmEligible(t)) continue;
     terminalTargets.push(t);
     if (isFleetWaitingAgentEligible(t)) waitingAgentTargets.push(t);
@@ -69,11 +71,11 @@ function parseConfirmed(args: unknown): boolean {
   return confirmed === true;
 }
 
-function countSessionLoss(targets: TerminalInstance[]): number {
+function countSessionLoss(targets: PtyPanelData[]): number {
   return targets.filter((t) => Boolean(t.agentSessionId)).length;
 }
 
-function requestConfirmation(kind: FleetPendingActionKind, targets: TerminalInstance[]): void {
+function requestConfirmation(kind: FleetPendingActionKind, targets: PtyPanelData[]): void {
   useFleetPendingActionStore.getState().request({
     kind,
     targetCount: targets.length,
@@ -389,7 +391,7 @@ export function registerFleetActions(actions: ActionRegistry): void {
     run: async () => {
       const focusedId = usePanelStore.getState().focusedId;
       if (!focusedId) return;
-      const terminal = usePanelStore.getState().panelsById[focusedId];
+      const terminal = getNarrowPanel(usePanelStore.getState().panelsById, focusedId);
       if (!isFleetArmEligible(terminal)) return;
       useFleetArmingStore.getState().toggleId(focusedId);
     },
@@ -601,7 +603,7 @@ function applySavedScope(scope: FleetSavedScope): void {
     const validIds: string[] = [];
     const ids = Array.isArray(scope.terminalIds) ? scope.terminalIds : [];
     for (const id of ids) {
-      if (isFleetArmEligible(panelsById[id])) validIds.push(id);
+      if (isFleetArmEligible(getNarrowPanel(panelsById, id))) validIds.push(id);
     }
     fleet.armIds(validIds);
     return;
@@ -629,7 +631,7 @@ export function computeSavedScopePaneCount(scope: FleetSavedScope): number {
     const ids = Array.isArray(scope.terminalIds) ? scope.terminalIds : [];
     let n = 0;
     for (const id of ids) {
-      if (isFleetArmEligible(panelsById[id])) n++;
+      if (isFleetArmEligible(getNarrowPanel(panelsById, id))) n++;
     }
     return n;
   }

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -660,6 +660,18 @@ describe("fleetArmingStore", () => {
         )
       ).toBe(false);
     });
+
+    it("rejects non-PTY panel kinds (browser, dev-preview, review)", () => {
+      // Documents the isPtyPanel guard added in #8957 — the carrier now
+      // surfaces non-PTY panels via the narrowed PanelInstance union, and
+      // fleet predicates must drop them before checking PTY-specific fields.
+      const browser = makeAgentTerminal("a", { kind: "browser", hasPty: undefined });
+      const devPreview = makeAgentTerminal("a", { kind: "dev-preview", hasPty: undefined });
+      const review = makeAgentTerminal("a", { kind: "review", hasPty: undefined });
+      expect(isFleetArmEligible(browser)).toBe(false);
+      expect(isFleetArmEligible(devPreview)).toBe(false);
+      expect(isFleetArmEligible(review)).toBe(false);
+    });
   });
 
   describe("agent Fleet action eligibility", () => {

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -1,7 +1,9 @@
 import { create } from "zustand";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import type { TerminalInstance } from "@shared/types";
+import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
 import type { AgentState } from "@/types";
 import { isAgentFleetActionEligible, isTerminalFleetEligible } from "./fleetEligibility";
 
@@ -67,7 +69,9 @@ function matchesPreset(state: AgentState | null | undefined, preset: FleetArmSta
   }
 }
 
-export function isFleetArmEligible(t: TerminalInstance | undefined): t is TerminalInstance {
+export function isFleetArmEligible(
+  t: PanelInstance | TerminalInstance | undefined
+): t is PtyPanelData {
   return isTerminalFleetEligible(t);
 }
 
@@ -82,7 +86,7 @@ export function collectEligibleIds(
   const state = usePanelStore.getState();
   const ids: string[] = [];
   for (const id of state.panelIds) {
-    const t = state.panelsById[id];
+    const t = getNarrowPanel(state.panelsById, id);
     if (!isFleetArmEligible(t)) continue;
     if (scope === "current") {
       if (!activeWorktreeId || t.worktreeId !== activeWorktreeId) continue;
@@ -105,7 +109,7 @@ export function computeArmByStateIds(
   const state = usePanelStore.getState();
   const ids: string[] = [];
   for (const id of state.panelIds) {
-    const t = state.panelsById[id];
+    const t = getNarrowPanel(state.panelsById, id);
     if (!isAgentFleetActionEligible(t)) continue;
     if (scope === "current") {
       if (!activeWorktreeId || t.worktreeId !== activeWorktreeId) continue;
@@ -134,7 +138,7 @@ export function collectFilterArmEligibleIds(
   const worktreeIdSet = new Set(worktreeIds);
   const ids: string[] = [];
   for (const id of panelIds) {
-    const t = panelsById[id];
+    const t = getNarrowPanel(panelsById, id);
     if (!isFleetArmEligible(t)) continue;
     if (!t.worktreeId || !worktreeIdSet.has(t.worktreeId)) continue;
     ids.push(id);
@@ -225,7 +229,7 @@ export const useFleetArmingStore = create<FleetArmingState>()((set, get) => ({
         if (seenInBatch.has(id)) continue;
         seenInBatch.add(id);
         if (nextArmed.has(id)) continue;
-        if (!isFleetArmEligible(panels[id])) continue;
+        if (!isFleetArmEligible(getNarrowPanel(panels, id))) continue;
         nextArmed.add(id);
         nextOrder.push(id);
         lastAdded = id;
@@ -391,7 +395,7 @@ export function subscribeFleetArmingPanelPruning(): () => void {
 
     const validIds = new Set<string>();
     for (const id of currentIds) {
-      const t = currentById[id];
+      const t = getNarrowPanel(currentById, id);
       if (isFleetArmEligible(t)) validIds.add(id);
     }
 

--- a/src/store/fleetEligibility.ts
+++ b/src/store/fleetEligibility.ts
@@ -1,4 +1,5 @@
 import type { BuiltInAgentId } from "@shared/config/agentIds";
+import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
 import type { TerminalInstance } from "@shared/types";
 import { getBuiltInRuntimeAgentId } from "@/utils/terminalType";
 
@@ -8,8 +9,11 @@ import { getBuiltInRuntimeAgentId } from "@/utils/terminalType";
  * the collapsed dock surface has no room to render the armed/follower visual
  * state that warns a user their keystrokes are being broadcast.
  */
-export function isTerminalFleetEligible(t: TerminalInstance | undefined): t is TerminalInstance {
+export function isTerminalFleetEligible(
+  t: PanelInstance | TerminalInstance | undefined
+): t is PtyPanelData {
   if (!t) return false;
+  if (!isPtyPanel(t)) return false;
   if (t.location === "trash" || t.location === "background" || t.location === "dock") return false;
   if (t.hasPty === false) return false;
   // `runtimeStatus` is the renderer's authoritative liveness signal. `hasPty`
@@ -27,9 +31,10 @@ export function isTerminalFleetEligible(t: TerminalInstance | undefined): t is T
  * gate because their downstream actions assume a live PTY.
  */
 export function isTerminalErrorClusterEligible(
-  t: TerminalInstance | undefined
-): t is TerminalInstance {
+  t: PanelInstance | TerminalInstance | undefined
+): t is PtyPanelData {
   if (!t) return false;
+  if (!isPtyPanel(t)) return false;
   if (t.location === "trash" || t.location === "background" || t.location === "dock") return false;
   if (t.hasPty === false) return false;
   return true;
@@ -42,31 +47,34 @@ export function isTerminalErrorClusterEligible(
  * still require an agent identity because those actions depend on agent state.
  */
 export function resolveFleetAgentCapabilityId(
-  t: TerminalInstance | undefined
+  t: PanelInstance | TerminalInstance | undefined
 ): BuiltInAgentId | undefined {
+  if (!t || !isPtyPanel(t)) return undefined;
   return getBuiltInRuntimeAgentId(t);
 }
 
-export function isAgentFleetActionEligible(t: TerminalInstance | undefined): t is TerminalInstance {
+export function isAgentFleetActionEligible(
+  t: PanelInstance | TerminalInstance | undefined
+): t is PtyPanelData {
   return isTerminalFleetEligible(t) && resolveFleetAgentCapabilityId(t) !== undefined;
 }
 
 export function isFleetWaitingAgentEligible(
-  t: TerminalInstance | undefined
-): t is TerminalInstance {
+  t: PanelInstance | TerminalInstance | undefined
+): t is PtyPanelData {
   return isAgentFleetActionEligible(t) && t.agentState === "waiting";
 }
 
 export function isFleetInterruptAgentEligible(
-  t: TerminalInstance | undefined
-): t is TerminalInstance {
+  t: PanelInstance | TerminalInstance | undefined
+): t is PtyPanelData {
   return (
     isAgentFleetActionEligible(t) && (t.agentState === "working" || t.agentState === "waiting")
   );
 }
 
 export function isFleetRestartAgentEligible(
-  t: TerminalInstance | undefined
-): t is TerminalInstance {
+  t: PanelInstance | TerminalInstance | undefined
+): t is PtyPanelData {
   return isAgentFleetActionEligible(t);
 }


### PR DESCRIPTION
## Summary

Batch A of a multi-PR strangler fig migration tracked by #8957. The goal is to drain `TerminalInstance` out of the renderer store carrier.

This batch covers four fleet files: `fleetEligibility`, `fleetArmingStore`, `fleetExecution`, and `fleetActions`.

Part of #8957

## Changes

- Fleet predicates now accept `PanelInstance | TerminalInstance | undefined` and return a `t is PtyPanelData` type guard
- Each predicate body adds an `isPtyPanel` guard so non-PTY panels are explicitly rejected before any PTY-specific field access
- Carrier reads route through the existing `getNarrowPanel` adapter at `src/store/slices/panelRegistry/selectors.ts`
- Drops the `(panel as TerminalInstance).title` cast and `any` escape hatch in `buildFleetTargetPreviews`
- `ArmedSnapshot` fields and confirmation helpers narrowed to `PtyPanelData[]`
- The carrier flip at `types.ts:72` (`panelsById: Record<string, TerminalInstance>`) is intentionally untouched — that's a later batch

## Testing

- tsc clean
- 115 vitest tests pass across fleet suites (+2 new tests covering the non-PTY and stale-id branches in `buildFleetTargetPreviews`)
- All 8 check scripts pass
- Lint ratchet decreased by 2