### PR TITLE
fix(fileviewer): replace plan file viewer spinner with skeleton

### DIFF
--- a/src/components/FileViewer/PlanFileViewer.tsx
+++ b/src/components/FileViewer/PlanFileViewer.tsx
@@ -2,7 +2,7 @@ import { AppDialog } from "@/components/ui/AppDialog";
 import { CodeViewer } from "./CodeViewer";
 import { usePlanFileContent } from "@/hooks/usePlanFileContent";
 import { FileText } from "lucide-react";
-import { Spinner } from "@/components/ui/Spinner";
+import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
 
 interface PlanFileViewerProps {
   isOpen: boolean;
@@ -41,11 +41,11 @@ export function PlanFileViewer({ isOpen, filePath, rootPath, onClose }: PlanFile
         )}
 
         {filePath && !isGone && status === "loading" && (
-          <div className="flex items-center justify-center h-48">
-            <div className="flex items-center gap-3 text-muted-foreground">
-              <Spinner size="lg" />
-              <span>Loading plan...</span>
-            </div>
+          <div className="p-4 space-y-3">
+            <Skeleton label="Loading plan">
+              <SkeletonBone className="h-5 w-1/3" />
+              <SkeletonText lines={15} />
+            </Skeleton>
           </div>
         )}
 

--- a/src/components/FileViewer/__tests__/PlanFileViewer.test.tsx
+++ b/src/components/FileViewer/__tests__/PlanFileViewer.test.tsx
@@ -69,7 +69,8 @@ describe("PlanFileViewer", () => {
     render(
       <PlanFileViewer isOpen={true} filePath="TODO.md" rootPath="/project" onClose={() => {}} />
     );
-    expect(screen.getByText(/Loading plan/)).toBeDefined();
+    expect(screen.getByRole("status", { name: /Loading plan/i })).toBeDefined();
+    expect(screen.queryByText(/Loading plan.../)).toBeNull();
   });
 
   it("renders file content in CodeViewer after successful read", async () => {


### PR DESCRIPTION
## Summary
- `PlanFileViewer` was showing a plain spinner with "Loading plan..." text while waiting for plan file content. Plan files are markdown — the content shape is predictable — so the convention is a skeleton, not a spinner.
- Replaced the spinner with a `Skeleton` wrapper (title bone + 15 lines of skeleton text), matching the pattern already used in `FileViewerModal` for view-loading states.
- Updated the corresponding test to assert on the skeleton's ARIA label instead of the old text.

Resolves #9216

## Changes
- `PlanFileViewer.tsx` — swapped `Spinner` for `Skeleton` / `SkeletonBone` / `SkeletonText` on the loading path
- `PlanFileViewer.test.tsx` — changed loading-state assertion to match the skeleton markup

## Testing
- Unit test updated and passing
- Visually verified the skeleton renders in the dialog before content arrives