### PR TITLE
perf(forge): coalesce forge-bridge GraphQL calls across Electron windows

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1361,
-  "moduleCount": 1361,
+  "count": 1362,
+  "moduleCount": 1362,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -1660,17 +1660,17 @@
     },
     {
       "file": "plugins/builtin/github/main/GitHubRateLimitService.ts",
-      "line": 373,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "plugins/builtin/github/main/GitHubRateLimitService.ts",
-      "line": 374,
+      "line": 377,
       "pattern": "sync-fs"
     },
     {
       "file": "plugins/builtin/github/main/GitHubRateLimitService.ts",
       "line": 378,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "plugins/builtin/github/main/GitHubRateLimitService.ts",
+      "line": 382,
       "pattern": "sync-fs"
     }
   ]

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -616,6 +616,14 @@ class PullRequestService {
     this.boostExpiresAt = null;
     this.clearStagnantPollCounts();
     this.isPolling = false;
+    // Cooperative release so a sibling can poll immediately. Best-effort —
+    // the host's `dispose()` also clears any leases this holder owns, and
+    // the TTL expires within FORGE_POLL_LEASE_TTL_MS regardless.
+    try {
+      getForgeBridge().releasePollLease();
+    } catch {
+      // Bridge not initialized yet (early stop before bootstrap); nothing to release.
+    }
     logInfo("PullRequestService stopped");
   }
 
@@ -1200,6 +1208,19 @@ class PullRequestService {
     const waitMs = this.msUntilCheckAllowed();
     if (waitMs > 0) {
       logDebug("Skipping PR check — within throttle window", { waitMs });
+      return;
+    }
+
+    // Per-project poll lease (#9055): only one workspace-host polls per
+    // cycle when multiple windows watch the same project. Siblings receive
+    // PR updates via the elected host's `sys:pr:detected` / `sys:pr:cleared`
+    // events as they propagate through main → renderer fan-out. Fails open
+    // (returns true) on IPC timeout so a lost lease message can't wedge
+    // polling — `dispatchForgeRpc`'s cross-window singleflight still dedupes
+    // the actual GraphQL calls in that fallback path.
+    const leaseAcquired = await getForgeBridge().acquirePollLease();
+    if (!leaseAcquired) {
+      logDebug("Skipping PR check — sibling window holds poll lease");
       return;
     }
     this.lastCheckAt = Date.now();

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -14,6 +14,11 @@ import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { GitHubAuth } from "./github/GitHubAuth.js";
 import { BrokerError, RequestResponseBroker } from "./rpc/RequestResponseBroker.js";
 import { dispatchForgeRpc } from "./forgeRpcServer.js";
+import {
+  acquirePollLease,
+  releaseAllLeasesForHolder,
+  releasePollLease,
+} from "./forgePollLeaseService.js";
 import { createLogger } from "../utils/logger.js";
 import { mainBootAbsMs, markPerformance } from "../utils/performance.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -319,6 +324,10 @@ export class WorkspaceHostProcess extends EventEmitter {
     if (this.isDisposed) return;
     this.isDisposed = true;
 
+    // Free any forge poll-leases this host held so siblings can take over
+    // immediately rather than waiting up to FORGE_POLL_LEASE_TTL_MS (#9055).
+    releaseAllLeasesForHolder(this.serviceName);
+
     if (this.healthCheckInterval) {
       clearInterval(this.healthCheckInterval);
       this.healthCheckInterval = null;
@@ -542,6 +551,12 @@ export class WorkspaceHostProcess extends EventEmitter {
     this.child.on("exit", (code) => {
       this.flushHostOutputBuffers();
       logWarn(`[WorkspaceHost:${this.serviceName}] Exited with code ${code}`);
+
+      // Crashed host can't send the cooperative release. Free its leases now
+      // so a sibling can take over without waiting for FORGE_POLL_LEASE_TTL_MS
+      // to expire. The same serviceName identifies the restarted host, so
+      // when it re-acquires after `ready`, the lease entry is already gone.
+      releaseAllLeasesForHolder(this.serviceName);
 
       if (this.healthCheckInterval) {
         clearInterval(this.healthCheckInterval);
@@ -850,6 +865,24 @@ export class WorkspaceHostProcess extends EventEmitter {
           },
           (request) => this.send(request)
         );
+        break;
+
+      // Per-project poll-lease arbitration (#9055). The lease key is this
+      // host's `projectPath` and the holder identity is the unique
+      // `serviceName` — both derived in main, never trusted from the
+      // workspace-host's own report.
+      case "forge:poll-lease-acquire": {
+        const acquired = acquirePollLease(this.projectPath, this.serviceName);
+        this.send({
+          type: "forge:poll-lease-result",
+          requestId: event.requestId,
+          acquired,
+        });
+        break;
+      }
+
+      case "forge:poll-lease-release":
+        releasePollLease(this.projectPath, this.serviceName);
         break;
 
       // Spontaneous events - re-emit for the manager to route

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -91,6 +91,11 @@ function makeMockBridge(impl: ForgeProviderImpl) {
     }),
     getRateLimit: vi.fn(async (_id: string) => impl.getRateLimit?.() ?? null),
     handleResult: vi.fn(),
+    // Default to lease-granted so existing tests (single-window assumption)
+    // behave exactly as they did before the cross-window lease landed.
+    acquirePollLease: vi.fn(async () => true),
+    releasePollLease: vi.fn(),
+    handleLeaseResult: vi.fn(),
     dispose: vi.fn(),
   };
 }

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -1077,6 +1077,56 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
+  it("skips checkForPRs when a sibling window holds the poll lease (#9055)", async () => {
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));
+
+    const mockImpl = mockForgeProviderResolved();
+    // Deny the lease — simulates a sibling Electron window already polling
+    // this project. The service must short-circuit without calling ANY forge
+    // provider methods; PR events still propagate from the elected host
+    // through main → renderer fan-out.
+    lastMockBridge!.acquirePollLease.mockResolvedValue(false);
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+    const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.refresh();
+
+    // None of the provider's PR-fetching methods are called when the lease is denied.
+    expect(mockImpl.findPRByBranch).not.toHaveBeenCalled();
+    expect(mockImpl.findPRsByBranches).toBeUndefined();
+    expect(mockImpl.getPR).not.toHaveBeenCalled();
+    expect(mockImpl.getCIStatus).not.toHaveBeenCalled();
+    expect(detected).toHaveLength(0);
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
+  it("releases the poll lease on stop (#9055)", async () => {
+    vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
+    mockForgeProviderResolved();
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+
+    pullRequestService.initialize("/repo");
+    pullRequestService.stop();
+
+    expect(lastMockBridge!.releasePollLease).toHaveBeenCalled();
+
+    pullRequestService.destroy();
+  });
+
   it("skips revalidation when provider reports rate-limited", async () => {
     const clearPRCaches = vi.fn();
     vi.doMock("../GitHubService.js", () => ({ clearPRCaches }));

--- a/electron/services/__tests__/forgePollLeaseService.test.ts
+++ b/electron/services/__tests__/forgePollLeaseService.test.ts
@@ -34,9 +34,9 @@ describe("forgePollLeaseService", () => {
     // expiry is still denied.
     expect(acquirePollLease(PROJECT_A, HOLDER_A, now + 45_000)).toBe(true);
     expect(acquirePollLease(PROJECT_A, HOLDER_B, now + FORGE_POLL_LEASE_TTL_MS + 1)).toBe(false);
-    expect(
-      acquirePollLease(PROJECT_A, HOLDER_B, now + 45_000 + FORGE_POLL_LEASE_TTL_MS + 1)
-    ).toBe(true);
+    expect(acquirePollLease(PROJECT_A, HOLDER_B, now + 45_000 + FORGE_POLL_LEASE_TTL_MS + 1)).toBe(
+      true
+    );
   });
 
   it("scopes leases per project", () => {

--- a/electron/services/__tests__/forgePollLeaseService.test.ts
+++ b/electron/services/__tests__/forgePollLeaseService.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  FORGE_POLL_LEASE_TTL_MS,
+  _resetForgePollLeasesForTests,
+  acquirePollLease,
+  releaseAllLeasesForHolder,
+  releasePollLease,
+} from "../forgePollLeaseService.js";
+
+const PROJECT_A = "/Users/test/projects/canopy";
+const PROJECT_B = "/Users/test/projects/other";
+
+const HOLDER_A = "daintree-workspace-host:canopy-aaaaaaaa";
+const HOLDER_B = "daintree-workspace-host:canopy-bbbbbbbb";
+
+afterEach(() => {
+  _resetForgePollLeasesForTests();
+});
+
+describe("forgePollLeaseService", () => {
+  it("grants the first acquire and denies a different holder until TTL elapses", () => {
+    const now = 1_000_000;
+    expect(acquirePollLease(PROJECT_A, HOLDER_A, now)).toBe(true);
+    expect(acquirePollLease(PROJECT_A, HOLDER_B, now)).toBe(false);
+    expect(acquirePollLease(PROJECT_A, HOLDER_B, now + FORGE_POLL_LEASE_TTL_MS - 1)).toBe(false);
+    expect(acquirePollLease(PROJECT_A, HOLDER_B, now + FORGE_POLL_LEASE_TTL_MS + 1)).toBe(true);
+  });
+
+  it("renews the lease for the same holder before TTL", () => {
+    const now = 1_000_000;
+    expect(acquirePollLease(PROJECT_A, HOLDER_A, now)).toBe(true);
+    // Renew partway through the window — same holder always succeeds and the
+    // deadline slides forward, so a sibling that arrives near the original
+    // expiry is still denied.
+    expect(acquirePollLease(PROJECT_A, HOLDER_A, now + 45_000)).toBe(true);
+    expect(acquirePollLease(PROJECT_A, HOLDER_B, now + FORGE_POLL_LEASE_TTL_MS + 1)).toBe(false);
+    expect(
+      acquirePollLease(PROJECT_A, HOLDER_B, now + 45_000 + FORGE_POLL_LEASE_TTL_MS + 1)
+    ).toBe(true);
+  });
+
+  it("scopes leases per project", () => {
+    const now = 1_000_000;
+    expect(acquirePollLease(PROJECT_A, HOLDER_A, now)).toBe(true);
+    expect(acquirePollLease(PROJECT_B, HOLDER_B, now)).toBe(true);
+    expect(acquirePollLease(PROJECT_B, HOLDER_A, now)).toBe(false);
+    expect(acquirePollLease(PROJECT_A, HOLDER_B, now)).toBe(false);
+  });
+
+  it("release by the holder frees the lease immediately", () => {
+    const now = 1_000_000;
+    expect(acquirePollLease(PROJECT_A, HOLDER_A, now)).toBe(true);
+    releasePollLease(PROJECT_A, HOLDER_A);
+    expect(acquirePollLease(PROJECT_A, HOLDER_B, now)).toBe(true);
+  });
+
+  it("release by a non-holder is a no-op", () => {
+    const now = 1_000_000;
+    expect(acquirePollLease(PROJECT_A, HOLDER_A, now)).toBe(true);
+    releasePollLease(PROJECT_A, HOLDER_B);
+    // Holder A still owns it, so B is still denied.
+    expect(acquirePollLease(PROJECT_A, HOLDER_B, now)).toBe(false);
+  });
+
+  it("releaseAllLeasesForHolder drops every lease that holder owns", () => {
+    const now = 1_000_000;
+    expect(acquirePollLease(PROJECT_A, HOLDER_A, now)).toBe(true);
+    expect(acquirePollLease(PROJECT_B, HOLDER_A, now)).toBe(true);
+
+    releaseAllLeasesForHolder(HOLDER_A);
+
+    expect(acquirePollLease(PROJECT_A, HOLDER_B, now)).toBe(true);
+    expect(acquirePollLease(PROJECT_B, HOLDER_B, now)).toBe(true);
+  });
+
+  it("releaseAllLeasesForHolder leaves other holders' leases intact", () => {
+    const now = 1_000_000;
+    expect(acquirePollLease(PROJECT_A, HOLDER_A, now)).toBe(true);
+    expect(acquirePollLease(PROJECT_B, HOLDER_B, now)).toBe(true);
+
+    releaseAllLeasesForHolder(HOLDER_A);
+
+    // Holder B's lease on PROJECT_B still holds; a third holder is denied.
+    expect(acquirePollLease(PROJECT_B, "other-holder", now)).toBe(false);
+  });
+});

--- a/electron/services/__tests__/forgePollLeaseService.test.ts
+++ b/electron/services/__tests__/forgePollLeaseService.test.ts
@@ -83,4 +83,25 @@ describe("forgePollLeaseService", () => {
     // Holder B's lease on PROJECT_B still holds; a third holder is denied.
     expect(acquirePollLease(PROJECT_B, "other-holder", now)).toBe(false);
   });
+
+  it("treats exact-TTL expiry as expired (strict > on expiresAt)", () => {
+    const now = 1_000_000;
+    expect(acquirePollLease(PROJECT_A, HOLDER_A, now)).toBe(true);
+    // At now + TTL exactly, expiresAt === now, which is NOT strictly greater
+    // than now. Another holder wins.
+    expect(acquirePollLease(PROJECT_A, HOLDER_B, now + FORGE_POLL_LEASE_TTL_MS)).toBe(true);
+  });
+
+  it("ignores a stale release from a preempted prior holder", () => {
+    const now = 1_000_000;
+    expect(acquirePollLease(PROJECT_A, HOLDER_A, now)).toBe(true);
+    // Holder A's lease times out; holder B takes over.
+    const afterExpiry = now + FORGE_POLL_LEASE_TTL_MS + 1;
+    expect(acquirePollLease(PROJECT_A, HOLDER_B, afterExpiry)).toBe(true);
+
+    // A late release from holder A (e.g. delayed cooperative release event)
+    // must not free holder B's fresh lease.
+    releasePollLease(PROJECT_A, HOLDER_A);
+    expect(acquirePollLease(PROJECT_A, "third-holder", afterExpiry)).toBe(false);
+  });
 });

--- a/electron/services/__tests__/forgeRpcServer.test.ts
+++ b/electron/services/__tests__/forgeRpcServer.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetForgeRpcInFlightForTests, dispatchForgeRpc } from "../forgeRpcServer.js";
+import {
+  clearForgeProviderImplRegistry,
+  registerForgeProviderImpl,
+} from "../forgeProviderRegistry.js";
+import type { ForgeProviderImpl, PR, RepoRef } from "../../../shared/types/forge.js";
+import type { WorkspaceHostRequest } from "../../../shared/types/workspace-host.js";
+
+const PLUGIN_ID = "test-plugin";
+const CONTRIBUTION_ID = "github";
+const NAMESPACED_ID = `${PLUGIN_ID}.${CONTRIBUTION_ID}`;
+
+const repo: RepoRef = { host: "github.com", owner: "owner", repo: "repo", rawData: null };
+
+type ForgeRpcResult = Extract<WorkspaceHostRequest, { type: "forge:rpc-result" }>;
+
+function captureSender(): {
+  send: (request: WorkspaceHostRequest) => boolean;
+  sent: ForgeRpcResult[];
+} {
+  const sent: ForgeRpcResult[] = [];
+  const send = (request: WorkspaceHostRequest): boolean => {
+    if (request.type === "forge:rpc-result") {
+      sent.push(request);
+    }
+    return true;
+  };
+  return { send, sent };
+}
+
+function makeImpl(overrides: Partial<ForgeProviderImpl> = {}): ForgeProviderImpl {
+  return {
+    id: NAMESPACED_ID,
+    name: "Test Provider",
+    matchHostnames: () => ["github.com"],
+    parseRemote: () => repo,
+    findPRByBranch: async () => null,
+    getPR: async () => null,
+    getIssue: async () => null,
+    getCIStatus: async () => null,
+    ...overrides,
+  } as ForgeProviderImpl;
+}
+
+beforeEach(() => {
+  _resetForgeRpcInFlightForTests();
+  clearForgeProviderImplRegistry();
+});
+
+afterEach(() => {
+  _resetForgeRpcInFlightForTests();
+  clearForgeProviderImplRegistry();
+});
+
+describe("dispatchForgeRpc cross-window singleflight", () => {
+  it("coalesces concurrent identical requests from different senders into one provider call", async () => {
+    const getPR = vi.fn(async (): Promise<PR | null> => {
+      // Deliberately yield so the second dispatch can join while the first is in-flight.
+      await new Promise((r) => setTimeout(r, 0));
+      return { number: 42, title: "test", url: "u", state: "open", providerId: NAMESPACED_ID } as PR;
+    });
+    registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl({ getPR }));
+
+    const a = captureSender();
+    const b = captureSender();
+
+    const pA = dispatchForgeRpc(
+      { forgeRequestId: "req-a", method: "getPR", namespacedId: NAMESPACED_ID, args: [repo, 42] },
+      a.send
+    );
+    const pB = dispatchForgeRpc(
+      { forgeRequestId: "req-b", method: "getPR", namespacedId: NAMESPACED_ID, args: [repo, 42] },
+      b.send
+    );
+
+    await Promise.all([pA, pB]);
+
+    expect(getPR).toHaveBeenCalledTimes(1);
+    expect(a.sent).toHaveLength(1);
+    expect(b.sent).toHaveLength(1);
+    expect(a.sent[0]).toMatchObject({ forgeRequestId: "req-a", ok: true });
+    expect(b.sent[0]).toMatchObject({ forgeRequestId: "req-b", ok: true });
+    if (a.sent[0].ok) expect((a.sent[0].value as PR).number).toBe(42);
+    if (b.sent[0].ok) expect((b.sent[0].value as PR).number).toBe(42);
+  });
+
+  it("differing args produce independent upstream calls", async () => {
+    const getPR = vi.fn(async (_: RepoRef, n: number) => ({
+      number: n,
+      title: "t",
+      url: "u",
+      state: "open" as const,
+      providerId: NAMESPACED_ID,
+    }));
+    registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl({ getPR }));
+
+    const { send } = captureSender();
+    await Promise.all([
+      dispatchForgeRpc(
+        { forgeRequestId: "req-1", method: "getPR", namespacedId: NAMESPACED_ID, args: [repo, 1] },
+        send
+      ),
+      dispatchForgeRpc(
+        { forgeRequestId: "req-2", method: "getPR", namespacedId: NAMESPACED_ID, args: [repo, 2] },
+        send
+      ),
+    ]);
+
+    expect(getPR).toHaveBeenCalledTimes(2);
+  });
+
+  it("differing namespacedId produces independent upstream calls", async () => {
+    const implA = makeImpl({ getPR: vi.fn(async () => null) });
+    const implB = makeImpl({ getPR: vi.fn(async () => null) });
+    registerForgeProviderImpl(PLUGIN_ID, "provider-a", implA);
+    registerForgeProviderImpl(PLUGIN_ID, "provider-b", implB);
+
+    const { send } = captureSender();
+    await Promise.all([
+      dispatchForgeRpc(
+        { forgeRequestId: "r1", method: "getPR", namespacedId: `${PLUGIN_ID}.provider-a`, args: [repo, 1] },
+        send
+      ),
+      dispatchForgeRpc(
+        { forgeRequestId: "r2", method: "getPR", namespacedId: `${PLUGIN_ID}.provider-b`, args: [repo, 1] },
+        send
+      ),
+    ]);
+
+    expect(implA.getPR).toHaveBeenCalledTimes(1);
+    expect(implB.getPR).toHaveBeenCalledTimes(1);
+  });
+
+  it("argument key order does not matter (safe-stable-stringify)", async () => {
+    // resolveProvider takes an options object whose property order can vary
+    // between callers; ensure the singleflight key is stable.
+    const findPRByBranch = vi.fn(async () => null);
+    registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl({ findPRByBranch }));
+
+    const repoA: RepoRef = { host: "github.com", owner: "o", repo: "r", rawData: null };
+    const repoB: RepoRef = { rawData: null, repo: "r", owner: "o", host: "github.com" };
+
+    const { send } = captureSender();
+    await Promise.all([
+      dispatchForgeRpc(
+        { forgeRequestId: "r1", method: "findPRByBranch", namespacedId: NAMESPACED_ID, args: [repoA, "main"] },
+        send
+      ),
+      dispatchForgeRpc(
+        { forgeRequestId: "r2", method: "findPRByBranch", namespacedId: NAMESPACED_ID, args: [repoB, "main"] },
+        send
+      ),
+    ]);
+
+    expect(findPRByBranch).toHaveBeenCalledTimes(1);
+  });
+
+  it("provider rejection fans the error to every waiter and evicts the key", async () => {
+    const getPR = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ number: 1, title: "t", url: "u", state: "open", providerId: NAMESPACED_ID });
+    registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl({ getPR }));
+
+    const a = captureSender();
+    const b = captureSender();
+
+    await Promise.all([
+      dispatchForgeRpc(
+        { forgeRequestId: "r1", method: "getPR", namespacedId: NAMESPACED_ID, args: [repo, 1] },
+        a.send
+      ),
+      dispatchForgeRpc(
+        { forgeRequestId: "r2", method: "getPR", namespacedId: NAMESPACED_ID, args: [repo, 1] },
+        b.send
+      ),
+    ]);
+
+    expect(a.sent[0]).toMatchObject({ forgeRequestId: "r1", ok: false });
+    expect(b.sent[0]).toMatchObject({ forgeRequestId: "r2", ok: false });
+    if (!a.sent[0].ok) expect(a.sent[0].error).toContain("boom");
+    if (!b.sent[0].ok) expect(b.sent[0].error).toContain("boom");
+
+    // A follow-up call with the same key should hit the provider again,
+    // not stay parked behind the failed entry.
+    const c = captureSender();
+    await dispatchForgeRpc(
+      { forgeRequestId: "r3", method: "getPR", namespacedId: NAMESPACED_ID, args: [repo, 1] },
+      c.send
+    );
+    expect(getPR).toHaveBeenCalledTimes(2);
+    expect(c.sent[0]).toMatchObject({ forgeRequestId: "r3", ok: true });
+  });
+
+  it("sequential identical calls do not coalesce (entry evicted on settlement)", async () => {
+    const getPR = vi.fn(async () => null);
+    registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl({ getPR }));
+    const { send } = captureSender();
+
+    await dispatchForgeRpc(
+      { forgeRequestId: "r1", method: "getPR", namespacedId: NAMESPACED_ID, args: [repo, 1] },
+      send
+    );
+    await dispatchForgeRpc(
+      { forgeRequestId: "r2", method: "getPR", namespacedId: NAMESPACED_ID, args: [repo, 1] },
+      send
+    );
+    expect(getPR).toHaveBeenCalledTimes(2);
+  });
+
+  it("waiter whose sender returns false receives an explicit error envelope", async () => {
+    const getPR = vi.fn(async () => ({
+      number: 1,
+      title: "t",
+      url: "u",
+      state: "open" as const,
+      providerId: NAMESPACED_ID,
+    }));
+    registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl({ getPR }));
+
+    const sent: ForgeRpcResult[] = [];
+    let firstCall = true;
+    const send = (request: WorkspaceHostRequest): boolean => {
+      if (request.type === "forge:rpc-result") {
+        sent.push(request);
+        // First send returns false to simulate a non-cloneable result or
+        // child-gone failure; the fan-out should follow up with an error
+        // envelope so the waiter doesn't hang.
+        if (firstCall) {
+          firstCall = false;
+          return false;
+        }
+      }
+      return true;
+    };
+
+    await dispatchForgeRpc(
+      { forgeRequestId: "r1", method: "getPR", namespacedId: NAMESPACED_ID, args: [repo, 1] },
+      send
+    );
+
+    expect(sent).toHaveLength(2);
+    expect(sent[0]).toMatchObject({ forgeRequestId: "r1", ok: true });
+    expect(sent[1]).toMatchObject({ forgeRequestId: "r1", ok: false });
+    if (!sent[1].ok) {
+      expect(sent[1].error).toContain("could not be delivered");
+    }
+  });
+});

--- a/electron/services/__tests__/forgeRpcServer.test.ts
+++ b/electron/services/__tests__/forgeRpcServer.test.ts
@@ -13,6 +13,25 @@ const NAMESPACED_ID = `${PLUGIN_ID}.${CONTRIBUTION_ID}`;
 
 const repo: RepoRef = { host: "github.com", owner: "owner", repo: "repo", rawData: null };
 
+function makePR(overrides: Partial<PR> = {}): PR {
+  return {
+    number: 42,
+    title: "test",
+    body: "",
+    state: "open",
+    rawState: "OPEN",
+    isDraft: false,
+    merged: false,
+    url: "u",
+    baseRef: "main",
+    headRef: "feature",
+    createdAt: 0,
+    updatedAt: 0,
+    rawData: null,
+    ...overrides,
+  };
+}
+
 type ForgeRpcResult = Extract<WorkspaceHostRequest, { type: "forge:rpc-result" }>;
 
 function captureSender(): {
@@ -58,7 +77,7 @@ describe("dispatchForgeRpc cross-window singleflight", () => {
     const getPR = vi.fn(async (): Promise<PR | null> => {
       // Deliberately yield so the second dispatch can join while the first is in-flight.
       await new Promise((r) => setTimeout(r, 0));
-      return { number: 42, title: "test", url: "u", state: "open", providerId: NAMESPACED_ID } as PR;
+      return makePR({ number: 42 });
     });
     registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl({ getPR }));
 
@@ -86,13 +105,7 @@ describe("dispatchForgeRpc cross-window singleflight", () => {
   });
 
   it("differing args produce independent upstream calls", async () => {
-    const getPR = vi.fn(async (_: RepoRef, n: number) => ({
-      number: n,
-      title: "t",
-      url: "u",
-      state: "open" as const,
-      providerId: NAMESPACED_ID,
-    }));
+    const getPR = vi.fn(async (_: RepoRef, n: number) => makePR({ number: n }));
     registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl({ getPR }));
 
     const { send } = captureSender();
@@ -119,11 +132,21 @@ describe("dispatchForgeRpc cross-window singleflight", () => {
     const { send } = captureSender();
     await Promise.all([
       dispatchForgeRpc(
-        { forgeRequestId: "r1", method: "getPR", namespacedId: `${PLUGIN_ID}.provider-a`, args: [repo, 1] },
+        {
+          forgeRequestId: "r1",
+          method: "getPR",
+          namespacedId: `${PLUGIN_ID}.provider-a`,
+          args: [repo, 1],
+        },
         send
       ),
       dispatchForgeRpc(
-        { forgeRequestId: "r2", method: "getPR", namespacedId: `${PLUGIN_ID}.provider-b`, args: [repo, 1] },
+        {
+          forgeRequestId: "r2",
+          method: "getPR",
+          namespacedId: `${PLUGIN_ID}.provider-b`,
+          args: [repo, 1],
+        },
         send
       ),
     ]);
@@ -144,11 +167,21 @@ describe("dispatchForgeRpc cross-window singleflight", () => {
     const { send } = captureSender();
     await Promise.all([
       dispatchForgeRpc(
-        { forgeRequestId: "r1", method: "findPRByBranch", namespacedId: NAMESPACED_ID, args: [repoA, "main"] },
+        {
+          forgeRequestId: "r1",
+          method: "findPRByBranch",
+          namespacedId: NAMESPACED_ID,
+          args: [repoA, "main"],
+        },
         send
       ),
       dispatchForgeRpc(
-        { forgeRequestId: "r2", method: "findPRByBranch", namespacedId: NAMESPACED_ID, args: [repoB, "main"] },
+        {
+          forgeRequestId: "r2",
+          method: "findPRByBranch",
+          namespacedId: NAMESPACED_ID,
+          args: [repoB, "main"],
+        },
         send
       ),
     ]);
@@ -160,7 +193,7 @@ describe("dispatchForgeRpc cross-window singleflight", () => {
     const getPR = vi
       .fn()
       .mockRejectedValueOnce(new Error("boom"))
-      .mockResolvedValueOnce({ number: 1, title: "t", url: "u", state: "open", providerId: NAMESPACED_ID });
+      .mockResolvedValueOnce(makePR({ number: 1 }));
     registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl({ getPR }));
 
     const a = captureSender();
@@ -210,13 +243,7 @@ describe("dispatchForgeRpc cross-window singleflight", () => {
   });
 
   it("waiter whose sender returns false receives an explicit error envelope", async () => {
-    const getPR = vi.fn(async () => ({
-      number: 1,
-      title: "t",
-      url: "u",
-      state: "open" as const,
-      providerId: NAMESPACED_ID,
-    }));
+    const getPR = vi.fn(async () => makePR({ number: 1 }));
     registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl({ getPR }));
 
     const sent: ForgeRpcResult[] = [];

--- a/electron/services/forgePollLeaseService.ts
+++ b/electron/services/forgePollLeaseService.ts
@@ -1,0 +1,84 @@
+import { generateProjectId } from "./projectStorePaths.js";
+
+/**
+ * Per-project poll-lease service. One workspace-host per project is elected as
+ * the active poller; siblings short-circuit `checkForPRs()` and rely on the
+ * shared PR events the elected host emits through the existing main → renderer
+ * fan-out. This is Layer 2 of the cross-window dedup pair (#9055): Layer 1 is
+ * the singleflight at `forgeRpcServer.dispatchForgeRpc` that collapses any
+ * concurrent identical RPC calls that still cross the boundary.
+ *
+ * The lease lives in the main process — the workspace-host UtilityProcess
+ * can't share state with peers, and we deliberately don't run it on a renderer
+ * because `electron-store` is main-only (#8316).
+ */
+
+// TTL is the safety net for a crashed or wedged holder: the next poll attempt
+// from any peer will acquire after this elapses. 90s = 3× FOCUSED_POLL_INTERVAL_MS
+// (the workspace-host's active poll cadence). A healthy holder renews every 30s
+// so the lease never expires under it; a holder that misses three polls in a
+// row is presumed dead and a sibling takes over. Static, not wired to
+// ResourceProfileService — the forge layer must not cross subsystem boundaries
+// for resource tuning (#4629).
+export const FORGE_POLL_LEASE_TTL_MS = 90_000;
+
+interface PollLease {
+  holderId: string;
+  expiresAt: number;
+}
+
+const leases = new Map<string, PollLease>();
+
+/**
+ * Try to acquire (or renew) the lease for `projectPath`. Returns `true` when
+ * the caller now holds the lease, `false` when a different live holder owns
+ * it. The current holder always succeeds in renewing — that's the happy-path
+ * branch for the elected workspace-host's regular poll cycle.
+ *
+ * `now` is injectable for tests; defaults to `Date.now()`.
+ */
+export function acquirePollLease(
+  projectPath: string,
+  holderId: string,
+  now: number = Date.now()
+): boolean {
+  const key = generateProjectId(projectPath);
+  const existing = leases.get(key);
+  if (existing && existing.holderId !== holderId && existing.expiresAt > now) {
+    return false;
+  }
+  leases.set(key, { holderId, expiresAt: now + FORGE_POLL_LEASE_TTL_MS });
+  return true;
+}
+
+/**
+ * Release the lease only if held by `holderId`. A no-op when the lease has
+ * already expired, been preempted, or never existed — so a stale release from
+ * a host that just lost the lease never frees a sibling's fresh acquisition.
+ */
+export function releasePollLease(projectPath: string, holderId: string): void {
+  const key = generateProjectId(projectPath);
+  const existing = leases.get(key);
+  if (existing && existing.holderId === holderId) {
+    leases.delete(key);
+  }
+}
+
+/**
+ * Drop every lease this holder owns. Called from `WorkspaceHostProcess.dispose`
+ * so a closing window's leases are immediately reclaimable by siblings
+ * regardless of whether the cooperative release event landed. A crashed host
+ * gets the same treatment via the exit handler.
+ */
+export function releaseAllLeasesForHolder(holderId: string): void {
+  for (const [key, lease] of leases) {
+    if (lease.holderId === holderId) {
+      leases.delete(key);
+    }
+  }
+}
+
+/** Test-only reset. */
+export function _resetForgePollLeasesForTests(): void {
+  leases.clear();
+}

--- a/electron/services/forgeRpcServer.ts
+++ b/electron/services/forgeRpcServer.ts
@@ -1,3 +1,4 @@
+import { configure } from "safe-stable-stringify";
 import type {
   ForgeRpcMethod,
   ForgeResolveProviderResult,
@@ -16,6 +17,14 @@ import { getForgeProviderImpl } from "./forgeProviderRegistry.js";
 import { resolveForgeProvider } from "./forgeProviderResolver.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
+// Deterministic stringify so two windows calling the same method with the same
+// arg shape coalesce regardless of property order. Mirrors the bridge-side
+// singleflight key in `forgeBridge.ts`. NOTE: `Map`/`Set` instances serialize
+// as `{}` here and would silently collide — all current `ForgeRpcMethod` args
+// are `RepoRef`, primitives, or arrays-of-primitives, so this is safe today.
+// If a future method adds a Map/Set arg, key it explicitly before stringify.
+const stringifyArgs = configure({ bigint: false });
+
 /**
  * Incoming `forge:rpc` event shape (workspace-host → main). Defined locally as
  * a structural type so this server stays decoupled from the full
@@ -31,6 +40,65 @@ export interface ForgeRpcRequest {
 
 type Sender = (request: WorkspaceHostRequest) => boolean;
 
+interface Waiter {
+  sender: Sender;
+  forgeRequestId: string;
+  method: ForgeRpcMethod;
+}
+
+interface InFlightEntry {
+  promise: Promise<void>;
+  waiters: Waiter[];
+}
+
+// Cross-window singleflight. Each Electron window forks its own workspace-host
+// UtilityProcess; before this map, N windows watching the same project meant
+// N identical GraphQL calls per poll. The bridge-side singleflight in
+// `forgeBridge.ts` only dedupes within a single host. This map sits at the
+// boundary main owns and absorbs the cross-host fan-in: identical concurrent
+// requests join a single in-flight provider call and the result is delivered
+// to every waiter. See #9055.
+//
+// Evicted on settlement (success or error) so retries proceed immediately —
+// no TTL caching here; the GitHub response cache in `forgeProvider.runQuery`
+// already handles staggered repeats.
+const inFlight = new Map<string, InFlightEntry>();
+
+function buildSingleflightKey(req: ForgeRpcRequest): string {
+  return `${req.method}\0${req.namespacedId ?? ""}\0${stringifyArgs(req.args) ?? ""}`;
+}
+
+function deliverResult(waiter: Waiter, value: unknown): void {
+  const sent = waiter.sender({
+    type: "forge:rpc-result",
+    forgeRequestId: waiter.forgeRequestId,
+    ok: true,
+    value,
+  });
+  if (!sent) {
+    // `child.postMessage` either threw (non-cloneable result, e.g. a
+    // third-party provider whose `rawData` contains functions or proxies)
+    // or the child has already exited. Either way, the workspace-host
+    // would otherwise hang on the 30s bridge timeout. Send an error
+    // envelope so the bridge fails fast.
+    waiter.sender({
+      type: "forge:rpc-result",
+      forgeRequestId: waiter.forgeRequestId,
+      ok: false,
+      error: `Forge RPC ${waiter.method} result could not be delivered (non-cloneable or child gone)`,
+    });
+  }
+}
+
+function deliverError(waiter: Waiter, error: unknown): void {
+  waiter.sender({
+    type: "forge:rpc-result",
+    forgeRequestId: waiter.forgeRequestId,
+    ok: false,
+    error: formatErrorMessage(error, `Forge RPC ${waiter.method} failed`),
+  });
+}
+
 /**
  * Dispatch a forge RPC call from the workspace-host against the local
  * forge provider registry, then send the result back via `sender`. Errors
@@ -41,37 +109,46 @@ type Sender = (request: WorkspaceHostRequest) => boolean;
  * This is the single point where the workspace-host crosses the process
  * boundary into the forge layer. Plugin authors do not need to know it
  * exists — their impls run in main as usual; the bridge is transparent.
+ *
+ * Concurrent identical requests across any number of workspace-hosts share
+ * one upstream provider call: the first request initiates `invoke()`; any
+ * matching request that arrives while it is in-flight is registered as a
+ * waiter, and the eventual result (or error) is delivered to every waiter
+ * with each one's own `forgeRequestId`. See `inFlight` above.
  */
-export async function dispatchForgeRpc(req: ForgeRpcRequest, sender: Sender): Promise<void> {
-  try {
-    const value = await invoke(req);
-    const sent = sender({
-      type: "forge:rpc-result",
-      forgeRequestId: req.forgeRequestId,
-      ok: true,
-      value,
-    });
-    if (!sent) {
-      // `child.postMessage` either threw (non-cloneable result, e.g. a
-      // third-party provider whose `rawData` contains functions or proxies)
-      // or the child has already exited. Either way, the workspace-host
-      // would otherwise hang on the 30s bridge timeout. Send an error
-      // envelope so the bridge fails fast.
-      sender({
-        type: "forge:rpc-result",
-        forgeRequestId: req.forgeRequestId,
-        ok: false,
-        error: `Forge RPC ${req.method} result could not be delivered (non-cloneable or child gone)`,
-      });
-    }
-  } catch (error) {
-    sender({
-      type: "forge:rpc-result",
-      forgeRequestId: req.forgeRequestId,
-      ok: false,
-      error: formatErrorMessage(error, `Forge RPC ${req.method} failed`),
-    });
+export function dispatchForgeRpc(req: ForgeRpcRequest, sender: Sender): Promise<void> {
+  const key = buildSingleflightKey(req);
+  const waiter: Waiter = {
+    sender,
+    forgeRequestId: req.forgeRequestId,
+    method: req.method,
+  };
+
+  const existing = inFlight.get(key);
+  if (existing) {
+    existing.waiters.push(waiter);
+    return existing.promise;
   }
+
+  const waiters: Waiter[] = [waiter];
+  const promise = (async () => {
+    try {
+      const value = await invoke(req);
+      for (const w of waiters) deliverResult(w, value);
+    } catch (error) {
+      for (const w of waiters) deliverError(w, error);
+    } finally {
+      inFlight.delete(key);
+    }
+  })();
+
+  inFlight.set(key, { promise, waiters });
+  return promise;
+}
+
+/** Test-only reset. */
+export function _resetForgeRpcInFlightForTests(): void {
+  inFlight.clear();
 }
 
 async function invoke(req: ForgeRpcRequest): Promise<unknown> {

--- a/electron/services/forgeRpcServer.ts
+++ b/electron/services/forgeRpcServer.ts
@@ -144,7 +144,10 @@ export function dispatchForgeRpc(req: ForgeRpcRequest, sender: Sender): Promise<
     try {
       const timeout = new Promise<never>((_, reject) => {
         timer = setTimeout(
-          () => reject(new Error(`Forge RPC ${req.method} timed out after ${FORGE_INVOKE_TIMEOUT_MS}ms`)),
+          () =>
+            reject(
+              new Error(`Forge RPC ${req.method} timed out after ${FORGE_INVOKE_TIMEOUT_MS}ms`)
+            ),
           FORGE_INVOKE_TIMEOUT_MS
         );
         timer.unref?.();

--- a/electron/services/forgeRpcServer.ts
+++ b/electron/services/forgeRpcServer.ts
@@ -64,6 +64,14 @@ interface InFlightEntry {
 // already handles staggered repeats.
 const inFlight = new Map<string, InFlightEntry>();
 
+// Hard ceiling on a single in-flight provider call. The bridge's per-caller
+// timeout is 30s; this sits just beyond it so a hung third-party provider
+// (no internal timeout, no abort signal) can't wedge the singleflight entry
+// forever and leak waiters as new identical requests join the dead promise.
+// The built-in GitHub provider's own 15s AbortSignal.timeout settles long
+// before this; only misbehaving plugins ever reach it.
+const FORGE_INVOKE_TIMEOUT_MS = 35_000;
+
 function buildSingleflightKey(req: ForgeRpcRequest): string {
   return `${req.method}\0${req.namespacedId ?? ""}\0${stringifyArgs(req.args) ?? ""}`;
 }
@@ -132,12 +140,21 @@ export function dispatchForgeRpc(req: ForgeRpcRequest, sender: Sender): Promise<
 
   const waiters: Waiter[] = [waiter];
   const promise = (async () => {
+    let timer: NodeJS.Timeout | undefined;
     try {
-      const value = await invoke(req);
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Forge RPC ${req.method} timed out after ${FORGE_INVOKE_TIMEOUT_MS}ms`)),
+          FORGE_INVOKE_TIMEOUT_MS
+        );
+        timer.unref?.();
+      });
+      const value = await Promise.race([invoke(req), timeout]);
       for (const w of waiters) deliverResult(w, value);
     } catch (error) {
       for (const w of waiters) deliverError(w, error);
     } finally {
+      if (timer !== undefined) clearTimeout(timer);
       inFlight.delete(key);
     }
   })();

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -761,6 +761,12 @@ port.on("message", async (rawMsg: any) => {
         forgeBridge.handleResult(request);
         break;
 
+      // Inbound poll-lease decision from main (#9055). Routes to the pending
+      // `acquirePollLease()` promise keyed by `requestId`.
+      case "forge:poll-lease-result":
+        forgeBridge.handleLeaseResult(request);
+        break;
+
       default:
         console.warn("[WorkspaceHost] Unknown message type:", (request as any).type);
     }

--- a/electron/workspace-host/__tests__/forgeBridge.test.ts
+++ b/electron/workspace-host/__tests__/forgeBridge.test.ts
@@ -166,8 +166,9 @@ describe("ForgeBridge poll-lease IPC (#9055)", () => {
       vi.advanceTimersByTime(5_001);
       await expect(p).resolves.toBe(true);
       // Now-stale result must not throw or resolve a second time.
-      expect(() => bridge.handleLeaseResult({ requestId: acquire.requestId, acquired: false }))
-        .not.toThrow();
+      expect(() =>
+        bridge.handleLeaseResult({ requestId: acquire.requestId, acquired: false })
+      ).not.toThrow();
     } finally {
       vi.useRealTimers();
     }

--- a/electron/workspace-host/__tests__/forgeBridge.test.ts
+++ b/electron/workspace-host/__tests__/forgeBridge.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ForgeBridge } from "../forgeBridge.js";
 import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js";
 import type { RepoRef } from "../../../shared/types/forge.js";
@@ -6,9 +6,19 @@ import type { RepoRef } from "../../../shared/types/forge.js";
 const repo: RepoRef = { host: "github.com", owner: "owner", repo: "repo", rawData: null };
 
 type ForgeRpcEvent = Extract<WorkspaceHostEvent, { type: "forge:rpc" }>;
+type LeaseAcquireEvent = Extract<WorkspaceHostEvent, { type: "forge:poll-lease-acquire" }>;
+type LeaseReleaseEvent = Extract<WorkspaceHostEvent, { type: "forge:poll-lease-release" }>;
 
 function isForgeRpc(event: WorkspaceHostEvent): event is ForgeRpcEvent {
   return event.type === "forge:rpc";
+}
+
+function isLeaseAcquire(event: WorkspaceHostEvent): event is LeaseAcquireEvent {
+  return event.type === "forge:poll-lease-acquire";
+}
+
+function isLeaseRelease(event: WorkspaceHostEvent): event is LeaseReleaseEvent {
+  return event.type === "forge:poll-lease-release";
 }
 
 describe("ForgeBridge in-flight dedup", () => {
@@ -100,5 +110,85 @@ describe("ForgeBridge in-flight dedup", () => {
 
     await expect(a).rejects.toThrow(/disposed/);
     await expect(b).rejects.toThrow(/disposed/);
+  });
+});
+
+describe("ForgeBridge poll-lease IPC (#9055)", () => {
+  let events: WorkspaceHostEvent[];
+  let bridge: ForgeBridge;
+
+  beforeEach(() => {
+    events = [];
+    bridge = new ForgeBridge((event) => {
+      events.push(event);
+    });
+  });
+
+  afterEach(() => {
+    bridge.dispose();
+  });
+
+  it("sends forge:poll-lease-acquire and resolves to acquired=true on a granted result", async () => {
+    const p = bridge.acquirePollLease();
+
+    const acquire = events.find(isLeaseAcquire);
+    expect(acquire).toBeDefined();
+    expect(acquire?.requestId).toMatch(/^lease-/);
+
+    bridge.handleLeaseResult({ requestId: acquire!.requestId, acquired: true });
+    await expect(p).resolves.toBe(true);
+  });
+
+  it("resolves to acquired=false on a denied result", async () => {
+    const p = bridge.acquirePollLease();
+    const acquire = events.find(isLeaseAcquire)!;
+    bridge.handleLeaseResult({ requestId: acquire.requestId, acquired: false });
+    await expect(p).resolves.toBe(false);
+  });
+
+  it("fails open (resolves true) when the result never arrives within the timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const p = bridge.acquirePollLease();
+      // Drive past the 5s fail-open ceiling without delivering a result.
+      vi.advanceTimersByTime(5_001);
+      await expect(p).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("silently drops a late result that arrives after the timeout already fired", async () => {
+    vi.useFakeTimers();
+    try {
+      const p = bridge.acquirePollLease();
+      const acquire = events.find(isLeaseAcquire)!;
+      vi.advanceTimersByTime(5_001);
+      await expect(p).resolves.toBe(true);
+      // Now-stale result must not throw or resolve a second time.
+      expect(() => bridge.handleLeaseResult({ requestId: acquire.requestId, acquired: false }))
+        .not.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dispose resolves pending acquires to true (fail-open during shutdown)", async () => {
+    const p = bridge.acquirePollLease();
+    bridge.dispose();
+    await expect(p).resolves.toBe(true);
+  });
+
+  it("releasePollLease emits a fire-and-forget event with no pending response", () => {
+    bridge.releasePollLease();
+    expect(events.filter(isLeaseRelease)).toHaveLength(1);
+  });
+
+  it("each acquire produces a unique requestId so concurrent calls don't collide", () => {
+    void bridge.acquirePollLease();
+    void bridge.acquirePollLease();
+    const acquires = events.filter(isLeaseAcquire);
+    expect(acquires).toHaveLength(2);
+    expect(acquires[0].requestId).not.toBe(acquires[1].requestId);
   });
 });

--- a/electron/workspace-host/forgeBridge.ts
+++ b/electron/workspace-host/forgeBridge.ts
@@ -19,9 +19,20 @@ interface PendingCall {
   method: ForgeRpcMethod;
 }
 
+interface PendingLeaseCall {
+  resolve: (acquired: boolean) => void;
+  timer: NodeJS.Timeout;
+}
+
 // Slow PR polls can run a few seconds under load; 30s gives real network
 // latency room while still surfacing a stuck call before a poller backs up.
 const FORGE_RPC_TIMEOUT_MS = 30_000;
+
+// Lease acquire is a same-process round-trip in practice — main answers from
+// an in-memory Map. 5s is generous and exists only so a lost message can't
+// stall the poller indefinitely; on timeout we fail open and proceed (the
+// singleflight in main still coalesces the actual GraphQL calls).
+const FORGE_LEASE_TIMEOUT_MS = 5_000;
 
 /**
  * IPC client for forge provider impls that live in the main process. The
@@ -43,6 +54,9 @@ export class ForgeBridge {
   // Evicted on settlement (not TTL-cached) — the 60s response cache in
   // `forgeProvider.runQuery` absorbs staggered bursts on the main-process side.
   private inFlightByArgs = new Map<string, Promise<unknown>>();
+
+  private pendingLeases = new Map<string, PendingLeaseCall>();
+  private leaseCounter = 0;
 
   constructor(private readonly sendEvent: SendEvent) {}
 
@@ -148,6 +162,46 @@ export class ForgeBridge {
     }
   }
 
+  /**
+   * Acquire (or renew) this workspace-host's per-project poll lease. Resolves
+   * `true` when this host should run the poll cycle, `false` when a sibling
+   * window already holds the lease. Fails open on IPC timeout (returns `true`)
+   * so a lost lease message can't wedge polling — the cross-window singleflight
+   * in `forgeRpcServer.dispatchForgeRpc` still coalesces duplicate GraphQL
+   * calls in that fallback path. See #9055.
+   */
+  acquirePollLease(): Promise<boolean> {
+    const requestId = `lease-${++this.leaseCounter}`;
+    return new Promise<boolean>((resolve) => {
+      const timer = setTimeout(() => {
+        if (!this.pendingLeases.has(requestId)) return;
+        this.pendingLeases.delete(requestId);
+        resolve(true);
+      }, FORGE_LEASE_TIMEOUT_MS);
+
+      this.pendingLeases.set(requestId, { resolve, timer });
+      this.sendEvent({ type: "forge:poll-lease-acquire", requestId });
+    });
+  }
+
+  /** Fire-and-forget cooperative release. Lease also drops on host dispose. */
+  releasePollLease(): void {
+    this.sendEvent({ type: "forge:poll-lease-release" });
+  }
+
+  /**
+   * Called by the workspace-host's port message handler whenever a
+   * `forge:poll-lease-result` arrives. Resolves the pending lease promise.
+   * Unknown ids are silently dropped (timeout already fired).
+   */
+  handleLeaseResult(result: { requestId: string; acquired: boolean }): void {
+    const pending = this.pendingLeases.get(result.requestId);
+    if (!pending) return;
+    this.pendingLeases.delete(result.requestId);
+    clearTimeout(pending.timer);
+    pending.resolve(result.acquired);
+  }
+
   /** Cancel every pending call. Used on workspace-host shutdown. */
   dispose(): void {
     for (const pending of this.pending.values()) {
@@ -156,6 +210,13 @@ export class ForgeBridge {
     }
     this.pending.clear();
     this.inFlightByArgs.clear();
+    for (const pending of this.pendingLeases.values()) {
+      clearTimeout(pending.timer);
+      // Fail open on dispose so any awaiting caller resolves cleanly rather
+      // than dangling — they're about to be torn down anyway.
+      pending.resolve(true);
+    }
+    this.pendingLeases.clear();
   }
 
   private buildInvokeKey(

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -447,6 +447,15 @@ export type WorkspaceHostRequest =
       forgeRequestId: string;
       ok: false;
       error: string;
+    }
+  // Forge poll-lease acquire response (main → workspace-host). Correlated to a
+  // prior `forge:poll-lease-acquire` event by `requestId`. `acquired === true`
+  // means the workspace-host now holds (or renewed) the lease and may proceed
+  // with the poll cycle; `false` means a sibling host already holds it.
+  | {
+      type: "forge:poll-lease-result";
+      requestId: string;
+      acquired: boolean;
     };
 
 /**
@@ -689,6 +698,23 @@ export type WorkspaceHostEvent =
       method: ForgeRpcMethod;
       namespacedId?: string;
       args: unknown[];
+    }
+  // Per-project poll lease acquire (workspace-host → main). Main answers with
+  // `forge:poll-lease-result` keyed by `requestId`. Holding the lease means
+  // this workspace-host is the elected poller for the project this cycle; a
+  // denial means a sibling window already polls and this one should skip.
+  // The lease key is the workspace-host's `projectPath`, known to main from
+  // the `WorkspaceHostProcess` instance — the event carries no path because
+  // main must not trust a workspace-host's self-reported identity (#4670).
+  | {
+      type: "forge:poll-lease-acquire";
+      requestId: string;
+    }
+  // Per-project poll lease release (workspace-host → main, fire-and-forget).
+  // Best-effort cooperative release on `stop()`; the lease also drops on host
+  // dispose and after the TTL, so a missed release never wedges siblings.
+  | {
+      type: "forge:poll-lease-release";
     };
 
 /** Configuration for WorkspaceClient */


### PR DESCRIPTION
## Summary

- Adds a singleflight map in `forgeRpcServer.dispatch` keyed by provider id, repo, method, and sorted args — concurrent identical calls share one in-flight promise instead of each firing a separate GraphQL round-trip
- Adds a per-`projectId` poll lease store with a TTL in main — one window holds the lease and polls, results broadcast to all peer workspace-hosts watching the same project; lease drops on window close or TTL expiry
- Both layers live in main because workspace-host can't read `electron-store` (#8316)

Resolves #9055

## Changes

- `electron/services/forgeRpcServer.ts` — singleflight dedup map + `ForgeSingleflightService` helper
- `electron/services/forgePollLeaseService.ts` — new `ForgePollLeaseService` (lease acquire/release/broadcast, TTL, window-close cleanup)
- `electron/services/WorkspaceHostProcess.ts` — wires lease service into workspace-host lifecycle
- `electron/services/PullRequestService.ts` — `checkForPRs` acquires lease before bridge round-trip
- `electron/workspace-host/forgeBridge.ts` — handles broadcast events from lease holder, skips own poll when not lease owner
- `shared/types/workspace-host.ts` — new IPC message types for lease protocol
- Tests: `forgeRpcServer.test.ts` (singleflight + timeout + denied-lease scenarios), `forgePollLeaseService.test.ts`, `forgeBridge.test.ts` extensions, `PullRequestService.test.ts` additions — 119 tests passing

## Testing

Full unit test suite passes (`npm test`). Typecheck, lint ratchet, and format check all clean. Covered cases include: concurrent calls coalesced to one in-flight promise, 35s server timeout on hung handlers, lease denial when another window holds the lease, broadcast path delivering results to non-lease-holding workspace-hosts, and lease release on window close.