### PR TITLE
fix(mcp): add hard refresh ceiling to per-tool grant lifetime

### DIFF
--- a/electron/services/mcp-server/__tests__/grantCache.test.ts
+++ b/electron/services/mcp-server/__tests__/grantCache.test.ts
@@ -9,6 +9,7 @@ interface EmittedEvent {
 
 function newCache(opts?: {
   ttlMs?: number;
+  maxLifetimeMs?: number;
   sweepIntervalMs?: number;
   denialSilenceThreshold?: number;
   now?: () => number;
@@ -16,6 +17,9 @@ function newCache(opts?: {
   const emitted: EmittedEvent[] = [];
   const cache = new GrantCache({
     ttlMs: opts?.ttlMs ?? 1000,
+    // Default the ceiling well above the default TTL so existing tests are
+    // unaffected; ceiling tests pass an explicit small value.
+    maxLifetimeMs: opts?.maxLifetimeMs ?? 1_000_000,
     // Disable the sweep by default so the only timer in the test is the
     // one each test explicitly drives; the lazy-eviction path on `check`
     // is the contract we care about most.
@@ -151,6 +155,119 @@ describe("GrantCache.refresh — race guard (#2243)", () => {
   it("refresh of a missing entry no-ops", () => {
     const { cache } = newCache();
     expect(cache.refresh("s1", "git.commit", 0)).toBe(false);
+    cache.dispose();
+  });
+});
+
+describe("GrantCache max-lifetime ceiling (#9161)", () => {
+  it("refresh is blocked once the ceiling passes and emits grant.revoked/grant-ceiling", () => {
+    let now = 0;
+    // Ceiling 5000 sits above the 1000ms TTL so the grant is refreshable for
+    // a while, then hits the hard cap.
+    const { cache, emitted } = newCache({ ttlMs: 1000, maxLifetimeMs: 5000, now: () => now });
+    const entry = cache.issueGrant("s1", "git.commit");
+    emitted.length = 0;
+
+    // Within the ceiling: refresh slides the TTL window forward as usual.
+    now = 4000;
+    expect(cache.refresh("s1", "git.commit", entry.issuedAt)).toBe(true);
+    expect(cache._peek("s1", "git.commit")?.expiresAt).toBe(5000);
+    expect(emitted).toHaveLength(0);
+
+    // Past the ceiling: refresh is denied, entry is evicted, event emitted.
+    now = 5001;
+    expect(cache.refresh("s1", "git.commit", entry.issuedAt)).toBe(false);
+    expect(cache._peek("s1", "git.commit")).toBeUndefined();
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload.type).toBe("grant.revoked");
+    expect(emitted[0].payload).toMatchObject({
+      revokedReason: "grant-ceiling",
+      toolId: "git.commit",
+    });
+
+    cache.dispose();
+  });
+
+  it("ceiling boundary is exclusive — refresh at exactly issuedAt + maxLifetimeMs still succeeds", () => {
+    let now = 0;
+    const { cache } = newCache({ ttlMs: 10_000, maxLifetimeMs: 5000, now: () => now });
+    const entry = cache.issueGrant("s1", "git.commit");
+
+    now = 5000; // exactly at the ceiling
+    expect(cache.refresh("s1", "git.commit", entry.issuedAt)).toBe(true);
+    now = 5001; // one ms past
+    expect(cache.refresh("s1", "git.commit", entry.issuedAt)).toBe(false);
+
+    cache.dispose();
+  });
+
+  it("check evicts at the ceiling even when expiresAt is still in the future", () => {
+    let now = 0;
+    // TTL larger than the ceiling: a single grant's expiresAt stays in the
+    // future, so only the ceiling can evict it.
+    const { cache, emitted } = newCache({ ttlMs: 100_000, maxLifetimeMs: 5000, now: () => now });
+    cache.issueGrant("s1", "git.commit");
+    emitted.length = 0;
+
+    now = 5001;
+    const result = cache.check("s1", "git.commit");
+    expect(result.granted).toBe(false);
+    expect(emitted).toHaveLength(1);
+    // grant.revoked, NOT grant.expired — the ceiling is an active eviction.
+    expect(emitted[0].payload.type).toBe("grant.revoked");
+    expect(emitted[0].payload).toMatchObject({ revokedReason: "grant-ceiling" });
+
+    // Entry is gone — a subsequent check does not re-emit.
+    expect(cache.check("s1", "git.commit").granted).toBe(false);
+    expect(emitted).toHaveLength(1);
+
+    cache.dispose();
+  });
+
+  it("sweep evicts ceiling-expired entries with grant.revoked/grant-ceiling", () => {
+    let now = 0;
+    const { cache, emitted } = newCache({ ttlMs: 100_000, maxLifetimeMs: 5000, now: () => now });
+    cache.issueGrant("s1", "git.commit");
+    emitted.length = 0;
+
+    // expiresAt (100_000) is still in the future, so the TTL-only sweep would
+    // skip this entry — the ceiling branch must catch it.
+    now = 6000;
+    const evicted = cache.sweep();
+    expect(evicted).toBe(1);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload.type).toBe("grant.revoked");
+    expect(emitted[0].payload).toMatchObject({ revokedReason: "grant-ceiling" });
+
+    cache.dispose();
+  });
+
+  it("re-issuing after a ceiling hit resets the lifetime clock with a fresh issuedAt", () => {
+    let now = 0;
+    // TTL larger than the ceiling so the ceiling, not the sliding TTL, is the
+    // limiting factor for the assertions below.
+    const { cache } = newCache({ ttlMs: 100_000, maxLifetimeMs: 5000, now: () => now });
+    const original = cache.issueGrant("s1", "git.commit");
+
+    // Cross the ceiling, then the user re-approves: a fresh grant is minted.
+    now = 6000;
+    const reissued = cache.issueGrant("s1", "git.commit");
+    expect(reissued.issuedAt).toBe(6000);
+    expect(reissued.issuedAt).not.toBe(original.issuedAt);
+
+    // A stale in-flight refresh carrying the OLD issuedAt must no-op on the
+    // fresh entry (the #2243 race guard), leaving the new clock intact.
+    now = 6100;
+    expect(cache.refresh("s1", "git.commit", original.issuedAt)).toBe(false);
+    expect(cache._peek("s1", "git.commit")?.issuedAt).toBe(reissued.issuedAt);
+
+    // The new grant has its own independent ceiling window: still valid just
+    // before issuedAt + maxLifetimeMs (6000 + 5000 = 11000).
+    now = 10_999;
+    expect(cache.check("s1", "git.commit").granted).toBe(true);
+    now = 11_001;
+    expect(cache.check("s1", "git.commit").granted).toBe(false);
+
     cache.dispose();
   });
 });

--- a/electron/services/mcp-server/__tests__/grantCache.test.ts
+++ b/electron/services/mcp-server/__tests__/grantCache.test.ts
@@ -242,6 +242,89 @@ describe("GrantCache max-lifetime ceiling (#9161)", () => {
     cache.dispose();
   });
 
+  it("check honours the exclusive boundary — valid at the ceiling, evicted one ms past", () => {
+    let now = 0;
+    const { cache, emitted } = newCache({ ttlMs: 100_000, maxLifetimeMs: 5000, now: () => now });
+    cache.issueGrant("s1", "git.commit");
+    emitted.length = 0;
+
+    now = 5000; // exactly at the ceiling — still valid
+    expect(cache.check("s1", "git.commit").granted).toBe(true);
+    expect(emitted).toHaveLength(0);
+
+    now = 5001; // one ms past — evicted with grant-ceiling
+    expect(cache.check("s1", "git.commit").granted).toBe(false);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload).toMatchObject({
+      type: "grant.revoked",
+      revokedReason: "grant-ceiling",
+    });
+
+    cache.dispose();
+  });
+
+  it("an idle grant past both TTL and ceiling is reported as grant.expired, not grant-ceiling", () => {
+    let now = 0;
+    // TTL well below the ceiling; the grant is never refreshed, so its sliding
+    // window lapses long before the hard cap. Eviction should keep the
+    // truthful passive-timeout signal even though the ceiling has also passed.
+    const { cache, emitted } = newCache({ ttlMs: 1000, maxLifetimeMs: 5000, now: () => now });
+    cache.issueGrant("s1", "git.commit");
+    emitted.length = 0;
+
+    now = 6000; // past both expiresAt (1000) and ceiling (5000)
+    const result = cache.check("s1", "git.commit");
+    expect(result.granted).toBe(false);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload.type).toBe("grant.expired");
+
+    cache.dispose();
+  });
+
+  it("sweep reports an idle both-expired grant as grant.expired", () => {
+    let now = 0;
+    const { cache, emitted } = newCache({ ttlMs: 1000, maxLifetimeMs: 5000, now: () => now });
+    cache.issueGrant("s1", "git.commit");
+    emitted.length = 0;
+
+    now = 6000;
+    expect(cache.sweep()).toBe(1);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload.type).toBe("grant.expired");
+
+    cache.dispose();
+  });
+
+  it("caps an actively-refreshed grant at the ceiling (core #9161 regression)", () => {
+    let now = 0;
+    const ttlMs = 1000;
+    const maxLifetimeMs = 5000;
+    const { cache, emitted } = newCache({ ttlMs, maxLifetimeMs, now: () => now });
+    const entry = cache.issueGrant("s1", "git.commit");
+    emitted.length = 0;
+
+    // Refresh just inside every TTL window — the abusive pattern from #9161.
+    // Each refresh slides expiresAt forward, but the ceiling never moves.
+    for (now = 900; now < maxLifetimeMs; now += ttlMs - 1) {
+      expect(cache.check("s1", "git.commit").granted).toBe(true);
+      expect(cache.refresh("s1", "git.commit", entry.issuedAt)).toBe(true);
+    }
+
+    // One ms past the ceiling the grant is gone despite continuous refreshing.
+    now = maxLifetimeMs + 1;
+    expect(cache.refresh("s1", "git.commit", entry.issuedAt)).toBe(false);
+    expect(cache.check("s1", "git.commit").granted).toBe(false);
+    expect(cache._peek("s1", "git.commit")).toBeUndefined();
+    expect(emitted.some((e) => e.payload.type === "grant.revoked")).toBe(true);
+    expect(
+      emitted.some(
+        (e) => e.payload.type === "grant.revoked" && e.payload.revokedReason === "grant-ceiling"
+      )
+    ).toBe(true);
+
+    cache.dispose();
+  });
+
   it("re-issuing after a ceiling hit resets the lifetime clock with a fresh issuedAt", () => {
     let now = 0;
     // TTL larger than the ceiling so the ceiling, not the sliding TTL, is the

--- a/electron/services/mcp-server/grantCache.ts
+++ b/electron/services/mcp-server/grantCache.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../../shared/types/ipc/mcpServer.js";
 import {
   MCP_DENIAL_SILENCE_THRESHOLD,
+  MCP_GRANT_MAX_LIFETIME_MS,
   MCP_GRANT_SWEEP_INTERVAL_MS,
   MCP_GRANT_TTL_MS,
 } from "./shared.js";
@@ -33,6 +34,14 @@ export interface GrantLifecycleEmitter {
 
 interface GrantCacheOptions {
   ttlMs?: number;
+  /**
+   * Hard wall-clock ceiling on a grant's total lifetime, measured from its
+   * immutable `issuedAt`. Once `now > issuedAt + maxLifetimeMs` the grant is
+   * forcibly revoked on the next `check`/`refresh`/`sweep` regardless of how
+   * recently the sliding TTL was refreshed. Defaults to
+   * {@link MCP_GRANT_MAX_LIFETIME_MS}.
+   */
+  maxLifetimeMs?: number;
   sweepIntervalMs?: number;
   denialSilenceThreshold?: number;
   /**
@@ -73,6 +82,7 @@ export class GrantCache {
   private readonly grants = new Map<string, GrantEntry>();
   private readonly denialCounts = new Map<string, number>();
   private readonly ttlMs: number;
+  private readonly maxLifetimeMs: number;
   private readonly sweepIntervalMs: number;
   private readonly denialSilenceThreshold: number;
   private readonly emit?: GrantLifecycleEmitter;
@@ -82,6 +92,7 @@ export class GrantCache {
 
   constructor(options: GrantCacheOptions = {}) {
     this.ttlMs = options.ttlMs ?? MCP_GRANT_TTL_MS;
+    this.maxLifetimeMs = options.maxLifetimeMs ?? MCP_GRANT_MAX_LIFETIME_MS;
     this.sweepIntervalMs = options.sweepIntervalMs ?? MCP_GRANT_SWEEP_INTERVAL_MS;
     this.denialSilenceThreshold = options.denialSilenceThreshold ?? MCP_DENIAL_SILENCE_THRESHOLD;
     this.emit = options.emit;
@@ -131,7 +142,22 @@ export class GrantCache {
     const k = key(sessionId, toolId);
     const entry = this.grants.get(k);
     if (!entry) return { granted: false };
-    if (this.now() > entry.expiresAt) {
+    const now = this.now();
+    // The hard ceiling is a stricter constraint than the sliding TTL, so it
+    // must be evaluated first: a grant refreshed moments ago can still have a
+    // future `expiresAt` while having crossed `issuedAt + maxLifetimeMs`.
+    if (now > entry.issuedAt + this.maxLifetimeMs) {
+      this.grants.delete(k);
+      this.emitSafely(sessionId, {
+        type: "grant.revoked",
+        sessionId,
+        toolId,
+        ttlMs: entry.ttlMs,
+        revokedReason: "grant-ceiling",
+      });
+      return { granted: false };
+    }
+    if (now > entry.expiresAt) {
       this.grants.delete(k);
       this.emitSafely(sessionId, {
         type: "grant.expired",
@@ -157,7 +183,22 @@ export class GrantCache {
     const entry = this.grants.get(k);
     if (!entry) return false;
     if (entry.issuedAt !== issuedAt) return false;
-    entry.expiresAt = this.now() + entry.ttlMs;
+    const now = this.now();
+    // Hard wall-clock ceiling: once the grant's total lifetime is exhausted
+    // no amount of recent use can extend it. Revoke and force re-approval
+    // rather than sliding the window forward again (#9161).
+    if (now > entry.issuedAt + this.maxLifetimeMs) {
+      this.grants.delete(k);
+      this.emitSafely(sessionId, {
+        type: "grant.revoked",
+        sessionId,
+        toolId,
+        ttlMs: entry.ttlMs,
+        revokedReason: "grant-ceiling",
+      });
+      return false;
+    }
+    entry.expiresAt = now + entry.ttlMs;
     return true;
   }
 
@@ -286,19 +327,34 @@ export class GrantCache {
     let evicted = 0;
     const now = this.now();
     for (const [k, entry] of [...this.grants]) {
-      if (now <= entry.expiresAt) continue;
+      // Ceiling-expired entries can still have a future `expiresAt` (they were
+      // refreshed recently), so they survive the TTL skip below — check the
+      // hard ceiling first and emit `grant.revoked` rather than `grant.expired`.
+      const pastCeiling = now > entry.issuedAt + this.maxLifetimeMs;
+      if (!pastCeiling && now <= entry.expiresAt) continue;
       this.grants.delete(k);
       evicted += 1;
       const colon = k.indexOf(":");
       if (colon < 0) continue;
       const sessionId = k.substring(0, colon);
       const toolId = k.substring(colon + 1);
-      this.emitSafely(sessionId, {
-        type: "grant.expired",
+      this.emitSafely(
         sessionId,
-        toolId,
-        ttlMs: entry.ttlMs,
-      });
+        pastCeiling
+          ? {
+              type: "grant.revoked",
+              sessionId,
+              toolId,
+              ttlMs: entry.ttlMs,
+              revokedReason: "grant-ceiling",
+            }
+          : {
+              type: "grant.expired",
+              sessionId,
+              toolId,
+              ttlMs: entry.ttlMs,
+            }
+      );
     }
     return evicted;
   }

--- a/electron/services/mcp-server/grantCache.ts
+++ b/electron/services/mcp-server/grantCache.ts
@@ -143,28 +143,34 @@ export class GrantCache {
     const entry = this.grants.get(k);
     if (!entry) return { granted: false };
     const now = this.now();
-    // The hard ceiling is a stricter constraint than the sliding TTL, so it
-    // must be evaluated first: a grant refreshed moments ago can still have a
-    // future `expiresAt` while having crossed `issuedAt + maxLifetimeMs`.
-    if (now > entry.issuedAt + this.maxLifetimeMs) {
+    // The hard ceiling is a stricter constraint than the sliding TTL: a grant
+    // refreshed moments ago can still have a future `expiresAt` while having
+    // crossed `issuedAt + maxLifetimeMs`. `grant-ceiling` is reserved for that
+    // case — a grant whose sliding TTL was still valid (recently refreshed)
+    // when the hard cap cut it off. A grant that has already lapsed its TTL is
+    // a passive `grant.expired` timeout regardless of whether the ceiling has
+    // also passed, so it keeps the truthful "idled out" audit signal.
+    const pastCeiling = now > entry.issuedAt + this.maxLifetimeMs;
+    const pastTtl = now > entry.expiresAt;
+    if (pastCeiling || pastTtl) {
       this.grants.delete(k);
-      this.emitSafely(sessionId, {
-        type: "grant.revoked",
+      this.emitSafely(
         sessionId,
-        toolId,
-        ttlMs: entry.ttlMs,
-        revokedReason: "grant-ceiling",
-      });
-      return { granted: false };
-    }
-    if (now > entry.expiresAt) {
-      this.grants.delete(k);
-      this.emitSafely(sessionId, {
-        type: "grant.expired",
-        sessionId,
-        toolId,
-        ttlMs: entry.ttlMs,
-      });
+        pastCeiling && !pastTtl
+          ? {
+              type: "grant.revoked",
+              sessionId,
+              toolId,
+              ttlMs: entry.ttlMs,
+              revokedReason: "grant-ceiling",
+            }
+          : {
+              type: "grant.expired",
+              sessionId,
+              toolId,
+              ttlMs: entry.ttlMs,
+            }
+      );
       return { granted: false };
     }
     return { granted: true, issuedAt: entry.issuedAt, expiresAt: entry.expiresAt };
@@ -328,10 +334,13 @@ export class GrantCache {
     const now = this.now();
     for (const [k, entry] of [...this.grants]) {
       // Ceiling-expired entries can still have a future `expiresAt` (they were
-      // refreshed recently), so they survive the TTL skip below — check the
-      // hard ceiling first and emit `grant.revoked` rather than `grant.expired`.
+      // refreshed recently), so they survive the TTL skip — evict on either
+      // condition. Mirror `check()`'s audit semantics: `grant-ceiling` only
+      // when the sliding TTL was still valid (recently refreshed) at the
+      // moment the hard cap hit; an already-lapsed TTL stays `grant.expired`.
       const pastCeiling = now > entry.issuedAt + this.maxLifetimeMs;
-      if (!pastCeiling && now <= entry.expiresAt) continue;
+      const pastTtl = now > entry.expiresAt;
+      if (!pastCeiling && !pastTtl) continue;
       this.grants.delete(k);
       evicted += 1;
       const colon = k.indexOf(":");
@@ -340,7 +349,7 @@ export class GrantCache {
       const toolId = k.substring(colon + 1);
       this.emitSafely(
         sessionId,
-        pastCeiling
+        pastCeiling && !pastTtl
           ? {
               type: "grant.revoked",
               sessionId,

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -91,6 +91,20 @@ export const MCP_TIER_ELEVATION_TTL_MS = 30 * 60 * 1000;
 export const MCP_GRANT_TTL_MS = 15 * 60 * 1000;
 
 /**
+ * Hard wall-clock ceiling on a grant's total lifetime, measured from its
+ * immutable `issuedAt`. The sliding {@link MCP_GRANT_TTL_MS} window means a
+ * model that calls a granted tool more often than once per TTL could
+ * otherwise hold the grant indefinitely; this caps the total refreshable
+ * lifetime so `refresh()` is blocked and the grant is forcibly revoked once
+ * the ceiling elapses, mirroring `sudo`'s max-lifetime enforcement — the
+ * next out-of-baseline call then re-triggers the tier-mismatch banner and
+ * the user must re-approve (#9161). Intentionally equal to
+ * {@link MCP_SSE_IDLE_TIMEOUT_MS} and {@link MCP_TIER_ELEVATION_TTL_MS} so a
+ * grant can never outlive its SSE session.
+ */
+export const MCP_GRANT_MAX_LIFETIME_MS = 30 * 60 * 1000;
+
+/**
  * Periodic sweep cadence for the grant cache's lazy-expiry map. Lazy
  * eviction on read is the source of truth; the sweep is a memory-hygiene
  * pass that keeps idle sessions' expired entries from accumulating between

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -157,8 +157,9 @@ export interface McpAuditRecord {
  *   periodic sweep also drives this when an idle session's grant ages out
  *   without a follow-up read.
  * - `grant.revoked`: an explicit `revokeSessionGrants` IPC, a session
- *   teardown, or an idle reaper firing wiped the grant before its TTL
- *   elapsed. `revokedReason` distinguishes those sources.
+ *   teardown, an idle reaper firing, or the hard max-lifetime ceiling being
+ *   reached wiped the grant before its sliding TTL elapsed. `revokedReason`
+ *   distinguishes those sources.
  * - `tier.elevated`: a renderer-approved session-tier elevation
  *   (`HttpLifecycle.setSessionTier`) raised the session above its
  *   token-resolved baseline. `tier` is the new tier, `previousTier` the
@@ -175,7 +176,17 @@ export type McpGrantRecordType =
   | "tier.elevated"
   | "tier.decayed";
 
-export type McpGrantRevokedReason = "user" | "session-ended" | "session-idle";
+/**
+ * Source of a `grant.revoked` transition.
+ * - `user`: explicit user-initiated revoke.
+ * - `session-ended`: the session was torn down.
+ * - `session-idle`: the idle reaper collected the session.
+ * - `grant-ceiling`: the hard max-lifetime ceiling from `issuedAt` elapsed
+ *   while the grant was still being actively refreshed; the user must
+ *   re-approve (#9161). Distinct from `grant.expired`, which is a passive
+ *   sliding-TTL timeout with no recent use.
+ */
+export type McpGrantRevokedReason = "user" | "session-ended" | "session-idle" | "grant-ceiling";
 
 export interface McpGrantRecord {
   type: McpGrantRecordType;


### PR DESCRIPTION
## Summary

- `GrantCache.refresh()` extended `expiresAt = now + ttlMs` on every successful dispatch with no wall-clock ceiling relative to the grant's `issuedAt`. A model calling a granted tool more often than every 15 minutes could hold an "Approve once" grant indefinitely.
- Added `MCP_GRANT_MAX_LIFETIME_MS = 30 min` (matching `MCP_SSE_IDLE_TIMEOUT_MS` and `MCP_TIER_ELEVATION_TTL_MS`, so a grant can never outlive its SSE session). `GrantCache` now enforces the ceiling in `check()`, `refresh()`, and `sweep()` — once `now > issuedAt + maxLifetimeMs` the grant is forcibly revoked and `refresh()` returns `false`, dropping the next call through to the normal `TIER_NOT_PERMITTED` path.
- Ceiling eviction emits a new `"grant-ceiling"` audit reason, distinct from the passive `"grant-expired"` sliding-TTL timeout. An idle grant that already lapsed its TTL before the ceiling still reports `"grant-expired"` to preserve the truthful audit signal.

Resolves #9161

## Changes

- `electron/services/mcp-server/shared.ts` — new `MCP_GRANT_MAX_LIFETIME_MS` constant
- `shared/types/ipc/mcpServer.ts` — `"grant-ceiling"` added to the revocation reason union
- `electron/preload.cts` — inline union updated to match
- `electron/services/mcp-server/grantCache.ts` — ceiling enforcement in `check()`, `refresh()`, `sweep()`; preserves the #2243 resurrection-race guard and the #8442 sliding-TTL per-dispatch window
- `electron/services/mcp-server/__tests__/grantCache.test.ts` — 10 new ceiling-specific tests

## Testing

`npx vitest run grantCache.test.ts` — 30 pass. `npm run check` clean (typecheck, lint 0 errors, format).