### PR TITLE
feat(logs): show per-source counts in Logs filter dropdown

### DIFF
--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -184,6 +184,16 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
     return counts;
   }, [logs]);
 
+  const sourceCounts = useMemo(() => {
+    const counts: Partial<Record<string, number>> = {};
+    for (const log of logs) {
+      if (log.id === "previous-session-separator") continue;
+      if (!log.source) continue;
+      counts[log.source] = (counts[log.source] ?? 0) + 1;
+    }
+    return counts;
+  }, [logs]);
+
   const filteredLogs = useMemo(() => filterLogs(logs, filters), [logs, filters]);
 
   const previousSessionEntry = filteredLogs.find((log) => log.id === "previous-session-separator");
@@ -248,6 +258,7 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
         onClear={clearFilters}
         availableSources={sources}
         levelCounts={levelCounts}
+        sourceCounts={sourceCounts}
       />
 
       {previousSessionEntry && !filters?.search && (

--- a/src/components/Logs/LogFilters.tsx
+++ b/src/components/Logs/LogFilters.tsx
@@ -184,7 +184,7 @@ export function LogFilters({
                     className={cn(
                       "w-full justify-start rounded-none",
                       isActive ? "text-status-info bg-status-info/10" : "text-daintree-text",
-                      count === 0 && "opacity-50"
+                      count === 0 && !isActive && "opacity-50"
                     )}
                     aria-pressed={isActive}
                   >

--- a/src/components/Logs/LogFilters.tsx
+++ b/src/components/Logs/LogFilters.tsx
@@ -11,6 +11,7 @@ interface LogFiltersProps {
   onClear: () => void;
   availableSources: string[];
   levelCounts?: Partial<Record<LogLevel, number>>;
+  sourceCounts?: Partial<Record<string, number>>;
 }
 
 const LOG_LEVELS: { level: LogLevel; label: string; color: string }[] = [
@@ -30,6 +31,7 @@ export function LogFilters({
   onClear,
   availableSources,
   levelCounts,
+  sourceCounts,
 }: LogFiltersProps) {
   const [searchValue, setSearchValue] = useState(filters.search || "");
   const [isSourcesOpen, setIsSourcesOpen] = useState(false);
@@ -172,6 +174,7 @@ export function LogFilters({
             >
               {availableSources.map((source) => {
                 const isActive = filters.sources?.includes(source) ?? false;
+                const count = sourceCounts?.[source] ?? 0;
                 return (
                   <Button
                     key={source}
@@ -180,12 +183,14 @@ export function LogFilters({
                     onClick={() => handleSourceToggle(source)}
                     className={cn(
                       "w-full justify-start rounded-none",
-                      isActive ? "text-status-info bg-status-info/10" : "text-daintree-text"
+                      isActive ? "text-status-info bg-status-info/10" : "text-daintree-text",
+                      count === 0 && "opacity-50"
                     )}
                     aria-pressed={isActive}
                   >
                     {isActive && "* "}
                     {source}
+                    <span className="ml-auto tabular-nums opacity-70">{count}</span>
                   </Button>
                 );
               })}

--- a/src/components/Logs/__tests__/LogFilters.test.tsx
+++ b/src/components/Logs/__tests__/LogFilters.test.tsx
@@ -101,16 +101,19 @@ describe("LogFilters accessibility", () => {
     const rendererBtn = screen.getByText(/^\*?renderer/).closest("button")!;
     const mainBtn = screen.getByText(/^\*?main/).closest("button")!;
     const preloadBtn = screen.getByText(/^\*?preload/).closest("button")!;
-    expect(rendererBtn.textContent).toContain("3");
-    expect(mainBtn.textContent).toContain("1");
-    expect(preloadBtn.textContent).toContain("0");
+    const rendererCount = rendererBtn.querySelector("span.ml-auto.tabular-nums");
+    const mainCount = mainBtn.querySelector("span.ml-auto.tabular-nums");
+    const preloadCount = preloadBtn.querySelector("span.ml-auto.tabular-nums");
+    expect(rendererCount?.textContent).toBe("3");
+    expect(mainCount?.textContent).toBe("1");
+    expect(preloadCount?.textContent).toBe("0");
   });
 
   it("dims zero-count source rows with opacity-50", () => {
     render(<LogFilters {...baseProps} />);
     fireEvent.click(screen.getByText(/Sources/).closest("button")!);
     const preloadBtn = screen.getByText(/^\*?preload/).closest("button")!;
-    expect(preloadBtn.className).toContain("opacity-50");
+    expect(preloadBtn.classList.contains("opacity-50")).toBe(true);
   });
 
   it("keeps zero-count source rows clickable", () => {
@@ -129,5 +132,26 @@ describe("LogFilters accessibility", () => {
     const countSpan = rendererBtn.querySelector("span.ml-auto.tabular-nums");
     expect(countSpan).toBeTruthy();
     expect(countSpan!.className).toContain("opacity-70");
+  });
+
+  it("does not dim zero-count rows when the source is actively selected", () => {
+    render(
+      <LogFilters
+        {...baseProps}
+        filters={{ sources: ["preload"] }}
+        sourceCounts={{ ...baseProps.sourceCounts, preload: 0 }}
+      />
+    );
+    fireEvent.click(screen.getByText(/Sources/).closest("button")!);
+    const preloadBtn = screen.getByText(/\* preload/).closest("button")!;
+    expect(preloadBtn.getAttribute("aria-pressed")).toBe("true");
+    expect(preloadBtn.classList.contains("opacity-50")).toBe(false);
+  });
+
+  it("does not dim non-zero source rows", () => {
+    render(<LogFilters {...baseProps} />);
+    fireEvent.click(screen.getByText(/Sources/).closest("button")!);
+    const rendererBtn = screen.getByText(/^\*?renderer/).closest("button")!;
+    expect(rendererBtn.classList.contains("opacity-50")).toBe(false);
   });
 });

--- a/src/components/Logs/__tests__/LogFilters.test.tsx
+++ b/src/components/Logs/__tests__/LogFilters.test.tsx
@@ -19,6 +19,7 @@ describe("LogFilters accessibility", () => {
     onClear: vi.fn(),
     availableSources: ["renderer", "main", "preload"],
     levelCounts: { debug: 1, info: 2, warn: 3, error: 4 } as const,
+    sourceCounts: { renderer: 3, main: 1, preload: 0 } as Partial<Record<string, number>>,
   };
 
   it("renders search input with type='search'", () => {
@@ -66,10 +67,10 @@ describe("LogFilters accessibility", () => {
   it("closes sources popover on Escape", async () => {
     render(<LogFilters {...baseProps} />);
     fireEvent.click(screen.getByText(/Sources/).closest("button")!);
-    expect(screen.getByText("renderer")).toBeTruthy();
+    expect(screen.getByText(/renderer/)).toBeTruthy();
     dispatchEscape();
     await waitFor(() => {
-      expect(screen.queryByText("renderer")).toBeNull();
+      expect(screen.queryByText(/renderer/)).toBeNull();
     });
   });
 
@@ -92,5 +93,41 @@ describe("LogFilters accessibility", () => {
     expect(onFiltersChange).not.toHaveBeenCalledWith(
       expect.objectContaining({ search: "foo" })
     );
+  });
+
+  it("renders source counts beside source names in dropdown", () => {
+    render(<LogFilters {...baseProps} />);
+    fireEvent.click(screen.getByText(/Sources/).closest("button")!);
+    const rendererBtn = screen.getByText(/^\*?renderer/).closest("button")!;
+    const mainBtn = screen.getByText(/^\*?main/).closest("button")!;
+    const preloadBtn = screen.getByText(/^\*?preload/).closest("button")!;
+    expect(rendererBtn.textContent).toContain("3");
+    expect(mainBtn.textContent).toContain("1");
+    expect(preloadBtn.textContent).toContain("0");
+  });
+
+  it("dims zero-count source rows with opacity-50", () => {
+    render(<LogFilters {...baseProps} />);
+    fireEvent.click(screen.getByText(/Sources/).closest("button")!);
+    const preloadBtn = screen.getByText(/^\*?preload/).closest("button")!;
+    expect(preloadBtn.className).toContain("opacity-50");
+  });
+
+  it("keeps zero-count source rows clickable", () => {
+    const onFiltersChange = vi.fn();
+    render(<LogFilters {...baseProps} onFiltersChange={onFiltersChange} />);
+    fireEvent.click(screen.getByText(/Sources/).closest("button")!);
+    const preloadBtn = screen.getByText(/^\*?preload/).closest("button")!;
+    fireEvent.click(preloadBtn);
+    expect(onFiltersChange).toHaveBeenCalledWith({ sources: ["preload"] });
+  });
+
+  it("right-aligns count with ml-auto and uses tabular-nums", () => {
+    render(<LogFilters {...baseProps} />);
+    fireEvent.click(screen.getByText(/Sources/).closest("button")!);
+    const rendererBtn = screen.getByText(/^\*?renderer/).closest("button")!;
+    const countSpan = rendererBtn.querySelector("span.ml-auto.tabular-nums");
+    expect(countSpan).toBeTruthy();
+    expect(countSpan!.className).toContain("opacity-70");
   });
 });


### PR DESCRIPTION
## Summary

- Adds per-source counts beside each source name in the diagnostics Logs filter dropdown, matching the severity-chip pattern that already shows counts for debug/info/warn/error.
- Zero-count rows stay visible and clickable but are dimmed (opacity-50), so the dropdown doesn't jump around as the buffer churns.
- Two commits: the feature implementation and a test assertion fix.

Resolves #9137

## Changes

- LogsContent.tsx — new sourceCounts memo, aggregating log.source values from the buffer (skipping the previous-session separator).
- LogFilters.tsx — new sourceCounts prop, rendering a right-aligned count in tabular-nums beside each source, plus opacity-50 when count is zero and the source isn't actively selected.
- LogFilters.test.tsx — new tests covering count rendering, zero-count dimming, dimmed-but-clickable behavior, active-selection override of dimming, and non-zero row assertions.

## Testing

- Unit tests verify all count, dimming, clickability, and edge-case behaviors.
- Manual verification: opened the Logs filter in the diagnostics dock, confirmed counts appear beside each source and update as the buffer changes.