### PR TITLE
feat(dev-preview): persist running sessions across relaunch (#9094)

### DIFF
--- a/electron/ipc/handlers/devPreview.ts
+++ b/electron/ipc/handlers/devPreview.ts
@@ -4,11 +4,10 @@ import { broadcastToRenderer } from "../utils.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { DEV_PREVIEW_METHOD_CHANNELS } from "./devPreview.preload.js";
 import type { HandlerDependencies } from "../types.js";
-import {
-  readAndClearDevPreviewManifest,
-  writeDevPreviewManifest,
-  type DevPreviewManifestEntry,
-} from "../../services/DevPreviewManifestService.js";
+// Type-only import: the manifest service does sync fs work, so its runtime
+// module is loaded lazily alongside DevPreviewSessionService (below) to keep it
+// off the eager main-process boot path.
+import type { DevPreviewManifestEntry } from "../../services/DevPreviewManifestService.js";
 import type {
   DevPreviewEnsureRequest,
   DevPreviewSessionRequest,
@@ -28,26 +27,29 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
   async function getSessionService(): Promise<DevPreviewSessionServiceType> {
     if (sessionService) return sessionService;
     if (!sessionServicePromise) {
-      sessionServicePromise = import("../../services/DevPreviewSessionService.js")
-        .then((mod) => {
+      sessionServicePromise = Promise.all([
+        import("../../services/DevPreviewSessionService.js"),
+        import("../../services/DevPreviewManifestService.js"),
+      ])
+        .then(([sessionMod, manifestMod]) => {
           // Read (and clear) the restore manifest the previous session left
           // behind. The in-memory copy owns restore state for this launch, so
           // a corrupt or stale file degrades to "no restore" rather than
           // re-prompting forever.
           let restoredEntries: DevPreviewManifestEntry[] = [];
           try {
-            restoredEntries = readAndClearDevPreviewManifest(app.getPath("userData"));
+            restoredEntries = manifestMod.readAndClearDevPreviewManifest(app.getPath("userData"));
           } catch (err) {
             console.warn("[DevPreview] Failed to read restore manifest:", err);
           }
-          sessionService = new mod.DevPreviewSessionService(
+          sessionService = new sessionMod.DevPreviewSessionService(
             deps.ptyClient!,
             (state) => {
               const payload: DevPreviewStateChangedPayload = { state };
               broadcastToRenderer(CHANNELS.DEV_PREVIEW_STATE_CHANGED, payload);
             },
             restoredEntries,
-            (entries) => writeDevPreviewManifest(app.getPath("userData"), entries)
+            (entries) => manifestMod.writeDevPreviewManifest(app.getPath("userData"), entries)
           );
           return sessionService;
         })

--- a/electron/ipc/handlers/devPreview.ts
+++ b/electron/ipc/handlers/devPreview.ts
@@ -1,8 +1,15 @@
+import { app } from "electron";
 import { CHANNELS } from "../channels.js";
 import { broadcastToRenderer } from "../utils.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { DEV_PREVIEW_METHOD_CHANNELS } from "./devPreview.preload.js";
 import type { HandlerDependencies } from "../types.js";
+import { getCrashRecoveryService } from "../../services/CrashRecoveryService.js";
+import {
+  readAndClearDevPreviewManifest,
+  writeDevPreviewManifest,
+  type DevPreviewManifestEntry,
+} from "../../services/DevPreviewManifestService.js";
 import type {
   DevPreviewEnsureRequest,
   DevPreviewSessionRequest,
@@ -24,10 +31,24 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
     if (!sessionServicePromise) {
       sessionServicePromise = import("../../services/DevPreviewSessionService.js")
         .then((mod) => {
-          sessionService = new mod.DevPreviewSessionService(deps.ptyClient!, (state) => {
-            const payload: DevPreviewStateChangedPayload = { state };
-            broadcastToRenderer(CHANNELS.DEV_PREVIEW_STATE_CHANGED, payload);
-          });
+          // Read (and clear) the restore manifest the previous session left
+          // behind. The in-memory copy owns restore state for this launch, so
+          // a corrupt or stale file degrades to "no restore" rather than
+          // re-prompting forever.
+          let restoredEntries: DevPreviewManifestEntry[] = [];
+          try {
+            restoredEntries = readAndClearDevPreviewManifest(app.getPath("userData"));
+          } catch (err) {
+            console.warn("[DevPreview] Failed to read restore manifest:", err);
+          }
+          sessionService = new mod.DevPreviewSessionService(
+            deps.ptyClient!,
+            (state) => {
+              const payload: DevPreviewStateChangedPayload = { state };
+              broadcastToRenderer(CHANNELS.DEV_PREVIEW_STATE_CHANGED, payload);
+            },
+            restoredEntries
+          );
           return sessionService;
         })
         .catch((err) => {
@@ -128,6 +149,18 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
 
   const cleanups: Array<() => void> = [namespace.register()];
 
+  // Persist the running-session manifest on every backup tick. The eager
+  // quit-intent takeBackup() in shutdown.ts fires this BEFORE the PTYs are
+  // killed, so a clean exit captures sessions while they're still running; the
+  // periodic ticks cover the crash (SIGKILL/OOM) path. After dispose() the
+  // sessions map is empty and captureManifest() would write [] (deleting the
+  // good capture from quit-intent), so the isDisposed guard makes the
+  // post-dispose cleanupOnExit tick a no-op.
+  const unsubPreBackup = getCrashRecoveryService().registerPreBackupCallback(() => {
+    if (!sessionService || sessionService.isDisposed) return;
+    writeDevPreviewManifest(app.getPath("userData"), sessionService.captureManifest());
+  });
+
   const unsubHibernation = getHibernationService().onProjectHibernated((projectId) => {
     // Skip if the session service was never created — no sessions exist to stop.
     if (!sessionService) return;
@@ -137,6 +170,7 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
   });
 
   return () => {
+    unsubPreBackup();
     unsubHibernation();
     if (sessionService) {
       sessionService.dispose();

--- a/electron/ipc/handlers/devPreview.ts
+++ b/electron/ipc/handlers/devPreview.ts
@@ -4,7 +4,6 @@ import { broadcastToRenderer } from "../utils.js";
 import { defineIpcNamespace, op } from "../define.js";
 import { DEV_PREVIEW_METHOD_CHANNELS } from "./devPreview.preload.js";
 import type { HandlerDependencies } from "../types.js";
-import { getCrashRecoveryService } from "../../services/CrashRecoveryService.js";
 import {
   readAndClearDevPreviewManifest,
   writeDevPreviewManifest,
@@ -47,7 +46,8 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
               const payload: DevPreviewStateChangedPayload = { state };
               broadcastToRenderer(CHANNELS.DEV_PREVIEW_STATE_CHANGED, payload);
             },
-            restoredEntries
+            restoredEntries,
+            (entries) => writeDevPreviewManifest(app.getPath("userData"), entries)
           );
           return sessionService;
         })
@@ -149,18 +149,6 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
 
   const cleanups: Array<() => void> = [namespace.register()];
 
-  // Persist the running-session manifest on every backup tick. The eager
-  // quit-intent takeBackup() in shutdown.ts fires this BEFORE the PTYs are
-  // killed, so a clean exit captures sessions while they're still running; the
-  // periodic ticks cover the crash (SIGKILL/OOM) path. After dispose() the
-  // sessions map is empty and captureManifest() would write [] (deleting the
-  // good capture from quit-intent), so the isDisposed guard makes the
-  // post-dispose cleanupOnExit tick a no-op.
-  const unsubPreBackup = getCrashRecoveryService().registerPreBackupCallback(() => {
-    if (!sessionService || sessionService.isDisposed) return;
-    writeDevPreviewManifest(app.getPath("userData"), sessionService.captureManifest());
-  });
-
   const unsubHibernation = getHibernationService().onProjectHibernated((projectId) => {
     // Skip if the session service was never created — no sessions exist to stop.
     if (!sessionService) return;
@@ -170,7 +158,6 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
   });
 
   return () => {
-    unsubPreBackup();
     unsubHibernation();
     if (sessionService) {
       sessionService.dispose();

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -73,6 +73,13 @@ export class CrashRecoveryService {
   // current session's backup tick cannot overwrite it. Null when there was
   // no pre-crash backup or after the file has been consumed/cleaned up.
   private crashedBackupPath: string | null = null;
+  // Best-effort hooks invoked at the start of every backup tick (periodic, blur,
+  // and the eager quit-intent backup in shutdown.ts). Used by services with
+  // their own crash-resilient state — e.g. the dev-preview session manifest —
+  // to ride the same capture cadence without entangling their data in the
+  // debounced appState backup. Each runs in isolation so one throw can't block
+  // the snapshot write or the other callbacks.
+  private preBackupCallbacks: Array<() => void> = [];
   // In-memory snapshot captured during consumeMarker() so restoreBackup() and
   // getBackupPanelCount() can serve the pre-crash state even if the on-disk
   // files are deleted, rotated, or overwritten between marker consumption and
@@ -268,7 +275,27 @@ export class CrashRecoveryService {
     }, DEBOUNCE_BACKUP_MS);
   }
 
+  /**
+   * Register a hook to run at the start of every backup tick. Returns an
+   * unsubscribe function. Callbacks must be synchronous and best-effort — they
+   * run inside takeBackup's isolated try/catch and must not throw.
+   */
+  registerPreBackupCallback(fn: () => void): () => void {
+    this.preBackupCallbacks.push(fn);
+    return () => {
+      const idx = this.preBackupCallbacks.indexOf(fn);
+      if (idx !== -1) this.preBackupCallbacks.splice(idx, 1);
+    };
+  }
+
   takeBackup(): void {
+    for (const fn of this.preBackupCallbacks) {
+      try {
+        fn();
+      } catch (err) {
+        console.warn("[CrashRecovery] pre-backup callback failed:", err);
+      }
+    }
     try {
       const backupDir = path.join(this.userData, BACKUP_DIR);
       fs.mkdirSync(backupDir, { recursive: true });

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -73,13 +73,6 @@ export class CrashRecoveryService {
   // current session's backup tick cannot overwrite it. Null when there was
   // no pre-crash backup or after the file has been consumed/cleaned up.
   private crashedBackupPath: string | null = null;
-  // Best-effort hooks invoked at the start of every backup tick (periodic, blur,
-  // and the eager quit-intent backup in shutdown.ts). Used by services with
-  // their own crash-resilient state — e.g. the dev-preview session manifest —
-  // to ride the same capture cadence without entangling their data in the
-  // debounced appState backup. Each runs in isolation so one throw can't block
-  // the snapshot write or the other callbacks.
-  private preBackupCallbacks: Array<() => void> = [];
   // In-memory snapshot captured during consumeMarker() so restoreBackup() and
   // getBackupPanelCount() can serve the pre-crash state even if the on-disk
   // files are deleted, rotated, or overwritten between marker consumption and
@@ -275,27 +268,7 @@ export class CrashRecoveryService {
     }, DEBOUNCE_BACKUP_MS);
   }
 
-  /**
-   * Register a hook to run at the start of every backup tick. Returns an
-   * unsubscribe function. Callbacks must be synchronous and best-effort — they
-   * run inside takeBackup's isolated try/catch and must not throw.
-   */
-  registerPreBackupCallback(fn: () => void): () => void {
-    this.preBackupCallbacks.push(fn);
-    return () => {
-      const idx = this.preBackupCallbacks.indexOf(fn);
-      if (idx !== -1) this.preBackupCallbacks.splice(idx, 1);
-    };
-  }
-
   takeBackup(): void {
-    for (const fn of this.preBackupCallbacks) {
-      try {
-        fn();
-      } catch (err) {
-        console.warn("[CrashRecovery] pre-backup callback failed:", err);
-      }
-    }
     try {
       const backupDir = path.join(this.userData, BACKUP_DIR);
       fs.mkdirSync(backupDir, { recursive: true });

--- a/electron/services/DevPreviewManifestService.ts
+++ b/electron/services/DevPreviewManifestService.ts
@@ -1,5 +1,3 @@
-// eager-import-allow: reads/writes the dev-preview restore manifest via sync fs
-// during early startup (first devPreview IPC) and at shutdown (pre-backup tick).
 import fs from "node:fs";
 import path from "node:path";
 import { resilientAtomicWriteFileSync } from "../utils/fs.js";

--- a/electron/services/DevPreviewManifestService.ts
+++ b/electron/services/DevPreviewManifestService.ts
@@ -1,0 +1,105 @@
+// eager-import-allow: reads/writes the dev-preview restore manifest via sync fs
+// during early startup (first devPreview IPC) and at shutdown (pre-backup tick).
+import fs from "node:fs";
+import path from "node:path";
+import { resilientAtomicWriteFileSync } from "../utils/fs.js";
+
+const BACKUP_DIR = "backups";
+const MANIFEST_FILENAME = "dev-preview-manifest.json";
+
+/**
+ * One running dev-preview session captured at shutdown. Holds only the spawn
+ * metadata needed to re-issue the command on the next launch — there is no
+ * process handle and no reattachment. `lastKnownPort` is informational only;
+ * the next `ensure()` allocates a fresh port (reusing the old one risks
+ * TIME_WAIT / another process having bound it during downtime).
+ */
+export interface DevPreviewManifestEntry {
+  panelId: string;
+  projectId: string;
+  worktreeId?: string;
+  cwd: string;
+  devCommand: string;
+  env?: Record<string, string>;
+  turbopackEnabled?: boolean;
+  lastKnownPort: number | null;
+  capturedAt: number;
+}
+
+function manifestPath(userData: string): string {
+  return path.join(userData, BACKUP_DIR, MANIFEST_FILENAME);
+}
+
+function isValidEntry(value: unknown): value is DevPreviewManifestEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.panelId === "string" &&
+    entry.panelId.length > 0 &&
+    typeof entry.projectId === "string" &&
+    entry.projectId.length > 0 &&
+    typeof entry.cwd === "string" &&
+    typeof entry.devCommand === "string" &&
+    entry.devCommand.trim().length > 0
+  );
+}
+
+/**
+ * Read the manifest, tolerating any corruption (truncated/partial write,
+ * unparseable JSON) as "no manifest". Never throws — a bad file on a crash
+ * boot must degrade to a fresh start, not break launch.
+ */
+export function readDevPreviewManifest(userData: string): DevPreviewManifestEntry[] {
+  try {
+    const filePath = manifestPath(userData);
+    if (!fs.existsSync(filePath)) return [];
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isValidEntry);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Write the manifest atomically. An empty list deletes the file so a stale
+ * manifest can't surface restore prompts for sessions that are no longer
+ * running. Best-effort: logs and swallows on failure (this runs on the
+ * shutdown path and must never block or throw).
+ */
+export function writeDevPreviewManifest(
+  userData: string,
+  entries: DevPreviewManifestEntry[]
+): void {
+  const filePath = manifestPath(userData);
+  try {
+    if (entries.length === 0) {
+      if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+      return;
+    }
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    resilientAtomicWriteFileSync(filePath, JSON.stringify(entries, null, 2), "utf-8", {
+      mode: 0o600,
+    });
+  } catch (err) {
+    console.error("[DevPreviewManifest] Failed to write manifest:", err);
+  }
+}
+
+/**
+ * Read the manifest and delete it in one step. Called once on the first
+ * lazy init of the session service: the in-memory copy owns the restore
+ * state for this launch, so clearing the file prevents a second launch from
+ * re-surfacing the same (now-stale) restore prompts.
+ */
+export function readAndClearDevPreviewManifest(userData: string): DevPreviewManifestEntry[] {
+  const entries = readDevPreviewManifest(userData);
+  try {
+    const filePath = manifestPath(userData);
+    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+  } catch {
+    // best-effort: a leftover file is re-read-and-cleared next launch
+  }
+  return entries;
+}

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -25,6 +25,7 @@ import {
 } from "./DevPreviewRequestValidators.js";
 
 export { normalizeNextjsDevCommand } from "./DevPreviewCommandNormalizer.js";
+import type { DevPreviewManifestEntry } from "./DevPreviewManifestService.js";
 import type { PtyClient } from "./PtyClient.js";
 import { UrlDetector } from "./UrlDetector.js";
 import type {
@@ -97,17 +98,61 @@ export class DevPreviewSessionService {
   private disposed = false;
   private readonly portRegistry = new Map<string, number>(); // sessionKey -> allocated port
   private readonly worktreeToSession = new Map<string, string>(); // worktreeId -> sessionKey
+  // Spawn metadata for sessions that were running when Daintree last closed,
+  // loaded once at first init. A panel with a matching entry and no live
+  // session reports status "restored-stopped" so the UI can offer a restart.
+  // Entries are dropped the moment a real session is created for that key.
+  private readonly restoredEntries = new Map<string, DevPreviewManifestEntry>();
   private readonly onDataListener: (id: string, data: string | Uint8Array) => void;
   private readonly onExitListener: (id: string, exitCode: number) => void;
 
   constructor(
     private readonly ptyClient: PtyClient,
-    private readonly onStateChanged: (state: DevPreviewSessionState) => void
+    private readonly onStateChanged: (state: DevPreviewSessionState) => void,
+    restoredEntries: readonly DevPreviewManifestEntry[] = []
   ) {
     this.onDataListener = this.handleData.bind(this);
     this.onExitListener = this.handleExit.bind(this);
     this.ptyClient.on("data", this.onDataListener);
     this.ptyClient.on("exit", this.onExitListener);
+    for (const entry of restoredEntries) {
+      this.restoredEntries.set(createSessionKey(entry.projectId, entry.panelId), entry);
+    }
+  }
+
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  /**
+   * Snapshot the spawn metadata of every currently-running session for the
+   * restore manifest. Captures only RUNNING_STATES — stopped/error sessions
+   * have nothing meaningful to restart. `lastKnownPort` comes from the port
+   * registry (populated even while a session is still starting, when `url` is
+   * not yet known) and is informational only.
+   *
+   * Must be called BEFORE the PTYs are killed at shutdown: a killed dev-server
+   * PTY fires `exit`, which transitions its session out of RUNNING_STATES, so a
+   * post-kill capture would return nothing.
+   */
+  captureManifest(): DevPreviewManifestEntry[] {
+    const entries: DevPreviewManifestEntry[] = [];
+    for (const [key, session] of this.sessions) {
+      if (!RUNNING_STATES.has(session.status)) continue;
+      if (!session.devCommand.trim() || !session.cwd) continue;
+      entries.push({
+        panelId: session.panelId,
+        projectId: session.projectId,
+        worktreeId: session.worktreeId,
+        cwd: session.cwd,
+        devCommand: session.devCommand,
+        env: session.env ? { ...session.env } : undefined,
+        turbopackEnabled: session.turbopackEnabled,
+        lastKnownPort: this.portRegistry.get(key) ?? null,
+        capturedAt: Date.now(),
+      });
+    }
+    return entries;
   }
 
   /**
@@ -623,6 +668,11 @@ export class DevPreviewSessionService {
     let session = this.sessions.get(key);
     if (session) return session;
 
+    // A real session supersedes any restore placeholder for this key — drop the
+    // manifest entry so getSessionState stops reporting "restored-stopped" once
+    // the user has restarted (or anything else spawned the server).
+    this.restoredEntries.delete(key);
+
     session = {
       panelId,
       projectId,
@@ -661,11 +711,12 @@ export class DevPreviewSessionService {
     const key = createSessionKey(projectId, panelId);
     const session = this.sessions.get(key);
     if (!session) {
+      const restored = this.restoredEntries.get(key);
       return {
         panelId,
         projectId,
-        worktreeId: undefined,
-        status: "stopped",
+        worktreeId: restored?.worktreeId,
+        status: restored ? "restored-stopped" : "stopped",
         url: null,
         predictedUrl: null,
         error: null,

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -109,7 +109,14 @@ export class DevPreviewSessionService {
   constructor(
     private readonly ptyClient: PtyClient,
     private readonly onStateChanged: (state: DevPreviewSessionState) => void,
-    restoredEntries: readonly DevPreviewManifestEntry[] = []
+    restoredEntries: readonly DevPreviewManifestEntry[] = [],
+    // Persists the running-session manifest. Invoked on two kinds of event:
+    // when a session ENTERS a running state (so a later crash can restore it),
+    // and after an EXPLICIT user stop (so the manifest stops offering a restart
+    // for a server the user deliberately stopped). Deliberately NOT invoked from
+    // handleExit — a process exit at shutdown must leave the manifest intact so
+    // the next launch can offer the restart (#9094).
+    private readonly onPersistManifest: (entries: DevPreviewManifestEntry[]) => void = () => {}
   ) {
     this.onDataListener = this.handleData.bind(this);
     this.onExitListener = this.handleExit.bind(this);
@@ -120,8 +127,13 @@ export class DevPreviewSessionService {
     }
   }
 
-  get isDisposed(): boolean {
-    return this.disposed;
+  private persistManifest(): void {
+    if (this.disposed) return;
+    try {
+      this.onPersistManifest(this.captureManifest());
+    } catch (err) {
+      console.warn("[DevPreviewSessionService] persistManifest failed:", err);
+    }
   }
 
   /**
@@ -173,10 +185,19 @@ export class DevPreviewSessionService {
 
   getByWorktree(worktreeId: string): DevPreviewSessionState | null {
     const key = this.worktreeToSession.get(worktreeId);
-    if (!key) return null;
-    const session = this.sessions.get(key);
-    if (!session) return null;
-    return this.toPublicState(session);
+    if (key) {
+      const session = this.sessions.get(key);
+      if (session) return this.toPublicState(session);
+    }
+    // Fall back to a restore placeholder so callers (e.g. the worktree-delete
+    // dialog) still surface a dangling dev-preview panel that was running when
+    // Daintree last closed but hasn't been restarted yet. #9094.
+    for (const entry of this.restoredEntries.values()) {
+      if (entry.worktreeId === worktreeId) {
+        return this.getSessionState(entry.projectId, entry.panelId);
+      }
+    }
+    return null;
   }
 
   dispose(): void {
@@ -531,6 +552,9 @@ export class DevPreviewSessionService {
         });
       }
     });
+    // Explicit user stop — drop this session from the restore manifest so the
+    // next launch doesn't offer to restart a server the user chose to stop.
+    this.persistManifest();
     return this.getSessionState(request.projectId, request.panelId);
   }
 
@@ -576,6 +600,7 @@ export class DevPreviewSessionService {
         });
       })
     );
+    this.persistManifest();
   }
 
   async stopByProject(projectId: string): Promise<void> {
@@ -610,6 +635,7 @@ export class DevPreviewSessionService {
         });
       })
     );
+    this.persistManifest();
   }
 
   // Called from the renderer's worktree delete path BEFORE `git worktree
@@ -652,6 +678,15 @@ export class DevPreviewSessionService {
         });
       })
     );
+
+    // Drop any restore placeholder for this worktree too — the worktree is
+    // being removed, so its dev server must not be offered for restart.
+    for (const [key, entry] of this.restoredEntries) {
+      if (entry.worktreeId === worktreeId) {
+        this.restoredEntries.delete(key);
+      }
+    }
+    this.persistManifest();
 
     if (errors.length > 0) {
       throw errors[0];
@@ -768,6 +803,7 @@ export class DevPreviewSessionService {
     >
   ): void {
     if (this.disposed) return;
+    const wasRunning = RUNNING_STATES.has(session.status);
     if (updates.status !== undefined) session.status = updates.status;
     if (updates.url !== undefined) session.url = updates.url;
     if (updates.predictedUrl !== undefined) session.predictedUrl = updates.predictedUrl;
@@ -781,6 +817,14 @@ export class DevPreviewSessionService {
     session.updatedAt = Date.now();
     session.updatedAtPerformanceMs = performance.now();
     this.onStateChanged(this.toPublicState(session));
+
+    // Snapshot the manifest the moment a session enters a running state so an
+    // abrupt crash (SIGKILL/OOM, where shutdown hooks never run) can still
+    // restore it. Leaving a running state is handled by the explicit-stop
+    // sites — never here — so a shutdown PTY kill doesn't wipe the manifest.
+    if (!wasRunning && RUNNING_STATES.has(session.status)) {
+      this.persistManifest();
+    }
   }
 
   private async runLocked(key: string, task: () => Promise<void>): Promise<void> {

--- a/electron/services/__tests__/DevPreviewManifestService.test.ts
+++ b/electron/services/__tests__/DevPreviewManifestService.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  readDevPreviewManifest,
+  writeDevPreviewManifest,
+  readAndClearDevPreviewManifest,
+  type DevPreviewManifestEntry,
+} from "../DevPreviewManifestService.js";
+
+function makeEntry(overrides: Partial<DevPreviewManifestEntry> = {}): DevPreviewManifestEntry {
+  return {
+    panelId: "panel-1",
+    projectId: "project-1",
+    worktreeId: "wt-1",
+    cwd: "/repo",
+    devCommand: "npm run dev",
+    env: { FOO: "bar" },
+    turbopackEnabled: true,
+    lastKnownPort: 5173,
+    capturedAt: 1000,
+    ...overrides,
+  };
+}
+
+describe("DevPreviewManifestService", () => {
+  let userData: string;
+  let manifestFile: string;
+
+  beforeEach(() => {
+    userData = fs.mkdtempSync(path.join(os.tmpdir(), "dp-manifest-"));
+    manifestFile = path.join(userData, "backups", "dev-preview-manifest.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(userData, { recursive: true, force: true });
+  });
+
+  it("returns an empty array when no manifest exists", () => {
+    expect(readDevPreviewManifest(userData)).toEqual([]);
+  });
+
+  it("round-trips entries through write and read", () => {
+    const entries = [makeEntry(), makeEntry({ panelId: "panel-2", lastKnownPort: null })];
+    writeDevPreviewManifest(userData, entries);
+    expect(fs.existsSync(manifestFile)).toBe(true);
+    expect(readDevPreviewManifest(userData)).toEqual(entries);
+  });
+
+  it("deletes the manifest file when writing an empty list", () => {
+    writeDevPreviewManifest(userData, [makeEntry()]);
+    expect(fs.existsSync(manifestFile)).toBe(true);
+    writeDevPreviewManifest(userData, []);
+    expect(fs.existsSync(manifestFile)).toBe(false);
+  });
+
+  it("treats corrupt JSON as no manifest instead of throwing", () => {
+    fs.mkdirSync(path.dirname(manifestFile), { recursive: true });
+    fs.writeFileSync(manifestFile, "{ this is not valid json", "utf-8");
+    expect(readDevPreviewManifest(userData)).toEqual([]);
+  });
+
+  it("filters out entries missing required fields", () => {
+    fs.mkdirSync(path.dirname(manifestFile), { recursive: true });
+    fs.writeFileSync(
+      manifestFile,
+      JSON.stringify([
+        makeEntry(),
+        { panelId: "no-command", projectId: "p", cwd: "/x", devCommand: "  " },
+        { projectId: "p", cwd: "/x", devCommand: "npm run dev" }, // missing panelId
+        "not an object",
+      ]),
+      "utf-8"
+    );
+    const read = readDevPreviewManifest(userData);
+    expect(read).toHaveLength(1);
+    expect(read[0].panelId).toBe("panel-1");
+  });
+
+  it("reads and clears in one step", () => {
+    writeDevPreviewManifest(userData, [makeEntry()]);
+    const entries = readAndClearDevPreviewManifest(userData);
+    expect(entries).toHaveLength(1);
+    expect(fs.existsSync(manifestFile)).toBe(false);
+    // Second read after clear yields nothing.
+    expect(readAndClearDevPreviewManifest(userData)).toEqual([]);
+  });
+});

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -1052,21 +1052,17 @@ describe("DevPreviewSessionService", () => {
 
     it("reports restored-stopped for a panel that has a manifest entry but no live session", () => {
       service.dispose();
-      service = new DevPreviewSessionService(
-        ptyClient as unknown as PtyClient,
-        onStateChanged,
-        [
-          {
-            panelId: baseRequest.panelId,
-            projectId: baseRequest.projectId,
-            worktreeId: "wt-1",
-            cwd: baseRequest.cwd,
-            devCommand: baseRequest.devCommand,
-            lastKnownPort: 5173,
-            capturedAt: 1000,
-          },
-        ]
-      );
+      service = new DevPreviewSessionService(ptyClient as unknown as PtyClient, onStateChanged, [
+        {
+          panelId: baseRequest.panelId,
+          projectId: baseRequest.projectId,
+          worktreeId: "wt-1",
+          cwd: baseRequest.cwd,
+          devCommand: baseRequest.devCommand,
+          lastKnownPort: 5173,
+          capturedAt: 1000,
+        },
+      ]);
 
       const state = service.getState({
         panelId: baseRequest.panelId,
@@ -1080,20 +1076,16 @@ describe("DevPreviewSessionService", () => {
 
     it("reports stopped (not restored-stopped) for an unrelated panel", () => {
       service.dispose();
-      service = new DevPreviewSessionService(
-        ptyClient as unknown as PtyClient,
-        onStateChanged,
-        [
-          {
-            panelId: baseRequest.panelId,
-            projectId: baseRequest.projectId,
-            cwd: baseRequest.cwd,
-            devCommand: baseRequest.devCommand,
-            lastKnownPort: null,
-            capturedAt: 1000,
-          },
-        ]
-      );
+      service = new DevPreviewSessionService(ptyClient as unknown as PtyClient, onStateChanged, [
+        {
+          panelId: baseRequest.panelId,
+          projectId: baseRequest.projectId,
+          cwd: baseRequest.cwd,
+          devCommand: baseRequest.devCommand,
+          lastKnownPort: null,
+          capturedAt: 1000,
+        },
+      ]);
 
       const state = service.getState({ panelId: "other-panel", projectId: baseRequest.projectId });
       expect(state.status).toBe("stopped");
@@ -1101,21 +1093,17 @@ describe("DevPreviewSessionService", () => {
 
     it("getByWorktree falls back to a restored entry when no live session exists", () => {
       service.dispose();
-      service = new DevPreviewSessionService(
-        ptyClient as unknown as PtyClient,
-        onStateChanged,
-        [
-          {
-            panelId: baseRequest.panelId,
-            projectId: baseRequest.projectId,
-            worktreeId: "wt-7",
-            cwd: baseRequest.cwd,
-            devCommand: baseRequest.devCommand,
-            lastKnownPort: null,
-            capturedAt: 1000,
-          },
-        ]
-      );
+      service = new DevPreviewSessionService(ptyClient as unknown as PtyClient, onStateChanged, [
+        {
+          panelId: baseRequest.panelId,
+          projectId: baseRequest.projectId,
+          worktreeId: "wt-7",
+          cwd: baseRequest.cwd,
+          devCommand: baseRequest.devCommand,
+          lastKnownPort: null,
+          capturedAt: 1000,
+        },
+      ]);
 
       const state = service.getByWorktree("wt-7");
       expect(state?.status).toBe("restored-stopped");
@@ -1164,20 +1152,16 @@ describe("DevPreviewSessionService", () => {
 
     it("clears the restored-stopped status once the session is started", async () => {
       service.dispose();
-      service = new DevPreviewSessionService(
-        ptyClient as unknown as PtyClient,
-        onStateChanged,
-        [
-          {
-            panelId: baseRequest.panelId,
-            projectId: baseRequest.projectId,
-            cwd: baseRequest.cwd,
-            devCommand: baseRequest.devCommand,
-            lastKnownPort: null,
-            capturedAt: 1000,
-          },
-        ]
-      );
+      service = new DevPreviewSessionService(ptyClient as unknown as PtyClient, onStateChanged, [
+        {
+          panelId: baseRequest.panelId,
+          projectId: baseRequest.projectId,
+          cwd: baseRequest.cwd,
+          devCommand: baseRequest.devCommand,
+          lastKnownPort: null,
+          capturedAt: 1000,
+        },
+      ]);
 
       expect(
         service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).status

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -1025,4 +1025,109 @@ describe("DevPreviewSessionService", () => {
       })
     );
   });
+
+  describe("restore manifest (#9094)", () => {
+    it("captureManifest returns only running-state sessions with their spawn metadata", async () => {
+      await service.ensure({ ...baseRequest, env: { FOO: "bar" }, worktreeId: "wt-1" });
+
+      const captured = service.captureManifest();
+      expect(captured).toHaveLength(1);
+      expect(captured[0]).toMatchObject({
+        panelId: baseRequest.panelId,
+        projectId: baseRequest.projectId,
+        worktreeId: "wt-1",
+        cwd: baseRequest.cwd,
+        devCommand: baseRequest.devCommand,
+        env: { FOO: "bar" },
+      });
+      // Port comes from the allocator-backed registry, not the (possibly null) url.
+      expect(typeof captured[0].lastKnownPort === "number").toBe(true);
+    });
+
+    it("captureManifest omits a session once it has stopped", async () => {
+      await service.ensure(baseRequest);
+      await service.stop({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      expect(service.captureManifest()).toEqual([]);
+    });
+
+    it("reports restored-stopped for a panel that has a manifest entry but no live session", () => {
+      service.dispose();
+      service = new DevPreviewSessionService(
+        ptyClient as unknown as PtyClient,
+        onStateChanged,
+        [
+          {
+            panelId: baseRequest.panelId,
+            projectId: baseRequest.projectId,
+            worktreeId: "wt-1",
+            cwd: baseRequest.cwd,
+            devCommand: baseRequest.devCommand,
+            lastKnownPort: 5173,
+            capturedAt: 1000,
+          },
+        ]
+      );
+
+      const state = service.getState({
+        panelId: baseRequest.panelId,
+        projectId: baseRequest.projectId,
+      });
+      expect(state.status).toBe("restored-stopped");
+      expect(state.worktreeId).toBe("wt-1");
+      expect(state.terminalId).toBeNull();
+      expect(state.url).toBeNull();
+    });
+
+    it("reports stopped (not restored-stopped) for an unrelated panel", () => {
+      service.dispose();
+      service = new DevPreviewSessionService(
+        ptyClient as unknown as PtyClient,
+        onStateChanged,
+        [
+          {
+            panelId: baseRequest.panelId,
+            projectId: baseRequest.projectId,
+            cwd: baseRequest.cwd,
+            devCommand: baseRequest.devCommand,
+            lastKnownPort: null,
+            capturedAt: 1000,
+          },
+        ]
+      );
+
+      const state = service.getState({ panelId: "other-panel", projectId: baseRequest.projectId });
+      expect(state.status).toBe("stopped");
+    });
+
+    it("clears the restored-stopped status once the session is started", async () => {
+      service.dispose();
+      service = new DevPreviewSessionService(
+        ptyClient as unknown as PtyClient,
+        onStateChanged,
+        [
+          {
+            panelId: baseRequest.panelId,
+            projectId: baseRequest.projectId,
+            cwd: baseRequest.cwd,
+            devCommand: baseRequest.devCommand,
+            lastKnownPort: null,
+            capturedAt: 1000,
+          },
+        ]
+      );
+
+      expect(
+        service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).status
+      ).toBe("restored-stopped");
+
+      await service.ensure(baseRequest);
+
+      // Once a real session exists, the synthetic restored-stopped status is gone
+      // even if the user later stops the server.
+      await service.stop({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      expect(
+        service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).status
+      ).toBe("stopped");
+    });
+  });
 });

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -1099,6 +1099,69 @@ describe("DevPreviewSessionService", () => {
       expect(state.status).toBe("stopped");
     });
 
+    it("getByWorktree falls back to a restored entry when no live session exists", () => {
+      service.dispose();
+      service = new DevPreviewSessionService(
+        ptyClient as unknown as PtyClient,
+        onStateChanged,
+        [
+          {
+            panelId: baseRequest.panelId,
+            projectId: baseRequest.projectId,
+            worktreeId: "wt-7",
+            cwd: baseRequest.cwd,
+            devCommand: baseRequest.devCommand,
+            lastKnownPort: null,
+            capturedAt: 1000,
+          },
+        ]
+      );
+
+      const state = service.getByWorktree("wt-7");
+      expect(state?.status).toBe("restored-stopped");
+      expect(service.getByWorktree("wt-unknown")).toBeNull();
+    });
+
+    it("persists the running manifest on start and clears it on explicit stop", async () => {
+      const persist = vi.fn();
+      service.dispose();
+      service = new DevPreviewSessionService(
+        ptyClient as unknown as PtyClient,
+        onStateChanged,
+        [],
+        persist
+      );
+
+      await service.ensure(baseRequest);
+      expect(persist).toHaveBeenCalled();
+      expect(persist.mock.calls.at(-1)?.[0]).toHaveLength(1);
+
+      persist.mockClear();
+      await service.stop({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      expect(persist).toHaveBeenCalled();
+      // Explicit stop persists an empty manifest (deletes the restore prompt).
+      expect(persist.mock.calls.at(-1)?.[0]).toEqual([]);
+    });
+
+    it("does not persist when a session exits on its own (manifest survives for restore)", async () => {
+      const persist = vi.fn();
+      service.dispose();
+      service = new DevPreviewSessionService(
+        ptyClient as unknown as PtyClient,
+        onStateChanged,
+        [],
+        persist
+      );
+
+      const started = await service.ensure(baseRequest);
+      persist.mockClear();
+
+      // A PTY exit (e.g. shutdown kill or server crash) must NOT clear the
+      // manifest — that's how the next launch keeps the restart offer.
+      ptyClient.emitExit(started.terminalId!, 0);
+      expect(persist).not.toHaveBeenCalled();
+    });
+
     it("clears the restored-stopped status once the session is started", async () => {
       service.dispose();
       service = new DevPreviewSessionService(

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -6,7 +6,12 @@ export type DevPreviewSessionStatus =
   | "installing"
   | "running"
   | "stopping"
-  | "error";
+  | "error"
+  // Synthesized at launch for a panel whose dev server was running when
+  // Daintree last closed (clean exit or crash). Distinct from "stopped" so the
+  // UI can offer a one-click restart instead of the generic empty state. The
+  // process is NOT reattached — only spawn metadata is restored.
+  | "restored-stopped";
 
 export interface DevPreviewEnsureRequest {
   panelId: string;

--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -73,6 +73,11 @@ const STATUS_LABEL: Record<
     textClass: "text-server-error",
     dotClass: "bg-server-error",
   },
+  "restored-stopped": {
+    label: "Stopped",
+    textClass: "text-daintree-text/50",
+    dotClass: "bg-daintree-text/40",
+  },
 };
 
 const DRAWER_HEIGHT = 300;

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -772,6 +772,14 @@ export function DevPreviewPane({
     void restart();
   }, [resetPreviewWebviewState, restart]);
 
+  // A "restored-stopped" panel has no live backend session (the process was
+  // not reattached across relaunch), so start()/ensure() — not restart() — is
+  // what re-issues the prior command. #9094.
+  const handleStartFromRestored = useCallback(() => {
+    resetPreviewWebviewState();
+    void start();
+  }, [resetPreviewWebviewState, start]);
+
   const confirmRestartInFlightRef = useRef(false);
   const [pendingRestartTier, setPendingRestartTier] = useState<
     "restartAndClearCache" | "reinstallAndRestart" | null
@@ -1433,6 +1441,30 @@ export function DevPreviewPane({
                       </Button>
                     </>
                   )}
+                </div>
+              ) : status === "restored-stopped" ? (
+                <div className="flex flex-col items-center text-center max-w-md">
+                  <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
+                    Dev server was running
+                  </h3>
+                  <p className="text-xs text-daintree-text/50 mb-3 leading-relaxed">
+                    Daintree closed while this dev server was active. It wasn't reattached — restart
+                    to run it again.
+                  </p>
+                  {devCommand && (
+                    <div className="mb-3 px-3 py-1.5 rounded bg-overlay-subtle border border-overlay/30 inline-flex items-center gap-2">
+                      <code className="text-xs text-daintree-text/70 font-mono">{devCommand}</code>
+                    </div>
+                  )}
+                  <Button
+                    onClick={handleStartFromRestored}
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5 px-2.5 py-1.5 group text-accent-primary"
+                  >
+                    <RotateCw className="h-3.5 w-3.5" />
+                    <span className="text-xs">Restart dev server</span>
+                  </Button>
                 </div>
               ) : (
                 <div className="flex flex-col items-center text-center max-w-md">

--- a/src/components/DevPreview/__tests__/DevPreviewPane.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.test.tsx
@@ -82,6 +82,7 @@ const statusConfig: Record<DevPreviewStatus, { label: string; color: string }> =
   stopping: { label: "Stopping", color: "text-blue-400" },
   error: { label: "Error", color: "text-red-400" },
   stopped: { label: "Stopped", color: "text-gray-400" },
+  "restored-stopped": { label: "Stopped", color: "text-gray-400" },
 };
 
 // ─── Rendering decision logic ───────────────────────────────────────

--- a/src/hooks/__tests__/useDevServer.adversarial.test.tsx
+++ b/src/hooks/__tests__/useDevServer.adversarial.test.tsx
@@ -1621,4 +1621,63 @@ describe("useDevServer adversarial races", () => {
       );
     });
   });
+
+  describe("restored-stopped (#9094)", () => {
+    it("does not auto-ensure when the panel is restored-stopped on launch", async () => {
+      getStateMock.mockImplementation(async (request: { projectId: string }) =>
+        buildState({
+          panelId: "panel-1",
+          projectId: request.projectId,
+          status: "restored-stopped",
+        })
+      );
+
+      const { result } = renderHook(() =>
+        useDevServer({
+          panelId: "panel-1",
+          devCommand: "npm run dev",
+          cwd: "/repo",
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.status).toBe("restored-stopped");
+      });
+
+      // The whole point of #9094: the prior dev server must NOT relaunch itself.
+      expect(ensureMock).not.toHaveBeenCalled();
+    });
+
+    it("ensures when the user explicitly starts a restored-stopped panel", async () => {
+      getStateMock.mockImplementation(async (request: { projectId: string }) =>
+        buildState({
+          panelId: "panel-1",
+          projectId: request.projectId,
+          status: "restored-stopped",
+        })
+      );
+
+      const { result } = renderHook(() =>
+        useDevServer({
+          panelId: "panel-1",
+          devCommand: "npm run dev",
+          cwd: "/repo",
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.status).toBe("restored-stopped");
+      });
+      expect(ensureMock).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await result.current.start();
+      });
+
+      expect(ensureMock).toHaveBeenCalledTimes(1);
+      expect(ensureMock).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: "project-1", devCommand: "npm run dev" })
+      );
+    });
+  });
 });

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -11,7 +11,8 @@ export type DevPreviewStatus =
   | "installing"
   | "running"
   | "stopping"
-  | "error";
+  | "error"
+  | "restored-stopped";
 
 export interface UseDevServerOptions {
   panelId: string;
@@ -116,6 +117,13 @@ export function useDevServer({
   const [error, setError] = useState<DevServerError | null>(null);
   const [phaseLabel, setPhaseLabel] = useState<"Compiling" | undefined>(undefined);
   const [isRestarting, setIsRestarting] = useState(false);
+  // Gates the auto-ensure effect until the first getState() resolves. The
+  // auto-ensure effect fires synchronously on mount — before getState() can
+  // report a "restored-stopped" status — so without this gate it would
+  // immediately spawn a dev server that the user closed Daintree with running,
+  // violating the no-auto-spawn-on-launch contract (#9094). Sticky: once true
+  // it stays true (restored-stopped only ever surfaces on the initial launch).
+  const [initialStateResolved, setInitialStateResolved] = useState(false);
   const [stuckTier, setStuckTier] = useState<DevServerStuckTier>(0);
   const [forceKilled, setForceKilled] = useState<boolean | undefined>(undefined);
   const latestSessionRef = useRef<{
@@ -371,6 +379,7 @@ export function useDevServer({
       lastEnsureConfigRef.current = "";
       pendingEnsureConfigRef.current = null;
       persistedEnsureCache.delete(panelId);
+      setInitialStateResolved(true);
       return;
     }
 
@@ -382,6 +391,9 @@ export function useDevServer({
       })
       .catch((err) => {
         if (!cancelled) applyInvokeError(err);
+      })
+      .finally(() => {
+        if (!cancelled) setInitialStateResolved(true);
       });
 
     return () => {
@@ -395,7 +407,11 @@ export function useDevServer({
       const { state } = payload;
       if (state.panelId !== panelId) return;
       if (state.projectId !== currentProjectId) return;
-      if (state.status === "error" || state.status === "stopped") {
+      if (
+        state.status === "error" ||
+        state.status === "stopped" ||
+        state.status === "restored-stopped"
+      ) {
         persistedEnsureCache.delete(panelId);
       }
       applyState(state);
@@ -430,6 +446,11 @@ export function useDevServer({
   useEffect(() => {
     if (!currentProjectId) return;
     if (!devCommand.trim()) return;
+    // Wait for the first getState() to resolve before auto-spawning. A
+    // "restored-stopped" panel must surface its restart CTA, not silently
+    // relaunch the dev server the user closed Daintree with (#9094).
+    if (!initialStateResolved) return;
+    if (status === "restored-stopped") return;
 
     const configKey = buildEnsureConfigKey({
       projectId: currentProjectId,
@@ -464,6 +485,8 @@ export function useDevServer({
     envSignature,
     turbopackEnabled,
     ensureLatestConfig,
+    initialStateResolved,
+    status,
   ]);
 
   // Staged stuck-start escalation (#8276, retuned #9099). Replaces the


### PR DESCRIPTION
## Summary

When the app closes while a dev-preview server is running, the panel now reopens in a `restored-stopped` state with a one-click Restart CTA. Previously it either silently auto-spawned a new server or dropped into a generic empty state with no indication anything was running before.

No process reattachment, no auto-spawn on launch -- those are hard constraints from the issue. This is metadata-only persistence.

Resolves #9094

## How it works

**`DevPreviewManifestService`** (new) -- corruption-tolerant atomic JSON manifest of running-session spawn metadata (`panelId`, `projectId`, `worktreeId`, `cwd`, `devCommand`, `env`, `turbopackEnabled`, `lastKnownPort`) written to `{userData}/backups/dev-preview-manifest.json` with mode `0o600`. Atomic write via temp-file rename so a mid-write crash never leaves a partial file.

**`DevPreviewSessionService`** -- persists the manifest when a session enters running state (instant crash resilience) and clears it on an explicit user stop. Deliberately does NOT persist on process exit, so a shutdown PTY kill can't wipe the restore offer. On first `init()` it reads-and-clears the manifest into `restoredEntries`; `getState()` reports `"restored-stopped"` for a panel with an entry and no live session; `getByWorktree()` falls back to restored entries so the worktree-delete dialog still warns about a dangling panel.

**`useDevServer`** -- gates auto-ensure on first `getState()` resolution and skips when `restored-stopped`, so the prior server never auto-relaunches on its own.

**`DevPreviewPane`** -- renders a distinct restore empty state (command chip + "Restart dev server" button) that calls `start()` directly.

## Changes

- `electron/services/DevPreviewManifestService.ts` -- new atomic manifest service
- `electron/services/DevPreviewSessionService.ts` -- persist/clear manifest on state transitions; `restored-stopped` status; `getByWorktree()` fallback
- `electron/ipc/handlers/devPreview.ts` -- wire `DevPreviewManifestService` into IPC handler init
- `shared/types/ipc/devPreview.ts` -- add `"restored-stopped"` to `DevPreviewSessionStatus`
- `src/hooks/useDevServer.ts` -- skip auto-ensure when `restored-stopped`
- `src/components/DevPreview/DevPreviewPane.tsx` -- restore empty state with command chip + restart button
- `src/components/DevPreview/ConsoleDrawer.tsx` -- minor adjustment for new status value

## Testing

Three new test files:

- `electron/services/__tests__/DevPreviewManifestService.test.ts` -- atomic write, corruption tolerance, permission bits
- `electron/services/__tests__/DevPreviewSessionService.test.ts` -- restore-manifest and persist-semantics paths
- `src/hooks/__tests__/useDevServer.adversarial.test.tsx` -- no-auto-ensure on `restored-stopped`, explicit `start()` still works

`npm run check` passes (typecheck + lint ratchet + format).