### PR TITLE
fix(dev-preview): retune stuck-tier thresholds and suppress Tier 2 mid-compile

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -121,21 +121,31 @@ interface DevPreviewStuckBannerProps {
   error: UseDevServerReturn["error"];
   /** Disables the banner actions while a restart is already in flight. */
   isRestarting: boolean;
+  /**
+   * When `"Compiling"` at Tier 3, the banner swaps to long-compile copy
+   * instead of the generic "didn't start" framing — the server clearly
+   * started, the first compile is just slow.
+   */
+  phaseLabel?: "Compiling";
   onRestart: () => void;
   onRemedy: (actionId: string) => void;
 }
 
 /**
- * Staged stuck-start escalation banner (#8276). Replaces the old silent
- * auto-restart with a user-driven signal: Tier 2 is a warning that the
- * server is slow, Tier 3 an error that names likely causes and, when the
- * dev server emitted a recognised error, offers a variant-specific remedy
- * (`error.recommendedActionId`) alongside a plain restart.
+ * Staged stuck-start escalation banner (#8276, copy retuned #9099). Replaces
+ * the old silent auto-restart with a user-driven signal: Tier 2 is a warning
+ * that the server is slow (suppressed by the hook while `phaseLabel ===
+ * "Compiling"` — compile evidence isn't "stuck"), Tier 3 an error that names
+ * likely causes and, when the dev server emitted a recognised error, offers
+ * a variant-specific remedy (`error.recommendedActionId`) alongside a plain
+ * restart. At Tier 3 with `phaseLabel === "Compiling"` the copy switches to
+ * a long-compile framing instead of the "didn't start" framing.
  */
 function DevPreviewStuckBanner({
   tier,
   error,
   isRestarting,
+  phaseLabel,
   onRestart,
   onRemedy,
 }: DevPreviewStuckBannerProps) {
@@ -179,15 +189,21 @@ function DevPreviewStuckBanner({
         ]
       : [restartAction];
 
+  const isLongCompile = phaseLabel === "Compiling" && !error?.message;
+  const title = isLongCompile
+    ? "First compile is taking longer than usual"
+    : "Dev server still hasn't started";
   const description = error?.message
     ? error.message
-    : "Likely causes: the port is still bound by another process, dependencies are missing, or the build cache is stuck. Check the terminal logs.";
+    : isLongCompile
+      ? "The initial compile is still running. Check the terminal logs — large projects can take 45s or more."
+      : "Likely causes: the port is still bound by another process, dependencies are missing, or the build cache is stuck. Check the terminal logs.";
 
   return (
     <InlineStatusBanner
       icon={AlertTriangle}
       severity="error"
-      title="Dev server still hasn't started"
+      title={title}
       description={description}
       role="alert"
       ariaLive="assertive"
@@ -1213,6 +1229,7 @@ export function DevPreviewPane({
             tier={stuckTier >= 3 ? 3 : 2}
             error={error}
             isRestarting={isRestarting}
+            phaseLabel={phaseLabel}
             onRestart={handleRestartDevServer}
             onRemedy={handleStuckRemedy}
           />

--- a/src/hooks/__tests__/useDevServer.adversarial.test.tsx
+++ b/src/hooks/__tests__/useDevServer.adversarial.test.tsx
@@ -610,7 +610,7 @@ describe("useDevServer adversarial races", () => {
     expect(result.current.url).toBe("http://localhost:4173/");
   });
 
-  it("escalates stuckTier at 6s/12s/25s without restarting a stuck starting session (#8276)", async () => {
+  it("escalates stuckTier at 6s/20s/45s without restarting a stuck starting session (#8276, retuned #9099)", async () => {
     vi.useFakeTimers();
     try {
       ensureMock.mockImplementation((request: { projectId: string }) =>
@@ -651,20 +651,23 @@ describe("useDevServer adversarial races", () => {
       expect(result.current.stuckTier).toBe(0);
       expect(ensureMock).toHaveBeenCalledTimes(1);
 
+      // 0 → 6000 (Tier 1)
       await act(async () => {
         vi.advanceTimersByTime(6000);
         await Promise.resolve();
       });
       expect(result.current.stuckTier).toBe(1);
 
+      // 6000 → 20000 (Tier 2)
       await act(async () => {
-        vi.advanceTimersByTime(6000);
+        vi.advanceTimersByTime(14000);
         await Promise.resolve();
       });
       expect(result.current.stuckTier).toBe(2);
 
+      // 20000 → 45000 (Tier 3)
       await act(async () => {
-        vi.advanceTimersByTime(13000);
+        vi.advanceTimersByTime(25000);
         await Promise.resolve();
       });
       expect(result.current.stuckTier).toBe(3);
@@ -756,7 +759,7 @@ describe("useDevServer adversarial races", () => {
     }
   });
 
-  it("advances stuckTier exactly on the 6s/12s/25s boundaries (#8276)", async () => {
+  it("advances stuckTier exactly on the 6s/20s/45s boundaries (#8276, retuned #9099)", async () => {
     vi.useFakeTimers();
     try {
       ensureMock.mockImplementation((request: { projectId: string }) =>
@@ -804,16 +807,152 @@ describe("useDevServer adversarial races", () => {
       expect(result.current.stuckTier).toBe(0);
       await tick(1); // 6000
       expect(result.current.stuckTier).toBe(1);
-      await tick(5999); // 11999
+      await tick(13999); // 19999
       expect(result.current.stuckTier).toBe(1);
-      await tick(1); // 12000
+      await tick(1); // 20000
       expect(result.current.stuckTier).toBe(2);
-      await tick(12999); // 24999
+      await tick(24999); // 44999
       expect(result.current.stuckTier).toBe(2);
-      await tick(1); // 25000
+      await tick(1); // 45000
       expect(result.current.stuckTier).toBe(3);
 
       expect(restartMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("suppresses Tier 2 when phaseLabel turns 'Compiling' before the 20s mark (#9099)", async () => {
+    vi.useFakeTimers();
+    try {
+      ensureMock.mockImplementation((request: { projectId: string }) =>
+        Promise.resolve(
+          buildState({
+            panelId: "panel-1",
+            projectId: request.projectId,
+            status: "starting",
+            terminalId: `term-${request.projectId}`,
+          })
+        )
+      );
+      getStateMock.mockImplementation((request: { projectId: string }) =>
+        Promise.resolve(
+          buildState({
+            panelId: "panel-1",
+            projectId: request.projectId,
+            status: "starting",
+            terminalId: `term-${request.projectId}`,
+          })
+        )
+      );
+      let stateChangedHandler: ((payload: { state: DevPreviewSessionState }) => void) | null = null;
+      onStateChangedMock.mockImplementation(
+        (cb: (payload: { state: DevPreviewSessionState }) => void) => {
+          stateChangedHandler = cb;
+          return vi.fn();
+        }
+      );
+
+      const { result } = renderHook(() =>
+        useDevServer({
+          panelId: "panel-1",
+          devCommand: "npm run dev",
+          cwd: "/repo",
+        })
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Advance past Tier 1 — confirm ambient signal still fires.
+      await act(async () => {
+        vi.advanceTimersByTime(6000);
+        await Promise.resolve();
+      });
+      expect(result.current.stuckTier).toBe(1);
+
+      // Backend emits "Compiling" before the 20s Tier 2 timer fires.
+      await act(async () => {
+        stateChangedHandler?.({
+          state: buildState({
+            panelId: "panel-1",
+            projectId: "project-1",
+            status: "starting",
+            terminalId: "term-project-1",
+            phaseLabel: "Compiling",
+          }),
+        });
+        await Promise.resolve();
+      });
+      expect(result.current.phaseLabel).toBe("Compiling");
+
+      // 6000 → 20000: Tier 2 timer fires, but the fire-time guard
+      // suppresses it because Compiling is now active.
+      await act(async () => {
+        vi.advanceTimersByTime(14000);
+        await Promise.resolve();
+      });
+      expect(result.current.stuckTier).toBe(1);
+
+      // 20000 → 45000: Tier 3 still fires even mid-compile.
+      await act(async () => {
+        vi.advanceTimersByTime(25000);
+        await Promise.resolve();
+      });
+      expect(result.current.stuckTier).toBe(3);
+
+      expect(restartMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("allows Tier 2 to fire normally when phaseLabel never reaches 'Compiling' (#9099)", async () => {
+    vi.useFakeTimers();
+    try {
+      ensureMock.mockImplementation((request: { projectId: string }) =>
+        Promise.resolve(
+          buildState({
+            panelId: "panel-1",
+            projectId: request.projectId,
+            status: "starting",
+            terminalId: `term-${request.projectId}`,
+          })
+        )
+      );
+      getStateMock.mockImplementation((request: { projectId: string }) =>
+        Promise.resolve(
+          buildState({
+            panelId: "panel-1",
+            projectId: request.projectId,
+            status: "starting",
+            terminalId: `term-${request.projectId}`,
+          })
+        )
+      );
+
+      const { result } = renderHook(() =>
+        useDevServer({
+          panelId: "panel-1",
+          devCommand: "npm run dev",
+          cwd: "/repo",
+        })
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Advance to 20s with no Compiling signal — Tier 2 must fire.
+      await act(async () => {
+        vi.advanceTimersByTime(20000);
+        await Promise.resolve();
+      });
+      expect(result.current.phaseLabel).toBeUndefined();
+      expect(result.current.stuckTier).toBe(2);
     } finally {
       vi.useRealTimers();
     }

--- a/src/hooks/__tests__/useDevServer.test.ts
+++ b/src/hooks/__tests__/useDevServer.test.ts
@@ -579,22 +579,26 @@ describe("useDevServer logic", () => {
     });
   });
 
-  // ─── Staged stuck-start escalation (#8276) ────────────────────────
+  // ─── Staged stuck-start escalation (#8276, retuned #9099) ─────────
   //
   // Mirrors the hook's timer effect: when the server is genuinely stuck
-  // in `starting`, `stuckTier` advances at 6s/12s/25s. The old behaviour
+  // in `starting`, `stuckTier` advances at 6s/20s/45s. The old behaviour
   // (silent `devPreview.restart()` at 10s) is gone — escalation now only
-  // produces a tier number; the user drives any restart.
+  // produces a tier number; the user drives any restart. Tier 2 is
+  // suppressed at fire time when `phaseLabel === "Compiling"` because a
+  // confirmed compile in progress is not "no signal." Tier 3 still fires
+  // at 45s even mid-compile.
   describe("stuckTier escalation", () => {
     const STUCK_TIER1_MS = 6000;
-    const STUCK_TIER2_MS = 12000;
-    const STUCK_TIER3_MS = 25000;
+    const STUCK_TIER2_MS = 20000;
+    const STUCK_TIER3_MS = 45000;
     const POST_SPAWN_POLL_WINDOW_MS = 5000; // lesson #4169
 
     type StuckSession = {
       status: DevPreviewStatus;
       url: string | null;
       terminalId: string | null;
+      phaseLabel?: "Compiling";
     };
 
     // Schedule-time gate: matches the effect's early `setStuckTier(0)`.
@@ -612,7 +616,8 @@ describe("useDevServer logic", () => {
     }
 
     // Fire-time guard + tier accumulation: matches `advanceTier`, which
-    // re-checks the latest session before raising the tier.
+    // re-checks the latest session (including phaseLabel) before raising
+    // the tier. Tier 2 is gated on `phaseLabel !== "Compiling"`.
     function computeStuckTier(
       elapsedMs: number,
       sessionAtFire: StuckSession,
@@ -624,7 +629,7 @@ describe("useDevServer logic", () => {
         sessionAtFire.status === "starting" && !sessionAtFire.url && !!sessionAtFire.terminalId;
       if (!stillStuck) return 0;
       if (elapsedMs >= STUCK_TIER1_MS) tier = 1;
-      if (elapsedMs >= STUCK_TIER2_MS) tier = 2;
+      if (elapsedMs >= STUCK_TIER2_MS && sessionAtFire.phaseLabel !== "Compiling") tier = 2;
       if (elapsedMs >= STUCK_TIER3_MS) tier = 3;
       return tier;
     }
@@ -638,12 +643,27 @@ describe("useDevServer logic", () => {
       ).toBe(0);
     });
 
-    it("escalates 1 → 2 → 3 at 6s / 12s / 25s", () => {
+    it("escalates 1 → 2 → 3 at 6s / 20s / 45s", () => {
       const eligible = isStuckEligible(starting, eligibleCtx);
       expect(computeStuckTier(STUCK_TIER1_MS, starting, eligible)).toBe(1);
       expect(computeStuckTier(STUCK_TIER2_MS, starting, eligible)).toBe(2);
       expect(computeStuckTier(STUCK_TIER3_MS, starting, eligible)).toBe(3);
-      expect(computeStuckTier(60000, starting, eligible)).toBe(3);
+      expect(computeStuckTier(90000, starting, eligible)).toBe(3);
+    });
+
+    it("suppresses Tier 2 when phaseLabel is 'Compiling' at fire time (#9099)", () => {
+      const compiling: StuckSession = {
+        ...starting,
+        phaseLabel: "Compiling",
+      };
+      const eligible = isStuckEligible(compiling, eligibleCtx);
+      // Tier 1 still fires at 6s — it is the cheap ambient signal.
+      expect(computeStuckTier(STUCK_TIER1_MS, compiling, eligible)).toBe(1);
+      // Tier 2 is suppressed: 20s mid-compile is not a stuck signal.
+      expect(computeStuckTier(STUCK_TIER2_MS, compiling, eligible)).toBe(1);
+      expect(computeStuckTier(STUCK_TIER3_MS - 1, compiling, eligible)).toBe(1);
+      // Tier 3 still fires at 45s — a 45s compile is itself worth surfacing.
+      expect(computeStuckTier(STUCK_TIER3_MS, compiling, eligible)).toBe(3);
     });
 
     it("never escalates while installing (first-run installs are exempt)", () => {
@@ -685,6 +705,14 @@ describe("useDevServer logic", () => {
       // Lesson #4169: the 5s URL-detection poll resolves fast-start false
       // positives; tier 1 must sit strictly past that window.
       expect(STUCK_TIER1_MS).toBeGreaterThan(POST_SPAWN_POLL_WINDOW_MS);
+    });
+
+    it("Tier 3 covers webpack-mode enterprise cold builds (#9099)", () => {
+      // Measured: Next.js webpack medium ~45s, webpack enterprise 45-90s.
+      // The new 45s threshold must reach those projects without firing on
+      // healthy Vite cold builds (15-45s, mostly below the new mark).
+      expect(STUCK_TIER3_MS).toBeGreaterThanOrEqual(45000);
+      expect(STUCK_TIER2_MS).toBeGreaterThanOrEqual(20000);
     });
 
     it("escalation produces only a tier — it never triggers a restart", () => {

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -37,24 +37,29 @@ export interface UseDevServerReturn extends UseDevServerState {
   isRestarting: boolean;
   /**
    * Escalation level while the server is stuck in `starting`. 0 = not stuck,
-   * 1 = ambient (6s), 2 = warning banner (12s), 3 = error banner (25s).
-   * Resets to 0 whenever status leaves `starting`.
+   * 1 = ambient (6s), 2 = warning banner (20s), 3 = error banner (45s).
+   * Resets to 0 whenever status leaves `starting`. Tier 2 is suppressed when
+   * `phaseLabel === "Compiling"` — a confirmed compile in progress is not
+   * "no signal," and Tier 3 still fires at 45s if the compile drags on.
    */
   stuckTier: DevServerStuckTier;
   forceKilled?: boolean;
 }
 
 /**
- * Staged stuck-start escalation thresholds (#8276). When the dev server stays
- * in `starting` past each threshold, `stuckTier` advances so the UI can
- * surface a progressively stronger, user-driven signal instead of silently
- * restarting (which wiped the logs explaining the stall). All three timers
- * are scheduled together from a single effect; tier 1 sits well past the 5s
- * post-spawn URL poll window so it never fires for fast-starting servers.
+ * Staged stuck-start escalation thresholds (#8276, retuned #9099). When the
+ * dev server stays in `starting` past each threshold, `stuckTier` advances so
+ * the UI can surface a progressively stronger, user-driven signal instead of
+ * silently restarting (which wiped the logs explaining the stall). The
+ * thresholds were rescaled in #9099 from 6/12/25s to 6/20/45s after measured
+ * cold-start data (Vite cold monorepo 15–45s, Next.js webpack medium ~45s,
+ * webpack enterprise 45–90s) showed the old values fired false alarms on
+ * realistic projects. Tier 1 still sits past the 5s post-spawn URL poll
+ * window so it never fires for fast-starting servers.
  */
 const STUCK_TIER1_MS = 6000;
-const STUCK_TIER2_MS = 12000;
-const STUCK_TIER3_MS = 25000;
+const STUCK_TIER2_MS = 20000;
+const STUCK_TIER3_MS = 45000;
 
 export type DevServerStuckTier = 0 | 1 | 2 | 3;
 
@@ -117,10 +122,12 @@ export function useDevServer({
     status: DevPreviewStatus;
     url: string | null;
     terminalId: string | null;
+    phaseLabel: "Compiling" | undefined;
   }>({
     status: "stopped",
     url: null,
     terminalId: null,
+    phaseLabel: undefined,
   });
   const isMountedRef = useRef(true);
   const isEnsuringRef = useRef(false);
@@ -177,6 +184,7 @@ export function useDevServer({
       status: state.status,
       url: state.url,
       terminalId: state.terminalId,
+      phaseLabel: state.phaseLabel,
     };
     setStatus(state.status);
     setUrl(state.url);
@@ -197,10 +205,12 @@ export function useDevServer({
       status: "error",
       url: null,
       terminalId: null,
+      phaseLabel: undefined,
     };
     setStatus("error");
     setError({ type: "unknown", message });
     setTerminalId(null);
+    setPhaseLabel(undefined);
     setIsRestarting(false);
   }, []);
 
@@ -350,11 +360,13 @@ export function useDevServer({
         status: "stopped",
         url: null,
         terminalId: null,
+        phaseLabel: undefined,
       };
       setStatus("stopped");
       setUrl(null);
       setTerminalId(null);
       setError(null);
+      setPhaseLabel(undefined);
       setIsRestarting(false);
       lastEnsureConfigRef.current = "";
       pendingEnsureConfigRef.current = null;
@@ -481,6 +493,11 @@ export function useDevServer({
       if (latestContext.panelId !== requestPanelId) return;
       if (latestSession.status !== "starting" || latestSession.url || !latestSession.terminalId)
         return;
+      // #9099: Tier 2 means "no signal yet" — once the backend has emitted
+      // `phaseLabel === "Compiling"`, that IS a signal, so suppress the
+      // warning banner. Tier 3 still fires at 45s even mid-compile because
+      // a 45s compile is itself worth surfacing.
+      if (tier === 2 && latestSession.phaseLabel === "Compiling") return;
 
       setStuckTier((prev) => (tier > prev ? tier : prev));
     };

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -466,11 +466,11 @@ export function useDevServer({
     ensureLatestConfig,
   ]);
 
-  // Staged stuck-start escalation (#8276). Replaces the old silent
-  // auto-restart: instead of firing `devPreview.restart()` once at 10s
-  // (which wiped the logs explaining the stall), we advance `stuckTier`
-  // at 6s/12s/25s so the UI can surface a user-driven signal. The user
-  // now drives any recovery explicitly via the banner actions.
+  // Staged stuck-start escalation (#8276, retuned #9099). Replaces the
+  // old silent auto-restart: instead of firing `devPreview.restart()`
+  // once at 10s (which wiped the logs explaining the stall), we advance
+  // `stuckTier` at 6s/20s/45s so the UI can surface a user-driven signal.
+  // The user now drives any recovery explicitly via the banner actions.
   useEffect(() => {
     if (status !== "starting" || !currentProjectId || !terminalId || url || isRestarting) {
       // `installing` and every other non-starting state falls through here,


### PR DESCRIPTION
## Summary

The stuck-tier escalation thresholds in `useDevServer.ts` were firing false alarms on realistic cold builds. Vite monorepo dep-prebundling runs 15–45s, Next.js webpack medium apps run ~45s, and webpack enterprise apps run 45–90s — Tier 3 at 25s was flagging a stalled server during what is actually a normal cold start for every framework we support.

Tier 2 had a second problem: it was firing on a wall-clock timer even when `phaseLabel === "Compiling"` was already active, meaning the user would see a warning banner at the same time they had visible compile progress in the terminal pane next to it.

Raises Tier 2 from 12s to 20s, Tier 3 from 25s to 45s. Tier 1 stays at 6s. Adds a fire-time guard in `advanceTier` so Tier 2 is suppressed when `phaseLabel === "Compiling"`. Tier 3 still fires at 45s mid-compile — a 45s compile is itself worth surfacing. Branches the Tier 3 banner copy: when compiling with no error message it shows a long-compile variant rather than the generic "Dev server still hasn't started" framing.

Resolves #9099

## Changes

- Threshold updates in `useDevServer.ts`: Tier 1 6s (unchanged), Tier 2 12s → 20s, Tier 3 25s → 45s
- `advanceTier` fire-time guard suppresses Tier 2 when `phaseLabel === "Compiling"`
- `latestSessionRef` extended with `phaseLabel`; written in all three sites (`applyState`, `applyInvokeError`, project-cleared reset)
- `phaseLabel` deliberately excluded from the stuck-tier `useEffect` dep array — adding it would reset all three countdown timers on every `phaseLabel` state change, exacerbated by React 19 StrictMode
- Tier 3 banner copy in `DevPreviewPane.tsx` branches on `phaseLabel === "Compiling"` with no error

## Testing

- Unit and adversarial fake-timer tests added covering Compiling suppression at fire time
- Existing threshold boundary tests updated to the new 6/20/45s values
- No E2E specs hardcoded the old constants