### PR TITLE
fix(terminal): enforce single-action rule on error banners at type level

### DIFF
--- a/src/components/DevPreview/BlockedNavBanner.tsx
+++ b/src/components/DevPreview/BlockedNavBanner.tsx
@@ -314,6 +314,27 @@ export function BlockedNavBanner({
       break;
   }
 
+  // Each phase contributes at most one action, so collapse to the single
+  // `action` prop. Severity is computed per phase, so branch on it to satisfy
+  // the discriminated union (error banners take a lone `action`).
+  const action = buildActions()[0];
+  const role = phase === "blocked" || phase === "oauth-started" ? "status" : "alert";
+
+  if (severity === "error") {
+    return (
+      <InlineStatusBanner
+        icon={icon}
+        title={title}
+        description={description}
+        contextLine={url}
+        severity="error"
+        action={action}
+        onClose={handleDismiss}
+        role={role}
+      />
+    );
+  }
+
   return (
     <InlineStatusBanner
       icon={icon}
@@ -321,9 +342,9 @@ export function BlockedNavBanner({
       description={description}
       contextLine={url}
       severity={severity}
-      actions={buildActions()}
+      action={action}
       onClose={handleDismiss}
-      role={phase === "blocked" || phase === "oauth-started" ? "status" : "alert"}
+      role={role}
     />
   );
 }

--- a/src/components/DevPreview/BlockedNavBanner.tsx
+++ b/src/components/DevPreview/BlockedNavBanner.tsx
@@ -335,9 +335,7 @@ export function BlockedNavBanner({
         contextLine={url}
         severity="error"
         action={primary}
-        trailingSlot={
-          overflow.length > 0 ? <BannerOverflowMenu actions={overflow} /> : undefined
-        }
+        trailingSlot={overflow.length > 0 ? <BannerOverflowMenu actions={overflow} /> : undefined}
         onClose={handleDismiss}
         role={role}
       />

--- a/src/components/DevPreview/BlockedNavBanner.tsx
+++ b/src/components/DevPreview/BlockedNavBanner.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ExternalLink, AlertTriangle, CircleCheck, Copy } from "lucide-react";
 import { InlineStatusBanner, type BannerAction } from "../Terminal/InlineStatusBanner";
+import { BannerOverflowMenu } from "../Terminal/BannerOverflowMenu";
 import { looksLikeOAuthUrl } from "@shared/utils/urlUtils";
 import type { SessionStorageEntry } from "./useDevPreviewLoadLifecycle";
 
@@ -314,13 +315,18 @@ export function BlockedNavBanner({
       break;
   }
 
-  // Each phase contributes at most one action, so collapse to the single
-  // `action` prop. Severity is computed per phase, so branch on it to satisfy
-  // the discriminated union (error banners take a lone `action`).
-  const action = buildActions()[0];
+  // `buildActions()` returns "Copy URL" followed by the phase-specific action
+  // (e.g. "Sign in via browser", "Try again"). Severity is computed per phase,
+  // so branch on it to satisfy the discriminated union. Non-error phases keep
+  // both actions; the error phases (oauth timeout/failure) keep the
+  // phase-specific recovery as the single primary action and demote "Copy URL"
+  // into the overflow menu.
+  const actions = buildActions();
   const role = phase === "blocked" || phase === "oauth-started" ? "status" : "alert";
 
   if (severity === "error") {
+    const primary = actions[actions.length - 1];
+    const overflow = actions.slice(0, -1);
     return (
       <InlineStatusBanner
         icon={icon}
@@ -328,7 +334,10 @@ export function BlockedNavBanner({
         description={description}
         contextLine={url}
         severity="error"
-        action={action}
+        action={primary}
+        trailingSlot={
+          overflow.length > 0 ? <BannerOverflowMenu actions={overflow} /> : undefined
+        }
         onClose={handleDismiss}
         role={role}
       />
@@ -342,7 +351,7 @@ export function BlockedNavBanner({
       description={description}
       contextLine={url}
       severity={severity}
-      action={action}
+      actions={actions}
       onClose={handleDismiss}
       role={role}
     />

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -29,6 +29,7 @@ import type { BrowserHistory } from "@shared/types/browser";
 import { ContentPanel, type BasePanelProps } from "@/components/Panel";
 import { BrowserToolbar } from "../Browser/BrowserToolbar";
 import { InlineStatusBanner, type BannerAction } from "../Terminal/InlineStatusBanner";
+import { BannerOverflowMenu } from "../Terminal/BannerOverflowMenu";
 import { normalizeBrowserUrl } from "../Browser/browserUtils";
 import {
   goBackBrowserHistory,
@@ -177,20 +178,21 @@ function DevPreviewStuckBanner({
 
   const remedyId = error?.recommendedActionId;
   const remedyLabel = remedyId ? STUCK_REMEDY_LABELS[remedyId] : undefined;
-  const actions: BannerAction[] =
-    remedyId && remedyLabel
-      ? [
-          {
-            id: `dev-preview-stuck-remedy-${remedyId}`,
-            label: remedyLabel,
-            icon: RotateCw,
-            variant: "primary",
-            disabled: isRestarting,
-            onClick: () => onRemedy(remedyId),
-          },
-          restartAction,
-        ]
-      : [restartAction];
+  // When a specific remedy is recommended it's the single primary action and
+  // the generic restart drops into the overflow menu; otherwise restart is the
+  // lone action. Keeps this error banner to one inline action.
+  const hasRemedy = !!(remedyId && remedyLabel);
+  const primaryAction: BannerAction = hasRemedy
+    ? {
+        id: `dev-preview-stuck-remedy-${remedyId}`,
+        label: remedyLabel,
+        icon: RotateCw,
+        variant: "primary",
+        disabled: isRestarting,
+        onClick: () => onRemedy(remedyId),
+      }
+    : restartAction;
+  const overflowActions: BannerAction[] = hasRemedy ? [restartAction] : [];
 
   const isLongCompile = phaseLabel === "Compiling" && !error?.message;
   const title = isLongCompile
@@ -210,7 +212,12 @@ function DevPreviewStuckBanner({
       description={description}
       role="alert"
       ariaLive="assertive"
-      actions={actions}
+      action={primaryAction}
+      trailingSlot={
+        overflowActions.length > 0 ? (
+          <BannerOverflowMenu actions={overflowActions} ariaLabel="More dev server options" />
+        ) : undefined
+      }
     />
   );
 }
@@ -1713,24 +1720,29 @@ export function DevPreviewPane({
                       }
                       severity="error"
                       animated={false}
-                      actions={[
-                        {
-                          id: "reload",
-                          label: "Reload",
-                          icon: RotateCw,
-                          variant: "dangerFilled",
-                          onClick: handleHardReload,
-                          ariaLabel: "Reload preview page",
-                        },
-                        {
-                          id: "hard-restart",
-                          label: "Hard restart",
-                          icon: RotateCw,
-                          variant: "danger",
-                          onClick: handleRestartDevServer,
-                          ariaLabel: "Hard restart preview",
-                        },
-                      ]}
+                      action={{
+                        id: "reload",
+                        label: "Reload",
+                        icon: RotateCw,
+                        variant: "dangerFilled",
+                        onClick: handleHardReload,
+                        ariaLabel: "Reload preview page",
+                      }}
+                      trailingSlot={
+                        <BannerOverflowMenu
+                          ariaLabel="More preview recovery options"
+                          actions={[
+                            {
+                              id: "hard-restart",
+                              label: "Hard restart",
+                              icon: RotateCw,
+                              variant: "danger",
+                              onClick: handleRestartDevServer,
+                              ariaLabel: "Hard restart preview",
+                            },
+                          ]}
+                        />
+                      }
                       onClose={() => {
                         setCrashState("none");
                         setCrashDetails(null);

--- a/src/components/DevPreview/__tests__/BlockedNavBanner.test.tsx
+++ b/src/components/DevPreview/__tests__/BlockedNavBanner.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Render the overflow popover open so demoted items are queryable.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverAnchor: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="overflow-content">{children}</div>
+  ),
+}));
+
+import { BlockedNavBanner } from "../BlockedNavBanner";
+
+type Phase =
+  | "blocked"
+  | "oauth-started"
+  | "oauth-intercepting"
+  | "oauth-completed"
+  | "oauth-timed-out"
+  | "oauth-error";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  (window as unknown as { electron: unknown }).electron = {
+    webview: {
+      onOAuthLoopbackStatus: vi.fn(() => () => {}),
+      cancelOAuthLoopback: vi.fn().mockResolvedValue(undefined),
+    },
+    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    system: { openExternal: vi.fn() },
+  };
+});
+
+function renderPhase(phase: Phase, extra: Partial<Record<string, unknown>> = {}) {
+  const state = {
+    url: "https://accounts.example.com/o/oauth2/auth",
+    canOpenExternal: false,
+    sessionStorageSnapshot: [],
+    isOAuth: true,
+    registrableDomain: "example.com",
+    phase,
+    errorMessage: phase === "oauth-error" ? "Sign-in failed" : null,
+    ...extra,
+  };
+  return render(
+    <BlockedNavBanner
+      state={state as never}
+      panelId="p-1"
+      webviewElement={null as never}
+      onDispatch={vi.fn()}
+    />
+  );
+}
+
+describe("BlockedNavBanner action selection", () => {
+  it("renders the phase-specific 'Sign in via browser' action for a blocked OAuth nav", () => {
+    renderPhase("blocked", { isOAuth: true });
+    // Regression guard: the phase action must not be dropped in favour of Copy URL.
+    expect(screen.getByRole("button", { name: /sign in via browser/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /copy url/i })).toBeTruthy();
+  });
+
+  it("renders 'Open in external browser' for a non-OAuth blocked nav", () => {
+    renderPhase("blocked", { isOAuth: false, canOpenExternal: true });
+    expect(screen.getByRole("button", { name: /open in external browser/i })).toBeTruthy();
+  });
+
+  it("keeps 'Try again' as the primary action on an OAuth error, demoting Copy URL", () => {
+    renderPhase("oauth-error");
+    const tryAgain = screen.getByRole("button", { name: /try again/i });
+    const overflow = screen.getByTestId("overflow-content");
+    // The recovery action is the inline primary; Copy URL is demoted.
+    expect(overflow.contains(tryAgain)).toBe(false);
+    expect(overflow.contains(screen.getByRole("button", { name: /copy url/i }))).toBe(true);
+  });
+});

--- a/src/components/Fleet/FleetFailureBanner.tsx
+++ b/src/components/Fleet/FleetFailureBanner.tsx
@@ -28,19 +28,17 @@ export function FleetFailureBanner(): ReactElement | null {
       ? `${count} ${noun} rejected a keystroke. Single keystrokes can't be replayed.`
       : `${count} ${noun} rejected the write.`;
 
-  const actions: BannerAction[] =
+  const retryAction: BannerAction | undefined =
     payload === null
-      ? []
-      : [
-          {
-            id: "retry",
-            label: "Retry failed",
-            variant: "primary",
-            onClick: () => {
-              void actionService.dispatch("fleet.retryFailures", undefined, { source: "user" });
-            },
+      ? undefined
+      : {
+          id: "retry",
+          label: "Retry failed",
+          variant: "primary",
+          onClick: () => {
+            void actionService.dispatch("fleet.retryFailures", undefined, { source: "user" });
           },
-        ];
+        };
 
   return (
     <InlineStatusBanner
@@ -48,7 +46,7 @@ export function FleetFailureBanner(): ReactElement | null {
       severity="error"
       title="Broadcast failed"
       description={description}
-      actions={actions}
+      action={retryAction}
       role="alert"
       onClose={() => useFleetFailureStore.getState().clear()}
     />

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -355,7 +355,6 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
             severity="error"
             title="Partial clone not removed"
             description={cleanupError}
-            actions={[]}
             onClose={() => setCleanupError(null)}
             className="rounded-lg"
           />
@@ -369,30 +368,28 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
             const showGitHubAuth =
               error.gitReason === "auth-failed" && isGitHubRemoteUrl(normalizeCloneUrl(url));
             if (showGitHubAuth) {
-              const actions: BannerAction[] = [
-                {
-                  id: "signin-github",
-                  label: "Sign in with GitHub",
-                  icon: LogIn,
-                  variant: "accent",
-                  onClick: () => {
-                    void actionService.dispatch(
-                      "app.settings.openTab",
-                      { tab: "github" },
-                      { source: "user" }
-                    );
-                  },
-                  title: "Open GitHub sign-in",
-                  ariaLabel: "Sign in with GitHub",
+              const signInAction: BannerAction = {
+                id: "signin-github",
+                label: "Sign in with GitHub",
+                icon: LogIn,
+                variant: "accent",
+                onClick: () => {
+                  void actionService.dispatch(
+                    "app.settings.openTab",
+                    { tab: "github" },
+                    { source: "user" }
+                  );
                 },
-              ];
+                title: "Open GitHub sign-in",
+                ariaLabel: "Sign in with GitHub",
+              };
               return (
                 <InlineStatusBanner
                   icon={AlertCircle}
                   title="Clone Failed"
                   description={error.message}
                   severity="error"
-                  actions={actions}
+                  action={signInAction}
                 />
               );
             }

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -126,12 +126,7 @@ vi.mock("@/components/Terminal/InlineStatusBanner", () => ({
         <span>{title}</span>
         <span>{description}</span>
         {actionList.map((a) => (
-          <button
-            key={a.id}
-            type="button"
-            aria-label={a.ariaLabel}
-            onClick={a.onClick}
-          >
+          <button key={a.id} type="button" aria-label={a.ariaLabel} onClick={a.onClick}>
             {a.label}
           </button>
         ))}

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -110,34 +110,39 @@ vi.mock("@/components/Terminal/InlineStatusBanner", () => ({
   InlineStatusBanner: ({
     title,
     description,
+    action,
     actions,
     onClose,
   }: {
     title: ReactNode;
     description?: ReactNode;
+    action?: MockBannerAction;
     actions?: MockBannerAction[];
     onClose?: () => void;
-  }) => (
-    <div data-testid="cleanup-banner">
-      <span>{title}</span>
-      <span>{description}</span>
-      {actions?.map((action) => (
-        <button
-          key={action.id}
-          type="button"
-          aria-label={action.ariaLabel}
-          onClick={action.onClick}
-        >
-          {action.label}
-        </button>
-      ))}
-      {onClose && (
-        <button type="button" onClick={onClose}>
-          banner-dismiss
-        </button>
-      )}
-    </div>
-  ),
+  }) => {
+    const actionList = actions ?? (action ? [action] : []);
+    return (
+      <div data-testid="cleanup-banner">
+        <span>{title}</span>
+        <span>{description}</span>
+        {actionList.map((a) => (
+          <button
+            key={a.id}
+            type="button"
+            aria-label={a.ariaLabel}
+            onClick={a.onClick}
+          >
+            {a.label}
+          </button>
+        ))}
+        {onClose && (
+          <button type="button" onClick={onClose}>
+            banner-dismiss
+          </button>
+        )}
+      </div>
+    );
+  },
 }));
 
 import { CloneRepoDialog } from "../CloneRepoDialog";

--- a/src/components/Recovery/HostCrashBanner.tsx
+++ b/src/components/Recovery/HostCrashBanner.tsx
@@ -64,15 +64,13 @@ export function HostCrashBanner() {
       severity="error"
       role="alert"
       animated={false}
-      actions={[
-        {
-          id: "restart",
-          label: isRestarting ? "Restarting…" : "Restart service",
-          variant: "dangerFilled",
-          onClick: handleRestart,
-          disabled: isRestarting,
-        },
-      ]}
+      action={{
+        id: "restart",
+        label: isRestarting ? "Restarting…" : "Restart service",
+        variant: "dangerFilled",
+        onClick: handleRestart,
+        disabled: isRestarting,
+      }}
     />
   );
 }

--- a/src/components/Sidebar/WorktreeLoadErrorBanner.tsx
+++ b/src/components/Sidebar/WorktreeLoadErrorBanner.tsx
@@ -43,18 +43,16 @@ export function WorktreeLoadErrorBanner({
     }
   }, [isRetrying, onRetry]);
 
-  const actions: BannerAction[] = [
-    {
-      id: "retry",
-      label: "Retry",
-      icon: RotateCcw,
-      variant: "primary",
-      onClick: () => void handleRetry(),
-      title: "Retry loading worktrees",
-      ariaLabel: "Retry loading worktrees",
-      loading: isRetrying,
-    },
-  ];
+  const retryAction: BannerAction = {
+    id: "retry",
+    label: "Retry",
+    icon: RotateCcw,
+    variant: "primary",
+    onClick: () => void handleRetry(),
+    title: "Retry loading worktrees",
+    ariaLabel: "Retry loading worktrees",
+    loading: isRetrying,
+  };
 
   return (
     <InlineStatusBanner
@@ -62,7 +60,7 @@ export function WorktreeLoadErrorBanner({
       title="Couldn't load worktrees"
       description={boundedErrorText(error)}
       severity="error"
-      actions={actions}
+      action={retryAction}
       className={className}
     />
   );

--- a/src/components/Terminal/BannerOverflowMenu.tsx
+++ b/src/components/Terminal/BannerOverflowMenu.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { MoreHorizontal } from "lucide-react";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type { BannerAction } from "./InlineStatusBanner";
+
+interface BannerOverflowMenuProps {
+  /** Secondary affordances demoted out of the banner's single primary action. */
+  actions: BannerAction[];
+  /** Accessible label for the trigger. Defaults to "More options". */
+  ariaLabel?: string;
+}
+
+/**
+ * Overflow menu for an inline banner's secondary affordances. Rendered in the
+ * banner's `trailingSlot`, it keeps the banner to a single primary `action`
+ * (CLAUDE.md Title-Message-Action) while still surfacing the demoted recovery
+ * options behind a `⋯` trigger — the same shape `SafeModeBanner` uses for its
+ * details popover. Renders nothing when there are no overflow actions.
+ */
+export function BannerOverflowMenu({ actions, ariaLabel = "More options" }: BannerOverflowMenuProps) {
+  const [open, setOpen] = useState(false);
+
+  if (actions.length === 0) return null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        type="button"
+        aria-label={ariaLabel}
+        title="More options"
+        className="p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent shrink-0"
+      >
+        <MoreHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+      </PopoverTrigger>
+      <PopoverContent align="end" sideOffset={8} className="p-1 min-w-44 text-xs">
+        {actions.map((item) => {
+          const isDanger = item.variant === "danger" || item.variant === "dangerFilled";
+          return (
+            <button
+              key={item.id}
+              type="button"
+              disabled={item.disabled}
+              aria-label={item.ariaLabel}
+              onClick={() => {
+                setOpen(false);
+                item.onClick();
+              }}
+              className={cn(
+                "flex items-center gap-2 w-full px-2 py-1.5 rounded text-left transition-colors",
+                "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-daintree-accent",
+                isDanger
+                  ? "text-status-error hover:bg-status-error/10"
+                  : "text-daintree-text hover:bg-daintree-border/50",
+                item.disabled && "cursor-not-allowed opacity-60 hover:bg-transparent"
+              )}
+            >
+              {item.icon && <item.icon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />}
+              {item.label}
+            </button>
+          );
+        })}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/Terminal/BannerOverflowMenu.tsx
+++ b/src/components/Terminal/BannerOverflowMenu.tsx
@@ -18,7 +18,10 @@ interface BannerOverflowMenuProps {
  * options behind a `⋯` trigger — the same shape `SafeModeBanner` uses for its
  * details popover. Renders nothing when there are no overflow actions.
  */
-export function BannerOverflowMenu({ actions, ariaLabel = "More options" }: BannerOverflowMenuProps) {
+export function BannerOverflowMenu({
+  actions,
+  ariaLabel = "More options",
+}: BannerOverflowMenuProps) {
   const [open, setOpen] = useState(false);
 
   if (actions.length === 0) return null;

--- a/src/components/Terminal/BannerOverflowMenu.tsx
+++ b/src/components/Terminal/BannerOverflowMenu.tsx
@@ -36,13 +36,16 @@ export function BannerOverflowMenu({ actions, ariaLabel = "More options" }: Bann
       <PopoverContent align="end" sideOffset={8} className="p-1 min-w-44 text-xs">
         {actions.map((item) => {
           const isDanger = item.variant === "danger" || item.variant === "dangerFilled";
+          const isDisabled = item.disabled || item.loading;
           return (
             <button
               key={item.id}
               type="button"
-              disabled={item.disabled}
+              disabled={isDisabled}
+              aria-busy={item.loading || undefined}
               aria-label={item.ariaLabel}
               onClick={() => {
+                if (isDisabled) return;
                 setOpen(false);
                 item.onClick();
               }}
@@ -52,7 +55,7 @@ export function BannerOverflowMenu({ actions, ariaLabel = "More options" }: Bann
                 isDanger
                   ? "text-status-error hover:bg-status-error/10"
                   : "text-daintree-text hover:bg-daintree-border/50",
-                item.disabled && "cursor-not-allowed opacity-60 hover:bg-transparent"
+                isDisabled && "cursor-not-allowed opacity-60 hover:bg-transparent"
               )}
             >
               {item.icon && <item.icon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />}

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -21,15 +21,13 @@ export interface BannerAction {
 
 export type InlineStatusBannerSeverity = "error" | "warning" | "info" | "success" | "neutral";
 
-export interface InlineStatusBannerProps {
+interface BaseInlineStatusBannerProps {
   icon: React.ComponentType<{ className?: string; style?: CSSProperties }>;
   title: React.ReactNode;
   description?: React.ReactNode;
   contextLine?: string;
-  severity?: InlineStatusBannerSeverity;
   animated?: boolean;
   className?: string;
-  actions: BannerAction[];
   role?: "alert" | "status";
   ariaLive?: "off" | "polite" | "assertive";
   onClose?: () => void;
@@ -38,7 +36,9 @@ export interface InlineStatusBannerProps {
   /**
    * Non-button control rendered alongside the actions (e.g. a Popover
    * trigger). Rendered first in the controls row, before the dismiss
-   * button and the primary action buttons.
+   * button and the primary action buttons. This is the escape hatch for
+   * surfacing secondary affordances on an error banner without breaking
+   * the single-action rule.
    */
   trailingSlot?: React.ReactNode;
   /**
@@ -55,6 +55,36 @@ export interface InlineStatusBannerProps {
    */
   autoDismissAfter?: number;
 }
+
+/**
+ * The action surface is gated on `severity`. Error banners follow the
+ * CLAUDE.md Title-Message-Action rule — at most one contextual `action`
+ * plus the optional close. The `actions?: never` here makes the
+ * single-action limit enforceable at the type level rather than only in
+ * prose: passing `actions` on an error banner is a compile error.
+ * Surface any demoted affordances through `trailingSlot`.
+ */
+interface ErrorActionProps {
+  action?: BannerAction;
+  actions?: never;
+}
+
+/**
+ * Non-error banners (warning / info / success / neutral) are not bound by
+ * the single-action rule and may pass an `actions` array, or the single
+ * `action` convenience prop (handy for callers whose severity is computed
+ * dynamically and may resolve to either branch).
+ */
+interface NonErrorActionProps {
+  action?: BannerAction;
+  actions?: BannerAction[];
+}
+
+export type InlineStatusBannerProps = BaseInlineStatusBannerProps &
+  (
+    | ({ severity: "error" } & ErrorActionProps)
+    | ({ severity: Exclude<InlineStatusBannerSeverity, "error"> } & NonErrorActionProps)
+  );
 
 const SEVERITY_VAR: Record<Exclude<InlineStatusBannerSeverity, "neutral">, string> = {
   error: "--color-status-error",
@@ -103,6 +133,7 @@ export function InlineStatusBanner({
   severity = "error",
   animated = true,
   className,
+  action,
   actions,
   role = "alert",
   ariaLive,
@@ -153,6 +184,8 @@ export function InlineStatusBanner({
     };
   }, [shouldAnimate]);
 
+  const actionList: BannerAction[] = actions ?? (action ? [action] : []);
+
   const hasDescription = description || contextLine || descriptionExtras;
 
   const closeButton = onClose ? (
@@ -169,7 +202,7 @@ export function InlineStatusBanner({
     </button>
   ) : null;
 
-  const showControlsRow = !!trailingSlot || (!hasDescription && !!onClose) || actions.length > 0;
+  const showControlsRow = !!trailingSlot || (!hasDescription && !!onClose) || actionList.length > 0;
 
   return (
     <div
@@ -259,7 +292,7 @@ export function InlineStatusBanner({
         <div className={cn("flex items-center shrink-0", hasDescription ? "gap-2 ml-6" : "gap-1")}>
           {trailingSlot}
           {!hasDescription && closeButton}
-          {actions.map((action) => {
+          {actionList.map((action) => {
             const variant = action.variant ?? "primary";
             const variantClasses = getButtonClasses(variant);
             const variantStyle = colorVar ? getButtonStyle(variant, colorVar) : undefined;

--- a/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
@@ -55,18 +55,16 @@ export function RecipeRunner({ activeWorktreeId, defaultCwd }: RecipeRunnerProps
             title={formatFailureTitle(runner.spawnFailureSummary)}
             description={runner.spawnFailureSummary.failures[0]?.error}
             severity="error"
-            actions={[
-              {
-                id: "retry-failed",
-                label: "Retry failed",
-                icon: RotateCcw,
-                variant: "primary",
-                onClick: runner.handleRetryFailed,
-                title: "Retry the terminals that failed to start",
-                ariaLabel: "Retry failed terminals",
-                loading: runner.isRetryingFailed,
-              },
-            ]}
+            action={{
+              id: "retry-failed",
+              label: "Retry failed",
+              icon: RotateCcw,
+              variant: "primary",
+              onClick: runner.handleRetryFailed,
+              title: "Retry the terminals that failed to start",
+              ariaLabel: "Retry failed terminals",
+              loading: runner.isRetryingFailed,
+            }}
             onClose={runner.dismissSpawnFailures}
           />
         </div>

--- a/src/components/Terminal/ReconnectErrorBanner.tsx
+++ b/src/components/Terminal/ReconnectErrorBanner.tsx
@@ -52,24 +52,42 @@ export function ReconnectErrorBanner({
   isRestarting = false,
   className,
 }: ReconnectErrorBannerProps) {
+  const severity = getErrorSeverity(error.type);
+  const retryAction = {
+    id: "retry",
+    label: "Retry",
+    icon: RotateCcw,
+    variant: "primary" as const,
+    onClick: () => onRestart(terminalId),
+    title: "Retry reconnecting",
+    ariaLabel: "Retry reconnecting",
+    loading: isRestarting,
+  };
+
+  // Severity is computed from the error type, so branch on it to satisfy the
+  // discriminated union on `InlineStatusBanner` (error banners take a single
+  // `action`). Either way this banner shows exactly one action.
+  if (severity === "error") {
+    return (
+      <InlineStatusBanner
+        icon={getErrorIcon(error.type)}
+        title={getErrorTitle(error.type)}
+        description={boundedErrorText(error.message)}
+        severity="error"
+        action={retryAction}
+        onClose={() => onDismiss(terminalId)}
+        className={className}
+      />
+    );
+  }
+
   return (
     <InlineStatusBanner
       icon={getErrorIcon(error.type)}
       title={getErrorTitle(error.type)}
       description={boundedErrorText(error.message)}
-      severity={getErrorSeverity(error.type)}
-      actions={[
-        {
-          id: "retry",
-          label: "Retry",
-          icon: RotateCcw,
-          variant: "primary",
-          onClick: () => onRestart(terminalId),
-          title: "Retry reconnecting",
-          ariaLabel: "Retry reconnecting",
-          loading: isRestarting,
-        },
-      ]}
+      severity={severity}
+      action={retryAction}
       onClose={() => onDismiss(terminalId)}
       className={className}
     />

--- a/src/components/Terminal/SpawnErrorBanner.tsx
+++ b/src/components/Terminal/SpawnErrorBanner.tsx
@@ -1,5 +1,6 @@
 import { XCircle, RotateCcw, FolderEdit, Trash2, Settings2 } from "lucide-react";
 import { InlineStatusBanner, type BannerAction } from "./InlineStatusBanner";
+import { BannerOverflowMenu } from "./BannerOverflowMenu";
 import { sanitizeErrorText, boundedErrorText } from "@/utils/errorText";
 import { actionService } from "@/services/ActionService";
 import type { SpawnError } from "@/types";
@@ -94,58 +95,60 @@ export function SpawnErrorBanner({
   const isCwdError = error.code === "ENOTDIR";
   const isResourceLimit = RESOURCE_LIMIT_CODES.has(error.code);
 
-  const actions: BannerAction[] = [];
-  if (isCwdError) {
-    actions.push({
-      id: "update-cwd",
-      label: "Change directory",
-      icon: FolderEdit,
-      variant: "accent",
-      onClick: () => onUpdateCwd(terminalId),
-      title: "Change working directory",
-      ariaLabel: "Update working directory",
-      disabled: isRestarting,
-    });
-  }
-  if (isResourceLimit) {
-    actions.push({
-      id: "open-limits",
-      label: "Terminal limits",
-      icon: Settings2,
-      variant: "accent",
-      onClick: () => {
-        void actionService.dispatch(
-          "app.settings.openTab",
-          { tab: "terminal", subtab: "performance", sectionId: "terminal-panel-limits" },
-          { source: "user" }
-        );
-      },
-      title: "Open terminal limits settings",
-      ariaLabel: "Open terminal limits settings",
-    });
-  }
-  actions.push(
-    {
-      id: "retry",
-      label: "Retry",
-      icon: RotateCcw,
-      variant: "primary",
-      onClick: () => onRetry(terminalId),
-      title: "Retry",
-      ariaLabel: "Retry starting terminal",
-      loading: isRestarting,
+  const retryAction: BannerAction = {
+    id: "retry",
+    label: "Retry",
+    icon: RotateCcw,
+    variant: "primary",
+    onClick: () => onRetry(terminalId),
+    title: "Retry",
+    ariaLabel: "Retry starting terminal",
+    loading: isRestarting,
+  };
+  const changeDirAction: BannerAction = {
+    id: "update-cwd",
+    label: "Change directory",
+    icon: FolderEdit,
+    variant: "accent",
+    onClick: () => onUpdateCwd(terminalId),
+    title: "Change working directory",
+    ariaLabel: "Update working directory",
+    disabled: isRestarting,
+  };
+  const limitsAction: BannerAction = {
+    id: "open-limits",
+    label: "Terminal limits",
+    icon: Settings2,
+    variant: "accent",
+    onClick: () => {
+      void actionService.dispatch(
+        "app.settings.openTab",
+        { tab: "terminal", subtab: "performance", sectionId: "terminal-panel-limits" },
+        { source: "user" }
+      );
     },
-    {
-      id: "trash",
-      label: "Remove terminal",
-      icon: Trash2,
-      variant: "danger",
-      onClick: () => onTrash(terminalId),
-      title: "Move to trash",
-      ariaLabel: "Move to trash",
-      disabled: isRestarting,
-    }
-  );
+    title: "Open terminal limits settings",
+    ariaLabel: "Open terminal limits settings",
+  };
+  const trashAction: BannerAction = {
+    id: "trash",
+    label: "Remove terminal",
+    icon: Trash2,
+    variant: "danger",
+    onClick: () => onTrash(terminalId),
+    title: "Move to trash",
+    ariaLabel: "Move to trash",
+    disabled: isRestarting,
+  };
+
+  // Single contextual action: the most specific recovery for the error code.
+  // Everything else moves into the overflow menu so the banner keeps to the
+  // one-action rule (CLAUDE.md Title-Message-Action).
+  const primaryAction = isCwdError ? changeDirAction : isResourceLimit ? limitsAction : retryAction;
+  const overflowActions: BannerAction[] = [
+    ...(primaryAction.id === retryAction.id ? [] : [retryAction]),
+    trashAction,
+  ];
 
   return (
     <InlineStatusBanner
@@ -154,7 +157,10 @@ export function SpawnErrorBanner({
       description={getErrorDescription(error, cwd)}
       contextLine={cwd ? `Directory: ${sanitizeErrorText(cwd)}` : undefined}
       severity="error"
-      actions={actions}
+      action={primaryAction}
+      trailingSlot={
+        <BannerOverflowMenu actions={overflowActions} ariaLabel="More recovery options" />
+      }
       className={className}
     />
   );

--- a/src/components/Terminal/TerminalErrorBanner.tsx
+++ b/src/components/Terminal/TerminalErrorBanner.tsx
@@ -1,5 +1,6 @@
 import { XCircle, RotateCcw, FolderEdit, Trash2 } from "lucide-react";
 import { InlineStatusBanner, type BannerAction } from "./InlineStatusBanner";
+import { BannerOverflowMenu } from "./BannerOverflowMenu";
 import { sanitizeErrorText, boundedErrorText } from "@/utils/errorText";
 import type { TerminalRestartError } from "@/types";
 
@@ -22,43 +23,48 @@ export function TerminalErrorBanner({
   isRestarting = false,
   className,
 }: TerminalErrorBannerProps) {
-  const isCwdError = error.code === "ENOENT" && error.context?.failedCwd;
+  const isCwdError = error.code === "ENOENT" && !!error.context?.failedCwd;
+  const canChangeDir = error.recoverable && isCwdError;
 
-  const actions: BannerAction[] = [];
-  if (error.recoverable && isCwdError) {
-    actions.push({
-      id: "update-cwd",
-      label: "Change directory",
-      icon: FolderEdit,
-      variant: "accent",
-      onClick: () => onUpdateCwd(terminalId),
-      title: "Change working directory",
-      ariaLabel: "Update working directory",
-      disabled: isRestarting,
-    });
-  }
-  actions.push(
-    {
-      id: "retry",
-      label: "Retry",
-      icon: RotateCcw,
-      variant: "primary",
-      onClick: () => onRetry(terminalId),
-      title: "Retry restart",
-      ariaLabel: "Retry restart",
-      loading: isRestarting,
-    },
-    {
-      id: "trash",
-      label: "Remove terminal",
-      icon: Trash2,
-      variant: "danger",
-      onClick: () => onTrash(terminalId),
-      title: "Move to trash",
-      ariaLabel: "Move to trash",
-      disabled: isRestarting,
-    }
-  );
+  const retryAction: BannerAction = {
+    id: "retry",
+    label: "Retry",
+    icon: RotateCcw,
+    variant: "primary",
+    onClick: () => onRetry(terminalId),
+    title: "Retry restart",
+    ariaLabel: "Retry restart",
+    loading: isRestarting,
+  };
+  const changeDirAction: BannerAction = {
+    id: "update-cwd",
+    label: "Change directory",
+    icon: FolderEdit,
+    variant: "accent",
+    onClick: () => onUpdateCwd(terminalId),
+    title: "Change working directory",
+    ariaLabel: "Update working directory",
+    disabled: isRestarting,
+  };
+  const trashAction: BannerAction = {
+    id: "trash",
+    label: "Remove terminal",
+    icon: Trash2,
+    variant: "danger",
+    onClick: () => onTrash(terminalId),
+    title: "Move to trash",
+    ariaLabel: "Move to trash",
+    disabled: isRestarting,
+  };
+
+  // Single contextual action: change directory is the specific fix for a
+  // missing-cwd restart failure, otherwise retry. The rest move into the
+  // overflow menu to honour the one-action rule.
+  const primaryAction = canChangeDir ? changeDirAction : retryAction;
+  const overflowActions: BannerAction[] = [
+    ...(primaryAction.id === retryAction.id ? [] : [retryAction]),
+    trashAction,
+  ];
 
   return (
     <InlineStatusBanner
@@ -71,7 +77,10 @@ export function TerminalErrorBanner({
           : undefined
       }
       severity="error"
-      actions={actions}
+      action={primaryAction}
+      trailingSlot={
+        <BannerOverflowMenu actions={overflowActions} ariaLabel="More recovery options" />
+      }
       className={className}
     />
   );

--- a/src/components/Terminal/TerminalRestartStatusBanner.tsx
+++ b/src/components/Terminal/TerminalRestartStatusBanner.tsx
@@ -63,17 +63,15 @@ export function TerminalRestartStatusBanner({
           title={RESTART_BANNER_COPY["exit-error"]({ exitCode: variant.exitCode }).title}
           severity="error"
           animated={false}
-          actions={[
-            {
-              id: "restart",
-              label: "Restart session",
-              icon: RotateCcw,
-              variant: "dangerFilled",
-              onClick: onRestart,
-              title: "Restart session",
-              ariaLabel: "Restart session",
-            },
-          ]}
+          action={{
+            id: "restart",
+            label: "Restart session",
+            icon: RotateCcw,
+            variant: "dangerFilled",
+            onClick: onRestart,
+            title: "Restart session",
+            ariaLabel: "Restart session",
+          }}
           onClose={onDismiss}
         />
       );

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -31,7 +31,12 @@ beforeAll(() => {
 describe("InlineStatusBanner", () => {
   it("defaults to role='alert' and emits no aria-live attribute", () => {
     render(
-      <InlineStatusBanner icon={XCircle} title="Something broke" severity="error" animated={false} />
+      <InlineStatusBanner
+        icon={XCircle}
+        title="Something broke"
+        severity="error"
+        animated={false}
+      />
     );
     const region = screen.getByRole("alert");
     expect(region.hasAttribute("aria-live")).toBe(false);
@@ -71,7 +76,9 @@ describe("InlineStatusBanner", () => {
     ["info", Info, "--color-status-info"],
     ["success", CheckCircle2, "--color-status-success"],
   ] as const)("renders %s severity using its status token", (severity, icon, token) => {
-    render(<InlineStatusBanner icon={icon} title={severity} severity={severity} animated={false} />);
+    render(
+      <InlineStatusBanner icon={icon} title={severity} severity={severity} animated={false} />
+    );
     const region = screen.getByRole("alert");
     expect(region.style.backgroundColor).toContain(token);
     expect(region.style.borderBottom).toContain(token);

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -31,17 +31,38 @@ beforeAll(() => {
 describe("InlineStatusBanner", () => {
   it("defaults to role='alert' and emits no aria-live attribute", () => {
     render(
-      <InlineStatusBanner
-        icon={XCircle}
-        title="Something broke"
-        severity="error"
-        animated={false}
-        actions={[]}
-      />
+      <InlineStatusBanner icon={XCircle} title="Something broke" severity="error" animated={false} />
     );
     const region = screen.getByRole("alert");
     expect(region.hasAttribute("aria-live")).toBe(false);
     expect(region.hasAttribute("aria-atomic")).toBe(false);
+  });
+
+  it("caps an error banner at a single inline action; secondary affordances go in trailingSlot", () => {
+    render(
+      <InlineStatusBanner
+        icon={XCircle}
+        title="Couldn't start terminal"
+        severity="error"
+        animated={false}
+        action={{ id: "retry", label: "Retry", onClick: () => {} }}
+        trailingSlot={<button type="button">More options</button>}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    // The single `action` renders one inline button; the rest live behind the slot.
+    expect(screen.getByRole("button", { name: "More options" })).toBeTruthy();
+
+    const _rejectsActionsOnError = (
+      // @ts-expect-error error banners forbid the multi-action `actions` prop.
+      <InlineStatusBanner
+        icon={XCircle}
+        title="Nope"
+        severity="error"
+        actions={[{ id: "a", label: "A", onClick: () => {} }]}
+      />
+    );
+    void _rejectsActionsOnError;
   });
 
   it.each([
@@ -50,18 +71,28 @@ describe("InlineStatusBanner", () => {
     ["info", Info, "--color-status-info"],
     ["success", CheckCircle2, "--color-status-success"],
   ] as const)("renders %s severity using its status token", (severity, icon, token) => {
-    render(
-      <InlineStatusBanner
-        icon={icon}
-        title={severity}
-        severity={severity}
-        animated={false}
-        actions={[]}
-      />
-    );
+    render(<InlineStatusBanner icon={icon} title={severity} severity={severity} animated={false} />);
     const region = screen.getByRole("alert");
     expect(region.style.backgroundColor).toContain(token);
     expect(region.style.borderBottom).toContain(token);
+  });
+
+  it("allows non-error banners to render multiple actions", () => {
+    render(
+      <InlineStatusBanner
+        icon={FileEdit}
+        title="3 files changed"
+        severity="neutral"
+        animated={false}
+        role="status"
+        actions={[
+          { id: "review", label: "Review", onClick: () => {} },
+          { id: "send", label: "Send to assistant", onClick: () => {} },
+        ]}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Review" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Send to assistant" })).toBeTruthy();
   });
 
   it("emits aria-live='off' without aria-atomic", () => {

--- a/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
@@ -18,6 +18,19 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+// Render the overflow popover open and in a tagged container so the inline
+// primary action (outside) can be told apart from the demoted items (inside).
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverAnchor: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="overflow-content">{children}</div>
+  ),
+}));
+
 import { SpawnErrorBanner } from "../SpawnErrorBanner";
 
 beforeAll(() => {
@@ -69,12 +82,33 @@ function renderBanner(
   );
 }
 
+const overflow = () => screen.getByTestId("overflow-content");
+
 describe("SpawnErrorBanner", () => {
+  it("keeps a single inline action and moves Remove terminal into the overflow menu", () => {
+    renderBanner("ENOENT");
+    // Generic error → Retry is the sole inline action (outside the overflow).
+    const retry = screen.getByRole("button", { name: /retry starting terminal/i });
+    expect(overflow().contains(retry)).toBe(false);
+    // Remove terminal is demoted into the overflow menu.
+    const trash = screen.getByRole("button", { name: /move to trash/i });
+    expect(overflow().contains(trash)).toBe(true);
+    expect(trash.textContent).toContain("Remove terminal");
+    // The overflow trigger keeps its accessible label.
+    expect(screen.getByRole("button", { name: /more recovery options/i })).toBeTruthy();
+  });
+
   it.each(["EMFILE", "EAGAIN", "ENOMEM", "ENXIO"] as const)(
-    "renders the terminal-limits action for %s",
+    "promotes the terminal-limits action to the inline primary for %s",
     (code) => {
       renderBanner(code);
-      expect(screen.getByRole("button", { name: /open terminal limits settings/i })).toBeTruthy();
+      const limits = screen.getByRole("button", { name: /open terminal limits settings/i });
+      // Resource-limit errors make "Terminal limits" the primary inline action.
+      expect(overflow().contains(limits)).toBe(false);
+      // Retry is demoted into the overflow for these codes.
+      expect(overflow().contains(screen.getByRole("button", { name: /retry starting terminal/i }))).toBe(
+        true
+      );
     }
   );
 
@@ -94,11 +128,24 @@ describe("SpawnErrorBanner", () => {
     );
   });
 
-  it("renders the destructive action with verb-noun label", () => {
-    renderBanner("ENOENT");
-    expect(screen.getByRole("button", { name: /move to trash/i }).textContent).toContain(
-      "Remove terminal"
+  it("makes Change directory the inline primary action for an invalid working directory", () => {
+    const onUpdateCwd = vi.fn();
+    renderBanner("ENOTDIR", { onUpdateCwd });
+    const changeDir = screen.getByRole("button", { name: /update working directory/i });
+    expect(overflow().contains(changeDir)).toBe(false);
+    fireEvent.click(changeDir);
+    expect(onUpdateCwd).toHaveBeenCalledWith("t-1");
+    // Retry is demoted into the overflow for cwd errors.
+    expect(overflow().contains(screen.getByRole("button", { name: /retry starting terminal/i }))).toBe(
+      true
     );
+  });
+
+  it("invokes onTrash from the overflow menu", () => {
+    const onTrash = vi.fn();
+    renderBanner("ENOENT", { onTrash });
+    fireEvent.click(screen.getByRole("button", { name: /move to trash/i }));
+    expect(onTrash).toHaveBeenCalledWith("t-1");
   });
 
   it("disables retry and shows aria-busy when isRestarting is true", () => {

--- a/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
@@ -106,9 +106,9 @@ describe("SpawnErrorBanner", () => {
       // Resource-limit errors make "Terminal limits" the primary inline action.
       expect(overflow().contains(limits)).toBe(false);
       // Retry is demoted into the overflow for these codes.
-      expect(overflow().contains(screen.getByRole("button", { name: /retry starting terminal/i }))).toBe(
-        true
-      );
+      expect(
+        overflow().contains(screen.getByRole("button", { name: /retry starting terminal/i }))
+      ).toBe(true);
     }
   );
 
@@ -136,9 +136,9 @@ describe("SpawnErrorBanner", () => {
     fireEvent.click(changeDir);
     expect(onUpdateCwd).toHaveBeenCalledWith("t-1");
     // Retry is demoted into the overflow for cwd errors.
-    expect(overflow().contains(screen.getByRole("button", { name: /retry starting terminal/i }))).toBe(
-      true
-    );
+    expect(
+      overflow().contains(screen.getByRole("button", { name: /retry starting terminal/i }))
+    ).toBe(true);
   });
 
   it("invokes onTrash from the overflow menu", () => {

--- a/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
@@ -168,4 +168,15 @@ describe("SpawnErrorBanner", () => {
     fireEvent.click(screen.getByRole("button", { name: /retry starting terminal/i }));
     expect(onRetry).toHaveBeenCalledWith("t-1");
   });
+
+  it("disables the demoted overflow Retry while restarting and does not invoke onRetry", () => {
+    const onRetry = vi.fn();
+    // ENOTDIR makes Change directory the primary, so Retry is demoted to overflow.
+    renderBanner("ENOTDIR", { isRestarting: true, onRetry });
+    const retry = screen.getByRole("button", { name: /retry starting terminal/i });
+    expect(overflow().contains(retry)).toBe(true);
+    expect(retry.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(retry);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- `InlineStatusBanner`'s `actions` prop is now a severity-discriminated union: `severity="error"` takes a single optional `action` prop (passing `actions` is a compile error); non-error severities keep the `actions` array. `severity` is now a required discriminant, which means the rule that previously only existed in the docs is now enforced by the type system.
- `SpawnErrorBanner` and `TerminalErrorBanner` are brought into compliance with one primary action chosen by error code (ENOTDIR → Change directory, resource-limit codes → Terminal limits, else → Retry), and remaining actions moved into a new shared `BannerOverflowMenu` component (Radix popover in `trailingSlot`, mirroring `SafeModeBanner`).
- All 13 `severity="error"` call sites migrated to `action`. `BlockedNavBanner` and `ReconnectErrorBanner` branch by severity. `DevPreviewPane` stuck/crashed banners promote the specific remedy to primary and demote the generic restart to overflow.

Resolves #9180

## Changes

- `InlineStatusBanner.tsx` — discriminated union on `severity` + `action`/`actions`; `severity` required
- `BannerOverflowMenu.tsx` — new shared overflow component (Radix popover, `trailingSlot`-mounted)
- `SpawnErrorBanner.tsx`, `TerminalErrorBanner.tsx` — single primary action by error code; overflow for the rest
- `BlockedNavBanner.tsx` — restored dropped phase-specific actions; overflow Retry disabled mid-restart
- `ReconnectErrorBanner.tsx`, `DevPreviewPane.tsx` — severity-branched / remedy-promoted
- `FleetFailureBanner.tsx`, `HostCrashBanner.tsx`, `WorktreeLoadErrorBanner.tsx`, `RecipeRunner.tsx`, `CloneRepoDialog.tsx`, `TerminalRestartStatusBanner.tsx` — migrated to `action` prop

## Testing

- `InlineStatusBanner.test.tsx` — single-action enforcement via `ts-expect-error`, type-level compile guard
- `SpawnErrorBanner.test.tsx` — primary action selection per error code, overflow demotion
- `BlockedNavBanner.test.tsx` — phase-action coverage, disabled state of overflow Retry during restart
- `CloneRepoDialog.test.tsx` — updated for migrated prop shape
- `tsc --noEmit` clean; `npm run fix` clean