### PR TITLE
fix(keybindings): block focus-region rebinds on bare text keys from stealing terminal input

### DIFF
--- a/src/hooks/__tests__/useGlobalKeybindings.test.tsx
+++ b/src/hooks/__tests__/useGlobalKeybindings.test.tsx
@@ -585,6 +585,93 @@ describe("useGlobalKeybindings — region focus key bypass (issue #7303)", () =>
       xterm.remove();
     }
   });
+
+  // Issue #9105 — bare-key focus-region rebinds (letters, punctuation) must not
+  // steal terminal input. Only non-text keys (F-keys, arrows, etc.) may bypass
+  // the xterm/editable bailouts as a focus-region escape.
+  it("does not let a bare letter focus-region rebind steal xterm input", () => {
+    mocks.keybindingService.getEffectiveCombo.mockImplementation((id: string) => {
+      if (id === "nav.focusRegion.next") return "q";
+      if (id === "nav.focusRegion.prev") return "Shift+q";
+      return undefined;
+    });
+    mocks.keybindingService.resolveKeybinding.mockReturnValue({
+      match: { actionId: "nav.focusRegion.next" },
+      chordPrefix: false,
+      shouldConsume: true,
+    });
+
+    const xterm = document.createElement("div");
+    xterm.className = "xterm";
+    document.body.appendChild(xterm);
+
+    try {
+      render(<Host />);
+      const event = dispatchKey("q", xterm);
+
+      expect(mocks.keybindingService.resolveKeybinding).not.toHaveBeenCalled();
+      expect(mocks.actionService.dispatch).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    } finally {
+      xterm.remove();
+    }
+  });
+
+  it("does not let a bare punctuation focus-region rebind steal xterm input", () => {
+    mocks.keybindingService.getEffectiveCombo.mockImplementation((id: string) => {
+      if (id === "nav.focusRegion.next") return "[";
+      if (id === "nav.focusRegion.prev") return "Shift+[";
+      return undefined;
+    });
+    mocks.keybindingService.resolveKeybinding.mockReturnValue({
+      match: { actionId: "nav.focusRegion.next" },
+      chordPrefix: false,
+      shouldConsume: true,
+    });
+
+    const xterm = document.createElement("div");
+    xterm.className = "xterm";
+    document.body.appendChild(xterm);
+
+    try {
+      render(<Host />);
+      const event = dispatchKey("[", xterm);
+
+      expect(mocks.keybindingService.resolveKeybinding).not.toHaveBeenCalled();
+      expect(mocks.actionService.dispatch).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    } finally {
+      xterm.remove();
+    }
+  });
+
+  it("does not let a bare letter focus-region rebind bypass the editable guard", () => {
+    mocks.keybindingService.getEffectiveCombo.mockImplementation((id: string) => {
+      if (id === "nav.focusRegion.next") return "q";
+      if (id === "nav.focusRegion.prev") return "Shift+q";
+      return undefined;
+    });
+    mocks.keybindingService.resolveKeybinding.mockReturnValue({
+      match: { actionId: "nav.focusRegion.next" },
+      chordPrefix: false,
+      shouldConsume: true,
+    });
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    try {
+      render(<Host />);
+      input.focus();
+      const event = dispatchKey("q", input);
+
+      expect(mocks.keybindingService.resolveKeybinding).not.toHaveBeenCalled();
+      expect(mocks.actionService.dispatch).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    } finally {
+      input.remove();
+    }
+  });
 });
 
 describe("useGlobalKeybindings — IME composition guard", () => {

--- a/src/hooks/useGlobalKeybindings.ts
+++ b/src/hooks/useGlobalKeybindings.ts
@@ -110,6 +110,11 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
       // below in resolveKeybinding → canExecute.
       const hasModifier = e.metaKey || e.ctrlKey;
       const isFocusRegion = isFocusRegionEvent(e);
+      // A single-character key (letter, digit, punctuation, Space) is text input
+      // that belongs to the terminal/editor — even if it happens to match a
+      // focus-region rebind. Only non-text keys (F-keys, arrows, Home/End/etc.)
+      // may bypass the editable/terminal bailouts as a focus-region escape.
+      const isFocusRegionNonTextKey = isFocusRegion && e.key.length !== 1;
       const isTerminalTabInput =
         isInTerminal &&
         (e.key === "Tab" || e.code === "Tab" || e.keyCode === 9) &&
@@ -117,7 +122,7 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
         !e.altKey &&
         !e.metaKey;
 
-      if (isEditable && !hasModifier && !pendingChord && !isFocusRegion) {
+      if (isEditable && !hasModifier && !pendingChord && !isFocusRegionNonTextKey) {
         return;
       }
 
@@ -132,7 +137,7 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
       // chord completion, or region focus. Bare keys (like X for fleet arming)
       // are blocked inside terminals so they don't steal typing — scoped
       // bindings only match when focus is outside .xterm.
-      if (isInTerminal && !hasModifier && !pendingChord && !isFocusRegion) {
+      if (isInTerminal && !hasModifier && !pendingChord && !isFocusRegionNonTextKey) {
         return;
       }
 


### PR DESCRIPTION
## Summary

The focus-region keybinding bypass was too broad. `isFocusRegionEvent()` returned true for the user's rebound combo and bypassed the terminal bare-key bailout entirely, so a key like `q` or `[` rebound to `nav.focusRegion.next`/`prev` would steal input from a focused terminal instead of reaching the shell.

The fix narrows the bypass to non-text keys only: `isFocusRegionNonTextKey = isFocusRegion && e.key.length !== 1`. Single-character keys (letters, digits, punctuation, Space) are text input — they pass through to the terminal or editor. F-keys, arrows, Home, End, PageUp, PageDown, Delete, Backspace, Escape, Enter, Insert, and Tab all have `e.key.length > 1` and continue to bypass as before. The Tab guard from #9083 stays orthogonal — it returns before `resolveKeybinding` regardless.

Closes #9105.

## Changes

- `src/hooks/useGlobalKeybindings.ts` — derive `isFocusRegionNonTextKey` from `e.key.length !== 1`; use it in place of `isFocusRegion` at the bypass site
- `src/hooks/__tests__/useGlobalKeybindings.test.tsx` — 3 new regression tests: bare letter (`q`), bare punctuation (`[`), bare letter in an editable input; existing F6/F7/Tab tests unchanged (26 total)

## Testing

- New regression tests cover the three failing cases from the issue
- Existing F6, F7, and Tab tests continue to pass
- E2E test at `e2e/full/platform/core-accessibility.spec.ts:293` (F6 escapes terminal) is unaffected — `"F6".length === 2` so the bypass still fires
- Format, typecheck, and lint all clean