### PR TITLE
feat(themes): even out surface elevation ramps across built-in themes

### DIFF
--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { BUILT_IN_THEME_SOURCES } from "../builtInThemes/index.js";
 import { getThemeContrastWarnings } from "../contrast.js";
+import { getSurfaceRampMetrics, hexToOklchL } from "../oklch.js";
 import { BUILT_IN_APP_SCHEMES } from "../themes.js";
 import { APP_THEME_TOKEN_KEYS } from "../types.js";
 
@@ -205,6 +206,44 @@ describe("built-in themes", () => {
       ).toBeGreaterThanOrEqual(0.25);
     }
   });
+
+  it("hexToOklchL anchors at known sRGB endpoints", () => {
+    // Sanity-pin Ottosson's sRGB→LMS path: pure black maps to L=0, pure white to L≈1.
+    // Catches sign flips, matrix transposes, and gamma errors before they ripple
+    // through the surface ramp gate below.
+    expect(hexToOklchL("#000000")).toBeCloseTo(0, 4);
+    expect(hexToOklchL("#ffffff")).toBeCloseTo(1, 4);
+  });
+
+  it.each(BUILT_IN_THEME_SOURCES.map((s) => [s.id, s] as const))(
+    "surface ramp for %s is monotonic, perceptible, and not runaway",
+    (_id, source) => {
+      // Surface elevation ramps (grid → sidebar → canvas → panel → elevated) must:
+      // (1) be monotonically lighter so depth ordering is unambiguous;
+      // (2) keep every adjacent step at or above the just-noticeable-difference
+      //     floor — dark themes get 0.015 ΔL (≈1 OKLCH JND, shadows can't compensate
+      //     at low luminance); light themes get 0.020 ΔL (1 JND is sufficient because
+      //     ambient cues help, and white-ceiling headroom is tight);
+      // (3) keep the largest step within 2.0× the smallest — a runaway elevated jump
+      //     reads as a discontinuity rather than the next floor in the ramp.
+      const metrics = getSurfaceRampMetrics(source.palette.surfaces);
+      const minStepFloor = source.type === "dark" ? 0.015 : 0.02;
+      const maxRatio = 2.0;
+      const diag = `${source.id} L=[grid=${metrics.lightness.grid.toFixed(4)}, sidebar=${metrics.lightness.sidebar.toFixed(4)}, canvas=${metrics.lightness.canvas.toFixed(4)}, panel=${metrics.lightness.panel.toFixed(4)}, elevated=${metrics.lightness.elevated.toFixed(4)}] steps=[${metrics.steps.gridToSidebar.toFixed(4)}, ${metrics.steps.sidebarToCanvas.toFixed(4)}, ${metrics.steps.canvasToPanel.toFixed(4)}, ${metrics.steps.panelToElevated.toFixed(4)}] min=${metrics.minStep.toFixed(4)} max=${metrics.maxStep.toFixed(4)} ratio=${metrics.ratio.toFixed(2)}`;
+      expect(
+        metrics.monotonic,
+        `${diag} — surfaces must be monotonically lighter from grid to elevated`
+      ).toBe(true);
+      expect(
+        metrics.minStep,
+        `${diag} — smallest step is below the ${minStepFloor} ΔL floor for ${source.type} themes`
+      ).toBeGreaterThanOrEqual(minStepFloor);
+      expect(
+        metrics.ratio,
+        `${diag} — step-uniformity ratio exceeds the ${maxRatio} ceiling`
+      ).toBeLessThanOrEqual(maxRatio);
+    }
+  );
 
   it("dark themes override toolbar-control-armed-shadow with a white-tinted hairline; light themes inherit the black-tinted CSS fallback", () => {
     // Dark themes must provide a white-tinted hairline override — the CSS fallback

--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -207,12 +207,38 @@ describe("built-in themes", () => {
     }
   });
 
-  it("hexToOklchL anchors at known sRGB endpoints", () => {
-    // Sanity-pin Ottosson's sRGB→LMS path: pure black maps to L=0, pure white to L≈1.
-    // Catches sign flips, matrix transposes, and gamma errors before they ripple
-    // through the surface ramp gate below.
+  it("hexToOklchL matches known sRGB reference points", () => {
+    // Sanity-pin Ottosson's sRGB→LMS path. Endpoints (black=0, white=1) confirm gamma
+    // and overall scaling; mid gray (#808080→0.5999) confirms the cube-root nonlinearity;
+    // pure red (#FF0000→0.6279) confirms the chromatic LMS matrix rows (a swapped R/B
+    // channel or wrong matrix coefficient would shift this materially).
     expect(hexToOklchL("#000000")).toBeCloseTo(0, 4);
     expect(hexToOklchL("#ffffff")).toBeCloseTo(1, 4);
+    expect(hexToOklchL("#808080")).toBeCloseTo(0.5999, 3);
+    expect(hexToOklchL("#ff0000")).toBeCloseTo(0.6279, 3);
+  });
+
+  it("hexToOklchL rejects non-#rrggbb input", () => {
+    // The contract is strict #rrggbb (lowercase or uppercase). All built-in theme
+    // palettes use that form; shorthand, alpha, or non-hex chars would be silently
+    // misparsed by parseInt and yield a phantom L value — the throw makes that loud.
+    expect(() => hexToOklchL("#fff")).toThrow();
+    expect(() => hexToOklchL("#ffffffff")).toThrow();
+    expect(() => hexToOklchL("#E8E6CG")).toThrow();
+    expect(() => hexToOklchL("")).toThrow();
+  });
+
+  it("every built-in source surfaces value is strict #rrggbb hex", () => {
+    // The ramp gate below depends on hexToOklchL, which only accepts #rrggbb. Catch
+    // any future theme that ships shorthand or alpha-channel hex before it reaches
+    // hexToOklchL's throw at runtime.
+    const hexRe = /^#[0-9a-fA-F]{6}$/;
+    for (const source of BUILT_IN_THEME_SOURCES) {
+      for (const key of ["grid", "sidebar", "canvas", "panel", "elevated"] as const) {
+        const value = source.palette.surfaces[key];
+        expect(value, `${source.id} surfaces.${key} "${value}" must be #rrggbb`).toMatch(hexRe);
+      }
+    }
   });
 
   it.each(BUILT_IN_THEME_SOURCES.map((s) => [s.id, s] as const))(

--- a/shared/theme/builtInThemes/arashiyama.ts
+++ b/shared/theme/builtInThemes/arashiyama.ts
@@ -11,9 +11,9 @@ export const theme: BuiltInThemeSource = {
     type: "dark",
     surfaces: {
       grid: "#0D0C0B",
-      sidebar: "#130F0E",
-      canvas: "#1B1715",
-      panel: "#261F1C",
+      sidebar: "#151310",
+      canvas: "#201A17",
+      panel: "#29241D",
       elevated: "#352E29",
     },
     text: {

--- a/shared/theme/builtInThemes/atacama.ts
+++ b/shared/theme/builtInThemes/atacama.ts
@@ -11,9 +11,9 @@ export const theme: BuiltInThemeSource = {
     type: "light",
     surfaces: {
       grid: "#DDD6CB",
-      sidebar: "#E5DDD4",
-      canvas: "#EDE7DF",
-      panel: "#F5F1EB",
+      sidebar: "#E7DDD7",
+      canvas: "#ECE7DD",
+      panel: "#F4EFE9",
       elevated: "#FAF8F4",
     },
     text: {

--- a/shared/theme/builtInThemes/bali.ts
+++ b/shared/theme/builtInThemes/bali.ts
@@ -10,11 +10,11 @@ export const theme: BuiltInThemeSource = {
   palette: {
     type: "light",
     surfaces: {
-      grid: "#E0E6D0",
-      sidebar: "#E8ECD6",
-      canvas: "#F0F4E6",
-      panel: "#F7F9F0",
-      elevated: "#FCFDF8",
+      grid: "#DAE2C9",
+      sidebar: "#E6E8CF",
+      canvas: "#EBF0DC",
+      panel: "#F5F8EE",
+      elevated: "#FDFEFA",
     },
     text: {
       primary: "#1D2B1E",

--- a/shared/theme/builtInThemes/bondi.ts
+++ b/shared/theme/builtInThemes/bondi.ts
@@ -10,10 +10,10 @@ export const theme: BuiltInThemeSource = {
   palette: {
     type: "light",
     surfaces: {
-      grid: "#EDEFF2",
-      sidebar: "#F0F1F4",
-      canvas: "#F5F6F8",
-      panel: "#FAFBFC",
+      grid: "#DBE2E4",
+      sidebar: "#E8E7EF",
+      canvas: "#EDF0F4",
+      panel: "#F7F7FA",
       elevated: "#FFFFFF",
     },
     text: {

--- a/shared/theme/builtInThemes/daintree.ts
+++ b/shared/theme/builtInThemes/daintree.ts
@@ -11,9 +11,9 @@ export const theme: BuiltInThemeSource = {
     type: "dark",
     surfaces: {
       grid: "#0e0e0d",
-      sidebar: "#131312",
-      canvas: "#19191a",
-      panel: "#1d1d1e",
+      sidebar: "#121510",
+      canvas: "#191B1C",
+      panel: "#222225",
       elevated: "#2b2b2c",
     },
     text: {

--- a/shared/theme/builtInThemes/fiordland.ts
+++ b/shared/theme/builtInThemes/fiordland.ts
@@ -11,9 +11,9 @@ export const theme: BuiltInThemeSource = {
     type: "dark",
     surfaces: {
       grid: "#04070B",
-      sidebar: "#080D14",
-      canvas: "#0C141D",
-      panel: "#111C29",
+      sidebar: "#070E16",
+      canvas: "#0B1721",
+      panel: "#122032",
       elevated: "#1A2C3E",
     },
     text: {

--- a/shared/theme/builtInThemes/highlands.ts
+++ b/shared/theme/builtInThemes/highlands.ts
@@ -11,9 +11,9 @@ export const theme: BuiltInThemeSource = {
     type: "dark",
     surfaces: {
       grid: "#131114",
-      sidebar: "#171519",
-      canvas: "#201D24",
-      panel: "#2C2831",
+      sidebar: "#1C191C",
+      canvas: "#24222C",
+      panel: "#312C37",
       elevated: "#3E3845",
     },
     text: {

--- a/shared/theme/builtInThemes/hokkaido.ts
+++ b/shared/theme/builtInThemes/hokkaido.ts
@@ -10,10 +10,10 @@ export const theme: BuiltInThemeSource = {
   palette: {
     type: "light",
     surfaces: {
-      grid: "#E6E4EE",
-      sidebar: "#EBE9F2",
-      canvas: "#F3F2F8",
-      panel: "#FAF8FB",
+      grid: "#E0DAEB",
+      sidebar: "#E4E4EC",
+      canvas: "#EDEBF4",
+      panel: "#F8F2F7",
       elevated: "#FDFBFD",
     },
     text: {

--- a/shared/theme/builtInThemes/redwoods.ts
+++ b/shared/theme/builtInThemes/redwoods.ts
@@ -11,9 +11,9 @@ export const theme: BuiltInThemeSource = {
     type: "dark",
     surfaces: {
       grid: "#090705",
-      sidebar: "#110B08",
-      canvas: "#16110D",
-      panel: "#1E1612",
+      sidebar: "#140A0A",
+      canvas: "#16140C",
+      panel: "#221A15",
       elevated: "#2E221B",
     },
     text: {

--- a/shared/theme/builtInThemes/serengeti.ts
+++ b/shared/theme/builtInThemes/serengeti.ts
@@ -10,11 +10,11 @@ export const theme: BuiltInThemeSource = {
   palette: {
     type: "light",
     surfaces: {
-      grid: "#F0E8D0",
-      sidebar: "#F4EDD8",
-      canvas: "#FAF5E6",
-      panel: "#FDFAF2",
-      elevated: "#FFFDF7",
+      grid: "#E8E6CA",
+      sidebar: "#F2EBD3",
+      canvas: "#F7F2DD",
+      panel: "#FAF9ED",
+      elevated: "#FFFFFE",
     },
     text: {
       primary: "#3D2D19",

--- a/shared/theme/builtInThemes/svalbard.ts
+++ b/shared/theme/builtInThemes/svalbard.ts
@@ -10,10 +10,10 @@ export const theme: BuiltInThemeSource = {
   palette: {
     type: "light",
     surfaces: {
-      grid: "#DCE4EC",
-      sidebar: "#E3EAF1",
-      canvas: "#EEF2F6",
-      panel: "#F6F9FB",
+      grid: "#D7DFEA",
+      sidebar: "#DEE7F0",
+      canvas: "#E9EEF3",
+      panel: "#F3F5F9",
       elevated: "#FBFDFE",
     },
     text: {

--- a/shared/theme/builtInThemes/table-mountain.ts
+++ b/shared/theme/builtInThemes/table-mountain.ts
@@ -10,10 +10,10 @@ export const theme: BuiltInThemeSource = {
   palette: {
     type: "light",
     surfaces: {
-      grid: "#E8E3DB",
-      sidebar: "#EDE8E1",
-      canvas: "#F4F0EA",
-      panel: "#FAF8F4",
+      grid: "#E3DCD0",
+      sidebar: "#E8E4DC",
+      canvas: "#F1EBE4",
+      panel: "#F9F2EF",
       elevated: "#FDFBF8",
     },
     text: {

--- a/shared/theme/oklch.ts
+++ b/shared/theme/oklch.ts
@@ -10,7 +10,7 @@ function hexChannelToLinear(channel: number): number {
 
 export function hexToOklchL(hex: string): number {
   const clean = hex.trim().replace(/^#/, "");
-  if (clean.length !== 6) {
+  if (!/^[0-9a-fA-F]{6}$/.test(clean)) {
     throw new Error(`hexToOklchL expects #rrggbb form, got "${hex}"`);
   }
   const r = hexChannelToLinear(parseInt(clean.slice(0, 2), 16));

--- a/shared/theme/oklch.ts
+++ b/shared/theme/oklch.ts
@@ -1,0 +1,74 @@
+import type { ThemePalette } from "./palette.js";
+
+// sRGB hex → OKLab/OKLCH lightness using Ottosson 2020's direct sRGB→LMS path
+// (CSS Color 4 spec). Accepts `#rrggbb` only — all built-in themes use this form.
+
+function hexChannelToLinear(channel: number): number {
+  const normalized = channel / 255;
+  return normalized <= 0.04045 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
+}
+
+export function hexToOklchL(hex: string): number {
+  const clean = hex.trim().replace(/^#/, "");
+  if (clean.length !== 6) {
+    throw new Error(`hexToOklchL expects #rrggbb form, got "${hex}"`);
+  }
+  const r = hexChannelToLinear(parseInt(clean.slice(0, 2), 16));
+  const g = hexChannelToLinear(parseInt(clean.slice(2, 4), 16));
+  const b = hexChannelToLinear(parseInt(clean.slice(4, 6), 16));
+  const lLms = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
+  const mLms = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
+  const sLms = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
+  const lCbrt = Math.cbrt(lLms);
+  const mCbrt = Math.cbrt(mLms);
+  const sCbrt = Math.cbrt(sLms);
+  return 0.2104542553 * lCbrt + 0.793617785 * mCbrt - 0.0040720468 * sCbrt;
+}
+
+export interface SurfaceRampMetrics {
+  lightness: { grid: number; sidebar: number; canvas: number; panel: number; elevated: number };
+  steps: {
+    gridToSidebar: number;
+    sidebarToCanvas: number;
+    canvasToPanel: number;
+    panelToElevated: number;
+  };
+  minStep: number;
+  maxStep: number;
+  ratio: number;
+  monotonic: boolean;
+}
+
+export function getSurfaceRampMetrics(surfaces: ThemePalette["surfaces"]): SurfaceRampMetrics {
+  const lightness = {
+    grid: hexToOklchL(surfaces.grid),
+    sidebar: hexToOklchL(surfaces.sidebar),
+    canvas: hexToOklchL(surfaces.canvas),
+    panel: hexToOklchL(surfaces.panel),
+    elevated: hexToOklchL(surfaces.elevated),
+  };
+  const steps = {
+    gridToSidebar: lightness.sidebar - lightness.grid,
+    sidebarToCanvas: lightness.canvas - lightness.sidebar,
+    canvasToPanel: lightness.panel - lightness.canvas,
+    panelToElevated: lightness.elevated - lightness.panel,
+  };
+  const stepValues = [
+    steps.gridToSidebar,
+    steps.sidebarToCanvas,
+    steps.canvasToPanel,
+    steps.panelToElevated,
+  ];
+  const monotonic = stepValues.every((s) => s > 0);
+  const absSteps = stepValues.map((s) => Math.abs(s));
+  const minStep = Math.min(...absSteps);
+  const maxStep = Math.max(...absSteps);
+  return {
+    lightness,
+    steps,
+    minStep,
+    maxStep,
+    ratio: minStep === 0 ? Infinity : maxStep / minStep,
+    monotonic,
+  };
+}


### PR DESCRIPTION
## Summary

- Two failure modes in the existing surface ramps: light themes had collapsed top steps (as low as `+0.007` ΔL in OKLCH, below the just-noticeable difference), dark themes over-accelerated the last step (2–3× earlier steps, step-uniformity ratio up to 3.6).
- Retuned 12 of 14 built-in themes so every step carries its weight without flattening each theme's character.
- Added an automated ramp gate to the theme test suite so this can't drift again.

Resolves #9224

## Changes

- `shared/theme/oklch.ts` — pure-math OKLCH L helper using the Ottosson 2020 direct sRGB→LMS path (CSS Color 4 spec, no new deps).
- `shared/theme/__tests__/builtInThemes.test.ts` — surface ramp gate: monotonic ordering, min step ≥ `0.015` ΔL dark / `0.020` ΔL light, max/min step ratio ≤ `2.0`; plus hardened hex validation fixtures.
- `shared/theme/builtInThemes/{arashiyama,atacama,bali,bondi,daintree,fiordland,highlands,hokkaido,redwoods,serengeti,svalbard,table-mountain}.ts` — surface palette retunes. Galapagos and Namib were already within spec and are unchanged.

## Testing

- All WCAG 4.5:1 text / 3.0:1 outline contrast assertions still pass. Bali's `panel` and Serengeti's `grid` carry a safety margin above the 3.0:1 floor for warm gold/amber overlays.
- New ramp gate passes for all 14 themes.