### PR TITLE
fix(crash-recovery): surface per-panel suspect reason in recovery dialog

### DIFF
--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -677,6 +677,10 @@ export class CrashRecoveryService {
       for (const entry of terminals) {
         if (typeof entry !== "object" || entry === null) continue;
         const t = entry as Record<string, unknown>;
+        const isSuspect =
+          typeof t.createdAt === "number"
+            ? Math.abs(crashTimestamp - t.createdAt) < SUSPECT_WINDOW_MS
+            : false;
         summaries.push({
           id: String(t.id ?? ""),
           kind: String(t.kind ?? "terminal"),
@@ -684,10 +688,8 @@ export class CrashRecoveryService {
           cwd: t.cwd ? String(t.cwd) : undefined,
           worktreeId: t.worktreeId ? String(t.worktreeId) : undefined,
           location: (t.location === "dock" ? "dock" : "grid") as "grid" | "dock",
-          isSuspect:
-            typeof t.createdAt === "number"
-              ? Math.abs(crashTimestamp - t.createdAt) < SUSPECT_WINDOW_MS
-              : false,
+          isSuspect,
+          suspectReason: isSuspect ? "crash-window" : undefined,
           agentState: coerceAgentState(t.agentState),
           lastStateChange: typeof t.lastStateChange === "number" ? t.lastStateChange : undefined,
         });

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -1010,7 +1010,9 @@ describe("CrashRecoveryService", () => {
 
       const pending = svc.getPendingCrash();
       expect(pending!.panels![0].isSuspect).toBe(false);
+      expect(pending!.panels![0].suspectReason).toBeUndefined();
       expect(pending!.panels![1].isSuspect).toBe(true);
+      expect(pending!.panels![1].suspectReason).toBe("crash-window");
     });
 
     it("includes agent state in panel summaries", () => {

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -1015,6 +1015,59 @@ describe("CrashRecoveryService", () => {
       expect(pending!.panels![1].suspectReason).toBe("crash-window");
     });
 
+    it("pins the suspect window boundary against the crash entry timestamp", () => {
+      const crashTime = Date.now();
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      const terminals = [
+        {
+          id: "inside",
+          kind: "terminal",
+          title: "Inside",
+          location: "grid",
+          createdAt: crashTime - 29_000,
+        },
+        {
+          id: "outside",
+          kind: "terminal",
+          title: "Outside",
+          location: "grid",
+          createdAt: crashTime - 31_000,
+        },
+      ];
+      fs.writeFileSync(
+        path.join(backupDir, "session-state.json"),
+        JSON.stringify({ capturedAt: Date.now(), appState: { terminals } })
+      );
+
+      const markerPath = path.join(userData, "running.lock");
+      fs.writeFileSync(
+        markerPath,
+        JSON.stringify({
+          sessionStartMs: crashTime - 600_000,
+          appVersion: "1.0.0",
+          platform: "darwin",
+        })
+      );
+
+      storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
+
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      const ref = pending!.entry.timestamp;
+      const inside = pending!.panels!.find((p) => p.id === "inside")!;
+      const outside = pending!.panels!.find((p) => p.id === "outside")!;
+      // Reference must be the crash entry timestamp, not sessionStartMs (set 10m earlier).
+      expect(Math.abs(ref - (crashTime - 29_000))).toBeLessThan(30_000);
+      expect(Math.abs(ref - (crashTime - 31_000))).toBeGreaterThanOrEqual(30_000);
+      expect(inside.isSuspect).toBe(true);
+      expect(inside.suspectReason).toBe("crash-window");
+      expect(outside.isSuspect).toBe(false);
+      expect(outside.suspectReason).toBeUndefined();
+    });
+
     it("includes agent state in panel summaries", () => {
       const backupDir = path.join(userData, "backups");
       fs.mkdirSync(backupDir, { recursive: true });

--- a/shared/types/ipc/crashRecovery.ts
+++ b/shared/types/ipc/crashRecovery.ts
@@ -79,6 +79,14 @@ export interface CrashLogEntry {
   watchdogMainPid?: number;
 }
 
+/**
+ * Why a panel was flagged `isSuspect`. `crash-window` = created within
+ * `SUSPECT_WINDOW_MS` of the crash. `repeated-suspect` is reserved for a
+ * future flow that propagates the quarantine ledger's consecutive-suspect
+ * count into the crash dialog; it is not produced yet.
+ */
+export type PanelSuspectReason = "crash-window" | "repeated-suspect";
+
 export interface PanelSummary {
   id: string;
   kind: string;
@@ -87,6 +95,8 @@ export interface PanelSummary {
   worktreeId?: string;
   location: "grid" | "dock";
   isSuspect: boolean;
+  /** Present only when `isSuspect` is true; drives per-panel reason copy. */
+  suspectReason?: PanelSuspectReason;
   agentState?: string;
   lastStateChange?: number;
 }

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -20,6 +20,7 @@ import { SettingsSwitch } from "../Settings/SettingsSwitch";
 import { InlineStatusBanner } from "../Terminal/InlineStatusBanner";
 import {
   getSuspectPanelBannerTitle,
+  getPanelSuspectReasonTitle,
   SUSPECT_PANEL_BANNER_DESCRIPTION_DESELECTED,
   SUSPECT_PANEL_BANNER_DESCRIPTION_SELECTED,
 } from "./recoveryCopy";
@@ -542,7 +543,7 @@ function PanelRow({
         {panel.isSuspect && (
           <span
             className="text-status-warning"
-            title="Created shortly before crash"
+            title={getPanelSuspectReasonTitle(panel.suspectReason)}
             data-testid={`suspect-badge-${panel.id}`}
           >
             <AlertTriangle className="h-3.5 w-3.5" />

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -119,6 +119,7 @@ const mockPanels = [
     cwd: "/project",
     location: "dock" as const,
     isSuspect: true,
+    suspectReason: "crash-window" as const,
     agentState: "working",
   },
   { id: "t3", kind: "browser", title: "Docs", location: "grid" as const, isSuspect: false },
@@ -228,6 +229,26 @@ describe("CrashRecoveryDialog", () => {
       setup();
       expect(screen.getByTestId("suspect-badge-t2")).toBeTruthy();
       expect(screen.queryByTestId("suspect-badge-t1")).toBeNull();
+    });
+
+    it("shows per-panel reason text in the suspect badge title", () => {
+      setup();
+      expect(screen.getByTestId("suspect-badge-t2").getAttribute("title")).toBe(
+        "Created within 30 seconds of the crash"
+      );
+    });
+
+    it("renders an icon-only suspect badge with no title when suspectReason is absent", () => {
+      setup({
+        crash: {
+          panels: [
+            { id: "t1", kind: "terminal", title: "Shell", location: "grid", isSuspect: true },
+          ],
+        },
+      });
+      const badge = screen.getByTestId("suspect-badge-t1");
+      expect(badge).toBeTruthy();
+      expect(badge.getAttribute("title")).toBeNull();
     });
 
     it("shows agent state for agent panels and not for non-agent panels", () => {

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -251,6 +251,44 @@ describe("CrashRecoveryDialog", () => {
       expect(badge.getAttribute("title")).toBeNull();
     });
 
+    it("renders an icon-only badge with no title for an unknown suspectReason", () => {
+      setup({
+        crash: {
+          panels: [
+            {
+              id: "t1",
+              kind: "terminal",
+              title: "Shell",
+              location: "grid",
+              isSuspect: true,
+              suspectReason: "some-future-reason" as never,
+            },
+          ],
+        },
+      });
+      const badge = screen.getByTestId("suspect-badge-t1");
+      expect(badge).toBeTruthy();
+      expect(badge.getAttribute("title")).toBeNull();
+    });
+
+    it("renders no suspect badge when suspectReason is set but isSuspect is false", () => {
+      setup({
+        crash: {
+          panels: [
+            {
+              id: "t1",
+              kind: "terminal",
+              title: "Shell",
+              location: "grid",
+              isSuspect: false,
+              suspectReason: "crash-window" as const,
+            },
+          ],
+        },
+      });
+      expect(screen.queryByTestId("suspect-badge-t1")).toBeNull();
+    });
+
     it("shows agent state for agent panels and not for non-agent panels", () => {
       setup();
       expect(screen.getByTestId("agent-state-t2")).toBeTruthy();

--- a/src/components/Recovery/recoveryCopy.ts
+++ b/src/components/Recovery/recoveryCopy.ts
@@ -1,4 +1,5 @@
 import type { CrashType } from "@shared/types/pty-host";
+import type { PanelSuspectReason } from "@shared/types/ipc/crashRecovery";
 
 export interface RecoveryBannerCopy {
   title: string;
@@ -59,6 +60,22 @@ export function getSuspectPanelBannerTitle(count: number, deselected: boolean): 
     return `${count} ${noun} deselected — created shortly before the crash`;
   }
   return `${count} ${noun} created shortly before the crash`;
+}
+
+/**
+ * Per-panel reason text shown on the suspect badge. Returns `undefined` for
+ * reasons with no user-facing copy yet (e.g. `repeated-suspect`), which the
+ * row renders as an icon-only badge with no tooltip.
+ */
+export function getPanelSuspectReasonTitle(reason?: PanelSuspectReason): string | undefined {
+  switch (reason) {
+    case "crash-window":
+      return "Created within 30 seconds of the crash";
+    case "repeated-suspect":
+      return "Flagged across multiple crash sessions";
+    default:
+      return undefined;
+  }
 }
 
 export const SUSPECT_PANEL_BANNER_DESCRIPTION_DESELECTED =

--- a/src/components/Recovery/recoveryCopy.ts
+++ b/src/components/Recovery/recoveryCopy.ts
@@ -63,16 +63,14 @@ export function getSuspectPanelBannerTitle(count: number, deselected: boolean): 
 }
 
 /**
- * Per-panel reason text shown on the suspect badge. Returns `undefined` for
- * reasons with no user-facing copy yet (e.g. `repeated-suspect`), which the
- * row renders as an icon-only badge with no tooltip.
+ * Per-panel reason text shown on the suspect badge. Reasons with no
+ * user-facing copy yet (and unknown/future values) return `undefined`, which
+ * the row renders as an icon-only badge with no tooltip.
  */
 export function getPanelSuspectReasonTitle(reason?: PanelSuspectReason): string | undefined {
   switch (reason) {
     case "crash-window":
       return "Created within 30 seconds of the crash";
-    case "repeated-suspect":
-      return "Flagged across multiple crash sessions";
     default:
       return undefined;
   }


### PR DESCRIPTION
## Summary

- The crash recovery dialog auto-deselects panels flagged as suspect but only showed a count banner and a generic hardcoded tooltip ("Created shortly before crash") with no per-panel explanation
- Threads a typed `PanelSuspectReason` through the IPC boundary so each suspect badge explains why that specific panel was flagged
- Backward compatible: `suspectReason` undefined renders the icon-only badge as before

Resolves #9132

## Changes

- `shared/types/ipc/crashRecovery.ts`: new `PanelSuspectReason` union (`"crash-window"` | `"repeated-suspect"`, the latter reserved for a future ledger-driven flow) and optional `suspectReason` field on `PanelSummary`
- `electron/services/CrashRecoveryService.ts`: `extractPanelSummaries()` sets `suspectReason: "crash-window"` alongside the existing time-window check
- `src/components/Recovery/recoveryCopy.ts`: `getPanelSuspectReasonTitle()` maps the reason to user copy ("Created within 30 seconds of the crash"); unknown/unmapped reasons return `undefined` (icon-only badge)
- `src/components/Recovery/CrashRecoveryDialog.tsx`: badge `title` uses the mapper instead of the hardcoded string; kept the native `title` attribute since a Radix tooltip would be invalid HTML inside the row `<label>`

## Testing

Added tests in both `CrashRecoveryService` and `CrashRecoveryDialog`:

- Boundary pinning against the crash entry timestamp
- `suspectReason` assertions in the service
- Badge title text in the dialog
- Unknown-reason fallback (returns `undefined`, renders icon-only)
- `isSuspect` gate (badge only renders when the panel is flagged)

99 service tests + 66 dialog tests, all green. Typecheck/lint/format clean.