### PR TITLE
fix(recipes): reject secret credentials in terminal env values

### DIFF
--- a/electron/ipc/handlers/__tests__/globalRecipes.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/globalRecipes.adversarial.test.ts
@@ -236,6 +236,37 @@ describe("globalRecipes IPC adversarial", () => {
     ).rejects.toThrow(/Invalid recipe ID/);
   });
 
+  const SECRET_PAT = `ghp_${"A".repeat(36)}`;
+  const secretTerminal = () => ({ type: "terminal", env: { GITHUB_TOKEN: SECRET_PAT } });
+
+  it("addRecipe rejects a terminal env value containing a secret", async () => {
+    await expect(
+      getHandler(CHANNELS.GLOBAL_ADD_RECIPE)(fakeEvent(), {
+        recipe: { ...validRecipe(), terminals: [secretTerminal()] },
+      })
+    ).rejects.toThrow(/secret.*github-pat|GITHUB_TOKEN/i);
+    expect(projectStoreMock.addGlobalRecipe).not.toHaveBeenCalled();
+  });
+
+  it("updateRecipe rejects a terminals patch containing a secret env value", async () => {
+    await expect(
+      getHandler(CHANNELS.GLOBAL_UPDATE_RECIPE)(fakeEvent(), {
+        recipeId: "r1",
+        updates: { terminals: [secretTerminal()] },
+      })
+    ).rejects.toThrow(/secret.*github-pat|GITHUB_TOKEN/i);
+    expect(projectStoreMock.updateGlobalRecipe).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe accepts a non-secret terminal env value", async () => {
+    const recipe = {
+      ...validRecipe(),
+      terminals: [{ type: "terminal", env: { NODE_ENV: "production" } }],
+    };
+    await getHandler(CHANNELS.GLOBAL_ADD_RECIPE)(fakeEvent(), { recipe });
+    expect(projectStoreMock.addGlobalRecipe).toHaveBeenCalledWith(recipe);
+  });
+
   it("cleanup removes all four handlers", () => {
     expect(ipcHandlers.size).toBe(4);
     cleanup();

--- a/electron/ipc/handlers/__tests__/globalRecipes.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/globalRecipes.adversarial.test.ts
@@ -267,6 +267,18 @@ describe("globalRecipes IPC adversarial", () => {
     expect(projectStoreMock.addGlobalRecipe).toHaveBeenCalledWith(recipe);
   });
 
+  it("addRecipe rejects a context-dependent secret (Datadog key named via env key)", async () => {
+    await expect(
+      getHandler(CHANNELS.GLOBAL_ADD_RECIPE)(fakeEvent(), {
+        recipe: {
+          ...validRecipe(),
+          terminals: [{ type: "terminal", env: { DD_API_KEY: "a".repeat(32) } }],
+        },
+      })
+    ).rejects.toThrow(/secret.*datadog-key|DD_API_KEY/i);
+    expect(projectStoreMock.addGlobalRecipe).not.toHaveBeenCalled();
+  });
+
   it("cleanup removes all four handlers", () => {
     expect(ipcHandlers.size).toBe(4);
     cleanup();

--- a/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
@@ -257,6 +257,71 @@ describe("projectRecipes IPC adversarial", () => {
     expect(projectStoreMock.deleteRecipe).not.toHaveBeenCalled();
   });
 
+  const SECRET_PAT = `ghp_${"A".repeat(36)}`;
+  const secretTerminal = () => ({ type: "terminal", env: { GITHUB_TOKEN: SECRET_PAT } });
+
+  it("addRecipe rejects a terminal env value containing a secret", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipe: { ...validRecipe(), terminals: [secretTerminal()] },
+      })
+    ).rejects.toThrow(/secret.*github-pat|GITHUB_TOKEN/i);
+    expect(projectStoreMock.addRecipe).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe accepts a terminal env value that is not a secret", async () => {
+    const recipe = {
+      ...validRecipe(),
+      terminals: [{ type: "terminal", env: { NODE_ENV: "production" } }],
+    };
+    await getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), { projectId: "p1", recipe });
+    expect(projectStoreMock.addRecipe).toHaveBeenCalledWith("p1", recipe);
+  });
+
+  it("updateRecipe rejects a terminals patch containing a secret env value", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_UPDATE_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipeId: "r1",
+        updates: { terminals: [secretTerminal()] },
+      })
+    ).rejects.toThrow(/secret.*github-pat|GITHUB_TOKEN/i);
+    expect(projectStoreMock.updateRecipe).not.toHaveBeenCalled();
+  });
+
+  it("saveRecipes rejects when any recipe terminal carries a secret env value", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_SAVE_RECIPES)(fakeEvent(), {
+        projectId: "p1",
+        recipes: [validRecipe(), { ...validRecipe(), id: "r2", terminals: [secretTerminal()] }],
+      })
+    ).rejects.toThrow(/secret.*github-pat|GITHUB_TOKEN/i);
+    expect(projectStoreMock.saveRecipes).not.toHaveBeenCalled();
+  });
+
+  it("syncInRepoRecipes rejects a recipe with a secret env value before writing", async () => {
+    projectStoreMock.getProjectById.mockReturnValueOnce({ path: "/repo" } as never);
+    await expect(
+      getHandler(CHANNELS.PROJECT_SYNC_INREPO_RECIPES)(fakeEvent(), {
+        projectId: "p1",
+        recipes: [{ ...validRecipe(), terminals: [secretTerminal()] }],
+      })
+    ).rejects.toThrow(/secret.*github-pat|GITHUB_TOKEN/i);
+    expect(projectStoreMock.writeInRepoRecipe).not.toHaveBeenCalled();
+  });
+
+  it("updateInRepoRecipe rejects a recipe with a secret env value", async () => {
+    projectStoreMock.getProjectById.mockReturnValueOnce({ path: "/repo" } as never);
+    await expect(
+      getHandler(CHANNELS.PROJECT_UPDATE_INREPO_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipe: { ...validRecipe(), terminals: [secretTerminal()] },
+      })
+    ).rejects.toThrow(/secret.*github-pat|GITHUB_TOKEN/i);
+    expect(projectStoreMock.writeInRepoRecipe).not.toHaveBeenCalled();
+  });
+
   it("cleanup removes all eleven handlers", () => {
     expect(ipcHandlers.size).toBe(11);
     cleanup();

--- a/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
@@ -329,7 +329,10 @@ describe("projectRecipes IPC adversarial", () => {
         recipe: {
           ...validRecipe(),
           terminals: [
-            { type: "terminal", env: { AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" } },
+            {
+              type: "terminal",
+              env: { AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" },
+            },
           ],
         },
       })

--- a/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
@@ -322,6 +322,45 @@ describe("projectRecipes IPC adversarial", () => {
     expect(projectStoreMock.writeInRepoRecipe).not.toHaveBeenCalled();
   });
 
+  it("addRecipe rejects a context-dependent secret (AWS key named via env key)", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipe: {
+          ...validRecipe(),
+          terminals: [
+            { type: "terminal", env: { AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" } },
+          ],
+        },
+      })
+    ).rejects.toThrow(/secret.*aws-secret-access-key|AWS_SECRET_ACCESS_KEY/i);
+    expect(projectStoreMock.addRecipe).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe rejects a non-string env value", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipe: {
+          ...validRecipe(),
+          terminals: [{ type: "terminal", env: { TOKEN: { nested: SECRET_PAT } } } as never],
+        },
+      })
+    ).rejects.toThrow(/must be a string/i);
+    expect(projectStoreMock.addRecipe).not.toHaveBeenCalled();
+  });
+
+  it("syncInRepoRecipes writes nothing when a later recipe carries a secret", async () => {
+    projectStoreMock.getProjectById.mockReturnValueOnce({ path: "/repo" } as never);
+    await expect(
+      getHandler(CHANNELS.PROJECT_SYNC_INREPO_RECIPES)(fakeEvent(), {
+        projectId: "p1",
+        recipes: [validRecipe(), { ...validRecipe(), id: "r2", terminals: [secretTerminal()] }],
+      })
+    ).rejects.toThrow(/secret.*github-pat|GITHUB_TOKEN/i);
+    expect(projectStoreMock.writeInRepoRecipe).not.toHaveBeenCalled();
+  });
+
   it("cleanup removes all eleven handlers", () => {
     expect(ipcHandlers.size).toBe(11);
     cleanup();

--- a/electron/ipc/handlers/globalRecipes.ts
+++ b/electron/ipc/handlers/globalRecipes.ts
@@ -2,7 +2,7 @@ import { projectStore } from "../../services/ProjectStore.js";
 import type { TerminalRecipe } from "../../types/index.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { GLOBAL_RECIPES_METHOD_CHANNELS } from "./globalRecipes.preload.js";
-import { assertRecipeUsageFields } from "./recipeValidation.js";
+import { assertNoSecretEnvValues, assertRecipeUsageFields } from "./recipeValidation.js";
 
 export const globalRecipesNamespace = defineIpcNamespace({
   name: "global-recipes",
@@ -42,6 +42,7 @@ export const globalRecipesNamespace = defineIpcNamespace({
           throw new Error("Recipe createdAt must be a finite number");
         }
         assertRecipeUsageFields(recipe);
+        assertNoSecretEnvValues(recipe.terminals);
         return projectStore.addGlobalRecipe(recipe);
       }
     ),
@@ -72,6 +73,9 @@ export const globalRecipesNamespace = defineIpcNamespace({
           throw new Error("Invalid updates: terminals must be an array");
         }
         assertRecipeUsageFields(patch);
+        if (Array.isArray(patch.terminals)) {
+          assertNoSecretEnvValues(patch.terminals as TerminalRecipe["terminals"]);
+        }
         return projectStore.updateGlobalRecipe(recipeId, updates);
       }
     ),

--- a/electron/ipc/handlers/projectRecipes.ts
+++ b/electron/ipc/handlers/projectRecipes.ts
@@ -7,7 +7,7 @@ import { stableInRepoId } from "../../../shared/utils/recipeFilename.js";
 import type { HandlerDependencies } from "../types.js";
 import type { TerminalRecipe } from "../../types/index.js";
 import { typedHandle, typedHandleWithContext } from "../utils.js";
-import { assertRecipeUsageFields } from "./recipeValidation.js";
+import { assertNoSecretEnvValues, assertRecipeUsageFields } from "./recipeValidation.js";
 
 export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -41,6 +41,11 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     }
     if (!Array.isArray(recipes)) {
       throw new Error("Invalid recipes array");
+    }
+    for (const recipe of recipes) {
+      if (Array.isArray(recipe?.terminals)) {
+        assertNoSecretEnvValues(recipe.terminals);
+      }
     }
     return projectStore.saveRecipes(projectId, recipes);
   };
@@ -76,6 +81,7 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
       throw new Error("Recipe createdAt must be a finite number");
     }
     assertRecipeUsageFields(recipe);
+    assertNoSecretEnvValues(recipe.terminals);
     return projectStore.addRecipe(projectId, recipe);
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_ADD_RECIPE, handleProjectAddRecipe));
@@ -109,6 +115,9 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
       throw new Error("Invalid updates: terminals must be an array");
     }
     assertRecipeUsageFields(patch);
+    if (Array.isArray(patch.terminals)) {
+      assertNoSecretEnvValues(patch.terminals as TerminalRecipe["terminals"]);
+    }
     return projectStore.updateRecipe(projectId, recipeId, updates);
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_UPDATE_RECIPE, handleProjectUpdateRecipe));
@@ -217,6 +226,11 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
       throw new Error(`Project not found: ${projectId}`);
     }
     for (const recipe of recipes) {
+      if (Array.isArray(recipe?.terminals)) {
+        assertNoSecretEnvValues(recipe.terminals);
+      }
+    }
+    for (const recipe of recipes) {
       await projectStore.writeInRepoRecipe(project.path, recipe);
     }
   };
@@ -241,6 +255,7 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     if (!project) {
       throw new Error(`Project not found: ${projectId}`);
     }
+    assertNoSecretEnvValues(recipe.terminals);
     await projectStore.writeInRepoRecipe(project.path, recipe);
     if (
       previousName &&

--- a/electron/ipc/handlers/recipeValidation.ts
+++ b/electron/ipc/handlers/recipeValidation.ts
@@ -42,8 +42,14 @@ export function assertNoSecretEnvValues(terminals: RecipeTerminal[]): void {
     const env = terminals[i]?.env;
     if (!env) continue;
     for (const [key, rawValue] of Object.entries(env)) {
-      if (typeof rawValue !== "string") continue;
-      const match = findSecretInValue(rawValue);
+      if (typeof rawValue !== "string") {
+        throw new Error(`Recipe terminal ${i} env "${key}" must be a string`);
+      }
+      // Several scrubber patterns are context-dependent — they only match when
+      // the key name precedes the value (e.g. `AWS_SECRET_ACCESS_KEY=...`,
+      // `DD_API_KEY=...`, `api_key=...`). Test the bare value first, then the
+      // `KEY=value` form so those patterns can anchor on the surrounding name.
+      const match = findSecretInValue(rawValue) ?? findSecretInValue(`${key}=${rawValue}`);
       if (match) {
         throw new Error(
           `Recipe terminal ${i} env "${key}" contains a secret (pattern: ${match.name}). ` +

--- a/electron/ipc/handlers/recipeValidation.ts
+++ b/electron/ipc/handlers/recipeValidation.ts
@@ -1,3 +1,6 @@
+import type { RecipeTerminal } from "../../../shared/types/project.js";
+import { findSecretInValue } from "../../utils/secretScrubber.js";
+
 const USAGE_HISTORY_LIMIT = 20;
 
 export function assertRecipeUsageFields(value: {
@@ -17,6 +20,36 @@ export function assertRecipeUsageFields(value: {
     for (const entry of value.usageHistory) {
       if (!Number.isFinite(entry)) {
         throw new Error("Recipe usageHistory entries must be finite numbers");
+      }
+    }
+  }
+}
+
+/**
+ * Refuses to save a recipe whose terminal env values contain a detectable
+ * secret. Recipe JSON is persisted to `.daintree/recipes/*.json`, which is
+ * git-tracked — pasting a token into an env value would commit the credential
+ * on the next push. We reject (rather than silently blank) so the user gets a
+ * useful error naming the offending key and pattern instead of a recipe that
+ * mysteriously runs with an empty env var. The in-repo write path already
+ * blanks env values as a defense-in-depth backstop; this is the primary guard.
+ *
+ * Fails fast on the first match, matching the throw-on-first-violation
+ * convention of {@link assertRecipeUsageFields}.
+ */
+export function assertNoSecretEnvValues(terminals: RecipeTerminal[]): void {
+  for (let i = 0; i < terminals.length; i++) {
+    const env = terminals[i]?.env;
+    if (!env) continue;
+    for (const [key, rawValue] of Object.entries(env)) {
+      if (typeof rawValue !== "string") continue;
+      const match = findSecretInValue(rawValue);
+      if (match) {
+        throw new Error(
+          `Recipe terminal ${i} env "${key}" contains a secret (pattern: ${match.name}). ` +
+            `Credentials must not be saved in recipes — they would be committed to git. ` +
+            `Remove the value and set it as a secure env var instead.`
+        );
       }
     }
   }

--- a/electron/utils/__tests__/secretScrubber.test.ts
+++ b/electron/utils/__tests__/secretScrubber.test.ts
@@ -990,6 +990,21 @@ describe("secretScrubber", () => {
       expect(findSecretInValue(token)?.name).toBe("github-pat");
     });
 
+    it("matches context-dependent patterns when the key name precedes the value", () => {
+      expect(findSecretInValue(`AWS_SECRET_ACCESS_KEY=${"A".repeat(40)}`)?.name).toBe(
+        "aws-secret-access-key"
+      );
+      expect(findSecretInValue(`DD_API_KEY=${"a".repeat(32)}`)?.name).toBe("datadog-key");
+      expect(findSecretInValue(`api_key=${"A".repeat(32)}`)?.name).toBe("generic-key-fallback");
+    });
+
+    it("does not match a bare context-dependent value without its key name", () => {
+      // The AWS secret pattern requires the key name as context — the bare
+      // 40-char value alone must not match (this is why assertNoSecretEnvValues
+      // also tests the `KEY=value` form).
+      expect(findSecretInValue("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")).toBeUndefined();
+    });
+
     it("does not mutate the shared PATTERNS lastIndex (scrubSecrets still works after)", () => {
       findSecretInValue(`ghp_${"A".repeat(36)}`);
       // If findSecretInValue had advanced a shared regex's lastIndex, this

--- a/electron/utils/__tests__/secretScrubber.test.ts
+++ b/electron/utils/__tests__/secretScrubber.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import safe from "safe-regex2";
-import { PATTERNS, REDACTED, scrubSecrets } from "../secretScrubber.js";
+import { findSecretInValue, PATTERNS, REDACTED, scrubSecrets } from "../secretScrubber.js";
 
 describe("secretScrubber", () => {
   describe("ReDoS safety", () => {
@@ -961,6 +961,40 @@ describe("secretScrubber", () => {
       expect(out).not.toMatch(/Bearer [A-Za-z0-9]/);
       const redactionCount = (out.match(/\[REDACTED\]/g) ?? []).length;
       expect(redactionCount).toBe(3);
+    });
+  });
+
+  describe("findSecretInValue", () => {
+    it("returns undefined for a clean string", () => {
+      expect(findSecretInValue("just a normal value")).toBeUndefined();
+    });
+
+    it("returns undefined for an empty string", () => {
+      expect(findSecretInValue("")).toBeUndefined();
+    });
+
+    it("returns the matching pattern for a GitHub PAT", () => {
+      const match = findSecretInValue(`ghp_${"A".repeat(36)}`);
+      expect(match?.name).toBe("github-pat");
+    });
+
+    it("identifies an Anthropic key", () => {
+      const match = findSecretInValue(`sk-ant-${"a".repeat(95)}`);
+      expect(match?.name).toBe("anthropic-api-key");
+    });
+
+    it("is stateless across repeated calls on the same value (no lastIndex leak)", () => {
+      const token = `ghp_${"A".repeat(36)}`;
+      expect(findSecretInValue(token)?.name).toBe("github-pat");
+      expect(findSecretInValue(token)?.name).toBe("github-pat");
+      expect(findSecretInValue(token)?.name).toBe("github-pat");
+    });
+
+    it("does not mutate the shared PATTERNS lastIndex (scrubSecrets still works after)", () => {
+      findSecretInValue(`ghp_${"A".repeat(36)}`);
+      // If findSecretInValue had advanced a shared regex's lastIndex, this
+      // global-flag .replace() would skip the leading match.
+      expect(scrubSecrets(`ghp_${"A".repeat(36)}`)).toBe(REDACTED);
     });
   });
 });

--- a/electron/utils/secretScrubber.ts
+++ b/electron/utils/secretScrubber.ts
@@ -439,3 +439,28 @@ export function scrubSecrets(value: string): string {
 
   return out;
 }
+
+/**
+ * Detects whether a string contains a known secret sigil, returning the first
+ * matching pattern (or `undefined` when clean). Unlike {@link scrubSecrets},
+ * this is a predicate — it reports a match instead of redacting.
+ *
+ * The shared `PATTERNS` regexes carry the `g` flag, which makes `.test()`
+ * stateful (`lastIndex` persists across calls on the same instance and yields
+ * non-deterministic false negatives in a loop). Each pattern is cloned with the
+ * `g`/`y` flags stripped before testing so detection stays stateless and the
+ * module-level catalogue is never mutated.
+ *
+ * @param value arbitrary string, e.g. a recipe env value
+ * @returns the first matching `SecretPattern`, or `undefined` when none match
+ */
+export function findSecretInValue(value: string): SecretPattern | undefined {
+  if (value.length === 0) return undefined;
+
+  for (const pattern of PATTERNS) {
+    const stateless = new RegExp(pattern.regex.source, pattern.regex.flags.replace(/[gy]/g, ""));
+    if (stateless.test(value)) return pattern;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary

- Recipe JSON files are committed to git — `terminals[].env` accepted arbitrary string values with no validation, so pasting a credential (e.g. `GITHUB_TOKEN=ghp_...`) would be committed on the next push
- Adds a save-path guard that rejects recipes whose terminal env values match the existing `secretScrubber` `PATTERNS` catalogue (50+ vendor patterns)
- Raises a named error identifying the offending terminal index, env key, and matched pattern so the user gets an actionable message rather than silent data loss

Resolves #9146

## Changes

- `findSecretInValue()` predicate in `electron/utils/secretScrubber.ts` — reuses `PATTERNS`; clones each regex stateless (strips `g`/`y` flags) to avoid `lastIndex` false negatives and module-level mutation
- `assertNoSecretEnvValues()` in `electron/ipc/handlers/recipeValidation.ts` — tests both the bare value and the `KEY=value` form so context-anchored patterns (aws-secret-access-key, datadog-key, telegram-bot-token, generic-key-fallback) fire correctly; rejects non-string env values
- Guard threaded into all 7 recipe write paths: project save/add/update/sync-inrepo/update-inrepo and global add/update
- In-repo write path's existing env-blanking is kept as defence-in-depth

## Testing

Tests added to `secretScrubber.test.ts` and both adversarial handler test suites — covering statelessness, context-dependent detection, non-string rejection, sync write-ordering, and clean-path acceptance. 287 tests pass; full check suite green.