### PR TITLE
refactor(fleet): drain TerminalInstance from fleet domain (#8957 batch B)

### DIFF
--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1228,
+  "count": 1226,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
     "@typescript-eslint/no-unsafe-type-assertion": 484,
-    "no-restricted-imports": 51,
+    "no-restricted-imports": 49,
     "no-restricted-syntax": 420,
     "no-useless-assignment": 20,
     "preserve-caught-error": 52,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 38
   },
-  "updatedAt": "2026-05-24T19:51:21.598Z"
+  "updatedAt": "2026-05-25T00:00:00.000Z"
 }

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1226,
+  "count": 1224,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
     "@typescript-eslint/no-unsafe-type-assertion": 484,
-    "no-restricted-imports": 49,
+    "no-restricted-imports": 47,
     "no-restricted-syntax": 420,
     "no-useless-assignment": 20,
     "preserve-caught-error": 52,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 38
   },
-  "updatedAt": "2026-05-25T00:00:00.000Z"
+  "updatedAt": "2026-05-25T09:00:06.718Z"
 }

--- a/src/components/Fleet/FleetPickerContent.tsx
+++ b/src/components/Fleet/FleetPickerContent.tsx
@@ -15,7 +15,7 @@ import {
   type PickerWorktreeGroup,
   type UseFleetPickerResult,
 } from "@/hooks/useFleetPicker";
-import type { SemanticSearchMatch, TerminalInstance } from "@shared/types";
+import type { AgentState, SemanticSearchMatch } from "@shared/types";
 
 export interface FleetPickerContentProps {
   /** Result of `useFleetPicker` — owned and called by the consumer. */
@@ -450,7 +450,7 @@ function SnippetLine({
   );
 }
 
-function renderStateBadge(agentState: TerminalInstance["agentState"]): ReactElement | null {
+function renderStateBadge(agentState: AgentState | undefined): ReactElement | null {
   if (agentState !== "waiting" && agentState !== "working") return null;
   const label = agentState === "waiting" ? "Waiting" : "Working";
   return (

--- a/src/components/Fleet/fleetRawInputBroadcast.ts
+++ b/src/components/Fleet/fleetRawInputBroadcast.ts
@@ -4,6 +4,7 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { isFleetArmEligible, useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
 import { usePanelStore } from "@/store/panelStore";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { logWarn } from "@/utils/logger";
 import type { BroadcastWriteResultPayload } from "@shared/types";
 import { PERMANENT_FAILURE_CODES } from "./fleetBroadcast";
@@ -16,8 +17,7 @@ function resolveLiveFleetTargetIds(): string[] {
   const targets: string[] = [];
   for (const id of armOrder) {
     if (!armedIds.has(id)) continue;
-    const panel = panelsById[id];
-    if (isFleetArmEligible(panel)) targets.push(id);
+    if (isFleetArmEligible(getNarrowPanel(panelsById, id))) targets.push(id);
   }
   return targets;
 }

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -7,6 +7,8 @@ import {
   isFleetInterruptAgentEligible,
   isFleetRestartAgentEligible,
   isFleetWaitingAgentEligible,
+  isTerminalErrorClusterEligible,
+  isTerminalFleetEligible,
   resolveFleetAgentCapabilityId,
   subscribeFleetArmingPanelPruning,
 } from "../fleetArmingStore";
@@ -397,6 +399,20 @@ describe("fleetArmingStore", () => {
       expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1", "a5"]);
     });
 
+    it("skips non-PTY panel kinds (browser, dev-preview, review) (#8957 batch B)", () => {
+      // The carrier surfaces non-PTY panels via the narrowed PanelInstance
+      // union now that #8957 routes reads through getNarrowPanel. Confirms
+      // collectFilterArmEligibleIds drops them via the isPtyPanel guard.
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("b1", { worktreeId: "wt-1", kind: "browser", hasPty: undefined }),
+        makeAgentTerminal("d1", { worktreeId: "wt-1", kind: "dev-preview", hasPty: undefined }),
+        makeAgentTerminal("r1", { worktreeId: "wt-1", kind: "review", hasPty: undefined }),
+      ]);
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+    });
+
     it("empty worktreeIds is a no-op and preserves any prior armed set", () => {
       seedPanels([makeAgentTerminal("a1"), makeAgentTerminal("a2")]);
       useFleetArmingStore.getState().armIds(["a1", "a2"]);
@@ -712,6 +728,37 @@ describe("fleetArmingStore", () => {
       expect(isFleetWaitingAgentEligible(working)).toBe(false);
       expect(isFleetInterruptAgentEligible(idle)).toBe(false);
     });
+
+    it("rejects non-PTY panel kinds across every fleet predicate (#8957 batch B)", () => {
+      // The narrowed PanelInstance union now flows non-PTY panels through these
+      // predicates; each must drop browser/dev-preview/review before touching
+      // PTY-specific fields. Mirrors the isFleetArmEligible coverage above so
+      // the entire fleet eligibility surface is covered.
+      const browser = makeAgentTerminal("a", {
+        kind: "browser",
+        hasPty: undefined,
+        agentState: "waiting",
+      });
+      const devPreview = makeAgentTerminal("a", {
+        kind: "dev-preview",
+        hasPty: undefined,
+        agentState: "working",
+      });
+      const review = makeAgentTerminal("a", {
+        kind: "review",
+        hasPty: undefined,
+        agentState: "waiting",
+      });
+      for (const panel of [browser, devPreview, review]) {
+        expect(isTerminalFleetEligible(panel)).toBe(false);
+        expect(isTerminalErrorClusterEligible(panel)).toBe(false);
+        expect(resolveFleetAgentCapabilityId(panel)).toBeUndefined();
+        expect(isAgentFleetActionEligible(panel)).toBe(false);
+        expect(isFleetWaitingAgentEligible(panel)).toBe(false);
+        expect(isFleetInterruptAgentEligible(panel)).toBe(false);
+        expect(isFleetRestartAgentEligible(panel)).toBe(false);
+      }
+    });
   });
 
   describe("broadcastSignal", () => {
@@ -846,6 +893,22 @@ describe("fleetArmingStore", () => {
       useFleetArmingStore.getState().armIds(["a", "b"]);
 
       seedPanels([makeAgentTerminal("a"), makeAgentTerminal("b", { location: "dock" })]);
+
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a"]);
+    });
+
+    it("drops armed ids when a panel mutates into a non-PTY kind (#8957 batch B)", () => {
+      // The reconcileAgainst path inside the subscription now consumes
+      // the narrowed PanelInstance union via getNarrowPanel. A panel
+      // whose kind flips to browser/dev-preview/review must fail the
+      // isPtyPanel guard and be pruned from the armed set.
+      seedPanels([makeAgentTerminal("a"), makeAgentTerminal("b")]);
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+
+      seedPanels([
+        makeAgentTerminal("a"),
+        makeAgentTerminal("b", { kind: "browser", hasPty: undefined }),
+      ]);
 
       expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a"]);
     });

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -206,6 +206,25 @@ describe("fleetArmingStore", () => {
       expect(s.lastArmedId).toBe("t1");
     });
 
+    it("is a no-op when every id in the batch is a non-PTY kind (#8957 batch B)", () => {
+      // Locks the no-op + lastArmedId-preservation contract for non-PTY input.
+      // addToFleet calls isFleetArmEligible(getNarrowPanel(...)) — the
+      // isPtyPanel guard rejects browser/dev-preview/review, so the batch
+      // should leave the prior fleet (and lastArmedId) untouched.
+      seedPanels([
+        makeAgentTerminal("t1"),
+        makeAgentTerminal("b1", { kind: "browser", hasPty: undefined }),
+        makeAgentTerminal("d1", { kind: "dev-preview", hasPty: undefined }),
+        makeAgentTerminal("r1", { kind: "review", hasPty: undefined }),
+      ]);
+      useFleetArmingStore.getState().armIds(["t1"]);
+      const before = useFleetArmingStore.getState().lastArmedId;
+      useFleetArmingStore.getState().addToFleet(["b1", "d1", "r1"]);
+      const s = useFleetArmingStore.getState();
+      expect(s.armOrder).toEqual(["t1"]);
+      expect(s.lastArmedId).toBe(before);
+    });
+
     it("seeds an empty fleet when armedIds is initially empty", () => {
       useFleetArmingStore.getState().addToFleet(["t2", "t3"]);
       const s = useFleetArmingStore.getState();
@@ -367,6 +386,20 @@ describe("fleetArmingStore", () => {
       useFleetArmingStore.getState().armAll("current");
 
       expect([...useFleetArmingStore.getState().armedIds]).toEqual(["runtime-a1"]);
+    });
+
+    it("skips non-PTY panel kinds via collectEligibleIds (#8957 batch B)", () => {
+      // collectEligibleIds → getNarrowPanel → isFleetArmEligible — the
+      // isPtyPanel guard must drop browser/dev-preview/review even when the
+      // panel reports a matching worktree.
+      seedPanels([
+        makeAgentTerminal("a1"),
+        makeAgentTerminal("b1", { kind: "browser", hasPty: undefined }),
+        makeAgentTerminal("d1", { kind: "dev-preview", hasPty: undefined }),
+        makeAgentTerminal("r1", { kind: "review", hasPty: undefined }),
+      ]);
+      useFleetArmingStore.getState().armAll("all");
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
     });
   });
 

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -2,16 +2,21 @@ import { create } from "zustand";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
-import type { TerminalInstance } from "@shared/types";
 import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
 import type { AgentState } from "@/types";
 import { isAgentFleetActionEligible, isTerminalFleetEligible } from "./fleetEligibility";
+
+// Carrier shape sourced from `getNarrowPanel`'s parameter so this file doesn't
+// have to name the legacy carrier type directly — auto-tracks the carrier flip
+// in step 5 of #8957.
+type PanelCarrierMap = Parameters<typeof getNarrowPanel>[0];
 
 export {
   isAgentFleetActionEligible,
   isFleetInterruptAgentEligible,
   isFleetRestartAgentEligible,
   isFleetWaitingAgentEligible,
+  isTerminalErrorClusterEligible,
   isTerminalFleetEligible,
   resolveFleetAgentCapabilityId,
 } from "./fleetEligibility";
@@ -70,7 +75,7 @@ function matchesPreset(state: AgentState | null | undefined, preset: FleetArmSta
 }
 
 export function isFleetArmEligible(
-  t: PanelInstance | TerminalInstance | undefined
+  t: PanelInstance | PanelCarrierMap[string] | undefined
 ): t is PtyPanelData {
   return isTerminalFleetEligible(t);
 }
@@ -132,7 +137,7 @@ export function computeArmByStateIds(
 export function collectFilterArmEligibleIds(
   worktreeIds: readonly string[],
   panelIds: readonly string[],
-  panelsById: Record<string, TerminalInstance>
+  panelsById: PanelCarrierMap
 ): string[] {
   if (worktreeIds.length === 0) return [];
   const worktreeIdSet = new Set(worktreeIds);
@@ -386,10 +391,7 @@ function getActiveWorktreeId(): string | null {
  * destroy → mutate panels → re-init) get pruned on re-registration.
  */
 export function subscribeFleetArmingPanelPruning(): () => void {
-  function reconcileAgainst(
-    currentIds: readonly string[],
-    currentById: Record<string, TerminalInstance>
-  ): void {
+  function reconcileAgainst(currentIds: readonly string[], currentById: PanelCarrierMap): void {
     const armed = useFleetArmingStore.getState().armedIds;
     if (armed.size === 0) return;
 

--- a/src/store/fleetEligibility.ts
+++ b/src/store/fleetEligibility.ts
@@ -1,7 +1,14 @@
 import type { BuiltInAgentId } from "@shared/config/agentIds";
 import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
-import type { TerminalInstance } from "@shared/types";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { getBuiltInRuntimeAgentId } from "@/utils/terminalType";
+
+// Carrier element from the legacy `panelsById` shape, sourced through
+// `getNarrowPanel`'s parameter so this file doesn't import the deprecated
+// `TerminalInstance` alias by name. Lets external callers that still hand
+// out raw carrier entries pass through these predicates while the rest of
+// the renderer migrates to `getNarrowPanel` (#8957).
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 /**
  * Fleet membership/broadcast predicate: the terminal has a writable PTY and is
@@ -10,7 +17,7 @@ import { getBuiltInRuntimeAgentId } from "@/utils/terminalType";
  * state that warns a user their keystrokes are being broadcast.
  */
 export function isTerminalFleetEligible(
-  t: PanelInstance | TerminalInstance | undefined
+  t: PanelInstance | CarrierPanel | undefined
 ): t is PtyPanelData {
   if (!t) return false;
   if (!isPtyPanel(t)) return false;
@@ -31,7 +38,7 @@ export function isTerminalFleetEligible(
  * gate because their downstream actions assume a live PTY.
  */
 export function isTerminalErrorClusterEligible(
-  t: PanelInstance | TerminalInstance | undefined
+  t: PanelInstance | CarrierPanel | undefined
 ): t is PtyPanelData {
   if (!t) return false;
   if (!isPtyPanel(t)) return false;
@@ -47,26 +54,26 @@ export function isTerminalErrorClusterEligible(
  * still require an agent identity because those actions depend on agent state.
  */
 export function resolveFleetAgentCapabilityId(
-  t: PanelInstance | TerminalInstance | undefined
+  t: PanelInstance | CarrierPanel | undefined
 ): BuiltInAgentId | undefined {
   if (!t || !isPtyPanel(t)) return undefined;
   return getBuiltInRuntimeAgentId(t);
 }
 
 export function isAgentFleetActionEligible(
-  t: PanelInstance | TerminalInstance | undefined
+  t: PanelInstance | CarrierPanel | undefined
 ): t is PtyPanelData {
   return isTerminalFleetEligible(t) && resolveFleetAgentCapabilityId(t) !== undefined;
 }
 
 export function isFleetWaitingAgentEligible(
-  t: PanelInstance | TerminalInstance | undefined
+  t: PanelInstance | CarrierPanel | undefined
 ): t is PtyPanelData {
   return isAgentFleetActionEligible(t) && t.agentState === "waiting";
 }
 
 export function isFleetInterruptAgentEligible(
-  t: PanelInstance | TerminalInstance | undefined
+  t: PanelInstance | CarrierPanel | undefined
 ): t is PtyPanelData {
   return (
     isAgentFleetActionEligible(t) && (t.agentState === "working" || t.agentState === "waiting")
@@ -74,7 +81,7 @@ export function isFleetInterruptAgentEligible(
 }
 
 export function isFleetRestartAgentEligible(
-  t: PanelInstance | TerminalInstance | undefined
+  t: PanelInstance | CarrierPanel | undefined
 ): t is PtyPanelData {
   return isAgentFleetActionEligible(t);
 }


### PR DESCRIPTION
## Summary

- Batch B of the `TerminalInstance` drain (#8957), following #9076 (batch A). Removes `TerminalInstance` imports from the four remaining fleet-domain files.
- Uses a `CarrierPanel` type alias derived from `Parameters<typeof getNarrowPanel>[0][string]` so external callers keep working without type assertions; `fleetArmingStore.ts` gets a matching `PanelCarrierMap` alias and re-exports `isTerminalErrorClusterEligible` for downstream consumers.
- ESLint baseline drops from 1228 to 1224 (`no-restricted-imports` 51 → 47).

Addresses #8957 (does not close — batches C+ and steps 5–6 still pending).

## Changes

- `src/store/fleetEligibility.ts` — drops `TerminalInstance` import; predicate unions typed via `CarrierPanel` alias
- `src/store/fleetArmingStore.ts` — drops `TerminalInstance` import; uses `PanelCarrierMap` alias; re-exports `isTerminalErrorClusterEligible`
- `src/components/Fleet/FleetPickerContent.tsx` — swaps `TerminalInstance["agentState"]` for a direct `AgentState` import
- `src/components/Fleet/fleetRawInputBroadcast.ts` — routes `resolveLiveFleetTargetIds` through `getNarrowPanel` instead of carrying a `TerminalInstance` reference
- `eslint-warnings-baseline.json` — ratcheted down to reflect the four removed `no-restricted-imports` violations

## Testing

Added `src/store/__tests__/fleetArmingStore.test.ts` covering:
- Non-PTY kind rejection across all 7 fleet eligibility predicates
- `armMatchingFilter`, `armAll`, `addToFleet` with non-PTY panels
- Panel-prune subscription behaviour

## Next steps

Batches C+ cover the Worktree, Terminal, DragDrop, hooks, and action-defs domains. Steps 5 (carrier flip) and 6 (cleanup) are deferred to separate PRs once all domains are drained.