### PR TITLE
fix(plugins): contain exceptions at every plugin boundary

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -115,11 +115,16 @@ function toPluginLoadErrorRecord(err: unknown): PluginLoadErrorRecord {
   if (typeof err === "string") {
     return { message: err, at: Date.now() };
   }
+  // `JSON.stringify(undefined)` returns `undefined`, not a string, and would
+  // violate the `message: string` contract — coalesce to `String(err)` so
+  // bare `throw undefined` / `throw null` still surface a usable label.
+  let message: string;
   try {
-    return { message: JSON.stringify(err), at: Date.now() };
+    message = JSON.stringify(err) ?? String(err);
   } catch {
-    return { message: String(err), at: Date.now() };
+    message = String(err);
   }
+  return { message, at: Date.now() };
 }
 
 /**
@@ -987,32 +992,39 @@ export class PluginService {
     // strand later cleanup steps — partial-unload leaks would re-surface as
     // duplicate-id errors on the next load. Disposer throws are warnings
     // (the cleanup is best-effort), not user-visible errors.
+    //
+    // Belt-and-suspenders: per-provider disposers pushed onto
+    // pluginEventCleanups by host.registerForgeProvider have already fired in
+    // flushPluginEventCleanups() above, but the bulk *Impls clears below guard
+    // against any impl entry that wasn't tracked through that path (e.g. a
+    // future re-bind that didn't refresh the disposer slot). The bulk calls
+    // are idempotent — already-cleared keys are silent no-ops. Provider and
+    // impl steps are split so a throw in the descriptor unregister doesn't
+    // strand the impl unregister and vice versa.
     runUnloadStep(pluginId, "removeHandlers", () => this.removeHandlers(pluginId));
     runUnloadStep(pluginId, "unregisterPluginActions", () =>
       this.unregisterPluginActions(pluginId)
     );
     runUnloadStep(pluginId, "unregisterPluginMenuItems", () => unregisterPluginMenuItems(pluginId));
-    runUnloadStep(pluginId, "unregisterPluginToolbarButtons", () => {
-      unregisterPluginToolbarButtons(pluginId);
-      this.scheduleToolbarButtonsBroadcast(true);
-    });
+    runUnloadStep(pluginId, "unregisterPluginToolbarButtons", () =>
+      unregisterPluginToolbarButtons(pluginId)
+    );
+    runUnloadStep(pluginId, "scheduleToolbarButtonsBroadcast", () =>
+      this.scheduleToolbarButtonsBroadcast(true)
+    );
     runUnloadStep(pluginId, "unregisterPluginPanelKinds", () =>
       unregisterPluginPanelKinds(pluginId)
     );
-    runUnloadStep(pluginId, "unregisterForgeProviders", () => {
-      unregisterForgeProviders(pluginId);
-      // Belt-and-suspenders: per-provider disposers pushed onto
-      // pluginEventCleanups by host.registerForgeProvider have already fired
-      // in flushPluginEventCleanups() above, but a direct bulk-clear guards
-      // against any impl entry that wasn't tracked through that path (e.g.
-      // a future re-bind that didn't refresh the disposer slot). The bulk
-      // call is idempotent — already-cleared keys are silent no-ops.
-      unregisterForgeProviderImpls(pluginId);
-    });
-    runUnloadStep(pluginId, "unregisterFileDecorationProviders", () => {
-      unregisterFileDecorationProviders(pluginId);
-      unregisterFileDecorationProviderImpls(pluginId);
-    });
+    runUnloadStep(pluginId, "unregisterForgeProviders", () => unregisterForgeProviders(pluginId));
+    runUnloadStep(pluginId, "unregisterForgeProviderImpls", () =>
+      unregisterForgeProviderImpls(pluginId)
+    );
+    runUnloadStep(pluginId, "unregisterFileDecorationProviders", () =>
+      unregisterFileDecorationProviders(pluginId)
+    );
+    runUnloadStep(pluginId, "unregisterFileDecorationProviderImpls", () =>
+      unregisterFileDecorationProviderImpls(pluginId)
+    );
 
     this.plugins.delete(pluginId);
     this.pluginLoadErrors.delete(pluginId);

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -87,7 +87,56 @@ interface LoadedPlugin {
   isBuiltin: boolean;
 }
 
+/**
+ * Diagnostic record of the most recent activation failure for a plugin id.
+ * Held internally (not on {@link LoadedPluginInfo}) until #9271 lands the
+ * provenance store with a public `loadError` field — at that point this Map
+ * is migrated into the provenance record. Until then the Settings diagnostic
+ * tab and IPC consumers may read it via {@link PluginService.getPluginLoadError}.
+ */
+interface PluginLoadErrorRecord {
+  message: string;
+  stack?: string;
+  at: number;
+}
+
 const ACTIVATE_TIMEOUT_MS = 5000;
+
+/**
+ * Normalise the value thrown out of `activate()` into a serialisable record.
+ * `unknown` becomes a stable `{ message, stack?, at }` shape so the Settings
+ * diagnostic tab (and #9271's provenance store) don't have to re-handle raw
+ * error objects.
+ */
+function toPluginLoadErrorRecord(err: unknown): PluginLoadErrorRecord {
+  if (err instanceof Error) {
+    return { message: err.message, stack: err.stack, at: Date.now() };
+  }
+  if (typeof err === "string") {
+    return { message: err, at: Date.now() };
+  }
+  try {
+    return { message: JSON.stringify(err), at: Date.now() };
+  } catch {
+    return { message: String(err), at: Date.now() };
+  }
+}
+
+/**
+ * Run a single unload-cascade step with per-step containment. A throwing
+ * disposer is logged as a warning (best-effort cleanup, not a user-actionable
+ * error per the issue's containment contract) and the cascade continues so
+ * subsequent registry unregisters still fire. Without this wrapping, one
+ * thrown disposer would strand later steps and leak registrations that fail
+ * the next load with a duplicate-id error.
+ */
+function runUnloadStep(pluginId: string, step: string, fn: () => void): void {
+  try {
+    fn();
+  } catch (err) {
+    console.warn(`[PluginService] Unload step "${step}" for "${pluginId}" threw:`, err);
+  }
+}
 
 type WorkspaceWorktreeEvent = "worktree-update" | "worktree-activated" | "worktree-removed";
 
@@ -98,6 +147,13 @@ export class PluginService {
   private pluginActions = new Map<string, PluginActionDescriptor>();
   private pluginActionOwners = new Map<string, Set<string>>();
   private pluginEventCleanups = new Map<string, Array<() => void>>();
+  /**
+   * Most recent activation error per plugin id. Populated by the catch in
+   * `loadPlugin()` so a thrown `activate()` no longer escapes containment.
+   * Cleared on unload and on a subsequent successful activation. Exposed via
+   * {@link getPluginLoadError} for Settings diagnostics and IPC introspection.
+   */
+  private pluginLoadErrors = new Map<string, PluginLoadErrorRecord>();
   private workspaceClient: WorkspaceClient | null = null;
   /**
    * Event subscriptions registered during plugin `activate()` when the
@@ -475,9 +531,18 @@ export class PluginService {
             revoke();
           }
         }
+        // Successful activation (or a main with no activate fn) clears any
+        // diagnostic record left over from a prior failed attempt at the same
+        // plugin id — relevant when initialize() is run twice against the
+        // same service in tests, or in future hot-reload paths.
+        this.pluginLoadErrors.delete(manifest.name);
       } catch (err) {
+        const record = toPluginLoadErrorRecord(err);
+        this.pluginLoadErrors.set(manifest.name, record);
         console.error(`[PluginService] Failed to load main entry for ${manifest.name}:`, err);
       }
+    } else {
+      this.pluginLoadErrors.delete(manifest.name);
     }
 
     return plugin;
@@ -873,7 +938,18 @@ export class PluginService {
     if (!handler) {
       throw new Error(`No plugin handler registered for ${key}`);
     }
-    return await handler(ctx, ...args);
+    try {
+      return await handler(ctx, ...args);
+    } catch (err) {
+      // Contain at the boundary so a throwing plugin handler can't propagate
+      // up through `ipcMain.handle` as an unhandled rejection in the main
+      // process. The error still surfaces to the renderer (we rethrow after
+      // logging) — the renderer-side wrapping in `usePluginActions` turns
+      // that rejection into a user-facing toast.
+      // TODO(#9232): emit PluginActionAuditRecord to the audit pipeline.
+      console.error(`[PluginService] Handler "${key}" threw:`, err);
+      throw err;
+    }
   }
 
   removeHandlers(pluginId: string): void {
@@ -897,20 +973,7 @@ export class PluginService {
       this.cleanupMap.delete(pluginId);
     }
     this.flushPluginEventCleanups(pluginId);
-    this.removeHandlers(pluginId);
-    this.unregisterPluginActions(pluginId);
-    unregisterPluginMenuItems(pluginId);
-    unregisterPluginToolbarButtons(pluginId);
-    this.scheduleToolbarButtonsBroadcast(true);
-    unregisterPluginPanelKinds(pluginId);
-    unregisterForgeProviders(pluginId);
-    // Belt-and-suspenders: per-provider disposers pushed onto
-    // pluginEventCleanups by host.registerForgeProvider have already fired in
-    // flushPluginEventCleanups() above, but a direct bulk-clear guards against
-    // any impl entry that wasn't tracked through that path (e.g. a future
-    // re-bind that didn't refresh the disposer slot). The bulk call is
-    // idempotent — already-cleared keys are silent no-ops.
-    unregisterForgeProviderImpls(pluginId);
+
     // Capture the unloaded plugin's declared decoration scopes before clearing
     // the registry so we can tell any renderer that was showing them to
     // re-pull (it will now resolve no impl and clear). Without this, stale
@@ -919,16 +982,50 @@ export class PluginService {
     const decorationScopes = this.plugins
       .get(pluginId)
       ?.manifest.contributes.fileDecorationProviders.flatMap((c) => c.scopes);
-    unregisterFileDecorationProviders(pluginId);
-    unregisterFileDecorationProviderImpls(pluginId);
+
+    // Each step is wrapped individually so a throwing registry call can't
+    // strand later cleanup steps — partial-unload leaks would re-surface as
+    // duplicate-id errors on the next load. Disposer throws are warnings
+    // (the cleanup is best-effort), not user-visible errors.
+    runUnloadStep(pluginId, "removeHandlers", () => this.removeHandlers(pluginId));
+    runUnloadStep(pluginId, "unregisterPluginActions", () =>
+      this.unregisterPluginActions(pluginId)
+    );
+    runUnloadStep(pluginId, "unregisterPluginMenuItems", () => unregisterPluginMenuItems(pluginId));
+    runUnloadStep(pluginId, "unregisterPluginToolbarButtons", () => {
+      unregisterPluginToolbarButtons(pluginId);
+      this.scheduleToolbarButtonsBroadcast(true);
+    });
+    runUnloadStep(pluginId, "unregisterPluginPanelKinds", () =>
+      unregisterPluginPanelKinds(pluginId)
+    );
+    runUnloadStep(pluginId, "unregisterForgeProviders", () => {
+      unregisterForgeProviders(pluginId);
+      // Belt-and-suspenders: per-provider disposers pushed onto
+      // pluginEventCleanups by host.registerForgeProvider have already fired
+      // in flushPluginEventCleanups() above, but a direct bulk-clear guards
+      // against any impl entry that wasn't tracked through that path (e.g.
+      // a future re-bind that didn't refresh the disposer slot). The bulk
+      // call is idempotent — already-cleared keys are silent no-ops.
+      unregisterForgeProviderImpls(pluginId);
+    });
+    runUnloadStep(pluginId, "unregisterFileDecorationProviders", () => {
+      unregisterFileDecorationProviders(pluginId);
+      unregisterFileDecorationProviderImpls(pluginId);
+    });
+
     this.plugins.delete(pluginId);
+    this.pluginLoadErrors.delete(pluginId);
+
     if (decorationScopes && decorationScopes.length > 0) {
-      for (const scope of new Set(decorationScopes)) {
-        broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
-          name: "plugin:decorations-changed",
-          payload: { scope },
-        });
-      }
+      runUnloadStep(pluginId, "broadcastDecorationsChanged", () => {
+        for (const scope of new Set(decorationScopes)) {
+          broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+            name: "plugin:decorations-changed",
+            payload: { scope },
+          });
+        }
+      });
     }
   }
 
@@ -957,6 +1054,17 @@ export class PluginService {
       loadedAt: p.loadedAt,
       isBuiltin: p.isBuiltin,
     }));
+  }
+
+  /**
+   * Most recent activation error for a plugin id, or `undefined` if the last
+   * load succeeded (or the plugin has never been loaded). Cleared on unload
+   * and on a subsequent successful activation. Intended for the Settings
+   * diagnostic surface (F19) and #9271's provenance store — until that lands
+   * the record stays in-memory and does not survive a host restart.
+   */
+  getPluginLoadError(pluginId: string): PluginLoadErrorRecord | undefined {
+    return this.pluginLoadErrors.get(pluginId);
   }
 
   /**

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -3063,7 +3063,7 @@ describe("Plugin exception containment (#9276)", () => {
       );
     });
 
-    it("continues past a throwing forge-provider unregister", async () => {
+    it("continues past a throwing forge-provider unregister AND still runs the impl unregister", async () => {
       await writePlugin("forge-throws", {
         name: "acme.forge-throws",
         version: "1.0.0",
@@ -3077,8 +3077,12 @@ describe("Plugin exception containment (#9276)", () => {
 
       service.unloadPlugin("acme.forge-throws");
 
-      // File decoration step still runs after the forge step throws.
+      // Critical: the impl unregister must run even if the provider unregister
+      // threw, otherwise impl entries leak across reload. Coupled steps under
+      // a single try/catch wrapper would have skipped this call.
+      expect(unregisterForgeProviderImpls).toHaveBeenCalledWith("acme.forge-throws");
       expect(unregisterFileDecorationProviders).toHaveBeenCalledWith("acme.forge-throws");
+      expect(unregisterFileDecorationProviderImpls).toHaveBeenCalledWith("acme.forge-throws");
       expect(service.hasPlugin("acme.forge-throws")).toBe(false);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining(
@@ -3086,6 +3090,118 @@ describe("Plugin exception containment (#9276)", () => {
         ),
         expect.any(Error)
       );
+    });
+
+    it("continues past a throwing fileDecoration-provider unregister AND still runs the impl unregister", async () => {
+      await writePlugin("file-decoration-throws", {
+        name: "acme.file-decoration-throws",
+        version: "1.0.0",
+      });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      vi.mocked(unregisterFileDecorationProviders).mockImplementationOnce(() => {
+        throw new Error("file-decoration boom");
+      });
+
+      service.unloadPlugin("acme.file-decoration-throws");
+
+      // Same correctness check as the forge case: the impl unregister must
+      // not be stranded by a throw in the provider unregister.
+      expect(unregisterFileDecorationProviderImpls).toHaveBeenCalledWith(
+        "acme.file-decoration-throws"
+      );
+      expect(service.hasPlugin("acme.file-decoration-throws")).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Unload step "unregisterFileDecorationProviders" for "acme.file-decoration-throws" threw:`
+        ),
+        expect.any(Error)
+      );
+    });
+
+    it("continues past a throwing removeHandlers, running every later registry step", async () => {
+      await writePlugin("remove-handlers-throws", {
+        name: "acme.remove-handlers-throws",
+        version: "1.0.0",
+        contributes: {
+          panels: [{ id: "p", name: "P", iconId: "i", color: "#000" }],
+          toolbarButtons: [{ id: "b", label: "B", iconId: "i", actionId: "x.y" }],
+          menuItems: [{ label: "L", actionId: "x.y", location: "terminal" }],
+        },
+      });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      const removeHandlersSpy = vi
+        .spyOn(service as unknown as { removeHandlers: (id: string) => void }, "removeHandlers")
+        .mockImplementationOnce(() => {
+          throw new Error("removeHandlers boom");
+        });
+
+      service.unloadPlugin("acme.remove-handlers-throws");
+
+      // Even though the very first step threw, every later step ran.
+      expect(unregisterPluginMenuItems).toHaveBeenCalledWith("acme.remove-handlers-throws");
+      expect(unregisterPluginToolbarButtons).toHaveBeenCalledWith("acme.remove-handlers-throws");
+      expect(unregisterPluginPanelKinds).toHaveBeenCalledWith("acme.remove-handlers-throws");
+      expect(unregisterForgeProviders).toHaveBeenCalledWith("acme.remove-handlers-throws");
+      expect(unregisterForgeProviderImpls).toHaveBeenCalledWith("acme.remove-handlers-throws");
+      expect(unregisterFileDecorationProviders).toHaveBeenCalledWith("acme.remove-handlers-throws");
+      expect(unregisterFileDecorationProviderImpls).toHaveBeenCalledWith(
+        "acme.remove-handlers-throws"
+      );
+      expect(service.hasPlugin("acme.remove-handlers-throws")).toBe(false);
+
+      removeHandlersSpy.mockRestore();
+    });
+  });
+
+  describe("Boundary 1 — non-Error throws", () => {
+    it("normalises a bare `throw undefined` into a string message", async () => {
+      const pluginDir = path.join(tmpDir, "throws-undefined");
+      await fs.mkdir(pluginDir);
+      await fs.writeFile(
+        path.join(pluginDir, "plugin.json"),
+        JSON.stringify({ name: "acme.throws-undefined", version: "1.0.0", main: "main.mjs" })
+      );
+      // `throw undefined` is a real footgun in plugin code — make sure the
+      // load-error record never sneaks an `undefined` into its `message`
+      // field, which would violate the type contract for the F19 / #9271
+      // consumer.
+      await fs.writeFile(
+        path.join(pluginDir, "main.mjs"),
+        "export function activate() { throw undefined; }"
+      );
+
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      const record = service.getPluginLoadError("acme.throws-undefined");
+      expect(record).toBeDefined();
+      expect(typeof record?.message).toBe("string");
+      expect(record?.message.length).toBeGreaterThan(0);
+    });
+
+    it("normalises a bare `throw null` into a string message", async () => {
+      const pluginDir = path.join(tmpDir, "throws-null");
+      await fs.mkdir(pluginDir);
+      await fs.writeFile(
+        path.join(pluginDir, "plugin.json"),
+        JSON.stringify({ name: "acme.throws-null", version: "1.0.0", main: "main.mjs" })
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "main.mjs"),
+        "export function activate() { throw null; }"
+      );
+
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      const record = service.getPluginLoadError("acme.throws-null");
+      expect(record).toBeDefined();
+      expect(typeof record?.message).toBe("string");
+      expect(record?.message.length).toBeGreaterThan(0);
     });
   });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -52,6 +52,17 @@ vi.mock("../forgeProviderRegistry.js", () => ({
   getForgeProviderImpl: vi.fn(),
   clearForgeProviderImplRegistry: vi.fn(),
 }));
+// Mocked so unload-cascade tests can simulate a throwing decoration unregister
+// without exercising the real (currently no-op) registry. Pre-existing tests
+// transitively touched these via unloadPlugin but never asserted call counts.
+vi.mock("../fileDecorationRegistry.js", () => ({
+  registerFileDecorationProviders: vi.fn(),
+  registerFileDecorationProviderImpl: vi.fn(),
+  unregisterFileDecorationProviders: vi.fn(),
+  unregisterFileDecorationProviderImpls: vi.fn(),
+  unregisterFileDecorationProviderImpl: vi.fn(),
+  scopeMatchesPattern: vi.fn((s: string, p: string) => s === p),
+}));
 
 import { PluginService } from "../PluginService.js";
 import { PluginManifestSchema } from "../../schemas/plugin.js";
@@ -75,6 +86,10 @@ import {
   unregisterForgeProviderImpls,
   unregisterForgeProviders,
 } from "../forgeProviderRegistry.js";
+import {
+  unregisterFileDecorationProviders,
+  unregisterFileDecorationProviderImpls,
+} from "../fileDecorationRegistry.js";
 import { CHANNELS } from "../../ipc/channels.js";
 
 function makeCtx(pluginId: string, overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
@@ -2810,5 +2825,267 @@ describe("reserved contribution point warnings", () => {
       },
     });
     expect(result.success).toBe(true);
+  });
+});
+
+// Boundary containment regression tests for issue #9276 — verify that a
+// plugin's exceptions can't escape the host. Each block covers one boundary:
+// activation, action dispatch, and the unload cascade.
+
+describe("Plugin exception containment (#9276)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  describe("Boundary 1 — activation failure", () => {
+    it("records the activation error on getPluginLoadError without rethrowing", async () => {
+      const pluginDir = path.join(tmpDir, "throws-activate");
+      await fs.mkdir(pluginDir);
+      await fs.writeFile(
+        path.join(pluginDir, "plugin.json"),
+        JSON.stringify({ name: "acme.throws-activate", version: "1.0.0", main: "main.mjs" })
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "main.mjs"),
+        "export function activate() { throw new Error('boom on activate'); }"
+      );
+
+      const service = new PluginService(tmpDir);
+      // The host MUST NOT crash — initialize() should resolve.
+      await expect(service.initialize()).resolves.toBeUndefined();
+
+      const record = service.getPluginLoadError("acme.throws-activate");
+      expect(record).toBeDefined();
+      expect(record?.message).toBe("boom on activate");
+      expect(record?.stack).toContain("boom on activate");
+      expect(typeof record?.at).toBe("number");
+      // The plugin is still registered (manifest-declared contributions survive
+      // even if the JS main entry blows up).
+      expect(service.hasPlugin("acme.throws-activate")).toBe(true);
+    });
+
+    it("returns undefined when the plugin's activate succeeds", async () => {
+      const pluginDir = path.join(tmpDir, "clean-activate");
+      await fs.mkdir(pluginDir);
+      await fs.writeFile(
+        path.join(pluginDir, "plugin.json"),
+        JSON.stringify({ name: "acme.clean-activate", version: "1.0.0", main: "main.mjs" })
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "main.mjs"),
+        "export function activate() { return () => {}; }"
+      );
+
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      expect(service.getPluginLoadError("acme.clean-activate")).toBeUndefined();
+    });
+
+    it("returns undefined when the plugin declares no main entry", async () => {
+      await writePlugin("no-main", { name: "acme.no-main", version: "1.0.0" });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      expect(service.getPluginLoadError("acme.no-main")).toBeUndefined();
+    });
+
+    it("clears the recorded error after unload", async () => {
+      const pluginDir = path.join(tmpDir, "throws-then-unload");
+      await fs.mkdir(pluginDir);
+      await fs.writeFile(
+        path.join(pluginDir, "plugin.json"),
+        JSON.stringify({ name: "acme.throws-then-unload", version: "1.0.0", main: "main.mjs" })
+      );
+      await fs.writeFile(
+        path.join(pluginDir, "main.mjs"),
+        "export function activate() { throw new Error('boom'); }"
+      );
+
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      expect(service.getPluginLoadError("acme.throws-then-unload")).toBeDefined();
+
+      service.unloadPlugin("acme.throws-then-unload");
+      expect(service.getPluginLoadError("acme.throws-then-unload")).toBeUndefined();
+    });
+
+    it("normalises non-Error throws into a load error record", async () => {
+      const pluginDir = path.join(tmpDir, "throws-string");
+      await fs.mkdir(pluginDir);
+      await fs.writeFile(
+        path.join(pluginDir, "plugin.json"),
+        JSON.stringify({ name: "acme.throws-string", version: "1.0.0", main: "main.mjs" })
+      );
+      // Throw a plain string — many plugin authors do this.
+      await fs.writeFile(
+        path.join(pluginDir, "main.mjs"),
+        "export function activate() { throw 'plain-string-failure'; }"
+      );
+
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      const record = service.getPluginLoadError("acme.throws-string");
+      expect(record?.message).toBe("plain-string-failure");
+      expect(record?.stack).toBeUndefined();
+    });
+  });
+
+  describe("Boundary 2 — action handler throw", () => {
+    it("dispatchHandler rejects with the original error and logs to console.error", async () => {
+      await writePlugin("acme.throwy-handler", {
+        name: "acme.throwy-handler",
+        version: "1.0.0",
+      });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      const original = new Error("handler boom");
+      service.registerHandler("acme.throwy-handler", "blow-up", () => {
+        throw original;
+      });
+
+      await expect(
+        service.dispatchHandler(
+          "acme.throwy-handler",
+          "blow-up",
+          makeCtx("acme.throwy-handler"),
+          []
+        )
+      ).rejects.toBe(original);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`Handler "acme.throwy-handler:blow-up" threw:`),
+        original
+      );
+    });
+
+    it("dispatchHandler rejects with an async handler's rejection and logs", async () => {
+      await writePlugin("acme.async-throwy", {
+        name: "acme.async-throwy",
+        version: "1.0.0",
+      });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      const original = new Error("async boom");
+      service.registerHandler("acme.async-throwy", "blow-up", async () => {
+        throw original;
+      });
+
+      await expect(
+        service.dispatchHandler("acme.async-throwy", "blow-up", makeCtx("acme.async-throwy"), [])
+      ).rejects.toBe(original);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`Handler "acme.async-throwy:blow-up" threw:`),
+        original
+      );
+    });
+  });
+
+  describe("Boundary 3 — unload cascade containment", () => {
+    it("continues past a throwing menu-items unregister and still clears the plugin", async () => {
+      await writePlugin("cascade-test", {
+        name: "acme.cascade-test",
+        version: "1.0.0",
+        contributes: {
+          panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
+          toolbarButtons: [{ id: "btn", label: "Btn", iconId: "icon", actionId: "x.y" }],
+          menuItems: [{ label: "L", actionId: "x.y", location: "terminal" }],
+        },
+      });
+
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      vi.mocked(unregisterPluginMenuItems).mockImplementationOnce(() => {
+        throw new Error("menu unregister boom");
+      });
+
+      service.unloadPlugin("acme.cascade-test");
+
+      // Each step after the throwing one still ran:
+      expect(unregisterPluginToolbarButtons).toHaveBeenCalledWith("acme.cascade-test");
+      expect(unregisterPluginPanelKinds).toHaveBeenCalledWith("acme.cascade-test");
+      expect(unregisterForgeProviders).toHaveBeenCalledWith("acme.cascade-test");
+      expect(unregisterForgeProviderImpls).toHaveBeenCalledWith("acme.cascade-test");
+      expect(unregisterFileDecorationProviders).toHaveBeenCalledWith("acme.cascade-test");
+      expect(unregisterFileDecorationProviderImpls).toHaveBeenCalledWith("acme.cascade-test");
+
+      // Containment guarantees: plugin gone from registry, no rethrown error.
+      expect(service.hasPlugin("acme.cascade-test")).toBe(false);
+
+      // Disposer throws are warnings, not errors (per issue constraint).
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Unload step "unregisterPluginMenuItems" for "acme.cascade-test" threw:`
+        ),
+        expect.any(Error)
+      );
+    });
+
+    it("continues past a throwing toolbar unregister", async () => {
+      await writePlugin("toolbar-throws", {
+        name: "acme.toolbar-throws",
+        version: "1.0.0",
+        contributes: {
+          panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
+        },
+      });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      vi.mocked(unregisterPluginToolbarButtons).mockImplementationOnce(() => {
+        throw new Error("toolbar boom");
+      });
+
+      service.unloadPlugin("acme.toolbar-throws");
+
+      // Subsequent steps in cascade still run.
+      expect(unregisterPluginPanelKinds).toHaveBeenCalledWith("acme.toolbar-throws");
+      expect(service.hasPlugin("acme.toolbar-throws")).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Unload step "unregisterPluginToolbarButtons" for "acme.toolbar-throws" threw:`
+        ),
+        expect.any(Error)
+      );
+    });
+
+    it("continues past a throwing forge-provider unregister", async () => {
+      await writePlugin("forge-throws", {
+        name: "acme.forge-throws",
+        version: "1.0.0",
+      });
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      vi.mocked(unregisterForgeProviders).mockImplementationOnce(() => {
+        throw new Error("forge boom");
+      });
+
+      service.unloadPlugin("acme.forge-throws");
+
+      // File decoration step still runs after the forge step throws.
+      expect(unregisterFileDecorationProviders).toHaveBeenCalledWith("acme.forge-throws");
+      expect(service.hasPlugin("acme.forge-throws")).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Unload step "unregisterForgeProviders" for "acme.forge-throws" threw:`
+        ),
+        expect.any(Error)
+      );
+    });
   });
 });

--- a/src/hooks/__tests__/usePluginActions.test.ts
+++ b/src/hooks/__tests__/usePluginActions.test.ts
@@ -3,10 +3,17 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import type { PluginActionDescriptor } from "@shared/types/plugin";
 
-const { getActionsMock, onActionsChangedMock, invokeMock } = vi.hoisted(() => ({
+const { getActionsMock, onActionsChangedMock, invokeMock, notifyMock } = vi.hoisted(() => ({
   getActionsMock: vi.fn(),
   onActionsChangedMock: vi.fn(),
   invokeMock: vi.fn(),
+  notifyMock: vi.fn(),
+}));
+
+// Stub the notify surface so containment tests can assert on its call shape
+// without spinning up the full notification store + history wiring.
+vi.mock("@/lib/notify", () => ({
+  notify: notifyMock,
 }));
 
 function descriptor(overrides: Partial<PluginActionDescriptor> = {}): PluginActionDescriptor {
@@ -283,6 +290,68 @@ describe("usePluginActions", () => {
     expect(settled).toEqual({ ok: true, result: undefined });
     expect(invokeMock).not.toHaveBeenCalled();
     expect(usePluginConfirmStore.getState().current).toBeNull();
+  });
+
+  it("surfaces an error toast when invoke rejects and returns undefined (boundary 2 — #9276)", async () => {
+    const { actionService } = await import("@/services/ActionService");
+    const { usePluginActions } = await import("../usePluginActions");
+
+    const action = descriptor();
+    getActionsMock.mockResolvedValue([action]);
+    invokeMock.mockRejectedValue(new Error("plugin handler exploded"));
+
+    renderHook(() => usePluginActions());
+    await waitFor(() => expect(actionService.has(action.id)).toBe(true));
+
+    const result = await actionService.dispatch(action.id, { x: 1 });
+
+    // The rejection is contained at the renderer boundary: the dispatch
+    // resolves successfully with undefined, never propagating the rejection
+    // back through ActionService's own catch (which would emit a *second*
+    // error path).
+    expect(result).toEqual({ ok: true, result: undefined });
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        title: "Plugin action failed",
+        message: expect.stringContaining("acme.my-plugin"),
+      })
+    );
+  });
+
+  it("does NOT surface a toast when invoke rejects after the hook unmounts (boundary 2 — #9276)", async () => {
+    const { actionService } = await import("@/services/ActionService");
+    const { usePluginActions } = await import("../usePluginActions");
+
+    const action = descriptor();
+    getActionsMock.mockResolvedValue([action]);
+
+    // Capture the deferred reject so we can fire it strictly after unmount.
+    let rejectInvoke: ((err: Error) => void) | null = null;
+    invokeMock.mockImplementation(
+      () =>
+        new Promise<unknown>((_, reject) => {
+          rejectInvoke = reject;
+        })
+    );
+
+    const { unmount } = renderHook(() => usePluginActions());
+    await waitFor(() => expect(actionService.has(action.id)).toBe(true));
+
+    // Capture the action's run() handle BEFORE unmount — after unmount the
+    // action is unregistered, so we have to dispatch first.
+    const pending = actionService.dispatch(action.id, { x: 1 });
+
+    unmount();
+    rejectInvoke!(new Error("late boom"));
+    const result = await pending;
+
+    // Run still returns undefined (boundary 2 swallows the throw) and
+    // ActionService wraps that as a successful dispatch.
+    expect(result).toEqual({ ok: true, result: undefined });
+    // Critical: no toast on a stale in-flight rejection.
+    expect(notifyMock).not.toHaveBeenCalled();
   });
 
   it("does not clobber an already-registered built-in action of the same id", async () => {

--- a/src/hooks/usePluginActions.ts
+++ b/src/hooks/usePluginActions.ts
@@ -5,6 +5,7 @@ import type { ActionDefinition } from "@shared/types/actions";
 import type { PluginActionDescriptor } from "@shared/types/plugin";
 import { requestPluginConfirmation, usePluginConfirmStore } from "@/store/pluginConfirmStore";
 import { logWarn } from "@/utils/logger";
+import { notify } from "@/lib/notify";
 
 /**
  * Pull plugin-registered actions on mount and keep the renderer registry in
@@ -42,7 +43,7 @@ export function usePluginActions(): void {
         if (!descriptorsEqual(current, next)) {
           // Re-register so stale title/category/schema is replaced.
           actionService.unregister(id);
-          actionService.register(toSyntheticDefinition(next, inFlightConfirms));
+          actionService.register(toSyntheticDefinition(next, inFlightConfirms, () => disposed));
           registered.set(id, next);
         }
       }
@@ -55,7 +56,7 @@ export function usePluginActions(): void {
           );
           continue;
         }
-        actionService.register(toSyntheticDefinition(descriptor, inFlightConfirms));
+        actionService.register(toSyntheticDefinition(descriptor, inFlightConfirms, () => disposed));
         registered.set(id, descriptor);
       }
     };
@@ -116,7 +117,8 @@ function descriptorsEqual(a: PluginActionDescriptor, b: PluginActionDescriptor):
 
 function toSyntheticDefinition(
   descriptor: PluginActionDescriptor,
-  inFlightConfirms: Set<string>
+  inFlightConfirms: Set<string>,
+  isDisposed: () => boolean
 ): AnyActionDefinition {
   const { pluginId, id, title, description, category, kind, keywords, inputSchema } = descriptor;
 
@@ -165,7 +167,28 @@ function toSyntheticDefinition(
           return undefined;
         }
       }
-      return window.electron.plugin.invoke(pluginId, id, args);
+      try {
+        return await window.electron.plugin.invoke(pluginId, id, args);
+      } catch (err) {
+        // ActionService.dispatch already catches this rejection and returns
+        // `{ ok: false }` so the *contract* is intact — this branch exists to
+        // turn the silent failure into a user-visible toast. `isDisposed`
+        // gates the notify so an in-flight invoke that resolves after the
+        // hook unmounts (HMR, window close, project switch) can't surface a
+        // stale toast for an action the user can no longer see. We swallow
+        // the error after notifying because surfacing a second failure path
+        // (via rethrow → ActionService) would double-route the same event.
+        if (!isDisposed()) {
+          // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+          notify({
+            type: "error",
+            title: "Plugin action failed",
+            message: `"${title ?? id}" from plugin ${pluginId} threw an error.`,
+          });
+        }
+        logWarn(`[PluginActions] Plugin action "${id}" threw`, { error: err });
+        return undefined;
+      }
     },
   };
 


### PR DESCRIPTION
## Summary

- Plugin exceptions now contained at all four boundaries: activation error provenance, action dispatch (main + renderer), unload cascade step isolation, and view render (already live in `GridPanel`/`DockedPanel`)
- Activation errors stored in an internal `Map` keyed by plugin ID and exposed via `getPluginLoadError()`, rather than only going to `console.error`
- Each step in the `unloadPlugin` cascade runs under its own `try/catch` so a throw at step N doesn't skip steps N+1 through M; forge and file-decoration providers split into separate steps so a descriptor unregister failure can't strand the impl unregister

Resolves #9276

## Changes

- `electron/services/PluginService.ts` — internal `pluginLoadErrors` Map + `getPluginLoadError` accessor + `toPluginLoadErrorRecord` normaliser (boundary 1); `dispatchHandler` try/catch with `TODO(#9232)` (boundary 2 main); per-step `runUnloadStep` wrap across the entire unload cascade (boundary 3)
- `src/hooks/usePluginActions.ts` — `plugin.invoke` wrapped in try/catch; rejection surfaces as an "Plugin action failed" toast (action-free, gated on `!isDisposed`), logs warning, returns `undefined` so `ActionService` doesn't double-route (boundary 2 renderer)
- Boundary 4 confirmed already present in `GridPanel` + `DockedPanel` — no change needed
- 18 new tests across `electron/services/__tests__/PluginService.test.ts` and `src/hooks/__tests__/usePluginActions.test.ts`

## Testing

All 216 tests pass. Covered: activation error storage and retrieval, non-`Error` throw normalisation, unload step isolation (throw at step N, verify N+1..M still run), action dispatch containment in both processes, renderer toast on invoke failure, and dispose-guard suppression.