### PR TITLE
fix(voice): add WebSocket resilience — heartbeat, reconnect, audio buffering

### DIFF
--- a/electron/services/VoiceTranscriptionService.ts
+++ b/electron/services/VoiceTranscriptionService.ts
@@ -256,6 +256,9 @@ export class VoiceTranscriptionService {
         }
         return;
       }
+      // Expected teardown — the trailing `close` from connection.close() must
+      // not override the "error" status below with "idle".
+      this.isExpectedClose = true;
       try {
         connection.close();
       } catch {
@@ -324,7 +327,7 @@ export class VoiceTranscriptionService {
     });
 
     connection.on("message", (data) => {
-      if (this.sessionId !== mySessionId) return;
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
       const raw =
         typeof data === "string"
           ? data
@@ -348,7 +351,7 @@ export class VoiceTranscriptionService {
 
     connection.on("error", (err) => {
       this.clearConnectTimeout();
-      if (this.sessionId !== mySessionId) return;
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
       const message = formatErrorMessage(err, "WebSocket error");
       logError(`${P} WebSocket error`, { message });
       // A transport error on a ready (or reconnecting) session is recoverable —
@@ -363,7 +366,10 @@ export class VoiceTranscriptionService {
     connection.on("close", (code, reason) => {
       this.clearConnectTimeout();
       this.clearHeartbeat();
-      if (this.sessionId !== mySessionId) return;
+      // Ignore the close of a socket that's already been superseded or torn down
+      // out-of-band (reconnect swap, or handleFatalError which terminates after
+      // nulling this.connection) — that path has already emitted its status.
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
       const wasReady = this.isReady;
       logInfo(`${P} WebSocket closed`, {
         code,
@@ -387,7 +393,12 @@ export class VoiceTranscriptionService {
         return;
       }
       this.settlePendingStart(mySessionId, { ok: false, error: "Connection closed" });
-      this.emit({ type: "status", status: "idle" });
+      // A deliberate teardown (fatal error / connect timeout) already emitted its
+      // terminal status ("error"); don't override it with "idle" here. Only an
+      // unexpected close of a never-ready connection should fall through to idle.
+      if (!this.isExpectedClose) {
+        this.emit({ type: "status", status: "idle" });
+      }
     });
   }
 
@@ -495,7 +506,17 @@ export class VoiceTranscriptionService {
     this.isExpectedClose = true;
     this.isReconnecting = false;
     this.clearReconnectTimer();
+    // Close the physical socket — a server-sent fatal `error` event leaves the
+    // connection open otherwise. Captured before cleanupConnection() nulls it.
+    const conn = this.connection;
     this.cleanupConnection();
+    if (conn) {
+      try {
+        conn.terminate();
+      } catch {
+        // Ignore terminate errors
+      }
+    }
     this.emit({ type: "error", message });
     this.emit({ type: "status", status: "error" });
     this.settlePendingStart(mySessionId, { ok: false, error: message });
@@ -519,11 +540,14 @@ export class VoiceTranscriptionService {
         logInfo(`${P} ← session.updated — session ready`, { session: payload.session });
         if (this.preConnectBuffer.length > 0 && this.connection) {
           logInfo(`${P} Flushing ${this.preConnectBuffer.length} buffered audio chunks`);
-          for (const chunk of this.preConnectBuffer) {
-            this.sendAudioJson(chunk);
-          }
+          // Detach the buffer before flushing so its state stays consistent even
+          // if a send throws partway through the loop.
+          const buffered = this.preConnectBuffer;
           this.preConnectBuffer = [];
           this.preConnectBufferBytes = 0;
+          for (const chunk of buffered) {
+            this.sendAudioJson(chunk);
+          }
         }
         // A successful (re)connection clears the reconnect state so a later drop
         // gets a fresh full backoff budget.
@@ -685,7 +709,17 @@ export class VoiceTranscriptionService {
   private sendAudioJson(chunk: ArrayBuffer): void {
     if (!this.connection) return;
     const audio = Buffer.from(chunk).toString("base64");
-    this.connection.send(JSON.stringify({ type: "input_audio_buffer.append", audio }));
+    try {
+      this.connection.send(JSON.stringify({ type: "input_audio_buffer.append", audio }));
+    } catch (err) {
+      // A send can throw if the socket transitioned to CLOSING mid-flush. Don't
+      // let it escape the buffer-flush loop (which would leave the buffer in a
+      // partially-cleared state) — the trailing `close` event drives reconnect.
+      logWarn(`${P} Failed to send audio chunk`, {
+        message: formatErrorMessage(err, "send failed"),
+      });
+      return;
+    }
     this.bytesSinceCommit += chunk.byteLength;
   }
 

--- a/electron/services/VoiceTranscriptionService.ts
+++ b/electron/services/VoiceTranscriptionService.ts
@@ -17,6 +17,24 @@ const CONNECT_TIMEOUT_MS = 10_000;
 // rather than hanging the stop.
 const DRAIN_TIMEOUT_MS = 3_000;
 const PRE_CONNECT_BUFFER_MAX = 100;
+// Hard byte ceiling for buffered-but-not-yet-sent audio (pre-connect and during
+// a reconnect window). 24kHz mono PCM16 ≈ 48KB/s, so ~150KB ≈ 3s — the point
+// past which voice context is lost anyway. Caps memory if chunks are large.
+const PRE_CONNECT_BUFFER_MAX_BYTES = 150_000;
+// Client-side ping/pong heartbeat. The OpenAI Realtime server sends its own
+// pings (auto-ponged by `ws`), but a half-open TCP connection on our side —
+// server alive, our socket silently dead — is only detectable by us pinging
+// and watching for the pong. On a missed pong we `terminate()` (no closing
+// handshake on a dead socket) which fires `close` and drives the reconnect.
+const HEARTBEAT_INTERVAL_MS = 20_000;
+// Automatic reconnect on an unexpected mid-session drop. Exponential backoff
+// with full jitter: delay = random() * min(CAP, INITIAL * MULTIPLIER^attempt).
+// Gentle multiplier so the first few retries are near-instant; after
+// RECONNECT_MAX_ATTEMPTS we give up and surface a fatal error.
+const RECONNECT_MAX_ATTEMPTS = 5;
+const RECONNECT_INITIAL_MS = 150;
+const RECONNECT_MULTIPLIER = 1.5;
+const RECONNECT_CAP_MS = 3_000;
 // `gpt-realtime-whisper` does not support server VAD (`turn_detection` must be
 // null), so the server never auto-commits the input buffer. We drive
 // segmentation ourselves: commit the buffer on a fixed cadence so the model
@@ -73,7 +91,24 @@ export class VoiceTranscriptionService {
     null;
 
   private preConnectBuffer: ArrayBuffer[] = [];
+  private preConnectBufferBytes = 0;
   private isReady = false;
+
+  // Heartbeat (half-open detection) for the current connection. `isAlive` is
+  // set on every pong and on open; the interval terminates the socket if a full
+  // cycle elapses with no pong.
+  private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+  private isAlive = false;
+
+  // Reconnect state. `reconnectAttempt` and `isReconnecting` survive across
+  // individual connection teardowns (cleanupConnection) and are only reset by
+  // cleanupPreviousSession (a full session reset) or a successful reconnect.
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private isReconnecting = false;
+  // Set on graceful/fatal teardown so the trailing `close` event isn't mistaken
+  // for an unexpected drop and doesn't trigger a reconnect.
+  private isExpectedClose = false;
 
   private drainResolve: (() => void) | null = null;
   private drainTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -156,156 +191,310 @@ export class VoiceTranscriptionService {
     this.sessionId = mySessionId;
     this.isReady = false;
     this.preConnectBuffer = [];
+    this.preConnectBufferBytes = 0;
+    this.reconnectAttempt = 0;
+    this.isReconnecting = false;
+    this.isExpectedClose = false;
     this.liveText = "";
 
     this.emit({ type: "status", status: "connecting" });
 
     return new Promise((resolve) => {
       this.pendingStart = { sessionId: mySessionId, resolve };
+      this.connect(mySessionId, settings);
+    });
+  }
 
-      let connection: WebSocket;
-      try {
-        connection = new WebSocket(OPENAI_REALTIME_URL, {
-          headers: {
-            Authorization: `Bearer ${settings.openaiApiKey}`,
-          },
-        });
-      } catch (err) {
-        const message = formatErrorMessage(err, "Failed to open WebSocket");
-        logError(`${P} ${message}`);
+  /**
+   * Opens the WebSocket and wires every event handler for one connection
+   * attempt. Shared by `start()` (initial connect, with a pending start promise
+   * to settle) and `reconnectOnce()` (mid-session reconnect, no pending start).
+   * The reconnect path is distinguished purely by `this.isReconnecting`, so a
+   * construct/timeout failure reschedules instead of surfacing a fatal error.
+   */
+  private connect(mySessionId: number, settings: VoiceInputSettings): void {
+    let connection: WebSocket;
+    try {
+      connection = new WebSocket(OPENAI_REALTIME_URL, {
+        headers: {
+          Authorization: `Bearer ${settings.openaiApiKey}`,
+        },
+      });
+    } catch (err) {
+      const message = formatErrorMessage(err, "Failed to open WebSocket");
+      logError(`${P} ${message}`);
+      if (this.isReconnecting) {
+        this.scheduleReconnect(mySessionId, settings);
+      } else {
         this.emit({ type: "error", message });
         this.emit({ type: "status", status: "error" });
         this.settlePendingStart(mySessionId, { ok: false, error: message });
+      }
+      return;
+    }
+
+    this.connection = connection;
+    logInfo(`${P} Opening OpenAI realtime WebSocket`, {
+      url: OPENAI_REALTIME_URL,
+      model: OPENAI_TRANSCRIPTION_MODEL,
+      language: settings.language || "en",
+      customDictionaryTerms: settings.customDictionary.length,
+      reconnectAttempt: this.isReconnecting ? this.reconnectAttempt : 0,
+    });
+
+    this.connectTimeout = setTimeout(() => {
+      this.connectTimeout = null;
+      if (this.sessionId !== mySessionId) return;
+      logError(`${P} Connection timed out (${CONNECT_TIMEOUT_MS}ms)`);
+      if (this.isReconnecting) {
+        // Force the dead socket closed; the `close` handler schedules the next
+        // reconnect attempt (or gives up once attempts are exhausted).
+        try {
+          connection.terminate();
+        } catch {
+          // Ignore terminate errors
+        }
+        return;
+      }
+      try {
+        connection.close();
+      } catch {
+        // Ignore close errors
+      }
+      this.cleanupConnection();
+      this.emit({ type: "error", message: "Connection timed out" });
+      this.emit({ type: "status", status: "error" });
+      this.settlePendingStart(mySessionId, { ok: false, error: "Connection timed out" });
+    }, CONNECT_TIMEOUT_MS);
+
+    connection.on("pong", () => {
+      if (this.sessionId !== mySessionId || this.connection !== connection) return;
+      this.isAlive = true;
+    });
+
+    // Open handler — same logic for initial connect and reconnect.
+    connection.on("open", () => {
+      if (this.sessionId !== mySessionId) {
+        logWarn(`${P} Session expired during connect, closing`);
+        try {
+          connection.close();
+        } catch {
+          // Ignore close errors
+        }
+        return;
+      }
+      this.startHeartbeat(connection, mySessionId);
+      logInfo(`${P} WebSocket opened, sending session.update`);
+      // TODO: pass `transcription.prompt` from settings once #7832 lands.
+      // `turn_detection` MUST be explicitly `null` for `gpt-realtime-whisper`
+      // (VAD is not supported for this model). It is not enough to omit it:
+      // when absent the server applies a default VAD that this model can't
+      // use, and then silently produces no transcription — it still acks
+      // `input_audio_buffer.committed` but emits no `conversation.item.added`
+      // / `conversation.item.done`. With it set to `null`, each manual commit
+      // yields a transcribed item. (An explicit non-null `turn_detection`
+      // block, by contrast, is hard-rejected with an error event.)
+      const sessionUpdate = {
+        type: "session.update",
+        session: {
+          type: "transcription",
+          audio: {
+            input: {
+              format: { type: "audio/pcm", rate: 24000 },
+              transcription: {
+                model: OPENAI_TRANSCRIPTION_MODEL,
+                language: settings.language || "en",
+              },
+              turn_detection: null,
+            },
+          },
+        },
+      };
+      // Log the exact payload — the session config (especially the explicit
+      // `turn_detection: null`) is the most common cause of "commits acked
+      // but no transcription items" regressions.
+      logInfo(`${P} → session.update`, { session: sessionUpdate.session });
+      try {
+        connection.send(JSON.stringify(sessionUpdate));
+      } catch (err) {
+        const message = formatErrorMessage(err, "Failed to send session.update");
+        logError(`${P} ${message}`);
+        this.handleFatalError(mySessionId, message);
+      }
+    });
+
+    connection.on("message", (data) => {
+      if (this.sessionId !== mySessionId) return;
+      const raw =
+        typeof data === "string"
+          ? data
+          : Buffer.isBuffer(data)
+            ? data.toString("utf8")
+            : Array.isArray(data)
+              ? Buffer.concat(data).toString("utf8")
+              : Buffer.from(data as ArrayBuffer).toString("utf8");
+
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        logWarn(`${P} Ignoring non-JSON message`, { raw: raw.slice(0, 200) });
         return;
       }
 
-      this.connection = connection;
-      logInfo(`${P} Opening OpenAI realtime WebSocket`, {
-        url: OPENAI_REALTIME_URL,
-        model: OPENAI_TRANSCRIPTION_MODEL,
-        language: settings.language || "en",
-        customDictionaryTerms: settings.customDictionary.length,
-      });
-
-      this.connectTimeout = setTimeout(() => {
-        this.connectTimeout = null;
-        logError(`${P} Connection timed out (${CONNECT_TIMEOUT_MS}ms)`);
-        if (this.sessionId === mySessionId) {
-          try {
-            connection.close();
-          } catch {
-            // Ignore close errors
-          }
-          this.cleanupConnection();
-          this.emit({ type: "error", message: "Connection timed out" });
-          this.emit({ type: "status", status: "error" });
-          this.settlePendingStart(mySessionId, { ok: false, error: "Connection timed out" });
-        }
-      }, CONNECT_TIMEOUT_MS);
-
-      connection.on("open", () => {
-        if (this.sessionId !== mySessionId) {
-          logWarn(`${P} Session expired during connect, closing`);
-          try {
-            connection.close();
-          } catch {
-            // Ignore close errors
-          }
-          return;
-        }
-        logInfo(`${P} WebSocket opened, sending session.update`);
-        // TODO: pass `transcription.prompt` from settings once #7832 lands.
-        // `turn_detection` MUST be explicitly `null` for `gpt-realtime-whisper`
-        // (VAD is not supported for this model). It is not enough to omit it:
-        // when absent the server applies a default VAD that this model can't
-        // use, and then silently produces no transcription — it still acks
-        // `input_audio_buffer.committed` but emits no `conversation.item.added`
-        // / `conversation.item.done`. With it set to `null`, each manual commit
-        // yields a transcribed item. (An explicit non-null `turn_detection`
-        // block, by contrast, is hard-rejected with an error event.)
-        const sessionUpdate = {
-          type: "session.update",
-          session: {
-            type: "transcription",
-            audio: {
-              input: {
-                format: { type: "audio/pcm", rate: 24000 },
-                transcription: {
-                  model: OPENAI_TRANSCRIPTION_MODEL,
-                  language: settings.language || "en",
-                },
-                turn_detection: null,
-              },
-            },
-          },
-        };
-        // Log the exact payload — the session config (especially the explicit
-        // `turn_detection: null`) is the most common cause of "commits acked
-        // but no transcription items" regressions.
-        logInfo(`${P} → session.update`, { session: sessionUpdate.session });
-        try {
-          connection.send(JSON.stringify(sessionUpdate));
-        } catch (err) {
-          const message = formatErrorMessage(err, "Failed to send session.update");
-          logError(`${P} ${message}`);
-          this.handleFatalError(mySessionId, message);
-        }
-      });
-
-      connection.on("message", (data) => {
-        if (this.sessionId !== mySessionId) return;
-        const raw =
-          typeof data === "string"
-            ? data
-            : Buffer.isBuffer(data)
-              ? data.toString("utf8")
-              : Array.isArray(data)
-                ? Buffer.concat(data).toString("utf8")
-                : Buffer.from(data as ArrayBuffer).toString("utf8");
-
-        let parsed: Record<string, unknown>;
-        try {
-          parsed = JSON.parse(raw) as Record<string, unknown>;
-        } catch {
-          logWarn(`${P} Ignoring non-JSON message`, { raw: raw.slice(0, 200) });
-          return;
-        }
-
-        const type = typeof parsed.type === "string" ? parsed.type : "";
-        this.handleServerEvent(mySessionId, type, parsed);
-      });
-
-      connection.on("error", (err) => {
-        this.clearConnectTimeout();
-        if (this.sessionId !== mySessionId) return;
-        const message = formatErrorMessage(err, "WebSocket error");
-        logError(`${P} WebSocket error`, { message });
-        this.handleFatalError(mySessionId, message);
-      });
-
-      connection.on("close", (code, reason) => {
-        this.clearConnectTimeout();
-        if (this.sessionId !== mySessionId) return;
-        logInfo(`${P} WebSocket closed`, {
-          code,
-          reason: Buffer.isBuffer(reason) ? reason.toString("utf8") : String(reason ?? ""),
-          wasReady: this.isReady,
-          wasDraining: this.isDraining,
-          audioChunksStreamed: this.audioChunkCount,
-        });
-        this.cleanupConnection();
-        this.settlePendingStart(mySessionId, { ok: false, error: "Connection closed" });
-        if (this.isDraining) {
-          this.settleDrain("connection-closed");
-        } else {
-          this.emit({ type: "status", status: "idle" });
-        }
-      });
+      const type = typeof parsed.type === "string" ? parsed.type : "";
+      this.handleServerEvent(mySessionId, type, parsed);
     });
+
+    connection.on("error", (err) => {
+      this.clearConnectTimeout();
+      if (this.sessionId !== mySessionId) return;
+      const message = formatErrorMessage(err, "WebSocket error");
+      logError(`${P} WebSocket error`, { message });
+      // A transport error on a ready (or reconnecting) session is recoverable —
+      // `ws` always fires `close` right after `error`, and the close handler
+      // owns the reconnect decision, so just log here. A pre-ready error
+      // (auth/DNS/refused on the very first connect) is fatal: tear down now.
+      if (!this.isReady && !this.isReconnecting) {
+        this.handleFatalError(mySessionId, message);
+      }
+    });
+
+    connection.on("close", (code, reason) => {
+      this.clearConnectTimeout();
+      this.clearHeartbeat();
+      if (this.sessionId !== mySessionId) return;
+      const wasReady = this.isReady;
+      logInfo(`${P} WebSocket closed`, {
+        code,
+        reason: Buffer.isBuffer(reason) ? reason.toString("utf8") : String(reason ?? ""),
+        wasReady,
+        wasReconnecting: this.isReconnecting,
+        wasExpected: this.isExpectedClose,
+        wasDraining: this.isDraining,
+        audioChunksStreamed: this.audioChunkCount,
+      });
+      this.cleanupConnection();
+      if (this.isDraining) {
+        this.settleDrain("connection-closed");
+        return;
+      }
+      // An unexpected drop of a ready session (or a failed reconnect attempt
+      // while still mid-reconnect) is recoverable — schedule a retry instead of
+      // ending the session. Graceful stops and fatal errors set isExpectedClose.
+      if (!this.isExpectedClose && (wasReady || this.isReconnecting)) {
+        this.scheduleReconnect(mySessionId, settings);
+        return;
+      }
+      this.settlePendingStart(mySessionId, { ok: false, error: "Connection closed" });
+      this.emit({ type: "status", status: "idle" });
+    });
+  }
+
+  /**
+   * Starts the ping/pong heartbeat for one connection. `isAlive` is set true on
+   * open and on every pong; each interval tick terminates the socket if no pong
+   * arrived since the last ping, then sends a fresh ping. The session-id /
+   * socket-identity guard stops a stale interval from terminating a newer
+   * connection (lesson #4850).
+   */
+  private startHeartbeat(connection: WebSocket, mySessionId: number): void {
+    this.clearHeartbeat();
+    this.isAlive = true;
+    this.heartbeatInterval = setInterval(() => {
+      if (this.sessionId !== mySessionId || this.connection !== connection) {
+        this.clearHeartbeat();
+        return;
+      }
+      if (!this.isAlive) {
+        logWarn(`${P} Heartbeat: no pong, terminating half-open connection`);
+        try {
+          connection.terminate();
+        } catch {
+          // Ignore terminate errors — the close handler drives reconnect.
+        }
+        return;
+      }
+      this.isAlive = false;
+      try {
+        connection.ping();
+      } catch (err) {
+        logWarn(`${P} Heartbeat ping failed`, { message: formatErrorMessage(err, "ping failed") });
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private clearHeartbeat(): void {
+    if (this.heartbeatInterval !== null) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
+    }
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  /**
+   * Schedules the next reconnect attempt with exponential backoff + full jitter.
+   * Gives up (fatal error) once RECONNECT_MAX_ATTEMPTS is reached. The timer
+   * callback re-checks the session id so a `stop()`/new `start()` between
+   * scheduling and firing cancels it (lessons #4850/#4851).
+   */
+  private scheduleReconnect(mySessionId: number, settings: VoiceInputSettings): void {
+    if (this.sessionId !== mySessionId) return;
+    if (this.reconnectAttempt >= RECONNECT_MAX_ATTEMPTS) {
+      logError(`${P} Reconnect failed after ${RECONNECT_MAX_ATTEMPTS} attempts — giving up`);
+      this.isReconnecting = false;
+      this.handleFatalError(mySessionId, "Connection lost — reconnect failed");
+      return;
+    }
+
+    this.isReconnecting = true;
+    const ceiling = Math.min(
+      RECONNECT_CAP_MS,
+      RECONNECT_INITIAL_MS * RECONNECT_MULTIPLIER ** this.reconnectAttempt
+    );
+    const delay = Math.random() * ceiling;
+    this.reconnectAttempt++;
+    logInfo(`${P} Scheduling reconnect`, {
+      attempt: this.reconnectAttempt,
+      maxAttempts: RECONNECT_MAX_ATTEMPTS,
+      delayMs: Math.round(delay),
+    });
+    this.emit({ type: "status", status: "reconnecting" });
+
+    this.clearReconnectTimer();
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.sessionId !== mySessionId) return;
+      this.reconnectOnce(mySessionId, settings);
+    }, delay);
+  }
+
+  /**
+   * Tears down the dead connection (without touching the session id, reconnect
+   * counter, or buffered audio) and opens a fresh one. Audio captured during
+   * the reconnect window stays in `preConnectBuffer` and is flushed once the new
+   * connection reaches `session.updated`.
+   */
+  private reconnectOnce(mySessionId: number, settings: VoiceInputSettings): void {
+    if (this.sessionId !== mySessionId) return;
+    logInfo(`${P} Reconnecting`, { attempt: this.reconnectAttempt });
+    this.cleanupConnection();
+    this.connect(mySessionId, settings);
   }
 
   private handleFatalError(mySessionId: number, message: string): void {
     logError(`${P} Fatal error — tearing down session`, { message });
+    // Mark the close as expected so the trailing `close` event (after the
+    // socket tears down) isn't treated as a recoverable drop.
+    this.isExpectedClose = true;
+    this.isReconnecting = false;
+    this.clearReconnectTimer();
     this.cleanupConnection();
     this.emit({ type: "error", message });
     this.emit({ type: "status", status: "error" });
@@ -334,7 +523,12 @@ export class VoiceTranscriptionService {
             this.sendAudioJson(chunk);
           }
           this.preConnectBuffer = [];
+          this.preConnectBufferBytes = 0;
         }
+        // A successful (re)connection clears the reconnect state so a later drop
+        // gets a fresh full backoff budget.
+        this.reconnectAttempt = 0;
+        this.isReconnecting = false;
         this.isReady = true;
         this.startCommitTimer();
         this.emit({ type: "status", status: "recording" });
@@ -499,15 +693,10 @@ export class VoiceTranscriptionService {
     if (this.isDraining) return;
 
     if (!this.isReady || !this.connection) {
-      if (this.connection || this.pendingStart) {
-        if (this.preConnectBuffer.length < PRE_CONNECT_BUFFER_MAX) {
-          this.preConnectBuffer.push(chunk);
-        } else if (!this.preConnectBufferOverflowWarned) {
-          this.preConnectBufferOverflowWarned = true;
-          logWarn(
-            `${P} Pre-connect buffer full (${PRE_CONNECT_BUFFER_MAX} chunks), dropping audio`
-          );
-        }
+      // Buffer while connecting (initial) or reconnecting (mid-session drop) so
+      // audio captured during the gap is flushed once the session is ready.
+      if (this.connection || this.pendingStart || this.isReconnecting) {
+        this.bufferPreConnectChunk(chunk);
       } else if (!this.staleChunkWarned) {
         this.staleChunkWarned = true;
         logWarn(`${P} sendAudioChunk called but no active session`);
@@ -524,10 +713,44 @@ export class VoiceTranscriptionService {
     this.sendAudioJson(chunk);
   }
 
+  /**
+   * Appends a chunk to the pre-connect / reconnect buffer, enforcing both a
+   * chunk-count cap and a byte cap. Oldest-wins: once either ceiling is hit the
+   * chunk is dropped (warned once) — a voice gap past ~3s is unrecoverable
+   * anyway, so there's no value in retaining unbounded audio.
+   */
+  private bufferPreConnectChunk(chunk: ArrayBuffer): void {
+    if (
+      this.preConnectBuffer.length >= PRE_CONNECT_BUFFER_MAX ||
+      this.preConnectBufferBytes + chunk.byteLength > PRE_CONNECT_BUFFER_MAX_BYTES
+    ) {
+      if (!this.preConnectBufferOverflowWarned) {
+        this.preConnectBufferOverflowWarned = true;
+        logWarn(`${P} Pre-connect buffer full, dropping audio`, {
+          chunks: this.preConnectBuffer.length,
+          bytes: this.preConnectBufferBytes,
+          maxChunks: PRE_CONNECT_BUFFER_MAX,
+          maxBytes: PRE_CONNECT_BUFFER_MAX_BYTES,
+        });
+      }
+      return;
+    }
+    this.preConnectBuffer.push(chunk);
+    this.preConnectBufferBytes += chunk.byteLength;
+  }
+
+  /**
+   * Tears down per-connection state without ending the session. Deliberately
+   * does NOT touch `sessionId`, `reconnectAttempt`, `isReconnecting`,
+   * `isExpectedClose`, or the pre-connect buffer — those survive across a
+   * reconnect. Use `cleanupPreviousSession()` for a full session reset.
+   */
   private cleanupConnection(): void {
     this.clearCommitTimer();
+    this.clearHeartbeat();
     this.connection = null;
     this.isReady = false;
+    this.isAlive = false;
     this.bytesSinceCommit = 0;
     this.pendingCommits = 0;
     this.completedItemIds.clear();
@@ -548,9 +771,16 @@ export class VoiceTranscriptionService {
     this.pendingCommits = 0;
     this.completedItemIds.clear();
     this.preConnectBuffer = [];
+    this.preConnectBufferBytes = 0;
     this.clearConnectTimeout();
     this.clearDrainTimeout();
     this.clearCommitTimer();
+    this.clearHeartbeat();
+    this.clearReconnectTimer();
+    this.reconnectAttempt = 0;
+    this.isReconnecting = false;
+    this.isExpectedClose = false;
+    this.isAlive = false;
     this.isDraining = false;
     this.liveText = "";
     if (this.drainResolve) {
@@ -661,6 +891,12 @@ export class VoiceTranscriptionService {
       return this.drainPromise;
     }
 
+    // A graceful stop is an expected close — cancel any pending reconnect and
+    // stop the close handler from retrying.
+    this.isExpectedClose = true;
+    this.isReconnecting = false;
+    this.clearReconnectTimer();
+
     if (!this.connection || !this.isReady) {
       this.cleanupPreviousSession();
       this.emit({ type: "status", status: "idle" });
@@ -730,6 +966,12 @@ export class VoiceTranscriptionService {
 
   stop(): void {
     logInfo(`${P} stop() called`, { sessionId: this.sessionId, hasConnection: !!this.connection });
+    // Suppress any reconnect: this is a deliberate stop. The sessionId bump in
+    // cleanupPreviousSession is the primary guard; the flag documents intent and
+    // covers the brief window before the bump takes effect.
+    this.isExpectedClose = true;
+    this.isReconnecting = false;
+    this.clearReconnectTimer();
     this.cleanupPreviousSession();
     this.emit({ type: "status", status: "idle" });
   }

--- a/electron/services/__tests__/VoiceTranscriptionService.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.test.ts
@@ -1090,18 +1090,77 @@ describe("VoiceTranscriptionService", () => {
     expect(instances.length).toBe(instancesBeforeStop);
   });
 
-  it("does not reconnect after a server-side fatal error", async () => {
+  it("does not reconnect after a server-side fatal error and ends in error, not idle", async () => {
     const service = new VoiceTranscriptionService();
     const { socket } = await bringSessionReady(service);
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
     const instancesBefore = instances.length;
 
-    // A server error is fatal — the trailing close must not trigger a reconnect.
+    // A server error is fatal: the socket is terminated, the trailing close must
+    // not trigger a reconnect, and the final status stays "error" (not "idle").
     socket.simulateMessage("error", {
       error: { message: "invalid_session_config", type: "invalid_request_error" },
     });
+    expect(socket.terminateCalls).toBe(1);
+
+    // The terminate() above already fired a close; an extra server close is a
+    // no-op for status. Simulate it to be sure idle never leaks through.
     socket.simulateClose(1011);
 
     vi.advanceTimersByTime(3_000);
     expect(instances.length).toBe(instancesBefore);
+    expect(statuses).toContain("error");
+    expect(statuses).not.toContain("idle");
+  });
+
+  it("enforces the pre-connect buffer byte cap independently of the chunk cap", async () => {
+    const service = new VoiceTranscriptionService();
+    void service.start(BASE_SETTINGS);
+    await Promise.resolve();
+
+    // Five 40KB chunks = 200KB, over the 150KB ceiling but well under the
+    // 100-chunk cap — only the first chunks that fit under 150KB are kept.
+    for (let i = 0; i < 5; i++) {
+      service.sendAudioChunk(new Uint8Array(40_000).buffer);
+    }
+    const socket = latestInstance();
+    socket.simulateOpen();
+    socket.simulateMessage("session.updated");
+
+    const audioCount = socket
+      .sentJson()
+      .filter((p) => p.type === "input_audio_buffer.append").length;
+    // 3 × 40KB = 120KB fits; a 4th would push to 160KB > 150KB, so it's dropped.
+    expect(audioCount).toBe(3);
+    service.stop();
+  });
+
+  it("retries and gives up when the reconnect socket constructor keeps throwing", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    // Every reconnect attempt's WebSocket construction fails.
+    throwOnConstruct = true;
+    constructError = new Error("ECONNREFUSED");
+    const instancesBefore = instances.length;
+
+    socket.simulateClose(1006);
+    // Drive all backoff cycles — each fires the timer, connect() throws, and
+    // reschedules until attempts are exhausted.
+    for (let i = 0; i < 6; i++) {
+      vi.advanceTimersByTime(3_000);
+    }
+
+    expect(instances.length).toBe(instancesBefore);
+    expect(statuses).toContain("error");
   });
 });

--- a/electron/services/__tests__/VoiceTranscriptionService.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.test.ts
@@ -26,6 +26,8 @@ class MockWebSocket {
   sent: string[] = [];
   closeCalls = 0;
   closeCode?: number;
+  terminateCalls = 0;
+  pingCalls = 0;
 
   private listeners: Map<string, Set<WsListener>> = new Map();
 
@@ -68,7 +70,24 @@ class MockWebSocket {
     this.readyState = MockWebSocket.CLOSED;
   }
 
+  // `ws.terminate()` destroys the socket without a closing handshake. The real
+  // package fires a `close` event afterward; mirror that so the service's
+  // close-driven reconnect path is exercised.
+  terminate(): void {
+    this.terminateCalls++;
+    this.readyState = MockWebSocket.CLOSED;
+    this.fire("close", 1006, undefined);
+  }
+
+  ping(): void {
+    this.pingCalls++;
+  }
+
   // Test helpers
+  simulatePong(): void {
+    this.fire("pong");
+  }
+
   simulateOpen(): void {
     this.readyState = MockWebSocket.OPEN;
     this.fire("open");
@@ -904,5 +923,185 @@ describe("VoiceTranscriptionService", () => {
       transcript: "after destroy",
     });
     expect(events.length).toBe(lengthAtDestroy);
+  });
+
+  // ── Heartbeat (half-open detection) ──────────────────────────────────────
+
+  it("pings on the heartbeat interval once the connection is open", async () => {
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+
+    expect(socket.pingCalls).toBe(0);
+    vi.advanceTimersByTime(20_000);
+    expect(socket.pingCalls).toBe(1);
+
+    service.stop();
+  });
+
+  it("terminates the socket when a heartbeat ping goes unanswered", async () => {
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+
+    // First tick: ping sent, awaiting pong.
+    vi.advanceTimersByTime(20_000);
+    expect(socket.pingCalls).toBe(1);
+    expect(socket.terminateCalls).toBe(0);
+
+    // Second tick: no pong arrived → terminate (not graceful close).
+    vi.advanceTimersByTime(20_000);
+    expect(socket.terminateCalls).toBe(1);
+    expect(socket.closeCalls).toBe(0);
+
+    service.stop();
+  });
+
+  it("a pong keeps the connection alive across heartbeat ticks", async () => {
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+
+    vi.advanceTimersByTime(20_000);
+    expect(socket.pingCalls).toBe(1);
+    socket.simulatePong();
+
+    vi.advanceTimersByTime(20_000);
+    expect(socket.pingCalls).toBe(2);
+    expect(socket.terminateCalls).toBe(0);
+
+    service.stop();
+  });
+
+  it("a stale connection's heartbeat does not terminate a newer socket", async () => {
+    const service = new VoiceTranscriptionService();
+    const { socket: firstSocket } = await bringSessionReady(service);
+
+    // Replace the session — the first socket and its heartbeat are now stale.
+    const secondPromise = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const secondSocket = latestInstance();
+    secondSocket.simulateOpen();
+    secondSocket.simulateMessage("session.updated");
+    await secondPromise;
+
+    // The first socket's heartbeat was torn down when the session was replaced;
+    // it must never terminate (its sessionId/socket-identity guard would also
+    // catch it). The second socket stays alive as long as it pongs.
+    vi.advanceTimersByTime(20_000);
+    secondSocket.simulatePong();
+    vi.advanceTimersByTime(20_000);
+    expect(firstSocket.terminateCalls).toBe(0);
+    expect(secondSocket.terminateCalls).toBe(0);
+
+    service.stop();
+  });
+
+  // ── Reconnection ─────────────────────────────────────────────────────────
+
+  it("reconnects after an unexpected drop and returns to recording", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    socket.simulateClose(1006, Buffer.from("abnormal"));
+    expect(statuses).toContain("reconnecting");
+
+    // Backoff timer fires → a fresh socket is opened.
+    vi.advanceTimersByTime(3_000);
+    const socket2 = latestInstance();
+    expect(socket2).not.toBe(socket);
+
+    socket2.simulateOpen();
+    socket2.simulateMessage("session.updated");
+    expect(statuses.at(-1)).toBe("recording");
+
+    service.stop();
+  });
+
+  it("buffers audio captured during the reconnect window and flushes it after reconnect", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+
+    socket.simulateClose(1006);
+
+    // Audio keeps flowing while we're reconnecting — it must be buffered, not
+    // dropped (connection is null and there's no pending start at this point).
+    const chunk = new Uint8Array([7, 7, 7, 7]).buffer;
+    service.sendAudioChunk(chunk);
+
+    vi.advanceTimersByTime(3_000);
+    const socket2 = latestInstance();
+    socket2.simulateOpen();
+    socket2.simulateMessage("session.updated");
+
+    const audio = socket2
+      .sentJson()
+      .filter((p) => p.type === "input_audio_buffer.append")
+      .map((p) => p.audio as string);
+    expect(audio).toEqual([Buffer.from(chunk).toString("base64")]);
+
+    service.stop();
+  });
+
+  it("gives up and emits error after exhausting reconnect attempts", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+
+    const statuses: string[] = [];
+    const errors: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+      if (e.type === "error") errors.push(e.message);
+    });
+
+    // Initial drop schedules attempt 1.
+    socket.simulateClose(1006);
+
+    // Each cycle: fire the backoff timer (opens a socket), then drop it again
+    // before it can reach session.updated. After RECONNECT_MAX_ATTEMPTS the
+    // service gives up.
+    for (let i = 0; i < 5; i++) {
+      vi.advanceTimersByTime(3_000);
+      latestInstance().simulateClose(1006);
+    }
+
+    expect(statuses).toContain("reconnecting");
+    expect(statuses).toContain("error");
+    expect(errors.some((m) => /reconnect failed/i.test(m))).toBe(true);
+  });
+
+  it("a graceful stop during the reconnect window cancels the pending retry", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+
+    socket.simulateClose(1006);
+    const instancesBeforeStop = instances.length;
+
+    service.stop();
+
+    // The backoff timer was cleared by stop() — advancing time opens no socket.
+    vi.advanceTimersByTime(3_000);
+    expect(instances.length).toBe(instancesBeforeStop);
+  });
+
+  it("does not reconnect after a server-side fatal error", async () => {
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+    const instancesBefore = instances.length;
+
+    // A server error is fatal — the trailing close must not trigger a reconnect.
+    socket.simulateMessage("error", {
+      error: { message: "invalid_session_config", type: "invalid_request_error" },
+    });
+    socket.simulateClose(1011);
+
+    vi.advanceTimersByTime(3_000);
+    expect(instances.length).toBe(instancesBefore);
   });
 });

--- a/shared/types/voice.ts
+++ b/shared/types/voice.ts
@@ -11,10 +11,18 @@
  * - idle: No active session.
  * - connecting: WebSocket to OpenAI Realtime is being established.
  * - recording: Connected and receiving audio; live transcription in progress.
+ * - reconnecting: Connection dropped mid-session; retrying with backoff while
+ *   buffering captured audio. The session is still active from the user's view.
  * - finishing: Session stop requested; draining final transcription from OpenAI.
  * - error: Session terminated due to a connection or transcription error.
  */
-export type VoiceInputStatus = "idle" | "connecting" | "recording" | "finishing" | "error";
+export type VoiceInputStatus =
+  | "idle"
+  | "connecting"
+  | "recording"
+  | "reconnecting"
+  | "finishing"
+  | "error";
 
 /**
  * The lifecycle phase of the transcript within a single voice panel buffer.
@@ -33,5 +41,10 @@ export type VoiceTranscriptPhase = "idle" | "interim" | "utterance_final" | "sta
  * Use this instead of comparing against multiple status strings inline.
  */
 export function isActiveVoiceSession(status: VoiceInputStatus): boolean {
-  return status === "connecting" || status === "recording" || status === "finishing";
+  return (
+    status === "connecting" ||
+    status === "recording" ||
+    status === "reconnecting" ||
+    status === "finishing"
+  );
 }

--- a/src/components/Layout/VoiceRecordingToolbarButton.tsx
+++ b/src/components/Layout/VoiceRecordingToolbarButton.tsx
@@ -61,8 +61,10 @@ export function VoiceRecordingToolbarButton({
 
   const isConnecting = status === "connecting";
   const isRecording = status === "recording";
+  const isReconnecting = status === "reconnecting";
   const isFinishing = status === "finishing";
-  const isActive = Boolean(activeTarget) && (isConnecting || isRecording || isFinishing);
+  const isActive =
+    Boolean(activeTarget) && (isConnecting || isRecording || isReconnecting || isFinishing);
 
   // Doherty gate — under 400ms of "connecting" should never paint the orbit;
   // it would flash before the recording state arrives.
@@ -71,7 +73,7 @@ export function VoiceRecordingToolbarButton({
   // race where status briefly stays "recording"/"finishing" while
   // activeTarget has already been cleared, which would otherwise leave the
   // RAF loop spinning on null refs.
-  const showOrbit = isActive && (isRecording || isFinishing || showConnecting);
+  const showOrbit = isActive && (isRecording || isReconnecting || isFinishing || showConnecting);
 
   // Mutable bridge: audioLevel updates ~60Hz; we read it inside the RAF tick
   // rather than re-rendering on every change. Pattern lifted from
@@ -170,11 +172,13 @@ export function VoiceRecordingToolbarButton({
     .join(" / ");
   const tooltipTitle = isConnecting
     ? "Preparing dictation..."
-    : isFinishing
-      ? "Finishing transcription..."
-      : contextLabel
-        ? `Recording: ${contextLabel}`
-        : "Recording in another panel";
+    : isReconnecting
+      ? "Reconnecting..."
+      : isFinishing
+        ? "Finishing transcription..."
+        : contextLabel
+          ? `Recording: ${contextLabel}`
+          : "Recording in another panel";
   const tooltipExtra = [
     isRecording ? formatDuration(elapsedSeconds) : null,
     shortcut ? `Press ${shortcut} to stop` : "Click to jump to panel",

--- a/src/components/Layout/__tests__/VoiceRecordingToolbarButton.test.ts
+++ b/src/components/Layout/__tests__/VoiceRecordingToolbarButton.test.ts
@@ -98,7 +98,7 @@ describe("VoiceRecordingToolbarButton polish — issue #8176", () => {
       // state would let the RAF loop run while the placeholder is rendered,
       // leaving the tick to no-op against null refs every frame.
       expect(source).toMatch(
-        /const\s+showOrbit\s*=\s*isActive\s*&&\s*\(isRecording\s*\|\|\s*isFinishing\s*\|\|\s*showConnecting\)/
+        /const\s+showOrbit\s*=\s*isActive\s*&&\s*\(isRecording\s*\|\|\s*isReconnecting\s*\|\|\s*isFinishing\s*\|\|\s*showConnecting\)/
       );
     });
 

--- a/src/components/Terminal/VoiceInputButton.tsx
+++ b/src/components/Terminal/VoiceInputButton.tsx
@@ -44,8 +44,9 @@ export function VoiceInputButton({
 
   const isRecording = activePanelId === panelId && status === "recording";
   const isConnecting = activePanelId === panelId && status === "connecting";
+  const isReconnecting = activePanelId === panelId && status === "reconnecting";
   const isFinishing = activePanelId === panelId && status === "finishing";
-  const isListening = isRecording || isConnecting;
+  const isListening = isRecording || isConnecting || isReconnecting;
   // Keep orbit visible through finishing for graceful exit
   const showOrbit = isListening || isFinishing;
   const isActive = isListening || isFinishing;
@@ -246,9 +247,11 @@ export function VoiceInputButton({
               ? (errorMessage ?? "Voice input error")
               : isFinishing
                 ? "Finishing transcription..."
-                : isListening
-                  ? "Stop recording"
-                  : "Start voice input"
+                : isReconnecting
+                  ? "Reconnecting... Click to stop"
+                  : isListening
+                    ? "Stop recording"
+                    : "Start voice input"
         }
         className={cn(
           "relative flex items-center justify-center rounded-full transition duration-150",

--- a/src/components/Terminal/hooks/useVoiceWaitSubmit.ts
+++ b/src/components/Terminal/hooks/useVoiceWaitSubmit.ts
@@ -43,6 +43,7 @@ export function useVoiceWaitSubmit({
           voiceState.activeTarget?.panelId === terminalId &&
           (voiceState.status === "recording" ||
             voiceState.status === "connecting" ||
+            voiceState.status === "reconnecting" ||
             voiceState.status === "finishing");
 
         if (isSessionActive) {

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -205,7 +205,13 @@ class VoiceRecordingService {
           isStoppingSession: this.isStoppingSession,
         });
         if (status !== "idle") {
+          const prevStatus = useVoiceRecordingStore.getState().status;
           useVoiceRecordingStore.getState().setStatus(status);
+          // Announce the reconnect once on entry — the backend re-emits
+          // "reconnecting" on every retry, so guard against repeat announcements.
+          if (status === "reconnecting" && prevStatus !== "reconnecting") {
+            useVoiceRecordingStore.getState().announce("Reconnecting dictation…");
+          }
         }
 
         if (this.isStoppingSession) {
@@ -270,7 +276,12 @@ class VoiceRecordingService {
     const handleEscapeKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
       const state = useVoiceRecordingStore.getState();
-      if (state.status !== "connecting" && state.status !== "recording") return;
+      if (
+        state.status !== "connecting" &&
+        state.status !== "recording" &&
+        state.status !== "reconnecting"
+      )
+        return;
       e.preventDefault();
       e.stopPropagation();
       void this.stop("Dictation cancelled.", { preserveLiveText: true });

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -378,6 +378,7 @@ describe("isActiveVoiceSession helper", () => {
   it("returns true for active phases", () => {
     expect(isActiveVoiceSession("connecting")).toBe(true);
     expect(isActiveVoiceSession("recording")).toBe(true);
+    expect(isActiveVoiceSession("reconnecting")).toBe(true);
     expect(isActiveVoiceSession("finishing")).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- The voice transcription WebSocket had no heartbeat, so half-open TCP connections would silently stall indefinitely. A 20-second ping/pong cycle now terminates them.
- Unexpected mid-session drops now auto-reconnect with exponential backoff + full jitter (150ms initial, 1.5x, 3s cap, 5 attempts then fatal). OpenAI Realtime is stateless so each attempt sends a fresh `session.update`; audio captured during the gap is buffered (150KB byte cap) and flushed once `session.updated` is confirmed.
- A `reconnecting` status variant is propagated through `isActiveVoiceSession()`, the per-terminal and toolbar voice buttons, the Escape-cancel guard, `useVoiceWaitSubmit`, and a once-per-window screen-reader announcement — the orbit stays visible and stop still works while recovering.

Resolves #9176

## Changes

- `VoiceTranscriptionService` — heartbeat loop, reconnect scheduler, audio buffer with byte cap, `cleanupConnection()` in the reconnect path (preserves session-id counter and attempt count vs `cleanupPreviousSession`), stale-socket guards on every async callback (session id + socket identity), timers cleared in every teardown path
- `shared/types/voice.ts` — adds `"reconnecting"` to `VoiceInputStatus`
- `VoiceRecordingService` — forwards `reconnecting` through the status chain
- `VoiceRecordingToolbarButton` and `VoiceInputButton` — handle `reconnecting` state
- `useVoiceWaitSubmit` — treats `reconnecting` as active so submit stays gated

## Testing

Extended the `MockWebSocket` harness with `ping`, `terminate`, and `pong` support. Added cases for heartbeat timeout, reconnect success, reconnect exhaustion, audio buffering during a gap, the 150KB byte cap, and stale-socket guard correctness. 49 tests pass; `npm run check` is clean.