### PR TITLE
feat(recovery): central demotion hook with category opt-out and settle period

### DIFF
--- a/src/components/Recovery/__tests__/useShouldSuppressLocalError.test.tsx
+++ b/src/components/Recovery/__tests__/useShouldSuppressLocalError.test.tsx
@@ -56,6 +56,28 @@ describe("useShouldSuppressLocalError", () => {
       expect(result.current).toBe(true);
     });
 
+    it("returns true on the first render after rawSuppressed flips true (sync sticky-on)", () => {
+      // Captures the value at every render. Sticky-on must be synchronous
+      // with render — if the hook depended on `useEffect` to flip state,
+      // the first re-render after the store update would still read `false`
+      // (effect runs after paint), and a local banner would briefly co-paint
+      // with the host-crash banner.
+      const renders: boolean[] = [];
+      renderHook(() => {
+        const v = useShouldSuppressLocalError("backend-dependent");
+        renders.push(v);
+        return v;
+      });
+      expect(renders).toEqual([false]);
+
+      act(() => {
+        usePanelStore.setState({ backendStatus: "recovering" });
+      });
+      // The Zustand selector triggers a synchronous re-render; that render
+      // must already return true (no effect cycle has run yet).
+      expect(renders[1]).toBe(true);
+    });
+
     it("stays suppressed for the full settle window after the cause clears", () => {
       const { result } = renderHook(() => useShouldSuppressLocalError("backend-dependent"));
 

--- a/src/components/Recovery/__tests__/useShouldSuppressLocalError.test.tsx
+++ b/src/components/Recovery/__tests__/useShouldSuppressLocalError.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act, cleanup } from "@testing-library/react";
+
+import { useShouldSuppressLocalError } from "../useShouldSuppressLocalError";
+import { LOCAL_ERROR_SETTLE_MS } from "@/lib/animationUtils";
+import { usePanelStore } from "@/store/panelStore";
+import { useSafeModeStore } from "@/store/safeModeStore";
+import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
+
+function resetStores() {
+  usePanelStore.setState({
+    backendStatus: "connected",
+    lastCrashType: null,
+    watchdogStatus: "active",
+    watchdogDisabledInfo: null,
+  });
+  useSafeModeStore.setState({
+    safeMode: false,
+    dismissed: false,
+    crashCount: undefined,
+    skippedPanelCount: undefined,
+    lastCrashAt: undefined,
+  });
+  useRestoreConfirmationStore.setState({ visible: false, suspectCount: 0, crashCount: 0 });
+}
+
+beforeEach(() => {
+  resetStores();
+  delete document.body.dataset.performanceMode;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  if (vi.isFakeTimers()) {
+    vi.useRealTimers();
+  }
+  delete document.body.dataset.performanceMode;
+});
+
+describe("useShouldSuppressLocalError", () => {
+  describe("backend-dependent category", () => {
+    it("is not suppressed when no global cause is active", () => {
+      const { result } = renderHook(() => useShouldSuppressLocalError("backend-dependent"));
+      expect(result.current).toBe(false);
+    });
+
+    it("suppresses immediately when a global cause activates", () => {
+      const { result } = renderHook(() => useShouldSuppressLocalError("backend-dependent"));
+      expect(result.current).toBe(false);
+
+      act(() => {
+        usePanelStore.setState({ backendStatus: "recovering" });
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it("stays suppressed for the full settle window after the cause clears", () => {
+      const { result } = renderHook(() => useShouldSuppressLocalError("backend-dependent"));
+
+      act(() => {
+        usePanelStore.setState({ backendStatus: "recovering" });
+      });
+      expect(result.current).toBe(true);
+
+      act(() => {
+        usePanelStore.setState({ backendStatus: "connected" });
+      });
+      // Still suppressed — the settle timer is pending.
+      expect(result.current).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(LOCAL_ERROR_SETTLE_MS - 1);
+      });
+      expect(result.current).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it("cancels pending un-suppress if the cause re-activates mid-settle", () => {
+      const { result } = renderHook(() => useShouldSuppressLocalError("backend-dependent"));
+
+      act(() => {
+        usePanelStore.setState({ backendStatus: "recovering" });
+      });
+      act(() => {
+        usePanelStore.setState({ backendStatus: "connected" });
+      });
+      act(() => {
+        vi.advanceTimersByTime(Math.floor(LOCAL_ERROR_SETTLE_MS / 2));
+      });
+      expect(result.current).toBe(true);
+
+      // Cause re-activates before the settle timer fires.
+      act(() => {
+        usePanelStore.setState({ backendStatus: "recovering" });
+      });
+      // Advance past the original timer's deadline; we should still be
+      // suppressed because the timer was cancelled.
+      act(() => {
+        vi.advanceTimersByTime(LOCAL_ERROR_SETTLE_MS * 2);
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it("starts suppressed when the cause is already active at mount", () => {
+      usePanelStore.setState({ backendStatus: "recovering" });
+      const { result } = renderHook(() => useShouldSuppressLocalError("backend-dependent"));
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe("parse-error category", () => {
+    it("is never suppressed, even when a global cause is active", () => {
+      usePanelStore.setState({ backendStatus: "recovering" });
+      const { result } = renderHook(() => useShouldSuppressLocalError("parse-error"));
+      expect(result.current).toBe(false);
+    });
+
+    it("stays unsuppressed across a backend disconnect/recover cycle", () => {
+      const { result } = renderHook(() => useShouldSuppressLocalError("parse-error"));
+      expect(result.current).toBe(false);
+
+      act(() => {
+        usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "UNKNOWN_CRASH" });
+      });
+      expect(result.current).toBe(false);
+
+      act(() => {
+        usePanelStore.setState({ backendStatus: "recovering" });
+      });
+      expect(result.current).toBe(false);
+
+      act(() => {
+        usePanelStore.setState({ backendStatus: "connected" });
+        vi.advanceTimersByTime(LOCAL_ERROR_SETTLE_MS * 2);
+      });
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe("permission-error category", () => {
+    it("is never suppressed by a global cause", () => {
+      usePanelStore.setState({ backendStatus: "recovering" });
+      const { result } = renderHook(() => useShouldSuppressLocalError("permission-error"));
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe("performance mode bypass", () => {
+    it("unsuppresses synchronously when performance mode is active", () => {
+      document.body.dataset.performanceMode = "true";
+      const { result } = renderHook(() => useShouldSuppressLocalError("backend-dependent"));
+
+      act(() => {
+        usePanelStore.setState({ backendStatus: "recovering" });
+      });
+      expect(result.current).toBe(true);
+
+      // No timer should be required; advancing 0 ticks suffices.
+      act(() => {
+        usePanelStore.setState({ backendStatus: "connected" });
+      });
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("clears the settle timer on unmount (no post-unmount state updates)", () => {
+      const { result, unmount } = renderHook(() =>
+        useShouldSuppressLocalError("backend-dependent")
+      );
+
+      act(() => {
+        usePanelStore.setState({ backendStatus: "recovering" });
+      });
+      act(() => {
+        usePanelStore.setState({ backendStatus: "connected" });
+      });
+      expect(result.current).toBe(true);
+
+      unmount();
+
+      // Advancing past the timer must not throw or warn after unmount.
+      expect(() => {
+        vi.advanceTimersByTime(LOCAL_ERROR_SETTLE_MS * 2);
+      }).not.toThrow();
+    });
+  });
+
+  describe("non-host-crash causes", () => {
+    it("still suppresses backend-dependent banners when watchdog is disabled", () => {
+      const { result } = renderHook(() => useShouldSuppressLocalError("backend-dependent"));
+      expect(result.current).toBe(false);
+
+      act(() => {
+        usePanelStore.setState({ backendStatus: "connected", watchdogStatus: "disabled" });
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it("still suppresses backend-dependent banners when safe mode is active", () => {
+      const { result } = renderHook(() => useShouldSuppressLocalError("backend-dependent"));
+      expect(result.current).toBe(false);
+
+      act(() => {
+        useSafeModeStore.setState({ safeMode: true, dismissed: false });
+      });
+      expect(result.current).toBe(true);
+    });
+  });
+});

--- a/src/components/Recovery/useShouldSuppressLocalError.ts
+++ b/src/components/Recovery/useShouldSuppressLocalError.ts
@@ -2,10 +2,10 @@ import { useEffect, useState } from "react";
 
 import { LOCAL_ERROR_SETTLE_MS, getPerformanceModeFloor } from "@/lib/animationUtils";
 
-import { useRecoveryPriority, type RecoveryBannerSlot } from "./useRecoveryPriority";
+import { useGlobalBannerPriority, type GlobalBannerSlot } from "./useGlobalBannerPriority";
 
 /** Classification of pane-local error banners. Determines whether an active
- *  global recovery cause (see `useRecoveryPriority`) suppresses the banner.
+ *  global recovery cause (see `useGlobalBannerPriority`) suppresses the banner.
  *
  *  - `backend-dependent` — the banner describes a failure whose only recovery
  *    path runs through the backend (spawn, reconnect, restart). Always
@@ -19,17 +19,14 @@ import { useRecoveryPriority, type RecoveryBannerSlot } from "./useRecoveryPrior
  */
 export type LocalErrorCategory = "backend-dependent" | "parse-error" | "permission-error";
 
-/** Thin alias for `useRecoveryPriority`. Returns the active global recovery
+/** Thin alias for `useGlobalBannerPriority`. Returns the active global recovery
  *  cause (or `null` if none). Co-located so callers of
  *  `useShouldSuppressLocalError` import both names from the same module. */
-export function useActiveGlobalCause(): RecoveryBannerSlot {
-  return useRecoveryPriority();
+export function useActiveGlobalCause(): GlobalBannerSlot {
+  return useGlobalBannerPriority();
 }
 
-function isSuppressedByGlobalCause(
-  cause: RecoveryBannerSlot,
-  category: LocalErrorCategory
-): boolean {
+function isSuppressedByGlobalCause(cause: GlobalBannerSlot, category: LocalErrorCategory): boolean {
   if (cause === null) return false;
   switch (category) {
     case "backend-dependent":

--- a/src/components/Recovery/useShouldSuppressLocalError.ts
+++ b/src/components/Recovery/useShouldSuppressLocalError.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+
+import { LOCAL_ERROR_SETTLE_MS, getPerformanceModeFloor } from "@/lib/animationUtils";
+
+import { useRecoveryPriority, type RecoveryBannerSlot } from "./useRecoveryPriority";
+
+/** Classification of pane-local error banners. Determines whether an active
+ *  global recovery cause (see `useRecoveryPriority`) suppresses the banner.
+ *
+ *  - `backend-dependent` — the banner describes a failure whose only recovery
+ *    path runs through the backend (spawn, reconnect, restart). Always
+ *    suppressed while a global cause is active, because the user can't act on
+ *    it until the global cause clears.
+ *  - `parse-error` — the banner describes a file-format or replay failure
+ *    that's independent of host connectivity (e.g. corrupt saved scrollback).
+ *    The terminal itself is operational; never suppressed.
+ *  - `permission-error` — the banner describes an OS-level permission denial
+ *    on a path the user can fix independently of the backend. Never suppressed.
+ */
+export type LocalErrorCategory = "backend-dependent" | "parse-error" | "permission-error";
+
+/** Thin alias for `useRecoveryPriority`. Returns the active global recovery
+ *  cause (or `null` if none). Co-located so callers of
+ *  `useShouldSuppressLocalError` import both names from the same module. */
+export function useActiveGlobalCause(): RecoveryBannerSlot {
+  return useRecoveryPriority();
+}
+
+function isSuppressedByGlobalCause(
+  cause: RecoveryBannerSlot,
+  category: LocalErrorCategory
+): boolean {
+  if (cause === null) return false;
+  switch (category) {
+    case "backend-dependent":
+      return true;
+    case "parse-error":
+    case "permission-error":
+      return false;
+    default: {
+      const _exhaustive: never = category;
+      return _exhaustive;
+    }
+  }
+}
+
+/** Returns whether a pane-local error banner of the given `category` should be
+ *  suppressed because of an active global recovery cause.
+ *
+ *  Sticky-on / delayed-off: suppression turns true immediately when a global
+ *  cause activates (so a local banner never races a host-crash banner into
+ *  view), and turns false only after `LOCAL_ERROR_SETTLE_MS` of sustained
+ *  no-cause — this absorbs `backendStatus` flicker between `"recovering"` and
+ *  `"connected"`. Performance mode bypasses the settle window (mirrors raw
+ *  state instantly via `getPerformanceModeFloor`). Reduced-motion does NOT
+ *  collapse this timer: per the app's policy, CSS owns reduced-motion;
+ *  JS timers stay intact.
+ *
+ *  Stacks on top of the 500ms backend-side recoveryTimer in
+ *  `src/store/listeners/panel/backendHealth.ts`. The total dead-zone from
+ *  reconnect to local banner reappear is roughly `500 + LOCAL_ERROR_SETTLE_MS`. */
+export function useShouldSuppressLocalError(category: LocalErrorCategory): boolean {
+  const cause = useActiveGlobalCause();
+  const rawSuppressed = isSuppressedByGlobalCause(cause, category);
+  const [suppressed, setSuppressed] = useState(rawSuppressed);
+
+  useEffect(() => {
+    if (rawSuppressed) {
+      setSuppressed(true);
+      return;
+    }
+    const delay = getPerformanceModeFloor(LOCAL_ERROR_SETTLE_MS);
+    if (delay <= 0) {
+      setSuppressed(false);
+      return;
+    }
+    const timer = setTimeout(() => setSuppressed(false), delay);
+    return () => clearTimeout(timer);
+  }, [rawSuppressed]);
+
+  return suppressed;
+}

--- a/src/components/Recovery/useShouldSuppressLocalError.ts
+++ b/src/components/Recovery/useShouldSuppressLocalError.ts
@@ -62,21 +62,26 @@ function isSuppressedByGlobalCause(
 export function useShouldSuppressLocalError(category: LocalErrorCategory): boolean {
   const cause = useActiveGlobalCause();
   const rawSuppressed = isSuppressedByGlobalCause(cause, category);
-  const [suppressed, setSuppressed] = useState(rawSuppressed);
+  // `held` tracks the delayed-off tail: once a cause has activated, `held`
+  // stays true until the settle window elapses with no cause active. The
+  // returned value is `rawSuppressed || held` so sticky-on is synchronous
+  // with render — passive effects run *after* paint, so relying on the
+  // effect to set state would leak one paint cycle of the local banner.
+  const [held, setHeld] = useState(rawSuppressed);
 
   useEffect(() => {
     if (rawSuppressed) {
-      setSuppressed(true);
+      setHeld(true);
       return;
     }
     const delay = getPerformanceModeFloor(LOCAL_ERROR_SETTLE_MS);
     if (delay <= 0) {
-      setSuppressed(false);
+      setHeld(false);
       return;
     }
-    const timer = setTimeout(() => setSuppressed(false), delay);
+    const timer = setTimeout(() => setHeld(false), delay);
     return () => clearTimeout(timer);
   }, [rawSuppressed]);
 
-  return suppressed;
+  return rawSuppressed || held;
 }

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -34,6 +34,7 @@ import { SpawnErrorBanner } from "./SpawnErrorBanner";
 import { TerminalPaneSkeleton } from "./TerminalPaneSkeleton";
 import { ReconnectErrorBanner } from "./ReconnectErrorBanner";
 import { ScrollbackRestoreErrorBanner } from "./ScrollbackRestoreErrorBanner";
+import { useShouldSuppressLocalError } from "@/components/Recovery/useShouldSuppressLocalError";
 import { UpdateCwdDialog } from "./UpdateCwdDialog";
 import { ErrorBanner } from "../Errors/ErrorBanner";
 import { AgentCompletionBanner } from "./AgentCompletionBanner";
@@ -414,7 +415,6 @@ function TerminalPaneComponent({
 
   const isBackendDisconnected = backendStatus === "disconnected";
   const isBackendRecovering = backendStatus === "recovering";
-  const isHostConnected = backendStatus === "connected";
 
   const isHibernated = useIsHibernated(id);
 
@@ -1076,15 +1076,22 @@ function TerminalPaneComponent({
     spawnError,
     backendStatus,
   });
-  const showRestartError = isHostConnected && Boolean(restartError);
-  const showSpawnError = isHostConnected && Boolean(spawnError) && !restartError;
+  // Backend-dependent banners (restart / spawn / reconnect) describe failures
+  // whose only recovery path runs through the host, so they're hidden while
+  // any global recovery cause is active. The parse-error category covers
+  // scrollback-restore failures, which are independent of host connectivity
+  // (terminal still works) and stay visible during a backend flap.
+  const suppressBackendDependent = useShouldSuppressLocalError("backend-dependent");
+  const suppressParseError = useShouldSuppressLocalError("parse-error");
+  const showRestartError = !suppressBackendDependent && Boolean(restartError);
+  const showSpawnError = !suppressBackendDependent && Boolean(spawnError) && !restartError;
   const showReconnectError =
-    isHostConnected && Boolean(reconnectError) && !restartError && !spawnError;
+    !suppressBackendDependent && Boolean(reconnectError) && !restartError && !spawnError;
   // Scrollback restore is independent of PTY launch state (spawn/reconnect),
   // so it can co-exist with those banners. Only restartError, which already
   // implies a destroyed-and-respawning PTY, suppresses it.
   const showScrollbackRestoreError =
-    isHostConnected && Boolean(scrollbackRestoreError) && !restartError;
+    !suppressParseError && Boolean(scrollbackRestoreError) && !restartError;
   const showRestartStatus = restartBannerVariant.type !== "none";
 
   return (

--- a/src/hooks/useDeferredLoading.ts
+++ b/src/hooks/useDeferredLoading.ts
@@ -4,6 +4,7 @@ import {
   UI_DOHERTY_THRESHOLD,
   UI_SKELETON_GATE_MS,
   UI_SKELETON_FLOOR_MS,
+  getPerformanceModeFloor,
 } from "@/lib/animationUtils";
 
 export function useDeferredLoading(isPending: boolean, delay: number): boolean {
@@ -41,19 +42,6 @@ export function useSkeletonGate(isPending: boolean): boolean {
   return useDeferredLoading(isPending, UI_SKELETON_GATE_MS);
 }
 
-/** Resolve the effective display floor, honoring the performance-mode bypass.
- *  Mirrors `getUiAnimationDuration`: performance mode collapses JS timers to 0
- *  so callers complete synchronously. Reduced-motion is intentionally NOT read
- *  here — CSS owns reduced-motion presentation, not JS timers. Reads
- *  `document.body` lazily (never at module load) for SSR/JSDOM safety. */
-function getEffectiveFloor(floorMs: number): number {
-  if (typeof document === "undefined") {
-    return floorMs;
-  }
-  const performanceMode = document.body?.dataset.performanceMode === "true";
-  return performanceMode ? 0 : floorMs;
-}
-
 /**
  * Hold a skeleton (or any loading placeholder) visible for at least `floorMs`
  * once it first shows, preventing a same-frame teardown flash when the
@@ -78,7 +66,7 @@ export function useSkeletonDisplayFloor(
   const shownAtRef = useRef<number | null>(isShowing ? Date.now() : null);
 
   useEffect(() => {
-    const floor = getEffectiveFloor(floorMs);
+    const floor = getPerformanceModeFloor(floorMs);
 
     const clearTimer = () => {
       if (timerRef.current !== null) {

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -36,6 +36,18 @@ export function getUiAnimationDuration(): number {
   return performanceMode ? 0 : UI_ANIMATION_DURATION;
 }
 
+/** Collapse a JS timer duration to 0 when performance mode is active; otherwise
+ *  return it unchanged. Mirrors `getUiAnimationDuration`'s policy — performance
+ *  mode bypasses JS timers, reduced-motion does NOT (CSS owns reduced-motion).
+ *  Reads `document.body` lazily for SSR/JSDOM safety; never at module load. */
+export function getPerformanceModeFloor(ms: number): number {
+  if (typeof document === "undefined") {
+    return ms;
+  }
+  const performanceMode = document.body?.dataset.performanceMode === "true";
+  return performanceMode ? 0 : ms;
+}
+
 export const UI_ENTER_DURATION = DURATION_200;
 export const UI_EXIT_DURATION = 120;
 
@@ -52,6 +64,16 @@ export const UI_PALETTE_EXIT_DURATION = DURATION_100;
  *  drift-contract test in animationUtils.test.ts enforces parity.
  *  See `UI_PALETTE_STALE_DELAY` for the typed-input counterpart. */
 export const UI_DOHERTY_THRESHOLD = 400;
+
+/** Pane-local settle window for `useShouldSuppressLocalError`. Once an active
+ *  global recovery cause clears, local error banners stay suppressed for this
+ *  long before reappearing — absorbs visible flicker when `backendStatus`
+ *  flaps between `"recovering"` and `"connected"`. Stacks on top of the
+ *  500ms recoveryTimer in `src/store/listeners/panel/backendHealth.ts`, so the
+ *  total dead-zone from a backend reconnect to a local banner re-show is
+ *  ~900ms at p50 — intentionally long enough to render the flap invisible.
+ *  Performance mode collapses this to 0 via `getPerformanceModeFloor`. */
+export const LOCAL_ERROR_SETTLE_MS = UI_DOHERTY_THRESHOLD;
 
 /** UX anti-flicker gate for palette typed-input stale dimming. Shorter than
  *  Doherty's 400ms because keystrokes arrive every ~200ms at normal typing


### PR DESCRIPTION
## Summary

- Adds `useShouldSuppressLocalError(category)` and `useActiveGlobalCause`, co-located with `useGlobalBannerPriority` in `src/components/Recovery/`. Three categories: `backend-dependent` (suppressed when a global cause is active), `parse-error` and `permission-error` (never suppressed).
- Sticky-on / delayed-off with `LOCAL_ERROR_SETTLE_MS = 400ms`. Stacks on top of the 500ms backend `recoveryTimer`, giving a ~900ms dead-zone that absorbs `backendStatus` flicker between `"recovering"` and `"connected"`. Suppression turns on synchronously with render to avoid a one-paint-cycle leak.
- `getPerformanceModeFloor` extracted to `animationUtils.ts` so the new hook and `useDeferredLoading` share the same bypass shape. `TerminalPane.tsx` migrates four raw `isHostConnected` gates: restart / spawn / reconnect → `backend-dependent`; scrollback-restore → `parse-error` (terminal works; file-format issue is independent of host connectivity).

Resolves #9185

## Changes

- `src/components/Recovery/useShouldSuppressLocalError.ts` — new hook + `useActiveGlobalCause`
- `src/components/Recovery/__tests__/useShouldSuppressLocalError.test.tsx` — 13 `renderHook` tests covering all categories, settle period, performance-mode bypass, cleanup, watchdog and safe-mode causes, and synchronous sticky-on via per-render capture
- `src/lib/animationUtils.ts` — `getPerformanceModeFloor` + `LOCAL_ERROR_SETTLE_MS` extracted from `useDeferredLoading`
- `src/hooks/useDeferredLoading.ts` — updated to use the extracted helpers
- `src/components/Terminal/TerminalPane.tsx` — four banner gates migrated to `useShouldSuppressLocalError`

## Testing

13 `renderHook` tests: no-cause baseline, immediate suppression on cause activate, synchronous sticky-on (per-render capture verifying no one-frame leak), full settle window hold, mid-settle re-activation cancellation, mount-with-active-cause, `parse-error` and `permission-error` pass-through, performance-mode bypass (immediate un-suppress), timer cleanup on unmount, and watchdog + safe-mode as global causes.