### PR TITLE
fix(terminal): pass bare F11 to PTY instead of toggling fullscreen (#9104)

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -296,7 +296,7 @@ export function XtermAdapter({
         // bubbles to the menu accelerator. Cancel the DOM/default path; return
         // true so xterm still emits the F11 sequence to the PTY.
         if (
-          event.key === "F11" &&
+          (event.key === "F11" || event.code === "F11" || event.keyCode === 122) &&
           !event.ctrlKey &&
           !event.altKey &&
           !event.metaKey &&

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -291,6 +291,22 @@ export function XtermAdapter({
           return true;
         }
 
+        // Bare F11 is Electron's fullscreen accelerator on Linux/Windows. xterm
+        // v6 leaves handled keys uncanceled in screen-reader mode, so the event
+        // bubbles to the menu accelerator. Cancel the DOM/default path; return
+        // true so xterm still emits the F11 sequence to the PTY.
+        if (
+          event.key === "F11" &&
+          !event.ctrlKey &&
+          !event.altKey &&
+          !event.metaKey &&
+          !event.shiftKey
+        ) {
+          event.preventDefault();
+          event.stopPropagation();
+          return true;
+        }
+
         // Skip repeat events
         if (event.repeat) {
           return true;

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -344,6 +344,10 @@ describe("XtermAdapter lifecycle", () => {
   });
 
   it("captures bare F11 so Electron's fullscreen accelerator does not fire (#9104)", async () => {
+    // The regression condition is xterm v6's screen-reader mode, which skips
+    // its internal preventDefault on handled keys and lets F11 bubble to the
+    // Electron menu accelerator. The guard itself is unconditional, so this
+    // test exercises the same handler path regardless of screenReaderMode.
     renderAdapter();
     await waitFor(() => expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1));
 
@@ -389,6 +393,22 @@ describe("XtermAdapter lifecycle", () => {
     keyHandler?.(shiftF11Event);
     expect(shiftPreventDefaultSpy).not.toHaveBeenCalled();
     expect(shiftStopPropagationSpy).not.toHaveBeenCalled();
+
+    // Some input methods report key="Unidentified" with code/keyCode intact.
+    // xterm still emits F11 to the PTY via keyCode 122, so the guard must too.
+    const unidentifiedF11Event = new KeyboardEvent("keydown", {
+      key: "Unidentified",
+      code: "F11",
+      keyCode: 122,
+      bubbles: true,
+      cancelable: true,
+    });
+    const unidentifiedPreventDefaultSpy = vi.spyOn(unidentifiedF11Event, "preventDefault");
+    const unidentifiedStopPropagationSpy = vi.spyOn(unidentifiedF11Event, "stopPropagation");
+    const unidentifiedResult = keyHandler?.(unidentifiedF11Event);
+    expect(unidentifiedResult).toBe(true);
+    expect(unidentifiedPreventDefaultSpy).toHaveBeenCalled();
+    expect(unidentifiedStopPropagationSpy).toHaveBeenCalled();
 
     expect(actionService.dispatch).not.toHaveBeenCalled();
   });

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -343,6 +343,56 @@ describe("XtermAdapter lifecycle", () => {
     expect(actionService.dispatch).not.toHaveBeenCalled();
   });
 
+  it("captures bare F11 so Electron's fullscreen accelerator does not fire (#9104)", async () => {
+    renderAdapter();
+    await waitFor(() => expect(mocks.terminalInstanceService.attach).toHaveBeenCalledTimes(1));
+
+    const keyHandler = mocks.getKeyHandler();
+    expect(keyHandler).toBeTruthy();
+
+    const f11Event = new KeyboardEvent("keydown", {
+      key: "F11",
+      code: "F11",
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = vi.spyOn(f11Event, "preventDefault");
+    const stopPropagationSpy = vi.spyOn(f11Event, "stopPropagation");
+    const f11Result = keyHandler?.(f11Event);
+    expect(f11Result).toBe(true);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(stopPropagationSpy).toHaveBeenCalled();
+
+    // F11 with modifiers must still reach TUIs that bind them (e.g. Ctrl+F11).
+    const ctrlF11Event = new KeyboardEvent("keydown", {
+      key: "F11",
+      code: "F11",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const ctrlPreventDefaultSpy = vi.spyOn(ctrlF11Event, "preventDefault");
+    const ctrlStopPropagationSpy = vi.spyOn(ctrlF11Event, "stopPropagation");
+    keyHandler?.(ctrlF11Event);
+    expect(ctrlPreventDefaultSpy).not.toHaveBeenCalled();
+    expect(ctrlStopPropagationSpy).not.toHaveBeenCalled();
+
+    const shiftF11Event = new KeyboardEvent("keydown", {
+      key: "F11",
+      code: "F11",
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const shiftPreventDefaultSpy = vi.spyOn(shiftF11Event, "preventDefault");
+    const shiftStopPropagationSpy = vi.spyOn(shiftF11Event, "stopPropagation");
+    keyHandler?.(shiftF11Event);
+    expect(shiftPreventDefaultSpy).not.toHaveBeenCalled();
+    expect(shiftStopPropagationSpy).not.toHaveBeenCalled();
+
+    expect(actionService.dispatch).not.toHaveBeenCalled();
+  });
+
   it("re-applies renderer policy when a stable tier provider returns a new tier", async () => {
     let tier = TerminalRefreshTier.BACKGROUND;
     const getRefreshTier = vi.fn(() => tier);


### PR DESCRIPTION
## Summary

On Linux and Windows, bare `F11` inside a focused terminal was being intercepted by Electron's fullscreen accelerator instead of reaching the TUI. The root cause is xterm v6's screen-reader mode, which skips `preventDefault` on keys it handles, so the event bubbles up to the menu accelerator registered in `electron/menu.ts:361`. Same class of bug as the Tab passthrough we fixed in #9082 (commit `50ddea696`).

The fix is a renderer-side guard in `XtermAdapter`'s `customKeyEventHandler` that mirrors the Tab triple-check (`key`/`code`/`keyCode`) pattern. Bare `F11` now reaches the PTY as `\x1b[23~`; `F11` with any modifier (Ctrl, Alt, Meta, Shift) still falls through to Electron as expected. macOS is unaffected — fullscreen there is `Ctrl+Cmd+F`.

Resolves #9104

## Changes

- `XtermAdapter.tsx` — added bare `F11` guard in `customKeyEventHandler` (`preventDefault` + `stopPropagation`, returns `true` to pass the key to xterm)
- `XtermAdapter.lifecycle.test.tsx` — regression test covering bare `F11` passthrough, modifier-negative cases (`Ctrl+F11`, `Shift+F11` fall through), and the `Unidentified`+`code` variant; comment documents the xterm v6 screen-reader mode regression condition

## Testing

Unit test added alongside the existing Tab regression test in `XtermAdapter.lifecycle.test.tsx`. Covers bare `F11`, all four modifier combinations that should fall through, and the `Unidentified` key variant that xterm v6 screen-reader mode can produce.