### PR TITLE
fix(terminal): pass Tab through to PTY for shell autocomplete (#9082)

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -13,7 +13,6 @@ import { getSoftNewlineSequence } from "../../../shared/utils/terminalInputProto
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
-import { resolveTerminalTabEscape } from "./terminalFocus";
 import { useTerminalFileTransfer } from "./useTerminalFileTransfer";
 
 export interface XtermAdapterProps {
@@ -258,36 +257,6 @@ export function XtermAdapter({
         // Only process keydown events to avoid double-firing
         if (event.type !== "keydown") {
           return true;
-        }
-
-        // Tab/Shift+Tab escape: xterm otherwise transmits Tab to the PTY as \t,
-        // trapping keyboard-only users in the terminal. Mirror F6 region cycling
-        // by dispatching the same navigation actions, then suppress the PTY
-        // write. Handled before the repeat guard so a held Tab can't leak \t on
-        // key-repeat; the focus move only dispatches on the initial keydown.
-        // resolveTerminalTabEscape itself ignores IME composition and
-        // Ctrl/Alt/Meta combos, so this stays ahead of the guards below. (#8935)
-        const tabEscape = resolveTerminalTabEscape(event);
-        if (tabEscape) {
-          if (!event.repeat) {
-            void actionService
-              .dispatch(
-                tabEscape === "prev" ? "nav.focusRegion.prev" : "nav.focusRegion.next",
-                undefined,
-                { source: "keybinding" }
-              )
-              .then((dispatchResult) => {
-                if (!dispatchResult.ok) {
-                  logError("[XtermTabEscape] Failed to move focus region", undefined, {
-                    error: dispatchResult.error,
-                  });
-                }
-              })
-              .catch((error) => {
-                logError("[XtermTabEscape] Unexpected error", error);
-              });
-          }
-          return false;
         }
 
         // Skip repeat events
@@ -646,7 +615,7 @@ export function XtermAdapter({
         ref={containerRef}
         className="w-full h-full min-h-0 min-w-0"
         aria-label="Terminal output"
-        aria-keyshortcuts="F6 Tab Shift+Tab"
+        aria-keyshortcuts="F6 Shift+F6"
         role="application"
       />
     </div>

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -297,10 +297,16 @@ describe("XtermAdapter lifecycle", () => {
     const keyHandler = mocks.getKeyHandler();
     expect(keyHandler).toBeTruthy();
 
-    const tabResult = keyHandler?.(
-      new KeyboardEvent("keydown", { key: "Tab", code: "Tab", bubbles: true, cancelable: true })
-    );
+    const tabEvent = new KeyboardEvent("keydown", {
+      key: "Tab",
+      code: "Tab",
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = vi.spyOn(tabEvent, "preventDefault");
+    const tabResult = keyHandler?.(tabEvent);
     expect(tabResult).toBe(true);
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
 
     const shiftTabResult = keyHandler?.(
       new KeyboardEvent("keydown", {
@@ -312,6 +318,19 @@ describe("XtermAdapter lifecycle", () => {
       })
     );
     expect(shiftTabResult).toBe(true);
+
+    // Held Tab (key-repeat) must also pass through — shell autocomplete and
+    // many TUIs rely on sustained Tab presses.
+    const repeatedTabResult = keyHandler?.(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        code: "Tab",
+        repeat: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    expect(repeatedTabResult).toBe(true);
 
     expect(actionService.dispatch).not.toHaveBeenCalled();
   });

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -5,6 +5,7 @@ import React, { Suspense } from "react";
 import { render, waitFor, cleanup } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalRefreshTier } from "@/types";
+import { actionService } from "@/services/ActionService";
 import { XtermAdapter } from "../XtermAdapter";
 
 const mocks = vi.hoisted(() => {
@@ -287,6 +288,32 @@ describe("XtermAdapter lifecycle", () => {
     expect(firstOnExit).not.toHaveBeenCalled();
     expect(secondOnExit).toHaveBeenCalledWith(7);
     expect(mocks.terminalInstanceService.detach).not.toHaveBeenCalled();
+  });
+
+  it("passes Tab and Shift+Tab through to the PTY without dispatching focus-region actions (#9082)", async () => {
+    renderAdapter();
+    await waitFor(() => expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1));
+
+    const keyHandler = mocks.getKeyHandler();
+    expect(keyHandler).toBeTruthy();
+
+    const tabResult = keyHandler?.(
+      new KeyboardEvent("keydown", { key: "Tab", code: "Tab", bubbles: true, cancelable: true })
+    );
+    expect(tabResult).toBe(true);
+
+    const shiftTabResult = keyHandler?.(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        code: "Tab",
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    expect(shiftTabResult).toBe(true);
+
+    expect(actionService.dispatch).not.toHaveBeenCalled();
   });
 
   it("re-applies renderer policy when a stable tier provider returns a new tier", async () => {

--- a/src/components/Terminal/__tests__/terminalFocus.test.ts
+++ b/src/components/Terminal/__tests__/terminalFocus.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   getTerminalFocusTarget,
   isLikelyAtSynthesizedPointer,
-  resolveTerminalTabEscape,
   shouldShowHybridInputBar,
   shouldSuppressUnfocusedClick,
 } from "../terminalFocus";
@@ -184,40 +183,5 @@ describe("isLikelyAtSynthesizedPointer", () => {
   it("honors a custom threshold", () => {
     expect(isLikelyAtSynthesizedPointer(1000, 1030, 20)).toBe(true);
     expect(isLikelyAtSynthesizedPointer(1000, 1010, 20)).toBe(false);
-  });
-});
-
-describe("resolveTerminalTabEscape", () => {
-  const base = {
-    key: "Tab",
-    shiftKey: false,
-    ctrlKey: false,
-    altKey: false,
-    metaKey: false,
-    isComposing: false,
-    keyCode: 9,
-  };
-
-  it("moves to the next region on plain Tab", () => {
-    expect(resolveTerminalTabEscape(base)).toBe("next");
-  });
-
-  it("moves to the previous region on Shift+Tab", () => {
-    expect(resolveTerminalTabEscape({ ...base, shiftKey: true })).toBe("prev");
-  });
-
-  it("ignores non-Tab keys", () => {
-    expect(resolveTerminalTabEscape({ ...base, key: "Enter" })).toBeNull();
-  });
-
-  it("ignores Tab during IME composition", () => {
-    expect(resolveTerminalTabEscape({ ...base, isComposing: true })).toBeNull();
-    expect(resolveTerminalTabEscape({ ...base, keyCode: 229 })).toBeNull();
-  });
-
-  it("ignores Tab combined with Ctrl/Alt/Meta so the TUI or global keybindings handle it", () => {
-    expect(resolveTerminalTabEscape({ ...base, ctrlKey: true })).toBeNull();
-    expect(resolveTerminalTabEscape({ ...base, altKey: true })).toBeNull();
-    expect(resolveTerminalTabEscape({ ...base, metaKey: true })).toBeNull();
   });
 });

--- a/src/components/Terminal/terminalFocus.ts
+++ b/src/components/Terminal/terminalFocus.ts
@@ -91,30 +91,3 @@ export function isLikelyAtSynthesizedPointer(
   if (lastMoveAt === null) return true;
   return now - lastMoveAt > thresholdMs;
 }
-
-export type TerminalFocusEscapeDirection = "next" | "prev";
-
-/**
- * Resolve whether a keydown inside a focused xterm should escape terminal
- * focus to an adjacent macro region, and in which direction.
- *
- * Tab is an *additive* escape path alongside F6 (handled separately) so
- * keyboard-only users aren't trapped — xterm otherwise transmits Tab to the
- * PTY as `\t`. Returns null for any other key, for Tab during IME composition,
- * and for Tab with Ctrl/Alt/Meta held (those reach the TUI or global
- * keybindings). Plain Tab moves to the next region; Shift+Tab the previous.
- */
-export function resolveTerminalTabEscape(event: {
-  key: string;
-  shiftKey: boolean;
-  ctrlKey: boolean;
-  altKey: boolean;
-  metaKey: boolean;
-  isComposing: boolean;
-  keyCode: number;
-}): TerminalFocusEscapeDirection | null {
-  if (event.key !== "Tab") return null;
-  if (event.isComposing || event.keyCode === 229) return null;
-  if (event.ctrlKey || event.altKey || event.metaKey) return null;
-  return event.shiftKey ? "prev" : "next";
-}


### PR DESCRIPTION
## Summary

- Tab and Shift+Tab were being intercepted in terminal panes and routed to focus-region navigation instead of the PTY, silently breaking shell and agent autocomplete.
- F6/Shift+F6 already covered that navigation path, making the Tab interception fully redundant.
- Pure deletion: removed `resolveTerminalTabEscape` and `TerminalFocusEscapeDirection` from `terminalFocus.ts`, removed the import and intercept block from `XtermAdapter.tsx`, updated `aria-keyshortcuts` from `"F6 Tab Shift+Tab"` to `"F6 Shift+F6"`, and removed the matching test block.

Resolves #9082

## Changes

- `src/components/Terminal/terminalFocus.ts` — removed `resolveTerminalTabEscape` function and `TerminalFocusEscapeDirection` type
- `src/components/Terminal/XtermAdapter.tsx` — removed import and Tab intercept block, updated `aria-keyshortcuts`
- `src/components/Terminal/__tests__/terminalFocus.test.ts` — removed the `resolveTerminalTabEscape` describe block
- `src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx` — added Tab passthrough regression test

## Testing

Added a regression test to `XtermAdapter.lifecycle.test.tsx` asserting the key handler returns `true` (PTY receives `\t`), `event.preventDefault()` is not called, Shift+Tab passes through, held Tab (key-repeat) passes through, and `actionService.dispatch` is never invoked. Typecheck, lint, format, and targeted vitest on both changed test files all pass.