### PR TITLE
fix(mcp): widen dedup allowlist to cover all destructive mutations

### DIFF
--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1934,19 +1934,22 @@ describe("MCP_DEDUP_ALLOWLIST widening (#9156)", () => {
     expect(RATE_LIMIT_TOOL_MAP.has("git.snapshotGet")).toBe(false);
   });
 
-  it("dedups a post-completion duplicate of a newly-allowlisted mutation", async () => {
-    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
-    const deps = fakeDeps({
-      sessionStore: fakeSessionStore("system"),
-      dispatchAction,
-    });
-    const server = createSessionServer("dedup-9156", deps);
+  it.each(NEW_MUTATIONS)(
+    "dedups a post-completion duplicate of newly-allowlisted %s",
+    async (tool) => {
+      const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+      const deps = fakeDeps({
+        sessionStore: fakeSessionStore("system"),
+        dispatchAction,
+      });
+      const server = createSessionServer(`dedup-9156-${tool}`, deps);
 
-    const args = { worktreeId: "wt-test" };
-    const first = await callTool(server, { name: "worktree.delete", arguments: args });
-    const second = await callTool(server, { name: "worktree.delete", arguments: args });
+      const args = { target: "x" };
+      const first = await callTool(server, { name: tool, arguments: args });
+      const second = await callTool(server, { name: tool, arguments: args });
 
-    expect(dispatchAction).toHaveBeenCalledTimes(1);
-    expect(second).toEqual(first);
-  });
+      expect(dispatchAction).toHaveBeenCalledTimes(1);
+      expect(second).toEqual(first);
+    }
+  );
 });

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -27,6 +27,7 @@ import {
   MCP_DEDUP_ALLOWLIST,
   MCP_RATE_LIMITED_CODE,
   RATE_LIMIT_TIERS,
+  RATE_LIMIT_TOOL_MAP,
   unwrapDispatchResult,
 } from "../shared.js";
 import { SessionBindingError } from "../rendererBridge.js";
@@ -1905,5 +1906,47 @@ describe("MCP_DEDUP_ALLOWLIST widening (#8468)", () => {
   it("stays bounded — does not blanket every mutation", () => {
     expect(MCP_DEDUP_ALLOWLIST.has("git.stageAll")).toBe(false);
     expect(MCP_DEDUP_ALLOWLIST.has("terminal.sendCommand")).toBe(false);
+  });
+});
+
+describe("MCP_DEDUP_ALLOWLIST widening (#9156)", () => {
+  const NEW_MUTATIONS = [
+    "worktree.delete",
+    "git.snapshotRevert",
+    "git.snapshotDelete",
+    "forge.assignIssue",
+  ];
+
+  it("adds the remaining destructive-mutation cohort", () => {
+    for (const tool of NEW_MUTATIONS) {
+      expect(MCP_DEDUP_ALLOWLIST.has(tool)).toBe(true);
+    }
+  });
+
+  it("maps the new cohort to the mutation rate-limit tier", () => {
+    for (const tool of NEW_MUTATIONS) {
+      expect(RATE_LIMIT_TOOL_MAP.get(tool)).toBe(RATE_LIMIT_TIERS.mutation);
+    }
+  });
+
+  it("stays bounded — adjacent read-only tools remain excluded", () => {
+    expect(MCP_DEDUP_ALLOWLIST.has("git.snapshotGet")).toBe(false);
+    expect(RATE_LIMIT_TOOL_MAP.has("git.snapshotGet")).toBe(false);
+  });
+
+  it("dedups a post-completion duplicate of a newly-allowlisted mutation", async () => {
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+    const deps = fakeDeps({
+      sessionStore: fakeSessionStore("system"),
+      dispatchAction,
+    });
+    const server = createSessionServer("dedup-9156", deps);
+
+    const args = { worktreeId: "wt-test" };
+    const first = await callTool(server, { name: "worktree.delete", arguments: args });
+    const second = await callTool(server, { name: "worktree.delete", arguments: args });
+
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
   });
 });

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -381,7 +381,10 @@ export const TIER_NOT_PERMITTED_CODE = "TIER_NOT_PERMITTED";
  * `worktree.createWithRecipe`, `agent.launch`, `recipe.run`) is widened
  * to the git/forge mutations (`git.commit`, `git.push`, `forge.openIssue`,
  * `github.openPR`) now that the args-hash collision guard (#8429) is in
- * place to make the widening safe.
+ * place to make the widening safe. Widened further (#9156) to the remaining
+ * destructive mutations — `worktree.delete`, `git.snapshotRevert`,
+ * `git.snapshotDelete`, `forge.assignIssue` — so every side-effecting tool
+ * that an LLM might retry is covered.
  *
  * Deliberately bounded: blanket-applying dedup to all mutations would mask
  * legitimate "do it again" cases (re-running the same git command, etc.).
@@ -395,6 +398,10 @@ export const MCP_DEDUP_ALLOWLIST: ReadonlySet<string> = new Set([
   "git.push",
   "forge.openIssue",
   "github.openPR",
+  "worktree.delete",
+  "git.snapshotRevert",
+  "git.snapshotDelete",
+  "forge.assignIssue",
 ]);
 
 /**
@@ -449,7 +456,7 @@ export const RATE_LIMIT_TIERS = {
 /**
  * Per-tool tier overrides. Tools absent from this map fall back to
  * {@link RATE_LIMIT_TIERS.standard}. Keep the mutation cohort aligned with
- * {@link MCP_DEDUP_ALLOWLIST}'s git/forge entries.
+ * {@link MCP_DEDUP_ALLOWLIST}'s destructive mutation entries.
  */
 export const RATE_LIMIT_TOOL_MAP: ReadonlyMap<string, RateLimitConfig> = new Map([
   ["terminal.getOutput", RATE_LIMIT_TIERS.highFreqRead],
@@ -459,6 +466,10 @@ export const RATE_LIMIT_TOOL_MAP: ReadonlyMap<string, RateLimitConfig> = new Map
   ["git.push", RATE_LIMIT_TIERS.mutation],
   ["forge.openIssue", RATE_LIMIT_TIERS.mutation],
   ["github.openPR", RATE_LIMIT_TIERS.mutation],
+  ["worktree.delete", RATE_LIMIT_TIERS.mutation],
+  ["git.snapshotRevert", RATE_LIMIT_TIERS.mutation],
+  ["git.snapshotDelete", RATE_LIMIT_TIERS.mutation],
+  ["forge.assignIssue", RATE_LIMIT_TIERS.mutation],
 ] as Array<[string, RateLimitConfig]>);
 
 /**


### PR DESCRIPTION
## Summary

- `MCP_DEDUP_ALLOWLIST` and `RATE_LIMIT_TOOL_MAP` were missing four destructive mutations that meet the documented inclusion criteria — `worktree.delete`, `git.snapshotRevert`, `git.snapshotDelete`, and `forge.assignIssue`
- The gap means an LLM retrying with different args bypasses the collision guard, and the mutation rate-limit tier is explicitly documented to stay aligned with the allowlist — both invariants were violated
- Adds the four entries to both maps, updates JSDoc comments, and adds a unit test block covering membership, rate-limit tier mapping, boundary exclusion, and parameterized dedup cache-hit across all four new tools

Resolves #9156

## Changes

- `electron/services/mcp-server/shared.ts` — added `worktree.delete`, `git.snapshotRevert`, `git.snapshotDelete`, `forge.assignIssue` to `MCP_DEDUP_ALLOWLIST` and `RATE_LIMIT_TOOL_MAP` (mutation tier); updated JSDoc
- `electron/services/mcp-server/__tests__/sessionServer.test.ts` — `#9156 widening` test block: membership assertions, rate-limit tier checks, boundary exclusions, and parameterized post-completion dedup cache-hit for all four new tools

## Testing

92 unit tests passing. Typecheck, lint ratchet, and format all clean.