### PR TITLE
fix(renderer): route FD-leak warning through logWarn to reach LogBuffer

### DIFF
--- a/src/store/listeners/panel/__tests__/fdLeakWarning.test.ts
+++ b/src/store/listeners/panel/__tests__/fdLeakWarning.test.ts
@@ -1,14 +1,16 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
+vi.mock("@/utils/logger", () => ({ logWarn: vi.fn() }));
+
+import { logWarn } from "@/utils/logger";
 import { setupFdLeakWarningListeners, _resetFdLeakWarningCooldown } from "../fdLeakWarning";
 
 let onFdLeakWarningCb: ((data: unknown) => void) | null = null;
-let warnSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   onFdLeakWarningCb = null;
-  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.clearAllMocks();
   _resetFdLeakWarningCooldown();
 
   vi.stubGlobal("electron", {
@@ -24,7 +26,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  warnSpy.mockRestore();
   vi.unstubAllGlobals();
 });
 
@@ -41,19 +42,23 @@ const makePayload = (overrides = {}) => ({
 describe("setupFdLeakWarningListeners", () => {
   it("logs the first warning without notifying the user", () => {
     const d = setupFdLeakWarningListeners();
-    onFdLeakWarningCb!(makePayload());
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.lastCall?.[0]).toContain("[TerminalDiagnostics] FD leak warning");
+    const payload = makePayload();
+    onFdLeakWarningCb!(payload);
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("[TerminalDiagnostics] FD leak warning"),
+      { data: payload }
+    );
     d.dispose();
   });
 
   it("suppresses repeat logs within cooldown period", () => {
     const d = setupFdLeakWarningListeners();
     onFdLeakWarningCb!(makePayload());
-    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(logWarn).toHaveBeenCalledTimes(1);
 
     onFdLeakWarningCb!(makePayload());
-    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(logWarn).toHaveBeenCalledTimes(1);
 
     d.dispose();
   });
@@ -61,24 +66,30 @@ describe("setupFdLeakWarningListeners", () => {
   it("includes ptmxLimit percentage in log message", () => {
     const d = setupFdLeakWarningListeners();
     onFdLeakWarningCb!(makePayload({ fdCount: 400, ptmxLimit: 511 }));
-    const message = warnSpy.mock.lastCall?.[0];
-    expect(message).toContain("78% of limit");
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("78% of limit"),
+      expect.any(Object)
+    );
     d.dispose();
   });
 
   it("omits percentage when ptmxLimit is null", () => {
     const d = setupFdLeakWarningListeners();
     onFdLeakWarningCb!(makePayload({ ptmxLimit: null }));
-    const message = warnSpy.mock.lastCall?.[0];
-    expect(message).not.toContain("of limit");
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.not.stringContaining("of limit"),
+      expect.any(Object)
+    );
     d.dispose();
   });
 
   it("includes orphaned pids when present", () => {
     const d = setupFdLeakWarningListeners();
     onFdLeakWarningCb!(makePayload({ orphanedPids: [123, 456] }));
-    const message = warnSpy.mock.lastCall?.[0];
-    expect(message).toContain("orphaned PIDs: 123, 456");
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("orphaned PIDs: 123, 456"),
+      expect.any(Object)
+    );
     d.dispose();
   });
 });

--- a/src/store/listeners/panel/fdLeakWarning.ts
+++ b/src/store/listeners/panel/fdLeakWarning.ts
@@ -1,5 +1,6 @@
 import type { FdLeakWarningPayload } from "@shared/types/pty-host";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
+import { logWarn } from "@/utils/logger";
 
 let lastWarningTimestamp = 0;
 const REARM_MS = 5 * 60 * 1000; // 5 min cooldown before logging again
@@ -34,7 +35,7 @@ export function setupFdLeakWarningListeners(): DisposableStore {
         if (now - lastWarningTimestamp < REARM_MS) return;
         lastWarningTimestamp = now;
 
-        console.warn(formatFdLeakWarning(data));
+        logWarn(formatFdLeakWarning(data), { data });
       })
     )
   );


### PR DESCRIPTION
## Summary
- Swapped a raw `console.warn` in the FD-leak warning listener for `logWarn` from the structured logger, so the warning lands in LogBuffer and appears in the Diagnostics > Logs tab.
- This was the last outlier -- peer listeners in the same directory already use `logWarn`.
- Updated the test file to match the new path.

Resolves #9198.

## Changes
- `src/store/listeners/panel/fdLeakWarning.ts` -- replaced `console.warn` with `logWarn`
- `src/store/listeners/panel/__tests__/fdLeakWarning.test.ts` -- updated assertions for `logWarn`

## Testing
- Unit tests pass. The structured logger already has an IPC-failure fallback to `console.warn`, so devtools visibility is preserved.