### PR TITLE
fix(security): strip E2E test backdoors from production builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,11 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Hard security gate (#9148) — no continue-on-error. Fails the build if any
+      # E2E test backdoor survived the production strip in dist-electron/electron/preload.cjs.
+      - name: Check preload backdoors stripped
+        run: npm run check:preload-backdoors
+
       - name: Build import budget metadata
         run: npm run import-budget:build
 

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -191,6 +191,9 @@ jobs:
           DEBUG: electron-builder,electron-notarize*,electron-osx-sign*
         run: |
           npm run build
+          # Hard security gate (#9148) — fail before packaging if any E2E
+          # backdoor survived the production strip.
+          npm run check:preload-backdoors
           PUBLISH_FLAG="always"
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             echo "::warning::Dry run — skipping publish to electron-builder targets"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -212,6 +212,9 @@ jobs:
           npm_config_build_from_source: "true"
         run: |
           npm run build
+          # Hard security gate (#9148) — fail before packaging if any E2E
+          # backdoor survived the production strip.
+          npm run check:preload-backdoors
           PUBLISH_FLAG="always"
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             echo "::warning::Dry run — skipping publish to electron-builder targets"

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -199,6 +199,9 @@ jobs:
           DEBUG: electron-builder,electron-notarize*,electron-osx-sign*
         run: |
           npm run build
+          # Hard security gate (#9148) — fail before packaging if any E2E
+          # backdoor survived the production strip.
+          npm run check:preload-backdoors
           # Windows binaries are published via the R2 upload in the publish
           # job (and the Microsoft Store step below), never by electron-builder
           # directly — so --publish is always "never" here.

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -131,8 +131,14 @@ import type { ToolbarButtonConfig } from "../shared/config/toolbarButtonRegistry
 
 export type { ElectronAPI };
 
-const isDemoMode =
-  !process.argv.some((a) => a.includes("app.asar")) && process.argv.includes("--demo-mode");
+// True for packaged production builds. `process.resourcesPath` is undefined in
+// sandboxed preloads (sandbox: true), so the only reliable signal here is the
+// `app.asar` segment Electron injects into argv when running from the asar.
+// Used to gate the E2E test bridges below as defense-in-depth (#9148) — the
+// primary strip happens at build time via esbuild defines in build-main.mjs.
+const isPackagedBuild = process.argv.some((a) => a.includes("app.asar"));
+
+const isDemoMode = !isPackagedBuild && process.argv.includes("--demo-mode");
 
 // Persisted color scheme id passed from the main process via
 // webPreferences.additionalArguments. Read synchronously here (process.argv is
@@ -2648,7 +2654,7 @@ _eventBusOn("window:sample-renderer-elu", ({ requestId }) => {
 
 // E2E test bridge: expose renderer-side IPC listener introspection in fault mode.
 // Gated by DAINTREE_E2E_FAULT_MODE to avoid production surface area.
-if (process.env.DAINTREE_E2E_FAULT_MODE === "1") {
+if (process.env.DAINTREE_E2E_FAULT_MODE === "1" && !isPackagedBuild) {
   contextBridge.exposeInMainWorld("__DAINTREE_E2E_IPC__", {
     getRendererListenerCount: (channel: string) => ipcRenderer.listenerCount(channel),
   });
@@ -2658,7 +2664,7 @@ if (process.env.DAINTREE_E2E_FAULT_MODE === "1") {
 // Used by the renderer to suppress side effects (like the auto-launched
 // primary agent at the end of onboarding) that would otherwise pollute
 // panel-count assertions in tests.
-if (process.env.DAINTREE_E2E_MODE === "1") {
+if (process.env.DAINTREE_E2E_MODE === "1" && !isPackagedBuild) {
   contextBridge.exposeInMainWorld("__DAINTREE_E2E_MODE__", true);
 }
 
@@ -2668,7 +2674,7 @@ if (process.env.DAINTREE_E2E_MODE === "1") {
 // only set when the E2E harness launches Electron. The sandboxed renderer
 // cannot read `process.env` directly, so the preload (which does have a
 // polyfilled `process.env` even under sandbox: true) is the propagation point.
-if (process.env.DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS === "1") {
+if (process.env.DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS === "1" && !isPackagedBuild) {
   contextBridge.exposeInMainWorld("__DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS__", true);
 }
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit && tsc -b electron/tsconfig.json && tsc --noEmit -p electron/tsconfig.preload.json",
     "check:channels": "node scripts/ci/check-channel-drift.mjs",
+    "check:preload-backdoors": "node scripts/ci/check-preload-backdoors.mjs",
     "check:crash-loop-constants": "node scripts/ci/check-crash-loop-constants.mjs",
     "codegen:ipc": "node scripts/codegen/ipc-map.mjs",
     "check:ipc": "node scripts/codegen/ipc-map.mjs --check",

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -32,6 +32,20 @@ const common = {
   pure: isProd ? ["console.log", "console.info", "console.warn", "console.debug"] : [],
   define: {
     "process.env.SENTRY_DSN": JSON.stringify(process.env.SENTRY_DSN || ""),
+    // Strip E2E test backdoors from production builds (#9148). Replacing these
+    // env-var reads with "" lets esbuild constant-fold the `=== "1"` checks to
+    // false and dead-code-eliminate the `contextBridge.exposeInMainWorld` blocks
+    // in preload.cts (plus the matching main-process test guards). Conditional
+    // spread, not a ternary value — esbuild stringifies a bare `undefined` define
+    // as the literal "undefined", so dev/test builds must omit these keys entirely
+    // to keep the branches intact for the E2E harness.
+    ...(isProd
+      ? {
+          "process.env.DAINTREE_E2E_FAULT_MODE": JSON.stringify(""),
+          "process.env.DAINTREE_E2E_MODE": JSON.stringify(""),
+          "process.env.DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS": JSON.stringify(""),
+        }
+      : {}),
   },
 };
 

--- a/scripts/ci/check-preload-backdoors.mjs
+++ b/scripts/ci/check-preload-backdoors.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Verifies that E2E test backdoors are stripped from the packaged preload (#9148).
+// The preload exposes three `contextBridge.exposeInMainWorld` bridges
+// (`__DAINTREE_E2E_*`) gated only by env-var reads — not a security boundary.
+// Production builds replace those env reads with "" via esbuild defines
+// (scripts/build-main.mjs), so the minifier dead-code-eliminates the bridges.
+// This gate runs after a production `npm run build` and fails if any of the
+// forbidden strings survive in the compiled CJS preload — the env-var names or
+// the exposed global keys both indicate the strip regressed.
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(here, "../..");
+
+const PRELOAD_BUNDLE = path.join(root, "dist-electron/electron/preload.cjs");
+
+// Both the exposed global keys and the gating env-var names. If the env reads
+// were not replaced, the names survive even when minify happens to drop the
+// branch body, so checking both is strictly safer.
+const FORBIDDEN = [
+  "__DAINTREE_E2E_IPC__",
+  "__DAINTREE_E2E_MODE__",
+  "__DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS__",
+  "DAINTREE_E2E_FAULT_MODE",
+  "DAINTREE_E2E_MODE",
+  "DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS",
+];
+
+if (!existsSync(PRELOAD_BUNDLE)) {
+  console.error(
+    `::error::${PRELOAD_BUNDLE} not found. Run a production build ` +
+      `(\`npm run build\`) before \`npm run check:preload-backdoors\`.`
+  );
+  process.exit(1);
+}
+
+const bundle = readFileSync(PRELOAD_BUNDLE, "utf8");
+
+const hits = FORBIDDEN.filter((needle) => bundle.includes(needle));
+
+if (hits.length > 0) {
+  for (const hit of hits) {
+    console.error(
+      `::error file=dist-electron/electron/preload.cjs::E2E backdoor "${hit}" ` +
+        `survived in the production preload. The esbuild defines in ` +
+        `scripts/build-main.mjs must strip it — confirm NODE_ENV=production and ` +
+        `minify are active.`
+    );
+  }
+  console.error(
+    `\npreload backdoor check failed: ${hits.length} forbidden string(s) in the packaged preload.`
+  );
+  process.exit(1);
+}
+
+console.log("[check-preload-backdoors] OK — no E2E backdoors in the production preload");


### PR DESCRIPTION
Closes #9148.

## Problem

Three `contextBridge.exposeInMainWorld` E2E bridges in `electron/preload.cts` — `__DAINTREE_E2E_IPC__`, `__DAINTREE_E2E_MODE__`, `__DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS__` — were gated **only** by env-var checks. An env-var check is not a security boundary in a packaged build: anyone launching the app with the right env var set would get the bridges exposed in the renderer.

## Fix — three layers, production-only

1. **Build-time strip (primary).** `scripts/build-main.mjs` adds esbuild `define`s, gated on `isProd` via a conditional spread, that replace the three `process.env.DAINTREE_E2E_*` reads with `""`. With `minify: isProd` already set, esbuild constant-folds `"" === "1"` to `false` and dead-code-eliminates the `exposeInMainWorld` blocks (and the matching main-process test guards) entirely. The conditional spread is deliberate — esbuild stringifies a bare `undefined` define as the literal `"undefined"`, so dev/test builds must omit the keys to keep branches intact.

2. **Runtime guard (defense-in-depth).** A shared `isPackagedBuild` const (`process.argv.some(a => a.includes("app.asar"))`) is added and `&& !isPackagedBuild` appended to the three guards. `process.resourcesPath` is **undefined** in sandboxed preloads (`sandbox: true`), so `argv` is the reliable signal — this reuses the existing `isDemoMode` pattern.

3. **CI gate.** New `scripts/ci/check-preload-backdoors.mjs` greps the built `dist-electron/electron/preload.cjs` for six forbidden strings and fails the build if any survive. Wired as a hard gate (no `continue-on-error`) into `ci.yml` after Build and into all three release workflows before packaging.

## Dev/test untouched

The defines only apply when `NODE_ENV=production`, so the E2E harness still receives the bridges in dev/test builds.

## Verification

- Production `build:main` → gate **PASS** (no forbidden strings in preload.cjs)
- Dev build → gate correctly **FAILs** (all six strings detected; confirms the gate enforces and the dev path is preserved)
- `npm run check` (typecheck + lint ratchet + format + IPC codegen) → all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)