### PR TITLE
feat(dev-preview): classify cert/SSL failures with distinct error overlays

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -332,6 +332,7 @@ export function DevPreviewPane({
   const crashTimestampsRef = useRef<number[]>([]);
   const crashReloadRef = useRef<() => void>(() => {});
   const blockedNavTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const CLIPBOARD_FEEDBACK_MS = 2000;
   const [certCopied, setCertCopied] = useState(false);
   const certCopyTimerRef = useRef<NodeJS.Timeout | null>(null);
   const handleCopyMkcert = useCallback(async () => {
@@ -339,7 +340,7 @@ export function DevPreviewPane({
       await window.electron.clipboard.writeText("mkcert -install");
       setCertCopied(true);
       if (certCopyTimerRef.current) clearTimeout(certCopyTimerRef.current);
-      certCopyTimerRef.current = setTimeout(() => setCertCopied(false), 2000);
+      certCopyTimerRef.current = setTimeout(() => setCertCopied(false), CLIPBOARD_FEEDBACK_MS);
     } catch {
       // clipboard unavailable — silently ignore
     }

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -2,12 +2,14 @@ import { useState, useCallback, useRef, useEffect, useMemo, useReducer } from "r
 import { useBrowserActionListeners } from "@/hooks/useBrowserActionListeners";
 import {
   AlertTriangle,
-  RotateCw,
+  Check,
   ChevronDown,
+  Copy,
   ExternalLink,
-  Settings,
   OctagonAlert,
   Play,
+  RotateCw,
+  Settings,
   XCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -330,6 +332,23 @@ export function DevPreviewPane({
   const crashTimestampsRef = useRef<number[]>([]);
   const crashReloadRef = useRef<() => void>(() => {});
   const blockedNavTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const [certCopied, setCertCopied] = useState(false);
+  const certCopyTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const handleCopyMkcert = useCallback(async () => {
+    try {
+      await window.electron.clipboard.writeText("mkcert -install");
+      setCertCopied(true);
+      if (certCopyTimerRef.current) clearTimeout(certCopyTimerRef.current);
+      certCopyTimerRef.current = setTimeout(() => setCertCopied(false), 2000);
+    } catch {
+      // clipboard unavailable — silently ignore
+    }
+  }, []);
+  useEffect(() => {
+    return () => {
+      if (certCopyTimerRef.current) clearTimeout(certCopyTimerRef.current);
+    };
+  }, []);
   const lastSetUrlRef = useRef<string>("");
   const [consoleTerminalId, setConsoleTerminalId] = useState<string | null>(terminalId);
   // Generation token to invalidate in-flight async scroll captures when the
@@ -1568,12 +1587,32 @@ export function DevPreviewPane({
                                 ? "Couldn't resolve address"
                                 : webviewLoadError.code === "internet_disconnected"
                                   ? "No internet connection"
-                                  : "Page load failed"}
+                                  : webviewLoadError.code === "cert" ||
+                                      webviewLoadError.code === "ssl_protocol"
+                                    ? "Certificate Error"
+                                    : "Page load failed"}
                       </h3>
                       <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
                         {webviewLoadError.message}
                       </p>
                       <div className="flex items-center gap-1">
+                        {webviewLoadError.code === "cert" && (
+                          <Button
+                            onClick={handleCopyMkcert}
+                            variant="ghost"
+                            size="sm"
+                            className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+                          >
+                            {certCopied ? (
+                              <Check className="h-3.5 w-3.5" />
+                            ) : (
+                              <Copy className="h-3.5 w-3.5" />
+                            )}
+                            <span className="text-xs">
+                              {certCopied ? "Copied" : "Copy `mkcert -install`"}
+                            </span>
+                          </Button>
+                        )}
                         {webviewLoadError.code === "connection_refused" ? (
                           <>
                             <Tooltip>

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -1510,6 +1510,113 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       expect(container.textContent).toContain("mkcert -install");
     });
 
+    it("cancels pending connection-refused retry when cert error arrives", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      // Fire a connection-refused to schedule a retry at 500ms
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -102,
+          errorDescription: "ERR_CONNECTION_REFUSED",
+          isMainFrame: true,
+          validatedURL: "http://localhost:5173/",
+        });
+      });
+
+      // Before the retry fires, a cert error arrives
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -202,
+          errorDescription: "ERR_CERT_AUTHORITY_INVALID",
+          isMainFrame: true,
+          validatedURL: "https://localhost:8443/",
+        });
+      });
+
+      // Advance past the retry timeout
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      // The stale retry must NOT have called loadURL
+      expect(webview.loadURL).not.toHaveBeenCalled();
+      // Cert error overlay must be visible
+      expect(container.textContent).toContain("Certificate Error");
+    });
+
+    it("classifies -299 (cert range lower bound) as cert, -199 and -300 fall through", () => {
+      const { container: c1 } = render(<DevPreviewPane {...baseProps} />);
+      const w1 = getWebviewElement(c1);
+      act(() => {
+        emitWebviewEvent(w1, "did-fail-load", {
+          errorCode: -299,
+          errorDescription: "ERR_CERT_VALIDITY_TOO_LONG",
+          isMainFrame: true,
+          validatedURL: "https://example.com/",
+        });
+      });
+      expect(c1.textContent).toContain("Certificate Error");
+
+      const { container: c2 } = render(<DevPreviewPane {...baseProps} />);
+      const w2 = getWebviewElement(c2);
+      act(() => {
+        emitWebviewEvent(w2, "did-fail-load", {
+          errorCode: -199,
+          errorDescription: "ERR_CERT_END",
+          isMainFrame: true,
+          validatedURL: "https://example.com/",
+        });
+      });
+      expect(c2.textContent).toContain("Page load failed");
+      expect(c2.textContent).not.toContain("mkcert");
+
+      const { container: c3 } = render(<DevPreviewPane {...baseProps} />);
+      const w3 = getWebviewElement(c3);
+      act(() => {
+        emitWebviewEvent(w3, "did-fail-load", {
+          errorCode: -300,
+          errorDescription: "ERR_CERT_START",
+          isMainFrame: true,
+          validatedURL: "https://example.com/",
+        });
+      });
+      expect(c3.textContent).toContain("Page load failed");
+      expect(c3.textContent).not.toContain("mkcert");
+    });
+
+    it("shows Copied feedback on mkcert copy button click", async () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -202,
+          errorDescription: "ERR_CERT_AUTHORITY_INVALID",
+          isMainFrame: true,
+          validatedURL: "https://localhost:8443/",
+        });
+      });
+
+      const buttons = Array.from(container.querySelectorAll("button"));
+      const mkcertButton = buttons.find((btn) => btn.textContent?.includes("mkcert -install"));
+      expect(mkcertButton).toBeTruthy();
+
+      await act(async () => {
+        mkcertButton!.click();
+        // Flush the microtask from the async clipboard handler
+        await Promise.resolve();
+      });
+
+      expect(mkcertButton!.textContent).toContain("Copied");
+
+      act(() => {
+        vi.advanceTimersByTime(2500);
+      });
+
+      expect(mkcertButton!.textContent).toContain("mkcert -install");
+    });
+
     it("cleans slow timer on unmount", () => {
       const { container, unmount } = render(<DevPreviewPane {...baseProps} />);
       const webview = getWebviewElement(container);

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -339,6 +339,9 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       window: {
         onDestroyHiddenWebviews: vi.fn(() => vi.fn()),
       },
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
       webview: {
         registerPanel: vi.fn(() => Promise.resolve()),
         onDialogRequest: vi.fn(() => vi.fn()),
@@ -1419,6 +1422,92 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       }
 
       expect(container.textContent).toContain("localhost:5173");
+    });
+
+    it("shows certificate error overlay for ERR_CERT_AUTHORITY_INVALID (-202)", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -202,
+          errorDescription: "ERR_CERT_AUTHORITY_INVALID",
+          isMainFrame: true,
+          validatedURL: "https://localhost:8443/",
+        });
+      });
+
+      expect(container.textContent).toContain("Certificate Error");
+      expect(container.textContent).toContain("certificate couldn't be verified");
+      expect(container.textContent).toContain("mkcert -install");
+      expect(container.textContent).toContain("localhost:8443");
+      // Should NOT enter the connection-refused retry loop
+      expect(container.textContent).not.toContain("Reconnecting");
+    });
+
+    it("copy button calls clipboard.writeText for cert errors", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -202,
+          errorDescription: "ERR_CERT_AUTHORITY_INVALID",
+          isMainFrame: true,
+          validatedURL: "https://localhost:8443/",
+        });
+      });
+
+      // Find the copy button by its text content
+      const buttons = Array.from(container.querySelectorAll("button"));
+      const mkcertButton = buttons.find((btn) => btn.textContent?.includes("mkcert -install"));
+      expect(mkcertButton).toBeTruthy();
+
+      act(() => {
+        mkcertButton!.click();
+      });
+
+      const electron = (window as unknown as { electron: Record<string, unknown> }).electron;
+      const clipboard = electron.clipboard as { writeText: ReturnType<typeof vi.fn> };
+      expect(clipboard.writeText).toHaveBeenCalledWith("mkcert -install");
+    });
+
+    it("shows SSL/TLS handshake message for ERR_SSL_PROTOCOL_ERROR (-107)", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -107,
+          errorDescription: "ERR_SSL_PROTOCOL_ERROR",
+          isMainFrame: true,
+          validatedURL: "https://localhost:8443/",
+        });
+      });
+
+      expect(container.textContent).toContain("Certificate Error");
+      expect(container.textContent).toContain("SSL/TLS handshake failed");
+      // -107 is also raised on protocol mismatch — the mkcert hint is wrong here
+      expect(container.textContent).not.toContain("mkcert");
+      // Should NOT enter the connection-refused retry loop
+      expect(container.textContent).not.toContain("Reconnecting");
+    });
+
+    it("classifies -200 (cert range boundary) as cert error", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -200,
+          errorDescription: "ERR_CERT_COMMON_NAME_INVALID",
+          isMainFrame: true,
+          validatedURL: "https://example.com/",
+        });
+      });
+
+      expect(container.textContent).toContain("Certificate Error");
+      expect(container.textContent).toContain("mkcert -install");
     });
 
     it("cleans slow timer on unmount", () => {

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -23,6 +23,8 @@ export type WebviewLoadErrorCode =
   | "name_not_resolved"
   | "internet_disconnected"
   | "connection_refused"
+  | "cert"
+  | "ssl_protocol"
   | "failed";
 
 export interface WebviewLoadError {
@@ -31,6 +33,11 @@ export interface WebviewLoadError {
   errorCode?: number;
   validatedURL?: string;
 }
+
+// Chromium net error codes — see net/base/net_error_list.h
+const ERR_SSL_PROTOCOL_ERROR = -107;
+const ERR_CERT_RANGE_END = -200;
+const ERR_CERT_RANGE_START = -299;
 
 interface UseDevPreviewLoadLifecycleParams {
   webviewElement: Electron.WebviewTag | null;
@@ -353,6 +360,32 @@ export function useDevPreviewLoadLifecycle({
           code: "timeout",
           message: `Connection to ${e.validatedURL} timed out. The server may be unreachable.`,
           errorCode: ERR_CONNECTION_TIMED_OUT,
+        });
+        return;
+      }
+
+      // Cert/SSL errors: deterministic, no retry. Classify before the
+      // connection-refused retry block so cert failures don't enter the
+      // exponential-backoff loop. -107 (SSL protocol) checked first so it
+      // gets a different message than the cert-validation range (-200..-299).
+      const isCertError = e.errorCode <= ERR_CERT_RANGE_END && e.errorCode >= ERR_CERT_RANGE_START;
+
+      if (e.errorCode === ERR_SSL_PROTOCOL_ERROR) {
+        setWebviewLoadError({
+          code: "ssl_protocol",
+          message: `SSL/TLS handshake failed to ${e.validatedURL || "the server"}. The server may not support HTTPS, or its certificate may be invalid.`,
+          errorCode: e.errorCode,
+          validatedURL: e.validatedURL || undefined,
+        });
+        return;
+      }
+
+      if (isCertError) {
+        setWebviewLoadError({
+          code: "cert",
+          message: `The site's certificate couldn't be verified for ${e.validatedURL || "the server"}. If this is a local development server, make sure the local CA is trusted (e.g. run \`mkcert -install\`).`,
+          errorCode: e.errorCode,
+          validatedURL: e.validatedURL || undefined,
         });
         return;
       }

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -371,6 +371,11 @@ export function useDevPreviewLoadLifecycle({
       const isCertError = e.errorCode <= ERR_CERT_RANGE_END && e.errorCode >= ERR_CERT_RANGE_START;
 
       if (e.errorCode === ERR_SSL_PROTOCOL_ERROR) {
+        if (failLoadRetryRef.current) {
+          clearTimeout(failLoadRetryRef.current);
+          failLoadRetryRef.current = null;
+        }
+        failLoadRetryCountRef.current = 0;
         setWebviewLoadError({
           code: "ssl_protocol",
           message: `SSL/TLS handshake failed to ${e.validatedURL || "the server"}. The server may not support HTTPS, or its certificate may be invalid.`,
@@ -381,6 +386,11 @@ export function useDevPreviewLoadLifecycle({
       }
 
       if (isCertError) {
+        if (failLoadRetryRef.current) {
+          clearTimeout(failLoadRetryRef.current);
+          failLoadRetryRef.current = null;
+        }
+        failLoadRetryCountRef.current = 0;
         setWebviewLoadError({
           code: "cert",
           message: `The site's certificate couldn't be verified for ${e.validatedURL || "the server"}. If this is a local development server, make sure the local CA is trusted (e.g. run \`mkcert -install\`).`,


### PR DESCRIPTION
## Summary

This classifies cert/SSL failures in dev preview so they get distinct error overlays with a `mkcert -install` hint, matching what the Browser pane already does.

3 changes:

- Cert/SSL classification branches in `useDevPreviewLoadLifecycle` and matching error overlay states in `DevPreviewPane`. The cert path (`-200..-299`) suggests `mkcert -install` with a one-click copy. The SSL protocol path (`-107`) names the HTTP-on-HTTPS possibility separately.
- Cancel the pending retry when a cert/SSL error fires -- retrying the same URL over HTTPS hits the same handshake failure.
- Hoist the clipboard feedback delay to a named constant so it's shared across error overlay actions.

Resolves #9202.

## Testing

Boundary tests added in `DevPreviewPane.webview.test.tsx` covering cert error overlay rendering, SSL protocol error rendering, and retry suppression for both paths.