### PR TITLE
fix(terminal): consolidate failure-banner errno wiring and surface diagnostics

### DIFF
--- a/src/components/Terminal/DiagnosticCopyButton.tsx
+++ b/src/components/Terminal/DiagnosticCopyButton.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Copy } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { sanitizeErrorText } from "@/utils/errorText";
+
+const COPIED_RESET_MS = 2000;
+
+export interface SpawnDiagnostics {
+  errno?: number;
+  syscall?: string;
+  path?: string;
+}
+
+export interface DiagnosticCopyButtonProps {
+  diagnostics: SpawnDiagnostics;
+  className?: string;
+}
+
+function formatDiagnostics(diagnostics: SpawnDiagnostics): string {
+  const parts: string[] = [];
+  if (typeof diagnostics.errno === "number") parts.push(`errno=${diagnostics.errno}`);
+  if (diagnostics.syscall) parts.push(`syscall=${sanitizeErrorText(diagnostics.syscall)}`);
+  if (diagnostics.path) parts.push(`path=${sanitizeErrorText(diagnostics.path)}`);
+  return parts.join(" ");
+}
+
+export function DiagnosticCopyButton({ diagnostics, className }: DiagnosticCopyButtonProps) {
+  const payload = formatDiagnostics(diagnostics);
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    generationRef.current += 1;
+    setCopied(false);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, [payload]);
+
+  useEffect(() => {
+    return () => {
+      generationRef.current += 1;
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const handleClick = useCallback(() => {
+    if (!payload) return;
+    if (!navigator.clipboard?.writeText) return;
+    const gen = generationRef.current;
+    void navigator.clipboard.writeText(payload).then(
+      () => {
+        if (gen !== generationRef.current) return;
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        setCopied(true);
+        timeoutRef.current = setTimeout(() => {
+          setCopied(false);
+          timeoutRef.current = null;
+        }, COPIED_RESET_MS);
+      },
+      () => {
+        // Clipboard rejected — stay silent.
+      }
+    );
+  }, [payload]);
+
+  if (!payload) return null;
+
+  return (
+    <div className={cn("mt-1 flex items-center gap-2 min-w-0", className)}>
+      <span
+        className="text-xs font-mono text-daintree-text/60 truncate min-w-0"
+        title={payload}
+        data-testid="diagnostic-payload"
+      >
+        {payload}
+      </span>
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-label={copied ? "Diagnostics copied" : "Copy diagnostics"}
+        className="flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/40 rounded transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0"
+      >
+        <Copy className="w-3 h-3" aria-hidden="true" />
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Terminal/DiagnosticCopyButton.tsx
+++ b/src/components/Terminal/DiagnosticCopyButton.tsx
@@ -16,11 +16,18 @@ export interface DiagnosticCopyButtonProps {
   className?: string;
 }
 
+// sanitizeErrorText() preserves HT/LF/CR by design (it's intended for multi-line
+// log text). For a single-line copy payload those would split values across
+// lines when pasted; collapse them to spaces here.
+function flattenWhitespace(text: string): string {
+  return sanitizeErrorText(text).replace(/[\t\r\n]+/g, " ");
+}
+
 function formatDiagnostics(diagnostics: SpawnDiagnostics): string {
   const parts: string[] = [];
   if (typeof diagnostics.errno === "number") parts.push(`errno=${diagnostics.errno}`);
-  if (diagnostics.syscall) parts.push(`syscall=${sanitizeErrorText(diagnostics.syscall)}`);
-  if (diagnostics.path) parts.push(`path=${sanitizeErrorText(diagnostics.path)}`);
+  if (diagnostics.syscall) parts.push(`syscall=${flattenWhitespace(diagnostics.syscall)}`);
+  if (diagnostics.path) parts.push(`path=${flattenWhitespace(diagnostics.path)}`);
   return parts.join(" ");
 }
 

--- a/src/components/Terminal/ReconnectErrorBanner.tsx
+++ b/src/components/Terminal/ReconnectErrorBanner.tsx
@@ -1,5 +1,5 @@
-import { Clock, RotateCcw, WifiOff } from "lucide-react";
-import { InlineStatusBanner } from "./InlineStatusBanner";
+import { Clock, RotateCcw, WifiOff, type LucideIcon } from "lucide-react";
+import { InlineStatusBanner, type InlineStatusBannerSeverity } from "./InlineStatusBanner";
 import { boundedErrorText } from "@/utils/errorText";
 import type { TerminalReconnectError } from "@/types";
 
@@ -12,37 +12,17 @@ export interface ReconnectErrorBannerProps {
   className?: string;
 }
 
-function getErrorTitle(type: TerminalReconnectError["type"]): string {
-  switch (type) {
-    case "timeout":
-      return "Reconnection timed out";
-    case "not_found":
-      return "Previous session not found";
-    default:
-      return "Reconnection failed";
-  }
+interface ReconnectBannerConfig {
+  title: string;
+  severity: InlineStatusBannerSeverity;
+  icon: LucideIcon;
 }
 
-function getErrorSeverity(type: TerminalReconnectError["type"]): "warning" | "error" {
-  switch (type) {
-    case "timeout":
-      return "warning";
-    case "not_found":
-    case "error":
-      return "error";
-    default:
-      return "warning";
-  }
-}
-
-function getErrorIcon(type: TerminalReconnectError["type"]) {
-  switch (type) {
-    case "timeout":
-      return Clock;
-    default:
-      return WifiOff;
-  }
-}
+const RECONNECT_BANNER_CONFIG = {
+  timeout: { title: "Reconnection timed out", severity: "warning", icon: Clock },
+  not_found: { title: "Previous session not found", severity: "error", icon: WifiOff },
+  error: { title: "Reconnection failed", severity: "error", icon: WifiOff },
+} as const satisfies Record<TerminalReconnectError["type"], ReconnectBannerConfig>;
 
 export function ReconnectErrorBanner({
   terminalId,
@@ -52,7 +32,7 @@ export function ReconnectErrorBanner({
   isRestarting = false,
   className,
 }: ReconnectErrorBannerProps) {
-  const severity = getErrorSeverity(error.type);
+  const config = RECONNECT_BANNER_CONFIG[error.type];
   const retryAction = {
     id: "retry",
     label: "Retry",
@@ -67,11 +47,11 @@ export function ReconnectErrorBanner({
   // Severity is computed from the error type, so branch on it to satisfy the
   // discriminated union on `InlineStatusBanner` (error banners take a single
   // `action`). Either way this banner shows exactly one action.
-  if (severity === "error") {
+  if (config.severity === "error") {
     return (
       <InlineStatusBanner
-        icon={getErrorIcon(error.type)}
-        title={getErrorTitle(error.type)}
+        icon={config.icon}
+        title={config.title}
         description={boundedErrorText(error.message)}
         severity="error"
         action={retryAction}
@@ -83,10 +63,10 @@ export function ReconnectErrorBanner({
 
   return (
     <InlineStatusBanner
-      icon={getErrorIcon(error.type)}
-      title={getErrorTitle(error.type)}
+      icon={config.icon}
+      title={config.title}
       description={boundedErrorText(error.message)}
-      severity={severity}
+      severity={config.severity}
       action={retryAction}
       onClose={() => onDismiss(terminalId)}
       className={className}

--- a/src/components/Terminal/ScrollbackRestoreErrorBanner.tsx
+++ b/src/components/Terminal/ScrollbackRestoreErrorBanner.tsx
@@ -1,4 +1,4 @@
-import { Clock, FileX2, History, RotateCcw } from "lucide-react";
+import { Clock, FileX2, History, RotateCcw, type LucideIcon } from "lucide-react";
 import { InlineStatusBanner } from "./InlineStatusBanner";
 import { boundedErrorText } from "@/utils/errorText";
 import type { TerminalScrollbackRestoreError } from "@/types";
@@ -12,45 +12,36 @@ export interface ScrollbackRestoreErrorBannerProps {
   className?: string;
 }
 
-function getErrorIcon(type: TerminalScrollbackRestoreError["type"]) {
-  switch (type) {
-    case "timeout":
-      return Clock;
-    case "parse":
-      return FileX2;
-    default:
-      return History;
-  }
+interface ScrollbackBannerConfig {
+  title: string;
+  icon: LucideIcon;
+  description: (message: string) => string;
 }
 
-function getErrorTitle(type: TerminalScrollbackRestoreError["type"]): string {
-  switch (type) {
-    case "timeout":
-      return "Scrollback restore timed out";
-    case "parse":
-      return "Scrollback contents couldn't be replayed";
-    default:
-      return "Scrollback restore failed";
-  }
-}
-
-function getErrorDescription(
-  type: TerminalScrollbackRestoreError["type"],
-  message: string
-): string {
-  // The terminal itself is still operational — only the replayed buffer is
-  // missing — so lead with that reassurance. The raw message is only useful
-  // for the generic "error" case, where the title doesn't already convey
-  // the cause; for "timeout" and "parse" the title is sufficient.
-  switch (type) {
-    case "timeout":
-      return "Replay didn't finish in time. The terminal still works — only its earlier output is missing.";
-    case "parse":
-      return "The saved buffer couldn't be replayed. The terminal still works — only its earlier output is missing.";
-    default:
-      return `${boundedErrorText(message)} The terminal still works — only its earlier output is missing.`;
-  }
-}
+// The terminal itself is still operational — only the replayed buffer is
+// missing — so the copy leads with that reassurance. The raw message is only
+// useful for the generic "error" case, where the title doesn't already convey
+// the cause; for "timeout" and "parse" the title is sufficient.
+const SCROLLBACK_BANNER_CONFIG = {
+  timeout: {
+    title: "Scrollback restore timed out",
+    icon: Clock,
+    description: () =>
+      "Replay didn't finish in time. The terminal still works — only its earlier output is missing.",
+  },
+  parse: {
+    title: "Scrollback contents couldn't be replayed",
+    icon: FileX2,
+    description: () =>
+      "The saved buffer couldn't be replayed. The terminal still works — only its earlier output is missing.",
+  },
+  error: {
+    title: "Scrollback restore failed",
+    icon: History,
+    description: (message) =>
+      `${boundedErrorText(message)} The terminal still works — only its earlier output is missing.`,
+  },
+} as const satisfies Record<TerminalScrollbackRestoreError["type"], ScrollbackBannerConfig>;
 
 export function ScrollbackRestoreErrorBanner({
   terminalId,
@@ -60,11 +51,12 @@ export function ScrollbackRestoreErrorBanner({
   isRestarting = false,
   className,
 }: ScrollbackRestoreErrorBannerProps) {
+  const config = SCROLLBACK_BANNER_CONFIG[error.type];
   return (
     <InlineStatusBanner
-      icon={getErrorIcon(error.type)}
-      title={getErrorTitle(error.type)}
-      description={getErrorDescription(error.type, error.message)}
+      icon={config.icon}
+      title={config.title}
+      description={config.description(error.message)}
       severity="warning"
       actions={[
         {

--- a/src/components/Terminal/ScrollbackRestoreErrorBanner.tsx
+++ b/src/components/Terminal/ScrollbackRestoreErrorBanner.tsx
@@ -38,8 +38,11 @@ const SCROLLBACK_BANNER_CONFIG = {
   error: {
     title: "Scrollback restore failed",
     icon: History,
-    description: (message) =>
-      `${boundedErrorText(message)} The terminal still works — only its earlier output is missing.`,
+    description: (message) => {
+      const sanitized = boundedErrorText(message);
+      const tail = "The terminal still works — only its earlier output is missing.";
+      return sanitized ? `${sanitized} ${tail}` : tail;
+    },
   },
 } as const satisfies Record<TerminalScrollbackRestoreError["type"], ScrollbackBannerConfig>;
 

--- a/src/components/Terminal/SpawnErrorBanner.tsx
+++ b/src/components/Terminal/SpawnErrorBanner.tsx
@@ -1,8 +1,10 @@
 import { XCircle, RotateCcw, FolderEdit, Trash2, Settings2 } from "lucide-react";
 import { InlineStatusBanner, type BannerAction } from "./InlineStatusBanner";
 import { BannerOverflowMenu } from "./BannerOverflowMenu";
-import { sanitizeErrorText, boundedErrorText } from "@/utils/errorText";
+import { sanitizeErrorText } from "@/utils/errorText";
 import { actionService } from "@/services/ActionService";
+import { SPAWN_ERROR_BANNER_COPY } from "./spawnErrorBannerCopy";
+import { DiagnosticCopyButton } from "./DiagnosticCopyButton";
 import type { SpawnError } from "@/types";
 
 const RESOURCE_LIMIT_CODES: ReadonlySet<SpawnError["code"]> = new Set([
@@ -23,65 +25,6 @@ export interface SpawnErrorBannerProps {
   className?: string;
 }
 
-function getErrorTitle(code: SpawnError["code"]): string {
-  switch (code) {
-    case "ENOENT":
-      return "Couldn't find shell or command";
-    case "EACCES":
-      return "Couldn't execute shell";
-    case "ENOTDIR":
-      return "Invalid working directory";
-    case "EIO":
-      return "Couldn't allocate terminal";
-    case "EMFILE":
-      return "File descriptor limit reached";
-    case "EAGAIN":
-      return "Process limit reached";
-    case "ENOMEM":
-      return "Out of memory";
-    case "ENXIO":
-      return "PTY pool exhausted";
-    case "EBUSY":
-      return "Terminal device busy";
-    case "DISCONNECTED":
-      return "Terminal disconnected";
-    default:
-      return "Couldn't start terminal";
-  }
-}
-
-function getErrorDescription(error: SpawnError, cwd?: string): string {
-  const safePath = error.path ? boundedErrorText(error.path) : "";
-  const safeCwd = cwd ? boundedErrorText(cwd) : "";
-  switch (error.code) {
-    case "ENOENT":
-      if (safePath) {
-        return `Couldn't find: ${safePath}`;
-      }
-      return boundedErrorText(error.message);
-    case "EACCES":
-      return `Couldn't execute ${safePath || "the shell"} — check permissions`;
-    case "ENOTDIR":
-      return `The working directory isn't valid: ${safeCwd || "(unknown)"}`;
-    case "EIO":
-      return "Couldn't allocate a terminal session. The system may be running low on resources.";
-    case "EMFILE":
-      return "The per-process file descriptor limit was reached. Try closing some terminals to free up descriptors.";
-    case "EAGAIN":
-      return "The system process limit was hit (fork failed). Wait a moment and retry, or close some terminals.";
-    case "ENOMEM":
-      return "The system is out of memory. Try closing other applications to free up memory.";
-    case "ENXIO":
-      return "The pseudo-terminal pool is exhausted. Try closing some terminals and retrying.";
-    case "EBUSY":
-      return "The terminal device is busy. Retry or close the conflicting terminal.";
-    case "DISCONNECTED":
-      return "The terminal process is no longer running.";
-    default:
-      return boundedErrorText(error.message);
-  }
-}
-
 export function SpawnErrorBanner({
   terminalId,
   error,
@@ -94,6 +37,7 @@ export function SpawnErrorBanner({
 }: SpawnErrorBannerProps) {
   const isCwdError = error.code === "ENOTDIR";
   const isResourceLimit = RESOURCE_LIMIT_CODES.has(error.code);
+  const copy = SPAWN_ERROR_BANNER_COPY[error.code];
 
   const retryAction: BannerAction = {
     id: "retry",
@@ -150,14 +94,27 @@ export function SpawnErrorBanner({
     trashAction,
   ];
 
+  const hasDiagnostics = typeof error.errno === "number" || !!error.syscall || !!error.path;
+
   return (
     <InlineStatusBanner
       icon={XCircle}
-      title={getErrorTitle(error.code)}
-      description={getErrorDescription(error, cwd)}
+      title={copy.title}
+      description={copy.description(error, cwd)}
       contextLine={cwd ? `Directory: ${sanitizeErrorText(cwd)}` : undefined}
       severity="error"
       action={primaryAction}
+      descriptionExtras={
+        hasDiagnostics ? (
+          <DiagnosticCopyButton
+            diagnostics={{
+              errno: error.errno,
+              syscall: error.syscall,
+              path: error.path,
+            }}
+          />
+        ) : undefined
+      }
       trailingSlot={
         <BannerOverflowMenu actions={overflowActions} ariaLabel="More recovery options" />
       }

--- a/src/components/Terminal/__tests__/DiagnosticCopyButton.test.tsx
+++ b/src/components/Terminal/__tests__/DiagnosticCopyButton.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+import { DiagnosticCopyButton } from "../DiagnosticCopyButton";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+function stubClipboard(writeText: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+}
+
+describe("DiagnosticCopyButton", () => {
+  it("renders nothing when all diagnostic fields are absent", () => {
+    const { container } = render(<DiagnosticCopyButton diagnostics={{}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("formats errno as a number with no quotes", () => {
+    render(<DiagnosticCopyButton diagnostics={{ errno: -2 }} />);
+    expect(screen.getByTestId("diagnostic-payload").textContent).toBe("errno=-2");
+  });
+
+  it("sanitizes escape sequences from path before display", () => {
+    render(<DiagnosticCopyButton diagnostics={{ path: "[31m/bad/path" }} />);
+    expect(screen.getByTestId("diagnostic-payload").textContent).toBe("path=/bad/path");
+  });
+
+  it("writes the formatted payload to clipboard and shows Copied state", async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    stubClipboard(writeText);
+
+    render(
+      <DiagnosticCopyButton diagnostics={{ errno: 13, syscall: "spawn", path: "/usr/bin/zsh" }} />
+    );
+
+    const button = screen.getByRole("button", { name: /copy diagnostics/i });
+    fireEvent.click(button);
+    expect(writeText).toHaveBeenCalledWith("errno=13 syscall=spawn path=/usr/bin/zsh");
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("button", { name: /diagnostics copied/i })).toBeTruthy();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByRole("button", { name: /copy diagnostics/i })).toBeTruthy();
+  });
+
+  it("does not throw when clipboard.writeText is unavailable", () => {
+    const original = navigator.clipboard;
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      render(<DiagnosticCopyButton diagnostics={{ errno: 1 }} />);
+      const button = screen.getByRole("button", { name: /copy diagnostics/i });
+      expect(() => fireEvent.click(button)).not.toThrow();
+    } finally {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: original,
+      });
+    }
+  });
+
+  it("ignores stale clipboard resolution after payload change", async () => {
+    vi.useFakeTimers();
+    let resolveWrite: () => void = () => {};
+    const writeText = vi
+      .fn()
+      .mockImplementation(() => new Promise<void>((resolve) => (resolveWrite = resolve)));
+    stubClipboard(writeText);
+
+    const { rerender } = render(<DiagnosticCopyButton diagnostics={{ errno: 1 }} />);
+    fireEvent.click(screen.getByRole("button", { name: /copy diagnostics/i }));
+
+    rerender(<DiagnosticCopyButton diagnostics={{ errno: 2 }} />);
+    await act(async () => {
+      resolveWrite();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByRole("button", { name: /diagnostics copied/i })).toBeNull();
+  });
+});

--- a/src/components/Terminal/__tests__/DiagnosticCopyButton.test.tsx
+++ b/src/components/Terminal/__tests__/DiagnosticCopyButton.test.tsx
@@ -48,6 +48,22 @@ describe("DiagnosticCopyButton", () => {
     expect(screen.getByTestId("diagnostic-payload").textContent).toBe("path=/bad/path");
   });
 
+  it("writes the same sanitized payload to clipboard as it displays", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    stubClipboard(writeText);
+    render(<DiagnosticCopyButton diagnostics={{ path: "\x1b[31m/bad/path", syscall: "spawn" }} />);
+    fireEvent.click(screen.getByRole("button", { name: /copy diagnostics/i }));
+    expect(writeText).toHaveBeenCalledWith("syscall=spawn path=/bad/path");
+  });
+
+  it("collapses newlines/tabs/carriage-returns in path or syscall to single spaces", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    stubClipboard(writeText);
+    render(<DiagnosticCopyButton diagnostics={{ path: "/a/b\n/c\td", syscall: "spa\rwn" }} />);
+    fireEvent.click(screen.getByRole("button", { name: /copy diagnostics/i }));
+    expect(writeText).toHaveBeenCalledWith("syscall=spa wn path=/a/b /c d");
+  });
+
   it("writes the formatted payload to clipboard and shows Copied state", async () => {
     vi.useFakeTimers();
     const writeText = vi.fn().mockResolvedValue(undefined);

--- a/src/components/Terminal/__tests__/ScrollbackRestoreErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/ScrollbackRestoreErrorBanner.test.tsx
@@ -83,6 +83,13 @@ describe("ScrollbackRestoreErrorBanner", () => {
     expect(screen.queryByText(/should not appear/i)).toBeNull();
   });
 
+  it("omits a leading space when the error message is empty", () => {
+    renderBanner("error", { message: "" });
+    const text = screen.getByText(/the terminal still works/i).textContent ?? "";
+    expect(text.startsWith(" ")).toBe(false);
+    expect(text).toBe("The terminal still works — only its earlier output is missing.");
+  });
+
   it("invokes onRestart with the terminal id when reset is clicked", () => {
     const onRestart = vi.fn();
     renderBanner("error", { onRestart });

--- a/src/components/Terminal/__tests__/ScrollbackRestoreErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/ScrollbackRestoreErrorBanner.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { TerminalScrollbackRestoreError } from "@/types";
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { ScrollbackRestoreErrorBanner } from "../ScrollbackRestoreErrorBanner";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderBanner(
+  type: TerminalScrollbackRestoreError["type"],
+  overrides: Partial<{
+    message: string;
+    isRestarting: boolean;
+    onRestart: (id: string) => void;
+    onDismiss: (id: string) => void;
+  }> = {}
+) {
+  const error: TerminalScrollbackRestoreError = {
+    type,
+    message: overrides.message ?? `simulated ${type} error`,
+    timestamp: 1700000000000,
+  };
+  return render(
+    <ScrollbackRestoreErrorBanner
+      terminalId="t-1"
+      error={error}
+      onDismiss={overrides.onDismiss ?? vi.fn()}
+      onRestart={overrides.onRestart ?? vi.fn()}
+      isRestarting={overrides.isRestarting}
+    />
+  );
+}
+
+describe("ScrollbackRestoreErrorBanner", () => {
+  it("renders the timeout title for timeout errors", () => {
+    renderBanner("timeout");
+    expect(screen.getByText(/scrollback restore timed out/i)).toBeTruthy();
+  });
+
+  it("renders the parse title for parse errors", () => {
+    renderBanner("parse");
+    expect(screen.getByText(/scrollback contents couldn't be replayed/i)).toBeTruthy();
+  });
+
+  it("renders the generic title for error type", () => {
+    renderBanner("error");
+    expect(screen.getByText(/scrollback restore failed/i)).toBeTruthy();
+  });
+
+  it("includes the message text in the description for the error type", () => {
+    renderBanner("error", { message: "boom from disk" });
+    expect(screen.getByText(/boom from disk/i)).toBeTruthy();
+  });
+
+  it("does not include the raw message in the description for timeout type", () => {
+    renderBanner("timeout", { message: "should not appear" });
+    expect(screen.queryByText(/should not appear/i)).toBeNull();
+  });
+
+  it("invokes onRestart with the terminal id when reset is clicked", () => {
+    const onRestart = vi.fn();
+    renderBanner("error", { onRestart });
+    fireEvent.click(screen.getByRole("button", { name: /reset terminal/i }));
+    expect(onRestart).toHaveBeenCalledWith("t-1");
+  });
+
+  it("invokes onDismiss when the close button is clicked", () => {
+    const onDismiss = vi.fn();
+    renderBanner("error", { onDismiss });
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledWith("t-1");
+  });
+
+  it("disables reset and shows aria-busy when isRestarting is true", () => {
+    renderBanner("error", { isRestarting: true });
+    const button = screen.getByRole("button", { name: /reset terminal/i });
+    expect(button.hasAttribute("disabled")).toBe(true);
+    expect(button.getAttribute("aria-busy")).toBe("true");
+  });
+});

--- a/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
@@ -120,14 +120,21 @@ describe("SpawnErrorBanner", () => {
     expect(screen.getByText(title)).toBeTruthy();
   });
 
-  it("renders the PENDING_SPAWNS_CAPPED title", () => {
-    renderBanner("PENDING_SPAWNS_CAPPED");
-    expect(screen.getByText(/too many pending restarts/i)).toBeTruthy();
+  // Hardcoded oracles — guard against a copy-table transposition that the
+  // table-driven test above would silently accept.
+  it.each([
+    ["ENOENT", "Couldn't find shell or command"],
+    ["EACCES", "Couldn't execute shell"],
+    ["ENOTDIR", "Invalid working directory"],
+    ["PENDING_SPAWNS_CAPPED", "Too many pending restarts"],
+    ["UNKNOWN", "Couldn't start terminal"],
+  ] as const)("renders the expected title for %s", (code, expected) => {
+    renderBanner(code);
+    expect(screen.getByText(expected)).toBeTruthy();
   });
 
   it("renders the UNKNOWN code with the message as description", () => {
     renderBanner("UNKNOWN");
-    expect(screen.getByText(/couldn't start terminal/i)).toBeTruthy();
     expect(screen.getByText(/simulated UNKNOWN error/i)).toBeTruthy();
   });
 
@@ -249,7 +256,7 @@ describe("SpawnErrorBanner", () => {
       expect(screen.getByTestId("diagnostic-payload").textContent).toBe("path=/bin/missing");
     });
 
-    it("renders the diagnostics section but not the copy button when clipboard is unavailable", () => {
+    it("still renders the copy button when clipboard is unavailable, but clicking is a no-op", () => {
       const original = navigator.clipboard;
       Object.defineProperty(navigator, "clipboard", {
         configurable: true,
@@ -258,7 +265,10 @@ describe("SpawnErrorBanner", () => {
       try {
         renderBanner("ENOENT", { errno: -2, syscall: "spawn", path: "/bin/x" });
         const button = screen.getByRole("button", { name: /copy diagnostics/i });
-        fireEvent.click(button);
+        expect(button).toBeTruthy();
+        expect(() => fireEvent.click(button)).not.toThrow();
+        // Label stays at "Copy diagnostics" (never flips to "Diagnostics copied").
+        expect(screen.queryByRole("button", { name: /diagnostics copied/i })).toBeNull();
       } finally {
         Object.defineProperty(navigator, "clipboard", {
           configurable: true,

--- a/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
@@ -32,6 +32,25 @@ vi.mock("@/components/ui/popover", () => ({
 }));
 
 import { SpawnErrorBanner } from "../SpawnErrorBanner";
+import { SPAWN_ERROR_BANNER_COPY } from "../spawnErrorBannerCopy";
+
+// Listing every variant explicitly (rather than `Object.keys() as SpawnErrorCode[]`)
+// keeps the array's element type sound and forces the test to be updated when a
+// new SpawnErrorCode is added.
+const ALL_SPAWN_ERROR_CODES: readonly SpawnErrorCode[] = [
+  "ENOENT",
+  "EACCES",
+  "ENOTDIR",
+  "EIO",
+  "EMFILE",
+  "EAGAIN",
+  "ENOMEM",
+  "ENXIO",
+  "EBUSY",
+  "DISCONNECTED",
+  "PENDING_SPAWNS_CAPPED",
+  "UNKNOWN",
+] as const;
 
 beforeAll(() => {
   Object.defineProperty(window, "matchMedia", {
@@ -55,6 +74,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 function renderBanner(
@@ -64,16 +84,24 @@ function renderBanner(
     onRetry: (id: string) => void;
     onTrash: (id: string) => void;
     onUpdateCwd: (id: string) => void;
+    errno: number;
+    syscall: string;
+    path: string;
+    cwd: string;
   }> = {}
 ) {
   const error: SpawnError = {
     code,
     message: `simulated ${code} error`,
+    errno: overrides.errno,
+    syscall: overrides.syscall,
+    path: overrides.path,
   };
   return render(
     <SpawnErrorBanner
       terminalId="t-1"
       error={error}
+      cwd={overrides.cwd}
       onUpdateCwd={overrides.onUpdateCwd ?? vi.fn()}
       onRetry={overrides.onRetry ?? vi.fn()}
       onTrash={overrides.onTrash ?? vi.fn()}
@@ -85,6 +113,24 @@ function renderBanner(
 const overflow = () => screen.getByTestId("overflow-content");
 
 describe("SpawnErrorBanner", () => {
+  it.each(ALL_SPAWN_ERROR_CODES)("renders a non-empty title for %s", (code) => {
+    renderBanner(code);
+    const title = SPAWN_ERROR_BANNER_COPY[code].title;
+    expect(title.length).toBeGreaterThan(0);
+    expect(screen.getByText(title)).toBeTruthy();
+  });
+
+  it("renders the PENDING_SPAWNS_CAPPED title", () => {
+    renderBanner("PENDING_SPAWNS_CAPPED");
+    expect(screen.getByText(/too many pending restarts/i)).toBeTruthy();
+  });
+
+  it("renders the UNKNOWN code with the message as description", () => {
+    renderBanner("UNKNOWN");
+    expect(screen.getByText(/couldn't start terminal/i)).toBeTruthy();
+    expect(screen.getByText(/simulated UNKNOWN error/i)).toBeTruthy();
+  });
+
   it("keeps a single inline action and moves Remove terminal into the overflow menu", () => {
     renderBanner("ENOENT");
     // Generic error → Retry is the sole inline action (outside the overflow).
@@ -178,5 +224,47 @@ describe("SpawnErrorBanner", () => {
     expect(retry.hasAttribute("disabled")).toBe(true);
     fireEvent.click(retry);
     expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  describe("diagnostic fields", () => {
+    it("renders no diagnostics section when errno/syscall/path are all absent", () => {
+      renderBanner("ENOENT");
+      expect(screen.queryByRole("button", { name: /copy diagnostics/i })).toBeNull();
+      expect(screen.queryByTestId("diagnostic-payload")).toBeNull();
+    });
+
+    it("renders all three diagnostic fields when present", () => {
+      renderBanner("ENOENT", { errno: -2, syscall: "spawn", path: "/usr/bin/zsh" });
+      const payload = screen.getByTestId("diagnostic-payload");
+      expect(payload.textContent).toBe("errno=-2 syscall=spawn path=/usr/bin/zsh");
+    });
+
+    it("omits absent fields from the payload (errno only)", () => {
+      renderBanner("EACCES", { errno: 13 });
+      expect(screen.getByTestId("diagnostic-payload").textContent).toBe("errno=13");
+    });
+
+    it("omits absent fields from the payload (path only)", () => {
+      renderBanner("ENOENT", { path: "/bin/missing" });
+      expect(screen.getByTestId("diagnostic-payload").textContent).toBe("path=/bin/missing");
+    });
+
+    it("renders the diagnostics section but not the copy button when clipboard is unavailable", () => {
+      const original = navigator.clipboard;
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: undefined,
+      });
+      try {
+        renderBanner("ENOENT", { errno: -2, syscall: "spawn", path: "/bin/x" });
+        const button = screen.getByRole("button", { name: /copy diagnostics/i });
+        fireEvent.click(button);
+      } finally {
+        Object.defineProperty(navigator, "clipboard", {
+          configurable: true,
+          value: original,
+        });
+      }
+    });
   });
 });

--- a/src/components/Terminal/__tests__/TerminalErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalErrorBanner.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { TerminalRestartError } from "@/types";
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Render the overflow popover open so the demoted trash button is queryable.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverAnchor: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="overflow-content">{children}</div>
+  ),
+}));
+
+import { TerminalErrorBanner } from "../TerminalErrorBanner";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderBanner(
+  error: TerminalRestartError,
+  overrides: Partial<{
+    isRestarting: boolean;
+    onRetry: (id: string) => void;
+    onTrash: (id: string) => void;
+    onUpdateCwd: (id: string) => void;
+  }> = {}
+) {
+  return render(
+    <TerminalErrorBanner
+      terminalId="t-1"
+      error={error}
+      onUpdateCwd={overrides.onUpdateCwd ?? vi.fn()}
+      onRetry={overrides.onRetry ?? vi.fn()}
+      onTrash={overrides.onTrash ?? vi.fn()}
+      isRestarting={overrides.isRestarting}
+    />
+  );
+}
+
+describe("TerminalErrorBanner", () => {
+  it("renders the restart-failed title", () => {
+    renderBanner({
+      message: "child process died",
+      recoverable: true,
+      timestamp: 1,
+    });
+    expect(screen.getByText(/terminal restart failed/i)).toBeTruthy();
+  });
+
+  it("does not show Change directory for non-ENOENT errors", () => {
+    renderBanner({
+      message: "child process died",
+      recoverable: true,
+      timestamp: 1,
+    });
+    expect(screen.queryByRole("button", { name: /update working directory/i })).toBeNull();
+  });
+
+  it("shows Change directory for ENOENT with failed cwd context", () => {
+    renderBanner({
+      message: "ENOENT",
+      code: "ENOENT",
+      recoverable: true,
+      timestamp: 1,
+      context: { failedCwd: "/missing/dir" },
+    });
+    expect(screen.getByRole("button", { name: /update working directory/i })).toBeTruthy();
+  });
+
+  it("hides Change directory when error is non-recoverable", () => {
+    renderBanner({
+      message: "ENOENT",
+      code: "ENOENT",
+      recoverable: false,
+      timestamp: 1,
+      context: { failedCwd: "/missing/dir" },
+    });
+    expect(screen.queryByRole("button", { name: /update working directory/i })).toBeNull();
+  });
+
+  it("renders the failed cwd in the context line", () => {
+    renderBanner({
+      message: "ENOENT",
+      code: "ENOENT",
+      recoverable: true,
+      timestamp: 1,
+      context: { failedCwd: "/missing/dir" },
+    });
+    expect(screen.getByText(/directory:.*\/missing\/dir/i)).toBeTruthy();
+  });
+
+  it("invokes onRetry with the terminal id", () => {
+    const onRetry = vi.fn();
+    renderBanner(
+      {
+        message: "failed",
+        recoverable: true,
+        timestamp: 1,
+      },
+      { onRetry }
+    );
+    fireEvent.click(screen.getByRole("button", { name: /retry restart/i }));
+    expect(onRetry).toHaveBeenCalledWith("t-1");
+  });
+
+  it("invokes onTrash with the terminal id", () => {
+    const onTrash = vi.fn();
+    renderBanner(
+      {
+        message: "failed",
+        recoverable: true,
+        timestamp: 1,
+      },
+      { onTrash }
+    );
+    fireEvent.click(screen.getByRole("button", { name: /move to trash/i }));
+    expect(onTrash).toHaveBeenCalledWith("t-1");
+  });
+
+  it("disables retry and shows aria-busy when isRestarting is true", () => {
+    renderBanner(
+      {
+        message: "failed",
+        recoverable: true,
+        timestamp: 1,
+      },
+      { isRestarting: true }
+    );
+    const retry = screen.getByRole("button", { name: /retry restart/i });
+    expect(retry.hasAttribute("disabled")).toBe(true);
+    expect(retry.getAttribute("aria-busy")).toBe("true");
+  });
+});

--- a/src/components/Terminal/spawnErrorBannerCopy.ts
+++ b/src/components/Terminal/spawnErrorBannerCopy.ts
@@ -1,0 +1,73 @@
+import type { SpawnError, SpawnErrorCode } from "@shared/types/pty-host";
+import { boundedErrorText } from "@/utils/errorText";
+
+export interface SpawnErrorBannerCopy {
+  title: string;
+  description: (error: SpawnError, cwd?: string) => string;
+}
+
+export const SPAWN_ERROR_BANNER_COPY = {
+  ENOENT: {
+    title: "Couldn't find shell or command",
+    description: (error) => {
+      const safePath = error.path ? boundedErrorText(error.path) : "";
+      return safePath ? `Couldn't find: ${safePath}` : boundedErrorText(error.message);
+    },
+  },
+  EACCES: {
+    title: "Couldn't execute shell",
+    description: (error) => {
+      const safePath = error.path ? boundedErrorText(error.path) : "";
+      return `Couldn't execute ${safePath || "the shell"} — check permissions`;
+    },
+  },
+  ENOTDIR: {
+    title: "Invalid working directory",
+    description: (_error, cwd) => {
+      const safeCwd = cwd ? boundedErrorText(cwd) : "";
+      return `The working directory isn't valid: ${safeCwd || "(unknown)"}`;
+    },
+  },
+  EIO: {
+    title: "Couldn't allocate terminal",
+    description: () =>
+      "Couldn't allocate a terminal session. The system may be running low on resources.",
+  },
+  EMFILE: {
+    title: "File descriptor limit reached",
+    description: () =>
+      "The per-process file descriptor limit was reached. Try closing some terminals to free up descriptors.",
+  },
+  EAGAIN: {
+    title: "Process limit reached",
+    description: () =>
+      "The system process limit was hit (fork failed). Wait a moment and retry, or close some terminals.",
+  },
+  ENOMEM: {
+    title: "Out of memory",
+    description: () =>
+      "The system is out of memory. Try closing other applications to free up memory.",
+  },
+  ENXIO: {
+    title: "PTY pool exhausted",
+    description: () =>
+      "The pseudo-terminal pool is exhausted. Try closing some terminals and retrying.",
+  },
+  EBUSY: {
+    title: "Terminal device busy",
+    description: () => "The terminal device is busy. Retry or close the conflicting terminal.",
+  },
+  DISCONNECTED: {
+    title: "Terminal disconnected",
+    description: () => "The terminal process is no longer running.",
+  },
+  PENDING_SPAWNS_CAPPED: {
+    title: "Too many pending restarts",
+    description: () =>
+      "Restart requests are being throttled to prevent a restart storm. Wait a moment and retry.",
+  },
+  UNKNOWN: {
+    title: "Couldn't start terminal",
+    description: (error) => boundedErrorText(error.message),
+  },
+} as const satisfies Record<SpawnErrorCode, SpawnErrorBannerCopy>;


### PR DESCRIPTION
## Summary

- Replaces the duplicate per-errno switch chains across `SpawnErrorBanner`, `ReconnectErrorBanner`, and `ScrollbackRestoreErrorBanner` with `satisfies Record<K, V>` lookup tables so adding a new discriminant is a compile error if any banner forgets to handle it.
- Adds `DiagnosticCopyButton`, a terminal-local widget that surfaces `SpawnError.errno`, `syscall`, and `path` as a compact monospace line plus a click-to-copy button. Wired into `SpawnErrorBanner` via the existing `InlineStatusBanner.descriptionExtras` slot — no changes to `InlineStatusBanner` itself.

Resolves #9136.

## Changes

- `src/components/Terminal/spawnErrorBannerCopy.ts` — new shared copy table; exhaustive over all 12 `SpawnErrorCode` variants (adds copy for the previously-unhandled `PENDING_SPAWNS_CAPPED` and `UNKNOWN`).
- `src/components/Terminal/DiagnosticCopyButton.tsx` — new component; mirrors the generation-counter + 2000ms-reset clipboard pattern from `ErrorBanner.tsx`. Renders nothing when no diagnostic fields are present, guards against missing `navigator.clipboard`, and sanitises path/syscall before both display and clipboard payload (collapsing tabs/newlines/CRs so multi-line paths don't fragment when pasted into a shell).
- `src/components/Terminal/SpawnErrorBanner.tsx` — switches replaced with the lookup table; `DiagnosticCopyButton` wired through `descriptionExtras`.
- `src/components/Terminal/ReconnectErrorBanner.tsx` — three per-type switches collapsed into one `RECONNECT_BANNER_CONFIG` record.
- `src/components/Terminal/ScrollbackRestoreErrorBanner.tsx` — three per-type switches collapsed into one `SCROLLBACK_BANNER_CONFIG` record; generic-error description no longer renders a leading space when the underlying message is empty.

`TerminalErrorBanner.tsx` is intentionally left unchanged — its `TerminalRestartError.code` is `string?` (not a union), so a `Record` would have no exhaustiveness benefit. `correlationId` is intentionally not threaded through the structured error types in this PR (would touch pty-host, store slices, and IPC handlers — disproportionate to the gain for this refactor; tracked as follow-up).

## Testing

- New `DiagnosticCopyButton.test.tsx`, `ScrollbackRestoreErrorBanner.test.tsx`, `TerminalErrorBanner.test.tsx`.
- Extended `SpawnErrorBanner.test.tsx` with coverage for every `SpawnErrorCode` (including the newly-handled `PENDING_SPAWNS_CAPPED` and `UNKNOWN`), hardcoded title spot-checks to catch copy-table transpositions, and the diagnostics-display + clipboard-unavailable paths.
- 69 tests pass across the affected files; full `npm run check` (typecheck, ratchets, format) clean.

## Test plan

- [x] All affected unit-test files pass locally
- [x] `npm run check` clean (typecheck, IPC ratchets, lint ratchet, format)
- [ ] CI green