### PR TITLE
feat(dev-server): add stop and restart to worktree context menu

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -460,6 +460,8 @@ export const CHANNELS = {
   DEV_PREVIEW_GET_DESTRUCTIVE_PREVIEW_META: "dev-preview:get-destructive-preview-meta",
   DEV_PREVIEW_GET_DESTRUCTIVE_PREVIEW_SIZES: "dev-preview:get-destructive-preview-sizes",
   DEV_PREVIEW_STOP_BY_WORKTREE: "dev-preview:stop-by-worktree",
+  DEV_PREVIEW_RESTART_BY_WORKTREE: "dev-preview:restart-by-worktree",
+  DEV_PREVIEW_STOP_DEV_SERVER_BY_WORKTREE: "dev-preview:stop-dev-server-by-worktree",
   DEV_PREVIEW_STATE_CHANGED: "dev-preview:state-changed",
 
   COMMANDS_LIST: "commands:list",

--- a/electron/ipc/handlers/devPreview.preload.ts
+++ b/electron/ipc/handlers/devPreview.preload.ts
@@ -12,6 +12,8 @@ export const DEV_PREVIEW_METHOD_CHANNELS = {
   getDestructivePreviewMeta: "dev-preview:get-destructive-preview-meta",
   getDestructivePreviewSizes: "dev-preview:get-destructive-preview-sizes",
   stopByWorktree: "dev-preview:stop-by-worktree",
+  restartByWorktree: "dev-preview:restart-by-worktree",
+  stopDevServerByWorktree: "dev-preview:stop-dev-server-by-worktree",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof DEV_PREVIEW_METHOD_CHANNELS;

--- a/electron/ipc/handlers/devPreview.ts
+++ b/electron/ipc/handlers/devPreview.ts
@@ -16,6 +16,8 @@ import type {
   DevPreviewGetByWorktreeRequest,
   DevPreviewDestructivePreviewSizesRequest,
   DevPreviewStopByWorktreeRequest,
+  DevPreviewRestartByWorktreeRequest,
+  DevPreviewStopDevServerByWorktreeRequest,
 } from "../../../shared/types/ipc/devPreview.js";
 import type { DevPreviewSessionService as DevPreviewSessionServiceType } from "../../services/DevPreviewSessionService.js";
 import { getHibernationService } from "../../services/HibernationService.js";
@@ -144,6 +146,26 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
           // the service just to no-op.
           if (!sessionService) return;
           await sessionService.stopByWorktree(request.worktreeId);
+        }
+      ),
+      restartByWorktree: op(
+        DEV_PREVIEW_METHOD_CHANNELS.restartByWorktree,
+        async (request: DevPreviewRestartByWorktreeRequest) => {
+          if (!request || typeof request.worktreeId !== "string" || !request.worktreeId.trim()) {
+            throw new Error("worktreeId is required");
+          }
+          const svc = await getSessionService();
+          return svc.restartByWorktree(request.worktreeId);
+        }
+      ),
+      stopDevServerByWorktree: op(
+        DEV_PREVIEW_METHOD_CHANNELS.stopDevServerByWorktree,
+        async (request: DevPreviewStopDevServerByWorktreeRequest) => {
+          if (!request || typeof request.worktreeId !== "string" || !request.worktreeId.trim()) {
+            throw new Error("worktreeId is required");
+          }
+          const svc = await getSessionService();
+          return svc.stopDevServerByWorktree(request.worktreeId);
         }
       ),
     },

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -685,6 +685,86 @@ export class DevPreviewSessionService {
     this.persistManifest();
   }
 
+  async stopDevServerByWorktree(worktreeId: string): Promise<DevPreviewSessionState> {
+    const key = this.worktreeToSession.get(worktreeId);
+    if (!key) {
+      return {
+        panelId: "",
+        projectId: "",
+        worktreeId: undefined,
+        status: "stopped",
+        url: null,
+        predictedUrl: null,
+        error: null,
+        terminalId: null,
+        isRestarting: false,
+        generation: 0,
+        updatedAt: Date.now(),
+        forceKilled: undefined,
+        phaseLabel: undefined,
+      };
+    }
+    const session = this.sessions.get(key);
+    if (!session) {
+      return {
+        panelId: "",
+        projectId: "",
+        worktreeId: undefined,
+        status: "stopped",
+        url: null,
+        predictedUrl: null,
+        error: null,
+        terminalId: null,
+        isRestarting: false,
+        generation: 0,
+        updatedAt: Date.now(),
+        forceKilled: undefined,
+        phaseLabel: undefined,
+      };
+    }
+    return this.stop({ panelId: session.panelId, projectId: session.projectId });
+  }
+
+  async restartByWorktree(worktreeId: string): Promise<DevPreviewSessionState> {
+    const key = this.worktreeToSession.get(worktreeId);
+    if (!key) {
+      return {
+        panelId: "",
+        projectId: "",
+        worktreeId: undefined,
+        status: "stopped",
+        url: null,
+        predictedUrl: null,
+        error: null,
+        terminalId: null,
+        isRestarting: false,
+        generation: 0,
+        updatedAt: Date.now(),
+        forceKilled: undefined,
+        phaseLabel: undefined,
+      };
+    }
+    const session = this.sessions.get(key);
+    if (!session) {
+      return {
+        panelId: "",
+        projectId: "",
+        worktreeId: undefined,
+        status: "stopped",
+        url: null,
+        predictedUrl: null,
+        error: null,
+        terminalId: null,
+        isRestarting: false,
+        generation: 0,
+        updatedAt: Date.now(),
+        forceKilled: undefined,
+        phaseLabel: undefined,
+      };
+    }
+    return this.restart({ panelId: session.panelId, projectId: session.projectId });
+  }
+
   // Called from the renderer's worktree delete path BEFORE `git worktree
   // remove` runs. On Windows the dev server holds a directory lock — if the
   // session isn't stopped first, the removal fails outright (#9084). The

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -91,3 +91,11 @@ export interface DevPreviewDestructivePreviewSizes {
 export interface DevPreviewStopByWorktreeRequest {
   worktreeId: string;
 }
+
+export interface DevPreviewRestartByWorktreeRequest {
+  worktreeId: string;
+}
+
+export interface DevPreviewStopDevServerByWorktreeRequest {
+  worktreeId: string;
+}

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -105,6 +105,9 @@ export interface GeneratedElectronAPI {
     restartAndClearCache(
       ...args: IpcInvokeMap["dev-preview:restart-and-clear-cache"]["args"]
     ): Promise<IpcInvokeMap["dev-preview:restart-and-clear-cache"]["result"]>;
+    restartByWorktree(
+      ...args: IpcInvokeMap["dev-preview:restart-by-worktree"]["args"]
+    ): Promise<IpcInvokeMap["dev-preview:restart-by-worktree"]["result"]>;
     stop(
       ...args: IpcInvokeMap["dev-preview:stop"]["args"]
     ): Promise<IpcInvokeMap["dev-preview:stop"]["result"]>;
@@ -114,6 +117,9 @@ export interface GeneratedElectronAPI {
     stopByWorktree(
       ...args: IpcInvokeMap["dev-preview:stop-by-worktree"]["args"]
     ): Promise<IpcInvokeMap["dev-preview:stop-by-worktree"]["result"]>;
+    stopDevServerByWorktree(
+      ...args: IpcInvokeMap["dev-preview:stop-dev-server-by-worktree"]["args"]
+    ): Promise<IpcInvokeMap["dev-preview:stop-dev-server-by-worktree"]["result"]>;
   };
   eventInspector: {
     clear(

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -216,6 +216,10 @@ export interface GeneratedIpcInvokeMap {
     args: [request: import("./devPreview.js").DevPreviewSessionRequest];
     result: import("./devPreview.js").DevPreviewSessionState;
   };
+  "dev-preview:restart-by-worktree": {
+    args: [request: import("./devPreview.js").DevPreviewRestartByWorktreeRequest];
+    result: import("./devPreview.js").DevPreviewSessionState;
+  };
   "dev-preview:stop": {
     args: [request: import("./devPreview.js").DevPreviewSessionRequest];
     result: import("./devPreview.js").DevPreviewSessionState;
@@ -227,6 +231,10 @@ export interface GeneratedIpcInvokeMap {
   "dev-preview:stop-by-worktree": {
     args: [request: import("./devPreview.js").DevPreviewStopByWorktreeRequest];
     result: void;
+  };
+  "dev-preview:stop-dev-server-by-worktree": {
+    args: [request: import("./devPreview.js").DevPreviewStopDevServerByWorktreeRequest];
+    result: import("./devPreview.js").DevPreviewSessionState;
   };
   "editor:discover": {
     args: [];

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -3,6 +3,7 @@ import { useShallow } from "zustand/react/shallow";
 import type { WorktreeState } from "../../types";
 import type { GitHubIssue } from "@shared/types/github";
 import { logError } from "@/utils/logger";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { useWorktreeTerminals } from "../../hooks/useWorktreeTerminals";
 
 import { useDroppable } from "@dnd-kit/core";
@@ -376,11 +377,15 @@ export function WorktreeCard({
   };
 
   const handleStopDevServer = useCallback((worktreeId: string) => {
-    void window.electron.devPreview.stopDevServerByWorktree({ worktreeId });
+    safeFireAndForget(window.electron.devPreview.stopDevServerByWorktree({ worktreeId }), {
+      context: "Stop dev server for worktree",
+    });
   }, []);
 
   const handleRestartDevServer = useCallback((worktreeId: string) => {
-    void window.electron.devPreview.restartByWorktree({ worktreeId });
+    safeFireAndForget(window.electron.devPreview.restartByWorktree({ worktreeId }), {
+      context: "Restart dev server for worktree",
+    });
   }, []);
 
   const handleResourceResume = () => {

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -375,6 +375,14 @@ export function WorktreeCard({
     );
   };
 
+  const handleStopDevServer = useCallback((worktreeId: string) => {
+    void window.electron.devPreview.stopDevServerByWorktree({ worktreeId });
+  }, []);
+
+  const handleRestartDevServer = useCallback((worktreeId: string) => {
+    void window.electron.devPreview.restartByWorktree({ worktreeId });
+  }, []);
+
   const handleResourceResume = () => {
     void actionService.dispatch(
       "worktree.resource.resume",
@@ -951,6 +959,8 @@ export function WorktreeCard({
                     : undefined,
                   onResourceStatus: hasStatusCommand ? handleResourceStatus : undefined,
                   onResourceTeardown: hasTeardownCommand ? handleResourceTeardown : undefined,
+                  onStopDevServer: handleStopDevServer,
+                  onRestartDevServer: handleRestartDevServer,
                 }}
               />
 
@@ -1105,6 +1115,8 @@ export function WorktreeCard({
           onResourceConnect={worktree.resourceConnectCommand ? handleResourceConnect : undefined}
           onResourceStatus={hasStatusCommand ? handleResourceStatus : undefined}
           onResourceTeardown={hasTeardownCommand ? handleResourceTeardown : undefined}
+          onStopDevServer={handleStopDevServer}
+          onRestartDevServer={handleRestartDevServer}
         />
       </ContextMenuContent>
     </ContextMenu>

--- a/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
@@ -95,6 +95,8 @@ interface WorktreeActionsToolbarProps {
     onResourceConnect?: () => void;
     onResourceStatus?: () => void;
     onResourceTeardown?: () => void;
+    onStopDevServer?: (worktreeId: string) => void;
+    onRestartDevServer?: (worktreeId: string) => void;
   };
   worktree: WorktreeState;
   isPinned: boolean;
@@ -245,6 +247,8 @@ export function WorktreeActionsToolbar({
             onResourceConnect={menu.onResourceConnect}
             onResourceStatus={menu.onResourceStatus}
             onResourceTeardown={menu.onResourceTeardown}
+            onStopDevServer={menu.onStopDevServer}
+            onRestartDevServer={menu.onRestartDevServer}
           />
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -114,6 +114,8 @@ export interface WorktreeHeaderProps {
     onResourceConnect?: () => void;
     onResourceStatus?: () => void;
     onResourceTeardown?: () => void;
+    onStopDevServer?: (worktreeId: string) => void;
+    onRestartDevServer?: (worktreeId: string) => void;
   };
 }
 

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -42,6 +42,7 @@ import {
   PanelBottomClose,
   Pause,
   SquareTerminal,
+  Square,
   Trash2,
   Undo2,
   Zap,
@@ -139,6 +140,8 @@ export interface WorktreeMenuItemsProps {
   onResourceConnect?: () => void;
   onResourceStatus?: () => void;
   onResourceTeardown?: () => void;
+  onStopDevServer?: (worktreeId: string) => void;
+  onRestartDevServer?: (worktreeId: string) => void;
 }
 
 export function WorktreeMenuItems({
@@ -193,6 +196,8 @@ export function WorktreeMenuItems({
   onResourceConnect,
   onResourceStatus,
   onResourceTeardown,
+  onStopDevServer,
+  onRestartDevServer,
 }: WorktreeMenuItemsProps) {
   const hasIssueItem = Boolean(worktree.issueNumber && onOpenIssueExternal);
   const hasPRItem = Boolean(worktree.linked?.pr && onOpenPRExternal);
@@ -319,6 +324,24 @@ export function WorktreeMenuItems({
       </C.Sub>
 
       <C.Separator />
+
+      {(onStopDevServer || onRestartDevServer) && (
+        <>
+          {onStopDevServer && (
+            <C.Item onSelect={() => onStopDevServer(worktree.id)}>
+              <Square className="w-3.5 h-3.5 mr-2" />
+              Stop Dev Server
+            </C.Item>
+          )}
+          {onRestartDevServer && (
+            <C.Item onSelect={() => onRestartDevServer(worktree.id)}>
+              <RefreshCw className="w-3.5 h-3.5 mr-2" />
+              Restart Dev Server
+            </C.Item>
+          )}
+          <C.Separator />
+        </>
+      )}
 
       {/* Resource */}
       {hasResourceConfig && (


### PR DESCRIPTION
## Summary

Issue #9089 requested stop and restart dev server actions in the worktree context menu. Before this, the only way to stop or restart the dev server was to first focus the DevPreview panel.

The actions already existed in `devServerActions.ts` and `devPreviewActions.ts`, but both resolved through `focusedTerminalId` or `panelId`, so they could not be invoked from a worktree row where only the worktree ID was available. This change wires up worktree-keyed entry points and adds session lookup by worktree ID.

## Changes

- Added Stop and Restart dev server entries to `WorktreeMenuItems.tsx`
- Wired IPC handlers in `devPreview.ts` and `devPreview.preload.ts`
- Added `DevPreviewSessionService` lookup by worktree ID
- Forwarded stop/restart callbacks through `WorktreeActionsToolbar.tsx`

Both actions are D0/safe -- stop is recoverable by clicking Start, and restart during HMR recovery is routine. No confirm dialogs. Context menu only; no inline button on the row chrome.

Depends on #9087 for the `worktreeId`-to-session resolver.

Resolves #9089

## Testing

- Verified stop and restart dev server appear in the worktree context menu
- Confirmed actions resolve correctly when the DevPreview panel is not focused
- Checked that both entries are properly wired through the IPC layer