### PR TITLE
perf(recipes): batch-spawn recipe panels in a single layout commit

### DIFF
--- a/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -155,12 +155,18 @@ vi.mock("@/store/worktreeStore", () => ({
 
 let mockTerminals: Array<{ id: string; exitCode?: number }> = [];
 const mockAddPanel = vi.fn();
+const mockBeginSpawnBatch = vi.fn(() => Symbol("test-spawn-batch"));
+const mockFlushSpawnBatch = vi.fn();
+const mockSetFocused = vi.fn();
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: {
     getState: () => ({
       panelsById: Object.fromEntries(mockTerminals.map((t) => [t.id, t])),
       panelIds: mockTerminals.map((t) => t.id),
       addPanel: (...args: unknown[]) => mockAddPanel(...args),
+      beginSpawnBatch: () => mockBeginSpawnBatch(),
+      flushSpawnBatch: (token: unknown) => mockFlushSpawnBatch(token),
+      setFocused: (id: string) => mockSetFocused(id),
     }),
   },
 }));

--- a/src/components/Worktree/__tests__/panelSpawning.test.ts
+++ b/src/components/Worktree/__tests__/panelSpawning.test.ts
@@ -340,8 +340,12 @@ describe("spawnPanelsFromRecipe", () => {
     // Flush receives the token returned by begin.
     expect(mockFlushSpawnBatch).toHaveBeenCalledWith(mockBeginSpawnBatch.mock.results[0]?.value);
     expect(mockAddPanel).toHaveBeenCalledTimes(2);
-    // Each panel bypasses the per-call limit (the batch gated the whole burst).
-    expect(mockAddPanel).toHaveBeenCalledWith(expect.objectContaining({ bypassLimits: true }));
+    // EVERY panel bypasses the per-call limit (the batch gated the whole burst).
+    expect(
+      mockAddPanel.mock.calls.every(
+        (c) => (c[0] as { bypassLimits?: boolean })?.bypassLimits === true
+      )
+    ).toBe(true);
   });
 
   it("flushes the spawn batch even when a panel spawn throws", async () => {

--- a/src/components/Worktree/__tests__/panelSpawning.test.ts
+++ b/src/components/Worktree/__tests__/panelSpawning.test.ts
@@ -28,9 +28,20 @@ vi.mock("@shared/types", async (importActual) => {
   };
 });
 
+const mockSetFocused = vi.fn();
+const mockBeginSpawnBatch = vi.fn(() => Symbol("spawn-batch"));
+const mockFlushSpawnBatch = vi.fn();
+
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: {
-    getState: () => ({ addPanel: (...args: unknown[]) => mockAddPanel(...args) }),
+    getState: () => ({
+      addPanel: (...args: unknown[]) => mockAddPanel(...args),
+      panelIds: [],
+      panelsById: {},
+      beginSpawnBatch: mockBeginSpawnBatch,
+      flushSpawnBatch: mockFlushSpawnBatch,
+      setFocused: mockSetFocused,
+    }),
   },
 }));
 
@@ -315,6 +326,35 @@ describe("spawnPanelsFromRecipe", () => {
     });
 
     expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens one spawn batch and flushes it once for a multi-panel recipe", async () => {
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal({ title: "T1" }), makeTerminal({ title: "T2" })],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    expect(mockBeginSpawnBatch).toHaveBeenCalledTimes(1);
+    expect(mockFlushSpawnBatch).toHaveBeenCalledTimes(1);
+    // Flush receives the token returned by begin.
+    expect(mockFlushSpawnBatch).toHaveBeenCalledWith(mockBeginSpawnBatch.mock.results[0]?.value);
+    expect(mockAddPanel).toHaveBeenCalledTimes(2);
+    // Each panel bypasses the per-call limit (the batch gated the whole burst).
+    expect(mockAddPanel).toHaveBeenCalledWith(expect.objectContaining({ bypassLimits: true }));
+  });
+
+  it("flushes the spawn batch even when a panel spawn throws", async () => {
+    mockAddPanel.mockRejectedValue(new Error("boom"));
+
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      onPanelSpawned: vi.fn(),
+    });
+
+    expect(mockFlushSpawnBatch).toHaveBeenCalledTimes(1);
   });
 
   it("collects errors from multiple panels and throws single AggregateError", async () => {

--- a/src/components/Worktree/panelSpawning.ts
+++ b/src/components/Worktree/panelSpawning.ts
@@ -3,6 +3,9 @@ import { agentSettingsClient, systemClient } from "@/clients";
 import { getAgentConfig } from "@/config/agents";
 import { generateAgentCommand } from "@shared/types";
 import type { RecipeTerminal } from "@shared/types";
+import { preflightSpawnBatchLimit } from "@/store/panelLimitStore";
+import { isMcpSpawnFocusSuppressed } from "@/store/mcpSpawnFocusGuard";
+import { isAssistantFocused } from "@/store/macroFocusStore";
 
 export interface SpawnPanelsOptions {
   terminals: RecipeTerminal[];
@@ -39,76 +42,143 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
     }
   }
 
+  if (signal?.aborted) return;
+
+  const store = usePanelStore.getState();
+
+  // Aggregate panel-limit gate before opening the batch. The batched `addPanel`
+  // path defers the `panelIds` append, so per-call limit checks would all read
+  // the same stale count; gate the whole burst once and pass `bypassLimits` on
+  // each call. (#9165)
+  const currentCount = store.panelIds.reduce(
+    (n, id) => (store.panelsById[id]?.location !== "trash" ? n + 1 : n),
+    0
+  );
+  const { allowed } = await preflightSpawnBatchLimit(currentCount, terminals.length);
+  if (signal?.aborted) return;
+
   const errors: { index: number; error: unknown }[] = [];
 
-  for (const [index, t] of terminals.entries()) {
-    if (signal?.aborted) return;
+  // Panels beyond the resolved limit can't spawn — report them as failures.
+  for (let index = allowed; index < terminals.length; index++) {
+    const err = new Error("Panel limit reached");
+    if (onPanelSpawned) {
+      onPanelSpawned(index, null, err);
+    } else {
+      errors.push({ index, error: err });
+    }
+  }
 
-    try {
-      let panelId: string | null;
+  // Capture focus intent before the batch (the batched path suppresses the
+  // per-panel focus mutation that would otherwise focus the last grid panel).
+  const suppressFocus = isMcpSpawnFocusSuppressed() || isAssistantFocused();
 
-      if (t.type === "dev-preview") {
-        panelId = await usePanelStore.getState().addPanel({
-          kind: "dev-preview",
-          title: t.title,
-          cwd,
-          worktreeId,
-          exitBehavior: t.exitBehavior,
-          devCommand: t.devCommand?.trim() || undefined,
-        });
-      } else if (t.type !== "terminal") {
-        const agentId = t.type;
-        const agentConfig = getAgentConfig(agentId);
-        const baseCommand = agentConfig?.command ?? "";
-        const entry = agentSettings?.agents?.[agentId] ?? {};
-        const command = generateAgentCommand(baseCommand, entry, agentId, {
-          clipboardDirectory,
-          modelId: t.agentModelId,
-        });
+  type Outcome = { index: number; panelId: string | null; error?: unknown; skipped?: boolean };
 
-        panelId = await usePanelStore.getState().addPanel({
-          kind: "terminal",
-          launchAgentId: agentId,
-          command,
-          title: t.title,
-          cwd,
-          worktreeId,
-          exitBehavior: t.exitBehavior,
-          agentModelId: t.agentModelId,
-          agentLaunchFlags: t.agentLaunchFlags,
-        });
-      } else {
-        panelId = await usePanelStore.getState().addPanel({
-          kind: "terminal",
-          title: t.title,
-          cwd,
-          worktreeId,
-          exitBehavior: t.exitBehavior,
-          command: t.command?.trim() || undefined,
-        });
-      }
+  // One batch for the whole burst: each `addPanel` commits `panelsById`
+  // immediately but defers the `panelIds` append, collapsing N grid reflows
+  // into one at flush. (#9165)
+  const batchToken = store.beginSpawnBatch();
+  let outcomes: Outcome[];
+  try {
+    outcomes = await Promise.all(
+      terminals.slice(0, allowed).map(async (t, index): Promise<Outcome> => {
+        // Re-check between (parallel) dispatches: a synchronous abort from an
+        // earlier panel's spawn still stops later panels from being created.
+        if (signal?.aborted) return { index, panelId: null, skipped: true };
 
-      if (panelId != null) {
         try {
-          onPanelSpawned?.(index, panelId);
-        } catch {
-          // Callback threw — it already fired once, nothing to do.
+          let panelId: string | null;
+
+          if (t.type === "dev-preview") {
+            panelId = await store.addPanel({
+              kind: "dev-preview",
+              title: t.title,
+              cwd,
+              worktreeId,
+              exitBehavior: t.exitBehavior,
+              devCommand: t.devCommand?.trim() || undefined,
+              bypassLimits: true,
+            });
+          } else if (t.type !== "terminal") {
+            const agentId = t.type;
+            const agentConfig = getAgentConfig(agentId);
+            const baseCommand = agentConfig?.command ?? "";
+            const entry = agentSettings?.agents?.[agentId] ?? {};
+            const command = generateAgentCommand(baseCommand, entry, agentId, {
+              clipboardDirectory,
+              modelId: t.agentModelId,
+            });
+
+            panelId = await store.addPanel({
+              kind: "terminal",
+              launchAgentId: agentId,
+              command,
+              title: t.title,
+              cwd,
+              worktreeId,
+              exitBehavior: t.exitBehavior,
+              agentModelId: t.agentModelId,
+              agentLaunchFlags: t.agentLaunchFlags,
+              bypassLimits: true,
+            });
+          } else {
+            panelId = await store.addPanel({
+              kind: "terminal",
+              title: t.title,
+              cwd,
+              worktreeId,
+              exitBehavior: t.exitBehavior,
+              command: t.command?.trim() || undefined,
+              bypassLimits: true,
+            });
+          }
+
+          return { index, panelId };
+        } catch (error) {
+          return { index, panelId: null, error };
         }
-      } else {
-        const err = new Error("addPanel returned null");
-        if (onPanelSpawned) {
-          onPanelSpawned(index, null, err);
-        } else {
-          errors.push({ index, error: err });
-        }
-      }
-    } catch (err) {
+      })
+    );
+  } finally {
+    store.flushSpawnBatch(batchToken);
+  }
+
+  // Report in index order (parallel settle order is non-deterministic).
+  let lastSpawnedId: string | null = null;
+  for (const outcome of outcomes) {
+    if (outcome.skipped) continue;
+
+    if (outcome.error !== undefined) {
       if (onPanelSpawned) {
-        onPanelSpawned(index, null, err);
+        onPanelSpawned(outcome.index, null, outcome.error);
       } else {
-        errors.push({ index, error: err });
+        errors.push({ index: outcome.index, error: outcome.error });
+      }
+      continue;
+    }
+
+    if (outcome.panelId != null) {
+      lastSpawnedId = outcome.panelId;
+      try {
+        onPanelSpawned?.(outcome.index, outcome.panelId);
+      } catch {
+        // Callback threw — it already fired once, nothing to do.
+      }
+    } else {
+      const err = new Error("addPanel returned null");
+      if (onPanelSpawned) {
+        onPanelSpawned(outcome.index, null, err);
+      } else {
+        errors.push({ index: outcome.index, error: err });
       }
     }
+  }
+
+  // Restore the per-panel focus the batch suppressed: focus the last spawned
+  // grid panel, matching the prior serial behaviour.
+  if (!suppressFocus && lastSpawnedId !== null) {
+    store.setFocused(lastSpawnedId);
   }
 
   if (errors.length > 0) {

--- a/src/components/Worktree/panelSpawning.ts
+++ b/src/components/Worktree/panelSpawning.ts
@@ -77,8 +77,8 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
 
   // One batch for the whole burst: each `addPanel` commits `panelsById`
   // immediately but defers the `panelIds` append, collapsing N grid reflows
-  // into one at flush. (#9165)
-  const batchToken = store.beginSpawnBatch();
+  // into one at flush. Skip opening it when the limit leaves no room. (#9165)
+  const batchToken = allowed > 0 ? store.beginSpawnBatch() : null;
   let outcomes: Outcome[];
   try {
     outcomes = await Promise.all(

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -735,6 +735,39 @@ describe("recipeStore", () => {
       expect(setFocusedMock).not.toHaveBeenCalled();
     });
 
+    it("reports out-of-bounds terminalIndices as structured failures without throwing", async () => {
+      // Regression: previously, recipe.terminals[i]! with a bad index handed
+      // `undefined` to the hasAgent loop and threw TypeError on `.type`. Now
+      // validation runs first and out-of-bounds indices go straight to failed.
+      addTerminalMock.mockResolvedValue("terminal-1");
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Test Recipe",
+            projectId: "project-1",
+            terminals: [{ type: "terminal", title: "Shell 1", command: "a", env: {} }],
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      const results = await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+          terminalIndices: [0, 99, -1],
+        });
+
+      expect(addTerminalMock).toHaveBeenCalledTimes(1);
+      expect(results.spawned).toHaveLength(1);
+      expect(results.spawned[0]?.index).toBe(0);
+      expect(results.failed).toHaveLength(2);
+      expect(results.failed.map((f) => f.index).sort()).toEqual([-1, 99]);
+      expect(results.failed.every((f) => f.error.includes("out of bounds"))).toBe(true);
+    });
+
     it("caps the burst at the hard panel limit and reports overflow as failed", async () => {
       const previousHardLimit = usePanelLimitStore.getState().hardLimit;
       usePanelLimitStore.setState({ hardLimit: 2, warningsDisabled: true });

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -60,14 +60,24 @@ vi.mock("@/clients", () => ({
   },
 }));
 
+const beginSpawnBatchMock = vi.fn(() => Symbol("spawn-batch"));
+const flushSpawnBatchMock = vi.fn();
+const setFocusedMock = vi.fn();
+
 const panelStoreState: {
   panelIds: string[];
   panelsById: Record<string, unknown>;
   addPanel: typeof addTerminalMock;
+  beginSpawnBatch: typeof beginSpawnBatchMock;
+  flushSpawnBatch: typeof flushSpawnBatchMock;
+  setFocused: typeof setFocusedMock;
 } = {
   panelIds: [],
   panelsById: {},
   addPanel: addTerminalMock,
+  beginSpawnBatch: beginSpawnBatchMock,
+  flushSpawnBatch: flushSpawnBatchMock,
+  setFocused: setFocusedMock,
 };
 
 vi.mock("../panelStore", () => ({
@@ -77,6 +87,7 @@ vi.mock("../panelStore", () => ({
 }));
 
 import { useRecipeStore } from "../recipeStore";
+import { usePanelLimitStore } from "../panelLimitStore";
 
 describe("recipeStore", () => {
   beforeEach(() => {
@@ -627,6 +638,131 @@ describe("recipeStore", () => {
       expect(addTerminalMock).toHaveBeenCalledTimes(1);
       expect(results.spawned).toHaveLength(1);
       expect(results.spawned[0]?.index).toBe(1);
+    });
+
+    it("opens one spawn batch and flushes it once, bypassing per-panel limits", async () => {
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Test Recipe",
+            projectId: "project-1",
+            terminals: [
+              { type: "terminal", title: "Shell 1", command: "a", env: {} },
+              { type: "terminal", title: "Shell 2", command: "b", env: {} },
+              { type: "terminal", title: "Shell 3", command: "c", env: {} },
+            ],
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1");
+
+      expect(beginSpawnBatchMock).toHaveBeenCalledTimes(1);
+      expect(flushSpawnBatchMock).toHaveBeenCalledTimes(1);
+      expect(flushSpawnBatchMock).toHaveBeenCalledWith(beginSpawnBatchMock.mock.results[0]?.value);
+      expect(addTerminalMock).toHaveBeenCalledWith(expect.objectContaining({ bypassLimits: true }));
+    });
+
+    it("focuses the last spawned grid panel after the batch flush", async () => {
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Test Recipe",
+            projectId: "project-1",
+            terminals: [
+              { type: "terminal", title: "Shell 1", command: "a", env: {} },
+              { type: "terminal", title: "Shell 2", command: "b", env: {} },
+            ],
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1");
+
+      expect(setFocusedMock).toHaveBeenCalledTimes(1);
+      expect(setFocusedMock).toHaveBeenCalledWith("terminal-2");
+    });
+
+    it("does not steal focus when focusPolicy is preserve", async () => {
+      addTerminalMock.mockResolvedValue("terminal-x");
+
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Test Recipe",
+            projectId: "project-1",
+            terminals: [{ type: "terminal", title: "Shell 1", command: "a", env: {} }],
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+          focusPolicy: "preserve",
+        });
+
+      expect(setFocusedMock).not.toHaveBeenCalled();
+    });
+
+    it("caps the burst at the hard panel limit and reports overflow as failed", async () => {
+      const previousHardLimit = usePanelLimitStore.getState().hardLimit;
+      usePanelLimitStore.setState({ hardLimit: 2, warningsDisabled: true });
+      try {
+        let callIndex = 0;
+        addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+        useRecipeStore.setState({
+          recipes: [
+            {
+              id: "recipe-1",
+              name: "Test Recipe",
+              projectId: "project-1",
+              terminals: [
+                { type: "terminal", title: "Shell 1", command: "a", env: {} },
+                { type: "terminal", title: "Shell 2", command: "b", env: {} },
+                { type: "terminal", title: "Shell 3", command: "c", env: {} },
+              ],
+              createdAt: Date.now(),
+            },
+          ],
+          isLoading: false,
+          currentProjectId: "project-1",
+        });
+
+        const results = await useRecipeStore
+          .getState()
+          .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1");
+
+        expect(addTerminalMock).toHaveBeenCalledTimes(2);
+        expect(results.spawned).toHaveLength(2);
+        expect(results.failed).toHaveLength(1);
+        expect(results.failed[0]).toEqual({ index: 2, error: "Panel limit reached" });
+      } finally {
+        usePanelLimitStore.setState({ hardLimit: previousHardLimit, warningsDisabled: false });
+      }
     });
   });
 

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -669,7 +669,15 @@ describe("recipeStore", () => {
       expect(beginSpawnBatchMock).toHaveBeenCalledTimes(1);
       expect(flushSpawnBatchMock).toHaveBeenCalledTimes(1);
       expect(flushSpawnBatchMock).toHaveBeenCalledWith(beginSpawnBatchMock.mock.results[0]?.value);
-      expect(addTerminalMock).toHaveBeenCalledWith(expect.objectContaining({ bypassLimits: true }));
+      expect(addTerminalMock).toHaveBeenCalledTimes(3);
+      // EVERY panel in the burst must bypass the per-call limit (the batch gated
+      // the whole burst); dropping it on one panel would re-introduce the
+      // stale-count under-enforcement.
+      expect(
+        addTerminalMock.mock.calls.every(
+          (c) => (c[0] as { bypassLimits?: boolean })?.bypassLimits === true
+        )
+      ).toBe(true);
     });
 
     it("focuses the last spawned grid panel after the batch flush", async () => {
@@ -757,6 +765,11 @@ describe("recipeStore", () => {
           .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1");
 
         expect(addTerminalMock).toHaveBeenCalledTimes(2);
+        expect(
+          addTerminalMock.mock.calls.every(
+            (c) => (c[0] as { bypassLimits?: boolean })?.bypassLimits === true
+          )
+        ).toBe(true);
         expect(results.spawned).toHaveLength(2);
         expect(results.failed).toHaveLength(1);
         expect(results.failed[0]).toEqual({ index: 2, error: "Panel limit reached" });

--- a/src/store/panelLimitStore.ts
+++ b/src/store/panelLimitStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
+import { notify } from "@/lib/notify";
 
 export const DEFAULT_SOFT_WARNING_LIMIT = 12;
 export const DEFAULT_CONFIRMATION_LIMIT = 20;
@@ -205,4 +206,56 @@ registerPersistedStore({
 
 export function _resetInitPromise(): void {
   _initPromise = null;
+}
+
+/**
+ * Aggregate panel-limit gate for batch spawns (recipes, worktree spin-up).
+ *
+ * Batched `addPanel` defers the `panelIds` append, so the per-call limit check
+ * in `addPanel` would read the same stale count for every panel in the burst
+ * and under-enforce the ceiling. Callers run this once up front against the
+ * pre-batch `currentCount`, spawn only the returned `allowed` count with
+ * `bypassLimits: true`, and report the rest as "Panel limit reached". The
+ * confirmation dialog (if the burst crosses the confirm threshold) is awaited
+ * here, before the batch opens, so it never renders mid-commit. See #9165.
+ *
+ * @returns `allowed` — how many of the requested panels may be spawned now
+ *   (0 when the hard limit is already reached or the user declines the confirm).
+ */
+export async function preflightSpawnBatchLimit(
+  currentCount: number,
+  requestedCount: number
+): Promise<{ allowed: number }> {
+  if (requestedCount <= 0) return { allowed: 0 };
+
+  const { confirmationLimit, hardLimit, warningsDisabled, requestConfirmation } =
+    usePanelLimitStore.getState();
+
+  const available = Math.max(0, hardLimit - currentCount);
+  if (available === 0) {
+    notify({
+      type: "warning",
+      priority: "high",
+      title: "Panel limit reached",
+      message: `Maximum of ${hardLimit} panels reached. Close some panels before adding new ones.`,
+      duration: 5000,
+      context: { eventKind: "uiFeedback" },
+    });
+    return { allowed: 0 };
+  }
+
+  const allowed = Math.min(available, requestedCount);
+  const projected = currentCount + allowed;
+
+  // Mirror `addPanel`'s per-call confirm tier: a panel added while the count is
+  // at or above `confirmationLimit` triggers a confirm. The batch crosses that
+  // threshold exactly when `projected > confirmationLimit`.
+  if (!warningsDisabled && projected > confirmationLimit) {
+    // Pass `null` for memory rather than firing an extra metrics IPC before the
+    // batch — the dialog renders without the memory hint, never blocks on it.
+    const confirmed = await requestConfirmation(projected, null);
+    if (!confirmed) return { allowed: 0 };
+  }
+
+  return { allowed };
 }

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -14,6 +14,7 @@ import {
   createWatchedPanelsSlice,
   flushPanelPersistence,
   isHydrationBatchActive,
+  resetBatchState,
   selectOrderedTerminals,
   type PanelRegistrySlice,
   type TerminalFocusSlice,
@@ -699,6 +700,11 @@ export const usePanelStore = create<PanelGridState>()(
 
       reset: async () => {
         const state = get();
+
+        // Discard any in-flight spawn/hydration batch so a reset mid-batch can't
+        // strand `isHydrationBatchActive()` as `true` and make the next
+        // `beginSpawnBatch()` decline to open. (#9165)
+        resetBatchState();
 
         for (const tid of state.panelIds) {
           try {

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -817,6 +817,11 @@ export const usePanelStore = create<PanelGridState>()(
       },
 
       clearTerminalStoreForSwitch: () => {
+        // Discard any in-flight spawn/hydration batch so a project switch mid-batch
+        // can't strand `isHydrationBatchActive()` true and make the next
+        // `beginSpawnBatch()` decline to open on the incoming project. (#9165)
+        resetBatchState();
+
         set({
           panelsById: {},
           panelIds: [],

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -623,10 +623,26 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     // WorktreeCard); MCP-initiated runs already get "preserve" via panelStore.
     const focusPolicy = options?.focusPolicy;
 
+    const results: RecipeSpawnResults = { spawned: [], failed: [] };
+
+    // Split out-of-bounds indices before anything else so they're reported
+    // regardless of how the limit gate or batch resolves. Must run before
+    // building `terminalsToSpawn`: `recipe.terminals[i]!` would otherwise
+    // pass `undefined` into the `hasAgent` check for any bad index and throw
+    // on `.type`, masking the structured failure path entirely.
+    const validIndices: number[] = [];
+    for (const index of indicesToSpawn) {
+      if (recipe.terminals[index]) {
+        validIndices.push(index);
+      } else {
+        results.failed.push({ index, error: `Terminal index ${index} out of bounds` });
+      }
+    }
+
     // Pre-fetch agent settings once for all agent terminals
     let agentSettings: Awaited<ReturnType<typeof agentSettingsClient.get>> | null = null;
     let clipboardDirectory: string | undefined;
-    const terminalsToSpawn = indicesToSpawn.map((i) => recipe.terminals[i]!);
+    const terminalsToSpawn = validIndices.map((i) => recipe.terminals[i]!);
     const hasAgent = terminalsToSpawn.some(
       (t) => t.type !== "terminal" && t.type !== "dev-preview"
     );
@@ -640,19 +656,6 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         clipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
       } catch (error) {
         logError("Failed to fetch agent settings for recipe", error);
-      }
-    }
-
-    const results: RecipeSpawnResults = { spawned: [], failed: [] };
-
-    // Split out-of-bounds indices before anything else so they're reported
-    // regardless of how the limit gate or batch resolves.
-    const validIndices: number[] = [];
-    for (const index of indicesToSpawn) {
-      if (recipe.terminals[index]) {
-        validIndices.push(index);
-      } else {
-        results.failed.push({ index, error: `Terminal index ${index} out of bounds` });
       }
     }
 

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -1,6 +1,9 @@
 import { create, type StateCreator } from "zustand";
 import type { TerminalRecipe, RecipeTerminal, RecipeTerminalType } from "@/types";
 import { usePanelStore } from "./panelStore";
+import { preflightSpawnBatchLimit } from "./panelLimitStore";
+import { isMcpSpawnFocusSuppressed } from "./mcpSpawnFocusGuard";
+import { isAssistantFocused } from "./macroFocusStore";
 import {
   isDevPreviewPanel,
   isPtyPanel,
@@ -642,69 +645,94 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
 
     const results: RecipeSpawnResults = { spawned: [], failed: [] };
 
+    // Split out-of-bounds indices before anything else so they're reported
+    // regardless of how the limit gate or batch resolves.
+    const validIndices: number[] = [];
     for (const index of indicesToSpawn) {
-      const terminal = recipe.terminals[index];
-      if (!terminal) {
+      if (recipe.terminals[index]) {
+        validIndices.push(index);
+      } else {
         results.failed.push({ index, error: `Terminal index ${index} out of bounds` });
-        continue;
       }
-      try {
-        // Handle dev-preview terminals
-        if (terminal.type === "dev-preview") {
-          const terminalId = await terminalStore.addPanel({
-            kind: "dev-preview",
-            title: terminal.title || "Dev Server",
-            cwd: worktreePath,
-            worktreeId: worktreeId,
-            devCommand: terminal.devCommand?.trim() || undefined,
-            env: terminal.env,
-            exitBehavior: terminal.exitBehavior,
-            spawnedBy,
-            focusPolicy,
-          });
-          if (terminalId) {
-            results.spawned.push({ index, terminalId });
-          } else {
-            results.failed.push({ index, error: "Panel limit reached" });
+    }
+
+    // Aggregate panel-limit gate BEFORE opening the batch. The batched path
+    // defers the `panelIds` append, so per-call limit checks would all read the
+    // same stale count and under-enforce the ceiling; gate the whole burst once
+    // here and pass `bypassLimits` on each individual call. (#9165)
+    const currentCount = terminalStore.panelIds.reduce(
+      (n, id) => (terminalStore.panelsById[id]?.location !== "trash" ? n + 1 : n),
+      0
+    );
+    const { allowed } = await preflightSpawnBatchLimit(currentCount, validIndices.length);
+    const spawnIndices = validIndices.slice(0, allowed);
+    for (const index of validIndices.slice(allowed)) {
+      results.failed.push({ index, error: "Panel limit reached" });
+    }
+
+    // Capture focus intent synchronously before the batch. The batched
+    // `addPanel` path suppresses the per-panel focus mutation (it would defeat
+    // the single commit), so focus is restored once after flush. Mirror
+    // panelStore.addPanel's gates so a recipe run can't steal focus from the
+    // assistant or an in-flight MCP dispatch.
+    const suppressFocus =
+      focusPolicy === "preserve" || isMcpSpawnFocusSuppressed() || isAssistantFocused();
+
+    // Open one batch for the whole burst: each `addPanel` commits its
+    // `panelsById` entry immediately but defers the `panelIds` append, so N
+    // panels trigger a single grid reflow at flush instead of N. (#9165)
+    const batchToken = terminalStore.beginSpawnBatch();
+    try {
+      const settled = await Promise.allSettled(
+        spawnIndices.map(async (index) => {
+          const terminal = recipe.terminals[index]!;
+
+          if (terminal.type === "dev-preview") {
+            return terminalStore.addPanel({
+              kind: "dev-preview",
+              title: terminal.title || "Dev Server",
+              cwd: worktreePath,
+              worktreeId: worktreeId,
+              devCommand: terminal.devCommand?.trim() || undefined,
+              env: terminal.env,
+              exitBehavior: terminal.exitBehavior,
+              spawnedBy,
+              focusPolicy,
+              bypassLimits: true,
+            });
           }
-          continue;
-        }
 
-        const isAgent = isAgentRecipeType(terminal.type);
-        let terminalId: string | null;
+          if (isAgentRecipeType(terminal.type)) {
+            const agentId = terminal.type as string;
+            const agentConfig = getAgentConfig(agentId);
+            const baseCommand = agentConfig?.command ?? "";
+            const rawPrompt = terminal.initialPrompt?.trim();
+            const resolvedContext: RecipeContext = { ...context, worktreePath };
+            const initialPrompt = rawPrompt
+              ? replaceRecipeVariables(rawPrompt, resolvedContext)
+              : undefined;
+            const entry = agentSettings?.agents?.[agentId] ?? {};
+            const command = generateAgentCommand(baseCommand, entry, agentId, {
+              initialPrompt,
+              clipboardDirectory,
+              recipeArgs: terminal.args?.trim() || undefined,
+            });
+            return terminalStore.addPanel({
+              kind: "terminal",
+              launchAgentId: agentId,
+              command,
+              title: terminal.title,
+              cwd: worktreePath,
+              worktreeId: worktreeId,
+              env: terminal.env,
+              exitBehavior: terminal.exitBehavior,
+              spawnedBy,
+              focusPolicy,
+              bypassLimits: true,
+            });
+          }
 
-        if (isAgent) {
-          const agentId = terminal.type as string;
-          const agentConfig = getAgentConfig(agentId);
-          const baseCommand = agentConfig?.command ?? "";
-          const rawPrompt = terminal.initialPrompt?.trim();
-          const resolvedContext: RecipeContext = {
-            ...context,
-            worktreePath,
-          };
-          const initialPrompt = rawPrompt
-            ? replaceRecipeVariables(rawPrompt, resolvedContext)
-            : undefined;
-          const entry = agentSettings?.agents?.[agentId] ?? {};
-          const command = generateAgentCommand(baseCommand, entry, agentId, {
-            initialPrompt,
-            clipboardDirectory,
-            recipeArgs: terminal.args?.trim() || undefined,
-          });
-          terminalId = await terminalStore.addPanel({
-            kind: "terminal",
-            launchAgentId: agentId,
-            command,
-            title: terminal.title,
-            cwd: worktreePath,
-            worktreeId: worktreeId,
-            env: terminal.env,
-            exitBehavior: terminal.exitBehavior,
-            spawnedBy,
-            focusPolicy,
-          });
-        } else {
-          terminalId = await terminalStore.addPanel({
+          return terminalStore.addPanel({
             kind: "terminal",
             title: terminal.title,
             cwd: worktreePath,
@@ -714,18 +742,40 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             exitBehavior: terminal.exitBehavior,
             spawnedBy,
             focusPolicy,
+            bypassLimits: true,
           });
-        }
-        if (terminalId) {
-          results.spawned.push({ index, terminalId });
+        })
+      );
+
+      settled.forEach((outcome, i) => {
+        const index = spawnIndices[i]!;
+        if (outcome.status === "fulfilled") {
+          if (outcome.value) {
+            results.spawned.push({ index, terminalId: outcome.value });
+          } else {
+            results.failed.push({ index, error: "Panel limit reached" });
+          }
         } else {
-          results.failed.push({ index, error: "Panel limit reached" });
+          const message = formatErrorMessage(outcome.reason, "Failed to spawn terminal");
+          logError(`Failed to spawn terminal for recipe ${recipeId}`, outcome.reason);
+          results.failed.push({ index, error: message });
         }
-      } catch (error) {
-        const message = formatErrorMessage(error, "Failed to spawn terminal");
-        logError(`Failed to spawn terminal for recipe ${recipeId}`, error);
-        results.failed.push({ index, error: message });
-      }
+      });
+    } finally {
+      // Always flush so the batch can never be left open (a no-op for a `null`
+      // token when a concurrent run already owns the active batch).
+      terminalStore.flushSpawnBatch(batchToken);
+    }
+
+    // Keep the index-ordered contract callers rely on; parallel settle order
+    // and the limit/out-of-bounds prepends would otherwise scramble it.
+    results.spawned.sort((a, b) => a.index - b.index);
+    results.failed.sort((a, b) => a.index - b.index);
+
+    // Restore the per-panel focus the batch suppressed: focus the last spawned
+    // grid panel, matching the prior serial behaviour (last `addPanel` won).
+    if (!suppressFocus && results.spawned.length > 0) {
+      terminalStore.setFocused(results.spawned[results.spawned.length - 1]!.terminalId);
     }
 
     return results;

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -680,8 +680,10 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
 
     // Open one batch for the whole burst: each `addPanel` commits its
     // `panelsById` entry immediately but defers the `panelIds` append, so N
-    // panels trigger a single grid reflow at flush instead of N. (#9165)
-    const batchToken = terminalStore.beginSpawnBatch();
+    // panels trigger a single grid reflow at flush instead of N. Skip opening
+    // the batch when nothing will spawn (hard limit hit or all indices invalid)
+    // so `isHydrationBatchActive()` never briefly flips for unrelated work. (#9165)
+    const batchToken = spawnIndices.length > 0 ? terminalStore.beginSpawnBatch() : null;
     try {
       const settled = await Promise.allSettled(
         spawnIndices.map(async (index) => {

--- a/src/store/slices/index.ts
+++ b/src/store/slices/index.ts
@@ -2,6 +2,7 @@ export {
   createPanelRegistrySlice,
   flushPanelPersistence,
   isHydrationBatchActive,
+  resetBatchState,
   selectOrderedTerminals,
   type PanelRegistrySlice,
   type TerminalInstance,

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -413,4 +413,87 @@ describe("hydration batch (#5196)", () => {
       unsubscribe();
     }
   });
+
+  describe("spawn batch aliases (#9165)", () => {
+    it("collapses a recipe spawn burst into a single panelIds render", async () => {
+      const { beginSpawnBatch, flushSpawnBatch, addPanel } = usePanelStore.getState();
+
+      let panelIdsNotifyCount = 0;
+      let lastPanelIds: string[] | undefined;
+      const unsubscribe = usePanelStore.subscribe((state) => {
+        if (state.panelIds !== lastPanelIds) {
+          panelIdsNotifyCount++;
+          lastPanelIds = state.panelIds;
+        }
+      });
+
+      try {
+        lastPanelIds = usePanelStore.getState().panelIds;
+
+        const token = beginSpawnBatch();
+        expect(token).not.toBeNull();
+        for (let i = 0; i < 5; i++) {
+          await addPanel({
+            kind: "browser",
+            requestedId: `spawn-${i}`,
+            cwd: "/",
+            bypassLimits: true,
+            browserUrl: "about:blank",
+          });
+        }
+        // Deferred: panelsById is populated but panelIds hasn't changed yet.
+        expect(usePanelStore.getState().panelsById["spawn-0"]).toBeDefined();
+        expect(panelIdsNotifyCount).toBe(0);
+
+        flushSpawnBatch(token);
+
+        expect(panelIdsNotifyCount).toBe(1);
+        expect(usePanelStore.getState().panelIds).toEqual([
+          "spawn-0",
+          "spawn-1",
+          "spawn-2",
+          "spawn-3",
+          "spawn-4",
+        ]);
+      } finally {
+        unsubscribe();
+      }
+    });
+
+    it("refuses to open a nested batch and sweeps overlapping ids via the active flush", async () => {
+      const { beginSpawnBatch, flushSpawnBatch, addPanel } = usePanelStore.getState();
+
+      // Run A opens the batch.
+      const tokenA = beginSpawnBatch();
+      expect(tokenA).not.toBeNull();
+
+      // An overlapping run B must not supersede A's in-flight batch.
+      const tokenB = beginSpawnBatch();
+      expect(tokenB).toBeNull();
+
+      await addPanel({
+        kind: "browser",
+        requestedId: "a-1",
+        cwd: "/",
+        bypassLimits: true,
+        browserUrl: "about:blank",
+      });
+      // B's panel, added while A's batch is still open, is collected too.
+      await addPanel({
+        kind: "browser",
+        requestedId: "b-1",
+        cwd: "/",
+        bypassLimits: true,
+        browserUrl: "about:blank",
+      });
+
+      // B's flush is a no-op for the null token — nothing is orphaned.
+      flushSpawnBatch(tokenB);
+      expect(usePanelStore.getState().panelIds).toEqual([]);
+
+      // A's flush sweeps up both runs' ids exactly once.
+      flushSpawnBatch(tokenA);
+      expect(usePanelStore.getState().panelIds).toEqual(["a-1", "b-1"]);
+    });
+  });
 });

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -495,5 +495,19 @@ describe("hydration batch (#5196)", () => {
       flushSpawnBatch(tokenA);
       expect(usePanelStore.getState().panelIds).toEqual(["a-1", "b-1"]);
     });
+
+    it("clears an unflushed batch on panelStore.reset() so the next batch can open", async () => {
+      const { beginSpawnBatch } = usePanelStore.getState();
+
+      // Open a batch but never flush it (simulates a reset/throw mid-batch).
+      expect(beginSpawnBatch()).not.toBeNull();
+      // While it's open, a second begin is declined.
+      expect(usePanelStore.getState().beginSpawnBatch()).toBeNull();
+
+      await usePanelStore.getState().reset();
+
+      // reset() discarded the stale batch — a fresh batch opens cleanly.
+      expect(usePanelStore.getState().beginSpawnBatch()).not.toBeNull();
+    });
   });
 });

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -509,5 +509,59 @@ describe("hydration batch (#5196)", () => {
       // reset() discarded the stale batch — a fresh batch opens cleanly.
       expect(usePanelStore.getState().beginSpawnBatch()).not.toBeNull();
     });
+
+    it("clears an unflushed batch on clearTerminalStoreForSwitch so a new project's batch can open", () => {
+      const { beginSpawnBatch, clearTerminalStoreForSwitch } = usePanelStore.getState();
+
+      // Spawn opens a batch on the outgoing project and never flushes (project switch fires).
+      expect(beginSpawnBatch()).not.toBeNull();
+      clearTerminalStoreForSwitch();
+
+      // The incoming project's first recipe run must be able to open its own batch.
+      expect(usePanelStore.getState().beginSpawnBatch()).not.toBeNull();
+    });
+
+    it("commits an in-flight spawn batch's ids when hydration starts mid-spawn", async () => {
+      const {
+        beginSpawnBatch,
+        beginHydrationBatch,
+        flushHydrationBatch,
+        flushSpawnBatch,
+        addPanel,
+      } = usePanelStore.getState();
+
+      // Spawn opens a batch and adds one panel.
+      const spawnToken = beginSpawnBatch();
+      expect(spawnToken).not.toBeNull();
+      await addPanel({
+        kind: "browser",
+        requestedId: "spawn-panel",
+        cwd: "/",
+        bypassLimits: true,
+        browserUrl: "about:blank",
+      });
+      expect(usePanelStore.getState().panelIds).toEqual([]);
+
+      // Hydration starts before the spawn's flush — it must inherit the spawn's
+      // collected ids rather than silently strand them in panelsById.
+      const hydrationToken = beginHydrationBatch();
+      expect(usePanelStore.getState().panelIds).toEqual(["spawn-panel"]);
+
+      // The stranded spawn token now sees a mismatch — its flush is a no-op,
+      // and the spawn panel does not get re-appended.
+      flushSpawnBatch(spawnToken);
+      expect(usePanelStore.getState().panelIds).toEqual(["spawn-panel"]);
+
+      // Hydration's own panels flush in its turn, with no duplication.
+      await addPanel({
+        kind: "browser",
+        requestedId: "hydration-panel",
+        cwd: "/",
+        bypassLimits: true,
+        browserUrl: "about:blank",
+      });
+      flushHydrationBatch(hydrationToken);
+      expect(usePanelStore.getState().panelIds).toEqual(["spawn-panel", "hydration-panel"]);
+    });
   });
 });

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -17,7 +17,12 @@ import {
 } from "./helpers";
 import type { TrashExpiryHelpers } from "./trash";
 import { logError, logWarn } from "@/utils/logger";
-import { beginBatch, beginSpawnBatch, consumeBatch } from "./hydrationBatch";
+import {
+  beginBatch,
+  beginSpawnBatch,
+  consumeActiveSpawnBatch,
+  consumeBatch,
+} from "./hydrationBatch";
 import type { HydrationBatchToken } from "./types";
 import { removeFromWorktreeIndex } from "./worktreeIndex";
 
@@ -25,29 +30,36 @@ type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
 
 /**
- * Append all panel ids collected since the batch opened in a single `set()`.
- * Shared by both the hydration and spawn batch flushes — the deferred
- * `panelIds` reveal + one-time persist is identical; only how the batch was
- * opened differs. A token mismatch (superseded or already flushed, or a `null`
- * token from `beginSpawnBatch` declining to open a nested batch) is a no-op.
+ * Reveal a batch's collected panel ids in `panelIds` and persist once. The
+ * filter drops ids that never landed in `panelsById` (failed addPanel) or are
+ * already present (reconnect path).
  */
-function applyBatchFlush(set: Set, token: HydrationBatchToken | null): void {
-  const pendingIds = consumeBatch(token);
-  if (pendingIds === null) return;
+function commitPendingIds(set: Set, pendingIds: string[]): void {
+  if (pendingIds.length === 0) return;
 
   set((state) => {
-    // `panelsById` was already updated per panel during the batch, so this
-    // final `set` only reveals `panelIds` to subscribers and persists once.
-    // Filter: reconnect ids are already in `panelIds`, and a failed addPanel
-    // might have been collected but never landed in `panelsById`.
     const existing = new Set(state.panelIds);
     const additions = pendingIds.filter(
       (id) => !existing.has(id) && state.panelsById[id] !== undefined
     );
-    const newIds = additions.length > 0 ? [...state.panelIds, ...additions] : state.panelIds;
+    if (additions.length === 0) return {};
+    const newIds = [...state.panelIds, ...additions];
     saveNormalized(state.panelsById, newIds);
-    return additions.length > 0 ? { panelIds: newIds } : {};
+    return { panelIds: newIds };
   });
+}
+
+/**
+ * Close a batch via `consumeBatch` and reveal its panel ids. Shared by both
+ * the hydration and spawn batch flushes — the deferred `panelIds` reveal +
+ * one-time persist is identical; only how the batch was opened differs. A
+ * token mismatch (superseded or already flushed, or a `null` token from
+ * `beginSpawnBatch` declining to open a nested batch) is a no-op.
+ */
+function applyBatchFlush(set: Set, token: HydrationBatchToken | null): void {
+  const pendingIds = consumeBatch(token);
+  if (pendingIds === null) return;
+  commitPendingIds(set, pendingIds);
 }
 
 export const createCorePanelActions = (
@@ -75,7 +87,21 @@ export const createCorePanelActions = (
   | "toggleTerminalLocation"
   | "emptyTrash"
 > => ({
-  beginHydrationBatch: () => beginBatch(),
+  beginHydrationBatch: () => {
+    // If a spawn batch is mid-flight when hydration starts (e.g. a recipe
+    // running during a project switch), commit its collected ids first.
+    // Otherwise the new hydration token would invalidate the spawn token —
+    // the spawn caller's `flushSpawnBatch` would see the mismatch and no-op,
+    // leaving the spawn's panels orphaned in `panelsById`. A stale prior
+    // hydration is intentionally NOT inherited (its panels came from a
+    // project the user is leaving — see #5196). The cross-project case is
+    // safe: `clearTerminalStoreForSwitch` calls `resetBatchState` first, so
+    // any pending ids drop out at the `panelsById[id] !== undefined` filter
+    // in `commitPendingIds`. (#9165)
+    const orphaned = consumeActiveSpawnBatch();
+    if (orphaned !== null) commitPendingIds(set, orphaned);
+    return beginBatch();
+  },
 
   flushHydrationBatch: (token) => applyBatchFlush(set, token),
 

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -17,11 +17,38 @@ import {
 } from "./helpers";
 import type { TrashExpiryHelpers } from "./trash";
 import { logError, logWarn } from "@/utils/logger";
-import { beginBatch, consumeBatch } from "./hydrationBatch";
+import { beginBatch, beginSpawnBatch, consumeBatch } from "./hydrationBatch";
+import type { HydrationBatchToken } from "./types";
 import { removeFromWorktreeIndex } from "./worktreeIndex";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
+
+/**
+ * Append all panel ids collected since the batch opened in a single `set()`.
+ * Shared by both the hydration and spawn batch flushes — the deferred
+ * `panelIds` reveal + one-time persist is identical; only how the batch was
+ * opened differs. A token mismatch (superseded or already flushed, or a `null`
+ * token from `beginSpawnBatch` declining to open a nested batch) is a no-op.
+ */
+function applyBatchFlush(set: Set, token: HydrationBatchToken | null): void {
+  const pendingIds = consumeBatch(token);
+  if (pendingIds === null) return;
+
+  set((state) => {
+    // `panelsById` was already updated per panel during the batch, so this
+    // final `set` only reveals `panelIds` to subscribers and persists once.
+    // Filter: reconnect ids are already in `panelIds`, and a failed addPanel
+    // might have been collected but never landed in `panelsById`.
+    const existing = new Set(state.panelIds);
+    const additions = pendingIds.filter(
+      (id) => !existing.has(id) && state.panelsById[id] !== undefined
+    );
+    const newIds = additions.length > 0 ? [...state.panelIds, ...additions] : state.panelIds;
+    saveNormalized(state.panelsById, newIds);
+    return additions.length > 0 ? { panelIds: newIds } : {};
+  });
+}
 
 export const createCorePanelActions = (
   set: Set,
@@ -32,6 +59,8 @@ export const createCorePanelActions = (
   PanelRegistrySlice,
   | "beginHydrationBatch"
   | "flushHydrationBatch"
+  | "beginSpawnBatch"
+  | "flushSpawnBatch"
   | "removePanel"
   | "updateTitle"
   | "updateLastObservedTitle"
@@ -48,25 +77,11 @@ export const createCorePanelActions = (
 > => ({
   beginHydrationBatch: () => beginBatch(),
 
-  flushHydrationBatch: (token) => {
-    const pendingIds = consumeBatch(token);
-    // Token mismatch means the batch was superseded or already flushed — ignore.
-    if (pendingIds === null) return;
+  flushHydrationBatch: (token) => applyBatchFlush(set, token),
 
-    set((state) => {
-      // `panelsById` was already updated per panel during the batch, so this
-      // final `set` only reveals `panelIds` to subscribers and persists once.
-      // Filter: reconnect ids are already in `panelIds`, and a failed addPanel
-      // might have been collected but never landed in `panelsById`.
-      const existing = new Set(state.panelIds);
-      const additions = pendingIds.filter(
-        (id) => !existing.has(id) && state.panelsById[id] !== undefined
-      );
-      const newIds = additions.length > 0 ? [...state.panelIds, ...additions] : state.panelIds;
-      saveNormalized(state.panelsById, newIds);
-      return additions.length > 0 ? { panelIds: newIds } : {};
-    });
-  },
+  beginSpawnBatch: () => beginSpawnBatch(),
+
+  flushSpawnBatch: (token) => applyBatchFlush(set, token),
 
   removePanel: (id) => {
     clearTrashExpiryTimer(id);

--- a/src/store/slices/panelRegistry/hydrationBatch.ts
+++ b/src/store/slices/panelRegistry/hydrationBatch.ts
@@ -1,19 +1,23 @@
 import type { HydrationBatchToken } from "./types";
 
 /**
- * Hydration batch state. Each restore phase runs inside begin/flush, and during
- * that window `addPanel` commits the per-panel `panelsById` entry immediately
- * (so IPC event listeners that look panels up by id always find them) but defers
- * the `panelIds` append. Flush applies a single `panelIds` update per phase —
- * which is the high-fanout subscription that the worktree dashboard, dock, and
- * grid subscribe to. Net: a phase of N panels triggers 1 `panelIds` render
- * instead of N, while never leaving spawned panels invisible to event handlers.
+ * Singleton batch state shared by hydration (#5196) and spawn (#9165). During a
+ * batch, `addPanel` commits the per-panel `panelsById` entry immediately (so
+ * IPC event listeners can look panels up by id) but defers the `panelIds`
+ * append. Flush applies a single `panelIds` update per batch — the
+ * high-fanout subscription that the worktree dashboard, dock, and grid read.
+ * Net: a phase of N panels triggers 1 `panelIds` render instead of N.
  *
- * Singleton: hydration is guarded by `isCurrent()` so at most one batch is active
- * at a time. `HydrationBatchToken` protects against stale flushes from cancelled
- * hydrations colliding with a fresh batch started by the superseding hydration.
+ * `kind` distinguishes the two use cases because their staleness contracts
+ * differ. A stale hydration is discarded on the next hydration — its panels
+ * came from a project that the user is leaving (#5196). A stale spawn is
+ * inherited by the next hydration — its panels are real user-initiated
+ * additions that we must not orphan in `panelsById`.
  */
-let activeHydrationBatch: {
+type BatchKind = "hydration" | "spawn";
+
+let activeBatch: {
+  kind: BatchKind;
   token: HydrationBatchToken;
   /** Ids pending append to `panelIds`; deduplicated via `seenIds`. */
   pendingIds: string[];
@@ -26,25 +30,27 @@ let activeHydrationBatch: {
  * otherwise they'd trigger one render per panel and defeat the batching.
  */
 export function isHydrationBatchActive(): boolean {
-  return activeHydrationBatch !== null;
+  return activeBatch !== null;
 }
 
 /** Record a new panel id for append to `panelIds` at flush time. Dedup-safe. */
 export function collectPanelIdForBatch(id: string): void {
-  if (activeHydrationBatch === null) return;
-  if (activeHydrationBatch.seenIds.has(id)) return;
-  activeHydrationBatch.seenIds.add(id);
-  activeHydrationBatch.pendingIds.push(id);
+  if (activeBatch === null) return;
+  if (activeBatch.seenIds.has(id)) return;
+  activeBatch.seenIds.add(id);
+  activeBatch.pendingIds.push(id);
 }
 
 /**
- * Open a new hydration batch and return its opaque token. A leftover batch from
- * a cancelled hydration is discarded — we prioritize the fresh hydration and
- * never flush stale panels into the store.
+ * Open a new hydration batch and return its opaque token. A leftover hydration
+ * batch is discarded — cancelled hydrations carry stale-project panels we
+ * never want to surface. A leftover SPAWN batch is the caller's responsibility
+ * to inherit via {@link consumeActiveSpawnBatch} before calling this; otherwise
+ * its collected panels would be silently dropped.
  */
 export function beginBatch(): HydrationBatchToken {
   const token: HydrationBatchToken = Symbol("hydration-batch");
-  activeHydrationBatch = { token, pendingIds: [], seenIds: new Set() };
+  activeBatch = { kind: "hydration", token, pendingIds: [], seenIds: new Set() };
   return token;
 }
 
@@ -59,8 +65,10 @@ export function beginBatch(): HydrationBatchToken {
  * `panelIds` commit while staying safe under concurrent spawns. See issue #9165.
  */
 export function beginSpawnBatch(): HydrationBatchToken | null {
-  if (activeHydrationBatch !== null) return null;
-  return beginBatch();
+  if (activeBatch !== null) return null;
+  const token: HydrationBatchToken = Symbol("spawn-batch");
+  activeBatch = { kind: "spawn", token, pendingIds: [], seenIds: new Set() };
+  return token;
 }
 
 /**
@@ -69,18 +77,36 @@ export function beginSpawnBatch(): HydrationBatchToken | null {
  * should treat that as a no-op flush.
  */
 export function consumeBatch(token: HydrationBatchToken | null): string[] | null {
-  if (activeHydrationBatch === null || activeHydrationBatch.token !== token) return null;
-  const pendingIds = activeHydrationBatch.pendingIds;
-  activeHydrationBatch = null;
+  if (activeBatch === null || activeBatch.token !== token) return null;
+  const pendingIds = activeBatch.pendingIds;
+  activeBatch = null;
   return pendingIds;
 }
 
 /**
- * Force-clear any in-flight batch. Called from `panelStore.reset()` so a batch
- * that was opened but never flushed (a store reset, project switch, or a test
- * that threw mid-batch) can't leave `isHydrationBatchActive()` stuck `true` and
- * make the next `beginSpawnBatch()` decline to open.
+ * If the active batch is a spawn batch, drain its pendingIds and reset.
+ * Used by `beginHydrationBatch` to inherit collected ids from a recipe run
+ * that's still in flight when hydration takes over (e.g. project switch
+ * mid-spawn): without this, the new hydration token would invalidate the
+ * spawn token, the spawn caller's `flushSpawnBatch` would no-op on the
+ * mismatch, and the spawn's panels would be orphaned in `panelsById`.
+ * Returns `null` when the active batch is hydration (intentionally discarded)
+ * or absent.
+ */
+export function consumeActiveSpawnBatch(): string[] | null {
+  if (activeBatch === null || activeBatch.kind !== "spawn") return null;
+  const pendingIds = activeBatch.pendingIds;
+  activeBatch = null;
+  return pendingIds;
+}
+
+/**
+ * Force-clear any in-flight batch. Called from `panelStore.reset()` and
+ * `clearTerminalStoreForSwitch()` so a batch that was opened but never flushed
+ * (a store reset, project switch, or a test that threw mid-batch) can't leave
+ * `isHydrationBatchActive()` stuck `true` and make the next `beginSpawnBatch()`
+ * decline to open.
  */
 export function resetBatchState(): void {
-  activeHydrationBatch = null;
+  activeBatch = null;
 }

--- a/src/store/slices/panelRegistry/hydrationBatch.ts
+++ b/src/store/slices/panelRegistry/hydrationBatch.ts
@@ -74,3 +74,13 @@ export function consumeBatch(token: HydrationBatchToken | null): string[] | null
   activeHydrationBatch = null;
   return pendingIds;
 }
+
+/**
+ * Force-clear any in-flight batch. Called from `panelStore.reset()` so a batch
+ * that was opened but never flushed (a store reset, project switch, or a test
+ * that threw mid-batch) can't leave `isHydrationBatchActive()` stuck `true` and
+ * make the next `beginSpawnBatch()` decline to open.
+ */
+export function resetBatchState(): void {
+  activeHydrationBatch = null;
+}

--- a/src/store/slices/panelRegistry/hydrationBatch.ts
+++ b/src/store/slices/panelRegistry/hydrationBatch.ts
@@ -49,11 +49,26 @@ export function beginBatch(): HydrationBatchToken {
 }
 
 /**
+ * Open a batch for a recipe/worktree spawn burst, but only if none is already
+ * active. Recipe runs are user-triggered and can overlap (two worktree cards,
+ * a double-click, or a run landing mid-hydration), so — unlike `beginBatch` —
+ * this never supersedes an in-flight batch. Returning `null` tells the caller
+ * to skip its own flush; any panels it adds during the window are still
+ * collected into the active batch and swept up by that batch's flush, where the
+ * dedup-on-flush guard appends each id exactly once. This keeps the single
+ * `panelIds` commit while staying safe under concurrent spawns. See issue #9165.
+ */
+export function beginSpawnBatch(): HydrationBatchToken | null {
+  if (activeHydrationBatch !== null) return null;
+  return beginBatch();
+}
+
+/**
  * Close the active batch if `token` matches and return its pending panel ids.
  * Returns `null` when the token was already consumed or superseded — callers
  * should treat that as a no-op flush.
  */
-export function consumeBatch(token: HydrationBatchToken): string[] | null {
+export function consumeBatch(token: HydrationBatchToken | null): string[] | null {
   if (activeHydrationBatch === null || activeHydrationBatch.token !== token) return null;
   const pendingIds = activeHydrationBatch.pendingIds;
   activeHydrationBatch = null;

--- a/src/store/slices/panelRegistry/index.ts
+++ b/src/store/slices/panelRegistry/index.ts
@@ -25,7 +25,7 @@ export type {
 export { MAX_GRID_TERMINALS, deriveRuntimeStatus, getDefaultTitle } from "./helpers";
 export { flushPanelPersistence } from "./persistence";
 export { selectOrderedTerminals } from "./selectors";
-export { isHydrationBatchActive } from "./hydrationBatch";
+export { isHydrationBatchActive, resetBatchState } from "./hydrationBatch";
 
 export const createPanelRegistrySlice =
   (

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -94,6 +94,16 @@ export interface PanelRegistrySlice {
   beginHydrationBatch: () => HydrationBatchToken;
   /** Apply all panels collected since `beginHydrationBatch` in a single `set()` call. */
   flushHydrationBatch: (token: HydrationBatchToken) => void;
+  /**
+   * Recipe/worktree spawn variant of {@link beginHydrationBatch}. Reuses the same
+   * single-commit machinery so an N-panel recipe run collapses to one `panelIds`
+   * render (one CSS Grid reflow) instead of N. Unlike hydration, it refuses to
+   * supersede an already-active batch (returns `null`) because recipe runs can
+   * overlap; a `null` token is a safe no-op at flush time. See issue #9165.
+   */
+  beginSpawnBatch: () => HydrationBatchToken | null;
+  /** Apply all panels collected since `beginSpawnBatch` in a single `set()`. No-op for a `null` token. */
+  flushSpawnBatch: (token: HydrationBatchToken | null) => void;
   removePanel: (id: string) => void;
   emptyTrash: (ids: string[]) => void;
   updateTitle: (id: string, newTitle: string) => void;

--- a/src/store/slices/panelRegistrySlice.ts
+++ b/src/store/slices/panelRegistrySlice.ts
@@ -3,6 +3,7 @@ export {
   createPanelRegistrySlice,
   flushPanelPersistence,
   isHydrationBatchActive,
+  resetBatchState,
   selectOrderedTerminals,
   MAX_GRID_TERMINALS,
   deriveRuntimeStatus,


### PR DESCRIPTION
## Summary

- Multi-panel recipe launches triggered N separate React commits and N CSS grid reflows because `spawnPanelsFromRecipe` and `recipeStore.runRecipeWithResults` used serial `for-await` loops awaiting each `addPanel`. `Promise.all` alone doesn't fix this — Zustand's `useSyncExternalStore` does a synchronous flush per `set()`, bypassing React 19 auto-batching.
- Fix reuses the existing hydration batch machinery via new `beginSpawnBatch`/`flushSpawnBatch` aliases. Deferring the `panelIds` append means N panels trigger one grid reflow at flush instead of N.
- The batch is begin-if-free (returns `null` rather than superseding an active batch), so overlapping recipe runs can't orphan each other's panels — the active batch's dedup-on-flush sweeps them.

Resolves #9165

## Changes

- `src/store/slices/panelRegistry/hydrationBatch.ts` — `beginSpawnBatch`/`flushSpawnBatch` aliases; focus restore runs once after flush, mirroring the `addPanel` assistant/MCP guards
- `src/store/slices/panelRegistry/core.ts` — deferred `panelIds` append path used by the spawn batch
- `src/store/slices/panelRegistry/types.ts` — spawn batch state shape
- `src/store/panelLimitStore.ts` — `preflightSpawnBatchLimit` aggregate check; spawn loops now pass `bypassLimits: true` so per-call limits don't under-enforce against deferred state
- `src/components/Worktree/panelSpawning.ts` — opens a spawn batch, runs `addPanel` calls in parallel via `Promise.allSettled`, flushes once
- `src/store/recipeStore.ts` — same parallel dispatch pattern with `Promise.all`; aggregate preflight gates before the batch opens
- PTY-host startup queue already serialises actual `node-pty` forks, so only the renderer-side commit needed batching

## Testing

Unit tests added alongside each changed module:

- Single-commit batching: real store, asserts exactly one `panelIds` render for a 5-panel burst
- Begin-if-free: nested batch refusal + overlapping sweep verified
- Reset clears batch state
- Hard limit cap + overflow reporting
- Focus restoration after flush, and suppression under `focusPolicy: "preserve"`
- `bypassLimits: true` confirmed on every spawned panel
- All pre-existing partial-failure / `AggregateError` contracts preserved