### PR TITLE
fix(security): funnel every shell.openExternal through openExternalUrl allowlist

### DIFF
--- a/docs/architecture/destructive-action-safeguards.md
+++ b/docs/architecture/destructive-action-safeguards.md
@@ -195,6 +195,24 @@ The MCP server is a shared surface: while it's running, external clients (Claude
 | `McpServerSettingsTab.tsx` `handleToggle` → `mcpServer.setEnabled(false)` (bypass — direct IPC) | confirm-when-connected | **Yes** — `ConfirmDialog` (default variant) names each connected external client (user-agent + relative connect time) before the stop fires; gated on `listActiveClients().length > 0`, zero clients disables immediately (#8779) | n/a (bypass) | shared-state (live external sessions severed; recovery is re-enable + each client reconnects) | every connected external client | D2 (D0 when no external clients) | Done (#8779) — confirm wired at the toggle call site; the named-client preview satisfies the "content, not count" rule; in-flight calls drain gracefully on the server side | — |
 | `DaintreeAssistantSettingsTab.tsx` `toggleDaintreeControl` → `helpAssistant.setSettings({ daintreeControl: false })` (bypass — direct IPC) | safe | n/a — turning off Daintree control does not stop the MCP server (the auto-couple is one-directional: turning it _on_ enables MCP, turning it _off_ leaves the server up for any other clients) | n/a (bypass) | reversible (toggle back on) | the assistant's own consumer only | D0 | Leave — no MCP side-effect on disable, so no clients are severed and no confirm is warranted (#8779) | — |
 
+## External launch surfaces (`shell.openExternal` / `shell.openPath` / `execFile`)
+
+These open URLs, files, or processes outside the app. The blast radius isn't app state — it's whatever the OS does with renderer-influenced input, so the gate is an **allowlist**, not a `ConfirmDialog`. The standing invariant: **every `shell.openExternal` call routes through `openExternalUrl`** (`electron/utils/openExternal.ts`), which rejects any protocol outside the platform-conditional `ALLOWED_PROTOCOLS` set (`http:`, `https:`, `mailto:` everywhere; `ms-windows-store:` / `ms-settings:` on win32; `x-apple.systempreferences:` on darwin). No call site may call `shell.openExternal` directly — the regression check is `grep -rn "shell\.openExternal" electron/` returning only `openExternal.ts` itself (#9155).
+
+`shell.openPath` takes a filesystem path (not a URL), so the protocol allowlist doesn't apply; the gate there is that every path is app-derived (log files, the app's own log dir) or validated absolute before the call. `execFile` callers that aren't reachable from the renderer (clone/version probes, smoke tests) are out of scope for this audit.
+
+| Call site | Sink | Input source | Gate | Tier |
+| --- | --- | --- | --- | --- |
+| `electron/services/OAuthLoopbackService.ts` `startOAuthLoopback` | `openExternalUrl` | renderer-supplied `authUrl` (webview) | protocol allowlist (`https:` etc.); disallowed scheme settles `open-external-failed` (#9155) | D2 |
+| `electron/ipc/handlers/github.ts` `handleGitHubOpenPR` | `openExternalUrl` | renderer-supplied `prUrl` | allowlist **plus** inline `github.com` / `*.github.com` hostname gate (second layer, preserved) | D1 |
+| `electron/ipc/handlers/github.ts` open issues / prs / commits / issue | `openExternalUrl` | `getRepoUrl(cwd)` (git-derived) | protocol allowlist | D1 |
+| `electron/ipc/handlers/forge.ts` open issues / prs / commits / issue | `openExternalUrl` | `ForgeProvider.build*Url()` (git-derived; typed `string`) | protocol allowlist | D1 |
+| `electron/ipc/handlers/voiceInput.ts` `openMicSettings` | `openExternalUrl` | hardcoded `x-apple.systempreferences:` (darwin) / `ms-settings:` (win32) | platform-conditional allowlist; rejection logged via `logDebug` | D0 |
+| `electron/menu.ts` "Learn More" | `openExternalUrl` | hardcoded `https://github.com/daintreehq/daintree` | protocol allowlist | D0 |
+| `electron/setup/protocols.ts`, `electron/window/createWindow.ts`, `electron/window/ProjectViewManager.ts`, `electron/services/PortalManager.ts`, `electron/ipc/handlers/systemShell.ts` | `openExternalUrl` | navigation / link intercepts | protocol allowlist (already funneled pre-#9155) | D1 |
+| `electron/ipc/handlers/logs.ts`, `electron/ipc/errorHandlers.ts`, `electron/ipc/handlers/recovery.ts` | `shell.openPath` | app log file/dir paths | app-derived path (no URL surface) | D0 |
+| `electron/ipc/handlers/systemShell.ts`, `electron/services/EditorService.ts` | `shell.openPath` | validated absolute path | absolute-path check before call | D0 |
+
 ## Known bypasses
 
 Direct `window.electron.*` IPC calls that skip `ActionService`. These are the highest-risk locations because the action's `danger` rating cannot gate them — the confirmation must live in the component itself.

--- a/electron/ipc/handlers/forge.ts
+++ b/electron/ipc/handlers/forge.ts
@@ -1,6 +1,6 @@
 // eager-import-allow: reads forge config via store.get synchronously in the IPC handler
-import { shell } from "electron";
 import { CHANNELS } from "../channels.js";
+import { openExternalUrl } from "../../utils/openExternal.js";
 import { typedHandle } from "../utils.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { store } from "../../store.js";
@@ -57,7 +57,7 @@ export function registerForgeHandlers(): () => void {
       const { namespaceId, repoRef } = await resolveForCwd(cwd);
       const impl = getImplForNamespace(namespaceId);
       const url = impl.buildIssuesUrl(repoRef, { query, state });
-      await shell.openExternal(url);
+      await openExternalUrl(url);
     })
   );
 
@@ -66,7 +66,7 @@ export function registerForgeHandlers(): () => void {
       const { namespaceId, repoRef } = await resolveForCwd(cwd);
       const impl = getImplForNamespace(namespaceId);
       const url = impl.buildPRsUrl(repoRef, { query, state });
-      await shell.openExternal(url);
+      await openExternalUrl(url);
     })
   );
 
@@ -78,7 +78,7 @@ export function registerForgeHandlers(): () => void {
       const { namespaceId, repoRef } = await resolveForCwd(cwd);
       const impl = getImplForNamespace(namespaceId);
       const url = impl.buildCommitsUrl(repoRef, branch);
-      await shell.openExternal(url);
+      await openExternalUrl(url);
     })
   );
 
@@ -102,7 +102,7 @@ export function registerForgeHandlers(): () => void {
         const { namespaceId, repoRef } = await resolveForCwd(payload.cwd);
         const impl = getImplForNamespace(namespaceId);
         const url = impl.buildIssueUrl(repoRef, payload.issueNumber);
-        await shell.openExternal(url);
+        await openExternalUrl(url);
       }
     )
   );

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -1,7 +1,7 @@
-import { shell } from "electron";
 import fs from "fs/promises";
 import path from "path";
 import { CHANNELS } from "../channels.js";
+import { openExternalUrl } from "../../utils/openExternal.js";
 import { broadcastToRenderer, checkRateLimit, typedHandle } from "../utils.js";
 import { defineIpcNamespace, op } from "../define.js";
 import type { HandlerDependencies } from "../types.js";
@@ -227,7 +227,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     }
     const q = buildGitHubSearchQuery(query, state, "issue");
     const url = q ? `${repoUrl}/issues?q=${encodeURIComponent(q)}` : `${repoUrl}/issues`;
-    await shell.openExternal(url);
+    await openExternalUrl(url);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_OPEN_ISSUES, handleGitHubOpenIssues));
 
@@ -246,7 +246,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     }
     const q = buildGitHubSearchQuery(query, state, "pr");
     const url = q ? `${repoUrl}/pulls?q=${encodeURIComponent(q)}` : `${repoUrl}/pulls`;
-    await shell.openExternal(url);
+    await openExternalUrl(url);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_OPEN_PRS, handleGitHubOpenPRs));
 
@@ -267,7 +267,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       throw new Error("Not a GitHub repository");
     }
     const url = branch ? `${repoUrl}/commits/${encodeURIComponent(branch)}` : `${repoUrl}/commits`;
-    await shell.openExternal(url);
+    await openExternalUrl(url);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_OPEN_COMMITS, handleGitHubOpenCommits));
 
@@ -294,7 +294,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     if (!issueUrl) {
       throw new Error("Not a GitHub repository");
     }
-    await shell.openExternal(issueUrl);
+    await openExternalUrl(issueUrl);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_OPEN_ISSUE, handleGitHubOpenIssue));
 
@@ -315,7 +315,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     } catch (error) {
       throw new Error(formatErrorMessage(error, "Invalid PR URL"), { cause: error });
     }
-    await shell.openExternal(prUrl);
+    // The hostname/protocol gate above is the narrower second layer; the funnel
+    // through `openExternalUrl` keeps the global protocol allowlist authoritative.
+    await openExternalUrl(prUrl);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_OPEN_PR, handleGitHubOpenPR));
 

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -1,5 +1,5 @@
 // eager-import-allow: reads voice-input settings via store.get synchronously in the IPC handler
-import { ipcMain, systemPreferences, shell } from "electron";
+import { ipcMain, systemPreferences } from "electron";
 import { spawn } from "child_process";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
@@ -13,6 +13,7 @@ import { applyDictationCommands } from "../../services/voiceDictationCommands.js
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
 import { voiceFileLinkResolver } from "../../services/VoiceFileLinkResolver.js";
 import { typedHandle, typedHandleValidated, typedHandleWithContext } from "../utils.js";
+import { openExternalUrl } from "../../utils/openExternal.js";
 import {
   VoiceInputCorrectPayloadSchema,
   type VoiceInputCorrectPayload,
@@ -123,12 +124,17 @@ async function requestMicPermission(): Promise<boolean> {
 }
 
 function openMicSettings(): void {
+  const logOpenFailure = (err: unknown) =>
+    logDebug("[VoiceInput] Failed to open mic settings", {
+      error: (err as Error)?.message ?? String(err),
+    });
+
   if (process.platform === "darwin") {
-    void shell.openExternal(
+    void openExternalUrl(
       "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
-    );
+    ).catch(logOpenFailure);
   } else if (process.platform === "win32") {
-    void shell.openExternal("ms-settings:privacy-microphone");
+    void openExternalUrl("ms-settings:privacy-microphone").catch(logOpenFailure);
   } else {
     // Linux: try gnome-control-center, fall back silently
     try {

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -1,5 +1,6 @@
-import { Menu, dialog, BrowserWindow, shell, app, webContents } from "electron";
+import { Menu, dialog, BrowserWindow, app, webContents } from "electron";
 import { projectStore } from "./services/ProjectStore.js";
+import { openExternalUrl } from "./utils/openExternal.js";
 import { CHANNELS } from "./ipc/channels.js";
 import { broadcastProjectSwitchUpdates } from "./ipc/projectSwitchBroadcast.js";
 import { getEffectiveRegistry } from "../shared/config/agentRegistry.js";
@@ -476,7 +477,7 @@ export function createApplicationMenu(
         {
           label: "Learn More",
           click: async () => {
-            await shell.openExternal("https://github.com/daintreehq/daintree");
+            await openExternalUrl("https://github.com/daintreehq/daintree");
           },
         },
         ...(process.platform !== "darwin" && app.isPackaged && !isWindowsStoreBuild()

--- a/electron/services/OAuthLoopbackService.ts
+++ b/electron/services/OAuthLoopbackService.ts
@@ -35,9 +35,20 @@ interface LoopbackSession {
 const activeSessions = new Map<string, LoopbackSession>();
 
 export function startOAuthLoopback(authUrl: string, panelId: string): Promise<OAuthLoopbackResult> {
+  // Validate the renderer-supplied URL before any side effect: a malformed
+  // string would otherwise throw out of the typed-result contract, and
+  // cancelling the in-flight session before validation would kill a live flow
+  // on a bad input.
+  let parsed: URL;
+  try {
+    parsed = new URL(authUrl);
+  } catch {
+    console.warn("[OAuthLoopback] Invalid auth URL");
+    return Promise.resolve({ success: false, cause: "server-error" });
+  }
+
   cancelOAuthLoopback(panelId);
 
-  const parsed = new URL(authUrl);
   const originalRedirectUri = parsed.searchParams.get("redirect_uri");
 
   if (!originalRedirectUri) {

--- a/electron/services/OAuthLoopbackService.ts
+++ b/electron/services/OAuthLoopbackService.ts
@@ -1,12 +1,13 @@
 /**
  * RFC 8252 OAuth loopback flow for dev-preview panels.
  * Ephemeral HTTP server on 127.0.0.1:0 captures the IdP callback after
- * shell.openExternal handles the authorization in the system browser.
+ * the system browser (via openExternalUrl) handles the authorization.
  * Requires the IdP to accept http://127.0.0.1:* as a redirect_uri (RFC 8252 §7.3).
  */
 
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from "http";
-import { app, shell } from "electron";
+import { app } from "electron";
+import { openExternalUrl } from "../utils/openExternal.js";
 
 export { looksLikeOAuthUrl } from "../../shared/utils/urlUtils.js";
 export type { OAuthLoopbackResult } from "../../shared/types/oauth.js";
@@ -135,7 +136,11 @@ export function startOAuthLoopback(authUrl: string, panelId: string): Promise<OA
           `Original redirect: ${originalRedirectUri} → Loopback: ${capturedLoopbackUri}`
       );
 
-      void shell.openExternal(parsed.toString()).catch((err) => {
+      // Funnel through the protocol allowlist — `authUrl` is renderer-supplied,
+      // so a disallowed scheme (file:, javascript:, …) must not reach the
+      // system browser. `openExternalUrl` throws on a disallowed protocol,
+      // which the `.catch` below settles as an open-external failure.
+      void openExternalUrl(parsed.toString()).catch((err) => {
         console.error("[OAuthLoopback] Failed to open system browser:", err);
         settle({ success: false, cause: "open-external-failed" });
       });

--- a/electron/services/__tests__/OAuthLoopbackService.test.ts
+++ b/electron/services/__tests__/OAuthLoopbackService.test.ts
@@ -102,6 +102,24 @@ describe("OAuthLoopbackService", () => {
       expect(shell.openExternal).not.toHaveBeenCalled();
     });
 
+    it("never opens a disallowed scheme even with a valid redirect_uri", async () => {
+      const redirect = encodeURIComponent("http://localhost:3000/auth/callback");
+
+      const fileResult = await startOAuthLoopback(
+        `file:///etc/passwd?redirect_uri=${redirect}`,
+        "test-panel"
+      );
+      expect(fileResult).toEqual({ success: false, cause: "open-external-failed" });
+
+      const customResult = await startOAuthLoopback(
+        `myapp://auth?redirect_uri=${redirect}`,
+        "test-panel"
+      );
+      expect(customResult).toEqual({ success: false, cause: "open-external-failed" });
+
+      expect(shell.openExternal).not.toHaveBeenCalled();
+    });
+
     it("starts a loopback server and rewrites redirect_uri", async () => {
       const authUrl =
         "https://auth.example.com/authorize?client_id=abc&response_type=code&redirect_uri=http://localhost:3000/auth/callback&state=xyz123";

--- a/electron/services/__tests__/OAuthLoopbackService.test.ts
+++ b/electron/services/__tests__/OAuthLoopbackService.test.ts
@@ -102,6 +102,31 @@ describe("OAuthLoopbackService", () => {
       expect(shell.openExternal).not.toHaveBeenCalled();
     });
 
+    it("returns server-error without throwing on a malformed auth URL", async () => {
+      const result = await startOAuthLoopback("not a url", "test-panel");
+      expect(result).toEqual({ success: false, cause: "server-error" });
+      expect(shell.openExternal).not.toHaveBeenCalled();
+    });
+
+    it("does not cancel an in-flight session when a later call has a malformed URL", async () => {
+      const authUrl =
+        "https://auth.example.com/authorize?client_id=abc&response_type=code&redirect_uri=http://localhost:3000/auth/callback";
+
+      const firstPromise = startOAuthLoopback(authUrl, "test-panel");
+      await vi.waitFor(() => {
+        expect(shell.openExternal).toHaveBeenCalledTimes(1);
+      });
+
+      // A malformed URL for the same panel must not disturb the live flow.
+      const badResult = await startOAuthLoopback("not a url", "test-panel");
+      expect(badResult).toEqual({ success: false, cause: "server-error" });
+
+      // The original session is still live — cancelling it now resolves it.
+      cancelOAuthLoopback("test-panel");
+      const firstResult = await firstPromise;
+      expect(firstResult).toEqual({ success: false, cause: "cancelled" });
+    });
+
     it("never opens a disallowed scheme even with a valid redirect_uri", async () => {
       const redirect = encodeURIComponent("http://localhost:3000/auth/callback");
 

--- a/electron/utils/__tests__/openExternal.test.ts
+++ b/electron/utils/__tests__/openExternal.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("electron", () => ({
+  shell: {
+    openExternal: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { shell } from "electron";
+import { buildAllowedProtocols, canOpenExternalUrl, openExternalUrl } from "../openExternal.js";
+
+const openExternalMock = shell.openExternal as ReturnType<typeof vi.fn>;
+
+describe("buildAllowedProtocols", () => {
+  it("always allows http, https, and mailto on every platform", () => {
+    for (const platform of ["darwin", "win32", "linux"] as NodeJS.Platform[]) {
+      const set = buildAllowedProtocols(platform);
+      expect(set.has("http:")).toBe(true);
+      expect(set.has("https:")).toBe(true);
+      expect(set.has("mailto:")).toBe(true);
+    }
+  });
+
+  it("gates x-apple.systempreferences: to macOS only", () => {
+    expect(buildAllowedProtocols("darwin").has("x-apple.systempreferences:")).toBe(true);
+    expect(buildAllowedProtocols("win32").has("x-apple.systempreferences:")).toBe(false);
+    expect(buildAllowedProtocols("linux").has("x-apple.systempreferences:")).toBe(false);
+  });
+
+  it("gates ms-settings: and ms-windows-store: to Windows only", () => {
+    for (const scheme of ["ms-settings:", "ms-windows-store:"]) {
+      expect(buildAllowedProtocols("win32").has(scheme)).toBe(true);
+      expect(buildAllowedProtocols("darwin").has(scheme)).toBe(false);
+      expect(buildAllowedProtocols("linux").has(scheme)).toBe(false);
+    }
+  });
+});
+
+describe("canOpenExternalUrl", () => {
+  it("allows http and https URLs", () => {
+    expect(canOpenExternalUrl("https://github.com/daintreehq/daintree")).toBe(true);
+    expect(canOpenExternalUrl("http://example.com")).toBe(true);
+    expect(canOpenExternalUrl("  https://example.com  ")).toBe(true);
+  });
+
+  it("rejects dangerous and unknown schemes", () => {
+    expect(canOpenExternalUrl("file:///etc/passwd")).toBe(false);
+    expect(canOpenExternalUrl("javascript:alert(1)")).toBe(false);
+    expect(canOpenExternalUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+    expect(canOpenExternalUrl("custom-scheme://do-something")).toBe(false);
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(canOpenExternalUrl("not a url")).toBe(false);
+    expect(canOpenExternalUrl("")).toBe(false);
+  });
+});
+
+describe("openExternalUrl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hands allowed URLs to shell.openExternal", async () => {
+    await openExternalUrl("https://github.com/daintreehq/daintree");
+    expect(openExternalMock).toHaveBeenCalledTimes(1);
+    expect(openExternalMock).toHaveBeenCalledWith("https://github.com/daintreehq/daintree", {
+      activate: true,
+    });
+  });
+
+  it("throws on a disallowed protocol without calling shell.openExternal", async () => {
+    await expect(openExternalUrl("file:///etc/passwd")).rejects.toThrow(/not allowed/);
+    await expect(openExternalUrl("javascript:alert(1)")).rejects.toThrow(/not allowed/);
+    expect(openExternalMock).not.toHaveBeenCalled();
+  });
+
+  it("throws on a malformed URL without calling shell.openExternal", async () => {
+    await expect(openExternalUrl("not a url")).rejects.toThrow(/Invalid URL/);
+    expect(openExternalMock).not.toHaveBeenCalled();
+  });
+});

--- a/electron/utils/openExternal.ts
+++ b/electron/utils/openExternal.ts
@@ -1,6 +1,24 @@
 import { shell } from "electron";
 
-const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "mailto:", "ms-windows-store:"]);
+/**
+ * Build the set of URL protocols `openExternalUrl` is allowed to hand to the
+ * system. Platform-specific schemes are gated to the platform that owns them:
+ * `ms-windows-store:` / `ms-settings:` only resolve meaningfully on Windows,
+ * and `x-apple.systempreferences:` only on macOS. Allowlisting them everywhere
+ * would widen the attack surface on platforms where a third-party app could
+ * register the scheme.
+ */
+export function buildAllowedProtocols(platform: NodeJS.Platform): Set<string> {
+  return new Set([
+    "http:",
+    "https:",
+    "mailto:",
+    ...(platform === "win32" ? ["ms-windows-store:", "ms-settings:"] : []),
+    ...(platform === "darwin" ? ["x-apple.systempreferences:"] : []),
+  ]);
+}
+
+const ALLOWED_PROTOCOLS = buildAllowedProtocols(process.platform);
 
 export function canOpenExternalUrl(url: string): boolean {
   try {


### PR DESCRIPTION
## Summary

Security hardening. Routes every direct `shell.openExternal` call through the centralized `openExternalUrl` allowlist (`electron/utils/openExternal.ts`), closing the renderer-controlled bypass in `OAuthLoopbackService` where `authUrl` reached the system browser after only a `typeof === "string"` check.

## Changes

- **`buildAllowedProtocols(platform)`** makes `ALLOWED_PROTOCOLS` platform-conditional: `http:`/`https:`/`mailto:` everywhere; `ms-windows-store:` + `ms-settings:` win32-only; `x-apple.systempreferences:` darwin-only — avoids cross-platform scheme hijack where a third-party app could register a scheme on a platform that doesn't own it.
- **`OAuthLoopbackService`** routes renderer-supplied `authUrl` through `openExternalUrl`; disallowed schemes (`file:`/`javascript:`/custom) settle `open-external-failed`. Also validates the URL before any side effect — no synchronous throw out of the typed-result contract, and a malformed URL no longer cancels an in-flight session.
- Funneled call sites: `forge.ts` (4), `github.ts` (5), `voiceInput.ts` (2), `menu.ts` (1). `handleGitHubOpenPR` keeps its `github.com` / `*.github.com` hostname gate as a second layer.
- New `openExternal` unit tests + `OAuthLoopback` disallowed-scheme / malformed-URL tests.
- `docs/architecture/destructive-action-safeguards.md` gains an **External launch surfaces** audit table with the regression invariant: `grep -rn "shell\.openExternal" electron/` returns only `openExternal.ts`.

## Testing

- All targeted vitest suites pass (openExternal, OAuthLoopback unit + integration).
- `npm run check` clean — typecheck, lint (no new warnings), format, IPC/channel checks all pass.

Closes #9155.