### PR TITLE
fix(dev-preview): inject --port into Vite-based dev commands

### DIFF
--- a/e2e/full/panels/core-dev-preview-per-worktree.spec.ts
+++ b/e2e/full/panels/core-dev-preview-per-worktree.spec.ts
@@ -111,7 +111,7 @@ test.describe.serial("Core: Dev Preview — Per-Worktree Port Registry", () => {
 
   // ── Test 1 ─────────────────────────────────────────────────────────────────
 
-  test("main-worktree panel reaches Running and shows an assignedUrl", async () => {
+  test("main-worktree panel reaches Running and shows a predictedUrl", async () => {
     const { window } = ctx;
 
     // Confirm we start on the main worktree (default view).
@@ -137,7 +137,7 @@ test.describe.serial("Core: Dev Preview — Per-Worktree Port Registry", () => {
     // Read the address bar URL and store for later comparison.
     // Note: the address bar displays a host-port form (e.g. "localhost:7514")
     // — protocol is stripped via getDisplayUrl(). Reconstruct the canonical
-    // URL so it matches the IPC `assignedUrl` shape later.
+    // URL so it matches the IPC `predictedUrl` shape later.
     const addressBar = window.locator(SEL.browser.addressBar).first();
     await expect(addressBar).toHaveValue(/localhost:\d+/, { timeout: T_MEDIUM });
     const displayUrl = (await addressBar.inputValue()).trim();
@@ -208,9 +208,9 @@ test.describe.serial("Core: Dev Preview — Per-Worktree Port Registry", () => {
     expect(mainSession?.status).toBe("running");
     expect(featureSession?.status).toBe("running");
 
-    // Each session's assignedUrl must match what we observed in the address bar.
-    expect(mainSession?.assignedUrl).toBe(urlMain);
-    expect(featureSession?.assignedUrl).toBe(urlFeature);
+    // Each session's predictedUrl must match what we observed in the address bar.
+    expect(mainSession?.predictedUrl).toBe(urlMain);
+    expect(featureSession?.predictedUrl).toBe(urlFeature);
 
     // Sanity: the two sessions must have different panel IDs.
     expect(mainSession?.panelId).not.toBe(featureSession?.panelId);
@@ -257,6 +257,6 @@ test.describe.serial("Core: Dev Preview — Per-Worktree Port Registry", () => {
       mainWorktreeId
     );
     expect(mainAfter?.status).toBe("running");
-    expect(mainAfter?.assignedUrl).toBe(urlMain);
+    expect(mainAfter?.predictedUrl).toBe(urlMain);
   });
 });

--- a/electron/ipc/handlers/__tests__/devPreview.session.test.ts
+++ b/electron/ipc/handlers/__tests__/devPreview.session.test.ts
@@ -609,7 +609,7 @@ describe("dev preview session handlers", () => {
         worktreeId: string;
         status: string;
         url: string | null;
-        assignedUrl: string | null;
+        predictedUrl: string | null;
       } | null
     >(CHANNELS.DEV_PREVIEW_GET_BY_WORKTREE);
 
@@ -636,7 +636,7 @@ describe("dev preview session handlers", () => {
       expect(state?.panelId).toBe("panel-wt-lookup");
       expect(state?.worktreeId).toBe("wt-lookup");
       expect(state?.url).toBe("http://localhost:5174/");
-      expect(state?.assignedUrl).toMatch(/^http:\/\/localhost:\d+/);
+      expect(state?.predictedUrl).toMatch(/^http:\/\/localhost:\d+/);
     });
   });
 

--- a/electron/services/DevPreviewCommandNormalizer.ts
+++ b/electron/services/DevPreviewCommandNormalizer.ts
@@ -22,11 +22,23 @@ export const FRAMEWORK_DEFAULT_PORTS: Array<[RegExp, number]> = [
   [/\bvite\b/, 5173],
   [/\bsvelte-kit\s+dev\b/, 5173],
   [/\bastro\s+dev\b/, 4321],
+  [/\bnuxt\s+dev\b/, 3000],
   [/\brails\s+server\b/, 3000],
   [/\bmanage\.py\s+runserver\b/, 8000],
   [/\bmix\s+phx\.server\b/, 4000],
   [/\bphp\s+artisan\s+serve\b/, 8000],
 ];
+
+// Vite and SvelteKit (SvelteKit v2+ runs on Vite) both expose --strictPort,
+// which makes the server exit on EADDRINUSE rather than drifting to the next
+// free port. Pinning strictPort lets the readiness poller trust the allocated
+// URL instead of needing UrlDetector to catch a silent reassignment.
+export const VITE_STRICT_PORT_RE = /\bvite(?:\s+dev)?\b|\bsvelte-kit\s+dev\b/;
+
+// Astro and Nuxt accept --port via their own CLIs but do NOT propagate
+// --strictPort to underlying Vite. Injecting it would cause the dev server
+// to error on an unknown flag, so we only pin the port here.
+export const VITE_SOFT_PORT_RE = /\bastro\s+dev\b|\bnuxt\s+dev\b/;
 
 export async function extractPort(command: string, cwd: string): Promise<number | null> {
   if (SHELL_CONTROL_RE.test(command)) return null;
@@ -106,4 +118,47 @@ export async function normalizeNextjsDevCommand(
   }
 
   return command;
+}
+
+// Vite, SvelteKit, Astro, and Nuxt all ignore process.env.PORT — the only
+// boundary-safe way to pin the allocated port is to inject the CLI flag.
+// Vite/SvelteKit also accept --strictPort so the server fails fast on
+// collision instead of silently drifting; Astro/Nuxt only accept --port.
+export async function normalizeViteDevCommand(
+  command: string,
+  cwd: string,
+  port: number
+): Promise<string> {
+  if (SHELL_CONTROL_RE.test(command)) return command;
+  if (PORT_FLAG_PRESENT_RE.test(command)) return command;
+
+  let resolved = command;
+  const scriptMatch = PKG_SCRIPT_RE.exec(command);
+  if (scriptMatch) {
+    const scriptName = scriptMatch[1];
+    try {
+      const pkgRaw = await fs.readFile(path.join(cwd, "package.json"), "utf-8");
+      const pkg = JSON.parse(pkgRaw);
+      const scriptBody = pkg?.scripts?.[scriptName];
+      if (typeof scriptBody !== "string") return command;
+      if (SHELL_CONTROL_RE.test(scriptBody)) return command;
+      if (PORT_FLAG_PRESENT_RE.test(scriptBody)) return command;
+      resolved = scriptBody;
+    } catch {
+      return command;
+    }
+  }
+
+  const isStrict = VITE_STRICT_PORT_RE.test(resolved);
+  const isSoft = !isStrict && VITE_SOFT_PORT_RE.test(resolved);
+  if (!isStrict && !isSoft) return command;
+
+  const flags = isStrict ? `--port ${port} --strictPort` : `--port ${port}`;
+  // npm/pnpm/yarn require `--` to forward flags through `run <script>`; bun
+  // forwards extra args directly. Direct CLI invocations (no pkg manager
+  // wrapping) take flags inline.
+  const isPkgScript = scriptMatch !== null;
+  const isBun = command.trimStart().startsWith("bun ");
+  const sep = isPkgScript && !isBun ? " -- " : " ";
+  return `${command}${sep}${flags}`;
 }

--- a/electron/services/DevPreviewCommandNormalizer.ts
+++ b/electron/services/DevPreviewCommandNormalizer.ts
@@ -12,9 +12,9 @@ export const PKG_SCRIPT_RE =
 export const SHELL_CONTROL_RE = /[;&|#`]|<|>|\$\(/;
 
 export const PORT_FLAG_RE =
-  /(?:--port(?:=|\s+)|-p\s+|\bPORT=)(["']?)(?:\$\{PORT:-)?(\d+)(?![.\w])\}?\1/i;
+  /(?:--port(?:=|\s+)|-p(?:\s+|(?=\d))|\bPORT=)(["']?)(?:\$\{PORT:-)?(\d+)(?![.\w])\}?\1/i;
 
-export const PORT_FLAG_PRESENT_RE = /(?:--port(?:=|\s+)|-p\s+|\bPORT=)/i;
+export const PORT_FLAG_PRESENT_RE = /(?:--port(?:=|\s+)|-p(?:\s+|(?=\d))|\bPORT=)/i;
 
 export const FRAMEWORK_DEFAULT_PORTS: Array<[RegExp, number]> = [
   [/\bnext\s+dev\b/, 3000],
@@ -32,8 +32,11 @@ export const FRAMEWORK_DEFAULT_PORTS: Array<[RegExp, number]> = [
 // Vite and SvelteKit (SvelteKit v2+ runs on Vite) both expose --strictPort,
 // which makes the server exit on EADDRINUSE rather than drifting to the next
 // free port. Pinning strictPort lets the readiness poller trust the allocated
-// URL instead of needing UrlDetector to catch a silent reassignment.
-export const VITE_STRICT_PORT_RE = /\bvite(?:\s+dev)?\b|\bsvelte-kit\s+dev\b/;
+// URL instead of needing UrlDetector to catch a silent reassignment. The
+// `(?![\w-])` lookahead keeps `vite-node` and similar hyphenated tools out
+// of the match — `\bvite\b` alone would treat `vite-node server.ts` as a
+// Vite dev command.
+export const VITE_STRICT_PORT_RE = /\bvite(?![\w-])(?:\s+dev)?|\bsvelte-kit\s+dev\b/;
 
 // Astro and Nuxt accept --port via their own CLIs but do NOT propagate
 // --strictPort to underlying Vite. Injecting it would cause the dev server

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   getInvalidCommandMessage,
   normalizeNextjsDevCommand,
+  normalizeViteDevCommand,
 } from "./DevPreviewCommandNormalizer.js";
 import {
   allocatePort,
@@ -208,7 +209,7 @@ export class DevPreviewSessionService {
           status: "error",
           error: { type: "unknown", message: commandError },
           url: null,
-          assignedUrl: null,
+          predictedUrl: null,
           terminalId: null,
           isRestarting: false,
         });
@@ -248,7 +249,7 @@ export class DevPreviewSessionService {
             status: "error",
             error: { type: "unknown", message: commandError },
             url: null,
-            assignedUrl: null,
+            predictedUrl: null,
             terminalId: null,
             isRestarting: false,
           });
@@ -298,7 +299,7 @@ export class DevPreviewSessionService {
           status: "error",
           error: { type: "unknown", message: commandError },
           url: null,
-          assignedUrl: null,
+          predictedUrl: null,
           terminalId: null,
           isRestarting: false,
         });
@@ -326,7 +327,7 @@ export class DevPreviewSessionService {
         this.updateSession(session, {
           status: "error",
           url: null,
-          assignedUrl: null,
+          predictedUrl: null,
           error: {
             type: "unknown",
             message: `Failed to clear cache: ${deletionError}`,
@@ -358,7 +359,7 @@ export class DevPreviewSessionService {
           status: "error",
           error: { type: "unknown", message: commandError },
           url: null,
-          assignedUrl: null,
+          predictedUrl: null,
           terminalId: null,
           isRestarting: false,
         });
@@ -388,7 +389,7 @@ export class DevPreviewSessionService {
         this.updateSession(session, {
           status: "error",
           url: null,
-          assignedUrl: null,
+          predictedUrl: null,
           error: {
             type: "unknown",
             message: `Failed to remove node_modules: ${message}`,
@@ -448,7 +449,7 @@ export class DevPreviewSessionService {
             this.updateSession(session, {
               status: "error",
               url: null,
-              assignedUrl: null,
+              predictedUrl: null,
               error: {
                 type: "port-conflict",
                 message: `Port ${port} did not release within ${PORT_FREE_TIMEOUT_MS / 1000}s after stopping. Retry to start again.`,
@@ -466,7 +467,7 @@ export class DevPreviewSessionService {
         this.updateSession(session, {
           status: "stopped",
           url: null,
-          assignedUrl: null,
+          predictedUrl: null,
           error: null,
           terminalId: null,
           isRestarting: false,
@@ -477,7 +478,7 @@ export class DevPreviewSessionService {
         this.updateSession(session, {
           status: "stopped",
           url: null,
-          assignedUrl: null,
+          predictedUrl: null,
           error: null,
           terminalId: null,
           isRestarting: false,
@@ -503,7 +504,7 @@ export class DevPreviewSessionService {
             this.updateSession(session, {
               status: "stopped",
               url: null,
-              assignedUrl: null,
+              predictedUrl: null,
               error: null,
               terminalId: null,
               isRestarting: false,
@@ -516,7 +517,7 @@ export class DevPreviewSessionService {
             this.updateSession(session, {
               status: "error",
               url: null,
-              assignedUrl: null,
+              predictedUrl: null,
               error: { type: "unknown", message: `Failed to stop dev preview: ${message}` },
               terminalId: null,
               isRestarting: false,
@@ -545,7 +546,7 @@ export class DevPreviewSessionService {
             this.updateSession(session, {
               status: "stopped",
               url: null,
-              assignedUrl: null,
+              predictedUrl: null,
               error: null,
               terminalId: null,
               isRestarting: false,
@@ -582,7 +583,7 @@ export class DevPreviewSessionService {
       worktreeId: undefined,
       status: "stopped",
       url: null,
-      assignedUrl: null,
+      predictedUrl: null,
       error: null,
       terminalId: null,
       isRestarting: false,
@@ -620,7 +621,7 @@ export class DevPreviewSessionService {
         worktreeId: undefined,
         status: "stopped",
         url: null,
-        assignedUrl: null,
+        predictedUrl: null,
         error: null,
         terminalId: null,
         isRestarting: false,
@@ -640,7 +641,7 @@ export class DevPreviewSessionService {
       worktreeId: session.worktreeId,
       status: session.status,
       url: session.url,
-      assignedUrl: session.assignedUrl,
+      predictedUrl: session.predictedUrl,
       error: session.error,
       terminalId: session.terminalId,
       isRestarting: session.isRestarting,
@@ -658,7 +659,7 @@ export class DevPreviewSessionService {
         DevPreviewSession,
         | "status"
         | "url"
-        | "assignedUrl"
+        | "predictedUrl"
         | "error"
         | "terminalId"
         | "isRestarting"
@@ -672,7 +673,7 @@ export class DevPreviewSessionService {
     if (this.disposed) return;
     if (updates.status !== undefined) session.status = updates.status;
     if (updates.url !== undefined) session.url = updates.url;
-    if (updates.assignedUrl !== undefined) session.assignedUrl = updates.assignedUrl;
+    if (updates.predictedUrl !== undefined) session.predictedUrl = updates.predictedUrl;
     if (updates.error !== undefined) session.error = updates.error;
     if (updates.terminalId !== undefined) session.terminalId = updates.terminalId;
     if (updates.isRestarting !== undefined) session.isRestarting = updates.isRestarting;
@@ -736,7 +737,7 @@ export class DevPreviewSessionService {
       session.markerSeen = false;
       session.needsInstall = false;
       session.isRunningInstall = false;
-      this.updateSession(session, { terminalId: null, url: null, assignedUrl: null });
+      this.updateSession(session, { terminalId: null, url: null, predictedUrl: null });
     }
 
     await this.spawnSessionTerminal(session);
@@ -766,21 +767,21 @@ export class DevPreviewSessionService {
       releasePort(this.portRegistry, sessionKey);
       return;
     }
-    const assignedUrl = `http://localhost:${port}`;
+    const predictedUrl = `http://localhost:${port}`;
 
     const spawnEnv: Record<string, string> = { ...session.env, PORT: String(port) };
 
     session.buffer = "";
     session.lastErrorKey = null;
     session.markerSeen = false;
-    session.assignedUrl = assignedUrl;
+    session.predictedUrl = predictedUrl;
     this.clearCompiling(session);
     this.attachTerminal(session, terminalId);
     this.updateSession(session, {
       terminalId,
       status: "starting",
       url: null,
-      assignedUrl,
+      predictedUrl,
       error: null,
       generation: nextGeneration,
       forceKilled: undefined,
@@ -803,9 +804,11 @@ export class DevPreviewSessionService {
         terminalId,
       });
 
-      // The allocated PORT is authoritative for the common zero-config path.
-      // Keep output URL detection below as an override for servers that choose
-      // their own port, but do not depend on a single terminal line to start.
+      // predictedUrl is the allocator-derived starting point for the readiness
+      // poller — it's accurate for frameworks that honor env.PORT or the
+      // injected --port flag, but not authoritative. UrlDetector overwrites
+      // state.url when real output reveals a different bind address (e.g. next
+      // dev auto-incrementing past EADDRINUSE on configs without --strictPort).
       setTimeout(() => {
         if (this.disposed) return;
         if (session.generation !== nextGeneration || session.terminalId !== terminalId) return;
@@ -813,7 +816,7 @@ export class DevPreviewSessionService {
 
         const abort = new AbortController();
         session.readinessAbort = abort;
-        this.pollServerReadiness(session, assignedUrl, abort.signal, nextGeneration);
+        this.pollServerReadiness(session, predictedUrl, abort.signal, nextGeneration);
       }, 0);
     } catch (error) {
       const message = formatErrorMessage(error, "Failed to start dev server");
@@ -821,7 +824,7 @@ export class DevPreviewSessionService {
       this.updateSession(session, {
         status: "error",
         url: null,
-        assignedUrl: null,
+        predictedUrl: null,
         error: { type: "unknown", message: `Failed to start dev server: ${message}` },
         terminalId: null,
         isRestarting: false,
@@ -844,6 +847,7 @@ export class DevPreviewSessionService {
     };
 
     void normalizeNextjsDevCommand(trimmedCommand, session.cwd, session.turbopackEnabled)
+      .then((nextNormalized) => normalizeViteDevCommand(nextNormalized, session.cwd, port))
       .then((normalizedCommand) => {
         submitCommand(normalizedCommand);
       })
@@ -981,7 +985,7 @@ export class DevPreviewSessionService {
     this.updateSession(session, {
       status: "error",
       url: null,
-      assignedUrl: null,
+      predictedUrl: null,
       error: {
         type: "port-conflict",
         message: `Port ${port} did not release within ${PORT_FREE_TIMEOUT_MS / 1000}s. Retry to start again.`,
@@ -1132,7 +1136,7 @@ export class DevPreviewSessionService {
       status: "error",
       error: result.error,
       url: null,
-      assignedUrl: null,
+      predictedUrl: null,
       isRestarting: false,
       phaseLabel: undefined,
     });
@@ -1165,7 +1169,7 @@ export class DevPreviewSessionService {
       this.updateSession(session, {
         status: "error",
         url: null,
-        assignedUrl: null,
+        predictedUrl: null,
         error: {
           type: "missing-dependencies",
           message: `Dependency installation failed (exit code ${exitCode})`,
@@ -1192,7 +1196,7 @@ export class DevPreviewSessionService {
       this.updateSession(session, {
         status: "error",
         url: null,
-        assignedUrl: null,
+        predictedUrl: null,
         error,
         terminalId: null,
         isRestarting: false,
@@ -1204,7 +1208,7 @@ export class DevPreviewSessionService {
     this.updateSession(session, {
       status: "stopped",
       url: null,
-      assignedUrl: null,
+      predictedUrl: null,
       error: null,
       terminalId: null,
       isRestarting: false,
@@ -1249,7 +1253,7 @@ export class DevPreviewSessionService {
       this.updateSession(session, {
         status: "error",
         url: null,
-        assignedUrl: null,
+        predictedUrl: null,
         error: { type: "unknown", message: `Failed to start dependency install: ${message}` },
         terminalId: null,
         isRestarting: false,
@@ -1473,7 +1477,7 @@ export class DevPreviewSessionService {
           this.updateSession(session, {
             status: "error",
             url: null,
-            assignedUrl: null,
+            predictedUrl: null,
             error: {
               type: "unknown",
               message: `Dev server at ${url} did not respond within ${READINESS_TIMEOUT_MS / 1000} seconds`,
@@ -1499,7 +1503,7 @@ export class DevPreviewSessionService {
         this.updateSession(session, {
           status: "error",
           url: null,
-          assignedUrl: null,
+          predictedUrl: null,
           error: {
             type: "unknown",
             message: `Dev server readiness check failed: ${message}`,

--- a/electron/services/__tests__/DevPreviewPortRegistry.test.ts
+++ b/electron/services/__tests__/DevPreviewPortRegistry.test.ts
@@ -4,9 +4,9 @@
  *
  * Bugs targeted:
  *   A – PORT env override: caller env.PORT silently beats the allocated port
- *   B – assignedUrl stale after crash exit (handleExit error path)
- *   C – assignedUrl stale after clean exit (handleExit stopped path)
- *   D – assignedUrl stale after install exit failure
+ *   B – predictedUrl stale after crash exit (handleExit error path)
+ *   C – predictedUrl stale after clean exit (handleExit stopped path)
+ *   D – predictedUrl stale after install exit failure
  *   E – real net socket calls leak into tests (net not mocked)
  *   F – getByWorktree stale after worktreeId change on same session
  *   G – worktreeToSession not cleaned up after stopByPanel (memory + correctness)
@@ -160,45 +160,45 @@ describe("DevPreviewSessionService — port registry (adversarial)", () => {
   });
 
   // ── Bug A ──────────────────────────────────────────────────────────────────
-  it("BUG-A: assignedUrl matches the port injected into the spawn env — caller env.PORT must not override", async () => {
+  it("BUG-A: predictedUrl matches the port injected into the spawn env — caller env.PORT must not override", async () => {
     // If the spread is wrong ({ PORT: allocated, ...session.env }), then
     // session.env.PORT=9000 wins and the spawn env gets PORT=9000 while
-    // assignedUrl still says http://localhost:3100 → mismatch.
+    // predictedUrl still says http://localhost:3100 → mismatch.
     const state = await service.ensure({
       ...base,
       worktreeId: "wt-1",
       env: { PORT: "9000" },
     });
 
-    expect(state.assignedUrl).toBeTruthy();
-    const allocatedPort = state.assignedUrl!.replace("http://localhost:", "");
+    expect(state.predictedUrl).toBeTruthy();
+    const allocatedPort = state.predictedUrl!.replace("http://localhost:", "");
 
     const lastSpawn = ptyClient.spawnCalls[ptyClient.spawnCalls.length - 1];
     const spawnedPort = (lastSpawn.opts.env as Record<string, string>).PORT;
 
-    // The port in assignedUrl must equal the port that was actually injected.
+    // The port in predictedUrl must equal the port that was actually injected.
     // Fails if the spread is reversed (caller env.PORT wins).
     expect(spawnedPort).toBe(allocatedPort);
   });
 
   // ── Bug B ──────────────────────────────────────────────────────────────────
-  it("BUG-B: assignedUrl is cleared when the terminal crashes (non-zero exit)", async () => {
+  it("BUG-B: predictedUrl is cleared when the terminal crashes (non-zero exit)", async () => {
     const state = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(state.assignedUrl).toBeTruthy();
+    expect(state.predictedUrl).toBeTruthy();
 
     // Simulate crash
     ptyClient.emitExit(state.terminalId!, 1);
 
     const after = service.getState(base);
-    // handleExit error-path does not clear assignedUrl → this assertion will fail
-    expect(after.assignedUrl).toBeNull();
+    // handleExit error-path does not clear predictedUrl → this assertion will fail
+    expect(after.predictedUrl).toBeNull();
   });
 
   // ── Bug C ──────────────────────────────────────────────────────────────────
-  it("BUG-C: assignedUrl is cleared when the terminal exits cleanly (zero exit from running state)", async () => {
+  it("BUG-C: predictedUrl is cleared when the terminal exits cleanly (zero exit from running state)", async () => {
     mockHttpResponse(200);
     const state = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(state.assignedUrl).toBeTruthy();
+    expect(state.predictedUrl).toBeTruthy();
 
     // Emit URL so status transitions to running
     ptyClient.emitData(state.terminalId!, "ready at http://localhost:5173\n");
@@ -208,15 +208,15 @@ describe("DevPreviewSessionService — port registry (adversarial)", () => {
     ptyClient.emitExit(state.terminalId!, 0);
 
     const after = service.getState(base);
-    // handleExit stopped-path does not clear assignedUrl → this assertion will fail
-    expect(after.assignedUrl).toBeNull();
+    // handleExit stopped-path does not clear predictedUrl → this assertion will fail
+    expect(after.predictedUrl).toBeNull();
   });
 
   // ── Bug D ──────────────────────────────────────────────────────────────────
-  it("BUG-D: assignedUrl is cleared when install subprocess exits with failure", async () => {
+  it("BUG-D: predictedUrl is cleared when install subprocess exits with failure", async () => {
     // Trigger install path: emit missing-dependencies error, then exit triggers install
     const state = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(state.assignedUrl).toBeTruthy();
+    expect(state.predictedUrl).toBeTruthy();
 
     // Emit a missing-dependencies error to set needsInstall = true
     ptyClient.emitData(
@@ -227,13 +227,13 @@ describe("DevPreviewSessionService — port registry (adversarial)", () => {
 
     // Mark as install subprocess running (simulate the install terminal exit with failure)
     // The service sets isRunningInstall=true when runInstall is triggered.
-    // Exit with failure code should clear assignedUrl.
+    // Exit with failure code should clear predictedUrl.
     ptyClient.emitExit(state.terminalId!, 1);
     await new Promise((r) => setTimeout(r, 20));
 
     const after = service.getState(base);
-    // handleExit install-failure path does not clear assignedUrl
-    expect(after.assignedUrl).toBeNull();
+    // handleExit install-failure path does not clear predictedUrl
+    expect(after.predictedUrl).toBeNull();
   });
 
   // ── Bug E ──────────────────────────────────────────────────────────────────
@@ -276,7 +276,7 @@ describe("DevPreviewSessionService — port registry (adversarial)", () => {
   // ── Regression H ──────────────────────────────────────────────────────────
   it("REGRESSION-H: restart reuses the same port (no orphaned allocations)", async () => {
     const first = await service.ensure({ ...base, worktreeId: "wt-1" });
-    const portBefore = first.assignedUrl;
+    const portBefore = first.predictedUrl;
     expect(portBefore).toBeTruthy();
 
     // Snapshot call count after initial allocation.
@@ -287,7 +287,7 @@ describe("DevPreviewSessionService — port registry (adversarial)", () => {
     const second = service.getState(base);
 
     // The same port should be reused after restart.
-    expect(second.assignedUrl).toBe(portBefore);
+    expect(second.predictedUrl).toBe(portBefore);
     // allocatePort returned early from registry (no allocation probe), but
     // restart now also calls waitForPortFree which probes once to confirm the
     // old PTY released the port before respawning. One additional probe call
@@ -297,11 +297,11 @@ describe("DevPreviewSessionService — port registry (adversarial)", () => {
   });
 
   // ── Positive baseline ──────────────────────────────────────────────────────
-  it("assignedUrl is populated immediately after ensure() before server is ready", async () => {
+  it("predictedUrl is populated immediately after ensure() before server is ready", async () => {
     const state = await service.ensure({ ...base, worktreeId: "wt-1" });
 
     expect(state.status).toBe("starting");
-    expect(state.assignedUrl).toMatch(/^http:\/\/localhost:\d+$/);
+    expect(state.predictedUrl).toMatch(/^http:\/\/localhost:\d+$/);
   });
 
   it("getByWorktree returns null for unknown worktreeId", () => {
@@ -329,27 +329,27 @@ describe("DevPreviewSessionService — port registry (adversarial)", () => {
       worktreeId: "wt-2",
     });
 
-    expect(s1.assignedUrl).toBeTruthy();
-    expect(s2.assignedUrl).toBeTruthy();
-    expect(s1.assignedUrl).not.toBe(s2.assignedUrl);
+    expect(s1.predictedUrl).toBeTruthy();
+    expect(s2.predictedUrl).toBeTruthy();
+    expect(s1.predictedUrl).not.toBe(s2.predictedUrl);
   });
 
-  it("assignedUrl is cleared after explicit stop()", async () => {
+  it("predictedUrl is cleared after explicit stop()", async () => {
     const state = await service.ensure(base);
-    expect(state.assignedUrl).toBeTruthy();
+    expect(state.predictedUrl).toBeTruthy();
 
     await service.stop(base);
     const after = service.getState(base);
-    expect(after.assignedUrl).toBeNull();
+    expect(after.predictedUrl).toBeNull();
   });
 
-  it("assignedUrl is cleared after stopByPanel()", async () => {
+  it("predictedUrl is cleared after stopByPanel()", async () => {
     const state = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(state.assignedUrl).toBeTruthy();
+    expect(state.predictedUrl).toBeTruthy();
 
     await service.stopByPanel({ panelId: base.panelId });
     // Session is removed — getState returns default null state
     const after = service.getState(base);
-    expect(after.assignedUrl).toBeNull();
+    expect(after.predictedUrl).toBeNull();
   });
 });

--- a/electron/services/__tests__/DevPreviewPortRegistry2.test.ts
+++ b/electron/services/__tests__/DevPreviewPortRegistry2.test.ts
@@ -2,9 +2,9 @@
  * Second-round adversarial tests for DevPreviewSessionService (quick-2 follow-up).
  *
  * Bugs targeted:
- *   I – stopByPanel success: onStateChanged broadcast has stale assignedUrl (assignedUrl: null omitted)
+ *   I – stopByPanel success: onStateChanged broadcast has stale predictedUrl (predictedUrl: null omitted)
  *   J – stopByProject success: same stale broadcast
- *   K – stopByPanel error-catch: onStateChanged broadcast has stale assignedUrl
+ *   K – stopByPanel error-catch: onStateChanged broadcast has stale predictedUrl
  *   L – worktreeToSession not cleaned up after stopByPanel / stopByProject (memory leak)
  *   M – getByWorktree IPC handler: accepts blank / whitespace / non-string worktreeId
  */
@@ -112,7 +112,7 @@ function createPtyClientMock() {
 
 // ─── suite ───────────────────────────────────────────────────────────────────
 
-describe("DevPreviewSessionService — stale assignedUrl broadcasts & map cleanup (adversarial)", () => {
+describe("DevPreviewSessionService — stale predictedUrl broadcasts & map cleanup (adversarial)", () => {
   const base = {
     panelId: "panel-1",
     projectId: "project-1",
@@ -143,10 +143,10 @@ describe("DevPreviewSessionService — stale assignedUrl broadcasts & map cleanu
   });
 
   // ── Bug I ──────────────────────────────────────────────────────────────────
-  it("BUG-I: last onStateChanged broadcast from stopByPanel has assignedUrl: null", async () => {
-    // Ensure a session so assignedUrl is populated.
+  it("BUG-I: last onStateChanged broadcast from stopByPanel has predictedUrl: null", async () => {
+    // Ensure a session so predictedUrl is populated.
     const state = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(state.assignedUrl).toBeTruthy();
+    expect(state.predictedUrl).toBeTruthy();
 
     broadcasts.length = 0; // reset — watch only stop broadcasts
 
@@ -155,14 +155,14 @@ describe("DevPreviewSessionService — stale assignedUrl broadcasts & map cleanu
     // At least one broadcast must have been emitted for the stop.
     expect(broadcasts.length).toBeGreaterThan(0);
 
-    // The final broadcast must have assignedUrl: null.
-    // Fails when updateSession({ status: "stopped", ... }) omits assignedUrl: null.
+    // The final broadcast must have predictedUrl: null.
+    // Fails when updateSession({ status: "stopped", ... }) omits predictedUrl: null.
     const lastBroadcast = broadcasts[broadcasts.length - 1];
-    expect(lastBroadcast.assignedUrl).toBeNull();
+    expect(lastBroadcast.predictedUrl).toBeNull();
   });
 
   // ── Bug J ──────────────────────────────────────────────────────────────────
-  it("BUG-J: last onStateChanged broadcast from stopByProject has assignedUrl: null", async () => {
+  it("BUG-J: last onStateChanged broadcast from stopByProject has predictedUrl: null", async () => {
     await service.ensure({ ...base, worktreeId: "wt-1" });
 
     broadcasts.length = 0;
@@ -171,15 +171,15 @@ describe("DevPreviewSessionService — stale assignedUrl broadcasts & map cleanu
 
     expect(broadcasts.length).toBeGreaterThan(0);
 
-    // Fails when updateSession({ status: "stopped", ... }) in stopByProject omits assignedUrl.
+    // Fails when updateSession({ status: "stopped", ... }) in stopByProject omits predictedUrl.
     const lastBroadcast = broadcasts[broadcasts.length - 1];
-    expect(lastBroadcast.assignedUrl).toBeNull();
+    expect(lastBroadcast.predictedUrl).toBeNull();
   });
 
   // ── Bug K ──────────────────────────────────────────────────────────────────
-  it("BUG-K: onStateChanged broadcast from stopByPanel error-catch has assignedUrl: null", async () => {
+  it("BUG-K: onStateChanged broadcast from stopByPanel error-catch has predictedUrl: null", async () => {
     const state = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(state.assignedUrl).toBeTruthy();
+    expect(state.predictedUrl).toBeTruthy();
 
     // Make stopSessionTerminal throw by killing the pty then making kill() throw.
     ptyClient.kill.mockImplementationOnce(() => {
@@ -194,10 +194,10 @@ describe("DevPreviewSessionService — stale assignedUrl broadcasts & map cleanu
     // Must have emitted at least one broadcast for the error state.
     expect(broadcasts.length).toBeGreaterThan(0);
 
-    // The final broadcast must have assignedUrl: null.
-    // Fails when the catch-branch updateSession({ status: "error", ... }) omits assignedUrl: null.
+    // The final broadcast must have predictedUrl: null.
+    // Fails when the catch-branch updateSession({ status: "error", ... }) omits predictedUrl: null.
     const lastBroadcast = broadcasts[broadcasts.length - 1];
-    expect(lastBroadcast.assignedUrl).toBeNull();
+    expect(lastBroadcast.predictedUrl).toBeNull();
   });
 
   // ── Bug L ──────────────────────────────────────────────────────────────────

--- a/electron/services/__tests__/DevPreviewPortRegistry3.test.ts
+++ b/electron/services/__tests__/DevPreviewPortRegistry3.test.ts
@@ -1,13 +1,13 @@
 /**
- * Third-round adversarial tests — assignedUrl leaks through every error/stop code path.
+ * Third-round adversarial tests — predictedUrl leaks through every error/stop code path.
  *
  * Bugs targeted:
- *   N – spawnSessionTerminal spawn-throw:  broadcast has stale assignedUrl
- *   P – ensure invalid-command path:       broadcast has stale assignedUrl
- *   Q – restart invalid-command path:      broadcast has stale assignedUrl
- *   R – handleData non-dep error output:   broadcast has stale assignedUrl
- *   S – runInstall spawn-throw path:       broadcast has stale assignedUrl
- *   T – pollServerReadiness timeout path:  broadcast has stale assignedUrl
+ *   N – spawnSessionTerminal spawn-throw:  broadcast has stale predictedUrl
+ *   P – ensure invalid-command path:       broadcast has stale predictedUrl
+ *   Q – restart invalid-command path:      broadcast has stale predictedUrl
+ *   R – handleData non-dep error output:   broadcast has stale predictedUrl
+ *   S – runInstall spawn-throw path:       broadcast has stale predictedUrl
+ *   T – pollServerReadiness timeout path:  broadcast has stale predictedUrl
  */
 
 import http from "node:http";
@@ -139,7 +139,7 @@ function createPtyClientMock() {
 
 // ─── suite ───────────────────────────────────────────────────────────────────
 
-describe("DevPreviewSessionService — assignedUrl must be null in every error broadcast (adversarial)", () => {
+describe("DevPreviewSessionService — predictedUrl must be null in every error broadcast (adversarial)", () => {
   const base = {
     panelId: "panel-1",
     projectId: "project-1",
@@ -171,10 +171,10 @@ describe("DevPreviewSessionService — assignedUrl must be null in every error b
   });
 
   // ── Bug N ──────────────────────────────────────────────────────────────────
-  it("BUG-N: assignedUrl is null in error broadcast when spawn throws", async () => {
-    // First ensure succeeds and sets assignedUrl on the session.
+  it("BUG-N: predictedUrl is null in error broadcast when spawn throws", async () => {
+    // First ensure succeeds and sets predictedUrl on the session.
     const first = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(first.assignedUrl).toBeTruthy();
+    expect(first.predictedUrl).toBeTruthy();
 
     // Stop the session so the port stays allocated but the terminal is gone.
     // Next ensure will call spawnSessionTerminal again (spawn #2).
@@ -187,37 +187,37 @@ describe("DevPreviewSessionService — assignedUrl must be null in every error b
 
     broadcasts.length = 0;
 
-    // Re-ensure → spawnSessionTerminal sets assignedUrl then spawn throws.
+    // Re-ensure → spawnSessionTerminal sets predictedUrl then spawn throws.
     await service.ensure({ ...base, worktreeId: "wt-1" });
 
-    // The error broadcast must have assignedUrl: null.
-    // Fails if spawnSessionTerminal's catch omits assignedUrl: null.
+    // The error broadcast must have predictedUrl: null.
+    // Fails if spawnSessionTerminal's catch omits predictedUrl: null.
     const errorBroadcast = broadcasts.find((b) => b.status === "error");
     expect(errorBroadcast).toBeDefined();
-    expect(errorBroadcast!.assignedUrl).toBeNull();
+    expect(errorBroadcast!.predictedUrl).toBeNull();
   });
 
   // ── Bug P ──────────────────────────────────────────────────────────────────
-  it("BUG-P: assignedUrl is null in error broadcast from ensure() with blank devCommand", async () => {
-    // Establish a running session so assignedUrl is populated.
+  it("BUG-P: predictedUrl is null in error broadcast from ensure() with blank devCommand", async () => {
+    // Establish a running session so predictedUrl is populated.
     const first = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(first.assignedUrl).toBeTruthy();
+    expect(first.predictedUrl).toBeTruthy();
 
     broadcasts.length = 0;
 
     // Re-ensure with an empty command → hits the commandError path.
     await service.ensure({ ...base, devCommand: "", worktreeId: "wt-1" });
 
-    // The error broadcast must have assignedUrl: null.
-    // Fails if ensure's commandError updateSession omits assignedUrl: null.
+    // The error broadcast must have predictedUrl: null.
+    // Fails if ensure's commandError updateSession omits predictedUrl: null.
     const errorBroadcast = broadcasts.find((b) => b.status === "error");
     expect(errorBroadcast).toBeDefined();
-    expect(errorBroadcast!.assignedUrl).toBeNull();
+    expect(errorBroadcast!.predictedUrl).toBeNull();
   });
 
   // ── Bug Q ──────────────────────────────────────────────────────────────────
-  it("BUG-Q: assignedUrl is null in error broadcast from restart() with stored blank devCommand", async () => {
-    // Establish session with assignedUrl.
+  it("BUG-Q: predictedUrl is null in error broadcast from restart() with stored blank devCommand", async () => {
+    // Establish session with predictedUrl.
     await service.ensure({ ...base, worktreeId: "wt-1" });
 
     // Corrupt devCommand to blank via a second ensure (exercises Bug P path too,
@@ -229,17 +229,17 @@ describe("DevPreviewSessionService — assignedUrl must be null in every error b
     // restart() reads stored devCommand="" → hits the commandError path.
     await service.restart(base);
 
-    // The error broadcast must have assignedUrl: null.
-    // Fails if restart's commandError updateSession omits assignedUrl: null.
+    // The error broadcast must have predictedUrl: null.
+    // Fails if restart's commandError updateSession omits predictedUrl: null.
     const errorBroadcast = broadcasts.find((b) => b.status === "error");
     expect(errorBroadcast).toBeDefined();
-    expect(errorBroadcast!.assignedUrl).toBeNull();
+    expect(errorBroadcast!.predictedUrl).toBeNull();
   });
 
   // ── Bug R ──────────────────────────────────────────────────────────────────
-  it("BUG-R: assignedUrl is null in error broadcast from EACCES output on terminal", async () => {
+  it("BUG-R: predictedUrl is null in error broadcast from EACCES output on terminal", async () => {
     const state = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(state.assignedUrl).toBeTruthy();
+    expect(state.predictedUrl).toBeTruthy();
 
     broadcasts.length = 0;
 
@@ -247,17 +247,17 @@ describe("DevPreviewSessionService — assignedUrl must be null in every error b
     ptyClient.emitData(state.terminalId!, "Error: EACCES: permission denied /repo/server.js\n");
     await new Promise((r) => setTimeout(r, 10));
 
-    // The error broadcast must have assignedUrl: null.
-    // Fails if handleData's non-dep error updateSession omits assignedUrl: null.
+    // The error broadcast must have predictedUrl: null.
+    // Fails if handleData's non-dep error updateSession omits predictedUrl: null.
     const errorBroadcast = broadcasts.find((b) => b.status === "error");
     expect(errorBroadcast).toBeDefined();
-    expect(errorBroadcast!.assignedUrl).toBeNull();
+    expect(errorBroadcast!.predictedUrl).toBeNull();
   });
 
   // ── Bug S ──────────────────────────────────────────────────────────────────
-  it("BUG-S: assignedUrl is null in error broadcast when install spawn throws", async () => {
+  it("BUG-S: predictedUrl is null in error broadcast when install spawn throws", async () => {
     const state = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(state.assignedUrl).toBeTruthy();
+    expect(state.predictedUrl).toBeTruthy();
 
     // Emit missing-deps output → needsInstall = true.
     ptyClient.emitData(state.terminalId!, "Error: Cannot find module 'express'\n");
@@ -274,15 +274,15 @@ describe("DevPreviewSessionService — assignedUrl must be null in every error b
     ptyClient.emitExit(state.terminalId!, 1);
     await new Promise((r) => setTimeout(r, 30));
 
-    // The error broadcast from the install-spawn failure must have assignedUrl: null.
-    // Fails if runInstall's catch-path updateSession omits assignedUrl: null.
+    // The error broadcast from the install-spawn failure must have predictedUrl: null.
+    // Fails if runInstall's catch-path updateSession omits predictedUrl: null.
     const errorBroadcast = broadcasts.find((b) => b.status === "error");
     expect(errorBroadcast).toBeDefined();
-    expect(errorBroadcast!.assignedUrl).toBeNull();
+    expect(errorBroadcast!.predictedUrl).toBeNull();
   });
 
   // ── Bug T ──────────────────────────────────────────────────────────────────
-  it("BUG-T: assignedUrl is null in error broadcast when readiness poll times out", async () => {
+  it("BUG-T: predictedUrl is null in error broadcast when readiness poll times out", async () => {
     vi.useFakeTimers();
 
     // Rebuild service under fake timers so Date.now() is controlled.
@@ -297,7 +297,7 @@ describe("DevPreviewSessionService — assignedUrl must be null in every error b
 
     // ensure() only uses the (mocked) net.createServer, no wall-clock sleeps.
     const state = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(state.assignedUrl).toBeTruthy();
+    expect(state.predictedUrl).toBeTruthy();
 
     broadcasts.length = 0;
 
@@ -308,10 +308,10 @@ describe("DevPreviewSessionService — assignedUrl must be null in every error b
     // Each 500ms poll-interval timer fires, http fails, loop re-checks deadline.
     await vi.advanceTimersByTimeAsync(31_000);
 
-    // The error broadcast must have assignedUrl: null.
-    // Fails if pollServerReadiness's !ready branch omits assignedUrl: null.
+    // The error broadcast must have predictedUrl: null.
+    // Fails if pollServerReadiness's !ready branch omits predictedUrl: null.
     const errorBroadcast = broadcasts.find((b) => b.status === "error");
     expect(errorBroadcast).toBeDefined();
-    expect(errorBroadcast!.assignedUrl).toBeNull();
+    expect(errorBroadcast!.predictedUrl).toBeNull();
   });
 });

--- a/electron/services/__tests__/DevPreviewPortRegistry4.test.ts
+++ b/electron/services/__tests__/DevPreviewPortRegistry4.test.ts
@@ -4,7 +4,7 @@
  * Bugs targeted:
  *   V – two panels share a worktreeId → second panel's stop orphans first panel
  *       (worktreeToSession stale after stopByPanel when another session still claims the key)
- *   W – ensureSessionTerminal dead-terminal path broadcasts assignedUrl while terminalId is null
+ *   W – ensureSessionTerminal dead-terminal path broadcasts predictedUrl while terminalId is null
  *       (intermediate state: server gone but URL still advertised)
  *   X – stop() does not remove the worktreeToSession entry: getByWorktree returns stopped
  *       session instead of null after explicit stop
@@ -173,7 +173,7 @@ describe("DevPreviewSessionService — worktreeToSession map invariants (adversa
 
   it("BUG-V3: after panel-2 steals wt-1 then stops, panel-1 getState still works normally", async () => {
     const s1 = await service.ensure({ ...project, panelId: "panel-1", worktreeId: "wt-1" });
-    expect(s1.assignedUrl).toBeTruthy();
+    expect(s1.predictedUrl).toBeTruthy();
 
     await service.ensure({ ...project, panelId: "panel-2", worktreeId: "wt-1" });
     await service.stopByPanel({ panelId: "panel-2" });
@@ -181,20 +181,20 @@ describe("DevPreviewSessionService — worktreeToSession map invariants (adversa
     // Panel 1's session should still be accessible via getState (different lookup path).
     const direct = service.getState({ ...project, panelId: "panel-1" });
     expect(direct.status).toBe("starting");
-    expect(direct.assignedUrl).toBeTruthy();
+    expect(direct.predictedUrl).toBeTruthy();
 
     // AND via getByWorktree (requires the fix).
     const byWt = service.getByWorktree("wt-1");
     expect(byWt).not.toBeNull();
-    expect(byWt!.assignedUrl).toBe(direct.assignedUrl);
+    expect(byWt!.predictedUrl).toBe(direct.predictedUrl);
   });
 
   // ── Bug W ──────────────────────────────────────────────────────────────────
 
-  it("BUG-W: ensureSessionTerminal dead-terminal intermediate broadcast has no assignedUrl", async () => {
-    // Ensure a session so a terminal is spawned and assignedUrl is set.
+  it("BUG-W: ensureSessionTerminal dead-terminal intermediate broadcast has no predictedUrl", async () => {
+    // Ensure a session so a terminal is spawned and predictedUrl is set.
     const state = await service.ensure({ ...project, panelId: "panel-1", worktreeId: "wt-1" });
-    expect(state.assignedUrl).toBeTruthy();
+    expect(state.predictedUrl).toBeTruthy();
 
     // Kill the terminal silently (no exit event) so isTerminalAlive returns false.
     ptyClient.kill(state.terminalId!);
@@ -202,14 +202,14 @@ describe("DevPreviewSessionService — worktreeToSession map invariants (adversa
     broadcasts.length = 0;
 
     // Re-ensure — ensureSessionTerminal detects dead terminal, clears terminalId/url,
-    // then re-spawns. The intermediate broadcast should NOT expose a non-null assignedUrl
+    // then re-spawns. The intermediate broadcast should NOT expose a non-null predictedUrl
     // with a null terminalId (server not running but URL still advertised).
     await service.ensure({ ...project, panelId: "panel-1", worktreeId: "wt-1" });
 
-    // Find any broadcast where terminalId was null but assignedUrl was non-null.
-    // Fails if the intermediate updateSession({ terminalId: null, url: null }) omits assignedUrl: null.
+    // Find any broadcast where terminalId was null but predictedUrl was non-null.
+    // Fails if the intermediate updateSession({ terminalId: null, url: null }) omits predictedUrl: null.
     const inconsistentBroadcast = broadcasts.find(
-      (b) => b.terminalId === null && b.assignedUrl !== null
+      (b) => b.terminalId === null && b.predictedUrl !== null
     );
     expect(inconsistentBroadcast).toBeUndefined();
   });
@@ -231,10 +231,10 @@ describe("DevPreviewSessionService — worktreeToSession map invariants (adversa
     const result = service.getByWorktree("wt-1");
 
     // The session still exists (stop() keeps it), so getByWorktree returns it.
-    // Assert the returned state is correct — status stopped, assignedUrl null.
+    // Assert the returned state is correct — status stopped, predictedUrl null.
     expect(result).not.toBeNull();
     expect(result!.status).toBe("stopped");
-    expect(result!.assignedUrl).toBeNull();
+    expect(result!.predictedUrl).toBeNull();
   });
 
   // ── Regression: single-panel worktreeToSession cleanup ────────────────────

--- a/electron/services/__tests__/DevPreviewPortRegistry5.test.ts
+++ b/electron/services/__tests__/DevPreviewPortRegistry5.test.ts
@@ -7,7 +7,7 @@
  *        is never killed or tracked.
  *
  *   CC – stop() releases the port from portRegistry; the next ensure() therefore
- *        allocates a NEW port and broadcasts a different assignedUrl, breaking
+ *        allocates a NEW port and broadcasts a different predictedUrl, breaking
  *        any agent that cached the URL. stop() should keep the port (session is
  *        still alive in "stopped" state); only stopByPanel / stopByProject /
  *        dispose should release ports.
@@ -17,10 +17,10 @@
  *
  * Real-life scenario proofs:
  *   RLS-1 – agent can call getByWorktree() immediately after ensure() and get
- *            a non-null assignedUrl even before the server prints its URL.
+ *            a non-null predictedUrl even before the server prints its URL.
  *   RLS-2 – after crash-and-re-ensure, getByWorktree() returns the new session
- *            with a valid assignedUrl (previous URL was cleared on crash).
- *   RLS-3 – stop() → ensure() cycle is idempotent: same assignedUrl, server
+ *            with a valid predictedUrl (previous URL was cleared on crash).
+ *   RLS-3 – stop() → ensure() cycle is idempotent: same predictedUrl, server
  *            restarts cleanly (verifies BUG-CC fix).
  */
 
@@ -237,10 +237,10 @@ describe("DevPreviewSessionService — real-life robustness invariants (adversar
 
   // ── Bug CC ─────────────────────────────────────────────────────────────────
 
-  it("BUG-CC: ensure() after stop() reuses the same port (assignedUrl is stable)", async () => {
+  it("BUG-CC: ensure() after stop() reuses the same port (predictedUrl is stable)", async () => {
     // First ensure allocates a port.
     const first = await service.ensure({ ...base, worktreeId: "wt-1" });
-    const originalUrl = first.assignedUrl;
+    const originalUrl = first.predictedUrl;
     expect(originalUrl).toBeTruthy();
 
     // Explicit stop keeps the session alive (status=stopped) but releases
@@ -248,33 +248,33 @@ describe("DevPreviewSessionService — real-life robustness invariants (adversar
     // This breaks agent URL caching: the URL silently changes.
     await service.stop(base);
 
-    // Re-ensure should reuse the original port — same assignedUrl.
+    // Re-ensure should reuse the original port — same predictedUrl.
     // Fails when stop() calls releasePort() for a still-live session.
     const second = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(second.assignedUrl).toBe(originalUrl);
+    expect(second.predictedUrl).toBe(originalUrl);
   });
 
-  it("BUG-CC2: getByWorktree returns the same assignedUrl after stop()+ensure() cycle", async () => {
+  it("BUG-CC2: getByWorktree returns the same predictedUrl after stop()+ensure() cycle", async () => {
     await service.ensure({ ...base, worktreeId: "wt-1" });
-    const originalUrl = service.getByWorktree("wt-1")?.assignedUrl;
+    const originalUrl = service.getByWorktree("wt-1")?.predictedUrl;
     expect(originalUrl).toBeTruthy();
 
     await service.stop(base);
     await service.ensure({ ...base, worktreeId: "wt-1" });
 
     // If stop() released the port, getByWorktree now returns a different URL.
-    const afterUrl = service.getByWorktree("wt-1")?.assignedUrl;
+    const afterUrl = service.getByWorktree("wt-1")?.predictedUrl;
     expect(afterUrl).toBe(originalUrl);
   });
 
   it("BUG-CC3: multiple stop()+ensure() cycles keep the same port throughout", async () => {
     const first = await service.ensure({ ...base, worktreeId: "wt-1" });
-    const originalUrl = first.assignedUrl;
+    const originalUrl = first.predictedUrl;
 
     for (let i = 0; i < 3; i++) {
       await service.stop(base);
       const state = await service.ensure({ ...base, worktreeId: "wt-1" });
-      expect(state.assignedUrl).toBe(originalUrl);
+      expect(state.predictedUrl).toBe(originalUrl);
     }
   });
 
@@ -328,79 +328,79 @@ describe("DevPreviewSessionService — real-life robustness invariants (adversar
     const b = service.getByWorktree("wt-b");
     expect(a).not.toBeNull();
     expect(b).not.toBeNull();
-    expect(a!.assignedUrl).toBeTruthy();
-    expect(b!.assignedUrl).toBeTruthy();
+    expect(a!.predictedUrl).toBeTruthy();
+    expect(b!.predictedUrl).toBeTruthy();
     // The invariant: two concurrent allocations never produce the same URL.
-    expect(a!.assignedUrl).not.toBe(b!.assignedUrl);
+    expect(a!.predictedUrl).not.toBe(b!.predictedUrl);
   });
 
   // ── Real-Life Scenario 1: agent URL pre-fetch ──────────────────────────────
 
-  it("RLS-1: assignedUrl is non-null immediately after ensure() before server prints URL", async () => {
+  it("RLS-1: predictedUrl is non-null immediately after ensure() before server prints URL", async () => {
     const state = await service.ensure({ ...base, worktreeId: "wt-1" });
 
     // The server has not printed anything yet — url is null, status is starting.
-    // But assignedUrl must already be set so agents can navigate before the server is ready.
+    // But predictedUrl must already be set so agents can navigate before the server is ready.
     expect(state.status).toBe("starting");
     expect(state.url).toBeNull();
-    expect(state.assignedUrl).toMatch(/^http:\/\/localhost:\d+$/);
+    expect(state.predictedUrl).toMatch(/^http:\/\/localhost:\d+$/);
   });
 
-  it("RLS-1b: getByWorktree() returns assignedUrl immediately after ensure()", async () => {
+  it("RLS-1b: getByWorktree() returns predictedUrl immediately after ensure()", async () => {
     await service.ensure({ ...base, worktreeId: "wt-1" });
 
     const session = service.getByWorktree("wt-1");
     expect(session).not.toBeNull();
-    expect(session!.assignedUrl).toMatch(/^http:\/\/localhost:\d+$/);
+    expect(session!.predictedUrl).toMatch(/^http:\/\/localhost:\d+$/);
 
-    // assignedUrl is available even while status is still starting.
+    // predictedUrl is available even while status is still starting.
     expect(session!.status).toBe("starting");
   });
 
   // ── Real-Life Scenario 2: crash-and-recover ────────────────────────────────
 
-  it("RLS-2: after terminal crash and re-ensure, getByWorktree has fresh assignedUrl", async () => {
+  it("RLS-2: after terminal crash and re-ensure, getByWorktree has fresh predictedUrl", async () => {
     const first = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(first.assignedUrl).toBeTruthy();
+    expect(first.predictedUrl).toBeTruthy();
 
     // Simulate server crash.
     ptyClient.emitExit(first.terminalId!, 1);
 
     const crashState = service.getState(base);
-    expect(crashState.assignedUrl).toBeNull();
+    expect(crashState.predictedUrl).toBeNull();
     expect(crashState.status).toBe("error");
 
-    // Re-ensure should spawn a new terminal and set a new assignedUrl.
+    // Re-ensure should spawn a new terminal and set a new predictedUrl.
     const recovered = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(recovered.assignedUrl).toMatch(/^http:\/\/localhost:\d+$/);
+    expect(recovered.predictedUrl).toMatch(/^http:\/\/localhost:\d+$/);
 
     // getByWorktree must reflect the recovered session.
     const byWt = service.getByWorktree("wt-1");
     expect(byWt).not.toBeNull();
-    expect(byWt!.assignedUrl).toBe(recovered.assignedUrl);
+    expect(byWt!.predictedUrl).toBe(recovered.predictedUrl);
     expect(byWt!.status).toBe("starting");
   });
 
   // ── Real-Life Scenario 3: stop / re-start lifecycle ────────────────────────
 
-  it("RLS-3: stop() then ensure() restarts the server with the same assignedUrl", async () => {
+  it("RLS-3: stop() then ensure() restarts the server with the same predictedUrl", async () => {
     const first = await service.ensure({ ...base, worktreeId: "wt-1" });
-    expect(first.assignedUrl).toBeTruthy();
+    expect(first.predictedUrl).toBeTruthy();
 
     await service.stop(base);
 
-    // After stop: session alive but stopped, assignedUrl null in public state.
+    // After stop: session alive but stopped, predictedUrl null in public state.
     const stopped = service.getState(base);
     expect(stopped.status).toBe("stopped");
-    expect(stopped.assignedUrl).toBeNull();
+    expect(stopped.predictedUrl).toBeNull();
 
     // Re-ensure restarts the server — same port, same URL.
     const restarted = await service.ensure({ ...base, worktreeId: "wt-1" });
     expect(restarted.status).toBe("starting");
-    expect(restarted.assignedUrl).toBe(first.assignedUrl);
+    expect(restarted.predictedUrl).toBe(first.predictedUrl);
 
     // getByWorktree picks up the restarted session.
     const byWt = service.getByWorktree("wt-1");
-    expect(byWt!.assignedUrl).toBe(first.assignedUrl);
+    expect(byWt!.predictedUrl).toBe(first.predictedUrl);
   });
 });

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -364,7 +364,7 @@ describe("DevPreviewSessionService", () => {
     const started = await service.ensure(baseRequest);
     expect(started.status).toBe("starting");
     expect(started.terminalId).toBeTruthy();
-    expect(started.assignedUrl).toMatch(/^http:\/\/localhost:\d+$/);
+    expect(started.predictedUrl).toMatch(/^http:\/\/localhost:\d+$/);
 
     await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -374,7 +374,7 @@ describe("DevPreviewSessionService", () => {
         projectId: baseRequest.projectId,
       });
       expect(updated.status).toBe("running");
-      expect(updated.url).toBe(started.assignedUrl);
+      expect(updated.url).toBe(started.predictedUrl);
     });
   });
 
@@ -857,7 +857,7 @@ describe("DevPreviewSessionService", () => {
     // After a port-free timeout the registry entry is released so the next
     // ensure() picks a fresh candidate via allocatePort.
     const restarted = await service.ensure(baseRequest);
-    expect(restarted.assignedUrl).not.toBe(started.assignedUrl);
+    expect(restarted.predictedUrl).not.toBe(started.predictedUrl);
   });
 
   it("transitions to stopped when waitForPortFree succeeds", async () => {

--- a/electron/services/__tests__/normalizeViteDevCommand.test.ts
+++ b/electron/services/__tests__/normalizeViteDevCommand.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizeViteDevCommand } from "../DevPreviewCommandNormalizer.js";
+
+const mockReadFile = vi.fn<(path: string, encoding: string) => Promise<string>>();
+
+vi.mock("node:fs/promises", () => ({
+  default: { readFile: (...args: unknown[]) => mockReadFile(...(args as [string, string])) },
+  readFile: (...args: unknown[]) => mockReadFile(...(args as [string, string])),
+}));
+
+beforeEach(() => {
+  mockReadFile.mockReset();
+});
+
+function mockPkg(scripts: Record<string, string>): void {
+  mockReadFile.mockResolvedValue(JSON.stringify({ scripts }));
+}
+
+function mockNoPkg(): void {
+  mockReadFile.mockRejectedValue(new Error("ENOENT"));
+}
+
+const CWD = "/project";
+const PORT = 43210;
+
+describe("normalizeViteDevCommand", () => {
+  describe("direct Vite commands", () => {
+    it("appends --port and --strictPort to bare 'vite'", async () => {
+      expect(await normalizeViteDevCommand("vite", CWD, PORT)).toBe(
+        `vite --port ${PORT} --strictPort`
+      );
+    });
+
+    it("appends --port and --strictPort to 'vite dev'", async () => {
+      expect(await normalizeViteDevCommand("vite dev", CWD, PORT)).toBe(
+        `vite dev --port ${PORT} --strictPort`
+      );
+    });
+
+    it("appends --port and --strictPort to 'npx vite'", async () => {
+      expect(await normalizeViteDevCommand("npx vite", CWD, PORT)).toBe(
+        `npx vite --port ${PORT} --strictPort`
+      );
+    });
+
+    it("preserves existing flags before appending", async () => {
+      expect(await normalizeViteDevCommand("vite dev --host 0.0.0.0", CWD, PORT)).toBe(
+        `vite dev --host 0.0.0.0 --port ${PORT} --strictPort`
+      );
+    });
+  });
+
+  describe("SvelteKit commands", () => {
+    it("appends --port and --strictPort to 'svelte-kit dev'", async () => {
+      expect(await normalizeViteDevCommand("svelte-kit dev", CWD, PORT)).toBe(
+        `svelte-kit dev --port ${PORT} --strictPort`
+      );
+    });
+  });
+
+  describe("Astro commands (no --strictPort)", () => {
+    it("appends --port only to 'astro dev'", async () => {
+      expect(await normalizeViteDevCommand("astro dev", CWD, PORT)).toBe(
+        `astro dev --port ${PORT}`
+      );
+    });
+
+    it("does NOT append --strictPort for Astro via pkg manager", async () => {
+      mockPkg({ dev: "astro dev" });
+      expect(await normalizeViteDevCommand("npm run dev", CWD, PORT)).toBe(
+        `npm run dev -- --port ${PORT}`
+      );
+    });
+  });
+
+  describe("Nuxt commands (no --strictPort)", () => {
+    it("appends --port only to 'nuxt dev'", async () => {
+      expect(await normalizeViteDevCommand("nuxt dev", CWD, PORT)).toBe(
+        `nuxt dev --port ${PORT}`
+      );
+    });
+  });
+
+  describe("package manager script commands", () => {
+    it("appends ` -- --port N --strictPort` for npm run dev resolving to vite", async () => {
+      mockPkg({ dev: "vite" });
+      expect(await normalizeViteDevCommand("npm run dev", CWD, PORT)).toBe(
+        `npm run dev -- --port ${PORT} --strictPort`
+      );
+    });
+
+    it("appends ` -- --port N --strictPort` for pnpm dev", async () => {
+      mockPkg({ dev: "vite" });
+      expect(await normalizeViteDevCommand("pnpm dev", CWD, PORT)).toBe(
+        `pnpm dev -- --port ${PORT} --strictPort`
+      );
+    });
+
+    it("appends ` -- --port N --strictPort` for pnpm run dev", async () => {
+      mockPkg({ dev: "vite" });
+      expect(await normalizeViteDevCommand("pnpm run dev", CWD, PORT)).toBe(
+        `pnpm run dev -- --port ${PORT} --strictPort`
+      );
+    });
+
+    it("appends ` -- --port N --strictPort` for yarn dev", async () => {
+      mockPkg({ dev: "vite" });
+      expect(await normalizeViteDevCommand("yarn dev", CWD, PORT)).toBe(
+        `yarn dev -- --port ${PORT} --strictPort`
+      );
+    });
+
+    it("appends ` --port N --strictPort` (no -- separator) for bun run dev", async () => {
+      mockPkg({ dev: "vite" });
+      expect(await normalizeViteDevCommand("bun run dev", CWD, PORT)).toBe(
+        `bun run dev --port ${PORT} --strictPort`
+      );
+    });
+
+    it("appends ` --port N --strictPort` for bun dev", async () => {
+      mockPkg({ dev: "vite" });
+      expect(await normalizeViteDevCommand("bun dev", CWD, PORT)).toBe(
+        `bun dev --port ${PORT} --strictPort`
+      );
+    });
+
+    it("resolves pkg script body for SvelteKit (vite dev under the hood)", async () => {
+      mockPkg({ dev: "vite dev" });
+      expect(await normalizeViteDevCommand("npm run dev", CWD, PORT)).toBe(
+        `npm run dev -- --port ${PORT} --strictPort`
+      );
+    });
+
+    it("resolves pkg script body for Astro and omits --strictPort", async () => {
+      mockPkg({ start: "astro dev" });
+      expect(await normalizeViteDevCommand("npm run start", CWD, PORT)).toBe(
+        `npm run start -- --port ${PORT}`
+      );
+    });
+
+    it("resolves pkg script body for Nuxt and omits --strictPort", async () => {
+      mockPkg({ dev: "nuxt dev" });
+      expect(await normalizeViteDevCommand("npm run dev", CWD, PORT)).toBe(
+        `npm run dev -- --port ${PORT}`
+      );
+    });
+  });
+
+  describe("skip conditions", () => {
+    it("does NOT modify when command already has --port flag", async () => {
+      expect(await normalizeViteDevCommand("vite --port 5173", CWD, PORT)).toBe(
+        "vite --port 5173"
+      );
+    });
+
+    it("does NOT modify when command has --port=N form", async () => {
+      expect(await normalizeViteDevCommand("vite --port=5173", CWD, PORT)).toBe(
+        "vite --port=5173"
+      );
+    });
+
+    it("does NOT modify when command has -p flag", async () => {
+      expect(await normalizeViteDevCommand("vite -p 5173", CWD, PORT)).toBe("vite -p 5173");
+    });
+
+    it("does NOT modify when command has PORT= env prefix", async () => {
+      expect(await normalizeViteDevCommand("PORT=5173 vite", CWD, PORT)).toBe("PORT=5173 vite");
+    });
+
+    it("does NOT modify when resolved pkg script already specifies --port", async () => {
+      mockPkg({ dev: "vite --port 5173" });
+      expect(await normalizeViteDevCommand("npm run dev", CWD, PORT)).toBe("npm run dev");
+    });
+
+    it("leaves compound && command unchanged", async () => {
+      expect(await normalizeViteDevCommand("vite && echo done", CWD, PORT)).toBe(
+        "vite && echo done"
+      );
+    });
+
+    it("leaves piped command unchanged", async () => {
+      expect(await normalizeViteDevCommand("vite | tee log", CWD, PORT)).toBe("vite | tee log");
+    });
+
+    it("leaves commented command unchanged", async () => {
+      expect(await normalizeViteDevCommand("vite # default", CWD, PORT)).toBe("vite # default");
+    });
+
+    it("leaves backtick-substituted command unchanged", async () => {
+      expect(await normalizeViteDevCommand("vite `whoami`", CWD, PORT)).toBe("vite `whoami`");
+    });
+
+    it("does NOT modify when pkg script body has shell control", async () => {
+      mockPkg({ dev: "vite && echo done" });
+      expect(await normalizeViteDevCommand("npm run dev", CWD, PORT)).toBe("npm run dev");
+    });
+
+    it("does NOT modify when no package.json exists", async () => {
+      mockNoPkg();
+      expect(await normalizeViteDevCommand("npm run dev", CWD, PORT)).toBe("npm run dev");
+    });
+
+    it("does NOT modify when script name not found in package.json", async () => {
+      mockPkg({ start: "vite" });
+      expect(await normalizeViteDevCommand("npm run dev", CWD, PORT)).toBe("npm run dev");
+    });
+
+    it("does NOT modify Next.js commands", async () => {
+      expect(await normalizeViteDevCommand("next dev", CWD, PORT)).toBe("next dev");
+    });
+
+    it("does NOT modify Remix commands (no CLI --port flag)", async () => {
+      expect(await normalizeViteDevCommand("remix dev", CWD, PORT)).toBe("remix dev");
+    });
+
+    it("does NOT modify arbitrary commands", async () => {
+      expect(await normalizeViteDevCommand("python manage.py runserver", CWD, PORT)).toBe(
+        "python manage.py runserver"
+      );
+    });
+
+    it("does NOT modify pkg manager scripts that resolve to non-Vite commands", async () => {
+      mockPkg({ dev: "next dev" });
+      expect(await normalizeViteDevCommand("npm run dev", CWD, PORT)).toBe("npm run dev");
+    });
+  });
+
+  describe("idempotency", () => {
+    it("calling twice does not double-append (PORT_FLAG_PRESENT_RE skip)", async () => {
+      const once = await normalizeViteDevCommand("vite", CWD, PORT);
+      const twice = await normalizeViteDevCommand(once, CWD, PORT);
+      expect(twice).toBe(once);
+    });
+  });
+});

--- a/electron/services/__tests__/normalizeViteDevCommand.test.ts
+++ b/electron/services/__tests__/normalizeViteDevCommand.test.ts
@@ -75,9 +75,7 @@ describe("normalizeViteDevCommand", () => {
 
   describe("Nuxt commands (no --strictPort)", () => {
     it("appends --port only to 'nuxt dev'", async () => {
-      expect(await normalizeViteDevCommand("nuxt dev", CWD, PORT)).toBe(
-        `nuxt dev --port ${PORT}`
-      );
+      expect(await normalizeViteDevCommand("nuxt dev", CWD, PORT)).toBe(`nuxt dev --port ${PORT}`);
     });
   });
 
@@ -148,15 +146,11 @@ describe("normalizeViteDevCommand", () => {
 
   describe("skip conditions", () => {
     it("does NOT modify when command already has --port flag", async () => {
-      expect(await normalizeViteDevCommand("vite --port 5173", CWD, PORT)).toBe(
-        "vite --port 5173"
-      );
+      expect(await normalizeViteDevCommand("vite --port 5173", CWD, PORT)).toBe("vite --port 5173");
     });
 
     it("does NOT modify when command has --port=N form", async () => {
-      expect(await normalizeViteDevCommand("vite --port=5173", CWD, PORT)).toBe(
-        "vite --port=5173"
-      );
+      expect(await normalizeViteDevCommand("vite --port=5173", CWD, PORT)).toBe("vite --port=5173");
     });
 
     it("does NOT modify when command has -p flag", async () => {

--- a/electron/services/__tests__/normalizeViteDevCommand.test.ts
+++ b/electron/services/__tests__/normalizeViteDevCommand.test.ts
@@ -163,6 +163,10 @@ describe("normalizeViteDevCommand", () => {
       expect(await normalizeViteDevCommand("vite -p 5173", CWD, PORT)).toBe("vite -p 5173");
     });
 
+    it("does NOT modify when command has compact -pN form", async () => {
+      expect(await normalizeViteDevCommand("vite -p5173", CWD, PORT)).toBe("vite -p5173");
+    });
+
     it("does NOT modify when command has PORT= env prefix", async () => {
       expect(await normalizeViteDevCommand("PORT=5173 vite", CWD, PORT)).toBe("PORT=5173 vite");
     });
@@ -219,6 +223,18 @@ describe("normalizeViteDevCommand", () => {
       );
     });
 
+    it("does NOT modify 'vite-node' (hyphenated tool name)", async () => {
+      expect(await normalizeViteDevCommand("vite-node server.ts", CWD, PORT)).toBe(
+        "vite-node server.ts"
+      );
+    });
+
+    it("does NOT modify 'npx vite-node'", async () => {
+      expect(await normalizeViteDevCommand("npx vite-node scripts/dev.ts", CWD, PORT)).toBe(
+        "npx vite-node scripts/dev.ts"
+      );
+    });
+
     it("does NOT modify pkg manager scripts that resolve to non-Vite commands", async () => {
       mockPkg({ dev: "next dev" });
       expect(await normalizeViteDevCommand("npm run dev", CWD, PORT)).toBe("npm run dev");
@@ -228,6 +244,14 @@ describe("normalizeViteDevCommand", () => {
   describe("idempotency", () => {
     it("calling twice does not double-append (PORT_FLAG_PRESENT_RE skip)", async () => {
       const once = await normalizeViteDevCommand("vite", CWD, PORT);
+      const twice = await normalizeViteDevCommand(once, CWD, PORT);
+      expect(twice).toBe(once);
+    });
+
+    it("calling twice on a pkg-manager script does not double-append", async () => {
+      mockPkg({ dev: "vite" });
+      const once = await normalizeViteDevCommand("npm run dev", CWD, PORT);
+      mockPkg({ dev: "vite" });
       const twice = await normalizeViteDevCommand(once, CWD, PORT);
       expect(twice).toBe(once);
     });

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -33,7 +33,7 @@ export interface DevPreviewSessionState {
   worktreeId?: string;
   status: DevPreviewSessionStatus;
   url: string | null;
-  assignedUrl: string | null;
+  predictedUrl: string | null;
   error: DevServerError | null;
   terminalId: string | null;
   isRestarting: boolean;

--- a/src/hooks/__tests__/useDevServer.adversarial.test.tsx
+++ b/src/hooks/__tests__/useDevServer.adversarial.test.tsx
@@ -36,7 +36,7 @@ function buildState(overrides: Partial<DevPreviewSessionState>): DevPreviewSessi
     worktreeId: overrides.worktreeId,
     status: overrides.status ?? "stopped",
     url: overrides.url ?? null,
-    assignedUrl: overrides.assignedUrl ?? null,
+    predictedUrl: overrides.predictedUrl ?? null,
     error: overrides.error ?? null,
     terminalId: overrides.terminalId ?? null,
     isRestarting: overrides.isRestarting ?? false,


### PR DESCRIPTION
## Summary

Vite-based dev servers (Vite, SvelteKit, Astro, Nuxt) ignore `process.env.PORT`, so the allocated port reaches the spawn environment but the dev server binds to its framework default instead. Added `normalizeViteDevCommand` that injects `--port <N> --strictPort` for Vite/SvelteKit and `--port <N>` for Astro/Nuxt, with the same pkg-manager separator handling as `normalizeNextjsDevCommand`.

Also renamed `DevPreviewSessionState.assignedUrl` to `predictedUrl` across 11 files. The old name implied the URL was authoritative; it's actually the allocator-derived starting point for the readiness poller, which can still update it as the server comes up.

Resolves #9092.

## Changes

- `electron/services/DevPreviewCommandNormalizer.ts` — add `normalizeViteDevCommand`; detect Vite/SvelteKit/Astro/Nuxt by command pattern; inject `--port` (and `--strictPort` where applicable)
- `electron/services/DevPreviewSessionService.ts` — wire `normalizeViteDevCommand` into session startup; rename `assignedUrl` → `predictedUrl`
- `shared/types/ipc/devPreview.ts` — rename field in shared IPC type
- `electron/services/__tests__/` — update five existing port-registry tests to use `predictedUrl`; add `normalizeViteDevCommand.test.ts` (253-line suite covering bare vite, npm/yarn/pnpm/bun run dev, SvelteKit, Astro, Nuxt, compact `-p N`, existing-flag dedup, `vite-node`)
- `e2e/full/panels/core-dev-preview-per-worktree.spec.ts` — update field reference

## Testing

Full unit test suite for `normalizeViteDevCommand` added. Existing dev-preview unit and E2E tests updated and passing.