### PR TITLE
[codex] perf(github): batch forge PR and CI lookups

### DIFF
--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -691,6 +691,61 @@ describe("GitHubService adversarial", () => {
     expect(result.results.get("wt-1")?.pr?.number).toBe(200);
   });
 
+  it("BATCHCHECK_ISSUE_TIMELINE_SELECTS_LATEST_LINKED_PR_WITH_CI", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      createETagResponse(200, 'W/"repo-with-issue-links"')
+    );
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_issue: {
+        issue: {
+          title: "Issue 12",
+          timelineItems: {
+            nodes: [
+              {
+                source: {
+                  number: 100,
+                  title: "Older open PR",
+                  url: "https://github.com/owner/repo/pull/100",
+                  state: "OPEN",
+                  merged: false,
+                  isDraft: false,
+                  updatedAt: "2026-01-01T00:00:00Z",
+                  commits: {
+                    nodes: [{ commit: { statusCheckRollup: { state: "SUCCESS" } } }],
+                  },
+                },
+              },
+              {
+                source: {
+                  number: 200,
+                  title: "Latest linked PR",
+                  url: "https://github.com/owner/repo/pull/200",
+                  state: "CLOSED",
+                  merged: true,
+                  isDraft: false,
+                  updatedAt: "2026-02-01T00:00:00Z",
+                  commits: {
+                    nodes: [{ commit: { statusCheckRollup: { state: "PENDING" } } }],
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const result = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", issueNumber: 12 },
+    ]);
+
+    expect(result.results.size).toBe(1);
+    expect(result.results.get("wt-1")?.issueTitle).toBe("Issue 12");
+    expect(result.results.get("wt-1")?.pr?.number).toBe(200);
+    expect(result.results.get("wt-1")?.pr?.state).toBe("merged");
+    expect(result.results.get("wt-1")?.pr?.ciStatus).toBe("PENDING");
+  });
+
   it("BATCHCHECK_DISCOVERY_BRANCH_PROBE_SENDS_IF_NONE_MATCH", async () => {
     // Cycle 1: repo-level probe (fetch #1) proceeds, then the branch probe
     // (fetch #2) seeds the branch-list ETag.

--- a/plugins/builtin/github/main/GitHubIssues.ts
+++ b/plugins/builtin/github/main/GitHubIssues.ts
@@ -33,15 +33,27 @@ export function extractLinkedPR(
   timelineItems:
     | {
         nodes?: Array<{
-          source?: { number?: number; state?: string; merged?: boolean; url?: string };
-          subject?: { number?: number; state?: string; merged?: boolean; url?: string };
+          source?: {
+            number?: number;
+            state?: string;
+            merged?: boolean;
+            url?: string;
+            updatedAt?: string;
+          };
+          subject?: {
+            number?: number;
+            state?: string;
+            merged?: boolean;
+            url?: string;
+            updatedAt?: string;
+          };
         }>;
       }
     | undefined
 ): LinkedPRInfo | undefined {
   if (!timelineItems?.nodes) return undefined;
 
-  const prs: Array<{ number: number; state: "OPEN" | "CLOSED" | "MERGED"; url: string }> = [];
+  const prs: LinkedPRInfo[] = [];
   const seenPRNumbers = new Set<number>();
 
   for (const node of timelineItems.nodes) {
@@ -51,21 +63,29 @@ export function extractLinkedPR(
       const state: "OPEN" | "CLOSED" | "MERGED" = prData.merged
         ? "MERGED"
         : (prData.state?.toUpperCase() as "OPEN" | "CLOSED") || "OPEN";
-      prs.push({ number: prData.number, state, url: prData.url });
+      prs.push({
+        number: prData.number,
+        state,
+        url: prData.url,
+        ...(typeof prData.updatedAt === "string" ? { updatedAt: prData.updatedAt } : {}),
+      });
     }
   }
 
   if (prs.length === 0) return undefined;
 
-  const openPRs = prs.filter((pr) => pr.state === "OPEN");
-  const mergedPRs = prs.filter((pr) => pr.state === "MERGED");
-  const closedPRs = prs.filter((pr) => pr.state === "CLOSED");
+  prs.sort(compareLinkedPRFreshness);
+  return prs[0];
+}
 
-  if (openPRs.length > 0) return openPRs[openPRs.length - 1];
-  if (mergedPRs.length > 0) return mergedPRs[mergedPRs.length - 1];
-  if (closedPRs.length > 0) return closedPRs[closedPRs.length - 1];
+function compareLinkedPRFreshness(a: LinkedPRInfo, b: LinkedPRInfo): number {
+  const aUpdatedAt = typeof a.updatedAt === "string" ? Date.parse(a.updatedAt) : 0;
+  const bUpdatedAt = typeof b.updatedAt === "string" ? Date.parse(b.updatedAt) : 0;
+  const aTime = Number.isFinite(aUpdatedAt) ? aUpdatedAt : 0;
+  const bTime = Number.isFinite(bUpdatedAt) ? bUpdatedAt : 0;
+  if (aTime !== bTime) return bTime - aTime;
 
-  return undefined;
+  return b.number - a.number;
 }
 
 export function parseIssueNode(node: Record<string, unknown>): GitHubIssue {
@@ -76,7 +96,20 @@ export function parseIssueNode(node: Record<string, unknown>): GitHubIssue {
   const timelineItems = node.timelineItems as
     | {
         nodes?: Array<{
-          source?: { number?: number; state?: string; merged?: boolean; url?: string };
+          source?: {
+            number?: number;
+            state?: string;
+            merged?: boolean;
+            url?: string;
+            updatedAt?: string;
+          };
+          subject?: {
+            number?: number;
+            state?: string;
+            merged?: boolean;
+            url?: string;
+            updatedAt?: string;
+          };
         }>;
       }
     | undefined;

--- a/plugins/builtin/github/main/GitHubPRDiscovery.ts
+++ b/plugins/builtin/github/main/GitHubPRDiscovery.ts
@@ -30,6 +30,7 @@ interface BatchPRRawNode extends BatchPRTooltipFields {
   state?: string;
   isDraft?: boolean;
   merged?: boolean;
+  updatedAt?: string;
   commits?: {
     nodes?: Array<{
       commit?: {
@@ -37,6 +38,19 @@ interface BatchPRRawNode extends BatchPRTooltipFields {
       } | null;
     }>;
   } | null;
+}
+
+function compareLinkedPRFreshness(
+  a: { pr: LinkedPR; raw: BatchPRRawNode },
+  b: { pr: LinkedPR; raw: BatchPRRawNode }
+): number {
+  const aUpdatedAt = typeof a.raw.updatedAt === "string" ? Date.parse(a.raw.updatedAt) : 0;
+  const bUpdatedAt = typeof b.raw.updatedAt === "string" ? Date.parse(b.raw.updatedAt) : 0;
+  const aTime = Number.isFinite(aUpdatedAt) ? aUpdatedAt : 0;
+  const bTime = Number.isFinite(bUpdatedAt) ? bUpdatedAt : 0;
+  if (aTime !== bTime) return bTime - aTime;
+
+  return (b.pr.number ?? 0) - (a.pr.number ?? 0);
 }
 
 const CI_STATUS_VALUES = new Set<GitHubPRCIStatus>([
@@ -137,18 +151,7 @@ function parseBatchPRResponse(
         }
       }
 
-      const openPRs = prs.filter((entry) => entry.pr.state === "open");
-      const mergedPRs = prs.filter((entry) => entry.pr.state === "merged");
-      const closedPRs = prs.filter((entry) => entry.pr.state === "closed");
-
-      let chosen: { pr: LinkedPR; raw: BatchPRRawNode } | undefined;
-      if (openPRs.length > 0) {
-        chosen = openPRs[openPRs.length - 1];
-      } else if (mergedPRs.length > 0) {
-        chosen = mergedPRs[mergedPRs.length - 1];
-      } else if (closedPRs.length > 0) {
-        chosen = closedPRs[closedPRs.length - 1];
-      }
+      const chosen = prs.sort(compareLinkedPRFreshness)[0];
       if (chosen) {
         foundPR = chosen.pr;
         foundTooltip = buildTooltipDataFromBatchNode(chosen.raw);

--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -318,7 +318,7 @@ async function enrichPRsWithRequiredStatus(
   });
 }
 
-function parseBatchRequiredChecksResponse(
+export function parseBatchRequiredChecksResponse(
   data: Record<string, unknown>,
   prNumbers: number[]
 ): Map<number, PRRequiredStatusEntry> {

--- a/plugins/builtin/github/main/GitHubQueries.ts
+++ b/plugins/builtin/github/main/GitHubQueries.ts
@@ -42,10 +42,10 @@ export const REPO_STATS_AND_PAGE_QUERY = `
           timelineItems(itemTypes: [CROSS_REFERENCED_EVENT, CONNECTED_EVENT], last: 20) {
             nodes {
               ... on CrossReferencedEvent {
-                source { ... on PullRequest { number state merged url } }
+                source { ... on PullRequest { number state merged url updatedAt } }
               }
               ... on ConnectedEvent {
-                subject { ... on PullRequest { number state merged url } }
+                subject { ... on PullRequest { number state merged url updatedAt } }
               }
             }
           }
@@ -206,6 +206,7 @@ export const LIST_ISSUES_QUERY = `
                     state
                     merged
                     url
+                    updatedAt
                   }
                 }
               }
@@ -216,6 +217,7 @@ export const LIST_ISSUES_QUERY = `
                     state
                     merged
                     url
+                    updatedAt
                   }
                 }
               }
@@ -455,6 +457,7 @@ export const GET_ISSUE_QUERY = `
                   state
                   merged
                   url
+                  updatedAt
                 }
               }
             }
@@ -465,6 +468,7 @@ export const GET_ISSUE_QUERY = `
                   state
                   merged
                   url
+                  updatedAt
                 }
               }
             }
@@ -644,6 +648,7 @@ export function buildBatchPRQuery(
                       merged
                       bodyText
                       createdAt
+                      updatedAt
                       author { login avatarUrl }
                       assignees(first: 10) { nodes { login avatarUrl } }
                       labels(first: 10) { nodes { name color } }
@@ -662,6 +667,7 @@ export function buildBatchPRQuery(
                       merged
                       bodyText
                       createdAt
+                      updatedAt
                       author { login avatarUrl }
                       assignees(first: 10) { nodes { login avatarUrl } }
                       labels(first: 10) { nodes { name color } }
@@ -692,6 +698,7 @@ export function buildBatchPRQuery(
               merged
               bodyText
               createdAt
+              updatedAt
               author { login avatarUrl }
               assignees(first: 10) { nodes { login avatarUrl } }
               labels(first: 10) { nodes { name color } }
@@ -843,6 +850,7 @@ export function buildBatchIssuesQuery(owner: string, repo: string, numbers: numb
                   state
                   merged
                   url
+                  updatedAt
                 }
               }
             }
@@ -853,6 +861,7 @@ export function buildBatchIssuesQuery(owner: string, repo: string, numbers: numb
                   state
                   merged
                   url
+                  updatedAt
                 }
               }
             }
@@ -918,9 +927,6 @@ export function buildBatchPRsQuery(owner: string, repo: string, numbers: number[
             login
             avatarUrl
           }
-        }
-        reviews(first: 1) {
-          totalCount
         }
         comments {
           totalCount

--- a/plugins/builtin/github/main/__tests__/GitHubIssues.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubIssues.test.ts
@@ -40,7 +40,7 @@ vi.mock("../GitHubRepoContext.js", () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-import { assignIssue } from "../GitHubIssues.js";
+import { assignIssue, extractLinkedPR } from "../GitHubIssues.js";
 
 describe("assignIssue error handling", () => {
   beforeEach(() => {
@@ -176,6 +176,65 @@ describe("assignIssue error handling", () => {
     });
 
     await expect(assignIssue("/test", 1, "someuser")).rejects.toThrow("HTTP 429");
+  });
+});
+
+describe("extractLinkedPR", () => {
+  it("chooses the latest linked PR by updatedAt instead of keeping an older open PR", () => {
+    const linked = extractLinkedPR({
+      nodes: [
+        {
+          source: {
+            number: 10,
+            state: "OPEN",
+            merged: false,
+            url: "https://github.com/test/repo/pull/10",
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        },
+        {
+          source: {
+            number: 20,
+            state: "CLOSED",
+            merged: true,
+            url: "https://github.com/test/repo/pull/20",
+            updatedAt: "2026-02-01T00:00:00Z",
+          },
+        },
+      ],
+    });
+
+    expect(linked).toEqual({
+      number: 20,
+      state: "MERGED",
+      url: "https://github.com/test/repo/pull/20",
+      updatedAt: "2026-02-01T00:00:00Z",
+    });
+  });
+
+  it("falls back to the highest PR number when timeline entries lack updatedAt", () => {
+    const linked = extractLinkedPR({
+      nodes: [
+        {
+          source: {
+            number: 10,
+            state: "OPEN",
+            merged: false,
+            url: "https://github.com/test/repo/pull/10",
+          },
+        },
+        {
+          subject: {
+            number: 20,
+            state: "CLOSED",
+            merged: false,
+            url: "https://github.com/test/repo/pull/20",
+          },
+        },
+      ],
+    });
+
+    expect(linked?.number).toBe(20);
   });
 });
 

--- a/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
@@ -272,6 +272,11 @@ describe("buildBatchPRQuery — statusCheckRollup", () => {
     expect(matches).not.toBeNull();
     expect(matches!.length).toBeGreaterThanOrEqual(2);
   });
+
+  it("requests updatedAt on issue-timeline PR fragments for latest-linked-PR selection", () => {
+    const query = buildBatchPRQuery("owner", "repo", [{ worktreeId: "wt-1", issueNumber: 42 }]);
+    expect(query).toContain("updatedAt");
+  });
 });
 
 describe("buildBatchPRQuery", () => {
@@ -660,11 +665,15 @@ describe("buildBatchPRsQuery", () => {
     expect(query).toContain("baseRepository");
     expect(query).toContain("author {");
     expect(query).toContain("assignees(first: 10)");
-    expect(query).toContain("reviews(first: 1)");
     expect(query).toContain("comments {");
     expect(query).toContain("labels(first: 10)");
     expect(query).toContain("commits(last: 1)");
     expect(query).toContain("statusCheckRollup");
+  });
+
+  it("does not include unused review-count fields", () => {
+    const query = buildBatchPRsQuery("owner", "repo", [1]);
+    expect(query).not.toContain("reviews(first: 1)");
   });
 
   it("includes rateLimit at operation root", () => {

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -589,6 +589,222 @@ describe("getPR tooltip pre-warm", () => {
   });
 });
 
+describe("batchLookups.findPRsByNumbers", () => {
+  beforeEach(() => mockGraphQLClient.mockReset());
+
+  it("chunks PR-number lookups and maps aliases back to PR numbers", async () => {
+    const numbers = Array.from({ length: 21 }, (_, i) => i + 1);
+    const firstResponse: Record<string, unknown> = {
+      repository: {},
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    };
+    const firstRepo = firstResponse.repository as Record<string, unknown>;
+    for (let i = 1; i <= 20; i++) {
+      firstRepo[`p${i}`] = makePRNode(i, `feature/${i}`);
+    }
+    const secondResponse = {
+      repository: { p21: makePRNode(21, "feature/21") },
+      rateLimit: { cost: 1, remaining: 4998, resetAt: "" },
+    };
+    mockGraphQLClient.mockResolvedValueOnce(firstResponse).mockResolvedValueOnce(secondResponse);
+
+    const result = await githubForgeProvider.batchLookups!.findPRsByNumbers!(repo, [...numbers, 1]);
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+    expect(result.size).toBe(21);
+    expect(result.get(1)?.headRef).toBe("feature/1");
+    expect(result.get(20)?.number).toBe(20);
+    expect(result.get(21)?.number).toBe(21);
+  });
+
+  it("distinguishes explicit null from omitted aliases", async () => {
+    mockGraphQLClient.mockResolvedValueOnce({
+      repository: {
+        p1: makePRNode(1, "feature/one"),
+        p2: null,
+        // p3 intentionally omitted: transient partial response, not confirmed missing.
+      },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+
+    const result = await githubForgeProvider.batchLookups!.findPRsByNumbers!(repo, [1, 2, 3]);
+
+    expect(result.get(1)?.number).toBe(1);
+    expect(result.has(2)).toBe(true);
+    expect(result.get(2)).toBeNull();
+    expect(result.has(3)).toBe(false);
+  });
+
+  it("pre-warms PR tooltip cache for batched PR-number hits", async () => {
+    mockGraphQLClient.mockResolvedValueOnce({
+      repository: {
+        p7: {
+          ...makePRNode(7, "feature/x"),
+          assignees: { nodes: [{ login: "alice", avatarUrl: "a.png" }] },
+          labels: { nodes: [{ name: "bug", color: "ff0000" }] },
+        },
+      },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    });
+
+    await githubForgeProvider.batchLookups!.findPRsByNumbers!(repo, [7]);
+
+    const tooltip = prTooltipCache.get("owner/repo:7");
+    expect(tooltip?.assignees[0]?.login).toBe("alice");
+    expect(tooltip?.labels[0]?.name).toBe("bug");
+  });
+
+  it("skips the network when the GraphQL budget gate is closed", async () => {
+    mockShouldBlockRequest.mockReturnValue({
+      blocked: true,
+      reason: "primary",
+      resumeAt: Date.now() + 1000,
+    } as ShouldBlockResult);
+
+    const result = await githubForgeProvider.batchLookups!.findPRsByNumbers!(repo, [1, 2]);
+
+    expect(result.size).toBe(0);
+    expect(mockGraphQLClient).not.toHaveBeenCalled();
+  });
+});
+
+function requiredChecksBatchResponse(
+  entries: Record<number, { state: string; contexts: Array<Record<string, unknown>> } | null>
+) {
+  const response: Record<string, unknown> = {
+    rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+  };
+  for (const [rawNumber, entry] of Object.entries(entries)) {
+    const number = Number(rawNumber);
+    response[`pr_${number}`] =
+      entry === null
+        ? { pullRequest: null }
+        : {
+            pullRequest: {
+              number,
+              commits: {
+                nodes: [
+                  {
+                    commit: {
+                      statusCheckRollup: {
+                        state: entry.state,
+                        contexts: {
+                          nodes: entry.contexts,
+                          pageInfo: { hasNextPage: false },
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          };
+  }
+  return response;
+}
+
+describe("batchLookups.getCIStatuses", () => {
+  beforeEach(() => mockGraphQLClient.mockReset());
+
+  it("chunks required-check lookups and returns normalized CI statuses", async () => {
+    const firstChunkEntries: Record<
+      number,
+      { state: string; contexts: Array<Record<string, unknown>> }
+    > = {};
+    for (let i = 1; i <= 20; i++) {
+      firstChunkEntries[i] = {
+        state: "SUCCESS",
+        contexts: [
+          {
+            __typename: "CheckRun",
+            conclusion: "SUCCESS",
+            status: "COMPLETED",
+            isRequired: true,
+          },
+        ],
+      };
+    }
+    firstChunkEntries[2] = {
+      state: "FAILURE",
+      contexts: [
+        {
+          __typename: "StatusContext",
+          state: "FAILURE",
+          isRequired: true,
+        },
+      ],
+    };
+    const secondChunk = requiredChecksBatchResponse({
+      21: {
+        state: "PENDING",
+        contexts: [
+          {
+            __typename: "CheckRun",
+            conclusion: null,
+            status: "IN_PROGRESS",
+            isRequired: true,
+          },
+        ],
+      },
+    });
+    mockGraphQLClient
+      .mockResolvedValueOnce(requiredChecksBatchResponse(firstChunkEntries))
+      .mockResolvedValueOnce(secondChunk);
+
+    const result = await githubForgeProvider.batchLookups!.getCIStatuses!(
+      repo,
+      Array.from({ length: 21 }, (_, i) => i + 1)
+    );
+
+    expect(mockGraphQLClient).toHaveBeenCalledTimes(2);
+    expect(result.get(1)?.state).toBe("success");
+    expect(result.get(1)?.total).toBe(1);
+    expect(result.get(2)?.state).toBe("failure");
+    expect(result.get(21)?.state).toBe("pending");
+    expect(prRequiredStatusCache.get("owner/repo:21")).toBeDefined();
+  });
+
+  it("serves cached required-check statuses without a GraphQL call", async () => {
+    prRequiredStatusCache.set("owner/repo:5", {
+      ciStatus: "SUCCESS",
+      ciSummary: { requiredTotal: 1, requiredFailing: 0, requiredPending: 0 },
+    });
+
+    const result = await githubForgeProvider.batchLookups!.getCIStatuses!(repo, [5]);
+
+    expect(mockGraphQLClient).not.toHaveBeenCalled();
+    expect(result.get(5)?.state).toBe("success");
+  });
+
+  it("distinguishes confirmed missing PRs from omitted aliases", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(requiredChecksBatchResponse({ 1: null }));
+
+    const result = await githubForgeProvider.batchLookups!.getCIStatuses!(repo, [1, 2]);
+
+    expect(result.has(1)).toBe(true);
+    expect(result.get(1)).toBeNull();
+    expect(result.has(2)).toBe(false);
+  });
+
+  it("returns cached hits and omits misses while rate-limited", async () => {
+    prRequiredStatusCache.set("owner/repo:5", {
+      ciStatus: "SUCCESS",
+      ciSummary: { requiredTotal: 1, requiredFailing: 0, requiredPending: 0 },
+    });
+    mockShouldBlockRequest.mockReturnValue({
+      blocked: true,
+      reason: "secondary",
+      resumeAt: Date.now() + 1000,
+    } as ShouldBlockResult);
+
+    const result = await githubForgeProvider.batchLookups!.getCIStatuses!(repo, [5, 6]);
+
+    expect(mockGraphQLClient).not.toHaveBeenCalled();
+    expect(result.get(5)?.state).toBe("success");
+    expect(result.has(6)).toBe(false);
+  });
+});
+
 describe("getCIStatus caching", () => {
   beforeEach(() => mockGraphQLClient.mockReset());
 

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -32,7 +32,10 @@ import {
   GET_PR_QUERY,
   GET_PR_REVIEW_THREADS_QUERY,
   BATCH_BRANCH_CHUNK_SIZE,
+  GRAPHQL_BATCH_CHUNK_SIZE,
   buildBatchBranchPRQuery,
+  buildBatchPRsQuery,
+  buildBatchRequiredChecksQuery,
 } from "./GitHubQueries.js";
 import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
 import {
@@ -55,7 +58,11 @@ import {
   writePRTooltip,
   type PRRequiredStatusEntry,
 } from "./GitHubCaches.js";
-import { buildListCacheKey, updateRepoStatsCount } from "./GitHubPRs.js";
+import {
+  buildListCacheKey,
+  parseBatchRequiredChecksResponse,
+  updateRepoStatsCount,
+} from "./GitHubPRs.js";
 import type { IssueTooltipData, PRTooltipData } from "../../../../shared/types/github.js";
 
 const REPO_METADATA_QUERY = `
@@ -314,6 +321,8 @@ const getIssueInflight = new Map<string, Promise<Issue | null>>();
 const getPRInflight = new Map<string, Promise<PR | null>>();
 const getCIStatusInflight = new Map<string, Promise<CIStatus | null>>();
 const findPRsByBranchesInflight = new Map<string, Promise<Map<string, PR | null>>>();
+const findPRsByNumbersInflight = new Map<string, Promise<Map<number, PR | null>>>();
+const getCIStatusesInflight = new Map<string, Promise<Map<number, CIStatus | null>>>();
 
 /**
  * Join an in-flight request for `key` when one exists, else start `fn` and
@@ -434,6 +443,21 @@ function buildCIStatus(entry: PRRequiredStatusEntry, rawData: unknown): CIStatus
     ...(requiredChecksPassing !== undefined ? { requiredChecksPassing } : {}),
     rawData,
   };
+}
+
+function uniquePositiveIntegers(values: number[]): number[] {
+  const unique: number[] = [];
+  const seen = new Set<number>();
+  for (const value of values) {
+    if (!Number.isInteger(value) || value <= 0 || seen.has(value)) continue;
+    seen.add(value);
+    unique.push(value);
+  }
+  return unique;
+}
+
+function buildNumberBatchInflightKey(repo: RepoRef, numbers: number[]): string {
+  return `${repo.owner}/${repo.repo}:${[...numbers].sort((a, b) => a - b).join(",")}`;
 }
 
 async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<Page<Issue>> {
@@ -720,6 +744,118 @@ async function findPRByBranchImpl(repo: RepoRef, branchName: string): Promise<PR
   return first ? toForgePR(first) : null;
 }
 
+async function findPRsByNumbersImpl(
+  repo: RepoRef,
+  prNumbers: number[]
+): Promise<Map<number, PR | null>> {
+  const unique = uniquePositiveIntegers(prNumbers);
+  if (unique.length === 0) return new Map<number, PR | null>();
+
+  const inflightKey = buildNumberBatchInflightKey(repo, unique);
+  return dedupe(findPRsByNumbersInflight, inflightKey, false, async () => {
+    const result = new Map<number, PR | null>();
+
+    const block = gitHubRateLimitService.shouldBlockRequest("graphql");
+    if (block.blocked) return result;
+
+    const requestedAt = Date.now();
+    for (let start = 0; start < unique.length; start += GRAPHQL_BATCH_CHUNK_SIZE) {
+      const chunk = unique.slice(start, start + GRAPHQL_BATCH_CHUNK_SIZE);
+      const query = buildBatchPRsQuery(repo.owner, repo.repo, chunk);
+      if (!query) continue;
+
+      let response: GraphQlQueryResponseData;
+      try {
+        response = await runQuery(query, {}, "BATCH_PRS_QUERY");
+      } catch {
+        // Omit this chunk so callers treat it as transient and keep stale data.
+        continue;
+      }
+
+      const repository = response?.repository as Record<string, unknown> | undefined;
+      if (!repository) continue;
+
+      for (const prNumber of chunk) {
+        const alias = `p${prNumber}`;
+        if (!(alias in repository)) continue;
+        const node = repository[alias] as Record<string, unknown> | null | undefined;
+        const forgePR = node ? toForgePR(node) : null;
+        result.set(prNumber, forgePR);
+
+        if (forgePR) {
+          const tooltip = prToTooltipData(forgePR);
+          if (tooltip) writePRTooltip(repo.owner, repo.repo, forgePR.number, tooltip, requestedAt);
+        }
+      }
+    }
+
+    return result;
+  });
+}
+
+async function getCIStatusesImpl(
+  repo: RepoRef,
+  prNumbers: number[]
+): Promise<Map<number, CIStatus | null>> {
+  const unique = uniquePositiveIntegers(prNumbers);
+  if (unique.length === 0) return new Map<number, CIStatus | null>();
+
+  const inflightKey = buildNumberBatchInflightKey(repo, unique);
+  return dedupe(getCIStatusesInflight, inflightKey, false, async () => {
+    const result = new Map<number, CIStatus | null>();
+    const missing: number[] = [];
+
+    for (const prNumber of unique) {
+      const cacheKey = `${repo.owner}/${repo.repo}:${prNumber}`;
+      const cached = prRequiredStatusCache.get(cacheKey);
+      if (cached) {
+        result.set(prNumber, buildCIStatus(cached, null));
+      } else {
+        missing.push(prNumber);
+      }
+    }
+
+    if (missing.length === 0) return result;
+
+    const block = gitHubRateLimitService.shouldBlockRequest("graphql");
+    if (block.blocked) return result;
+
+    for (let start = 0; start < missing.length; start += GRAPHQL_BATCH_CHUNK_SIZE) {
+      const chunk = missing.slice(start, start + GRAPHQL_BATCH_CHUNK_SIZE);
+      const query = buildBatchRequiredChecksQuery(repo.owner, repo.repo, chunk);
+      if (!query) continue;
+
+      let response: GraphQlQueryResponseData;
+      try {
+        response = await runQuery(query, {}, "BATCH_REQUIRED_CHECKS_QUERY");
+      } catch {
+        // Omit this chunk so callers treat it as transient and retry later.
+        continue;
+      }
+
+      const responseRecord = response as Record<string, unknown>;
+      const fetched = parseBatchRequiredChecksResponse(responseRecord, chunk);
+      for (const prNumber of chunk) {
+        const alias = `pr_${prNumber}`;
+        if (!(alias in responseRecord)) continue;
+        const repoNode = responseRecord[alias] as { pullRequest?: unknown } | null | undefined;
+        if (repoNode == null || repoNode.pullRequest == null) {
+          result.set(prNumber, null);
+          continue;
+        }
+        const entry = fetched.get(prNumber) ?? {
+          ciStatus: undefined,
+          ciSummary: undefined,
+        };
+        prRequiredStatusCache.set(`${repo.owner}/${repo.repo}:${prNumber}`, entry);
+        result.set(prNumber, buildCIStatus(entry, null));
+      }
+    }
+
+    return result;
+  });
+}
+
 async function getCIStatusImpl(repo: RepoRef, prNumber: number): Promise<CIStatus | null> {
   // Shares the 60s required-status cache with the legacy enrich path (same key
   // and {@link PRRequiredStatusEntry} value). This is the hottest forge path —
@@ -926,6 +1062,10 @@ export const githubForgeProvider: ForgeProviderImpl = {
   findPRByBranch: findPRByBranchImpl,
   findPRsByBranches: findPRsByBranchesImpl,
   getCIStatus: getCIStatusImpl,
+  batchLookups: {
+    findPRsByNumbers: findPRsByNumbersImpl,
+    getCIStatuses: getCIStatusesImpl,
+  },
   getRepoMetadata: getRepoMetadataImpl,
 
   buildIssueUrl(repo: RepoRef, number: number): string {

--- a/shared/types/github.ts
+++ b/shared/types/github.ts
@@ -26,6 +26,12 @@ export interface LinkedPRInfo {
   state: "OPEN" | "CLOSED" | "MERGED";
   /** PR URL */
   url: string;
+  /** Last updated timestamp, when selected by a query that includes it */
+  updatedAt?: string;
+  /** CI status rollup from the latest commit, when selected by the linked-PR query */
+  ciStatus?: GitHubPRCIStatus;
+  /** Required-check summary, when selected by a hydrated linked-PR query */
+  ciSummary?: GitHubPRCISummary;
 }
 
 /** GitHub issue representation */


### PR DESCRIPTION
## Summary

- Implements GitHub CodeForge `batchLookups.findPRsByNumbers` and `batchLookups.getCIStatuses` so host-side BatchLoader fan-out resolves in chunked GraphQL calls instead of per-PR queries.
- Reuses the existing batch PR and required-check query builders, required-status cache, rate-limit gate, in-flight dedupe, and PR tooltip prewarm path.
- Removes the unused `reviews(first: 1)` selection from batched PR-number queries.
- Selects the latest issue-linked PR by `updatedAt`/number and carries `updatedAt` through issue timeline queries so stale older linked PRs are less likely to persist.

## Why

Recent work added the CodeForge batching contract and host-side coalescing, but the built-in GitHub provider still lacked the optional batch lookup implementations. That meant CI enrichment and PR revalidation could still degrade to O(number of PRs) GraphQL calls. This keeps the fix within the CodeForge provider system.

## Validation

- `pnpm exec vitest run plugins/builtin/github/main/__tests__/forgeProvider.test.ts plugins/builtin/github/main/__tests__/GitHubQueries.test.ts plugins/builtin/github/main/__tests__/GitHubIssues.test.ts`
- `pnpm exec vitest run electron/services/__tests__/GitHubService.adversarial.test.ts`
- `pnpm typecheck`
- `pnpm exec prettier --check electron/services/__tests__/GitHubService.adversarial.test.ts plugins/builtin/github/main/GitHubIssues.ts plugins/builtin/github/main/GitHubPRDiscovery.ts plugins/builtin/github/main/GitHubPRs.ts plugins/builtin/github/main/GitHubQueries.ts plugins/builtin/github/main/__tests__/GitHubIssues.test.ts plugins/builtin/github/main/__tests__/GitHubQueries.test.ts plugins/builtin/github/main/__tests__/forgeProvider.test.ts plugins/builtin/github/main/forgeProvider.ts shared/types/github.ts`

Note: an earlier broad `pnpm test -- ...` invocation matched unrelated suites and surfaced an unrelated `ProjectStore.recipes` failure before I reran the intended files directly.
