### PR TITLE
fix(clipboard): bound temp-file accumulation and cap write payload sizes

### DIFF
--- a/electron/__tests__/clipboard.test.ts
+++ b/electron/__tests__/clipboard.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+// Mock electron so importing the clipboard handler module doesn't pull in the
+// real native bindings. The cleanup logic under test never touches these.
+vi.mock("electron", () => ({
+  clipboard: { readImage: vi.fn(), writeImage: vi.fn(), writeText: vi.fn(), readText: vi.fn() },
+  nativeImage: { createFromBuffer: vi.fn(), createFromPath: vi.fn() },
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+}));
+
+// Redirect os.tmpdir() to a throwaway directory so the cleanup operates on real
+// files we control. The base dir is created inside the factory where the real
+// os module is still available.
+const osMockState = vi.hoisted(() => ({ base: "" }));
+vi.mock("node:os", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("node:os");
+  const nodeFs = await import("node:fs");
+  const nodePath = await import("node:path");
+  osMockState.base = nodeFs.mkdtempSync(nodePath.join(actual.tmpdir(), "clipboard-test-"));
+  return { ...actual, tmpdir: () => osMockState.base };
+});
+
+// Dynamic import so the mocks apply before the module loads.
+const { cleanupOldClipboardImages } = await import("../ipc/handlers/clipboard.js");
+
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const MAX_FILE_COUNT = 20;
+// Round to a second boundary to avoid mtime truncation on filesystems with 1s
+// granularity (ext4).
+const NOW = Math.floor(Date.now() / 1000) * 1000;
+
+function clipboardDir(): string {
+  return path.join(osMockState.base, "daintree-clipboard");
+}
+
+async function createClipboardFile(name: string, ageMs: number): Promise<string> {
+  const filePath = path.join(clipboardDir(), name);
+  await fs.writeFile(filePath, "png-bytes");
+  const mtime = new Date(NOW - ageMs);
+  await fs.utimes(filePath, mtime, mtime);
+  return filePath;
+}
+
+async function listClipboardFiles(): Promise<string[]> {
+  const entries = await fs.readdir(clipboardDir());
+  return entries.sort();
+}
+
+beforeEach(async () => {
+  await fs.rm(clipboardDir(), { recursive: true, force: true });
+  await fs.mkdir(clipboardDir(), { recursive: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterAll(async () => {
+  await fs.rm(osMockState.base, { recursive: true, force: true });
+});
+
+describe("cleanupOldClipboardImages — age eviction", () => {
+  it("deletes files older than the 24h window", async () => {
+    const old = await createClipboardFile("clipboard-1-aaa.png", MAX_AGE_MS + 60_000);
+    await cleanupOldClipboardImages();
+    await expect(fs.access(old)).rejects.toThrow();
+  });
+
+  it("preserves files within the 24h window", async () => {
+    const fresh = await createClipboardFile("clipboard-2-bbb.png", MAX_AGE_MS - 60_000);
+    await cleanupOldClipboardImages();
+    await expect(fs.access(fresh)).resolves.toBeUndefined();
+  });
+
+  it("ignores files that don't match the clipboard naming pattern", async () => {
+    const other = path.join(clipboardDir(), "unrelated.txt");
+    await fs.writeFile(other, "keep me");
+    const mtime = new Date(NOW - (MAX_AGE_MS + 60_000));
+    await fs.utimes(other, mtime, mtime);
+
+    await cleanupOldClipboardImages();
+    await expect(fs.access(other)).resolves.toBeUndefined();
+  });
+
+  it("returns without error when the clipboard dir doesn't exist", async () => {
+    await fs.rm(clipboardDir(), { recursive: true, force: true });
+    await expect(cleanupOldClipboardImages()).resolves.toBeUndefined();
+  });
+});
+
+describe("cleanupOldClipboardImages — count cap", () => {
+  it("keeps only the newest MAX_FILE_COUNT files when more survive the age check", async () => {
+    const total = MAX_FILE_COUNT + 5;
+    // Older index => older mtime. All within the 24h window so age eviction
+    // doesn't apply; only the count cap should.
+    for (let i = 0; i < total; i++) {
+      const ageMs = (total - i) * 60_000; // i=0 oldest, i=total-1 newest
+      await createClipboardFile(`clipboard-${i}-x.png`, ageMs);
+    }
+
+    await cleanupOldClipboardImages();
+
+    const remaining = await listClipboardFiles();
+    expect(remaining).toHaveLength(MAX_FILE_COUNT);
+    // The 5 oldest (indices 0-4) should be gone; the newest 20 (5-24) kept.
+    expect(remaining).not.toContain("clipboard-0-x.png");
+    expect(remaining).not.toContain("clipboard-4-x.png");
+    expect(remaining).toContain("clipboard-5-x.png");
+    expect(remaining).toContain(`clipboard-${total - 1}-x.png`);
+  });
+
+  it("does not evict when exactly MAX_FILE_COUNT files survive", async () => {
+    for (let i = 0; i < MAX_FILE_COUNT; i++) {
+      await createClipboardFile(`clipboard-${i}-x.png`, (i + 1) * 60_000);
+    }
+
+    await cleanupOldClipboardImages();
+
+    const remaining = await listClipboardFiles();
+    expect(remaining).toHaveLength(MAX_FILE_COUNT);
+  });
+
+  it("applies age eviction before the count cap", async () => {
+    // 3 old (evicted by age) + 22 fresh. After age eviction 22 survive; count
+    // cap trims to 20.
+    for (let i = 0; i < 3; i++) {
+      await createClipboardFile(`clipboard-old-${i}.png`, MAX_AGE_MS + (i + 1) * 60_000);
+    }
+    for (let i = 0; i < 22; i++) {
+      await createClipboardFile(`clipboard-fresh-${i}.png`, (i + 1) * 1_000);
+    }
+
+    await cleanupOldClipboardImages();
+
+    const remaining = await listClipboardFiles();
+    expect(remaining).toHaveLength(MAX_FILE_COUNT);
+    expect(remaining.every((name) => name.startsWith("clipboard-fresh-"))).toBe(true);
+  });
+});

--- a/electron/__tests__/clipboard.test.ts
+++ b/electron/__tests__/clipboard.test.ts
@@ -64,14 +64,25 @@ afterAll(async () => {
 describe("cleanupOldClipboardImages — age eviction", () => {
   it("deletes files older than the 24h window", async () => {
     const old = await createClipboardFile("clipboard-1-aaa.png", MAX_AGE_MS + 60_000);
-    await cleanupOldClipboardImages();
+    await cleanupOldClipboardImages(NOW);
     await expect(fs.access(old)).rejects.toThrow();
   });
 
   it("preserves files within the 24h window", async () => {
     const fresh = await createClipboardFile("clipboard-2-bbb.png", MAX_AGE_MS - 60_000);
-    await cleanupOldClipboardImages();
+    await cleanupOldClipboardImages(NOW);
     await expect(fs.access(fresh)).resolves.toBeUndefined();
+  });
+
+  it("preserves a file exactly at the 24h boundary but evicts one past it", async () => {
+    const atBoundary = await createClipboardFile("clipboard-at-boundary.png", MAX_AGE_MS);
+    const pastBoundary = await createClipboardFile(
+      "clipboard-past-boundary.png",
+      MAX_AGE_MS + 1000
+    );
+    await cleanupOldClipboardImages(NOW);
+    await expect(fs.access(atBoundary)).resolves.toBeUndefined();
+    await expect(fs.access(pastBoundary)).rejects.toThrow();
   });
 
   it("ignores files that don't match the clipboard naming pattern", async () => {
@@ -80,13 +91,13 @@ describe("cleanupOldClipboardImages — age eviction", () => {
     const mtime = new Date(NOW - (MAX_AGE_MS + 60_000));
     await fs.utimes(other, mtime, mtime);
 
-    await cleanupOldClipboardImages();
+    await cleanupOldClipboardImages(NOW);
     await expect(fs.access(other)).resolves.toBeUndefined();
   });
 
   it("returns without error when the clipboard dir doesn't exist", async () => {
     await fs.rm(clipboardDir(), { recursive: true, force: true });
-    await expect(cleanupOldClipboardImages()).resolves.toBeUndefined();
+    await expect(cleanupOldClipboardImages(NOW)).resolves.toBeUndefined();
   });
 });
 
@@ -100,7 +111,7 @@ describe("cleanupOldClipboardImages — count cap", () => {
       await createClipboardFile(`clipboard-${i}-x.png`, ageMs);
     }
 
-    await cleanupOldClipboardImages();
+    await cleanupOldClipboardImages(NOW);
 
     const remaining = await listClipboardFiles();
     expect(remaining).toHaveLength(MAX_FILE_COUNT);
@@ -116,7 +127,7 @@ describe("cleanupOldClipboardImages — count cap", () => {
       await createClipboardFile(`clipboard-${i}-x.png`, (i + 1) * 60_000);
     }
 
-    await cleanupOldClipboardImages();
+    await cleanupOldClipboardImages(NOW);
 
     const remaining = await listClipboardFiles();
     expect(remaining).toHaveLength(MAX_FILE_COUNT);
@@ -132,10 +143,15 @@ describe("cleanupOldClipboardImages — count cap", () => {
       await createClipboardFile(`clipboard-fresh-${i}.png`, (i + 1) * 1_000);
     }
 
-    await cleanupOldClipboardImages();
+    await cleanupOldClipboardImages(NOW);
 
     const remaining = await listClipboardFiles();
     expect(remaining).toHaveLength(MAX_FILE_COUNT);
     expect(remaining.every((name) => name.startsWith("clipboard-fresh-"))).toBe(true);
+    // fresh-21 and fresh-20 carry the largest age offsets (oldest mtimes), so
+    // the count cap evicts exactly those two.
+    expect(remaining).not.toContain("clipboard-fresh-21.png");
+    expect(remaining).not.toContain("clipboard-fresh-20.png");
+    expect(remaining).toContain("clipboard-fresh-0.png");
   });
 });

--- a/electron/ipc/handlers/__tests__/clipboard.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/clipboard.handlers.test.ts
@@ -178,6 +178,87 @@ describe("clipboard:write-text handler", () => {
   });
 });
 
+describe("clipboard:write-text size cap", () => {
+  const MAX_TEXT_BYTES = 8 * 1024 * 1024;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cleanup = registerClipboardHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("accepts text at exactly the 8 MB limit", async () => {
+    const handler = getHandler("clipboard:write-text");
+    const text = "a".repeat(MAX_TEXT_BYTES);
+    await handler(fakeEvent, text);
+    expect(clipboardMock.writeText).toHaveBeenCalledWith(text);
+  });
+
+  it("rejects text one byte over the limit with PAYLOAD_TOO_LARGE", async () => {
+    const handler = getHandler("clipboard:write-text");
+    const text = "a".repeat(MAX_TEXT_BYTES + 1);
+    await expect(handler(fakeEvent, text)).rejects.toMatchObject({
+      name: "AppError",
+      code: "PAYLOAD_TOO_LARGE",
+    });
+    expect(clipboardMock.writeText).not.toHaveBeenCalled();
+  });
+
+  it("measures UTF-8 bytes, not string length, for multibyte input", async () => {
+    const handler = getHandler("clipboard:write-text");
+    // "😀" is 2 UTF-16 code units (.length 2) but 4 UTF-8 bytes. A string
+    // under the char limit can still exceed the byte limit.
+    const emojiCount = MAX_TEXT_BYTES / 4 + 1;
+    const text = "😀".repeat(emojiCount);
+    expect(text.length).toBeLessThan(MAX_TEXT_BYTES);
+    await expect(handler(fakeEvent, text)).rejects.toMatchObject({
+      name: "AppError",
+      code: "PAYLOAD_TOO_LARGE",
+    });
+    expect(clipboardMock.writeText).not.toHaveBeenCalled();
+  });
+});
+
+describe("clipboard:write-image size cap", () => {
+  const MAX_IMAGE_BYTES = 50 * 1024 * 1024;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cleanup = registerClipboardHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("rejects image data one byte over the limit before touching nativeImage", async () => {
+    const handler = getHandler("clipboard:write-image");
+    const pngData = new Uint8Array(MAX_IMAGE_BYTES + 1);
+    await expect(handler(fakeEvent, pngData)).rejects.toMatchObject({
+      name: "AppError",
+      code: "PAYLOAD_TOO_LARGE",
+    });
+    expect(nativeImageMock.createFromBuffer).not.toHaveBeenCalled();
+    expect(clipboardMock.writeImage).not.toHaveBeenCalled();
+  });
+
+  it("accepts image data within the limit", async () => {
+    const fakeImage = { isEmpty: () => false };
+    nativeImageMock.createFromBuffer.mockReturnValue(fakeImage);
+
+    const handler = getHandler("clipboard:write-image");
+    await handler(fakeEvent, new Uint8Array([0x89, 0x50, 0x4e, 0x47]));
+
+    expect(nativeImageMock.createFromBuffer).toHaveBeenCalledTimes(1);
+    expect(clipboardMock.writeImage).toHaveBeenCalledWith(fakeImage);
+  });
+});
+
 describe("clipboard:write-selection handler", () => {
   const originalPlatform = process.platform;
   let cleanup: () => void;

--- a/electron/ipc/handlers/__tests__/clipboard.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/clipboard.handlers.test.ts
@@ -33,6 +33,7 @@ vi.mock("node:crypto", () => ({
 }));
 
 import { ipcMain } from "electron";
+import * as fsPromises from "node:fs/promises";
 import { registerClipboardHandlers } from "../clipboard.js";
 
 type Handler = (event: Electron.IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown>;
@@ -178,6 +179,47 @@ describe("clipboard:write-text handler", () => {
   });
 });
 
+describe("clipboard:save-image cleanup trigger", () => {
+  let cleanup: () => void;
+
+  const fakeClipboardImage = {
+    isEmpty: () => false,
+    toPNG: () => Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+    getSize: () => ({ width: 80, height: 40 }),
+    resize: () => ({ toPNG: () => Buffer.from([0x89]) }),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clipboardMock.readImage.mockReturnValue(fakeClipboardImage);
+    vi.mocked(fsPromises.readdir).mockResolvedValue([]);
+    cleanup = registerClipboardHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("runs cleanup fire-and-forget after writing the image", async () => {
+    const handler = getHandler("clipboard:save-image");
+    await handler(fakeEvent);
+
+    expect(fsPromises.writeFile).toHaveBeenCalled();
+    // cleanup reads the clipboard dir; startup also runs it once, so assert it
+    // ran again after the save (≥2 invocations total).
+    expect(vi.mocked(fsPromises.readdir).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not reject the save when cleanup fails", async () => {
+    vi.mocked(fsPromises.readdir).mockRejectedValue(new Error("disk gone"));
+    const handler = getHandler("clipboard:save-image");
+    await expect(handler(fakeEvent)).resolves.toMatchObject({
+      filePath: expect.any(String),
+      thumbnailDataUrl: expect.stringContaining("data:image/png;base64,"),
+    });
+  });
+});
+
 describe("clipboard:write-text size cap", () => {
   const MAX_TEXT_BYTES = 8 * 1024 * 1024;
   let cleanup: () => void;
@@ -256,6 +298,29 @@ describe("clipboard:write-image size cap", () => {
 
     expect(nativeImageMock.createFromBuffer).toHaveBeenCalledTimes(1);
     expect(clipboardMock.writeImage).toHaveBeenCalledWith(fakeImage);
+  });
+
+  it("accepts image data exactly at the 50 MB limit", async () => {
+    const fakeImage = { isEmpty: () => false };
+    nativeImageMock.createFromBuffer.mockReturnValue(fakeImage);
+
+    const handler = getHandler("clipboard:write-image");
+    await handler(fakeEvent, new Uint8Array(MAX_IMAGE_BYTES));
+
+    expect(nativeImageMock.createFromBuffer).toHaveBeenCalledTimes(1);
+    expect(clipboardMock.writeImage).toHaveBeenCalledWith(fakeImage);
+  });
+
+  it("rejects non-Uint8Array input with VALIDATION before any allocation", async () => {
+    const handler = getHandler("clipboard:write-image");
+    for (const bad of [null, new ArrayBuffer(8)]) {
+      await expect(handler(fakeEvent, bad as unknown as Uint8Array)).rejects.toMatchObject({
+        name: "AppError",
+        code: "VALIDATION",
+      });
+    }
+    expect(nativeImageMock.createFromBuffer).not.toHaveBeenCalled();
+    expect(clipboardMock.writeImage).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/ipc/handlers/clipboard.ts
+++ b/electron/ipc/handlers/clipboard.ts
@@ -10,12 +10,31 @@ import { AppError } from "../../utils/errorTypes.js";
 
 const CLIPBOARD_DIR_NAME = "daintree-clipboard";
 const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+// Cap the number of surviving clipboard images so a long session can't
+// accumulate temp PNGs without bound even when they're all under MAX_AGE_MS.
+const MAX_FILE_COUNT = 20;
+// Reject oversized clipboard writes before any native API call. Binary
+// (Uint8Array) payloads skip the IPC envelope budget check (see
+// electron/setup/security.ts), so these handler-level caps are the backstop.
+const MAX_TEXT_BYTES = 8 * 1024 * 1024;
+const MAX_IMAGE_BYTES = 50 * 1024 * 1024;
 
 function getClipboardDir(): string {
   return path.join(os.tmpdir(), CLIPBOARD_DIR_NAME);
 }
 
-async function cleanupOldClipboardImages(): Promise<void> {
+function logCleanupRejections(results: PromiseSettledResult<unknown>[]): void {
+  for (const result of results) {
+    if (result.status === "rejected") {
+      const code = (result.reason as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        console.warn("[clipboard] Unexpected error during cleanup:", result.reason);
+      }
+    }
+  }
+}
+
+export async function cleanupOldClipboardImages(): Promise<void> {
   const dir = getClipboardDir();
   let entries: Dirent[];
   try {
@@ -26,29 +45,50 @@ async function cleanupOldClipboardImages(): Promise<void> {
     return;
   }
 
-  const now = Date.now();
-  const results = await Promise.allSettled(
-    entries
-      .filter(
-        (dirent) =>
-          dirent.isFile() && dirent.name.startsWith("clipboard-") && dirent.name.endsWith(".png")
-      )
-      .map(async (dirent) => {
-        const filePath = path.join(dir, dirent.name);
-        const stat = await fs.stat(filePath);
-        if (now - stat.mtimeMs > MAX_AGE_MS) {
-          await fs.unlink(filePath);
-        }
-      })
+  const clipboardFiles = entries.filter(
+    (dirent) =>
+      dirent.isFile() && dirent.name.startsWith("clipboard-") && dirent.name.endsWith(".png")
   );
 
-  for (const result of results) {
+  // Pass 1 — stat every clipboard file; tolerate races where a file vanishes.
+  const statResults = await Promise.allSettled(
+    clipboardFiles.map(async (dirent) => {
+      const filePath = path.join(dir, dirent.name);
+      const stat = await fs.stat(filePath);
+      return { filePath, mtimeMs: stat.mtimeMs };
+    })
+  );
+
+  const surviving: { filePath: string; mtimeMs: number }[] = [];
+  const now = Date.now();
+  const ageEvictions: Promise<void>[] = [];
+
+  // Pass 2 — age eviction: delete anything older than the 24h window.
+  for (const result of statResults) {
     if (result.status === "rejected") {
       const code = (result.reason as NodeJS.ErrnoException).code;
       if (code !== "ENOENT") {
         console.warn("[clipboard] Unexpected error during cleanup:", result.reason);
       }
+      continue;
     }
+    const { filePath, mtimeMs } = result.value;
+    if (now - mtimeMs > MAX_AGE_MS) {
+      ageEvictions.push(fs.unlink(filePath));
+    } else {
+      surviving.push({ filePath, mtimeMs });
+    }
+  }
+
+  logCleanupRejections(await Promise.allSettled(ageEvictions));
+
+  // Pass 3 — count cap: if too many recent files survive, evict the oldest.
+  if (surviving.length > MAX_FILE_COUNT) {
+    surviving.sort((a, b) => a.mtimeMs - b.mtimeMs);
+    const toEvict = surviving.slice(0, surviving.length - MAX_FILE_COUNT);
+    logCleanupRejections(
+      await Promise.allSettled(toEvict.map((entry) => fs.unlink(entry.filePath)))
+    );
   }
 }
 
@@ -70,6 +110,12 @@ async function handleSaveImage(): Promise<{ filePath: string; thumbnailDataUrl: 
   const filename = `clipboard-${Date.now()}-${id}.png`;
   const filePath = path.join(dir, filename);
   await fs.writeFile(filePath, pngBuffer);
+
+  // Fire-and-forget — bound temp-file accumulation after every save without
+  // blocking the save's return path. Mirrors the startup cleanup call.
+  void cleanupOldClipboardImages().catch((err) => {
+    console.warn("[clipboard] Cleanup failed unexpectedly:", err);
+  });
 
   const size = image.getSize();
   const thumbHeight = 40;
@@ -103,6 +149,13 @@ async function handleThumbnailFromPath(
 }
 
 async function handleWriteImage(pngData: Uint8Array): Promise<void> {
+  if (pngData.byteLength > MAX_IMAGE_BYTES) {
+    throw new AppError({
+      code: "PAYLOAD_TOO_LARGE",
+      message: `Image payload exceeds ${MAX_IMAGE_BYTES} byte limit`,
+      userMessage: "The image is too large to copy to the clipboard.",
+    });
+  }
   const buffer = Buffer.from(pngData.buffer, pngData.byteOffset, pngData.byteLength);
   const image = nativeImage.createFromBuffer(buffer);
   if (image.isEmpty()) {
@@ -120,6 +173,13 @@ async function handleWriteText(text: string): Promise<void> {
     throw new AppError({
       code: "VALIDATION",
       message: "Text must be a string",
+    });
+  }
+  if (Buffer.byteLength(text, "utf8") > MAX_TEXT_BYTES) {
+    throw new AppError({
+      code: "PAYLOAD_TOO_LARGE",
+      message: `Text payload exceeds ${MAX_TEXT_BYTES} byte limit`,
+      userMessage: "The text is too large to copy to the clipboard.",
     });
   }
   clipboard.writeText(text);

--- a/electron/ipc/handlers/clipboard.ts
+++ b/electron/ipc/handlers/clipboard.ts
@@ -34,7 +34,7 @@ function logCleanupRejections(results: PromiseSettledResult<unknown>[]): void {
   }
 }
 
-export async function cleanupOldClipboardImages(): Promise<void> {
+export async function cleanupOldClipboardImages(now: number = Date.now()): Promise<void> {
   const dir = getClipboardDir();
   let entries: Dirent[];
   try {
@@ -60,7 +60,6 @@ export async function cleanupOldClipboardImages(): Promise<void> {
   );
 
   const surviving: { filePath: string; mtimeMs: number }[] = [];
-  const now = Date.now();
   const ageEvictions: Promise<void>[] = [];
 
   // Pass 2 — age eviction: delete anything older than the 24h window.
@@ -84,7 +83,9 @@ export async function cleanupOldClipboardImages(): Promise<void> {
 
   // Pass 3 — count cap: if too many recent files survive, evict the oldest.
   if (surviving.length > MAX_FILE_COUNT) {
-    surviving.sort((a, b) => a.mtimeMs - b.mtimeMs);
+    // Tie-break by path so files sharing an mtime (coarse-resolution FSes)
+    // evict in a deterministic order rather than relying on readdir order.
+    surviving.sort((a, b) => a.mtimeMs - b.mtimeMs || a.filePath.localeCompare(b.filePath));
     const toEvict = surviving.slice(0, surviving.length - MAX_FILE_COUNT);
     logCleanupRejections(
       await Promise.allSettled(toEvict.map((entry) => fs.unlink(entry.filePath)))
@@ -149,6 +150,12 @@ async function handleThumbnailFromPath(
 }
 
 async function handleWriteImage(pngData: Uint8Array): Promise<void> {
+  if (!(pngData instanceof Uint8Array)) {
+    throw new AppError({
+      code: "VALIDATION",
+      message: "Image data must be a Uint8Array",
+    });
+  }
   if (pngData.byteLength > MAX_IMAGE_BYTES) {
     throw new AppError({
       code: "PAYLOAD_TOO_LARGE",


### PR DESCRIPTION
## Summary

- `cleanupOldClipboardImages` now runs fire-and-forget after every `saveImage` call instead of only at startup, so a long-running session no longer accumulates PNG files indefinitely
- Added a `MAX_FILE_COUNT` of 20 with oldest-first eviction (by mtime, path as tie-break) alongside the existing 24h age cap, so the temp dir stays bounded even within the retention window
- `writeText` and `writeImage` now reject oversized payloads at the handler boundary (8 MB and 50 MB respectively); `writeImage` also guards against non-`Uint8Array` input and accepts an injectable `now` param for testability

Resolves #9159

## Changes

- `electron/ipc/handlers/clipboard.ts` — periodic cleanup trigger, count cap, payload size guards, input validation hardening, injectable `now`
- `electron/ipc/handlers/__tests__/clipboard.handlers.test.ts` — size-cap and save-image cleanup-trigger tests
- `electron/__tests__/clipboard.test.ts` (new) — real-fs cleanup tests covering age eviction, count cap, boundary cases, mtime ordering, and `ENOENT` tolerance

## Testing

40 tests pass across the two test files. Covers the happy path for each eviction mechanism, the boundary where count is exactly at the cap, oldest-first ordering, and graceful handling of missing files mid-sweep.