### PR TITLE
feat(file-viewer): add sticky scope header and hide replace UI in code viewer

### DIFF
--- a/src/components/FileViewer/CodeViewer.tsx
+++ b/src/components/FileViewer/CodeViewer.tsx
@@ -196,6 +196,7 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
   const rafRef = useRef<number | null>(null);
   const stickyScopeRef = useRef<string | null>(null);
   const [stickyScope, setStickyScope] = useState<string | null>(null);
+  const [cmLineHeight, setCmLineHeight] = useState<number>(24);
 
   useImperativeHandle(
     ref,
@@ -321,6 +322,7 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
   const handleCreateEditor = useCallback(
     (view: EditorView) => {
       viewRef.current = view;
+      setCmLineHeight(view.defaultLineHeight);
       if (initialLine === undefined || initialLine < 1) return;
       const lineNum = Math.min(initialLine, view.state.doc.lines);
 
@@ -361,8 +363,8 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
             : "border-transparent bg-transparent text-transparent"
         )}
         style={{
-          height: viewRef.current ? `${viewRef.current.defaultLineHeight}px` : "1.5em",
-          lineHeight: viewRef.current ? `${viewRef.current.defaultLineHeight}px` : "1.5em",
+          height: `${cmLineHeight}px`,
+          lineHeight: `${cmLineHeight}px`,
         }}
       >
         {stickyScope ?? " "}

--- a/src/components/FileViewer/CodeViewer.tsx
+++ b/src/components/FileViewer/CodeViewer.tsx
@@ -9,8 +9,8 @@ import {
 } from "react";
 import CodeMirror from "@uiw/react-codemirror";
 import { EditorView, Decoration, type DecorationSet, keymap } from "@codemirror/view";
-import { type Extension, StateEffect, StateField } from "@codemirror/state";
-import { LanguageDescription } from "@codemirror/language";
+import { type Extension, StateEffect, StateField, EditorState } from "@codemirror/state";
+import { LanguageDescription, syntaxTree } from "@codemirror/language";
 import { search, openSearchPanel, gotoLine } from "@codemirror/search";
 import { daintreeTheme } from "./editorTheme";
 import { editorSearchHighlightTheme } from "./editorSearchTheme";
@@ -112,11 +112,56 @@ const searchPanelTheme = EditorView.theme({
 const BASE_EXTENSIONS: Extension[] = [
   highlightedLineField,
   highlightLineTheme,
+  EditorState.readOnly.of(true),
   search({ top: true }),
   keymap.of([{ key: "Mod-l", run: gotoLine }]),
   searchPanelTheme,
   editorSearchHighlightTheme,
 ];
+
+const SCOPE_NODE_TYPES_BY_LANGUAGE: Record<string, Set<string>> = {
+  JavaScript: new Set([
+    "FunctionDeclaration",
+    "ClassDeclaration",
+    "MethodDeclaration",
+    "ArrowFunction",
+    "FunctionExpression",
+    "ClassExpression",
+    "InterfaceDeclaration",
+    "EnumDeclaration",
+    "NamespaceDeclaration",
+  ]),
+  TypeScript: new Set([
+    "FunctionDeclaration",
+    "ClassDeclaration",
+    "MethodDeclaration",
+    "ArrowFunction",
+    "FunctionExpression",
+    "ClassExpression",
+    "InterfaceDeclaration",
+    "EnumDeclaration",
+    "NamespaceDeclaration",
+  ]),
+  Python: new Set(["FunctionDefinition", "ClassDefinition"]),
+  Go: new Set(["FunctionDecl", "MethodDecl", "TypeDecl"]),
+  Rust: new Set([
+    "FunctionItem",
+    "StructItem",
+    "ImplItem",
+    "TraitItem",
+    "EnumItem",
+    "ModItem",
+    "UnionItem",
+  ]),
+  Java: new Set([
+    "ClassDeclaration",
+    "MethodDeclaration",
+    "InterfaceDeclaration",
+    "EnumDeclaration",
+  ]),
+  "C++": new Set(["FunctionDefinition", "ClassSpecifier", "StructSpecifier"]),
+  C: new Set(["FunctionDefinition", "ClassSpecifier", "StructSpecifier"]),
+};
 
 export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function CodeViewer(
   { content, filePath, initialLine, className },
@@ -124,19 +169,37 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
 ) {
   const [langExtension, setLangExtension] = useState<Extension | null>(null);
   const viewRef = useRef<EditorView | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const stickyScopeRef = useRef<string | null>(null);
+  const [stickyScope, setStickyScope] = useState<string | null>(null);
 
-  useImperativeHandle(ref, () => ({
-    openSearch() {
-      if (viewRef.current) {
-        openSearchPanel(viewRef.current);
-      }
-    },
-    openGotoLine() {
-      if (viewRef.current) {
-        gotoLine(viewRef.current);
-      }
-    },
-  }));
+  useImperativeHandle(
+    ref,
+    () => ({
+      openSearch() {
+        if (viewRef.current) {
+          openSearchPanel(viewRef.current);
+        }
+      },
+      openGotoLine() {
+        if (viewRef.current) {
+          gotoLine(viewRef.current);
+        }
+      },
+    }),
+    []
+  );
+
+  const langName = useMemo(() => {
+    const basename = filePath.split(/[/\\]/).filter(Boolean).pop() ?? filePath;
+    return LanguageDescription.matchFilename(CODEMIRROR_LANGUAGES, basename)?.name ?? null;
+  }, [filePath]);
+
+  const scopeTypes = useMemo(
+    () => (langName ? (SCOPE_NODE_TYPES_BY_LANGUAGE[langName] ?? null) : null),
+    [langName]
+  );
 
   useEffect(() => {
     const basename = filePath.split(/[/\\]/).filter(Boolean).pop() ?? filePath;
@@ -163,6 +226,75 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
     () => (langExtension ? [...BASE_EXTENSIONS, langExtension] : BASE_EXTENSIONS),
     [langExtension]
   );
+
+  const handleScroll = useCallback(() => {
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const view = viewRef.current;
+      const wrapper = scrollRef.current;
+      if (!view || !wrapper) return;
+      if (wrapper.scrollTop <= 0) {
+        stickyScopeRef.current = null;
+        setStickyScope(null);
+        return;
+      }
+      if (!scopeTypes || scopeTypes.size === 0) {
+        stickyScopeRef.current = null;
+        setStickyScope(null);
+        return;
+      }
+      try {
+        const wrapperRect = wrapper.getBoundingClientRect();
+        const editorTop = view.dom.getBoundingClientRect().top - wrapperRect.top;
+        const adjustedScrollTop = wrapper.scrollTop - editorTop;
+        const line = view.lineBlockAtHeight(adjustedScrollTop);
+        const tree = syntaxTree(view.state);
+        let node = tree.resolve(line.from, -1);
+        let found: { from: number } | null = null;
+        while (node && node !== tree.topNode) {
+          if (scopeTypes.has(node.type.name)) {
+            found = { from: node.from };
+          }
+          if (node.parent) {
+            node = node.parent;
+          } else {
+            break;
+          }
+        }
+        if (found) {
+          const text = view.state.doc.lineAt(found.from).text.trimEnd();
+          if (stickyScopeRef.current !== text) {
+            stickyScopeRef.current = text;
+            setStickyScope(text);
+          }
+        } else {
+          if (stickyScopeRef.current !== null) {
+            stickyScopeRef.current = null;
+            setStickyScope(null);
+          }
+        }
+      } catch {
+        if (stickyScopeRef.current !== null) {
+          stickyScopeRef.current = null;
+          setStickyScope(null);
+        }
+      }
+    });
+  }, [scopeTypes]);
+
+  useEffect(() => {
+    handleScroll();
+  }, [content, handleScroll]);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, []);
 
   const handleCreateEditor = useCallback(
     (view: EditorView) => {
@@ -192,11 +324,24 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
 
   return (
     <div
+      ref={scrollRef}
+      onScroll={handleScroll}
       className={cn(
         "overflow-auto text-[13px] [&_.cm-editor]:min-h-full [&_.cm-scroller]:!overflow-visible",
         className
       )}
     >
+      {stickyScope !== null && (
+        <div
+          className="sticky top-0 z-10 pointer-events-none flex items-center px-2 truncate border-b border-[var(--theme-border-default)] bg-[var(--theme-surface-sidebar)] text-[var(--theme-text-secondary)] whitespace-pre"
+          style={{
+            height: viewRef.current ? `${viewRef.current.defaultLineHeight}px` : "1.5em",
+            lineHeight: viewRef.current ? `${viewRef.current.defaultLineHeight}px` : "1.5em",
+          }}
+        >
+          {stickyScope}
+        </div>
+      )}
       <CodeMirror
         value={content}
         theme={daintreeTheme}

--- a/src/components/FileViewer/CodeViewer.tsx
+++ b/src/components/FileViewer/CodeViewer.tsx
@@ -10,7 +10,8 @@ import {
 import CodeMirror from "@uiw/react-codemirror";
 import { EditorView, Decoration, type DecorationSet, keymap } from "@codemirror/view";
 import { type Extension, StateEffect, StateField, EditorState } from "@codemirror/state";
-import { LanguageDescription, syntaxTree, type SyntaxNode } from "@codemirror/language";
+import { LanguageDescription, syntaxTree } from "@codemirror/language";
+import { type SyntaxNode } from "@lezer/common";
 import { search, openSearchPanel, gotoLine } from "@codemirror/search";
 import { daintreeTheme } from "./editorTheme";
 import { editorSearchHighlightTheme } from "./editorSearchTheme";

--- a/src/components/FileViewer/CodeViewer.tsx
+++ b/src/components/FileViewer/CodeViewer.tsx
@@ -10,7 +10,7 @@ import {
 import CodeMirror from "@uiw/react-codemirror";
 import { EditorView, Decoration, type DecorationSet, keymap } from "@codemirror/view";
 import { type Extension, StateEffect, StateField, EditorState } from "@codemirror/state";
-import { LanguageDescription, syntaxTree } from "@codemirror/language";
+import { LanguageDescription, syntaxTree, type SyntaxNode } from "@codemirror/language";
 import { search, openSearchPanel, gotoLine } from "@codemirror/search";
 import { daintreeTheme } from "./editorTheme";
 import { editorSearchHighlightTheme } from "./editorSearchTheme";
@@ -159,6 +159,28 @@ const SCOPE_NODE_TYPES_BY_LANGUAGE: Record<string, Set<string>> = {
     "InterfaceDeclaration",
     "EnumDeclaration",
   ]),
+  TSX: new Set([
+    "FunctionDeclaration",
+    "ClassDeclaration",
+    "MethodDeclaration",
+    "ArrowFunction",
+    "FunctionExpression",
+    "ClassExpression",
+    "InterfaceDeclaration",
+    "EnumDeclaration",
+    "NamespaceDeclaration",
+  ]),
+  JSX: new Set([
+    "FunctionDeclaration",
+    "ClassDeclaration",
+    "MethodDeclaration",
+    "ArrowFunction",
+    "FunctionExpression",
+    "ClassExpression",
+    "InterfaceDeclaration",
+    "EnumDeclaration",
+    "NamespaceDeclaration",
+  ]),
   "C++": new Set(["FunctionDefinition", "ClassSpecifier", "StructSpecifier"]),
   C: new Set(["FunctionDefinition", "ClassSpecifier", "StructSpecifier"]),
 };
@@ -245,22 +267,17 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
         return;
       }
       try {
-        const wrapperRect = wrapper.getBoundingClientRect();
-        const editorTop = view.dom.getBoundingClientRect().top - wrapperRect.top;
-        const adjustedScrollTop = wrapper.scrollTop - editorTop;
-        const line = view.lineBlockAtHeight(adjustedScrollTop);
+        const cmScrollTop = wrapper.getBoundingClientRect().top - view.documentTop;
+        const line = view.lineBlockAtHeight(Math.max(0, cmScrollTop));
         const tree = syntaxTree(view.state);
-        let node = tree.resolve(line.from, -1);
+        let node: SyntaxNode | null = tree.resolve(line.from, -1);
         let found: { from: number } | null = null;
         while (node && node !== tree.topNode) {
           if (scopeTypes.has(node.type.name)) {
             found = { from: node.from };
-          }
-          if (node.parent) {
-            node = node.parent;
-          } else {
             break;
           }
+          node = node.parent;
         }
         if (found) {
           const text = view.state.doc.lineAt(found.from).text.trimEnd();
@@ -286,6 +303,10 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
   useEffect(() => {
     handleScroll();
   }, [content, handleScroll]);
+
+  useEffect(() => {
+    handleScroll();
+  }, [langExtension, handleScroll]);
 
   useEffect(() => {
     return () => {
@@ -331,17 +352,20 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
         className
       )}
     >
-      {stickyScope !== null && (
-        <div
-          className="sticky top-0 z-10 pointer-events-none flex items-center px-2 truncate border-b border-[var(--theme-border-default)] bg-[var(--theme-surface-sidebar)] text-[var(--theme-text-secondary)] whitespace-pre"
-          style={{
-            height: viewRef.current ? `${viewRef.current.defaultLineHeight}px` : "1.5em",
-            lineHeight: viewRef.current ? `${viewRef.current.defaultLineHeight}px` : "1.5em",
-          }}
-        >
-          {stickyScope}
-        </div>
-      )}
+      <div
+        className={cn(
+          "sticky top-0 z-10 pointer-events-none flex items-center px-2 truncate border-b whitespace-pre",
+          stickyScope !== null
+            ? "border-[var(--theme-border-default)] bg-[var(--theme-surface-sidebar)] text-[var(--theme-text-secondary)]"
+            : "border-transparent bg-transparent text-transparent"
+        )}
+        style={{
+          height: viewRef.current ? `${viewRef.current.defaultLineHeight}px` : "1.5em",
+          lineHeight: viewRef.current ? `${viewRef.current.defaultLineHeight}px` : "1.5em",
+        }}
+      >
+        {stickyScope ?? " "}
+      </div>
       <CodeMirror
         value={content}
         theme={daintreeTheme}


### PR DESCRIPTION
## Summary
- Added a sticky scope header that shows the current function/class when scrolling through code. Uses CodeMirror's syntax tree to resolve the innermost scope node at the top of the viewport.
- Set the code viewer to read-only mode, which both prevents accidental edits and hides the find/replace UI (keeping only find).
- Supports scope detection across 10+ languages including JavaScript, TypeScript, Python, Go, Rust, Java, C, C++, JSX, and TSX.

Resolves #9218

## Changes
- Added `SCOPE_NODE_TYPES_BY_LANGUAGE` registry mapping language names to scope node types
- Added `stickyScope` state and a scroll-driven header above the CodeMirror editor
- Implemented scope resolution using `syntaxTree`, walking parent nodes to find the innermost matching scope
- Added `EditorState.readOnly.of(true)` to base extensions to suppress the replace UI
- Fixed `SyntaxNode` import to use `@lezer/common` directly

## Testing
- Verified sticky header updates correctly when scrolling through code files of different languages
- Confirmed read-only mode hides replace UI while keeping find/search functional
- Tested edge cases: scroll-to-top clears header, empty files, files without recognized scope types