### PR TITLE
fix(terminal): skeleton placeholder for spawn state, keep failed terminals in grid

### DIFF
--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -375,7 +375,7 @@ export interface PtyPanelData extends BasePanelData {
    * then "ready". Absent (undefined) on hydrated panels — treat as "ready".
    * Never serialized — see `serializePtyPanel`.
    */
-  spawnStatus?: "spawning" | "ready" | "missing-cli";
+  spawnStatus?: "spawning" | "ready" | "missing-cli" | "failed";
   /**
    * Original user-selected preset ID. Set on first spawn, never overwritten
    * when a fallback activates. Used to display "was {original} → {active}".
@@ -609,7 +609,7 @@ export interface TerminalInstance {
    * then "ready". Absent (undefined) on hydrated panels — treat as "ready".
    * Never serialized — see `serializePtyPanel`.
    */
-  spawnStatus?: "spawning" | "ready" | "missing-cli";
+  spawnStatus?: "spawning" | "ready" | "missing-cli" | "failed";
   /** Original user-selected preset ID; immutable across fallback hops. */
   originalPresetId?: string;
   /** Whether this panel is currently running on a fallback preset. */

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -412,7 +412,12 @@ export function HelpPanel({
         // trust the bar's internal rAF to take focus when its ref is present
         // — no xterm fallback in that branch, otherwise CodeMirror would
         // steal focus from xterm one frame later and produce a focus flicker.
-        if (terminalId && terminal && terminalPty?.spawnStatus !== "missing-cli") {
+        if (
+          terminalId &&
+          terminal &&
+          terminalPty?.spawnStatus !== "missing-cli" &&
+          terminalPty?.spawnStatus !== "failed"
+        ) {
           if (showHybridInputBar && inputBarRef.current) {
             inputBarRef.current.focusWithCursorAtEnd();
             return;

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -31,6 +31,7 @@ import { TerminalRestartStatusBanner } from "./TerminalRestartStatusBanner";
 import { getRestartBannerVariant } from "./restartStatus";
 import { TerminalErrorBanner } from "./TerminalErrorBanner";
 import { SpawnErrorBanner } from "./SpawnErrorBanner";
+import { TerminalPaneSkeleton } from "./TerminalPaneSkeleton";
 import { ReconnectErrorBanner } from "./ReconnectErrorBanner";
 import { ScrollbackRestoreErrorBanner } from "./ScrollbackRestoreErrorBanner";
 import { UpdateCwdDialog } from "./UpdateCwdDialog";
@@ -186,15 +187,8 @@ export function BannerSlot({ visible, children }: BannerSlotProps) {
   );
 }
 
-function TerminalStartupPlaceholder({ agentId }: { agentId?: string }) {
-  return (
-    <div className="flex h-full min-h-0 items-center justify-center bg-daintree-bg text-sm text-daintree-text/60">
-      <div className="flex items-center gap-2">
-        <Spinner size="sm" className="text-daintree-text/45" />
-        <span>{agentId ? "Starting agent" : "Starting terminal"}</span>
-      </div>
-    </div>
-  );
+function TerminalStartupPlaceholder({ agentId: _agentId }: { agentId?: string }) {
+  return <TerminalPaneSkeleton />;
 }
 
 export interface ActivityState {
@@ -1251,6 +1245,10 @@ function TerminalPaneComponent({
           />
         ) : spawnStatus === "spawning" ? (
           <TerminalStartupPlaceholder agentId={agentId} />
+        ) : spawnStatus === "failed" ? (
+          <div className="flex-1 min-h-0 bg-daintree-bg flex items-center justify-center">
+            <p className="text-sm text-daintree-text/50">Terminal failed to start</p>
+          </div>
         ) : (
           <>
             <div className="flex-1 relative min-h-0">

--- a/src/components/Terminal/TerminalPaneSkeleton.tsx
+++ b/src/components/Terminal/TerminalPaneSkeleton.tsx
@@ -1,0 +1,41 @@
+import { SkeletonHint } from "@/components/ui/Skeleton";
+
+interface TerminalPaneSkeletonProps {
+  label?: string;
+}
+
+export function TerminalPaneSkeleton({ label = "Starting terminal" }: TerminalPaneSkeletonProps) {
+  return (
+    <div className="relative flex flex-col h-full w-full">
+      <div
+        className="flex flex-col h-full w-full"
+        role="status"
+        aria-busy="true"
+        aria-label={label}
+      >
+        <span className="sr-only">{label}</span>
+
+        {/* Header row — matches PanelHeader h-8 */}
+        <div
+          className="flex items-center justify-between px-3 shrink-0 h-8 border-b border-divider bg-surface"
+          aria-hidden="true"
+        >
+          <div className="flex items-center gap-2">
+            <div className="animate-pulse-delayed h-3.5 w-3.5 bg-muted rounded" />
+            <div className="animate-pulse-delayed h-3 w-20 bg-muted rounded" />
+          </div>
+          <div className="flex items-center gap-1">
+            <div className="animate-pulse-delayed h-4 w-4 bg-muted rounded" />
+            <div className="animate-pulse-delayed h-4 w-4 bg-muted rounded" />
+            <div className="animate-pulse-delayed h-4 w-4 bg-muted rounded" />
+          </div>
+        </div>
+
+        {/* Body area — dark rectangle, no fake terminal lines */}
+        <div className="flex-1 min-h-0 bg-daintree-bg" />
+      </div>
+
+      <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
+    </div>
+  );
+}

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -327,10 +327,10 @@ describe("hydration batch (#5196)", () => {
     expect(after?.activityHeadline).toBe("writing code");
   });
 
-  it("removes the optimistic placeholder when the background spawn rejects", async () => {
-    // #5789: addPanel is optimistic — the panel lands in panelsById before spawn
-    // resolves. If spawn rejects, the placeholder must be cleaned up so the grid
-    // doesn't end up with a zombie panel that has no live PTY.
+  it("keeps the optimistic placeholder with spawnStatus 'failed' when spawn rejects", async () => {
+    // #9166: addPanel is optimistic — the panel lands in panelsById before spawn
+    // resolves. If spawn rejects, the panel stays with spawnStatus "failed" so
+    // per-cell error chrome can render.
     const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
 
     const { terminalClient } = (await import("@/clients")) as unknown as {
@@ -356,22 +356,23 @@ describe("hydration batch (#5196)", () => {
       bypassLimits: true,
     });
 
-    // Drain microtasks so the failed spawn's rejection handler runs removePanel.
-    // The background spawn promise chains through Promise.all(env) → spawn → .then,
-    // which takes several ticks.
     for (let i = 0; i < 20; i++) await Promise.resolve();
 
     saveNormalizedMock.mockClear();
     flushHydrationBatch(token);
 
-    // The failed id is evicted from panelsById by removePanel; the flush filter
-    // only appends ids that still exist in panelsById, so panelIds gets just ok-1.
-    expect(usePanelStore.getState().panelIds).toEqual(["ok-1"]);
-    expect(usePanelStore.getState().panelsById["fail-1"]).toBeUndefined();
+    // Both panels persist: the failed panel stays with spawnStatus "failed",
+    // the successful one with spawnStatus "ready".
+    const state = usePanelStore.getState();
+    expect(state.panelIds).toEqual(["fail-1", "ok-1"]);
+    expect(state.panelsById["fail-1"]).toBeDefined();
+    expect(
+      (state.panelsById["fail-1"] as import("@shared/types/panel").PtyPanelData).spawnStatus
+    ).toBe("failed");
 
     expect(saveNormalizedMock).toHaveBeenCalled();
     const lastCall = saveNormalizedMock.mock.calls.at(-1) as [Record<string, unknown>, string[]];
-    expect(lastCall[1]).toEqual(["ok-1"]);
+    expect(lastCall[1]).toEqual(["fail-1", "ok-1"]);
   });
 
   it("collapses N panel additions into a single panelIds render", async () => {

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -226,7 +226,7 @@ describe("optimistic panel spawn (#5789)", () => {
     }
   });
 
-  it("removes the panel when the background spawn rejects", async () => {
+  it("keeps the panel with spawnStatus 'failed' when the background spawn rejects", async () => {
     const { terminalClient } = (await import("@/clients")) as unknown as {
       terminalClient: { spawn: ReturnType<typeof vi.fn> };
     };
@@ -247,12 +247,16 @@ describe("optimistic panel spawn (#5789)", () => {
     expect(id).toBe("will-fail");
     expect(usePanelStore.getState().panelsById["will-fail"]).toBeDefined();
 
-    // Drain microtasks for the rejection handler to run removePanel.
+    // Drain microtasks for the rejection handler to set spawnStatus: "failed".
     await drainMicrotasks();
 
     const state = usePanelStore.getState();
-    expect(state.panelsById["will-fail"]).toBeUndefined();
-    expect(state.panelIds).not.toContain("will-fail");
+    const failed = state.panelsById["will-fail"] as PtyPanelData | undefined;
+    expect(failed).toBeDefined();
+    expect(failed?.spawnStatus).toBe("failed");
+    expect(failed?.spawnError?.code).toBe("UNKNOWN");
+    expect(failed?.spawnError?.message).toBe("spawn boom");
+    expect(failed?.runtimeStatus).toBe("error");
   });
 
   it("marks reconnect panels as 'ready' without calling spawn", async () => {

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -750,6 +750,9 @@ export const createAddPanelActions = (
             },
           };
         });
+
+        const after = get();
+        saveNormalized(after.panelsById, after.panelIds);
       }
     });
 

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -29,6 +29,7 @@ import {
   DOCK_PREWARM_HEIGHT_PX,
 } from "./helpers";
 import { logDebug, logWarn, logError } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { collectPanelIdForBatch, isHydrationBatchActive } from "./hydrationBatch";
 import { addToWorktreeIndex, transferBetweenWorktreeIndex } from "./worktreeIndex";
 
@@ -731,12 +732,15 @@ export const createAddPanelActions = (
         const current = get().panelsById[id];
         if (!current || !isPtyPanel(current) || current.spawnStatus !== "spawning") return;
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- error shape from node-pty spawn rejection
+        const err = error as { code?: string; errno?: number; syscall?: string; path?: string };
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- SpawnError construction from caught IPC error
         const spawnError = {
-          code: (error as { code?: string })?.code ?? "UNKNOWN",
-          message: error instanceof Error ? error.message : String(error),
-          errno: (error as { errno?: number })?.errno,
-          syscall: (error as { syscall?: string })?.syscall,
-          path: (error as { path?: string })?.path,
+          code: err.code ?? "UNKNOWN",
+          message: formatErrorMessage(error, "Failed to start terminal process"),
+          errno: err.errno,
+          syscall: err.syscall,
+          path: err.path,
         } as import("@shared/types/pty-host").SpawnError;
 
         set((state) => {

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -325,7 +325,7 @@ export const createAddPanelActions = (
     const ptyKindConfig = getPanelKindConfig(kind);
     const ptyPluginId = ptyKindConfig?.extensionId ?? options.pluginId;
     // Reconnects don't go through a fresh spawn — mark them "ready" directly.
-    const spawnStatus: "spawning" | "ready" = isReconnect ? "ready" : "spawning";
+    const spawnStatus: "spawning" | "ready" | "failed" = isReconnect ? "ready" : "spawning";
 
     const terminal = {
       id,
@@ -728,20 +728,28 @@ export const createAddPanelActions = (
         }
       } catch (error) {
         logError("[TerminalStore] Failed to spawn terminal", error);
-        // Only remove the placeholder we committed. If the id has been reused
-        // (e.g. the user closed the panel mid-spawn and a reconnect slot picked
-        // the id up) or the panel was already removed, skip the cleanup —
-        // otherwise we'd destroy someone else's panel.
         const current = get().panelsById[id];
         if (!current || !isPtyPanel(current) || current.spawnStatus !== "spawning") return;
-        try {
-          get().removePanel(id);
-        } catch (removeError) {
-          logWarn("[TerminalStore] Failed to remove panel after spawn failure", {
-            id,
-            error: removeError,
-          });
-        }
+
+        const spawnError = {
+          code: (error as { code?: string })?.code ?? "UNKNOWN",
+          message: error instanceof Error ? error.message : String(error),
+          errno: (error as { errno?: number })?.errno,
+          syscall: (error as { syscall?: string })?.syscall,
+          path: (error as { path?: string })?.path,
+        } as import("@shared/types/pty-host").SpawnError;
+
+        set((state) => {
+          const _current = state.panelsById[id];
+          if (!_current || !isPtyPanel(_current) || _current.spawnStatus !== "spawning")
+            return state;
+          return {
+            panelsById: {
+              ...state.panelsById,
+              [id]: { ..._current, spawnStatus: "failed", spawnError, runtimeStatus: "error" },
+            },
+          };
+        });
       }
     });
 

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -199,6 +199,10 @@ export const createRestartActions = (
         spawnError: undefined,
         scrollbackRestoreError: undefined,
         isRestarting: true,
+        spawnStatus:
+          (t as import("@shared/types/panel").PtyPanelData).spawnStatus === "failed"
+            ? "spawning"
+            : (t as import("@shared/types/panel").PtyPanelData).spawnStatus,
       }))
     );
 
@@ -538,7 +542,16 @@ export const createRestartActions = (
       }
 
       unmarkTerminalRestarting(id);
-      set((state) => updateTerminal(state, id, (t) => ({ ...t, isRestarting: false })));
+      set((state) =>
+        updateTerminal(state, id, (t) => ({
+          ...t,
+          isRestarting: false,
+          spawnStatus:
+            (t as import("@shared/types/panel").PtyPanelData).spawnStatus === "spawning"
+              ? "ready"
+              : (t as import("@shared/types/panel").PtyPanelData).spawnStatus,
+        }))
+      );
     } catch (error) {
       const errorMessage = formatErrorMessage(error, "Failed to restart terminal");
       const errorCode = (error as { code?: string })?.code;

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -191,6 +191,11 @@ export const createRestartActions = (
     cancelReconnectErrorDebounce(id);
 
     // Also set the store flag for UI and other consumers
+    // Track whether we're restarting from a failed spawn so we can clear
+    // spawnStatus (allowing XtermAdapter to mount) and restore it on failure.
+    const wasFailed =
+      (get().panelsById[id] as import("@shared/types/panel").PtyPanelData | undefined)
+        ?.spawnStatus === "failed";
     set((state) =>
       updateTerminal(state, id, (t) => ({
         ...t,
@@ -199,10 +204,7 @@ export const createRestartActions = (
         spawnError: undefined,
         scrollbackRestoreError: undefined,
         isRestarting: true,
-        spawnStatus:
-          (t as import("@shared/types/panel").PtyPanelData).spawnStatus === "failed"
-            ? "spawning"
-            : (t as import("@shared/types/panel").PtyPanelData).spawnStatus,
+        ...(wasFailed ? { spawnStatus: undefined } : {}),
       }))
     );
 
@@ -247,7 +249,12 @@ export const createRestartActions = (
 
       unmarkTerminalRestarting(id);
       set((state) =>
-        updateTerminal(state, id, (t) => ({ ...t, isRestarting: false, restartError }))
+        updateTerminal(state, id, (t) => ({
+          ...t,
+          isRestarting: false,
+          restartError,
+          ...(wasFailed ? { spawnStatus: "failed" as const } : {}),
+        }))
       );
       logWarn("[TerminalStore] Restart validation failed for terminal", { id, restartError });
       return;
@@ -542,16 +549,7 @@ export const createRestartActions = (
       }
 
       unmarkTerminalRestarting(id);
-      set((state) =>
-        updateTerminal(state, id, (t) => ({
-          ...t,
-          isRestarting: false,
-          spawnStatus:
-            (t as import("@shared/types/panel").PtyPanelData).spawnStatus === "spawning"
-              ? "ready"
-              : (t as import("@shared/types/panel").PtyPanelData).spawnStatus,
-        }))
-      );
+      set((state) => updateTerminal(state, id, (t) => ({ ...t, isRestarting: false })));
     } catch (error) {
       const errorMessage = formatErrorMessage(error, "Failed to restart terminal");
       const errorCode = (error as { code?: string })?.code;
@@ -589,6 +587,7 @@ export const createRestartActions = (
           restartError,
           // Restore session ID so user can retry resume
           ...(consumedSessionId ? { agentSessionId: consumedSessionId } : {}),
+          ...(wasFailed ? { spawnStatus: "failed" as const } : {}),
         }))
       );
 

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -193,9 +193,8 @@ export const createRestartActions = (
     // Also set the store flag for UI and other consumers
     // Track whether we're restarting from a failed spawn so we can clear
     // spawnStatus (allowing XtermAdapter to mount) and restore it on failure.
-    const wasFailed =
-      (get().panelsById[id] as import("@shared/types/panel").PtyPanelData | undefined)
-        ?.spawnStatus === "failed";
+    const ptyPanel = get().panelsById[id] as import("@shared/types/panel").PtyPanelData | undefined; // eslint-disable-line @typescript-eslint/no-unsafe-type-assertion -- narrow to PtyPanelData for spawnStatus access
+    const wasFailed = ptyPanel?.spawnStatus === "failed";
     set((state) =>
       updateTerminal(state, id, (t) => ({
         ...t,


### PR DESCRIPTION
This PR polishes two rough edges in per-cell terminal spawn state rendering.

## Skeleton placeholder instead of Spinner

When a terminal mounts with `spawnStatus: "spawning"`, we were showing a `Spinner` plus "Starting terminal" copy. The loading guidance in CLAUDE.md reserves `Spinner` for unknown shapes and says to use a skeleton for predictable layouts. A terminal cell has a known shape (frame, title bar, body), so the skeleton is the right choice.

`TerminalStartupPlaceholder` now renders a `TerminalPaneSkeleton` that uses the existing `animate-pulse-delayed` utility, which enforces the 400ms Doherty threshold automatically.

## Failed spawns stay in the grid

Added a `"failed"` variant to the `spawnStatus` union. Before this, when a PTY spawn failed inside a multi-panel recipe, the panel was removed from the grid entirely. The only failure surface was a bulk retry banner keyed by index number, which forced users to mentally map "Terminal 3" back to a cell. Now the failed panel stays in the grid with inline error text and remains restartable.

The restart logic preserves and restores `spawnStatus: "failed"` across retries so the state does not get lost on a failed restart.

## Changes
- Replaced spinner with `TerminalPaneSkeleton` (uses `animate-pulse-delayed`)
- Added `"failed"` to `spawnStatus` union in `shared/types/panel.ts`
- Failed panels persist in grid with error chrome instead of being removed
- Updated restart logic to preserve/restore `failed` state
- Updated optimistic spawn and hydration batch tests for keep-on-failure behavior
- Gate HelpPanel focus-steal on `"failed"` alongside `"missing-cli"`

Resolves #9166.