### PR TITLE
refactor(panels): finish TerminalInstance drain (closes #8957)

### DIFF
--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1224,
+  "count": 1183,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
-    "@typescript-eslint/no-unsafe-type-assertion": 484,
-    "no-restricted-imports": 47,
-    "no-restricted-syntax": 420,
+    "@typescript-eslint/no-unsafe-type-assertion": 487,
+    "no-restricted-imports": 8,
+    "no-restricted-syntax": 414,
     "no-useless-assignment": 20,
     "preserve-caught-error": 52,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 38
   },
-  "updatedAt": "2026-05-25T09:00:06.718Z"
+  "updatedAt": "2026-05-25T16:08:42.314Z"
 }

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -11,5 +11,5 @@
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-05-25T17:52:38.054Z"
+  "updatedAt": "2026-05-25T18:31:00.911Z"
 }

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1188,
+  "count": 1187,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
     "@typescript-eslint/no-unsafe-type-assertion": 490,
-    "no-restricted-imports": 9,
+    "no-restricted-imports": 8,
     "no-restricted-syntax": 413,
     "no-useless-assignment": 20,
     "preserve-caught-error": 52,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-05-25T17:35:25.028Z"
+  "updatedAt": "2026-05-25T17:52:38.054Z"
 }

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1183,
+  "count": 1188,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 54,
     "@typescript-eslint/no-floating-promises": 93,
-    "@typescript-eslint/no-unsafe-type-assertion": 487,
-    "no-restricted-imports": 8,
-    "no-restricted-syntax": 414,
+    "@typescript-eslint/no-unsafe-type-assertion": 490,
+    "no-restricted-imports": 9,
+    "no-restricted-syntax": 413,
     "no-useless-assignment": 20,
     "preserve-caught-error": 52,
     "react-compiler/react-compiler": 16,
-    "react-hooks/exhaustive-deps": 38
+    "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-05-25T16:08:42.314Z"
+  "updatedAt": "2026-05-25T17:35:25.028Z"
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -583,44 +583,6 @@ export default tseslint.config(
               message:
                 "Importing githubClient from the barrel is restricted. If this file is in the allowlist, import from @/clients/githubClient directly. Otherwise use forgeClient or dispatch forge.* actions. See #8460.",
             },
-            // TerminalInstance is the legacy kitchen-sink carrier interface being
-            // drained from the renderer store (#8957). New code should read the
-            // PanelInstance discriminated union via the getNarrowPanel/getNarrowPanels
-            // adapter selectors in src/store/slices/panelRegistry/selectors.ts.
-            // Restriction is a warning so the existing ~50 call sites are ratcheted
-            // down domain-by-domain in follow-up PRs rather than blocked all at once.
-            // Note: relative imports (e.g. `./types` inside panelRegistry/) are not
-            // matched by these alias entries — a known gap for slice-internal files.
-            {
-              name: "@shared/types",
-              importNames: ["TerminalInstance"],
-              message:
-                "TerminalInstance is the legacy carrier interface. Use PanelInstance from @shared/types/panel plus the getNarrowPanel/getNarrowPanels adapter selectors. See #8957.",
-            },
-            {
-              name: "@shared/types/panel",
-              importNames: ["TerminalInstance"],
-              message:
-                "TerminalInstance is the legacy carrier interface. Use PanelInstance from @shared/types/panel plus the getNarrowPanel/getNarrowPanels adapter selectors. See #8957.",
-            },
-            {
-              name: "@/types",
-              importNames: ["TerminalInstance"],
-              message:
-                "TerminalInstance is the legacy carrier interface. Use PanelInstance from @shared/types/panel plus the getNarrowPanel/getNarrowPanels adapter selectors. See #8957.",
-            },
-            {
-              name: "@/store",
-              importNames: ["TerminalInstance"],
-              message:
-                "TerminalInstance is the legacy carrier interface. Use PanelInstance from @shared/types/panel plus the getNarrowPanel/getNarrowPanels adapter selectors. See #8957.",
-            },
-            {
-              name: "@/store/panelStore",
-              importNames: ["TerminalInstance"],
-              message:
-                "TerminalInstance is the legacy carrier interface. Use PanelInstance from @shared/types/panel plus the getNarrowPanel/getNarrowPanels adapter selectors. See #8957.",
-            },
           ],
           patterns: [
             {

--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -13,6 +13,7 @@ import { usePreferencesStore } from "@/store/preferencesStore";
 import { useGitHubConfigStore } from "../stores/githubConfigStore";
 import { useRecipeStore, type RecipeSpawnResults } from "@/store/recipeStore";
 import { useProjectStore } from "@/store/projectStore";
+import { isPtyPanel } from "@shared/types/panel";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -692,7 +693,7 @@ export function BulkCreateWorktreeDialog({
 
           const crashedCount = tracked.spawnedTerminalIds.filter((tid) => {
             const t = panelsById[tid];
-            return t && t.exitCode !== undefined && t.exitCode !== 0;
+            return t && isPtyPanel(t) && t.exitCode !== undefined && t.exitCode !== 0;
           }).length;
 
           if (crashedCount > 0) {

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -624,6 +624,14 @@ export interface TerminalInstance {
    * when its registration is gone.
    */
   pluginId?: string;
+  /** Legacy persisted creation timestamp (milliseconds since epoch). */
+  createdAt?: number;
+  /**
+   * Timestamp (ms) of the last user-initiated focus on this panel. Used by
+   * panel restore to promote the most-recently-active panel per worktree to
+   * the priority restore tier.
+   */
+  lastActiveAt?: number;
   // Note: Tab membership is now stored in TabGroup objects, not on panels
 }
 

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -209,6 +209,14 @@ interface BasePanelData {
    * when its registration is gone.
    */
   pluginId?: string;
+  /** Persisted creation timestamp (milliseconds since epoch). */
+  createdAt?: number;
+  /**
+   * Timestamp (ms) of the last user-initiated focus on this panel. Used by
+   * panel restore to promote the most-recently-active panel per worktree to
+   * the priority restore tier.
+   */
+  lastActiveAt?: number;
   // Note: Tab membership is now stored in TabGroup objects, not on panels
 }
 
@@ -554,20 +562,8 @@ export interface TerminalInstance {
   devPreviewConsoleOpen?: boolean;
   /** Active dev-preview console drawer tab ("output" = PTY, "console" = guest-page console) */
   devPreviewConsoleTab?: "output" | "console";
-  /** Active viewport preset for dev-preview responsive emulation (undefined = fill) */
-  viewportPreset?: ViewportPresetId;
-  /** Whether the active dev-preview viewport preset is rotated to landscape */
-  viewportRotated?: boolean;
-  /** Device-pixel-ratio override for the active dev-preview viewport preset */
-  viewportDpr?: 1 | 2 | 3;
-  /** Whether the dev-preview viewport is scaled to fit the available pane */
-  viewportFit?: boolean;
-  /** Last captured dev-preview scroll position, paired with URL for stale-scroll prevention */
-  devPreviewScrollPosition?: { url: string; scrollY: number };
   /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */
   exitBehavior?: PanelExitBehavior;
-  /** Legacy persisted creation timestamp (milliseconds since epoch) */
-  createdAt?: number;
   /** Whether this terminal has an active PTY process (false for orphaned terminals that exited) */
   hasPty?: boolean;
   /** Detected process icon ID for dynamic terminal icons (transient, not persisted) */
@@ -628,12 +624,6 @@ export interface TerminalInstance {
    * when its registration is gone.
    */
   pluginId?: string;
-  /**
-   * Timestamp (ms) of the last user-initiated focus on this panel. Used by
-   * panel restore to promote the most-recently-active panel per worktree to
-   * the priority restore tier.
-   */
-  lastActiveAt?: number;
   // Note: Tab membership is now stored in TabGroup objects, not on panels
 }
 

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -139,6 +139,8 @@ export interface PanelSnapshot {
    * the priority restore tier.
    */
   lastActiveAt?: number;
+  /** Legacy persisted creation timestamp (milliseconds since epoch). */
+  createdAt?: number;
   // Note: Tab membership is now stored in ProjectState.tabGroups, not on terminals
 }
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -61,7 +61,7 @@ import {
   getEffectiveViewportSize,
   computeFitScale,
 } from "@/panels/dev-preview/viewportPresets";
-import type { ViewportPresetId } from "@shared/types/panel";
+import { isDevPreviewPanel, type ViewportPresetId } from "@shared/types/panel";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { getDevPreviewWebContents, buildEmulationParams } from "./viewportEmulation";
 import { logError } from "@/utils/logger";
@@ -235,7 +235,10 @@ export function DevPreviewPane({
   const projectEnv = projectSettings?.environmentVariables;
   const isDragging = useIsDragging();
 
-  const terminal = usePanelStore((state) => state.getTerminal(id));
+  const terminal = usePanelStore((state) => {
+    const p = state.getTerminal(id);
+    return p && isDevPreviewPanel(p) ? p : undefined;
+  });
   const devCommand =
     terminal?.devCommand?.trim() || projectSettings?.devServerCommand?.trim() || "";
   const viewportPreset = terminal?.viewportPreset;

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -294,6 +294,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       return element;
     }) as typeof document.createElement;
     terminalStoreState.getTerminal.mockImplementation(() => ({
+      kind: "dev-preview",
       id: "dev-preview-panel-1",
       browserHistory: {
         past: [],
@@ -373,6 +374,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
   it("binds loading listeners when webview mounts after initial waiting state", async () => {
     terminalStoreState.getTerminal.mockImplementation(() => ({
+      kind: "dev-preview",
       id: "dev-preview-panel-1",
       browserHistory: {
         past: [],
@@ -487,6 +489,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
   describe("viewport device emulation", () => {
     const withPreset = (preset: string | undefined) => {
       terminalStoreState.getTerminal.mockImplementation(() => ({
+        kind: "dev-preview",
         id: "dev-preview-panel-1",
         browserHistory: { past: [], present: "http://localhost:5173/", future: [] },
         browserZoom: 1.4,
@@ -1117,6 +1120,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         })
     );
     terminalStoreState.getTerminal.mockImplementation(() => ({
+      kind: "dev-preview",
       id: "dev-preview-panel-1",
       browserHistory: {
         past: ["http://localhost:3000/old"],

--- a/src/components/DevPreview/__tests__/useDevPreviewConsoleCapture.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewConsoleCapture.test.tsx
@@ -7,7 +7,7 @@ import { useDevPreviewConsoleCapture } from "../useDevPreviewConsoleCapture";
 import { useConsoleCaptureStore } from "@/store/consoleCaptureStore";
 import { usePanelStore } from "@/store";
 import type { SerializedConsoleRow } from "@shared/types/ipc/webviewConsole";
-import type { TerminalInstance } from "@/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 const PANE_ID = "pane-1";
 const WC_ID = 42;
@@ -187,7 +187,7 @@ describe("useDevPreviewConsoleCapture", () => {
     // Panel is still registered: unmount is a tab-switch deactivation, not a
     // deletion, so captured rows must survive until the user switches back.
     usePanelStore.setState({
-      panelsById: { [PANE_ID]: { id: PANE_ID } as unknown as TerminalInstance },
+      panelsById: { [PANE_ID]: { id: PANE_ID } as unknown as PtyPanelData },
     });
     const webview = makeWebviewElement();
     const { unmount } = renderHook(() =>

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { usePanelStore } from "@/store";
 import { useUrlHistoryStore } from "@/store/urlHistoryStore";
 import type { BrowserHistory } from "@shared/types/browser";
+import { isDevPreviewPanel } from "@shared/types/panel";
 import { getViewportPreset } from "@/panels/dev-preview/viewportPresets";
 import { getDevPreviewWebContents, buildEmulationParams } from "./viewportEmulation";
 import { pushBrowserHistory } from "../Browser/historyUtils";
@@ -101,7 +102,10 @@ export function useDevPreviewLoadLifecycle({
   // re-apply overrides after cross-origin navigation without the load-listener
   // effect depending on these values (which would tear down/rebuild load timers
   // on every change). Updated on each render from the terminal store selector.
-  const terminal = usePanelStore((s) => s.getTerminal(id));
+  const terminal = usePanelStore((s) => {
+    const p = s.getTerminal(id);
+    return p && isDevPreviewPanel(p) ? p : undefined;
+  });
   const viewportPresetRef = useRef(terminal?.viewportPreset);
   viewportPresetRef.current = terminal?.viewportPreset;
   const viewportRotatedRef = useRef(terminal?.viewportRotated ?? false);
@@ -516,7 +520,10 @@ export function useDevPreviewLoadLifecycle({
         loadTimeoutRef.current = null;
       }
 
-      const saved = usePanelStore.getState().getTerminal(id)?.devPreviewScrollPosition;
+      const currentPanel = usePanelStore.getState().getTerminal(id);
+      const saved = currentPanel && isDevPreviewPanel(currentPanel)
+        ? currentPanel.devPreviewScrollPosition
+        : undefined;
       if (saved && Number.isFinite(saved.scrollY) && saved.scrollY > 0 && saved.url) {
         try {
           const loadedUrl = webview.getURL();
@@ -549,7 +556,10 @@ export function useDevPreviewLoadLifecycle({
         // dom-ready already fired before this listener attached. Run scroll
         // restore here so the position survives tab switches and other
         // re-renders that don't trigger another dom-ready.
-        const saved = usePanelStore.getState().getTerminal(id)?.devPreviewScrollPosition;
+        const currentPanel = usePanelStore.getState().getTerminal(id);
+        const saved = currentPanel && isDevPreviewPanel(currentPanel)
+          ? currentPanel.devPreviewScrollPosition
+          : undefined;
         if (saved && Number.isFinite(saved.scrollY) && saved.scrollY > 0 && saved.url) {
           if (existingUrl === saved.url) {
             webview

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -521,9 +521,10 @@ export function useDevPreviewLoadLifecycle({
       }
 
       const currentPanel = usePanelStore.getState().getTerminal(id);
-      const saved = currentPanel && isDevPreviewPanel(currentPanel)
-        ? currentPanel.devPreviewScrollPosition
-        : undefined;
+      const saved =
+        currentPanel && isDevPreviewPanel(currentPanel)
+          ? currentPanel.devPreviewScrollPosition
+          : undefined;
       if (saved && Number.isFinite(saved.scrollY) && saved.scrollY > 0 && saved.url) {
         try {
           const loadedUrl = webview.getURL();
@@ -557,9 +558,10 @@ export function useDevPreviewLoadLifecycle({
         // restore here so the position survives tab switches and other
         // re-renders that don't trigger another dom-ready.
         const currentPanel = usePanelStore.getState().getTerminal(id);
-        const saved = currentPanel && isDevPreviewPanel(currentPanel)
-          ? currentPanel.devPreviewScrollPosition
-          : undefined;
+        const saved =
+          currentPanel && isDevPreviewPanel(currentPanel)
+            ? currentPanel.devPreviewScrollPosition
+            : undefined;
         if (saved && Number.isFinite(saved.scrollY) && saved.scrollY > 0 && saved.url) {
           if (existingUrl === saved.url) {
             webview

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -35,8 +35,9 @@ import {
   type ScreenReaderInstructions,
 } from "@dnd-kit/core";
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
-import { usePanelStore, useWorktreeSelectionStore, type TerminalInstance } from "@/store";
-
+import { usePanelStore, useWorktreeSelectionStore } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { TerminalDragPreview, TERMINAL_DRAG_PREVIEW_WIDTH } from "./TerminalDragPreview";
 import { WorktreeDragPreview } from "./WorktreeDragPreview";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -69,6 +70,8 @@ import {
   getUiAnimationDuration,
 } from "@/lib/animationUtils";
 
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
+
 // Placeholder ID used when dragging from dock to grid
 export const GRID_PLACEHOLDER_ID = "__grid-placeholder__";
 
@@ -79,7 +82,7 @@ export const TRASH_DROPPABLE_ID = "__trash-droppable__";
 interface DndPlaceholderContextValue {
   placeholderIndex: number | null;
   sourceContainer: "grid" | "dock" | null;
-  activeTerminal: TerminalInstance | null;
+  activeTerminal: PanelInstance | null;
   isDragging: boolean;
   isWorktreeSortDragging: boolean;
   /** If dragging a tab group, the group ID */
@@ -160,7 +163,7 @@ interface DndProviderProps {
 }
 
 export interface DragData {
-  terminal: TerminalInstance;
+  terminal: PanelInstance;
   sourceLocation: "grid" | "dock";
   sourceIndex: number;
   /** If panel is part of a tab group, the group ID */
@@ -368,7 +371,7 @@ function DragOverlayWithCursorTracking({
   groupTabCount,
   isCancelDrop,
 }: {
-  activeTerminal: TerminalInstance | null;
+  activeTerminal: PanelInstance | null;
   activeWorktree: WorktreeSnapshot | null;
   groupTabCount?: number;
   isCancelDrop: boolean;
@@ -566,12 +569,12 @@ export function DndProvider({ children }: DndProviderProps) {
   const setFocused = usePanelStore((s) => s.setFocused);
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
 
-  const activeTerminal = useMemo(() => {
+  const activeTerminal = useMemo((): PanelInstance | null => {
     if (!activeId && !activeData) return null;
     if (activeData?.terminal) return activeData.terminal;
     // Parse accordion IDs to get actual terminal ID
     const terminalId = parseAccordionDragId(activeId!) ?? activeId;
-    return (terminalId ? panelsById[terminalId] : null) ?? null;
+    return (terminalId ? getNarrowPanel(panelsById, terminalId) : null) ?? null;
   }, [activeId, activeData, panelsById]);
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
@@ -806,7 +809,7 @@ export function DndProvider({ children }: DndProviderProps) {
         const overTerminal = freshTerminalsById[actualOverId];
 
         if (overTerminal && actualDraggedId !== actualOverId) {
-          const containerTerminals: TerminalInstance[] = [];
+          const containerTerminals: CarrierPanel[] = [];
           for (const tid of freshTerminalIds) {
             const t = freshTerminalsById[tid];
             if (!t || (t.worktreeId ?? null) !== (accordionWorktreeId ?? null)) continue;
@@ -998,7 +1001,7 @@ export function DndProvider({ children }: DndProviderProps) {
 
         // Only stabilize grid terminals in the ACTIVE worktree
         // Use nullish coalescing to handle null/undefined mismatch (matches ContentGrid filter)
-        const gridTerminalsList: TerminalInstance[] = [];
+        const gridTerminalsList: CarrierPanel[] = [];
         for (const tid of storeState.panelIds) {
           const t = storeState.panelsById[tid];
           if (

--- a/src/components/DragDrop/SortableDockItem.tsx
+++ b/src/components/DragDrop/SortableDockItem.tsx
@@ -3,12 +3,12 @@ import { CSS } from "@dnd-kit/utilities";
 import { m } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { UI_ANIMATION_DURATION, DRAG_GHOST_OPACITY, DRAG_GHOST_EASING } from "@/lib/animationUtils";
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 import type { DragData } from "./DndProvider";
 import { DragHandleProvider } from "./DragHandleContext";
 
 interface SortableDockItemProps {
-  terminal: TerminalInstance;
+  terminal: PanelInstance;
   sourceIndex: number;
   children: React.ReactNode;
   /** If this panel is part of a tab group, the group ID */

--- a/src/components/DragDrop/SortableTerminal.tsx
+++ b/src/components/DragDrop/SortableTerminal.tsx
@@ -3,7 +3,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { m, type TransformProperties, type Transition } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { UI_ANIMATION_DURATION, DRAG_GHOST_OPACITY, DRAG_GHOST_EASING } from "@/lib/animationUtils";
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 import type { DragData } from "./DndProvider";
 import { DragHandleProvider } from "./DragHandleContext";
 
@@ -17,7 +17,7 @@ export function pixelSnapTransform({ x, y }: TransformProperties): string {
 }
 
 interface SortableTerminalProps {
-  terminal: TerminalInstance;
+  terminal: PanelInstance;
   sourceLocation: "grid" | "dock";
   sourceIndex: number;
   children: React.ReactNode;

--- a/src/components/DragDrop/SortableWorktreeTerminal.tsx
+++ b/src/components/DragDrop/SortableWorktreeTerminal.tsx
@@ -3,13 +3,13 @@ import { CSS } from "@dnd-kit/utilities";
 import { m } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { UI_ANIMATION_DURATION, DRAG_GHOST_OPACITY, DRAG_GHOST_EASING } from "@/lib/animationUtils";
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 import type { WorktreeDragData } from "./DndProvider";
 import { DragHandleProvider } from "./DragHandleContext";
 import { pixelSnapTransform } from "./SortableTerminal";
 
 interface SortableWorktreeTerminalProps {
-  terminal: TerminalInstance;
+  terminal: PanelInstance;
   worktreeId: string;
   sourceIndex: number;
   children: React.ReactNode;

--- a/src/components/DragDrop/TerminalDragPreview.tsx
+++ b/src/components/DragDrop/TerminalDragPreview.tsx
@@ -1,5 +1,5 @@
 import { Layers } from "lucide-react";
-import type { TerminalInstance } from "@/store";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { PlaceholderContent } from "./PlaceholderContent";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
@@ -10,7 +10,7 @@ import {
 import { cn } from "@/lib/utils";
 
 interface TerminalDragPreviewProps {
-  terminal: TerminalInstance;
+  terminal: PanelInstance;
   /** Number of tabs if dragging a multi-tab group */
   groupTabCount?: number;
 }
@@ -25,7 +25,8 @@ export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPre
   // Drag visual color mirrors the same chrome descriptor used by tabs/panels.
   const chrome = deriveTerminalChrome(terminal);
   const brandColor = chrome.color;
-  const displayAgentState = getTerminalAgentDisplayState(chrome, terminal.agentState);
+  const agentState = isPtyPanel(terminal) ? terminal.agentState : undefined;
+  const displayAgentState = getTerminalAgentDisplayState(chrome, agentState);
   const StateIcon = displayAgentState ? getEffectiveStateIcon(displayAgentState) : null;
   const isGroupDrag = (groupTabCount ?? 0) > 1;
 

--- a/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
 import { SortableDockItem } from "../SortableDockItem";
 import { useDragHandle } from "../DragHandleContext";
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 
 let mockIsDragging = false;
 const mockSetActivatorNodeRef = vi.fn();
@@ -28,8 +28,9 @@ vi.mock("@dnd-kit/utilities", () => ({
   },
 }));
 
-const terminal: TerminalInstance = {
+const terminal: PanelInstance = {
   id: "t2",
+  kind: "terminal",
   title: "Dock Terminal",
   cwd: "/test",
   cols: 80,
@@ -37,7 +38,7 @@ const terminal: TerminalInstance = {
   worktreeId: "wt1",
   location: "dock",
   isVisible: true,
-};
+} as PanelInstance;
 
 describe("SortableDockItem", () => {
   it("renders children through DragHandleProvider", () => {

--- a/src/components/DragDrop/__tests__/SortableTerminal.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableTerminal.test.tsx
@@ -4,7 +4,7 @@ import { render } from "@testing-library/react";
 import { CSS } from "@dnd-kit/utilities";
 import { SortableTerminal } from "../SortableTerminal";
 import { useDragHandle } from "../DragHandleContext";
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 
 let mockIsDragging = false;
 const useSortableSpy = vi.fn();
@@ -36,8 +36,9 @@ vi.mock("@dnd-kit/utilities", () => ({
   },
 }));
 
-const terminal: TerminalInstance = {
+const terminal: PanelInstance = {
   id: "t1",
+  kind: "terminal",
   title: "Terminal 1",
   cwd: "/test",
   cols: 80,
@@ -45,7 +46,7 @@ const terminal: TerminalInstance = {
   worktreeId: "wt1",
   location: "grid",
   isVisible: true,
-};
+} as PanelInstance;
 
 describe("SortableTerminal", () => {
   it("renders contain-layout and contain-style on the inner sortable div", () => {

--- a/src/components/DragDrop/__tests__/SortableWorktreeTerminal.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableWorktreeTerminal.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
 import { SortableWorktreeTerminal } from "../SortableWorktreeTerminal";
 import { useDragHandle } from "../DragHandleContext";
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 
 let mockIsDragging = false;
 const mockSetActivatorNodeRef = vi.fn();
@@ -28,8 +28,9 @@ vi.mock("@dnd-kit/utilities", () => ({
   },
 }));
 
-const terminal: TerminalInstance = {
+const terminal: PanelInstance = {
   id: "t3",
+  kind: "terminal",
   title: "Worktree Terminal",
   cwd: "/test",
   cols: 80,
@@ -37,7 +38,7 @@ const terminal: TerminalInstance = {
   worktreeId: "wt1",
   location: "grid",
   isVisible: true,
-};
+} as PanelInstance;
 
 describe("SortableWorktreeTerminal", () => {
   it("renders children when given a ReactNode", () => {

--- a/src/components/DragDrop/__tests__/dropResolution.test.ts
+++ b/src/components/DragDrop/__tests__/dropResolution.test.ts
@@ -10,12 +10,17 @@ import {
 import type { PanelInstance } from "@shared/types/panel";
 import type { TabGroup } from "@shared/types";
 
-function makeTerminal(
-  id: string,
-  location: "grid" | "dock",
-  worktreeId?: string
-): PanelInstance {
-  return { id, kind: "terminal", location, worktreeId, title: `Terminal ${id}`, cwd: "/tmp", cols: 80, rows: 24 } as PanelInstance;
+function makeTerminal(id: string, location: "grid" | "dock", worktreeId?: string): PanelInstance {
+  return {
+    id,
+    kind: "terminal",
+    location,
+    worktreeId,
+    title: `Terminal ${id}`,
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
+  } as PanelInstance;
 }
 
 function makeTabGroup(

--- a/src/components/DragDrop/__tests__/dropResolution.test.ts
+++ b/src/components/DragDrop/__tests__/dropResolution.test.ts
@@ -7,15 +7,15 @@ import {
   resolveGroupPlacementIndex,
   findGroupIndex,
 } from "../dropResolution";
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 import type { TabGroup } from "@shared/types";
 
 function makeTerminal(
   id: string,
   location: "grid" | "dock",
   worktreeId?: string
-): TerminalInstance {
-  return { id, location, worktreeId, title: `Terminal ${id}` } as TerminalInstance;
+): PanelInstance {
+  return { id, kind: "terminal", location, worktreeId, title: `Terminal ${id}`, cwd: "/tmp", cols: 80, rows: 24 } as PanelInstance;
 }
 
 function makeTabGroup(

--- a/src/components/DragDrop/dropResolution.ts
+++ b/src/components/DragDrop/dropResolution.ts
@@ -1,5 +1,7 @@
-import type { TerminalInstance } from "@/store";
 import type { TabGroup } from "@shared/types";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 export interface OverDropData {
   container?: "grid" | "dock";
@@ -17,12 +19,12 @@ export function resolveContainerId(containerId: string): "grid" | "dock" | null 
 
 /** Filter terminals to those in a given container and worktree, preserving panelIds order. */
 export function filterTerminalsByContainer(
-  terminalsById: Record<string, TerminalInstance | undefined>,
+  terminalsById: Record<string, CarrierPanel | undefined>,
   panelIds: readonly string[],
   container: "grid" | "dock",
   worktreeId: string | null | undefined
-): TerminalInstance[] {
-  const result: TerminalInstance[] = [];
+): CarrierPanel[] {
+  const result: CarrierPanel[] = [];
   for (const tid of panelIds) {
     const t = terminalsById[tid];
     if (!t || (t.worktreeId ?? undefined) !== (worktreeId ?? undefined)) continue;
@@ -44,7 +46,7 @@ export function detectTargetContainer(
   overData: OverDropData | undefined,
   dropContainer: "grid" | "dock" | null,
   overId: string,
-  terminalsById: Record<string, TerminalInstance | undefined>,
+  terminalsById: Record<string, CarrierPanel | undefined>,
   skipAccordionTarget: boolean
 ): "grid" | "dock" | null {
   if (overData?.container) return overData.container;
@@ -70,7 +72,7 @@ export function detectTargetContainer(
  * Falls back: exact terminal match → sortable.index → append-to-end.
  */
 export function resolveTargetIndex(
-  terminalsById: Record<string, TerminalInstance | undefined>,
+  terminalsById: Record<string, CarrierPanel | undefined>,
   panelIds: readonly string[],
   worktreeId: string | null | undefined,
   targetContainer: "grid" | "dock",

--- a/src/components/Fleet/FleetCountChip.tsx
+++ b/src/components/Fleet/FleetCountChip.tsx
@@ -8,6 +8,7 @@ import { FleetPickerContent } from "@/components/Fleet/FleetPickerContent";
 import type { AgentState } from "@/types";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
 import { useFleetWorktreeScope } from "./useFleetWorktreeScope";
@@ -84,7 +85,8 @@ export function FleetCountChip({
     useShallow((state) => {
       const out: Record<string, AgentState | undefined> = {};
       for (const id of armOrder) {
-        out[id] = state.panelsById[id]?.agentState;
+        const p = state.panelsById[id];
+        out[id] = p && isPtyPanel(p) ? p.agentState : undefined;
       }
       return out;
     })

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -116,10 +116,7 @@ function seed(terminals: PtyPanelData[]): void {
   usePanelStore.setState({ panelsById, panelIds });
 }
 
-function makeAgent(
-  id: string,
-  agentState: PtyPanelData["agentState"] = "idle"
-): PtyPanelData {
+function makeAgent(id: string, agentState: PtyPanelData["agentState"] = "idle"): PtyPanelData {
   return {
     id,
     title: id,

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -87,7 +87,7 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { dispatchEscape, _resetForTests as resetEscapeStack } from "@/lib/escapeStack";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 function resetStores() {
   useFleetArmingStore.setState({
@@ -106,8 +106,8 @@ function resetStores() {
   resetEscapeStack();
 }
 
-function seed(terminals: TerminalInstance[]): void {
-  const panelsById: Record<string, TerminalInstance> = {};
+function seed(terminals: PtyPanelData[]): void {
+  const panelsById: Record<string, PtyPanelData> = {};
   const panelIds: string[] = [];
   for (const t of terminals) {
     panelsById[t.id] = t;
@@ -118,19 +118,22 @@ function seed(terminals: TerminalInstance[]): void {
 
 function makeAgent(
   id: string,
-  agentState: TerminalInstance["agentState"] = "idle"
-): TerminalInstance {
+  agentState: PtyPanelData["agentState"] = "idle"
+): PtyPanelData {
   return {
     id,
     title: id,
     kind: "terminal",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     detectedAgentId: "claude",
     worktreeId: "wt-1",
     projectId: "proj-1",
     location: "grid",
     agentState,
     hasPty: true,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 describe("FleetArmingRibbon", () => {
@@ -193,8 +196,8 @@ describe("FleetArmingRibbon", () => {
 
   it("surfaces the cross-worktree count in the chip's visible label", () => {
     seed([
-      { ...makeAgent("t1"), worktreeId: "wt-a" } as TerminalInstance,
-      { ...makeAgent("t2"), worktreeId: "wt-b" } as TerminalInstance,
+      { ...makeAgent("t1"), worktreeId: "wt-a" } as PtyPanelData,
+      { ...makeAgent("t2"), worktreeId: "wt-b" } as PtyPanelData,
     ]);
     useFleetArmingStore.getState().armIds(["t1", "t2"]);
     render(<FleetArmingRibbon />);
@@ -231,12 +234,12 @@ describe("FleetArmingRibbon", () => {
 
   it("renders per-row health badges for working/waiting/exited and skips idle/completed/directing", () => {
     seed([
-      { ...makeAgent("t1", "working"), title: "alpha" } as TerminalInstance,
-      { ...makeAgent("t2", "waiting"), title: "beta" } as TerminalInstance,
-      { ...makeAgent("t3", "exited"), title: "gamma" } as TerminalInstance,
-      { ...makeAgent("t4", "idle"), title: "delta" } as TerminalInstance,
-      { ...makeAgent("t5", "completed"), title: "epsilon" } as TerminalInstance,
-      { ...makeAgent("t6", "directing"), title: "zeta" } as TerminalInstance,
+      { ...makeAgent("t1", "working"), title: "alpha" } as PtyPanelData,
+      { ...makeAgent("t2", "waiting"), title: "beta" } as PtyPanelData,
+      { ...makeAgent("t3", "exited"), title: "gamma" } as PtyPanelData,
+      { ...makeAgent("t4", "idle"), title: "delta" } as PtyPanelData,
+      { ...makeAgent("t5", "completed"), title: "epsilon" } as PtyPanelData,
+      { ...makeAgent("t6", "directing"), title: "zeta" } as PtyPanelData,
     ]);
     useFleetArmingStore.getState().armIds(["t1", "t2", "t3", "t4", "t5", "t6"]);
     render(<FleetArmingRibbon />);
@@ -252,8 +255,8 @@ describe("FleetArmingRibbon", () => {
 
   it("renders one badge per pane when multiple panes share the same state", () => {
     seed([
-      { ...makeAgent("t1", "exited"), title: "alpha" } as TerminalInstance,
-      { ...makeAgent("t2", "exited"), title: "beta" } as TerminalInstance,
+      { ...makeAgent("t1", "exited"), title: "alpha" } as PtyPanelData,
+      { ...makeAgent("t2", "exited"), title: "beta" } as PtyPanelData,
     ]);
     useFleetArmingStore.getState().armIds(["t1", "t2"]);
     render(<FleetArmingRibbon />);
@@ -285,8 +288,8 @@ describe("FleetArmingRibbon", () => {
 
   it("count chip opens a popover listing armed terminal titles", () => {
     seed([
-      { ...makeAgent("t1"), title: "frontend·main" } as TerminalInstance,
-      { ...makeAgent("t2"), title: "backend·main" } as TerminalInstance,
+      { ...makeAgent("t1"), title: "frontend·main" } as PtyPanelData,
+      { ...makeAgent("t2"), title: "backend·main" } as PtyPanelData,
     ]);
     useFleetArmingStore.getState().armIds(["t1", "t2"]);
     render(<FleetArmingRibbon />);
@@ -298,8 +301,8 @@ describe("FleetArmingRibbon", () => {
 
   it("per-row disarm button in the popover calls disarmId", () => {
     seed([
-      { ...makeAgent("t1"), title: "frontend·main" } as TerminalInstance,
-      { ...makeAgent("t2"), title: "backend·main" } as TerminalInstance,
+      { ...makeAgent("t1"), title: "frontend·main" } as PtyPanelData,
+      { ...makeAgent("t2"), title: "backend·main" } as PtyPanelData,
     ]);
     useFleetArmingStore.getState().armIds(["t1", "t2"]);
     render(<FleetArmingRibbon />);
@@ -315,8 +318,8 @@ describe("FleetArmingRibbon", () => {
     // targets: it closes the armed-list popover when open, but never
     // disarms the fleet. Exit requires ⌘Esc or the visible ✕ chip.
     seed([
-      { ...makeAgent("t1"), title: "frontend·main" } as TerminalInstance,
-      { ...makeAgent("t2"), title: "backend·main" } as TerminalInstance,
+      { ...makeAgent("t1"), title: "frontend·main" } as PtyPanelData,
+      { ...makeAgent("t2"), title: "backend·main" } as PtyPanelData,
     ]);
     useFleetArmingStore.getState().armIds(["t1", "t2"]);
     render(<FleetArmingRibbon />);
@@ -717,7 +720,7 @@ describe("FleetArmingRibbon", () => {
       seed([
         makeAgent("t1", "working"),
         makeAgent("t2", "waiting"),
-        { ...makeAgent("t3", "waiting"), worktreeId: "wt-2" } as TerminalInstance,
+        { ...makeAgent("t3", "waiting"), worktreeId: "wt-2" } as PtyPanelData,
       ]);
       useFleetArmingStore.getState().armIds(["t1", "t3"]);
       render(<FleetArmingRibbon />);
@@ -730,7 +733,7 @@ describe("FleetArmingRibbon", () => {
       seed([
         makeAgent("t1", "working"),
         makeAgent("t2", "waiting"),
-        { ...makeAgent("t3", "waiting"), worktreeId: "wt-2" } as TerminalInstance,
+        { ...makeAgent("t3", "waiting"), worktreeId: "wt-2" } as PtyPanelData,
       ]);
       useFleetArmingStore.getState().armIds(["t1", "t2"]);
       render(<FleetArmingRibbon />);
@@ -753,7 +756,7 @@ describe("FleetArmingRibbon", () => {
         makeAgent("t1", "working"),
         makeAgent("t2", "waiting"),
         makeAgent("t3", "completed"),
-        { ...makeAgent("t4", "waiting"), worktreeId: "wt-2" } as TerminalInstance,
+        { ...makeAgent("t4", "waiting"), worktreeId: "wt-2" } as PtyPanelData,
       ]);
       useFleetArmingStore.getState().armIds(["t1", "t4"]);
       render(<FleetArmingRibbon />);

--- a/src/components/Fleet/__tests__/FleetPickerContent.test.tsx
+++ b/src/components/Fleet/__tests__/FleetPickerContent.test.tsx
@@ -12,9 +12,10 @@ import { useFleetPickerSessionStore } from "@/store/fleetPickerSessionStore";
 import { _resetForTests as resetEscapeStack, dispatchEscape } from "@/lib/escapeStack";
 import { WorktreeStoreContext } from "@/contexts/WorktreeStoreContext";
 import { createWorktreeStore } from "@/store/createWorktreeStore";
-import type { TerminalInstance, WorktreeSnapshot } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
+import type { WorktreeSnapshot } from "@shared/types";
 
-function makeTerminal(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeTerminal(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     title: id,
@@ -25,11 +26,11 @@ function makeTerminal(id: string, overrides: Partial<TerminalInstance> = {}): Te
     agentState: "idle",
     runtimeStatus: "running",
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
-function seedTerminals(terminals: TerminalInstance[]): void {
-  const panelsById: Record<string, TerminalInstance> = {};
+function seedTerminals(terminals: PtyPanelData[]): void {
+  const panelsById: Record<string, PtyPanelData> = {};
   const panelIds: string[] = [];
   for (const t of terminals) {
     panelsById[t.id] = t;

--- a/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
+++ b/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
@@ -33,9 +33,10 @@ import { useFleetPickerSessionStore } from "@/store/fleetPickerSessionStore";
 import { _resetForTests as resetEscapeStack, dispatchEscape } from "@/lib/escapeStack";
 import { WorktreeStoreContext } from "@/contexts/WorktreeStoreContext";
 import { createWorktreeStore } from "@/store/createWorktreeStore";
-import type { TerminalInstance, WorktreeSnapshot } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
+import type { WorktreeSnapshot } from "@shared/types";
 
-function makeTerminal(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeTerminal(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     title: id,
@@ -46,11 +47,11 @@ function makeTerminal(id: string, overrides: Partial<TerminalInstance> = {}): Te
     agentState: "idle",
     runtimeStatus: "running",
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
-function seedTerminals(terminals: TerminalInstance[]): void {
-  const panelsById: Record<string, TerminalInstance> = {};
+function seedTerminals(terminals: PtyPanelData[]): void {
+  const panelsById: Record<string, PtyPanelData> = {};
   const panelIds: string[] = [];
   for (const t of terminals) {
     panelsById[t.id] = t;

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -18,7 +18,8 @@ import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
 import { setCurrentViewStore } from "@/store/createWorktreeStore";
 import type { WorktreeViewState, WorktreeViewActions } from "@/store/createWorktreeStore";
-import type { TerminalInstance, WorktreeSnapshot } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
+import type { WorktreeSnapshot } from "@shared/types";
 
 function resetStores() {
   useFleetArmingStore.setState({
@@ -30,8 +31,8 @@ function resetStores() {
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
 }
 
-function seedPanels(terminals: TerminalInstance[]): void {
-  const panelsById: Record<string, TerminalInstance> = {};
+function seedPanels(terminals: PtyPanelData[]): void {
+  const panelsById: Record<string, PtyPanelData> = {};
   const panelIds: string[] = [];
   for (const t of terminals) {
     panelsById[t.id] = t;
@@ -40,11 +41,14 @@ function seedPanels(terminals: TerminalInstance[]): void {
   usePanelStore.setState({ panelsById, panelIds });
 }
 
-function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeAgent(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     title: id,
     kind: "terminal",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     detectedAgentId: "claude",
     worktreeId: "wt-1",
     projectId: "proj-1",
@@ -52,7 +56,7 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     agentState: "idle",
     hasPty: true,
     ...(overrides as object),
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 function makeWorktree(id: string, overrides: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {

--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -14,7 +14,7 @@ import {
 } from "@/store/fleetTargetOverridesStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore } from "@/store/panelStore";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 const submitMock = vi.fn<(id: string, text: string) => Promise<void>>();
 
@@ -31,22 +31,25 @@ vi.mock("@/clients", async (importOriginal) => {
 
 import { cancelActiveBroadcast, tryFleetBroadcastFromEditor } from "../fleetEnterBroadcast";
 
-function makeAgent(id: string): TerminalInstance {
+function makeAgent(id: string): PtyPanelData {
   return {
     id,
     title: id,
     kind: "terminal",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     detectedAgentId: "claude",
     worktreeId: "wt-1",
     projectId: "proj-1",
     location: "grid",
     agentState: "idle",
     hasPty: true,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 function arm(ids: string[]): void {
-  const panelsById: Record<string, TerminalInstance> = {};
+  const panelsById: Record<string, PtyPanelData> = {};
   for (const id of ids) panelsById[id] = makeAgent(id);
   usePanelStore.setState({ panelsById, panelIds: ids });
   useFleetArmingStore.getState().armIds(ids);
@@ -139,7 +142,7 @@ describe("tryFleetBroadcastFromEditor — a11y announcements", () => {
     // the remaining 7 are skipped.
     const ids = Array.from({ length: 12 }, (_, i) => `t${i}`);
     const agents = ids.map((id) => makeAgent(id));
-    const panelsById: Record<string, TerminalInstance> = {};
+    const panelsById: Record<string, PtyPanelData> = {};
     for (const a of agents) panelsById[a.id] = a;
     usePanelStore.setState({ panelsById, panelIds: ids });
     useFleetArmingStore.getState().armIds(ids);
@@ -335,7 +338,7 @@ describe("tryFleetBroadcastFromEditor — confirmation gate", () => {
     usePanelStore.setState({
       panelsById: {
         a: makeAgent("a"),
-        b: { ...makeAgent("b"), location: "trash" } as TerminalInstance,
+        b: { ...makeAgent("b"), location: "trash" } as PtyPanelData,
         c: makeAgent("c"),
       },
       panelIds: ["a", "b", "c"],

--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -10,7 +10,7 @@ import { terminalClient } from "@/clients";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData, PanelInstance } from "@shared/types/panel";
 
 const submitMock = vi.fn<(id: string, text: string) => Promise<void>>();
 const notifyUserInputMock = vi.hoisted(() => vi.fn<(id: string, data?: string) => void>());
@@ -36,11 +36,14 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   },
 }));
 
-function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeAgent(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     title: id,
     kind: "terminal",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     detectedAgentId: "claude",
     worktreeId: "wt-1",
     projectId: "proj-1",
@@ -48,11 +51,11 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     agentState: "idle",
     hasPty: true,
     ...(overrides as object),
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
-function seedPanels(terminals: TerminalInstance[]): void {
-  const panelsById: Record<string, TerminalInstance> = {};
+function seedPanels(terminals: PanelInstance[]): void {
+  const panelsById: Record<string, PanelInstance> = {};
   const panelIds: string[] = [];
   for (const t of terminals) {
     panelsById[t.id] = t;
@@ -577,7 +580,7 @@ describe("buildFleetTargetPreviews", () => {
     // cast which silently coerced any shape into the eligible branch.
     seedPanels([
       makeAgent("terminal-1"),
-      makeAgent("browser-1", { kind: "browser", title: "Browser pane", hasPty: undefined }),
+      { id: "browser-1", kind: "browser", title: "Browser pane", location: "grid" } as PanelInstance,
     ]);
     useFleetArmingStore.getState().armIds(["terminal-1", "browser-1"]);
     const previews = buildFleetTargetPreviews("hi");

--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -580,7 +580,12 @@ describe("buildFleetTargetPreviews", () => {
     // cast which silently coerced any shape into the eligible branch.
     seedPanels([
       makeAgent("terminal-1"),
-      { id: "browser-1", kind: "browser", title: "Browser pane", location: "grid" } as PanelInstance,
+      {
+        id: "browser-1",
+        kind: "browser",
+        title: "Browser pane",
+        location: "grid",
+      } as PanelInstance,
     ]);
     useFleetArmingStore.getState().armIds(["terminal-1", "browser-1"]);
     const previews = buildFleetTargetPreviews("hi");

--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -6,7 +6,7 @@ import { useFleetFailureStore } from "@/store/fleetFailureStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 const broadcastMock = vi.hoisted(() => vi.fn<(ids: string[], data: string) => void>());
 const notifyUserInputMock = vi.hoisted(() => vi.fn<(id: string, data?: string) => void>());
@@ -32,21 +32,24 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   },
 }));
 
-function makeTerminal(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeTerminal(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     title: id,
     kind: "terminal",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     worktreeId: "wt-1",
     projectId: "proj-1",
     location: "grid",
     hasPty: true,
     ...(overrides as object),
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
-function seedPanels(terminals: TerminalInstance[]): void {
-  const panelsById: Record<string, TerminalInstance> = {};
+function seedPanels(terminals: PtyPanelData[]): void {
+  const panelsById: Record<string, PtyPanelData> = {};
   const panelIds: string[] = [];
   for (const terminal of terminals) {
     panelsById[terminal.id] = terminal;

--- a/src/components/Fleet/__tests__/fleetResolutionPreview.test.tsx
+++ b/src/components/Fleet/__tests__/fleetResolutionPreview.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/store/fleetTargetOverridesStore";
 import { usePanelStore } from "@/store/panelStore";
 import { FleetDraftingPill } from "../FleetDraftingPill";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 function resetStores() {
   useFleetArmingStore.setState({
@@ -24,18 +24,21 @@ function resetStores() {
   __resetFleetTargetOverridesStoreForTesting();
 }
 
-function seedPanel(panel: TerminalInstance) {
+function seedPanel(panel: PtyPanelData) {
   usePanelStore.setState({
     panelsById: { [panel.id]: panel },
     panelIds: [panel.id],
   });
 }
 
-function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeAgent(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     title: id,
     kind: "terminal",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     detectedAgentId: "claude",
     worktreeId: "wt-1",
     projectId: "proj-1",
@@ -43,7 +46,7 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     agentState: "idle",
     hasPty: true,
     ...(overrides as object),
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 function armAgent(terminalId: string, index: number) {

--- a/src/components/Fleet/useFleetWorktreeScope.ts
+++ b/src/components/Fleet/useFleetWorktreeScope.ts
@@ -3,6 +3,7 @@ import { useShallow } from "zustand/react/shallow";
 import { useWorktreeColorMap } from "@/hooks";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
 import type { AgentState } from "@/types";
 
 export interface FleetWorktreeScope {
@@ -30,7 +31,8 @@ export function useFleetWorktreeScope(): FleetWorktreeScope {
     useShallow((state) => {
       const out: Record<string, AgentState | undefined> = {};
       for (const id of armOrder) {
-        out[id] = state.panelsById[id]?.agentState;
+        const p = state.panelsById[id];
+        out[id] = p && isPtyPanel(p) ? p.agentState : undefined;
       }
       return out;
     })

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -45,6 +45,7 @@ import { useEscapeStack } from "@/hooks/useEscapeStack";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { TerminalRefreshTier } from "@/types";
 import { CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
+import { isPtyPanel } from "@shared/types/panel";
 import type { PinnedActionContextSnapshot } from "@shared/types/ipc/help";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { TABBABLE_SELECTOR } from "@/lib/accessibility";
@@ -157,14 +158,16 @@ export function HelpPanel({
   } = useHelpPanelStore();
 
   const terminal = usePanelStore((s) => (terminalId ? s.panelsById[terminalId] : undefined));
+  const terminalPty = terminal && isPtyPanel(terminal) ? terminal : undefined;
   // Mirrors useGettingStartedChecklist.ts:45-55 — must stay in sync. Gates the
   // intro banner so it never reappears once the user has launched any assistant
   // (`everDetectedAgent` is persisted via panelStore so this survives restarts).
   const hasEverLaunchedAgent = usePanelStore((s) =>
     s.panelIds.some((id) => {
       const p = s.panelsById[id];
+      if (!p || !isPtyPanel(p)) return false;
       return (
-        Boolean(p?.launchAgentId) || Boolean(p?.detectedAgentId) || p?.everDetectedAgent === true
+        Boolean(p.launchAgentId) || Boolean(p.detectedAgentId) || p.everDetectedAgent === true
       );
     })
   );
@@ -207,9 +210,11 @@ export function HelpPanel({
   // PTY can no longer receive dispatched commands), warning when the user has
   // since focused a different worktree than the one the session is bound to.
   // Danger wins — a dead target is the more urgent mismatch.
+  const pinnedTerminalPanelPty =
+    pinnedTerminalPanel && isPtyPanel(pinnedTerminalPanel) ? pinnedTerminalPanel : undefined;
   const isPinnedTerminalDead =
     pinnedContext?.terminalId != null &&
-    (!pinnedTerminalPanel || pinnedTerminalPanel.exitCode !== undefined);
+    (!pinnedTerminalPanel || pinnedTerminalPanelPty?.exitCode !== undefined);
   const isPinnedWorktreeDiverged =
     pinnedContext?.worktreeId != null &&
     focusedWorktreeId !== null &&
@@ -302,13 +307,13 @@ export function HelpPanel({
   // idle so the close-confirm guard protects accumulated chat history
   // indefinitely.
   useEffect(() => {
-    if (terminalId && terminal?.agentState !== undefined && terminal.agentState !== "idle") {
+    if (terminalId && terminalPty?.agentState !== undefined && terminalPty.agentState !== "idle") {
       const store = useHelpPanelStore.getState();
       if (store.terminalId === terminalId) {
         markConversationStarted();
       }
     }
-  }, [terminalId, terminal?.agentState, markConversationStarted]);
+  }, [terminalId, terminalPty?.agentState, markConversationStarted]);
 
   // React to a Settings agent change while a session is already bound.
   // `setTerminal` no longer overwrites `preferredAgentId`, so a user choice
@@ -336,7 +341,7 @@ export function HelpPanel({
     if (prevPreferredAgentIdRef.current === preferredAgentId) return;
     prevPreferredAgentIdRef.current = preferredAgentId;
     const shouldConfirm =
-      (terminal?.agentState !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(terminal.agentState)) ||
+      (terminalPty?.agentState !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(terminalPty.agentState)) ||
       conversationTouched;
     if (shouldConfirm) {
       // The dialog title and confirm action both read live `preferredAgentId`,
@@ -351,7 +356,7 @@ export function HelpPanel({
     preferredAgentId,
     terminalId,
     agentId,
-    terminal?.agentState,
+    terminalPty?.agentState,
     conversationTouched,
     showAgentSwitchConfirm,
   ]);
@@ -408,7 +413,7 @@ export function HelpPanel({
         // trust the bar's internal rAF to take focus when its ref is present
         // — no xterm fallback in that branch, otherwise CodeMirror would
         // steal focus from xterm one frame later and produce a focus flicker.
-        if (terminalId && terminal && terminal.spawnStatus !== "missing-cli") {
+        if (terminalId && terminal && terminalPty?.spawnStatus !== "missing-cli") {
           if (showHybridInputBar && inputBarRef.current) {
             inputBarRef.current.focusWithCursorAtEnd();
             return;
@@ -509,7 +514,7 @@ export function HelpPanel({
   // Confirm only when there's something to lose — a working agent or a
   // conversation the user has actually engaged with.
   const shouldConfirmNewSession =
-    (terminal?.agentState !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(terminal.agentState)) ||
+    (terminalPty?.agentState !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(terminalPty.agentState)) ||
     conversationTouched;
 
   const handleNewSession = useCallback(() => {
@@ -598,7 +603,7 @@ export function HelpPanel({
   }, [isOpen, terminal]);
 
   const showTerminal = terminalId && terminal;
-  const isMissingCli = showTerminal && terminal?.spawnStatus === "missing-cli";
+  const isMissingCli = showTerminal && terminalPty?.spawnStatus === "missing-cli";
 
   return (
     <aside
@@ -649,7 +654,7 @@ export function HelpPanel({
       />
 
       <HelpPanelHeader
-        agentState={terminal?.agentState}
+        agentState={terminalPty?.agentState}
         canStartNewSession={Boolean(terminalId && agentId)}
         onNewSession={handleNewSession}
         onOpenDocs={handleOpenAssistantDocs}
@@ -696,7 +701,7 @@ export function HelpPanel({
                     terminalId={terminalId}
                     launchAgentId={agentId ?? undefined}
                     getRefreshTier={getRefreshTier}
-                    cwd={terminal.cwd}
+                    cwd={terminalPty?.cwd}
                     hasBottomBar={showHybridInputBar}
                   />
                 </Suspense>
@@ -706,13 +711,13 @@ export function HelpPanel({
                   <LazyHybridInputBar
                     ref={inputBarRef}
                     terminalId={terminalId}
-                    cwd={terminal?.cwd ?? ""}
+                    cwd={terminalPty?.cwd ?? ""}
                     agentId={effectiveAgentId}
-                    agentHasLifecycleEvent={terminal?.stateChangeTrigger !== undefined}
-                    agentState={terminal?.agentState}
-                    disabled={terminal?.isInputLocked === true}
+                    agentHasLifecycleEvent={terminalPty?.stateChangeTrigger !== undefined}
+                    agentState={terminalPty?.agentState}
+                    disabled={terminalPty?.isInputLocked === true}
                     onSend={({ text }) => {
-                      if (terminal?.isInputLocked === true) return;
+                      if (terminalPty?.isInputLocked === true) return;
                       terminalInstanceService.notifyUserInput(terminalId);
                       // submit can now reject for dead PTYs (#8706); swallow
                       // to log so the unhandled rejection doesn't leak — the
@@ -722,7 +727,7 @@ export function HelpPanel({
                       });
                     }}
                     onSendKey={(key) => {
-                      if (terminal?.isInputLocked === true) return;
+                      if (terminalPty?.isInputLocked === true) return;
                       terminalInstanceService.notifyUserInput(terminalId);
                       terminalClient.sendKey(terminalId, key);
                     }}

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -166,9 +166,7 @@ export function HelpPanel({
     s.panelIds.some((id) => {
       const p = s.panelsById[id];
       if (!p || !isPtyPanel(p)) return false;
-      return (
-        Boolean(p.launchAgentId) || Boolean(p.detectedAgentId) || p.everDetectedAgent === true
-      );
+      return Boolean(p.launchAgentId) || Boolean(p.detectedAgentId) || p.everDetectedAgent === true;
     })
   );
   const cliDetail = useCliAvailabilityStore((s) => (agentId ? s.details[agentId] : undefined));
@@ -341,7 +339,8 @@ export function HelpPanel({
     if (prevPreferredAgentIdRef.current === preferredAgentId) return;
     prevPreferredAgentIdRef.current = preferredAgentId;
     const shouldConfirm =
-      (terminalPty?.agentState !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(terminalPty.agentState)) ||
+      (terminalPty?.agentState !== undefined &&
+        CLOSE_CONFIRM_AGENT_STATES.has(terminalPty.agentState)) ||
       conversationTouched;
     if (shouldConfirm) {
       // The dialog title and confirm action both read live `preferredAgentId`,
@@ -514,7 +513,8 @@ export function HelpPanel({
   // Confirm only when there's something to lose — a working agent or a
   // conversation the user has actually engaged with.
   const shouldConfirmNewSession =
-    (terminalPty?.agentState !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(terminalPty.agentState)) ||
+    (terminalPty?.agentState !== undefined &&
+      CLOSE_CONFIRM_AGENT_STATES.has(terminalPty.agentState)) ||
     conversationTouched;
 
   const handleNewSession = useCallback(() => {

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -56,6 +56,7 @@ import {
   agentStateDotColor,
 } from "@/components/Worktree/AgentStatusIndicator";
 import { getRuntimeOrBootAgentId } from "@/utils/terminalType";
+import { isPtyPanel } from "@shared/types/panel";
 
 type AgentType = BuiltInAgentId;
 
@@ -209,7 +210,7 @@ export function AgentButton({
       let firstId: string | null = null;
       for (const pid of ids) {
         const p = state.panelsById[pid];
-        if (!p) continue;
+        if (!p || !isPtyPanel(p)) continue;
         if (getRuntimeOrBootAgentId(p) !== type) continue;
         if (p.location === "trash" || p.location === "background") continue;
         if (!ACTIVE_AGENT_STATES.has(p.agentState)) continue;

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -69,6 +69,7 @@ import {
 } from "@/components/Worktree/AgentStatusIndicator";
 import { cn } from "@/lib/utils";
 import { getRuntimeOrBootAgentId } from "@/utils/terminalType";
+import { isPtyPanel } from "@shared/types/panel";
 
 interface AgentTrayButtonProps {
   agentAvailability?: CliAvailability;
@@ -410,7 +411,7 @@ export function AgentTrayButton({
       // Runtime identity wins so a plain shell that starts Claude/Codex is
       // tracked under the same tray entry. Launch intent is only a boot-window
       // fallback before any detector result has committed.
-      if (!p || p.location === "trash" || p.location === "background") continue;
+      if (!p || !isPtyPanel(p) || p.location === "trash" || p.location === "background") continue;
       const agentId = getRuntimeOrBootAgentId(p);
       if (!agentId) continue;
       if (activeWorktreeId && p.worktreeId !== activeWorktreeId) continue;

--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -6,7 +6,8 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/utils";
-import { usePanelStore, type TerminalInstance } from "@/store";
+import { usePanelStore } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import type { TrashedTerminalGroupMetadata } from "@/store/slices";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -25,14 +26,14 @@ interface BackgroundContainerProps {
 
 interface BackgroundDisplaySingle {
   type: "single";
-  terminal: TerminalInstance;
+  terminal: PtyPanelData;
 }
 
 interface BackgroundDisplayGroup {
   type: "group";
   groupRestoreId: string;
   groupMetadata: TrashedTerminalGroupMetadata;
-  terminals: TerminalInstance[];
+  terminals: PtyPanelData[];
 }
 
 type BackgroundDisplayItem = BackgroundDisplaySingle | BackgroundDisplayGroup;
@@ -94,10 +95,10 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
       string,
       {
         metadata: TrashedTerminalGroupMetadata | undefined;
-        terminals: TerminalInstance[];
+        terminals: PtyPanelData[];
       }
     >();
-    const singles: TerminalInstance[] = [];
+    const singles: PtyPanelData[] = [];
 
     for (const terminal of terminals) {
       const bgInfo = backgroundedTerminals.get(terminal.id);
@@ -144,7 +145,7 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
   }, [terminals, backgroundedTerminals]);
 
   const handleRestoreSingle = useCallback(
-    (terminal: TerminalInstance) => {
+    (terminal: PtyPanelData) => {
       const worktreeId = terminal.worktreeId?.trim();
       if (worktreeId && worktreeId !== activeWorktreeId) {
         trackTerminalFocus(worktreeId, terminal.id);
@@ -193,7 +194,7 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
   );
 
   const handleWatchToggle = useCallback(
-    (terminal: TerminalInstance) => {
+    (terminal: PtyPanelData) => {
       const id = terminal.id;
       if (watchedPanels.has(id)) {
         unwatchPanel(id);
@@ -373,11 +374,11 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
 }
 
 interface BackgroundSingleItemProps {
-  terminal: TerminalInstance;
+  terminal: PtyPanelData;
   worktreeName: string | undefined;
   isWatched: boolean;
-  onRestore: (terminal: TerminalInstance) => void;
-  onWatchToggle: (terminal: TerminalInstance) => void;
+  onRestore: (terminal: PtyPanelData) => void;
+  onWatchToggle: (terminal: PtyPanelData) => void;
   onKill: (terminalId: string) => void;
   compact?: boolean;
 }
@@ -532,12 +533,12 @@ function BackgroundGroupItem({
 }: {
   groupRestoreId: string;
   groupMetadata: TrashedTerminalGroupMetadata;
-  terminals: TerminalInstance[];
+  terminals: PtyPanelData[];
   worktreeMap: ReturnType<typeof useWorktrees>["worktreeMap"];
   watchedPanels: Set<string>;
   onRestoreGroup: (groupRestoreId: string, metadata: TrashedTerminalGroupMetadata) => void;
-  onRestoreSingle: (terminal: TerminalInstance) => void;
-  onWatchToggle: (terminal: TerminalInstance) => void;
+  onRestoreSingle: (terminal: PtyPanelData) => void;
+  onWatchToggle: (terminal: PtyPanelData) => void;
   onKill: (terminalId: string) => void;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -5,12 +5,9 @@ import { useDndContext, useDroppable } from "@dnd-kit/core";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  usePanelStore,
-  useProjectStore,
-  useWorktreeSelectionStore,
-  type TerminalInstance,
-} from "@/store";
+import { usePanelStore, useProjectStore, useWorktreeSelectionStore } from "@/store";
+import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import type { TrashedTerminal } from "@/store/slices";
 import { DockedTerminalItem } from "./DockedTerminalItem";
 import { DockedTabGroup } from "./DockedTabGroup";
@@ -108,17 +105,22 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
     helpTerminalId,
   ]);
 
-  const dockTerminals = useMemo(() => {
-    return storeTerminalIds
-      .map((id) => panelsById[id])
-      .filter(
-        (terminal): terminal is TerminalInstance =>
-          terminal !== undefined &&
-          terminal.location === "dock" &&
-          !trashedTerminals.has(terminal.id) &&
-          terminal.id !== helpTerminalId &&
-          (terminal.worktreeId == null || terminal.worktreeId === activeWorktreeId)
-      );
+  const dockTerminals = useMemo<PtyPanelData[]>(() => {
+    const result: PtyPanelData[] = [];
+    for (const id of storeTerminalIds) {
+      const terminal = getNarrowPanel(panelsById, id);
+      if (
+        terminal &&
+        isPtyPanel(terminal) &&
+        terminal.location === "dock" &&
+        !trashedTerminals.has(terminal.id) &&
+        terminal.id !== helpTerminalId &&
+        (terminal.worktreeId == null || terminal.worktreeId === activeWorktreeId)
+      ) {
+        result.push(terminal);
+      }
+    }
+    return result;
   }, [storeTerminalIds, panelsById, trashedTerminals, helpTerminalId, activeWorktreeId]);
 
   const { worktrees } = useWorktrees();
@@ -287,18 +289,18 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
 
   const trashedItems = Array.from(trashedTerminals.values())
     .map((trashed) => ({
-      terminal: panelsById[trashed.id],
+      terminal: panelsById[trashed.id] as PanelInstance | undefined,
       trashedInfo: trashed,
     }))
     .filter(
-      (item): item is { terminal: TerminalInstance; trashedInfo: TrashedTerminal } =>
+      (item): item is { terminal: PanelInstance; trashedInfo: TrashedTerminal } =>
         item.terminal !== undefined
     );
 
   const dockItems = useMemo<DockRenderItem[]>(() => {
     return buildDockRenderItems(
       tabGroups,
-      (groupId) => getTabGroupPanels(groupId, "dock"),
+      (groupId) => getTabGroupPanels(groupId, "dock").filter(isPtyPanel),
       helpTerminalId,
       dockTerminals
     );

--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -9,7 +9,8 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { useShallow } from "zustand/react/shallow";
-import { usePanelStore, useWorktreeSelectionStore, type TerminalInstance } from "@/store";
+import { usePanelStore, useWorktreeSelectionStore } from "@/store";
+import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { DockedPanel } from "@/components/Terminal/DockedPanel";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
@@ -50,11 +51,12 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
   const helpTerminalId = useHelpPanelStore((s) => s.terminalId);
   const dockTerminals = usePanelStore(
     useShallow((s) => {
-      const result: TerminalInstance[] = [];
+      const result: PtyPanelData[] = [];
       for (const id of s.panelIds) {
         const t = s.panelsById[id];
         if (
           t &&
+          isPtyPanel(t) &&
           t.location === "dock" &&
           !s.trashedTerminals.has(t.id) &&
           t.id !== helpTerminalId &&
@@ -91,7 +93,7 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
 
   // Handler for adding a new tab to a single panel (creates a tab group)
   const handleAddTabForPanel = useCallback(
-    async (panel: TerminalInstance) => {
+    async (panel: PtyPanelData) => {
       let groupId: string;
       let createdNewGroup = false;
 

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -24,11 +24,7 @@ import {
 import { cn, getBaseTitle } from "@/lib/utils";
 import { logError } from "@/utils/logger";
 import { useTabOverflow } from "@/hooks";
-import {
-  useTerminalInputStore,
-  usePanelStore,
-  useFocusStore,
-} from "@/store";
+import { useTerminalInputStore, usePanelStore, useFocusStore } from "@/store";
 import type { PtyPanelData } from "@shared/types/panel";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -28,8 +28,8 @@ import {
   useTerminalInputStore,
   usePanelStore,
   useFocusStore,
-  type TerminalInstance,
 } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
@@ -68,7 +68,7 @@ const TERMINAL_FOCUS_DELAY_MS = 50;
 
 interface DockedTabGroupProps {
   group: TabGroup;
-  panels: TerminalInstance[];
+  panels: PtyPanelData[];
 }
 
 export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -2,11 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDndMonitor } from "@dnd-kit/core";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn, getBaseTitle } from "@/lib/utils";
-import {
-  useTerminalInputStore,
-  usePanelStore,
-  useFocusStore,
-} from "@/store";
+import { useTerminalInputStore, usePanelStore, useFocusStore } from "@/store";
 import type { PtyPanelData } from "@shared/types/panel";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -6,8 +6,8 @@ import {
   useTerminalInputStore,
   usePanelStore,
   useFocusStore,
-  type TerminalInstance,
 } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
@@ -31,7 +31,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { DockPopoverChildProvider } from "@/components/ui/DockPopoverChildContext";
 
 interface DockedTerminalItemProps {
-  terminal: TerminalInstance;
+  terminal: PtyPanelData;
 }
 
 export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {

--- a/src/components/Layout/StatusContainer.tsx
+++ b/src/components/Layout/StatusContainer.tsx
@@ -8,7 +8,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
-import type { TerminalInstance } from "@/store/panelStore";
+import type { PtyPanelData } from "@shared/types/panel";
 import type { PanelLocation } from "@shared/types";
 import type { ComponentType } from "react";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
@@ -32,7 +32,7 @@ export interface StatusContainerConfig {
 
 interface StatusContainerProps {
   config: StatusContainerConfig;
-  terminals: TerminalInstance[];
+  terminals: PtyPanelData[];
   compact?: boolean;
 }
 

--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -9,6 +9,7 @@ import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { useFocusStore } from "@/store/focusStore";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store";
+import { isPtyPanel } from "@shared/types/panel";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { useMcpReadiness } from "@/hooks/useMcpReadiness";
 import type { McpRuntimeSnapshot } from "@shared/types";
@@ -86,9 +87,11 @@ export function ToolbarAssistantButton({
   // assistant terminal id changes, then when its agentState transitions.
   // Returning a primitive avoids needing useShallow.
   const assistantTerminalId = useHelpPanelStore((s) => s.terminalId);
-  const agentState = usePanelStore((s) =>
-    assistantTerminalId ? (s.panelsById[assistantTerminalId]?.agentState ?? null) : null
-  );
+  const agentState = usePanelStore((s) => {
+    if (!assistantTerminalId) return null;
+    const p = s.panelsById[assistantTerminalId];
+    return p && isPtyPanel(p) ? (p.agentState ?? null) : null;
+  });
   const mcp = useMcpReadiness();
   const shortcut = useKeybindingDisplay("help.togglePanel");
   const ariaShortcut = useAriaKeyshortcuts("help.togglePanel");

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useState } from "react";
 import { RotateCcw, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { usePanelStore, type TerminalInstance } from "@/store";
+import { usePanelStore } from "@/store";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import type { TrashedTerminal } from "@/store/slices";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
@@ -18,7 +19,7 @@ import { cn } from "@/lib/utils";
 const COUNTDOWN_CRITICAL_SECONDS = 5;
 
 interface TrashBinItemProps {
-  terminal: TerminalInstance;
+  terminal: PanelInstance;
   trashedInfo: TrashedTerminal;
   worktreeName?: string;
 }
@@ -50,14 +51,16 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
   }, [removePanel, terminal.id]);
 
   const terminalName = (() => {
-    const observed = terminal.lastObservedTitle;
-    if (observed && !isUselessTitle(observed)) return observed;
-    // Launch-intent only: trash labels should read the stable launch identity
-    // so a terminal's name doesn't change as runtime detection flips after trashing.
-    if (terminal.launchAgentId) {
-      if (terminal.title && !isUselessTitle(terminal.title)) return terminal.title;
-      const agentConfig = getEffectiveAgentConfig(terminal.launchAgentId);
-      return agentConfig?.name ?? terminal.launchAgentId;
+    if (isPtyPanel(terminal)) {
+      const observed = terminal.lastObservedTitle;
+      if (observed && !isUselessTitle(observed)) return observed;
+      // Launch-intent only: trash labels should read the stable launch identity
+      // so a terminal's name doesn't change as runtime detection flips after trashing.
+      if (terminal.launchAgentId) {
+        if (terminal.title && !isUselessTitle(terminal.title)) return terminal.title;
+        const agentConfig = getEffectiveAgentConfig(terminal.launchAgentId);
+        return agentConfig?.name ?? terminal.launchAgentId;
+      }
     }
     return terminal.title || "Terminal";
   })();

--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -15,7 +15,8 @@ import {
   TRASH_DROPPABLE_ID,
 } from "@/components/DragDrop";
 import { DURATION_200, UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
-import { usePanelStore, type TerminalInstance } from "@/store";
+import { usePanelStore } from "@/store";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import type { TrashedTerminal, TrashedTerminalGroupMetadata } from "@/store/slices";
 import { TrashBinItem } from "./TrashBinItem";
 import { TrashGroupItem } from "./TrashGroupItem";
@@ -24,7 +25,7 @@ const MOVED_HINT_MAX_SHOWS = 3;
 
 interface TrashContainerProps {
   trashedTerminals: Array<{
-    terminal: TerminalInstance;
+    terminal: PanelInstance;
     trashedInfo: TrashedTerminal;
   }>;
   compact?: boolean;
@@ -32,7 +33,7 @@ interface TrashContainerProps {
 
 interface GroupedTrashItem {
   type: "single";
-  terminal: TerminalInstance;
+  terminal: PanelInstance;
   trashedInfo: TrashedTerminal;
   sortKey: number;
 }
@@ -42,7 +43,7 @@ interface GroupedTrashGroup {
   groupRestoreId: string;
   groupMetadata: TrashedTerminalGroupMetadata;
   terminals: Array<{
-    terminal: TerminalInstance;
+    terminal: PanelInstance;
     trashedInfo: TrashedTerminal;
   }>;
   earliestExpiry: number;
@@ -113,12 +114,12 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
       string,
       {
         metadata: TrashedTerminalGroupMetadata | undefined;
-        terminals: Array<{ terminal: TerminalInstance; trashedInfo: TrashedTerminal }>;
+        terminals: Array<{ terminal: PanelInstance; trashedInfo: TrashedTerminal }>;
         earliestExpiry: number;
         latestExpiry: number;
       }
     >();
-    const singles: Array<{ terminal: TerminalInstance; trashedInfo: TrashedTerminal }> = [];
+    const singles: Array<{ terminal: PanelInstance; trashedInfo: TrashedTerminal }> = [];
 
     for (const item of trashedTerminals) {
       const { trashedInfo } = item;
@@ -192,7 +193,8 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
     const titles: string[] = [];
     for (const item of trashedTerminals) {
       const panel = item.terminal;
-      const title = panel.title || panel.lastObservedTitle;
+      const lastObservedTitle = isPtyPanel(panel) ? panel.lastObservedTitle : undefined;
+      const title = panel.title || lastObservedTitle;
       titles.push(title || "Untitled");
     }
     return titles;

--- a/src/components/Layout/TrashGroupItem.tsx
+++ b/src/components/Layout/TrashGroupItem.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback } from "react";
 import { RotateCcw, X, Layers, ChevronDown, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { usePanelStore, type TerminalInstance } from "@/store";
+import { usePanelStore } from "@/store";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import type { TrashedTerminal, TrashedTerminalGroupMetadata } from "@/store/slices";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
@@ -18,7 +19,7 @@ interface TrashGroupItemProps {
   groupRestoreId: string;
   groupMetadata: TrashedTerminalGroupMetadata;
   terminals: Array<{
-    terminal: TerminalInstance;
+    terminal: PanelInstance;
     trashedInfo: TrashedTerminal;
   }>;
   worktreeName?: string;
@@ -72,12 +73,14 @@ export function TrashGroupItem({
   const resolvedActiveTitle = (() => {
     if (!activeEntry) return null;
     const { terminal } = activeEntry;
-    const observed = terminal.lastObservedTitle;
-    if (observed && !isUselessTitle(observed)) return observed;
-    if (terminal.launchAgentId) {
-      if (terminal.title && !isUselessTitle(terminal.title)) return terminal.title;
-      const agentConfig = getEffectiveAgentConfig(terminal.launchAgentId);
-      return agentConfig?.name ?? terminal.launchAgentId;
+    if (isPtyPanel(terminal)) {
+      const observed = terminal.lastObservedTitle;
+      if (observed && !isUselessTitle(observed)) return observed;
+      if (terminal.launchAgentId) {
+        if (terminal.title && !isUselessTitle(terminal.title)) return terminal.title;
+        const agentConfig = getEffectiveAgentConfig(terminal.launchAgentId);
+        return agentConfig?.name ?? terminal.launchAgentId;
+      }
     }
     if (terminal.title && !isUselessTitle(terminal.title)) return terminal.title;
     return null;

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -6,7 +6,8 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/utils";
-import { usePanelStore, type TerminalInstance } from "@/store";
+import { usePanelStore } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWaitingTerminals } from "@/hooks/useTerminalSelectors";
@@ -23,14 +24,14 @@ interface WaitingContainerProps {
 
 interface WaitingDisplaySingle {
   type: "single";
-  terminal: TerminalInstance;
+  terminal: PtyPanelData;
   groupId: string | null;
 }
 
 interface WaitingDisplayGroup {
   type: "group";
   group: TabGroup;
-  waitingTerminals: TerminalInstance[];
+  waitingTerminals: PtyPanelData[];
 }
 
 type WaitingDisplayItem = WaitingDisplaySingle | WaitingDisplayGroup;
@@ -62,7 +63,7 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
     // getPanelGroup so a stale group whose location no longer matches the
     // panel falls through to a single row instead of mis-routing setActiveTab.
     const panelToGroup = new Map<string, TabGroup>();
-    const waitingByPanelId = new Map<string, TerminalInstance>();
+    const waitingByPanelId = new Map<string, PtyPanelData>();
     for (const terminal of terminals) waitingByPanelId.set(terminal.id, terminal);
     for (const group of tabGroups.values()) {
       for (const panelId of group.panelIds) {
@@ -74,7 +75,7 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
       }
     }
 
-    const groupBuckets = new Map<string, { group: TabGroup; waitingMembers: TerminalInstance[] }>();
+    const groupBuckets = new Map<string, { group: TabGroup; waitingMembers: PtyPanelData[] }>();
     const singles: WaitingDisplaySingle[] = [];
 
     for (const terminal of terminals) {
@@ -111,7 +112,7 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
   }, [terminals, tabGroups]);
 
   const handleActivate = useCallback(
-    (terminal: TerminalInstance, groupId: string | null) => {
+    (terminal: PtyPanelData, groupId: string | null) => {
       const worktreeId = terminal.worktreeId?.trim();
       if (worktreeId && worktreeId !== activeWorktreeId) {
         trackTerminalFocus(worktreeId, terminal.id);
@@ -270,10 +271,10 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
 }
 
 interface WaitingSingleItemProps {
-  terminal: TerminalInstance;
+  terminal: PtyPanelData;
   groupId: string | null;
   worktreeName: string | undefined;
-  onActivate: (terminal: TerminalInstance, groupId: string | null) => void;
+  onActivate: (terminal: PtyPanelData, groupId: string | null) => void;
   onKill: (terminalId: string) => void;
   compact?: boolean;
 }
@@ -389,9 +390,9 @@ function WaitingSingleItem({
 
 interface WaitingGroupItemProps {
   group: TabGroup;
-  waitingTerminals: TerminalInstance[];
+  waitingTerminals: PtyPanelData[];
   worktreeMap: ReturnType<typeof useWorktrees>["worktreeMap"];
-  onActivate: (terminal: TerminalInstance, groupId: string | null) => void;
+  onActivate: (terminal: PtyPanelData, groupId: string | null) => void;
   onKill: (terminalId: string) => void;
 }
 

--- a/src/components/Layout/__tests__/BackgroundContainer.test.tsx
+++ b/src/components/Layout/__tests__/BackgroundContainer.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, within } from "@testing-library/react";
-import type { TerminalInstance } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 import type { AgentState } from "@/types";
 
 const watchPanelMock = vi.fn();
@@ -14,7 +14,7 @@ const fireWatchNotificationMock = vi.fn();
 const selectWorktreeMock = vi.fn();
 const trackTerminalFocusMock = vi.fn();
 
-let mockTerminals: TerminalInstance[] = [];
+let mockTerminals: PtyPanelData[] = [];
 let mockBackgroundedTerminals = new Map<string, { groupRestoreId?: string }>();
 let mockWatchedPanels = new Set<string>();
 
@@ -171,7 +171,7 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({
 
 import { BackgroundContainer } from "../BackgroundContainer";
 
-function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeTerminal(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id: "t1",
     kind: "terminal",
@@ -180,8 +180,11 @@ function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstan
     worktreeId: "wt-1",
     agentState: "idle" as AgentState,
     lastStateChange: 1700000000000,
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 beforeEach(() => {

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -10,7 +10,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, fireEvent, render } from "@testing-library/react";
 import { useEffect } from "react";
-import type { TerminalInstance } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 import type { TabGroup } from "@/types";
 
 const trashPanelMock = vi.fn();
@@ -248,14 +248,17 @@ import { DockedTabGroup } from "../DockedTabGroup";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 
-function makePanel(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makePanel(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id: "t-1",
     title: "Terminal",
     location: "dock",
     kind: "terminal",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 function makeGroup(panelIds: string[], activeTabId = panelIds[0]!): TabGroup {

--- a/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
@@ -11,7 +11,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render } from "@testing-library/react";
 import { useEffect } from "react";
-import type { TerminalInstance } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 import type { TabGroup } from "@/types";
 
 const trashPanelMock = vi.fn();
@@ -243,14 +243,17 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({
 
 import { DockedTabGroup } from "../DockedTabGroup";
 
-function makePanel(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makePanel(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id: "t-1",
     title: "Terminal",
     location: "dock",
     kind: "terminal",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 function makeGroup(panelIds: string[], activeTabId = panelIds[0]!): TabGroup {

--- a/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
@@ -11,7 +11,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render } from "@testing-library/react";
 import { useEffect } from "react";
-import type { TerminalInstance } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 
 const openDockTerminalMock = vi.fn();
 const closeDockTerminalMock = vi.fn();
@@ -164,14 +164,17 @@ import { DockedTerminalItem } from "../DockedTerminalItem";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 
-function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeTerminal(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id: "t-1",
     title: "Terminal",
     location: "dock",
     kind: "terminal",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 describe("DockedTerminalItem mount-time close guard (#6602)", () => {

--- a/src/components/Layout/__tests__/ErrorsContainer.test.tsx
+++ b/src/components/Layout/__tests__/ErrorsContainer.test.tsx
@@ -2,9 +2,9 @@
 import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
 import { ErrorsContainer } from "../ErrorsContainer";
-import type { TerminalInstance } from "@/store/panelStore";
+import type { PtyPanelData } from "@shared/types/panel";
 
-const mockErrored: TerminalInstance[] = [
+const mockErrored: PtyPanelData[] = [
   {
     id: "t1",
     title: "Agent 1",
@@ -14,7 +14,10 @@ const mockErrored: TerminalInstance[] = [
     location: "grid",
     agentState: "exited",
     exitCode: 1,
-  } as TerminalInstance,
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
+  } as PtyPanelData,
 ];
 
 vi.mock("@/hooks/useTerminalSelectors", () => ({

--- a/src/components/Layout/__tests__/TrashBinItem.test.tsx
+++ b/src/components/Layout/__tests__/TrashBinItem.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render } from "@testing-library/react";
 import { TrashBinItem } from "../TrashBinItem";
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 import type { TrashedTerminal } from "@/store/slices";
 
 vi.mock("@/store", () => ({
@@ -54,15 +54,18 @@ vi.mock("@shared/config/agentRegistry", () => ({
     agentId === "claude" ? { name: "Claude" } : undefined,
 }));
 
-function makeAgentTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeAgentTerminal(overrides: Partial<PanelInstance> = {}): PanelInstance {
   return {
     id: "t1",
     kind: "terminal",
     launchAgentId: "claude",
     title: "claude",
     location: "trash",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     ...overrides,
-  } as TerminalInstance;
+  } as PanelInstance;
 }
 
 describe("TrashBinItem", () => {
@@ -118,7 +121,10 @@ describe("TrashBinItem", () => {
         kind: "terminal" as const,
         title: "my dev shell",
         location: "trash" as const,
-      } as TerminalInstance;
+        cwd: "/tmp",
+        cols: 80,
+        rows: 24,
+      } as PanelInstance;
       const trashedInfo: TrashedTerminal = {
         id: "t2",
         expiresAt: Date.now() + 20000,

--- a/src/components/Layout/__tests__/TrashContainer.test.tsx
+++ b/src/components/Layout/__tests__/TrashContainer.test.tsx
@@ -5,7 +5,7 @@ import { TrashContainer } from "../TrashContainer";
 import { usePanelStore } from "@/store";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 import type { TrashedTerminal } from "@/store/slices";
 
 let emptyTrashSpy: (...args: unknown[]) => unknown;
@@ -135,11 +135,11 @@ function makeTrashedItem(
   id: string,
   expiresAt: number = Date.now() + 10_000
 ): {
-  terminal: TerminalInstance;
+  terminal: PanelInstance;
   trashedInfo: TrashedTerminal;
 } {
   return {
-    terminal: { id, title: `Terminal ${id}` } as TerminalInstance,
+    terminal: { id, kind: "terminal", title: `Terminal ${id}`, location: "grid", cwd: "/tmp", cols: 80, rows: 24 } as PanelInstance,
     trashedInfo: {
       id,
       expiresAt,
@@ -152,9 +152,9 @@ function makeGroupAnchor(
   id: string,
   groupRestoreId: string,
   expiresAt: number
-): { terminal: TerminalInstance; trashedInfo: TrashedTerminal } {
+): { terminal: PanelInstance; trashedInfo: TrashedTerminal } {
   return {
-    terminal: { id, title: `Terminal ${id}` } as TerminalInstance,
+    terminal: { id, kind: "terminal", title: `Terminal ${id}`, location: "grid", cwd: "/tmp", cols: 80, rows: 24 } as PanelInstance,
     trashedInfo: {
       id,
       expiresAt,
@@ -174,9 +174,9 @@ function makeGroupMember(
   id: string,
   groupRestoreId: string,
   expiresAt: number
-): { terminal: TerminalInstance; trashedInfo: TrashedTerminal } {
+): { terminal: PanelInstance; trashedInfo: TrashedTerminal } {
   return {
-    terminal: { id, title: `Terminal ${id}` } as TerminalInstance,
+    terminal: { id, kind: "terminal", title: `Terminal ${id}`, location: "grid", cwd: "/tmp", cols: 80, rows: 24 } as PanelInstance,
     trashedInfo: {
       id,
       expiresAt,

--- a/src/components/Layout/__tests__/TrashContainer.test.tsx
+++ b/src/components/Layout/__tests__/TrashContainer.test.tsx
@@ -139,7 +139,15 @@ function makeTrashedItem(
   trashedInfo: TrashedTerminal;
 } {
   return {
-    terminal: { id, kind: "terminal", title: `Terminal ${id}`, location: "grid", cwd: "/tmp", cols: 80, rows: 24 } as PanelInstance,
+    terminal: {
+      id,
+      kind: "terminal",
+      title: `Terminal ${id}`,
+      location: "grid",
+      cwd: "/tmp",
+      cols: 80,
+      rows: 24,
+    } as PanelInstance,
     trashedInfo: {
       id,
       expiresAt,
@@ -154,7 +162,15 @@ function makeGroupAnchor(
   expiresAt: number
 ): { terminal: PanelInstance; trashedInfo: TrashedTerminal } {
   return {
-    terminal: { id, kind: "terminal", title: `Terminal ${id}`, location: "grid", cwd: "/tmp", cols: 80, rows: 24 } as PanelInstance,
+    terminal: {
+      id,
+      kind: "terminal",
+      title: `Terminal ${id}`,
+      location: "grid",
+      cwd: "/tmp",
+      cols: 80,
+      rows: 24,
+    } as PanelInstance,
     trashedInfo: {
       id,
       expiresAt,
@@ -176,7 +192,15 @@ function makeGroupMember(
   expiresAt: number
 ): { terminal: PanelInstance; trashedInfo: TrashedTerminal } {
   return {
-    terminal: { id, kind: "terminal", title: `Terminal ${id}`, location: "grid", cwd: "/tmp", cols: 80, rows: 24 } as PanelInstance,
+    terminal: {
+      id,
+      kind: "terminal",
+      title: `Terminal ${id}`,
+      location: "grid",
+      cwd: "/tmp",
+      cols: 80,
+      rows: 24,
+    } as PanelInstance,
     trashedInfo: {
       id,
       expiresAt,

--- a/src/components/Layout/__tests__/TrashGroupItem.test.tsx
+++ b/src/components/Layout/__tests__/TrashGroupItem.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render } from "@testing-library/react";
 import { TrashGroupItem } from "../TrashGroupItem";
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 import type { TrashedTerminal, TrashedTerminalGroupMetadata } from "@/store/slices";
 
 vi.mock("@shared/config/agentRegistry", () => ({
@@ -58,14 +58,17 @@ vi.mock("@/components/ui/tooltip", () => {
   };
 });
 
-function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeTerminal(overrides: Partial<PanelInstance> = {}): PanelInstance {
   return {
     id: "t1",
     kind: "terminal",
     title: "claude",
     location: "trash",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     ...overrides,
-  } as TerminalInstance;
+  } as PanelInstance;
 }
 
 const groupMetadata: TrashedTerminalGroupMetadata = {

--- a/src/components/Layout/__tests__/WaitingContainer.test.tsx
+++ b/src/components/Layout/__tests__/WaitingContainer.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, within } from "@testing-library/react";
-import type { TerminalInstance } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 import type { TabGroup, AgentState } from "@/types";
 
 const activateTerminalMock = vi.fn();
@@ -11,7 +11,7 @@ const setActiveTabMock = vi.fn();
 const selectWorktreeMock = vi.fn();
 const trackTerminalFocusMock = vi.fn();
 
-let mockTerminals: TerminalInstance[] = [];
+let mockTerminals: PtyPanelData[] = [];
 let mockTabGroups = new Map<string, TabGroup>();
 
 vi.mock("@/hooks/useTerminalSelectors", () => ({
@@ -159,7 +159,7 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({
 
 import { WaitingContainer } from "../WaitingContainer";
 
-function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeTerminal(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id: "t1",
     kind: "terminal",
@@ -168,8 +168,11 @@ function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstan
     worktreeId: "wt-1",
     agentState: "waiting" as AgentState,
     lastStateChange: 1700000000000,
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 function makeGroup(overrides: Partial<TabGroup> = {}): TabGroup {

--- a/src/components/Layout/__tests__/dockRenderItems.test.ts
+++ b/src/components/Layout/__tests__/dockRenderItems.test.ts
@@ -1,18 +1,19 @@
 import { describe, expect, it } from "vitest";
-import type { TerminalInstance } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 import type { TabGroup } from "@/types";
 import { buildDockRenderItems } from "../dockRenderItems";
 
-function terminal(id: string): TerminalInstance {
+function terminal(id: string): PtyPanelData {
   return {
     id,
     title: id,
+    kind: "terminal",
     cwd: "/test",
     cols: 80,
     rows: 24,
     location: "dock",
     isVisible: false,
-  };
+  } as PtyPanelData;
 }
 
 function group(panelIds: string[], activeTabId = panelIds[0] ?? ""): TabGroup {

--- a/src/components/Layout/dockRenderItems.ts
+++ b/src/components/Layout/dockRenderItems.ts
@@ -1,16 +1,16 @@
-import type { TerminalInstance } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 import type { TabGroup } from "@/types";
 
 export interface DockRenderItem {
   group: TabGroup;
-  panels: TerminalInstance[];
+  panels: PtyPanelData[];
 }
 
 export function buildDockRenderItems(
   tabGroups: TabGroup[],
-  resolvePanels: (groupId: string) => TerminalInstance[],
+  resolvePanels: (groupId: string) => PtyPanelData[],
   excludedPanelId?: string | null,
-  dockTerminals: TerminalInstance[] = []
+  dockTerminals: PtyPanelData[] = []
 ): DockRenderItem[] {
   const renderedPanelIds = new Set<string>();
   const items = tabGroups.flatMap((group) => {

--- a/src/components/Layout/useOverflowBadgeSeverity.ts
+++ b/src/components/Layout/useOverflowBadgeSeverity.ts
@@ -10,6 +10,7 @@ import { getRuntimeOrBootAgentId } from "@/utils/terminalType";
 import { BUILT_IN_AGENT_IDS, isBuiltInAgentId, type BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentState } from "@shared/types";
 import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
+import { isPtyPanel } from "@shared/types/panel";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
 
 export type OverflowBadgeSeverity = "critical" | "warning" | "info" | null;
@@ -72,7 +73,7 @@ export function useOverflowBadgeSeverity(
       // meant to surface.
       for (const pid of panelIds) {
         const p = panelsById[pid];
-        if (!p || p.location === "trash" || p.location === "background") continue;
+        if (!p || !isPtyPanel(p) || p.location === "trash" || p.location === "background") continue;
         const agentId = getRuntimeOrBootAgentId(p);
         if (!agentId || !overflowedAgentSet.has(agentId)) continue;
         if (activeWorktreeId && p.worktreeId !== activeWorktreeId) continue;

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -289,8 +289,11 @@ function PanelHeaderComponent({
   const isInputLocked = terminalPty?.isInputLocked ?? false;
   const hasPty = panelKindHasPty(kind);
 
-  // Whether the overflow "..." menu has any items to show
-  const showMoveToDock = !!onMinimize && !isMaximized && location !== "dock";
+  // Whether the overflow "..." menu has any items to show.
+  // Dock rendering is PTY-only (`ContentDock` / `DockPanelOffscreenContainer`
+  // filter via `isPtyPanel`); offering the move-to-dock affordance for
+  // browser/dev-preview/review panels would silently strand them.
+  const showMoveToDock = !!onMinimize && !isMaximized && location !== "dock" && hasPty;
   const hasOverflowItems = true;
 
   // Restart handler for Radix DropdownMenu onSelect

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -67,6 +67,7 @@ import { TabButton, type TabInfo } from "./TabButton";
 import { SortableTabButton } from "./SortableTabButton";
 
 import { panelKindCanRestart, panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { isPtyPanel } from "@shared/types/panel";
 import { actionService } from "@/services/ActionService";
 import { fireWatchNotification } from "@/lib/watchNotification";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
@@ -284,7 +285,8 @@ function PanelHeaderComponent({
   );
 
   const terminal = usePanelStore((state) => state.panelsById[id]);
-  const isInputLocked = terminal?.isInputLocked ?? false;
+  const terminalPty = terminal && isPtyPanel(terminal) ? terminal : undefined;
+  const isInputLocked = terminalPty?.isInputLocked ?? false;
   const hasPty = panelKindHasPty(kind);
 
   // Whether the overflow "..." menu has any items to show
@@ -346,15 +348,15 @@ function PanelHeaderComponent({
     if (isWatched) {
       unwatchPanel(id);
     } else if (
-      terminal?.agentState === "completed" ||
-      terminal?.agentState === "waiting" ||
-      terminal?.agentState === "exited"
+      terminalPty?.agentState === "completed" ||
+      terminalPty?.agentState === "waiting" ||
+      terminalPty?.agentState === "exited"
     ) {
-      fireWatchNotification(id, terminal.title ?? id, terminal.agentState);
+      fireWatchNotification(id, terminal?.title ?? id, terminalPty.agentState);
     } else {
       watchPanel(id);
     }
-  }, [id, isWatched, unwatchPanel, watchPanel, terminal]);
+  }, [id, isWatched, unwatchPanel, watchPanel, terminal, terminalPty]);
 
   // Bump a generation counter on each false→true transition of
   // `isFleetPreviewed` so the enter-cue overlay (keyed by this counter)

--- a/src/components/Project/RunningTaskList.tsx
+++ b/src/components/Project/RunningTaskList.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { X, Eye, RotateCw } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
-import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
+import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { terminalClient } from "@/clients";
 import { cn } from "@/lib/utils";
 import { logError } from "@/utils/logger";
@@ -12,7 +14,7 @@ const AUTO_CLEAR_DELAY = 3000;
 
 type TaskStatus = "running" | "success" | "failed" | "restarting";
 
-function deriveTaskStatus(t: TerminalInstance): TaskStatus {
+function deriveTaskStatus(t: PtyPanelData): TaskStatus {
   if (t.isRestarting) return "restarting";
   if (t.runtimeStatus === "exited") {
     return t.exitCode === 0 ? "success" : "failed";
@@ -34,16 +36,17 @@ interface RunningTaskListProps {
 export function RunningTaskList({ worktreeId }: RunningTaskListProps) {
   const quickRunTerminals = usePanelStore(
     useShallow((state) => {
-      const result: TerminalInstance[] = [];
+      const result: PtyPanelData[] = [];
       for (const id of state.panelIds) {
-        const t = state.panelsById[id];
+        const panel = getNarrowPanel(state.panelsById, id);
         if (
-          t &&
-          t.spawnedBy === "quickrun" &&
-          t.worktreeId === worktreeId &&
-          t.location !== "trash"
+          panel &&
+          isPtyPanel(panel) &&
+          panel.spawnedBy === "quickrun" &&
+          panel.worktreeId === worktreeId &&
+          panel.location !== "trash"
         ) {
-          result.push(t);
+          result.push(panel);
         }
       }
       return result;
@@ -175,7 +178,7 @@ export function RunningTaskList({ worktreeId }: RunningTaskListProps) {
 }
 
 interface TaskRowProps {
-  terminal: TerminalInstance;
+  terminal: PtyPanelData;
   status: TaskStatus;
   now: number;
   onStop: (id: string) => void;

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -78,6 +78,7 @@ import { useRecipeDialogState } from "./useRecipeDialogState";
 import { RecipeEditor } from "@/components/TerminalRecipe/RecipeEditor";
 import { RecipeManager } from "@/components/TerminalRecipe/RecipeManager";
 import { isAgentTerminal } from "@/utils/terminalType";
+import { isPtyPanel } from "@shared/types/panel";
 import { isTerminalVisible } from "@/lib/terminalVisibility";
 import { useWorktreeIds } from "@/hooks/useTerminalSelectors";
 import { logError } from "@/utils/logger";
@@ -609,7 +610,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         if (!t) continue;
         if (!isTerminalVisible(t, isInTrash, worktreeIds)) continue;
         terminalCount++;
-        if (!isAgentTerminal(t)) continue;
+        if (!isAgentTerminal(t) || !isPtyPanel(t)) continue;
         if (t.agentState === "working") hasWorkingAgent = true;
         if (t.agentState === "waiting") {
           hasWaitingAgent = true;

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -7,6 +7,7 @@ import { useHomeDir } from "@/hooks/app/useHomeDir";
 import { svgToDataUrl, sanitizeSvg } from "@/lib/svg";
 import { actionService } from "@/services/ActionService";
 import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
 import { useRecipeStore } from "@/store/recipeStore";
 import { formatPath, middleTruncate } from "@/utils/textParsing";
 import { RotatingTip } from "./contentGridTips";
@@ -50,8 +51,9 @@ export function ContentGridEmptyState({
   const hasEverLaunchedAgent = usePanelStore((state) =>
     state.panelIds.some((id) => {
       const p = state.panelsById[id];
+      if (!p || !isPtyPanel(p)) return false;
       return (
-        Boolean(p?.launchAgentId) || Boolean(p?.detectedAgentId) || p?.everDetectedAgent === true
+        Boolean(p.launchAgentId) || Boolean(p.detectedAgentId) || p.everDetectedAgent === true
       );
     })
   );

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -52,9 +52,7 @@ export function ContentGridEmptyState({
     state.panelIds.some((id) => {
       const p = state.panelsById[id];
       if (!p || !isPtyPanel(p)) return false;
-      return (
-        Boolean(p.launchAgentId) || Boolean(p.detectedAgentId) || p.everDetectedAgent === true
-      );
+      return Boolean(p.launchAgentId) || Boolean(p.detectedAgentId) || p.everDetectedAgent === true;
     })
   );
   // Suppress RecipeRunner until the recipe store has settled for the current

--- a/src/components/Terminal/DockedPanel.tsx
+++ b/src/components/Terminal/DockedPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useSyncExternalStore } from "react";
-import { usePanelStore, type TerminalInstance } from "@/store";
+import { usePanelStore } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import {
   getPanelKindDefinition,
@@ -12,7 +13,7 @@ import { usePanelHandlers } from "@/hooks/usePanelHandlers";
 import { buildPanelProps } from "@/utils/panelProps";
 
 export interface DockedPanelProps {
-  terminal: TerminalInstance;
+  terminal: PanelInstance;
   onPopoverClose?: () => void;
   onAddTab?: () => void;
   /** Show the inline "Open in grid" header control (single-panel dock only). */

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useMemo, useSyncExternalStore } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { usePanelStore, type TerminalInstance } from "@/store";
+import { usePanelStore } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import {
   getPanelKindDefinition,
@@ -44,7 +46,7 @@ export interface GridPanelProps {
   // Panel-aware add-tab callback. Receives the subscribed terminal. Pass a
   // stable handler (e.g., `ctx.handleAddTabForPanel`) — GridPanel composes
   // the no-arg shape internally and skips it in fleet scope.
-  onAddTabForPanel?: (terminal: TerminalInstance) => void | Promise<void>;
+  onAddTabForPanel?: (terminal: PanelInstance) => void | Promise<void>;
   onTabReorder?: (newOrder: string[]) => void;
 }
 
@@ -126,7 +128,11 @@ export const GridPanel = React.memo(function GridPanel({
     if (onAddTab) return onAddTab;
     if (onAddTabForPanel && terminal) {
       return () => {
-        void onAddTabForPanel(terminal);
+        const narrowed = getNarrowPanel(
+          usePanelStore.getState().panelsById,
+          terminal.id
+        );
+        if (narrowed) void onAddTabForPanel(narrowed);
       };
     }
     return undefined;

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -128,10 +128,7 @@ export const GridPanel = React.memo(function GridPanel({
     if (onAddTab) return onAddTab;
     if (onAddTabForPanel && terminal) {
       return () => {
-        const narrowed = getNarrowPanel(
-          usePanelStore.getState().panelsById,
-          terminal.id
-        );
+        const narrowed = getNarrowPanel(usePanelStore.getState().panelsById, terminal.id);
         if (narrowed) void onAddTabForPanel(narrowed);
       };
     }

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useMemo, useEffect, useEffectEvent, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { usePanelStore, type TerminalInstance } from "@/store";
+import { usePanelStore } from "@/store";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { logError } from "@/utils/logger";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
@@ -34,8 +36,8 @@ export const GridTabGroup = React.memo(function GridTabGroup({
   const panels = usePanelStore(
     useShallow((state) =>
       group.panelIds
-        .map((id) => state.panelsById[id])
-        .filter((p): p is TerminalInstance => p !== undefined)
+        .map((id) => getNarrowPanel(state.panelsById, id))
+        .filter((p): p is PanelInstance => p !== undefined)
     )
   );
 
@@ -94,47 +96,48 @@ export const GridTabGroup = React.memo(function GridTabGroup({
     ]);
 
     return panels.map((p) => {
-      let presetColor = p.agentPresetColor;
+      const pty = isPtyPanel(p) ? p : null;
+      let presetColor = pty?.agentPresetColor;
       let fallbackTooltip: string | undefined;
-      if (p.launchAgentId && p.agentPresetId) {
+      if (pty?.launchAgentId && pty.agentPresetId) {
         const presets = getMergedPresets(
-          p.launchAgentId,
-          agentSettings?.agents?.[p.launchAgentId]?.customPresets,
-          ccrPresetsByAgent[p.launchAgentId],
-          projectPresetsByAgent[p.launchAgentId]
+          pty.launchAgentId,
+          agentSettings?.agents?.[pty.launchAgentId]?.customPresets,
+          ccrPresetsByAgent[pty.launchAgentId],
+          projectPresetsByAgent[pty.launchAgentId]
         );
-        const live = presets.find((f) => f.id === p.agentPresetId);
+        const live = presets.find((f) => f.id === pty.agentPresetId);
         if (live) presetColor = live.color ?? presetColor;
-        if (p.isUsingFallback && p.originalPresetId) {
-          const original = presets.find((f) => f.id === p.originalPresetId);
-          const originalName = original?.name ?? p.originalPresetId;
-          const activeName = live?.name ?? p.agentPresetId;
+        if (pty.isUsingFallback && pty.originalPresetId) {
+          const original = presets.find((f) => f.id === pty.originalPresetId);
+          const originalName = original?.name ?? pty.originalPresetId;
+          const activeName = live?.name ?? pty.agentPresetId;
           fallbackTooltip = `Using fallback "${activeName}" — "${originalName}" unavailable`;
         }
       }
 
       const hasDangerousFlags =
-        p.agentLaunchFlags?.some((flag) => dangerousFlags.has(flag)) ?? false;
+        pty?.agentLaunchFlags?.some((flag) => dangerousFlags.has(flag)) ?? false;
 
       return {
         id: p.id,
         title: p.title,
         chrome: deriveTerminalChrome({
           kind: p.kind,
-          launchAgentId: p.launchAgentId,
-          runtimeIdentity: p.runtimeIdentity,
-          detectedAgentId: p.detectedAgentId,
-          detectedProcessId: p.detectedProcessId,
-          agentState: p.agentState,
-          runtimeStatus: p.runtimeStatus,
-          exitCode: p.exitCode,
+          launchAgentId: pty?.launchAgentId,
+          runtimeIdentity: pty?.runtimeIdentity,
+          detectedAgentId: pty?.detectedAgentId,
+          detectedProcessId: pty?.detectedProcessId,
+          agentState: pty?.agentState,
+          runtimeStatus: pty?.runtimeStatus,
+          exitCode: pty?.exitCode,
           presetColor,
         }),
         kind: p.kind ?? "terminal",
-        agentState: p.agentState,
+        agentState: pty?.agentState,
         isActive: p.id === activeTabId,
         presetColor,
-        isUsingFallback: p.isUsingFallback,
+        isUsingFallback: pty?.isUsingFallback,
         fallbackTooltip,
         hasDangerousFlags,
       };
@@ -146,7 +149,13 @@ export const GridTabGroup = React.memo(function GridTabGroup({
 
   // Compute highest-urgency agent state across all tabs so the group container
   // reflects blocked/working state even when the blocking tab is not active.
-  const groupAmbientState = useMemo(() => getGroupAmbientAgentState(panels), [panels]);
+  // Filter to PTY panels because getGroupAmbientAgentState expects agent-state
+  // fields only present on PtyPanelData; browser/dev-preview panels contribute
+  // nothing to ambient state anyway.
+  const groupAmbientState = useMemo(
+    () => getGroupAmbientAgentState(panels.filter(isPtyPanel)),
+    [panels]
+  );
 
   // Restore focus to the destination tab when switching tabs within a focused
   // group. The registry handler routes to either xterm or the hybrid input

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -9,7 +9,7 @@ import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStor
 import { isValidBrowserUrl } from "@/components/Browser/browserUtils";
 import { actionService } from "@/services/ActionService";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
-import { isBrowserPanel, isDevPreviewPanel, isReviewPanel } from "@shared/types/panel";
+import { isBrowserPanel, isDevPreviewPanel, isPtyPanel, isReviewPanel } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useIsHibernated } from "@/hooks/useIsHibernated";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
@@ -132,9 +132,11 @@ export function TerminalContextMenu({
     [terminalId]
   );
 
+  const terminalPty = terminal && isPtyPanel(terminal) ? terminal : undefined;
+  const terminalBrowser = terminal && isBrowserPanel(terminal) ? terminal : undefined;
   const isPaused =
-    terminal?.flowStatus === "paused-backpressure" ||
-    terminal?.flowStatus === "paused-resource-governor";
+    terminalPty?.flowStatus === "paused-backpressure" ||
+    terminalPty?.flowStatus === "paused-resource-governor";
 
   const currentLocation: PanelLocation = forceLocation ?? terminal?.location ?? "grid";
 
@@ -336,26 +338,26 @@ export function TerminalContextMenu({
           );
           break;
         case "open-external":
-          if (terminal.browserUrl && isValidBrowserUrl(terminal.browserUrl)) {
+          if (terminalBrowser?.browserUrl && isValidBrowserUrl(terminalBrowser.browserUrl)) {
             void actionService.dispatch(
               "browser.openExternal",
-              { url: terminal.browserUrl },
+              { url: terminalBrowser.browserUrl },
               { source: sourceRef.current }
             );
           }
           break;
         case "copy-url":
-          if (terminal.browserUrl && isValidBrowserUrl(terminal.browserUrl)) {
+          if (terminalBrowser?.browserUrl && isValidBrowserUrl(terminalBrowser.browserUrl)) {
             void actionService.dispatch(
               "browser.copyUrl",
-              { url: terminal.browserUrl },
+              { url: terminalBrowser.browserUrl },
               { source: sourceRef.current }
             );
           }
           break;
       }
     },
-    [terminal, terminalId]
+    [terminal, terminalId, terminalPty, terminalBrowser]
   );
 
   const handleCloseAutoFocus = useCallback((event: Event) => {
@@ -433,7 +435,7 @@ export function TerminalContextMenu({
           </ContextMenuSubContent>
         </ContextMenuSub>
       )}
-      {terminal.launchAgentId && (
+      {terminalPty?.launchAgentId && (
         <ContextMenuItem
           onSelect={() =>
             void actionService.dispatch(

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { AlertTriangle, Trash2 } from "lucide-react";
 import { BANNER_ENTER_DURATION } from "@/lib/animationUtils";
 import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelLimitStore, shouldShowSoftWarning } from "@/store/panelLimitStore";
 import { InlineStatusBanner } from "./InlineStatusBanner";
@@ -19,10 +20,11 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
       let completed = 0;
       for (const id of state.panelIds) {
         const t = state.panelsById[id];
-        if (t && t.location !== "trash" && t.ephemeral !== true) {
-          active++;
-          if (t.agentState === "completed" || t.agentState === "exited") completed++;
-        }
+        if (!t || t.location === "trash") continue;
+        const pty = isPtyPanel(t) ? t : undefined;
+        if (pty?.ephemeral === true) continue;
+        active++;
+        if (pty?.agentState === "completed" || pty?.agentState === "exited") completed++;
       }
       return { activeCount: active, completedCount: completed };
     })
@@ -83,12 +85,10 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
       const idsToClose: string[] = [];
       for (const id of panelIds) {
         const t = panelsById[id];
-        if (
-          t &&
-          (t.agentState === "completed" || t.agentState === "exited") &&
-          t.location !== "trash" &&
-          t.ephemeral !== true
-        ) {
+        if (!t || t.location === "trash") continue;
+        const pty = isPtyPanel(t) ? t : undefined;
+        if (pty?.ephemeral === true) continue;
+        if (pty?.agentState === "completed" || pty?.agentState === "exited") {
           idsToClose.push(t.id);
         }
       }

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/Worktree/terminalStateConfig";
 import type { ActivityState } from "./TerminalPane";
 import { usePanelStore } from "@/store";
+import { isPtyPanel } from "@shared/types/panel";
 import { useShallow } from "zustand/react/shallow";
 import { formatElapsedDuration } from "@/utils/formatElapsedDuration";
 import { formatTokenCount } from "@/utils/formatTokenCount";
@@ -105,8 +106,8 @@ export function TerminalHeaderContent({
 }: TerminalHeaderContentProps) {
   const resourceEnabled = useResourceMonitoringStore((s) => s.enabled);
   const resourceState = useResourceMonitoringStore((s) => s.metrics.get(id));
-  const isPtyPanel = kind == null || panelKindHasPty(kind);
-  const showResource = resourceEnabled && isPtyPanel && resourceState != null;
+  const hasPtyKind = kind == null || panelKindHasPty(kind);
+  const showResource = resourceEnabled && hasPtyKind && resourceState != null;
 
   const [stickySeverity, setStickySeverity] = useState<ResourceSeverity>("muted");
   const pendingCandidateRef = useRef<ResourceSeverity | null>(null);
@@ -160,14 +161,15 @@ export function TerminalHeaderContent({
   } = usePanelStore(
     useShallow((state) => {
       const t = state.panelsById[id];
+      const pty = t && isPtyPanel(t) ? t : undefined;
       return {
-        isInputLocked: t?.isInputLocked ?? false,
-        startedAt: t?.startedAt,
-        lastStateChange: t?.lastStateChange,
-        stateChangeTrigger: t?.stateChangeTrigger,
-        stateChangeConfidence: t?.stateChangeConfidence,
-        sessionCost: t?.sessionCost,
-        sessionTokens: t?.sessionTokens,
+        isInputLocked: pty?.isInputLocked ?? false,
+        startedAt: pty?.startedAt,
+        lastStateChange: pty?.lastStateChange,
+        stateChangeTrigger: pty?.stateChangeTrigger,
+        stateChangeConfidence: pty?.stateChangeConfidence,
+        sessionCost: pty?.sessionCost,
+        sessionTokens: pty?.sessionTokens,
       };
     })
   );

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -9,6 +9,7 @@ import { actionService } from "@/services/ActionService";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
 
 const SYNC_MODE_POLL_MS = 250;
 
@@ -131,7 +132,8 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [syncMode, setSyncMode] = useState<boolean | null>(null);
-  const panel = usePanelStore((state) => state.panelsById[terminalId]);
+  const panelRaw = usePanelStore((state) => state.panelsById[terminalId]);
+  const panel = panelRaw && isPtyPanel(panelRaw) ? panelRaw : undefined;
 
   useEffect(() => {
     if (!isOpen) {

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -80,6 +80,7 @@ import {
 import { decideChromeAction } from "./multiSelectGestures";
 import { registerPanelFocusHandler } from "./terminalFocusRegistry";
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
+import { isPtyPanel } from "@shared/types/panel";
 import type { TerminalRuntimeIdentity } from "@shared/types/panel";
 
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
@@ -350,8 +351,9 @@ function TerminalPaneComponent({
   };
 
   const handleRunAnyway = () => {
-    const panel = usePanelStore.getState().panelsById[id];
-    if (!panel || !agentId) return;
+    const _panel = usePanelStore.getState().panelsById[id];
+    if (!_panel || !agentId || !isPtyPanel(_panel)) return;
+    const panel = _panel;
 
     const presetEnv = panel.extensionState?.presetEnv as Record<string, string> | undefined;
 
@@ -391,13 +393,14 @@ function TerminalPaneComponent({
   const terminalState = usePanelStore(
     useShallow((state) => {
       const terminal = state.panelsById[id];
+      const pty = terminal && isPtyPanel(terminal) ? terminal : undefined;
       return {
-        isInputLocked: terminal?.isInputLocked ?? false,
-        stateChangeTrigger: terminal?.stateChangeTrigger,
-        isRestarting: terminal?.isRestarting ?? false,
-        exitBehavior: terminal?.exitBehavior,
+        isInputLocked: pty?.isInputLocked ?? false,
+        stateChangeTrigger: pty?.stateChangeTrigger,
+        isRestarting: pty?.isRestarting ?? false,
+        exitBehavior: pty?.exitBehavior,
         isTrashedOrRemoved: terminal?.location === "trash" || terminal === undefined,
-        spawnStatus: terminal?.spawnStatus,
+        spawnStatus: pty?.spawnStatus,
       };
     })
   );
@@ -984,12 +987,16 @@ function TerminalPaneComponent({
   // and is idle/waiting — writing into a working or directing agent would
   // corrupt its input mid-stream.
   const helpTerminalId = useHelpPanelStore((s) => s.terminalId);
-  const helpAgentState = usePanelStore((s) =>
-    helpTerminalId ? s.panelsById[helpTerminalId]?.agentState : undefined
-  );
-  const helpInputLocked = usePanelStore((s) =>
-    helpTerminalId ? s.panelsById[helpTerminalId]?.isInputLocked === true : false
-  );
+  const helpAgentState = usePanelStore((s) => {
+    if (!helpTerminalId) return undefined;
+    const p = s.panelsById[helpTerminalId];
+    return p && isPtyPanel(p) ? p.agentState : undefined;
+  });
+  const helpInputLocked = usePanelStore((s) => {
+    if (!helpTerminalId) return false;
+    const p = s.panelsById[helpTerminalId];
+    return p && isPtyPanel(p) ? p.isInputLocked === true : false;
+  });
   const assistantAvailable =
     !!helpTerminalId &&
     helpTerminalId !== id &&
@@ -1007,7 +1014,7 @@ function TerminalPaneComponent({
         t.location !== "trash" &&
         t.location !== "background" &&
         (t.kind ? panelKindHasPty(t.kind) : true) &&
-        t.hasPty !== false
+        (!isPtyPanel(t) || t.hasPty !== false)
       );
     })
   );
@@ -1018,7 +1025,8 @@ function TerminalPaneComponent({
     if (!helpTid || helpTid === id) return;
     const state = terminalInstanceService.getAgentState(helpTid);
     if (state !== "idle" && state !== "waiting") return;
-    if (usePanelStore.getState().panelsById[helpTid]?.isInputLocked === true) return;
+    const _helpPanel = usePanelStore.getState().panelsById[helpTid];
+    if (_helpPanel && isPtyPanel(_helpPanel) && _helpPanel.isInputLocked === true) return;
     const text = terminalInstanceService.captureBufferText(id, 20000);
     if (!text) return;
 

--- a/src/components/Terminal/TwoPaneSplitLayout.tsx
+++ b/src/components/Terminal/TwoPaneSplitLayout.tsx
@@ -4,7 +4,7 @@ import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortabl
 import { cn } from "@/lib/utils";
 import { useTwoPaneSplitStore } from "@/store";
 import { resolveEffectiveRatio } from "@/store/twoPaneSplitStore";
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 import { SortableTerminal } from "@/components/DragDrop";
 import { GridPanel } from "./GridPanel";
 import { TwoPaneSplitDivider, DIVIDER_WIDTH_PX } from "./TwoPaneSplitDivider";
@@ -17,13 +17,13 @@ import {
 } from "@/lib/layoutTransitionLock";
 
 interface TwoPaneSplitLayoutProps {
-  terminals: [TerminalInstance, TerminalInstance];
+  terminals: [PanelInstance, PanelInstance];
   focusedId: string | null;
   activeWorktreeId: string | null;
   isInTrash: (id: string) => boolean;
   // Stable panel-aware add-tab callback. GridPanel binds it to the
   // subscribed terminal internally so we never recreate inline closures here.
-  onAddTabForPanel?: (terminal: TerminalInstance) => void | Promise<void>;
+  onAddTabForPanel?: (terminal: PanelInstance) => void | Promise<void>;
 }
 
 export function TwoPaneSplitLayout({

--- a/src/components/Terminal/__tests__/contentGridFocus.test.ts
+++ b/src/components/Terminal/__tests__/contentGridFocus.test.ts
@@ -1,16 +1,17 @@
 import { describe, expect, it } from "vitest";
 import { getMaximizedGroupFocusTarget } from "../contentGridFocus";
-import type { TerminalInstance } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 
-function createTerminal(id: string): TerminalInstance {
+function createTerminal(id: string): PtyPanelData {
   return {
     id,
     title: id,
+    kind: "terminal",
     cwd: "/project",
     cols: 80,
     rows: 24,
     location: "grid",
-  };
+  } as PtyPanelData;
 }
 
 describe("getMaximizedGroupFocusTarget", () => {

--- a/src/components/Terminal/contentGridFleetPanels.ts
+++ b/src/components/Terminal/contentGridFleetPanels.ts
@@ -1,4 +1,7 @@
-import type { TerminalInstance } from "@/store";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+import type { PanelInstance } from "@shared/types/panel";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 // Single source of truth for the ordered, grid-renderable fleet panel set.
 // Keeping this pure and shared prevents the navigation model in
@@ -8,15 +11,17 @@ import type { TerminalInstance } from "@/store";
 export function buildFleetPanels(
   armOrder: readonly string[],
   armedIds: ReadonlySet<string>,
-  panelsById: Record<string, TerminalInstance>
-): TerminalInstance[] {
-  const result: TerminalInstance[] = [];
+  panelsById: Record<string, CarrierPanel>
+): PanelInstance[] {
+  const result: PanelInstance[] = [];
   for (const id of armOrder) {
     if (!armedIds.has(id)) continue;
     const t = panelsById[id];
     if (!t) continue;
     if (t.location === "trash" || t.location === "background" || t.location === "dock") continue;
-    result.push(t);
+    const narrowed = getNarrowPanel(panelsById, id);
+    if (!narrowed) continue;
+    result.push(narrowed);
   }
   return result;
 }

--- a/src/components/Terminal/contentGridFocus.ts
+++ b/src/components/Terminal/contentGridFocus.ts
@@ -1,9 +1,9 @@
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance } from "@shared/types/panel";
 
 interface MaximizedGroupFocusArgs {
   focusedId: string | null;
   groupId: string;
-  groupPanels: TerminalInstance[];
+  groupPanels: PanelInstance[];
   getActiveTabId: (groupId: string) => string | null;
 }
 

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -20,8 +20,8 @@ import {
   useWorktreeSelectionStore,
   usePreferencesStore,
   useTwoPaneSplitStore,
-  type TerminalInstance,
 } from "@/store";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useProjectStore } from "@/store/projectStore";
@@ -34,7 +34,7 @@ import {
   getClosingIdsSnapshot,
 } from "@/services/terminal/optimisticPanelClose";
 import { TerminalRefreshTier } from "@shared/types/panel";
-import type { TabGroup, TabGroupLocation } from "@shared/types/panel";
+import type { PanelInstance, TabGroup, TabGroupLocation } from "@shared/types/panel";
 import {
   computeGridColumns,
   computeScrollRowHeight,
@@ -70,7 +70,7 @@ import { actionService } from "@/services/ActionService";
 // spurious re-render emitting a new `[]` each call). Module-local; never
 // mutated.
 const EMPTY_PANEL_IDS: string[] = [];
-const EMPTY_TERMINALS: TerminalInstance[] = [];
+const EMPTY_TERMINALS: PanelInstance[] = [];
 const EMPTY_TAB_GROUPS: TabGroup[] = [];
 
 export function pixelSnapTransform({ x, y }: TransformProperties): string {
@@ -90,13 +90,13 @@ export interface ContentGridContext {
   defaultCwd?: string;
   agentAvailability?: CliAvailability;
   emptyContent?: React.ReactNode;
-  gridTerminals: TerminalInstance[];
+  gridTerminals: PanelInstance[];
   tabGroups: TabGroup[];
   focusedId: string | null;
   maximizedId: string | null;
   maximizeTarget: ReturnType<typeof usePanelStore.getState>["maximizeTarget"];
   maximizedGroup: TabGroup | undefined;
-  maximizedGroupPanels: TerminalInstance[];
+  maximizedGroupPanels: PanelInstance[];
   maximizedGroupFocusTarget: string | null;
   gridCols: number;
   fleetGridCols: number;
@@ -109,7 +109,7 @@ export interface ContentGridContext {
   layoutConfig: ReturnType<typeof useLayoutConfigStore.getState>["layoutConfig"];
   gridWidth: number | null;
   isFleetScopeRender: boolean;
-  fleetPanels: TerminalInstance[];
+  fleetPanels: PanelInstance[];
   fleetNeedsWorktreePrefix: boolean;
   isOver: boolean;
   isDragging: boolean;
@@ -131,10 +131,10 @@ export interface ContentGridContext {
   isProjectSwitching: boolean;
   panelIds: string[];
   gridItemCount: number;
-  twoPaneTerminals: [TerminalInstance, TerminalInstance] | null;
+  twoPaneTerminals: [PanelInstance, PanelInstance] | null;
   gridAgentMenuItems: { id: string; name: string; canLaunch: boolean }[];
   gridContextMenuContent: React.ReactNode;
-  handleAddTabForPanel: (panel: TerminalInstance) => Promise<void>;
+  handleAddTabForPanel: (panel: PanelInstance) => Promise<void>;
   handleGridLaunch: (agentId: string) => void;
   handleGridLayoutChange: (strategy: "automatic" | "fixed-columns" | "fixed-rows") => void;
   handleGridRegionKeyDown: (e: React.KeyboardEvent) => void;
@@ -152,7 +152,7 @@ export interface ContentGridContext {
   worktreeMap: ReturnType<typeof useWorktrees>["worktreeMap"];
   isInTrash: (id: string) => boolean;
   isWorktreeInitialized: boolean;
-  getTabGroupPanels: (groupId: string, location?: TabGroupLocation) => TerminalInstance[];
+  getTabGroupPanels: (groupId: string, location?: TabGroupLocation) => PanelInstance[];
   getPanelGroup: (panelId: string) => TabGroup | undefined;
   getActiveTabId: (groupId: string) => string | null;
   storeTerminalIds: string[];
@@ -281,11 +281,11 @@ export function useContentGridContext({
   const gridTerminals = useMemo(() => {
     if (gridPanelIds.length === 0) return EMPTY_TERMINALS;
     const byId = panelStoreApi.getState().panelsById;
-    const result: TerminalInstance[] = [];
+    const result: PanelInstance[] = [];
     for (const id of gridPanelIds) {
       if (closingIds.has(id)) continue;
-      const t = byId[id];
-      if (t) result.push(t);
+      const narrowed = getNarrowPanel(byId, id);
+      if (narrowed) result.push(narrowed);
     }
     return result.length === 0 ? EMPTY_TERMINALS : result;
   }, [gridPanelIds, closingIds]);
@@ -334,7 +334,7 @@ export function useContentGridContext({
   }, [getTabGroups, activeWorktreeId, gridPanelIds, storeTabGroups, trashedTerminals, closingIds]);
 
   const handleAddTabForPanel = useCallback(
-    async (panel: TerminalInstance) => {
+    async (panel: PanelInstance) => {
       let groupId: string;
       let createdNewGroup = false;
 
@@ -689,11 +689,11 @@ export function useContentGridContext({
   const fleetPanels = useMemo(() => {
     if (fleetPanelIds.length === 0) return EMPTY_TERMINALS;
     const byId = panelStoreApi.getState().panelsById;
-    const result: TerminalInstance[] = [];
+    const result: PanelInstance[] = [];
     for (const id of fleetPanelIds) {
       if (closingIds.has(id)) continue;
-      const t = byId[id];
-      if (t) result.push(t);
+      const narrowed = getNarrowPanel(byId, id);
+      if (narrowed) result.push(narrowed);
     }
     return result.length === 0 ? EMPTY_TERMINALS : result;
   }, [fleetPanelIds, closingIds]);
@@ -855,14 +855,18 @@ export function useContentGridContext({
     !maximizedId &&
     !showPlaceholder;
 
-  const twoPaneTerminals = useMemo((): [TerminalInstance, TerminalInstance] | null => {
+  const twoPaneTerminals = useMemo((): [PanelInstance, PanelInstance] | null => {
     if (!useTwoPaneSplitMode) return null;
+    const byId = panelStoreApi.getState().panelsById;
     const panels = tabGroups
       .slice(0, 2)
-      .map((g) => getTabGroupPanels(g.id, "grid")[0])
-      .filter((t): t is TerminalInstance => t !== undefined);
+      .map((g) => {
+        const raw = getTabGroupPanels(g.id, "grid")[0];
+        return raw ? getNarrowPanel(byId, raw.id) : undefined;
+      })
+      .filter((p): p is PanelInstance => p !== undefined);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    return panels.length === 2 ? (panels as [TerminalInstance, TerminalInstance]) : null;
+    return panels.length === 2 ? (panels as [PanelInstance, PanelInstance]) : null;
   }, [useTwoPaneSplitMode, tabGroups, getTabGroupPanels]);
 
   const prevModeRef = useRef<boolean>(useTwoPaneSplitMode);
@@ -913,10 +917,13 @@ export function useContentGridContext({
     maximizedId && maximizeTarget?.type === "group"
       ? tabGroups.find((group) => group.id === maximizeTarget.id)
       : undefined;
-  const maximizedGroupPanels = useMemo(
-    () => (maximizedGroup ? getTabGroupPanels(maximizedGroup.id, "grid") : []),
-    [getTabGroupPanels, maximizedGroup]
-  );
+  const maximizedGroupPanels = useMemo((): PanelInstance[] => {
+    if (!maximizedGroup) return [];
+    const byId = panelStoreApi.getState().panelsById;
+    return getTabGroupPanels(maximizedGroup.id, "grid")
+      .map((raw) => getNarrowPanel(byId, raw.id))
+      .filter((p): p is PanelInstance => p !== undefined);
+  }, [getTabGroupPanels, maximizedGroup]);
   const maximizedGroupFocusTarget = useMemo(
     () =>
       maximizedGroup
@@ -1020,6 +1027,19 @@ export function useContentGridContext({
     </ContextMenuContent>
   );
 
+  // Wrap the store's getTabGroupPanels (returns carrier shape) so the
+  // context surface exposes PanelInstance[] — narrowed via getNarrowPanel at
+  // call time so callers never touch the carrier shape.
+  const getTabGroupPanelsMapped = useCallback(
+    (groupId: string, location?: TabGroupLocation): PanelInstance[] => {
+      const byId = panelStoreApi.getState().panelsById;
+      return getTabGroupPanels(groupId, location)
+        .map((raw) => getNarrowPanel(byId, raw.id))
+        .filter((p): p is PanelInstance => p !== undefined);
+    },
+    [getTabGroupPanels]
+  );
+
   const isEmpty = gridTerminals.length === 0;
 
   const ctx: ContentGridContext = {
@@ -1080,7 +1100,7 @@ export function useContentGridContext({
     worktreeMap,
     isInTrash,
     isWorktreeInitialized,
-    getTabGroupPanels,
+    getTabGroupPanels: getTabGroupPanelsMapped,
     getPanelGroup,
     getActiveTabId,
     storeTerminalIds,

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -9,7 +9,8 @@ import { useDroppable } from "@dnd-kit/core";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
 import { useIsWorktreeSortDragging } from "../DragDrop/DndProvider";
 import { GripVertical } from "lucide-react";
-import { useErrorStore, usePanelStore, type RetryAction, type TerminalInstance } from "../../store";
+import { useErrorStore, usePanelStore, type RetryAction } from "../../store";
+import type { PtyPanelData } from "@shared/types/panel";
 import { useRecipeStore } from "../../store/recipeStore";
 import { useUIStore } from "../../store/uiStore";
 import { useWorktreeSelectionStore } from "../../store/worktreeStore";
@@ -521,7 +522,7 @@ export function WorktreeCard({
     });
   };
 
-  const handleTerminalSelect = (terminal: TerminalInstance) => {
+  const handleTerminalSelect = (terminal: PtyPanelData) => {
     // Switch to this worktree if it isn't already active
     if (!isActive) {
       if (terminal.worktreeId) {

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import type React from "react";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import type { TerminalInstance } from "@/store/panelStore";
+import type { PtyPanelData } from "@shared/types/panel";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { cn } from "@/lib/utils";
 import type { WorktreeTerminalCounts } from "@/hooks/useWorktreeTerminals";
@@ -41,8 +41,8 @@ interface MarqueeBox {
 }
 
 interface TerminalRowProps {
-  term: TerminalInstance;
-  onClick: (term: TerminalInstance) => void;
+  term: PtyPanelData;
+  onClick: (term: PtyPanelData) => void;
 }
 
 function TerminalRow({ term, onClick }: TerminalRowProps) {
@@ -172,9 +172,9 @@ export interface WorktreeTerminalSectionProps {
   worktreeId: string;
   isExpanded: boolean;
   counts: WorktreeTerminalCounts;
-  terminals: TerminalInstance[];
+  terminals: PtyPanelData[];
   onToggle: (e: React.MouseEvent) => void;
-  onTerminalSelect: (terminal: TerminalInstance) => void;
+  onTerminalSelect: (terminal: PtyPanelData) => void;
 }
 
 const FLEET_HINT_DISMISSED_KEY = "daintree:fleet-selection-hint-dismissed";
@@ -231,7 +231,7 @@ export function WorktreeTerminalSection({
   );
 
   const handleTerminalClick = useCallback(
-    (term: TerminalInstance) => {
+    (term: PtyPanelData) => {
       if (!isFleetArmEligible(term)) {
         onTerminalSelect(term);
         return;

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
@@ -8,7 +8,7 @@ import {
   WorktreeTerminalSection,
   type WorktreeTerminalSectionProps,
 } from "../WorktreeTerminalSection";
-import type { TerminalInstance } from "@/store/panelStore";
+import type { PtyPanelData } from "@shared/types/panel";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 
@@ -52,7 +52,7 @@ vi.mock("@/config/agents", () => ({
 
 let terminalCounter = 0;
 
-function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeTerminal(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id: `term-${++terminalCounter}`,
     pid: 1234,
@@ -61,8 +61,11 @@ function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstan
     location: "grid",
     worktreeId: "wt-1",
     lastActivityTimestamp: Date.now(),
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 const baseCounts: WorktreeTerminalSectionProps["counts"] = {

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -17,6 +17,7 @@ import type { UseAgentLauncherReturn } from "@/hooks/useAgentLauncher";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
@@ -278,6 +279,7 @@ export function WorktreeOverviewModal({
           continue;
         terminalCount++;
         if (!isAgentTerminal(t)) continue;
+        if (!isPtyPanel(t)) continue;
         if (t.agentState === "working") hasWorkingAgent = true;
         if (t.agentState === "waiting") {
           hasWaitingAgent = true;

--- a/src/components/Worktree/worktreeDeleteHelper.ts
+++ b/src/components/Worktree/worktreeDeleteHelper.ts
@@ -1,4 +1,5 @@
 import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
 
 const WORKTREE_DELETE_TERMINAL_CLOSE_TIMEOUT_MS = 10_000;
 const WORKTREE_DELETE_TERMINAL_CLOSE_POLL_MS = 100;
@@ -12,7 +13,9 @@ export function getLiveTerminalIdsForWorktree(worktreeId: string): string[] {
   return state.panelIds.filter((id) => {
     const panel = state.panelsById[id];
     return (
-      panel?.worktreeId === worktreeId && panel.location !== "trash" && panel.ephemeral !== true
+      panel?.worktreeId === worktreeId &&
+      panel.location !== "trash" &&
+      (!isPtyPanel(panel) || panel.ephemeral !== true)
     );
   });
 }

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -11,6 +11,7 @@ import { getAgentConfig } from "@/config/agents";
 import { actionService } from "@/services/ActionService";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { usePanelStore, useProjectStore } from "@/store";
+import { isPtyPanel } from "@shared/types/panel";
 import { projectClient } from "@/clients/projectClient";
 import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
@@ -1181,7 +1182,7 @@ export class HelpSessionController {
 
     const panelState = usePanelStore.getState();
     const livePanel = panelState.panelsById[initialTerminalId];
-    if (!livePanel) return;
+    if (!livePanel || !isPtyPanel(livePanel)) return;
     const agentState = livePanel.agentState;
     if (agentState && ACTIVE_AGENT_STATES.has(agentState)) {
       // Re-check shortly without restarting the full hibernate countdown —
@@ -1205,7 +1206,7 @@ export class HelpSessionController {
     // fire — writing project A's session into project B's hibernate slot
     // would resume the wrong conversation on next open.
     const projectId = initialProjectId;
-    const cwd = livePanel.cwd ?? "";
+    const cwd = livePanel.cwd;
     const sessionToRevoke = helpState.sessionId;
     const liveAgentId = helpState.agentId ?? initialAgentId;
 

--- a/src/hooks/__tests__/useAgentClusters.hook.test.tsx
+++ b/src/hooks/__tests__/useAgentClusters.hook.test.tsx
@@ -2,7 +2,7 @@
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { usePanelStore } from "@/store/panelStore";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 const { useWorktreeStoreMock } = vi.hoisted(() => ({
   useWorktreeStoreMock: vi.fn(),
@@ -15,7 +15,7 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
 import { useAgentClusters } from "../useAgentClusters";
 import { _resetWorktreeIdCacheForTests } from "../useTerminalSelectors";
 
-function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeAgent(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     title: id,
@@ -26,11 +26,11 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     agentState: "idle",
     hasPty: true,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
-function seedPanels(terminals: TerminalInstance[]): void {
-  const panelsById: Record<string, TerminalInstance> = {};
+function seedPanels(terminals: PtyPanelData[]): void {
+  const panelsById: Record<string, PtyPanelData> = {};
   const panelIds: string[] = [];
   for (const t of terminals) {
     panelsById[t.id] = t;

--- a/src/hooks/__tests__/useAgentClusters.test.ts
+++ b/src/hooks/__tests__/useAgentClusters.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { deriveHighestPriorityCluster } from "../useAgentClusters";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 const NOW = 1_700_000_000_000;
 
-function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeAgent(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     title: id,
@@ -16,11 +16,11 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     agentState: "idle",
     hasPty: true,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
-function build(terminals: TerminalInstance[]) {
-  const panelsById: Record<string, TerminalInstance> = {};
+function build(terminals: PtyPanelData[]) {
+  const panelsById: Record<string, PtyPanelData> = {};
   const panelIds: string[] = [];
   for (const t of terminals) {
     panelsById[t.id] = t;
@@ -32,7 +32,7 @@ function build(terminals: TerminalInstance[]) {
 const noTrash = () => false;
 const EMPTY_WORKTREE_IDS = new Set<string>();
 
-function derive(terminals: TerminalInstance[], now: number = NOW) {
+function derive(terminals: PtyPanelData[], now: number = NOW) {
   const { panelsById, panelIds } = build(terminals);
   return deriveHighestPriorityCluster({
     panelIds,

--- a/src/hooks/__tests__/useGridNavigation.test.tsx
+++ b/src/hooks/__tests__/useGridNavigation.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { NavigationDirection } from "../useGridNavigation";
 import { buildFleetPanels } from "@/components/Terminal/contentGridFleetPanels";
-import type { TerminalInstance } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 
 interface GridPosition {
   terminalId: string;
@@ -473,12 +473,16 @@ describe("Grid Navigation Logic", () => {
   });
 
   describe("buildFleetPanels filter", () => {
-    const makePanel = (id: string, location: TerminalInstance["location"]): TerminalInstance =>
+    const makePanel = (id: string, location: PtyPanelData["location"]): PtyPanelData =>
       ({
         id,
         title: id,
+        kind: "terminal",
         location,
-      }) as TerminalInstance;
+        cwd: "/tmp",
+        cols: 80,
+        rows: 24,
+      }) as PtyPanelData;
 
     it("returns panels in armOrder", () => {
       const panelsById = {

--- a/src/hooks/__tests__/usePanelStore.integration.test.ts
+++ b/src/hooks/__tests__/usePanelStore.integration.test.ts
@@ -37,10 +37,7 @@ type MockTerminal = Partial<PtyPanelData> & { id: string };
 
 function setTerminals(terminals: MockTerminal[]) {
   usePanelStore.setState({
-    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<
-      string,
-      PtyPanelData
-    >,
+    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<string, PtyPanelData>,
     panelIds: terminals.map((t) => t.id),
   });
 }

--- a/src/hooks/__tests__/usePanelStore.integration.test.ts
+++ b/src/hooks/__tests__/usePanelStore.integration.test.ts
@@ -408,7 +408,7 @@ describe("Terminal Store Integration", () => {
 
     it("should update agent state", () => {
       const state = usePanelStore.getState();
-      const terminal = state.panelsById["term-1"]!;
+      const terminal = state.panelsById["term-1"] as PtyPanelData;
 
       usePanelStore.setState({
         panelsById: {
@@ -417,7 +417,7 @@ describe("Terminal Store Integration", () => {
         },
       });
 
-      const updated = usePanelStore.getState().panelsById["term-1"];
+      const updated = usePanelStore.getState().panelsById["term-1"] as PtyPanelData | undefined;
       expect(updated?.agentState).toBe("working");
     });
 
@@ -431,7 +431,7 @@ describe("Terminal Store Integration", () => {
 
       states.forEach((agentState) => {
         const curState = usePanelStore.getState();
-        const terminal = curState.panelsById["term-1"]!;
+        const terminal = curState.panelsById["term-1"] as PtyPanelData;
         usePanelStore.setState({
           panelsById: {
             ...curState.panelsById,
@@ -440,13 +440,13 @@ describe("Terminal Store Integration", () => {
         });
       });
 
-      const final = usePanelStore.getState().panelsById["term-1"];
+      const final = usePanelStore.getState().panelsById["term-1"] as PtyPanelData | undefined;
       expect(final?.agentState).toBe("completed");
     });
 
     it("should handle completed state", () => {
       const state = usePanelStore.getState();
-      const terminal = state.panelsById["term-1"]!;
+      const terminal = state.panelsById["term-1"] as PtyPanelData;
 
       usePanelStore.setState({
         panelsById: {
@@ -455,7 +455,7 @@ describe("Terminal Store Integration", () => {
         },
       });
 
-      const updated = usePanelStore.getState().panelsById["term-1"];
+      const updated = usePanelStore.getState().panelsById["term-1"] as PtyPanelData | undefined;
       expect(updated?.agentState).toBe("completed");
     });
   });
@@ -523,7 +523,7 @@ describe("Terminal Store Integration", () => {
         },
       ]);
 
-      const terminal = usePanelStore.getState().panelsById["term-1"]!;
+      const terminal = usePanelStore.getState().panelsById["term-1"] as PtyPanelData;
       expect(terminal.launchAgentId).toBe("claude");
       expect(terminal.title).toBe("Claude Agent");
       expect(terminal.worktreeId).toBe("worktree-1");
@@ -553,7 +553,7 @@ describe("Terminal Store Integration", () => {
         },
       ]);
 
-      const terminal = usePanelStore.getState().panelsById["term-1"]!;
+      const terminal = usePanelStore.getState().panelsById["term-1"] as PtyPanelData;
       expect(terminal.title).toBe("Updated Title");
       expect(terminal.cols).toBe(100);
       expect(terminal.rows).toBe(30);

--- a/src/hooks/__tests__/usePanelStore.integration.test.ts
+++ b/src/hooks/__tests__/usePanelStore.integration.test.ts
@@ -31,15 +31,15 @@ vi.mock("@/services/TerminalInstanceService", () => ({
 }));
 
 const { usePanelStore } = await import("../../store/panelStore");
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 import type { AddPanelOptions } from "../../store/panelStore";
-type MockTerminal = Partial<TerminalInstance> & { id: string };
+type MockTerminal = Partial<PtyPanelData> & { id: string };
 
 function setTerminals(terminals: MockTerminal[]) {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<
       string,
-      TerminalInstance
+      PtyPanelData
     >,
     panelIds: terminals.map((t) => t.id),
   });
@@ -216,7 +216,7 @@ describe("Terminal Store Integration", () => {
 
       const terminals = getTerminals();
       const { focusedId } = usePanelStore.getState();
-      expect(terminals.find((t: TerminalInstance) => t.id === "term-1")?.location).toBe("dock");
+      expect(terminals.find((t) => t.id === "term-1")?.location).toBe("dock");
       expect(focusedId).toBe("term-2");
     });
 
@@ -239,8 +239,8 @@ describe("Terminal Store Integration", () => {
           return t.id === id ? { ...t, location: "grid" as const } : t;
         });
         usePanelStore.setState({
-          panelsById: Object.fromEntries(terminals.map((t: TerminalInstance) => [t.id, t])),
-          panelIds: terminals.map((t: TerminalInstance) => t.id),
+          panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
+          panelIds: terminals.map((t) => t.id),
           focusedId: id,
         });
         return true;
@@ -251,7 +251,7 @@ describe("Terminal Store Integration", () => {
 
       const terminals = getTerminals();
       const { focusedId } = usePanelStore.getState();
-      expect(terminals.find((t: TerminalInstance) => t.id === "term-1")?.location).toBe("grid");
+      expect(terminals.find((t) => t.id === "term-1")?.location).toBe("grid");
       expect(focusedId).toBe("term-1");
     });
   });
@@ -305,7 +305,7 @@ describe("Terminal Store Integration", () => {
 
       const terminals = getTerminals();
       const { focusedId } = usePanelStore.getState();
-      expect(terminals.find((t: TerminalInstance) => t.id === "term-1")?.location).toBe("trash");
+      expect(terminals.find((t) => t.id === "term-1")?.location).toBe("trash");
       expect(focusedId).toBe("term-2");
     });
 
@@ -328,8 +328,8 @@ describe("Terminal Store Integration", () => {
           return t.id === id ? { ...t, location: "grid" as const } : t;
         });
         usePanelStore.setState({
-          panelsById: Object.fromEntries(terminals.map((t: TerminalInstance) => [t.id, t])),
-          panelIds: terminals.map((t: TerminalInstance) => t.id),
+          panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
+          panelIds: terminals.map((t) => t.id),
           focusedId: id,
         });
       });
@@ -339,7 +339,7 @@ describe("Terminal Store Integration", () => {
 
       const terminals = getTerminals();
       const { focusedId } = usePanelStore.getState();
-      expect(terminals.find((t: TerminalInstance) => t.id === "term-1")?.location).toBe("grid");
+      expect(terminals.find((t) => t.id === "term-1")?.location).toBe("grid");
       expect(focusedId).toBe("term-1");
     });
 

--- a/src/hooks/__tests__/useWorktreeTerminals.test.ts
+++ b/src/hooks/__tests__/useWorktreeTerminals.test.ts
@@ -5,14 +5,15 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { TerminalInstance, AgentState } from "../../types";
+import type { PtyPanelData } from "@shared/types/panel";
+import type { AgentState } from "../../types";
 import { aggregateAgentStates } from "../useWorktreeTerminals";
 
 /**
  * Helper function that implements the core logic of useWorktreeTerminals
  * This allows testing without React hooks infrastructure
  */
-function calculateWorktreeCounts(terminals: TerminalInstance[], worktreeId: string) {
+function calculateWorktreeCounts(terminals: PtyPanelData[], worktreeId: string) {
   const worktreeTerminals = terminals.filter((t) => t.worktreeId === worktreeId);
 
   const byState: Record<AgentState, number> = {
@@ -55,9 +56,10 @@ describe("useWorktreeTerminals logic", () => {
   });
 
   it("filters terminals by worktreeId", () => {
-    const terminals: TerminalInstance[] = [
+    const terminals: PtyPanelData[] = [
       {
         id: "term-1",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Shell 1",
         cwd: "/path/1",
@@ -67,6 +69,7 @@ describe("useWorktreeTerminals logic", () => {
       },
       {
         id: "term-2",
+        kind: "terminal" as const,
         worktreeId: "worktree-2",
         title: "Shell 2",
         cwd: "/path/2",
@@ -76,6 +79,7 @@ describe("useWorktreeTerminals logic", () => {
       },
       {
         id: "term-3",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Claude",
         cwd: "/path/1",
@@ -93,9 +97,10 @@ describe("useWorktreeTerminals logic", () => {
   });
 
   it("counts terminals without agentState as idle", () => {
-    const terminals: TerminalInstance[] = [
+    const terminals: PtyPanelData[] = [
       {
         id: "term-1",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Shell",
         cwd: "/path/1",
@@ -106,6 +111,7 @@ describe("useWorktreeTerminals logic", () => {
       },
       {
         id: "term-2",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Shell 2",
         cwd: "/path/1",
@@ -124,9 +130,10 @@ describe("useWorktreeTerminals logic", () => {
   });
 
   it("aggregates terminals by agent state", () => {
-    const terminals: TerminalInstance[] = [
+    const terminals: PtyPanelData[] = [
       {
         id: "term-1",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Claude 1",
         cwd: "/path/1",
@@ -137,6 +144,7 @@ describe("useWorktreeTerminals logic", () => {
       },
       {
         id: "term-2",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Claude 2",
         cwd: "/path/1",
@@ -147,6 +155,7 @@ describe("useWorktreeTerminals logic", () => {
       },
       {
         id: "term-3",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Gemini",
         cwd: "/path/1",
@@ -157,6 +166,7 @@ describe("useWorktreeTerminals logic", () => {
       },
       {
         id: "term-4",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Claude 3",
         cwd: "/path/1",
@@ -177,9 +187,10 @@ describe("useWorktreeTerminals logic", () => {
   });
 
   it("handles terminals without worktreeId", () => {
-    const terminals: TerminalInstance[] = [
+    const terminals: PtyPanelData[] = [
       {
         id: "term-1",
+        kind: "terminal" as const,
         title: "Shell",
         cwd: "/path/1",
         cols: 80,
@@ -189,6 +200,7 @@ describe("useWorktreeTerminals logic", () => {
       },
       {
         id: "term-2",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Shell 2",
         cwd: "/path/1",
@@ -206,9 +218,10 @@ describe("useWorktreeTerminals logic", () => {
   });
 
   it("handles mixed agent states", () => {
-    const terminals: TerminalInstance[] = [
+    const terminals: PtyPanelData[] = [
       {
         id: "term-1",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Claude",
         cwd: "/path/1",
@@ -219,6 +232,7 @@ describe("useWorktreeTerminals logic", () => {
       },
       {
         id: "term-2",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Shell",
         cwd: "/path/1",
@@ -229,6 +243,7 @@ describe("useWorktreeTerminals logic", () => {
       },
       {
         id: "term-3",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Gemini",
         cwd: "/path/1",
@@ -248,9 +263,10 @@ describe("useWorktreeTerminals logic", () => {
   });
 
   it("counts shell terminals with mixed agent states", () => {
-    const terminals: TerminalInstance[] = [
+    const terminals: PtyPanelData[] = [
       {
         id: "term-1",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Shell",
         cwd: "/path/1",
@@ -261,6 +277,7 @@ describe("useWorktreeTerminals logic", () => {
       },
       {
         id: "term-2",
+        kind: "terminal" as const,
         worktreeId: "worktree-1",
         title: "Shell 2",
         cwd: "/path/1",
@@ -283,9 +300,10 @@ describe("useWorktreeTerminals logic", () => {
 // even when agent identity hasn't committed yet, so collapsed worktree badges
 // surface live progress instead of staying idle until detection lands.
 describe("aggregateAgentStates (#6650)", () => {
-  function term(overrides: Partial<TerminalInstance>): TerminalInstance {
+  function term(overrides: Partial<PtyPanelData>): PtyPanelData {
     return {
       id: "t-" + Math.random().toString(36).slice(2),
+      kind: "terminal" as const,
       worktreeId: "wt-1",
       title: "T",
       cwd: "/x",
@@ -293,7 +311,7 @@ describe("aggregateAgentStates (#6650)", () => {
       rows: 24,
       location: "grid",
       ...overrides,
-    } as TerminalInstance;
+    } as PtyPanelData;
   }
 
   it("counts a working terminal toward byState.working even with no agent identity", () => {

--- a/src/hooks/app/useAccessibilityAnnouncements.ts
+++ b/src/hooks/app/useAccessibilityAnnouncements.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { usePanelStore } from "@/store";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import type { AgentState } from "@shared/types/agent";
+import { isPtyPanel } from "@shared/types/panel";
 
 interface TerminalStateSnapshot {
   agentState?: AgentState;
@@ -57,7 +58,7 @@ export function useAccessibilityAnnouncements() {
 
     for (const id of panelIds) {
       const terminal = panelsById[id];
-      if (!terminal) continue;
+      if (!terminal || !isPtyPanel(terminal)) continue;
       if (!terminal.agentState) continue;
 
       const prev = prevStates.get(terminal.id);

--- a/src/hooks/app/useAgentWaitingNudge.ts
+++ b/src/hooks/app/useAgentWaitingNudge.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
 import { useNotificationStore } from "@/store/notificationStore";
 import { notify } from "@/lib/notify";
 import { isElectronAvailable } from "../useElectron";
@@ -83,7 +84,10 @@ export function useAgentWaitingNudge(isStateLoaded: boolean): void {
         eligibleRef.current = true;
 
         const { panelsById, panelIds } = usePanelStore.getState();
-        const waitingId = panelIds.find((id) => panelsById[id]?.agentState === "waiting");
+        const waitingId = panelIds.find((id) => {
+          const p = panelsById[id];
+          return p && isPtyPanel(p) && p.agentState === "waiting";
+        });
         if (waitingId && !firedRef.current) {
           fireNudge(waitingId);
         }
@@ -103,19 +107,25 @@ export function useAgentWaitingNudge(isStateLoaded: boolean): void {
 
     const initState = usePanelStore.getState();
     let prevAgentStates = new Map<string, string | undefined>(
-      initState.panelIds.map((id) => [id, initState.panelsById[id]?.agentState])
+      initState.panelIds.map((id) => {
+        const p = initState.panelsById[id];
+        return [id, p && isPtyPanel(p) ? p.agentState : undefined];
+      })
     );
 
     const unsubscribe = usePanelStore.subscribe((state) => {
       if (!eligibleRef.current || firedRef.current) return;
 
       const currentAgentStates = new Map<string, string | undefined>(
-        state.panelIds.map((id) => [id, state.panelsById[id]?.agentState])
+        state.panelIds.map((id) => {
+          const p = state.panelsById[id];
+          return [id, p && isPtyPanel(p) ? p.agentState : undefined];
+        })
       );
 
       for (const id of state.panelIds) {
         const terminal = state.panelsById[id];
-        if (!terminal) continue;
+        if (!terminal || !isPtyPanel(terminal)) continue;
         const prev = prevAgentStates.get(id);
         if (terminal.agentState === "waiting" && prev !== "waiting") {
           fireNudge(id);

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -8,13 +8,17 @@ import { logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import type { ChecklistState, ChecklistItemId } from "@shared/types/ipc/maps";
 import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
-import type { TerminalInstance } from "@shared/types/panel";
+import { isPtyPanel } from "@shared/types/panel";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 
-function countActiveAgentPanels(panelsById: Record<string, TerminalInstance>): number {
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
+
+function countActiveAgentPanels(panelsById: Record<string, CarrierPanel>): number {
   let count = 0;
-  for (const panel of Object.values(panelsById)) {
-    if (!panel?.detectedAgentId && !panel?.launchAgentId) continue;
-    const state = panel.agentState;
+  for (const raw of Object.values(panelsById)) {
+    if (!raw || !isPtyPanel(raw)) continue;
+    if (!raw.detectedAgentId && !raw.launchAgentId) continue;
+    const state = raw.agentState;
     if (state && ACTIVE_AGENT_STATES.has(state)) count += 1;
     if (count >= 2) return count;
   }

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -50,8 +50,9 @@ function reconcileCurrentState(
     !cl.items.launchedAgent &&
     usePanelStore.getState().panelIds.some((id) => {
       const p = usePanelStore.getState().panelsById[id];
+      if (!p || !isPtyPanel(p)) return false;
       return (
-        Boolean(p?.launchAgentId) || Boolean(p?.detectedAgentId) || p?.everDetectedAgent === true
+        Boolean(p.launchAgentId) || Boolean(p.detectedAgentId) || p.everDetectedAgent === true
       );
     })
   ) {
@@ -198,10 +199,11 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
           !cl.items.launchedAgent &&
           state.panelIds.some((id) => {
             const p = state.panelsById[id];
+            if (!p || !isPtyPanel(p)) return false;
             return (
-              Boolean(p?.launchAgentId) ||
-              Boolean(p?.detectedAgentId) ||
-              p?.everDetectedAgent === true
+              Boolean(p.launchAgentId) ||
+              Boolean(p.detectedAgentId) ||
+              p.everDetectedAgent === true
             );
           })
         ) {

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -51,9 +51,7 @@ function reconcileCurrentState(
     usePanelStore.getState().panelIds.some((id) => {
       const p = usePanelStore.getState().panelsById[id];
       if (!p || !isPtyPanel(p)) return false;
-      return (
-        Boolean(p.launchAgentId) || Boolean(p.detectedAgentId) || p.everDetectedAgent === true
-      );
+      return Boolean(p.launchAgentId) || Boolean(p.detectedAgentId) || p.everDetectedAgent === true;
     })
   ) {
     markItem("launchedAgent");
@@ -201,9 +199,7 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
             const p = state.panelsById[id];
             if (!p || !isPtyPanel(p)) return false;
             return (
-              Boolean(p.launchAgentId) ||
-              Boolean(p.detectedAgentId) ||
-              p.everDetectedAgent === true
+              Boolean(p.launchAgentId) || Boolean(p.detectedAgentId) || p.everDetectedAgent === true
             );
           })
         ) {

--- a/src/hooks/app/useOrchestrationMilestones.ts
+++ b/src/hooks/app/useOrchestrationMilestones.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { isElectronAvailable } from "../useElectron";
 import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useRecipeStore } from "@/store/recipeStore";
 import { notify } from "@/lib/notify";
@@ -47,14 +48,20 @@ const TOAST_STAGGER = 5500;
 function checkAgentCompleted(): boolean {
   const { panelsById, panelIds } = usePanelStore.getState();
   return panelIds.some((id) => {
-    const state = panelsById[id]?.agentState;
-    return state === "completed" || state === "exited";
+    const p = panelsById[id];
+    if (!p || !isPtyPanel(p)) return false;
+    return p.agentState === "completed" || p.agentState === "exited";
   });
 }
 
 function checkConcurrentAgents(): boolean {
   const { panelsById, panelIds } = usePanelStore.getState();
-  return panelIds.filter((id) => panelsById[id]?.agentState === "working").length >= 3;
+  return (
+    panelIds.filter((id) => {
+      const p = panelsById[id];
+      return p && isPtyPanel(p) && p.agentState === "working";
+    }).length >= 3
+  );
 }
 
 function checkContextInjection(): boolean {
@@ -160,25 +167,33 @@ export function useOrchestrationMilestones(isStateLoaded: boolean): void {
 
         unsubs.push(
           usePanelStore.subscribe((state, prev) => {
+            const completedOrExited = (
+              byId: Record<string, PanelInstance>,
+              ids: readonly string[]
+            ): boolean =>
+              ids.some((id) => {
+                const p = byId[id];
+                if (!p || !isPtyPanel(p)) return false;
+                return p.agentState === "completed" || p.agentState === "exited";
+              });
+            const workingCount = (
+              byId: Record<string, PanelInstance>,
+              ids: readonly string[]
+            ): number =>
+              ids.filter((id) => {
+                const p = byId[id];
+                return p && isPtyPanel(p) && p.agentState === "working";
+              }).length;
+
             if (!shown["first-agent-completed"]) {
-              const had = prev.panelIds.some((id) => {
-                const s = prev.panelsById[id]?.agentState;
-                return s === "completed" || s === "exited";
-              });
-              const has = state.panelIds.some((id) => {
-                const s = state.panelsById[id]?.agentState;
-                return s === "completed" || s === "exited";
-              });
+              const had = completedOrExited(prev.panelsById, prev.panelIds);
+              const has = completedOrExited(state.panelsById, state.panelIds);
               if (!had && has) showToast("first-agent-completed");
             }
 
             if (!shown["first-concurrent-agents"]) {
-              const prevCount = prev.panelIds.filter(
-                (id) => prev.panelsById[id]?.agentState === "working"
-              ).length;
-              const curCount = state.panelIds.filter(
-                (id) => state.panelsById[id]?.agentState === "working"
-              ).length;
+              const prevCount = workingCount(prev.panelsById, prev.panelIds);
+              const curCount = workingCount(state.panelsById, state.panelIds);
               if (prevCount < 3 && curCount >= 3) showToast("first-concurrent-agents");
             }
           })

--- a/src/hooks/useAgentClusters.ts
+++ b/src/hooks/useAgentClusters.ts
@@ -1,10 +1,14 @@
 import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
+import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { isFleetArmEligible } from "@/store/fleetArmingStore";
 import { isTerminalErrorClusterEligible } from "@/store/fleetEligibility";
 import { useWorktreeIds } from "@/hooks/useTerminalSelectors";
 import { isTerminalVisible } from "@/lib/terminalVisibility";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 export type ClusterType = "waiting" | "error" | "completion";
 
@@ -58,7 +62,7 @@ interface BucketMember {
 
 interface DeriveParams {
   panelIds: string[];
-  panelsById: Record<string, TerminalInstance | undefined>;
+  panelsById: Record<string, CarrierPanel | undefined>;
   isInTrash: (id: string) => boolean;
   worktreeIds: Set<string>;
   now: number;
@@ -81,8 +85,10 @@ export function deriveHighestPriorityCluster(params: DeriveParams): ClusterGroup
   };
 
   for (const id of panelIds) {
-    const t = panelsById[id];
-    if (!t) continue;
+    const raw = panelsById[id];
+    if (!raw) continue;
+    if (!isPtyPanel(raw)) continue;
+    const t = raw;
     if (!isTerminalVisible(t, isInTrash, worktreeIds)) continue;
 
     const lsc =

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
-import { usePanelStore, type AddPanelOptions, type TerminalInstance } from "@/store/panelStore";
+import { usePanelStore, type AddPanelOptions } from "@/store/panelStore";
+import type { PtyPanelData } from "@shared/types/panel";
 import { useProjectStore } from "@/store/projectStore";
 import { useScratchStore } from "@/store/scratchStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -520,13 +521,15 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
             cachedLaunchCliDetail ?? (await getCurrentLaunchCliDetail(agentId));
           if (launchCliDetail && !isAgentLaunchable(launchCliDetail.state)) {
             const gateId = `terminal-${crypto.randomUUID()}`;
-            const gatePanel: TerminalInstance = {
+            const gatePanel: PtyPanelData = {
               id: gateId,
               kind: "terminal",
               launchAgentId: agentId,
               title: presetTitle,
               worktreeId: targetWorktreeId || undefined,
               cwd,
+              cols: 80,
+              rows: 24,
               location: launchOptions?.location === "dock" ? "dock" : "grid",
               command: command as string | undefined,
               agentLaunchFlags: launchFlags,

--- a/src/hooks/useContextInjection.ts
+++ b/src/hooks/useContextInjection.ts
@@ -2,6 +2,7 @@ import { useCallback, useState, useEffect, useRef, useSyncExternalStore } from "
 
 import { usePanelStore } from "@/store/panelStore";
 import { useErrorStore } from "@/store/errorStore";
+import { isPtyPanel } from "@shared/types/panel";
 import type { AgentState, CopyTreeProgress } from "@/types";
 import { copyTreeClient } from "@/clients";
 import { DEFAULT_COPYTREE_FORMAT } from "@/lib/copyTreeFormat";
@@ -171,11 +172,10 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
       }
 
       // Only process if agent state changed to ready
-      if (
-        terminal &&
-        isAgentReady(terminal.agentState) &&
-        !isAgentReady(prevTerminal?.agentState)
-      ) {
+      const currAgentState = terminal && isPtyPanel(terminal) ? terminal.agentState : undefined;
+      const prevAgentState =
+        prevTerminal && isPtyPanel(prevTerminal) ? prevTerminal.agentState : undefined;
+      if (terminal && isAgentReady(currAgentState) && !isAgentReady(prevAgentState)) {
         pending.resolve();
         globalInjectionState.pendingInjection = null;
         globalInjectionState.isPendingInjection = false;
@@ -217,9 +217,10 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
       // Gate injection for live agent terminals that are not ready. Runtime
       // detection matters here: a plain shell that started Claude is an agent
       // target, while a demoted launch-agent panel is just a shell again.
-      if (isAgentTerminal(terminal) && !isAgentReady(terminal.agentState)) {
+      const terminalAgentState = isPtyPanel(terminal) ? terminal.agentState : undefined;
+      if (isAgentTerminal(terminal) && !isAgentReady(terminalAgentState)) {
         logDebug("[useContextInjection] Agent not ready, waiting for idle", {
-          agentState: terminal.agentState,
+          agentState: terminalAgentState,
         });
 
         // Cancel any existing pending injection (regardless of terminal)
@@ -253,7 +254,9 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
 
             // Immediately re-check if agent became ready between initial check and pending setup
             const currentTerminal = usePanelStore.getState().panelsById[activeTerminal];
-            if (currentTerminal && isAgentReady(currentTerminal.agentState)) {
+            const currentAgentState =
+              currentTerminal && isPtyPanel(currentTerminal) ? currentTerminal.agentState : undefined;
+            if (currentTerminal && isAgentReady(currentAgentState)) {
               resolve();
               globalInjectionState.pendingInjection = null;
               globalInjectionState.isPendingInjection = false;
@@ -278,9 +281,10 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
         }
 
         // Verify agent is still ready (could have changed during race)
-        if (isAgentTerminal(updatedTerminal) && !isAgentReady(updatedTerminal.agentState)) {
+        const updatedAgentState = isPtyPanel(updatedTerminal) ? updatedTerminal.agentState : undefined;
+        if (isAgentTerminal(updatedTerminal) && !isAgentReady(updatedAgentState)) {
           logDebug("[useContextInjection] Agent state changed while waiting, aborting injection", {
-            agentState: updatedTerminal.agentState,
+            agentState: updatedAgentState,
           });
           setError("Agent became busy again, injection aborted");
           // Clear stale progress on early abort

--- a/src/hooks/useContextInjection.ts
+++ b/src/hooks/useContextInjection.ts
@@ -255,7 +255,9 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
             // Immediately re-check if agent became ready between initial check and pending setup
             const currentTerminal = usePanelStore.getState().panelsById[activeTerminal];
             const currentAgentState =
-              currentTerminal && isPtyPanel(currentTerminal) ? currentTerminal.agentState : undefined;
+              currentTerminal && isPtyPanel(currentTerminal)
+                ? currentTerminal.agentState
+                : undefined;
             if (currentTerminal && isAgentReady(currentAgentState)) {
               resolve();
               globalInjectionState.pendingInjection = null;
@@ -281,7 +283,9 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
         }
 
         // Verify agent is still ready (could have changed during race)
-        const updatedAgentState = isPtyPanel(updatedTerminal) ? updatedTerminal.agentState : undefined;
+        const updatedAgentState = isPtyPanel(updatedTerminal)
+          ? updatedTerminal.agentState
+          : undefined;
         if (isAgentTerminal(updatedTerminal) && !isAgentReady(updatedAgentState)) {
           logDebug("[useContextInjection] Agent state changed while waiting, aborting injection", {
             agentState: updatedAgentState,

--- a/src/hooks/useFleetPicker.ts
+++ b/src/hooks/useFleetPicker.ts
@@ -17,7 +17,8 @@ import { usePanelStore } from "@/store/panelStore";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useFleetPickerSessionStore, type FleetPickerOwner } from "@/store/fleetPickerSessionStore";
-import type { SemanticSearchMatch, TerminalInstance } from "@shared/types";
+import type { SemanticSearchMatch } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 // Fallback empty worktree store for hosts that mount the picker without a
 // `WorktreeStoreContext.Provider` (e.g. legacy ribbon tests, places where the
@@ -43,7 +44,7 @@ export interface PickerTerminal {
   id: string;
   title: string;
   worktreeId: string;
-  agentState: TerminalInstance["agentState"];
+  agentState: PtyPanelData["agentState"];
 }
 
 export interface PickerWorktreeGroup {

--- a/src/hooks/useMemoryLeakDetection.ts
+++ b/src/hooks/useMemoryLeakDetection.ts
@@ -4,6 +4,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { notify } from "@/lib/notify";
 import { isElectronAvailable } from "@/hooks/useElectron";
 import { DEFAULT_AUTO_RESTART_THRESHOLD_MB } from "@/store/memoryLeakConfigStore";
+import { isPtyPanel } from "@shared/types/panel";
 
 export const MEMORY_HISTORY_SIZE = 30;
 export const STARTUP_SKIP_SAMPLES = 30;
@@ -189,7 +190,12 @@ export function useMemoryLeakDetection(
           !leakState.dismissed
         ) {
           const terminal = usePanelStore.getState().panelsById[id];
-          if (terminal && terminal.agentState !== "waiting" && !terminal.isInputLocked) {
+          if (
+            terminal &&
+            isPtyPanel(terminal) &&
+            terminal.agentState !== "waiting" &&
+            !terminal.isInputLocked
+          ) {
             leakState.dismissed = true;
             usePanelStore.getState().restartTerminal(id);
             notify({

--- a/src/hooks/useQuickSwitcher.ts
+++ b/src/hooks/useQuickSwitcher.ts
@@ -1,10 +1,10 @@
 import { useCallback, useMemo, useEffect } from "react";
 import Fuse, { type IFuseOptions } from "fuse.js";
 import { useShallow } from "zustand/react/shallow";
-import { usePanelStore, type TerminalInstance } from "@/store";
+import { usePanelStore } from "@/store";
 import { useWorktrees } from "./useWorktrees";
 import { useWorktreeSelectionStore } from "@/store";
-import { isPtyPanel } from "@shared/types/panel";
+import { isPtyPanel, type PanelKind } from "@shared/types/panel";
 import { useSearchablePalette } from "./useSearchablePalette";
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
 
@@ -15,7 +15,7 @@ export interface QuickSwitcherItem {
   type: QuickSwitcherItemType;
   title: string;
   subtitle?: string;
-  terminalKind?: TerminalInstance["kind"];
+  terminalKind?: PanelKind;
   chrome?: TerminalChromeDescriptor;
   worktreeId?: string;
 }

--- a/src/hooks/useQuickSwitcher.ts
+++ b/src/hooks/useQuickSwitcher.ts
@@ -78,9 +78,9 @@ export function useQuickSwitcher(): UseQuickSwitcherReturn {
       const t = panelsById[id];
       if (!t) continue;
       if (t.location === "trash") continue;
+      if (!isPtyPanel(t)) continue;
       if (t.ephemeral === true) continue;
       if (t.hasPty === false) continue;
-      if (!isPtyPanel(t)) continue;
       const worktreeName = t.worktreeId ? worktreeMap.get(t.worktreeId)?.name : undefined;
       const isBackground = t.location === "background";
       const baseSubtitle = worktreeName ?? t.cwd ?? undefined;

--- a/src/hooks/useSendToAgentPalette.ts
+++ b/src/hooks/useSendToAgentPalette.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 import Fuse, { type IFuseOptions } from "fuse.js";
-import { usePanelStore, type TerminalInstance } from "@/store";
+import { usePanelStore } from "@/store";
+import type { PanelKind } from "@shared/types/panel";
 import { useSearchablePalette } from "./useSearchablePalette";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -13,7 +14,7 @@ export interface SendToAgentItem {
   id: string;
   title: string;
   subtitle?: string;
-  terminalKind?: TerminalInstance["kind"];
+  terminalKind?: PanelKind;
   chrome: TerminalChromeDescriptor;
   isInputLocked?: boolean;
 }

--- a/src/hooks/useSendToAgentPalette.ts
+++ b/src/hooks/useSendToAgentPalette.ts
@@ -1,9 +1,8 @@
 import { useCallback, useMemo } from "react";
 import Fuse, { type IFuseOptions } from "fuse.js";
 import { usePanelStore } from "@/store";
-import type { PanelKind } from "@shared/types/panel";
+import { isPtyPanel, type PanelKind } from "@shared/types/panel";
 import { useSearchablePalette } from "./useSearchablePalette";
-import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { terminalClient } from "@/clients";
 import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
@@ -31,7 +30,7 @@ function hasSendTargets(sourceTerminalId: string | null): boolean {
       t.id !== sourceTerminalId &&
       t.location !== "trash" &&
       t.location !== "background" &&
-      (t.kind ? panelKindHasPty(t.kind) : true) &&
+      isPtyPanel(t) &&
       t.hasPty !== false
     );
   });
@@ -112,7 +111,7 @@ export function useSendToAgentPalette() {
       if (!t) continue;
       if (sourceId && t.id === sourceId) continue;
       if (t.location === "trash" || t.location === "background") continue;
-      if (t.kind && !panelKindHasPty(t.kind)) continue;
+      if (!isPtyPanel(t)) continue;
       if (t.hasPty === false) continue;
 
       const chrome = deriveTerminalChrome(t);

--- a/src/hooks/useTerminalSelectors.ts
+++ b/src/hooks/useTerminalSelectors.ts
@@ -1,8 +1,10 @@
 import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
+import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import type { WorktreeSnapshot } from "@shared/types";
+import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
+import { getNarrowPanels } from "@/store/slices/panelRegistry/selectors";
 import { isTerminalOrphaned, isTerminalVisible } from "@/lib/terminalVisibility";
 import { isTerminalErrorClusterEligible } from "@/store/fleetEligibility";
 export { isTerminalOrphaned, isTerminalVisible };
@@ -59,16 +61,15 @@ export function useTerminalNotificationCounts(blurTime?: number | null): {
 
       let waitingCount = 0;
 
-      for (const id of state.panelIds) {
-        const terminal = state.panelsById[id];
-        if (!terminal) continue;
-        if (!isTerminalVisible(terminal, state.isInTrash, worktreeIds)) continue;
+      for (const panel of getNarrowPanels(state.panelsById, state.panelIds)) {
+        if (!isPtyPanel(panel)) continue;
+        if (!isTerminalVisible(panel, state.isInTrash, worktreeIds)) continue;
 
-        if (terminal.agentState !== "waiting") continue;
+        if (panel.agentState !== "waiting") continue;
 
         if (blurTime !== undefined) {
-          if (terminal.lastStateChange == null) continue;
-          if (terminal.lastStateChange <= blurTime) continue;
+          if (panel.lastStateChange == null) continue;
+          if (panel.lastStateChange <= blurTime) continue;
         }
 
         waitingCount += 1;
@@ -79,18 +80,17 @@ export function useTerminalNotificationCounts(blurTime?: number | null): {
   );
 }
 
-export function useWaitingTerminals(): TerminalInstance[] {
+export function useWaitingTerminals(): PtyPanelData[] {
   const worktreeIds = useWorktreeIds();
 
   return usePanelStore(
     useShallow((state) => {
-      const out: TerminalInstance[] = [];
-      for (const id of state.panelIds) {
-        const t = state.panelsById[id];
-        if (!t) continue;
-        if (t.agentState !== "waiting") continue;
-        if (!isTerminalVisible(t, state.isInTrash, worktreeIds)) continue;
-        out.push(t);
+      const out: PtyPanelData[] = [];
+      for (const panel of getNarrowPanels(state.panelsById, state.panelIds)) {
+        if (!isPtyPanel(panel)) continue;
+        if (panel.agentState !== "waiting") continue;
+        if (!isTerminalVisible(panel, state.isInTrash, worktreeIds)) continue;
+        out.push(panel);
       }
       return out;
     })
@@ -102,42 +102,40 @@ export function useWaitingTerminalIds(): string[] {
   return useMemo(() => waiting.map((t) => t.id), [waiting]);
 }
 
-export function useErrorTerminals(): TerminalInstance[] {
+export function useErrorTerminals(): PtyPanelData[] {
   const worktreeIds = useWorktreeIds();
 
   return usePanelStore(
     useShallow((state) => {
-      const out: TerminalInstance[] = [];
-      for (const id of state.panelIds) {
-        const t = state.panelsById[id];
-        if (!t) continue;
-        if (t.agentState !== "exited") continue;
-        if (typeof t.exitCode !== "number" || t.exitCode === 0) continue;
+      const out: PtyPanelData[] = [];
+      for (const panel of getNarrowPanels(state.panelsById, state.panelIds)) {
+        if (!isPtyPanel(panel)) continue;
+        if (panel.agentState !== "exited") continue;
+        if (typeof panel.exitCode !== "number" || panel.exitCode === 0) continue;
         // isTerminalVisible rejects trash/background/ephemeral/orphaned;
         // isTerminalErrorClusterEligible adds the dock-location exclusion.
         // Without the orphan gate, clicking an entry from a deleted worktree
         // would call selectWorktree() on a stale ID and persist it.
-        if (!isTerminalVisible(t, state.isInTrash, worktreeIds)) continue;
-        if (!isTerminalErrorClusterEligible(t)) continue;
-        out.push(t);
+        if (!isTerminalVisible(panel, state.isInTrash, worktreeIds)) continue;
+        if (!isTerminalErrorClusterEligible(panel)) continue;
+        out.push(panel);
       }
       return out;
     })
   );
 }
 
-export function useBackgroundedTerminals(): TerminalInstance[] {
+export function useBackgroundedTerminals(): PtyPanelData[] {
   const worktreeIds = useWorktreeIds();
 
   return usePanelStore(
     useShallow((state) => {
-      const out: TerminalInstance[] = [];
-      for (const id of state.panelIds) {
-        const t = state.panelsById[id];
-        if (!t) continue;
-        if (t.location !== "background") continue;
-        if (isTerminalOrphaned(t, worktreeIds)) continue;
-        out.push(t);
+      const out: PtyPanelData[] = [];
+      for (const panel of getNarrowPanels(state.panelsById, state.panelIds)) {
+        if (!isPtyPanel(panel)) continue;
+        if (panel.location !== "background") continue;
+        if (isTerminalOrphaned(panel, worktreeIds)) continue;
+        out.push(panel);
       }
       return out;
     })
@@ -169,12 +167,10 @@ export function useBackgroundPanelStats(excludeId: string): {
     useShallow((state) => {
       let active = 0;
       let working = 0;
-      for (const id of state.panelIds) {
-        const t = state.panelsById[id];
-        if (!t) continue;
-        if (t.id !== excludeId && (t.location === "grid" || t.location === undefined)) {
+      for (const panel of getNarrowPanels(state.panelsById, state.panelIds)) {
+        if (panel.id !== excludeId && (panel.location === "grid" || panel.location === undefined)) {
           active++;
-          if (t.agentState === "working") working++;
+          if (isPtyPanel(panel) && panel.agentState === "working") working++;
         }
       }
       return { activeCount: active, workingCount: working };

--- a/src/hooks/useWatchedPanelNotifications.ts
+++ b/src/hooks/useWatchedPanelNotifications.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { fireWatchNotification } from "@/lib/watchNotification";
+import { isPtyPanel } from "@shared/types/panel";
 
 const NOTIFICATION_STAGGER_MS = 250;
 export const MAX_STAGGER_QUEUE_LENGTH = 50;
@@ -40,7 +41,7 @@ export function useWatchedPanelNotifications(): void {
     let prevAgentStates = new Map<string, string | undefined>(
       usePanelStore.getState().panelIds.map((id) => {
         const t = usePanelStore.getState().panelsById[id];
-        return [id, t?.agentState];
+        return [id, t && isPtyPanel(t) ? t.agentState : undefined];
       })
     );
     const staggerQueue: Array<() => void> = [];
@@ -72,7 +73,10 @@ export function useWatchedPanelNotifications(): void {
     const unsubscribe = usePanelStore.subscribe((state) => {
       const { watchedPanels, panelsById, panelIds } = state;
       const currentAgentStates = new Map<string, string | undefined>(
-        panelIds.map((id) => [id, panelsById[id]?.agentState])
+        panelIds.map((id) => {
+          const p = panelsById[id];
+          return [id, p && isPtyPanel(p) ? p.agentState : undefined];
+        })
       );
 
       for (const panelId of watchedPanels) {

--- a/src/hooks/useWorktreeTerminals.ts
+++ b/src/hooks/useWorktreeTerminals.ts
@@ -94,8 +94,9 @@ export function useWorktreeTerminals(worktreeId: string): UseWorktreeTerminalsRe
       for (const id of ids) {
         const raw = state.panelsById[id];
         if (!raw) continue;
-        if (raw.location === "trash" || raw.ephemeral === true) continue;
+        if (raw.location === "trash") continue;
         if (!isPtyPanel(raw)) continue;
+        if (raw.ephemeral === true) continue;
         out.push(raw);
       }
       return out;

--- a/src/hooks/useWorktreeTerminals.ts
+++ b/src/hooks/useWorktreeTerminals.ts
@@ -1,9 +1,10 @@
 import { useMemo, useState, useEffect, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
+import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
 import type { AgentState } from "@/types";
 import { getDominantAgentState } from "@/components/Worktree/AgentStatusIndicator";
-import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { deriveTerminalChrome, type TerminalChromeInput } from "@/utils/terminalChrome";
 import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
 
 export interface WorktreeTerminalCounts {
@@ -12,10 +13,14 @@ export interface WorktreeTerminalCounts {
 }
 
 export interface UseWorktreeTerminalsResult {
-  terminals: TerminalInstance[];
+  terminals: PtyPanelData[];
   counts: WorktreeTerminalCounts;
   dominantAgentState: AgentState | null;
 }
+
+/** Minimum shape consumed by `aggregateAgentStates`; satisfied by both
+ *  `PtyPanelData` (production) and legacy `TerminalInstance` fixtures (tests). */
+type AggregateInput = TerminalChromeInput & { agentState?: AgentState };
 
 /**
  * Pure aggregator over a worktree's terminal list, exposed for unit tests.
@@ -25,7 +30,7 @@ export interface UseWorktreeTerminalsResult {
  * completed states count as waiting, and exited or plain-shell terminals count
  * as idle so stale states don't bleed into badges.
  */
-export function aggregateAgentStates(terminals: TerminalInstance[]): {
+export function aggregateAgentStates(terminals: AggregateInput[]): {
   byState: Record<AgentState, number>;
   agentStates: (AgentState | undefined)[];
 } {
@@ -85,12 +90,15 @@ export function useWorktreeTerminals(worktreeId: string): UseWorktreeTerminalsRe
     useShallow((state) => {
       const ids = state.panelIdsByWorktreeId[worktreeId];
       if (!ids || ids.length === 0) return [];
-      return ids
-        .map((id) => state.panelsById[id])
-        .filter(
-          (t): t is TerminalInstance =>
-            t !== undefined && t.location !== "trash" && t.ephemeral !== true
-        );
+      const out: PtyPanelData[] = [];
+      for (const id of ids) {
+        const raw = state.panelsById[id];
+        if (!raw) continue;
+        if (raw.location === "trash" || raw.ephemeral === true) continue;
+        if (!isPtyPanel(raw)) continue;
+        out.push(raw);
+      }
+      return out;
     })
   );
 

--- a/src/lib/__tests__/terminalVisibility.test.ts
+++ b/src/lib/__tests__/terminalVisibility.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { isTerminalOrphaned, isTerminalVisible } from "@/lib/terminalVisibility";
-import type { TerminalInstance } from "@/store/panelStore";
+import type { PtyPanelData } from "@shared/types/panel";
 
-function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeTerminal(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id: "t1",
     worktreeId: "wt1",
@@ -10,7 +10,7 @@ function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstan
     ephemeral: false,
     agentState: "working",
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 describe("isTerminalOrphaned", () => {

--- a/src/lib/terminalVisibility.ts
+++ b/src/lib/terminalVisibility.ts
@@ -1,6 +1,14 @@
-import type { TerminalInstance } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 
-export function isTerminalOrphaned(terminal: TerminalInstance, worktreeIds: Set<string>): boolean {
+// Carrier element from the legacy `panelsById` shape, sourced through
+// `getNarrowPanel`'s parameter so this file doesn't import the deprecated
+// `TerminalInstance` alias by name. Lets external callers that still hand
+// out raw carrier entries pass through these predicates while the rest of
+// the renderer migrates to `getNarrowPanel` (#8957).
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
+
+export function isTerminalOrphaned(terminal: CarrierPanel, worktreeIds: Set<string>): boolean {
   const worktreeId = typeof terminal.worktreeId === "string" ? terminal.worktreeId.trim() : "";
   if (!worktreeId) return false;
   if (worktreeIds.size === 0) return false;
@@ -8,14 +16,14 @@ export function isTerminalOrphaned(terminal: TerminalInstance, worktreeIds: Set<
 }
 
 export function isTerminalVisible(
-  terminal: TerminalInstance,
+  terminal: CarrierPanel,
   isInTrash: (id: string) => boolean,
   worktreeIds: Set<string>
 ): boolean {
   if (isInTrash(terminal.id)) return false;
   if (terminal.location === "trash") return false;
   if (terminal.location === "background") return false;
-  if (terminal.ephemeral === true) return false;
+  if (isPtyPanel(terminal) && terminal.ephemeral === true) return false;
   if (isTerminalOrphaned(terminal, worktreeIds)) return false;
   return true;
 }

--- a/src/lib/worktreeCyclingOrder.ts
+++ b/src/lib/worktreeCyclingOrder.ts
@@ -1,5 +1,6 @@
 import type { WorktreeSnapshot, WorktreeState } from "@shared/types";
 import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
 import { computeChipState } from "@/components/Worktree/utils/computeChipState";
@@ -48,6 +49,7 @@ function buildDerivedMeta(
       continue;
     terminalCount++;
     if (!isAgentTerminal(t)) continue;
+    if (!isPtyPanel(t)) continue;
     if (t.agentState === "working") hasWorkingAgent = true;
     if (t.agentState === "waiting") {
       hasWaitingAgent = true;

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -218,12 +218,6 @@ const browserHistoryFixture: BrowserHistory = {
   future: [],
 };
 
-function baseFields(
-  kind: PanelInstance["kind"]
-): Pick<TerminalInstance, "id" | "title" | "location" | "kind"> {
-  return { id: `panel-${kind}`, title: "Panel", location: "grid", kind };
-}
-
 function assertCovers(
   label: string,
   output: Record<string, unknown>,
@@ -256,11 +250,16 @@ function assertCovers(
 // non-empty, non-null value so every conditional spread in the serializers
 // emits its key.
 
-const terminalFixture: TerminalInstance = {
-  ...baseFields("terminal"),
+const terminalFixture: PtySerializeInput = {
+  id: "panel-terminal",
+  title: "Panel",
+  location: "grid",
+  kind: "terminal",
   launchAgentId: "claude",
   titleMode: "default",
   cwd: "/home/project",
+  cols: 80,
+  rows: 24,
   command: "npm start",
   exitBehavior: "keep" satisfies PanelExitBehavior,
   agentSessionId: "session-abc",
@@ -277,8 +276,11 @@ const terminalFixture: TerminalInstance = {
   lastActiveAt: 1_700_000_000_001,
 };
 
-const browserFixture: TerminalInstance = {
-  ...baseFields("browser"),
+const browserFixture: BrowserPanelData = {
+  id: "panel-browser",
+  title: "Panel",
+  location: "grid",
+  kind: "browser",
   browserUrl: "https://example.com",
   browserHistory: browserHistoryFixture,
   browserZoom: 1.5,
@@ -287,8 +289,11 @@ const browserFixture: TerminalInstance = {
   browserConsoleOpen: false,
 };
 
-const devPreviewFixture: TerminalInstance = {
-  ...baseFields("dev-preview"),
+const devPreviewFixture: DevPreviewSerializeInput = {
+  id: "panel-dev-preview",
+  title: "Panel",
+  location: "grid",
+  kind: "dev-preview",
   cwd: "/home/project",
   devCommand: "npm run dev",
   browserUrl: "http://localhost:3000",

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -1,10 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { getPanelKindConfig } from "@shared/config/panelKindRegistry";
-import type {
-  BrowserPanelData,
-  BuiltInPanelKind,
-  PanelExitBehavior,
-} from "@shared/types/panel";
+import type { BrowserPanelData, BuiltInPanelKind, PanelExitBehavior } from "@shared/types/panel";
 import type { BrowserHistory } from "@shared/types/browser";
 import { getDeserializer } from "@/config/panelKindSerialisers";
 import type { SavedTerminalData } from "@/utils/stateHydration/statePatcher";

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -4,8 +4,6 @@ import type {
   BrowserPanelData,
   BuiltInPanelKind,
   PanelExitBehavior,
-  PanelInstance,
-  TerminalInstance,
 } from "@shared/types/panel";
 import type { BrowserHistory } from "@shared/types/browser";
 import { getDeserializer } from "@/config/panelKindSerialisers";
@@ -110,9 +108,10 @@ const PTY_FIELD_CLASSIFICATION = {
   ephemeral: false,
   startedAt: false,
   exitCode: false,
-  // PtySerializeInput widener fields (persisted)
-  createdAt: true,
-  lastActiveAt: true,
+  // BasePanelData carrier-bookkeeping timestamps — written by the base
+  // serialization layer in panelToSnapshot, not the PTY serializer.
+  createdAt: false,
+  lastActiveAt: false,
 } as const satisfies Record<keyof PtySerializeInput, boolean>;
 
 // ── Browser field classification ─────────────────────────────────────
@@ -133,6 +132,10 @@ const BROWSER_FIELD_CLASSIFICATION = {
   browserHistory: true,
   browserZoom: true,
   browserConsoleOpen: true,
+  // BasePanelData carrier-bookkeeping timestamps — written by the base
+  // serialization layer in panelToSnapshot, not per-kind serializers.
+  createdAt: false,
+  lastActiveAt: false,
 } as const satisfies Record<keyof BrowserPanelData, boolean>;
 
 // ── Dev-preview field classification ─────────────────────────────────
@@ -168,8 +171,10 @@ const DEV_PREVIEW_FIELD_CLASSIFICATION = {
   devServerUrl: false,
   devServerError: false,
   devServerTerminalId: false,
-  // DevPreviewSerializeInput widener (persisted)
-  createdAt: true,
+  // BasePanelData carrier-bookkeeping timestamps — written by the base
+  // serialization layer in panelToSnapshot, not per-kind serializers.
+  createdAt: false,
+  lastActiveAt: false,
 } as const satisfies Record<keyof DevPreviewSerializeInput, boolean>;
 
 // ── Built-in kind exhaustiveness ─────────────────────────────────────
@@ -196,21 +201,11 @@ function persistedKeys<T extends Record<string, boolean>>(map: T): (keyof T)[] {
   return (Object.keys(map) as (keyof T)[]).filter((k) => map[k]);
 }
 
-// Compile-time carrier-boundary pin (#8957). The renderer store carrier is being
-// drained from `TerminalInstance` (kitchen-sink) to the `PanelInstance` union.
-// Every key on `TerminalInstance` must be coverable by some `PanelInstance`
-// variant plus the two carrier-only timestamps (`createdAt`/`lastActiveAt`,
-// which live on `TerminalInstance` but not `BasePanelData`). If a new field is
-// added to `TerminalInstance` without a home in the union, this assignment
-// fails with a message naming the orphaned key — forcing it onto the proper
-// variant before the carrier flip lands.
-type _KeysOfUnion<T> = T extends unknown ? keyof T : never;
-type _AllowedPanelCarrierKeys = _KeysOfUnion<PanelInstance> | "createdAt" | "lastActiveAt";
-type _OrphanedTerminalInstanceKeys = Exclude<keyof TerminalInstance, _AllowedPanelCarrierKeys>;
-const _terminalInstanceKeysCovered: [_OrphanedTerminalInstanceKeys] extends [never]
-  ? true
-  : _OrphanedTerminalInstanceKeys = true;
-void _terminalInstanceKeysCovered;
+// Carrier-boundary pin retired. The renderer carrier is now
+// `Record<string, PanelInstance>` (#8957 step 5) and the `TerminalInstance`
+// interface only exists as the persistence Tolerant Reader. New fields must be
+// added to the appropriate `PanelInstance` variant; the discriminated union
+// itself enforces coverage at every consumer.
 
 const browserHistoryFixture: BrowserHistory = {
   past: ["https://prev.example"],

--- a/src/panels/__tests__/registry.roundtrip.test.ts
+++ b/src/panels/__tests__/registry.roundtrip.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect } from "vitest";
 import { fc, test } from "@fast-check/vitest";
 import { getPanelKindConfig } from "@shared/config/panelKindRegistry";
-import type { PanelInstance, TerminalInstance } from "@shared/types/panel";
+import type { PanelInstance } from "@shared/types/panel";
 import { getDeserializer } from "@/config/panelKindSerialisers";
 import type { SavedTerminalData } from "@/utils/stateHydration/statePatcher";
 import { initBuiltInPanelKinds } from "../registry";
@@ -121,7 +121,7 @@ const devPreviewArb = fc.record(devPreviewArbSpec);
 
 function basePanel(
   kind: PanelInstance["kind"]
-): Pick<TerminalInstance, "id" | "title" | "location" | "kind"> {
+): Pick<PanelInstance, "id" | "title" | "location" | "kind"> {
   return { id: "panel-id", title: "Panel", location: "grid", kind };
 }
 
@@ -132,7 +132,7 @@ describe("panel serializer round-trip (property tests)", () => {
     // agent session resume and model-selection logic outside this file's scope.
     // Property test the serializer's output shape and trimming/omission rules.
     test.prop([ptyArb])("serializer output matches input under trim & omit rules", (fields) => {
-      const input: TerminalInstance = { ...basePanel("terminal"), ...fields };
+      const input: PtyData = { ...basePanel("terminal"), cols: 80, rows: 24, ...fields } as PtyData;
       const result = getPanelKindConfig("terminal")!.serialize!(input);
 
       expect(result.launchAgentId).toBe(fields.launchAgentId);
@@ -182,7 +182,7 @@ describe("panel serializer round-trip (property tests)", () => {
     test.prop([browserArb])(
       "deserialize(serialize(x)) preserves all persisted fields",
       (fields) => {
-        const input: TerminalInstance = { ...basePanel("browser"), ...fields };
+        const input: BrowserData = { ...basePanel("browser"), ...fields } as BrowserData;
         const saved = getPanelKindConfig("browser")!.serialize!(input) as SavedTerminalData;
         const restored = getDeserializer("browser")!(saved);
 
@@ -198,10 +198,10 @@ describe("panel serializer round-trip (property tests)", () => {
     test.prop([devPreviewArb])(
       "deserialize(serialize(x)) preserves fields through devCommand↔command rename",
       (fields) => {
-        const input: TerminalInstance = {
+        const input: DevPreviewData = {
           ...basePanel("dev-preview"),
           ...fields,
-        };
+        } as DevPreviewData;
         const saved = getPanelKindConfig("dev-preview")!.serialize!(input) as SavedTerminalData;
         const restored = getDeserializer("dev-preview")!(saved);
 

--- a/src/panels/__tests__/registry.serialization.test.ts
+++ b/src/panels/__tests__/registry.serialization.test.ts
@@ -7,7 +7,9 @@ beforeAll(() => {
   initBuiltInPanelKinds();
 });
 
-function makePanel(overrides: Partial<PanelInstance> & Record<string, unknown> = {}): PanelInstance {
+function makePanel(
+  overrides: Partial<PanelInstance> & Record<string, unknown> = {}
+): PanelInstance {
   return {
     id: "t1",
     title: "Test",

--- a/src/panels/__tests__/registry.serialization.test.ts
+++ b/src/panels/__tests__/registry.serialization.test.ts
@@ -37,7 +37,6 @@ describe("panelKindRegistry serialize hooks (co-located)", () => {
         launchAgentId: undefined,
         cwd: "/home",
         command: "ls -la",
-        createdAt: 100,
         exitBehavior: "keep",
       });
     });
@@ -121,7 +120,6 @@ describe("panelKindRegistry serialize hooks (co-located)", () => {
         browserZoom: 1.0,
         devPreviewConsoleOpen: true,
         devPreviewConsoleTab: "console",
-        createdAt: 100,
         exitBehavior: "keep",
       });
     });

--- a/src/panels/__tests__/registry.serialization.test.ts
+++ b/src/panels/__tests__/registry.serialization.test.ts
@@ -1,19 +1,23 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { getPanelKindConfig } from "@shared/config/panelKindRegistry";
-import type { TerminalInstance } from "@shared/types/panel";
+import type { PanelInstance } from "@shared/types/panel";
 import { initBuiltInPanelKinds } from "../registry";
 
 beforeAll(() => {
   initBuiltInPanelKinds();
 });
 
-function makePanel(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makePanel(overrides: Partial<PanelInstance> & Record<string, unknown> = {}): PanelInstance {
   return {
     id: "t1",
     title: "Test",
     location: "grid",
+    kind: "terminal",
+    cwd: "",
+    cols: 80,
+    rows: 24,
     ...overrides,
-  };
+  } as PanelInstance;
 }
 
 describe("panelKindRegistry serialize hooks (co-located)", () => {

--- a/src/panels/dev-preview/serializer.ts
+++ b/src/panels/dev-preview/serializer.ts
@@ -1,13 +1,7 @@
 import type { DevPreviewPanelData } from "@shared/types/panel";
 import type { PanelSnapshot } from "@shared/types/project";
 
-/**
- * Serializer input: `DevPreviewPanelData` plus the legacy `createdAt` field,
- * which is persisted but not declared on the shared variant interface.
- */
-export type DevPreviewSerializeInput = DevPreviewPanelData & {
-  createdAt?: number;
-};
+export type DevPreviewSerializeInput = DevPreviewPanelData;
 
 export function serializeDevPreview(t: DevPreviewSerializeInput): Partial<PanelSnapshot> {
   return {
@@ -29,7 +23,6 @@ export function serializeDevPreview(t: DevPreviewSerializeInput): Partial<PanelS
     ...(t.devPreviewScrollPosition !== undefined && {
       devPreviewScrollPosition: t.devPreviewScrollPosition,
     }),
-    ...(t.createdAt !== undefined && { createdAt: t.createdAt }),
     ...(t.exitBehavior !== undefined && { exitBehavior: t.exitBehavior }),
   };
 }

--- a/src/panels/terminal/__tests__/serializer.test.ts
+++ b/src/panels/terminal/__tests__/serializer.test.ts
@@ -143,28 +143,7 @@ describe("serializePtyPanel — detectedAgentId is never persisted", () => {
   });
 });
 
-// `lastActiveAt` (#8703) is the focus-stamp used by the restore predicate to
-// promote each worktree's most-recently-active panel to the priority tier.
-describe("serializePtyPanel — lastActiveAt", () => {
-  it("includes lastActiveAt in the snapshot when set to a real timestamp", () => {
-    const panel = makePanel({ lastActiveAt: 1_700_000_000_000 } as Partial<PtyPanelData> & {
-      lastActiveAt: number;
-    });
-    const snapshot = serializePtyPanel(panel);
-    expect(snapshot.lastActiveAt).toBe(1_700_000_000_000);
-  });
-
-  it("omits lastActiveAt when undefined", () => {
-    const panel = makePanel();
-    const snapshot = serializePtyPanel(panel) as Record<string, unknown>;
-    expect("lastActiveAt" in snapshot).toBe(false);
-  });
-
-  it("preserves an explicit zero rather than coercing it to undefined", () => {
-    const panel = makePanel({ lastActiveAt: 0 } as Partial<PtyPanelData> & {
-      lastActiveAt: number;
-    });
-    const snapshot = serializePtyPanel(panel);
-    expect(snapshot.lastActiveAt).toBe(0);
-  });
-});
+// `lastActiveAt` (#8703) is the focus-stamp used by the restore predicate.
+// Since #8957 step 6 the field lives on BasePanelData and is written by the
+// base layer in panelToSnapshot, not by per-kind serializers — coverage
+// lives in panelPersistence tests instead.

--- a/src/panels/terminal/serializer.ts
+++ b/src/panels/terminal/serializer.ts
@@ -1,19 +1,13 @@
 import type { PtyPanelData } from "@shared/types/panel";
 import type { PanelSnapshot } from "@shared/types/project";
 
-/**
- * Serializer input: `PtyPanelData` plus the legacy `createdAt` and
- * `lastActiveAt` fields, which are persisted but intentionally not declared
- * on the shared variant interface.
- */
-export type PtySerializeInput = PtyPanelData & { createdAt?: number; lastActiveAt?: number };
+export type PtySerializeInput = PtyPanelData;
 
 export function serializePtyPanel(t: PtySerializeInput): Partial<PanelSnapshot> {
   return {
     launchAgentId: t.launchAgentId,
     cwd: t.cwd,
     command: t.command?.trim() || undefined,
-    ...(t.createdAt !== undefined && { createdAt: t.createdAt }),
     ...(t.exitBehavior !== undefined && { exitBehavior: t.exitBehavior }),
     ...(t.agentSessionId && { agentSessionId: t.agentSessionId }),
     ...(t.agentLaunchFlags?.length && { agentLaunchFlags: t.agentLaunchFlags }),
@@ -28,6 +22,5 @@ export function serializePtyPanel(t: PtySerializeInput): Partial<PanelSnapshot> 
     // indicator on the next reload (issue #5832).
     ...(t.agentState && t.agentState !== "directing" && { agentState: t.agentState }),
     ...(t.lastStateChange !== undefined && { lastStateChange: t.lastStateChange }),
-    ...(t.lastActiveAt !== undefined && { lastActiveAt: t.lastActiveAt }),
   };
 }

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { TerminalInstance } from "@shared/types/panel";
+import type { PtyPanelData } from "@shared/types/panel";
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 
 const mocks = vi.hoisted(() => {
@@ -316,7 +316,7 @@ function buildRegistry(
   return actions;
 }
 
-function createTerminal(overrides: Record<string, unknown> = {}): TerminalInstance {
+function createTerminal(overrides: Record<string, unknown> = {}): PtyPanelData {
   return {
     id: "term-1",
     kind: "terminal",
@@ -329,7 +329,7 @@ function createTerminal(overrides: Record<string, unknown> = {}): TerminalInstan
     hasPty: true,
     isVisible: true,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 beforeEach(() => {

--- a/src/services/actions/definitions/__tests__/browserActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/browserActions.adversarial.test.ts
@@ -89,7 +89,7 @@ describe("browserActions adversarial", () => {
   it("browser.openExternal explicit url wins over stale store browserUrl", async () => {
     setPanelState({
       focusedId: "b1",
-      panelsById: { b1: { browserUrl: "https://stale.example" } },
+      panelsById: { b1: { kind: "browser", browserUrl: "https://stale.example" } },
     });
     const run = setupActions();
     await run("browser.openExternal", { url: "https://fresh.example" });
@@ -100,7 +100,7 @@ describe("browserActions adversarial", () => {
   it("browser.openExternal falls back to stored browserUrl when no explicit url is given", async () => {
     setPanelState({
       focusedId: "b1",
-      panelsById: { b1: { browserUrl: "https://stored.example" } },
+      panelsById: { b1: { kind: "browser", browserUrl: "https://stored.example" } },
     });
     const run = setupActions();
     await run("browser.openExternal");
@@ -111,7 +111,7 @@ describe("browserActions adversarial", () => {
   it("browser.openExternal throws when neither explicit url nor stored browserUrl exists", async () => {
     setPanelState({
       focusedId: "b1",
-      panelsById: { b1: {} },
+      panelsById: { b1: { kind: "browser" } },
     });
     const run = setupActions();
 
@@ -130,7 +130,7 @@ describe("browserActions adversarial", () => {
   it("browser.copyUrl writes to clipboard when url is derivable", async () => {
     setPanelState({
       focusedId: "b1",
-      panelsById: { b1: { browserUrl: "https://copy.example" } },
+      panelsById: { b1: { kind: "browser", browserUrl: "https://copy.example" } },
     });
     const run = setupActions();
     await run("browser.copyUrl");

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -59,7 +59,7 @@ type ActionRegistry = Awaited<
   ReturnType<typeof import("@/services/actions/actionDefinitions").createActionDefinitions>
 >;
 
-function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeAgent(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     title: id,
@@ -71,10 +71,10 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     agentState: "waiting",
     hasPty: true,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
-function seedPanels(terminals: TerminalInstance[]): void {
+function seedPanels(terminals: PtyPanelData[]): void {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
     panelIds: terminals.map((t) => t.id),

--- a/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { FleetSavedScope, TerminalInstance } from "@shared/types";
+import type { FleetSavedScope } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 const getSettingsMock = vi.hoisted(() => vi.fn());
 const saveSettingsMock = vi.hoisted(() => vi.fn());
@@ -64,7 +65,7 @@ type ActionRegistry = Awaited<
   ReturnType<typeof import("@/services/actions/actionDefinitions").createActionDefinitions>
 >;
 
-function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeAgent(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     title: id,
@@ -76,10 +77,10 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     agentState: "waiting",
     hasPty: true,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
-function seedPanels(terminals: TerminalInstance[]): void {
+function seedPanels(terminals: PtyPanelData[]): void {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
     panelIds: terminals.map((t) => t.id),

--- a/src/services/actions/definitions/__tests__/terminalGetStatusAction.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalGetStatusAction.test.ts
@@ -75,7 +75,7 @@ describe("terminal.getStatus", () => {
       panelIds: ["t1", "t2"],
       panelsById: {
         t1: { id: "t1", kind: "terminal", location: "grid", agentState: "working" },
-        t2: { id: "t2", kind: "agent", location: "grid", agentState: "completed" },
+        t2: { id: "t2", kind: "terminal", location: "grid", agentState: "completed" },
       },
     });
 

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -13,7 +13,7 @@ import { useProjectStatsStore } from "@/store/projectStatsStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { AGENT_REGISTRY } from "@/config/agents";
 import type { ActionId } from "@shared/types/actions";
-import type { TerminalSpawnSource } from "@shared/types/panel";
+import { isPtyPanel, type TerminalSpawnSource } from "@shared/types/panel";
 export function registerAgentActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   actions.set("agent.launch", () => ({
     id: "agent.launch",
@@ -392,7 +392,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         // Skip ephemeral panels (e.g. the Daintree Assistant's own dock
         // terminal) for the same reason terminal.list filters them — the
         // assistant must not be able to introspect its own process.
-        if (!panel || panel.ephemeral === true) continue;
+        if (!panel || !isPtyPanel(panel) || panel.ephemeral === true) continue;
         const effectiveAgentId = panel.detectedAgentId ?? panel.launchAgentId;
         if (effectiveAgentId === agentId) {
           return {

--- a/src/services/actions/definitions/browserActions.ts
+++ b/src/services/actions/definitions/browserActions.ts
@@ -2,6 +2,15 @@ import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
 import { systemClient } from "@/clients";
 import { usePanelStore } from "@/store/panelStore";
+import { isBrowserPanel, isDevPreviewPanel } from "@shared/types/panel";
+
+function readBrowserUrl(id: string | undefined): string | undefined {
+  if (!id) return undefined;
+  const panel = usePanelStore.getState().panelsById[id];
+  if (!panel) return undefined;
+  if (isBrowserPanel(panel) || isDevPreviewPanel(panel)) return panel.browserUrl;
+  return undefined;
+}
 
 export function registerBrowserActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
   actions.set("browser.reload", () => ({
@@ -93,8 +102,7 @@ export function registerBrowserActions(actions: ActionRegistry, _callbacks: Acti
     run: async (args: unknown) => {
       const { terminalId, url } = (args as { terminalId?: string; url?: string } | undefined) ?? {};
       const targetId = terminalId ?? usePanelStore.getState().focusedId ?? undefined;
-      const derivedUrl =
-        url ?? (targetId ? usePanelStore.getState().panelsById[targetId]?.browserUrl : undefined);
+      const derivedUrl = url ?? readBrowserUrl(targetId);
 
       if (!derivedUrl) {
         throw new Error("No browser URL available to open externally");
@@ -118,8 +126,7 @@ export function registerBrowserActions(actions: ActionRegistry, _callbacks: Acti
     run: async (args: unknown) => {
       const { terminalId, url } = (args as { terminalId?: string; url?: string } | undefined) ?? {};
       const targetId = terminalId ?? usePanelStore.getState().focusedId ?? undefined;
-      const derivedUrl =
-        url ?? (targetId ? usePanelStore.getState().panelsById[targetId]?.browserUrl : undefined);
+      const derivedUrl = url ?? readBrowserUrl(targetId);
 
       if (!derivedUrl) {
         throw new Error("No browser URL available to copy");

--- a/src/services/actions/definitions/panelCoreActions.ts
+++ b/src/services/actions/definitions/panelCoreActions.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 import { useDiagnosticsStore } from "@/store/diagnosticsStore";
 import { useErrorStore } from "@/store/errorStore";
 import { usePortalStore } from "@/store/portalStore";
-import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
+import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 
 export function registerPanelCoreActions(
   actions: ActionRegistry,
@@ -53,7 +54,7 @@ export function registerPanelCoreActions(
       const state = usePanelStore.getState();
       let panels = state.panelIds
         .map((id) => state.panelsById[id])
-        .filter((p): p is TerminalInstance => p !== undefined);
+        .filter((p): p is PanelInstance => p !== undefined);
 
       if (worktreeId) {
         panels = panels.filter((p) => p.worktreeId === worktreeId);
@@ -75,8 +76,8 @@ export function registerPanelCoreActions(
           worktreeId: p.worktreeId ?? null,
           title: p.title ?? null,
           location: p.location ?? "grid",
-          agentId: p.launchAgentId ?? null,
-          agentState: p.agentState ?? null,
+          agentId: isPtyPanel(p) ? (p.launchAgentId ?? null) : null,
+          agentState: isPtyPanel(p) ? (p.agentState ?? null) : null,
         })),
         dock: {
           panelCount: panels.filter((p) => p.location === "dock").length,

--- a/src/services/actions/definitions/terminalInputActions.ts
+++ b/src/services/actions/definitions/terminalInputActions.ts
@@ -8,6 +8,7 @@ import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStor
 import { usePanelStore } from "@/store/panelStore";
 import { triggerPopStash, triggerStashInput } from "@/store/terminalInputStore";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { isPtyPanel } from "@shared/types/panel";
 import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
 export function registerTerminalInputActions(
   actions: ActionRegistry,
@@ -68,7 +69,7 @@ export function registerTerminalInputActions(
       const targetId = terminalId ?? state.focusedId;
       if (!targetId) return;
       const terminal = state.panelsById[targetId];
-      if (terminal?.isInputLocked) return;
+      if (terminal && isPtyPanel(terminal) && terminal.isInputLocked) return;
       const managed = terminalInstanceService.get(targetId);
       if (!managed || managed.isInputLocked) return;
       try {

--- a/src/services/actions/definitions/terminalLayoutActions.ts
+++ b/src/services/actions/definitions/terminalLayoutActions.ts
@@ -5,6 +5,7 @@ import { computeGridColumns } from "@/lib/terminalLayout";
 import { useLayoutConfigStore } from "@/store/layoutConfigStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useLayoutUndoStore } from "@/store/layoutUndoStore";
+import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 export function registerTerminalLayoutActions(
   actions: ActionRegistry,
   callbacks: ActionCallbacks
@@ -26,6 +27,12 @@ export function registerTerminalLayoutActions(
       if (targetId) {
         const terminal = state.panelsById[targetId];
         if (!terminal) {
+          return;
+        }
+        // Dock rendering is PTY-only (see ContentDock + DockPanelOffscreenContainer).
+        // Reject browser / dev-preview / review panels so they don't silently
+        // disappear into a dock slot that won't render them.
+        if (!panelKindHasPty(terminal.kind)) {
           return;
         }
 

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -584,11 +584,7 @@ export function registerTerminalLifecycleActions(
       } else {
         const terminal = state.panelsById[targetId];
         const agentState = terminal && isPtyPanel(terminal) ? terminal.agentState : undefined;
-        if (
-          agentState === "completed" ||
-          agentState === "waiting" ||
-          agentState === "exited"
-        ) {
+        if (agentState === "completed" || agentState === "waiting" || agentState === "exited") {
           fireWatchNotification(targetId, terminal?.title ?? targetId, agentState);
         } else {
           state.watchPanel(targetId);

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -6,6 +6,7 @@ import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
 import { fireWatchNotification } from "@/lib/watchNotification";
 import { usePanelStore } from "@/store/panelStore";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { isPtyPanel } from "@shared/types/panel";
 import {
   useTerminalPendingDestructiveActionStore,
   type TerminalPendingDestructiveActionKind,
@@ -444,9 +445,10 @@ export function registerTerminalLifecycleActions(
       // shouldn't get swept up by a "close all" command.
       const idsToClose = state.panelIds.filter((id) => {
         const t = state.panelsById[id];
+        if (!t) return false;
+        const isEphemeral = isPtyPanel(t) && t.ephemeral === true;
         return (
-          t &&
-          t.ephemeral !== true &&
+          !isEphemeral &&
           t.location !== "trash" &&
           (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
         );
@@ -481,7 +483,10 @@ export function registerTerminalLifecycleActions(
       const state = usePanelStore.getState();
       const targets = state.panelIds
         .map((id) => state.panelsById[id])
-        .filter((t): t is NonNullable<typeof t> => t != null && t.ephemeral !== true);
+        .filter((t): t is NonNullable<typeof t> => {
+          if (t == null) return false;
+          return !(isPtyPanel(t) && t.ephemeral === true);
+        });
       if (targets.length === 0) return;
       const runningAgents = collectRunningAgentTerminals(targets);
       if (!parseConfirmed(args) && runningAgents.length > 0) {
@@ -578,12 +583,13 @@ export function registerTerminalLifecycleActions(
         state.unwatchPanel(targetId);
       } else {
         const terminal = state.panelsById[targetId];
+        const agentState = terminal && isPtyPanel(terminal) ? terminal.agentState : undefined;
         if (
-          terminal?.agentState === "completed" ||
-          terminal?.agentState === "waiting" ||
-          terminal?.agentState === "exited"
+          agentState === "completed" ||
+          agentState === "waiting" ||
+          agentState === "exited"
         ) {
-          fireWatchNotification(targetId, terminal.title ?? targetId, terminal.agentState);
+          fireWatchNotification(targetId, terminal?.title ?? targetId, agentState);
         } else {
           state.watchPanel(targetId);
         }

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -4,7 +4,10 @@ import { TerminalSummarySchema, TerminalStatusEntrySchema } from "./schemas";
 import { stripAnsiCodes } from "@shared/utils/artifactParser";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { terminalClient } from "@/clients";
-import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
+import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+import type { AgentState, WaitingReason } from "@shared/types/agent";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import {
   MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS,
@@ -43,7 +46,7 @@ export function registerTerminalQueryActions(
       // process during bulk operations.
       let terminals = state.panelIds
         .map((id) => state.panelsById[id])
-        .filter((t): t is TerminalInstance => t !== undefined && t.ephemeral !== true);
+        .filter((t): t is PanelInstance => t !== undefined && (!isPtyPanel(t) || t.ephemeral !== true));
 
       // Filter by worktree if specified
       if (worktreeId) {
@@ -66,9 +69,9 @@ export function registerTerminalQueryActions(
         worktreeId: t.worktreeId ?? null,
         title: t.title ?? null,
         location: t.location ?? "grid",
-        agentId: t.detectedAgentId ?? t.launchAgentId ?? null,
-        agentState: t.agentState ?? null,
-        isInputLocked: t.isInputLocked ?? false,
+        agentId: isPtyPanel(t) ? (t.detectedAgentId ?? t.launchAgentId ?? null) : null,
+        agentState: isPtyPanel(t) ? (t.agentState ?? null) : null,
+        isInputLocked: isPtyPanel(t) ? (t.isInputLocked ?? false) : false,
         isFocused: t.id === state.focusedId,
       }));
 
@@ -233,24 +236,24 @@ export function registerTerminalQueryActions(
       type StatusEntry = {
         terminalId: string;
         agentId: string | null;
-        agentState: TerminalInstance["agentState"] | null;
-        waitingReason?: TerminalInstance["waitingReason"];
+        agentState: AgentState | null;
+        waitingReason?: WaitingReason;
         lastTransitionAt?: number;
         recentOutput?: string | null;
         error?: string;
       };
 
-      const resolved: Array<{ id: string; terminal: TerminalInstance | undefined }> = [];
+      const resolved: Array<{ id: string; terminal: PanelInstance | undefined }> = [];
 
       // An explicitly passed `terminalIds` (even empty) selects the targeted
       // path — never silently fall back to the fleet path, which would surprise
       // a caller asking for a specific subset.
       if (terminalIds !== undefined) {
         for (const id of terminalIds) {
-          const t = panelsById[id];
+          const t = getNarrowPanel(panelsById, id);
           // Treat ephemeral panels as not found — they're tooling-internal and
           // must never expose state to MCP callers (mirrors terminal.list).
-          if (!t || t.ephemeral === true) {
+          if (!t || (isPtyPanel(t) && t.ephemeral === true)) {
             resolved.push({ id, terminal: undefined });
           } else {
             resolved.push({ id, terminal: t });
@@ -259,7 +262,7 @@ export function registerTerminalQueryActions(
       } else {
         let terminals = state.panelIds
           .map((id) => panelsById[id])
-          .filter((t): t is TerminalInstance => t !== undefined && t.ephemeral !== true);
+          .filter((t): t is PanelInstance => t !== undefined && (!isPtyPanel(t) || t.ephemeral !== true));
 
         if (worktreeId) {
           terminals = terminals.filter((t) => t.worktreeId === worktreeId);
@@ -310,12 +313,18 @@ export function registerTerminalQueryActions(
 
         const entry: StatusEntry = {
           terminalId: terminal.id,
-          agentId: terminal.detectedAgentId ?? terminal.launchAgentId ?? null,
-          agentState: terminal.agentState ?? null,
-          lastTransitionAt: terminal.lastStateChange,
+          agentId: isPtyPanel(terminal)
+            ? (terminal.detectedAgentId ?? terminal.launchAgentId ?? null)
+            : null,
+          agentState: isPtyPanel(terminal) ? (terminal.agentState ?? null) : null,
+          lastTransitionAt: isPtyPanel(terminal) ? terminal.lastStateChange : undefined,
         };
 
-        if (terminal.agentState === "waiting" && terminal.waitingReason !== undefined) {
+        if (
+          isPtyPanel(terminal) &&
+          terminal.agentState === "waiting" &&
+          terminal.waitingReason !== undefined
+        ) {
           entry.waitingReason = terminal.waitingReason;
         }
 
@@ -424,7 +433,7 @@ export function registerTerminalQueryActions(
       }
 
       // Check if terminal has PTY capability
-      if (terminal.hasPty === false) {
+      if (isPtyPanel(terminal) && terminal.hasPty === false) {
         throw new Error("Terminal does not have PTY capability");
       }
 

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -46,7 +46,9 @@ export function registerTerminalQueryActions(
       // process during bulk operations.
       let terminals = state.panelIds
         .map((id) => state.panelsById[id])
-        .filter((t): t is PanelInstance => t !== undefined && (!isPtyPanel(t) || t.ephemeral !== true));
+        .filter(
+          (t): t is PanelInstance => t !== undefined && (!isPtyPanel(t) || t.ephemeral !== true)
+        );
 
       // Filter by worktree if specified
       if (worktreeId) {
@@ -262,7 +264,9 @@ export function registerTerminalQueryActions(
       } else {
         let terminals = state.panelIds
           .map((id) => panelsById[id])
-          .filter((t): t is PanelInstance => t !== undefined && (!isPtyPanel(t) || t.ephemeral !== true));
+          .filter(
+            (t): t is PanelInstance => t !== undefined && (!isPtyPanel(t) || t.ephemeral !== true)
+          );
 
         if (worktreeId) {
           terminals = terminals.filter((t) => t.worktreeId === worktreeId);

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -5,8 +5,9 @@ import { useLayoutUndoStore } from "@/store/layoutUndoStore";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { flushOptimisticCloses } from "@/services/terminal/optimisticPanelClose";
 import { getDefaultTitle } from "@/store/slices/panelRegistry/helpers";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
-import type { TerminalSpawnSource } from "@shared/types/panel";
+import type { PtyPanelData, TerminalSpawnSource } from "@shared/types/panel";
 export function registerTerminalSpawnActions(
   actions: ActionRegistry,
   callbacks: ActionCallbacks
@@ -79,9 +80,12 @@ export function registerTerminalSpawnActions(
         const terminal = state.panelsById[targetId];
         if (!terminal) return;
 
+        const narrowedTerminal = getNarrowPanel(state.panelsById, targetId);
+        if (!narrowedTerminal) return;
+
         const location =
           terminal.location === "grid" || terminal.location === "dock" ? terminal.location : "grid";
-        const options = await buildPanelDuplicateOptions(terminal, location);
+        const options = await buildPanelDuplicateOptions(narrowedTerminal, location);
         if (options.title) {
           const defaultTitle = getDefaultTitle(terminal.kind, terminal);
           if (options.title !== defaultTitle) {
@@ -102,11 +106,14 @@ export function registerTerminalSpawnActions(
             ? await buildPanelDuplicateOptions(
                 {
                   id: "last-closed",
+                  kind: "terminal",
+                  cols: 80,
+                  rows: 24,
                   title: lastClosed.title ?? "Terminal",
                   cwd: lastClosed.cwd ?? callbacks.getDefaultCwd(),
                   location: "grid",
                   ...lastClosed,
-                },
+                } as PtyPanelData,
                 "grid"
               )
             : lastClosed;

--- a/src/services/actions/definitions/workflowUtilityActions.ts
+++ b/src/services/actions/definitions/workflowUtilityActions.ts
@@ -8,6 +8,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { selectOrderedTerminals } from "@/store/slices/panelRegistry";
 import { isTerminalVisible } from "@/lib/terminalVisibility";
+import { isPtyPanel } from "@shared/types/panel";
 
 export function registerWorkflowUtilityActions(actions: ActionRegistry): void {
   actions.set("workflow.prepBranchForReview", () =>
@@ -136,8 +137,12 @@ export function registerWorkflowUtilityActions(actions: ActionRegistry): void {
         const inScope = terminals.filter((t) =>
           isTerminalVisible(t, state.isInTrash, validWorktreeIds)
         );
-        const waitingCount = inScope.filter((t) => t.agentState === "waiting").length;
-        const workingCount = inScope.filter((t) => t.agentState === "working").length;
+        const waitingCount = inScope.filter(
+          (t) => isPtyPanel(t) && t.agentState === "waiting"
+        ).length;
+        const workingCount = inScope.filter(
+          (t) => isPtyPanel(t) && t.agentState === "working"
+        ).length;
 
         if (waitingCount > 0) {
           state.focusNextWaiting(state.isInTrash, validWorktreeIds);

--- a/src/services/terminal/TerminalLinkHandler.ts
+++ b/src/services/terminal/TerminalLinkHandler.ts
@@ -4,6 +4,7 @@ import { isLocalhostUrl, normalizeBrowserUrl } from "@/components/Browser/browse
 import { usePanelStore } from "@/store/panelStore";
 import { isMac } from "@/lib/platform";
 import { logError } from "@/utils/logger";
+import { isPtyPanel } from "@shared/types/panel";
 
 export class TerminalLinkHandler {
   openLink(url: string, terminalId: string, event?: MouseEvent): void {
@@ -35,7 +36,7 @@ export class TerminalLinkHandler {
           kind: "browser",
           browserUrl: normalized.url,
           worktreeId: targetWorktreeId ?? undefined,
-          cwd: currentTerminal?.cwd ?? "",
+          cwd: (isPtyPanel(currentTerminal) ? currentTerminal.cwd : undefined) ?? "",
         });
       }
     } else {

--- a/src/services/terminal/__tests__/panelDuplicationService.test.ts
+++ b/src/services/terminal/__tests__/panelDuplicationService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { TerminalInstance } from "@/store";
+import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
 import type { AddPanelOptions } from "@/store/slices/panelRegistry/types";
 import type { BrowserPanelOptions, DevPreviewPanelOptions } from "@shared/types/addPanelOptions";
 
@@ -59,7 +59,7 @@ vi.mock("@/store/projectPresetsStore", () => ({
   },
 }));
 
-function makePanel(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makePanel(overrides: Partial<PtyPanelData> | Partial<PanelInstance> = {}): PanelInstance {
   return {
     id: "panel-1",
     title: "Test Panel",
@@ -67,11 +67,11 @@ function makePanel(overrides: Partial<TerminalInstance> = {}): TerminalInstance 
     kind: "terminal",
     cwd: "/home/user",
     ...overrides,
-  } as TerminalInstance;
+  } as PanelInstance;
 }
 
 describe("buildPanelSnapshotOptions", () => {
-  let buildPanelSnapshotOptions: (panel: TerminalInstance) => AddPanelOptions | null;
+  let buildPanelSnapshotOptions: (panel: PanelInstance) => AddPanelOptions | null;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -102,7 +102,7 @@ describe("buildPanelSnapshotOptions", () => {
     });
     // agentLaunchFlags should be a new array (deep copy)
     expect(result!.agentLaunchFlags).toEqual(["--flag"]);
-    expect(result!.agentLaunchFlags).not.toBe(panel.agentLaunchFlags);
+    expect(result!.agentLaunchFlags).not.toBe((panel as PtyPanelData).agentLaunchFlags);
   });
 
   it("copies title to the snapshot", () => {
@@ -235,7 +235,7 @@ describe("buildPanelSnapshotOptions", () => {
 
 describe("panelDuplicationService", () => {
   let buildPanelDuplicateOptions: (
-    panel: TerminalInstance,
+    panel: PanelInstance,
     location: "grid" | "dock"
   ) => Promise<AddPanelOptions>;
 
@@ -326,7 +326,7 @@ describe("panelDuplicationService", () => {
       devCommand: "npm run dev",
       browserUrl: "http://localhost:3000",
       devPreviewConsoleOpen: true,
-    } as Partial<TerminalInstance>);
+    } as Partial<PanelInstance>);
 
     const result = (await buildPanelDuplicateOptions(panel, "grid")) as DevPreviewPanelOptions;
 
@@ -580,7 +580,7 @@ describe("panelDuplicationService", () => {
 
 describe("adversarial: behavioral overrides flow to generateAgentCommand in duplication", () => {
   let buildPanelDuplicateOptions: (
-    panel: TerminalInstance,
+    panel: PanelInstance,
     location: "grid" | "dock"
   ) => Promise<AddPanelOptions>;
 

--- a/src/services/terminal/panelDuplicationService.ts
+++ b/src/services/terminal/panelDuplicationService.ts
@@ -1,5 +1,10 @@
-import type { TerminalInstance } from "@/store";
 import type { AddPanelOptions } from "@/store/slices/panelRegistry/types";
+import {
+  isPtyPanel,
+  isBrowserPanel,
+  isDevPreviewPanel,
+  type PanelInstance,
+} from "@shared/types/panel";
 import type { TabGroupLocation } from "@/types";
 import { generateAgentCommand } from "@shared/types";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
@@ -27,8 +32,8 @@ export interface ResolvedCommand {
  * merges globalEnv + preset env the same way useAgentLauncher does (global
  * first, preset overrides). For all others, copies the existing command.
  */
-async function resolveCommandForPanel(panel: TerminalInstance): Promise<ResolvedCommand> {
-  if (panel.launchAgentId && isRegisteredAgent(panel.launchAgentId)) {
+async function resolveCommandForPanel(panel: PanelInstance): Promise<ResolvedCommand> {
+  if (isPtyPanel(panel) && panel.launchAgentId && isRegisteredAgent(panel.launchAgentId)) {
     const agentConfig = getAgentConfig(panel.launchAgentId);
     if (agentConfig) {
       try {
@@ -83,22 +88,22 @@ async function resolveCommandForPanel(panel: TerminalInstance): Promise<Resolved
     }
   }
   return {
-    command: panel.command,
+    command: isPtyPanel(panel) ? panel.command : undefined,
     env: undefined,
-    agentLaunchFlags: panel.agentLaunchFlags,
+    agentLaunchFlags: isPtyPanel(panel) ? panel.agentLaunchFlags : undefined,
     preset: undefined,
     presetWasStale: false,
   };
 }
 
-function buildBrowserOptions(panel: TerminalInstance) {
+function buildBrowserOptions(panel: import("@shared/types/panel").BrowserPanelData) {
   return {
     browserUrl: panel.browserUrl,
     browserConsoleOpen: panel.browserConsoleOpen,
   };
 }
 
-function buildDevPreviewOptions(panel: TerminalInstance) {
+function buildDevPreviewOptions(panel: import("@shared/types/panel").DevPreviewPanelData) {
   return {
     devCommand: panel.devCommand,
     browserUrl: panel.browserUrl,
@@ -118,10 +123,10 @@ function buildDevPreviewOptions(panel: TerminalInstance) {
  * silently dropping agent identity (the #5211 bare-shell bug) is worse than no
  * snapshot.
  */
-export function buildPanelSnapshotOptions(panel: TerminalInstance): AddPanelOptions | null {
-  const kind = panel.kind ?? "terminal";
+export function buildPanelSnapshotOptions(panel: PanelInstance): AddPanelOptions | null {
+  const kind = panel.kind;
 
-  if (panel.launchAgentId && kind === "terminal") {
+  if (isPtyPanel(panel) && panel.launchAgentId && kind === "terminal") {
     if (!panel.command) {
       return null;
     }
@@ -144,24 +149,21 @@ export function buildPanelSnapshotOptions(panel: TerminalInstance): AddPanelOpti
     };
   }
 
-  if (kind === "browser") {
+  if (isBrowserPanel(panel)) {
     return {
       kind: "browser",
-      cwd: panel.cwd || "",
+      cwd: "",
       worktreeId: panel.worktreeId,
-      exitBehavior: panel.exitBehavior,
-      isInputLocked: panel.isInputLocked,
       ...buildBrowserOptions(panel),
     };
   }
 
-  if (kind === "dev-preview") {
+  if (isDevPreviewPanel(panel)) {
     return {
       kind: "dev-preview",
       cwd: panel.cwd || "",
       worktreeId: panel.worktreeId,
       exitBehavior: panel.exitBehavior,
-      isInputLocked: panel.isInputLocked,
       ...buildDevPreviewOptions(panel),
     };
   }
@@ -173,20 +175,24 @@ export function buildPanelSnapshotOptions(panel: TerminalInstance): AddPanelOpti
     };
   }
 
-  return {
-    kind: "terminal",
-    launchAgentId: panel.launchAgentId,
-    title: panel.title,
-    cwd: panel.cwd || "",
-    worktreeId: panel.worktreeId,
-    exitBehavior: panel.exitBehavior,
-    isInputLocked: panel.isInputLocked,
-    agentModelId: panel.agentModelId,
-    agentPresetId: panel.agentPresetId,
-    agentPresetColor: panel.agentPresetColor,
-    agentLaunchFlags: panel.agentLaunchFlags ? [...panel.agentLaunchFlags] : undefined,
-    command: panel.command,
-  };
+  if (isPtyPanel(panel)) {
+    return {
+      kind: "terminal",
+      launchAgentId: panel.launchAgentId,
+      title: panel.title,
+      cwd: panel.cwd || "",
+      worktreeId: panel.worktreeId,
+      exitBehavior: panel.exitBehavior,
+      isInputLocked: panel.isInputLocked,
+      agentModelId: panel.agentModelId,
+      agentPresetId: panel.agentPresetId,
+      agentPresetColor: panel.agentPresetColor,
+      agentLaunchFlags: panel.agentLaunchFlags ? [...panel.agentLaunchFlags] : undefined,
+      command: panel.command,
+    };
+  }
+
+  return null;
 }
 
 /**
@@ -198,14 +204,14 @@ export function buildPanelSnapshotOptions(panel: TerminalInstance): AddPanelOpti
  * `agentId` is unresolvable — callers already wrap this in try/catch.
  */
 export async function buildPanelDuplicateOptions(
-  sourcePanel: TerminalInstance,
+  sourcePanel: PanelInstance,
   targetLocation: TabGroupLocation
 ): Promise<AddPanelOptions> {
-  const kind = sourcePanel.kind ?? "terminal";
+  const kind = sourcePanel.kind;
   const { command, env, agentLaunchFlags, preset, presetWasStale } =
     await resolveCommandForPanel(sourcePanel);
 
-  if (sourcePanel.launchAgentId && kind === "terminal") {
+  if (isPtyPanel(sourcePanel) && sourcePanel.launchAgentId && kind === "terminal") {
     if (!command) {
       throw new Error(`Cannot duplicate agent terminal: command is missing`);
     }
@@ -238,26 +244,23 @@ export async function buildPanelDuplicateOptions(
     };
   }
 
-  if (kind === "browser") {
+  if (isBrowserPanel(sourcePanel)) {
     return {
       kind: "browser",
-      cwd: sourcePanel.cwd || "",
+      cwd: "",
       worktreeId: sourcePanel.worktreeId,
       location: targetLocation,
-      exitBehavior: sourcePanel.exitBehavior,
-      isInputLocked: sourcePanel.isInputLocked,
       ...buildBrowserOptions(sourcePanel),
     };
   }
 
-  if (kind === "dev-preview") {
+  if (isDevPreviewPanel(sourcePanel)) {
     return {
       kind: "dev-preview",
       cwd: sourcePanel.cwd || "",
       worktreeId: sourcePanel.worktreeId,
       location: targetLocation,
       exitBehavior: sourcePanel.exitBehavior,
-      isInputLocked: sourcePanel.isInputLocked,
       ...buildDevPreviewOptions(sourcePanel),
     };
   }
@@ -270,20 +273,24 @@ export async function buildPanelDuplicateOptions(
     };
   }
 
-  return {
-    kind: "terminal",
-    launchAgentId: sourcePanel.launchAgentId,
-    cwd: sourcePanel.cwd || "",
-    title: sourcePanel.title,
-    worktreeId: sourcePanel.worktreeId,
-    location: targetLocation,
-    exitBehavior: sourcePanel.exitBehavior,
-    isInputLocked: sourcePanel.isInputLocked,
-    agentModelId: sourcePanel.agentModelId,
-    agentPresetId: sourcePanel.agentPresetId,
-    agentPresetColor: sourcePanel.agentPresetColor,
-    agentLaunchFlags: sourcePanel.agentLaunchFlags,
-    env,
-    command,
-  };
+  if (isPtyPanel(sourcePanel)) {
+    return {
+      kind: "terminal",
+      launchAgentId: sourcePanel.launchAgentId,
+      cwd: sourcePanel.cwd || "",
+      title: sourcePanel.title,
+      worktreeId: sourcePanel.worktreeId,
+      location: targetLocation,
+      exitBehavior: sourcePanel.exitBehavior,
+      isInputLocked: sourcePanel.isInputLocked,
+      agentModelId: sourcePanel.agentModelId,
+      agentPresetId: sourcePanel.agentPresetId,
+      agentPresetColor: sourcePanel.agentPresetColor,
+      agentLaunchFlags: sourcePanel.agentLaunchFlags,
+      env,
+      command,
+    };
+  }
+
+  throw new Error(`Cannot duplicate panel of kind "${kind}"`);
 }

--- a/src/store/__tests__/atomicStateSwap.test.ts
+++ b/src/store/__tests__/atomicStateSwap.test.ts
@@ -52,7 +52,7 @@ const { terminalInstanceService } = await import("@/services/TerminalInstanceSer
 function seedTerminals() {
   const t1 = {
     id: "term-1",
-    type: "terminal" as const,
+    kind: "terminal" as const,
     title: "Shell 1",
     cwd: "/test",
     cols: 80,
@@ -61,7 +61,7 @@ function seedTerminals() {
   };
   const t2 = {
     id: "term-2",
-    type: "terminal" as const,
+    kind: "terminal" as const,
     title: "Shell 2",
     cwd: "/test",
     cols: 80,

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -738,8 +738,8 @@ describe("fleetArmingStore", () => {
       });
       expect(resolveFleetAgentCapabilityId(exAgent)).toBeUndefined();
       expect(isAgentFleetActionEligible(exAgent)).toBe(false);
-      expect(isFleetWaitingAgentEligible({ ...exAgent, agentState: "waiting" })).toBe(false);
-      expect(isFleetInterruptAgentEligible({ ...exAgent, agentState: "working" })).toBe(false);
+      expect(isFleetWaitingAgentEligible({ ...exAgent, agentState: "waiting" } as PanelInstance)).toBe(false);
+      expect(isFleetInterruptAgentEligible({ ...exAgent, agentState: "working" } as PanelInstance)).toBe(false);
       expect(isFleetRestartAgentEligible(exAgent)).toBe(false);
     });
 

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../fleetArmingStore";
 import { usePanelStore } from "../panelStore";
 import { useWorktreeSelectionStore } from "../worktreeStore";
-import type { TerminalInstance } from "@shared/types";
+import type { PanelInstance } from "@shared/types/panel";
 
 function resetStore() {
   useFleetArmingStore.setState({
@@ -29,8 +29,8 @@ function resetStore() {
 
 function makeAgentTerminal(
   id: string,
-  overrides: Partial<TerminalInstance> = {}
-): TerminalInstance {
+  overrides: Record<string, unknown> = {}
+): PanelInstance {
   return {
     id,
     title: id,
@@ -41,12 +41,12 @@ function makeAgentTerminal(
     location: "grid",
     agentState: "idle",
     hasPty: true,
-    ...(overrides as object),
-  } as TerminalInstance;
+    ...overrides,
+  } as PanelInstance;
 }
 
-function seedPanels(terminals: TerminalInstance[]): void {
-  const panelsById: Record<string, TerminalInstance> = {};
+function seedPanels(terminals: PanelInstance[]): void {
+  const panelsById: Record<string, PanelInstance> = {};
   const panelIds: string[] = [];
   for (const t of terminals) {
     panelsById[t.id] = t;

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -27,10 +27,7 @@ function resetStore() {
   });
 }
 
-function makeAgentTerminal(
-  id: string,
-  overrides: Record<string, unknown> = {}
-): PanelInstance {
+function makeAgentTerminal(id: string, overrides: Record<string, unknown> = {}): PanelInstance {
   return {
     id,
     title: id,
@@ -738,8 +735,12 @@ describe("fleetArmingStore", () => {
       });
       expect(resolveFleetAgentCapabilityId(exAgent)).toBeUndefined();
       expect(isAgentFleetActionEligible(exAgent)).toBe(false);
-      expect(isFleetWaitingAgentEligible({ ...exAgent, agentState: "waiting" } as PanelInstance)).toBe(false);
-      expect(isFleetInterruptAgentEligible({ ...exAgent, agentState: "working" } as PanelInstance)).toBe(false);
+      expect(
+        isFleetWaitingAgentEligible({ ...exAgent, agentState: "waiting" } as PanelInstance)
+      ).toBe(false);
+      expect(
+        isFleetInterruptAgentEligible({ ...exAgent, agentState: "working" } as PanelInstance)
+      ).toBe(false);
       expect(isFleetRestartAgentEligible(exAgent)).toBe(false);
     });
 

--- a/src/store/__tests__/fleetFailureStore.test.ts
+++ b/src/store/__tests__/fleetFailureStore.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { useFleetFailureStore } from "../fleetFailureStore";
 import { useFleetArmingStore } from "../fleetArmingStore";
 import { usePanelStore } from "../panelStore";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 function resetStores() {
   useFleetFailureStore.setState({ failedIds: new Set(), payload: null, recordedAt: null });
@@ -16,12 +16,14 @@ function resetStores() {
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
 }
 
-function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeAgent(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     title: id,
-    type: "terminal",
     kind: "terminal",
+    cwd: "/tmp",
+    cols: 80,
+    rows: 24,
     agentId: "claude",
     worktreeId: "wt-1",
     projectId: "proj-1",
@@ -29,7 +31,7 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     agentState: "waiting",
     hasPty: true,
     ...(overrides as object),
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 describe("useFleetFailureStore", () => {

--- a/src/store/__tests__/layoutUndoStore.test.ts
+++ b/src/store/__tests__/layoutUndoStore.test.ts
@@ -46,27 +46,27 @@ vi.mock("@/clients/appClient", () => ({
 import { useLayoutUndoStore } from "../layoutUndoStore";
 import { usePanelStore } from "../panelStore";
 import { useLayoutConfigStore } from "../layoutConfigStore";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 let terminalCounter = 0;
 
-function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeTerminal(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id: `t-${++terminalCounter}`,
     title: "test",
     location: "grid",
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
-function setTerminals(terminals: TerminalInstance[]) {
+function setTerminals(terminals: PtyPanelData[]) {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
     panelIds: terminals.map((t) => t.id),
   });
 }
 
-function seedTerminals(terminals: TerminalInstance[]) {
+function seedTerminals(terminals: PtyPanelData[]) {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
     panelIds: terminals.map((t) => t.id),

--- a/src/store/__tests__/layoutUndoStore.test.ts
+++ b/src/store/__tests__/layoutUndoStore.test.ts
@@ -84,7 +84,7 @@ function getTerminals() {
 
 function firstTerminal() {
   const s = usePanelStore.getState();
-  return s.panelsById[s.panelIds[0]!]!;
+  return s.panelsById[s.panelIds[0]!]! as PtyPanelData;
 }
 
 describe("layoutUndoStore", () => {

--- a/src/store/__tests__/panelStore.assistantFocusGuard.test.ts
+++ b/src/store/__tests__/panelStore.assistantFocusGuard.test.ts
@@ -83,6 +83,7 @@ vi.mock("@/store/terminalInputStore", () => ({
 import { usePanelStore } from "../panelStore";
 import { useMacroFocusStore } from "../macroFocusStore";
 import { runWithMcpSpawnFocusSuppressed } from "../mcpSpawnFocusGuard";
+import type { PtyPanelData } from "@shared/types/panel";
 
 function resetState() {
   usePanelStore.setState((s) => ({
@@ -185,8 +186,8 @@ describe("panelStore.addPanel focus guard (#6959)", () => {
     const state = usePanelStore.getState();
     expect(state.focusedId).toBe("incumbent-1");
     expect(state.previousFocusedId).toBeNull();
-    expect(state.panelsById[newId!]?.spawnedBy).toBe("mcp");
-    expect(state.panelsById[newId!]?.focusPolicy).toBe("preserve");
+    expect((state.panelsById[newId!] as PtyPanelData | undefined)?.spawnedBy).toBe("mcp");
+    expect((state.panelsById[newId!] as PtyPanelData | undefined)?.focusPolicy).toBe("preserve");
   });
 
   it("does not advance focusedId while an MCP dispatch is active even without explicit focusPolicy", async () => {
@@ -202,7 +203,7 @@ describe("panelStore.addPanel focus guard (#6959)", () => {
     const state = usePanelStore.getState();
     expect(state.focusedId).toBe("incumbent-1");
     expect(state.previousFocusedId).toBeNull();
-    expect(state.panelsById[newId!]?.focusPolicy).toBe("preserve");
+    expect((state.panelsById[newId!] as PtyPanelData | undefined)?.focusPolicy).toBe("preserve");
   });
 
   it("still advances focusedId for a normal user-initiated grid spawn", async () => {
@@ -267,7 +268,7 @@ describe("panelStore.addPanel focus guard (#6959)", () => {
       expect(state.activeDockTerminalId).toBeNull();
       expect(state.focusedId).toBe("incumbent-1");
       expect(state.previousFocusedId).toBeNull();
-      expect(state.panelsById[newId!]?.focusPolicy).toBe("preserve");
+      expect((state.panelsById[newId!] as PtyPanelData | undefined)?.focusPolicy).toBe("preserve");
       expect(state.panelsById[newId!]?.location).toBe("dock");
     });
 

--- a/src/store/__tests__/panelStore.processDetectionListeners.test.ts
+++ b/src/store/__tests__/panelStore.processDetectionListeners.test.ts
@@ -226,6 +226,11 @@ vi.mock("@/services/TerminalInstanceService", () => ({
 
 const { usePanelStore, setupTerminalStoreListeners, cleanupTerminalStoreListeners } =
   await import("../panelStore");
+import type { PtyPanelData } from "@shared/types/panel";
+
+function getPtyPanel(id: string): PtyPanelData | undefined {
+  return usePanelStore.getState().panelsById[id] as PtyPanelData | undefined;
+}
 
 describe("terminalStore process detection listeners", () => {
   beforeEach(() => {
@@ -281,7 +286,7 @@ describe("terminalStore process detection listeners", () => {
       timestamp: Date.now(),
     });
 
-    expect(usePanelStore.getState().panelsById["term-1"]?.detectedProcessId).toBe("npm");
+    expect(getPtyPanel("term-1")?.detectedProcessId).toBe("npm");
 
     detected?.({
       terminalId: "term-1",
@@ -290,7 +295,7 @@ describe("terminalStore process detection listeners", () => {
       timestamp: Date.now(),
     });
 
-    expect(usePanelStore.getState().panelsById["term-1"]?.detectedProcessId).toBe("npm");
+    expect(getPtyPanel("term-1")?.detectedProcessId).toBe("npm");
     cleanup();
   });
 
@@ -305,13 +310,13 @@ describe("terminalStore process detection listeners", () => {
       processName: "claude",
       timestamp: Date.now(),
     });
-    expect(usePanelStore.getState().panelsById["term-1"]?.detectedProcessId).toBe("claude");
+    expect(getPtyPanel("term-1")?.detectedProcessId).toBe("claude");
 
     exited?.({
       terminalId: "term-1",
       timestamp: Date.now(),
     });
-    expect(usePanelStore.getState().panelsById["term-1"]?.detectedProcessId).toBeUndefined();
+    expect(getPtyPanel("term-1")?.detectedProcessId).toBeUndefined();
     cleanup();
   });
 
@@ -330,7 +335,7 @@ describe("terminalStore process detection listeners", () => {
       timestamp: Date.now(),
     });
 
-    expect(usePanelStore.getState().panelsById["term-1"]?.everDetectedAgent).toBe(true);
+    expect(getPtyPanel("term-1")?.everDetectedAgent).toBe(true);
     cleanup();
   });
 
@@ -345,7 +350,7 @@ describe("terminalStore process detection listeners", () => {
       timestamp: Date.now(),
     });
 
-    expect(usePanelStore.getState().panelsById["term-1"]?.everDetectedAgent).toBeUndefined();
+    expect(getPtyPanel("term-1")?.everDetectedAgent).toBeUndefined();
     cleanup();
   });
 
@@ -362,7 +367,7 @@ describe("terminalStore process detection listeners", () => {
       timestamp,
     });
 
-    const panel = usePanelStore.getState().panelsById["term-1"];
+    const panel = getPtyPanel("term-1");
     expect(panel?.detectedAgentId).toBe("claude");
     expect(panel?.runtimeIdentity).toMatchObject({
       kind: "agent",
@@ -406,7 +411,7 @@ describe("terminalStore process detection listeners", () => {
       timestamp: Date.now(),
     });
 
-    const panel = usePanelStore.getState().panelsById["term-1"];
+    const panel = getPtyPanel("term-1");
     expect(panel?.detectedAgentId).toBe("claude");
     expect(panel?.detectedProcessId).toBe("claude");
     expect(panel?.runtimeIdentity).toMatchObject({
@@ -432,7 +437,7 @@ describe("terminalStore process detection listeners", () => {
       timestamp: Date.now(),
     });
 
-    expect(usePanelStore.getState().panelsById["term-1"]?.detectedAgentId).toBeUndefined();
+    expect(getPtyPanel("term-1")?.detectedAgentId).toBeUndefined();
     cleanup();
   });
 
@@ -447,7 +452,7 @@ describe("terminalStore process detection listeners", () => {
       timestamp: Date.now(),
     });
 
-    expect(usePanelStore.getState().panelsById["term-1"]?.detectedAgentId).toBeUndefined();
+    expect(getPtyPanel("term-1")?.detectedAgentId).toBeUndefined();
     cleanup();
   });
 
@@ -463,10 +468,10 @@ describe("terminalStore process detection listeners", () => {
       processName: "gemini",
       timestamp: Date.now(),
     });
-    expect(usePanelStore.getState().panelsById["term-1"]?.detectedAgentId).toBe("gemini");
+    expect(getPtyPanel("term-1")?.detectedAgentId).toBe("gemini");
 
     exited?.({ terminalId: "term-1", timestamp: Date.now() });
-    expect(usePanelStore.getState().panelsById["term-1"]?.detectedAgentId).toBeUndefined();
+    expect(getPtyPanel("term-1")?.detectedAgentId).toBeUndefined();
     cleanup();
   });
 
@@ -567,7 +572,7 @@ describe("terminalStore process detection listeners", () => {
 
     exited?.({ terminalId: "term-1", agentType: "claude", timestamp: Date.now() });
 
-    const panel = usePanelStore.getState().panelsById["term-1"];
+    const panel = getPtyPanel("term-1");
     expect(panel?.launchAgentId).toBe("claude");
     expect(panel?.detectedAgentId).toBeUndefined();
     cleanup();
@@ -589,7 +594,7 @@ describe("terminalStore process detection listeners", () => {
 
     exited?.({ terminalId: "term-1", timestamp: Date.now() });
 
-    const panel = usePanelStore.getState().panelsById["term-1"];
+    const panel = getPtyPanel("term-1");
     expect(panel?.launchAgentId).toBeUndefined();
     expect(panel?.detectedProcessId).toBeUndefined();
     cleanup();
@@ -607,10 +612,10 @@ describe("terminalStore process detection listeners", () => {
       processName: "claude",
       timestamp: Date.now(),
     });
-    expect(usePanelStore.getState().panelsById["term-1"]?.everDetectedAgent).toBe(true);
+    expect(getPtyPanel("term-1")?.everDetectedAgent).toBe(true);
 
     exited?.({ terminalId: "term-1", timestamp: Date.now() });
-    expect(usePanelStore.getState().panelsById["term-1"]?.everDetectedAgent).toBe(true);
+    expect(getPtyPanel("term-1")?.everDetectedAgent).toBe(true);
     cleanup();
   });
 
@@ -631,7 +636,7 @@ describe("terminalStore process detection listeners", () => {
 
     exit?.("term-1", 0);
 
-    const panel = usePanelStore.getState().panelsById["term-1"];
+    const panel = getPtyPanel("term-1");
     expect(panel).toBeDefined();
     expect(panel?.location).not.toBe("trash");
     expect(panel?.everDetectedAgent).toBe(true);
@@ -644,7 +649,7 @@ describe("terminalStore process detection listeners", () => {
 
     exit?.("term-1", 0);
 
-    const panel = usePanelStore.getState().panelsById["term-1"];
+    const panel = getPtyPanel("term-1");
     // Either moved to trash (location === "trash") or removed entirely.
     expect(panel === undefined || panel.location === "trash").toBe(true);
     cleanup();

--- a/src/store/__tests__/panelStore.refreshTier.test.ts
+++ b/src/store/__tests__/panelStore.refreshTier.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { getTerminalRefreshTier } from "../panelStore";
 import { TerminalRefreshTier } from "@shared/types/panel";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 // Pure unit tests for the refresh-tier gate that decides which panels are
 // eligible to hibernate. Uses durable agent affinity so a toolbar-launched or
 // restored agent terminal stays active until a strong exit signal arrives.
 
-function makeTerminal(overrides: Partial<TerminalInstance>): TerminalInstance {
+function makeTerminal(overrides: Partial<PtyPanelData>): PtyPanelData {
   return {
     id: overrides.id ?? "t-1",
     title: "test",
@@ -17,7 +17,7 @@ function makeTerminal(overrides: Partial<TerminalInstance>): TerminalInstance {
     cols: 80,
     rows: 24,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 describe("getTerminalRefreshTier - runtime agent identity", () => {

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { PtyPanelData, PanelInstance } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -119,6 +120,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-1": {
           id: "term-1",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -144,6 +146,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-2": {
           id: "term-2",
           title: "T2",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -166,6 +169,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-1": {
           id: "term-1",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -194,7 +198,7 @@ describe("rendererStoreOrchestrator", () => {
           cols: 80,
           rows: 24,
           location: "grid",
-        },
+        } as PanelInstance,
       },
       panelIds: [panelId],
     });
@@ -226,6 +230,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-1": {
           id: "term-1",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -248,6 +253,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-1": {
           id: "term-1",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -273,6 +279,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-1": {
           id: "term-1",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -295,6 +302,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-1": {
           id: "term-1",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -321,6 +329,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-1": {
           id: "term-1",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -330,6 +339,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-2": {
           id: "term-2",
           title: "T2",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -356,6 +366,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-1": {
           id: "term-1",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -381,7 +392,7 @@ describe("rendererStoreOrchestrator", () => {
           cols: 80,
           rows: 24,
           location: "grid",
-        },
+        } as PanelInstance,
         "t-2": {
           id: "t-2",
           kind: "browser",
@@ -390,7 +401,7 @@ describe("rendererStoreOrchestrator", () => {
           cols: 80,
           rows: 24,
           location: "grid",
-        },
+        } as PanelInstance,
       },
       panelIds: ["t-1", "t-2"],
     });
@@ -433,6 +444,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-1": {
           id: "term-1",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -457,6 +469,7 @@ describe("rendererStoreOrchestrator", () => {
         "bg-1": {
           id: "bg-1",
           title: "BG",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -480,6 +493,7 @@ describe("rendererStoreOrchestrator", () => {
         "dock-bg-1": {
           id: "dock-bg-1",
           title: "Dock BG",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -504,6 +518,7 @@ describe("rendererStoreOrchestrator", () => {
         "grid-1": {
           id: "grid-1",
           title: "Grid",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -529,6 +544,7 @@ describe("rendererStoreOrchestrator", () => {
         [panelId]: {
           id: panelId,
           title: "T1",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -553,6 +569,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-no-voice": {
           id: "term-no-voice",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -575,6 +592,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-1": {
           id: "term-1",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -595,6 +613,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-1": {
           id: "term-1",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -615,6 +634,7 @@ describe("rendererStoreOrchestrator", () => {
         "t-a": {
           id: "t-a",
           title: "A",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -623,6 +643,7 @@ describe("rendererStoreOrchestrator", () => {
         "t-b": {
           id: "t-b",
           title: "B",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -650,6 +671,7 @@ describe("rendererStoreOrchestrator", () => {
           "t-1": {
             id: "t-1",
             title: "T1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -659,6 +681,7 @@ describe("rendererStoreOrchestrator", () => {
           "t-2": {
             id: "t-2",
             title: "T2",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -668,6 +691,7 @@ describe("rendererStoreOrchestrator", () => {
           "t-3": {
             id: "t-3",
             title: "T3",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -701,6 +725,7 @@ describe("rendererStoreOrchestrator", () => {
           "t-1": {
             id: "t-1",
             title: "T1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -735,6 +760,7 @@ describe("rendererStoreOrchestrator", () => {
           "t-1": {
             id: "t-1",
             title: "T1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -766,6 +792,7 @@ describe("rendererStoreOrchestrator", () => {
         "term-1": {
           id: "term-1",
           title: "T1",
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -983,7 +1010,7 @@ describe("rendererStoreOrchestrator", () => {
             everDetectedAgent: true,
             agentState: "idle",
             hasPty: true,
-          },
+          } as PtyPanelData,
           "agent-b": {
             id: "agent-b",
             kind: "terminal",
@@ -994,7 +1021,7 @@ describe("rendererStoreOrchestrator", () => {
             everDetectedAgent: true,
             agentState: "idle",
             hasPty: true,
-          },
+          } as PtyPanelData,
         },
         panelIds: ["agent-a", "agent-b"],
       });
@@ -1040,7 +1067,7 @@ describe("rendererStoreOrchestrator", () => {
             everDetectedAgent: true,
             agentState: "idle",
             hasPty: true,
-          },
+          } as PtyPanelData,
         },
         panelIds: ["agent-a"],
       });

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -544,7 +544,7 @@ describe("rendererStoreOrchestrator", () => {
         [panelId]: {
           id: panelId,
           title: "T1",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -671,7 +671,7 @@ describe("rendererStoreOrchestrator", () => {
           "t-1": {
             id: "t-1",
             title: "T1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -681,7 +681,7 @@ describe("rendererStoreOrchestrator", () => {
           "t-2": {
             id: "t-2",
             title: "T2",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -691,7 +691,7 @@ describe("rendererStoreOrchestrator", () => {
           "t-3": {
             id: "t-3",
             title: "T3",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -725,7 +725,7 @@ describe("rendererStoreOrchestrator", () => {
           "t-1": {
             id: "t-1",
             title: "T1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -760,7 +760,7 @@ describe("rendererStoreOrchestrator", () => {
           "t-1": {
             id: "t-1",
             title: "T1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,

--- a/src/store/__tests__/resetWithoutKilling.test.ts
+++ b/src/store/__tests__/resetWithoutKilling.test.ts
@@ -5,7 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TabGroup } from "@/types";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -48,13 +48,13 @@ const { usePanelStore } = await import("../panelStore");
 const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
 const { terminalClient } = await import("@/clients");
 
-type MockTerminal = Partial<TerminalInstance> & { id: string };
+type MockTerminal = Partial<PtyPanelData> & { id: string };
 
 function setTerminals(terminals: MockTerminal[]) {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<
       string,
-      TerminalInstance
+      PtyPanelData
     >,
     panelIds: terminals.map((t) => t.id),
   });

--- a/src/store/__tests__/resetWithoutKilling.test.ts
+++ b/src/store/__tests__/resetWithoutKilling.test.ts
@@ -52,10 +52,7 @@ type MockTerminal = Partial<PtyPanelData> & { id: string };
 
 function setTerminals(terminals: MockTerminal[]) {
   usePanelStore.setState({
-    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<
-      string,
-      PtyPanelData
-    >,
+    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<string, PtyPanelData>,
     panelIds: terminals.map((t) => t.id),
   });
 }

--- a/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
+++ b/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { TerminalInstance } from "@shared/types";
+import type { PanelInstance } from "@shared/types/panel";
 
 const fullWakeMock = vi.fn();
 const isFocusedMock = vi.fn();
@@ -18,7 +18,7 @@ vi.mock("@/utils/logger", () => ({
 
 let mockActiveWorktreeId: string | null = null;
 let mockPanelIds: string[] = [];
-let mockPanelsById: Record<string, TerminalInstance> = {};
+let mockPanelsById: Record<string, PanelInstance> = {};
 
 vi.mock("@/store/worktreeStore", () => ({
   useWorktreeSelectionStore: {
@@ -34,13 +34,14 @@ vi.mock("@/store/panelStore", () => ({
 
 const { wakeActiveWorktreeTerminals } = await import("@/store/wakeActiveWorktreeTerminals");
 
-function panel(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function panel(id: string, overrides: Partial<PanelInstance> = {}): PanelInstance {
   return {
     id,
     title: id,
+    kind: "terminal",
     location: "grid",
     ...overrides,
-  } as TerminalInstance;
+  } as PanelInstance;
 }
 
 beforeEach(() => {
@@ -219,7 +220,7 @@ describe("wakeActiveWorktreeTerminals", () => {
     mockPanelIds = ids;
     mockPanelsById = Object.fromEntries(
       ids.map((id) => [id, panel(id, { worktreeId: "wt-1" })])
-    ) as Record<string, TerminalInstance>;
+    ) as Record<string, PanelInstance>;
 
     let inFlight = 0;
     let maxInFlight = 0;

--- a/src/store/layoutUndoStore.ts
+++ b/src/store/layoutUndoStore.ts
@@ -1,6 +1,9 @@
 import { create } from "zustand";
 import { usePanelStore } from "./panelStore";
-import type { TabGroup, TerminalInstance } from "@shared/types";
+import type { TabGroup } from "@shared/types";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 const MAX_UNDO_HISTORY = 10;
 
@@ -34,7 +37,7 @@ function captureCurrentLayout(): LayoutSnapshot {
   return {
     terminals: state.panelIds
       .map((id) => state.panelsById[id])
-      .filter((t): t is TerminalInstance => Boolean(t) && t!.location !== "trash")
+      .filter((t): t is CarrierPanel => Boolean(t) && t!.location !== "trash")
       .map((t) => ({
         id: t.id,
         location: t.location,
@@ -77,12 +80,12 @@ function applySnapshot(snapshot: LayoutSnapshot): boolean {
 
   // Rebuild the normalized store preserving non-layout fields. No grid-capacity
   // clamp is applied (#8805) — the scrollable grid absorbs every entry.
-  const newTerminalsById: Record<string, TerminalInstance> = {};
+  const newTerminalsById: Record<string, CarrierPanel> = {};
   const newTerminalIds: string[] = [];
   for (const entry of allEntries) {
     const current = panelsById[entry.id];
     if (!current) continue;
-    const restored: TerminalInstance = { ...current, location: entry.location };
+    const restored: CarrierPanel = { ...current, location: entry.location };
     if (entry.worktreeId !== undefined) {
       restored.worktreeId = entry.worktreeId;
     } else {

--- a/src/store/listeners/panel/__tests__/panelStatusBuffer.test.ts
+++ b/src/store/listeners/panel/__tests__/panelStatusBuffer.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { usePanelStore } from "@/store/panelStore";
+import type { PtyPanelData } from "@shared/types/panel";
 import {
   cancelPanelStatusBuffer,
   enqueueActivityUpdate,
@@ -38,6 +39,10 @@ function installFakeRaf(): FakeRaf {
       }
     },
   };
+}
+
+function getPtyPanel(id: string): PtyPanelData | undefined {
+  return usePanelStore.getState().panelsById[id] as PtyPanelData | undefined;
 }
 
 function seedPanel(id: string, overrides: Record<string, unknown> = {}): void {
@@ -89,9 +94,8 @@ describe("panelStatusBuffer — activity batching", () => {
     raf.flushAll();
     expect(setSpy).toHaveBeenCalledTimes(1);
 
-    const state = usePanelStore.getState();
     for (let i = 0; i < 10; i++) {
-      const t = state.panelsById[`term-${i}`];
+      const t = getPtyPanel(`term-${i}`);
       expect(t?.activityHeadline).toBe(`Working ${i}`);
       expect(t?.activityStatus).toBe("working");
       expect(t?.activityType).toBe("interactive");
@@ -105,7 +109,7 @@ describe("panelStatusBuffer — activity batching", () => {
     enqueueActivityUpdate("term-1", "First", "working", "interactive", 100, "a");
     enqueueActivityUpdate("term-1", "Second", "waiting", "interactive", 200, "b");
     raf.flushAll();
-    const t = usePanelStore.getState().panelsById["term-1"];
+    const t = getPtyPanel("term-1");
     expect(t?.activityHeadline).toBe("Second");
     expect(t?.activityStatus).toBe("waiting");
     expect(t?.activityTimestamp).toBe(200);
@@ -126,7 +130,7 @@ describe("panelStatusBuffer — activity batching", () => {
     // setState is still called once (the fold runs), but the returned object
     // reflects no terminal change. Assert via state equality, not call count.
     expect(setSpy).toHaveBeenCalledTimes(1);
-    const t = usePanelStore.getState().panelsById["term-1"];
+    const t = getPtyPanel("term-1");
     expect(t?.activityHeadline).toBe("Stable");
   });
 
@@ -150,9 +154,8 @@ describe("panelStatusBuffer — flow-status batching", () => {
 
     raf.flushAll();
     expect(setSpy).toHaveBeenCalledTimes(1);
-    const state = usePanelStore.getState();
     for (let i = 0; i < 5; i++) {
-      const t = state.panelsById[`term-${i}`];
+      const t = getPtyPanel(`term-${i}`);
       expect(t?.flowStatus).toBe("suspended");
       expect(t?.flowStatusTimestamp).toBe(1000 + i);
       // deriveRuntimeStatus(isVisible=true, flowStatus="suspended", "running") -> "suspended"
@@ -174,7 +177,7 @@ describe("panelStatusBuffer — flow-status batching", () => {
       },
     }));
     raf.flushAll();
-    const t = usePanelStore.getState().panelsById["term-1"];
+    const t = getPtyPanel("term-1");
     expect(t?.flowStatus).toBe("running");
     expect(t?.runtimeStatus).toBe("background");
   });
@@ -188,7 +191,7 @@ describe("panelStatusBuffer — flow-status batching", () => {
     enqueueFlowStatusUpdate("term-1", "running", 200);
     enqueueFlowStatusUpdate("term-1", "suspended", 100);
     raf.flushAll();
-    const t = usePanelStore.getState().panelsById["term-1"];
+    const t = getPtyPanel("term-1");
     expect(t?.flowStatus).toBe("running");
     expect(t?.flowStatusTimestamp).toBe(200);
   });
@@ -202,7 +205,7 @@ describe("panelStatusBuffer — flow-status batching", () => {
     });
     enqueueFlowStatusUpdate("term-1", "suspended", 400);
     raf.flushAll();
-    const t = usePanelStore.getState().panelsById["term-1"];
+    const t = getPtyPanel("term-1");
     expect(t?.flowStatus).toBe("running");
     expect(t?.flowStatusTimestamp).toBe(500);
   });
@@ -212,7 +215,7 @@ describe("panelStatusBuffer — flow-status batching", () => {
     enqueueFlowStatusUpdate("term-1", "suspended", 100);
     enqueueFlowStatusUpdate("term-1", "paused-backpressure", 200);
     raf.flushAll();
-    const t = usePanelStore.getState().panelsById["term-1"];
+    const t = getPtyPanel("term-1");
     expect(t?.flowStatus).toBe("paused-backpressure");
     expect(t?.flowStatusTimestamp).toBe(200);
   });
@@ -230,9 +233,8 @@ describe("panelStatusBuffer — combined flush", () => {
     raf.flushAll();
     expect(setSpy).toHaveBeenCalledTimes(1);
 
-    const state = usePanelStore.getState();
-    expect(state.panelsById["term-1"]?.activityHeadline).toBe("Doing");
-    expect(state.panelsById["term-2"]?.flowStatus).toBe("suspended");
+    expect(getPtyPanel("term-1")?.activityHeadline).toBe("Doing");
+    expect(getPtyPanel("term-2")?.flowStatus).toBe("suspended");
   });
 
   it("same terminal: activity + flow-status patches do not clobber each other", () => {
@@ -243,7 +245,7 @@ describe("panelStatusBuffer — combined flush", () => {
     enqueueActivityUpdate("term-1", "Compiling", "working", "interactive", 100, "npm run dev");
     enqueueFlowStatusUpdate("term-1", "suspended", 100);
     raf.flushAll();
-    const t = usePanelStore.getState().panelsById["term-1"];
+    const t = getPtyPanel("term-1");
     expect(t?.activityHeadline).toBe("Compiling");
     expect(t?.activityStatus).toBe("working");
     expect(t?.lastCommand).toBe("npm run dev");
@@ -260,7 +262,7 @@ describe("panelStatusBuffer — lifecycle", () => {
     cancelPanelStatusBuffer();
     cancelPanelStatusBuffer();
     raf.flushAll();
-    const t = usePanelStore.getState().panelsById["term-1"];
+    const t = getPtyPanel("term-1");
     expect(t?.activityHeadline).toBeUndefined();
   });
 
@@ -270,7 +272,7 @@ describe("panelStatusBuffer — lifecycle", () => {
     cancelPanelStatusBuffer();
     enqueueActivityUpdate("term-1", "Second", "working", "interactive", 200, undefined);
     raf.flushAll();
-    const t = usePanelStore.getState().panelsById["term-1"];
+    const t = getPtyPanel("term-1");
     expect(t?.activityHeadline).toBe("Second");
   });
 

--- a/src/store/listeners/panel/identity.ts
+++ b/src/store/listeners/panel/identity.ts
@@ -72,11 +72,13 @@ export function setupIdentityListeners(): DisposableStore {
 
         const clampedConfidence = Math.max(0, Math.min(1, confidence || 0));
 
-        const terminal = usePanelStore.getState().panelsById[terminalId];
+        const _terminalRaw = usePanelStore.getState().panelsById[terminalId];
 
-        if (!terminal) {
+        if (!_terminalRaw || !isPtyPanel(_terminalRaw)) {
           return;
         }
+
+        const terminal = _terminalRaw;
 
         if (terminal.isRestarting) {
           return;

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -1,4 +1,5 @@
 import type { TerminalStatusPayload } from "@shared/types";
+import { isPtyPanel } from "@shared/types/panel";
 import { terminalRegistryController } from "@/controllers";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -34,8 +35,9 @@ export async function handleFallbackTriggered(data: {
   const { terminalId, agentId, fromPresetId, reason } = data;
   if (fallbackInFlight.has(terminalId)) return;
 
-  const panel = usePanelStore.getState().panelsById[terminalId];
-  if (!panel) return;
+  const _panelRaw = usePanelStore.getState().panelsById[terminalId];
+  if (!_panelRaw || !isPtyPanel(_panelRaw)) return;
+  const panel = _panelRaw;
   if (panel.isRestarting) return;
 
   // Drop stale duplicate events: if the panel has already advanced past the
@@ -252,9 +254,10 @@ export function setupLifecycleListeners(): DisposableStore {
         }
 
         const state = usePanelStore.getState();
-        const terminal = state.panelsById[id];
+        const _terminalRaw = state.panelsById[id];
 
-        if (!terminal) return;
+        if (!_terminalRaw || !isPtyPanel(_terminalRaw)) return;
+        const terminal = _terminalRaw;
 
         // Also check store flag for safety (handles edge cases)
         if (terminal.isRestarting) {
@@ -317,11 +320,6 @@ export function setupLifecycleListeners(): DisposableStore {
         }
 
         // exitBehavior undefined - use default behavior based on terminal type
-        // Preserve dev-preview panels so users can inspect stopped/error states
-        if (terminal.kind === "dev-preview") {
-          return;
-        }
-
         // Preserve successfully completed agent terminals to enable reboot and output review.
         // Also preserve plain terminals that ran an agent mid-session (runtime detection);
         // everDetectedAgent is sticky in the PTY host so it survives past the inner agent exit.
@@ -372,8 +370,8 @@ export function setupLifecycleListeners(): DisposableStore {
           }
         } else {
           // Spawn succeeded - clear any previous spawn error
-          const terminal = usePanelStore.getState().panelsById[id];
-          if (terminal?.spawnError) {
+          const _spawnTerminal = usePanelStore.getState().panelsById[id];
+          if (_spawnTerminal && isPtyPanel(_spawnTerminal) && _spawnTerminal.spawnError) {
             usePanelStore.getState().clearSpawnError(id);
           }
         }

--- a/src/store/panelStatusBuffer.ts
+++ b/src/store/panelStatusBuffer.ts
@@ -2,6 +2,7 @@ import type { TerminalActivityPayload } from "@shared/types";
 import type { PersistableFlowStatus } from "@shared/types";
 import { usePanelStore } from "@/store/panelStore";
 import { deriveRuntimeStatus } from "@/store/slices/panelRegistry/helpers";
+import { isPtyPanel } from "@shared/types/panel";
 
 // Shared RAF-flushed buffer for high-frequency panel-status writes. Listeners
 // in src/store/listeners/panel/ (activity, lifecycle onStatus) enqueue patches
@@ -88,7 +89,7 @@ export function flushPanelStatusBuffer(): void {
     if (activity) {
       for (const [id, patch] of activity) {
         const terminal = nextById[id];
-        if (!terminal) continue;
+        if (!terminal || !isPtyPanel(terminal)) continue;
         if (
           terminal.activityHeadline === patch.headline &&
           terminal.activityStatus === patch.status &&
@@ -113,7 +114,7 @@ export function flushPanelStatusBuffer(): void {
     if (flow) {
       for (const [id, patch] of flow) {
         const terminal = nextById[id];
-        if (!terminal) continue;
+        if (!terminal || !isPtyPanel(terminal)) continue;
 
         const prevTs = terminal.flowStatusTimestamp;
         if (prevTs !== undefined && patch.timestamp < prevTs) continue;

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -49,9 +49,8 @@ type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 export type { AddPanelOptions, QueuedCommand, CrashType };
 // Re-exported for backwards-compat with tests still typing fixtures as
-// `TerminalInstance`. Production code drains in #8957 batch C+; this
-// re-export goes away with the interface itself in #8957 step 6.
-// eslint-disable-next-line no-restricted-imports -- sanctioned re-export of the draining alias
+// `TerminalInstance`. The interface itself is now the persistence Tolerant
+// Reader; production code uses `PanelInstance` from `@shared/types/panel`.
 export type { TerminalInstance } from "@shared/types";
 export { isAgentReady };
 export type { TerminalMruSlice, WatchedPanelsSlice };

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -157,8 +157,10 @@ export function getTerminalRefreshTier(
     return TerminalRefreshTierEnum.BACKGROUND;
   }
 
+  const ptyTerminal = isPtyPanel(terminal) ? terminal : undefined;
+
   // Working agents that ARE visible get max refresh to prevent render jitter.
-  if (terminal.agentState === "working") {
+  if (ptyTerminal?.agentState === "working") {
     return TerminalRefreshTierEnum.FOCUSED;
   }
 
@@ -167,12 +169,12 @@ export function getTerminalRefreshTier(
   // promptly instead of being parked in the background tier.
   if (
     options.isFleetArmed &&
-    terminal.hasPty !== false &&
+    ptyTerminal?.hasPty !== false &&
     terminal.location !== "trash" &&
     terminal.location !== "background" &&
     terminal.location !== "dock" &&
-    terminal.runtimeStatus !== "exited" &&
-    terminal.runtimeStatus !== "error"
+    ptyTerminal?.runtimeStatus !== "exited" &&
+    ptyTerminal?.runtimeStatus !== "error"
   ) {
     return TerminalRefreshTierEnum.VISIBLE;
   }
@@ -182,8 +184,8 @@ export function getTerminalRefreshTier(
   // Uses runtime-detected identity so panels that have left agent mode can hibernate.
   if (
     isRuntimeAgentTerminal(terminal) &&
-    terminal.agentState !== "completed" &&
-    terminal.agentState !== "exited"
+    ptyTerminal?.agentState !== "completed" &&
+    ptyTerminal?.agentState !== "exited"
   ) {
     return TerminalRefreshTierEnum.VISIBLE;
   }

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -25,7 +25,8 @@ import {
   type QueuedCommand,
   isAgentReady,
 } from "./slices";
-import type { TerminalInstance, TerminalRefreshTier, AddPanelFocusPolicy } from "@shared/types";
+import type { TerminalRefreshTier, AddPanelFocusPolicy } from "@shared/types";
+import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
 import { TerminalRefreshTier as TerminalRefreshTierEnum } from "@/types";
 import { terminalRegistryController } from "@/controllers";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -37,9 +38,21 @@ import { isRuntimeAgentTerminal } from "@/utils/terminalType";
 import { logInfo, logWarn, logError } from "@/utils/logger";
 import { clearTerminalRestartGuard } from "./restartExitSuppression";
 import { buildPanelSnapshotOptions } from "@/services/terminal/panelDuplicationService";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { resolvePanelKindPolicy, type PanelKindPolicy } from "@shared/config/panelKindRegistry";
 
-export type { TerminalInstance, AddPanelOptions, QueuedCommand, CrashType };
+// Carrier element from the legacy `panelsById` shape, sourced through
+// `getNarrowPanel`'s parameter so this file doesn't import the deprecated
+// `TerminalInstance` alias by name (#8957). The alias auto-resolves once
+// the carrier flips to `PanelInstance` in step 5.
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
+
+export type { AddPanelOptions, QueuedCommand, CrashType };
+// Re-exported for backwards-compat with tests still typing fixtures as
+// `TerminalInstance`. Production code drains in #8957 batch C+; this
+// re-export goes away with the interface itself in #8957 step 6.
+// eslint-disable-next-line no-restricted-imports -- sanctioned re-export of the draining alias
+export type { TerminalInstance } from "@shared/types";
 export { isAgentReady };
 export type { TerminalMruSlice, WatchedPanelsSlice };
 
@@ -50,7 +63,7 @@ const PROJECT_SWITCH_RESIZE_SUPPRESSION_MS = 10_000;
  * panel store so the helper stays pure and easy to test in isolation.
  */
 interface FallbackFocusStateSnapshot {
-  panelsById: Record<string, TerminalInstance>;
+  panelsById: Record<string, CarrierPanel>;
   panelIds: string[];
   previousFocusedId: string | null;
 }
@@ -93,7 +106,7 @@ function pickFallbackFocusId(
   }
 
   // Default "first-grid" path (also the fallback for unknown strategies).
-  const gridTerminals: TerminalInstance[] = [];
+  const gridTerminals: CarrierPanel[] = [];
   for (const tid of state.panelIds) {
     const t = state.panelsById[tid];
     if (
@@ -112,7 +125,7 @@ function pickFallbackFocusId(
   return gridTerminals[0]?.id ?? null;
 }
 
-function isVisibleLivePtyTerminal(terminal: TerminalInstance): boolean {
+function isVisibleLivePtyTerminal(terminal: PtyPanelData): boolean {
   const location = terminal.location ?? "grid";
   if (location === "trash" || location === "background" || location === "dock") return false;
   if (terminal.isVisible === false) return false;
@@ -124,7 +137,7 @@ function isVisibleLivePtyTerminal(terminal: TerminalInstance): boolean {
 }
 
 export function getTerminalRefreshTier(
-  terminal: TerminalInstance | undefined,
+  terminal: CarrierPanel | undefined,
   isFocused: boolean,
   options: { isFleetArmed?: boolean } = {}
 ): TerminalRefreshTier {
@@ -179,7 +192,7 @@ export function getTerminalRefreshTier(
   // The previous "working" guard was too dependent on activity heuristics:
   // if a long-running process was still classified as waiting/idle, the
   // renderer moved to BACKGROUND and output stopped until focus/wake.
-  if (isVisibleLivePtyTerminal(terminal)) {
+  if (isPtyPanel(terminal) && isVisibleLivePtyTerminal(terminal)) {
     return TerminalRefreshTierEnum.VISIBLE;
   }
 
@@ -459,7 +472,8 @@ export const usePanelStore = create<PanelGridState>()(
         const state = get();
         const terminalToTrash = state.panelsById[id];
         if (terminalToTrash && terminalToTrash.location !== "trash") {
-          const snapshot = buildPanelSnapshotOptions(terminalToTrash);
+          const narrowed = getNarrowPanel(state.panelsById, id);
+          const snapshot = narrowed ? buildPanelSnapshotOptions(narrowed) : null;
           if (snapshot !== null) {
             set({ lastClosedConfig: snapshot });
           }
@@ -512,7 +526,8 @@ export const usePanelStore = create<PanelGridState>()(
           group && panelIdsInGroup.includes(state.focusedId ?? "") ? state.focusedId! : panelId;
         const snapshotSource = state.panelsById[snapshotSourceId];
         if (snapshotSource && snapshotSource.location !== "trash") {
-          const snapshot = buildPanelSnapshotOptions(snapshotSource);
+          const narrowedSource = getNarrowPanel(state.panelsById, snapshotSourceId);
+          const snapshot = narrowedSource ? buildPanelSnapshotOptions(narrowedSource) : null;
           if (snapshot !== null) {
             set({ lastClosedConfig: snapshot });
           }

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-restricted-imports -- panelToSnapshot is the persistence Tolerant Reader; PanelSnapshot is the on-disk wire format and intentionally keeps the wide TerminalInstance read shape (#8957)
 import type { TerminalInstance, PanelSnapshot, TabGroup } from "@/types";
 import { projectClient } from "@/clients";
 import { debounce } from "@/utils/debounce";
@@ -30,6 +29,8 @@ const BASE_PANEL_FIELDS = [
   "location",
   "extensionState",
   "pluginId",
+  "createdAt",
+  "lastActiveAt",
 ] as const satisfies readonly (keyof PanelSnapshot)[];
 const BASE_PANEL_FIELD_SET: ReadonlySet<string> = new Set(BASE_PANEL_FIELDS);
 
@@ -45,6 +46,8 @@ export function panelToSnapshot(
     location: t.location === "trash" || t.location === "background" ? "grid" : t.location,
     ...(t.extensionState !== undefined && { extensionState: t.extensionState }),
     ...(t.pluginId !== undefined && { pluginId: t.pluginId }),
+    ...(t.createdAt !== undefined && { createdAt: t.createdAt }),
+    ...(t.lastActiveAt !== undefined && { lastActiveAt: t.lastActiveAt }),
   };
 
   const config = getPanelKindConfig(t.kind ?? "terminal");

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- panelToSnapshot is the persistence Tolerant Reader; PanelSnapshot is the on-disk wire format and intentionally keeps the wide TerminalInstance read shape (#8957)
 import type { TerminalInstance, PanelSnapshot, TabGroup } from "@/types";
 import { projectClient } from "@/clients";
 import { debounce } from "@/utils/debounce";

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -22,6 +22,7 @@ import {
 } from "./storeAccessors";
 import type { ProjectSwitchOutgoingState } from "@shared/types/ipc/project";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+import { isPtyPanel } from "@shared/types/panel";
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
@@ -30,7 +31,7 @@ function shouldPersistTerminal(t: NonNullable<CarrierPanel>): boolean {
     t.location !== "trash" &&
     t.location !== "background" &&
     t.kind !== "assistant" &&
-    t.ephemeral !== true &&
+    !(isPtyPanel(t) && t.ephemeral === true) &&
     !isSmokeTestTerminalId(t.id)
   );
 }

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -21,9 +21,11 @@ import {
   getWorktreeSelectionSnapshot,
 } from "./storeAccessors";
 import type { ProjectSwitchOutgoingState } from "@shared/types/ipc/project";
-import type { TerminalInstance } from "@shared/types";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 
-function shouldPersistTerminal(t: TerminalInstance): boolean {
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
+
+function shouldPersistTerminal(t: NonNullable<CarrierPanel>): boolean {
   return (
     t.location !== "trash" &&
     t.location !== "background" &&
@@ -57,7 +59,7 @@ function buildOutgoingState(projectId: string): ProjectSwitchOutgoingState {
   const prevSnapshotMap = panelPersistence.getPreviousSnapshotMap(projectId);
   const terminals = panelIds
     .map((id) => panelsById[id])
-    .filter((t): t is TerminalInstance => t != null && shouldPersistTerminal(t))
+    .filter((t): t is NonNullable<CarrierPanel> => t != null && shouldPersistTerminal(t))
     .map((t) => panelToSnapshot(t, prevSnapshotMap?.get(t.id)));
 
   const tabGroupArray = Array.from(tabGroups.values()).filter((g) => g.panelIds.length > 1);

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -30,7 +30,10 @@ function shouldPersistTerminal(t: NonNullable<CarrierPanel>): boolean {
   return (
     t.location !== "trash" &&
     t.location !== "background" &&
-    t.kind !== "assistant" &&
+    // The carrier's kind is the discriminated union of built-in kinds; the
+    // runtime can still hand us an assistant panel whose kind escapes the
+    // declared union, so widen to string before comparing.
+    (t.kind as string) !== "assistant" &&
     !(isPtyPanel(t) && t.ephemeral === true) &&
     !isSmokeTestTerminalId(t.id)
   );

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -1,7 +1,12 @@
 import { create, type StateCreator } from "zustand";
 import type { TerminalRecipe, RecipeTerminal, RecipeTerminalType } from "@/types";
 import { usePanelStore } from "./panelStore";
-import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
+import {
+  isDevPreviewPanel,
+  isPtyPanel,
+  type DevPreviewPanelData,
+  type PtyPanelData,
+} from "@shared/types/panel";
 import { projectClient, agentSettingsClient, systemClient, globalRecipesClient } from "@/clients";
 import { getAgentConfig } from "@/config/agents";
 import { generateAgentCommand } from "@shared/types";
@@ -75,13 +80,25 @@ function sanitizeRecipeTerminal(terminal: RecipeTerminal): RecipeTerminal {
   };
 }
 
-function terminalToRecipeTerminal(terminal: PtyPanelData): RecipeTerminal {
+function terminalToRecipeTerminal(terminal: PtyPanelData | DevPreviewPanelData): RecipeTerminal {
   // Map kind to RecipeTerminalType.
   // Launch-intent only: recipes encode what the terminal was launched as, not
   // what runtime detection observed. Persisting `detectedAgentId` would corrupt
   // a recipe by baking ephemeral session state into a reusable template.
-  const type: RecipeTerminalType = terminal.launchAgentId ?? "terminal";
+  if (isDevPreviewPanel(terminal)) {
+    return {
+      type: "dev-preview",
+      title: terminal.title || undefined,
+      command: undefined,
+      devCommand: terminal.devCommand,
+      env: {},
+      exitBehavior: terminal.exitBehavior,
+      agentModelId: undefined,
+      agentLaunchFlags: undefined,
+    };
+  }
 
+  const type: RecipeTerminalType = terminal.launchAgentId ?? "terminal";
   const isAgent = isAgentRecipeType(type);
 
   return {
@@ -838,7 +855,9 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
 
     const terminalsToCapture = activeTerminals.slice(0, MAX_TERMINALS_PER_RECIPE);
 
-    return terminalsToCapture.filter(isPtyPanel).map(terminalToRecipeTerminal);
+    return terminalsToCapture
+      .filter((t): t is PtyPanelData | DevPreviewPanelData => isPtyPanel(t) || isDevPreviewPanel(t))
+      .map(terminalToRecipeTerminal);
   },
 
   reset: () =>

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -1,6 +1,7 @@
 import { create, type StateCreator } from "zustand";
 import type { TerminalRecipe, RecipeTerminal, RecipeTerminalType } from "@/types";
-import { usePanelStore, type TerminalInstance } from "./panelStore";
+import { usePanelStore } from "./panelStore";
+import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
 import { projectClient, agentSettingsClient, systemClient, globalRecipesClient } from "@/clients";
 import { getAgentConfig } from "@/config/agents";
 import { generateAgentCommand } from "@shared/types";
@@ -74,13 +75,12 @@ function sanitizeRecipeTerminal(terminal: RecipeTerminal): RecipeTerminal {
   };
 }
 
-function terminalToRecipeTerminal(terminal: TerminalInstance): RecipeTerminal {
+function terminalToRecipeTerminal(terminal: PtyPanelData): RecipeTerminal {
   // Map kind to RecipeTerminalType.
   // Launch-intent only: recipes encode what the terminal was launched as, not
   // what runtime detection observed. Persisting `detectedAgentId` would corrupt
   // a recipe by baking ephemeral session state into a reusable template.
-  const type: RecipeTerminalType =
-    terminal.kind === "dev-preview" ? "dev-preview" : (terminal.launchAgentId ?? "terminal");
+  const type: RecipeTerminalType = terminal.launchAgentId ?? "terminal";
 
   const isAgent = isAgentRecipeType(type);
 
@@ -88,7 +88,7 @@ function terminalToRecipeTerminal(terminal: TerminalInstance): RecipeTerminal {
     type,
     title: terminal.title || undefined,
     command: terminal.command || undefined,
-    devCommand: terminal.kind === "dev-preview" ? terminal.devCommand : undefined,
+    devCommand: undefined,
     env: {},
     exitBehavior: terminal.exitBehavior,
     agentModelId: isAgent ? terminal.agentModelId : undefined,
@@ -838,7 +838,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
 
     const terminalsToCapture = activeTerminals.slice(0, MAX_TERMINALS_PER_RECIPE);
 
-    return terminalsToCapture.map(terminalToRecipeTerminal);
+    return terminalsToCapture.filter(isPtyPanel).map(terminalToRecipeTerminal);
   },
 
   reset: () =>

--- a/src/store/slices/__tests__/fleetBulkActions.test.ts
+++ b/src/store/slices/__tests__/fleetBulkActions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { TerminalInstance } from "../../panelStore";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -41,7 +41,7 @@ vi.mock("../../persistence/panelPersistence", () => ({
 
 const { usePanelStore } = await import("../../panelStore");
 
-function makeTerminal(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeTerminal(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     type: "terminal",
@@ -50,10 +50,10 @@ function makeTerminal(id: string, overrides: Partial<TerminalInstance> = {}): Te
     worktreeId: "wt-1",
     location: "grid",
     ...overrides,
-  } as unknown as TerminalInstance;
+  } as unknown as PtyPanelData;
 }
 
-function setTerminals(terminals: TerminalInstance[]) {
+function setTerminals(terminals: PtyPanelData[]) {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
     panelIds: terminals.map((t) => t.id),

--- a/src/store/slices/__tests__/gridCapacity.test.ts
+++ b/src/store/slices/__tests__/gridCapacity.test.ts
@@ -115,7 +115,9 @@ describe("Grid Capacity Enforcement", () => {
         devServerTerminalId: "dev-preview-pty-1",
       });
 
-      const panel = usePanelStore.getState().getTerminal("dev-preview-1") as DevPreviewPanelData | undefined;
+      const panel = usePanelStore.getState().getTerminal("dev-preview-1") as
+        | DevPreviewPanelData
+        | undefined;
 
       expect(panel?.kind).toBe("dev-preview");
       expect(panel?.devServerStatus).toBe("running");

--- a/src/store/slices/__tests__/gridCapacity.test.ts
+++ b/src/store/slices/__tests__/gridCapacity.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { initBuiltInPanelKinds } from "@/panels/registry";
 import { MAX_GRID_TERMINALS } from "../panelRegistrySlice";
+import type { PtyPanelData, DevPreviewPanelData } from "@shared/types/panel";
 
 initBuiltInPanelKinds();
 
@@ -114,7 +115,7 @@ describe("Grid Capacity Enforcement", () => {
         devServerTerminalId: "dev-preview-pty-1",
       });
 
-      const panel = usePanelStore.getState().getTerminal("dev-preview-1");
+      const panel = usePanelStore.getState().getTerminal("dev-preview-1") as DevPreviewPanelData | undefined;
 
       expect(panel?.kind).toBe("dev-preview");
       expect(panel?.devServerStatus).toBe("running");
@@ -133,7 +134,7 @@ describe("Grid Capacity Enforcement", () => {
 
       const result = usePanelStore.getState().moveTerminalToGrid("docked-1");
 
-      const terminal = usePanelStore.getState().panelsById["docked-1"];
+      const terminal = usePanelStore.getState().panelsById["docked-1"] as PtyPanelData | undefined;
       expect(result).toBe(true);
       expect(terminal?.location).toBe("grid");
       expect(terminal?.isVisible).toBe(true);

--- a/src/store/slices/__tests__/moveTerminalToWorktree.test.ts
+++ b/src/store/slices/__tests__/moveTerminalToWorktree.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalRefreshTier } from "@/types";
-import { type TerminalInstance } from "../panelRegistrySlice";
+import type { PtyPanelData } from "@shared/types/panel";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
 vi.mock("@/clients", () => ({
@@ -33,7 +33,7 @@ const { usePanelStore } = await import("../../panelStore");
 const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
 const { panelPersistence } = await import("../../persistence/panelPersistence");
 
-function setTerminals(terminals: TerminalInstance[]) {
+function setTerminals(terminals: PtyPanelData[]) {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
     panelIds: terminals.map((t) => t.id),
@@ -44,10 +44,11 @@ function createMockTerminal(
   id: string,
   worktreeId: string,
   location: "grid" | "dock" | "trash" = "grid"
-): TerminalInstance {
+): PtyPanelData {
   return {
     id,
     title: `Terminal ${id}`,
+    kind: "terminal" as const,
     cwd: "/test",
     cols: 80,
     rows: 24,

--- a/src/store/slices/__tests__/terminalCommandQueueSlice.test.ts
+++ b/src/store/slices/__tests__/terminalCommandQueueSlice.test.ts
@@ -4,7 +4,7 @@ import {
   type TerminalCommandQueueSlice,
 } from "../terminalCommandQueueSlice";
 import { terminalClient } from "@/clients";
-import type { TerminalInstance } from "../panelRegistrySlice";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -16,6 +16,7 @@ describe("TerminalCommandQueueSlice", () => {
   const mockTerminal = {
     id: "test-terminal",
     title: "Test Terminal",
+    kind: "terminal",
     type: "claude",
     cwd: "/test",
     location: "grid",
@@ -23,7 +24,7 @@ describe("TerminalCommandQueueSlice", () => {
     isVisible: true,
     cols: 80,
     rows: 24,
-  } as TerminalInstance;
+  } as PtyPanelData;
 
   const getTerminal = vi.fn((id: string) => {
     if (id === "test-terminal" || id === "terminal-b") {

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from "vitest";
 import { createTerminalFocusSlice, type TerminalFocusSlice } from "../terminalFocusSlice";
-import type { TerminalInstance } from "../panelRegistrySlice";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
@@ -13,7 +13,7 @@ const mockStampLastActive = vi.fn();
 const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
 
 describe("TerminalFocusSlice - Layout Snapshot", () => {
-  const mockTerminals: TerminalInstance[] = [
+  const mockTerminals: PtyPanelData[] = [
     {
       id: "term-1",
       title: "Terminal 1",
@@ -36,7 +36,7 @@ describe("TerminalFocusSlice - Layout Snapshot", () => {
       rows: 24,
       worktreeId: "worktree-1",
     },
-  ] as TerminalInstance[];
+  ] as PtyPanelData[];
 
   const getTerminals = vi.fn(() => mockTerminals);
 
@@ -135,7 +135,7 @@ describe("TerminalFocusSlice - preferredTerminalFocusTarget", () => {
   let state: TerminalFocusSlice;
   let setState: any;
   let getState: any;
-  const getTerminals = vi.fn(() => [] as TerminalInstance[]);
+  const getTerminals = vi.fn(() => [] as PtyPanelData[]);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -185,7 +185,7 @@ describe("TerminalFocusSlice - preferredTerminalFocusTarget", () => {
 });
 
 describe("TerminalFocusSlice - Tab Group Maximize", () => {
-  const mockTerminals: TerminalInstance[] = [
+  const mockTerminals: PtyPanelData[] = [
     {
       id: "term-1",
       title: "Terminal 1",
@@ -219,7 +219,7 @@ describe("TerminalFocusSlice - Tab Group Maximize", () => {
       rows: 24,
       worktreeId: "worktree-1",
     },
-  ] as TerminalInstance[];
+  ] as PtyPanelData[];
 
   const mockGroup = {
     id: "group-1",
@@ -409,10 +409,11 @@ describe("TerminalFocusSlice - dock focus sync invariant", () => {
     id: string,
     location: "grid" | "dock",
     worktreeId = "worktree-1"
-  ): TerminalInstance =>
+  ): PtyPanelData =>
     ({
       id,
       title: id,
+      kind: "terminal",
       type: "terminal",
       cwd: "/test",
       location,
@@ -421,9 +422,9 @@ describe("TerminalFocusSlice - dock focus sync invariant", () => {
       cols: 80,
       rows: 24,
       worktreeId,
-    }) as TerminalInstance;
+    }) as PtyPanelData;
 
-  let terminals: TerminalInstance[];
+  let terminals: PtyPanelData[];
   let state: TerminalFocusSlice;
 
   const setup = () => {
@@ -602,10 +603,11 @@ describe("TerminalFocusSlice - focusNextBlockedDock", () => {
     id: string,
     agentState: string,
     worktreeId = "worktree-1"
-  ): TerminalInstance =>
+  ): PtyPanelData =>
     ({
       id,
       title: id,
+      kind: "terminal",
       type: "claude",
       cwd: "/test",
       location: "dock",
@@ -614,9 +616,9 @@ describe("TerminalFocusSlice - focusNextBlockedDock", () => {
       cols: 80,
       rows: 24,
       worktreeId,
-    }) as TerminalInstance;
+    }) as PtyPanelData;
 
-  let terminals: TerminalInstance[];
+  let terminals: PtyPanelData[];
   let getTerminals: any;
   let state: TerminalFocusSlice;
   let setState: any;
@@ -685,7 +687,7 @@ describe("TerminalFocusSlice - focusNextBlockedDock", () => {
       {
         ...makeDockTerminal("g1", "waiting"),
         location: "grid",
-      } as TerminalInstance,
+      } as PtyPanelData,
       makeDockTerminal("d1", "waiting", "worktree-2"),
       makeDockTerminal("d2", "waiting"),
     ];
@@ -738,7 +740,7 @@ describe("TerminalFocusSlice - focusNextAgent / focusPreviousAgent runtime ident
       everDetectedAgent?: boolean;
       agentState?: string;
     } = {}
-  ): TerminalInstance =>
+  ): PtyPanelData =>
     ({
       id,
       title: id,
@@ -753,9 +755,9 @@ describe("TerminalFocusSlice - focusNextAgent / focusPreviousAgent runtime ident
       cols: 80,
       rows: 24,
       worktreeId: "worktree-1",
-    }) as TerminalInstance;
+    }) as PtyPanelData;
 
-  let terminals: TerminalInstance[];
+  let terminals: PtyPanelData[];
   let state: TerminalFocusSlice;
 
   const setup = () => {
@@ -921,7 +923,7 @@ describe("TerminalFocusSlice - cycle from non-matching focus (issue #5834)", () 
       everDetectedAgent?: boolean;
       agentState?: string;
     } = {}
-  ): TerminalInstance =>
+  ): PtyPanelData =>
     ({
       id,
       title: id,
@@ -936,9 +938,9 @@ describe("TerminalFocusSlice - cycle from non-matching focus (issue #5834)", () 
       cols: 80,
       rows: 24,
       worktreeId: "worktree-1",
-    }) as TerminalInstance;
+    }) as PtyPanelData;
 
-  let terminals: TerminalInstance[];
+  let terminals: PtyPanelData[];
   let state: TerminalFocusSlice;
 
   beforeEach(() => {
@@ -1086,7 +1088,7 @@ describe("TerminalFocusSlice - cycle from non-matching focus (issue #5834)", () 
 });
 
 describe("TerminalFocusSlice - setFocused ping gating", () => {
-  const mockTerminals: TerminalInstance[] = [
+  const mockTerminals: PtyPanelData[] = [
     {
       id: "term-1",
       title: "Terminal 1",
@@ -1109,7 +1111,7 @@ describe("TerminalFocusSlice - setFocused ping gating", () => {
       rows: 24,
       worktreeId: "worktree-1",
     },
-  ] as TerminalInstance[];
+  ] as PtyPanelData[];
 
   const getTerminals = vi.fn(() => mockTerminals);
 
@@ -1190,7 +1192,7 @@ describe("TerminalFocusSlice - focusAlternate (last-pane toggle)", () => {
     id: string,
     location: "grid" | "dock" | "trash" | "background" = "grid",
     worktreeId = "worktree-1"
-  ): TerminalInstance =>
+  ): PtyPanelData =>
     ({
       id,
       title: id,
@@ -1201,9 +1203,9 @@ describe("TerminalFocusSlice - focusAlternate (last-pane toggle)", () => {
       cols: 80,
       rows: 24,
       worktreeId,
-    }) as TerminalInstance;
+    }) as PtyPanelData;
 
-  let terminals: TerminalInstance[];
+  let terminals: PtyPanelData[];
   let state: TerminalFocusSlice;
 
   const setup = () => {
@@ -1415,7 +1417,7 @@ describe("TerminalFocusSlice - lastActiveAt stamping (issue #8703)", () => {
   const makeTerminal = (
     id: string,
     location: "grid" | "dock" | "trash" | "background" = "grid"
-  ): TerminalInstance =>
+  ): PtyPanelData =>
     ({
       id,
       title: id,
@@ -1426,9 +1428,9 @@ describe("TerminalFocusSlice - lastActiveAt stamping (issue #8703)", () => {
       cols: 80,
       rows: 24,
       worktreeId: "worktree-1",
-    }) as TerminalInstance;
+    }) as PtyPanelData;
 
-  let terminals: TerminalInstance[];
+  let terminals: PtyPanelData[];
   let state: TerminalFocusSlice;
 
   beforeEach(() => {

--- a/src/store/slices/__tests__/worktreeBulkActions.test.ts
+++ b/src/store/slices/__tests__/worktreeBulkActions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { TerminalInstance } from "../../panelStore";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -38,7 +38,7 @@ vi.mock("../../persistence/panelPersistence", () => ({
 
 const { usePanelStore } = await import("../../panelStore");
 
-function setTerminals(terminals: TerminalInstance[]) {
+function setTerminals(terminals: PtyPanelData[]) {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
     panelIds: terminals.map((t) => t.id),
@@ -49,7 +49,7 @@ function createMockTerminal(
   id: string,
   worktreeId: string,
   location: "grid" | "dock" | "trash" = "grid"
-): TerminalInstance {
+): PtyPanelData {
   return {
     id,
     type: "terminal",
@@ -59,7 +59,7 @@ function createMockTerminal(
     rows: 24,
     worktreeId,
     location,
-  } as unknown as TerminalInstance;
+  } as unknown as PtyPanelData;
 }
 
 describe("Worktree-scoped bulk actions", () => {

--- a/src/store/slices/panelRegistry/__tests__/activeTabTracking.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/activeTabTracking.test.ts
@@ -80,7 +80,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -89,7 +89,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -98,7 +98,7 @@ describe("unified active tab tracking", () => {
           "term-3": {
             id: "term-3",
             title: "Shell 3",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -125,7 +125,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -158,7 +158,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -167,7 +167,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -176,7 +176,7 @@ describe("unified active tab tracking", () => {
           "term-3": {
             id: "term-3",
             title: "Shell 3",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -210,7 +210,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -219,7 +219,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -263,7 +263,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -272,7 +272,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -293,7 +293,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -332,7 +332,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -341,7 +341,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -363,7 +363,7 @@ describe("unified active tab tracking", () => {
           "term-bg": {
             id: "term-bg",
             title: "Background",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -386,7 +386,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -395,7 +395,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -404,7 +404,7 @@ describe("unified active tab tracking", () => {
           "term-3": {
             id: "term-3",
             title: "Shell 3",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -413,7 +413,7 @@ describe("unified active tab tracking", () => {
           "term-4": {
             id: "term-4",
             title: "Shell 4",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -459,7 +459,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -496,7 +496,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -505,7 +505,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -540,7 +540,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -549,7 +549,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
-                        kind: "terminal" as const,
+            kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,

--- a/src/store/slices/panelRegistry/__tests__/activeTabTracking.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/activeTabTracking.test.ts
@@ -80,6 +80,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -88,6 +89,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -96,6 +98,7 @@ describe("unified active tab tracking", () => {
           "term-3": {
             id: "term-3",
             title: "Shell 3",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -122,6 +125,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -154,6 +158,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -162,6 +167,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -170,6 +176,7 @@ describe("unified active tab tracking", () => {
           "term-3": {
             id: "term-3",
             title: "Shell 3",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -203,6 +210,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -211,6 +219,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -254,6 +263,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -262,6 +272,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -282,6 +293,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -320,6 +332,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -328,6 +341,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -349,6 +363,7 @@ describe("unified active tab tracking", () => {
           "term-bg": {
             id: "term-bg",
             title: "Background",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -371,6 +386,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -379,6 +395,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -387,6 +404,7 @@ describe("unified active tab tracking", () => {
           "term-3": {
             id: "term-3",
             title: "Shell 3",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -395,6 +413,7 @@ describe("unified active tab tracking", () => {
           "term-4": {
             id: "term-4",
             title: "Shell 4",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -440,6 +459,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -476,6 +496,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -484,6 +505,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -518,6 +540,7 @@ describe("unified active tab tracking", () => {
           "term-1": {
             id: "term-1",
             title: "Shell 1",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,
@@ -526,6 +549,7 @@ describe("unified active tab tracking", () => {
           "term-2": {
             id: "term-2",
             title: "Shell 2",
+                        kind: "terminal" as const,
             cwd: "/test",
             cols: 80,
             rows: 24,

--- a/src/store/slices/panelRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
@@ -45,10 +45,7 @@ type MockTerminal = Partial<PtyPanelData> & { id: string };
 
 function setTerminals(terminals: MockTerminal[]) {
   usePanelStore.setState({
-    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<
-      string,
-      PtyPanelData
-    >,
+    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<string, PtyPanelData>,
     panelIds: terminals.map((t) => t.id),
   });
 }

--- a/src/store/slices/panelRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { TabGroup } from "@/types";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -41,13 +41,13 @@ vi.mock("@/services/TerminalInstanceService", () => ({
 
 const { usePanelStore } = await import("../../../panelStore");
 
-type MockTerminal = Partial<TerminalInstance> & { id: string };
+type MockTerminal = Partial<PtyPanelData> & { id: string };
 
 function setTerminals(terminals: MockTerminal[]) {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<
       string,
-      TerminalInstance
+      PtyPanelData
     >,
     panelIds: terminals.map((t) => t.id),
   });

--- a/src/store/slices/panelRegistry/__tests__/consoleCaptureCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/consoleCaptureCleanup.test.ts
@@ -221,7 +221,7 @@ describe("removePanel consoleCaptureStore cleanup", () => {
         [panelId]: {
           id: panelId,
           title: "Shell",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,

--- a/src/store/slices/panelRegistry/__tests__/consoleCaptureCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/consoleCaptureCleanup.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { PanelInstance } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -91,7 +92,7 @@ describe("removePanel consoleCaptureStore cleanup", () => {
           cols: 80,
           rows: 24,
           location: "grid",
-        },
+        } as PanelInstance,
       },
       panelIds: [panelId],
     });
@@ -128,7 +129,7 @@ describe("removePanel consoleCaptureStore cleanup", () => {
           cols: 80,
           rows: 24,
           location: "grid",
-        },
+        } as PanelInstance,
       },
       panelIds: [panelId],
     });
@@ -166,7 +167,7 @@ describe("removePanel consoleCaptureStore cleanup", () => {
           cols: 80,
           rows: 24,
           location: "grid",
-        },
+        } as PanelInstance,
         "browser-b": {
           id: "browser-b",
           kind: "browser",
@@ -175,7 +176,7 @@ describe("removePanel consoleCaptureStore cleanup", () => {
           cols: 80,
           rows: 24,
           location: "grid",
-        },
+        } as PanelInstance,
       },
       panelIds: ["browser-a", "browser-b"],
     });
@@ -220,6 +221,7 @@ describe("removePanel consoleCaptureStore cleanup", () => {
         [panelId]: {
           id: panelId,
           title: "Shell",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,

--- a/src/store/slices/panelRegistry/__tests__/devPreviewLifecycle.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/devPreviewLifecycle.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { TabGroup } from "@/types";
+import type { PanelInstance } from "@shared/types/panel";
 
 const mockStopByPanel = vi.fn().mockResolvedValue(undefined);
 
@@ -98,7 +99,7 @@ describe("dev-preview lifecycle integration", () => {
           rows: 24,
           location: "grid",
           devCommand: "npm run dev",
-        },
+        } as PanelInstance,
       },
       panelIds: ["dev-panel-1"],
     });
@@ -120,7 +121,7 @@ describe("dev-preview lifecycle integration", () => {
           rows: 24,
           location: "grid",
           devCommand: "npm run dev",
-        },
+        } as PanelInstance,
       },
       panelIds: ["dev-panel-2"],
     });
@@ -149,7 +150,7 @@ describe("dev-preview lifecycle integration", () => {
           rows: 24,
           location: "grid",
           devCommand: "npm run dev",
-        },
+        } as PanelInstance,
         "term-1": {
           id: "term-1",
           kind: "terminal",
@@ -189,7 +190,7 @@ describe("dev-preview lifecycle integration", () => {
           rows: 24,
           location: "grid",
           devCommand: "npm run dev",
-        },
+        } as PanelInstance,
         "dev-panel-b": {
           id: "dev-panel-b",
           kind: "dev-preview",
@@ -199,7 +200,7 @@ describe("dev-preview lifecycle integration", () => {
           rows: 24,
           location: "grid",
           devCommand: "pnpm dev",
-        },
+        } as PanelInstance,
         "term-2": {
           id: "term-2",
           kind: "terminal",
@@ -233,7 +234,7 @@ describe("dev-preview lifecycle integration", () => {
           rows: 24,
           location: "grid",
           devCommand: "npm run dev",
-        },
+        } as PanelInstance,
       },
       panelIds: ["dev-panel-bg"],
     });
@@ -262,7 +263,7 @@ describe("dev-preview lifecycle integration", () => {
           rows: 24,
           location: "grid",
           devCommand: "npm run dev",
-        },
+        } as PanelInstance,
         "term-bg-1": {
           id: "term-bg-1",
           kind: "terminal",

--- a/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import type { PtyPanelData } from "@shared/types/panel";
 
 const acknowledgeWaitingMock = vi.fn();
 const acknowledgeWorkingPulseMock = vi.fn();
@@ -689,7 +690,7 @@ describe("dock watchdog hardening (#7278)", () => {
           title: "Test",
           location: "dock" as const,
           worktreeId: "wt-b",
-        },
+        } as PtyPanelData,
       },
       panelIds: [targetId],
       activeDockTerminalId: targetId,

--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { TerminalInstance } from "../../panelRegistrySlice";
-import type { TabGroup } from "@shared/types/panel";
+import type { PtyPanelData, TabGroup } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -46,7 +45,7 @@ vi.mock("@/store/layoutConfigStore", () => ({
 
 const { usePanelStore } = await import("../../../panelStore");
 
-function setTerminals(terminals: TerminalInstance[]) {
+function setTerminals(terminals: PtyPanelData[]) {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
     panelIds: terminals.map((t) => t.id),
@@ -56,10 +55,11 @@ function setTerminals(terminals: TerminalInstance[]) {
 function createMockTerminal(
   id: string,
   location: "grid" | "dock" | "trash" = "grid"
-): TerminalInstance {
+): PtyPanelData {
   return {
     id,
     title: `Terminal ${id}`,
+    kind: "terminal" as const,
     cwd: "/test",
     cols: 80,
     rows: 24,
@@ -72,7 +72,7 @@ function createMockTerminal(
 function createGlobalMockTerminal(
   id: string,
   location: "grid" | "dock" | "trash" = "grid"
-): TerminalInstance {
+): PtyPanelData {
   const terminal = createMockTerminal(id, location);
   return { ...terminal, worktreeId: undefined };
 }

--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -110,7 +110,7 @@ describe("dock ↔ grid transitions", () => {
 
       usePanelStore.getState().moveTerminalToDock("t1");
 
-      const updated = usePanelStore.getState().panelsById["t1"];
+      const updated = usePanelStore.getState().panelsById["t1"] as PtyPanelData | undefined;
       expect(updated!.location).toBe("dock");
       expect(updated!.isVisible).toBe(false);
       expect(updated!.runtimeStatus).toBe("background");
@@ -247,7 +247,7 @@ describe("dock ↔ grid transitions", () => {
 
       usePanelStore.getState().moveTerminalToPosition("t1", 0, "grid", "wt-1");
 
-      const updated = usePanelStore.getState().panelsById["t1"];
+      const updated = usePanelStore.getState().panelsById["t1"] as PtyPanelData | undefined;
       expect(updated!.location).toBe("grid");
       expect(updated!.isVisible).toBe(true);
       expect(updated!.runtimeStatus).toBe("running");

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -269,7 +270,7 @@ describe("hydration batch (#5196)", () => {
           lastStateChange: 1234,
           exitBehavior: "restart",
           extensionState: { foo: "bar" },
-        } as import("../types").TerminalInstance,
+        } as unknown as PtyPanelData,
       },
       panelIds: [...state.panelIds, "term-1"],
     }));

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -288,7 +288,7 @@ describe("hydration batch (#5196)", () => {
     });
     flushHydrationBatch(token);
 
-    const result = usePanelStore.getState().panelsById["term-1"];
+    const result = usePanelStore.getState().panelsById["term-1"] as PtyPanelData | undefined;
     expect(result?.agentState).toBe("working");
     expect(result?.lastStateChange).toBe(1234);
     expect(result?.exitBehavior).toBe("restart");
@@ -316,13 +316,13 @@ describe("hydration batch (#5196)", () => {
     updateAgentState("term-1", "waiting");
     updateActivity("term-1", "writing code", "working", "interactive", 100);
 
-    const mid = usePanelStore.getState().panelsById["term-1"];
+    const mid = usePanelStore.getState().panelsById["term-1"] as PtyPanelData | undefined;
     expect(mid?.agentState).toBe("waiting");
     expect(mid?.activityHeadline).toBe("writing code");
 
     flushHydrationBatch(token);
 
-    const after = usePanelStore.getState().panelsById["term-1"];
+    const after = usePanelStore.getState().panelsById["term-1"] as PtyPanelData | undefined;
     expect(after?.agentState).toBe("waiting");
     expect(after?.activityHeadline).toBe("writing code");
   });

--- a/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
 
 const mockSubmit = vi.fn().mockResolvedValue(undefined);
 const mockGracefulKill = vi.fn().mockResolvedValue(null);
@@ -234,7 +235,7 @@ describe("moveToNewWorktreeAndTransfer (#4773)", () => {
     }
 
     // Check that agentSessionId was cleared
-    const terminal = usePanelStore.getState().panelsById["test-1"];
+    const terminal = usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined;
     expect(terminal?.agentSessionId).toBeUndefined();
   });
 

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -76,6 +77,10 @@ beforeEach(() => {
 
 const { usePanelStore } = await import("../../../panelStore");
 
+function getPtyPanel(id: string): PtyPanelData | undefined {
+  return usePanelStore.getState().panelsById[id] as PtyPanelData | undefined;
+}
+
 // Drain microtasks. The background spawn promise chains through Promise.all
 // (env fetch) → terminalClient.spawn → .then, which takes several ticks.
 async function drainMicrotasks(iterations = 100): Promise<void> {
@@ -125,7 +130,7 @@ describe("optimistic panel spawn (#5789)", () => {
     });
 
     expect(id).toBe("opt-1");
-    const panel = usePanelStore.getState().panelsById["opt-1"];
+    const panel = getPtyPanel("opt-1");
     expect(panel).toBeDefined();
     expect(panel?.spawnStatus).toBe("spawning");
     expect(panel?.runtimeIdentity).toMatchObject({
@@ -139,7 +144,7 @@ describe("optimistic panel spawn (#5789)", () => {
     // Drain microtasks so spawnStatus transitions to "ready".
     await drainMicrotasks();
 
-    const after = usePanelStore.getState().panelsById["opt-1"];
+    const after = getPtyPanel("opt-1");
     expect(after?.spawnStatus).toBe("ready");
   });
 
@@ -196,7 +201,7 @@ describe("optimistic panel spawn (#5789)", () => {
 
     const state = usePanelStore.getState();
     for (const id of ids) {
-      expect(state.panelsById[id]?.spawnStatus).toBe("spawning");
+      expect((state.panelsById[id] as PtyPanelData | undefined)?.spawnStatus).toBe("spawning");
       expect(state.panelIds).toContain(id);
     }
 
@@ -217,7 +222,7 @@ describe("optimistic panel spawn (#5789)", () => {
 
     const after = usePanelStore.getState();
     for (const id of ids) {
-      expect(after.panelsById[id]?.spawnStatus).toBe("ready");
+      expect((after.panelsById[id] as PtyPanelData | undefined)?.spawnStatus).toBe("ready");
     }
   });
 
@@ -266,7 +271,7 @@ describe("optimistic panel spawn (#5789)", () => {
     });
 
     expect(id).toBe("reconnect-1");
-    expect(usePanelStore.getState().panelsById["reconnect-1"]?.spawnStatus).toBe("ready");
+    expect(getPtyPanel("reconnect-1")?.spawnStatus).toBe("ready");
     expect(terminalClient.spawn).not.toHaveBeenCalled();
   });
 
@@ -312,13 +317,13 @@ describe("optimistic panel spawn (#5789)", () => {
       cwd: "/",
       bypassLimits: true,
     });
-    expect(usePanelStore.getState().panelsById["shared-id"]?.spawnStatus).toBe("ready");
+    expect(getPtyPanel("shared-id")?.spawnStatus).toBe("ready");
 
     // Now A's spawn finally rejects. The replacement must survive.
     rejectA(new Error("late failure"));
     await drainMicrotasks();
 
-    const after = usePanelStore.getState().panelsById["shared-id"];
+    const after = getPtyPanel("shared-id");
     expect(after).toBeDefined();
     expect(after?.spawnStatus).toBe("ready");
   });
@@ -401,13 +406,13 @@ describe("optimistic panel spawn (#5789)", () => {
     });
 
     expect(id).toBe("env-latent");
-    expect(usePanelStore.getState().panelsById["env-latent"]?.spawnStatus).toBe("spawning");
+    expect(getPtyPanel("env-latent")?.spawnStatus).toBe("spawning");
     expect(usePanelStore.getState().panelIds).toContain("env-latent");
 
     releaseEnv();
     releaseSettings();
     await drainMicrotasks();
-    expect(usePanelStore.getState().panelsById["env-latent"]?.spawnStatus).toBe("ready");
+    expect(getPtyPanel("env-latent")?.spawnStatus).toBe("ready");
   });
 
   it("propagates the pre-assigned id to terminalClient.spawn", async () => {

--- a/src/store/slices/panelRegistry/__tests__/reconnectErrorDebounce.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/reconnectErrorDebounce.test.ts
@@ -105,8 +105,12 @@ describe("reconnect error debounce", () => {
   it("does not write reconnectError synchronously", () => {
     seedPanel("t-1");
     usePanelStore.getState().setReconnectError("t-1", ERROR_A);
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toBeUndefined();
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.runtimeStatus).toBeUndefined();
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError
+    ).toBeUndefined();
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.runtimeStatus
+    ).toBeUndefined();
   });
 
   it("writes the error after the 400ms gate elapses", async () => {
@@ -114,12 +118,18 @@ describe("reconnect error debounce", () => {
     usePanelStore.getState().setReconnectError("t-1", ERROR_A);
 
     await vi.advanceTimersByTimeAsync(399);
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toBeUndefined();
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError
+    ).toBeUndefined();
 
     await vi.advanceTimersByTimeAsync(1);
     await Promise.resolve();
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toEqual(ERROR_A);
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.runtimeStatus).toBe("error");
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError
+    ).toEqual(ERROR_A);
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.runtimeStatus
+    ).toBe("error");
   });
 
   it("collapses rapid repeated calls into a single write of the latest error", async () => {
@@ -128,11 +138,15 @@ describe("reconnect error debounce", () => {
     await vi.advanceTimersByTimeAsync(200);
     usePanelStore.getState().setReconnectError("t-1", ERROR_B);
     await vi.advanceTimersByTimeAsync(399);
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toBeUndefined();
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError
+    ).toBeUndefined();
 
     await vi.advanceTimersByTimeAsync(1);
     await Promise.resolve();
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toEqual(ERROR_B);
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError
+    ).toEqual(ERROR_B);
   });
 
   it("clearReconnectError cancels a pending debounce so no stale write lands", async () => {
@@ -142,8 +156,12 @@ describe("reconnect error debounce", () => {
 
     await vi.advanceTimersByTimeAsync(1000);
     await Promise.resolve();
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toBeUndefined();
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.runtimeStatus).toBeUndefined();
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError
+    ).toBeUndefined();
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.runtimeStatus
+    ).toBeUndefined();
   });
 
   it("removePanel cancels a pending debounce so it can't resurrect a removed panel", async () => {
@@ -163,8 +181,12 @@ describe("reconnect error debounce", () => {
 
     await vi.advanceTimersByTimeAsync(1000);
     await Promise.resolve();
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toBeUndefined();
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.runtimeStatus).not.toBe("error");
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError
+    ).toBeUndefined();
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.runtimeStatus
+    ).not.toBe("error");
   });
 
   it("evicts the debouncer entry from the map after firing", async () => {
@@ -174,7 +196,9 @@ describe("reconnect error debounce", () => {
 
     await vi.advanceTimersByTimeAsync(400);
     await Promise.resolve();
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toEqual(ERROR_A);
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError
+    ).toEqual(ERROR_A);
     expect(__getReconnectErrorDebouncerCountForTesting()).toBe(0);
   });
 
@@ -203,12 +227,18 @@ describe("reconnect error debounce", () => {
     // t-1's gate elapses first
     await vi.advanceTimersByTimeAsync(100);
     await Promise.resolve();
-    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toEqual(ERROR_A);
-    expect(( usePanelStore.getState().panelsById["t-2"] as PtyPanelData | undefined)?.reconnectError).toBeUndefined();
+    expect(
+      (usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError
+    ).toEqual(ERROR_A);
+    expect(
+      (usePanelStore.getState().panelsById["t-2"] as PtyPanelData | undefined)?.reconnectError
+    ).toBeUndefined();
 
     // t-2's gate elapses 300ms later
     await vi.advanceTimersByTimeAsync(300);
     await Promise.resolve();
-    expect(( usePanelStore.getState().panelsById["t-2"] as PtyPanelData | undefined)?.reconnectError).toEqual(ERROR_B);
+    expect(
+      (usePanelStore.getState().panelsById["t-2"] as PtyPanelData | undefined)?.reconnectError
+    ).toEqual(ERROR_B);
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/reconnectErrorDebounce.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/reconnectErrorDebounce.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -104,8 +105,8 @@ describe("reconnect error debounce", () => {
   it("does not write reconnectError synchronously", () => {
     seedPanel("t-1");
     usePanelStore.getState().setReconnectError("t-1", ERROR_A);
-    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toBeUndefined();
-    expect(usePanelStore.getState().panelsById["t-1"]?.runtimeStatus).toBeUndefined();
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toBeUndefined();
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.runtimeStatus).toBeUndefined();
   });
 
   it("writes the error after the 400ms gate elapses", async () => {
@@ -113,12 +114,12 @@ describe("reconnect error debounce", () => {
     usePanelStore.getState().setReconnectError("t-1", ERROR_A);
 
     await vi.advanceTimersByTimeAsync(399);
-    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toBeUndefined();
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toBeUndefined();
 
     await vi.advanceTimersByTimeAsync(1);
     await Promise.resolve();
-    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toEqual(ERROR_A);
-    expect(usePanelStore.getState().panelsById["t-1"]?.runtimeStatus).toBe("error");
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toEqual(ERROR_A);
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.runtimeStatus).toBe("error");
   });
 
   it("collapses rapid repeated calls into a single write of the latest error", async () => {
@@ -127,11 +128,11 @@ describe("reconnect error debounce", () => {
     await vi.advanceTimersByTimeAsync(200);
     usePanelStore.getState().setReconnectError("t-1", ERROR_B);
     await vi.advanceTimersByTimeAsync(399);
-    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toBeUndefined();
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toBeUndefined();
 
     await vi.advanceTimersByTimeAsync(1);
     await Promise.resolve();
-    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toEqual(ERROR_B);
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toEqual(ERROR_B);
   });
 
   it("clearReconnectError cancels a pending debounce so no stale write lands", async () => {
@@ -141,8 +142,8 @@ describe("reconnect error debounce", () => {
 
     await vi.advanceTimersByTimeAsync(1000);
     await Promise.resolve();
-    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toBeUndefined();
-    expect(usePanelStore.getState().panelsById["t-1"]?.runtimeStatus).toBeUndefined();
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toBeUndefined();
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.runtimeStatus).toBeUndefined();
   });
 
   it("removePanel cancels a pending debounce so it can't resurrect a removed panel", async () => {
@@ -162,8 +163,8 @@ describe("reconnect error debounce", () => {
 
     await vi.advanceTimersByTimeAsync(1000);
     await Promise.resolve();
-    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toBeUndefined();
-    expect(usePanelStore.getState().panelsById["t-1"]?.runtimeStatus).not.toBe("error");
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toBeUndefined();
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.runtimeStatus).not.toBe("error");
   });
 
   it("evicts the debouncer entry from the map after firing", async () => {
@@ -173,7 +174,7 @@ describe("reconnect error debounce", () => {
 
     await vi.advanceTimersByTimeAsync(400);
     await Promise.resolve();
-    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toEqual(ERROR_A);
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toEqual(ERROR_A);
     expect(__getReconnectErrorDebouncerCountForTesting()).toBe(0);
   });
 
@@ -202,12 +203,12 @@ describe("reconnect error debounce", () => {
     // t-1's gate elapses first
     await vi.advanceTimersByTimeAsync(100);
     await Promise.resolve();
-    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toEqual(ERROR_A);
-    expect(usePanelStore.getState().panelsById["t-2"]?.reconnectError).toBeUndefined();
+    expect(( usePanelStore.getState().panelsById["t-1"] as PtyPanelData | undefined)?.reconnectError).toEqual(ERROR_A);
+    expect(( usePanelStore.getState().panelsById["t-2"] as PtyPanelData | undefined)?.reconnectError).toBeUndefined();
 
     // t-2's gate elapses 300ms later
     await vi.advanceTimersByTimeAsync(300);
     await Promise.resolve();
-    expect(usePanelStore.getState().panelsById["t-2"]?.reconnectError).toEqual(ERROR_B);
+    expect(( usePanelStore.getState().panelsById["t-2"] as PtyPanelData | undefined)?.reconnectError).toEqual(ERROR_B);
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/removePanelFromGroup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/removePanelFromGroup.test.ts
@@ -90,6 +90,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -98,6 +99,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -128,6 +130,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -158,6 +161,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -166,6 +170,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -174,6 +179,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -205,6 +211,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -213,6 +220,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -221,6 +229,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -252,6 +261,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -260,6 +270,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -268,6 +279,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -292,6 +304,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -329,6 +342,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -337,6 +351,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -345,6 +360,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -353,6 +369,7 @@ describe("removePanelFromGroup", () => {
         "term-4": {
           id: "term-4",
           title: "Shell 4",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -361,6 +378,7 @@ describe("removePanelFromGroup", () => {
         "term-5": {
           id: "term-5",
           title: "Shell 5",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -398,6 +416,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -406,6 +425,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -414,6 +434,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -446,6 +467,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -454,6 +476,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -484,6 +507,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -492,6 +516,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -500,6 +525,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -531,6 +557,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -540,6 +567,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -549,6 +577,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
+                    kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,

--- a/src/store/slices/panelRegistry/__tests__/removePanelFromGroup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/removePanelFromGroup.test.ts
@@ -90,7 +90,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -99,7 +99,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -130,7 +130,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -161,7 +161,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -170,7 +170,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -179,7 +179,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -211,7 +211,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -220,7 +220,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -229,7 +229,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -261,7 +261,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -270,7 +270,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -279,7 +279,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -304,7 +304,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -342,7 +342,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -351,7 +351,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -360,7 +360,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -369,7 +369,7 @@ describe("removePanelFromGroup", () => {
         "term-4": {
           id: "term-4",
           title: "Shell 4",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -378,7 +378,7 @@ describe("removePanelFromGroup", () => {
         "term-5": {
           id: "term-5",
           title: "Shell 5",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -416,7 +416,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -425,7 +425,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -434,7 +434,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -467,7 +467,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -476,7 +476,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -507,7 +507,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -516,7 +516,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -525,7 +525,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -557,7 +557,7 @@ describe("removePanelFromGroup", () => {
         "term-1": {
           id: "term-1",
           title: "Shell 1",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -567,7 +567,7 @@ describe("removePanelFromGroup", () => {
         "term-2": {
           id: "term-2",
           title: "Shell 2",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,
@@ -577,7 +577,7 @@ describe("removePanelFromGroup", () => {
         "term-3": {
           id: "term-3",
           title: "Shell 3",
-                    kind: "terminal" as const,
+          kind: "terminal" as const,
           cwd: "/test",
           cols: 80,
           rows: 24,

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -245,7 +245,9 @@ describe("restartTerminal agent-exited demotion (#5764)", () => {
       SHARED: "preset",
       PRESET_ONLY: "preset",
     });
-    expect(( usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined)?.agentPresetColor).toBe("#3366ff");
+    expect(
+      (usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined)?.agentPresetColor
+    ).toBe("#3366ff");
   });
 
   it("reapplies runtime settings env on demoted shell restart without relaunching the agent", async () => {

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
 
 const mockSpawn = vi.fn().mockResolvedValue({ id: "test-1" });
 const mockKill = vi.fn().mockResolvedValue(undefined);
@@ -244,7 +245,7 @@ describe("restartTerminal agent-exited demotion (#5764)", () => {
       SHARED: "preset",
       PRESET_ONLY: "preset",
     });
-    expect(usePanelStore.getState().panelsById["test-1"]?.agentPresetColor).toBe("#3366ff");
+    expect(( usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined)?.agentPresetColor).toBe("#3366ff");
   });
 
   it("reapplies runtime settings env on demoted shell restart without relaunching the agent", async () => {
@@ -301,7 +302,7 @@ describe("restartTerminal agent-exited demotion (#5764)", () => {
 
     await usePanelStore.getState().restartTerminal("test-1");
 
-    const after = usePanelStore.getState().panelsById["test-1"];
+    const after = usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined;
     expect(after?.launchAgentId).toBe("claude");
   });
 
@@ -317,7 +318,7 @@ describe("restartTerminal agent-exited demotion (#5764)", () => {
 
     await usePanelStore.getState().restartTerminal("test-1");
 
-    const afterFirst = usePanelStore.getState().panelsById["test-1"];
+    const afterFirst = usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined;
     expect(afterFirst?.agentState).toBe("exited");
 
     await usePanelStore.getState().restartTerminal("test-1");
@@ -343,7 +344,7 @@ describe("restartTerminal agent-exited demotion (#5764)", () => {
 
     await usePanelStore.getState().restartTerminal("test-1");
 
-    const after = usePanelStore.getState().panelsById["test-1"];
+    const after = usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined;
     expect(after?.command).toBeUndefined();
   });
 });
@@ -438,7 +439,7 @@ describe("restartTerminal exit/demotion semantics (#5807)", () => {
     // Launch identity on the panel is preserved for future deliberate
     // restart-as-agent flows; agentState stays "exited" to keep demotion
     // sticky across repeat restarts (#5764).
-    const after = usePanelStore.getState().panelsById["test-1"];
+    const after = usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined;
     expect(after?.launchAgentId).toBe("claude");
     expect(after?.agentState).toBe("exited");
   });

--- a/src/store/slices/panelRegistry/__tests__/restoreTerminalOrder.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restoreTerminalOrder.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -45,7 +46,7 @@ function addMockTerminal(id: string, location: "grid" | "dock" = "grid") {
     location,
     worktreeId: "wt-1",
     isVisible: true,
-  } as import("../types").TerminalInstance;
+  } as unknown as PtyPanelData;
   usePanelStore.setState((state) => ({
     panelsById: { ...state.panelsById, [id]: terminal },
     panelIds: [...state.panelIds, id],

--- a/src/store/slices/panelRegistry/__tests__/selectors.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/selectors.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import type { TerminalInstance } from "@shared/types";
+import type { PanelInstance } from "@shared/types/panel";
 import { _resetSelectorCacheForTests, getNarrowPanel, getNarrowPanels } from "../selectors";
 
 // Adapter selectors that narrow the legacy `TerminalInstance` carrier to the
 // `PanelInstance` union via the kind type guards (#8957). A missing `kind`
 // defaults to "terminal", matching the guard convention.
 
-function panel(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function panel(id: string, overrides: Partial<PanelInstance> = {}): PanelInstance {
   return {
     id,
     kind: "terminal",
@@ -16,7 +16,7 @@ function panel(id: string, overrides: Partial<TerminalInstance> = {}): TerminalI
     rows: 24,
     location: "grid",
     ...overrides,
-  } as TerminalInstance;
+  } as PanelInstance;
 }
 
 beforeEach(() => {
@@ -48,7 +48,7 @@ describe("getNarrowPanel", () => {
   });
 
   it("returns undefined for an extension/unknown kind", () => {
-    const ext = panel("x", { kind: "acme.tool" as TerminalInstance["kind"] });
+    const ext = panel("x", { kind: "acme.tool" as unknown as PanelInstance["kind"] });
     expect(getNarrowPanel({ x: ext }, "x")).toBeUndefined();
   });
 
@@ -83,7 +83,7 @@ describe("getNarrowPanels", () => {
   it("drops extension/unknown-kind panels from the result", () => {
     const byId = {
       a: panel("a"),
-      x: panel("x", { kind: "acme.tool" as TerminalInstance["kind"] }),
+      x: panel("x", { kind: "acme.tool" as unknown as PanelInstance["kind"] }),
     };
     const result = getNarrowPanels(byId, ["a", "x"]);
     expect(result.map((p) => p.id)).toEqual(["a"]);

--- a/src/store/slices/panelRegistry/__tests__/selectors.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/selectors.test.ts
@@ -33,13 +33,9 @@ describe("getNarrowPanel", () => {
     expect(p?.kind).toBe("terminal");
   });
 
-  it("backfills the terminal discriminant for a no-kind legacy record", () => {
-    const noKind = panel("t", { kind: undefined });
-    const p = getNarrowPanel({ t: noKind }, "t");
-    expect(p?.kind).toBe("terminal");
-    // A fresh object so the union's literal `kind: "terminal"` holds at runtime.
-    expect(p).not.toBe(noKind);
-  });
+  // No-kind legacy records are no longer representable on the carrier
+  // (#8957 step 5 flipped `panelsById` to `Record<string, PanelInstance>`,
+  // which requires a discriminant). The backfill branch was removed.
 
   it("preserves identity for a record that already carries kind: terminal", () => {
     const withKind = panel("t");

--- a/src/store/slices/panelRegistry/__tests__/setDevPreviewScrollPosition.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/setDevPreviewScrollPosition.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { PanelInstance, DevPreviewPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -88,7 +89,7 @@ describe("setDevPreviewScrollPosition", () => {
           cols: 80,
           rows: 24,
           location: "grid",
-        },
+        } as PanelInstance,
       },
       panelIds: ["dev-1"],
     });
@@ -97,7 +98,7 @@ describe("setDevPreviewScrollPosition", () => {
       .getState()
       .setDevPreviewScrollPosition("dev-1", { url: "http://localhost:3000", scrollY: 420 });
 
-    const stored = usePanelStore.getState().panelsById["dev-1"];
+    const stored = usePanelStore.getState().panelsById["dev-1"] as DevPreviewPanelData | undefined;
     expect(stored?.kind).toBe("dev-preview");
     expect(stored?.devPreviewScrollPosition).toEqual({
       url: "http://localhost:3000",
@@ -118,14 +119,14 @@ describe("setDevPreviewScrollPosition", () => {
           rows: 24,
           location: "grid",
           devPreviewScrollPosition: { url: "http://localhost:3000", scrollY: 100 },
-        },
+        } as PanelInstance,
       },
       panelIds: ["dev-1"],
     });
 
     usePanelStore.getState().setDevPreviewScrollPosition("dev-1", undefined);
 
-    const stored = usePanelStore.getState().panelsById["dev-1"];
+    const stored = usePanelStore.getState().panelsById["dev-1"] as DevPreviewPanelData | undefined;
     expect(stored?.devPreviewScrollPosition).toBeUndefined();
   });
 
@@ -164,7 +165,7 @@ describe("setDevPreviewScrollPosition", () => {
           cols: 80,
           rows: 24,
           location: "grid",
-        },
+        } as PanelInstance,
       },
       panelIds: ["dev-1"],
     });
@@ -186,7 +187,7 @@ describe("setDevPreviewScrollPosition", () => {
           rows: 24,
           location: "grid",
           devPreviewScrollPosition: { url: "http://localhost:3000", scrollY: 420 },
-        },
+        } as PanelInstance,
       },
       panelIds: ["dev-1"],
     });

--- a/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalRefreshTier } from "@/types";
-import type { TerminalInstance } from "../../panelRegistrySlice";
-import type { TabGroup } from "@shared/types/panel";
+import type { PtyPanelData, TabGroup } from "@shared/types/panel";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
 vi.mock("@/clients", () => ({
@@ -49,7 +48,7 @@ vi.mock("@/store/layoutConfigStore", () => ({
 const { usePanelStore } = await import("../../../panelStore");
 const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
 
-function setTerminals(terminals: TerminalInstance[]) {
+function setTerminals(terminals: PtyPanelData[]) {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
     panelIds: terminals.map((t) => t.id),
@@ -60,10 +59,11 @@ function createMockTerminal(
   id: string,
   worktreeId: string | undefined,
   location: "grid" | "dock" | "trash" = "grid"
-): TerminalInstance {
+): PtyPanelData {
   return {
     id,
     title: `Terminal ${id}`,
+    kind: "terminal" as const,
     cwd: "/test",
     cols: 80,
     rows: 24,

--- a/src/store/slices/panelRegistry/__tests__/trashTerminalGroupCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/trashTerminalGroupCleanup.test.ts
@@ -47,10 +47,7 @@ type MockTerminal = Partial<PtyPanelData> & { id: string };
 
 function setTerminals(terminals: MockTerminal[]) {
   usePanelStore.setState({
-    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<
-      string,
-      PtyPanelData
-    >,
+    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<string, PtyPanelData>,
     panelIds: terminals.map((t) => t.id),
   });
 }

--- a/src/store/slices/panelRegistry/__tests__/trashTerminalGroupCleanup.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/trashTerminalGroupCleanup.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { TabGroup } from "@/types";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -43,13 +43,13 @@ vi.mock("@/services/TerminalInstanceService", () => ({
 
 const { usePanelStore } = await import("../../../panelStore");
 
-type MockTerminal = Partial<TerminalInstance> & { id: string };
+type MockTerminal = Partial<PtyPanelData> & { id: string };
 
 function setTerminals(terminals: MockTerminal[]) {
   usePanelStore.setState({
     panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])) as Record<
       string,
-      TerminalInstance
+      PtyPanelData
     >,
     panelIds: terminals.map((t) => t.id),
   });

--- a/src/store/slices/panelRegistry/__tests__/updateActivityEarlyExit.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/updateActivityEarlyExit.test.ts
@@ -121,7 +121,7 @@ describe("updateActivity early-exit (#2701)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(( after[baseTerminal.id] as PtyPanelData)!.activityHeadline).toBe("Tests passed");
+    expect((after[baseTerminal.id] as PtyPanelData)!.activityHeadline).toBe("Tests passed");
   });
 
   it("replaces array reference when status changes", () => {
@@ -145,7 +145,7 @@ describe("updateActivity early-exit (#2701)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(( after[baseTerminal.id] as PtyPanelData)!.activityStatus).toBe("success");
+    expect((after[baseTerminal.id] as PtyPanelData)!.activityStatus).toBe("success");
   });
 
   it("replaces array reference when timestamp changes", () => {
@@ -169,7 +169,7 @@ describe("updateActivity early-exit (#2701)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(( after[baseTerminal.id] as PtyPanelData)!.activityTimestamp).toBe(2000);
+    expect((after[baseTerminal.id] as PtyPanelData)!.activityTimestamp).toBe(2000);
   });
 
   it("replaces array reference when activityType changes", () => {
@@ -193,7 +193,7 @@ describe("updateActivity early-exit (#2701)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(( after[baseTerminal.id] as PtyPanelData)!.activityType).toBe("interactive");
+    expect((after[baseTerminal.id] as PtyPanelData)!.activityType).toBe("interactive");
   });
 
   it("replaces array reference when lastCommand changes", () => {
@@ -217,7 +217,7 @@ describe("updateActivity early-exit (#2701)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(( after[baseTerminal.id] as PtyPanelData)!.lastCommand).toBe("npm run build");
+    expect((after[baseTerminal.id] as PtyPanelData)!.lastCommand).toBe("npm run build");
   });
 
   it("preserves array reference for unchanged terminal when sibling terminal differs", () => {
@@ -269,7 +269,7 @@ describe("updateActivity early-exit (#2701)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(( after[baseTerminal.id] as PtyPanelData)!.activityHeadline).toBe("Updated headline");
+    expect((after[baseTerminal.id] as PtyPanelData)!.activityHeadline).toBe("Updated headline");
     expect(after[sibling.id]).toBe(siblingBefore);
   });
 

--- a/src/store/slices/panelRegistry/__tests__/updateActivityEarlyExit.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/updateActivityEarlyExit.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -120,7 +121,7 @@ describe("updateActivity early-exit (#2701)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(after[baseTerminal.id]!.activityHeadline).toBe("Tests passed");
+    expect(( after[baseTerminal.id] as PtyPanelData)!.activityHeadline).toBe("Tests passed");
   });
 
   it("replaces array reference when status changes", () => {
@@ -144,7 +145,7 @@ describe("updateActivity early-exit (#2701)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(after[baseTerminal.id]!.activityStatus).toBe("success");
+    expect(( after[baseTerminal.id] as PtyPanelData)!.activityStatus).toBe("success");
   });
 
   it("replaces array reference when timestamp changes", () => {
@@ -168,7 +169,7 @@ describe("updateActivity early-exit (#2701)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(after[baseTerminal.id]!.activityTimestamp).toBe(2000);
+    expect(( after[baseTerminal.id] as PtyPanelData)!.activityTimestamp).toBe(2000);
   });
 
   it("replaces array reference when activityType changes", () => {
@@ -192,7 +193,7 @@ describe("updateActivity early-exit (#2701)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(after[baseTerminal.id]!.activityType).toBe("interactive");
+    expect(( after[baseTerminal.id] as PtyPanelData)!.activityType).toBe("interactive");
   });
 
   it("replaces array reference when lastCommand changes", () => {
@@ -216,7 +217,7 @@ describe("updateActivity early-exit (#2701)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(after[baseTerminal.id]!.lastCommand).toBe("npm run build");
+    expect(( after[baseTerminal.id] as PtyPanelData)!.lastCommand).toBe("npm run build");
   });
 
   it("preserves array reference for unchanged terminal when sibling terminal differs", () => {
@@ -268,7 +269,7 @@ describe("updateActivity early-exit (#2701)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(after[baseTerminal.id]!.activityHeadline).toBe("Updated headline");
+    expect(( after[baseTerminal.id] as PtyPanelData)!.activityHeadline).toBe("Updated headline");
     expect(after[sibling.id]).toBe(siblingBefore);
   });
 

--- a/src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts
@@ -73,7 +73,10 @@ describe("updateAgentState store action (#3217)", () => {
 
     usePanelStore.getState().updateAgentState("test-terminal-1", "waiting");
 
-    expect((usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined)?.agentState).toBe("waiting");
+    expect(
+      (usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined)
+        ?.agentState
+    ).toBe("waiting");
   });
 
   it("allows working to overwrite directing", () => {
@@ -84,7 +87,10 @@ describe("updateAgentState store action (#3217)", () => {
 
     usePanelStore.getState().updateAgentState("test-terminal-1", "working");
 
-    expect((usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined)?.agentState).toBe("working");
+    expect(
+      (usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined)
+        ?.agentState
+    ).toBe("working");
   });
 
   it("allows idle to overwrite directing", () => {
@@ -95,7 +101,10 @@ describe("updateAgentState store action (#3217)", () => {
 
     usePanelStore.getState().updateAgentState("test-terminal-1", "idle");
 
-    expect((usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined)?.agentState).toBe("idle");
+    expect(
+      (usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined)
+        ?.agentState
+    ).toBe("idle");
   });
 
   it("allows waiting when current state is not directing", () => {
@@ -107,7 +116,10 @@ describe("updateAgentState store action (#3217)", () => {
 
     usePanelStore.getState().updateAgentState("test-terminal-1", "waiting");
 
-    expect((usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined)?.agentState).toBe("waiting");
+    expect(
+      (usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined)
+        ?.agentState
+    ).toBe("waiting");
   });
 
   it("returns unchanged state for nonexistent terminal", () => {
@@ -233,7 +245,9 @@ describe("updateAgentState store action (#3217)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect((after[seededTerminal.id] as PtyPanelData | undefined)?.stateChangeTrigger).toBe("input");
+    expect((after[seededTerminal.id] as PtyPanelData | undefined)?.stateChangeTrigger).toBe(
+      "input"
+    );
     expect((after[seededTerminal.id] as PtyPanelData | undefined)?.lastStateChange).toBe(1500);
   });
 
@@ -296,7 +310,9 @@ describe("setupTerminalStoreListeners directing guard (#3217)", () => {
       panelIds: [baseTerminal.id],
     });
 
-    const terminal = usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined;
+    const terminal = usePanelStore.getState().panelsById["test-terminal-1"] as
+      | PtyPanelData
+      | undefined;
     expect(shouldSuppressBackendState(terminal?.agentState, "waiting")).toBe(true);
   });
 
@@ -306,7 +322,9 @@ describe("setupTerminalStoreListeners directing guard (#3217)", () => {
       panelIds: [baseTerminal.id],
     });
 
-    const terminal = usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined;
+    const terminal = usePanelStore.getState().panelsById["test-terminal-1"] as
+      | PtyPanelData
+      | undefined;
     expect(shouldSuppressBackendState(terminal?.agentState, "working")).toBe(false);
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -72,7 +73,7 @@ describe("updateAgentState store action (#3217)", () => {
 
     usePanelStore.getState().updateAgentState("test-terminal-1", "waiting");
 
-    expect(usePanelStore.getState().panelsById["test-terminal-1"]!.agentState).toBe("waiting");
+    expect((usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined)?.agentState).toBe("waiting");
   });
 
   it("allows working to overwrite directing", () => {
@@ -83,7 +84,7 @@ describe("updateAgentState store action (#3217)", () => {
 
     usePanelStore.getState().updateAgentState("test-terminal-1", "working");
 
-    expect(usePanelStore.getState().panelsById["test-terminal-1"]!.agentState).toBe("working");
+    expect((usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined)?.agentState).toBe("working");
   });
 
   it("allows idle to overwrite directing", () => {
@@ -94,7 +95,7 @@ describe("updateAgentState store action (#3217)", () => {
 
     usePanelStore.getState().updateAgentState("test-terminal-1", "idle");
 
-    expect(usePanelStore.getState().panelsById["test-terminal-1"]!.agentState).toBe("idle");
+    expect((usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined)?.agentState).toBe("idle");
   });
 
   it("allows waiting when current state is not directing", () => {
@@ -106,7 +107,7 @@ describe("updateAgentState store action (#3217)", () => {
 
     usePanelStore.getState().updateAgentState("test-terminal-1", "waiting");
 
-    expect(usePanelStore.getState().panelsById["test-terminal-1"]!.agentState).toBe("waiting");
+    expect((usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined)?.agentState).toBe("waiting");
   });
 
   it("returns unchanged state for nonexistent terminal", () => {
@@ -142,7 +143,7 @@ describe("updateAgentState store action (#3217)", () => {
     const after = usePanelStore.getState().panelsById;
     expect(after).toBe(before);
     expect(after[seededTerminal.id]).toBe(terminalBefore);
-    expect(after[seededTerminal.id]!.lastStateChange).toBe(12345);
+    expect((after[seededTerminal.id] as PtyPanelData | undefined)?.lastStateChange).toBe(12345);
   });
 
   it("preserves panelsById ref when re-delivered waiting with the same waitingReason", () => {
@@ -173,7 +174,7 @@ describe("updateAgentState store action (#3217)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).toBe(before);
-    expect(after[seededTerminal.id]!.lastStateChange).toBe(9999);
+    expect((after[seededTerminal.id] as PtyPanelData | undefined)?.lastStateChange).toBe(9999);
   });
 
   it("writes when waiting is re-delivered with a different waitingReason", () => {
@@ -204,8 +205,8 @@ describe("updateAgentState store action (#3217)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(after[seededTerminal.id]!.waitingReason).toBe("question");
-    expect(after[seededTerminal.id]!.lastStateChange).not.toBe(100);
+    expect((after[seededTerminal.id] as PtyPanelData | undefined)?.waitingReason).toBe("question");
+    expect((after[seededTerminal.id] as PtyPanelData | undefined)?.lastStateChange).not.toBe(100);
   });
 
   // #8592: TerminalAgentStateController.onEnterPressed() writes the optimistic
@@ -232,8 +233,8 @@ describe("updateAgentState store action (#3217)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(after[seededTerminal.id]!.stateChangeTrigger).toBe("input");
-    expect(after[seededTerminal.id]!.lastStateChange).toBe(1500);
+    expect((after[seededTerminal.id] as PtyPanelData | undefined)?.stateChangeTrigger).toBe("input");
+    expect((after[seededTerminal.id] as PtyPanelData | undefined)?.lastStateChange).toBe(1500);
   });
 
   it("preserves panelsById ref when re-delivered same state + same trigger", () => {
@@ -256,7 +257,7 @@ describe("updateAgentState store action (#3217)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).toBe(before);
-    expect(after[seededTerminal.id]!.lastStateChange).toBe(300);
+    expect((after[seededTerminal.id] as PtyPanelData | undefined)?.lastStateChange).toBe(300);
   });
 
   it("writes when the error message differs even though agentState is unchanged", () => {
@@ -277,7 +278,7 @@ describe("updateAgentState store action (#3217)", () => {
 
     const after = usePanelStore.getState().panelsById;
     expect(after).not.toBe(before);
-    expect(after[seededTerminal.id]!.error).toBe("EPIPE");
+    expect((after[seededTerminal.id] as PtyPanelData | undefined)?.error).toBe("EPIPE");
   });
 });
 
@@ -295,7 +296,7 @@ describe("setupTerminalStoreListeners directing guard (#3217)", () => {
       panelIds: [baseTerminal.id],
     });
 
-    const terminal = usePanelStore.getState().panelsById["test-terminal-1"];
+    const terminal = usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined;
     expect(shouldSuppressBackendState(terminal?.agentState, "waiting")).toBe(true);
   });
 
@@ -305,7 +306,7 @@ describe("setupTerminalStoreListeners directing guard (#3217)", () => {
       panelIds: [baseTerminal.id],
     });
 
-    const terminal = usePanelStore.getState().panelsById["test-terminal-1"];
+    const terminal = usePanelStore.getState().panelsById["test-terminal-1"] as PtyPanelData | undefined;
     expect(shouldSuppressBackendState(terminal?.agentState, "working")).toBe(false);
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/workingPanelCount.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/workingPanelCount.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { computeWorkingGridAgentCount } from "../helpers";
-import type { TerminalInstance } from "@shared/types";
+import type { PtyPanelData } from "@shared/types/panel";
 
 // Selector-based fleet workload counter (issue #8596). Derived rather than
 // maintained at write-time so listeners that bypass `updateAgentState`
 // (identity reducers, raw setState, restart catch blocks) can't desync it.
 
-function panel(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function panel(id: string, overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id,
     kind: "terminal",
@@ -17,7 +17,7 @@ function panel(id: string, overrides: Partial<TerminalInstance> = {}): TerminalI
     location: "grid",
     isVisible: true,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
 describe("computeWorkingGridAgentCount (#8596)", () => {

--- a/src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -46,7 +47,7 @@ function seedTerminal(id: string, worktreeId: string, location: "grid" | "dock" 
     location,
     worktreeId,
     isVisible: true,
-  } as import("../types").TerminalInstance;
+  } as unknown as PtyPanelData;
   usePanelStore.setState((state) => ({
     panelsById: { ...state.panelsById, [id]: terminal },
     panelIds: [...state.panelIds, id],

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -1,6 +1,6 @@
 import type { TerminalRuntimeStatus } from "@/types";
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
-import { type PanelInstance, type PtyPanelData } from "@shared/types/panel";
+import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
 import { getNarrowPanel } from "./selectors";
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
@@ -390,21 +390,22 @@ export const createAddPanelActions = (
       // Batched path: commit `panelsById` immediately; defer `panelIds` append.
       set((state) => {
         const existing = state.panelsById[id];
+        const existingPty = existing && isPtyPanel(existing) ? existing : undefined;
         const preservedTerminal: CarrierPanel =
           existing && isReconnect
             ? {
                 ...ptyTerminal,
-                agentState: ptyTerminal.agentState ?? existing.agentState,
-                lastStateChange: ptyTerminal.lastStateChange ?? existing.lastStateChange,
-                exitBehavior: ptyTerminal.exitBehavior ?? existing.exitBehavior,
+                agentState: ptyTerminal.agentState ?? existingPty?.agentState,
+                lastStateChange: ptyTerminal.lastStateChange ?? existingPty?.lastStateChange,
+                exitBehavior: ptyTerminal.exitBehavior ?? existingPty?.exitBehavior,
                 extensionState: ptyTerminal.extensionState ?? existing.extensionState,
                 // Sticky: once detected, never downgrade on a partial reconnect payload.
-                everDetectedAgent: ptyTerminal.everDetectedAgent || existing.everDetectedAgent,
+                everDetectedAgent: ptyTerminal.everDetectedAgent || existingPty?.everDetectedAgent,
                 // Prefer the fresh reconnect value if present; otherwise keep an existing
                 // live detection (live IPC event may have landed before reconnect flush).
-                detectedAgentId: ptyTerminal.detectedAgentId ?? existing.detectedAgentId,
-                detectedProcessId: ptyTerminal.detectedProcessId ?? existing.detectedProcessId,
-                runtimeIdentity: ptyTerminal.runtimeIdentity ?? existing.runtimeIdentity,
+                detectedAgentId: ptyTerminal.detectedAgentId ?? existingPty?.detectedAgentId,
+                detectedProcessId: ptyTerminal.detectedProcessId ?? existingPty?.detectedProcessId,
+                runtimeIdentity: ptyTerminal.runtimeIdentity ?? existingPty?.runtimeIdentity,
                 // Capability is sealed at spawn — values should match — but
                 // preserve the existing entry if a partial reconnect omits it.
               }
@@ -439,20 +440,21 @@ export const createAddPanelActions = (
           // Update existing terminal in place (reconnection case or double hydration)
           logDebug("[TerminalStore] Terminal already exists, updating instead of adding", { id });
           // Preserve existing agentState/lastStateChange/exitBehavior if new values are undefined
+          const existingPty2 = isPtyPanel(existing) ? existing : undefined;
           const preservedTerminal: CarrierPanel = isReconnect
             ? {
                 ...ptyTerminal,
-                agentState: ptyTerminal.agentState ?? existing.agentState,
-                lastStateChange: ptyTerminal.lastStateChange ?? existing.lastStateChange,
-                exitBehavior: ptyTerminal.exitBehavior ?? existing.exitBehavior,
+                agentState: ptyTerminal.agentState ?? existingPty2?.agentState,
+                lastStateChange: ptyTerminal.lastStateChange ?? existingPty2?.lastStateChange,
+                exitBehavior: ptyTerminal.exitBehavior ?? existingPty2?.exitBehavior,
                 extensionState: ptyTerminal.extensionState ?? existing.extensionState,
                 // Sticky: once detected, never downgrade on a partial reconnect payload.
-                everDetectedAgent: ptyTerminal.everDetectedAgent || existing.everDetectedAgent,
+                everDetectedAgent: ptyTerminal.everDetectedAgent || existingPty2?.everDetectedAgent,
                 // Prefer the fresh reconnect value if present; otherwise keep an existing
                 // live detection (live IPC event may have landed before reconnect flush).
-                detectedAgentId: ptyTerminal.detectedAgentId ?? existing.detectedAgentId,
-                detectedProcessId: ptyTerminal.detectedProcessId ?? existing.detectedProcessId,
-                runtimeIdentity: ptyTerminal.runtimeIdentity ?? existing.runtimeIdentity,
+                detectedAgentId: ptyTerminal.detectedAgentId ?? existingPty2?.detectedAgentId,
+                detectedProcessId: ptyTerminal.detectedProcessId ?? existingPty2?.detectedProcessId,
+                runtimeIdentity: ptyTerminal.runtimeIdentity ?? existingPty2?.runtimeIdentity,
                 // Capability is sealed at spawn — values should match — but
                 // preserve the existing entry if a partial reconnect omits it.
               }
@@ -627,7 +629,8 @@ export const createAddPanelActions = (
     // frame. spawnStatus remains "spawning" while queued, so TerminalPane shows
     // lightweight chrome instead of mounting XtermAdapter.
     terminalStartupQueue.enqueue(async () => {
-      if (get().panelsById[id]?.spawnStatus !== "spawning") return;
+      const _p0 = get().panelsById[id];
+      if (!_p0 || !isPtyPanel(_p0) || _p0.spawnStatus !== "spawning") return;
 
       try {
         let mergedEnv: Record<string, string> | undefined = options.env;
@@ -659,7 +662,8 @@ export const createAddPanelActions = (
           logWarn("[TerminalStore] Failed to fetch environment variables", { error });
         }
 
-        if (get().panelsById[id]?.spawnStatus !== "spawning") return;
+        const _p1 = get().panelsById[id];
+        if (!_p1 || !isPtyPanel(_p1) || _p1.spawnStatus !== "spawning") return;
 
         const commandToExecute = options.skipCommandExecution ? undefined : options.command;
         await terminalClient.spawn({
@@ -695,7 +699,7 @@ export const createAddPanelActions = (
             orphaned = true;
             return state;
           }
-          if (current.spawnStatus !== "spawning") return state;
+          if (!isPtyPanel(current) || current.spawnStatus !== "spawning") return state;
           mountedPanel = true;
           return {
             panelsById: { ...state.panelsById, [id]: { ...current, spawnStatus: "ready" } },
@@ -729,7 +733,7 @@ export const createAddPanelActions = (
         // the id up) or the panel was already removed, skip the cleanup —
         // otherwise we'd destroy someone else's panel.
         const current = get().panelsById[id];
-        if (current?.spawnStatus !== "spawning") return;
+        if (!current || !isPtyPanel(current) || current.spawnStatus !== "spawning") return;
         try {
           get().removePanel(id);
         } catch (removeError) {

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -1,5 +1,9 @@
 import type { TerminalRuntimeStatus } from "@/types";
-import type { PanelRegistryStoreApi, PanelRegistrySlice, TerminalInstance } from "./types";
+import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
+import { type PanelInstance, type PtyPanelData } from "@shared/types/panel";
+import { getNarrowPanel } from "./selectors";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 import { terminalClient, projectClient, globalEnvClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
@@ -169,7 +173,8 @@ export const createAddPanelActions = (
       // of an unregistered kind) wins over a live registry lookup only when the
       // registry has no matching entry.
       const pluginId = kindConfig?.extensionId ?? options.pluginId;
-      const terminal: TerminalInstance = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- panel shape is guaranteed by the registered createDefaults factory
+      const terminal = {
         id,
         kind: requestedKind,
         title,
@@ -181,7 +186,7 @@ export const createAddPanelActions = (
         pluginId,
         ephemeral: options.ephemeral,
         ...kindFields,
-      };
+      } as PanelInstance;
 
       if (isHydrationBatchActive()) {
         // Batched path: commit `panelsById` immediately (event listeners can find
@@ -321,7 +326,8 @@ export const createAddPanelActions = (
     const ptyPluginId = ptyKindConfig?.extensionId ?? options.pluginId;
     // Reconnects don't go through a fresh spawn — mark them "ready" directly.
     const spawnStatus: "spawning" | "ready" = isReconnect ? "ready" : "spawning";
-    const terminal: TerminalInstance = {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- panel shape is guaranteed by the registered createDefaults factory
+    const terminal = {
       id,
       kind,
       launchAgentId,
@@ -369,35 +375,40 @@ export const createAddPanelActions = (
       ephemeral: options.ephemeral,
       startedAt: Date.now(),
       spawnStatus,
-    };
+    } as PanelInstance;
 
     // Commit the panel to `panelsById` BEFORE any async IPC (#5789 optimistic
     // placeholder) so the user sees the panel immediately and IPC event
     // listeners (onAgentStateChanged, onExit, onAgentDetected, activity flushes,
     // etc.) that look panels up by id always find the entry.
+    // PTY-specific field access within the closures below requires the narrow view.
+    // `terminal` is `PanelInstance` (cast above); the PTY path always produces a
+    // PtyPanelData shape at runtime so the re-assertion is safe here.
+    const ptyTerminal = terminal as PtyPanelData;
+
     if (isHydrationBatchActive()) {
       // Batched path: commit `panelsById` immediately; defer `panelIds` append.
       set((state) => {
         const existing = state.panelsById[id];
-        const preservedTerminal =
+        const preservedTerminal: CarrierPanel =
           existing && isReconnect
             ? {
-                ...terminal,
-                agentState: terminal.agentState ?? existing.agentState,
-                lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
-                exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
-                extensionState: terminal.extensionState ?? existing.extensionState,
+                ...ptyTerminal,
+                agentState: ptyTerminal.agentState ?? existing.agentState,
+                lastStateChange: ptyTerminal.lastStateChange ?? existing.lastStateChange,
+                exitBehavior: ptyTerminal.exitBehavior ?? existing.exitBehavior,
+                extensionState: ptyTerminal.extensionState ?? existing.extensionState,
                 // Sticky: once detected, never downgrade on a partial reconnect payload.
-                everDetectedAgent: terminal.everDetectedAgent || existing.everDetectedAgent,
+                everDetectedAgent: ptyTerminal.everDetectedAgent || existing.everDetectedAgent,
                 // Prefer the fresh reconnect value if present; otherwise keep an existing
                 // live detection (live IPC event may have landed before reconnect flush).
-                detectedAgentId: terminal.detectedAgentId ?? existing.detectedAgentId,
-                detectedProcessId: terminal.detectedProcessId ?? existing.detectedProcessId,
-                runtimeIdentity: terminal.runtimeIdentity ?? existing.runtimeIdentity,
+                detectedAgentId: ptyTerminal.detectedAgentId ?? existing.detectedAgentId,
+                detectedProcessId: ptyTerminal.detectedProcessId ?? existing.detectedProcessId,
+                runtimeIdentity: ptyTerminal.runtimeIdentity ?? existing.runtimeIdentity,
                 // Capability is sealed at spawn — values should match — but
                 // preserve the existing entry if a partial reconnect omits it.
               }
-            : terminal;
+            : ptyTerminal;
         return {
           panelsById: { ...state.panelsById, [id]: preservedTerminal },
           panelIdsByWorktreeId: existing
@@ -428,24 +439,24 @@ export const createAddPanelActions = (
           // Update existing terminal in place (reconnection case or double hydration)
           logDebug("[TerminalStore] Terminal already exists, updating instead of adding", { id });
           // Preserve existing agentState/lastStateChange/exitBehavior if new values are undefined
-          const preservedTerminal = isReconnect
+          const preservedTerminal: CarrierPanel = isReconnect
             ? {
-                ...terminal,
-                agentState: terminal.agentState ?? existing.agentState,
-                lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
-                exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
-                extensionState: terminal.extensionState ?? existing.extensionState,
+                ...ptyTerminal,
+                agentState: ptyTerminal.agentState ?? existing.agentState,
+                lastStateChange: ptyTerminal.lastStateChange ?? existing.lastStateChange,
+                exitBehavior: ptyTerminal.exitBehavior ?? existing.exitBehavior,
+                extensionState: ptyTerminal.extensionState ?? existing.extensionState,
                 // Sticky: once detected, never downgrade on a partial reconnect payload.
-                everDetectedAgent: terminal.everDetectedAgent || existing.everDetectedAgent,
+                everDetectedAgent: ptyTerminal.everDetectedAgent || existing.everDetectedAgent,
                 // Prefer the fresh reconnect value if present; otherwise keep an existing
                 // live detection (live IPC event may have landed before reconnect flush).
-                detectedAgentId: terminal.detectedAgentId ?? existing.detectedAgentId,
-                detectedProcessId: terminal.detectedProcessId ?? existing.detectedProcessId,
-                runtimeIdentity: terminal.runtimeIdentity ?? existing.runtimeIdentity,
+                detectedAgentId: ptyTerminal.detectedAgentId ?? existing.detectedAgentId,
+                detectedProcessId: ptyTerminal.detectedProcessId ?? existing.detectedProcessId,
+                runtimeIdentity: ptyTerminal.runtimeIdentity ?? existing.runtimeIdentity,
                 // Capability is sealed at spawn — values should match — but
                 // preserve the existing entry if a partial reconnect omits it.
               }
-            : terminal;
+            : ptyTerminal;
           const newById = { ...state.panelsById, [id]: preservedTerminal };
           const newIndex = transferBetweenWorktreeIndex(
             state.panelIdsByWorktreeId,

--- a/src/store/slices/panelRegistry/background.ts
+++ b/src/store/slices/panelRegistry/background.ts
@@ -1,5 +1,8 @@
-import type { PanelRegistryStoreApi, PanelRegistrySlice, TerminalInstance } from "./types";
+import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { getNarrowPanel } from "./selectors";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 import { isDevPreviewPanel } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
@@ -55,7 +58,7 @@ export const createBackgroundActions = (
     set((state) => {
       const existing = state.panelsById[id];
       if (!existing) return state;
-      const newById: Record<string, TerminalInstance> = {
+      const newById: Record<string, CarrierPanel> = {
         ...state.panelsById,
         [id]: { ...existing, location: "background" as const },
       };

--- a/src/store/slices/panelRegistry/browser.ts
+++ b/src/store/slices/panelRegistry/browser.ts
@@ -1,6 +1,7 @@
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
 import type { TerminalReconnectError } from "@/types";
 import { panelKindUsesTerminalUi } from "@shared/config/panelKindRegistry";
+import { isPtyPanel } from "@shared/types/panel";
 import { saveNormalized } from "./persistence";
 import { debounce } from "@/utils/debounce";
 
@@ -302,7 +303,7 @@ export const createBrowserActions = (
   setScrollbackRestoreError: (id, error) => {
     set((state) => {
       const terminal = state.panelsById[id];
-      if (!terminal) return state;
+      if (!terminal || !isPtyPanel(terminal)) return state;
 
       return {
         panelsById: {
@@ -316,7 +317,7 @@ export const createBrowserActions = (
   clearScrollbackRestoreError: (id) => {
     set((state) => {
       const terminal = state.panelsById[id];
-      if (!terminal) return state;
+      if (!terminal || !isPtyPanel(terminal)) return state;
       if (terminal.scrollbackRestoreError === undefined) return state;
 
       return {

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -1,8 +1,4 @@
-import type {
-  PanelRegistryStoreApi,
-  PanelRegistrySlice,
-  PanelRegistryMiddleware,
-} from "./types";
+import type { PanelRegistryStoreApi, PanelRegistrySlice, PanelRegistryMiddleware } from "./types";
 import { isPtyPanel } from "@shared/types/panel";
 import type { PanelInstance } from "@shared/types/panel";
 import { terminalClient } from "@/clients";

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -2,8 +2,9 @@ import type {
   PanelRegistryStoreApi,
   PanelRegistrySlice,
   PanelRegistryMiddleware,
-  TerminalInstance,
 } from "./types";
+import { isPtyPanel } from "@shared/types/panel";
+import type { PanelInstance } from "@shared/types/panel";
 import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
@@ -229,7 +230,7 @@ export const createCorePanelActions = (
   updateLastObservedTitle: (id, title) => {
     set((state) => {
       const terminal = state.panelsById[id];
-      if (!terminal) return state;
+      if (!terminal || !isPtyPanel(terminal)) return state;
       const trimmed = title.trim();
       if (!trimmed || terminal.lastObservedTitle === trimmed) return state;
       const newById = {
@@ -258,6 +259,7 @@ export const createCorePanelActions = (
         logWarn("[TerminalStore] Cannot update agent state: terminal not found", { id });
         return state;
       }
+      if (!isPtyPanel(terminal)) return state;
 
       // Equality short-circuit: skip the write (and crucially `lastStateChange`)
       // when no user-visible field changed. `lastStateChange` gates the
@@ -311,7 +313,7 @@ export const createCorePanelActions = (
   updateActivity: (id, headline, status, type, timestamp, lastCommand) => {
     set((state) => {
       const terminal = state.panelsById[id];
-      if (!terminal) return state;
+      if (!terminal || !isPtyPanel(terminal)) return state;
 
       if (
         terminal.activityHeadline === headline &&
@@ -342,7 +344,7 @@ export const createCorePanelActions = (
   updateLastCommand: (id, lastCommand) => {
     set((state) => {
       const terminal = state.panelsById[id];
-      if (!terminal) return state;
+      if (!terminal || !isPtyPanel(terminal)) return state;
 
       return {
         panelsById: {
@@ -359,16 +361,24 @@ export const createCorePanelActions = (
       if (!terminal) return state;
       if (terminal.isVisible === isVisible) return state;
 
-      const runtimeStatus = deriveRuntimeStatus(
-        isVisible,
-        terminal.flowStatus,
-        terminal.runtimeStatus
-      );
+      if (isPtyPanel(terminal)) {
+        const runtimeStatus = deriveRuntimeStatus(
+          isVisible,
+          terminal.flowStatus,
+          terminal.runtimeStatus
+        );
+        return {
+          panelsById: {
+            ...state.panelsById,
+            [id]: { ...terminal, isVisible, runtimeStatus },
+          },
+        };
+      }
 
       return {
         panelsById: {
           ...state.panelsById,
-          [id]: { ...terminal, isVisible, runtimeStatus },
+          [id]: { ...terminal, isVisible },
         },
       };
     });
@@ -406,15 +416,15 @@ export const createCorePanelActions = (
       if (!terminal || terminal.location === "dock") return state;
 
       const groupPrune = removePanelIdsFromTabGroups(state.tabGroups, new Set([id]));
-      const newById = {
-        ...state.panelsById,
-        [id]: {
-          ...terminal,
-          location: "dock" as const,
-          isVisible: false,
-          runtimeStatus: deriveRuntimeStatus(false, terminal.flowStatus, terminal.runtimeStatus),
-        },
-      };
+      const updatedPanel = isPtyPanel(terminal)
+        ? {
+            ...terminal,
+            location: "dock" as const,
+            isVisible: false,
+            runtimeStatus: deriveRuntimeStatus(false, terminal.flowStatus, terminal.runtimeStatus),
+          }
+        : { ...terminal, location: "dock" as const, isVisible: false };
+      const newById = { ...state.panelsById, [id]: updatedPanel };
       saveNormalized(newById, state.panelIds);
       if (groupPrune.changed) {
         saveTabGroups(groupPrune.tabGroups);
@@ -440,7 +450,7 @@ export const createCorePanelActions = (
 
     // Single ungrouped panel - move just this panel
     let moveSucceeded = false;
-    let terminal: TerminalInstance | undefined;
+    let terminal: PanelInstance | undefined;
 
     set((state) => {
       terminal = state.panelsById[id];
@@ -450,15 +460,16 @@ export const createCorePanelActions = (
       // succeed, the grid scrolls vertically to absorb additional panels.
       moveSucceeded = true;
       const groupPrune = removePanelIdsFromTabGroups(state.tabGroups, new Set([id]));
-      const newById = {
-        ...state.panelsById,
-        [id]: {
-          ...terminal!,
-          location: "grid" as const,
-          isVisible: true,
-          runtimeStatus: deriveRuntimeStatus(true, terminal!.flowStatus, terminal!.runtimeStatus),
-        },
-      };
+      const t = terminal!;
+      const updatedPanel = isPtyPanel(t)
+        ? {
+            ...t,
+            location: "grid" as const,
+            isVisible: true,
+            runtimeStatus: deriveRuntimeStatus(true, t.flowStatus, t.runtimeStatus),
+          }
+        : { ...t, location: "grid" as const, isVisible: true };
+      const newById = { ...state.panelsById, [id]: updatedPanel };
       saveNormalized(newById, state.panelIds);
       if (groupPrune.changed) {
         saveTabGroups(groupPrune.tabGroups);

--- a/src/store/slices/panelRegistry/helpers.ts
+++ b/src/store/slices/panelRegistry/helpers.ts
@@ -7,7 +7,10 @@ import { isBuiltInAgentId } from "@shared/config/agentIds";
 import { ABSOLUTE_MAX_GRID_TERMINALS } from "@/lib/terminalLayout";
 import { deriveTerminalChrome, type TerminalChromeInput } from "@/utils/terminalChrome";
 import { logError } from "@/utils/logger";
-import type { TerminalInstance } from "./types";
+import { isPtyPanel } from "@shared/types/panel";
+import { getNarrowPanel } from "./selectors";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 /**
  * Count grid-visible panels currently in `agentState === "working"`. O(N) over
@@ -18,12 +21,12 @@ import type { TerminalInstance } from "./types";
  * write-time because many listeners (`onAgentExited`, identity reducers,
  * restart paths) bypass `updateAgentState` and silently desync a counter.
  */
-export function computeWorkingGridAgentCount(panelsById: Record<string, TerminalInstance>): number {
+export function computeWorkingGridAgentCount(panelsById: Record<string, CarrierPanel>): number {
   let count = 0;
   for (const id in panelsById) {
     const t = panelsById[id];
     if (!t) continue;
-    if (t.agentState !== "working") continue;
+    if (!isPtyPanel(t) || t.agentState !== "working") continue;
     const location = t.location ?? "grid";
     if (location !== "grid") continue;
     if (t.isVisible === false) continue;

--- a/src/store/slices/panelRegistry/index.ts
+++ b/src/store/slices/panelRegistry/index.ts
@@ -12,8 +12,8 @@ import { createBrowserActions } from "./browser";
 import { createTabGroupActions } from "./tabGroups";
 
 // Re-exports for backward compatibility
+export type { TerminalInstance } from "@shared/types/panel";
 export type {
-  TerminalInstance,
   AddPanelOptions,
   TrashedTerminal,
   TrashedTerminalGroupMetadata,

--- a/src/store/slices/panelRegistry/ordering.ts
+++ b/src/store/slices/panelRegistry/ordering.ts
@@ -1,11 +1,15 @@
-import type { PanelRegistryStoreApi, PanelRegistrySlice, TerminalInstance } from "./types";
+import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { type PanelInstance } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { deriveRuntimeStatus, removePanelIdsFromTabGroups } from "./helpers";
 import { buildWorktreeIndex } from "./worktreeIndex";
+import { getNarrowPanel } from "./selectors";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
@@ -23,9 +27,9 @@ export const createOrderingActions = (
     set((state) => {
       const hasWorktreeFilter = worktreeId !== undefined;
       const targetWorktreeId = worktreeId ?? null;
-      const matchesWorktree = (t: TerminalInstance) =>
+      const matchesWorktree = (t: CarrierPanel) =>
         !hasWorktreeFilter || (t.worktreeId ?? null) === targetWorktreeId;
-      const matchesLocation = (t: TerminalInstance) =>
+      const matchesLocation = (t: CarrierPanel) =>
         location === "grid"
           ? t.location === "grid" || t.location === undefined
           : t.location === "dock";
@@ -81,9 +85,9 @@ export const createOrderingActions = (
       const targetWorktreeId =
         worktreeId !== undefined ? worktreeId : (terminal.worktreeId ?? null);
       const hasWorktreeFilter = worktreeId !== undefined;
-      const matchesWorktree = (t: TerminalInstance) =>
+      const matchesWorktree = (t: CarrierPanel) =>
         !hasWorktreeFilter || (t.worktreeId ?? null) === (targetWorktreeId ?? null);
-      const matchesLocation = (t: TerminalInstance) =>
+      const matchesLocation = (t: CarrierPanel) =>
         location === "grid"
           ? t.location === "grid" || t.location === undefined
           : t.location === "dock";
@@ -113,12 +117,13 @@ export const createOrderingActions = (
               : scopedIndices[clampedIndex]!;
 
       const isVisible = location === "grid";
-      const updatedTerminal: TerminalInstance = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- spread preserves the panel's discriminant; overrides are base-field-compatible
+      const updatedTerminal = {
         ...terminal,
         location,
         isVisible,
         runtimeStatus: deriveRuntimeStatus(isVisible, terminal.flowStatus, terminal.runtimeStatus),
-      };
+      } as PanelInstance;
 
       // Insert at the right position
       const newIds = [...filteredIds];

--- a/src/store/slices/panelRegistry/ordering.ts
+++ b/src/store/slices/panelRegistry/ordering.ts
@@ -123,7 +123,11 @@ export const createOrderingActions = (
         ...terminal,
         location,
         isVisible,
-        runtimeStatus: deriveRuntimeStatus(isVisible, ptyTerminal?.flowStatus, ptyTerminal?.runtimeStatus),
+        runtimeStatus: deriveRuntimeStatus(
+          isVisible,
+          ptyTerminal?.flowStatus,
+          ptyTerminal?.runtimeStatus
+        ),
       } as PanelInstance;
 
       // Insert at the right position

--- a/src/store/slices/panelRegistry/ordering.ts
+++ b/src/store/slices/panelRegistry/ordering.ts
@@ -1,6 +1,6 @@
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
-import { type PanelInstance } from "@shared/types/panel";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
@@ -117,12 +117,13 @@ export const createOrderingActions = (
               : scopedIndices[clampedIndex]!;
 
       const isVisible = location === "grid";
+      const ptyTerminal = isPtyPanel(terminal) ? terminal : undefined;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- spread preserves the panel's discriminant; overrides are base-field-compatible
       const updatedTerminal = {
         ...terminal,
         location,
         isVisible,
-        runtimeStatus: deriveRuntimeStatus(isVisible, terminal.flowStatus, terminal.runtimeStatus),
+        runtimeStatus: deriveRuntimeStatus(isVisible, ptyTerminal?.flowStatus, ptyTerminal?.runtimeStatus),
       } as PanelInstance;
 
       // Insert at the right position

--- a/src/store/slices/panelRegistry/persistence.ts
+++ b/src/store/slices/panelRegistry/persistence.ts
@@ -13,10 +13,7 @@ export function savePanels(panels: PanelInstance[]): void {
   panelPersistence.save(panels);
 }
 
-export function saveNormalized(
-  panelsById: Record<string, CarrierPanel>,
-  panelIds: string[]
-): void {
+export function saveNormalized(panelsById: Record<string, CarrierPanel>, panelIds: string[]): void {
   const panels = panelIds
     .map((id) => panelsById[id])
     .filter((t): t is NonNullable<typeof t> => Boolean(t));

--- a/src/store/slices/panelRegistry/persistence.ts
+++ b/src/store/slices/panelRegistry/persistence.ts
@@ -1,22 +1,26 @@
 import { panelPersistence } from "../../persistence/panelPersistence";
-import type { TerminalInstance } from "./types";
+import { type PanelInstance } from "@shared/types/panel";
+import { getNarrowPanel } from "./selectors";
 import type { TabGroup } from "@/types";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 export function flushPanelPersistence(): void {
   panelPersistence.flush();
 }
 
-export function savePanels(terminals: TerminalInstance[]): void {
-  panelPersistence.save(terminals);
+export function savePanels(panels: PanelInstance[]): void {
+  panelPersistence.save(panels);
 }
 
 export function saveNormalized(
-  panelsById: Record<string, TerminalInstance>,
+  panelsById: Record<string, CarrierPanel>,
   panelIds: string[]
 ): void {
-  panelPersistence.save(
-    panelIds.map((id) => panelsById[id]).filter((t): t is TerminalInstance => Boolean(t))
-  );
+  const panels = panelIds
+    .map((id) => panelsById[id])
+    .filter((t): t is NonNullable<typeof t> => Boolean(t));
+  panelPersistence.save(panels);
 }
 
 export function saveTabGroups(tabGroups: Map<string, TabGroup>): void {

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -23,6 +23,7 @@ import { getAgentConfig } from "@/config/agents";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { isPtyPanel } from "@shared/types/panel";
 import { markTerminalRestarting, unmarkTerminalRestarting } from "@/store/restartExitSuppression";
 import { saveNormalized } from "./persistence";
 import { optimizeForDock } from "./layout";
@@ -173,6 +174,8 @@ export const createRestartActions = (
       return;
     }
 
+    if (!isPtyPanel(terminal)) return;
+
     // Guard against concurrent restart attempts
     if (terminal.isRestarting) {
       logWarn("[TerminalStore] Terminal is already restarting, ignoring", { id });
@@ -247,9 +250,16 @@ export const createRestartActions = (
     }
 
     // Re-read terminal from state in case it was modified during async validation
-    const currentTerminal = get().panelsById[id];
+    const _currentTerminalRaw = get().panelsById[id];
+    if (!_currentTerminalRaw || !isPtyPanel(_currentTerminalRaw)) {
+      unmarkTerminalRestarting(id);
+      set((state) => updateTerminal(state, id, (t) => ({ ...t, isRestarting: false })));
+      logWarn("[TerminalStore] Terminal no longer exists or was trashed", { id });
+      return;
+    }
+    const currentTerminal = _currentTerminalRaw;
 
-    if (!currentTerminal || currentTerminal.location === "trash") {
+    if (currentTerminal.location === "trash") {
       // Terminal was removed or trashed while we were validating
       unmarkTerminalRestarting(id);
       set((state) => updateTerminal(state, id, (t) => ({ ...t, isRestarting: false })));
@@ -455,7 +465,7 @@ export const createRestartActions = (
       // Update terminal in store: increment restartKey, reset agent state, update location
       set((state) => {
         const t = state.panelsById[id];
-        if (!t) return state;
+        if (!t || !isPtyPanel(t)) return state;
         const updated = {
           ...t,
           location: targetLocation,
@@ -645,6 +655,7 @@ export const createRestartActions = (
 
       const t = state.panelsById[id];
       if (!t) return state;
+      const ptyT = isPtyPanel(t) ? t : undefined;
       const newById = {
         ...state.panelsById,
         [id]: {
@@ -652,8 +663,8 @@ export const createRestartActions = (
           worktreeId,
           location: newLocation,
           isVisible: newLocation === "grid" ? true : false,
-          runtimeStatus: deriveRuntimeStatus(newLocation === "grid", t.flowStatus, t.runtimeStatus),
-        },
+          runtimeStatus: deriveRuntimeStatus(newLocation === "grid", ptyT?.flowStatus, ptyT?.runtimeStatus),
+        } as typeof t,
       };
       const newIndex = transferBetweenWorktreeIndex(
         state.panelIdsByWorktreeId,
@@ -678,6 +689,7 @@ export const createRestartActions = (
   moveToNewWorktreeAndTransfer: (id) => {
     const terminal = get().panelsById[id];
     if (!terminal || terminal.location === "trash") return;
+    if (!isPtyPanel(terminal)) return;
     if (terminal.isRestarting) return;
 
     // Determine if this is an agent terminal before any async work
@@ -728,7 +740,8 @@ export const createRestartActions = (
 
               // After restart, inject captured history as a first prompt for agent terminals
               const restarted = get().panelsById[id];
-              if (isAgent && capturedHistory.trim().length > 0 && !restarted?.restartError) {
+              const restartedPty = restarted && isPtyPanel(restarted) ? restarted : undefined;
+              if (isAgent && capturedHistory.trim().length > 0 && !restartedPty?.restartError) {
                 scheduleHistoryInjection(id, capturedHistory, newCwd ?? "");
               }
             } catch (err) {
@@ -761,6 +774,7 @@ export const createRestartActions = (
     set((state) => {
       const terminal = state.panelsById[id];
       if (!terminal) return state;
+      if (!isPtyPanel(terminal)) return state;
 
       const prevTs = terminal.flowStatusTimestamp;
       if (prevTs !== undefined && timestamp < prevTs) return state;
@@ -784,6 +798,7 @@ export const createRestartActions = (
     set((state) => {
       const terminal = state.panelsById[id];
       if (!terminal) return state;
+      if (!isPtyPanel(terminal)) return state;
       if (terminal.runtimeStatus === status) return state;
 
       return {
@@ -799,6 +814,7 @@ export const createRestartActions = (
     set((state) => {
       const terminal = state.panelsById[id];
       if (!terminal) return state;
+      if (!isPtyPanel(terminal)) return state;
       if (terminal.isInputLocked === locked) return state;
 
       const newById = {
@@ -817,6 +833,7 @@ export const createRestartActions = (
     set((state) => {
       const terminal = state.panelsById[id];
       if (!terminal) return state;
+      if (!isPtyPanel(terminal)) return state;
 
       const locked = !terminal.isInputLocked;
       const newById = {
@@ -835,6 +852,9 @@ export const createRestartActions = (
     const terminal = get().panelsById[id];
     if (!terminal) {
       return { success: false, error: "terminal not found" };
+    }
+    if (!isPtyPanel(terminal)) {
+      return { success: false, error: "panel is not a PTY panel" };
     }
     if (terminal.isRestarting) {
       return { success: false, error: "already restarting" };
@@ -932,7 +952,7 @@ export const createRestartActions = (
 
       set((state) => {
         const t = state.panelsById[id];
-        if (!t) return state;
+        if (!t || !isPtyPanel(t)) return state;
         const updated = {
           ...t,
           restartKey: (t.restartKey ?? 0) + 1,

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -663,7 +663,11 @@ export const createRestartActions = (
           worktreeId,
           location: newLocation,
           isVisible: newLocation === "grid" ? true : false,
-          runtimeStatus: deriveRuntimeStatus(newLocation === "grid", ptyT?.flowStatus, ptyT?.runtimeStatus),
+          runtimeStatus: deriveRuntimeStatus(
+            newLocation === "grid",
+            ptyT?.flowStatus,
+            ptyT?.runtimeStatus
+          ),
         } as typeof t,
       };
       const newIndex = transferBetweenWorktreeIndex(

--- a/src/store/slices/panelRegistry/selectors.ts
+++ b/src/store/slices/panelRegistry/selectors.ts
@@ -5,16 +5,15 @@ import {
   isReviewPanel,
   type PanelInstance,
 } from "@shared/types/panel";
-import type { TerminalInstance } from "./types";
 
-let _prevById: Record<string, TerminalInstance> | null = null;
+let _prevById: Record<string, PanelInstance> | null = null;
 let _prevIds: string[] | null = null;
-let _prevResult: TerminalInstance[] | null = null;
+let _prevResult: PanelInstance[] | null = null;
 
 export function selectOrderedTerminals(
-  panelsById: Record<string, TerminalInstance>,
+  panelsById: Record<string, PanelInstance>,
   panelIds: string[]
-): TerminalInstance[] {
+): PanelInstance[] {
   if (panelsById === _prevById && panelIds === _prevIds && _prevResult) {
     return _prevResult;
   }
@@ -22,26 +21,22 @@ export function selectOrderedTerminals(
   _prevIds = panelIds;
   _prevResult = panelIds
     .map((id) => panelsById[id])
-    .filter((t): t is TerminalInstance => Boolean(t));
+    .filter((t): t is PanelInstance => Boolean(t));
   return _prevResult;
 }
 
 /**
  * Adapter selector: narrow a single carrier entry to the `PanelInstance`
- * discriminated union. The carrier is still typed `Record<string, TerminalInstance>`
- * (#8957 drains that incrementally); this is the sanctioned read path for new
- * code that wants the narrow union instead of the kitchen-sink interface.
- *
- * Uses the existing kind type guards (which default a missing `kind` to
- * "terminal"), so a no-`kind` legacy record narrows to `PtyPanelData` — no
- * blanket `as unknown as PanelInstance` cast.
+ * discriminated union. Since the carrier now is `Record<string, PanelInstance>`
+ * the narrowing is mostly a passthrough — kept around as the sanctioned read
+ * path for callers that want to drop carrier entries with extension/plugin
+ * `kind` values that aren't part of the built-in `PanelInstance` union.
  *
  * Returns `undefined` for an absent id and for any panel whose `kind` is
- * outside the built-in union (e.g. an extension/plugin kind); such panels are
- * intentionally not representable by `PanelInstance` and are dropped here.
+ * outside the built-in union (e.g. an extension/plugin kind).
  */
 export function getNarrowPanel(
-  panelsById: Record<string, TerminalInstance>,
+  panelsById: Record<string, PanelInstance>,
   id: string
 ): PanelInstance | undefined {
   const panel = panelsById[id];
@@ -49,20 +44,11 @@ export function getNarrowPanel(
   if (isBrowserPanel(panel)) return panel;
   if (isDevPreviewPanel(panel)) return panel;
   if (isReviewPanel(panel)) return panel;
-  if (isPtyPanel(panel)) {
-    // The guard defaults an absent `kind` to "terminal", so a legacy no-`kind`
-    // record lands here. Backfill the literal discriminant when it's missing so
-    // the returned `PtyPanelData` is sound for downstream `switch (kind)`;
-    // preserve object identity when the panel already carries it.
-    if ("kind" in panel && panel.kind) {
-      return panel;
-    }
-    return { ...panel, kind: "terminal" };
-  }
+  if (isPtyPanel(panel)) return panel;
   return undefined;
 }
 
-let _prevNarrowById: Record<string, TerminalInstance> | null = null;
+let _prevNarrowById: Record<string, PanelInstance> | null = null;
 let _prevNarrowIds: string[] | null = null;
 let _prevNarrowResult: PanelInstance[] | null = null;
 
@@ -73,7 +59,7 @@ let _prevNarrowResult: PanelInstance[] | null = null;
  * so repeated calls in React render paths return a stable array reference.
  */
 export function getNarrowPanels(
-  panelsById: Record<string, TerminalInstance>,
+  panelsById: Record<string, PanelInstance>,
   panelIds: string[]
 ): PanelInstance[] {
   if (panelsById === _prevNarrowById && panelIds === _prevNarrowIds && _prevNarrowResult) {

--- a/src/store/slices/panelRegistry/selectors.ts
+++ b/src/store/slices/panelRegistry/selectors.ts
@@ -19,9 +19,7 @@ export function selectOrderedTerminals(
   }
   _prevById = panelsById;
   _prevIds = panelIds;
-  _prevResult = panelIds
-    .map((id) => panelsById[id])
-    .filter((t): t is PanelInstance => Boolean(t));
+  _prevResult = panelIds.map((id) => panelsById[id]).filter((t): t is PanelInstance => Boolean(t));
   return _prevResult;
 }
 

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -1,6 +1,6 @@
 import type { TabGroup, TabGroupLocation } from "@/types";
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
-import { type PanelInstance } from "@shared/types/panel";
+import { type PanelInstance, isPtyPanel } from "@shared/types/panel";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { getNarrowPanel } from "./selectors";
 
@@ -325,12 +325,13 @@ export const createTabGroupActions = (
         const t = newById[pid];
         if (!t) continue;
         if (t.location === "trash" || state.trashedTerminals.has(t.id)) continue;
+        const ptyT = isPtyPanel(t) ? t : undefined;
         newById[pid] = {
           ...t,
           location,
           isVisible: location === "grid",
-          runtimeStatus: deriveRuntimeStatus(location === "grid", t.flowStatus, t.runtimeStatus),
-        };
+          runtimeStatus: deriveRuntimeStatus(location === "grid", ptyT?.flowStatus, ptyT?.runtimeStatus),
+        } as PanelInstance;
       }
 
       saveNormalized(newById, state.panelIds);
@@ -378,6 +379,7 @@ export const createTabGroupActions = (
         const t = newById[pid];
         if (!t) continue;
         if (t.location === "trash" || state.trashedTerminals.has(t.id)) continue;
+        const ptyT2 = isPtyPanel(t) ? t : undefined;
         newById[pid] = {
           ...t,
           worktreeId,
@@ -385,10 +387,10 @@ export const createTabGroupActions = (
           isVisible: targetLocation === "grid",
           runtimeStatus: deriveRuntimeStatus(
             targetLocation === "grid",
-            t.flowStatus,
-            t.runtimeStatus
+            ptyT2?.flowStatus,
+            ptyT2?.runtimeStatus
           ),
-        };
+        } as PanelInstance;
         newIndex = transferBetweenWorktreeIndex(newIndex, t.worktreeId, worktreeId, pid);
       }
 
@@ -636,6 +638,7 @@ export const createTabGroupActions = (
                   tid
                 );
               }
+              const ptyT3 = isPtyPanel(t) ? t : undefined;
               newById[tid] = {
                 ...t,
                 location: effectiveLocation,
@@ -643,10 +646,10 @@ export const createTabGroupActions = (
                 isVisible: effectiveLocation === "grid",
                 runtimeStatus: deriveRuntimeStatus(
                   effectiveLocation === "grid",
-                  t.flowStatus,
-                  t.runtimeStatus
+                  ptyT3?.flowStatus,
+                  ptyT3?.runtimeStatus
                 ),
-              };
+              } as PanelInstance;
             }
             break;
           }

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -1,6 +1,10 @@
 import type { TabGroup, TabGroupLocation } from "@/types";
-import type { PanelRegistryStoreApi, PanelRegistrySlice, TerminalInstance } from "./types";
+import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
+import { type PanelInstance } from "@shared/types/panel";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { getNarrowPanel } from "./selectors";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
@@ -11,7 +15,7 @@ import { transferBetweenWorktreeIndex } from "./worktreeIndex";
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
 
-function getPanelTabGroupLocation(panel: TerminalInstance | undefined): TabGroupLocation | null {
+function getPanelTabGroupLocation(panel: PanelInstance | CarrierPanel | undefined): TabGroupLocation | null {
   if (!panel || panel.location === "trash" || panel.location === "background") return null;
   return panel.location === "dock" ? "dock" : "grid";
 }
@@ -203,7 +207,7 @@ export const createTabGroupActions = (
       return group.panelIds
         .map((id) => state.panelsById[id])
         .filter(
-          (t): t is TerminalInstance =>
+          (t): t is CarrierPanel =>
             t !== undefined &&
             getPanelTabGroupLocation(t) !== null &&
             (location === undefined || getPanelTabGroupLocation(t) === location) &&
@@ -212,7 +216,7 @@ export const createTabGroupActions = (
     }
 
     // Not an explicit group - check if it's a single ungrouped panel
-    const panel = state.panelsById[groupId];
+    const panel: CarrierPanel | undefined = state.panelsById[groupId];
     if (
       panel &&
       getPanelTabGroupLocation(panel) !== null &&
@@ -266,7 +270,7 @@ export const createTabGroupActions = (
     }
 
     // Find ungrouped panels
-    const ungroupedPanels: TerminalInstance[] = [];
+    const ungroupedPanels: CarrierPanel[] = [];
     for (const tid of state.panelIds) {
       const t = state.panelsById[tid];
       if (!t) continue;
@@ -429,7 +433,7 @@ export const createTabGroupActions = (
       reorderedGroups.splice(toGroupIndex, 0, movedGroup);
 
       // Build new panelIds with the reordered groups
-      const matchesLocation = (t: TerminalInstance) =>
+      const matchesLocation = (t: CarrierPanel) =>
         location === "grid"
           ? t.location === "grid" || t.location === undefined
           : t.location === "dock";

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -15,7 +15,9 @@ import { transferBetweenWorktreeIndex } from "./worktreeIndex";
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
 
-function getPanelTabGroupLocation(panel: PanelInstance | CarrierPanel | undefined): TabGroupLocation | null {
+function getPanelTabGroupLocation(
+  panel: PanelInstance | CarrierPanel | undefined
+): TabGroupLocation | null {
   if (!panel || panel.location === "trash" || panel.location === "background") return null;
   return panel.location === "dock" ? "dock" : "grid";
 }
@@ -330,7 +332,11 @@ export const createTabGroupActions = (
           ...t,
           location,
           isVisible: location === "grid",
-          runtimeStatus: deriveRuntimeStatus(location === "grid", ptyT?.flowStatus, ptyT?.runtimeStatus),
+          runtimeStatus: deriveRuntimeStatus(
+            location === "grid",
+            ptyT?.flowStatus,
+            ptyT?.runtimeStatus
+          ),
         } as PanelInstance;
       }
 

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -1,5 +1,8 @@
-import type { PanelRegistryStoreApi, PanelRegistrySlice, TerminalInstance } from "./types";
+import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
 import type { TrashExpiryHelpers } from "./trash";
+import { getNarrowPanel } from "./selectors";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
@@ -74,7 +77,7 @@ export const createTrashActions = (
     set((state) => {
       const existing = state.panelsById[id];
       if (!existing) return state;
-      const newById: Record<string, TerminalInstance> = {
+      const newById: Record<string, CarrierPanel> = {
         ...state.panelsById,
         [id]: { ...existing, location: "trash" as const },
       };
@@ -170,7 +173,7 @@ export const createTrashActions = (
     }
 
     set((state) => {
-      const newById: Record<string, TerminalInstance> = { ...state.panelsById };
+      const newById: Record<string, CarrierPanel> = { ...state.panelsById };
       for (const tid of trashPanelIds) {
         const current = newById[tid];
         if (current) {
@@ -405,7 +408,7 @@ export const createTrashActions = (
           saveNormalized(state.panelsById, state.panelIds);
           return { trashedTerminals: newTrashed };
         }
-        const newById: Record<string, TerminalInstance> = {
+        const newById: Record<string, CarrierPanel> = {
           ...state.panelsById,
           [id]: { ...existing, location: "trash" as const },
         };

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -7,7 +7,7 @@ import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
-import { isDevPreviewPanel } from "@shared/types/panel";
+import { isDevPreviewPanel, isPtyPanel } from "@shared/types/panel";
 import { TRASH_TTL_MS } from "@shared/config/trash";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
@@ -48,7 +48,7 @@ export const createTrashActions = (
     // Ephemeral panels (e.g. the help-panel assistant terminal) are bound to
     // a transient UI surface and must never linger in trash for the TTL window
     // — they bypass the trash flow and are removed outright.
-    if (terminal.ephemeral === true) {
+    if (isPtyPanel(terminal) && terminal.ephemeral === true) {
       get().removePanel(id);
       return;
     }

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -12,10 +12,8 @@ import type {
   BrowserHistory,
   AddPanelOptions,
 } from "@/types";
-// eslint-disable-next-line no-restricted-imports -- local alias for the carrier shape; flips to PanelInstance in #8957 step 5
-import type { TerminalInstance as TerminalInstanceType } from "@/types";
+import type { PanelInstance } from "@shared/types/panel";
 
-export type TerminalInstance = TerminalInstanceType;
 export type { AddPanelOptions };
 
 /**
@@ -70,7 +68,7 @@ export interface BackgroundedTerminal {
 export type HydrationBatchToken = symbol;
 
 export interface PanelRegistrySlice {
-  panelsById: Record<string, TerminalInstance>;
+  panelsById: Record<string, PanelInstance>;
   panelIds: string[];
   /**
    * Per-worktree panel id buckets, maintained at write time (add/remove/transfer)
@@ -128,7 +126,7 @@ export interface PanelRegistrySlice {
    * to the priority tier. Idempotent on missing panels.
    */
   stampLastActive: (id: string) => void;
-  getTerminal: (id: string) => TerminalInstance | undefined;
+  getTerminal: (id: string) => PanelInstance | undefined;
 
   moveTerminalToDock: (id: string) => void;
   moveTerminalToGrid: (id: string) => boolean;
@@ -219,7 +217,7 @@ export interface PanelRegistrySlice {
 
   // Tab grouping methods - TabGroup is the single source of truth
   /** Get all panels in a group, ordered by group's panelIds array. Location param is deprecated. */
-  getTabGroupPanels: (groupId: string, location?: TabGroupLocation) => TerminalInstance[];
+  getTabGroupPanels: (groupId: string, location?: TabGroupLocation) => PanelInstance[];
   /** Get all tab groups for a location/worktree */
   getTabGroups: (location: TabGroupLocation, worktreeId?: string) => TabGroup[];
   /** Get the group a panel belongs to, if any */
@@ -269,7 +267,7 @@ export type PanelRegistryMiddleware = {
     id: string,
     removedIndex: number,
     remainingIds: string[],
-    removedTerminal: TerminalInstance | undefined
+    removedTerminal: PanelInstance | undefined
   ) => void;
 };
 

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -1,6 +1,5 @@
 import type { StoreApi } from "zustand";
 import type {
-  TerminalInstance as TerminalInstanceType,
   AgentState,
   AgentStateChangeTrigger,
   PersistableFlowStatus,
@@ -13,6 +12,8 @@ import type {
   BrowserHistory,
   AddPanelOptions,
 } from "@/types";
+// eslint-disable-next-line no-restricted-imports -- local alias for the carrier shape; flips to PanelInstance in #8957 step 5
+import type { TerminalInstance as TerminalInstanceType } from "@/types";
 
 export type TerminalInstance = TerminalInstanceType;
 export type { AddPanelOptions };

--- a/src/store/slices/terminalBulkActionsSlice.ts
+++ b/src/store/slices/terminalBulkActionsSlice.ts
@@ -78,8 +78,7 @@ export const createTerminalBulkActionsSlice = (
     bulkCloseByWorktree: (worktreeId, state) => {
       const terminals = getTerminals();
       const toRemove = terminals.filter(
-        (t) =>
-          t.worktreeId === worktreeId && (!state || (isPtyPanel(t) && t.agentState === state))
+        (t) => t.worktreeId === worktreeId && (!state || (isPtyPanel(t) && t.agentState === state))
       );
       toRemove.forEach((t) => removePanel(t.id));
     },
@@ -113,8 +112,8 @@ export const createTerminalBulkActionsSlice = (
 
     bulkRestartAll: async () => {
       const terminals = getTerminals();
-      const activeTerminals = terminals.filter((t): t is PtyPanelData =>
-        isPtyPanel(t) && t.location !== "trash"
+      const activeTerminals = terminals.filter(
+        (t): t is PtyPanelData => isPtyPanel(t) && t.location !== "trash"
       );
       await restartTerminals(activeTerminals);
     },
@@ -123,8 +122,8 @@ export const createTerminalBulkActionsSlice = (
       const idSet = ids instanceof Set ? ids : new Set(ids);
       if (idSet.size === 0) return;
       const terminals = getTerminals();
-      const activeTerminals = terminals.filter((t): t is PtyPanelData =>
-        isPtyPanel(t) && idSet.has(t.id) && t.location !== "trash"
+      const activeTerminals = terminals.filter(
+        (t): t is PtyPanelData => isPtyPanel(t) && idSet.has(t.id) && t.location !== "trash"
       );
       if (activeTerminals.length === 0) return;
       try {
@@ -139,8 +138,8 @@ export const createTerminalBulkActionsSlice = (
 
     bulkRestartPreflightCheck: async () => {
       const terminals = getTerminals();
-      const activeTerminals = terminals.filter((t): t is PtyPanelData =>
-        isPtyPanel(t) && t.location !== "trash"
+      const activeTerminals = terminals.filter(
+        (t): t is PtyPanelData => isPtyPanel(t) && t.location !== "trash"
       );
 
       const validationResults = await validateTerminals(activeTerminals);
@@ -163,8 +162,8 @@ export const createTerminalBulkActionsSlice = (
     bulkRestartPreflightCheckSet: async (ids) => {
       const idSet = ids instanceof Set ? ids : new Set(ids);
       const terminals = getTerminals();
-      const activeTerminals = terminals.filter((t): t is PtyPanelData =>
-        isPtyPanel(t) && idSet.has(t.id) && t.location !== "trash"
+      const activeTerminals = terminals.filter(
+        (t): t is PtyPanelData => isPtyPanel(t) && idSet.has(t.id) && t.location !== "trash"
       );
 
       const validationResults = await validateTerminals(activeTerminals);
@@ -228,8 +227,9 @@ export const createTerminalBulkActionsSlice = (
 
     bulkRestartPreflightCheckByWorktree: async (worktreeId) => {
       const terminals = getTerminals();
-      const activeTerminals = terminals.filter((t): t is PtyPanelData =>
-        isPtyPanel(t) && t.worktreeId === worktreeId && t.location !== "trash"
+      const activeTerminals = terminals.filter(
+        (t): t is PtyPanelData =>
+          isPtyPanel(t) && t.worktreeId === worktreeId && t.location !== "trash"
       );
 
       const validationResults = await validateTerminals(activeTerminals);
@@ -251,8 +251,9 @@ export const createTerminalBulkActionsSlice = (
 
     bulkRestartByWorktree: async (worktreeId) => {
       const terminals = getTerminals();
-      const activeTerminals = terminals.filter((t): t is PtyPanelData =>
-        isPtyPanel(t) && t.worktreeId === worktreeId && t.location !== "trash"
+      const activeTerminals = terminals.filter(
+        (t): t is PtyPanelData =>
+          isPtyPanel(t) && t.worktreeId === worktreeId && t.location !== "trash"
       );
       if (activeTerminals.length === 0) return;
 
@@ -324,8 +325,7 @@ export const createTerminalBulkActionsSlice = (
     getCountByWorktree: (worktreeId, state) => {
       const terminals = getTerminals();
       return terminals.filter(
-        (t) =>
-          t.worktreeId === worktreeId && (!state || (isPtyPanel(t) && t.agentState === state))
+        (t) => t.worktreeId === worktreeId && (!state || (isPtyPanel(t) && t.agentState === state))
       ).length;
     },
 

--- a/src/store/slices/terminalBulkActionsSlice.ts
+++ b/src/store/slices/terminalBulkActionsSlice.ts
@@ -1,14 +1,17 @@
 import PQueue from "p-queue";
 import type { StateCreator } from "zustand";
-import type { TerminalInstance } from "./panelRegistrySlice";
+import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
 import type { AgentState } from "@/types";
 import { isRuntimeAgentTerminal } from "../../utils/terminalType";
 import { validateTerminals, type ValidationResult } from "@/utils/terminalValidation";
 import { logError } from "@/utils/logger";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 export interface BulkRestartValidation {
-  valid: TerminalInstance[];
-  invalid: Array<{ terminal: TerminalInstance; errors: ValidationResult }>;
+  valid: PtyPanelData[];
+  invalid: Array<{ terminal: PtyPanelData; errors: ValidationResult }>;
 }
 
 export interface TerminalBulkActionsSlice {
@@ -37,7 +40,7 @@ export interface TerminalBulkActionsSlice {
 }
 
 export const createTerminalBulkActionsSlice = (
-  getTerminals: () => TerminalInstance[],
+  getTerminals: () => CarrierPanel[],
   removePanel: (id: string) => void,
   restartTerminal: (id: string) => Promise<void>,
   trashPanel: (id: string) => void,
@@ -49,7 +52,7 @@ export const createTerminalBulkActionsSlice = (
 ): StateCreator<TerminalBulkActionsSlice, [], [], TerminalBulkActionsSlice> => {
   const restartQueue = new PQueue({ concurrency: 4, timeout: 30_000 });
 
-  const restartTerminals = async (terminalsToRestart: TerminalInstance[]) => {
+  const restartTerminals = async (terminalsToRestart: PtyPanelData[]) => {
     const ids = Array.from(new Set(terminalsToRestart.map((t) => t.id)));
     await restartQueue.addAll(
       ids.map((id) => async () => {
@@ -66,14 +69,17 @@ export const createTerminalBulkActionsSlice = (
     bulkCloseByState: (states) => {
       const stateArray = Array.isArray(states) ? states : [states];
       const terminals = getTerminals();
-      const toRemove = terminals.filter((t) => t.agentState && stateArray.includes(t.agentState));
+      const toRemove = terminals.filter(
+        (t) => isPtyPanel(t) && t.agentState != null && stateArray.includes(t.agentState)
+      );
       toRemove.forEach((t) => removePanel(t.id));
     },
 
     bulkCloseByWorktree: (worktreeId, state) => {
       const terminals = getTerminals();
       const toRemove = terminals.filter(
-        (t) => t.worktreeId === worktreeId && (!state || t.agentState === state)
+        (t) =>
+          t.worktreeId === worktreeId && (!state || (isPtyPanel(t) && t.agentState === state))
       );
       toRemove.forEach((t) => removePanel(t.id));
     },
@@ -107,7 +113,9 @@ export const createTerminalBulkActionsSlice = (
 
     bulkRestartAll: async () => {
       const terminals = getTerminals();
-      const activeTerminals = terminals.filter((t) => t.location !== "trash");
+      const activeTerminals = terminals.filter((t): t is PtyPanelData =>
+        isPtyPanel(t) && t.location !== "trash"
+      );
       await restartTerminals(activeTerminals);
     },
 
@@ -115,7 +123,9 @@ export const createTerminalBulkActionsSlice = (
       const idSet = ids instanceof Set ? ids : new Set(ids);
       if (idSet.size === 0) return;
       const terminals = getTerminals();
-      const activeTerminals = terminals.filter((t) => idSet.has(t.id) && t.location !== "trash");
+      const activeTerminals = terminals.filter((t): t is PtyPanelData =>
+        isPtyPanel(t) && idSet.has(t.id) && t.location !== "trash"
+      );
       if (activeTerminals.length === 0) return;
       try {
         const validationResults = await validateTerminals(activeTerminals);
@@ -129,12 +139,14 @@ export const createTerminalBulkActionsSlice = (
 
     bulkRestartPreflightCheck: async () => {
       const terminals = getTerminals();
-      const activeTerminals = terminals.filter((t) => t.location !== "trash");
+      const activeTerminals = terminals.filter((t): t is PtyPanelData =>
+        isPtyPanel(t) && t.location !== "trash"
+      );
 
       const validationResults = await validateTerminals(activeTerminals);
 
-      const valid: TerminalInstance[] = [];
-      const invalid: Array<{ terminal: TerminalInstance; errors: ValidationResult }> = [];
+      const valid: PtyPanelData[] = [];
+      const invalid: Array<{ terminal: PtyPanelData; errors: ValidationResult }> = [];
 
       for (const terminal of activeTerminals) {
         const result = validationResults.get(terminal.id);
@@ -151,12 +163,14 @@ export const createTerminalBulkActionsSlice = (
     bulkRestartPreflightCheckSet: async (ids) => {
       const idSet = ids instanceof Set ? ids : new Set(ids);
       const terminals = getTerminals();
-      const activeTerminals = terminals.filter((t) => idSet.has(t.id) && t.location !== "trash");
+      const activeTerminals = terminals.filter((t): t is PtyPanelData =>
+        isPtyPanel(t) && idSet.has(t.id) && t.location !== "trash"
+      );
 
       const validationResults = await validateTerminals(activeTerminals);
 
-      const valid: TerminalInstance[] = [];
-      const invalid: Array<{ terminal: TerminalInstance; errors: ValidationResult }> = [];
+      const valid: PtyPanelData[] = [];
+      const invalid: Array<{ terminal: PtyPanelData; errors: ValidationResult }> = [];
 
       for (const terminal of activeTerminals) {
         const result = validationResults.get(terminal.id);
@@ -214,14 +228,14 @@ export const createTerminalBulkActionsSlice = (
 
     bulkRestartPreflightCheckByWorktree: async (worktreeId) => {
       const terminals = getTerminals();
-      const activeTerminals = terminals.filter(
-        (t) => t.worktreeId === worktreeId && t.location !== "trash"
+      const activeTerminals = terminals.filter((t): t is PtyPanelData =>
+        isPtyPanel(t) && t.worktreeId === worktreeId && t.location !== "trash"
       );
 
       const validationResults = await validateTerminals(activeTerminals);
 
-      const valid: TerminalInstance[] = [];
-      const invalid: Array<{ terminal: TerminalInstance; errors: ValidationResult }> = [];
+      const valid: PtyPanelData[] = [];
+      const invalid: Array<{ terminal: PtyPanelData; errors: ValidationResult }> = [];
 
       for (const terminal of activeTerminals) {
         const result = validationResults.get(terminal.id);
@@ -237,8 +251,8 @@ export const createTerminalBulkActionsSlice = (
 
     bulkRestartByWorktree: async (worktreeId) => {
       const terminals = getTerminals();
-      const activeTerminals = terminals.filter(
-        (t) => t.worktreeId === worktreeId && t.location !== "trash"
+      const activeTerminals = terminals.filter((t): t is PtyPanelData =>
+        isPtyPanel(t) && t.worktreeId === worktreeId && t.location !== "trash"
       );
       if (activeTerminals.length === 0) return;
 
@@ -296,20 +310,22 @@ export const createTerminalBulkActionsSlice = (
       // (a plain shell where `claude` is currently the foreground process),
       // not just spawn-sealed agent terminals.
       const idleAgents = terminals.filter(
-        (t) => t.agentState === "idle" && isRuntimeAgentTerminal(t)
+        (t): t is PtyPanelData =>
+          isPtyPanel(t) && t.agentState === "idle" && isRuntimeAgentTerminal(t)
       );
       await restartTerminals(idleAgents);
     },
 
     getCountByState: (state) => {
       const terminals = getTerminals();
-      return terminals.filter((t) => t.agentState === state).length;
+      return terminals.filter((t) => isPtyPanel(t) && t.agentState === state).length;
     },
 
     getCountByWorktree: (worktreeId, state) => {
       const terminals = getTerminals();
       return terminals.filter(
-        (t) => t.worktreeId === worktreeId && (!state || t.agentState === state)
+        (t) =>
+          t.worktreeId === worktreeId && (!state || (isPtyPanel(t) && t.agentState === state))
       ).length;
     },
 

--- a/src/store/slices/terminalCommandQueueSlice.ts
+++ b/src/store/slices/terminalCommandQueueSlice.ts
@@ -1,7 +1,10 @@
 import type { StateCreator } from "zustand";
-import type { TerminalInstance } from "./panelRegistrySlice";
+import { isPtyPanel } from "@shared/types/panel";
 import type { AgentState } from "@/types";
 import { terminalClient } from "@/clients";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 export type InputOrigin = "user" | "automation";
 
@@ -34,7 +37,7 @@ export interface TerminalCommandQueueSlice {
 
 export const createTerminalCommandQueueSlice =
   (
-    getTerminal: (id: string) => TerminalInstance | undefined
+    getTerminal: (id: string) => CarrierPanel | undefined
   ): StateCreator<TerminalCommandQueueSlice, [], [], TerminalCommandQueueSlice> =>
   (set, get) => ({
     commandQueue: [],
@@ -53,7 +56,8 @@ export const createTerminalCommandQueueSlice =
         return;
       }
 
-      if (isAgentReady(terminal.agentState)) {
+      const agentState = isPtyPanel(terminal) ? terminal.agentState : undefined;
+      if (isAgentReady(agentState)) {
         terminalClient.write(terminalId, payload);
         return;
       }
@@ -73,9 +77,10 @@ export const createTerminalCommandQueueSlice =
 
     processQueue: (terminalId) => {
       const terminal = getTerminal(terminalId);
-      if (!terminal || !isAgentReady(terminal.agentState)) {
+      const agentState = terminal && isPtyPanel(terminal) ? terminal.agentState : undefined;
+      if (!terminal || !isAgentReady(agentState)) {
         console.warn(
-          `Cannot process queue: terminal ${terminalId} is not ready (state: ${terminal?.agentState})`
+          `Cannot process queue: terminal ${terminalId} is not ready (state: ${agentState})`
         );
         return;
       }

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -1,10 +1,13 @@
 import type { StateCreator } from "zustand";
-import type { TerminalInstance } from "./panelRegistrySlice";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { isRuntimeAgentTerminal } from "@/utils/terminalType";
 import { isTerminalVisible } from "@/lib/terminalVisibility";
 import type { TerminalFocusTarget } from "@/components/Terminal/terminalFocus";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 export type NavigationDirection = "up" | "down" | "left" | "right";
 
@@ -15,13 +18,13 @@ export type NavigationDirection = "up" | "down" | "left" | "right";
 // "next" lands on the next match after that position rather than resetting to
 // index 0 — and stays robust when an agent's state changes between presses.
 function cycleToMatch(
-  terminals: TerminalInstance[],
+  terminals: CarrierPanel[],
   focusedId: string | null,
   isInTrash: (id: string) => boolean,
   validWorktreeIds: Set<string>,
-  predicate: (t: TerminalInstance) => boolean,
+  predicate: (t: CarrierPanel) => boolean,
   direction: "next" | "prev"
-): TerminalInstance | undefined {
+): CarrierPanel | undefined {
   const visibleList = terminals.filter((t) => isTerminalVisible(t, isInTrash, validWorktreeIds));
   const len = visibleList.length;
   if (len === 0) return undefined;
@@ -40,8 +43,8 @@ function cycleToMatch(
 }
 
 function isOpenableDockTerminal(
-  terminal: TerminalInstance | undefined
-): terminal is TerminalInstance {
+  terminal: CarrierPanel | undefined
+): terminal is CarrierPanel {
   if (!terminal) return false;
   if (terminal.location !== "dock") return false;
   return true;
@@ -103,7 +106,7 @@ export interface TerminalFocusSlice {
   /** Validate and cleanup maximize state if target is invalid */
   validateMaximizeTarget: (
     getPanelGroup: (panelId: string) => { id: string; panelIds: string[] } | undefined,
-    getTerminal: (id: string) => TerminalInstance | undefined
+    getTerminal: (id: string) => CarrierPanel | undefined
   ) => void;
   clearPreMaximizeLayout: () => void;
   focusNext: () => void;
@@ -143,14 +146,14 @@ export interface TerminalFocusSlice {
 
   handleTerminalRemoved: (
     removedId: string,
-    terminals: TerminalInstance[],
+    terminals: CarrierPanel[],
     removedIndex: number
   ) => void;
 }
 
 export const createTerminalFocusSlice =
   (
-    getTerminals: () => TerminalInstance[],
+    getTerminals: () => CarrierPanel[],
     getActiveWorktreeId: () => string | null,
     stampLastActive: (id: string) => void
   ): StateCreator<TerminalFocusSlice, [], [], TerminalFocusSlice> =>
@@ -338,7 +341,7 @@ export const createTerminalFocusSlice =
       focusNext: () => {
         const terminals = getTerminals();
         const activeWorktreeId = getActiveWorktreeId();
-        const worktreeMatch = (t: TerminalInstance) =>
+        const worktreeMatch = (t: CarrierPanel) =>
           (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined);
 
         const gridTerminals = terminals.filter(
@@ -357,7 +360,7 @@ export const createTerminalFocusSlice =
       focusPrevious: () => {
         const terminals = getTerminals();
         const activeWorktreeId = getActiveWorktreeId();
-        const worktreeMatch = (t: TerminalInstance) =>
+        const worktreeMatch = (t: CarrierPanel) =>
           (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined);
 
         const gridTerminals = terminals.filter(
@@ -414,10 +417,10 @@ export const createTerminalFocusSlice =
         if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
           terminalInstanceService.wake(id);
         }
-        if (terminal?.agentState === "waiting") {
+        if (isPtyPanel(terminal) && terminal.agentState === "waiting") {
           window.electron?.notification?.acknowledgeWaiting(id);
         }
-        if (terminal?.agentState === "working") {
+        if (isPtyPanel(terminal) && terminal.agentState === "working") {
           window.electron?.notification?.acknowledgeWorkingPulse(id);
         }
         const previousFocusedId = get().focusedId;
@@ -451,10 +454,10 @@ export const createTerminalFocusSlice =
         const focusActuallyChanged = id !== previousFocusedId;
 
         if (terminal.location === "dock") {
-          if (terminal.agentState === "waiting") {
+          if (isPtyPanel(terminal) && terminal.agentState === "waiting") {
             window.electron?.notification?.acknowledgeWaiting(id);
           }
-          if (terminal.agentState === "working") {
+          if (isPtyPanel(terminal) && terminal.agentState === "working") {
             window.electron?.notification?.acknowledgeWorkingPulse(id);
           }
           set({
@@ -492,7 +495,7 @@ export const createTerminalFocusSlice =
           focusedId,
           isInTrash,
           validWorktreeIds,
-          (t) => t.agentState === "waiting",
+          (t) => isPtyPanel(t) && t.agentState === "waiting",
           "next"
         );
         if (!next) return;
@@ -507,7 +510,7 @@ export const createTerminalFocusSlice =
           focusedId,
           isInTrash,
           validWorktreeIds,
-          (t) => t.agentState === "working",
+          (t) => isPtyPanel(t) && t.agentState === "working",
           "next"
         );
         if (!next) return;
@@ -524,7 +527,7 @@ export const createTerminalFocusSlice =
           focusedId,
           isInTrash,
           validWorktreeIds,
-          isRuntimeAgentTerminal,
+          (t) => isRuntimeAgentTerminal(t),
           "next"
         );
         if (!next) return;
@@ -541,7 +544,7 @@ export const createTerminalFocusSlice =
           focusedId,
           isInTrash,
           validWorktreeIds,
-          isRuntimeAgentTerminal,
+          (t) => isRuntimeAgentTerminal(t),
           "prev"
         );
         if (!prev) return;
@@ -557,10 +560,11 @@ export const createTerminalFocusSlice =
           .setActiveTab;
 
         const dockTerminals = terminals.filter(
-          (t) =>
+          (t): t is PanelInstance =>
             t.location === "dock" &&
-            t.ephemeral !== true &&
             (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined) &&
+            isPtyPanel(t) &&
+            t.ephemeral !== true &&
             t.agentState === "waiting"
         );
 

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -42,9 +42,7 @@ function cycleToMatch(
   return undefined;
 }
 
-function isOpenableDockTerminal(
-  terminal: CarrierPanel | undefined
-): terminal is CarrierPanel {
+function isOpenableDockTerminal(terminal: CarrierPanel | undefined): terminal is CarrierPanel {
   if (!terminal) return false;
   if (terminal.location !== "dock") return false;
   return true;

--- a/src/store/storeAccessors.ts
+++ b/src/store/storeAccessors.ts
@@ -1,7 +1,14 @@
-import type { TerminalInstance, TabGroup } from "@shared/types";
+import type { TabGroup } from "@shared/types";
+import { getNarrowPanel } from "./slices/panelRegistry/selectors";
+
+// Carrier element from the legacy `panelsById` shape, sourced through
+// `getNarrowPanel`'s parameter so this file doesn't import the deprecated
+// `TerminalInstance` alias by name. The carrier itself flips to
+// `PanelInstance` in #8957 step 5; this alias auto-resolves through.
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 export interface PanelStoreSnapshot {
-  panelsById: Record<string, TerminalInstance>;
+  panelsById: Record<string, CarrierPanel>;
   panelIds: string[];
   tabGroups: Map<string, TabGroup>;
 }

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -1,6 +1,6 @@
 import { create, type StateCreator } from "zustand";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
-import { TerminalRefreshTier } from "@shared/types/panel";
+import { TerminalRefreshTier, isPtyPanel } from "@shared/types/panel";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
 import type { FleetScopeToken } from "@shared/types/worktree";
@@ -816,7 +816,7 @@ function applyWorktreeTerminalPolicy(
     terminalInstanceService.applyRendererPolicy(terminal.id, targetTier);
     if (
       targetTier !== TerminalRefreshTier.BACKGROUND &&
-      terminal.hasPty !== false &&
+      (!isPtyPanel(terminal) || terminal.hasPty !== false) &&
       panelKindHasPty(terminal.kind ?? "terminal")
     ) {
       try {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 // Re-exports shared types - eliminates manual type synchronization
+// eslint-disable-next-line no-restricted-imports -- TerminalInstance bleeds through the star re-export; sanctioned until step 6 (#8957) retires the interface
 export * from "@shared/types";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,2 @@
 // Re-exports shared types - eliminates manual type synchronization
-// eslint-disable-next-line no-restricted-imports -- TerminalInstance bleeds through the star re-export; sanctioned until step 6 (#8957) retires the interface
 export * from "@shared/types";

--- a/src/utils/__tests__/panelProps.test.ts
+++ b/src/utils/__tests__/panelProps.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { buildPanelProps } from "../panelProps";
-import type { TerminalInstance } from "@/store";
+import type { PtyPanelData } from "@shared/types/panel";
 import type { ActivityState } from "@/components/Terminal/TerminalPane";
 
 const noop = () => {};
 
-function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+function makeTerminal(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id: "t-1",
     title: "Terminal 1",
@@ -27,10 +27,10 @@ function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstan
     detectedProcessId: undefined,
     browserUrl: undefined,
     ...overrides,
-  } as TerminalInstance;
+  } as PtyPanelData;
 }
 
-function build(terminal: TerminalInstance) {
+function build(terminal: PtyPanelData) {
   return buildPanelProps({
     terminal,
     isFocused: false,

--- a/src/utils/destructiveSessionConfirm.ts
+++ b/src/utils/destructiveSessionConfirm.ts
@@ -1,6 +1,7 @@
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { CLOSE_CONFIRM_AGENT_STATES, coerceAgentState } from "@shared/types/agent";
 import { isAgentTerminal } from "@/utils/terminalType";
+import { isPtyPanel } from "@shared/types/panel";
 
 // Carrier element from the legacy `panelsById` shape, sourced through
 // `getNarrowPanel`'s parameter so this file doesn't import the deprecated
@@ -25,7 +26,7 @@ export function terminalHasRunningAgentSession(
 ): boolean {
   if (!terminal) return false;
   if (!isAgentTerminal(terminal)) return false;
-  const state = coerceAgentState(terminal.agentState);
+  const state = coerceAgentState(isPtyPanel(terminal) ? terminal.agentState : undefined);
   return state !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(state);
 }
 

--- a/src/utils/destructiveSessionConfirm.ts
+++ b/src/utils/destructiveSessionConfirm.ts
@@ -1,6 +1,13 @@
-import type { TerminalInstance } from "@shared/types";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { CLOSE_CONFIRM_AGENT_STATES, coerceAgentState } from "@shared/types/agent";
 import { isAgentTerminal } from "@/utils/terminalType";
+
+// Carrier element from the legacy `panelsById` shape, sourced through
+// `getNarrowPanel`'s parameter so this file doesn't import the deprecated
+// `TerminalInstance` alias by name. Lets external callers that still hand
+// out raw carrier entries pass through until the rest of the renderer
+// migrates to `getNarrowPanel` (#8957).
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 /**
  * True when a terminal is an agent terminal AND is currently in an
@@ -14,7 +21,7 @@ import { isAgentTerminal } from "@/utils/terminalType";
  * terminals only confirm while truly mid-work.
  */
 export function terminalHasRunningAgentSession(
-  terminal: TerminalInstance | undefined | null
+  terminal: CarrierPanel | undefined | null
 ): boolean {
   if (!terminal) return false;
   if (!isAgentTerminal(terminal)) return false;
@@ -27,7 +34,7 @@ export function terminalHasRunningAgentSession(
  * Used by bulk actions to decide whether to confirm before mutating.
  */
 export function collectRunningAgentTerminals(
-  terminals: ReadonlyArray<TerminalInstance>
-): TerminalInstance[] {
+  terminals: ReadonlyArray<CarrierPanel>
+): CarrierPanel[] {
   return terminals.filter((t) => terminalHasRunningAgentSession(t));
 }

--- a/src/utils/destructiveSessionConfirm.ts
+++ b/src/utils/destructiveSessionConfirm.ts
@@ -21,9 +21,7 @@ type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
  * and their bulk siblings: bare PTY terminals stay D0 (no confirm), agent
  * terminals only confirm while truly mid-work.
  */
-export function terminalHasRunningAgentSession(
-  terminal: CarrierPanel | undefined | null
-): boolean {
+export function terminalHasRunningAgentSession(terminal: CarrierPanel | undefined | null): boolean {
   if (!terminal) return false;
   if (!isAgentTerminal(terminal)) return false;
   const state = coerceAgentState(isPtyPanel(terminal) ? terminal.agentState : undefined);

--- a/src/utils/panelProps.ts
+++ b/src/utils/panelProps.ts
@@ -3,6 +3,7 @@ import type { PanelComponentProps } from "@/registry";
 import type { ActivityState } from "@/components/Terminal/TerminalPane";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 import { clampZoom } from "@/components/Browser/browserUtils";
+import { isPtyPanel, isBrowserPanel } from "@shared/types/panel";
 
 // Carrier element from the legacy `panelsById` shape, sourced through
 // `getNarrowPanel`'s parameter so this file doesn't import the deprecated
@@ -57,6 +58,9 @@ export function buildPanelProps({
   isFocused,
   overrides,
 }: BuildPanelPropsConfig): PanelComponentProps {
+  const pty = isPtyPanel(terminal) ? terminal : undefined;
+  const browser = isBrowserPanel(terminal) ? terminal : undefined;
+
   return {
     id: terminal.id,
     title: terminal.title,
@@ -70,49 +74,49 @@ export function buildPanelProps({
 
     // Terminal-specific
     type: undefined,
-    everDetectedAgent: terminal.everDetectedAgent,
-    agentId: terminal.launchAgentId,
-    detectedAgentId: terminal.detectedAgentId,
-    runtimeIdentity: terminal.runtimeIdentity,
+    everDetectedAgent: pty?.everDetectedAgent,
+    agentId: pty?.launchAgentId,
+    detectedAgentId: pty?.detectedAgentId,
+    runtimeIdentity: pty?.runtimeIdentity,
     chrome: deriveTerminalChrome({
       kind: terminal.kind,
-      launchAgentId: terminal.launchAgentId,
-      runtimeIdentity: terminal.runtimeIdentity,
-      detectedAgentId: terminal.detectedAgentId,
-      detectedProcessId: terminal.detectedProcessId,
-      agentState: terminal.agentState,
-      runtimeStatus: terminal.runtimeStatus,
-      exitCode: terminal.exitCode,
-      presetColor: terminal.agentPresetColor,
+      launchAgentId: pty?.launchAgentId,
+      runtimeIdentity: pty?.runtimeIdentity,
+      detectedAgentId: pty?.detectedAgentId,
+      detectedProcessId: pty?.detectedProcessId,
+      agentState: pty?.agentState,
+      runtimeStatus: pty?.runtimeStatus,
+      exitCode: pty?.exitCode,
+      presetColor: pty?.agentPresetColor,
     }),
-    agentPresetId: terminal.agentPresetId,
-    presetColor: terminal.agentPresetColor,
-    agentLaunchFlags: terminal.agentLaunchFlags,
-    cwd: terminal.cwd,
-    agentState: terminal.agentState,
+    agentPresetId: pty?.agentPresetId,
+    presetColor: pty?.agentPresetColor,
+    agentLaunchFlags: pty?.agentLaunchFlags,
+    cwd: pty?.cwd,
+    agentState: pty?.agentState,
     activity: getStableActivity(
       terminal.id,
-      terminal.activityHeadline,
-      terminal.activityStatus,
-      terminal.activityType
+      pty?.activityHeadline,
+      pty?.activityStatus,
+      pty?.activityType
     ),
-    activityStatus: terminal.activityStatus,
-    lastCommand: terminal.lastCommand,
-    flowStatus: terminal.flowStatus,
-    restartKey: terminal.restartKey,
-    restartError: terminal.restartError,
-    reconnectError: terminal.reconnectError,
-    spawnError: terminal.spawnError,
-    scrollbackRestoreError: terminal.scrollbackRestoreError,
-    detectedProcessId: terminal.detectedProcessId,
+    activityStatus: pty?.activityStatus,
+    lastCommand: pty?.lastCommand,
+    flowStatus: pty?.flowStatus,
+    restartKey: pty?.restartKey,
+    restartError: pty?.restartError,
+    reconnectError: pty?.reconnectError,
+    spawnError: pty?.spawnError,
+    scrollbackRestoreError: pty?.scrollbackRestoreError,
+    detectedProcessId: pty?.detectedProcessId,
 
     // Extension state
     extensionState: terminal.extensionState,
 
     // Browser-specific
-    initialUrl: terminal.browserUrl || "http://localhost:3000",
-    initialHistory: terminal.browserHistory,
-    initialZoom: clampZoom(terminal.browserZoom ?? 1.0),
+    initialUrl: browser?.browserUrl || "http://localhost:3000",
+    initialHistory: browser?.browserHistory,
+    initialZoom: clampZoom(browser?.browserZoom ?? 1.0),
 
     ...overrides,
   };

--- a/src/utils/panelProps.ts
+++ b/src/utils/panelProps.ts
@@ -1,8 +1,15 @@
-import type { TerminalInstance } from "@/store";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import type { PanelComponentProps } from "@/registry";
 import type { ActivityState } from "@/components/Terminal/TerminalPane";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 import { clampZoom } from "@/components/Browser/browserUtils";
+
+// Carrier element from the legacy `panelsById` shape, sourced through
+// `getNarrowPanel`'s parameter so this file doesn't import the deprecated
+// `TerminalInstance` alias by name. Lets external callers that still hand
+// out raw carrier entries pass through until the rest of the renderer
+// migrates to `getNarrowPanel` (#8957).
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 const activityCache = new Map<string, ActivityState>();
 
@@ -40,7 +47,7 @@ function getStableActivity(
 }
 
 export interface BuildPanelPropsConfig {
-  terminal: TerminalInstance;
+  terminal: CarrierPanel;
   isFocused: boolean;
   overrides: Partial<PanelComponentProps>;
 }

--- a/src/utils/terminalValidation.ts
+++ b/src/utils/terminalValidation.ts
@@ -1,5 +1,12 @@
-import type { TerminalInstance } from "@/types";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { systemClient } from "@/clients/systemClient";
+
+// Carrier element from the legacy `panelsById` shape, sourced through
+// `getNarrowPanel`'s parameter so this file doesn't import the deprecated
+// `TerminalInstance` alias by name. Lets external callers that still hand
+// out raw carrier entries pass through until the rest of the renderer
+// migrates to `getNarrowPanel` (#8957).
+type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 import { getAgentConfig } from "@/config/agents";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
@@ -16,7 +23,7 @@ export interface ValidationResult {
 }
 
 export async function validateTerminalConfig(
-  terminal: TerminalInstance
+  terminal: CarrierPanel
 ): Promise<ValidationResult> {
   const errors: ValidationError[] = [];
 
@@ -77,7 +84,7 @@ export async function validateTerminalConfig(
 }
 
 export async function validateTerminals(
-  terminals: TerminalInstance[]
+  terminals: CarrierPanel[]
 ): Promise<Map<string, ValidationResult>> {
   const results = new Map<string, ValidationResult>();
 

--- a/src/utils/terminalValidation.ts
+++ b/src/utils/terminalValidation.ts
@@ -1,5 +1,6 @@
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { systemClient } from "@/clients/systemClient";
+import { isPtyPanel } from "@shared/types/panel";
 
 // Carrier element from the legacy `panelsById` shape, sourced through
 // `getNarrowPanel`'s parameter so this file doesn't import the deprecated
@@ -27,14 +28,16 @@ export async function validateTerminalConfig(
 ): Promise<ValidationResult> {
   const errors: ValidationError[] = [];
 
+  const pty = isPtyPanel(terminal) ? terminal : undefined;
+
   // Only validate cwd for PTY panels that have it
-  if (terminal.cwd) {
+  if (pty?.cwd) {
     try {
-      const cwdExists = await systemClient.checkDirectory(terminal.cwd);
+      const cwdExists = await systemClient.checkDirectory(pty.cwd);
       if (!cwdExists) {
         errors.push({
           type: "cwd",
-          message: `Working directory does not exist: ${terminal.cwd}`,
+          message: `Working directory does not exist: ${pty.cwd}`,
           code: "ENOENT",
           recoverable: true,
         });
@@ -43,7 +46,7 @@ export async function validateTerminalConfig(
       const message = formatErrorMessage(error, "Failed to check directory");
       errors.push({
         type: "config",
-        message: `Failed to validate working directory "${terminal.cwd}": ${message}`,
+        message: `Failed to validate working directory "${pty.cwd}": ${message}`,
         recoverable: true,
       });
     }
@@ -54,7 +57,7 @@ export async function validateTerminalConfig(
   // the user asked for is on PATH. `detectedAgentId` doesn't exist yet at that
   // point, and using it later would validate the wrong binary for runtime-morphed
   // sessions (e.g., a plain shell that started a different agent).
-  const agentId = terminal.launchAgentId;
+  const agentId = pty?.launchAgentId;
   if (agentId && agentId !== "terminal") {
     try {
       const agentConfig = getAgentConfig(agentId);

--- a/src/utils/terminalValidation.ts
+++ b/src/utils/terminalValidation.ts
@@ -23,9 +23,7 @@ export interface ValidationResult {
   errors: ValidationError[];
 }
 
-export async function validateTerminalConfig(
-  terminal: CarrierPanel
-): Promise<ValidationResult> {
+export async function validateTerminalConfig(terminal: CarrierPanel): Promise<ValidationResult> {
   const errors: ValidationError[] = [];
 
   const pty = isPtyPanel(terminal) ? terminal : undefined;


### PR DESCRIPTION
## Summary

Finishes draining `TerminalInstance` from the renderer store carrier, completing #8957. Five commits across three drain phases, bundled into one PR rather than the originally planned three sequential PRs — each commit requires the previous, and there's no natural reviewable boundary between them.

## Commits

1. **Batch C+** — drain `TerminalInstance` from all remaining consumers (121 files)
2. **Step 5** — flip the `panelsById` carrier to `PanelInstance` (86 files)
3. **Step 6** — retire `TerminalInstance` entirely; lift `createdAt`/`lastActiveAt` to `BasePanelData` (12 files)
4. **Review fixup** — restore `createdAt`/`lastActiveAt` on `TerminalInstance` + `PanelSnapshot`; gate dock move on `hasPty` (5 files)
5. **Format** — Prettier autoformat pass covering the changed files (40 files)

## Why one PR instead of three?

The original plan was three sequential PRs. In practice each commit depends on the previous one to type-check, and none of them form a self-contained reviewable chunk on their own. Bundling is cleaner and easier to roll back if anything goes sideways.

Closes #8957

## Test plan

- [ ] Terminal panels open and close without console errors
- [ ] Fleet arming works across PTY and non-PTY panel kinds
- [ ] `panelStore` serialization round-trips correctly (open app, reload, panels restore)
- [ ] Existing unit tests pass (`npm test`)