### PR TITLE
fix(mcp): close observability and teardown gaps in session lifecycle

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -275,13 +275,26 @@ if (!gotTheLock) {
           console.error("[main] closePortsForView failed during cache:", err);
         }
       },
-      onViewCrashed: () => {
+      onViewCrashed: (wc) => {
         // Tear down the per-window PTY MessagePort on renderer crash so the
         // pty-host's PortQueueManager can drop stale queue accounting before
         // reload re-issues a fresh port. Without this, a stale port keeps the
         // safety-timeout pause loop wedged for the entire reload window (#6244).
         if (win.isDestroyed()) return;
         getPtyClient()?.disconnectMessagePort(win.id);
+        // Revoke help-session tokens pinned to the crashed WebContents (#9151).
+        // The renderer comes back with a brand-new (monotonic) WebContents id,
+        // so the old pin is now a tombstone — every CallTool would return
+        // SESSION_BINDING_GONE and the targeted tier-mismatch / revoked IPCs
+        // would silently no-op against the dead id. Mirrors the synchronous
+        // eviction-hook revoke (lesson #5009); `wc.id` is the dead id the
+        // session pinned at provision time.
+        const crashedWcId = wc.id;
+        import("./services/HelpSessionService.js")
+          .then(({ helpSessionService }) => helpSessionService.revokeByWebContentsId(crashedWcId))
+          .catch((err) => {
+            console.warn("[main] revokeByWebContentsId failed during crash:", err);
+          });
       },
       onViewReady: (wc) => {
         // Re-distribute PTY MessagePort on every view load/reload.

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -14,7 +14,10 @@ import { isTrustedRendererUrl } from "../shared/utils/trustedRenderer.js";
 import { isIpcEnvelope } from "../shared/types/ipc/errors.js";
 import { deserializeError } from "../shared/utils/ipcErrorSerialization.js";
 import type { AppErrorCode } from "../shared/types/appError.js";
-import type { McpRuntimeSnapshot } from "../shared/types/ipc/mcpServer.js";
+import type {
+  McpRuntimeSnapshot,
+  McpGrantLifecyclePayload,
+} from "../shared/types/ipc/mcpServer.js";
 import type { ActionContext } from "../shared/types/actions.js";
 import type { PushProgressEvent } from "../shared/types/ipc/gitPush.js";
 import { CHANNELS } from "./ipc/channels.js";
@@ -2324,16 +2327,8 @@ const api: ElectronAPI = {
         targetTier: "workbench" | "action" | "system" | null;
       }) => void
     ) => _typedOn(CHANNELS.MCP_TIER_NOT_PERMITTED, callback),
-    onGrantLifecycle: (
-      callback: (payload: {
-        type: "grant.issued" | "grant.expired" | "grant.revoked";
-        sessionId: string;
-        toolId: string;
-        ttlMs: number;
-        expiresAt?: number;
-        revokedReason?: "user" | "session-ended" | "session-idle";
-      }) => void
-    ) => _typedOn(CHANNELS.MCP_GRANT_LIFECYCLE, callback),
+    onGrantLifecycle: (callback: (payload: McpGrantLifecyclePayload) => void) =>
+      _typedOn(CHANNELS.MCP_GRANT_LIFECYCLE, callback),
   },
 
   helpAssistant: buildHelpAssistantPreloadBindings(_unwrappingInvoke),

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -247,6 +247,7 @@ export class HelpSessionService {
   private mcpRegistry: WindowRegistry | null = null;
   private ptyClient: PtyKillClient | null = null;
   private pendingHibernationStore: PendingHelpHibernationStore | null = null;
+  private onMcpSessionRevokedFn: ((token: string) => void) | null = null;
   private disposed = false;
 
   setMcpRegistry(registry: WindowRegistry): void {
@@ -255,6 +256,16 @@ export class HelpSessionService {
 
   setPtyClient(client: PtyKillClient | null): void {
     this.ptyClient = client;
+  }
+
+  /**
+   * Wire the eager MCP-session teardown invoked on revoke (#9151). Given the
+   * revoked help session's raw bearer token, the callback drops the live MCP
+   * session(s) it owns so tier/grants/pin don't linger until the idle reaper.
+   * Idempotent — re-set on every `ensureMcpServerReady`.
+   */
+  setOnMcpSessionRevoked(cb: ((token: string) => void) | null): void {
+    this.onMcpSessionRevokedFn = cb;
   }
 
   setPendingHibernationStore(store: PendingHelpHibernationStore | null): void {
@@ -874,6 +885,23 @@ export class HelpSessionService {
       }
     }
 
+    // Eagerly tear down the live MCP session(s) bound to this bearer (#9151).
+    // Without this the MCP session keeps its tier, grants, and renderer pin
+    // until the abuse policy trips on accumulated 401s or the 30-minute idle
+    // reaper collects it — up to a full 30 minutes of stale state for a
+    // session that goes idle right after revoke. Fires unconditionally (the
+    // MCP session is live regardless of whether we captured a hibernation
+    // resume ID); a no-op when the agent never reached the MCP server.
+    try {
+      this.onMcpSessionRevokedFn?.(record.token);
+    } catch (err) {
+      console.warn(
+        "[HelpSessionService] MCP session teardown during revoke failed:",
+        sessionId,
+        err
+      );
+    }
+
     if (capturedAgentSessionId && this.pendingHibernationStore && !displacedDuringCapture) {
       void this.pendingHibernationStore
         .set(record.projectId, {
@@ -1184,6 +1212,8 @@ export class HelpSessionService {
       this.getActionContextForToken(token)
     );
     mcpServerService.setSessionIdResolver((terminalId) => this.getSessionIdForTerminal(terminalId));
+    // Eager MCP-session teardown on revoke (#9151). Idempotent re-set.
+    this.setOnMcpSessionRevoked((token) => mcpServerService.disconnectHelpBearer(token));
     if (!mcpServerService.isEnabled()) {
       // setEnabled() will only call start() internally if it has its own
       // `registry` already set — which it doesn't on cold boot if the

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -970,6 +970,20 @@ export class HelpSessionService {
         this.terminalBySessionId.delete(prior.sessionId);
         this.killTerminal(terminalId, "help-session-displaced");
       }
+      // Tear down the displaced session's live MCP transport too (#9151).
+      // Displacement is just a same-project re-provision flavour of revoke —
+      // without this the old bearer keeps its tier/grants/pin until the
+      // 30-minute idle reaper, exactly the stale state this issue closes on
+      // the `revokeSession` path.
+      try {
+        this.onMcpSessionRevokedFn?.(prior.token);
+      } catch (err) {
+        console.warn(
+          "[HelpSessionService] MCP session teardown during displacement failed:",
+          prior.sessionId,
+          err
+        );
+      }
     }
     // Also clear any stale active-terminal binding the renderer never
     // confirmed via `markTerminalForToken` — leaving it would leak the

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -98,7 +98,7 @@ export class McpServerService {
         // below). The closure defers the reference until teardown time, by
         // which point the field is assigned. Mirrors `dropAbuseState`.
         dropBearerState: (sessionId) => this.httpLifecycle.detachBearerSession(sessionId),
-        onTierDecayed: (sessionId) => {
+        onTierDecayed: (sessionId, previousTier, newTier) => {
           // Tier just decayed to the workbench baseline (#8462). Push a
           // tools/list_changed so the model re-fetches the now-narrowed
           // manifest instead of calling a tool it no longer has. The
@@ -111,6 +111,21 @@ export class McpServerService {
             // Transport already closing/closed — the model will see the
             // narrowed surface on its next list call regardless.
           });
+          // Positive audit trail for the decay (#9151): the elevation window
+          // closed and access narrowed back to the baseline. Best-effort —
+          // an audit-write failure must never block the tier rollback.
+          try {
+            this.auditService.appendGrantRecord({
+              type: "tier.decayed",
+              sessionId,
+              toolId: "*",
+              ttlMs: 0,
+              previousTier,
+              tier: newTier,
+            });
+          } catch (err) {
+            console.error("[MCP] Failed to append tier.decayed audit record:", err);
+          }
         },
       }
     );
@@ -488,6 +503,21 @@ export class McpServerService {
     this.httpLifecycle.clearBearer(tokenHash);
     this.emitRuntimeStateChange();
     return { tokenHash, disconnected: true };
+  }
+
+  /**
+   * Eagerly tear down the live MCP session(s) a help-session bearer owns
+   * when the help session is revoked (#9151). Resolves the raw help token to
+   * its register key, then reuses {@link disconnectBearer} so tier, grants,
+   * and pin drop immediately instead of lingering until the 30-minute idle
+   * reaper. A no-op when the agent never connected (or already disconnected)
+   * — the token won't be tracked. Wired in via
+   * `HelpSessionService.setOnMcpSessionRevoked`.
+   */
+  disconnectHelpBearer(rawToken: string): void {
+    const tokenHash = this.httpLifecycle.findHelpBearerHash(rawToken);
+    if (tokenHash === null) return;
+    this.disconnectBearer(tokenHash);
   }
 
   /**

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -29,6 +29,7 @@ const {
     setHelpSessionWebContentsResolver: vi.fn(),
     setHelpSessionActionContextResolver: vi.fn(),
     setSessionIdResolver: vi.fn(),
+    disconnectHelpBearer: vi.fn(),
     recordTurnOutcome: vi.fn(),
     getRuntimeState: vi.fn<
       () => import("../../../shared/types/ipc/mcpServer.js").McpRuntimeSnapshot
@@ -176,6 +177,7 @@ describe("HelpSessionService", () => {
     mockMcpServerService.setHelpTokenValidator.mockClear();
     mockMcpServerService.setHelpSessionWebContentsResolver.mockClear();
     mockMcpServerService.setSessionIdResolver.mockClear();
+    mockMcpServerService.disconnectHelpBearer.mockClear();
     mockMcpServerService.recordTurnOutcome.mockClear();
     mockProbeMcpServer.mockReset();
     mockProbeMcpServer.mockResolvedValue(undefined);
@@ -551,6 +553,55 @@ describe("HelpSessionService", () => {
     expect(after.mcpServers.daintree).toBeUndefined();
     // daintree-docs entry must remain — it doesn't depend on a live session.
     expect(after.mcpServers["daintree-docs"]).toBeDefined();
+  });
+
+  it("tears down the live MCP session via disconnectHelpBearer on revoke (#9151)", async () => {
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+
+    await service.revokeSession(result.sessionId);
+
+    // The bearer token is handed to McpServerService so it can drop the
+    // session's tier/grants/pin immediately instead of leaving them for the
+    // 30-minute idle reaper.
+    expect(mockMcpServerService.disconnectHelpBearer).toHaveBeenCalledWith(result.token);
+  });
+
+  it("tears down the MCP session even when a hibernation resume id is captured (#9151)", async () => {
+    mockPtyGracefulKill.mockResolvedValueOnce("resume-id-123");
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+    mockMcpServerService.disconnectHelpBearer.mockClear();
+
+    await service.revokeSession(result.sessionId, { captureHibernation: true });
+
+    // The live MCP session is orthogonal to transcript capture — it must be
+    // dropped regardless of whether we preserved a resume id.
+    expect(mockMcpServerService.disconnectHelpBearer).toHaveBeenCalledWith(result.token);
+  });
+
+  it("revokeByWebContentsId drops the MCP session for each matched session (crash/eviction path, #9151)", async () => {
+    // Distinct projects so neither provision displaces the other — we want
+    // both sessions live and pinned to different WebContents.
+    const a = await service.provisionSession({
+      ...provisionInput(),
+      projectId: "proj-a",
+      projectPath: "/tmp/proj-a",
+      projectViewWebContentsId: 1,
+    });
+    const b = await service.provisionSession({
+      ...provisionInput(),
+      projectId: "proj-b",
+      projectPath: "/tmp/proj-b",
+      projectViewWebContentsId: 2,
+    });
+    if (!a || !b) throw new Error("expected provisions");
+    mockMcpServerService.disconnectHelpBearer.mockClear();
+
+    await service.revokeByWebContentsId(1);
+
+    expect(mockMcpServerService.disconnectHelpBearer).toHaveBeenCalledWith(a.token);
+    expect(mockMcpServerService.disconnectHelpBearer).not.toHaveBeenCalledWith(b.token);
   });
 
   it("reuses the same per-project session dir across consecutive launches with a freshly rotated bearer", async () => {

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -580,6 +580,19 @@ describe("HelpSessionService", () => {
     expect(mockMcpServerService.disconnectHelpBearer).toHaveBeenCalledWith(result.token);
   });
 
+  it("tears down the displaced session's MCP transport on same-project re-provision (#9151)", async () => {
+    const first = await service.provisionSession(provisionInput());
+    if (!first) throw new Error("expected first provision");
+    mockMcpServerService.disconnectHelpBearer.mockClear();
+
+    // A second provision for the same project displaces the first — its live
+    // MCP session must be dropped, not left for the idle reaper.
+    const second = await service.provisionSession(provisionInput());
+    if (!second) throw new Error("expected second provision");
+
+    expect(mockMcpServerService.disconnectHelpBearer).toHaveBeenCalledWith(first.token);
+  });
+
   it("revokeByWebContentsId drops the MCP session for each matched session (crash/eviction path, #9151)", async () => {
     // Distinct projects so neither provision displaces the other — we want
     // both sessions live and pinned to different WebContents.

--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -373,6 +373,70 @@ describe("AuditService hydrate — backward compat", () => {
   });
 });
 
+describe("AuditService.appendGrantRecord — tier records (#9151)", () => {
+  it("persists tier.elevated with tier/previousTier and surfaces it in getLogRecords", () => {
+    const { service } = makeFixture();
+    service.appendGrantRecord({
+      type: "tier.elevated",
+      sessionId: "sess-1",
+      toolId: "*",
+      ttlMs: 1800000,
+      expiresAt: 5000,
+      tier: "action",
+      previousTier: "workbench",
+    });
+    const logRecords = service.getLogRecords();
+    expect(logRecords).toHaveLength(1);
+    const [record] = logRecords;
+    expect(record).toMatchObject({
+      type: "tier.elevated",
+      sessionId: "sess-1",
+      toolId: "*",
+      ttlMs: 1800000,
+      expiresAt: 5000,
+      tier: "action",
+      previousTier: "workbench",
+    });
+    // Tier records are grant records — excluded from the dispatch-only view.
+    expect(service.getRecords()).toHaveLength(0);
+  });
+
+  it("persists tier.decayed with the baseline it decayed to", () => {
+    const { service } = makeFixture();
+    service.appendGrantRecord({
+      type: "tier.decayed",
+      sessionId: "sess-2",
+      toolId: "*",
+      ttlMs: 0,
+      previousTier: "action",
+      tier: "workbench",
+    });
+    const [record] = service.getLogRecords();
+    expect(record).toMatchObject({
+      type: "tier.decayed",
+      sessionId: "sess-2",
+      previousTier: "action",
+      tier: "workbench",
+    });
+    // No expiresAt on decay — the elevation window already closed.
+    expect("expiresAt" in record!).toBe(false);
+  });
+
+  it("omits tier fields on grant.* records so legacy shapes are unchanged", () => {
+    const { service } = makeFixture();
+    service.appendGrantRecord({
+      type: "grant.issued",
+      sessionId: "sess-3",
+      toolId: "files.search",
+      ttlMs: 60000,
+      expiresAt: 9000,
+    });
+    const [record] = service.getLogRecords();
+    expect("tier" in record!).toBe(false);
+    expect("previousTier" in record!).toBe(false);
+  });
+});
+
 describe("AuditService.recordAuth401 / getAuditStats", () => {
   it("starts at zero", () => {
     const { service } = makeFixture();

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -341,6 +341,20 @@ describe("HttpLifecycle", () => {
       expect(record.expiresAt).toBeGreaterThan(0);
     });
 
+    it("does not audit a same-tier re-elevation (no actual privilege change, #9151)", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionTierMap.set("sess-same", "action");
+      pinnedSession(deps, "sess-same", 42);
+
+      const lc = new HttpLifecycle(deps);
+      const result = lc.setSessionTier("sess-same", "action");
+
+      expect(result.tier).toBe("action");
+      // Same tier in → nothing elevated → no audit row (would be a misleading
+      // action→action entry).
+      expect(deps.auditService.appendGrantRecord).not.toHaveBeenCalled();
+    });
+
     it("refuses downgrades silently and keeps current tier without auditing", () => {
       const deps = fakeDeps();
       deps.sessionStore.sessionTierMap.set("sess-2", "system");
@@ -544,6 +558,15 @@ describe("HttpLifecycle", () => {
       const handle = lc as unknown as BearerTestHandle;
       handle.touchBearer("Bearer help-token-xyz", "Help/1", "sess-help", "action");
       handle.detachBearerSession("sess-help");
+      expect(lc.findHelpBearerHash("help-token-xyz")).toBeNull();
+    });
+
+    it("findHelpBearerHash returns null after clearBearer evicts the entry (server stop/restart, #9151)", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerTestHandle;
+      const auth = "Bearer help-token-xyz";
+      handle.touchBearer(auth, "Help/1", "sess-help", "action");
+      lc.clearBearer(hashOf(auth));
       expect(lc.findHelpBearerHash("help-token-xyz")).toBeNull();
     });
 

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -80,6 +80,7 @@ function fakeDeps(overrides?: Partial<HttpLifecycleDeps>): HttpLifecycleDeps {
       hydrate: vi.fn(),
       flushNow: vi.fn(),
       appendRecord: vi.fn(),
+      appendGrantRecord: vi.fn(),
       recordAuth401: vi.fn(),
       getAuditStats: vi.fn(() => ({ auth401Count: 0 })),
     },
@@ -318,7 +319,29 @@ describe("HttpLifecycle", () => {
       );
     });
 
-    it("refuses downgrades silently and keeps current tier", () => {
+    it("writes a tier.elevated audit record with from/to tier and the bounded window (#9151)", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionTierMap.set("sess-aud", "workbench");
+      pinnedSession(deps, "sess-aud", 42);
+
+      const lc = new HttpLifecycle(deps);
+      lc.setSessionTier("sess-aud", "action");
+
+      expect(deps.auditService.appendGrantRecord).toHaveBeenCalledTimes(1);
+      const record = (deps.auditService.appendGrantRecord as ReturnType<typeof vi.fn>).mock
+        .calls[0]![0];
+      expect(record).toMatchObject({
+        type: "tier.elevated",
+        sessionId: "sess-aud",
+        toolId: "*",
+        tier: "action",
+        previousTier: "workbench",
+      });
+      expect(record.ttlMs).toBeGreaterThan(0);
+      expect(record.expiresAt).toBeGreaterThan(0);
+    });
+
+    it("refuses downgrades silently and keeps current tier without auditing", () => {
       const deps = fakeDeps();
       deps.sessionStore.sessionTierMap.set("sess-2", "system");
       pinnedSession(deps, "sess-2", 42);
@@ -328,6 +351,8 @@ describe("HttpLifecycle", () => {
 
       expect(result.tier).toBe("system");
       expect(deps.sessionStore.sessionTierMap.get("sess-2")).toBe("system");
+      // No mutation, no audit row — only accepted elevations are logged.
+      expect(deps.auditService.appendGrantRecord).not.toHaveBeenCalled();
     });
 
     it("throws for unknown sessions", () => {
@@ -480,15 +505,46 @@ describe("HttpLifecycle", () => {
       expect(bearers[0]).not.toHaveProperty("sessionIds");
     });
 
-    it("tracks only external-tier bearers, never internal (help/pane) tokens", () => {
-      const lc = new HttpLifecycle(fakeDeps());
+    it("hides internal (help/pane) bearers from the settings list but still tracks them (#9151)", () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
       const handle = lc as unknown as BearerTestHandle;
       handle.touchBearer(authA, "Help/1", "sess-help", "action");
       handle.touchBearer(authB, "Pane/1", "sess-pane", "workbench");
+      // Filtered out of the External-clients settings row...
       expect(lc.listActiveBearers()).toHaveLength(0);
-      // A subsequent external bearer is still tracked.
+      // ...but tracked in the register so eager teardown can find them.
+      expect(lc.getBearerSessionIds(hashOf(authA))).toEqual(["sess-help"]);
+      expect(lc.getBearerSessionIds(hashOf(authB))).toEqual(["sess-pane"]);
+      // Help-bearer handshakes don't push a runtime-state change (they never
+      // surface in the UI) — only the external bearer below does.
+      expect(deps.emitRuntimeStateChange).not.toHaveBeenCalled();
+      // A subsequent external bearer is still tracked AND listed.
       handle.touchBearer("Bearer external-cccc", "Claude/1", "sess-ext", "external");
       expect(lc.listActiveBearers()).toHaveLength(1);
+      expect(deps.emitRuntimeStateChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("findHelpBearerHash resolves a help token to its register key, ignoring external bearers (#9151)", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerTestHandle;
+      // Raw tokens are the part after "Bearer ".
+      handle.touchBearer("Bearer help-token-xyz", "Help/1", "sess-help", "action");
+      handle.touchBearer("Bearer ext-token-abc", "Claude/1", "sess-ext", "external");
+
+      expect(lc.findHelpBearerHash("help-token-xyz")).toBe(hashOf("Bearer help-token-xyz"));
+      // External bearers are not help sessions — never resolved by token here.
+      expect(lc.findHelpBearerHash("ext-token-abc")).toBeNull();
+      // Unknown token → null.
+      expect(lc.findHelpBearerHash("never-seen")).toBeNull();
+    });
+
+    it("findHelpBearerHash returns null after the help session detaches (#9151)", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerTestHandle;
+      handle.touchBearer("Bearer help-token-xyz", "Help/1", "sess-help", "action");
+      handle.detachBearerSession("sess-help");
+      expect(lc.findHelpBearerHash("help-token-xyz")).toBeNull();
     });
 
     it("pushes a runtime-state change on connect and on final disconnect", () => {

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -621,14 +621,17 @@ describe("SessionStore dropBearerState wiring (#8778)", () => {
 describe("SessionStore tier-elevation decay (#8462)", () => {
   let store: SessionStore;
   let decayed: string[];
+  let decayedArgs: Array<{ sessionId: string; previousTier: string; newTier: string }>;
 
   beforeEach(() => {
     vi.useFakeTimers();
     setAwakeTime(0);
     decayed = [];
+    decayedArgs = [];
     store = new SessionStore(() => {}, {
-      onTierDecayed: (sessionId) => {
+      onTierDecayed: (sessionId, previousTier, newTier) => {
         decayed.push(sessionId);
+        decayedArgs.push({ sessionId, previousTier, newTier });
       },
     });
   });
@@ -649,6 +652,18 @@ describe("SessionStore tier-elevation decay (#8462)", () => {
 
     expect(store.getTier("s")).toBe("workbench");
     expect(decayed).toEqual(["s"]);
+  });
+
+  it("passes the elevated tier and baseline to onTierDecayed for the audit trail (#9151)", () => {
+    store.sessions.set("s", fakeSseSession());
+    store.sessionTierMap.set("s", "action");
+    store.armTierElevationTimer("s", "system", "action");
+    store.sessionTierMap.set("s", "system");
+
+    setAwakeTime(MCP_TIER_ELEVATION_TTL_MS);
+    vi.advanceTimersByTime(MCP_TIER_ELEVATION_TTL_MS + 1);
+
+    expect(decayedArgs).toEqual([{ sessionId: "s", previousTier: "system", newTier: "action" }]);
   });
 
   it("decays to the session's token baseline, not hardcoded workbench", () => {

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -225,6 +225,8 @@ export class AuditService {
     ttlMs: number;
     expiresAt?: number;
     revokedReason?: McpGrantRevokedReason;
+    tier?: McpTier;
+    previousTier?: McpTier;
   }): void {
     if (this.readConfig().auditEnabled === false) return;
     this.hydrate();
@@ -239,6 +241,8 @@ export class AuditService {
     };
     if (input.expiresAt !== undefined) record.expiresAt = input.expiresAt;
     if (input.revokedReason !== undefined) record.revokedReason = input.revokedReason;
+    if (input.tier !== undefined) record.tier = input.tier;
+    if (input.previousTier !== undefined) record.previousTier = input.previousTier;
 
     this.enqueueAndTrim(record);
   }

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -1240,20 +1240,24 @@ export class HttpLifecycle {
     this.deps.sessionStore.armTierElevationTimer(sessionId, tier, current);
     // Positive audit trail for the elevation (#9151): records who elevated
     // (via the pinned session), the target tier, the pre-elevation tier, and
-    // the bounded window. Best-effort — an audit-write failure must never
-    // block the user-approved elevation.
-    try {
-      this.deps.auditService.appendGrantRecord({
-        type: "tier.elevated",
-        sessionId,
-        toolId: "*",
-        ttlMs: MCP_TIER_ELEVATION_TTL_MS,
-        expiresAt: Date.now() + MCP_TIER_ELEVATION_TTL_MS,
-        tier,
-        previousTier: current,
-      });
-    } catch (err) {
-      console.error("[MCP] Failed to append tier.elevated audit record:", err);
+    // the bounded window. Only genuine elevations are logged — a same-tier
+    // call (`newRank === currentRank`) arms no timer and changes nothing, so
+    // recording an `action → action` row would be misleading noise.
+    // Best-effort: an audit-write failure must never block the elevation.
+    if (newRank > currentRank) {
+      try {
+        this.deps.auditService.appendGrantRecord({
+          type: "tier.elevated",
+          sessionId,
+          toolId: "*",
+          ttlMs: MCP_TIER_ELEVATION_TTL_MS,
+          expiresAt: Date.now() + MCP_TIER_ELEVATION_TTL_MS,
+          tier,
+          previousTier: current,
+        });
+      } catch (err) {
+        console.error("[MCP] Failed to append tier.elevated audit record:", err);
+      }
     }
     return { sessionId, tier };
   }

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -45,6 +45,7 @@ import {
   RESTART_STABLE_RESET_MS,
   MCP_STOP_DRAIN_TIMEOUT_MS,
   MCP_SERVER_KEY,
+  MCP_TIER_ELEVATION_TTL_MS,
 } from "./shared.js";
 
 export interface HttpLifecycleDeps {
@@ -119,6 +120,21 @@ interface BearerEntry {
   lastActiveAt: number;
   requestsSinceLaunch: number;
   sessionIds: Set<string>;
+  /**
+   * True for renderer-pinned help-session bearers (any non-`external` tier).
+   * They are tracked in the register so {@link HttpLifecycle.findHelpBearerHash}
+   * can resolve a help session's live MCP sessions for eager teardown
+   * (#9151), but filtered out of {@link HttpLifecycle.listActiveBearers} so the
+   * External-clients settings row only ever lists genuine external clients.
+   */
+  isHelpSession: boolean;
+  /**
+   * The raw bearer token, retained only for help-session entries so the
+   * eager-teardown path can resolve `record.token` → this entry's
+   * `tokenHash` without reconstructing (and re-hashing) the exact
+   * `Authorization` header the agent sent. Never exposed across IPC.
+   */
+  helpToken?: string;
 }
 
 export class HttpLifecycle {
@@ -265,9 +281,14 @@ export class HttpLifecycle {
     sessionId: string,
     tier: McpTier
   ): void {
-    if (tier !== "external") return;
+    // Help-session bearers (any non-`external` tier) used to be skipped
+    // outright. They are now tracked so `revokeSession` can tear down their
+    // live MCP sessions eagerly (#9151); the `isHelpSession` flag keeps them
+    // out of the External-clients settings row.
+    const isHelpSession = tier !== "external";
+    const rawToken = extractBearerToken(authHeader);
     const tokenHash = createHash("sha256").update(authHeader).digest("hex");
-    const token4LastChars = extractBearerToken(authHeader)?.slice(-4) ?? "****";
+    const token4LastChars = rawToken?.slice(-4) ?? "****";
     const now = Date.now();
     let entry = this.bearerRegister.get(tokenHash);
     if (!entry) {
@@ -278,7 +299,9 @@ export class HttpLifecycle {
         lastActiveAt: now,
         requestsSinceLaunch: 0,
         sessionIds: new Set<string>(),
+        isHelpSession,
       };
+      if (isHelpSession && rawToken) entry.helpToken = rawToken;
       this.bearerRegister.set(tokenHash, entry);
     }
     entry.userAgent = userAgent;
@@ -286,7 +309,10 @@ export class HttpLifecycle {
     entry.requestsSinceLaunch += 1;
     entry.sessionIds.add(sessionId);
     this.sessionToTokenHash.set(sessionId, tokenHash);
-    this.deps.emitRuntimeStateChange();
+    // Only external bearers surface in the settings UI, so only their
+    // handshakes need a runtime-state push. Help bearers are filtered out of
+    // `listActiveBearers`; emitting for them would be needless IPC chatter.
+    if (!isHelpSession) this.deps.emitRuntimeStateChange();
   }
 
   /**
@@ -322,18 +348,46 @@ export class HttpLifecycle {
     if (entry.sessionIds.size === 0) {
       this.bearerRegister.delete(tokenHash);
     }
-    this.deps.emitRuntimeStateChange();
+    // Help bearers are filtered out of `listActiveBearers`, so their teardown
+    // changes nothing the settings UI shows — skip the runtime-state push to
+    // avoid needless IPC chatter (mirrors the `touchBearer` gate).
+    if (!entry.isHelpSession) this.deps.emitRuntimeStateChange();
   }
 
-  /** Live snapshot for the settings tab. The raw token is never exposed. */
+  /**
+   * Live snapshot for the settings tab. The raw token is never exposed.
+   * Renderer-pinned help-session bearers are filtered out — they are
+   * Daintree's own internal consumers, recursive to name in a dialog the
+   * user opens to disconnect external clients (#9151).
+   */
   listActiveBearers(): ActiveBearerRecord[] {
-    return Array.from(this.bearerRegister.values(), (entry) => ({
-      tokenHash: entry.tokenHash,
-      token4LastChars: entry.token4LastChars,
-      userAgent: entry.userAgent,
-      lastActiveAt: entry.lastActiveAt,
-      requestsSinceLaunch: entry.requestsSinceLaunch,
-    }));
+    const records: ActiveBearerRecord[] = [];
+    for (const entry of this.bearerRegister.values()) {
+      if (entry.isHelpSession) continue;
+      records.push({
+        tokenHash: entry.tokenHash,
+        token4LastChars: entry.token4LastChars,
+        userAgent: entry.userAgent,
+        lastActiveAt: entry.lastActiveAt,
+        requestsSinceLaunch: entry.requestsSinceLaunch,
+      });
+    }
+    return records;
+  }
+
+  /**
+   * Resolve a help-session bearer's raw token to its register key so the
+   * eager-teardown path (#9151) can hand it to {@link disconnectBearer}
+   * without re-hashing the original `Authorization` header (whose exact
+   * whitespace it no longer holds). Returns null when the token isn't
+   * currently tracked — the agent may never have connected, or already
+   * disconnected. O(n) over the small bearer register; only called on revoke.
+   */
+  findHelpBearerHash(rawToken: string): string | null {
+    for (const entry of this.bearerRegister.values()) {
+      if (entry.isHelpSession && entry.helpToken === rawToken) return entry.tokenHash;
+    }
+    return null;
   }
 
   /**
@@ -1184,6 +1238,23 @@ export class HttpLifecycle {
     // refreshes the window from now; a chained re-elevation preserves the
     // original baseline.
     this.deps.sessionStore.armTierElevationTimer(sessionId, tier, current);
+    // Positive audit trail for the elevation (#9151): records who elevated
+    // (via the pinned session), the target tier, the pre-elevation tier, and
+    // the bounded window. Best-effort — an audit-write failure must never
+    // block the user-approved elevation.
+    try {
+      this.deps.auditService.appendGrantRecord({
+        type: "tier.elevated",
+        sessionId,
+        toolId: "*",
+        ttlMs: MCP_TIER_ELEVATION_TTL_MS,
+        expiresAt: Date.now() + MCP_TIER_ELEVATION_TTL_MS,
+        tier,
+        previousTier: current,
+      });
+    } catch (err) {
+      console.error("[MCP] Failed to append tier.elevated audit record:", err);
+    }
     return { sessionId, tier };
   }
 

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -45,8 +45,13 @@ export interface SessionStoreOptions {
    * decayed session so the model's tool manifest reflects the narrowed
    * surface immediately. Optional so bare test fixtures construct without
    * one (decay still mutates the tier map; only the notification is skipped).
+   *
+   * `previousTier` is the elevated tier the session left; `newTier` is the
+   * baseline it decayed back to. Both are passed so the wiring can write a
+   * `tier.decayed` audit record without re-reading the (already-mutated)
+   * tier map.
    */
-  onTierDecayed?: (sessionId: string) => void;
+  onTierDecayed?: (sessionId: string, previousTier: McpTier, newTier: McpTier) => void;
 }
 
 /**
@@ -162,7 +167,11 @@ export class SessionStore {
   private readonly cleanupResourceSubscriptionsFn: (sessionId: string) => void;
   private readonly dropAbuseStateFn: (sessionId: string) => void;
   private readonly dropBearerStateFn: (sessionId: string) => void;
-  private readonly onTierDecayedFn: (sessionId: string) => void;
+  private readonly onTierDecayedFn: (
+    sessionId: string,
+    previousTier: McpTier,
+    newTier: McpTier
+  ) => void;
 
   constructor(
     cleanupResourceSubscriptions: (sessionId: string) => void,
@@ -529,7 +538,7 @@ export class SessionStore {
     // (the #8462 acceptance criterion). Per-tool grants survive — they are
     // an orthogonal explicit approval (#8442).
     this.grantCache.clearDenialCounts(sessionId);
-    this.onTierDecayedFn(sessionId);
+    this.onTierDecayedFn(sessionId, current, baseline);
   }
 
   /**

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -159,8 +159,21 @@ export interface McpAuditRecord {
  * - `grant.revoked`: an explicit `revokeSessionGrants` IPC, a session
  *   teardown, or an idle reaper firing wiped the grant before its TTL
  *   elapsed. `revokedReason` distinguishes those sources.
+ * - `tier.elevated`: a renderer-approved session-tier elevation
+ *   (`HttpLifecycle.setSessionTier`) raised the session above its
+ *   token-resolved baseline. `tier` is the new tier, `previousTier` the
+ *   pre-elevation tier, `ttlMs`/`expiresAt` the bounded elevation window.
+ *   `toolId` is `"*"` — the elevation is session-scoped, not tool-scoped.
+ * - `tier.decayed`: a bounded elevation aged out (`SessionStore.decayTier`)
+ *   and the session silently fell back to its baseline. `tier` is the
+ *   baseline it decayed to, `previousTier` the elevated tier it left.
  */
-export type McpGrantRecordType = "grant.issued" | "grant.expired" | "grant.revoked";
+export type McpGrantRecordType =
+  | "grant.issued"
+  | "grant.expired"
+  | "grant.revoked"
+  | "tier.elevated"
+  | "tier.decayed";
 
 export type McpGrantRevokedReason = "user" | "session-ended" | "session-idle";
 
@@ -180,6 +193,16 @@ export interface McpGrantRecord {
   expiresAt?: number;
   /** Source of the revocation; only set on `grant.revoked`. */
   revokedReason?: McpGrantRevokedReason;
+  /**
+   * Tier context for `tier.elevated`/`tier.decayed` records. `tier` is the
+   * tier the session moved *to* (the elevated tier on elevation, the
+   * baseline on decay); `previousTier` is the tier it moved *from*. Both are
+   * absent on the `grant.*` variants so existing on-disk rows deserialize
+   * unchanged. Typed as `string` to keep this shared shape free of the
+   * main-process `McpTier` union.
+   */
+  tier?: string;
+  previousTier?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Tier changes (`setSessionTier` elevation, `SessionStore.decayTier` decay) now write `tier.elevated` / `tier.decayed` audit rows via `appendGrantRecord`. Same-tier re-elevations are skipped to avoid misleading noise.
- `revokeByWebContentsId` now fires on renderer crash, not just LRU eviction. `onViewCrashed` in `main.ts` now accepts the crashed `WebContents` and revokes help sessions pinned to its (now-tombstoned) id.
- `HelpSessionService.revokeSession` and the `displacePriorSessions` re-provision path now tear down the live MCP session immediately via `disconnectHelpBearer` / `disconnectBearer`, rather than leaving stale tier/grants/pin for the 30-minute idle reaper. Help-session bearers are now tracked in `httpLifecycle`'s `bearerRegister` so the eager-teardown path can resolve them; they remain filtered out of `listActiveBearers` so the External-clients settings row is unaffected.

Resolves #9151

## Changes

- `shared/types/ipc/mcpServer.ts` — widened `McpGrantRecordType` with `tier.elevated` / `tier.decayed`; added optional `tier` / `previousTier` fields to `McpGrantRecord`; `onTierDecayed` callback now carries `previousTier` / `newTier`; new shared `McpGrantLifecyclePayload` used by preload
- `electron/services/mcp-server/auditLog.ts` — new audit record shapes for tier transitions
- `electron/services/mcp-server/httpLifecycle.ts` — `setSessionTier` emits `tier.elevated` on success (best-effort, try/catch); help-session bearers now tracked in `bearerRegister` but excluded from `listActiveBearers`; new `findHelpBearerHash` / `disconnectHelpBearer` helpers
- `electron/services/mcp-server/sessionStore.ts` — `decayTier` emits `tier.decayed` with previous/new tier
- `electron/services/HelpSessionService.ts` — `revokeSession` calls `disconnectHelpBearer` before cleanup; `displacePriorSessions` tears down displaced sessions
- `electron/services/McpServerService.ts` — exposes `disconnectHelpBearer` for `HelpSessionService`
- `electron/main.ts` — `onViewCrashed` now accepts `WebContents` and calls `revokeByWebContentsId`
- `electron/preload.cts` — uses shared `McpGrantLifecyclePayload` in `onGrantLifecycle`

## Testing

Extended test suites for `auditLog`, `httpLifecycle`, `sessionStore`, and `HelpSessionService` — 264 tests pass across the affected files. Typecheck, lint, and format clean.