### PR TITLE
feat(worktree): wire IPC schemas and contain createWorktree to repo parent

### DIFF
--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -46,16 +46,14 @@ vi.mock("../../../window/webContentsRegistry.js", () => ({
   getWindowForWebContents: getWindowForWebContentsMock,
 }));
 
-vi.mock("../../utils.js", () => ({
-  checkRateLimit: checkRateLimitMock,
-  waitForRateLimitSlot: waitForRateLimitSlotMock,
-  typedHandle: (channel: string, handler: unknown) => {
+vi.mock("../../utils.js", () => {
+  const typedHandle = (channel: string, handler: unknown) => {
     ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
       (handler as (...a: unknown[]) => unknown)(...args)
     );
     return () => ipcMainMock.removeHandler(channel);
-  },
-  typedHandleWithContext: (channel: string, handler: unknown) => {
+  };
+  const typedHandleWithContext = (channel: string, handler: unknown) => {
     ipcMainMock.handle(
       channel,
       (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
@@ -69,8 +67,46 @@ vi.mock("../../utils.js", () => ({
       }
     );
     return () => ipcMainMock.removeHandler(channel);
-  },
-}));
+  };
+  const parseOrThrow = (
+    channel: string,
+    schema: { safeParse: (input: unknown) => { success: boolean } },
+    input: unknown
+  ) => {
+    const result = schema.safeParse(input);
+    if (!result.success) {
+      // Mirror the real ValidationError shape — sanitized, no Zod issues.
+      const err = new Error(`IPC validation failed: ${channel}`);
+      (err as Error & { name: string }).name = "ValidationError";
+      throw err;
+    }
+    return (result as { success: true; data: unknown }).data;
+  };
+  return {
+    checkRateLimit: checkRateLimitMock,
+    waitForRateLimitSlot: waitForRateLimitSlotMock,
+    typedHandle,
+    typedHandleWithContext,
+    typedHandleValidated: (
+      channel: string,
+      schema: { safeParse: (input: unknown) => { success: boolean } },
+      handler: unknown
+    ) =>
+      typedHandle(channel, async (...args: unknown[]) => {
+        const parsed = parseOrThrow(channel, schema, args[0]);
+        return (handler as (payload: unknown) => unknown)(parsed);
+      }),
+    typedHandleWithContextValidated: (
+      channel: string,
+      schema: { safeParse: (input: unknown) => { success: boolean } },
+      handler: unknown
+    ) =>
+      typedHandleWithContext(channel, async (ctx: unknown, ...args: unknown[]) => {
+        const parsed = parseOrThrow(channel, schema, args[0]);
+        return (handler as (ctx: unknown, payload: unknown) => unknown)(ctx, parsed);
+      }),
+  };
+});
 
 vi.mock("../../../store.js", () => ({ store: storeMock }));
 
@@ -241,13 +277,19 @@ describe("worktree IPC adversarial", () => {
   it("WORKTREE_CREATE rejects malformed payloads before validating (#7033)", async () => {
     const handler = getHandler(CHANNELS.WORKTREE_CREATE);
 
-    await expect(handler(fakeEvent(), null)).rejects.toThrow(/Invalid worktree create payload/);
-    await expect(handler(fakeEvent(), {})).rejects.toThrow(/Invalid worktree create payload/);
+    // Sanitized validation message: schema details, field paths, and user
+    // input never appear in the renderer-facing message (#9154).
+    await expect(handler(fakeEvent(), null)).rejects.toThrow(
+      /IPC validation failed: worktree:create/
+    );
+    await expect(handler(fakeEvent(), {})).rejects.toThrow(
+      /IPC validation failed: worktree:create/
+    );
     await expect(handler(fakeEvent(), { rootPath: "/repo" })).rejects.toThrow(
-      /Invalid worktree create payload/
+      /IPC validation failed: worktree:create/
     );
     await expect(handler(fakeEvent(), { rootPath: "/repo", options: null })).rejects.toThrow(
-      /Invalid worktree create payload/
+      /IPC validation failed: worktree:create/
     );
 
     expect(validateBranchNameMock).not.toHaveBeenCalled();

--- a/electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts
@@ -15,16 +15,14 @@ vi.mock("electron", () => ({
   },
 }));
 
-vi.mock("../../utils.js", () => ({
-  checkRateLimit: checkRateLimitMock,
-  waitForRateLimitSlot: waitForRateLimitSlotMock,
-  typedHandle: (channel: string, handler: unknown) => {
+vi.mock("../../utils.js", () => {
+  const typedHandle = (channel: string, handler: unknown) => {
     ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
       (handler as (...a: unknown[]) => unknown)(...args)
     );
     return () => ipcMainMock.removeHandler(channel);
-  },
-  typedHandleWithContext: (channel: string, handler: unknown) => {
+  };
+  const typedHandleWithContext = (channel: string, handler: unknown) => {
     ipcMainMock.handle(
       channel,
       (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
@@ -38,8 +36,45 @@ vi.mock("../../utils.js", () => ({
       }
     );
     return () => ipcMainMock.removeHandler(channel);
-  },
-}));
+  };
+  const parseOrThrow = (
+    channel: string,
+    schema: { safeParse: (input: unknown) => { success: boolean } },
+    input: unknown
+  ) => {
+    const result = schema.safeParse(input);
+    if (!result.success) {
+      const err = new Error(`IPC validation failed: ${channel}`);
+      (err as Error & { name: string }).name = "ValidationError";
+      throw err;
+    }
+    return (result as { success: true; data: unknown }).data;
+  };
+  return {
+    checkRateLimit: checkRateLimitMock,
+    waitForRateLimitSlot: waitForRateLimitSlotMock,
+    typedHandle,
+    typedHandleWithContext,
+    typedHandleValidated: (
+      channel: string,
+      schema: { safeParse: (input: unknown) => { success: boolean } },
+      handler: unknown
+    ) =>
+      typedHandle(channel, async (...args: unknown[]) => {
+        const parsed = parseOrThrow(channel, schema, args[0]);
+        return (handler as (payload: unknown) => unknown)(parsed);
+      }),
+    typedHandleWithContextValidated: (
+      channel: string,
+      schema: { safeParse: (input: unknown) => { success: boolean } },
+      handler: unknown
+    ) =>
+      typedHandleWithContext(channel, async (ctx: unknown, ...args: unknown[]) => {
+        const parsed = parseOrThrow(channel, schema, args[0]);
+        return (handler as (ctx: unknown, payload: unknown) => unknown)(ctx, parsed);
+      }),
+  };
+});
 
 vi.mock("../../../services/ProjectStore.js", () => ({
   projectStore: {

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -1,16 +1,21 @@
 // eager-import-allow: reads worktree settings via store.get synchronously in the IPC handler
+import { isAbsolute } from "path";
+import type { z } from "zod";
 import { CHANNELS } from "../../channels.js";
 import { store } from "../../../store.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
-import type { WorktreeSetActivePayload, WorktreeDeletePayload } from "../../../types/index.js";
+import type { WorktreeDeletePayload } from "../../../types/index.js";
 import type { WorktreeState } from "../../../../shared/types/worktree.js";
-import type { CreateWorktreeOptions } from "../../../../shared/types/git.js";
 import { fileSearchService } from "../../../services/FileSearchService.js";
 import { getSoundService } from "../../../services/getSoundService.js";
 import type * as SoundServiceModule from "../../../services/SoundService.js";
-import { defineIpcNamespace, op } from "../../define.js";
+import { defineIpcNamespace, op, opValidated } from "../../define.js";
+import {
+  WorktreeCreatePayloadSchema,
+  WorktreeSetActivePayloadSchema,
+} from "../../../schemas/ipc.js";
 import { checkRateLimit, waitForRateLimitSlot } from "../../utils.js";
 import { validateBranchName } from "../../../../shared/utils/pathPattern.js";
 import { WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS } from "./constants.js";
@@ -40,7 +45,7 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
 
   const handleWorktreeSetActive = async (
     ctx: IpcContext,
-    payload: WorktreeSetActivePayload
+    payload: z.output<typeof WorktreeSetActivePayloadSchema>
   ): Promise<void> => {
     if (!deps.worktreeService) {
       return;
@@ -50,17 +55,14 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     });
   };
 
-  const handleWorktreeCreate = async (payload: {
-    rootPath: string;
-    options: CreateWorktreeOptions;
-  }): Promise<string> => {
-    if (
-      !payload ||
-      typeof payload !== "object" ||
-      !payload.options ||
-      typeof payload.options !== "object"
-    ) {
-      throw new Error("Invalid worktree create payload");
+  const handleWorktreeCreate = async (
+    payload: z.output<typeof WorktreeCreatePayloadSchema>
+  ): Promise<string> => {
+    // Semantic guard: rootPath flows into createHardenedGit at the service
+    // layer and must be an absolute path. The schema enforces structure
+    // (non-empty, no null bytes); absoluteness is checked here. #3742.
+    if (!isAbsolute(payload.rootPath)) {
+      throw new Error("rootPath must be an absolute path");
     }
     // Defense-in-depth: WorkspaceService.createWorktree also validates, but
     // throwing here surfaces a clean Error to the renderer without consuming
@@ -202,8 +204,17 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     ops: {
       getAll: op(CHANNELS.WORKTREE_GET_ALL, handleWorktreeGetAll, { withContext: true }),
       refresh: op(CHANNELS.WORKTREE_REFRESH, handleWorktreeRefresh),
-      setActive: op(CHANNELS.WORKTREE_SET_ACTIVE, handleWorktreeSetActive, { withContext: true }),
-      create: op(CHANNELS.WORKTREE_CREATE, handleWorktreeCreate),
+      setActive: opValidated(
+        CHANNELS.WORKTREE_SET_ACTIVE,
+        WorktreeSetActivePayloadSchema,
+        handleWorktreeSetActive,
+        { withContext: true }
+      ),
+      create: opValidated(
+        CHANNELS.WORKTREE_CREATE,
+        WorktreeCreatePayloadSchema,
+        handleWorktreeCreate
+      ),
       restartService: op(CHANNELS.WORKTREE_RESTART_SERVICE, handleWorktreeRestartService, {
         withContext: true,
       }),

--- a/electron/schemas/__tests__/worktreePayloadValidation.test.ts
+++ b/electron/schemas/__tests__/worktreePayloadValidation.test.ts
@@ -24,6 +24,31 @@ describe("WorktreeCreatePayloadSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("preserves all optional CreateWorktreeOptions fields (no silent stripping)", () => {
+    // Regression guard: a plain z.object() strips undeclared fields, which
+    // would break PR-dropdown, remote-mode, and branch-reuse creation paths.
+    const fullOptions = {
+      ...validOptions,
+      fromRemote: true,
+      useExistingBranch: true,
+      provisionResource: true,
+      worktreeMode: "remote",
+      sourcePrNumber: 42,
+      sourcePrTitle: "Add feature",
+      sourcePrUrl: "https://github.com/o/r/pull/42",
+      sourcePrState: "open" as const,
+      sourcePrLinkedIssueNumber: 7,
+    };
+    const result = WorktreeCreatePayloadSchema.safeParse({
+      rootPath: "/home/user/repo",
+      options: fullOptions,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.options).toEqual(fullOptions);
+    }
+  });
+
   it("rejects a null byte in rootPath", () => {
     const result = WorktreeCreatePayloadSchema.safeParse({
       rootPath: "/home/user/repo\x00",

--- a/electron/schemas/__tests__/worktreePayloadValidation.test.ts
+++ b/electron/schemas/__tests__/worktreePayloadValidation.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { WorktreeCreatePayloadSchema, WorktreeSetActivePayloadSchema } from "../ipc.js";
+
+const validOptions = {
+  baseBranch: "main",
+  newBranch: "feature/test",
+  path: "/repo-worktrees/feature-test",
+};
+
+describe("WorktreeCreatePayloadSchema", () => {
+  it("accepts a well-formed payload", () => {
+    const result = WorktreeCreatePayloadSchema.safeParse({
+      rootPath: "/home/user/repo",
+      options: validOptions,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts the optional fromRemote flag", () => {
+    const result = WorktreeCreatePayloadSchema.safeParse({
+      rootPath: "/home/user/repo",
+      options: { ...validOptions, fromRemote: true },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a null byte in rootPath", () => {
+    const result = WorktreeCreatePayloadSchema.safeParse({
+      rootPath: "/home/user/repo\x00",
+      options: validOptions,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a null byte in options.path", () => {
+    const result = WorktreeCreatePayloadSchema.safeParse({
+      rootPath: "/home/user/repo",
+      options: { ...validOptions, path: "/repo-worktrees/feature\x00" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty rootPath", () => {
+    const result = WorktreeCreatePayloadSchema.safeParse({
+      rootPath: "",
+      options: validOptions,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty options.path", () => {
+    const result = WorktreeCreatePayloadSchema.safeParse({
+      rootPath: "/home/user/repo",
+      options: { ...validOptions, path: "" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("does not false-positive on a '..' substring (containment is service-level)", () => {
+    // Path traversal is enforced by assertWorktreePathContained at the service
+    // layer, not the schema. A legitimate path containing '..' as part of a
+    // segment name must still parse. #4702.
+    const result = WorktreeCreatePayloadSchema.safeParse({
+      rootPath: "/home/user/repo",
+      options: { ...validOptions, path: "/home/user/repo..worktrees/feature" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a path that exceeds the length cap", () => {
+    const result = WorktreeCreatePayloadSchema.safeParse({
+      rootPath: "/home/user/repo",
+      options: { ...validOptions, path: `/${"a".repeat(4097)}` },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("WorktreeSetActivePayloadSchema", () => {
+  it("accepts a valid worktreeId", () => {
+    const result = WorktreeSetActivePayloadSchema.safeParse({ worktreeId: "wt-123" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty worktreeId", () => {
+    const result = WorktreeSetActivePayloadSchema.safeParse({ worktreeId: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing worktreeId", () => {
+    const result = WorktreeSetActivePayloadSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -474,11 +474,21 @@ export const WorktreeSetActivePayloadSchema = z.object({
 });
 
 export const WorktreeCreatePayloadSchema = z.object({
-  rootPath: z.string().min(1),
+  rootPath: z
+    .string()
+    .min(1)
+    .max(4096)
+    // eslint-disable-next-line no-control-regex
+    .regex(/^[^\x00]*$/, "Null bytes not allowed"),
   options: z.object({
     baseBranch: z.string().min(1),
     newBranch: z.string().min(1),
-    path: z.string().min(1),
+    path: z
+      .string()
+      .min(1)
+      .max(4096)
+      // eslint-disable-next-line no-control-regex
+      .regex(/^[^\x00]*$/, "Null bytes not allowed"),
     fromRemote: z.boolean().optional(),
   }),
 });

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -480,6 +480,10 @@ export const WorktreeCreatePayloadSchema = z.object({
     .max(4096)
     // eslint-disable-next-line no-control-regex
     .regex(/^[^\x00]*$/, "Null bytes not allowed"),
+  // Mirrors CreateWorktreeOptions (shared/types/git.ts). All fields are declared
+  // so none are silently stripped before reaching WorkspaceService.createWorktree
+  // — the PR-dropdown, remote-mode, and branch-reuse paths all depend on the
+  // optional fields surviving parse.
   options: z.object({
     baseBranch: z.string().min(1),
     newBranch: z.string().min(1),
@@ -490,6 +494,14 @@ export const WorktreeCreatePayloadSchema = z.object({
       // eslint-disable-next-line no-control-regex
       .regex(/^[^\x00]*$/, "Null bytes not allowed"),
     fromRemote: z.boolean().optional(),
+    useExistingBranch: z.boolean().optional(),
+    provisionResource: z.boolean().optional(),
+    worktreeMode: z.string().optional(),
+    sourcePrNumber: z.number().optional(),
+    sourcePrTitle: z.string().optional(),
+    sourcePrUrl: z.string().optional(),
+    sourcePrState: z.enum(["open", "closed", "merged"]).optional(),
+    sourcePrLinkedIssueNumber: z.number().optional(),
   }),
 });
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -47,6 +47,7 @@ import {
   parseCheckedOutBranches,
   nextAvailableBranchName,
   ensureNoteFile,
+  assertWorktreePathContained,
 } from "./worktreeUtils.js";
 import { applyResourceConfigToMonitor } from "./resourceConfigHelpers.js";
 import { ResourceActionExecutor } from "./ResourceActionExecutor.js";
@@ -1629,6 +1630,11 @@ export class WorkspaceService {
       // through programmatic callers) is checked against the right parent
       // rather than against process.cwd.
       const absoluteCreatePath = isAbsolute(path) ? pathResolve(path) : pathResolve(rootPath, path);
+      // Containment gate (#9154): a renderer-supplied path must not escape the
+      // repository's parent directory — the outermost location the worktree
+      // path patterns can produce. Runs before any mkdir/git so an out-of-bounds
+      // target never creates directories or invokes git.
+      await assertWorktreePathContained(rootPath, absoluteCreatePath);
       const parentDir = dirname(absoluteCreatePath);
       if (!existsSync(parentDir)) {
         await mkdir(parentDir, { recursive: true });

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -74,6 +74,10 @@ vi.mock("fs/promises", () => ({
   access: vi.fn().mockResolvedValue(undefined),
   readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
   cp: vi.fn().mockResolvedValue(undefined),
+  // Identity by default: containment check (assertWorktreePathContained)
+  // realpaths the repo parent and the target's nearest existing ancestor;
+  // identity keeps resolved paths unchanged so existing assertions hold.
+  realpath: vi.fn().mockImplementation((p: string) => Promise.resolve(p)),
 }));
 
 // Default to "exists" so existing tests focus on the git/monitor logic rather
@@ -274,10 +278,15 @@ describe("WorkspaceService adversarial", () => {
   it("does not accumulate duplicate monitors when delete and create overlap on the same path", async () => {
     const racePath = pathResolve("/repo/wt-race");
     let releaseGit!: () => void;
+    let signalRawCalled!: () => void;
+    const rawCalled = new Promise<void>((resolve) => {
+      signalRawCalled = resolve;
+    });
     mockSimpleGit.raw.mockImplementationOnce(
       () =>
         new Promise<void>((resolve) => {
           releaseGit = resolve;
+          signalRawCalled();
         })
     );
 
@@ -289,6 +298,11 @@ describe("WorkspaceService adversarial", () => {
 
     const deletePromise = service.deleteWorktree("req-race-delete", racePath);
 
+    // The containment check (#9154) introduces an await on realpath before
+    // `git.raw` runs, so synchronously calling releaseGit() here would land
+    // before the mock implementation ran. Wait for the raw call to capture
+    // the resolver first.
+    await rawCalled;
     releaseGit();
     await Promise.allSettled([createPromise, deletePromise]);
 

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -121,6 +121,10 @@ vi.mock("fs/promises", () => ({
   access: vi.fn().mockResolvedValue(undefined),
   readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
   cp: vi.fn().mockResolvedValue(undefined),
+  // Identity by default: no symlinks in unit tests. The containment check
+  // (assertWorktreePathContained) realpaths the repo parent and the target's
+  // nearest existing ancestor; identity keeps resolved paths unchanged.
+  realpath: vi.fn().mockImplementation((p: string) => Promise.resolve(p)),
 }));
 
 // Default to "exists" so pre-existing tests don't exercise the parent mkdir
@@ -156,6 +160,11 @@ describe("WorkspaceService.createWorktree", () => {
 
     const fsModule = await import("../../utils/fs.js");
     waitForPathExists = vi.mocked(fsModule.waitForPathExists);
+
+    // Re-anchor realpath to identity each test so a per-test symlink override
+    // (the containment-escape cases below) can't leak into later tests.
+    const fsPromisesModule = await import("fs/promises");
+    vi.mocked(fsPromisesModule.realpath).mockImplementation((p: any) => Promise.resolve(p));
 
     mockSendEvent = vi.fn();
 
@@ -970,7 +979,9 @@ describe("WorkspaceService.createWorktree", () => {
   });
 
   it("creates the parent directory when it does not exist", async () => {
-    const expectedWorktreePath = path.resolve("/missing/parent/worktree");
+    // Nested under the repo's parent boundary (/test) so the containment gate
+    // passes; the parent (/test/sub) is the not-yet-existing dir under test.
+    const expectedWorktreePath = path.resolve("/test/sub/worktree");
     const fsModule = await import("fs");
     const fsPromisesModule = await import("fs/promises");
     vi.mocked(fsModule.existsSync).mockReturnValueOnce(false);
@@ -978,7 +989,7 @@ describe("WorkspaceService.createWorktree", () => {
     await service.createWorktree("req-no-parent", "/test/root", {
       baseBranch: "main",
       newBranch: "feature/foo",
-      path: "/missing/parent/worktree",
+      path: "/test/sub/worktree",
     });
 
     expect(fsPromisesModule.mkdir).toHaveBeenCalledWith(path.dirname(expectedWorktreePath), {
@@ -991,7 +1002,7 @@ describe("WorkspaceService.createWorktree", () => {
       "feature/foo",
       "--no-track",
       "--end-of-options",
-      "/missing/parent/worktree",
+      "/test/sub/worktree",
       "main",
     ]);
     expect(mockSendEvent).toHaveBeenCalledWith(
@@ -1102,6 +1113,94 @@ describe("WorkspaceService.createWorktree", () => {
         requestId: "req-normalized-absolute",
         success: true,
         worktreeId: expectedPath,
+      })
+    );
+  });
+
+  it("rejects an absolute path outside the repository's parent directory (#9154)", async () => {
+    await service.createWorktree("req-escape-abs", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/escape",
+      path: "/etc/cron.d/evil",
+    });
+
+    expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-escape-abs",
+        success: false,
+        error: expect.stringContaining("parent directory"),
+      })
+    );
+  });
+
+  it("rejects a relative path that traverses outside the parent directory (#9154)", async () => {
+    // /test/root + ../../escape resolves to /escape, above the /test boundary.
+    await service.createWorktree("req-escape-rel", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/escape-rel",
+      path: "../../escape",
+    });
+
+    expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-escape-rel",
+        success: false,
+        error: expect.stringContaining("parent directory"),
+      })
+    );
+  });
+
+  it("rejects a symlinked ancestor that escapes the parent directory (#9154)", async () => {
+    // /test/evil is a symlink to /outside; the not-yet-created worktree dir
+    // /test/evil/wt therefore really lives at /outside/wt, outside the /test
+    // boundary. canonicalizeNearestExisting must resolve the symlink.
+    const fsPromisesModule = await import("fs/promises");
+    vi.mocked(fsPromisesModule.realpath).mockImplementation((p: any) => {
+      const s = String(p);
+      if (s === path.resolve("/test/evil/wt")) {
+        return Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+      }
+      if (s === path.resolve("/test/evil")) {
+        return Promise.resolve(path.resolve("/outside"));
+      }
+      return Promise.resolve(s);
+    });
+
+    await service.createWorktree("req-escape-symlink", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/escape-symlink",
+      path: "/test/evil/wt",
+    });
+
+    expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-escape-symlink",
+        success: false,
+        error: expect.stringContaining("parent directory"),
+      })
+    );
+  });
+
+  it("allows the default sibling worktree path under the parent directory (#9154)", async () => {
+    // Mirrors DEFAULT_WORKTREE_PATH_PATTERN: {parent-dir}/{base-folder}-worktrees/...
+    await service.createWorktree("req-sibling-ok", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/ok",
+      path: "/test/root-worktrees/feature-ok",
+    });
+
+    expect(mockSimpleGit.raw).toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-sibling-ok",
+        success: true,
       })
     );
   });

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -1187,6 +1187,54 @@ describe("WorkspaceService.createWorktree", () => {
     );
   });
 
+  it("rejects a path equal to the parent-directory boundary itself (#9154)", async () => {
+    // path "/test" == dirname("/test/root"); rel === "" must be rejected.
+    await service.createWorktree("req-boundary-eq", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/boundary",
+      path: "/test",
+    });
+
+    expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-boundary-eq",
+        success: false,
+        error: expect.stringContaining("parent directory"),
+      })
+    );
+  });
+
+  it("propagates a non-ENOENT realpath error instead of degrading containment (#9154)", async () => {
+    // EACCES on an existing-but-unreadable segment must fail closed, not be
+    // treated as a not-yet-created directory.
+    const fsPromisesModule = await import("fs/promises");
+    vi.mocked(fsPromisesModule.realpath).mockImplementation((p: any) => {
+      const s = String(p);
+      if (s === path.resolve("/test/locked/wt")) {
+        return Promise.reject(Object.assign(new Error("EACCES"), { code: "EACCES" }));
+      }
+      return Promise.resolve(s);
+    });
+
+    await service.createWorktree("req-eacces", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/eacces",
+      path: "/test/locked/wt",
+    });
+
+    expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-eacces",
+        success: false,
+        error: expect.stringContaining("EACCES"),
+      })
+    );
+  });
+
   it("allows the default sibling worktree path under the parent directory (#9154)", async () => {
     // Mirrors DEFAULT_WORKTREE_PATH_PATTERN: {parent-dir}/{base-folder}-worktrees/...
     await service.createWorktree("req-sibling-ok", "/test/root", {

--- a/electron/workspace-host/worktreeUtils.ts
+++ b/electron/workspace-host/worktreeUtils.ts
@@ -151,7 +151,15 @@ export async function canonicalizeNearestExisting(target: string): Promise<strin
     try {
       const real = await realpath(current);
       return tail.length ? pathResolve(real, ...tail) : real;
-    } catch {
+    } catch (error) {
+      // Only "does not exist" justifies walking up. A real failure (EACCES on
+      // an existing-but-unreadable segment, EIO, ELOOP) must not be silently
+      // downgraded to lexical reasoning — that would let an inaccessible
+      // symlink escape containment. Re-throw anything other than absent paths.
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") {
+        throw error;
+      }
       const parent = dirname(current);
       if (parent === current) {
         return pathResolve(target);
@@ -175,7 +183,15 @@ export async function assertWorktreePathContained(
   rootPath: string,
   absoluteCreatePath: string
 ): Promise<void> {
-  const boundary = await realpath(dirname(pathResolve(rootPath)));
+  const resolvedRoot = pathResolve(rootPath);
+  const parentDir = dirname(resolvedRoot);
+  // A repo at the filesystem root would make the parent boundary the root
+  // itself, which would accept any path on the system. Reject rather than
+  // degrade to an open boundary.
+  if (parentDir === resolvedRoot) {
+    throw new Error("Cannot create a worktree for a repository at the filesystem root");
+  }
+  const boundary = await realpath(parentDir);
   const target = await canonicalizeNearestExisting(absoluteCreatePath);
   const rel = pathRelative(boundary, target);
   // Reject the boundary itself (rel === ""), escapes ("../…"), and absolute

--- a/electron/workspace-host/worktreeUtils.ts
+++ b/electron/workspace-host/worktreeUtils.ts
@@ -1,6 +1,14 @@
 import { execFile } from "child_process";
-import { mkdir, writeFile, stat } from "fs/promises";
-import { join as pathJoin, dirname } from "path";
+import { mkdir, writeFile, stat, realpath } from "fs/promises";
+import {
+  join as pathJoin,
+  dirname,
+  basename,
+  resolve as pathResolve,
+  relative as pathRelative,
+  isAbsolute as pathIsAbsolute,
+  sep,
+} from "path";
 import { getGitDir } from "../utils/gitUtils.js";
 import { getGitLocaleEnv } from "../utils/hardenedGit.js";
 import { isGitHubRemoteUrl } from "../../shared/utils/githubUrl.js";
@@ -123,5 +131,57 @@ export async function ensureNoteFile(worktreePath: string): Promise<void> {
         console.warn("[WorkspaceHost] Failed to create note file:", notePath);
       }
     }
+  }
+}
+
+/**
+ * Canonicalize the nearest existing ancestor of `target` through `realpath`,
+ * then re-append the not-yet-created tail segments. A worktree directory does
+ * not exist when its path is validated, so `realpath(target)` would throw
+ * ENOENT; walking up to the first existing ancestor still canonicalizes any
+ * symlink in the existing portion of the path (e.g. a parent symlinked outside
+ * the workspace) without requiring the leaf to exist. Falls back to the
+ * lexically resolved path if no ancestor exists.
+ */
+export async function canonicalizeNearestExisting(target: string): Promise<string> {
+  let current = pathResolve(target);
+  const tail: string[] = [];
+  // Bounded by path depth; dirname() reaches a fixed point at the fs root.
+  for (;;) {
+    try {
+      const real = await realpath(current);
+      return tail.length ? pathResolve(real, ...tail) : real;
+    } catch {
+      const parent = dirname(current);
+      if (parent === current) {
+        return pathResolve(target);
+      }
+      tail.unshift(basename(current));
+      current = parent;
+    }
+  }
+}
+
+/**
+ * Enforce that a worktree create target stays within the repository's parent
+ * directory. That parent is the outermost location the worktree path patterns
+ * can produce — the default `{parent-dir}/{base-folder}-worktrees/{branch-slug}`
+ * places the worktree as a sibling of the repo, and `validatePathPattern`
+ * rejects absolute patterns that don't start with `{parent-dir}`. Containing to
+ * the parent (rather than rootPath itself) preserves that model while rejecting
+ * arbitrary writable locations and symlink escapes. Throws on violation. #9154.
+ */
+export async function assertWorktreePathContained(
+  rootPath: string,
+  absoluteCreatePath: string
+): Promise<void> {
+  const boundary = await realpath(dirname(pathResolve(rootPath)));
+  const target = await canonicalizeNearestExisting(absoluteCreatePath);
+  const rel = pathRelative(boundary, target);
+  // Reject the boundary itself (rel === ""), escapes ("../…"), and absolute
+  // results (different drive on Windows). A plain "startsWith('..')" would
+  // misfire on a legitimate sibling like "..foo"; gate on the separator. #4702.
+  if (rel === "" || rel === ".." || rel.startsWith(".." + sep) || pathIsAbsolute(rel)) {
+    throw new Error("Worktree path must be within the repository's parent directory");
   }
 }

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1034,7 +1034,25 @@ export interface GeneratedIpcInvokeMap {
     result: void;
   };
   "worktree:create": {
-    args: [payload: { rootPath: string; options: import("../git.js").CreateWorktreeOptions }];
+    args: [
+      payload: {
+        rootPath: string;
+        options: {
+          baseBranch: string;
+          newBranch: string;
+          path: string;
+          fromRemote?: boolean | undefined;
+          useExistingBranch?: boolean | undefined;
+          provisionResource?: boolean | undefined;
+          worktreeMode?: string | undefined;
+          sourcePrNumber?: number | undefined;
+          sourcePrTitle?: string | undefined;
+          sourcePrUrl?: string | undefined;
+          sourcePrState?: "merged" | "open" | "closed" | undefined;
+          sourcePrLinkedIssueNumber?: number | undefined;
+        };
+      },
+    ];
     result: string;
   };
   "worktree:delete": {
@@ -1098,7 +1116,7 @@ export interface GeneratedIpcInvokeMap {
     result: void;
   };
   "worktree:set-active": {
-    args: [payload: import("./worktree.js").WorktreeSetActivePayload];
+    args: [payload: { worktreeId: string }];
     result: void;
   };
 }


### PR DESCRIPTION
## Summary

- Wires `WorktreeCreatePayloadSchema` and `WorktreeSetActivePayloadSchema` into the worktree lifecycle IPC handlers via `opValidated()`, replacing the existing `typeof` guards with proper Zod validation.
- Hardens `WorktreeCreatePayloadSchema`: null-byte rejection and length caps on `rootPath` and `options.path`; declares all `CreateWorktreeOptions` fields so optional fields aren't silently stripped.
- Adds `isAbsolute(rootPath)` semantic guard in `handleWorktreeCreate`, and a path-containment guard in `performCreateWorktree` (via `worktreeUtils`): the worktree target must stay within the repository's parent directory. Uses `realpath` to canonicalize the nearest existing ancestor to block symlink escapes; fails closed on non-ENOENT errors (e.g. `EACCES`); rejects a repo at the filesystem root.

The containment boundary is `dirname(rootPath)` rather than `rootPath` itself — a literal rootPath-descendant check would break the default sibling worktree placement (`{parent-dir}/{base-folder}-worktrees/{branch-slug}`).

Resolves #9154

## Changes

- `electron/ipc/handlers/worktree/lifecycle.ts` — wire `opValidated()` for create and set-active handlers; add `isAbsolute` guard
- `electron/schemas/ipc.ts` — harden `WorktreeCreatePayloadSchema` (null bytes, length caps, full `CreateWorktreeOptions` fields)
- `electron/workspace-host/worktreeUtils.ts` — add `assertWorktreePathContained()` with `realpath`-based symlink defence
- `electron/workspace-host/WorkspaceService.ts` — call `assertWorktreePathContained()` in `performCreateWorktree`
- `shared/types/ipc/generated.ts` — regenerated IPC type map
- `electron/ipc/handlers/worktree/__tests__/worktreePayloadValidation.test.ts` — new schema validation suite
- `electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts` — containment tests (absolute escape, relative traversal, symlinked ancestor, boundary-equal, EACCES, sibling allowed, optional-field round-trip)

## Testing

50 targeted tests pass covering schema validation and path containment. `npm run check` clean (typecheck + lint + format).