### PR TITLE
fix(persistence): preserve user config on corruption and write failure

### DIFF
--- a/src/store/__tests__/persistenceBoundaryHardening.test.ts
+++ b/src/store/__tests__/persistenceBoundaryHardening.test.ts
@@ -431,6 +431,116 @@ describe("persistence boundary hardening", () => {
     expect(getMarks[0]?.meta?.ok).toBe(true);
   });
 
+  it("createSafeJSONStorage.getItem recovers from the backup key when the primary blob is corrupt", async () => {
+    const backup = JSON.stringify({ state: { value: 99 }, version: 1 });
+    installLocalStorage(
+      createStorageMock({
+        getItem: (key) => {
+          if (key === "recover-key") return "{corrupt";
+          if (key === "recover-key.__bak") return backup;
+          return null;
+        },
+      })
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+
+    expect(storage.getItem("recover-key")).toEqual({ state: { value: 99 }, version: 1 });
+    const recoveredWarn = warnSpy.mock.calls.find((call) =>
+      String(call[0]).includes("recovered from backup")
+    );
+    expect(recoveredWarn).toBeDefined();
+  });
+
+  it("createSafeJSONStorage.setItem writes a backup copy alongside the primary key", async () => {
+    const mock = createStorageMock();
+    installLocalStorage(mock);
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+
+    storage.setItem("backup-write-key", { state: { value: 5 }, version: 1 });
+
+    expect(mock.getItem("backup-write-key.__bak")).toBe(
+      JSON.stringify({ state: { value: 5 }, version: 1 })
+    );
+  });
+
+  it("createSafeJSONStorage.getItem returns null when both primary and backup are corrupt", async () => {
+    installLocalStorage(
+      createStorageMock({
+        getItem: (key) =>
+          key === "both-corrupt" ? "{corrupt" : key === "both-corrupt.__bak" ? "{also-bad" : null,
+      })
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+
+    expect(storage.getItem("both-corrupt")).toBeNull();
+    const resetWarn = warnSpy.mock.calls.find((call) =>
+      String(call[0]).includes("resetting to defaults")
+    );
+    expect(resetWarn).toBeDefined();
+  });
+
+  it("createResilientStorage treats QuotaExceededError as transient and keeps using localStorage", async () => {
+    let setCalls = 0;
+    const written = new Map<string, string>();
+    installLocalStorage(
+      createStorageMock({
+        setItem: (key, value) => {
+          setCalls += 1;
+          if (setCalls === 1) {
+            throw new DOMException("Quota exceeded", "QuotaExceededError");
+          }
+          written.set(key, value);
+        },
+      })
+    );
+    const marks = seedPerfMarks();
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+
+    storage.setItem("quota-key-1", { state: { value: 1 }, version: 1 });
+    storage.setItem("quota-key-2", { state: { value: 2 }, version: 1 });
+
+    const setMarks = marks.filter((m) => m.mark === "persistence_localstorage_set");
+    // Second write must still target localStorage — no permanent memory fallback.
+    expect(setMarks[1]?.meta?.storage).toBe("localStorage");
+    expect(setMarks[1]?.meta?.ok).toBe(true);
+    expect(written.get("quota-key-2")).toBe(JSON.stringify({ state: { value: 2 }, version: 1 }));
+  });
+
+  it("preferencesStore clamps a corrupt closed-set field at the current version via merge", async () => {
+    installLocalStorage(
+      createStorageMock({
+        getItem: (key) =>
+          key === "daintree-preferences"
+            ? JSON.stringify({
+                state: {
+                  dockDensity: "dense",
+                  diffViewType: "side-by-side",
+                  skipPushConfirmByWorktreePath: "all",
+                },
+                version: 9,
+              })
+            : null,
+      })
+    );
+
+    const { usePreferencesStore } = await import("../preferencesStore");
+
+    const state = usePreferencesStore.getState();
+    expect(state.dockDensity).toBe("normal");
+    expect(state.diffViewType).toBe("split");
+    expect(state.skipPushConfirmByWorktreePath).toEqual({});
+  });
+
   it("createResilientStorage emits no marks when DAINTREE_PERF_MARKS is absent and capture is disabled", async () => {
     installLocalStorage(createStorageMock());
 

--- a/src/store/__tests__/persistenceBoundaryHardening.test.ts
+++ b/src/store/__tests__/persistenceBoundaryHardening.test.ts
@@ -516,6 +516,105 @@ describe("persistence boundary hardening", () => {
     expect(written.get("quota-key-2")).toBe(JSON.stringify({ state: { value: 2 }, version: 1 }));
   });
 
+  it("does not advance the backup when the primary write hits a quota error", async () => {
+    const backend = new Map<string, string>();
+    const good = JSON.stringify({ state: { value: 1 }, version: 1 });
+    backend.set("stale-key", good);
+    backend.set("stale-key.__bak", good);
+    installLocalStorage(
+      createStorageMock({
+        getItem: (key) => backend.get(key) ?? null,
+        setItem: (key, value) => {
+          if (key === "stale-key") {
+            throw new DOMException("Quota exceeded", "QuotaExceededError");
+          }
+          backend.set(key, value);
+        },
+        removeItem: (key) => {
+          backend.delete(key);
+        },
+      })
+    );
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+
+    storage.setItem("stale-key", { state: { value: 2 }, version: 1 });
+
+    // Primary write quota-failed and kept the old value — the backup must NOT
+    // advance to the new value, or a later recovery would surface stale state.
+    expect(backend.get("stale-key.__bak")).toBe(good);
+  });
+
+  it("removeItem clears both the primary key and its backup", async () => {
+    const mock = createStorageMock();
+    installLocalStorage(mock);
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+
+    storage.setItem("rm-key", { state: { value: 1 }, version: 1 });
+    expect(mock.getItem("rm-key")).not.toBeNull();
+    expect(mock.getItem("rm-key.__bak")).not.toBeNull();
+
+    storage.removeItem("rm-key");
+    expect(mock.getItem("rm-key")).toBeNull();
+    expect(mock.getItem("rm-key.__bak")).toBeNull();
+  });
+
+  it("recovers from a backup written by an earlier setItem on the same instance", async () => {
+    const backend = new Map<string, string>();
+    installLocalStorage(
+      createStorageMock({
+        getItem: (key) => backend.get(key) ?? null,
+        setItem: (key, value) => {
+          backend.set(key, value);
+        },
+        removeItem: (key) => {
+          backend.delete(key);
+        },
+      })
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+
+    storage.setItem("e2e-key", { state: { value: 7 }, version: 1 });
+    // Corrupt only the primary; the backup written by setItem stays intact.
+    backend.set("e2e-key", "{corrupt");
+
+    expect(storage.getItem("e2e-key")).toEqual({ state: { value: 7 }, version: 1 });
+    expect(
+      warnSpy.mock.calls.some((call) => String(call[0]).includes("recovered from backup"))
+    ).toBe(true);
+  });
+
+  it("notifies exactly once when a permanent structural fallback occurs", async () => {
+    const notifySpy = vi.fn();
+    vi.doMock("@/lib/notify", () => ({ notify: notifySpy }));
+    installLocalStorage(
+      createStorageMock({
+        setItem: () => {
+          // Plain Error (not a quota DOMException) → permanent fallback.
+          throw new Error("SecurityError");
+        },
+      })
+    );
+
+    try {
+      const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+      const storage = createSafeJSONStorage<{ value: number }>();
+
+      storage.setItem("notify-key-1", { state: { value: 1 }, version: 1 });
+      storage.setItem("notify-key-2", { state: { value: 2 }, version: 1 });
+
+      expect(notifySpy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.doUnmock("@/lib/notify");
+    }
+  });
+
   it("preferencesStore clamps a corrupt closed-set field at the current version via merge", async () => {
     installLocalStorage(
       createStorageMock({

--- a/src/store/persistence/safeStorage.ts
+++ b/src/store/persistence/safeStorage.ts
@@ -74,13 +74,25 @@ function resolveLocalStorage(): StateStorage | undefined {
 }
 
 /**
+ * Outcome of a resilient write, so the caller can keep the backup copy
+ * consistent with what actually reached durable storage:
+ * - `durable`  — written to real localStorage; the backup may advance.
+ * - `quota`    — transient quota error; primary unchanged, backup must NOT advance.
+ * - `memory`   — written only to the in-memory fallback; nothing durable to back up.
+ */
+type ResilientWriteResult = "durable" | "quota" | "memory";
+
+/**
  * Resilient storage augmented with best-effort backup operations. The backup
  * methods write/read a sibling `${key}.__bak` entry directly on the real
  * localStorage — bypassing the perf-marked primary path and skipping entirely
  * once a permanent in-memory fallback is active (a backup in memory buys
  * nothing and would needlessly re-hit broken localStorage).
  */
-interface ResilientStorage extends StateStorage {
+interface ResilientStorage {
+  getItem: (name: string) => string | null | Promise<string | null>;
+  setItem: (name: string, value: string) => ResilientWriteResult;
+  removeItem: (name: string) => void;
   writeBackup: (name: string, value: string) => void;
   readBackup: (name: string) => string | null;
   removeBackup: (name: string) => void;
@@ -154,6 +166,7 @@ function createResilientStorage(baseStorage: StateStorage | undefined): Resilien
       const payloadBytes = collectPerf ? estimateStringBytes(value) : null;
       const storage: "localStorage" | "memory" =
         activeStorage === memoryStorage ? "memory" : "localStorage";
+      const wroteToMemory = activeStorage === memoryStorage;
       try {
         activeStorage.setItem(name, value);
         if (collectPerf) {
@@ -165,6 +178,7 @@ function createResilientStorage(baseStorage: StateStorage | undefined): Resilien
             storage,
           });
         }
+        return wroteToMemory ? "memory" : "durable";
       } catch (error) {
         if (collectPerf) {
           markRendererPerformance("persistence_localstorage_set", {
@@ -176,17 +190,19 @@ function createResilientStorage(baseStorage: StateStorage | undefined): Resilien
           });
         }
         if (isQuotaExceededError(error)) {
-          // Transient: keep localStorage active so later (smaller) writes retry
-          // it. Mirror this write into memory so the value isn't lost outright.
+          // Transient: storage is healthy but this write was too large. Keep
+          // localStorage active so later (smaller) writes retry it. The value
+          // still lives in the in-memory React store this session; it simply
+          // isn't persisted, so we don't switch storages or notify.
           console.warn("[safeStorage] storage quota exceeded, skipping persistent write", {
             key: name,
             error: formatErrorMessage(error, "Storage quota exceeded"),
           });
-          memoryStorage.setItem(name, value);
-          return;
+          return "quota";
         }
         switchToMemoryStorage().setItem(name, value);
         notifyPermanentFallbackOnce();
+        return "memory";
       }
     },
     removeItem: (name) => {
@@ -212,7 +228,8 @@ function createResilientStorage(baseStorage: StateStorage | undefined): Resilien
       }
     },
     readBackup: (name) => {
-      if (!baseStorage) return null;
+      // localStorage is known broken once we've fallen back — don't re-hit it.
+      if (activeStorage === memoryStorage || !baseStorage) return null;
       try {
         const value = baseStorage.getItem(backupKeyFor(name));
         return value instanceof Promise ? null : value;
@@ -297,8 +314,12 @@ export function createSafeJSONStorage<T>(): PersistStorage<T> {
     },
     setItem: (name, value) => {
       const serialized = JSON.stringify(value);
-      raw.setItem(name, serialized);
-      raw.writeBackup(name, serialized);
+      // Only advance the backup when the primary write actually reached durable
+      // storage. On a quota failure the primary keeps its old value, so writing
+      // a newer backup would leave the two inconsistent and recover stale state.
+      if (raw.setItem(name, serialized) === "durable") {
+        raw.writeBackup(name, serialized);
+      }
     },
     removeItem: (name) => {
       raw.removeItem(name);

--- a/src/store/persistence/safeStorage.ts
+++ b/src/store/persistence/safeStorage.ts
@@ -1,8 +1,25 @@
 import type { PersistStorage, StateStorage, StorageValue } from "zustand/middleware";
 import { isRendererPerfCaptureEnabled, markRendererPerformance } from "@/utils/performance";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { notify } from "@/lib/notify";
 
 const fallbackStorageData = new Map<string, string>();
+
+const BACKUP_KEY_SUFFIX = ".__bak";
+
+/**
+ * A `QuotaExceededError` (or its Firefox alias) is transient: the write was
+ * too large, but storage is still healthy, so smaller subsequent writes can
+ * succeed. We must NOT permanently route a store to in-memory storage on quota
+ * — that would silently drop every later write for the session (issue #9170).
+ */
+function isQuotaExceededError(error: unknown): boolean {
+  return (
+    typeof DOMException !== "undefined" &&
+    error instanceof DOMException &&
+    (error.name === "QuotaExceededError" || error.name === "NS_ERROR_DOM_QUOTA_REACHED")
+  );
+}
 
 function shouldCollectPersistencePerf(): boolean {
   if (typeof window === "undefined") return false;
@@ -56,12 +73,48 @@ function resolveLocalStorage(): StateStorage | undefined {
   return hasStorageApi ? (candidate as StateStorage) : undefined;
 }
 
-function createResilientStorage(baseStorage: StateStorage | undefined): StateStorage {
+/**
+ * Resilient storage augmented with best-effort backup operations. The backup
+ * methods write/read a sibling `${key}.__bak` entry directly on the real
+ * localStorage — bypassing the perf-marked primary path and skipping entirely
+ * once a permanent in-memory fallback is active (a backup in memory buys
+ * nothing and would needlessly re-hit broken localStorage).
+ */
+interface ResilientStorage extends StateStorage {
+  writeBackup: (name: string, value: string) => void;
+  readBackup: (name: string) => string | null;
+  removeBackup: (name: string) => void;
+}
+
+function createResilientStorage(baseStorage: StateStorage | undefined): ResilientStorage {
   let activeStorage = baseStorage ?? memoryStorage;
+  let hasNotifiedPermanentFallback = false;
 
   const switchToMemoryStorage = (): StateStorage => {
     activeStorage = memoryStorage;
     return activeStorage;
+  };
+
+  const backupKeyFor = (name: string): string => `${name}${BACKUP_KEY_SUFFIX}`;
+
+  // Fire exactly once per storage instance when a structural failure forces a
+  // permanent in-memory fallback. Until then writes never reach localStorage,
+  // so changes this session are lost on restart — a degradation the user can't
+  // otherwise observe. Quota errors are transient and never reach here.
+  const notifyPermanentFallbackOnce = (): void => {
+    if (hasNotifiedPermanentFallback) return;
+    hasNotifiedPermanentFallback = true;
+    try {
+      notify({
+        type: "warning",
+        title: "Settings won't be saved",
+        message:
+          "Couldn't write to local storage, so changes made this session won't persist after restart.",
+        context: { eventKind: "settings" },
+      });
+    } catch {
+      // The notification surface is best-effort — never let it break persistence.
+    }
   };
 
   return {
@@ -112,7 +165,7 @@ function createResilientStorage(baseStorage: StateStorage | undefined): StateSto
             storage,
           });
         }
-      } catch {
+      } catch (error) {
         if (collectPerf) {
           markRendererPerformance("persistence_localstorage_set", {
             key: name,
@@ -122,14 +175,57 @@ function createResilientStorage(baseStorage: StateStorage | undefined): StateSto
             storage,
           });
         }
+        if (isQuotaExceededError(error)) {
+          // Transient: keep localStorage active so later (smaller) writes retry
+          // it. Mirror this write into memory so the value isn't lost outright.
+          console.warn("[safeStorage] storage quota exceeded, skipping persistent write", {
+            key: name,
+            error: formatErrorMessage(error, "Storage quota exceeded"),
+          });
+          memoryStorage.setItem(name, value);
+          return;
+        }
         switchToMemoryStorage().setItem(name, value);
+        notifyPermanentFallbackOnce();
       }
     },
     removeItem: (name) => {
       try {
         activeStorage.removeItem(name);
-      } catch {
+      } catch (error) {
+        if (isQuotaExceededError(error)) {
+          memoryStorage.removeItem(name);
+          return;
+        }
         switchToMemoryStorage().removeItem(name);
+        notifyPermanentFallbackOnce();
+      }
+    },
+    writeBackup: (name, value) => {
+      // Skip while in memory fallback: localStorage is known broken, so a write
+      // here would just re-hit it (and a memory backup duplicates live state).
+      if (activeStorage === memoryStorage || !baseStorage) return;
+      try {
+        baseStorage.setItem(backupKeyFor(name), value);
+      } catch {
+        // Backup is opportunistic — losing it is acceptable.
+      }
+    },
+    readBackup: (name) => {
+      if (!baseStorage) return null;
+      try {
+        const value = baseStorage.getItem(backupKeyFor(name));
+        return value instanceof Promise ? null : value;
+      } catch {
+        return null;
+      }
+    },
+    removeBackup: (name) => {
+      if (!baseStorage) return;
+      try {
+        baseStorage.removeItem(backupKeyFor(name));
+      } catch {
+        // Best-effort cleanup.
       }
     },
   };
@@ -158,6 +254,19 @@ export function safeJSONParse<T>(
   }
 }
 
+/**
+ * Parse a recovered backup blob, returning null when it is absent or itself
+ * corrupt so the caller falls through to a clean reset.
+ */
+function parseBackup<T>(raw: string | null): StorageValue<T> | null {
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw) as StorageValue<T>;
+  } catch {
+    return null;
+  }
+}
+
 export function createSafeJSONStorage<T>(): PersistStorage<T> {
   const raw = createResilientStorage(resolveLocalStorage());
 
@@ -169,6 +278,16 @@ export function createSafeJSONStorage<T>(): PersistStorage<T> {
       try {
         return JSON.parse(value) as StorageValue<T>;
       } catch (error) {
+        // The live blob is corrupt but present — try the last known-good backup
+        // before discarding the user's config to defaults (issue #9170).
+        const recovered = parseBackup<T>(raw.readBackup(name));
+        if (recovered !== null) {
+          console.warn("[safeStorage] corrupt persisted state, recovered from backup", {
+            key: name,
+            error: formatErrorMessage(error, "Corrupt persisted state"),
+          });
+          return recovered;
+        }
         console.warn("[safeStorage] corrupt persisted state, resetting to defaults", {
           key: name,
           error: formatErrorMessage(error, "Corrupt persisted state"),
@@ -177,10 +296,13 @@ export function createSafeJSONStorage<T>(): PersistStorage<T> {
       }
     },
     setItem: (name, value) => {
-      raw.setItem(name, JSON.stringify(value));
+      const serialized = JSON.stringify(value);
+      raw.setItem(name, serialized);
+      raw.writeBackup(name, serialized);
     },
     removeItem: (name) => {
       raw.removeItem(name);
+      raw.removeBackup(name);
     },
   };
 }

--- a/src/store/persistence/safeStorage.ts
+++ b/src/store/persistence/safeStorage.ts
@@ -249,6 +249,16 @@ function createResilientStorage(baseStorage: StateStorage | undefined): Resilien
 }
 
 /**
+ * Single sanctioned `JSON.parse` boundary for this module. `JSON.parse` returns
+ * `any`, so the cast to the caller's expected shape is inherently unchecked —
+ * centralising it here keeps that one unsafe assertion auditable in one place
+ * (callers always wrap this in try/catch and validate the result downstream).
+ */
+function parseJson<R>(raw: string): R {
+  return JSON.parse(raw) as R;
+}
+
+/**
  * Parse a JSON string safely, returning a typed fallback and logging a warning
  * with caller-supplied context (store/key) when the parse fails. Null input is
  * treated as an absent value and returns the fallback without warning —
@@ -261,7 +271,7 @@ export function safeJSONParse<T>(
 ): T {
   if (raw === null) return fallback;
   try {
-    return JSON.parse(raw) as T;
+    return parseJson<T>(raw);
   } catch (error) {
     console.warn("[safeStorage] JSON parse failed", {
       ...context,
@@ -278,7 +288,7 @@ export function safeJSONParse<T>(
 function parseBackup<T>(raw: string | null): StorageValue<T> | null {
   if (raw === null) return null;
   try {
-    return JSON.parse(raw) as StorageValue<T>;
+    return parseJson<StorageValue<T>>(raw);
   } catch {
     return null;
   }
@@ -293,7 +303,7 @@ export function createSafeJSONStorage<T>(): PersistStorage<T> {
       if (value instanceof Promise) return null;
       if (value === null) return null;
       try {
-        return JSON.parse(value) as StorageValue<T>;
+        return parseJson<StorageValue<T>>(value);
       } catch (error) {
         // The live blob is corrupt but present — try the last known-good backup
         // before discarding the user's config to defaults (issue #9170).

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -35,6 +35,44 @@ interface PreferencesState {
   setSkipPushConfirmForWorktree: (worktreePath: string, value: boolean) => void;
 }
 
+const DOCK_DENSITIES: readonly DockDensity[] = ["compact", "normal", "comfortable"];
+const DIFF_VIEW_TYPES: readonly DiffViewType[] = ["split", "unified"];
+
+/**
+ * Normalise the closed-set and record-shaped fields of a persisted blob against
+ * the current schema. Run from the persist `merge` callback so it executes on
+ * EVERY hydration — not only on version change, which is all `migrate` covers
+ * (issue #9170). A corrupt-but-parseable value (e.g. hand-edited
+ * `dockDensity: "dense"`, or a string where a record is expected) is replaced
+ * with a safe default instead of flowing into live state unchecked.
+ */
+function sanitizePersistedPreferences(
+  raw: Partial<PreferencesState> | undefined | null
+): Partial<PreferencesState> {
+  if (!raw || typeof raw !== "object") return {};
+  const sanitized: Partial<PreferencesState> = { ...raw };
+
+  if (!DOCK_DENSITIES.includes(sanitized.dockDensity as DockDensity)) {
+    sanitized.dockDensity = "normal";
+  }
+
+  if (!DIFF_VIEW_TYPES.includes(sanitized.diffViewType as DiffViewType)) {
+    sanitized.diffViewType = "split";
+  }
+
+  // A truthy non-record value here would otherwise bypass the push-confirm gate.
+  const skip = sanitized.skipPushConfirmByWorktreePath;
+  const validatedSkip: Record<string, boolean> = {};
+  if (skip !== null && typeof skip === "object" && !Array.isArray(skip)) {
+    for (const [key, value] of Object.entries(skip)) {
+      if (typeof value === "boolean") validatedSkip[key] = value;
+    }
+  }
+  sanitized.skipPushConfirmByWorktreePath = validatedSkip;
+
+  return sanitized;
+}
+
 export const usePreferencesStore = create<PreferencesState>()(
   persist(
     (set) => ({
@@ -86,6 +124,13 @@ export const usePreferencesStore = create<PreferencesState>()(
       name: "daintree-preferences",
       storage: createSafeJSONStorage(),
       version: 9,
+      // Runs on every hydration (unlike `migrate`, which Zustand skips when the
+      // persisted version matches). Closed-set normalisation lives here so a
+      // corrupt-but-parseable value is clamped even at the current version.
+      merge: (persisted, current) => ({
+        ...current,
+        ...sanitizePersistedPreferences(persisted as Partial<PreferencesState> | undefined | null),
+      }),
       migrate: (persisted, version) => {
         if (version === 0 || version === undefined) {
           if (persisted && typeof persisted === "object") {

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -35,8 +35,13 @@ interface PreferencesState {
   setSkipPushConfirmForWorktree: (worktreePath: string, value: boolean) => void;
 }
 
-const DOCK_DENSITIES: readonly DockDensity[] = ["compact", "normal", "comfortable"];
-const DIFF_VIEW_TYPES: readonly DiffViewType[] = ["split", "unified"];
+function isDockDensity(value: unknown): value is DockDensity {
+  return value === "compact" || value === "normal" || value === "comfortable";
+}
+
+function isDiffViewType(value: unknown): value is DiffViewType {
+  return value === "split" || value === "unified";
+}
 
 /**
  * Normalise the closed-set and record-shaped fields of a persisted blob against
@@ -52,13 +57,8 @@ function sanitizePersistedPreferences(
   if (!raw || typeof raw !== "object") return {};
   const sanitized: Partial<PreferencesState> = { ...raw };
 
-  if (!DOCK_DENSITIES.includes(sanitized.dockDensity as DockDensity)) {
-    sanitized.dockDensity = "normal";
-  }
-
-  if (!DIFF_VIEW_TYPES.includes(sanitized.diffViewType as DiffViewType)) {
-    sanitized.diffViewType = "split";
-  }
+  if (!isDockDensity(sanitized.dockDensity)) sanitized.dockDensity = "normal";
+  if (!isDiffViewType(sanitized.diffViewType)) sanitized.diffViewType = "split";
 
   // A truthy non-record value here would otherwise bypass the push-confirm gate.
   const skip = sanitized.skipPushConfirmByWorktreePath;


### PR DESCRIPTION
## Summary

Three silent data-loss paths in the persistence layer, all of which could reset user config without any visible indication.

- **Corrupt JSON recovery** -- `createSafeJSONStorage` now writes a `${key}.__bak` backup on every durable write and recovers from it when the primary blob fails to parse. Previously, a corrupt-but-present blob would silently reset the store to defaults.
- **Transient quota errors** -- a `QuotaExceededError` no longer permanently routes the store to in-memory storage for the session. Quota is treated as transient (`localStorage` stays active for later writes); only a structural failure (e.g. `SecurityError`) switches permanently, and that now emits a warning notification so the otherwise-silent degradation is observable.
- **Closed-set field validation on hydration** -- `dockDensity`, `diffViewType`, and `skipPushConfirmByWorktreePath` in `preferencesStore` are now validated in the `merge` callback on every hydration, not just inside `migrate` (which Zustand skips when the persisted version matches).

The backup only advances on a durable primary write, so it can never recover stale state after a quota failure.

Resolves #9170

## Changes

- `src/store/persistence/safeStorage.ts` -- backup-on-write + transient quota handling
- `src/store/preferencesStore.ts` -- closed-set field validation moved to merge callback
- `src/store/__tests__/persistenceBoundaryHardening.test.ts` -- regression tests for all three paths

## Testing

Regression tests added covering corrupt-blob recovery, quota-error transience, and field validation on hydration. All three previously-failing scenarios now pass.