### PR TITLE
feat(git): show per-file churn in branch comparison views

### DIFF
--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -393,7 +393,15 @@ ${lines.map((l) => "+" + l).join("\n")}`;
           range,
         ]),
         this.git
-          .raw(["diff", "--no-ext-diff", "--no-renames", "--numstat", "--end-of-options", range])
+          .raw([
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-renames",
+            "--numstat",
+            "--end-of-options",
+            range,
+          ])
           .catch((error) => {
             logWarn(
               "Failed to read numstat for cross-worktree comparison; continuing without churn",

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -1,7 +1,7 @@
 // eager-import-allow: performs sync fs existence checks while resolving git paths
 import type { SimpleGit, BranchSummary } from "simple-git";
 import { resolve, dirname, normalize, sep, isAbsolute } from "path";
-import { existsSync } from "fs";
+import { existsSync, realpathSync } from "fs";
 import { readFile, stat } from "fs/promises";
 import { logDebug, logError, logWarn } from "../utils/logger.js";
 import type { GitStatus, WorktreeChanges } from "../../shared/types/index.js";
@@ -11,6 +11,8 @@ import type { CrossWorktreeDiffResult, CrossWorktreeFile } from "../../shared/ty
 import { createHardenedGit } from "../utils/hardenedGit.js";
 import { validateBranchName } from "../../shared/utils/pathPattern.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { parseNumstat } from "../utils/git.js";
+import type { DiffStat } from "../utils/git.js";
 
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -379,19 +381,53 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       }
     }
 
-    // Return the list of changed files
+    // Return the list of changed files with per-file churn (--numstat)
     try {
-      const output = await this.git.raw([
-        "diff",
-        "--no-ext-diff",
-        "--no-textconv",
-        "--name-status",
-        "--end-of-options",
-        range,
+      const [nameStatusOutput, numstatOutput, toplevel] = await Promise.all([
+        this.git.raw([
+          "diff",
+          "--no-ext-diff",
+          "--no-textconv",
+          "--name-status",
+          "--end-of-options",
+          range,
+        ]),
+        this.git
+          .raw(["diff", "--no-ext-diff", "--no-renames", "--numstat", "--end-of-options", range])
+          .catch((error) => {
+            logWarn(
+              "Failed to read numstat for cross-worktree comparison; continuing without churn",
+              {
+                branch1,
+                branch2,
+                message: (error as Error).message,
+              }
+            );
+            return "";
+          }),
+        this.git.revparse(["--show-toplevel"]),
       ]);
+
+      const gitRoot = realpathSync(toplevel.trim()).replace(/\\/g, "/");
+      const rootPrefix = gitRoot.endsWith("/") ? gitRoot : `${gitRoot}/`;
+
+      // Build relative-path-keyed numstat map from the numstat output
+      let numstatByRelPath = new Map<string, DiffStat>();
+      if (numstatOutput) {
+        const numstatByAbsPath = parseNumstat(numstatOutput, gitRoot);
+        numstatByRelPath = new Map<string, DiffStat>();
+        for (const [absPath, stats] of numstatByAbsPath) {
+          const normalized = absPath.replace(/\\/g, "/");
+          const relative = normalized.startsWith(rootPrefix)
+            ? normalized.slice(rootPrefix.length)
+            : normalized;
+          numstatByRelPath.set(relative, stats);
+        }
+      }
+
       const files: CrossWorktreeFile[] = [];
 
-      for (const line of output.split("\n")) {
+      for (const line of nameStatusOutput.split("\n")) {
         const trimmed = line.trim();
         if (!trimmed) continue;
 
@@ -402,14 +438,25 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         const status = statusRaw[0] as CrossWorktreeFile["status"];
 
         if (status === "R" || status === "C") {
-          // Renamed/copied: parts[1] = old path, parts[2] = new path
+          const newPath = parts[2] ?? parts[1];
+          const oldPath = parts[1];
+          const insStats = numstatByRelPath.get(newPath);
+          const delStats = numstatByRelPath.get(oldPath);
           files.push({
             status,
-            path: parts[2] ?? parts[1],
-            oldPath: parts[1],
+            path: newPath,
+            oldPath,
+            insertions: insStats?.insertions ?? null,
+            deletions: delStats?.deletions ?? null,
           });
         } else {
-          files.push({ status, path: parts[1] });
+          const stats = numstatByRelPath.get(parts[1]);
+          files.push({
+            status,
+            path: parts[1],
+            insertions: stats?.insertions ?? null,
+            deletions: stats?.deletions ?? null,
+          });
         }
       }
 

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -271,8 +271,8 @@ describe("GitService", () => {
       expect(typeof result).toBe("object");
       if (typeof result === "object") {
         expect(result.files).toHaveLength(2);
-        expect(result.files[0]).toEqual({ status: "M", path: "src/app.ts" });
-        expect(result.files[1]).toEqual({ status: "A", path: "src/new.ts" });
+        expect(result.files[0]).toMatchObject({ status: "M", path: "src/app.ts" });
+        expect(result.files[1]).toMatchObject({ status: "A", path: "src/new.ts" });
       }
     });
 
@@ -285,7 +285,7 @@ describe("GitService", () => {
       expect(typeof result).toBe("object");
       if (typeof result === "object") {
         expect(result.files).toHaveLength(1);
-        expect(result.files[0]).toEqual({ status: "M", path: "src/app.ts" });
+        expect(result.files[0]).toMatchObject({ status: "M", path: "src/app.ts" });
       }
     });
 

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -23,7 +23,7 @@ export function invalidateWorktreeCache(cwd: string): void {
 
 export { invalidateWorktreeCache as invalidateGitStatusCache };
 
-interface DiffStat {
+export interface DiffStat {
   insertions: number | null;
   deletions: number | null;
 }
@@ -160,7 +160,7 @@ function normalizeNumstatPath(rawPath: string): string {
   return rawPath.trim();
 }
 
-function parseNumstat(diffOutput: string, gitRoot: string): Map<string, DiffStat> {
+export function parseNumstat(diffOutput: string, gitRoot: string): Map<string, DiffStat> {
   const stats = new Map<string, DiffStat>();
   const lines = diffOutput.split("\n");
 

--- a/shared/types/ipc/git.ts
+++ b/shared/types/ipc/git.ts
@@ -33,6 +33,10 @@ export interface CrossWorktreeFile {
   oldPath?: string;
   /** Change status: A=added, D=deleted, M=modified, R=renamed, C=copied, U=unmerged */
   status: "A" | "D" | "M" | "R" | "C" | "U" | string;
+  /** Lines inserted (null for binary files or when numstat is unavailable) */
+  insertions: number | null;
+  /** Lines deleted (null for binary files or when numstat is unavailable) */
+  deletions: number | null;
 }
 
 /** Result of comparing two branches */

--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -44,6 +44,9 @@ interface CrossWorktreeFileRowProps {
 function CrossWorktreeFileRow({ file, isSelected, onClick }: CrossWorktreeFileRowProps) {
   const { ref, isTruncated } = useTruncationDetection();
   const { label, className: statusClass } = statusLabel(file.status);
+  const insertions = file.insertions ?? 0;
+  const deletions = file.deletions ?? 0;
+  const hasChurn = insertions > 0 || deletions > 0;
 
   return (
     <TruncatedTooltip content={file.path} isTruncated={isTruncated}>
@@ -52,7 +55,7 @@ function CrossWorktreeFileRow({ file, isSelected, onClick }: CrossWorktreeFileRo
         onClick={onClick}
         className={cn(
           "w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-surface-panel-elevated transition-colors",
-          isSelected && "bg-surface-panel-elevated"
+          isSelected && "bg-overlay-subtle"
         )}
       >
         <span className={cn("font-mono font-bold shrink-0 w-3 text-center", statusClass)}>
@@ -62,8 +65,37 @@ function CrossWorktreeFileRow({ file, isSelected, onClick }: CrossWorktreeFileRo
         <span ref={ref} className="text-text-secondary truncate min-w-0">
           {file.path.split(/[/\\]/).filter(Boolean).pop()}
         </span>
+        {hasChurn && (
+          <span className="ml-auto flex items-center gap-1 shrink-0 text-[10px] tabular-nums">
+            {insertions > 0 && <span className="text-status-success/80">+{insertions}</span>}
+            {deletions > 0 && <span className="text-status-error/80">-{deletions}</span>}
+          </span>
+        )}
       </button>
     </TruncatedTooltip>
+  );
+}
+
+function AggregateChurn({ files }: { files: CrossWorktreeFile[] }) {
+  const { totalInsertions, totalDeletions } = files.reduce(
+    (acc, f) => ({
+      totalInsertions: acc.totalInsertions + (f.insertions ?? 0),
+      totalDeletions: acc.totalDeletions + (f.deletions ?? 0),
+    }),
+    { totalInsertions: 0, totalDeletions: 0 }
+  );
+
+  return (
+    <>
+      {files.length} file{files.length !== 1 ? "s" : ""}
+      {(totalInsertions > 0 || totalDeletions > 0) && (
+        <>
+          {" "}
+          <span className="text-status-success/80">+{totalInsertions}</span>{" "}
+          <span className="text-status-error/80">-{totalDeletions}</span>
+        </>
+      )}
+    </>
   );
 }
 
@@ -227,9 +259,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
         {/* File list sidebar */}
         <div className="w-64 shrink-0 border-r border-border-subtle flex flex-col overflow-hidden">
           <div className="px-3 py-2 text-xs text-text-muted border-b border-border-subtle shrink-0">
-            {result
-              ? `${result.files.length} file${result.files.length === 1 ? "" : "s"} changed`
-              : "Files"}
+            {result ? <AggregateChurn files={result.files} /> : "Files"}
           </div>
           <div className="flex-1 overflow-y-auto">
             {loading && (
@@ -250,11 +280,19 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
               </div>
             )}
             {!loading && !error && !result && (
-              <div className="p-4 text-text-muted text-xs">Select two worktrees to compare</div>
+              <div className="flex flex-col items-center justify-center py-12 text-text-muted">
+                <p className="text-sm">Select two worktrees to compare</p>
+                <p className="text-xs mt-1">
+                  Pick branches from the selectors above to view changes
+                </p>
+              </div>
             )}
             {result?.files.length === 0 && (
-              <div className="p-4 text-text-muted text-xs">
-                No differences between these branches
+              <div className="flex flex-col items-center justify-center py-12 text-text-muted">
+                <p className="text-sm">No differences between these branches</p>
+                <p className="text-xs mt-1">
+                  Select different branches or verify both branches have diverged
+                </p>
               </div>
             )}
             {result?.files.map((file) => (

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -131,6 +131,9 @@ function BaseBranchFileRow({
   const lastSlash = normalized.lastIndexOf("/");
   const dir = lastSlash === -1 ? "" : normalized.slice(0, lastSlash);
   const base = lastSlash === -1 ? normalized : normalized.slice(lastSlash + 1);
+  const insertions = file.insertions ?? 0;
+  const deletions = file.deletions ?? 0;
+  const hasChurn = insertions > 0 || deletions > 0;
 
   return (
     <TruncatedTooltip content={file.path}>
@@ -180,6 +183,15 @@ function BaseBranchFileRow({
             {base}
           </span>
         </button>
+        {hasChurn && (
+          <div
+            data-testid="base-branch-file-row-churn"
+            className="ml-2 flex items-center gap-1 shrink-0 text-[10px] tabular-nums"
+          >
+            {insertions > 0 && <span className="text-status-success/80">+{insertions}</span>}
+            {deletions > 0 && <span className="text-status-error/80">-{deletions}</span>}
+          </div>
+        )}
         {unresolvedCount !== undefined && unresolvedCount > 0 && (
           <button
             type="button"
@@ -371,6 +383,18 @@ export function ReviewHubContent({
           )
         : null,
     [baseBranchFiles]
+  );
+
+  const baseBranchChurn = useMemo(
+    () =>
+      sortedBaseBranchFiles?.reduce(
+        (acc, f) => ({
+          ins: acc.ins + (f.insertions ?? 0),
+          del: acc.del + (f.deletions ?? 0),
+        }),
+        { ins: 0, del: 0 }
+      ) ?? { ins: 0, del: 0 },
+    [sortedBaseBranchFiles]
   );
 
   const mainBranch = useWorktreeStore(
@@ -1558,6 +1582,15 @@ export function ReviewHubContent({
                     <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
                       {sortedBaseBranchFiles.length} file
                       {sortedBaseBranchFiles.length !== 1 ? "s" : ""}
+                      {(baseBranchChurn.ins > 0 || baseBranchChurn.del > 0) && (
+                        <>
+                          {" "}
+                          <span className="text-status-success/80">
+                            +{baseBranchChurn.ins}
+                          </span>{" "}
+                          <span className="text-status-error/80">-{baseBranchChurn.del}</span>
+                        </>
+                      )}
                     </span>
                   </span>
                 </div>


### PR DESCRIPTION
## Summary

Both branch comparison views now show per-file insertions and deletions counts, so you can gauge the scale of a change without opening each file. Before this, those views only showed a status letter and filename - you would see that `foo.ts` was modified but not whether it was a two-line tweak or a thousand-line rewrite.

## Changes

- `CrossWorktreeFile` gained `insertions` and `deletions` fields, fed by `git diff --numstat` through the existing `compareWorktrees` IPC handler
- Both the Compare Worktrees modal and the Review Hub base-branch diff now show per-file `+N -N` counts alongside each row
- An aggregate header bar sums the file count and total lines added/removed across the whole comparison
- The Compare Worktrees modal also got a small UX fix: the selected file row no longer shares the same background as hovered rows, so you can tell which file is open in the diff panel

Resolves #9226

## Testing

- Per-file counts render correctly for added, modified, renamed, and deleted files
- The aggregate header matches the sum of per-file counts
- Binary files and zero-change files correctly show no insertions/deletions
- Selected row styling is visually distinct from hover in the Compare Worktrees modal