### PR TITLE
feat(dev-preview): framework-aware dev-script detection and cache dirs

### DIFF
--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -82,12 +82,16 @@ const RUNNING_STATES: ReadonlySet<DevPreviewSessionStatus> = new Set([
 ]);
 
 // Framework build/dep caches wiped by restartAndClearCache, relative to the
-// session cwd. node_modules/.vite is Vite's dep-optimization cache and is
-// distinct from a root-level .vite directory.
+// session cwd. Covers Next, Vite, Turbo, SvelteKit, Astro, and Nuxt root caches
+// plus Vite's node_modules/.vite dep-optimization cache (distinct from a
+// root-level .vite directory). Missing dirs are tolerated by removal callers.
 const CACHE_DIRS: readonly string[] = [
   ".next",
   ".vite",
   ".turbo",
+  ".svelte-kit",
+  ".astro",
+  ".nuxt",
   path.join("node_modules", ".vite"),
 ];
 

--- a/electron/services/RunCommandDetector.ts
+++ b/electron/services/RunCommandDetector.ts
@@ -26,6 +26,46 @@ function isSafeScriptName(name: string): boolean {
   return SAFE_SCRIPT_NAME_PATTERN.test(name);
 }
 
+type NpmFrameworkSignature = {
+  readonly packages: readonly string[];
+  readonly canonicalScript: "dev" | "start";
+};
+
+// Ordered most-specific to least-specific. Full-stack frameworks beat generic
+// bundlers when multiple are present (e.g. a Next.js repo that also lists vite
+// as a transitive devDep should still pick `next dev`).
+const NPM_FRAMEWORK_PRIORITY: readonly NpmFrameworkSignature[] = [
+  { packages: ["next"], canonicalScript: "dev" },
+  { packages: ["@remix-run/dev"], canonicalScript: "dev" },
+  { packages: ["@react-router/dev"], canonicalScript: "dev" },
+  { packages: ["nuxt"], canonicalScript: "dev" },
+  { packages: ["@sveltejs/kit"], canonicalScript: "dev" },
+  { packages: ["astro"], canonicalScript: "dev" },
+  { packages: ["react-scripts"], canonicalScript: "start" },
+  { packages: ["vite"], canonicalScript: "dev" },
+];
+
+function detectNpmFrameworkCanonicalScript(
+  deps: Record<string, unknown> | undefined,
+  devDeps: Record<string, unknown> | undefined,
+  scripts: Record<string, unknown>
+): "dev" | "start" | undefined {
+  const hasDep = (name: string): boolean => {
+    return (
+      (typeof deps === "object" && deps !== null && name in deps) ||
+      (typeof devDeps === "object" && devDeps !== null && name in devDeps)
+    );
+  };
+
+  for (const signature of NPM_FRAMEWORK_PRIORITY) {
+    if (!signature.packages.some(hasDep)) continue;
+    if (typeof scripts[signature.canonicalScript] === "string") {
+      return signature.canonicalScript;
+    }
+  }
+  return undefined;
+}
+
 export class RunCommandDetector {
   private readonly cache = new Cache<string, RunCommand[]>({
     maxSize: 50,
@@ -73,7 +113,7 @@ export class RunCommandDetector {
         runner = "yarn";
       }
 
-      return Object.entries(pkg.scripts)
+      const commands: RunCommand[] = Object.entries(pkg.scripts)
         .filter(([name, script]) => {
           if (typeof script !== "string") {
             return false;
@@ -91,6 +131,21 @@ export class RunCommandDetector {
           icon: "npm",
           description: script as string,
         }));
+
+      const canonicalScript = detectNpmFrameworkCanonicalScript(
+        pkg.dependencies,
+        pkg.devDependencies,
+        pkg.scripts as Record<string, unknown>
+      );
+      if (canonicalScript) {
+        const idx = commands.findIndex((cmd) => cmd.name === canonicalScript);
+        if (idx > 0) {
+          const [promoted] = commands.splice(idx, 1);
+          commands.unshift(promoted);
+        }
+      }
+
+      return commands;
     } catch (error) {
       console.warn(`[RunCommandDetector] Failed to parse ${pkgPath}:`, error);
       return [];

--- a/electron/services/RunCommandDetector.ts
+++ b/electron/services/RunCommandDetector.ts
@@ -29,20 +29,31 @@ function isSafeScriptName(name: string): boolean {
 type NpmFrameworkSignature = {
   readonly packages: readonly string[];
   readonly canonicalScript: "dev" | "start";
+  // The canonical script body must contain at least one of these tokens to
+  // count as a match. Guards against repos that list a framework as a dep
+  // but whose dev/start script does something unrelated (e.g. CRA listed in
+  // deps but `start: "node server.js"`); without this we'd promote the wrong
+  // script and regress vs. plain name-priority order.
+  readonly bodyTokens: readonly RegExp[];
 };
 
 // Ordered most-specific to least-specific. Full-stack frameworks beat generic
 // bundlers when multiple are present (e.g. a Next.js repo that also lists vite
 // as a transitive devDep should still pick `next dev`).
 const NPM_FRAMEWORK_PRIORITY: readonly NpmFrameworkSignature[] = [
-  { packages: ["next"], canonicalScript: "dev" },
-  { packages: ["@remix-run/dev"], canonicalScript: "dev" },
-  { packages: ["@react-router/dev"], canonicalScript: "dev" },
-  { packages: ["nuxt"], canonicalScript: "dev" },
-  { packages: ["@sveltejs/kit"], canonicalScript: "dev" },
-  { packages: ["astro"], canonicalScript: "dev" },
-  { packages: ["react-scripts"], canonicalScript: "start" },
-  { packages: ["vite"], canonicalScript: "dev" },
+  { packages: ["next"], canonicalScript: "dev", bodyTokens: [/\bnext\b/] },
+  { packages: ["@remix-run/dev"], canonicalScript: "dev", bodyTokens: [/\bremix\b/] },
+  { packages: ["@react-router/dev"], canonicalScript: "dev", bodyTokens: [/\breact-router\b/] },
+  { packages: ["nuxt"], canonicalScript: "dev", bodyTokens: [/\bnuxt\b/, /\bnuxi\b/] },
+  {
+    packages: ["@sveltejs/kit"],
+    canonicalScript: "dev",
+    // SvelteKit v1 used `svelte-kit dev`; v2+ runs via `vite dev`.
+    bodyTokens: [/\bvite\b/, /\bsvelte-kit\b/],
+  },
+  { packages: ["astro"], canonicalScript: "dev", bodyTokens: [/\bastro\b/] },
+  { packages: ["react-scripts"], canonicalScript: "start", bodyTokens: [/\breact-scripts\b/] },
+  { packages: ["vite"], canonicalScript: "dev", bodyTokens: [/\bvite\b/] },
 ];
 
 function detectNpmFrameworkCanonicalScript(
@@ -59,9 +70,10 @@ function detectNpmFrameworkCanonicalScript(
 
   for (const signature of NPM_FRAMEWORK_PRIORITY) {
     if (!signature.packages.some(hasDep)) continue;
-    if (typeof scripts[signature.canonicalScript] === "string") {
-      return signature.canonicalScript;
-    }
+    const body = scripts[signature.canonicalScript];
+    if (typeof body !== "string") continue;
+    if (!signature.bodyTokens.some((re) => re.test(body))) continue;
+    return signature.canonicalScript;
   }
   return undefined;
 }
@@ -139,9 +151,12 @@ export class RunCommandDetector {
       );
       if (canonicalScript) {
         const idx = commands.findIndex((cmd) => cmd.name === canonicalScript);
-        if (idx > 0) {
-          const [promoted] = commands.splice(idx, 1);
-          commands.unshift(promoted);
+        if (idx >= 0) {
+          commands[idx] = { ...commands[idx], isFrameworkDefault: true };
+          if (idx > 0) {
+            const [promoted] = commands.splice(idx, 1);
+            commands.unshift(promoted);
+          }
         }
       }
 

--- a/electron/services/__tests__/RunCommandDetector.test.ts
+++ b/electron/services/__tests__/RunCommandDetector.test.ts
@@ -1173,6 +1173,45 @@ describe("RunCommandDetector", () => {
       const commands = await detector.detect(tempDir);
       expect(npmNames(commands)).toEqual(["build", "lint"]);
     });
+
+    it("does not promote `start` for CRA when the start body does not invoke react-scripts", async () => {
+      await writePkg({
+        name: "cra-stale-deps",
+        scripts: { start: "node server.js", dev: "vite", build: "vite build" },
+        dependencies: { "react-scripts": "5.0.1" },
+        devDependencies: { vite: "8.0.0" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["dev", "start", "build"]);
+    });
+
+    it("preserves declaration order when framework dep is present but the canonical script body does not invoke it", async () => {
+      await writePkg({
+        name: "next-stale-dep-only",
+        scripts: { start: "node ./build/index.js", dev: "node --watch ./src/index.js" },
+        dependencies: { next: "15.0.0" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["start", "dev"]);
+      expect(commands.find((c) => c.id.startsWith("npm-"))?.isFrameworkDefault).toBeUndefined();
+    });
+
+    it("marks the promoted script with isFrameworkDefault", async () => {
+      await writePkg({
+        name: "cra-marked",
+        scripts: { dev: "echo unrelated", start: "react-scripts start" },
+        dependencies: { "react-scripts": "5.0.1" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      const npm = commands.filter((c) => c.id.startsWith("npm-"));
+      expect(npm[0]?.name).toBe("start");
+      expect(npm[0]?.isFrameworkDefault).toBe(true);
+      // Non-promoted scripts must not carry the flag.
+      expect(npm[1]?.isFrameworkDefault).toBeUndefined();
+    });
   });
 
   describe("caching", () => {

--- a/electron/services/__tests__/RunCommandDetector.test.ts
+++ b/electron/services/__tests__/RunCommandDetector.test.ts
@@ -1029,6 +1029,152 @@ describe("RunCommandDetector", () => {
     });
   });
 
+  describe("framework-aware ordering", () => {
+    const writePkg = async (pkg: Record<string, unknown>) => {
+      await fs.writeFile(path.join(tempDir, "package.json"), JSON.stringify(pkg, null, 2), "utf-8");
+    };
+
+    const npmNames = (commands: { id: string; name: string }[]): string[] =>
+      commands.filter((cmd) => cmd.id.startsWith("npm-")).map((cmd) => cmd.name);
+
+    it("promotes `start` for Create React App (react-scripts)", async () => {
+      await writePkg({
+        name: "cra-app",
+        scripts: {
+          dev: "echo unrelated",
+          start: "react-scripts start",
+          build: "react-scripts build",
+        },
+        dependencies: { "react-scripts": "5.0.1" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["start", "dev", "build"]);
+    });
+
+    it("promotes `dev` for Next.js", async () => {
+      await writePkg({
+        name: "next-app",
+        scripts: { start: "next start", build: "next build", dev: "next dev" },
+        dependencies: { next: "15.0.0" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["dev", "start", "build"]);
+    });
+
+    it("promotes `dev` for Vite", async () => {
+      await writePkg({
+        name: "vite-app",
+        scripts: { build: "vite build", dev: "vite" },
+        devDependencies: { vite: "8.0.0" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["dev", "build"]);
+    });
+
+    it("promotes `dev` for Astro", async () => {
+      await writePkg({
+        name: "astro-app",
+        scripts: { build: "astro build", dev: "astro dev" },
+        devDependencies: { astro: "5.0.0" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["dev", "build"]);
+    });
+
+    it("promotes `dev` for Nuxt", async () => {
+      await writePkg({
+        name: "nuxt-app",
+        scripts: { build: "nuxt build", dev: "nuxt dev" },
+        dependencies: { nuxt: "3.0.0" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["dev", "build"]);
+    });
+
+    it("promotes `dev` for Remix", async () => {
+      await writePkg({
+        name: "remix-app",
+        scripts: { build: "remix build", dev: "remix dev" },
+        devDependencies: { "@remix-run/dev": "2.0.0" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["dev", "build"]);
+    });
+
+    it("promotes `dev` for React Router v7", async () => {
+      await writePkg({
+        name: "rr7-app",
+        scripts: { build: "react-router build", dev: "react-router dev" },
+        devDependencies: { "@react-router/dev": "7.0.0" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["dev", "build"]);
+    });
+
+    it("promotes `dev` for SvelteKit", async () => {
+      await writePkg({
+        name: "sveltekit-app",
+        scripts: { build: "vite build", dev: "vite dev" },
+        devDependencies: { "@sveltejs/kit": "2.0.0", vite: "8.0.0" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["dev", "build"]);
+    });
+
+    it("prefers Next.js over generic Vite when both deps are present", async () => {
+      await writePkg({
+        name: "ambiguous-app",
+        scripts: { build: "next build", dev: "next dev", start: "next start" },
+        dependencies: { next: "15.0.0" },
+        devDependencies: { vite: "8.0.0" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)[0]).toBe("dev");
+    });
+
+    it("falls through to lower-priority framework when canonical script is absent", async () => {
+      await writePkg({
+        name: "cra-fallthrough",
+        scripts: { dev: "vite", build: "vite build" },
+        dependencies: { "react-scripts": "5.0.1" },
+        devDependencies: { vite: "8.0.0" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["dev", "build"]);
+    });
+
+    it("preserves declaration order when no recognised framework is present", async () => {
+      await writePkg({
+        name: "plain-app",
+        scripts: { start: "node server.js", dev: "node --watch server.js", lint: "eslint ." },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["start", "dev", "lint"]);
+    });
+
+    it("preserves declaration order when framework is detected but neither dev nor start script exists", async () => {
+      await writePkg({
+        name: "weird-next",
+        scripts: { build: "next build", lint: "eslint ." },
+        dependencies: { next: "15.0.0" },
+      });
+
+      const commands = await detector.detect(tempDir);
+      expect(npmNames(commands)).toEqual(["build", "lint"]);
+    });
+  });
+
   describe("caching", () => {
     it("returns cached results on second call without re-reading files", async () => {
       await fs.writeFile(

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -264,6 +264,11 @@ export interface RunCommand {
   preferredLocation?: "dock" | "grid";
   /** Whether to auto-restart the command on exit */
   preferredAutoRestart?: boolean;
+  /** True when the detector identified this script as the canonical dev script
+   * for a known framework signature (e.g. `start` for Create React App). Lets
+   * the renderer trust the upstream framework-aware ordering instead of
+   * re-imposing name-only priority. */
+  isFrameworkDefault?: boolean;
 }
 
 /** CopyTree context generation settings */

--- a/src/utils/__tests__/devServerDetection.test.ts
+++ b/src/utils/__tests__/devServerDetection.test.ts
@@ -182,4 +182,34 @@ describe("findAllDevServerCandidates", () => {
     const runners = [runner("serve", "npm run serve"), runner("dev", "npm run dev", "vite")];
     expect(findDevServerCandidate(runners)?.name).toBe("dev");
   });
+
+  describe("isFrameworkDefault honoring", () => {
+    it("promotes the framework default ahead of name-priority matches", () => {
+      const runners = [
+        { ...runner("start", "npm run start", "react-scripts start"), isFrameworkDefault: true },
+        runner("dev", "npm run dev", "echo unrelated"),
+      ];
+      const result = findAllDevServerCandidates(runners);
+      expect(result.map((r) => r.name)).toEqual(["start", "dev"]);
+    });
+
+    it("falls back to name-priority when no framework default is set", () => {
+      const runners = [
+        runner("start", "npm run start", "node server.js"),
+        runner("dev", "npm run dev", "vite"),
+      ];
+      const result = findAllDevServerCandidates(runners);
+      expect(result.map((r) => r.name)).toEqual(["dev", "start"]);
+    });
+
+    it("keeps the framework default first even when array order is unchanged", () => {
+      const runners = [
+        runner("build", "npm run build"),
+        { ...runner("start", "npm run start", "react-scripts start"), isFrameworkDefault: true },
+        runner("dev", "npm run dev", "echo unrelated"),
+      ];
+      const result = findAllDevServerCandidates(runners);
+      expect(result.map((r) => r.name)).toEqual(["start", "dev", "build"]);
+    });
+  });
 });

--- a/src/utils/devServerDetection.ts
+++ b/src/utils/devServerDetection.ts
@@ -26,6 +26,17 @@ export function findAllDevServerCandidates(
   const result: RunCommand[] = [];
   let hasPriorityMatch = false;
 
+  // If the upstream detector marked a script as the framework default (e.g.
+  // `start` for Create React App, `dev` for Next.js), trust that signal over
+  // name-only priority — otherwise we'd re-demote `start` below `dev` and
+  // undo the framework-aware ordering decided in RunCommandDetector.
+  const frameworkDefault = allDetectedRunners.find((r) => r.isFrameworkDefault === true);
+  if (frameworkDefault) {
+    seen.add(frameworkDefault.id);
+    result.push(applyNextjsTurbopack(frameworkDefault, turbopackEnabled));
+    hasPriorityMatch = true;
+  }
+
   for (const name of DEV_SCRIPT_PRIORITY) {
     const runner = allDetectedRunners.find((r) => r.name === name && !seen.has(r.id));
     if (runner) {


### PR DESCRIPTION
## Summary

- `RunCommandDetector.detectNpm` now inspects `package.json` dependencies to identify the framework in use (`react-scripts`, `next`, `vite`, `astro`, `nuxt`, `remix`, `svelte-kit`) and picks the canonical dev script for it — `start` for CRA, `dev` for everything else. Falls back to the existing name-order priority when no recognised framework is detected.
- `CACHE_DIRS` in `DevPreviewSessionService` now includes `.svelte-kit`, `.astro`, and `.nuxt` alongside the existing `.next` and `.vite` entries, so `restartAndClearCache` actually clears the right directories for those frameworks.

Resolves #9096

## Changes

- `electron/services/RunCommandDetector.ts` — framework signature map + detection logic in `detectNpm`
- `electron/services/DevPreviewSessionService.ts` — extended `CACHE_DIRS`
- `shared/types/project.ts` — `frameworkDefault` flag on the detected command type
- `src/utils/devServerDetection.ts` — thread `frameworkDefault` through to the renderer
- `electron/services/__tests__/RunCommandDetector.test.ts` — unit tests covering each framework and the fallback path
- `src/utils/__tests__/devServerDetection.test.ts` — renderer-side detection tests

## Testing

Unit tests added for `RunCommandDetector` (7 framework cases + fallback) and the renderer-side detection utility. Verified against a CRA project where `start` was previously outranked by an unrelated `dev` script.