### PR TITLE
feat(auto-update): detect silent install failures on macOS

### DIFF
--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -184,11 +184,18 @@ class AutoUpdaterService {
   // UPDATE_QUIT_AND_INSTALL IPC handler. Both call sites need identical
   // behavior: defer past the menu-close frame via `setImmediate` (Windows
   // animation timing), then arm a macOS-only watchdog that force-exits if
-  // ShipIt fails to land its `app.quit()`. Wrapped `app.exit(0)` so a thrown
-  // exception in shutdown doesn't escape and become an unhandled rejection.
+  // ShipIt fails to land its `app.quit()`. `quitAndInstall()` is wrapped so
+  // a thrown exception still arms the watchdog (force-exit is still the
+  // right move — ShipIt has its best chance on the next launch), and the
+  // `app.exit(0)` inside the watchdog is wrapped so a shutdown-time throw
+  // doesn't become an unhandled rejection.
   private executeQuitAndInstall(): void {
     setImmediate(() => {
-      autoUpdater.quitAndInstall();
+      try {
+        autoUpdater.quitAndInstall();
+      } catch (err) {
+        console.error("[MAIN] autoUpdater.quitAndInstall() threw:", err);
+      }
       if (process.platform !== "darwin") return;
       this.watchdogTimeout = setTimeout(() => {
         this.watchdogTimeout = null;
@@ -476,6 +483,14 @@ class AutoUpdaterService {
         this.resetRetryState();
         this.clearCheckingMenuTimeout();
         this.setMenuState("idle");
+        // Drop the pending-install marker for the prior channel so the next
+        // boot doesn't fire a false-positive mismatch (issue #9261). The new
+        // channel's download will re-arm it via update-downloaded.
+        try {
+          store.delete("pendingUpdateVersion");
+        } catch (err) {
+          console.error("[MAIN] Failed to clear pendingUpdateVersion on channel switch:", err);
+        }
         // Transition to Idle done; now discard the staged installer on disk
         // and reconfigure the feed. Re-arm happens in the update-downloaded
         // handler when the new channel's download completes.
@@ -661,9 +676,13 @@ class AutoUpdaterService {
         // future electron-updater revision.
         if (typeof info.version === "string") {
           const trimmed = info.version.trim();
-          if (trimmed.length > 0 && semver.valid(trimmed)) {
+          // Persist the canonical semver form (no leading `v`, no `=` prefix)
+          // so the boot comparison round-trips cleanly against
+          // `app.getVersion()`, which already emits canonical form.
+          const canonical = trimmed.length > 0 ? semver.valid(trimmed) : null;
+          if (canonical) {
             try {
-              store.set("pendingUpdateVersion", trimmed);
+              store.set("pendingUpdateVersion", canonical);
             } catch (err) {
               console.error("[MAIN] Failed to persist pendingUpdateVersion:", err);
             }

--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -9,6 +9,7 @@ import { CHANNELS } from "../ipc/channels.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { getCrashRecoveryService } from "./CrashRecoveryService.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
+import { trackEvent } from "./TelemetryService.js";
 import { store } from "../store.js";
 import { PRODUCT_NAME } from "../utils/productBranding.js";
 import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
@@ -88,6 +89,15 @@ const { autoUpdater } = electronUpdater;
 
 const RESUME_CHECK_DELAY_MS = 7_000;
 
+// macOS-only watchdog after `autoUpdater.quitAndInstall()`: if the process is
+// still alive after 5s, Squirrel.Mac's ShipIt likely failed to acquire its
+// staging lock (electron-builder #8997) and the in-flight `app.quit()` will
+// never fire. `app.exit(0)` force-terminates so ShipIt has a clean shot on the
+// next launch. 5s is the community-recommended floor — 3s is too tight under
+// memory pressure or slow disk. Windows/Linux keep the original setImmediate
+// timing (no force-exit) because their installer paths don't share this mode.
+const QUIT_AND_INSTALL_WATCHDOG_MS = 5_000;
+
 // 400ms Doherty threshold gates the "Checking…" menu label so a fast CDN
 // round-trip (sub-threshold) never flickers a transient label change.
 const CHECKING_MENU_DELAY_MS = 400;
@@ -99,6 +109,7 @@ class AutoUpdaterService {
   private startupJitterTimeout: NodeJS.Timeout | null = null;
   private retryTimeout: NodeJS.Timeout | null = null;
   private resumeTimeout: NodeJS.Timeout | null = null;
+  private watchdogTimeout: NodeJS.Timeout | null = null;
   private removeSuspendListener: (() => void) | null = null;
   private removeWakeListener: (() => void) | null = null;
   private retryCount = 0;
@@ -169,6 +180,53 @@ class AutoUpdaterService {
     };
   }
 
+  // Shared install-trigger for `quitAndInstallIfReady()` and the
+  // UPDATE_QUIT_AND_INSTALL IPC handler. Both call sites need identical
+  // behavior: defer past the menu-close frame via `setImmediate` (Windows
+  // animation timing), then arm a macOS-only watchdog that force-exits if
+  // ShipIt fails to land its `app.quit()`. Wrapped `app.exit(0)` so a thrown
+  // exception in shutdown doesn't escape and become an unhandled rejection.
+  private executeQuitAndInstall(): void {
+    setImmediate(() => {
+      autoUpdater.quitAndInstall();
+      if (process.platform !== "darwin") return;
+      this.watchdogTimeout = setTimeout(() => {
+        this.watchdogTimeout = null;
+        try {
+          app.exit(0);
+        } catch (err) {
+          console.error("[MAIN] Quit-and-install watchdog app.exit(0) failed:", err);
+        }
+      }, QUIT_AND_INSTALL_WATCHDOG_MS);
+    });
+  }
+
+  private checkPendingUpdateInstallVersion(): void {
+    // Read+delete synchronously before any await so a crash between the two
+    // doesn't re-fire on every subsequent boot. Mirrors the crash-counter
+    // clear-on-read pattern in CrashRecoveryService.
+    const raw = store.get("pendingUpdateVersion");
+    try {
+      store.delete("pendingUpdateVersion");
+    } catch (err) {
+      console.error("[MAIN] Failed to clear pendingUpdateVersion:", err);
+    }
+    if (typeof raw !== "string") return;
+    const expected = raw.trim();
+    if (expected.length === 0 || !semver.valid(expected)) return;
+    const actual = app.getVersion();
+    if (expected === actual) return;
+    try {
+      trackEvent("auto_update_install_version_mismatch", {
+        expectedVersion: expected,
+        actualVersion: actual,
+        platform: process.platform,
+      });
+    } catch (err) {
+      console.error("[MAIN] Failed to track auto_update_install_version_mismatch:", err);
+    }
+  }
+
   quitAndInstallIfReady(): boolean {
     if (isWindowsStoreBuild()) return false;
     if (this.menuState !== "ready" || !this.updateDownloaded) return false;
@@ -186,9 +244,7 @@ class AutoUpdaterService {
     // Disarm the before-quit listener so the explicit quitAndInstall() path
     // and the autoInstallOnAppQuit path don't race the installer subprocess.
     autoUpdater.autoInstallOnAppQuit = false;
-    // setImmediate defers past the menu-close animation frame so the OS doesn't
-    // tear the click target while we're walking away (Windows-sensitive).
-    setImmediate(() => autoUpdater.quitAndInstall());
+    this.executeQuitAndInstall();
     return true;
   }
 
@@ -462,6 +518,15 @@ class AutoUpdaterService {
       return;
     }
 
+    // Boot-time install verification (issue #9261). Runs on every packaged
+    // platform — the Windows-Store / Linux guards below cause early returns
+    // before electron-updater is wired up, but a prior install could still
+    // have left `pendingUpdateVersion` on disk (e.g. user switched packaging
+    // mode between launches). Run before those guards so the marker is always
+    // consumed exactly once. Cross-platform because NSIS empty-directory
+    // races (electron-builder #9181) produce the same observable symptom.
+    this.checkPendingUpdateInstallVersion();
+
     if (isWindowsStoreBuild()) {
       console.log("[MAIN] Auto-updater disabled for Windows Store builds");
       return;
@@ -589,6 +654,21 @@ class AutoUpdaterService {
         if (this.channelGeneration !== this.downloadGeneration) return;
         this.updateDownloaded = true;
         autoUpdater.autoInstallOnAppQuit = true;
+        // Persist the staged version so the next boot can detect a silent
+        // install failure (issue #9261). Write before broadcasting so a crash
+        // between event delivery and the IPC frame still leaves the marker on
+        // disk. `semver.valid` defends against a malformed payload from a
+        // future electron-updater revision.
+        if (typeof info.version === "string") {
+          const trimmed = info.version.trim();
+          if (trimmed.length > 0 && semver.valid(trimmed)) {
+            try {
+              store.set("pendingUpdateVersion", trimmed);
+            } catch (err) {
+              console.error("[MAIN] Failed to persist pendingUpdateVersion:", err);
+            }
+          }
+        }
         this.setMenuState("ready");
         broadcastToRenderer(CHANNELS.UPDATE_DOWNLOADED, { version: info.version });
       };
@@ -612,7 +692,7 @@ class AutoUpdaterService {
           console.error("[MAIN] Crash recovery cleanup before quit-and-install failed:", err);
         }
         autoUpdater.autoInstallOnAppQuit = false;
-        setImmediate(() => autoUpdater.quitAndInstall());
+        this.executeQuitAndInstall();
       });
 
       // Handle manual check-for-updates request from renderer
@@ -689,6 +769,10 @@ class AutoUpdaterService {
     if (this.resumeTimeout) {
       clearTimeout(this.resumeTimeout);
       this.resumeTimeout = null;
+    }
+    if (this.watchdogTimeout) {
+      clearTimeout(this.watchdogTimeout);
+      this.watchdogTimeout = null;
     }
     this.retryCount = 0;
 

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -2195,6 +2195,20 @@ describe("AutoUpdaterService", () => {
       vi.advanceTimersByTime(60_000);
       expect(appMock.exit).not.toHaveBeenCalled();
     });
+
+    it("still arms the watchdog when autoUpdater.quitAndInstall throws", () => {
+      autoUpdaterMock.quitAndInstall.mockImplementationOnce(() => {
+        throw new Error("no staged installer");
+      });
+      downloadedHandler({ version: "2.0.0" });
+      quitAndInstallHandler(TRUSTED_SENDER);
+
+      expect(() => vi.advanceTimersToNextTimer()).not.toThrow();
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(5_000);
+      expect(appMock.exit).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("pendingUpdateVersion persistence (issue #9261)", () => {
@@ -2259,6 +2273,79 @@ describe("AutoUpdaterService", () => {
         throw new Error("disk full");
       });
       expect(() => downloadedHandler({ version: "2.0.0" })).not.toThrow();
+    });
+
+    it("persists before broadcasting UPDATE_DOWNLOADED so a crash mid-event leaves the marker on disk", () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      const setOrder =
+        (storeMock.set as Mock).mock.calls
+          .map((args, i) => ({ args, order: (storeMock.set as Mock).mock.invocationCallOrder[i] }))
+          .find((c) => c.args[0] === "pendingUpdateVersion")?.order ?? Infinity;
+      const broadcastOrder =
+        (broadcastMock as Mock).mock.calls
+          .map((args, i) => ({ args, order: (broadcastMock as Mock).mock.invocationCallOrder[i] }))
+          .find((c) => c.args[0] === CHANNELS.UPDATE_DOWNLOADED)?.order ?? -1;
+
+      expect(setOrder).toBeLessThan(broadcastOrder);
+    });
+
+    it("stores the canonical semver form (no leading v prefix)", () => {
+      downloadedHandler({ version: "v2.0.0" });
+      expect(storeMock.set).toHaveBeenCalledWith("pendingUpdateVersion", "2.0.0");
+    });
+  });
+
+  describe("pendingUpdateVersion channel-switch clear (issue #9261)", () => {
+    it("clears the marker when the user switches channels", async () => {
+      autoUpdaterService.initialize();
+      const downloadedHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-downloaded"
+      )![1] as (info: { version: string }) => void;
+      const setChannelHandler = (ipcMainMock.handle as Mock).mock.calls.find(
+        (args) => args[0] === CHANNELS.UPDATE_SET_CHANNEL
+      )![1] as (event: unknown, channel: string) => Promise<unknown>;
+
+      downloadedHandler({ version: "2.0.0" });
+      expect(storeMock.set).toHaveBeenCalledWith("pendingUpdateVersion", "2.0.0");
+
+      storeMock.get.mockImplementation((key: string) =>
+        key === "updateChannel" ? "stable" : undefined
+      );
+      storeMock.delete.mockClear();
+      await setChannelHandler({}, "nightly");
+
+      expect(storeMock.delete).toHaveBeenCalledWith("pendingUpdateVersion");
+    });
+
+    it("does not clear the marker on a same-channel re-save", async () => {
+      autoUpdaterService.initialize();
+      const setChannelHandler = (ipcMainMock.handle as Mock).mock.calls.find(
+        (args) => args[0] === CHANNELS.UPDATE_SET_CHANNEL
+      )![1] as (event: unknown, channel: string) => Promise<unknown>;
+
+      storeMock.get.mockImplementation((key: string) =>
+        key === "updateChannel" ? "stable" : undefined
+      );
+      storeMock.delete.mockClear();
+      await setChannelHandler({}, "stable");
+
+      expect(storeMock.delete).not.toHaveBeenCalledWith("pendingUpdateVersion");
+    });
+
+    it("does not throw if store.delete rejects during channel switch", async () => {
+      autoUpdaterService.initialize();
+      const setChannelHandler = (ipcMainMock.handle as Mock).mock.calls.find(
+        (args) => args[0] === CHANNELS.UPDATE_SET_CHANNEL
+      )![1] as (event: unknown, channel: string) => Promise<unknown>;
+
+      storeMock.get.mockImplementation((key: string) =>
+        key === "updateChannel" ? "stable" : undefined
+      );
+      storeMock.delete.mockImplementationOnce(() => {
+        throw new Error("disk full");
+      });
+      await expect(setChannelHandler({}, "nightly")).resolves.toBe("nightly");
     });
   });
 

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -3,7 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vite
 const appMock = vi.hoisted(() => ({
   isPackaged: true,
   getVersion: vi.fn(() => "1.0.0"),
+  exit: vi.fn(),
 }));
+
+const trackEventMock = vi.hoisted(() => vi.fn());
 
 const ipcMainMock = vi.hoisted(() => ({
   handle: vi.fn(),
@@ -69,6 +72,10 @@ vi.mock("../CrashRecoveryService.js", () => ({
   getCrashRecoveryService: () => ({ cleanupOnExit: cleanupOnExitMock }),
 }));
 
+vi.mock("../TelemetryService.js", () => ({
+  trackEvent: trackEventMock,
+}));
+
 vi.mock("electron", () => ({
   app: appMock,
   ipcMain: ipcMainMock,
@@ -130,6 +137,9 @@ describe("AutoUpdaterService", () => {
     trustedRendererMock.isTrustedRendererUrl.mockImplementation((url: string) =>
       url.startsWith("app://daintree")
     );
+    appMock.getVersion.mockReset().mockReturnValue("1.0.0");
+    appMock.exit.mockReset();
+    trackEventMock.mockReset();
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -2091,6 +2101,277 @@ describe("AutoUpdaterService", () => {
 
       const registeredChannels = (ipcMainMock.handle as Mock).mock.calls.map((args) => args[0]);
       expect(registeredChannels).toContain(CHANNELS.UPDATE_DISMISS_TOAST);
+    });
+  });
+
+  describe("quit-and-install watchdog (issue #9261)", () => {
+    let quitAndInstallHandler: (event: unknown) => void;
+    let downloadedHandler: (info: { version: string }) => void;
+
+    beforeEach(() => {
+      autoUpdaterService.initialize();
+
+      quitAndInstallHandler = (ipcMainMock.handle as Mock).mock.calls.find(
+        (args) => args[0] === CHANNELS.UPDATE_QUIT_AND_INSTALL
+      )![1];
+
+      downloadedHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-downloaded"
+      )![1];
+    });
+
+    it("arms a 5s app.exit(0) watchdog on darwin after quitAndInstall fires", () => {
+      downloadedHandler({ version: "2.0.0" });
+      quitAndInstallHandler(TRUSTED_SENDER);
+
+      vi.advanceTimersToNextTimer();
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+      expect(appMock.exit).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(4_999);
+      expect(appMock.exit).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(appMock.exit).toHaveBeenCalledTimes(1);
+      expect(appMock.exit).toHaveBeenCalledWith(0);
+    });
+
+    it("does not arm the watchdog on win32", () => {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      downloadedHandler({ version: "2.0.0" });
+      quitAndInstallHandler(TRUSTED_SENDER);
+
+      vi.advanceTimersToNextTimer();
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(60_000);
+      expect(appMock.exit).not.toHaveBeenCalled();
+    });
+
+    it("does not arm the watchdog on linux", () => {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      downloadedHandler({ version: "2.0.0" });
+      quitAndInstallHandler(TRUSTED_SENDER);
+
+      vi.advanceTimersToNextTimer();
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(60_000);
+      expect(appMock.exit).not.toHaveBeenCalled();
+    });
+
+    it("swallows a thrown app.exit so the watchdog callback never escapes", () => {
+      appMock.exit.mockImplementation(() => {
+        throw new Error("exit refused");
+      });
+      downloadedHandler({ version: "2.0.0" });
+      quitAndInstallHandler(TRUSTED_SENDER);
+
+      vi.advanceTimersToNextTimer();
+      expect(() => vi.advanceTimersByTime(5_000)).not.toThrow();
+      expect(appMock.exit).toHaveBeenCalledTimes(1);
+    });
+
+    it("quitAndInstallIfReady also arms the macOS watchdog", () => {
+      downloadedHandler({ version: "2.0.0" });
+      const triggered = autoUpdaterService.quitAndInstallIfReady();
+      expect(triggered).toBe(true);
+
+      vi.advanceTimersToNextTimer();
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+      expect(appMock.exit).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(5_000);
+      expect(appMock.exit).toHaveBeenCalledTimes(1);
+    });
+
+    it("dispose() cancels a pending watchdog so app.exit never fires", () => {
+      downloadedHandler({ version: "2.0.0" });
+      quitAndInstallHandler(TRUSTED_SENDER);
+      vi.advanceTimersToNextTimer();
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+
+      autoUpdaterService.dispose();
+      vi.advanceTimersByTime(60_000);
+      expect(appMock.exit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("pendingUpdateVersion persistence (issue #9261)", () => {
+    let downloadedHandler: (info: { version?: unknown }) => void;
+
+    beforeEach(() => {
+      autoUpdaterService.initialize();
+      downloadedHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-downloaded"
+      )![1];
+    });
+
+    it("persists a valid version on update-downloaded", () => {
+      downloadedHandler({ version: "2.0.0" });
+      expect(storeMock.set).toHaveBeenCalledWith("pendingUpdateVersion", "2.0.0");
+    });
+
+    it("persists a pre-release version", () => {
+      downloadedHandler({ version: "0.9.0-nightly.20251231" });
+      expect(storeMock.set).toHaveBeenCalledWith("pendingUpdateVersion", "0.9.0-nightly.20251231");
+    });
+
+    it("trims surrounding whitespace before persisting", () => {
+      downloadedHandler({ version: "  2.0.0  " });
+      expect(storeMock.set).toHaveBeenCalledWith("pendingUpdateVersion", "2.0.0");
+    });
+
+    it("ignores a non-string version", () => {
+      downloadedHandler({ version: 42 });
+      expect(storeMock.set).not.toHaveBeenCalledWith("pendingUpdateVersion", expect.anything());
+    });
+
+    it("ignores an empty version", () => {
+      downloadedHandler({ version: "   " });
+      expect(storeMock.set).not.toHaveBeenCalledWith("pendingUpdateVersion", expect.anything());
+    });
+
+    it("ignores a malformed semver", () => {
+      downloadedHandler({ version: "not-a-version" });
+      expect(storeMock.set).not.toHaveBeenCalledWith("pendingUpdateVersion", expect.anything());
+    });
+
+    it("does not persist when the download belongs to a stale channel", () => {
+      const availableHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-available"
+      )![1] as (info: { version: string }) => void;
+      availableHandler({ version: "2.0.0" });
+
+      const setChannelHandler = (ipcMainMock.handle as Mock).mock.calls.find(
+        (args) => args[0] === CHANNELS.UPDATE_SET_CHANNEL
+      )![1] as (event: unknown, channel: string) => Promise<unknown>;
+      storeMock.get.mockReturnValueOnce("stable");
+      void setChannelHandler({}, "nightly");
+
+      storeMock.set.mockClear();
+      downloadedHandler({ version: "2.0.0" });
+      expect(storeMock.set).not.toHaveBeenCalledWith("pendingUpdateVersion", expect.anything());
+    });
+
+    it("does not throw if store.set rejects", () => {
+      storeMock.set.mockImplementationOnce(() => {
+        throw new Error("disk full");
+      });
+      expect(() => downloadedHandler({ version: "2.0.0" })).not.toThrow();
+    });
+  });
+
+  describe("boot-time install verification (issue #9261)", () => {
+    it("fires trackEvent on version mismatch in packaged mode", () => {
+      appMock.getVersion.mockReturnValue("1.0.0");
+      storeMock.get.mockImplementation((key: string) =>
+        key === "pendingUpdateVersion" ? "2.0.0" : undefined
+      );
+
+      autoUpdaterService.initialize();
+
+      expect(storeMock.delete).toHaveBeenCalledWith("pendingUpdateVersion");
+      expect(trackEventMock).toHaveBeenCalledWith("auto_update_install_version_mismatch", {
+        expectedVersion: "2.0.0",
+        actualVersion: "1.0.0",
+        platform: "darwin",
+      });
+    });
+
+    it("does not fire trackEvent when versions match", () => {
+      appMock.getVersion.mockReturnValue("2.0.0");
+      storeMock.get.mockImplementation((key: string) =>
+        key === "pendingUpdateVersion" ? "2.0.0" : undefined
+      );
+
+      autoUpdaterService.initialize();
+
+      expect(storeMock.delete).toHaveBeenCalledWith("pendingUpdateVersion");
+      expect(trackEventMock).not.toHaveBeenCalled();
+    });
+
+    it("clears the marker but does not fire trackEvent in non-packaged mode", () => {
+      appMock.isPackaged = false;
+      storeMock.get.mockImplementation((key: string) =>
+        key === "pendingUpdateVersion" ? "2.0.0" : undefined
+      );
+
+      autoUpdaterService.initialize();
+
+      expect(storeMock.delete).not.toHaveBeenCalledWith("pendingUpdateVersion");
+      expect(trackEventMock).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when no pendingUpdateVersion is stored", () => {
+      storeMock.get.mockReturnValue(undefined);
+
+      autoUpdaterService.initialize();
+
+      expect(trackEventMock).not.toHaveBeenCalled();
+    });
+
+    it("clears but does not fire trackEvent on an invalid stored value", () => {
+      storeMock.get.mockImplementation((key: string) =>
+        key === "pendingUpdateVersion" ? "not-a-version" : undefined
+      );
+
+      autoUpdaterService.initialize();
+
+      expect(storeMock.delete).toHaveBeenCalledWith("pendingUpdateVersion");
+      expect(trackEventMock).not.toHaveBeenCalled();
+    });
+
+    it("clears but does not fire trackEvent on a non-string stored value", () => {
+      storeMock.get.mockImplementation((key: string) =>
+        key === "pendingUpdateVersion" ? 42 : undefined
+      );
+
+      autoUpdaterService.initialize();
+
+      expect(storeMock.delete).toHaveBeenCalledWith("pendingUpdateVersion");
+      expect(trackEventMock).not.toHaveBeenCalled();
+    });
+
+    it("propagates the actual platform on linux", () => {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      process.env.APPIMAGE = "/path/to/app.AppImage";
+      appMock.getVersion.mockReturnValue("1.0.0");
+      storeMock.get.mockImplementation((key: string) =>
+        key === "pendingUpdateVersion" ? "2.0.0" : undefined
+      );
+
+      autoUpdaterService.initialize();
+
+      expect(trackEventMock).toHaveBeenCalledWith(
+        "auto_update_install_version_mismatch",
+        expect.objectContaining({ platform: "linux" })
+      );
+    });
+
+    it("does not crash when store.delete throws", () => {
+      storeMock.get.mockImplementation((key: string) =>
+        key === "pendingUpdateVersion" ? "2.0.0" : undefined
+      );
+      storeMock.delete.mockImplementationOnce(() => {
+        throw new Error("disk full");
+      });
+
+      expect(() => autoUpdaterService.initialize()).not.toThrow();
+      // trackEvent still fires because the delete failure is logged but
+      // doesn't abort the comparison path.
+      expect(trackEventMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("swallows a thrown trackEvent so initialize never throws", () => {
+      storeMock.get.mockImplementation((key: string) =>
+        key === "pendingUpdateVersion" ? "2.0.0" : undefined
+      );
+      trackEventMock.mockImplementationOnce(() => {
+        throw new Error("sentry offline");
+      });
+
+      expect(() => autoUpdaterService.initialize()).not.toThrow();
     });
   });
 });

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -275,6 +275,15 @@ export interface StoreSchema {
   dismissedUpdateAt?: number;
   lastUpdateCheck?: number | null;
   /**
+   * Persisted between `update-downloaded` and the next boot so we can detect
+   * silent install failures (e.g. macOS ShipIt aborting without surfacing an
+   * error, NSIS empty-directory races on Windows). Read-and-deleted on boot
+   * before any await; if the stored version doesn't match `app.getVersion()`
+   * the mismatch is reported via `trackEvent`. Absent means "no install
+   * pending" — no migration entry required (mirrors `dismissedUpdateVersion`).
+   */
+  pendingUpdateVersion?: string;
+  /**
    * Windows Store notifier state. All fields are optional and read with `??`
    * fallbacks at the call site so an absent value behaves like a default —
    * no migration entry required (mirrors `dismissedUpdateVersion` pattern).


### PR DESCRIPTION
## Summary

- Adds a `quitAndInstall` watchdog: if the app hasn't exited within 5 seconds on macOS, `app.exit(0)` forces termination so ShipIt runs. Watchdog is macOS-only — the existing `setImmediate` timing on Windows is left alone.
- Persists `pendingUpdateVersion` to the store when `update-downloaded` fires. On next boot, `checkPendingUpdateInstallVersion` compares it against `app.getVersion()` and logs a structured Sentry event if they don't match.
- Consolidates both IPC and menu call sites into a shared `executeQuitAndInstall` helper.

Resolves #9261

## Changes

- `electron/services/AutoUpdaterService.ts`: `executeQuitAndInstall` helper with macOS watchdog; `checkPendingUpdateInstallVersion` boot check; persist `pendingUpdateVersion` on `update-downloaded`; clear on channel switch; dispose watchdog timer in `dispose()`
- `electron/store.ts`: `pendingUpdateVersion?: string` field added to `StoreSchema`
- `electron/services/__tests__/AutoUpdaterService.test.ts`: 16 new tests covering watchdog behaviour, version persistence, boot verification, and channel-switch clearing

## Testing

176 unit tests pass. Typecheck, lint, and format all clean.