### PR TITLE
fix(dev-preview): probe rejects half-warm servers (#9097)

### DIFF
--- a/electron/services/DevPreviewReadinessProbe.ts
+++ b/electron/services/DevPreviewReadinessProbe.ts
@@ -160,11 +160,16 @@ export async function probeHmrWebSocket(
       }
       sockets.push(socket);
 
-      socket.once("open", () => settle(true));
+      // ws emits both "error" and "close" on a failed connection. Guard so a single
+      // socket can only decrement `pending` once regardless of event ordering.
+      let counted = false;
       const onFail = () => {
+        if (counted) return;
+        counted = true;
         pending -= 1;
         if (pending === 0 && !settled) settle(false);
       };
+      socket.once("open", () => settle(true));
       socket.once("error", onFail);
       socket.once("close", onFail);
     }

--- a/electron/services/DevPreviewReadinessProbe.ts
+++ b/electron/services/DevPreviewReadinessProbe.ts
@@ -1,9 +1,19 @@
 import http from "node:http";
 import https from "node:https";
+import WebSocket from "ws";
 
 export const READINESS_TIMEOUT_MS = 30000;
 export const READINESS_POLL_INTERVAL_MS = 500;
 export const READINESS_REQUEST_TIMEOUT_MS = 5000;
+export const READINESS_HMR_TIMEOUT_MS = 1500;
+
+type ProbeResult = "ready" | "5xx" | "fail";
+
+const HMR_PROBE_CANDIDATES: ReadonlyArray<{ path: string; subprotocols?: string[] }> = [
+  { path: "/", subprotocols: ["vite-hmr"] },
+  { path: "/_next/webpack-hmr" },
+  { path: "/ws" },
+];
 
 function buildReadinessUrls(url: string): string[] | null {
   let parsed: URL;
@@ -25,13 +35,13 @@ function buildReadinessUrls(url: string): string[] | null {
   return [...new Set(urls)];
 }
 
-async function probeUrl(url: string, useHttps: boolean, signal: AbortSignal): Promise<boolean> {
+async function probeUrl(url: string, useHttps: boolean, signal: AbortSignal): Promise<ProbeResult> {
   const requestModule = useHttps ? https : http;
 
-  return new Promise<boolean>((resolve) => {
+  return new Promise<ProbeResult>((resolve) => {
     let settled = false;
     let onAbort: () => void = () => {};
-    const settle = (value: boolean) => {
+    const settle = (value: ProbeResult) => {
       if (settled) return;
       settled = true;
       signal.removeEventListener("abort", onAbort);
@@ -42,39 +52,131 @@ async function probeUrl(url: string, useHttps: boolean, signal: AbortSignal): Pr
       const req = requestModule.request(
         url,
         {
-          method: "HEAD",
+          method: "GET",
           timeout: READINESS_REQUEST_TIMEOUT_MS,
           ...(useHttps ? { rejectUnauthorized: false } : {}),
         },
         (res) => {
           res.resume();
           const status = res.statusCode ?? 0;
-          if (status >= 200 && status < 500) {
-            settle(true);
+          if (status >= 200 && status < 400) {
+            settle("ready");
+          } else if (status >= 500 && status < 600) {
+            settle("5xx");
           } else {
-            settle(false);
+            settle("fail");
           }
         }
       );
       onAbort = () => {
         req.destroy();
-        settle(false);
+        settle("fail");
       };
-      req.on("error", () => settle(false));
+      req.on("error", () => settle("fail"));
       req.on("timeout", () => {
         req.destroy();
-        settle(false);
+        settle("fail");
       });
       if (signal.aborted) {
         req.destroy();
-        settle(false);
+        settle("fail");
       } else {
         signal.addEventListener("abort", onAbort, { once: true });
         req.end();
       }
     } catch {
-      settle(false);
+      settle("fail");
     }
+  });
+}
+
+export async function probeHmrWebSocket(
+  httpUrl: string,
+  signal: AbortSignal,
+  timeoutMs = READINESS_HMR_TIMEOUT_MS
+): Promise<boolean> {
+  let parsed: URL;
+  try {
+    parsed = new URL(httpUrl);
+  } catch {
+    return false;
+  }
+
+  const wsScheme = parsed.protocol === "https:" ? "wss:" : "ws:";
+  const origin = `${parsed.protocol}//${parsed.host}`;
+  const sockets: WebSocket[] = [];
+
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let onAbort: () => void = () => {};
+
+    const cleanup = () => {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      signal.removeEventListener("abort", onAbort);
+      for (const socket of sockets) {
+        try {
+          socket.terminate();
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    };
+
+    const settle = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+
+    if (signal.aborted) {
+      settle(false);
+      return;
+    }
+
+    let pending = HMR_PROBE_CANDIDATES.length;
+
+    const isSecure = wsScheme === "wss:";
+    const baseOptions = {
+      headers: { Origin: origin },
+      ...(isSecure ? { rejectUnauthorized: false } : {}),
+    };
+
+    for (const candidate of HMR_PROBE_CANDIDATES) {
+      const wsUrl = `${wsScheme}//${parsed.host}${candidate.path}`;
+      let socket: WebSocket;
+      try {
+        socket = candidate.subprotocols
+          ? new WebSocket(wsUrl, candidate.subprotocols, baseOptions)
+          : new WebSocket(wsUrl, baseOptions);
+      } catch {
+        pending -= 1;
+        if (pending === 0) settle(false);
+        continue;
+      }
+      sockets.push(socket);
+
+      socket.once("open", () => settle(true));
+      const onFail = () => {
+        pending -= 1;
+        if (pending === 0 && !settled) settle(false);
+      };
+      socket.once("error", onFail);
+      socket.once("close", onFail);
+    }
+
+    if (pending === 0) {
+      settle(false);
+      return;
+    }
+
+    onAbort = () => settle(false);
+    signal.addEventListener("abort", onAbort, { once: true });
+    timer = setTimeout(() => settle(false), timeoutMs);
   });
 }
 
@@ -94,12 +196,26 @@ export async function waitForServerReady(
     return false;
   }
 
+  let hasSeen5xx = false;
+  let awaitingConfirmation = false;
+
   while (performance.now() < deadline) {
     if (signal.aborted) return false;
 
     for (const candidateUrl of urls) {
       if (signal.aborted) return false;
-      if (await probeUrl(candidateUrl, useHttps, signal)) return true;
+      const result = await probeUrl(candidateUrl, useHttps, signal);
+      if (result === "5xx") {
+        hasSeen5xx = true;
+        awaitingConfirmation = false;
+      } else if (result === "ready") {
+        if (!hasSeen5xx || awaitingConfirmation) {
+          await probeHmrWebSocket(candidateUrl, signal);
+          if (signal.aborted) return false;
+          return true;
+        }
+        awaitingConfirmation = true;
+      }
     }
 
     if (signal.aborted) return false;

--- a/electron/services/__tests__/DevPreviewReadinessProbe.test.ts
+++ b/electron/services/__tests__/DevPreviewReadinessProbe.test.ts
@@ -8,11 +8,25 @@ type MockRequest = {
   destroy: ReturnType<typeof vi.fn>;
 };
 
-const { mockRequest } = vi.hoisted(() => ({
+type WsListener = (...args: unknown[]) => void;
+type WsHeaders = Record<string, string>;
+type MockWebSocket = {
+  url: string;
+  subprotocols: string[];
+  headers: WsHeaders;
+  listeners: { open: WsListener[]; error: WsListener[]; close: WsListener[] };
+  once: ReturnType<typeof vi.fn>;
+  terminate: ReturnType<typeof vi.fn>;
+  emit: (event: "open" | "error" | "close", ...args: unknown[]) => void;
+};
+
+const { mockRequest, wsInstances, wsBehavior } = vi.hoisted(() => ({
   mockRequest:
     vi.fn<
       (url: string, options: Record<string, unknown>, callback: RequestCallback) => MockRequest
     >(),
+  wsInstances: [] as MockWebSocket[],
+  wsBehavior: { mode: "error" as "error" | "open" | "throw" | "openOn", openOnUrl: "" },
 }));
 
 vi.mock("node:http", () => ({
@@ -24,17 +38,66 @@ vi.mock("node:https", () => ({
   request: mockRequest,
 }));
 
-import { waitForServerReady, READINESS_TIMEOUT_MS } from "../DevPreviewReadinessProbe.js";
-
-function mockSuccessResponse() {
-  const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
-  mockRequest.mockImplementation(
-    (_url: string, _options: Record<string, unknown>, callback: RequestCallback) => {
-      callback({ statusCode: 200, resume: vi.fn() });
-      return req;
+vi.mock("ws", () => {
+  class WebSocketMock {
+    url: string;
+    subprotocols: string[];
+    headers: WsHeaders;
+    listeners: MockWebSocket["listeners"] = { open: [], error: [], close: [] };
+    once = vi.fn((event: "open" | "error" | "close", listener: WsListener) => {
+      this.listeners[event].push(listener);
+      return this;
+    });
+    terminate = vi.fn();
+    emit(event: "open" | "error" | "close", ...args: unknown[]) {
+      const listeners = this.listeners[event];
+      this.listeners[event] = [];
+      for (const listener of listeners) listener(...args);
     }
-  );
-  return req;
+    constructor(url: string, protocolsOrOptions?: unknown, maybeOptions?: unknown) {
+      this.url = url;
+      const hasProtocols = Array.isArray(protocolsOrOptions);
+      this.subprotocols = hasProtocols ? (protocolsOrOptions as string[]) : [];
+      const options = (hasProtocols ? maybeOptions : protocolsOrOptions) as
+        | { headers?: WsHeaders }
+        | undefined;
+      this.headers = options?.headers ?? {};
+
+      if (wsBehavior.mode === "throw") {
+        throw new Error("invalid ws url");
+      }
+
+      wsInstances.push(this as unknown as MockWebSocket);
+
+      const shouldOpen =
+        wsBehavior.mode === "open" ||
+        (wsBehavior.mode === "openOn" && url === wsBehavior.openOnUrl);
+
+      queueMicrotask(() => {
+        if (shouldOpen) {
+          this.emit("open");
+        } else {
+          this.emit("error", new Error("ws connect failed"));
+        }
+      });
+    }
+  }
+  return {
+    default: WebSocketMock,
+  };
+});
+
+import {
+  waitForServerReady,
+  probeHmrWebSocket,
+  READINESS_TIMEOUT_MS,
+  READINESS_HMR_TIMEOUT_MS,
+} from "../DevPreviewReadinessProbe.js";
+
+function resetWsState() {
+  wsInstances.length = 0;
+  wsBehavior.mode = "error";
+  wsBehavior.openOnUrl = "";
 }
 
 function mockResponseWithStatus(statusCode: number) {
@@ -46,6 +109,19 @@ function mockResponseWithStatus(statusCode: number) {
     }
   );
   return req;
+}
+
+function mockResponseSequence(statuses: number[]) {
+  let i = 0;
+  mockRequest.mockImplementation(
+    (_url: string, _options: Record<string, unknown>, callback: RequestCallback) => {
+      const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
+      const status = statuses[Math.min(i, statuses.length - 1)] ?? 0;
+      i += 1;
+      callback({ statusCode: status, resume: vi.fn() });
+      return req;
+    }
+  );
 }
 
 function mockConnectionRefused() {
@@ -68,13 +144,22 @@ function mockConnectionRefused() {
 describe("waitForServerReady", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetWsState();
   });
 
   it("returns true on HTTP 200", async () => {
-    mockSuccessResponse();
+    mockResponseWithStatus(200);
     const signal = new AbortController().signal;
     const result = await waitForServerReady("http://localhost:3000", signal, 100);
     expect(result).toBe(true);
+  });
+
+  it("uses GET method, not HEAD", async () => {
+    mockResponseWithStatus(200);
+    const signal = new AbortController().signal;
+    await waitForServerReady("http://localhost:3000", signal, 100);
+    const optionsArg = mockRequest.mock.calls[0]?.[1];
+    expect(optionsArg?.method).toBe("GET");
   });
 
   it("falls back to IPv4 loopback when localhost is refused", async () => {
@@ -125,25 +210,221 @@ describe("waitForServerReady", () => {
     expect(result).toBe(false);
   });
 
-  describe("accepted status range (200–499)", () => {
-    it.each([200, 204, 301, 401, 404, 499])("returns true on HTTP %i", async (status) => {
+  describe("accepted status range", () => {
+    it.each([200, 204, 301, 302, 307, 308])("returns true on HTTP %i", async (status) => {
       mockResponseWithStatus(status);
       const signal = new AbortController().signal;
       const result = await waitForServerReady("http://localhost:3000", signal, 100);
       expect(result).toBe(true);
     });
 
-    it.each([100, 199, 500, 502, 503, 599])("returns false on HTTP %i", async (status) => {
-      mockResponseWithStatus(status);
+    it.each([100, 199, 400, 401, 404, 405, 499, 500, 502, 503, 599])(
+      "returns false on HTTP %i",
+      async (status) => {
+        mockResponseWithStatus(status);
+        const signal = new AbortController().signal;
+        const result = await waitForServerReady("http://localhost:3000", signal, 100);
+        expect(result).toBe(false);
+      }
+    );
+  });
+
+  describe("5xx memory", () => {
+    it("requires a follow-up 2xx/3xx after a 5xx before resolving", async () => {
+      mockResponseSequence([502, 200, 200]);
       const signal = new AbortController().signal;
-      const result = await waitForServerReady("http://localhost:3000", signal, 100);
-      expect(result).toBe(false);
+      const result = await waitForServerReady("http://localhost:3000", signal, 5000);
+      expect(result).toBe(true);
+      const statusCount = mockRequest.mock.calls.length;
+      expect(statusCount).toBeGreaterThanOrEqual(3);
     });
+
+    it("does not resolve on the first 200 immediately after a 5xx", async () => {
+      let idx = 0;
+      const statuses = [502, 200];
+      mockRequest.mockImplementation(
+        (_url: string, _options: Record<string, unknown>, callback: RequestCallback) => {
+          const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
+          const status = statuses[Math.min(idx, statuses.length - 1)] ?? 200;
+          idx += 1;
+          callback({ statusCode: status, resume: vi.fn() });
+          return req;
+        }
+      );
+      const signal = new AbortController().signal;
+      // Single-candidate URL (no IPv4/IPv6 fallback fanout) so each round = 1 call.
+      // Timeout 600ms allows ~2 rounds (poll interval 500ms): round 1 = 502, round 2 = 200,
+      // then deadline expires before a round 3 follow-up 200 could resolve.
+      const result = await waitForServerReady("http://127.0.0.1:3000", signal, 600);
+      expect(result).toBe(false);
+      expect(idx).toBeGreaterThanOrEqual(2);
+    });
+
+    it("resolves on first 2xx when no 5xx ever observed (ECONNREFUSED then 200)", async () => {
+      let callCount = 0;
+      mockRequest.mockImplementation(
+        (_url: string, _options: Record<string, unknown>, callback: RequestCallback) => {
+          const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
+          callCount += 1;
+          if (callCount === 1) {
+            setTimeout(() => {
+              const errorHandler = req.on.mock.calls.find(
+                (c: unknown[]) => c[0] === "error"
+              )?.[1] as ((err: Error) => void) | undefined;
+              errorHandler?.(new Error("ECONNREFUSED"));
+            }, 0);
+            return req;
+          }
+          callback({ statusCode: 200, resume: vi.fn() });
+          return req;
+        }
+      );
+      const signal = new AbortController().signal;
+      const result = await waitForServerReady("http://localhost:3000", signal, 5000);
+      expect(result).toBe(true);
+    });
+
+    it("resets confirmation when a new 5xx interrupts the recovery", async () => {
+      mockResponseSequence([502, 200, 502, 200, 200]);
+      const signal = new AbortController().signal;
+      const result = await waitForServerReady("http://localhost:3000", signal, 5000);
+      expect(result).toBe(true);
+      expect(mockRequest.mock.calls.length).toBeGreaterThanOrEqual(5);
+    });
+  });
+
+  describe("HMR WebSocket handshake", () => {
+    it("opens WS probe after HTTP succeeds", async () => {
+      mockResponseWithStatus(200);
+      wsBehavior.mode = "error";
+      const signal = new AbortController().signal;
+      const result = await waitForServerReady("http://localhost:3000", signal, 5000);
+      expect(result).toBe(true);
+      expect(wsInstances.length).toBe(3);
+    });
+
+    it("returns true even when all WS candidates fail (opportunistic)", async () => {
+      mockResponseWithStatus(200);
+      wsBehavior.mode = "error";
+      const signal = new AbortController().signal;
+      const result = await waitForServerReady("http://localhost:3000", signal, 5000);
+      expect(result).toBe(true);
+    });
+
+    it("spoofs Origin header on every WS candidate", async () => {
+      mockResponseWithStatus(200);
+      wsBehavior.mode = "error";
+      const signal = new AbortController().signal;
+      await waitForServerReady("http://localhost:3000", signal, 5000);
+      for (const instance of wsInstances) {
+        expect(instance.headers.Origin).toBe("http://localhost:3000");
+      }
+    });
+
+    it("uses vite-hmr subprotocol on the root WS path", async () => {
+      mockResponseWithStatus(200);
+      wsBehavior.mode = "error";
+      const signal = new AbortController().signal;
+      await waitForServerReady("http://localhost:3000", signal, 5000);
+      const root = wsInstances.find((ws) => ws.url === "ws://localhost:3000/");
+      expect(root).toBeDefined();
+      expect(root?.subprotocols).toEqual(["vite-hmr"]);
+    });
+
+    it("probes all three HMR endpoints", async () => {
+      mockResponseWithStatus(200);
+      wsBehavior.mode = "error";
+      const signal = new AbortController().signal;
+      await waitForServerReady("http://localhost:3000", signal, 5000);
+      const urls = wsInstances.map((ws) => ws.url).sort();
+      expect(urls).toEqual([
+        "ws://localhost:3000/",
+        "ws://localhost:3000/_next/webpack-hmr",
+        "ws://localhost:3000/ws",
+      ]);
+    });
+
+    it("derives wss:// scheme from https:// HTTP URL", async () => {
+      mockResponseWithStatus(200);
+      wsBehavior.mode = "error";
+      const signal = new AbortController().signal;
+      await waitForServerReady("https://localhost:3000", signal, 5000);
+      expect(wsInstances.every((ws) => ws.url.startsWith("wss://"))).toBe(true);
+    });
+
+    it("terminates all sockets after settlement", async () => {
+      mockResponseWithStatus(200);
+      wsBehavior.mode = "error";
+      const signal = new AbortController().signal;
+      await waitForServerReady("http://localhost:3000", signal, 5000);
+      for (const instance of wsInstances) {
+        expect(instance.terminate).toHaveBeenCalled();
+      }
+    });
+
+    it("survives a synchronous WS constructor throw", async () => {
+      mockResponseWithStatus(200);
+      wsBehavior.mode = "throw";
+      const signal = new AbortController().signal;
+      const result = await waitForServerReady("http://localhost:3000", signal, 5000);
+      expect(result).toBe(true);
+    });
+  });
+});
+
+describe("probeHmrWebSocket", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetWsState();
+  });
+
+  it("resolves true when any candidate opens", async () => {
+    wsBehavior.mode = "openOn";
+    wsBehavior.openOnUrl = "ws://localhost:3000/_next/webpack-hmr";
+    const signal = new AbortController().signal;
+    const result = await probeHmrWebSocket("http://localhost:3000", signal);
+    expect(result).toBe(true);
+  });
+
+  it("resolves false when all candidates error", async () => {
+    wsBehavior.mode = "error";
+    const signal = new AbortController().signal;
+    const result = await probeHmrWebSocket("http://localhost:3000", signal);
+    expect(result).toBe(false);
+  });
+
+  it("resolves false when signal is already aborted", async () => {
+    wsBehavior.mode = "open";
+    const controller = new AbortController();
+    controller.abort();
+    const result = await probeHmrWebSocket("http://localhost:3000", controller.signal);
+    expect(result).toBe(false);
+    expect(wsInstances.length).toBe(0);
+  });
+
+  it("resolves false on invalid URL", async () => {
+    wsBehavior.mode = "open";
+    const signal = new AbortController().signal;
+    const result = await probeHmrWebSocket("not-a-url", signal);
+    expect(result).toBe(false);
+  });
+
+  it("resolves false when all WS constructors throw", async () => {
+    wsBehavior.mode = "throw";
+    const signal = new AbortController().signal;
+    const result = await probeHmrWebSocket("http://localhost:3000", signal);
+    expect(result).toBe(false);
   });
 });
 
 describe("READINESS_TIMEOUT_MS", () => {
   it("is the expected default", () => {
     expect(READINESS_TIMEOUT_MS).toBe(30000);
+  });
+});
+
+describe("READINESS_HMR_TIMEOUT_MS", () => {
+  it("is the expected default", () => {
+    expect(READINESS_HMR_TIMEOUT_MS).toBe(1500);
   });
 });

--- a/electron/services/__tests__/DevPreviewReadinessProbe.test.ts
+++ b/electron/services/__tests__/DevPreviewReadinessProbe.test.ts
@@ -26,7 +26,10 @@ const { mockRequest, wsInstances, wsBehavior } = vi.hoisted(() => ({
       (url: string, options: Record<string, unknown>, callback: RequestCallback) => MockRequest
     >(),
   wsInstances: [] as MockWebSocket[],
-  wsBehavior: { mode: "error" as "error" | "open" | "throw" | "openOn", openOnUrl: "" },
+  wsBehavior: {
+    mode: "error" as "error" | "open" | "throw" | "openOn" | "manual",
+    openOnUrl: "",
+  },
 }));
 
 vi.mock("node:http", () => ({
@@ -68,6 +71,10 @@ vi.mock("ws", () => {
       }
 
       wsInstances.push(this as unknown as MockWebSocket);
+
+      if (wsBehavior.mode === "manual") {
+        return;
+      }
 
       const shouldOpen =
         wsBehavior.mode === "open" ||
@@ -414,6 +421,32 @@ describe("probeHmrWebSocket", () => {
     const signal = new AbortController().signal;
     const result = await probeHmrWebSocket("http://localhost:3000", signal);
     expect(result).toBe(false);
+  });
+
+  it("does not double-count error+close on the same failed socket", async () => {
+    // Regression: ws emits both "error" and "close" on a failed connection.
+    // Without per-socket guarding, two failed sockets (4 events) would settle
+    // the probe to false before the third (successful) socket fires "open".
+    wsBehavior.mode = "manual";
+    const signal = new AbortController().signal;
+    const probePromise = probeHmrWebSocket("http://localhost:3000", signal);
+
+    // Let the constructor loop complete (synchronous), then drive events.
+    await Promise.resolve();
+    expect(wsInstances.length).toBe(3);
+
+    // Two sockets fail with both error then close (the ws-native sequence).
+    wsInstances[0].emit("error", new Error("refused"));
+    wsInstances[0].emit("close");
+    wsInstances[1].emit("error", new Error("refused"));
+    wsInstances[1].emit("close");
+
+    // Third socket opens successfully — guard must have kept pending > 0 so
+    // settle(false) wasn't called prematurely.
+    wsInstances[2].emit("open");
+
+    const result = await probePromise;
+    expect(result).toBe(true);
   });
 });
 

--- a/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
@@ -29,6 +29,18 @@ vi.mock("../UrlDetector.js", () => ({
 vi.mock("node:http", () => ({ default: { request: vi.fn() }, request: vi.fn() }));
 vi.mock("node:https", () => ({ default: { request: vi.fn() }, request: vi.fn() }));
 
+vi.mock("ws", () => {
+  class WebSocketMock {
+    once(event: "open" | "error" | "close", listener: () => void) {
+      if (event === "error") queueMicrotask(() => listener());
+      return this;
+    }
+    terminate() {}
+    constructor() {}
+  }
+  return { default: WebSocketMock };
+});
+
 type DataListener = (id: string, data: string | Uint8Array) => void;
 type ExitListener = (id: string, exitCode: number) => void;
 type TerminalRecord = {

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -9,6 +9,18 @@ import type { DevPreviewSessionState } from "../../../shared/types/ipc/devPrevie
 vi.mock("node:http", () => ({ default: { request: vi.fn() }, request: vi.fn() }));
 vi.mock("node:https", () => ({ default: { request: vi.fn() }, request: vi.fn() }));
 
+vi.mock("ws", () => {
+  class WebSocketMock {
+    once(event: "open" | "error" | "close", listener: () => void) {
+      if (event === "error") queueMicrotask(() => listener());
+      return this;
+    }
+    terminate() {}
+    constructor() {}
+  }
+  return { default: WebSocketMock };
+});
+
 type DataListener = (id: string, data: string | Uint8Array) => void;
 type ExitListener = (id: string, exitCode: number) => void;
 type MockIncomingMessage = {
@@ -402,7 +414,8 @@ describe("DevPreviewSessionService", () => {
     expect(after.status).toBe("error");
   });
 
-  it("treats HTTP 4xx responses as ready (server is reachable)", async () => {
+  it("does not treat HTTP 4xx as ready (waits for 2xx/3xx)", async () => {
+    vi.useFakeTimers();
     mockHttpResponse(404);
 
     const started = await service.ensure(baseRequest);
@@ -410,14 +423,13 @@ describe("DevPreviewSessionService", () => {
 
     ptyClient.emitData(started.terminalId!, "ready at http://localhost:4173\n");
 
-    await vi.waitFor(() => {
-      const updated = service.getState({
-        panelId: baseRequest.panelId,
-        projectId: baseRequest.projectId,
-      });
-      expect(updated.status).toBe("running");
-      expect(updated.url).toMatch(/^http:\/\/localhost:4173\/?$/);
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    const after = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
     });
+    expect(after.status).toBe("error");
   });
 
   it("stays in starting status while readiness poll is in progress", async () => {


### PR DESCRIPTION
## Summary

- The probe in `electron/services/DevPreviewReadinessProbe.ts` was treating 4xx responses as ready, and gateway error pages from 5xx-then-2xx warmup sequences (Docker/dev-container port-forwards) as ready
- Narrows HTTP acceptance to 2xx/3xx only; adds a warmup-race guard that requires a follow-up 2xx/3xx after any observed 5xx before resolving
- Layers a WebSocket handshake probe against Vite, Next.js, and webpack-dev-server HMR endpoints to confirm the bundler is past its blocking compile phase — WS probe spoofs `Origin` to pass CVE-patched framework validation

Resolves #9097

## Changes

- `DevPreviewReadinessProbe.ts` — narrow HTTP gate to 2xx/3xx; warmup-race guard; WebSocket handshake against `/vite-hmr`, `/_next/webpack-hmr`, and `/ws`; spoofed `Origin` header for CVE compatibility; error+close double-count guard
- `DevPreviewReadinessProbe.test.ts` — 43 unit tests covering all HTTP acceptance paths, warmup race sequences, WS handshake success/failure/timeout, and double-resolve guard

## Testing

43 unit tests added covering all code paths. All `npm run check` commands pass.