### PR TITLE
fix(theme): seed renderer with persisted scheme on first paint

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -131,6 +131,15 @@ export type { ElectronAPI };
 const isDemoMode =
   !process.argv.some((a) => a.includes("app.asar")) && process.argv.includes("--demo-mode");
 
+// Persisted color scheme id passed from the main process via
+// webPreferences.additionalArguments. Read synchronously here (process.argv is
+// available even under sandbox: true) so the renderer can apply the saved theme
+// on its very first paint instead of a prefers-color-scheme default (#9169).
+const INITIAL_COLOR_SCHEME_ARG = "--daintree-initial-color-scheme-id=";
+const initialColorSchemeId = process.argv
+  .find((a) => a.startsWith(INITIAL_COLOR_SCHEME_ARG))
+  ?.slice(INITIAL_COLOR_SCHEME_ARG.length);
+
 // Store MessagePort for direct Renderer ↔ Pty Host communication
 // Note: We cannot return MessagePort via contextBridge (it's not cloneable/transferable via that API).
 // Instead, we use window.postMessage to transfer it to the main world.
@@ -2661,4 +2670,13 @@ if (process.env.DAINTREE_E2E_MODE === "1") {
 // polyfilled `process.env` even under sandbox: true) is the propagation point.
 if (process.env.DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS === "1") {
   contextBridge.exposeInMainWorld("__DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS__", true);
+}
+
+// Surface the persisted color scheme id (seeded via additionalArguments) so the
+// renderer applies the saved theme on first paint, eliminating the flash of the
+// prefers-color-scheme default before the async theme config resolves (#9169).
+if (initialColorSchemeId) {
+  contextBridge.exposeInMainWorld("__DAINTREE_INITIAL_THEME__", {
+    colorSchemeId: initialColorSchemeId,
+  });
 }

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -26,7 +26,11 @@ import { getPtyManager } from "../services/PtyManager.js";
 import { notifyError } from "../ipc/errorHandlers.js";
 import { logInfo, logWarn } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
-import { injectSkeletonCss } from "./skeletonCss.js";
+import {
+  injectSkeletonCss,
+  resolveInitialColorSchemeId,
+  INITIAL_COLOR_SCHEME_ARG,
+} from "./skeletonCss.js";
 import { CHANNELS } from "../ipc/channels.js";
 import {
   attachRendererConsoleCapture,
@@ -973,6 +977,10 @@ export class ProjectViewManager {
         webviewTag: true,
         navigateOnDragDrop: false,
         v8CacheOptions: "code",
+        // Seed the renderer with the persisted theme so project-switch cold
+        // starts and LRU-evicted views paint the saved scheme on first frame
+        // instead of a prefers-color-scheme default (#9169).
+        additionalArguments: [`${INITIAL_COLOR_SCHEME_ARG}=${resolveInitialColorSchemeId()}`],
       },
     });
   }

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -127,6 +127,8 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  resolveInitialColorSchemeId: vi.fn(() => "daintree"),
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -111,6 +111,8 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  resolveInitialColorSchemeId: vi.fn(() => "daintree"),
 }));
 
 vi.mock("../rendererConsoleCapture.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -133,6 +133,8 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  resolveInitialColorSchemeId: vi.fn(() => "daintree"),
 }));
 
 vi.mock("../rendererConsoleCapture.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -82,6 +82,8 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  resolveInitialColorSchemeId: vi.fn(() => "daintree"),
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -83,6 +83,8 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  resolveInitialColorSchemeId: vi.fn(() => "daintree"),
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -133,6 +133,8 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  resolveInitialColorSchemeId: vi.fn(() => "daintree"),
 }));
 
 vi.mock("../rendererConsoleCapture.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -122,6 +122,8 @@ vi.mock("../../ipc/errorHandlers.js", () => ({
 
 vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
+  INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  resolveInitialColorSchemeId: vi.fn(() => "daintree"),
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({

--- a/electron/window/__tests__/resolveInitialColorSchemeId.test.ts
+++ b/electron/window/__tests__/resolveInitialColorSchemeId.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests resolveInitialColorSchemeId from skeletonCss.ts — the helper that seeds
+ * the renderer's first-paint theme via webPreferences.additionalArguments
+ * (#9169). It must mirror createWindow/getAppThemeConfig fallback behavior.
+ */
+
+const mocks = vi.hoisted(() => ({
+  storeGet: vi.fn(),
+  shouldUseDarkColors: { value: true },
+}));
+
+vi.mock("../../store.js", () => ({
+  store: { get: mocks.storeGet },
+}));
+
+vi.mock("electron", () => ({
+  nativeTheme: {
+    get shouldUseDarkColors() {
+      return mocks.shouldUseDarkColors.value;
+    },
+  },
+}));
+
+import { resolveInitialColorSchemeId } from "../skeletonCss.js";
+
+describe("resolveInitialColorSchemeId (#9169)", () => {
+  const originalScreenshotScale = process.env.DAINTREE_SCREENSHOT_SCALE;
+
+  beforeEach(() => {
+    mocks.storeGet.mockReset();
+    mocks.shouldUseDarkColors.value = true;
+    delete process.env.DAINTREE_SCREENSHOT_SCALE;
+  });
+
+  afterEach(() => {
+    if (originalScreenshotScale === undefined) {
+      delete process.env.DAINTREE_SCREENSHOT_SCALE;
+    } else {
+      process.env.DAINTREE_SCREENSHOT_SCALE = originalScreenshotScale;
+    }
+  });
+
+  it("returns the persisted color scheme id, trimmed", () => {
+    mocks.storeGet.mockReturnValue({ colorSchemeId: "  bondi  " });
+    expect(resolveInitialColorSchemeId()).toBe("bondi");
+  });
+
+  it("returns a custom persisted id verbatim", () => {
+    mocks.storeGet.mockReturnValue({ colorSchemeId: "my-custom-scheme" });
+    expect(resolveInitialColorSchemeId()).toBe("my-custom-scheme");
+  });
+
+  it("falls back to daintree when no theme is persisted and the OS prefers dark", () => {
+    mocks.storeGet.mockReturnValue(undefined);
+    mocks.shouldUseDarkColors.value = true;
+    expect(resolveInitialColorSchemeId()).toBe("daintree");
+  });
+
+  it("falls back to bondi when no theme is persisted and the OS prefers light", () => {
+    mocks.storeGet.mockReturnValue(undefined);
+    mocks.shouldUseDarkColors.value = false;
+    expect(resolveInitialColorSchemeId()).toBe("bondi");
+  });
+
+  it("falls back when colorSchemeId is not a string", () => {
+    mocks.storeGet.mockReturnValue({ colorSchemeId: 123 });
+    mocks.shouldUseDarkColors.value = false;
+    expect(resolveInitialColorSchemeId()).toBe("bondi");
+  });
+
+  it("falls back when colorSchemeId is whitespace only", () => {
+    mocks.storeGet.mockReturnValue({ colorSchemeId: "   " });
+    mocks.shouldUseDarkColors.value = false;
+    expect(resolveInitialColorSchemeId()).toBe("bondi");
+  });
+
+  it("forces daintree when DAINTREE_SCREENSHOT_SCALE is set, even on a light OS", () => {
+    mocks.storeGet.mockReturnValue(undefined);
+    mocks.shouldUseDarkColors.value = false;
+    process.env.DAINTREE_SCREENSHOT_SCALE = "2";
+    expect(resolveInitialColorSchemeId()).toBe("daintree");
+  });
+});

--- a/electron/window/__tests__/resolveInitialColorSchemeId.test.ts
+++ b/electron/window/__tests__/resolveInitialColorSchemeId.test.ts
@@ -23,7 +23,7 @@ vi.mock("electron", () => ({
   },
 }));
 
-import { resolveInitialColorSchemeId } from "../skeletonCss.js";
+import { resolveInitialColorSchemeId, INITIAL_COLOR_SCHEME_ARG } from "../skeletonCss.js";
 
 describe("resolveInitialColorSchemeId (#9169)", () => {
   const originalScreenshotScale = process.env.DAINTREE_SCREENSHOT_SCALE;
@@ -81,5 +81,20 @@ describe("resolveInitialColorSchemeId (#9169)", () => {
     mocks.shouldUseDarkColors.value = false;
     process.env.DAINTREE_SCREENSHOT_SCALE = "2";
     expect(resolveInitialColorSchemeId()).toBe("daintree");
+  });
+
+  it("matches the prefix preload.cts parses (drift guard)", () => {
+    // preload.cts hardcodes this literal rather than importing the constant
+    // (esbuild cross-bundle); this ties both halves of the contract together so
+    // a rename of INITIAL_COLOR_SCHEME_ARG fails loudly instead of silently
+    // reintroducing the flash (#9169).
+    expect(`${INITIAL_COLOR_SCHEME_ARG}=`).toBe("--daintree-initial-color-scheme-id=");
+  });
+
+  it("returns a trimmed value with no whitespace for a valid argv flag", () => {
+    mocks.storeGet.mockReturnValue({ colorSchemeId: "  table-mountain  " });
+    const arg = `${INITIAL_COLOR_SCHEME_ARG}=${resolveInitialColorSchemeId()}`;
+    expect(arg).toBe("--daintree-initial-color-scheme-id=table-mountain");
+    expect(arg).not.toMatch(/\s/);
   });
 });

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -1,13 +1,5 @@
 // eager-import-allow: reads persisted window state via store.get synchronously when creating the window
-import {
-  app,
-  BrowserWindow,
-  WebContentsView,
-  dialog,
-  ipcMain,
-  session,
-  nativeTheme,
-} from "electron";
+import { app, BrowserWindow, WebContentsView, dialog, ipcMain, session } from "electron";
 import {
   getWindowForWebContents,
   registerWebContents,
@@ -34,7 +26,11 @@ import { sendToRenderer } from "../ipc/handlers.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { notifyError } from "../ipc/errorHandlers.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
-import { injectSkeletonCss } from "./skeletonCss.js";
+import {
+  injectSkeletonCss,
+  resolveInitialColorSchemeId,
+  INITIAL_COLOR_SCHEME_ARG,
+} from "./skeletonCss.js";
 import { attachRendererConsoleCapture } from "./rendererConsoleCapture.js";
 import { markPerformance } from "../utils/performance.js";
 import { registerProtocolsForSession, getDistPath } from "../setup/protocols.js";
@@ -144,25 +140,10 @@ export function setupBrowserWindow(
   // Resolve the saved theme to set the correct background color at construction time,
   // avoiding a dark flash when a light theme is active.
   const themeConfig = store.get("appTheme");
-  let colorSchemeId: string;
-  if (
-    themeConfig &&
-    typeof themeConfig === "object" &&
-    !Array.isArray(themeConfig) &&
-    "colorSchemeId" in themeConfig &&
-    typeof themeConfig.colorSchemeId === "string" &&
-    themeConfig.colorSchemeId
-  ) {
-    colorSchemeId = themeConfig.colorSchemeId.trim();
-  } else {
-    // Daintree always defaults to its dark theme on first run, regardless of
-    // the OS color-scheme preference. Users who want light or system-following
-    // behavior can opt in via Settings → Appearance.
-    colorSchemeId =
-      process.env.DAINTREE_SCREENSHOT_SCALE || nativeTheme.shouldUseDarkColors
-        ? "daintree"
-        : "bondi";
-  }
+  // Daintree always defaults to its dark theme on first run, regardless of the
+  // OS color-scheme preference. Users who want light or system-following
+  // behavior can opt in via Settings → Appearance.
+  const colorSchemeId = resolveInitialColorSchemeId();
 
   // Apply lazy migration for legacy string-encoded customSchemes
   let customSchemes: AppColorScheme[] = [];
@@ -259,6 +240,9 @@ export function setupBrowserWindow(
       webviewTag: true,
       navigateOnDragDrop: false,
       v8CacheOptions: "code",
+      // Seed the renderer with the persisted theme so first paint applies the
+      // saved scheme instead of a prefers-color-scheme default (#9169).
+      additionalArguments: [`${INITIAL_COLOR_SCHEME_ARG}=${colorSchemeId}`],
     },
   });
 

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -7,7 +7,7 @@
  * Called from both createWindow (initial load) and ProjectViewManager
  * (project switch cold starts).
  */
-import type { WebContents } from "electron";
+import { nativeTheme, type WebContents } from "electron";
 import { store } from "../store.js";
 import { resolveAppTheme, getAppThemeCssVariables } from "../../shared/theme/index.js";
 import type { AppColorScheme } from "../../shared/theme/index.js";
@@ -16,6 +16,39 @@ import {
   appCustomSchemesWriteSchema,
   migrateCustomSchemes,
 } from "../schemas/customSchemes.js";
+
+/**
+ * Command-line argument carrying the persisted color scheme id from the main
+ * process into each renderer context. Read synchronously in preload.cts from
+ * `process.argv` (available even under `sandbox: true`) and exposed to the
+ * renderer as `window.__DAINTREE_INITIAL_THEME__` so first paint applies the
+ * saved theme instead of a `prefers-color-scheme` default (#9169).
+ */
+export const INITIAL_COLOR_SCHEME_ARG = "--daintree-initial-color-scheme-id";
+
+/**
+ * Resolves the color scheme id to seed the renderer with on cold start.
+ * Mirrors the fallback logic in createWindow and getAppThemeConfig: the raw
+ * persisted id when present (without resolving `followSystem` — that happens
+ * post-mount), else Daintree's dark default, or Bondi when the OS prefers a
+ * light appearance.
+ */
+export function resolveInitialColorSchemeId(): string {
+  const themeConfig = store.get("appTheme");
+  if (
+    themeConfig &&
+    typeof themeConfig === "object" &&
+    !Array.isArray(themeConfig) &&
+    "colorSchemeId" in themeConfig &&
+    typeof themeConfig.colorSchemeId === "string" &&
+    themeConfig.colorSchemeId.trim()
+  ) {
+    return themeConfig.colorSchemeId.trim();
+  }
+  return process.env.DAINTREE_SCREENSHOT_SCALE || nativeTheme.shouldUseDarkColors
+    ? "daintree"
+    : "bondi";
+}
 
 export function injectSkeletonCss(wc: WebContents): void {
   const appState = store.get("appState");

--- a/src/theme/__tests__/applyAppTheme.test.ts
+++ b/src/theme/__tests__/applyAppTheme.test.ts
@@ -220,6 +220,17 @@ describe("applyDefaultAppTheme (#9169)", () => {
     expect(root.dataset.theme).toBe("daintree");
   });
 
+  it("falls back to prefers-color-scheme when the seeded id is an empty string", () => {
+    mockPrefersDark(true);
+    window.__DAINTREE_INITIAL_THEME__ = { colorSchemeId: "" };
+    const root = document.createElement("div");
+
+    const applied = applyDefaultAppTheme(root);
+
+    expect(applied.id).toBe("daintree");
+    expect(root.dataset.theme).toBe("daintree");
+  });
+
   it("seeds a non-default built-in scheme that exists in the registry", () => {
     mockPrefersDark(true);
     // Sanity: the seeded id resolves to a real built-in scheme object.

--- a/src/theme/__tests__/applyAppTheme.test.ts
+++ b/src/theme/__tests__/applyAppTheme.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
-import { APP_THEME_TOKEN_KEYS, type AppColorScheme } from "@shared/theme";
-import { applyAppThemeToRoot, applyColorVisionMode } from "../applyAppTheme";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { APP_THEME_TOKEN_KEYS, getAppThemeById, type AppColorScheme } from "@shared/theme";
+import { applyAppThemeToRoot, applyColorVisionMode, applyDefaultAppTheme } from "../applyAppTheme";
 
 function createTestScheme(
   id: string,
@@ -164,5 +164,72 @@ describe("applyColorVisionMode", () => {
     expect(root.style.getPropertyValue("--theme-category-blue")).toBe("#dc267f");
     expect(root.style.getPropertyValue("--theme-category-teal")).toBe("#009e73");
     expect(root.dataset.colorblind).toBe("blue-yellow");
+  });
+});
+
+describe("applyDefaultAppTheme (#9169)", () => {
+  function mockPrefersDark(prefersDark: boolean): void {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes("dark") ? prefersDark : !prefersDark,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }))
+    );
+  }
+
+  afterEach(() => {
+    delete window.__DAINTREE_INITIAL_THEME__;
+    vi.unstubAllGlobals();
+  });
+
+  it("applies the seeded persisted scheme over the prefers-color-scheme default", () => {
+    // OS prefers dark (would resolve to daintree) but the persisted scheme is bondi.
+    mockPrefersDark(true);
+    window.__DAINTREE_INITIAL_THEME__ = { colorSchemeId: "bondi" };
+    const root = document.createElement("div");
+
+    const applied = applyDefaultAppTheme(root);
+
+    expect(applied.id).toBe("bondi");
+    expect(root.dataset.theme).toBe("bondi");
+  });
+
+  it("falls back to prefers-color-scheme when the seeded id is unknown (e.g. a custom scheme)", () => {
+    // Unknown ids must not paint a wrong built-in theme — they defer to the
+    // async useAppThemeConfig phase. OS prefers light → bondi.
+    mockPrefersDark(false);
+    window.__DAINTREE_INITIAL_THEME__ = { colorSchemeId: "totally-unknown-scheme" };
+    const root = document.createElement("div");
+
+    const applied = applyDefaultAppTheme(root);
+
+    expect(applied.id).toBe("bondi");
+    expect(root.dataset.theme).toBe("bondi");
+  });
+
+  it("falls back to prefers-color-scheme (dark) when no scheme is seeded", () => {
+    mockPrefersDark(true);
+    const root = document.createElement("div");
+
+    const applied = applyDefaultAppTheme(root);
+
+    expect(applied.id).toBe("daintree");
+    expect(root.dataset.theme).toBe("daintree");
+  });
+
+  it("seeds a non-default built-in scheme that exists in the registry", () => {
+    mockPrefersDark(true);
+    // Sanity: the seeded id resolves to a real built-in scheme object.
+    expect(getAppThemeById("table-mountain")).toBeDefined();
+    window.__DAINTREE_INITIAL_THEME__ = { colorSchemeId: "table-mountain" };
+    const root = document.createElement("div");
+
+    const applied = applyDefaultAppTheme(root);
+
+    expect(applied.id).toBe("table-mountain");
+    expect(root.dataset.theme).toBe("table-mountain");
   });
 });

--- a/src/theme/applyAppTheme.ts
+++ b/src/theme/applyAppTheme.ts
@@ -1,4 +1,9 @@
-import { getAppThemeCssVariables, resolveAppTheme, type AppColorScheme } from "@shared/theme";
+import {
+  getAppThemeById,
+  getAppThemeCssVariables,
+  resolveAppTheme,
+  type AppColorScheme,
+} from "@shared/theme";
 import type { ColorVisionMode } from "@shared/types";
 
 const RED_GREEN_OVERRIDES: Record<string, string> = {
@@ -101,6 +106,19 @@ export function applyColorVisionMode(root: HTMLElement, mode: ColorVisionMode): 
 }
 
 export function applyDefaultAppTheme(root: HTMLElement): AppColorScheme {
+  // Prefer the persisted scheme seeded by the main process (via preload) so the
+  // first paint matches the saved theme instead of flashing a
+  // prefers-color-scheme default before the async theme config resolves (#9169).
+  // Only built-in ids resolve synchronously here — custom schemes load during
+  // the async useAppThemeConfig phase, so an unknown id falls through to the
+  // prefers-color-scheme default rather than painting the wrong built-in theme.
+  const seededId = window.__DAINTREE_INITIAL_THEME__?.colorSchemeId;
+  const seededScheme = seededId ? getAppThemeById(seededId) : undefined;
+  if (seededScheme) {
+    applyAppThemeToRoot(root, seededScheme);
+    return seededScheme;
+  }
+
   const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
   const schemeId = prefersDark ? "daintree" : "bondi";
   const scheme = resolveAppTheme(schemeId);

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -27,6 +27,8 @@ declare global {
     };
     __DAINTREE_E2E_MODE__?: boolean;
     __DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS__?: boolean;
+    /** Persisted color scheme id seeded by preload for first-paint theming (#9169). */
+    __DAINTREE_INITIAL_THEME__?: { colorSchemeId: string };
     __daintreeDispatchAction?: (
       actionId: string,
       args?: unknown,


### PR DESCRIPTION
## Summary

On cold start, \`applyDefaultAppTheme\` was resolving the color scheme from \`prefers-color-scheme\` and writing it as inline styles on \`documentElement\`. Inline styles are author-origin and beat the main process's user-origin \`insertCSS\` in the CSS cascade, so the wrong default flashed until \`useAppThemeConfig\`'s async \`appThemeClient.get()\` resolved.

The fix seeds the renderer with the persisted color scheme ID at the inline-style level on first paint, so the correct theme is applied before any frame is drawn.

Resolves #9169

## Changes

- **`skeletonCss.ts`**: added `resolveInitialColorSchemeId` (mirrors the same logic in `createWindow.ts` / `getAppThemeConfig`; does not resolve `followSystem` by design) and `INITIAL_COLOR_SCHEME_ARG` as the single source of truth for the bootstrap scheme arg prefix
- **`createWindow.ts` + `ProjectViewManager.createView()`**: pass the resolved id via `webPreferences.additionalArguments` — covers initial load, project-switch, and LRU-evicted cold starts
- **`preload.cts`**: reads `process.argv` (works under `sandbox: true`) and exposes `window.__DAINTREE_INITIAL_THEME__`
- **`applyAppTheme.ts`**: `applyDefaultAppTheme` prefers the seeded scheme via `getAppThemeById`; unknown or custom ids defer to the async `useAppThemeConfig` phase rather than painting a wrong built-in, with `prefers-color-scheme` as the final fallback
- **`electron.d.ts`**: `Window` type for the new global

## Testing

- New `resolveInitialColorSchemeId.test.ts`: fallback matrix + preload arg-prefix drift guard
- Extended `applyAppTheme.test.ts`: seeded-over-prefers, unknown/empty-id fallback, built-in seed paths
- Updated 7 `ProjectViewManager` test mocks for the new `skeletonCss` exports
- Full unit suite green (27429 passed), typecheck/lint/format clean