### PR TITLE
fix(dev-preview): wait for TCP port release before restart (#9088)

### DIFF
--- a/electron/services/DevPreviewPortAllocator.ts
+++ b/electron/services/DevPreviewPortAllocator.ts
@@ -1,5 +1,8 @@
 import net from "node:net";
 
+export const PORT_FREE_POLL_INTERVAL_MS = 200;
+export const PORT_FREE_TIMEOUT_MS = 15_000;
+
 export async function allocatePort(
   portRegistry: Map<string, number>,
   sessionKey: string
@@ -45,4 +48,83 @@ export async function allocatePort(
 
 export function releasePort(portRegistry: Map<string, number>, sessionKey: string): void {
   portRegistry.delete(sessionKey);
+}
+
+/**
+ * Wait for a TCP port to become bindable again. Returns true when free, false
+ * on timeout or abort. Primarily addresses Windows TIME_WAIT after a force-kill
+ * of a dev server — the kernel can hold the socket for up to ~240s, which
+ * causes the next allocatePort/spawn to fail with EADDRINUSE on the same port.
+ * Probes with the same listen() call allocatePort uses, so a "free" answer
+ * here implies the allocator will also succeed (TOCTOU window aside).
+ */
+export async function waitForPortFree(
+  port: number,
+  signal: AbortSignal,
+  timeoutMs = PORT_FREE_TIMEOUT_MS
+): Promise<boolean> {
+  const deadline = performance.now() + timeoutMs;
+  while (performance.now() < deadline) {
+    if (signal.aborted) return false;
+    if (await probePortFree(port, signal)) return true;
+    if (signal.aborted) return false;
+    try {
+      await sleepWithAbort(PORT_FREE_POLL_INTERVAL_MS, signal);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+function probePortFree(port: number, signal: AbortSignal): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    let onAbort: () => void = () => {};
+    const settle = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      resolve(value);
+    };
+    if (signal.aborted) {
+      settle(false);
+      return;
+    }
+    const srv = net.createServer();
+    srv.unref();
+    srv.once("error", () => settle(false));
+    onAbort = () => {
+      try {
+        srv.close();
+      } catch {
+        // server may already be closing
+      }
+      settle(false);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    try {
+      srv.listen(port, "0.0.0.0", () => srv.close(() => settle(true)));
+    } catch {
+      settle(false);
+    }
+  });
+}
+
+function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -5,7 +5,12 @@ import {
   getInvalidCommandMessage,
   normalizeNextjsDevCommand,
 } from "./DevPreviewCommandNormalizer.js";
-import { allocatePort, releasePort } from "./DevPreviewPortAllocator.js";
+import {
+  allocatePort,
+  releasePort,
+  waitForPortFree,
+  PORT_FREE_TIMEOUT_MS,
+} from "./DevPreviewPortAllocator.js";
 import { waitForServerReady, READINESS_TIMEOUT_MS } from "./DevPreviewReadinessProbe.js";
 import {
   createSessionKey,
@@ -254,6 +259,10 @@ export class DevPreviewSessionService {
         });
 
         await this.stopSessionTerminal(session, "restart");
+        if (!(await this.waitForRegisteredPortFree(session, key))) {
+          state = this.getSessionState(request.projectId, request.panelId);
+          return;
+        }
         await this.spawnSessionTerminal(session);
         state = this.getSessionState(request.projectId, request.panelId);
       });
@@ -301,6 +310,10 @@ export class DevPreviewSessionService {
       // Next.js hold file handles on these directories, and a live process
       // causes EPERM on Windows.
       await this.stopSessionTerminal(session, "restart-clear-cache");
+
+      if (!(await this.waitForRegisteredPortFree(session, key))) {
+        return;
+      }
 
       const deletionError = await this.clearCacheDirs(session.cwd);
       if (deletionError) {
@@ -417,6 +430,33 @@ export class DevPreviewSessionService {
         const stopStartedAt = performance.now();
         await this.stopSessionTerminal(session, "stop", DEV_PREVIEW_STOP_ESCALATION_MS);
         const forceKilled = performance.now() - stopStartedAt >= DEV_PREVIEW_STOP_ESCALATION_MS;
+
+        const port = this.portRegistry.get(key);
+        if (port !== undefined) {
+          const portAbort = new AbortController();
+          const portFree = await waitForPortFree(port, portAbort.signal);
+          if (!portFree) {
+            // Release the registry entry so a subsequent ensure() picks a fresh
+            // port via allocatePort instead of immediately re-hitting the busy one.
+            releasePort(this.portRegistry, key);
+            this.updateSession(session, {
+              status: "error",
+              url: null,
+              assignedUrl: null,
+              error: {
+                type: "port-conflict",
+                message: `Port ${port} did not release within ${PORT_FREE_TIMEOUT_MS / 1000}s after stopping. Retry to start again.`,
+                port: String(port),
+              },
+              terminalId: null,
+              isRestarting: false,
+              forceKilled,
+              phaseLabel: undefined,
+            });
+            return;
+          }
+        }
+
         this.updateSession(session, {
           status: "stopped",
           url: null,
@@ -911,6 +951,41 @@ export class DevPreviewSessionService {
       normalized.includes("terminal not found") ||
       normalized.includes("unknown terminal")
     );
+  }
+
+  /**
+   * Wait for the session's registered port to release before respawning. On
+   * Windows a force-killed dev server can hold the socket in TIME_WAIT, which
+   * would otherwise cause the next spawn to fail with EADDRINUSE on the same
+   * port (allocatePort returns the registered port without re-probing).
+   * Returns true if free (or no port registered); on timeout, releases the
+   * port from the registry so a subsequent allocate picks a fresh candidate
+   * and surfaces an error state.
+   */
+  private async waitForRegisteredPortFree(
+    session: DevPreviewSession,
+    key: string
+  ): Promise<boolean> {
+    const port = this.portRegistry.get(key);
+    if (port === undefined) return true;
+    const abort = new AbortController();
+    const free = await waitForPortFree(port, abort.signal);
+    if (free) return true;
+    releasePort(this.portRegistry, key);
+    this.updateSession(session, {
+      status: "error",
+      url: null,
+      assignedUrl: null,
+      error: {
+        type: "port-conflict",
+        message: `Port ${port} did not release within ${PORT_FREE_TIMEOUT_MS / 1000}s. Retry to start again.`,
+        port: String(port),
+      },
+      terminalId: null,
+      isRestarting: false,
+      phaseLabel: undefined,
+    });
+    return false;
   }
 
   private async waitForTerminalGone(

--- a/electron/services/__tests__/DevPreviewPortAllocator.test.ts
+++ b/electron/services/__tests__/DevPreviewPortAllocator.test.ts
@@ -1,41 +1,70 @@
-import { describe, expect, it, vi } from "vitest";
-import { allocatePort, releasePort } from "../DevPreviewPortAllocator.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const netMock = vi.hoisted(() => ({
+  // Ports that should fail to bind (simulating EADDRINUSE).
+  busyPorts: new Set<number>(),
+  // Per-port: number of remaining failures before the port becomes free.
+  busyForCalls: new Map<number, number>(),
+}));
 
 vi.mock("node:net", () => {
-  const createServer = vi.fn((_options?: Record<string, unknown>) => {
-    let port = 0;
+  const createServer = vi.fn(() => {
+    let listenPort = 0;
+    const errorHandlers: Array<(err: Error) => void> = [];
+    let closed = false;
     return {
-      unref: vi.fn(function (this: ReturnType<typeof createServer>) {
+      unref(this: unknown) {
         return this;
-      }),
-      once(_event: string, cb: (err?: Error) => void) {
-        if (_event === "error") {
-          if (port === 4444) {
-            cb(new Error("EADDRINUSE"));
+      },
+      once(this: unknown, event: string, cb: (...args: unknown[]) => void) {
+        if (event === "error") errorHandlers.push(cb as (err: Error) => void);
+        return this;
+      },
+      listen(this: unknown, port: number, _host: string, cb?: () => void) {
+        listenPort = port;
+        queueMicrotask(() => {
+          if (closed) return;
+          let isBusy = netMock.busyPorts.has(port);
+          const remaining = netMock.busyForCalls.get(port);
+          if (remaining !== undefined && remaining > 0) {
+            isBusy = true;
+            netMock.busyForCalls.set(port, remaining - 1);
           }
-        }
+          if (isBusy) {
+            for (const h of errorHandlers) h(new Error("EADDRINUSE"));
+          } else {
+            cb?.();
+          }
+        });
         return this;
       },
-      listen(_port: number, _host: string, cb: () => void) {
-        port = _port;
-        if (_port === 4444) return;
-        cb();
-        return this;
-      },
-      close(cb: () => void) {
-        cb();
+      close(this: unknown, cb?: () => void) {
+        closed = true;
+        queueMicrotask(() => cb?.());
         return this;
       },
       address() {
-        return { port: 5678 };
+        return { port: listenPort === 0 ? 5678 : listenPort };
       },
     };
   });
+  return { default: { createServer }, createServer };
+});
 
-  return {
-    default: { createServer },
-    createServer,
-  };
+import {
+  allocatePort,
+  releasePort,
+  waitForPortFree,
+  PORT_FREE_POLL_INTERVAL_MS,
+} from "../DevPreviewPortAllocator.js";
+
+beforeEach(() => {
+  netMock.busyPorts.clear();
+  netMock.busyForCalls.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("allocatePort", () => {
@@ -65,5 +94,42 @@ describe("releasePort", () => {
   it("is harmless for missing keys", () => {
     const registry = new Map<string, number>();
     expect(() => releasePort(registry, "nonexistent")).not.toThrow();
+  });
+});
+
+describe("waitForPortFree", () => {
+  it("resolves true when the port is free on the first probe", async () => {
+    const free = await waitForPortFree(5000, new AbortController().signal, 1000);
+    expect(free).toBe(true);
+  });
+
+  it("resolves true once the port becomes free after several probes", async () => {
+    netMock.busyForCalls.set(6000, 3);
+    const free = await waitForPortFree(6000, new AbortController().signal, 5000);
+    expect(free).toBe(true);
+  });
+
+  it("resolves false on timeout when port stays busy", async () => {
+    netMock.busyPorts.add(4444);
+    const free = await waitForPortFree(4444, new AbortController().signal, 50);
+    expect(free).toBe(false);
+  });
+
+  it("resolves false when signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const free = await waitForPortFree(5000, controller.signal, 1000);
+    expect(free).toBe(false);
+  });
+
+  it("resolves false when aborted mid-poll", async () => {
+    netMock.busyPorts.add(4445);
+    const controller = new AbortController();
+    const promise = waitForPortFree(4445, controller.signal, 5000);
+    // Wait long enough for the first probe failure + sleep to start
+    await new Promise((resolve) => setTimeout(resolve, PORT_FREE_POLL_INTERVAL_MS / 2));
+    controller.abort();
+    const free = await promise;
+    expect(free).toBe(false);
   });
 });

--- a/electron/services/__tests__/DevPreviewPortRegistry.test.ts
+++ b/electron/services/__tests__/DevPreviewPortRegistry.test.ts
@@ -288,9 +288,12 @@ describe("DevPreviewSessionService — port registry (adversarial)", () => {
 
     // The same port should be reused after restart.
     expect(second.assignedUrl).toBe(portBefore);
-    // Port was reused — allocatePort returned early from registry, no new probe.
+    // allocatePort returned early from registry (no allocation probe), but
+    // restart now also calls waitForPortFree which probes once to confirm the
+    // old PTY released the port before respawning. One additional probe call
+    // is expected; allocatePort itself still does no extra work.
     const callsAfterRestart = vi.mocked(net.createServer).mock.calls.length;
-    expect(callsAfterRestart).toBe(callsAfterEnsure);
+    expect(callsAfterRestart).toBe(callsAfterEnsure + 1);
   });
 
   // ── Positive baseline ──────────────────────────────────────────────────────

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -2,6 +2,7 @@ import http from "node:http";
 import https from "node:https";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DevPreviewSessionService } from "../DevPreviewSessionService.js";
+import * as portAllocator from "../DevPreviewPortAllocator.js";
 import type { PtyClient } from "../PtyClient.js";
 import type { DevPreviewSessionState } from "../../../shared/types/ipc/devPreview.js";
 
@@ -834,6 +835,92 @@ describe("DevPreviewSessionService", () => {
 
     // Replay should not be called since URL was already detected
     expect(ptyClient.replayHistoryAsync).not.toHaveBeenCalled();
+  });
+
+  it("transitions to error when port doesn't release after stop", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.terminalId).toBeTruthy();
+
+    const waitSpy = vi.spyOn(portAllocator, "waitForPortFree").mockResolvedValueOnce(false);
+
+    const result = await service.stop({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+
+    expect(waitSpy).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("error");
+    expect(result.error?.type).toBe("port-conflict");
+    expect(result.error?.port).toBeDefined();
+    expect(result.terminalId).toBeNull();
+
+    // After a port-free timeout the registry entry is released so the next
+    // ensure() picks a fresh candidate via allocatePort.
+    const restarted = await service.ensure(baseRequest);
+    expect(restarted.assignedUrl).not.toBe(started.assignedUrl);
+  });
+
+  it("transitions to stopped when waitForPortFree succeeds", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.terminalId).toBeTruthy();
+
+    const waitSpy = vi.spyOn(portAllocator, "waitForPortFree").mockResolvedValueOnce(true);
+
+    const result = await service.stop({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+
+    expect(waitSpy).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("stopped");
+    expect(result.error).toBeNull();
+  });
+
+  it("does not wait for port-free when stopping a session with no terminal", async () => {
+    const waitSpy = vi.spyOn(portAllocator, "waitForPortFree");
+
+    const result = await service.stop({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+
+    expect(waitSpy).not.toHaveBeenCalled();
+    expect(result.status).toBe("stopped");
+  });
+
+  it("transitions to error when port doesn't release before restart", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.terminalId).toBeTruthy();
+    const initialSpawnCount = ptyClient.spawn.mock.calls.length;
+
+    vi.spyOn(portAllocator, "waitForPortFree").mockResolvedValueOnce(false);
+
+    const result = await service.restart({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error?.type).toBe("port-conflict");
+    // Spawn must not run when port is still occupied.
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(initialSpawnCount);
+  });
+
+  it("transitions to error when port doesn't release before restart-and-clear-cache", async () => {
+    const started = await service.ensure(baseRequest);
+    expect(started.terminalId).toBeTruthy();
+    const initialSpawnCount = ptyClient.spawn.mock.calls.length;
+
+    vi.spyOn(portAllocator, "waitForPortFree").mockResolvedValueOnce(false);
+
+    const result = await service.restartAndClearCache({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error?.type).toBe("port-conflict");
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(initialSpawnCount);
   });
 
   it("continues stop-by-panel cleanup when one session stop fails", async () => {


### PR DESCRIPTION
## Summary

- Process death isn't sufficient to declare a dev-preview session stopped — on Windows, a SIGKILL-escalated Node.js socket can sit in `TIME_WAIT` for up to ~240s, causing the next start to fail with `EADDRINUSE` on the same port.
- Adds a `waitForPortFree` helper to `DevPreviewPortAllocator` (200ms poll, 15s timeout, `AbortSignal`-aware, probes via `net.createServer().listen()`) and wires it into `stop`, `restart`, and `restartAndClearCache` in `DevPreviewSessionService` after `stopSessionTerminal` and before any respawn or `stopped` transition.
- On timeout, the port is evicted from the registry so the next `ensure()` call picks a fresh candidate via `allocatePort`, and a port-conflict error state is surfaced so the UI doesn't show a misleading stopped state while the socket is still held.

Resolves #9088

## Changes

- `DevPreviewPortAllocator.ts` — `waitForPortFree` helper + supporting constants
- `DevPreviewSessionService.ts` — private `waitForRegisteredPortFree` helper wired into `stop`, `restart`, `restartAndClearCache`
- `DevPreviewPortAllocator.test.ts` — rewritten mock to handle async error events + per-port busy state; 5 new `waitForPortFree` tests (free/becomes-free/busy-timeout/abort)
- `DevPreviewSessionService.test.ts` — 5 new integration tests covering the stop, restart, and restartAndClearCache paths
- `DevPreviewPortRegistry.test.ts` — updated `REGRESSION-H` to expect the one extra `createServer` call during restart (port reuse intent unchanged)

## Testing

127 tests across the 10 DevPreview-related files pass. On macOS/Linux the `waitForPortFree` probe is effectively a no-op fast path since listening sockets release immediately on process exit — the fix is load-bearing on Windows where `TIME_WAIT` persists after SIGKILL escalation.