### PR TITLE
fix(pty): wake suspended processes with SIGCONT after SIGTERM

### DIFF
--- a/electron/services/pty/ProcessTreeKiller.ts
+++ b/electron/services/pty/ProcessTreeKiller.ts
@@ -69,6 +69,7 @@ export class ProcessTreeKiller {
     const descendants = this.processTreeCache?.getDescendantPids(shellPid) ?? [];
 
     for (const pid of descendants) {
+      let sigtermBlocked = false;
       try {
         process.kill(pid, "SIGTERM");
       } catch (err) {
@@ -78,8 +79,14 @@ export class ProcessTreeKiller {
         // operator needs to know.
         if (code !== "ESRCH") {
           console.warn(`[ProcessTreeKiller] SIGTERM pid=${pid}: ${(err as Error).message}`);
+          sigtermBlocked = true;
         }
       }
+      // Skip SIGCONT when SIGTERM was rejected (EPERM, etc.) — there is no
+      // queued kill to deliver, and waking a process we couldn't signal does
+      // nothing useful. ESRCH falls through (the SIGCONT will also ESRCH and
+      // be silent).
+      if (sigtermBlocked) continue;
       try {
         process.kill(pid, "SIGCONT");
       } catch (err) {

--- a/electron/services/pty/ProcessTreeKiller.ts
+++ b/electron/services/pty/ProcessTreeKiller.ts
@@ -59,7 +59,13 @@ export class ProcessTreeKiller {
       return;
     }
 
-    // Unix: SIGTERM descendants bottom-up, then kill the shell
+    // Unix: SIGTERM descendants bottom-up, then kill the shell.
+    // SIGTERM is queued (not delivered) while a process is stopped via SIGSTOP
+    // (Ctrl+Z). SIGCONT wakes the process; the kernel then delivers the queued
+    // SIGTERM before any user-space code runs, so handlers like vite's port
+    // release fire normally. SIGTERM-then-SIGCONT (per pid) is the correct
+    // order — reversing it lets the resumed process fork() new children in the
+    // window between SIGCONT delivery and SIGTERM delivery.
     const descendants = this.processTreeCache?.getDescendantPids(shellPid) ?? [];
 
     for (const pid of descendants) {
@@ -74,12 +80,36 @@ export class ProcessTreeKiller {
           console.warn(`[ProcessTreeKiller] SIGTERM pid=${pid}: ${(err as Error).message}`);
         }
       }
+      try {
+        process.kill(pid, "SIGCONT");
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        // ESRCH is silent; EPERM warns because a failed SIGCONT leaves the
+        // stopped process holding its queued SIGTERM forever — a permanent
+        // orphan rather than a clean shutdown.
+        if (code !== "ESRCH") {
+          console.warn(`[ProcessTreeKiller] SIGCONT pid=${pid}: ${(err as Error).message}`);
+        }
+      }
     }
 
     try {
       this.ptyProcess.kill();
     } catch {
       // Process may already be dead
+    }
+
+    // node-pty's IPty.kill() sends SIGHUP to the shell, which also queues
+    // while stopped. Wake the shell so the queued SIGHUP delivers. Kept
+    // outside the ptyProcess.kill() try/catch so it still fires if that
+    // throws (already-dead shell → ESRCH here, silent).
+    try {
+      process.kill(shellPid, "SIGCONT");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ESRCH") {
+        console.warn(`[ProcessTreeKiller] SIGCONT pid=${shellPid}: ${(err as Error).message}`);
+      }
     }
 
     if (immediate) {

--- a/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
+++ b/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
@@ -58,6 +58,13 @@ describe("ProcessTreeKiller — kill() error discrimination", () => {
     killer.execute(true);
 
     expect(warnSpy).not.toHaveBeenCalled();
+    // Guard against the loop being silently skipped: both descendants must
+    // have received SIGTERM and the follow-up SIGCONT (ESRCH on SIGTERM is
+    // treated as "process already gone" — SIGCONT still runs and ESRCHs too).
+    expect(killSpy).toHaveBeenCalledWith(1001, "SIGTERM");
+    expect(killSpy).toHaveBeenCalledWith(1001, "SIGCONT");
+    expect(killSpy).toHaveBeenCalledWith(1002, "SIGTERM");
+    expect(killSpy).toHaveBeenCalledWith(1002, "SIGCONT");
   });
 
   it("warns once per pid when SIGTERM fails with EPERM", () => {
@@ -126,6 +133,10 @@ describe("ProcessTreeKiller — kill() error discrimination", () => {
       .map((c: unknown[]) => String(c[0]))
       .filter((m: string) => m.includes("SIGKILL"));
     expect(sigkillWarnings).toHaveLength(0);
+    // Guard against the sweep being a no-op: SIGKILL must have been attempted
+    // for both descendant and shell pids.
+    expect(killSpy).toHaveBeenCalledWith(3001, "SIGKILL");
+    expect(killSpy).toHaveBeenCalledWith(3000, "SIGKILL");
   });
 
   it("sends SIGCONT after SIGTERM for each descendant, then SIGCONT for shell", () => {
@@ -171,6 +182,11 @@ describe("ProcessTreeKiller — kill() error discrimination", () => {
       .map((c: unknown[]) => String(c[0]))
       .filter((m: string) => m.includes("SIGCONT"));
     expect(sigcontWarnings).toHaveLength(0);
+    // Guard against SIGCONT being silently skipped: each descendant and the
+    // shell must have received a SIGCONT call.
+    expect(killSpy).toHaveBeenCalledWith(5001, "SIGCONT");
+    expect(killSpy).toHaveBeenCalledWith(5002, "SIGCONT");
+    expect(killSpy).toHaveBeenCalledWith(5000, "SIGCONT");
   });
 
   it("warns once per pid when SIGCONT fails with EPERM", () => {
@@ -198,6 +214,30 @@ describe("ProcessTreeKiller — kill() error discrimination", () => {
     sigcontWarnings.forEach((m: string) => {
       expect(m).toContain("[ProcessTreeKiller]");
     });
+  });
+
+  it("skips SIGCONT when SIGTERM fails with EPERM", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
+      if (sig === "SIGTERM") {
+        throw makeErrnoError("EPERM", "kill EPERM");
+      }
+      return true;
+    });
+
+    const killer = new ProcessTreeKiller(makePty(8000), makeTreeCache([8001, 8002]));
+    killer.execute(true);
+
+    // Descendant SIGCONT must NOT be called when its SIGTERM was rejected.
+    // Waking a process we couldn't signal would let it run freely without
+    // the queued SIGTERM the wake was meant to deliver.
+    expect(killSpy).not.toHaveBeenCalledWith(8001, "SIGCONT");
+    expect(killSpy).not.toHaveBeenCalledWith(8002, "SIGCONT");
+    // Shell SIGCONT is independent of the descendant gate — it's tied to
+    // ptyProcess.kill() (SIGHUP), not the descendant SIGTERM loop.
+    expect(killSpy).toHaveBeenCalledWith(8000, "SIGCONT");
   });
 
   it("sends shell SIGCONT even when ptyProcess.kill() throws", () => {

--- a/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
+++ b/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
@@ -127,4 +127,95 @@ describe("ProcessTreeKiller — kill() error discrimination", () => {
       .filter((m: string) => m.includes("SIGKILL"));
     expect(sigkillWarnings).toHaveLength(0);
   });
+
+  it("sends SIGCONT after SIGTERM for each descendant, then SIGCONT for shell", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const pty = makePty(4000);
+    const killer = new ProcessTreeKiller(pty, makeTreeCache([4001, 4002]));
+    // Use a deferred escalation so SIGKILL doesn't fire and obscure the
+    // SIGTERM/SIGCONT call sequence we're asserting.
+    killer.execute(false);
+
+    const signals = killSpy.mock.calls.map((c: unknown[]) => [c[0], c[1]]);
+    expect(signals).toEqual([
+      [4001, "SIGTERM"],
+      [4001, "SIGCONT"],
+      [4002, "SIGTERM"],
+      [4002, "SIGCONT"],
+      [4000, "SIGCONT"],
+    ]);
+    expect(pty.kill).toHaveBeenCalledTimes(1);
+
+    killer.abort();
+  });
+
+  it("silently ignores ESRCH from SIGCONT calls", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
+      if (sig === "SIGCONT") {
+        throw makeErrnoError("ESRCH");
+      }
+      return true;
+    });
+
+    const killer = new ProcessTreeKiller(makePty(5000), makeTreeCache([5001, 5002]));
+    killer.execute(true);
+
+    const sigcontWarnings = warnSpy.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .filter((m: string) => m.includes("SIGCONT"));
+    expect(sigcontWarnings).toHaveLength(0);
+  });
+
+  it("warns once per pid when SIGCONT fails with EPERM", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
+      if (sig === "SIGCONT") {
+        throw makeErrnoError("EPERM", "kill EPERM");
+      }
+      return true;
+    });
+
+    const killer = new ProcessTreeKiller(makePty(6000), makeTreeCache([6001, 6002]));
+    killer.execute(true);
+
+    const sigcontWarnings = warnSpy.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .filter((m: string) => m.includes("SIGCONT"));
+    // Two descendants + one shell SIGCONT.
+    expect(sigcontWarnings).toHaveLength(3);
+    expect(sigcontWarnings.some((m: string) => m.includes("pid=6001"))).toBe(true);
+    expect(sigcontWarnings.some((m: string) => m.includes("pid=6002"))).toBe(true);
+    expect(sigcontWarnings.some((m: string) => m.includes("pid=6000"))).toBe(true);
+    sigcontWarnings.forEach((m: string) => {
+      expect(m).toContain("[ProcessTreeKiller]");
+    });
+  });
+
+  it("sends shell SIGCONT even when ptyProcess.kill() throws", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const pty = makePty(7000);
+    (pty.kill as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("pty already exited");
+    });
+    const killer = new ProcessTreeKiller(pty, makeTreeCache([]));
+    killer.execute(true);
+
+    const shellSigcont = killSpy.mock.calls.find(
+      (c: unknown[]) => c[0] === 7000 && c[1] === "SIGCONT"
+    );
+    expect(shellSigcont).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary

- When a process is suspended (Ctrl+Z / `SIGSTOP`), it ignores `SIGTERM`. `ProcessTreeKiller` was sending `SIGTERM` then waiting 500ms to escalate to `SIGKILL`, so any stopped descendant always took the `SIGKILL` path and never ran its shutdown handlers. Dev servers like `vite` and `next dev` use those handlers to release bound ports and child workers, so the result was orphaned ports or subprocesses after every terminal close on a suspended process.
- Fix: send `SIGCONT` after `SIGTERM` for each descendant. POSIX queues `SIGTERM` while the process is stopped and delivers it on `SIGCONT` before any user code runs, so handlers fire normally. `ptyProcess.kill()` (node-pty sends `SIGHUP`) also gets a matching `SIGCONT`. Signal order is `SIGTERM`-then-`SIGCONT` intentionally -- reversing it risks the resumed process `fork()`ing untracked children in the delivery window before `SIGTERM` arrives.
- `sigkillSweep` is unchanged -- `SIGKILL` is uncatchable, so the kernel delivers it to stopped processes directly; `SIGCONT` beforehand is redundant. `SIGCONT` is also skipped when the preceding `SIGTERM` was rejected with a non-`ESRCH` error (e.g. `EPERM`) -- waking a process we couldn't signal would let it run freely with a permanently undelivered kill. `ESRCH` on `SIGCONT` is swallowed silently; `EPERM` logs a warning because a failed wake leaves the stopped process orphaned. POSIX-only change -- Windows uses `taskkill /T /F`.

Resolves #9085

## Changes

- `electron/services/pty/ProcessTreeKiller.ts` -- added `SIGCONT` after `SIGTERM` in the descendant kill loop, `SIGCONT` after `ptyProcess.kill()`, and the associated error handling
- `electron/services/pty/__tests__/ProcessTreeKiller.test.ts` -- 5 new vitest cases on top of the existing 4 (signal ordering, `SIGCONT` `ESRCH` silent, `SIGCONT` `EPERM` warns per pid, shell `SIGCONT` fires even when `ptyProcess.kill()` throws, `SIGCONT` skipped when `SIGTERM` `EPERM`s)

## Testing

9 vitest cases covering the full signal-ordering contract, all error-handling branches, and the shell `SIGCONT` path.