### PR TITLE
fix(theme): consolidate CVD override maps and add syntax token coverage

### DIFF
--- a/src/components/Settings/ColorVisionPicker.tsx
+++ b/src/components/Settings/ColorVisionPicker.tsx
@@ -29,7 +29,11 @@ const SWATCH_TOKENS = [
   { label: "Success", var: "--theme-status-success" },
   { label: "Danger", var: "--theme-status-danger" },
   { label: "Warning", var: "--theme-status-warning" },
+  { label: "Info", var: "--theme-status-info" },
   { label: "Active", var: "--theme-activity-active" },
+  { label: "Keyword", var: "--theme-syntax-keyword" },
+  { label: "String", var: "--theme-syntax-string" },
+  { label: "Comment", var: "--theme-syntax-comment" },
 ];
 
 function SwatchPreview() {

--- a/src/index.css
+++ b/src/index.css
@@ -801,34 +801,6 @@ code.hljs {
     display: none;
   }
 
-  /* Color vision deficiency overrides — Red-Green (Deuteranopia / Protanopia) */
-  html[data-colorblind="red-green"] {
-    --theme-status-success: #009e73;
-    --theme-status-danger: #fe6100;
-    --theme-activity-active: #648fff;
-    --theme-activity-working: #648fff;
-    --theme-pr-open: #648fff;
-    --theme-pr-closed: #fe6100;
-    --theme-terminal-selection: #1a1f2e;
-    --theme-terminal-red: #d55e00;
-    --theme-terminal-green: #009e73;
-    --theme-terminal-bright-red: #fe6100;
-    --theme-terminal-bright-green: #48c9a0;
-    --theme-terminal-magenta: #cc79a7;
-    --theme-terminal-bright-magenta: #d98fc4;
-  }
-
-  /* Color vision deficiency overrides — Blue-Yellow (Tritanopia) */
-  html[data-colorblind="blue-yellow"] {
-    --theme-status-warning: #94a3b8;
-    --theme-activity-waiting: #94a3b8;
-    --theme-pr-merged: #f97316;
-    --theme-terminal-yellow: #cc79a7;
-    --theme-terminal-blue: #0072b2;
-    --theme-terminal-bright-yellow: #d98fc4;
-    --theme-terminal-bright-blue: #56b4e9;
-  }
-
   /* Xterm font - required for correct font measurement */
   .xterm {
     font-family: var(--font-mono);

--- a/src/theme/__tests__/applyAppTheme.test.ts
+++ b/src/theme/__tests__/applyAppTheme.test.ts
@@ -2,7 +2,12 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { APP_THEME_TOKEN_KEYS, getAppThemeById, type AppColorScheme } from "@shared/theme";
-import { applyAppThemeToRoot, applyColorVisionMode, applyDefaultAppTheme } from "../applyAppTheme";
+import {
+  ALL_CVD_TOKENS,
+  applyAppThemeToRoot,
+  applyColorVisionMode,
+  applyDefaultAppTheme,
+} from "../applyAppTheme";
 
 function createTestScheme(
   id: string,
@@ -164,6 +169,76 @@ describe("applyColorVisionMode", () => {
     expect(root.style.getPropertyValue("--theme-category-blue")).toBe("#dc267f");
     expect(root.style.getPropertyValue("--theme-category-teal")).toBe("#009e73");
     expect(root.dataset.colorblind).toBe("blue-yellow");
+  });
+
+  it("applies all 10 syntax tokens in red-green mode", () => {
+    const root = document.createElement("div");
+    applyColorVisionMode(root, "red-green");
+
+    expect(root.style.getPropertyValue("--theme-syntax-comment")).toBe("#999999");
+    expect(root.style.getPropertyValue("--theme-syntax-punctuation")).toBe("#555555");
+    expect(root.style.getPropertyValue("--theme-syntax-number")).toBe("#0072B2");
+    expect(root.style.getPropertyValue("--theme-syntax-string")).toBe("#E69F00");
+    expect(root.style.getPropertyValue("--theme-syntax-operator")).toBe("#555555");
+    expect(root.style.getPropertyValue("--theme-syntax-keyword")).toBe("#D55E00");
+    expect(root.style.getPropertyValue("--theme-syntax-function")).toBe("#0072B2");
+    expect(root.style.getPropertyValue("--theme-syntax-link")).toBe("#0072B2");
+    expect(root.style.getPropertyValue("--theme-syntax-quote")).toBe("#009E73");
+    expect(root.style.getPropertyValue("--theme-syntax-chip")).toBe("#CC79A7");
+  });
+
+  it("applies all 10 syntax tokens and status-info in blue-yellow mode", () => {
+    const root = document.createElement("div");
+    applyColorVisionMode(root, "blue-yellow");
+
+    expect(root.style.getPropertyValue("--theme-status-info")).toBe("#333333");
+    expect(root.style.getPropertyValue("--theme-syntax-comment")).toBe("#999999");
+    expect(root.style.getPropertyValue("--theme-syntax-punctuation")).toBe("#555555");
+    expect(root.style.getPropertyValue("--theme-syntax-number")).toBe("#CC79A7");
+    expect(root.style.getPropertyValue("--theme-syntax-string")).toBe("#E69F00");
+    expect(root.style.getPropertyValue("--theme-syntax-operator")).toBe("#555555");
+    expect(root.style.getPropertyValue("--theme-syntax-keyword")).toBe("#D55E00");
+    expect(root.style.getPropertyValue("--theme-syntax-function")).toBe("#56B4E9");
+    expect(root.style.getPropertyValue("--theme-syntax-link")).toBe("#0072B2");
+    expect(root.style.getPropertyValue("--theme-syntax-quote")).toBe("#F0E442");
+    expect(root.style.getPropertyValue("--theme-syntax-chip")).toBe("#009E73");
+  });
+
+  it("does not set status-info in red-green mode", () => {
+    const root = document.createElement("div");
+    applyColorVisionMode(root, "red-green");
+
+    expect(root.style.getPropertyValue("--theme-status-info")).toBe("");
+  });
+
+  it("ALL_CVD_TOKENS covers the expected token count", () => {
+    // Canary: if someone adds or removes tokens from either map,
+    // this size changes and the test catches it for review.
+    // 31 red-green + 26 blue-yellow = 57 total, 39 unique after dedup
+    expect(ALL_CVD_TOKENS.size).toBe(39);
+  });
+
+  it("switches from blue-yellow to red-green clearing blue-yellow-only tokens", () => {
+    const root = document.createElement("div");
+    applyColorVisionMode(root, "blue-yellow");
+    applyColorVisionMode(root, "red-green");
+
+    expect(root.style.getPropertyValue("--theme-status-info")).toBe("");
+    expect(root.style.getPropertyValue("--theme-syntax-number")).toBe("#0072B2");
+    expect(root.style.getPropertyValue("--theme-syntax-quote")).toBe("#009E73");
+    expect(root.dataset.colorblind).toBe("red-green");
+  });
+
+  it("switches from red-green to default clearing syntax tokens", () => {
+    const root = document.createElement("div");
+    applyColorVisionMode(root, "red-green");
+    applyColorVisionMode(root, "default");
+
+    expect(root.style.getPropertyValue("--theme-syntax-comment")).toBe("");
+    expect(root.style.getPropertyValue("--theme-syntax-keyword")).toBe("");
+    expect(root.style.getPropertyValue("--theme-syntax-string")).toBe("");
+    expect(root.style.getPropertyValue("--theme-category-blue")).toBe("");
+    expect(root.dataset.colorblind).toBeUndefined();
   });
 });
 

--- a/src/theme/applyAppTheme.ts
+++ b/src/theme/applyAppTheme.ts
@@ -20,6 +20,16 @@ const RED_GREEN_OVERRIDES: Record<string, string> = {
   "--theme-terminal-bright-green": "#48c9a0",
   "--theme-terminal-magenta": "#cc79a7",
   "--theme-terminal-bright-magenta": "#d98fc4",
+  "--theme-syntax-comment": "#999999",
+  "--theme-syntax-punctuation": "#555555",
+  "--theme-syntax-number": "#0072B2",
+  "--theme-syntax-string": "#E69F00",
+  "--theme-syntax-operator": "#555555",
+  "--theme-syntax-keyword": "#D55E00",
+  "--theme-syntax-function": "#0072B2",
+  "--theme-syntax-link": "#0072B2",
+  "--theme-syntax-quote": "#009E73",
+  "--theme-syntax-chip": "#CC79A7",
   "--theme-category-blue": "#0072b2",
   "--theme-category-orange": "#e69f00",
   "--theme-category-teal": "#009e73",
@@ -38,6 +48,17 @@ const BLUE_YELLOW_OVERRIDES: Record<string, string> = {
   "--theme-terminal-blue": "#0072b2",
   "--theme-terminal-bright-yellow": "#d98fc4",
   "--theme-terminal-bright-blue": "#56b4e9",
+  "--theme-status-info": "#333333",
+  "--theme-syntax-comment": "#999999",
+  "--theme-syntax-punctuation": "#555555",
+  "--theme-syntax-number": "#CC79A7",
+  "--theme-syntax-string": "#E69F00",
+  "--theme-syntax-operator": "#555555",
+  "--theme-syntax-keyword": "#D55E00",
+  "--theme-syntax-function": "#56B4E9",
+  "--theme-syntax-link": "#0072B2",
+  "--theme-syntax-quote": "#F0E442",
+  "--theme-syntax-chip": "#009E73",
   "--theme-category-blue": "#dc267f",
   "--theme-category-orange": "#fe6100",
   "--theme-category-teal": "#009e73",
@@ -48,7 +69,7 @@ const BLUE_YELLOW_OVERRIDES: Record<string, string> = {
   "--theme-category-cyan": "#228833",
 };
 
-const ALL_CVD_TOKENS = new Set([
+export const ALL_CVD_TOKENS = new Set([
   ...Object.keys(RED_GREEN_OVERRIDES),
   ...Object.keys(BLUE_YELLOW_OVERRIDES),
 ]);


### PR DESCRIPTION
## Summary
- Removed dead `html[data-colorblind]` CSS block in `index.css` — it was outranked by inline styles and had already drifted out of sync.
- Added 10 `syntax-*` tokens to both the red-green and blue-yellow CVD override maps, plus a `status-info` token to the blue-yellow map.
- Extended the `ColorVisionPicker` swatch preview from 4 to 8 tokens so the new coverage is visible in settings.

## Changes
- `src/theme/applyAppTheme.ts` — Added `syntax-*` tokens to both maps, `status-info` to blue-yellow, exported `ALL_CVD_TOKENS`
- `src/index.css` — Removed the dead `html[data-colorblind]` CSS block
- `src/components/Settings/ColorVisionPicker.tsx` — Extended `SWATCH_TOKENS` from 4 to 8
- `src/theme/__tests__/applyAppTheme.test.ts` — 6 new tests bringing total to 17

Resolves #9221

## Testing
- All 17 vitest tests pass
- `tsc --noEmit` clean
- ESLint and Prettier pass (no new warnings)