### PR TITLE
fix(plugin): harden confirm dialog with cooldown and args preview

### DIFF
--- a/src/components/Plugin/PluginConfirmDialog.tsx
+++ b/src/components/Plugin/PluginConfirmDialog.tsx
@@ -4,6 +4,14 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { usePluginConfirmStore, type PluginConfirmationDecision } from "@/store/pluginConfirmStore";
 
 /**
+ * Lower-bound read-time gate for destructive dispatches. `resolveOnce` guards
+ * the second click; this disables the primary button briefly after each item
+ * is promoted so a click meant for the previous modal can't silently approve a
+ * freshly-promoted destructive write before the user has read it.
+ */
+const CONFIRM_COOLDOWN_MS = 1_200;
+
+/**
  * Singleton dialog driven by the plugin-action confirmation queue. Mounted
  * once near the top of `App.tsx`, sibling to `McpConfirmDialog`. Reads
  * `current` from `usePluginConfirmStore` and surfaces one `ConfirmDialog`
@@ -49,6 +57,9 @@ export function PluginConfirmDialog() {
     );
   }
 
+  const isDestructive = current.effectiveDanger === "confirm";
+  const variant = isDestructive ? "destructive" : "default";
+
   return (
     <ErrorBoundary variant="component" componentName="PluginConfirmDialog" resetKeys={[resetKey]}>
       <ConfirmDialog
@@ -56,14 +67,22 @@ export function PluginConfirmDialog() {
         onClose={() => resolveOnce(current.requestId, "rejected")}
         title={`Run '${current.actionTitle}'?`}
         description={
-          current.actionDescription ||
-          `This action is contributed by the '${current.pluginId}' plugin.`
+          current.actionDescription || `Action contributed by the '${current.pluginId}' plugin.`
         }
         confirmLabel={current.actionTitle}
         cancelLabel="Cancel"
         onConfirm={() => resolveOnce(current.requestId, "approved")}
-        variant="destructive"
-      />
+        variant={variant}
+        confirmCooldownMs={isDestructive ? CONFIRM_COOLDOWN_MS : undefined}
+        cooldownKey={current.requestId}
+      >
+        <div className="space-y-2">
+          <div className="text-xs text-daintree-text/60 uppercase tracking-wide">Arguments</div>
+          <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">
+            {current.argsSummary || "(none)"}
+          </pre>
+        </div>
+      </ConfirmDialog>
     </ErrorBoundary>
   );
 }

--- a/src/components/Plugin/PluginConfirmDialog.tsx
+++ b/src/components/Plugin/PluginConfirmDialog.tsx
@@ -67,7 +67,8 @@ export function PluginConfirmDialog() {
         onClose={() => resolveOnce(current.requestId, "rejected")}
         title={`Run '${current.actionTitle}'?`}
         description={
-          current.actionDescription || `Action contributed by the '${current.pluginId}' plugin.`
+          current.actionDescription.trim() ||
+          `Action contributed by the '${current.pluginId}' plugin.`
         }
         confirmLabel={current.actionTitle}
         cancelLabel="Cancel"

--- a/src/components/__tests__/PluginConfirmDialog.test.tsx
+++ b/src/components/__tests__/PluginConfirmDialog.test.tsx
@@ -1,0 +1,350 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PluginConfirmDialog } from "../Plugin/PluginConfirmDialog";
+import {
+  __resetPluginConfirmStoreForTesting,
+  requestPluginConfirmation,
+} from "@/store/pluginConfirmStore";
+import type { ActionDanger } from "@shared/types/actions";
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: unknown) => fn,
+}));
+
+vi.mock("@/store", () => ({
+  usePortalStore: () => ({ isOpen: false, width: 0 }),
+}));
+
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useOverlayState: () => {} };
+});
+
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({ isOpen }: { isOpen: boolean }) => ({
+    isVisible: isOpen,
+    shouldRender: isOpen,
+  }),
+}));
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+function enqueue(
+  overrides: {
+    requestId?: string;
+    actionTitle?: string;
+    effectiveDanger?: ActionDanger;
+    argsSummary?: string;
+    pluginId?: string;
+  } = {}
+) {
+  return requestPluginConfirmation({
+    requestId: overrides.requestId ?? "req-1",
+    pluginId: overrides.pluginId ?? "test-plugin",
+    actionId: "worktree.delete",
+    actionTitle: overrides.actionTitle ?? "Delete worktree",
+    actionDescription: "Permanently delete a worktree.",
+    effectiveDanger: overrides.effectiveDanger ?? "confirm",
+    argsSummary: overrides.argsSummary ?? '{"worktreeId":"wt-1"}',
+  });
+}
+
+const PENDING_PROBE_MS = 20;
+
+async function expectStillPending(promise: Promise<unknown>) {
+  const sentinel = Symbol("pending");
+  const race = Promise.race([
+    promise,
+    new Promise((resolve) => setTimeout(() => resolve(sentinel), PENDING_PROBE_MS)),
+  ]);
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(PENDING_PROBE_MS);
+  });
+  expect(await race).toBe(sentinel);
+}
+
+describe("PluginConfirmDialog", () => {
+  beforeEach(() => {
+    __resetPluginConfirmStoreForTesting();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    __resetPluginConfirmStoreForTesting();
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("labels the confirm button with the action title, not a generic verb", () => {
+    void enqueue({ actionTitle: "Delete worktree" });
+    render(<PluginConfirmDialog />);
+
+    expect(screen.getByRole("button", { name: "Delete worktree" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^run action$/i })).toBeNull();
+  });
+
+  it("renders destructive styling for effectiveDanger:confirm dispatches", () => {
+    void enqueue({ actionTitle: "Delete worktree", effectiveDanger: "confirm" });
+    const { unmount } = render(<PluginConfirmDialog />);
+
+    expect(screen.getByRole("button", { name: "Delete worktree" }).className).toContain(
+      "bg-destructive"
+    );
+
+    unmount();
+    __resetPluginConfirmStoreForTesting();
+
+    void enqueue({ actionTitle: "List worktrees", effectiveDanger: "safe" });
+    render(<PluginConfirmDialog />);
+
+    expect(screen.getByRole("button", { name: "List worktrees" }).className).not.toContain(
+      "bg-destructive"
+    );
+  });
+
+  it("resolves exactly once on a rapid double-confirm, never approving the queued item", async () => {
+    vi.useFakeTimers();
+    try {
+      const pA = enqueue({ requestId: "A", actionTitle: "Delete worktree" });
+      const pB = enqueue({ requestId: "B", actionTitle: "Push branch" });
+
+      render(<PluginConfirmDialog />);
+
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+
+      const confirmBtn = screen.getByRole("button", { name: "Delete worktree" });
+
+      act(() => {
+        confirmBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        confirmBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      await expect(pA).resolves.toBe("approved");
+
+      await expectStillPending(pB);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("disables the confirm button on mount for effectiveDanger:confirm, re-enabling after the cooldown", () => {
+    vi.useFakeTimers();
+    try {
+      void enqueue({ actionTitle: "Delete worktree", effectiveDanger: "confirm" });
+      render(<PluginConfirmDialog />);
+
+      const confirmBtn = screen.getByRole("button", {
+        name: "Delete worktree",
+      }) as HTMLButtonElement;
+      expect(confirmBtn.disabled).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+      expect(confirmBtn.disabled).toBe(false);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not gate non-destructive dispatches with a cooldown", () => {
+    vi.useFakeTimers();
+    try {
+      void enqueue({ actionTitle: "List worktrees", effectiveDanger: "safe" });
+      render(<PluginConfirmDialog />);
+
+      const confirmBtn = screen.getByRole("button", {
+        name: "List worktrees",
+      }) as HTMLButtonElement;
+      expect(confirmBtn.disabled).toBe(false);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("restarts the cooldown when a fresh destructive item is promoted", async () => {
+    vi.useFakeTimers();
+    try {
+      const pA = enqueue({
+        requestId: "A",
+        actionTitle: "Delete worktree",
+        effectiveDanger: "confirm",
+      });
+      void enqueue({ requestId: "B", actionTitle: "Reset branch", effectiveDanger: "confirm" });
+
+      render(<PluginConfirmDialog />);
+
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+      const firstBtn = screen.getByRole("button", {
+        name: "Delete worktree",
+      }) as HTMLButtonElement;
+      expect(firstBtn.disabled).toBe(false);
+
+      act(() => {
+        firstBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await expect(pA).resolves.toBe("approved");
+
+      const secondBtn = screen.getByRole("button", {
+        name: "Reset branch",
+      }) as HTMLButtonElement;
+      expect(secondBtn.disabled).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+      expect(secondBtn.disabled).toBe(false);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("arms the cooldown for the first destructive item even when mounted empty", () => {
+    vi.useFakeTimers();
+    try {
+      render(<PluginConfirmDialog />);
+
+      act(() => {
+        void enqueue({ actionTitle: "Delete worktree", effectiveDanger: "confirm" });
+      });
+
+      const btn = screen.getByRole("button", {
+        name: "Delete worktree",
+      }) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores a click on a freshly-promoted item that lands before its cooldown clears", async () => {
+    vi.useFakeTimers();
+    try {
+      const pA = enqueue({
+        requestId: "A",
+        actionTitle: "Delete worktree",
+        effectiveDanger: "confirm",
+      });
+      const pB = enqueue({
+        requestId: "B",
+        actionTitle: "Reset branch",
+        effectiveDanger: "confirm",
+      });
+
+      render(<PluginConfirmDialog />);
+
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+      const aBtn = screen.getByRole("button", { name: "Delete worktree" });
+      act(() => {
+        aBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await expect(pA).resolves.toBe("approved");
+
+      const bBtn = screen.getByRole("button", { name: "Reset branch" });
+      act(() => {
+        bBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      await expectStillPending(pB);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows the plugin provenance description when there is no action description", () => {
+    void enqueue({ pluginId: "my-plugin" });
+    const { unmount } = render(<PluginConfirmDialog />);
+
+    // When actionDescription is set, it takes precedence over the fallback.
+    expect(screen.getByText("Permanently delete a worktree.")).toBeTruthy();
+
+    unmount();
+    __resetPluginConfirmStoreForTesting();
+
+    // With an empty actionDescription, the provenance fallback renders.
+    void requestPluginConfirmation({
+      requestId: "req-2",
+      pluginId: "my-plugin",
+      actionId: "worktree.delete",
+      actionTitle: "Delete worktree",
+      actionDescription: "",
+      effectiveDanger: "confirm",
+      argsSummary: "{}",
+    });
+    render(<PluginConfirmDialog />);
+
+    expect(screen.getByText("Action contributed by the 'my-plugin' plugin.")).toBeTruthy();
+  });
+
+  it("renders the args preview block", () => {
+    void enqueue({ argsSummary: '{"key":"value"}' });
+    render(<PluginConfirmDialog />);
+
+    expect(screen.getByText("Arguments")).toBeTruthy();
+    expect(screen.getByText('{"key":"value"}')).toBeTruthy();
+  });
+
+  it("shows (none) for empty args summary", () => {
+    void enqueue({ argsSummary: "" });
+    render(<PluginConfirmDialog />);
+
+    expect(screen.getByText("(none)")).toBeTruthy();
+  });
+
+  it("rejects when cancel is clicked", async () => {
+    const p = enqueue();
+    render(<PluginConfirmDialog />);
+
+    act(() => {
+      screen
+        .getByRole("button", { name: "Cancel" })
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await expect(p).resolves.toBe("rejected");
+  });
+
+  it("approves when confirm is clicked after cooldown", async () => {
+    vi.useFakeTimers();
+    try {
+      const p = enqueue();
+      render(<PluginConfirmDialog />);
+
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+
+      act(() => {
+        screen
+          .getByRole("button", { name: "Delete worktree" })
+          .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      await expect(p).resolves.toBe("approved");
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/hooks/usePluginActions.ts
+++ b/src/hooks/usePluginActions.ts
@@ -149,6 +149,12 @@ function toSyntheticDefinition(
         inFlightConfirms.add(requestId);
         let decision;
         try {
+          let argsSummary: string;
+          try {
+            argsSummary = summarizeMcpArgs(args);
+          } catch {
+            argsSummary = "<unserializable>";
+          }
           decision = await requestPluginConfirmation({
             requestId,
             pluginId,
@@ -156,7 +162,7 @@ function toSyntheticDefinition(
             actionTitle: title ?? id,
             actionDescription: description ?? "",
             effectiveDanger,
-            argsSummary: summarizeMcpArgs(args),
+            argsSummary,
           });
         } finally {
           inFlightConfirms.delete(requestId);

--- a/src/hooks/usePluginActions.ts
+++ b/src/hooks/usePluginActions.ts
@@ -4,6 +4,7 @@ import type { AnyActionDefinition } from "@/services/actions/actionTypes";
 import type { ActionDefinition } from "@shared/types/actions";
 import type { PluginActionDescriptor } from "@shared/types/plugin";
 import { requestPluginConfirmation, usePluginConfirmStore } from "@/store/pluginConfirmStore";
+import { summarizeMcpArgs } from "@shared/utils/mcpArgsSummary";
 import { logWarn } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 
@@ -154,6 +155,8 @@ function toSyntheticDefinition(
             actionId: id,
             actionTitle: title ?? id,
             actionDescription: description ?? "",
+            effectiveDanger,
+            argsSummary: summarizeMcpArgs(args),
           });
         } finally {
           inFlightConfirms.delete(requestId);

--- a/src/store/pluginConfirmStore.ts
+++ b/src/store/pluginConfirmStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { ActionDanger } from "@shared/types/actions";
 
 /**
  * User decision on a plugin-action confirmation. Unlike the MCP confirm
@@ -20,6 +21,10 @@ export interface PendingPluginConfirm {
   actionId: string;
   actionTitle: string;
   actionDescription: string;
+  /** Host-authoritative danger classification. Always `"confirm"` in practice (the dialog only fires for destructive actions) but stored for the provenance line and test assertions. */
+  effectiveDanger: ActionDanger;
+  /** Redacted single-level JSON summary of the action's invocation args, produced by `summarizeMcpArgs`. */
+  argsSummary: string;
   enqueuedAt: number;
 }
 


### PR DESCRIPTION
## Summary
- Adds a 1200ms read-time cooldown on the confirm button, matching the pattern already in `McpConfirmDialog`. This prevents a click queued for the previous modal from silently approving a freshly-promoted destructive action.
- Surfaces plugin provenance so the user can see which plugin owns the action, and renders an arguments preview block showing the serialized args.
- Adds a comprehensive test suite covering double-confirm guarding, cooldown mechanics, destructive-vs-safe styling, provenance display, and args preview.

Resolves #9248

## Changes
- `PluginConfirmDialog.tsx` — cooldown gating (`CONFIRM_COOLDOWN_MS = 1_200`), conditional `variant`, provenance fallback, and args preview block
- `pluginConfirmStore.ts` — added `effectiveDanger` and `argsSummary` fields to `PendingPluginConfirm`
- `usePluginActions.ts` — computes `argsSummary` via `summarizeMcpArgs` and passes the new fields to the store
- `PluginConfirmDialog.test.tsx` — 350-line test suite (13 cases)

## Testing
- All 13 unit tests pass locally
- Types checked clean with `tsc --noEmit`