### PR TITLE
fix(portal): eliminate white flash and preserve embedded state across overlay cycles

### DIFF
--- a/electron/services/PortalManager.ts
+++ b/electron/services/PortalManager.ts
@@ -7,6 +7,13 @@ import { getAppWebContents } from "../window/webContentsRegistry.js";
 
 export const PORTAL_MAX_LIVE_TABS = 3;
 
+// Negative coordinates park a hidden view far enough off-screen that no part of
+// it is composited on any monitor configuration, but keeps the WebContentsView
+// in the contentView child list so its renderer state (scroll, in-flight
+// requests, WebSocket/SSE connections) is preserved across overlay open/close.
+// Bypasses validateBounds() which clamps x/y to 0.
+const OFFSCREEN_BOUNDS = { x: -99999, y: -99999, width: 1, height: 1 } as const;
+
 export class PortalManager {
   private window: BrowserWindow;
   private viewMap = new Map<string, WebContentsView>();
@@ -14,9 +21,13 @@ export class PortalManager {
   private activeTabId: string | null = null;
   private lruOrder = new Map<string, true>();
   private lastShownTabId: string | null = null;
+  private readonly backgroundColor: string;
+  private readonly attachedViews = new Set<WebContentsView>();
+  private readonly lastShownBounds = new Map<string, { width: number; height: number }>();
 
-  constructor(window: BrowserWindow) {
+  constructor(window: BrowserWindow, backgroundColor: string = "#000000") {
     this.window = window;
+    this.backgroundColor = backgroundColor;
   }
 
   private sendToApp(channel: string, ...args: unknown[]): void {
@@ -43,13 +54,21 @@ export class PortalManager {
     // Detach state synchronously first so hasTab() returns false immediately
     this.viewMap.delete(tabId);
     this.lruOrder.delete(tabId);
+    this.lastShownBounds.delete(tabId);
 
-    if (this.activeView === view) {
+    // Any attached view (active or parked offscreen) must be detached from the
+    // contentView child list before its webContents is closed — otherwise the
+    // compositor holds a dangling reference.
+    if (this.attachedViews.has(view)) {
       try {
         this.window.contentView.removeChildView(view);
       } catch {
         // ignore if already removed
       }
+      this.attachedViews.delete(view);
+    }
+
+    if (this.activeView === view) {
       this.activeView = null;
       this.activeTabId = null;
     }
@@ -114,6 +133,10 @@ export class PortalManager {
         },
       });
 
+      // Set before loadURL so the first paint matches the app's window
+      // background instead of the default opaque white — fixes #9207 flash.
+      view.setBackgroundColor(this.backgroundColor);
+
       view.webContents.setWindowOpenHandler(({ url }) => {
         if (typeof url === "string" && url.trim()) {
           void openExternalUrl(url).catch((error) => {
@@ -154,12 +177,18 @@ export class PortalManager {
       view.webContents.once("destroyed", () => {
         this.viewMap.delete(tabId);
         this.lruOrder.delete(tabId);
-        if (this.activeTabId === tabId) {
+        this.lastShownBounds.delete(tabId);
+        // Detach if attached — covers both the active view and any view parked
+        // offscreen via hideAll().
+        if (this.attachedViews.has(view)) {
           try {
             this.window.contentView.removeChildView(view);
           } catch {
             // ignore if already removed
           }
+          this.attachedViews.delete(view);
+        }
+        if (this.activeTabId === tabId) {
           this.activeView = null;
           this.activeTabId = null;
         }
@@ -312,16 +341,25 @@ export class PortalManager {
     const view = this.viewMap.get(tabId);
     if (!view) return;
 
+    // Park the previously-active view offscreen instead of detaching it —
+    // keeps its renderer state (scroll, in-flight requests, sockets) alive.
     if (this.activeView && this.activeView !== view) {
-      this.window.contentView.removeChildView(this.activeView);
+      this.activeView.setBounds(OFFSCREEN_BOUNDS);
     }
 
-    if (this.activeView !== view) {
+    // Attach on first show only; subsequent shows just move bounds.
+    // addChildView throws if the view is already a child.
+    if (!this.attachedViews.has(view)) {
       this.window.contentView.addChildView(view);
+      this.attachedViews.add(view);
     }
 
     const validatedBounds = this.validateBounds(bounds);
     view.setBounds(validatedBounds);
+    this.lastShownBounds.set(tabId, {
+      width: validatedBounds.width,
+      height: validatedBounds.height,
+    });
     this.activeView = view;
     this.activeTabId = tabId;
     this.touchLru(tabId);
@@ -344,10 +382,14 @@ export class PortalManager {
   }
 
   hideAll(): void {
+    // Park the active view offscreen instead of removing it from the
+    // contentView child list — the detach/reattach cycle that overlay
+    // open/close used to perform resets embedded page state (chat scroll,
+    // in-flight responses). Keep activeView/activeTabId set so the same tab
+    // re-appears when the overlay closes and so destroyHiddenTabs() still
+    // protects the right tab from memory-pressure eviction.
     if (this.activeView) {
-      this.window.contentView.removeChildView(this.activeView);
-      this.activeView = null;
-      this.activeTabId = null;
+      this.activeView.setBounds(OFFSCREEN_BOUNDS);
     }
   }
 
@@ -433,5 +475,7 @@ export class PortalManager {
     this.activeView = null;
     this.activeTabId = null;
     this.lastShownTabId = null;
+    this.attachedViews.clear();
+    this.lastShownBounds.clear();
   }
 }

--- a/electron/services/PortalManager.ts
+++ b/electron/services/PortalManager.ts
@@ -21,6 +21,10 @@ export class PortalManager {
   private activeTabId: string | null = null;
   private lruOrder = new Map<string, true>();
   private lastShownTabId: string | null = null;
+  // True while the active view is parked offscreen by hideAll(). Guards
+  // updateBounds() so a window resize during an open overlay does not pull
+  // the hidden view back on top of the overlay.
+  private hidden = false;
   private readonly backgroundColor: string;
   private readonly attachedViews = new Set<WebContentsView>();
   private readonly lastShownBounds = new Map<string, { width: number; height: number }>();
@@ -71,6 +75,7 @@ export class PortalManager {
     if (this.activeView === view) {
       this.activeView = null;
       this.activeTabId = null;
+      this.hidden = false;
     }
 
     // Flush storage before closing to prevent localStorage data loss
@@ -191,6 +196,7 @@ export class PortalManager {
         if (this.activeTabId === tabId) {
           this.activeView = null;
           this.activeTabId = null;
+          this.hidden = false;
         }
       });
 
@@ -362,6 +368,7 @@ export class PortalManager {
     });
     this.activeView = view;
     this.activeTabId = tabId;
+    this.hidden = false;
     this.touchLru(tabId);
     this.evictIfNeeded();
     this.lastShownTabId = tabId;
@@ -390,10 +397,30 @@ export class PortalManager {
     // protects the right tab from memory-pressure eviction.
     if (this.activeView) {
       this.activeView.setBounds(OFFSCREEN_BOUNDS);
+      this.hidden = true;
+      // Return focus to the main app webContents. The old removeChildView
+      // path implicitly blurred the portal view; keep that behavior so
+      // keyboard input goes to the overlay's focus-trap (in the renderer's
+      // V8 context), not the now-hidden portal page.
+      if (!this.window.isDestroyed()) {
+        try {
+          const appWc = getAppWebContents(this.window);
+          if (!appWc.isDestroyed()) {
+            appWc.focus();
+          }
+        } catch {
+          // Best-effort focus return; never block overlay open on this.
+        }
+      }
     }
   }
 
   updateBounds(bounds: PortalBounds): void {
+    // Renderer-side syncBounds (PortalDock ResizeObserver + window resize
+    // listener) only gates on activeTabId, which is preserved across
+    // hideAll(). Without this guard a window resize while an overlay is open
+    // would re-show the parked view on top of the overlay.
+    if (this.hidden) return;
     if (this.activeView) {
       const validatedBounds = this.validateBounds(bounds);
       this.activeView.setBounds(validatedBounds);
@@ -475,6 +502,7 @@ export class PortalManager {
     this.activeView = null;
     this.activeTabId = null;
     this.lastShownTabId = null;
+    this.hidden = false;
     this.attachedViews.clear();
     this.lastShownBounds.clear();
   }

--- a/electron/services/__tests__/PortalManager.adversarial.test.ts
+++ b/electron/services/__tests__/PortalManager.adversarial.test.ts
@@ -28,6 +28,7 @@ vi.mock("electron", () => {
   class MockWebContentsView {
     webContents = createMockWebContents();
     setBounds = vi.fn();
+    setBackgroundColor = vi.fn();
 
     constructor() {
       createdWebContents.push(this.webContents);

--- a/electron/services/__tests__/PortalManager.test.ts
+++ b/electron/services/__tests__/PortalManager.test.ts
@@ -291,6 +291,71 @@ describe("PortalManager", () => {
       expect(mockWindow.contentView.removeChildView).not.toHaveBeenCalled();
     });
 
+    it("updateBounds is a no-op while parked offscreen", () => {
+      // Regression guard for #9207 follow-up: PortalDock's ResizeObserver and
+      // window-resize listener only gate on activeTabId, which is preserved
+      // across hideAll(). Without this guard a window resize while an overlay
+      // is open would re-show the parked view on top of the overlay.
+      const manager = new PortalManagerClass(mockWindow);
+
+      const addChildViewMock = mockWindow.contentView.addChildView as ReturnType<typeof vi.fn>;
+      manager.createTab("tab-resize", "http://localhost:3000");
+      manager.showTab("tab-resize", { x: 0, y: 0, width: 800, height: 600 });
+      const view = addChildViewMock.mock.calls.at(-1)?.[0] as {
+        setBounds: ReturnType<typeof vi.fn>;
+      };
+
+      manager.hideAll();
+      const setBoundsCallsAfterHide = view.setBounds.mock.calls.length;
+
+      // Simulate a window resize firing through PortalDock → portal.resize.
+      manager.updateBounds({ x: 0, y: 0, width: 1024, height: 768 });
+
+      // The view must remain offscreen — updateBounds was suppressed.
+      expect(view.setBounds.mock.calls.length).toBe(setBoundsCallsAfterHide);
+    });
+
+    it("updateBounds resumes after showTab re-shows the parked tab", () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      const addChildViewMock = mockWindow.contentView.addChildView as ReturnType<typeof vi.fn>;
+      manager.createTab("tab-resume", "http://localhost:3000");
+      manager.showTab("tab-resume", { x: 0, y: 0, width: 800, height: 600 });
+      const view = addChildViewMock.mock.calls.at(-1)?.[0] as {
+        setBounds: ReturnType<typeof vi.fn>;
+      };
+
+      manager.hideAll();
+      manager.showTab("tab-resume", { x: 0, y: 0, width: 1024, height: 768 });
+
+      const setBoundsCallsBefore = view.setBounds.mock.calls.length;
+      manager.updateBounds({ x: 0, y: 0, width: 1200, height: 900 });
+
+      // updateBounds is no longer suppressed — view receives the new bounds.
+      expect(view.setBounds.mock.calls.length).toBe(setBoundsCallsBefore + 1);
+      const lastBounds = view.setBounds.mock.calls.at(-1)?.[0];
+      expect(lastBounds.width).toBe(1200);
+      expect(lastBounds.height).toBe(900);
+    });
+
+    it("hideAll returns focus to the main app webContents", () => {
+      // The old removeChildView path implicitly blurred the portal view.
+      // Keep that behavior so the overlay's renderer focus-trap receives
+      // keyboard input instead of the now-hidden portal page.
+      const manager = new PortalManagerClass(mockWindow);
+
+      // The window's webContents is the app WebContents in this test mock
+      // (single-WebContents BrowserWindow stand-in).
+      const focusMock = vi.fn();
+      (mockWindow.webContents as unknown as { focus: typeof focusMock }).focus = focusMock;
+
+      manager.createTab("tab-focus", "http://localhost:3000");
+      manager.showTab("tab-focus", { x: 0, y: 0, width: 800, height: 600 });
+      manager.hideAll();
+
+      expect(focusMock).toHaveBeenCalledTimes(1);
+    });
+
     it("is safe to call when no tab is active", () => {
       const manager = new PortalManagerClass(mockWindow);
 

--- a/electron/services/__tests__/PortalManager.test.ts
+++ b/electron/services/__tests__/PortalManager.test.ts
@@ -28,6 +28,7 @@ vi.mock("electron", () => {
   class MockWebContentsView {
     webContents = createMockWebContents();
     setBounds = vi.fn();
+    setBackgroundColor = vi.fn();
     constructor() {
       createdWebContents.push(this.webContents);
     }
@@ -185,7 +186,10 @@ describe("PortalManager", () => {
 
       manager.showTab("tab-b", { x: 0, y: 0, width: 800, height: 600 });
       expect(manager.getActiveTabId()).toBe("tab-b");
-      expect(mockWindow.contentView.removeChildView).toHaveBeenCalled();
+      // Tab switching parks the previous active view offscreen rather than
+      // detaching it — preserves embedded page state across switches.
+      expect(mockWindow.contentView.removeChildView).not.toHaveBeenCalled();
+      expect(mockWindow.contentView.addChildView).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -233,7 +237,7 @@ describe("PortalManager", () => {
   });
 
   describe("hideAll()", () => {
-    it("hides all tabs and clears active tab", () => {
+    it("parks active view offscreen without detaching or clearing activeTabId", () => {
       const manager = new PortalManagerClass(mockWindow);
 
       manager.createTab("tab-hide", "http://localhost:3000");
@@ -241,10 +245,50 @@ describe("PortalManager", () => {
 
       expect(manager.getActiveTabId()).toBe("tab-hide");
 
+      const view = createdWebContents[createdWebContents.length - 1];
+      // Resolve the WebContentsView instance via the same mock pattern other
+      // tests use — setBounds is on the view itself, not webContents.
+      const electronModule = (
+        mockWindow as unknown as { contentView: { addChildView: ReturnType<typeof vi.fn> } }
+      ).contentView;
+      const addedView = electronModule.addChildView.mock.calls.at(-1)?.[0] as {
+        setBounds: ReturnType<typeof vi.fn>;
+      };
+
+      const setBoundsCallsBefore = addedView.setBounds.mock.calls.length;
+
       manager.hideAll();
 
-      expect(manager.getActiveTabId()).toBeNull();
-      expect(mockWindow.contentView.removeChildView).toHaveBeenCalled();
+      // activeView/activeTabId remain set so the same tab re-appears when the
+      // overlay closes and destroyHiddenTabs() still protects this tab.
+      expect(manager.getActiveTabId()).toBe("tab-hide");
+      // No detach — preserves embedded page state across overlay open/close.
+      expect(mockWindow.contentView.removeChildView).not.toHaveBeenCalled();
+      // setBounds was called with offscreen coordinates.
+      expect(addedView.setBounds.mock.calls.length).toBe(setBoundsCallsBefore + 1);
+      const offscreenBounds = addedView.setBounds.mock.calls.at(-1)?.[0];
+      expect(offscreenBounds.x).toBeLessThan(0);
+      expect(offscreenBounds.y).toBeLessThan(0);
+      // Suppress unused-warning for `view` — it is still imported to allow the
+      // test name to refer to "view" semantics even though webContents-level
+      // assertions aren't needed here.
+      expect(view).toBeDefined();
+    });
+
+    it("re-showing the same tab after hideAll does not call addChildView again", () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      manager.createTab("tab-cycle", "http://localhost:3000");
+      manager.showTab("tab-cycle", { x: 0, y: 0, width: 800, height: 600 });
+      expect(mockWindow.contentView.addChildView).toHaveBeenCalledTimes(1);
+
+      manager.hideAll();
+      manager.showTab("tab-cycle", { x: 0, y: 0, width: 800, height: 600 });
+
+      // No second addChildView — view stayed attached across hide/show cycle.
+      // This is what preserves embedded WebContents state across overlay open/close.
+      expect(mockWindow.contentView.addChildView).toHaveBeenCalledTimes(1);
+      expect(mockWindow.contentView.removeChildView).not.toHaveBeenCalled();
     });
 
     it("is safe to call when no tab is active", () => {
@@ -252,6 +296,45 @@ describe("PortalManager", () => {
 
       expect(() => manager.hideAll()).not.toThrow();
       expect(manager.getActiveTabId()).toBeNull();
+    });
+  });
+
+  describe("setBackgroundColor (flash prevention)", () => {
+    it("applies background color to new view before loadURL", () => {
+      const customBg = "#1a1a1a";
+      const manager = new PortalManagerClass(mockWindow, customBg);
+
+      const addChildViewMock = mockWindow.contentView.addChildView as ReturnType<typeof vi.fn>;
+      const beforeCalls = addChildViewMock.mock.calls.length;
+
+      manager.createTab("tab-bg", "http://localhost:3000");
+      manager.showTab("tab-bg", { x: 0, y: 0, width: 800, height: 600 });
+
+      const view = addChildViewMock.mock.calls[beforeCalls]?.[0] as {
+        setBackgroundColor: ReturnType<typeof vi.fn>;
+      };
+      const wc = createdWebContents[createdWebContents.length - 1];
+
+      expect(view.setBackgroundColor).toHaveBeenCalledWith(customBg);
+
+      // Order: setBackgroundColor must run before loadURL so the first paint
+      // doesn't show the default opaque white.
+      const bgOrder = view.setBackgroundColor.mock.invocationCallOrder[0];
+      const loadOrder = wc.loadURL.mock.invocationCallOrder[0];
+      expect(bgOrder).toBeLessThan(loadOrder);
+    });
+
+    it("defaults to black when no backgroundColor is provided", () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      const addChildViewMock = mockWindow.contentView.addChildView as ReturnType<typeof vi.fn>;
+      manager.createTab("tab-default-bg", "http://localhost:3000");
+      manager.showTab("tab-default-bg", { x: 0, y: 0, width: 800, height: 600 });
+
+      const view = addChildViewMock.mock.calls.at(-1)?.[0] as {
+        setBackgroundColor: ReturnType<typeof vi.fn>;
+      };
+      expect(view.setBackgroundColor).toHaveBeenCalledWith("#000000");
     });
   });
 
@@ -796,12 +879,14 @@ describe("PortalManager destroyHiddenTabs()", () => {
     expect(manager.hasTab("tab-c")).toBe(false);
   });
 
-  it("preserves lastShownTabId when activeTabId is null", async () => {
+  it("hideAll keeps activeTabId set so the parked tab is protected from eviction", async () => {
     const manager = new PortalManagerClass(mockWindow);
     manager.createTab("tab-1", "http://localhost:3000");
     manager.createTab("tab-2", "http://localhost:3001");
     manager.showTab("tab-1", { x: 0, y: 0, width: 800, height: 600 });
-    manager.hideAll(); // clears activeTabId, but lastShownTabId = tab-1
+    manager.hideAll(); // parks tab-1 offscreen; activeTabId stays "tab-1"
+
+    expect(manager.getActiveTabId()).toBe("tab-1");
 
     const result = await manager.destroyHiddenTabs();
 

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -3,6 +3,8 @@ import type { HandlerDependencies } from "../ipc/types.js";
 import { sendToRenderer } from "../ipc/handlers.js";
 import { getAppWebContents } from "./webContentsRegistry.js";
 import { distributePortsToView } from "./portDistribution.js";
+import { resolveInitialColorSchemeId } from "./skeletonCss.js";
+import { resolveAppTheme } from "../../shared/theme/index.js";
 import { PtyClient } from "../services/PtyClient.js";
 import {
   getMainProcessWatchdogClient,
@@ -313,7 +315,15 @@ export async function initPerWindowServices(
   // bus so early-boot events (migrations, PTY init, hydration) reach the
   // inspector. Deferring would drop those events.
   ctx.services.eventBuffer.start();
-  ctx.services.portalManager = new PortalManager(win);
+  // Match the main app view's background color so portal WebContentsView's
+  // first paint blends with the window chrome instead of flashing white when a
+  // tab is created or returned to after an overlay (#9207). Custom-scheme
+  // precision isn't load-bearing here — the goal is "not white", so we resolve
+  // the base scheme without threading customSchemes through this code path.
+  const portalBackgroundColor = resolveAppTheme(resolveInitialColorSchemeId(), []).tokens[
+    "surface-canvas"
+  ];
+  ctx.services.portalManager = new PortalManager(win, portalBackgroundColor);
   ctx.services.projectSwitchService = new ProjectSwitchService({
     mainWindow: win,
     ptyClient: ptyClient ?? undefined,


### PR DESCRIPTION
## Summary

- `WebContentsView` defaults to a white background. `PortalManager.createTab()` now calls `setBackgroundColor()` before `loadURL`, matching the same pattern already applied to the main app view in `createWindow.ts`.
- `hideAll()` and `showTab()` park views offscreen (`setBounds({x:-99999,...})`) instead of calling `removeChildView`/`addChildView`. The view stays attached, so embedded page state (scroll position, in-flight animations, running JS) is fully preserved across overlay open/close cycles.
- `updateBounds()` returns early when the portal is hidden, so a window resize fired by `PortalDock`'s `ResizeObserver` during an open overlay doesn't pull the parked view back on top.

Resolves #9207

## Changes

- `electron/services/PortalManager.ts`: `backgroundColor` constructor param, `hidden` flag, `attachedViews` set (first-attach guard), `lastShownBounds` map. `hideAll()` parks and returns focus to the main app `webContents`. `showTab()` parks the previously-active view instead of detaching. `updateBounds()` early-exits when hidden. Cleanup paths (`destroyView`, `destroy`) clear the new state consistently.
- `electron/window/perWindowInit.ts`: derives `portalBackgroundColor` from `resolveAppTheme(...).tokens["surface-canvas"]` and passes it to `PortalManager`.
- Tests: `setBackgroundColor` mock added to `MockWebContentsView` in both test files. New cases cover background-color ordering, hide/show without re-attach, tab-switch parks instead of detaching, `updateBounds` no-op while parked, `updateBounds` resumes after re-show, and focus return on `hideAll`. Old tests that asserted `removeChildView` on hide updated to the park pattern.

## Testing

- All 125 `PortalManager` unit tests pass.
- `npm run check` clean (all 9 gates pass).
- Manually verified against all three default portal hosts: `claude.ai`, `chatgpt.com`, `gemini.google.com` — no white flash on overlay open/close, embedded page state preserved.