### PR TITLE
fix(terminal): manual restart banner, input lock, parallel IPCs (#9164)

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1348,7 +1348,9 @@ function TerminalPaneComponent({
                 <LazyHybridInputBar
                   ref={inputBarRef}
                   terminalId={id}
-                  disabled={isBackendDisconnected || isBackendRecovering || isInputLocked}
+                  disabled={
+                    isBackendDisconnected || isBackendRecovering || isInputLocked || isRestarting
+                  }
                   cwd={cwd}
                   agentId={effectiveAgentId}
                   agentHasLifecycleEvent={stateChangeTrigger !== undefined}
@@ -1356,7 +1358,7 @@ function TerminalPaneComponent({
                   restartKey={restartKey}
                   onActivate={handleClick}
                   onSend={({ trackerData, text }) => {
-                    if (!isInputLocked) {
+                    if (!isInputLocked && !isRestarting) {
                       terminalInstanceService.notifyUserInput(id);
                       // submit now rejects when the PTY is gone (#8706); the
                       // single-pane path has no recovery UI for that, so
@@ -1369,7 +1371,7 @@ function TerminalPaneComponent({
                     }
                   }}
                   onSendKey={(key) => {
-                    if (!isInputLocked) {
+                    if (!isInputLocked && !isRestarting) {
                       terminalInstanceService.notifyUserInput(id);
                       terminalClient.sendKey(id, key);
                     }

--- a/src/components/Terminal/TerminalRestartStatusBanner.tsx
+++ b/src/components/Terminal/TerminalRestartStatusBanner.tsx
@@ -43,6 +43,19 @@ export function TerminalRestartStatusBanner({
         />
       );
 
+    case "restarting":
+      return (
+        <InlineStatusBanner
+          icon={SpinnerIcon}
+          title={RESTART_BANNER_COPY["restarting"].title}
+          severity="info"
+          animated={false}
+          role="status"
+          ariaLive="polite"
+          actions={[]}
+        />
+      );
+
     case "exit-error":
       return (
         <InlineStatusBanner

--- a/src/components/Terminal/__tests__/restartBannerCopy.test.ts
+++ b/src/components/Terminal/__tests__/restartBannerCopy.test.ts
@@ -6,6 +6,10 @@ describe("RESTART_BANNER_COPY", () => {
     expect(RESTART_BANNER_COPY["auto-restarting"].title).toBe("Auto-restarting…");
   });
 
+  it("renders the restarting title with a Unicode ellipsis", () => {
+    expect(RESTART_BANNER_COPY["restarting"].title).toBe("Restarting…");
+  });
+
   it("interpolates exitCode into the exit-error title", () => {
     expect(RESTART_BANNER_COPY["exit-error"]({ exitCode: 1 }).title).toBe(
       "Session exited with code 1"

--- a/src/components/Terminal/__tests__/restartStatus.test.ts
+++ b/src/components/Terminal/__tests__/restartStatus.test.ts
@@ -70,8 +70,57 @@ describe("getRestartBannerVariant", () => {
     expect(result).toEqual({ type: "none" });
   });
 
-  it("returns none when isRestarting is true", () => {
+  it("returns restarting when isRestarting is true and no errors", () => {
     const result = getRestartBannerVariant({ ...base, isRestarting: true });
+    expect(result).toEqual({ type: "restarting" });
+  });
+
+  it("returns auto-restarting over restarting when both isAutoRestarting and isRestarting are true", () => {
+    const result = getRestartBannerVariant({
+      ...base,
+      isRestarting: true,
+      isAutoRestarting: true,
+    });
+    expect(result).toEqual({ type: "auto-restarting" });
+  });
+
+  it("returns none when isRestarting is true but restartError is present", () => {
+    const result = getRestartBannerVariant({
+      ...base,
+      isRestarting: true,
+      restartError: {
+        message: "failed",
+        code: "RESTART_FAILED",
+        timestamp: Date.now(),
+        recoverable: false,
+      },
+    });
+    expect(result).toEqual({ type: "none" });
+  });
+
+  it("returns none when isRestarting is true but reconnectError is present", () => {
+    const result = getRestartBannerVariant({
+      ...base,
+      isRestarting: true,
+      reconnectError: {
+        message: "lost connection",
+        code: "RECONNECT_FAILED",
+        timestamp: Date.now(),
+      } as never,
+    });
+    expect(result).toEqual({ type: "none" });
+  });
+
+  it("returns none when isRestarting is true but spawnError is present", () => {
+    const result = getRestartBannerVariant({
+      ...base,
+      isRestarting: true,
+      spawnError: {
+        message: "spawn failed",
+        code: "SPAWN_FAILED",
+        timestamp: Date.now(),
+      } as never,
+    });
     expect(result).toEqual({ type: "none" });
   });
 

--- a/src/components/Terminal/restartBannerCopy.ts
+++ b/src/components/Terminal/restartBannerCopy.ts
@@ -1,9 +1,11 @@
 export interface RestartBannerCopyMap {
   "auto-restarting": { title: string };
+  restarting: { title: string };
   "exit-error": (args: { exitCode: number }) => { title: string };
 }
 
 export const RESTART_BANNER_COPY: RestartBannerCopyMap = {
   "auto-restarting": { title: "Auto-restarting…" },
+  restarting: { title: "Restarting…" },
   "exit-error": ({ exitCode }) => ({ title: `Session exited with code ${exitCode}` }),
 };

--- a/src/components/Terminal/restartStatus.ts
+++ b/src/components/Terminal/restartStatus.ts
@@ -4,6 +4,7 @@ import type { BackendStatus } from "@/store/panelStore";
 
 export type RestartBannerVariant =
   | { type: "auto-restarting" }
+  | { type: "restarting" }
   | { type: "exit-error"; exitCode: number }
   | { type: "none" };
 
@@ -23,6 +24,16 @@ export interface RestartBannerInput {
 export function getRestartBannerVariant(input: RestartBannerInput): RestartBannerVariant {
   if (input.isAutoRestarting && !input.restartError && !input.reconnectError && !input.spawnError) {
     return { type: "auto-restarting" };
+  }
+
+  if (
+    input.isRestarting &&
+    !input.isAutoRestarting &&
+    !input.restartError &&
+    !input.reconnectError &&
+    !input.spawnError
+  ) {
+    return { type: "restarting" };
   }
 
   if (

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -58,6 +58,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     fit: vi.fn(),
     captureBufferText: vi.fn().mockReturnValue(""),
     addAgentStateListener: vi.fn().mockReturnValue(vi.fn()),
+    setInputLocked: vi.fn(),
   },
 }));
 
@@ -587,5 +588,151 @@ describe("restartTerminal resume-latest fallback (#8787)", () => {
     // Existing fallback chain (persisted flags / generated command)
     expect(payload.command).toBeDefined();
     expect(payload.command).not.toBe("claude --continue");
+  });
+});
+
+describe("restartTerminal input lock + parallel IPC (#9164)", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    getMergedPresetMock.mockReturnValue(undefined);
+    buildAgentLaunchFlagsMock.mockReturnValue([]);
+    const { agentSettingsClient, projectClient } = await import("@/clients");
+    (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (projectClient.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const { reset } = usePanelStore.getState();
+    await reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  it("locks input before destroy and unlocks on successful restart", async () => {
+    const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+    const setInputLocked = terminalInstanceService.setInputLocked as ReturnType<typeof vi.fn>;
+    const destroy = terminalInstanceService.destroy as ReturnType<typeof vi.fn>;
+
+    const calls: string[] = [];
+    setInputLocked.mockImplementation((_id: string, locked: boolean) => {
+      calls.push(locked ? "lock" : "unlock");
+    });
+    destroy.mockImplementation(() => {
+      calls.push("destroy");
+    });
+
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+    };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    // First lock fires before destroy; re-lock fires after waitForInstance;
+    // final unlock on success.
+    expect(calls[0]).toBe("lock");
+    expect(calls[1]).toBe("destroy");
+    expect(calls).toContain("unlock");
+    expect(calls[calls.length - 1]).toBe("unlock");
+
+    // Exactly two lock(true) calls (pre-destroy + post-waitForInstance) and
+    // one lock(false) on success.
+    const lockTrueCalls = setInputLocked.mock.calls.filter((c) => c[1] === true);
+    const lockFalseCalls = setInputLocked.mock.calls.filter((c) => c[1] === false);
+    expect(lockTrueCalls).toHaveLength(2);
+    expect(lockFalseCalls).toHaveLength(1);
+  });
+
+  it("unlocks input on failed restart so the instance is not permanently locked", async () => {
+    const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+    const setInputLocked = terminalInstanceService.setInputLocked as ReturnType<typeof vi.fn>;
+
+    // Make the spawn fail to drive the catch path.
+    mockSpawn.mockRejectedValueOnce(new Error("spawn failed"));
+
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+    };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    // The catch branch must unlock so the user can keep using the terminal.
+    const lockFalseCalls = setInputLocked.mock.calls.filter((c) => c[1] === false);
+    expect(lockFalseCalls.length).toBeGreaterThanOrEqual(1);
+    expect(setInputLocked.mock.calls[setInputLocked.mock.calls.length - 1]?.[1]).toBe(false);
+  });
+
+  it("does not call the store setInputLocked action during restart (avoids persisting transient lock)", async () => {
+    // The transient input lock during restart must go through the service
+    // directly, NOT through the store action which persists to disk.
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+    };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    const after = usePanelStore.getState().panelsById["test-1"] as PtyPanelData | undefined;
+    // isInputLocked must not be true on the persisted panel after a
+    // successful restart.
+    expect(after?.isInputLocked).not.toBe(true);
+  });
+
+  it("starts terminalClient.kill before awaiting buildRestartEnv IPCs (parallelization)", async () => {
+    const { projectClient, globalEnvClient } = await import("@/clients");
+    const projectSettings = projectClient.getSettings as ReturnType<typeof vi.fn>;
+    const globalEnvGet = globalEnvClient.get as ReturnType<typeof vi.fn>;
+
+    const order: string[] = [];
+    mockKill.mockImplementation(() => {
+      order.push("kill-start");
+      return Promise.resolve();
+    });
+    projectSettings.mockImplementation(() => {
+      order.push("project-settings-start");
+      return Promise.resolve(null);
+    });
+    globalEnvGet.mockImplementation(() => {
+      order.push("global-env-start");
+      return Promise.resolve({});
+    });
+
+    const active = {
+      ...agentPanelBase,
+      agentState: "working" as const,
+    };
+    usePanelStore.setState({
+      panelsById: { [active.id]: active },
+      panelIds: [active.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    // All three IPC starts should appear before spawn — i.e. they were
+    // launched as part of the Promise.all, not awaited serially.
+    expect(order).toContain("kill-start");
+    expect(order).toContain("global-env-start");
+    // The kill IPC must have been invoked before the spawn IPC.
+    const killOrder = mockKill.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY;
+    const spawnOrder = mockSpawn.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY;
+    expect(killOrder).toBeLessThan(spawnOrder);
   });
 });

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -461,16 +461,30 @@ export const createRestartActions = (
         spawnRows = managedInstance.terminal.rows || spawnRows;
       }
 
+      // Lock input on the live instance while the restart is in flight, so
+      // keystrokes can't leak into the kill/spawn window. Bypass the store
+      // action to avoid persisting `isInputLocked: true` to disk for a
+      // transient state.
+      terminalInstanceService.setInputLocked(id, true);
+
       // AGGRESSIVE TEARDOWN: Destroy frontend FIRST to prevent race condition
       terminalInstanceService.destroy(id);
 
       terminalInstanceService.suppressNextExit(id, 10000);
 
-      try {
-        await terminalClient.kill(id);
-      } catch (error) {
-        logWarn("[TerminalStore] kill failed during restart; continuing", { id, error });
-      }
+      // Capture project ID before async work to avoid race conditions (issue #3690).
+      const projectStore = await resolveProjectStore();
+      const capturedProjectId = projectStore.getState().currentProject?.id;
+
+      // Parallelize the kill IPC with the env-fetch IPCs (#9164): they have
+      // no ordering dependency, so awaiting them serially adds a needless
+      // round-trip to the restart hot path.
+      const [, restartEnv] = await Promise.all([
+        terminalClient.kill(id).catch((error: unknown) => {
+          logWarn("[TerminalStore] kill failed during restart; continuing", { id, error });
+        }),
+        buildRestartEnv(capturedProjectId, runtimeForEnv?.settings.env, "restart"),
+      ]);
 
       // Update terminal in store: increment restartKey, reset agent state, update location
       set((state) => {
@@ -510,15 +524,9 @@ export const createRestartActions = (
 
       await terminalInstanceService.waitForInstance(id, { timeoutMs: 5000 });
 
-      // Capture project ID before async work to avoid race conditions (issue #3690).
-      const projectStore = await resolveProjectStore();
-      const capturedProjectId = projectStore.getState().currentProject?.id;
-
-      const restartEnv = await buildRestartEnv(
-        capturedProjectId,
-        runtimeForEnv?.settings.env,
-        "restart"
-      );
+      // Re-apply the input lock on the freshly created xterm instance:
+      // xterm 6.0 does not inherit `disableStdin` across instance recreation.
+      terminalInstanceService.setInputLocked(id, true);
 
       await terminalClient.spawn({
         id,
@@ -546,6 +554,9 @@ export const createRestartActions = (
       } else {
         terminalInstanceService.fit(id);
       }
+
+      // Release the transient input lock now that the new PTY is live.
+      terminalInstanceService.setInputLocked(id, false);
 
       unmarkTerminalRestarting(id);
       set((state) => updateTerminal(state, id, (t) => ({ ...t, isRestarting: false })));
@@ -577,6 +588,10 @@ export const createRestartActions = (
           agentId: effectiveAgentId,
         },
       };
+
+      // Always release the transient input lock so a failed restart can't
+      // leave the (possibly recreated) instance permanently locked.
+      terminalInstanceService.setInputLocked(id, false);
 
       unmarkTerminalRestarting(id);
       set((state) =>


### PR DESCRIPTION
## Summary

- Manual terminal restart had no visible feedback, no input lock, and ran two independent IPC calls in series — all three fixed here.
- Adds a `{ type: "restarting" }` `RestartBannerVariant` that renders an `InlineStatusBanner` with `SpinnerIcon` for user-initiated restarts (same pattern as the existing auto-restart banner). Also gates the hybrid input bar on `isRestarting` so submissions during an in-flight restart on agent panels fail loudly instead of silently.
- Parallelizes `terminalClient.kill` and `buildRestartEnv` via `Promise.all`, removing one IPC round-trip from the restart hot path.

Resolves #9164

## Changes

- `restartStatus.ts` — new `"restarting"` variant returned when `isRestarting && !isAutoRestarting` with no errors present
- `restartBannerCopy.ts` — copy for the `"restarting"` variant ("Restarting…" with Unicode ellipsis)
- `TerminalRestartStatusBanner.tsx` — renders `InlineStatusBanner` for the new variant
- `restart.ts` — input locked via `terminalInstanceService.setInputLocked` before `destroy`, unlocked on both success and catch paths; `terminalClient.kill` + `buildRestartEnv` parallelized with `Promise.all`; `resolveProjectStore` + `capturedProjectId` hoisted before the parallel block
- `TerminalPane.tsx` — hybrid input bar gated on `isRestarting` to prevent silent PTY-killed failures

## Testing

49 vitest tests pass across three spec files. New tests cover: `restartStatus` returns `"restarting"` when appropriate and defers to auto-restart when both flags are true; `restartBannerCopy` renders the correct title; `restartTerminal` lock-before-destroy ordering, unlock on success, unlock on failure, no store-action call (lock isn't persisted to disk), and `kill` invoked before `spawn`.