### PR TITLE
fix(window): gate win.show() on dom-ready to eliminate blank-window flash

### DIFF
--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -176,16 +176,11 @@ export async function launchApp(options: LaunchOptions = {}): Promise<AppContext
         DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS:
           options.env?.DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS ?? "1",
         DAINTREE_DISABLE_WEBGL: "1",
-        // Force the v0.8.0 serial boot path for e2e: load the renderer only
-        // after PtyClient is ready and the WebContentsView is positioned and
-        // shown. v0.9.0's `perf(startup)` change flipped early-renderer to
-        // default-on (commit 2de3d3fe5), which races a not-yet-painted
-        // WebContentsView against the BrowserWindow show step on macOS/Linux
-        // and lets Playwright pick the blank BW shell as the "active" page —
-        // the `[aria-label="Toggle Sidebar"]` selector then never resolves
-        // and `electron.launch` times out at 60s. Production keeps the
-        // early-renderer perf gain; only e2e opts out for determinism.
-        DAINTREE_EARLY_RENDERER: "0",
+        // E2E now exercises the production early-renderer path. The
+        // win.show() call is gated on appWebContents `dom-ready` in
+        // createWindow.ts, so Playwright sees the WebContentsView page in
+        // app.windows() before the BrowserWindow is mapped — no boot-path
+        // divergence is needed for macOS/Linux determinism.
         ...(isWindowsCI
           ? {
               DAINTREE_E2E_DEFER_RENDERER_LOAD: "1",

--- a/electron/window/__tests__/windowServicesEarlyRenderer.test.ts
+++ b/electron/window/__tests__/windowServicesEarlyRenderer.test.ts
@@ -1,47 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { shouldDeferRendererLoadForE2E, shouldEnableEarlyRenderer } from "../earlyRenderer.js";
-
-describe("shouldEnableEarlyRenderer", () => {
-  it("returns true when DAINTREE_EARLY_RENDERER is unset (default on)", () => {
-    expect(shouldEnableEarlyRenderer({ isSmokeTest: false, env: {} })).toBe(true);
-  });
-
-  it("returns false when DAINTREE_EARLY_RENDERER=0 (opt-out)", () => {
-    expect(
-      shouldEnableEarlyRenderer({
-        isSmokeTest: false,
-        env: { DAINTREE_EARLY_RENDERER: "0" },
-      })
-    ).toBe(false);
-  });
-
-  it("returns true for non-zero values", () => {
-    for (const value of ["1", "true", "yes", "on", ""]) {
-      expect(
-        shouldEnableEarlyRenderer({
-          isSmokeTest: false,
-          env: { DAINTREE_EARLY_RENDERER: value },
-        })
-      ).toBe(true);
-    }
-  });
-
-  it("returns false in smoke-test mode regardless of DAINTREE_EARLY_RENDERER", () => {
-    // Smoke tests assert deterministic readiness — keep them on the serial path.
-    expect(
-      shouldEnableEarlyRenderer({
-        isSmokeTest: true,
-        env: {},
-      })
-    ).toBe(false);
-    expect(
-      shouldEnableEarlyRenderer({
-        isSmokeTest: true,
-        env: { DAINTREE_EARLY_RENDERER: "1" },
-      })
-    ).toBe(false);
-  });
-});
+import { shouldDeferRendererLoadForE2E } from "../earlyRenderer.js";
 
 describe("shouldDeferRendererLoadForE2E", () => {
   it("returns true only for the explicit Windows E2E deferral flag", () => {

--- a/electron/window/__tests__/windowShowSequence.test.ts
+++ b/electron/window/__tests__/windowShowSequence.test.ts
@@ -32,6 +32,8 @@ interface SetupArgs {
   injectSkeletonCss: (wc: unknown) => void;
 }
 
+const SHOW_FALLBACK_MS = 5_000;
+
 /**
  * Replicates the production `loadRenderer` show/CSS sequence from
  * `createWindow.ts` so the ordering can be verified without bringing the
@@ -50,13 +52,62 @@ function buildLoadRenderer({ win, appView, windowBg, injectSkeletonCss }: SetupA
       injectSkeletonCss(appWebContents);
     });
 
-    appWebContents.loadURL(`app://daintree/index.html?reason=${reason}`);
+    let shown = false;
+    const showOnce = (): void => {
+      if (shown) return;
+      shown = true;
+      if (fallbackTimer) {
+        clearTimeout(fallbackTimer);
+        fallbackTimer = null;
+      }
+      if (!win.isDestroyed()) win.show();
+    };
+    let fallbackTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+      fallbackTimer = null;
+      showOnce();
+    }, SHOW_FALLBACK_MS);
+    appWebContents.once("dom-ready", showOnce);
 
-    if (!win.isDestroyed()) win.show();
+    appWebContents.loadURL(`app://daintree/index.html?reason=${reason}`);
   };
 }
 
+function fireDomReady(listeners: ListenerMap): void {
+  const handlers = listeners.get("dom-ready") ?? [];
+  for (const h of handlers) h();
+}
+
 describe("window show sequence", () => {
+  it("does not show the window until dom-ready fires", () => {
+    const listeners: ListenerMap = new Map();
+    const win = createMockWindow();
+    const appView = createMockAppView(listeners);
+
+    const loadRenderer = buildLoadRenderer({
+      win,
+      appView,
+      windowBg: "#0e0e0d",
+      injectSkeletonCss: vi.fn(),
+    });
+
+    loadRenderer("startup");
+
+    // loadURL has been called but the window stays hidden until dom-ready.
+    expect(appView.webContents.loadURL).toHaveBeenCalledOnce();
+    expect(win.show).not.toHaveBeenCalled();
+
+    fireDomReady(listeners);
+
+    expect(win.show).toHaveBeenCalledOnce();
+
+    // loadURL ordering: the dom-ready/once gate is wired BEFORE loadURL so
+    // a synchronous dom-ready from a cached navigation can't slip past it.
+    expect(appView.webContents.once).toHaveBeenCalledWith("dom-ready", expect.any(Function));
+    const onceOrder = appView.webContents.once.mock.invocationCallOrder[0];
+    const loadOrder = appView.webContents.loadURL.mock.invocationCallOrder[0];
+    expect(onceOrder).toBeLessThan(loadOrder);
+  });
+
   it("sets appView background before showing the window", () => {
     const listeners: ListenerMap = new Map();
     const win = createMockWindow();
@@ -71,36 +122,12 @@ describe("window show sequence", () => {
     });
 
     loadRenderer("startup");
+    fireDomReady(listeners);
 
     expect(appView.setBackgroundColor).toHaveBeenCalledWith("#0e0e0d");
     const bgOrder = appView.setBackgroundColor.mock.invocationCallOrder[0];
     const showOrder = win.show.mock.invocationCallOrder[0];
     expect(bgOrder).toBeLessThan(showOrder);
-  });
-
-  it("calls win.show after loadURL, not after did-finish-load", () => {
-    const listeners: ListenerMap = new Map();
-    const win = createMockWindow();
-    const appView = createMockAppView(listeners);
-
-    const loadRenderer = buildLoadRenderer({
-      win,
-      appView,
-      windowBg: "#0e0e0d",
-      injectSkeletonCss: vi.fn(),
-    });
-
-    loadRenderer("startup");
-
-    expect(appView.webContents.loadURL).toHaveBeenCalledOnce();
-    expect(win.show).toHaveBeenCalledOnce();
-
-    const loadOrder = appView.webContents.loadURL.mock.invocationCallOrder[0];
-    const showOrder = win.show.mock.invocationCallOrder[0];
-    expect(loadOrder).toBeLessThan(showOrder);
-
-    // No did-finish-load listener is registered — show must not depend on it.
-    expect(listeners.has("did-finish-load")).toBe(false);
   });
 
   it("registers a persistent dom-ready listener for skeleton CSS injection", () => {
@@ -121,9 +148,14 @@ describe("window show sequence", () => {
     // CSS is not injected before the document parses.
     expect(injectSkeletonCss).not.toHaveBeenCalled();
 
+    // Two dom-ready listeners are wired: one persistent (.on) for CSS
+    // re-injection on every parse, one .once for win.show().
     const domReadyHandlers = listeners.get("dom-ready") ?? [];
-    expect(domReadyHandlers).toHaveLength(1);
+    expect(domReadyHandlers).toHaveLength(2);
+    expect(appView.webContents.on).toHaveBeenCalledWith("dom-ready", expect.any(Function));
+    expect(appView.webContents.once).toHaveBeenCalledWith("dom-ready", expect.any(Function));
 
+    // The persistent listener (registered via `.on`) is the CSS one.
     domReadyHandlers[0]();
     expect(injectSkeletonCss).toHaveBeenCalledOnce();
     expect(injectSkeletonCss).toHaveBeenCalledWith(appView.webContents);
@@ -144,22 +176,20 @@ describe("window show sequence", () => {
 
     loadRenderer("startup");
 
+    // The first dom-ready listener (.on) is the CSS one — fire it twice to
+    // simulate the initial load and a renderer-crash auto-reload.
     const domReadyHandlers = listeners.get("dom-ready") ?? [];
-    expect(domReadyHandlers).toHaveLength(1);
+    const persistentCssHandler = domReadyHandlers[0];
 
-    // First load
-    domReadyHandlers[0]();
-    // Renderer crash → appWebContents.reload() → second dom-ready
-    domReadyHandlers[0]();
+    persistentCssHandler();
+    persistentCssHandler();
 
     expect(injectSkeletonCss).toHaveBeenCalledTimes(2);
-    expect(appView.webContents.on).toHaveBeenCalledWith("dom-ready", expect.any(Function));
   });
 
-  it("does not set a fallback timer — window is already shown", () => {
+  it("shows the window via the 5s fallback timer when dom-ready never fires", () => {
     vi.useFakeTimers();
     try {
-      const setTimeoutSpy = vi.spyOn(global, "setTimeout");
       const listeners: ListenerMap = new Map();
       const win = createMockWindow();
       const appView = createMockAppView(listeners);
@@ -173,7 +203,41 @@ describe("window show sequence", () => {
 
       loadRenderer("startup");
 
-      expect(setTimeoutSpy).not.toHaveBeenCalled();
+      // Just before the deadline: still hidden.
+      vi.advanceTimersByTime(SHOW_FALLBACK_MS - 1);
+      expect(win.show).not.toHaveBeenCalled();
+
+      // At the deadline: window shows anyway.
+      vi.advanceTimersByTime(1);
+      expect(win.show).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the fallback timer when dom-ready fires — no double-show", () => {
+    vi.useFakeTimers();
+    try {
+      const listeners: ListenerMap = new Map();
+      const win = createMockWindow();
+      const appView = createMockAppView(listeners);
+
+      const loadRenderer = buildLoadRenderer({
+        win,
+        appView,
+        windowBg: "#0e0e0d",
+        injectSkeletonCss: vi.fn(),
+      });
+
+      loadRenderer("startup");
+
+      // dom-ready arrives before the deadline.
+      fireDomReady(listeners);
+      expect(win.show).toHaveBeenCalledOnce();
+
+      // Advancing past the deadline must NOT re-fire show.
+      vi.advanceTimersByTime(SHOW_FALLBACK_MS * 2);
+      expect(win.show).toHaveBeenCalledOnce();
     } finally {
       vi.useRealTimers();
     }
@@ -194,6 +258,8 @@ describe("window show sequence", () => {
     loadRenderer("startup");
     loadRenderer("startup");
     loadRenderer("startup");
+
+    fireDomReady(listeners);
 
     expect(appView.webContents.loadURL).toHaveBeenCalledOnce();
     expect(win.show).toHaveBeenCalledOnce();

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -317,6 +317,7 @@ export function setupBrowserWindow(
   }
 
   let rendererLoadRequested = false;
+  const SHOW_FALLBACK_MS = 5_000;
   const loadRenderer = (reason: string, projectId?: string): void => {
     if (!win || win.isDestroyed() || rendererLoadRequested) return;
     rendererLoadRequested = true;
@@ -329,6 +330,32 @@ export function setupBrowserWindow(
       injectSkeletonCss(appWebContents);
     });
 
+    // Gate win.show() on the WebContentsView's first dom-ready so the HTML
+    // skeleton is parsed before the OS maps the window — eliminates the
+    // blank-window flash. `ready-to-show` on BrowserWindow does NOT cover
+    // child WebContentsView paint, and fires immediately for the sentinel
+    // data: page; dom-ready on appWebContents is the correct signal.
+    // 5s timeout fallback ensures a hung renderer doesn't leave the window
+    // permanently hidden — strictly worse than a brief blank.
+    let shown = false;
+    const showOnce = (): void => {
+      if (shown) return;
+      shown = true;
+      if (fallbackTimer) {
+        clearTimeout(fallbackTimer);
+        fallbackTimer = null;
+      }
+      if (!win.isDestroyed()) win.show();
+    };
+    let fallbackTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+      fallbackTimer = null;
+      console.warn(
+        `[MAIN] dom-ready not received after ${SHOW_FALLBACK_MS}ms — showing window anyway`
+      );
+      showOnce();
+    }, SHOW_FALLBACK_MS);
+    appWebContents.once("dom-ready", showOnce);
+
     const qs = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
     console.log(`[MAIN] Loading renderer (${reason})...`);
     if (process.env.NODE_ENV === "development") {
@@ -339,11 +366,6 @@ export function setupBrowserWindow(
       console.log("[MAIN] Loading production build via app:// protocol");
       appWebContents.loadURL(`app://daintree/index.html${qs}`);
     }
-
-    // Show the window as soon as the navigation is in flight so the HTML
-    // skeleton in index.html paints during bundle parse instead of leaving
-    // the user with a blank background while JS loads.
-    if (!win.isDestroyed()) win.show();
   };
 
   // Window open handler — on the app view's webContents

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -355,6 +355,12 @@ export function setupBrowserWindow(
       showOnce();
     }, SHOW_FALLBACK_MS);
     appWebContents.once("dom-ready", showOnce);
+    win.once("closed", () => {
+      if (fallbackTimer) {
+        clearTimeout(fallbackTimer);
+        fallbackTimer = null;
+      }
+    });
 
     const qs = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
     console.log(`[MAIN] Loading renderer (${reason})...`);

--- a/electron/window/earlyRenderer.ts
+++ b/electron/window/earlyRenderer.ts
@@ -1,20 +1,10 @@
 /**
- * Decide whether to start the renderer in parallel with PTY host bootstrap.
- *
- * Early-renderer mode is the default: `loadRenderer()` is hoisted ahead of the
- * workspace/PTY init block so first paint stops waiting on the PTY handshake
- * (~70–150ms cold). Set `DAINTREE_EARLY_RENDERER=0` to restore the serial path
- * (await `ptyClient.waitForReady()` before `loadRenderer()`). The smoke test
- * path is always excluded so its deterministic readiness checks keep working
- * unmodified.
+ * Windows E2E only: opt-in flag that defers the in-WebContentsView renderer
+ * load until per-window services are ready. The Playwright CDP handshake on
+ * Windows CI races concurrent target creation; deferring the WebContentsView
+ * load keeps the BrowserWindow sentinel page as the lone target until launch
+ * resolves.
  */
-export function shouldEnableEarlyRenderer(opts: {
-  isSmokeTest: boolean;
-  env: NodeJS.ProcessEnv;
-}): boolean {
-  return !opts.isSmokeTest && opts.env.DAINTREE_EARLY_RENDERER !== "0";
-}
-
 export function shouldDeferRendererLoadForE2E(opts: { env: NodeJS.ProcessEnv }): boolean {
   return opts.env.DAINTREE_E2E_DEFER_RENDERER_LOAD === "1";
 }

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -22,7 +22,7 @@ import {
   getEarlyPathRefreshPromise,
   kickOffEarlyPathRefresh,
 } from "../setup/environment.js";
-import { shouldDeferRendererLoadForE2E, shouldEnableEarlyRenderer } from "./earlyRenderer.js";
+import { shouldDeferRendererLoadForE2E } from "./earlyRenderer.js";
 import { extractCliPath, getPendingCliPath, setPendingCliPath } from "../lifecycle/appLifecycle.js";
 import type { WindowContext, WindowRegistry } from "./WindowRegistry.js";
 import { resetDeferredQueue } from "./deferredInitQueue.js";
@@ -123,12 +123,13 @@ export async function setupWindowServices(
     markPerformance(PERF_MARKS.SERVICE_INIT_IPC_READY);
   }
 
-  // Early-renderer mode is the default: the did-finish-load handler is
-  // registered and loadRenderer() is fired before the workspace/PTY init
-  // block, so first paint stops waiting on the PTY handshake. Set
-  // DAINTREE_EARLY_RENDERER=0 to restore the serial path:
-  // workspace init → handler → loadRenderer.
-  const earlyRendererEnabled = shouldEnableEarlyRenderer({ isSmokeTest, env: process.env });
+  // Default boot path: the did-finish-load handler is registered and
+  // loadRenderer() fires before the workspace/PTY init block, so first
+  // paint stops waiting on the PTY handshake. Two paths fall back to the
+  // serial after-services-ready trigger: smoke tests (deterministic
+  // readiness checks) and the Windows E2E DAINTREE_E2E_DEFER_RENDERER_LOAD
+  // opt-in, which keeps the WebContentsView load behind the BrowserWindow
+  // sentinel for Playwright's CDP handshake.
   const deferRendererLoadForE2E = shouldDeferRendererLoadForE2E({ env: process.env });
 
   let rendererLoadStarted = false;
@@ -180,10 +181,10 @@ export async function setupWindowServices(
     opts.loadRenderer(reason, opts.initialProjectId);
   };
 
-  if (earlyRendererEnabled && !deferRendererLoadForE2E) {
-    console.log("[MAIN] Early renderer enabled — loading renderer in parallel with PTY init");
+  if (!deferRendererLoadForE2E && !isSmokeTest) {
+    console.log("[MAIN] Loading renderer in parallel with PTY init");
     startRendererLoad("early-renderer");
-  } else if (earlyRendererEnabled) {
+  } else if (deferRendererLoadForE2E) {
     console.log("[MAIN] E2E renderer-load deferral enabled — waiting for services");
   }
 
@@ -308,13 +309,12 @@ export async function setupWindowServices(
   const { armRestoreQuota } = await import("../ipc/utils.js");
   armRestoreQuota(50, 120_000);
 
-  // With early-renderer mode (default), the RENDERER_READY mark can fire
-  // before this point, since the renderer is loading concurrently with
-  // workspace init.
+  // On the default path the RENDERER_READY mark can fire before this point,
+  // since the renderer is loading concurrently with workspace init.
   markPerformance(PERF_MARKS.SERVICE_INIT_COMPLETE);
-  // Opt-out path (DAINTREE_EARLY_RENDERER=0): renderer load happens here,
-  // after workspace + PTY are ready. With early-renderer mode active this is
-  // a no-op (already started above).
+  // Serial fallback: smoke tests and the Windows E2E deferral path land
+  // here after workspace + PTY are ready. With the default path this is a
+  // no-op (already started above).
   startRendererLoad("after-services-ready");
 
   // Error handlers also use ipcMain.handle — register once


### PR DESCRIPTION
## Summary

- Gates `win.show()` on the `dom-ready` event instead of showing the window shell before first paint, eliminating the blank-window flash on cold start. Uses a 5s timeout fallback (listener wired before `loadURL()` to avoid a cached-load race). The `ready-to-show` event doesn't fire for `WebContentsView` children in Electron 41, so `dom-ready` is the correct hook.
- Clears the fallback timer in a `win.once("closed")` handler so the closure doesn't stay alive for up to 5s after an early window close.
- Removes `DAINTREE_EARLY_RENDERER` and `shouldEnableEarlyRenderer` — they existed solely to let e2e skip the production boot path, which meant the test suite was exercising a diverged path. `DAINTREE_E2E_DEFER_RENDERER_LOAD` (Playwright CDP handshake on Windows CI) and `DAINTREE_E2E_DISABLE_CACHED_VIEW_CPU_THROTTLE` (CDP exclusivity vs `debugger.attach()`) are kept — both serve real coexistence constraints, not boot-path divergence.

Resolves #9112

## Changes

- `electron/window/createWindow.ts` — `dom-ready` gating + 5s fallback + close-handler cleanup
- `electron/window/earlyRenderer.ts` — removed `shouldEnableEarlyRenderer`; kept `shouldDeferRendererLoadForE2E`
- `electron/window/windowServices.ts` — removed `DAINTREE_EARLY_RENDERER` references
- `e2e/helpers/launch.ts` — dropped `DAINTREE_EARLY_RENDERER=0` so e2e exercises the production path
- `electron/window/__tests__/windowShowSequence.test.ts` — rewritten for `dom-ready` gating
- `electron/window/__tests__/windowServicesEarlyRenderer.test.ts` — trimmed to the surviving helper

## Testing

Typecheck clean, lint baseline maintained (1183 warnings, no new), format clean, all IPC/channel/crash-loop generator checks pass, 392/392 window unit tests pass.