### PR TITLE
docs(plugins): formalize hybrid plugin trust contract

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -46,7 +46,7 @@ The `engines.daintree` field in your manifest controls host compatibility. Plugi
 
 ## Security and trust
 
-Plugin code runs with full Node.js privileges. Daintree does not sandbox plugins at runtime. The plugin manifest's `capabilities` field is a **disclosure mechanism** — it tells the user what the plugin can do, but it is not enforced. A plugin that declares `capabilities: ["fs:project-read"]` is not prevented from making network requests.
+Plugin code runs with full Node.js privileges. Daintree does not sandbox plugins at runtime, so a plugin that declares `capabilities: ["fs:project-read"]` is not blocked from making network requests. The `capabilities` field is **disclosure-first with host-side policy effects**: it tells the user what the plugin claims to need, and high-risk tokens (`shell:exec`, `git:write`, `fs:project-write`, `fs:user-data-write`, `agent:invoke`) raise the plugin's actions to a confirm dialog. It is not an enforcement boundary against malicious code. See the [trust model](./trust-model.md) for the full contract.
 
 Install only plugins from sources you trust. For plugins you author yourself, this is trivially true. For plugins you install from URLs or files, inspect the code before running it — especially if it requests broad capabilities like `shell:exec` or `network:fetch`.
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -46,7 +46,7 @@ The `engines.daintree` field in your manifest controls host compatibility. Plugi
 
 ## Security and trust
 
-Plugin code runs with full Node.js privileges. Daintree does not sandbox plugins at runtime, so a plugin that declares `capabilities: ["fs:project-read"]` is not blocked from making network requests. The `capabilities` field is **disclosure-first with host-side policy effects**: it tells the user what the plugin claims to need, and high-risk tokens (`shell:exec`, `git:write`, `fs:project-write`, `fs:user-data-write`, `agent:invoke`) raise the plugin's actions to a confirm dialog. It is not an enforcement boundary against malicious code. See the [trust model](./trust-model.md) for the full contract.
+Plugin code runs with full Node.js privileges. Daintree does not sandbox plugins at runtime, so a plugin that declares `permissions: ["fs:project-read"]` is not blocked from making network requests. The declared-capability field (`permissions` today, renamed to `capabilities` in #9268) is **disclosure-first with host-side policy effects**: it tells the user what the plugin claims to need, and high-risk tokens (`shell:exec`, `git:write`, `fs:project-write`, `fs:user-data-write`, `agent:invoke`) raise the plugin's actions to a confirm dialog. It is not an enforcement boundary against malicious code. See the [trust model](./trust-model.md) for the full contract.
 
 Install only plugins from sources you trust. For plugins you author yourself, this is trivially true. For plugins you install from URLs or files, inspect the code before running it — especially if it requests broad capabilities like `shell:exec` or `network:fetch`.
 

--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -147,7 +147,7 @@ Plugin manifest `env` values support `${settings:settingId}` syntax. Substitutio
 
 MCP subprocesses run with the full privileges of the Daintree process. There's no sandboxing. The curation model (review by human, trusted source, signed distribution) is the primary defense.
 
-An MCP server can do anything the plugin could do: make network requests, read and write files, spawn further processes. The manifest's `capabilities` array is disclosed to the user at install — if a plugin declares `network:fetch` because its MCP server calls Linear's API, the user sees that during install and decides whether to trust it.
+An MCP server can do anything the plugin could do: make network requests, read and write files, spawn further processes. The manifest's declared capabilities (the `permissions` field today; renamed to `capabilities` in #9268) are disclosed to the user at install — if a plugin declares `network:fetch` because its MCP server calls Linear's API, the user sees that during install and decides whether to trust it.
 
 ## Worktree observability
 

--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -177,7 +177,7 @@ Plugins consuming worktree events during `activate()` — before the WorkspaceCl
 
 ## Capability disclosure
 
-The `capabilities` field in the manifest is a **disclosure mechanism**, not a runtime sandbox. Daintree does not prevent a plugin from doing anything — a plugin declaring `capabilities: []` can still make network requests and write files.
+Capabilities are **disclosure-first with host-side policy effects** — a hybrid model. The host does not sandbox plugin code: a plugin declaring `capabilities: []` can still make network requests and write files via raw Node APIs. But declared capabilities are not purely advisory either. They drive host-side policy, most concretely danger classification on plugin-registered actions. See the [trust model](./trust-model.md) for the full decision record, decision matrix, and forthcoming schema.
 
 What disclosure does:
 
@@ -185,9 +185,12 @@ What disclosure does:
 - Installed plugins' detail views show the same list.
 - The install dialog shows the list in large, clear text before the user confirms.
 
-The purpose is to let users judge plugins by what they claim to need. A simple theme-packager plugin declaring `shell:exec` looks suspicious; a Linear integration declaring `network:fetch` looks expected. This is the same reasoning Chrome extension permissions use — informational, pre-install, not post-install runtime gates.
+What the host derives from declared capabilities:
 
-Declaring honestly matters. A plugin that silently makes network requests without declaring `network:fetch` erodes the ecosystem's trust model, even though nothing blocks the call at runtime.
+- **Danger classification (live today).** When a manifest holds any high-risk token in `CONFIRM_TRIGGERING_PERMISSIONS` (`shell:exec`, `git:write`, `fs:project-write`, `fs:user-data-write`, `agent:invoke`), every action that plugin registers is raised to `effectiveDanger: "confirm"` — gating the renderer's confirm dialog, MRU-rail eligibility, and `repeatLast`. The host may only raise danger, never lower it. This is host-side UX policy on Daintree's own action system; it does **not** block the plugin from executing code or calling IPC directly.
+- A compound-permission lattice, scope attenuation, and MCP advertisement gates are forthcoming (#9247, #9234). See the trust model for the complete list.
+
+The purpose is to let users judge plugins by what they claim to need and to apply proportional friction at high-risk intent surfaces. A simple theme-packager plugin declaring `shell:exec` looks suspicious; a Linear integration declaring `network:fetch` looks expected. Declaring honestly matters: a plugin that silently makes network requests without declaring `network:fetch` erodes the ecosystem's trust model, even though nothing blocks the call at runtime.
 
 ## Signing and kill-switch
 
@@ -209,7 +212,7 @@ A short rationale for the decisions most likely to feel arbitrary:
 
 **Why dual-path action binding (filesystem convention + imperative)?** The filesystem convention (Raycast-style: `commands[].name` → `src/{name}.ts` default export) is delightful for simple cases — zero boilerplate, co-located with declaration. Imperative registration via `host.registerAction` is needed for truly dynamic commands and matches the existing imperative pattern Daintree uses for its own ~258 built-in actions. Supporting both is cheap and handles both ends of the complexity spectrum.
 
-**Why no runtime permission enforcement?** The audience is power users who write their own plugins and trusted Daintree-authored plugins. Enforcing runtime permissions requires either Wasm sandboxing (Zed's approach — great DX cost) or iframe isolation (worse DX, breaks React integration) or permission prompts for every Node API call (unusable). For a curated-trust model, disclosure is the right fidelity.
+**Why no runtime permission enforcement?** There is no Node sandbox and there can't be one — plugins share the host's V8 + Node process, so a plugin bypasses any custom-API gate by calling `require("fs")` or `child_process.spawn` directly. Full enforcement would require Wasm sandboxing (Zed's approach — great DX cost), iframe isolation (worse DX, breaks React integration), or a prompt on every Node call (unusable). Instead of claiming enforcement we can't deliver, declared capabilities drive host-side policy effects (danger derivation today; the compound lattice and MCP consent forthcoming) while the model stays honest that it does not sandbox arbitrary code. See the [trust model](./trust-model.md).
 
 **Why no separate hooks contribution point (PreToolUse/PostToolUse)?** An MCP server can act as a proxy in front of other tools, intercepting and modifying tool calls. This uses the ecosystem we're already committed to (MCP) rather than inventing a parallel API. Plugins that genuinely need this can build it cleanly.
 

--- a/docs/plugins/getting-started.md
+++ b/docs/plugins/getting-started.md
@@ -38,7 +38,7 @@ A minimal `plugin.json` looks like:
   "description": "An example Daintree plugin.",
   "main": "dist/index.js",
   "engines": { "daintree": "^0.8.0" },
-  "capabilities": [],
+  "permissions": [],
   "contributes": {
     "commands": [
       {

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -136,7 +136,9 @@ Daintree is pre-1.0. Pin tightly during this phase — a plugin that works on Da
 
 ### `capabilities`
 
-Array of capability tokens the plugin wants. This is a **disclosure mechanism** shown to the user at install time, not a runtime sandbox. The plugin is not prevented from doing anything it claims not to need, and is not prevented from doing things it declares.
+Array of capability tokens the plugin wants. The model is **disclosure-first with host-side policy effects** — there is no Node sandbox, so a plugin is not blocked from doing anything regardless of what it declares, but declared tokens are not purely advisory. Five high-risk tokens (`shell:exec`, `git:write`, `fs:project-write`, `fs:user-data-write`, `agent:invoke`) currently raise every action the plugin registers to a confirm dialog (`effectiveDanger: "confirm"`) via the host's `CONFIRM_TRIGGERING_PERMISSIONS` set. A forthcoming scoped object form (`{ name, scopes }`) and `mcp:*` tokens are not yet parsed. See the [trust model](./trust-model.md) for the full contract.
+
+> The current manifest field is `permissions` (`PluginPermission[]`) at the TypeScript level; the rename to `capabilities` and the discriminated-union schema are tracked in #9268.
 
 | Token                | Intent                                                   |
 | -------------------- | -------------------------------------------------------- |
@@ -153,7 +155,7 @@ Array of capability tokens the plugin wants. This is a **disclosure mechanism** 
 | `clipboard:write`    | Write to the system clipboard                            |
 | `shell:exec`         | Spawn subprocesses                                       |
 
-Declare honestly even though it's not enforced — the install UI lists what you've declared, and users judge plugins by what they ask for. A plugin declaring `shell:exec` for no obvious reason looks suspicious. A plugin that silently executes shells without declaring it damages the ecosystem.
+Declare honestly. The install UI lists what you've declared and users judge plugins by what they ask for; the host also derives policy from the high-risk tokens above. A plugin declaring `shell:exec` for no obvious reason looks suspicious. A plugin that silently executes shells without declaring it damages the ecosystem — and nothing at runtime stops it, which is exactly why honest declaration matters.
 
 ### `contributes`
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -33,8 +33,10 @@ Daintree reads the manifest eagerly at startup. Contribution points declared her
   },
 
   // Declared capabilities, shown to the user at install time.
-  // Disclosure only; not enforced at runtime. See "Capabilities" below.
-  "capabilities": ["fs:project-read", "network:fetch"],
+  // Disclosure-first with host-side policy effects (no Node sandbox).
+  // The live field key is "permissions"; it becomes "capabilities" in #9268.
+  // See "Capabilities" below and ./trust-model.md.
+  "permissions": ["fs:project-read", "network:fetch"],
 
   // The plugin's UI and functional contributions.
   "contributes": {

--- a/docs/plugins/trust-model.md
+++ b/docs/plugins/trust-model.md
@@ -89,7 +89,7 @@ The chosen contract changes what these issues must do:
 - **#9268** — adopt `capabilities` as the field name and extend the element schema to the discriminated union above. The field rename and the non-guarantee both freeze here.
 - **#9228** — bake the canonical statement into the manifest contract before the SDK ships to npm; the field name and the non-guarantee must be frozen before external authors depend on them.
 - **#9247** — the compound-permission lattice and scope attenuation are load-bearing parts of this contract, not optional add-ons. Ship them in the same release as the schema.
-- **#9234** — `elicitation` / `sampling` advertisement is now gated by `mcp:elicitation` / `mcp:sampling` capabilities; tool advertisement is bounded by the manifest as the upper bound.
+- **#9234** — `elicitation` / `sampling` advertisement must be gated by `mcp:elicitation` / `mcp:sampling` capabilities; tool advertisement must be bounded by the manifest as the upper bound.
 
 ## Open questions
 

--- a/docs/plugins/trust-model.md
+++ b/docs/plugins/trust-model.md
@@ -1,0 +1,97 @@
+# Plugin trust model
+
+This is the canonical decision record for what a plugin's declared `capabilities` mean. It settles a contradiction that had accumulated across the codebase: the docs claimed pure disclosure while the code already applied a small derived gate. The contract is now **hybrid** — disclosure-first, with load-bearing host-side policy effects. Everything downstream (`#9268` schema, `#9247` lattice, `#9234` MCP consent) builds on this record.
+
+## The contract in one line
+
+> **Capabilities are disclosure-first with host-side policy effects.** The host does not sandbox plugin code — a plugin can call any Node API directly. The `capabilities` field is shown to the user at install, drives host-derived danger classification on plugin-registered actions, gates which MCP client capabilities are advertised to plugin-hosted servers, and is the upper bound on which MCP tools are exposed. It is not an enforcement boundary against malicious code; it is an honest, machine-readable description of what a plugin claims to need, used by the host to apply proportional friction at high-risk intent surfaces.
+
+## The three options
+
+Three contracts were on the table. Only one is honest about the constraint that defines our situation: there is no sandbox, and there cannot be one. Plugins share the host's React 19 + Node.js process. A plugin can `require("fs")` and `child_process.spawn` directly, and no custom-API gate intercepts that.
+
+|  | (a) Disclosure-only | (b) Pure gated | (c) Hybrid (recommended) |
+| --- | --- | --- | --- |
+| Enforcement cost | None | Very high — checks on every host-API method, plus the impossible task of intercepting raw Node calls | Moderate — extend the existing `effectiveDanger` derivation, add the lattice (#9247), add the MCP advertisement gate (#9234) |
+| Plugin-author cost | None | High — calls can fail mid-flow with `PermissionDenied` | Low — declare honestly; high-risk declarations show a confirm dialog (already true) |
+| False-negative risk | **High** — compound attacks (read + network) declare nothing individually risky | Medium — gates work at the host-API surface but raw Node bypasses them, giving false confidence | Medium — same Node bypass, but the model never claims to prevent it; the lattice catches the compound classes |
+| False-positive risk | None | High — risks training users to dismiss dialogs | Low — gates fire only on the five high-risk tokens + lattice; scopes attenuate further |
+| Interaction with #9247 | No derived effects to raise | A lattice would refuse calls, but the enforcement surface doesn't exist | The lattice raises `effectiveDanger`; URL/glob scopes narrow sinks |
+| Interaction with #9234 | MCP consent runs independent of the manifest — shadow privilege escalation | The manifest caps MCP at advertisement | The manifest caps MCP advertisement; `mcp:elicitation` / `mcp:sampling` become explicit opt-in tokens |
+| Honest framing | Truthful (no sandbox) but invites attacks | Misleading — implies enforcement we can't deliver | Truthful: we disclose, we don't sandbox, but high-risk intent gets a confirm dialog |
+
+## Recommendation
+
+**Hybrid.** Three reasons.
+
+**The code already does this.** `electron/services/PluginService.ts` raises a plugin action's `effectiveDanger` to `"confirm"` whenever the manifest holds one of five high-risk tokens. The docs claimed pure disclosure. The docs were wrong, not the code — this record reconciles them.
+
+**Pure disclosure is the no-sandbox baseline, and it's the model that failed publicly.** VS Code, Cursor, Obsidian, and JetBrains all ship pure disclosure. That's the industry default, and it's exactly the class the malicious `ChatGPT - 中文版` / `ChatMoss` VS Code extensions exploited in January 2026 — over 1.5M combined installs, exfiltrating developer code using only the implicit filesystem + network access every editor extension already gets. They declared nothing individually risky because nothing gated the capabilities they abused. Pure disclosure has no surface to detect that compound class.
+
+**Pure gated is security theatre without a sandbox.** Zed gates at the WebAssembly Component Model boundary; Tauri 2.x gates at the IPC bridge because that bridge is the only path from webview to host. Neither precedent transfers — we run shared V8 with Node, so a plugin bypasses any custom-API gate by calling Node directly. Claiming runtime enforcement we cannot deliver is worse than admitting we cannot.
+
+Hybrid threads the needle: be honest that we don't sandbox Node, and still use declared capabilities as load-bearing host-side policy input.
+
+## The three roles, by guarantee strength
+
+The contract carries three roles, in descending order of how strong a guarantee each provides.
+
+### 1. Disclosure (always)
+
+Declared capabilities are shown in the install dialog and the Settings detail view as a humanised list ("This plugin can read your worktree files, make network requests, and spawn subprocesses"). This is the same reasoning Chrome extension permissions use — informational, pre-install. It is always present and never an enforcement boundary.
+
+### 2. Host-side policy input (load-bearing)
+
+Declared capabilities feed five derived effects. Be precise about what is live today versus what these sibling issues add — only the first is implemented.
+
+- **`effectiveDanger` raise — _live today._** When a plugin's manifest holds any token in `CONFIRM_TRIGGERING_PERMISSIONS` (`shell:exec`, `git:write`, `fs:project-write`, `fs:user-data-write`, `agent:invoke`), every action that plugin registers is raised to `effectiveDanger: "confirm"`, regardless of the `danger` the plugin self-declared. The host may only raise, never lower. **This affects Daintree's own action system** — it gates the renderer's confirm dialog, MRU-rail eligibility, and `repeatLast`. It does **not** block the plugin from executing code or calling IPC directly. It is host-side UX policy, not a sandbox. (`PluginService.ts` — `CONFIRM_TRIGGERING_PERMISSIONS`, `effectiveDanger` derivation.)
+- **Compound-permission lattice — _forthcoming (#9247)._** Combinations that are individually benign but dangerous together — read-source + unconstrained-sink, or unconstrained-sink + local-write — raise `effectiveDanger` even when no single token triggers. This is the surface that catches the compound benign-permission attack class.
+- **Scope attenuation — _forthcoming (#9247)._** `network:fetch` with a URL allowlist, `fs:project-write` with a glob allowlist. The schema rejects `*` and `**`. A scoped declaration skips lattice elevation because it has narrowed its own sink.
+- **MCP client-capability advertisement — _forthcoming (#9234)._** `elicitation` and `sampling` are advertised to a plugin-hosted MCP server in the `initialize` handshake only when the plugin declares `mcp:elicitation` / `mcp:sampling`. Default-deny.
+- **MCP tool advertisement — _forthcoming (#9234)._** The host refuses to expose tools whose declared scope exceeds the manifest. The manifest is the upper bound.
+
+### 3. Explicit non-guarantee (written prominently)
+
+The host does not sandbox Node. A plugin can call `require("fs")` directly, spawn subprocesses, and open sockets regardless of what it declared. The capability list governs declared intent through host-side UX policy; it is not a kernel of enforcement against arbitrary code. Trust in a plugin's code is the user's responsibility — install only from sources you trust, and inspect plugins that request broad capabilities.
+
+## Schema shape (forthcoming — #9268)
+
+> The current parser accepts only flat string tokens (`PluginPermission = BuiltInPluginPermission` in `shared/types/plugin.ts`, exposed today as the manifest field `permissions`). The discriminated-union form below and the `mcp:*` tokens are **not yet parsed** — do not use the object form in a manifest today. The field rename (`permissions` → `capabilities`) and the schema extension are tracked in #9268.
+
+```ts
+capabilities: Array<
+  | BuiltInCapability // "shell:exec", "git:write", "fs:project-read", ...
+  | { name: "network:fetch"; scopes: { allow: string[] } } // URL prefix allowlist
+  | { name: "fs:project-write"; scopes: { allow: string[] } } // glob allowlist
+  | { name: "mcp:elicitation" }
+  | { name: "mcp:sampling" }
+>;
+```
+
+The array is kept (it matches the current shape and stays grep-friendly). The element becomes a discriminated union — a bare token for the unchanged cases, a `{ name, scopes }` object for the scoped ones, and dedicated `mcp:*` tokens for the MCP advertisement gates. `*` and `**` are rejected at the schema level. `mcp:*` tokens are opt-in only and are never implied by any other capability.
+
+## Industry precedent
+
+The prior art divides cleanly along one axis: whether a sandbox exists to gate against.
+
+- **VS Code** — pure disclosure. Workspace Trust gates _workspace features_ (auto-run tasks, terminals, workspace-settings injection), **not** the extension API surface. Extensions self-attest a trust level and voluntarily gate their own behaviour; once running, an extension is an unsandboxed Node.js process. Not a runtime API gate.
+- **Obsidian** — pure disclosure. Community plugins get full Node/Electron access; Obsidian's own docs concede they cannot reliably restrict them, which is why community plugins live behind a Restricted Mode and a prominent warning.
+- **Chrome extensions** — gated, because a sandbox exists. Pre-install disclosure plus `host_permissions` / `optional_permissions`, enforced at runtime — an undeclared cross-origin fetch is blocked at the platform boundary.
+- **Tauri 2.x** — gated at the IPC bridge, which is the only path from webview to host. A command can't be dispatched without a capability declaration. Scope attenuation (allow/deny globs) is enforced _within_ the command handler via an injected scope, not before dispatch.
+- **Zed** — gated at the WebAssembly Component Model boundary (wasmtime). The host controls which host functions the guest can call. This is the "pure gated needs a sandbox" precedent.
+
+Daintree has no equivalent boundary — shared V8 + Node means there is no chokepoint to gate at. Hybrid is the honest model for that constraint.
+
+## Sibling-issue amendments
+
+The chosen contract changes what these issues must do:
+
+- **#9268** — adopt `capabilities` as the field name and extend the element schema to the discriminated union above. The field rename and the non-guarantee both freeze here.
+- **#9228** — bake the canonical statement into the manifest contract before the SDK ships to npm; the field name and the non-guarantee must be frozen before external authors depend on them.
+- **#9247** — the compound-permission lattice and scope attenuation are load-bearing parts of this contract, not optional add-ons. Ship them in the same release as the schema.
+- **#9234** — `elicitation` / `sampling` advertisement is now gated by `mcp:elicitation` / `mcp:sampling` capabilities; tool advertisement is bounded by the manifest as the upper bound.
+
+## Open questions
+
+- Whether `mcp:elicitation` / `mcp:sampling` should be top-level tokens or nested under an `mcp:` object. The current bias is flat, for grep-ability.
+- Whether scope wildcards should be allowed for built-in plugins via a signed-manifest path. Probably not for 1.15; revisit later.


### PR DESCRIPTION
## Summary

- Formalizes the plugin trust contract decision from #9267: hybrid model, disclosure-first with host-side policy effects
- Adds `docs/plugins/trust-model.md` as the canonical decision record covering the three-option matrix, role guarantees, forthcoming schema changes, and industry precedent
- Updates existing plugin docs to match the live behavior and correct field naming (`permissions`, not `capabilities`)

Resolves #9267

## Changes

- `docs/plugins/trust-model.md` (new) — decision record: three-option matrix, hybrid recommendation, "three roles by guarantee strength" breakdown (5 derived host-side effects, only `effectiveDanger` raise live today; lattice + scope + MCP gates forthcoming via #9247 / #9234), explicit non-guarantees (no Node sandbox), the discriminated-union schema deferred to #9268, and industry precedent for VS Code / Obsidian / Chrome / Tauri / Zed with accurate enforcement-boundary characterization
- `docs/plugins/architecture.md` — replaced pure-disclosure "Capability disclosure" section with hybrid framing; reframed the "Why no runtime permission enforcement?" rationale to match the live `effectiveDanger` gate
- `docs/plugins/manifest.md` — capabilities section updated to hybrid; full-schema example corrected to the live `permissions` key
- `docs/plugins/README.md`, `docs/plugins/getting-started.md` — security copy and examples updated to hybrid framing and live field key

No code changes.

## Key correctness notes

- The live manifest field is `permissions` (strict Zod schema rejects unknown keys); the rename to `capabilities` + discriminated-union schema is explicitly deferred to #9268
- The `effectiveDanger` gate affects `ActionService` routing (confirm dialog / MRU / `repeatLast`) — it does NOT block plugin execution or IPC; the docs state this explicitly
- Sibling issues needing amendment are noted in `trust-model.md`: #9268 (field rename + schema), #9228 (freeze contract before SDK ships), #9247 (lattice + scope attenuation), #9234 (MCP advertisement gates)

## Testing

Docs-only change. Verified all cross-references and field names match the live `PluginService.ts` / `PluginManifestSchema`.