### PR TITLE
fix(dev-preview): surface Compiling signal during HMR and post-URL

### DIFF
--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -61,8 +61,9 @@ interface DevPreviewSession extends DevPreviewSessionState {
   startupReplayTimer: ReturnType<typeof setTimeout> | null;
   updatedAtPerformanceMs: number;
   phaseLabel?: "Compiling";
-  compilingEmitted: boolean;
+  compiling: boolean;
   compilingTimer: ReturnType<typeof setTimeout> | null;
+  compilingClearTimer: ReturnType<typeof setTimeout> | null;
   forceKilled?: boolean;
   // Crash-loop guard state. crashCount is the number of consecutive fast
   // install→crash cycles in the current window; devSpawnedAt marks when the
@@ -101,6 +102,8 @@ const STALE_START_RECOVERY_MS = 10000;
 const STARTUP_REPLAY_DELAY_MS = 1500;
 const REPLAY_HISTORY_MAX_LINES = 300;
 const PTY_SUBMIT_AFTER_SPAWN_MS = 100;
+const COMPILE_ARM_MS = 1000;
+const COMPILE_CLEAR_MS = 1500;
 
 // Per-session crash-loop guard. A broken config (missing deps that an install
 // can't fix) otherwise drives an unbounded install→crash→reinstall cycle that
@@ -866,8 +869,9 @@ export class DevPreviewSessionService {
       isRunningInstall: false,
       installAttemptedGeneration: null,
       startupReplayTimer: null,
-      compilingEmitted: false,
+      compiling: false,
       compilingTimer: null,
+      compilingClearTimer: null,
       crashCount: 0,
       devSpawnedAt: null,
       backoffAbort: null,
@@ -1410,7 +1414,11 @@ export class DevPreviewSessionService {
       clearTimeout(session.compilingTimer);
       session.compilingTimer = null;
     }
-    session.compilingEmitted = false;
+    if (session.compilingClearTimer !== null) {
+      clearTimeout(session.compilingClearTimer);
+      session.compilingClearTimer = null;
+    }
+    session.compiling = false;
     if (session.phaseLabel === "Compiling") {
       session.phaseLabel = undefined;
     }
@@ -1446,8 +1454,6 @@ export class DevPreviewSessionService {
       // readiness marker to accelerate it again.
       session.markerSeen = false;
 
-      this.clearCompiling(session);
-
       this.pollServerReadiness(session, result.url, abort.signal, session.generation);
       urlJustStarted = true;
     }
@@ -1465,29 +1471,59 @@ export class DevPreviewSessionService {
       this.pollServerReadiness(session, session.pendingUrl, abort.signal, session.generation);
     }
 
-    // A readyMarker without a pending URL (post-install, pre-URL detection)
-    // signals the framework is compiling. Debounce at 600ms to avoid label
-    // flicker from markers that fire on consecutive data chunks.
+    // Compile marker detection fires whenever the framework emits a
+    // compile-start line (HMR rebuild, initial compilation burst). Uses a
+    // two-stage timer: arm debounce prevents flicker from rapid marker
+    // bursts, auto-clear removes the signal when markers go quiet.
     if (
-      result.readyMarker &&
-      !session.compilingEmitted &&
-      session.status === "starting" &&
-      !session.pendingUrl &&
-      !session.isRunningInstall &&
-      session.compilingTimer === null
+      result.compileMarker &&
+      session.status !== "stopped" &&
+      session.status !== "error" &&
+      !session.isRunningInstall
     ) {
-      session.compilingTimer = setTimeout(() => {
-        session.compilingTimer = null;
-        if (
-          session.status === "starting" &&
-          !session.pendingUrl &&
-          !session.url &&
-          !session.compilingEmitted
-        ) {
-          session.compilingEmitted = true;
-          this.updateSession(session, { phaseLabel: "Compiling" });
+      if (session.compiling) {
+        // Already visible — reset the auto-clear timer so the signal
+        // persists through a burst (HMR chains, multi-file saves).
+        if (session.compilingClearTimer !== null) {
+          clearTimeout(session.compilingClearTimer);
+          session.compilingClearTimer = setTimeout(() => {
+            session.compilingClearTimer = null;
+            this.clearCompiling(session);
+            this.onStateChanged(this.toPublicState(session));
+          }, COMPILE_CLEAR_MS);
         }
-      }, 600);
+      } else if (session.compilingTimer === null) {
+        // Start the arm debounce — if no additional markers arrive before
+        // COMPILE_ARM_MS, publish the Compiling label.
+        session.compilingTimer = setTimeout(() => {
+          session.compilingTimer = null;
+          if (
+            session.status === "stopped" ||
+            session.status === "error" ||
+            session.isRunningInstall
+          ) {
+            return;
+          }
+          session.compiling = true;
+          this.updateSession(session, { phaseLabel: "Compiling" });
+          session.compilingClearTimer = setTimeout(() => {
+            session.compilingClearTimer = null;
+            this.clearCompiling(session);
+            this.onStateChanged(this.toPublicState(session));
+          }, COMPILE_CLEAR_MS);
+        }, COMPILE_ARM_MS);
+      }
+    }
+
+    // A readyMarker during an active compile phase cancels both timers
+    // and clears the label early — the framework signaled completion.
+    if (result.readyMarker && (session.compiling || session.compilingTimer !== null)) {
+      if (session.compilingTimer !== null) {
+        clearTimeout(session.compilingTimer);
+        session.compilingTimer = null;
+      }
+      this.clearCompiling(session);
+      this.onStateChanged(this.toPublicState(session));
     }
 
     if (!result.error) return;

--- a/electron/services/UrlDetector.ts
+++ b/electron/services/UrlDetector.ts
@@ -6,6 +6,7 @@ export interface ScanResult {
   error: DevServerError | null;
   buffer: string;
   readyMarker: boolean;
+  compileMarker: boolean;
 }
 
 // Startup readiness lines printed by common dev servers once the HTTP server is
@@ -21,6 +22,20 @@ const READY_MARKERS: RegExp[] = [
   // webpack-dev-server / CRA / webpack-dev-middleware
   /webpack\s+compiled\s+successfully/i,
   /\[webpack-dev-middleware\]\s+compiled\s+successfully/i,
+];
+
+// HMR / recompilation start patterns emitted during a running session. These
+// signal the framework is actively rebuilding, distinct from startup readiness
+// markers which signal the first bind.
+const COMPILE_MARKERS: RegExp[] = [
+  // webpack: "compiling..." (webpack-dev-server, CRA, Storybook)
+  /compiling\.\.\./i,
+  // Vite HMR: "[vite] hmr update /src/App.tsx"
+  /\[vite\]\s+hmr\s+update/i,
+  // Vite full reload: "[vite] page reload src/main.tsx"
+  /\[vite\]\s+page\s+reload/i,
+  // Next.js webpack mode: "Compiling /route" (word-anchored to avoid matching "Compiled")
+  /\bcompiling\s+\//i,
 ];
 
 export class UrlDetector {
@@ -43,12 +58,14 @@ export class UrlDetector {
 
     const strippedChunk = stripAnsiAndOscCodes(data);
     const readyMarker = READY_MARKERS.some((pattern) => pattern.test(strippedChunk));
+    const compileMarker = COMPILE_MARKERS.some((pattern) => pattern.test(strippedChunk));
 
     return {
       url: preferredUrl,
       error,
       buffer: newBuffer,
       readyMarker,
+      compileMarker,
     };
   }
 

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -1177,4 +1177,154 @@ describe("DevPreviewSessionService", () => {
       ).toBe("stopped");
     });
   });
+
+  describe("compile markers", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    async function sessionToRunning(): Promise<string> {
+      vi.useRealTimers();
+      const started = await service.ensure(baseRequest);
+      const tid = started.terminalId!;
+      ptyClient.emitData(tid, "ready at http://localhost:4173\n");
+      await vi.waitFor(() => {
+        const s = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+        expect(s.status).toBe("running");
+      });
+      vi.useFakeTimers();
+      onStateChanged.mockClear();
+      return tid;
+    }
+
+    it("arms then publishes Compiling after 1000ms during running session", async () => {
+      const tid = await sessionToRunning();
+
+      ptyClient.emitData(tid, "compiling...");
+
+      await vi.advanceTimersByTimeAsync(500);
+      let state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      expect(state.phaseLabel).toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(500);
+      state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      expect(state.phaseLabel).toBe("Compiling");
+
+      await vi.advanceTimersByTimeAsync(1500);
+      state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      expect(state.phaseLabel).toBeUndefined();
+    });
+
+    it("fires compile marker during starting with pendingUrl set", async () => {
+      mockHttpError();
+      vi.useRealTimers();
+      const started = await service.ensure(baseRequest);
+      const tid = started.terminalId!;
+      ptyClient.emitData(tid, "http://localhost:3000\n");
+      await vi.waitFor(() => {
+        const s = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+        expect(s.status).toBe("starting");
+        expect(s.url).toBeNull();
+      });
+
+      vi.useFakeTimers();
+      onStateChanged.mockClear();
+
+      ptyClient.emitData(tid, "compiling...");
+      await vi.advanceTimersByTimeAsync(1000);
+      const state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      expect(state.phaseLabel).toBe("Compiling");
+    });
+
+    it("readyMarker within arm window cancels compile and never publishes", async () => {
+      const tid = await sessionToRunning();
+
+      ptyClient.emitData(tid, "compiling...");
+      await vi.advanceTimersByTimeAsync(400);
+      ptyClient.emitData(tid, "webpack compiled successfully");
+      await vi.advanceTimersByTimeAsync(1000);
+
+      const state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      expect(state.phaseLabel).toBeUndefined();
+    });
+
+    it("second compile marker while visible resets auto-clear timer", async () => {
+      const tid = await sessionToRunning();
+
+      ptyClient.emitData(tid, "compiling...");
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBe("Compiling");
+
+      // Advance 1300ms: auto-clear fires at 1500ms from publish, 200ms remain.
+      await vi.advanceTimersByTimeAsync(1300);
+
+      // Second compile marker resets the auto-clear timer.
+      ptyClient.emitData(tid, "Compiling /new-route");
+
+      // Old timer point (200ms later): should be suppressed (was cancelled).
+      await vi.advanceTimersByTimeAsync(200);
+      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBe("Compiling");
+
+      // Still visible 1100ms later (1400ms since reset, 100ms before new auto-clear).
+      await vi.advanceTimersByTimeAsync(1100);
+      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBe("Compiling");
+
+      // Auto-clear fires after remaining 200ms (1500ms since reset).
+      await vi.advanceTimersByTimeAsync(200);
+      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBeUndefined();
+    });
+
+    it("stop clears arm timer and never publishes", async () => {
+      const tid = await sessionToRunning();
+
+      ptyClient.emitData(tid, "compiling...");
+      await vi.advanceTimersByTimeAsync(500);
+
+      await service.stop({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      const state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      expect(state.phaseLabel).toBeUndefined();
+    });
+
+    it("error in data handler clears compile timers", async () => {
+      const tid = await sessionToRunning();
+
+      ptyClient.emitData(tid, "compiling...");
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBe("Compiling");
+
+      ptyClient.emitData(tid, "Error: EACCES: permission denied");
+
+      const state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      expect(state.status).toBe("error");
+      expect(state.phaseLabel).toBeUndefined();
+    });
+
+    it("terminal exit clears compile timers", async () => {
+      const tid = await sessionToRunning();
+
+      ptyClient.emitData(tid, "compiling...");
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBe("Compiling");
+
+      ptyClient.emitExit(tid, 0);
+
+      const state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      expect(state.phaseLabel).toBeUndefined();
+    });
+
+    it("readyMarker during active compile clears label early", async () => {
+      const tid = await sessionToRunning();
+
+      ptyClient.emitData(tid, "compiling...");
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBe("Compiling");
+
+      ptyClient.emitData(tid, "webpack compiled successfully");
+
+      const state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      expect(state.phaseLabel).toBeUndefined();
+    });
+  });
 });

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -1189,11 +1189,14 @@ describe("DevPreviewSessionService", () => {
       const tid = started.terminalId!;
       ptyClient.emitData(tid, "ready at http://localhost:4173\n");
       await vi.waitFor(() => {
-        const s = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+        const s = service.getState({
+          panelId: baseRequest.panelId,
+          projectId: baseRequest.projectId,
+        });
         expect(s.status).toBe("running");
       });
       vi.useFakeTimers();
-      onStateChanged.mockClear();
+      (onStateChanged as unknown as ReturnType<typeof vi.fn>).mockClear();
       return tid;
     }
 
@@ -1203,7 +1206,10 @@ describe("DevPreviewSessionService", () => {
       ptyClient.emitData(tid, "compiling...");
 
       await vi.advanceTimersByTimeAsync(500);
-      let state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      let state = service.getState({
+        panelId: baseRequest.panelId,
+        projectId: baseRequest.projectId,
+      });
       expect(state.phaseLabel).toBeUndefined();
 
       await vi.advanceTimersByTimeAsync(500);
@@ -1222,17 +1228,23 @@ describe("DevPreviewSessionService", () => {
       const tid = started.terminalId!;
       ptyClient.emitData(tid, "http://localhost:3000\n");
       await vi.waitFor(() => {
-        const s = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+        const s = service.getState({
+          panelId: baseRequest.panelId,
+          projectId: baseRequest.projectId,
+        });
         expect(s.status).toBe("starting");
         expect(s.url).toBeNull();
       });
 
       vi.useFakeTimers();
-      onStateChanged.mockClear();
+      (onStateChanged as unknown as ReturnType<typeof vi.fn>).mockClear();
 
       ptyClient.emitData(tid, "compiling...");
       await vi.advanceTimersByTimeAsync(1000);
-      const state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      const state = service.getState({
+        panelId: baseRequest.panelId,
+        projectId: baseRequest.projectId,
+      });
       expect(state.phaseLabel).toBe("Compiling");
     });
 
@@ -1244,7 +1256,10 @@ describe("DevPreviewSessionService", () => {
       ptyClient.emitData(tid, "webpack compiled successfully");
       await vi.advanceTimersByTimeAsync(1000);
 
-      const state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      const state = service.getState({
+        panelId: baseRequest.panelId,
+        projectId: baseRequest.projectId,
+      });
       expect(state.phaseLabel).toBeUndefined();
     });
 
@@ -1253,7 +1268,10 @@ describe("DevPreviewSessionService", () => {
 
       ptyClient.emitData(tid, "compiling...");
       await vi.advanceTimersByTimeAsync(1000);
-      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBe("Compiling");
+      expect(
+        service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId })
+          .phaseLabel
+      ).toBe("Compiling");
 
       // Advance 1300ms: auto-clear fires at 1500ms from publish, 200ms remain.
       await vi.advanceTimersByTimeAsync(1300);
@@ -1263,15 +1281,24 @@ describe("DevPreviewSessionService", () => {
 
       // Old timer point (200ms later): should be suppressed (was cancelled).
       await vi.advanceTimersByTimeAsync(200);
-      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBe("Compiling");
+      expect(
+        service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId })
+          .phaseLabel
+      ).toBe("Compiling");
 
       // Still visible 1100ms later (1400ms since reset, 100ms before new auto-clear).
       await vi.advanceTimersByTimeAsync(1100);
-      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBe("Compiling");
+      expect(
+        service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId })
+          .phaseLabel
+      ).toBe("Compiling");
 
       // Auto-clear fires after remaining 200ms (1500ms since reset).
       await vi.advanceTimersByTimeAsync(200);
-      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBeUndefined();
+      expect(
+        service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId })
+          .phaseLabel
+      ).toBeUndefined();
     });
 
     it("stop clears arm timer and never publishes", async () => {
@@ -1283,7 +1310,10 @@ describe("DevPreviewSessionService", () => {
       await service.stop({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
 
       await vi.advanceTimersByTimeAsync(1000);
-      const state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      const state = service.getState({
+        panelId: baseRequest.panelId,
+        projectId: baseRequest.projectId,
+      });
       expect(state.phaseLabel).toBeUndefined();
     });
 
@@ -1292,11 +1322,17 @@ describe("DevPreviewSessionService", () => {
 
       ptyClient.emitData(tid, "compiling...");
       await vi.advanceTimersByTimeAsync(1000);
-      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBe("Compiling");
+      expect(
+        service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId })
+          .phaseLabel
+      ).toBe("Compiling");
 
       ptyClient.emitData(tid, "Error: EACCES: permission denied");
 
-      const state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      const state = service.getState({
+        panelId: baseRequest.panelId,
+        projectId: baseRequest.projectId,
+      });
       expect(state.status).toBe("error");
       expect(state.phaseLabel).toBeUndefined();
     });
@@ -1306,11 +1342,17 @@ describe("DevPreviewSessionService", () => {
 
       ptyClient.emitData(tid, "compiling...");
       await vi.advanceTimersByTimeAsync(1000);
-      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBe("Compiling");
+      expect(
+        service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId })
+          .phaseLabel
+      ).toBe("Compiling");
 
       ptyClient.emitExit(tid, 0);
 
-      const state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      const state = service.getState({
+        panelId: baseRequest.panelId,
+        projectId: baseRequest.projectId,
+      });
       expect(state.phaseLabel).toBeUndefined();
     });
 
@@ -1319,11 +1361,17 @@ describe("DevPreviewSessionService", () => {
 
       ptyClient.emitData(tid, "compiling...");
       await vi.advanceTimersByTimeAsync(1000);
-      expect(service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).phaseLabel).toBe("Compiling");
+      expect(
+        service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId })
+          .phaseLabel
+      ).toBe("Compiling");
 
       ptyClient.emitData(tid, "webpack compiled successfully");
 
-      const state = service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+      const state = service.getState({
+        panelId: baseRequest.panelId,
+        projectId: baseRequest.projectId,
+      });
       expect(state.phaseLabel).toBeUndefined();
     });
   });

--- a/electron/services/__tests__/UrlDetector.test.ts
+++ b/electron/services/__tests__/UrlDetector.test.ts
@@ -374,5 +374,50 @@ describe("UrlDetector", () => {
         expect(result.url).toBe("http://localhost:3000/");
       });
     });
+
+    describe("compile markers", () => {
+      it("detects webpack 'compiling...' line", () => {
+        const result = detector.scanOutput("compiling...", "");
+        expect(result.compileMarker).toBe(true);
+        expect(result.readyMarker).toBe(false);
+      });
+
+      it("detects Vite hmr update", () => {
+        const result = detector.scanOutput("[vite] hmr update /src/App.tsx", "");
+        expect(result.compileMarker).toBe(true);
+      });
+
+      it("detects Vite page reload", () => {
+        const result = detector.scanOutput("[vite] page reload src/main.tsx", "");
+        expect(result.compileMarker).toBe(true);
+      });
+
+      it("detects Next.js 'Compiling /route'", () => {
+        const result = detector.scanOutput("Compiling /dashboard", "");
+        expect(result.compileMarker).toBe(true);
+      });
+
+      it("does not match 'Compiled' (completion, not compile-start)", () => {
+        const result = detector.scanOutput("Compiled successfully in 234ms", "");
+        expect(result.compileMarker).toBe(false);
+      });
+
+      it("does not match unrelated output", () => {
+        const result = detector.scanOutput("Watching for file changes...", "");
+        expect(result.compileMarker).toBe(false);
+        expect(result.readyMarker).toBe(false);
+      });
+
+      it("handles ANSI-coloured compile markers", () => {
+        const withAnsi = "\x1b[36mcompiling...\x1b[0m";
+        const result = detector.scanOutput(withAnsi, "");
+        expect(result.compileMarker).toBe(true);
+      });
+
+      it("returns false for empty data", () => {
+        const result = detector.scanOutput("", "");
+        expect(result.compileMarker).toBe(false);
+      });
+    });
   });
 });

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1252,9 +1252,11 @@ export function DevPreviewPane({
       isMultiPanelGrid={isMultiPanelGrid}
       kind="dev-preview"
       className={
-        phaseLabel === "Compiling" ? "panel-state-compiling"
-        : stuckTier >= 1 ? "panel-state-working"
-        : undefined
+        phaseLabel === "Compiling"
+          ? "panel-state-compiling"
+          : stuckTier >= 1
+            ? "panel-state-working"
+            : undefined
       }
     >
       <div className="flex flex-col h-full">

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1251,7 +1251,11 @@ export function DevPreviewPane({
       onRestore={onRestore}
       isMultiPanelGrid={isMultiPanelGrid}
       kind="dev-preview"
-      className={stuckTier >= 1 ? "panel-state-working" : undefined}
+      className={
+        phaseLabel === "Compiling" ? "panel-state-compiling"
+        : stuckTier >= 1 ? "panel-state-working"
+        : undefined
+      }
     >
       <div className="flex flex-col h-full">
         <BrowserToolbar

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -513,8 +513,8 @@ export function useDevServer({
     // When the backend signals a compile is in progress, downgrade any
     // existing Tier 2 "no signal" banner to Tier 1 (benign pulse). The
     // compile IS the signal — the user doesn't need both warnings.
-    if (phaseLabel === "Compiling" && stuckTier >= 2) {
-      setStuckTier(1);
+    if (phaseLabel === "Compiling") {
+      setStuckTier((prev) => (prev >= 2 ? 1 : prev));
     }
 
     const requestVersion = requestVersionRef.current;

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -510,6 +510,13 @@ export function useDevServer({
       return;
     }
 
+    // When the backend signals a compile is in progress, downgrade any
+    // existing Tier 2 "no signal" banner to Tier 1 (benign pulse). The
+    // compile IS the signal — the user doesn't need both warnings.
+    if (phaseLabel === "Compiling" && stuckTier >= 2) {
+      setStuckTier(1);
+    }
+
     const requestVersion = requestVersionRef.current;
     const requestProjectId = currentProjectId;
     const requestPanelId = panelId;
@@ -542,7 +549,7 @@ export function useDevServer({
     return () => {
       for (const timer of timers) window.clearTimeout(timer);
     };
-  }, [panelId, currentProjectId, status, terminalId, url, isRestarting]);
+  }, [panelId, currentProjectId, status, terminalId, url, isRestarting, phaseLabel]);
 
   return {
     status,

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -510,13 +510,6 @@ export function useDevServer({
       return;
     }
 
-    // When the backend signals a compile is in progress, downgrade any
-    // existing Tier 2 "no signal" banner to Tier 1 (benign pulse). The
-    // compile IS the signal — the user doesn't need both warnings.
-    if (phaseLabel === "Compiling") {
-      setStuckTier((prev) => (prev >= 2 ? 1 : prev));
-    }
-
     const requestVersion = requestVersionRef.current;
     const requestProjectId = currentProjectId;
     const requestPanelId = panelId;
@@ -549,7 +542,18 @@ export function useDevServer({
     return () => {
       for (const timer of timers) window.clearTimeout(timer);
     };
-  }, [panelId, currentProjectId, status, terminalId, url, isRestarting, phaseLabel]);
+  }, [panelId, currentProjectId, status, terminalId, url, isRestarting]);
+
+  // When the backend signals a compile is in progress, downgrade any
+  // existing Tier 2 "no signal yet" banner to Tier 1 (benign pulse). The
+  // compile IS the signal — the user doesn't need both warnings.
+  // Kept in a separate effect so timer starts from the main effect aren't
+  // reset when phaseLabel toggles (Tier 3 at 45s must still fire).
+  useEffect(() => {
+    if (phaseLabel === "Compiling") {
+      setStuckTier((prev) => (prev >= 2 ? 1 : prev));
+    }
+  }, [phaseLabel]);
 
   return {
     status,

--- a/src/index.css
+++ b/src/index.css
@@ -1755,6 +1755,7 @@ body,
   .animate-agent-pulse,
   .animate-breathe,
   .status-working,
+  .panel-state-compiling,
   .panel-state-working {
     transition: none;
   }
@@ -1853,6 +1854,17 @@ body,
   box-shadow:
     inset 0 0 0 1px color-mix(in oklab, var(--color-activity-waiting) 15%, transparent),
     0 0 0 1px color-mix(in oklab, var(--color-activity-waiting) 10%, transparent);
+}
+
+/* Compiling state — neutral surface treatment surfacing framework compile
+ * activity (HMR rebuilds, lazy-compilation bursts). Uses --color-border-subtle
+ * (not the accent token) per the accent-restraint constraint. Ambient Tier 1
+ * signal: less prominent than working/waiting, more visible than hibernated. */
+.panel-state-compiling {
+  border-color: color-mix(in oklab, var(--color-border-subtle) 60%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in oklab, var(--color-border-subtle) 10%, transparent),
+    0 0 0 1px color-mix(in oklab, var(--color-border-subtle) 8%, transparent);
 }
 
 /* Working state hint — static colored border. Was a 4s infinite breathe,
@@ -2603,6 +2615,10 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     border-left-color: Highlight;
   }
 
+  .panel-state-compiling {
+    border-color: GrayText;
+  }
+
   .panel-state-waiting {
     border-color: Highlight;
     outline: 2px solid Highlight;
@@ -2713,6 +2729,7 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     border-left-width: 2px;
   }
 
+  .panel-state-compiling,
   .panel-state-waiting,
   .panel-state-working,
   .panel-state-hibernated {


### PR DESCRIPTION
## Summary

The dev preview has a blind spot: once it detects the dev server URL, it stops showing any Compiling state. This is exactly when Vite and most lazy-compiling frameworks start their first real compile. HMR rebuilds during a running session are invisible for the same reason -- the `!session.url` gate in `DevPreviewSessionService.handleData` only fires the `phaseLabel: "Compiling"` emission while `session.status === "starting"` and no URL exists yet.

This removes that gate and adds compile-marker detection to `UrlDetector` so the backend can surface Compiling whenever the framework emits a marker. A sliding-window debounce prevents short HMR bursts from strobing the indicator. The rendering surface is ambient panel chrome (`panel-state-compiling`), not a banner or toast.

Resolves #9209.

## Changes

- **`DevPreviewSessionService`**: removed the `!session.url` gate from the Compiling label emission. The signal now fires during HMR rebuilds in a running session, not just during initial start.
- **`UrlDetector`**: added compile-marker detection (`compiled successfully`, `ready in N ms`) so the backend can emit `phaseLabel: "Compiling"` when the framework outputs compile markers, independent of URL detection.
- **Sliding-window debounce (1.5s)**: short bursts of HMR markers don't flicker the indicator on and off. The Compiling signal stays lit until the marker stream goes quiet.
- **`DevPreviewPane`**: added the `panel-state-compiling` CSS class when `phaseLabel === "Compiling"`. Neutral surface treatment -- this is a Tier 1 ambient indicator, consistent with the existing `working` and `waiting` border treatments on `ContentPanel`.
- **`stuckTier` downgrade**: used a functional `setStuckTier` updater so when the backend signals Compiling after Tier 2 has already fired, it downgrades to Tier 1. The compile IS the signal -- the user doesn't need both warnings.
- **Tests**: added compile-marker behavior tests for both `DevPreviewSessionService` and `UrlDetector`.

## Testing

- `npm run check` passes (typecheck, lint ratchet, format)
- Unit tests cover: compile marker emission during `starting` state, post-URL detection, HMR rebuild scenarios, sliding-window debounce behavior, and stuckTier downgrade