### PR TITLE
fix(ci): make Microsoft Store submission best-effort in Windows release

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -243,6 +243,7 @@ jobs:
 
       - name: Submit to Microsoft Store (Windows)
         if: inputs.dry_run != true && steps.store-secrets.outputs.configured == 'true'
+        continue-on-error: true
         shell: pwsh
         env:
           PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
@@ -257,14 +258,17 @@ jobs:
             --clientId $env:PARTNER_CENTER_CLIENT_ID `
             --clientSecret $env:PARTNER_CENTER_CLIENT_SECRET
           if ($LASTEXITCODE -ne 0) {
-            Write-Host "::error::msstore reconfigure failed (exit $LASTEXITCODE)"
+            Write-Host "::warning::msstore reconfigure failed (exit $LASTEXITCODE)"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ":warning: Microsoft Store submission skipped — msstore reconfigure failed (exit $LASTEXITCODE)"
             exit $LASTEXITCODE
           }
           msstore publish . --appId $env:STORE_PRODUCT_ID --inputDirectory .\release
           if ($LASTEXITCODE -ne 0) {
-            Write-Host "::error::msstore publish failed (exit $LASTEXITCODE). If the failure is 'unknown command,' the CLI grammar may have shifted — run 'msstore --help' on the runner and update this step."
+            Write-Host "::warning::msstore publish failed (exit $LASTEXITCODE). If the failure is 'unknown command,' the CLI grammar may have shifted — run 'msstore --help' on the runner and update this step."
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ":warning: Microsoft Store submission skipped — msstore publish failed (exit $LASTEXITCODE)"
             exit $LASTEXITCODE
           }
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ":rocket: Microsoft Store submission published (product $env:STORE_PRODUCT_ID)"
 
       - name: Validate update metadata (Windows NSIS)
         shell: bash


### PR DESCRIPTION
## Summary

The Microsoft Store submission step hard-blocks the Windows release when `msstore reconfigure` or `msstore publish` fails, contradicting the best-effort posture stated in CLAUDE.md.

- Added `continue-on-error: true` to the Submit step so msstore failures show as warnings (yellow) instead of blocking the release
- Demoted `::error::` messages to `::warning::` for both reconfigure and publish failures
- Added `$GITHUB_STEP_SUMMARY` entries so the Actions run summary reflects the actual outcome
- Mirrors the existing WACK step's best-effort precedent (lines 232-255 in the same workflow)

## Test plan

- [x] YAML syntax validated
- [ ] Confirm WACK step pattern is the correct precedent for best-effort CI steps
- [ ] CI passes on push

Closes #9243

🤖 Generated with [Claude Code](https://claude.com/claude-code)