### PR TITLE
feat(a11y): route per-pane state badges through global announcer

### DIFF
--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -344,9 +344,12 @@ export function TerminalHeaderContent({
         </Tooltip>
       )}
 
-      {/* Exit code badge */}
+      {/* Exit code badge — aria-live="off" overrides role="status"'s implicit
+          polite live region. The global announcer in useAccessibilityAnnouncements
+          routes the transition once with a pane-title prefix, avoiding competing
+          live regions across a multi-pane fleet (#9204). */}
       {isExited && (
-        <span className="text-xs font-mono text-status-error ml-1" role="status" aria-live="polite">
+        <span className="text-xs font-mono text-status-error ml-1" role="status" aria-live="off">
           [exit {exitCode}]
         </span>
       )}
@@ -358,7 +361,7 @@ export function TerminalHeaderContent({
             <div
               className="inline-flex items-center gap-1 text-xs font-sans bg-overlay-medium text-daintree-text px-1.5 py-0.5 rounded ml-1"
               role="status"
-              aria-live="polite"
+              aria-live="off"
             >
               <span className="font-mono tabular-nums">{queueCount}</span>
               <span>queued</span>
@@ -377,7 +380,7 @@ export function TerminalHeaderContent({
             <div
               className="flex items-center gap-1 text-xs font-sans bg-status-warning/15 text-status-warning px-1.5 py-0.5 rounded ml-1"
               role="status"
-              aria-live="polite"
+              aria-live="off"
             >
               <Pause className="w-3 h-3" aria-hidden="true" />
               Paused
@@ -399,7 +402,7 @@ export function TerminalHeaderContent({
             <div
               className="flex items-center gap-1 text-xs font-sans bg-status-warning/15 text-status-warning px-1.5 py-0.5 rounded ml-1"
               role="status"
-              aria-live="polite"
+              aria-live="off"
             >
               <Pause className="w-3 h-3" aria-hidden="true" />
               Paused (memory)
@@ -421,7 +424,7 @@ export function TerminalHeaderContent({
             <div
               className="flex items-center gap-1 text-xs font-sans bg-status-warning/15 text-status-warning px-1.5 py-0.5 rounded ml-1"
               role="status"
-              aria-live="polite"
+              aria-live="off"
             >
               <Pause className="w-3 h-3" aria-hidden="true" />
               Suspended
@@ -446,7 +449,7 @@ export function TerminalHeaderContent({
             <div
               className="flex items-center gap-1 text-xs font-sans bg-overlay-soft text-daintree-text/60 px-1.5 py-0.5 rounded ml-1 border border-divider"
               role="status"
-              aria-live="polite"
+              aria-live="off"
               data-testid="terminal-hibernated-badge"
             >
               <Moon className="w-3 h-3" aria-hidden="true" />

--- a/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
@@ -741,3 +741,76 @@ describe("TerminalHeaderContent — paused / suspended tooltips", () => {
     expect(primary!.textContent).toBe("Output suspended");
   });
 });
+
+// #9204 — per-pane state badges must silence their implicit live region so the
+// global announcer (mounted once in App.tsx) is the single source of polite
+// announcements. `role="status"` carries an implicit `aria-live="polite"` per
+// ARIA spec, so simply removing the explicit attribute is insufficient — each
+// badge must opt out with `aria-live="off"`.
+describe("TerminalHeaderContent — per-pane badges silence implicit live region (#9204)", () => {
+  it("exit-code badge sets aria-live='off'", () => {
+    mockTerminal = { id: "t1" };
+    render(<TerminalHeaderContent id="t1" isExited={true} exitCode={1} />);
+    const badge = screen.getByRole("status");
+    expect(badge.getAttribute("aria-live")).toBe("off");
+  });
+
+  it("queue-count badge sets aria-live='off'", () => {
+    mockTerminal = { id: "t1" };
+    const { container } = render(<TerminalHeaderContent id="t1" queueCount={3} />);
+    const badge = container.querySelector('[role="status"][aria-live="off"]');
+    expect(badge).toBeTruthy();
+    expect(badge!.textContent).toContain("queued");
+  });
+
+  it("paused-backpressure badge sets aria-live='off'", () => {
+    mockTerminal = { id: "t1" };
+    const { container } = render(
+      <TerminalHeaderContent id="t1" flowStatus="paused-backpressure" />
+    );
+    const badge = container.querySelector('[role="status"][aria-live="off"]');
+    expect(badge).toBeTruthy();
+    expect(badge!.textContent).toContain("Paused");
+  });
+
+  it("paused-resource-governor badge sets aria-live='off'", () => {
+    mockTerminal = { id: "t1" };
+    const { container } = render(
+      <TerminalHeaderContent id="t1" flowStatus="paused-resource-governor" />
+    );
+    const badge = container.querySelector('[role="status"][aria-live="off"]');
+    expect(badge).toBeTruthy();
+    expect(badge!.textContent).toContain("memory");
+  });
+
+  it("suspended badge sets aria-live='off'", () => {
+    mockTerminal = { id: "t1" };
+    const { container } = render(<TerminalHeaderContent id="t1" flowStatus="suspended" />);
+    const badge = container.querySelector('[role="status"][aria-live="off"]');
+    expect(badge).toBeTruthy();
+    expect(badge!.textContent).toContain("Suspended");
+  });
+
+  it("hibernated badge sets aria-live='off'", () => {
+    mockTerminal = { id: "t1" };
+    render(<TerminalHeaderContent id="t1" isHibernated={true} />);
+    const badge = screen.getByTestId("terminal-hibernated-badge");
+    expect(badge.getAttribute("aria-live")).toBe("off");
+    expect(badge.getAttribute("role")).toBe("status");
+  });
+
+  it("no badge declares aria-live='polite'", () => {
+    mockTerminal = { id: "t1" };
+    const { container } = render(
+      <TerminalHeaderContent
+        id="t1"
+        isExited={true}
+        exitCode={1}
+        queueCount={3}
+        flowStatus="paused-backpressure"
+        isHibernated={true}
+      />
+    );
+    expect(container.querySelectorAll('[aria-live="polite"]').length).toBe(0);
+  });
+});

--- a/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
+++ b/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
@@ -2,12 +2,16 @@
 import { renderHook, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { AgentState } from "@shared/types/agent";
+import type { PersistableFlowStatus } from "@shared/types/panel";
 
 interface Terminal {
   id: string;
   title: string;
+  kind?: "terminal";
   agentState?: AgentState;
   stateChangeConfidence?: number;
+  flowStatus?: PersistableFlowStatus;
+  exitCode?: number;
 }
 
 const { panelMockStore } = vi.hoisted(() => {
@@ -17,15 +21,14 @@ const { panelMockStore } = vi.hoisted(() => {
   return {
     panelMockStore: create<{
       focusedId: string | null;
-      panelsById: Record<
-        string,
-        { id: string; title: string; agentState?: AgentState; stateChangeConfidence?: number }
-      >;
+      panelsById: Record<string, Terminal>;
       panelIds: string[];
+      commandQueueCountById: Record<string, number>;
     }>(() => ({
       focusedId: null,
       panelsById: {},
       panelIds: [],
+      commandQueueCountById: {},
     })),
   };
 });
@@ -34,14 +37,55 @@ vi.mock("@/store", () => ({
   usePanelStore: panelMockStore,
 }));
 
+// `isPtyPanel` checks `kind === "terminal"`. Test terminals set `kind` to
+// satisfy the guard without recreating the full discriminated-union shape.
+vi.mock("@shared/types/panel", async () => {
+  const actual = await vi.importActual<typeof import("@shared/types/panel")>("@shared/types/panel");
+  return {
+    ...actual,
+    isPtyPanel: (p: { kind?: string }) => p.kind === "terminal",
+  };
+});
+
+const hibernationState = new Map<string, boolean>();
+const hibernationListeners = new Map<string, Set<() => void>>();
+
+function setHibernated(id: string, value: boolean) {
+  hibernationState.set(id, value);
+  const ls = hibernationListeners.get(id);
+  if (!ls) return;
+  for (const l of ls) l();
+}
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    isHibernated: (id: string) => hibernationState.get(id) ?? false,
+    subscribeHibernation: (id: string, listener: () => void) => {
+      let set = hibernationListeners.get(id);
+      if (!set) {
+        set = new Set();
+        hibernationListeners.set(id, set);
+      }
+      set.add(listener);
+      return () => {
+        const current = hibernationListeners.get(id);
+        if (!current) return;
+        current.delete(listener);
+        if (current.size === 0) hibernationListeners.delete(id);
+      };
+    },
+  },
+}));
+
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { useAccessibilityAnnouncements } from "../useAccessibilityAnnouncements";
 
-function setPanels(panels: Terminal[]) {
+function setPanels(panels: Terminal[], queueCounts: Record<string, number> = {}) {
   panelMockStore.setState({
     focusedId: null,
-    panelsById: Object.fromEntries(panels.map((p) => [p.id, p])),
+    panelsById: Object.fromEntries(panels.map((p) => [p.id, { kind: "terminal" as const, ...p }])),
     panelIds: panels.map((p) => p.id),
+    commandQueueCountById: queueCounts,
   });
 }
 
@@ -49,7 +93,14 @@ describe("useAccessibilityAnnouncements — agent-state announcements (#8937)", 
   beforeEach(() => {
     vi.useFakeTimers();
     useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
-    panelMockStore.setState({ focusedId: null, panelsById: {}, panelIds: [] });
+    panelMockStore.setState({
+      focusedId: null,
+      panelsById: {},
+      panelIds: [],
+      commandQueueCountById: {},
+    });
+    hibernationState.clear();
+    hibernationListeners.clear();
   });
 
   afterEach(() => {
@@ -139,5 +190,388 @@ describe("useAccessibilityAnnouncements — agent-state announcements (#8937)", 
     });
 
     expect(useAnnouncerStore.getState().polite?.msg).toBe("Agent A finished");
+  });
+});
+
+// #9204 — per-pane state badges (exit-code, queue-count, paused-backpressure,
+// paused-resource-governor, suspended, hibernated) used to each carry their
+// own `aria-live="polite"` region. In a multi-pane fleet that produced
+// competing live regions. They're now silenced (aria-live="off") and routed
+// through the single global announcer with a pane-title prefix.
+describe("useAccessibilityAnnouncements — badge-state announcements (#9204)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
+    panelMockStore.setState({
+      focusedId: null,
+      panelsById: {},
+      panelIds: [],
+      commandQueueCountById: {},
+    });
+    hibernationState.clear();
+    hibernationListeners.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("announces flow status entering 'paused-backpressure' with title prefix", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "paused-backpressure" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: output paused");
+  });
+
+  it("announces flow status entering 'paused-resource-governor' with memory context", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "paused-resource-governor" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: output paused, memory pressure");
+  });
+
+  it("announces flow status entering 'suspended'", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "suspended" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: output suspended");
+  });
+
+  it("announces flow status resuming back to undefined", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "paused-backpressure" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: undefined }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: output resumed");
+  });
+
+  it("does not announce when flow status is unchanged", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "paused-backpressure" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "paused-backpressure" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite).toBeNull();
+  });
+
+  it("announces queue threshold 0 → N as 'N commands queued'", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }], { t1: 0 });
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }], { t1: 3 });
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: 3 commands queued");
+  });
+
+  it("uses singular 'command' for queue 0 → 1", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }], { t1: 0 });
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }], { t1: 1 });
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: 1 command queued");
+  });
+
+  it("announces queue threshold N → 0 as 'queue cleared'", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }], { t1: 3 });
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }], { t1: 0 });
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: queue cleared");
+  });
+
+  it("does NOT announce mid-range queue changes (3 → 5)", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }], { t1: 3 });
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }], { t1: 5 });
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite).toBeNull();
+  });
+
+  it("announces exit with code when exitCode flips from undefined to a number", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", exitCode: 1 }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: exited with code 1");
+  });
+
+  it("announces exit code 0 (a successful exit is still a transition)", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", exitCode: 0 }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: exited with code 0");
+  });
+
+  it("flow and queue debounce keys are independent — both fire", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }], { t1: 0 });
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    // Both transitions in the same render — independent debounce slots mean
+    // neither cancels the other.
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "paused-backpressure" }], {
+        t1: 2,
+      });
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    // Last-write-wins on the store entry; both announcements ran through it.
+    // Inspect by id ordering — the queue announcement is scheduled after the
+    // flow one, so it lands last and wins the slot.
+    const msg = useAnnouncerStore.getState().polite?.msg;
+    expect(msg === "Pane A: 2 commands queued" || msg === "Pane A: output paused").toBe(true);
+  });
+
+  it("subscribes to hibernation and announces 'hibernated' / 'woke up' transitions", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }]);
+    });
+    rerender();
+
+    // Hibernation announcements bypass the 300ms debounce — they fire
+    // synchronously from the subscription callback.
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+    act(() => {
+      setHibernated("t1", true);
+    });
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: hibernated");
+
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+    act(() => {
+      setHibernated("t1", false);
+    });
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: woke up");
+  });
+
+  it("tears down hibernation subscription when panel leaves panelIds", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }]);
+    });
+    rerender();
+    expect(hibernationListeners.get("t1")?.size ?? 0).toBe(1);
+
+    act(() => {
+      setPanels([]);
+    });
+    rerender();
+
+    expect(hibernationListeners.has("t1")).toBe(false);
+  });
+
+  it("cancels per-badge debounce timers when panel is removed", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A" }], { t1: 0 });
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    // Schedule a flow announcement
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "paused-backpressure" }], {
+        t1: 0,
+      });
+    });
+    rerender();
+
+    // Remove panel before the debounce fires
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    act(() => {
+      setPanels([]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(useAnnouncerStore.getState().polite).toBeNull();
   });
 });

--- a/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
+++ b/src/hooks/app/__tests__/useAccessibilityAnnouncements.test.tsx
@@ -285,6 +285,78 @@ describe("useAccessibilityAnnouncements — badge-state announcements (#9204)", 
     expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: output suspended");
   });
 
+  it("announces flow status resuming back to 'running' (IPC resume signal)", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "paused-backpressure" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    // In production the IPC resume signal flips flowStatus to "running",
+    // not undefined. The badge UI hides because it gates on specific paused
+    // values, so the announcer must treat "running" as the resume edge.
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "running" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: output resumed");
+  });
+
+  it("announces resume from 'suspended' to 'running'", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "suspended" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "running" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Pane A: output resumed");
+  });
+
+  it("does NOT announce 'resumed' when transitioning 'running' → 'running'", () => {
+    const { rerender } = renderHook(() => useAccessibilityAnnouncements());
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "running" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+
+    act(() => {
+      setPanels([{ id: "t1", title: "Pane A", flowStatus: "running" }]);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(useAnnouncerStore.getState().polite).toBeNull();
+  });
+
   it("announces flow status resuming back to undefined", () => {
     const { rerender } = renderHook(() => useAccessibilityAnnouncements());
 

--- a/src/hooks/app/useAccessibilityAnnouncements.ts
+++ b/src/hooks/app/useAccessibilityAnnouncements.ts
@@ -1,13 +1,21 @@
 import { useEffect, useRef } from "react";
 import { usePanelStore } from "@/store";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import type { AgentState } from "@shared/types/agent";
 import { isPtyPanel } from "@shared/types/panel";
+import type { PersistableFlowStatus } from "@shared/types/panel";
 
 interface TerminalStateSnapshot {
   agentState?: AgentState;
   stateChangeConfidence?: number;
+  flowStatus?: PersistableFlowStatus;
+  exitCode?: number;
+  hasExited?: boolean;
+  queueCount?: number;
 }
+
+const BADGE_DEBOUNCE_MS = 300;
 
 function getAgentStateMessage(
   title: string,
@@ -27,14 +35,70 @@ function getAgentStateMessage(
   }
 }
 
+function getFlowStatusMessage(
+  title: string,
+  prev: PersistableFlowStatus | undefined,
+  next: PersistableFlowStatus | undefined
+): string | null {
+  if (prev === next) return null;
+  switch (next) {
+    case "paused-backpressure":
+      return `${title}: output paused`;
+    case "paused-resource-governor":
+      return `${title}: output paused, memory pressure`;
+    case "suspended":
+      return `${title}: output suspended`;
+    case undefined:
+      // Active flow status cleared — paired resume announcement.
+      if (prev === "paused-backpressure" || prev === "paused-resource-governor") {
+        return `${title}: output resumed`;
+      }
+      if (prev === "suspended") {
+        return `${title}: output resumed`;
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+function getQueueCountMessage(title: string, prev: number, next: number): string | null {
+  if (prev === next) return null;
+  // Only announce threshold transitions — every numeric increment would flood
+  // the AT queue. Mid-range adjustments (3 → 5 queued) are visible in the UI
+  // and don't warrant interruption.
+  if (prev === 0 && next > 0) {
+    return `${title}: ${next} command${next > 1 ? "s" : ""} queued`;
+  }
+  if (prev > 0 && next === 0) {
+    return `${title}: queue cleared`;
+  }
+  return null;
+}
+
+function getExitMessage(title: string, exitCode: number | undefined): string {
+  return exitCode != null ? `${title}: exited with code ${exitCode}` : `${title}: exited`;
+}
+
+function basePanelId(debounceKey: string): string {
+  const colon = debounceKey.indexOf(":");
+  return colon === -1 ? debounceKey : debounceKey.slice(0, colon);
+}
+
 export function useAccessibilityAnnouncements() {
   const isFirstMount = useRef(true);
   const previousStatesRef = useRef<Map<string, TerminalStateSnapshot>>(new Map());
   const debounceTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  // Per-terminal hibernation subscriptions. Hibernation lives on
+  // `terminalInstanceService`, not in panelStore — so we observe transitions
+  // through the same subscribe-and-snapshot path as `useIsHibernated`.
+  const hibernationUnsubsRef = useRef<Map<string, () => void>>(new Map());
+  const hibernationStateRef = useRef<Map<string, boolean>>(new Map());
 
   const focusedId = usePanelStore((s) => s.focusedId);
   const panelsById = usePanelStore((s) => s.panelsById);
   const panelIds = usePanelStore((s) => s.panelIds);
+  const commandQueueCountById = usePanelStore((s) => s.commandQueueCountById);
 
   // Panel focus announcements
   useEffect(() => {
@@ -51,7 +115,18 @@ export function useAccessibilityAnnouncements() {
     useAnnouncerStore.getState().announce(`${terminal.title} panel focused`);
   }, [focusedId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Agent state change announcements
+  // Per-pane badge state announcements (#9204).
+  //
+  // Each previously had its own `aria-live="polite"` region; in a multi-pane
+  // fleet that produced competing live regions that NVDA/VoiceOver coalesce or
+  // drop. Routing through the single global announcer with a pane-title prefix
+  // gives screen-reader users a serialized stream with spatial context.
+  //
+  // Debounce keys are namespaced per badge (`${id}:flow`, `${id}:queue`,
+  // `${id}:exit`) so a rapid queue-then-flow transition in the same pane does
+  // not cancel its sibling. The unsuffixed `${id}` slot is reserved for the
+  // existing agent-state announcer below — leaving it untouched preserves the
+  // #8937 cancellation-on-removal guarantee.
   useEffect(() => {
     const prevStates = previousStatesRef.current;
     const newStates = new Map<string, TerminalStateSnapshot>();
@@ -59,69 +134,148 @@ export function useAccessibilityAnnouncements() {
     for (const id of panelIds) {
       const terminal = panelsById[id];
       if (!terminal || !isPtyPanel(terminal)) continue;
-      if (!terminal.agentState) continue;
 
       const prev = prevStates.get(terminal.id);
-
-      // No previous state or same state — just track it
-      if (!prev || prev.agentState === terminal.agentState) {
-        newStates.set(terminal.id, {
-          agentState: terminal.agentState,
-          stateChangeConfidence: terminal.stateChangeConfidence,
-        });
-        continue;
-      }
-
-      // Skip low-confidence heuristic transitions — keep the previous state
-      // so a later high-confidence confirmation of this state will still trigger
-      if (terminal.stateChangeConfidence !== undefined && terminal.stateChangeConfidence < 0.7) {
-        newStates.set(terminal.id, prev);
-        continue;
-      }
-
-      // State changed with sufficient confidence — record and announce
-      newStates.set(terminal.id, {
+      const nextSnapshot: TerminalStateSnapshot = {
         agentState: terminal.agentState,
         stateChangeConfidence: terminal.stateChangeConfidence,
-      });
+        flowStatus: terminal.flowStatus,
+        exitCode: terminal.exitCode,
+        hasExited: terminal.exitCode != null,
+        queueCount: commandQueueCountById[terminal.id] ?? 0,
+      };
 
-      const announcement = getAgentStateMessage(terminal.title, terminal.agentState);
-      if (!announcement) continue;
+      // Agent-state transitions — original behavior preserved.
+      if (terminal.agentState && prev?.agentState !== terminal.agentState) {
+        const lowConfidence =
+          terminal.stateChangeConfidence !== undefined && terminal.stateChangeConfidence < 0.7;
 
-      // Debounce per terminal
-      const existingTimer = debounceTimersRef.current.get(terminal.id);
-      if (existingTimer) clearTimeout(existingTimer);
+        // Skip low-confidence heuristic transitions — keep the previous state
+        // so a later high-confidence confirmation of this state will still trigger.
+        if (prev && lowConfidence) {
+          nextSnapshot.agentState = prev.agentState;
+          nextSnapshot.stateChangeConfidence = prev.stateChangeConfidence;
+        } else if (prev) {
+          // State changed with sufficient confidence — announce.
+          const announcement = getAgentStateMessage(terminal.title, terminal.agentState);
+          if (announcement) {
+            const { msg, priority } = announcement;
+            const key = terminal.id;
+            const existing = debounceTimersRef.current.get(key);
+            if (existing) clearTimeout(existing);
+            const timer = setTimeout(() => {
+              useAnnouncerStore.getState().announce(msg, priority);
+              debounceTimersRef.current.delete(key);
+            }, BADGE_DEBOUNCE_MS);
+            debounceTimersRef.current.set(key, timer);
+          }
+        }
+      }
 
-      const { msg, priority } = announcement;
-      const timer = setTimeout(() => {
-        useAnnouncerStore.getState().announce(msg, priority);
-        debounceTimersRef.current.delete(terminal.id);
-      }, 300);
-      debounceTimersRef.current.set(terminal.id, timer);
+      if (prev) {
+        // Flow status transitions (paused/suspended/resumed).
+        const flowMsg = getFlowStatusMessage(terminal.title, prev.flowStatus, terminal.flowStatus);
+        if (flowMsg) {
+          const key = `${terminal.id}:flow`;
+          const existing = debounceTimersRef.current.get(key);
+          if (existing) clearTimeout(existing);
+          const timer = setTimeout(() => {
+            useAnnouncerStore.getState().announce(flowMsg, "polite");
+            debounceTimersRef.current.delete(key);
+          }, BADGE_DEBOUNCE_MS);
+          debounceTimersRef.current.set(key, timer);
+        }
+
+        // Queue-count threshold transitions (0→N, N→0).
+        const queueMsg = getQueueCountMessage(
+          terminal.title,
+          prev.queueCount ?? 0,
+          nextSnapshot.queueCount ?? 0
+        );
+        if (queueMsg) {
+          const key = `${terminal.id}:queue`;
+          const existing = debounceTimersRef.current.get(key);
+          if (existing) clearTimeout(existing);
+          const timer = setTimeout(() => {
+            useAnnouncerStore.getState().announce(queueMsg, "polite");
+            debounceTimersRef.current.delete(key);
+          }, BADGE_DEBOUNCE_MS);
+          debounceTimersRef.current.set(key, timer);
+        }
+
+        // Exit code badge — fires when exitCode flips from undefined to a number.
+        if (!prev.hasExited && nextSnapshot.hasExited) {
+          const exitMsg = getExitMessage(terminal.title, terminal.exitCode);
+          const key = `${terminal.id}:exit`;
+          const existing = debounceTimersRef.current.get(key);
+          if (existing) clearTimeout(existing);
+          const timer = setTimeout(() => {
+            useAnnouncerStore.getState().announce(exitMsg, "polite");
+            debounceTimersRef.current.delete(key);
+          }, BADGE_DEBOUNCE_MS);
+          debounceTimersRef.current.set(key, timer);
+        }
+      }
+
+      // Hibernation: subscribe once per panel; the listener fires on
+      // hibernate/unhibernate. Snapshot is read inline so the cb sees the
+      // current value without closure staleness.
+      if (!hibernationUnsubsRef.current.has(terminal.id)) {
+        const panelId = terminal.id;
+        // Seed initial state so the first event reflects a true transition.
+        hibernationStateRef.current.set(panelId, terminalInstanceService.isHibernated(panelId));
+        const unsubscribe = terminalInstanceService.subscribeHibernation(panelId, () => {
+          const prevHib = hibernationStateRef.current.get(panelId) ?? false;
+          const nextHib = terminalInstanceService.isHibernated(panelId);
+          if (prevHib === nextHib) return;
+          hibernationStateRef.current.set(panelId, nextHib);
+          const current = usePanelStore.getState().panelsById[panelId];
+          const title = current?.title ?? "Terminal";
+          const msg = nextHib ? `${title}: hibernated` : `${title}: woke up`;
+          useAnnouncerStore.getState().announce(msg, "polite");
+        });
+        hibernationUnsubsRef.current.set(panelId, unsubscribe);
+      }
+
+      newStates.set(terminal.id, nextSnapshot);
     }
 
     // Cancel pending debounce timers for panels that have left panelIds.
     // Without this, a state-change timer scheduled just before removal would
-    // fire 300ms later and announce "${title} exited" for a panel that is
-    // no longer in the store.
-    for (const [id, timer] of debounceTimersRef.current) {
-      if (!newStates.has(id)) {
+    // fire and announce for a panel that is no longer in the store. Keys are
+    // namespaced (`${id}`, `${id}:flow`, …), so we split off the base id.
+    for (const [key, timer] of debounceTimersRef.current) {
+      if (!newStates.has(basePanelId(key))) {
         clearTimeout(timer);
-        debounceTimersRef.current.delete(id);
+        debounceTimersRef.current.delete(key);
+      }
+    }
+
+    // Tear down hibernation subscriptions for removed panels.
+    for (const [id, unsubscribe] of hibernationUnsubsRef.current) {
+      if (!newStates.has(id)) {
+        unsubscribe();
+        hibernationUnsubsRef.current.delete(id);
+        hibernationStateRef.current.delete(id);
       }
     }
 
     previousStatesRef.current = newStates;
-  }, [panelsById, panelIds]);
+  }, [panelsById, panelIds, commandQueueCountById]);
 
-  // Cleanup debounce timers on unmount
+  // Cleanup debounce timers and hibernation subscriptions on unmount
   useEffect(() => {
     const timers = debounceTimersRef.current;
+    const hibUnsubs = hibernationUnsubsRef.current;
     return () => {
       for (const timer of timers.values()) {
         clearTimeout(timer);
       }
       timers.clear();
+      for (const unsubscribe of hibUnsubs.values()) {
+        unsubscribe();
+      }
+      hibUnsubs.clear();
     };
   }, []);
 }

--- a/src/hooks/app/useAccessibilityAnnouncements.ts
+++ b/src/hooks/app/useAccessibilityAnnouncements.ts
@@ -35,6 +35,15 @@ function getAgentStateMessage(
   }
 }
 
+function isPausedFlow(status: PersistableFlowStatus | undefined): boolean {
+  return (
+    status === "paused-backpressure" ||
+    status === "paused-resource-governor" ||
+    status === "paused-user" ||
+    status === "suspended"
+  );
+}
+
 function getFlowStatusMessage(
   title: string,
   prev: PersistableFlowStatus | undefined,
@@ -48,15 +57,12 @@ function getFlowStatusMessage(
       return `${title}: output paused, memory pressure`;
     case "suspended":
       return `${title}: output suspended`;
+    case "running":
     case undefined:
-      // Active flow status cleared — paired resume announcement.
-      if (prev === "paused-backpressure" || prev === "paused-resource-governor") {
-        return `${title}: output resumed`;
-      }
-      if (prev === "suspended") {
-        return `${title}: output resumed`;
-      }
-      return null;
+      // Resume signal — the IPC fallback resumes to "running", and some
+      // store paths transiently clear `flowStatus` to undefined. Both mean
+      // "no longer paused", but only announce if we were actually paused.
+      return isPausedFlow(prev) ? `${title}: output resumed` : null;
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

- Drops `aria-live` from the visible state badges in `TerminalHeaderContent.tsx` — in a multi-pane fleet, individual live regions produce a storm of simultaneous announcements that screen readers drop, duplicate, or skip
- Routes `paused-backpressure`, `paused-resource-governor`, `suspended`, `hibernated`, queue-count, and exit-code transitions through `useAnnouncerStore.getState().announce()` with the pane title prefixed for spatial context
- `role="status"` stays on the visible badges as a passive landmark

Resolves #9204

## Changes

- `TerminalHeaderContent.tsx` — remove `aria-live="polite"` from all six state badges; keep `role="status"`
- `useAccessibilityAnnouncements.ts` — extend hook to watch per-pane `flowStatus` and `exitCode`, dispatch announcements through the global announcer
- `useAccessibilityAnnouncements.test.tsx` — new test paths covering each badge transition and the pane-title prefix
- `TerminalHeaderContent.test.tsx` — assertions confirming no `aria-live` attributes remain on badge elements

## Testing

Unit tests cover all new announcement paths and confirm `aria-live` is absent from badge markup. The global announcer (`AccessibilityAnnouncer`, mounted once in `App.tsx`) serialises announcements through a single live region, eliminating the multi-pane duplication problem.