### PR TITLE
feat(plugins): register plugin:// protocol handler for static assets

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -21,6 +21,7 @@ import { enforceIpcSenderValidation, setupPermissionLockdown } from "./setup/sec
 import {
   registerAppProtocol,
   registerDaintreeFileProtocol,
+  registerPluginProtocol,
   setupWebviewCSP,
 } from "./setup/protocols.js";
 import {
@@ -114,6 +115,19 @@ protocol.registerSchemesAsPrivileged([
     privileges: {
       secure: true,
       supportFetchAPI: true,
+    },
+  },
+  {
+    // Per-plugin static asset scheme: plugin://{pluginId}/{path}. standard+secure
+    // so relative ESM imports resolve and the renderer treats it as a secure
+    // context; the {pluginId} host segment is a distinct origin per plugin
+    // (corsEnabled). bypassCSP defaults to false — plugins stay subject to CSP.
+    scheme: "plugin",
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      corsEnabled: true,
     },
   },
 ]);
@@ -420,6 +434,7 @@ if (!gotTheLock) {
       setupPermissionLockdown();
       registerAppProtocol(distPath);
       registerDaintreeFileProtocol();
+      registerPluginProtocol();
       setupWebviewCSP();
       // Prime the hydrate prefetch cache for the last-active project so the
       // renderer's first `app:boot` invoke resolves as a cache hit instead of

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -918,6 +918,16 @@ export class PluginService {
     return this.plugins.has(pluginId);
   }
 
+  /**
+   * Resolve a plugin's installed on-disk root directory by id, or null if no
+   * plugin with that id is loaded. Used by the `plugin://` protocol handler to
+   * map `plugin://{pluginId}/...` URLs to files on disk. Looked up at request
+   * time so reinstall/unload is reflected immediately.
+   */
+  getPluginDir(pluginId: string): string | null {
+    return this.plugins.get(pluginId)?.dir ?? null;
+  }
+
   registerHandler(pluginId: string, channel: string, handler: PluginIpcHandler): void {
     if (!this.plugins.has(pluginId)) {
       throw new Error(`Unknown plugin: ${pluginId}`);

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -518,6 +518,16 @@ describe("PluginService", () => {
     expect(service.listPlugins()).toEqual([]);
   });
 
+  it("getPluginDir returns the on-disk root for a loaded plugin and null otherwise", async () => {
+    await writePlugin("test-plugin", { name: "acme.test-plugin", version: "1.0.0" });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    expect(service.getPluginDir("acme.test-plugin")).toBe(path.join(tmpDir, "test-plugin"));
+    expect(service.getPluginDir("acme.unknown")).toBeNull();
+  });
+
   it("skips plugins with invalid JSON", async () => {
     const dir = path.join(tmpDir, "bad-json");
     await fs.mkdir(dir);

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -528,6 +528,17 @@ describe("PluginService", () => {
     expect(service.getPluginDir("acme.unknown")).toBeNull();
   });
 
+  it("getPluginDir returns null after the plugin is unloaded", async () => {
+    await writePlugin("test-plugin", { name: "acme.test-plugin", version: "1.0.0" });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    expect(service.getPluginDir("acme.test-plugin")).toBe(path.join(tmpDir, "test-plugin"));
+
+    service.unloadPlugin("acme.test-plugin");
+    expect(service.getPluginDir("acme.test-plugin")).toBeNull();
+  });
+
   it("skips plugins with invalid JSON", async () => {
     const dir = path.join(tmpDir, "bad-json");
     await fs.mkdir(dir);

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -113,8 +113,20 @@ vi.mock("../../ipc/channels.js", () => ({
   },
 }));
 
+const pluginServiceMock = vi.hoisted(() => ({
+  getPluginDir: vi.fn<(pluginId: string) => string | null>(() => null),
+}));
+vi.mock("../../services/PluginService.js", () => ({
+  pluginService: pluginServiceMock,
+}));
+
+vi.mock("../../../shared/config/devServer.js", () => ({
+  getDevServerOrigins: vi.fn<() => string[]>(() => []),
+}));
+
 import {
   registerDaintreeFileProtocol,
+  registerPluginProtocol,
   registerProtocolsForSession,
   setupWebviewCSP,
 } from "../protocols.js";
@@ -766,15 +778,16 @@ describe("protocol registration", () => {
     vi.clearAllMocks();
   });
 
-  it("registers app and daintree-file protocols on per-project sessions", async () => {
+  it("registers app, daintree-file, and plugin protocols on per-project sessions", async () => {
     const handle = vi.fn();
     const mockSession = { protocol: { handle } } as unknown as Electron.Session;
 
     registerProtocolsForSession(mockSession, "/tmp/dist");
 
-    expect(handle).toHaveBeenCalledTimes(2);
+    expect(handle).toHaveBeenCalledTimes(3);
     expect(handle).toHaveBeenCalledWith("app", expect.any(Function));
     expect(handle).toHaveBeenCalledWith("daintree-file", expect.any(Function));
+    expect(handle).toHaveBeenCalledWith("plugin", expect.any(Function));
   });
 
   it("registers the default-session daintree-file protocol", async () => {
@@ -783,6 +796,14 @@ describe("protocol registration", () => {
     registerDaintreeFileProtocol();
 
     expect(protocol.handle).toHaveBeenCalledWith("daintree-file", expect.any(Function));
+  });
+
+  it("registers the default-session plugin protocol", async () => {
+    const { protocol } = await import("electron");
+
+    registerPluginProtocol();
+
+    expect(protocol.handle).toHaveBeenCalledWith("plugin", expect.any(Function));
   });
 });
 
@@ -1152,5 +1173,159 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     } finally {
       relativeSpy.mockRestore();
     }
+  });
+});
+
+describe("createPluginProtocolHandler — plugin asset resolution & containment", () => {
+  type ProtocolHandler = (request: GlobalRequest) => Promise<Response>;
+
+  const PLUGIN_ROOT = "/plugins/acme.demo";
+
+  async function captureHandler(): Promise<ProtocolHandler> {
+    const handle = vi.fn();
+    const mockSession = { protocol: { handle } } as unknown as Electron.Session;
+    registerProtocolsForSession(mockSession, "/tmp/dist");
+    const call = handle.mock.calls.find((c) => c[0] === "plugin");
+    if (!call) throw new Error("handler for plugin not registered");
+    return call[1] as ProtocolHandler;
+  }
+
+  function makeRequest(
+    pluginId: string,
+    assetPath: string,
+    init: { method?: string; origin?: string } = {}
+  ): GlobalRequest {
+    const headers: Record<string, string> = {};
+    if (init.origin) headers["Origin"] = init.origin;
+    return new Request(`plugin://${pluginId}/${assetPath}`, {
+      method: init.method,
+      headers,
+    }) as GlobalRequest;
+  }
+
+  function makeFileHandle(content: string | Buffer = "data") {
+    const buffer = typeof content === "string" ? Buffer.from(content) : content;
+    return {
+      readFile: vi.fn().mockResolvedValue(buffer),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    pluginServiceMock.getPluginDir.mockReturnValue(PLUGIN_ROOT);
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({
+      isFile: () => true,
+      mtime: new Date(0),
+      size: 4,
+    } as unknown as Awaited<ReturnType<typeof fs.stat>>);
+    vi.mocked(fs.open).mockResolvedValue(
+      makeFileHandle() as unknown as Awaited<ReturnType<typeof fs.open>>
+    );
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("application/javascript");
+    const devServer = await import("../../../shared/config/devServer.js");
+    vi.mocked(devServer.getDevServerOrigins).mockReturnValue([]);
+  });
+
+  it("serves a file for a known plugin and opens the resolved path with O_NOFOLLOW", async () => {
+    const fs = await import("fs/promises");
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("acme.demo", "dist/index.mjs"));
+
+    expect(response.status).toBe(200);
+    expect(pluginServiceMock.getPluginDir).toHaveBeenCalledWith("acme.demo");
+    expect(response.headers.get("Content-Type")).toBe("application/javascript");
+    expect(response.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("app://daintree");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(fs.open).toHaveBeenCalledTimes(1);
+    const openArgs = vi.mocked(fs.open).mock.calls[0];
+    expect(openArgs[0]).toBe(path.resolve(PLUGIN_ROOT, "dist/index.mjs"));
+    expect(openArgs[1]).toBe(fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  });
+
+  it("returns 404 for an unknown plugin without touching the filesystem", async () => {
+    const fs = await import("fs/promises");
+    pluginServiceMock.getPluginDir.mockReturnValue(null);
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("ghost.plugin", "index.mjs"));
+
+    expect(response.status).toBe(404);
+    expect(fs.realpath).not.toHaveBeenCalled();
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("blocks a symlink/traversal escape after realpath and never opens the file", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) =>
+      Promise.resolve(p === PLUGIN_ROOT ? PLUGIN_ROOT : "/etc/passwd")
+    );
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("acme.demo", "link.mjs"));
+
+    expect(response.status).toBe(404);
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the final path component is a symlink (ELOOP on open)", async () => {
+    const fs = await import("fs/promises");
+    const eloop = Object.assign(new Error("ELOOP"), { code: "ELOOP" });
+    vi.mocked(fs.open).mockRejectedValue(eloop);
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("acme.demo", "evil.mjs"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 405 for non-GET/HEAD methods", async () => {
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("acme.demo", "index.mjs", { method: "POST" }));
+
+    expect(response.status).toBe(405);
+  });
+
+  it("returns 404 for a directory request (no listing, no index fallback)", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.stat).mockResolvedValue({
+      isFile: () => false,
+      mtime: new Date(0),
+      size: 0,
+    } as unknown as Awaited<ReturnType<typeof fs.stat>>);
+
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("acme.demo", "dist"));
+
+    expect(response.status).toBe(404);
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("echoes a trusted dev-server Origin into Access-Control-Allow-Origin", async () => {
+    const devServer = await import("../../../shared/config/devServer.js");
+    vi.mocked(devServer.getDevServerOrigins).mockReturnValue(["http://localhost:5173"]);
+
+    const handler = await captureHandler();
+    const response = await handler(
+      makeRequest("acme.demo", "index.mjs", { origin: "http://localhost:5173" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:5173");
+  });
+
+  it("falls back to app://daintree for an untrusted Origin", async () => {
+    const handler = await captureHandler();
+    const response = await handler(
+      makeRequest("acme.demo", "index.mjs", { origin: "https://evil.example" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("app://daintree");
   });
 });

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1284,11 +1284,35 @@ describe("createPluginProtocolHandler — plugin asset resolution & containment"
     expect(response.status).toBe(404);
   });
 
-  it("returns 405 for non-GET/HEAD methods", async () => {
+  it("returns 405 for non-GET/HEAD methods without touching PluginService or the filesystem", async () => {
+    const fs = await import("fs/promises");
     const handler = await captureHandler();
     const response = await handler(makeRequest("acme.demo", "index.mjs", { method: "POST" }));
 
     expect(response.status).toBe(405);
+    expect(pluginServiceMock.getPluginDir).not.toHaveBeenCalled();
+    expect(fs.realpath).not.toHaveBeenCalled();
+    expect(fs.stat).not.toHaveBeenCalled();
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for an empty asset path (plugin://acme.demo/) with no listing", async () => {
+    const fs = await import("fs/promises");
+    const handler = await captureHandler();
+    const response = await handler(makeRequest("acme.demo", ""));
+
+    expect(response.status).toBe(404);
+    expect(fs.open).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 (not 500) for malformed percent-encoding in the path", async () => {
+    const fs = await import("fs/promises");
+    const handler = await captureHandler();
+    // "%ZZ" is a valid URL but decodeURIComponent throws URIError on it.
+    const response = await handler(makeRequest("acme.demo", "%ZZ"));
+
+    expect(response.status).toBe(404);
+    expect(fs.open).not.toHaveBeenCalled();
   });
 
   it("returns 404 for a directory request (no listing, no index fallback)", async () => {
@@ -1317,6 +1341,16 @@ describe("createPluginProtocolHandler — plugin asset resolution & containment"
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:5173");
+  });
+
+  it("echoes the production app://daintree Origin into Access-Control-Allow-Origin", async () => {
+    const handler = await captureHandler();
+    const response = await handler(
+      makeRequest("acme.demo", "index.mjs", { origin: "app://daintree" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("app://daintree");
   });
 
   it("falls back to app://daintree for an untrusted Origin", async () => {

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -21,6 +21,8 @@ import { isLocalhostUrl, isSafeNavigationUrl } from "../../shared/utils/urlUtils
 import { getWebviewDialogService } from "../services/WebviewDialogService.js";
 import { looksLikeOAuthUrl } from "../services/OAuthLoopbackService.js";
 import { CHANNELS } from "../ipc/channels.js";
+import { pluginService } from "../services/PluginService.js";
+import { getDevServerOrigins } from "../../shared/config/devServer.js";
 
 // Track which sessions have had protocols registered to avoid double-registration
 const registeredSessions = new WeakSet<Electron.Session>();
@@ -259,10 +261,177 @@ function createDaintreeFileProtocolHandler() {
   };
 }
 
+// The renderer shell that loads plugin:// sub-resources. In production it is
+// app://daintree; in development it is the Vite dev server origin. ESM import()
+// and fetch() of cross-origin plugin modules need a matching CORS allow-origin,
+// so we echo the request Origin when it is one of these trusted shells and fall
+// back to app://daintree otherwise. Non-CORS subresource loads (img/css/script)
+// are governed by Cross-Origin-Resource-Policy: cross-origin instead.
+function resolvePluginAllowOrigin(request: GlobalRequest): string {
+  const origin = request.headers.get("Origin");
+  if (origin && (origin === "app://daintree" || getDevServerOrigins().includes(origin))) {
+    return origin;
+  }
+  return "app://daintree";
+}
+
+// Hardened response headers for plugin:// assets. CORP is cross-origin because
+// the app://daintree (or dev-server) renderer is a different origin and
+// same-origin would block every sub-resource load. No size cap (plugin JS
+// bundles routinely exceed daintree-file's 512KB limit) and no sandbox CSP
+// (plugin modules must execute — they stay subject to the host page CSP, which
+// allows `plugin:` in script-src/connect-src/img-src/style-src). nosniff hardens
+// MIME-confusion; no-cache + Last-Modified lets the renderer revalidate.
+function buildPluginHeaders(
+  mimeType: string,
+  contentLength: number,
+  allowOrigin: string,
+  mtime?: Date
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": mimeType,
+    "Content-Length": String(contentLength),
+    "Cross-Origin-Resource-Policy": "cross-origin",
+    "Access-Control-Allow-Origin": allowOrigin,
+    "X-Content-Type-Options": "nosniff",
+    "Cache-Control": "no-cache, must-revalidate",
+  };
+  if (mtime) {
+    headers["Last-Modified"] = mtime.toUTCString();
+  }
+  return headers;
+}
+
+function buildPluginErrorHeaders(allowOrigin: string): Record<string, string> {
+  return {
+    "Content-Type": "text/plain",
+    "Cross-Origin-Resource-Policy": "cross-origin",
+    "Access-Control-Allow-Origin": allowOrigin,
+    "X-Content-Type-Options": "nosniff",
+    "Cache-Control": "no-store",
+  };
+}
+
 /**
- * Register app:// and daintree-file:// protocol handlers on a specific session.
- * Safe to call multiple times — skips sessions that are already configured.
- * Used for per-project session partitions that don't inherit the default session's handlers.
+ * Create the plugin:// protocol handler. Resolves plugin://{pluginId}/{path} to
+ * a file under the plugin's installed root (looked up from PluginService at
+ * request time). Uses fs.realpath containment + O_NOFOLLOW to block path
+ * traversal and symlink escapes — identical to the daintree-file:// pattern, but
+ * the root is dynamic per pluginId. Always 404 on miss/escape (no 403, no
+ * directory listings, no index.html fallback) to avoid leaking what exists.
+ */
+function createPluginProtocolHandler() {
+  return async (request: GlobalRequest) => {
+    const allowOrigin = resolvePluginAllowOrigin(request);
+
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: buildPluginErrorHeaders(allowOrigin),
+      });
+    }
+
+    const notFound = () =>
+      new Response("Not Found", {
+        status: 404,
+        headers: buildPluginErrorHeaders(allowOrigin),
+      });
+
+    try {
+      const url = new URL(request.url);
+      const pluginId = url.hostname;
+      if (!pluginId) {
+        return notFound();
+      }
+
+      // Request-time lookup so plugin reinstall/unload is reflected immediately.
+      const pluginRoot = pluginService.getPluginDir(pluginId);
+      if (!pluginRoot) {
+        return notFound();
+      }
+
+      const rawPath = url.pathname.startsWith("/") ? url.pathname.slice(1) : url.pathname;
+      if (!rawPath) {
+        return notFound();
+      }
+
+      const decodedPath = decodeURIComponent(rawPath);
+      if (decodedPath.includes("\0")) {
+        return new Response("Invalid path", {
+          status: 400,
+          headers: buildPluginErrorHeaders(allowOrigin),
+        });
+      }
+
+      // path.resolve normalizes ".." segments; the realpath containment below is
+      // the load-bearing guard against traversal and in-root symlink escapes.
+      const candidate = path.resolve(pluginRoot, decodedPath);
+
+      let realRoot: string;
+      let realFile: string;
+      try {
+        realRoot = await fs.realpath(pluginRoot);
+        realFile = await fs.realpath(candidate);
+      } catch {
+        return notFound();
+      }
+
+      const rel = path.relative(realRoot, realFile);
+      // Match exact ".." and "../*" — bare startsWith("..") would reject legitimate
+      // files like "..hidden/x". isAbsolute catches Windows cross-drive escapes.
+      if (rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel)) {
+        return notFound();
+      }
+
+      let fileStat: Awaited<ReturnType<typeof fs.stat>>;
+      try {
+        fileStat = await fs.stat(realFile);
+      } catch {
+        return notFound();
+      }
+      if (!fileStat.isFile()) {
+        return notFound();
+      }
+
+      // Open the resolved candidate with O_NOFOLLOW so a final-component symlink
+      // injected after the realpath check is rejected with ELOOP (TOCTOU close).
+      // On Windows O_NOFOLLOW is 0 (no-op); realpath containment still applies.
+      let fileHandle: Awaited<ReturnType<typeof fs.open>>;
+      try {
+        fileHandle = await fs.open(candidate, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+      } catch (err) {
+        const errCode = (err as NodeJS.ErrnoException).code;
+        if (errCode === "ELOOP" || errCode === "ENOENT") {
+          return notFound();
+        }
+        throw err;
+      }
+
+      try {
+        const buffer = await fileHandle.readFile();
+        const mimeType = getMimeType(realFile);
+        return new Response(buffer, {
+          status: 200,
+          headers: buildPluginHeaders(mimeType, buffer.length, allowOrigin, fileStat.mtime),
+        });
+      } finally {
+        await fileHandle.close().catch(() => {});
+      }
+    } catch (err) {
+      console.error("[MAIN] plugin protocol error:", err);
+      return new Response("Internal Server Error", {
+        status: 500,
+        headers: buildPluginErrorHeaders(allowOrigin),
+      });
+    }
+  };
+}
+
+/**
+ * Register app://, daintree-file://, and plugin:// protocol handlers on a
+ * specific session. Safe to call multiple times — skips sessions that are
+ * already configured. Used for per-project session partitions that don't inherit
+ * the default session's handlers.
  */
 export function registerProtocolsForSession(ses: Electron.Session, distPath: string): void {
   if (registeredSessions.has(ses)) return;
@@ -270,6 +439,7 @@ export function registerProtocolsForSession(ses: Electron.Session, distPath: str
 
   ses.protocol.handle("app", createAppProtocolHandler(distPath));
   ses.protocol.handle("daintree-file", createDaintreeFileProtocolHandler());
+  ses.protocol.handle("plugin", createPluginProtocolHandler());
 }
 
 export function registerAppProtocol(distPath: string): void {
@@ -279,6 +449,10 @@ export function registerAppProtocol(distPath: string): void {
 
 export function registerDaintreeFileProtocol(): void {
   protocol.handle("daintree-file", createDaintreeFileProtocolHandler());
+}
+
+export function registerPluginProtocol(): void {
+  protocol.handle("plugin", createPluginProtocolHandler());
 }
 
 /**

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -293,6 +293,9 @@ function buildPluginHeaders(
     "Content-Length": String(contentLength),
     "Cross-Origin-Resource-Policy": "cross-origin",
     "Access-Control-Allow-Origin": allowOrigin,
+    // ACAO varies per request Origin — declare it so any future caching layer
+    // doesn't serve one origin's allow-origin to another.
+    Vary: "Origin",
     "X-Content-Type-Options": "nosniff",
     "Cache-Control": "no-cache, must-revalidate",
   };
@@ -307,6 +310,7 @@ function buildPluginErrorHeaders(allowOrigin: string): Record<string, string> {
     "Content-Type": "text/plain",
     "Cross-Origin-Resource-Policy": "cross-origin",
     "Access-Control-Allow-Origin": allowOrigin,
+    Vary: "Origin",
     "X-Content-Type-Options": "nosniff",
     "Cache-Control": "no-store",
   };
@@ -338,7 +342,14 @@ function createPluginProtocolHandler() {
       });
 
     try {
-      const url = new URL(request.url);
+      let url: URL;
+      try {
+        url = new URL(request.url);
+      } catch {
+        // Malformed URL (e.g. bad percent-encoding) — treat as not found rather
+        // than letting it fall through to the 500 path.
+        return notFound();
+      }
       const pluginId = url.hostname;
       if (!pluginId) {
         return notFound();
@@ -355,7 +366,14 @@ function createPluginProtocolHandler() {
         return notFound();
       }
 
-      const decodedPath = decodeURIComponent(rawPath);
+      let decodedPath: string;
+      try {
+        decodedPath = decodeURIComponent(rawPath);
+      } catch {
+        // Malformed percent-encoding (e.g. "%ZZ") — decodeURIComponent throws a
+        // URIError. Treat as not found rather than a 500.
+        return notFound();
+      }
       if (decodedPath.includes("\0")) {
         return new Response("Invalid path", {
           status: 400,
@@ -410,7 +428,10 @@ function createPluginProtocolHandler() {
       try {
         const buffer = await fileHandle.readFile();
         const mimeType = getMimeType(realFile);
-        return new Response(buffer, {
+        // HEAD must not carry a body, but Content-Length still reflects the
+        // resource size so clients can read it from the headers.
+        const body = request.method === "HEAD" ? null : buffer;
+        return new Response(body, {
           status: 200,
           headers: buildPluginHeaders(mimeType, buffer.length, allowOrigin, fileStat.mtime),
         });
@@ -435,11 +456,14 @@ function createPluginProtocolHandler() {
  */
 export function registerProtocolsForSession(ses: Electron.Session, distPath: string): void {
   if (registeredSessions.has(ses)) return;
-  registeredSessions.add(ses);
 
   ses.protocol.handle("app", createAppProtocolHandler(distPath));
   ses.protocol.handle("daintree-file", createDaintreeFileProtocolHandler());
   ses.protocol.handle("plugin", createPluginProtocolHandler());
+
+  // Mark registered only after all handlers install — a throw mid-registration
+  // must not leave the session permanently flagged as partially configured.
+  registeredSessions.add(ses);
 }
 
 export function registerAppProtocol(distPath: string): void {

--- a/electron/utils/appProtocol.ts
+++ b/electron/utils/appProtocol.ts
@@ -31,8 +31,10 @@ const IMMUTABLE_ASSET_RE =
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html",
   ".js": "text/javascript",
+  ".mjs": "application/javascript",
   ".css": "text/css",
   ".json": "application/json",
+  ".map": "application/json",
   ".png": "image/png",
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",

--- a/shared/config/__tests__/csp.test.ts
+++ b/shared/config/__tests__/csp.test.ts
@@ -28,4 +28,18 @@ describe("Daintree app CSP", () => {
     expect(getDaintreeAppCSP(true)).toBe(getDaintreeAppDevCSP());
     expect(getDaintreeAppCSP(false)).toBe(getDaintreeAppProdCSP());
   });
+
+  it("allows the plugin: scheme in script/connect/img/style directives (prod and dev)", () => {
+    for (const csp of [getDaintreeAppProdCSP(), getDaintreeAppDevCSP()]) {
+      const directive = (name: string) =>
+        csp
+          .split(";")
+          .map((d) => d.trim())
+          .find((d) => d.startsWith(`${name} `)) ?? "";
+      expect(directive("script-src")).toContain("plugin:");
+      expect(directive("connect-src")).toContain("plugin:");
+      expect(directive("img-src")).toContain("plugin:");
+      expect(directive("style-src")).toContain("plugin:");
+    }
+  });
 });

--- a/shared/config/csp.ts
+++ b/shared/config/csp.ts
@@ -3,6 +3,12 @@ import { getDevServerOrigins, getDevServerWebSocketOrigins } from "./devServer.j
 // Custom protocol scheme the renderer fetches/loads from.
 const FILE_SCHEMES = "daintree-file:";
 
+// Per-plugin static asset scheme (plugin://{pluginId}/...). Plugin view bundles
+// load as cross-origin ESM modules, CSS, and images from the app shell, so the
+// scheme must be allowed in script/connect/img/style directives — 'self' does
+// not cover it. Plugins stay subject to CSP (registered with bypassCSP: false).
+const PLUGIN_SCHEME = "plugin:";
+
 // Localhost origins allowed for embedded <webview> guests in BrowserPane and
 // DevPreviewPane. Without these in frame-src the host page cannot mount its
 // webview elements at all.
@@ -47,10 +53,10 @@ export const TRUSTED_TYPES_POLICY_NAME = "daintree-svg";
 export function getDaintreeAppProdCSP(): string {
   return [
     "default-src 'self'",
-    "script-src 'self' 'wasm-unsafe-eval'",
-    "style-src 'self' 'unsafe-inline'",
-    `connect-src 'self' ${FILE_SCHEMES}`,
-    `img-src 'self' ${GITHUB_AVATARS} ${GRAVATAR} ${FILE_SCHEMES} data: blob:`,
+    `script-src 'self' 'wasm-unsafe-eval' ${PLUGIN_SCHEME}`,
+    `style-src 'self' 'unsafe-inline' ${PLUGIN_SCHEME}`,
+    `connect-src 'self' ${FILE_SCHEMES} ${PLUGIN_SCHEME}`,
+    `img-src 'self' ${GITHUB_AVATARS} ${GRAVATAR} ${FILE_SCHEMES} ${PLUGIN_SCHEME} data: blob:`,
     "font-src 'self' data:",
     "media-src 'self'",
     "worker-src 'self' blob:",
@@ -81,10 +87,10 @@ export function getDaintreeAppDevCSP(): string {
 
   return [
     `default-src 'self' ${origins} ${wsOrigins}`,
-    `script-src 'self' ${origins} 'unsafe-inline' 'unsafe-eval'`,
-    `style-src 'self' ${origins} 'unsafe-inline'`,
-    `connect-src 'self' ${origins} ${wsOrigins} ${FILE_SCHEMES}`,
-    `img-src 'self' ${origins} ${GITHUB_AVATARS} ${GRAVATAR} ${FILE_SCHEMES} data: blob:`,
+    `script-src 'self' ${origins} 'unsafe-inline' 'unsafe-eval' ${PLUGIN_SCHEME}`,
+    `style-src 'self' ${origins} 'unsafe-inline' ${PLUGIN_SCHEME}`,
+    `connect-src 'self' ${origins} ${wsOrigins} ${FILE_SCHEMES} ${PLUGIN_SCHEME}`,
+    `img-src 'self' ${origins} ${GITHUB_AVATARS} ${GRAVATAR} ${FILE_SCHEMES} ${PLUGIN_SCHEME} data: blob:`,
     `font-src 'self' ${origins} data:`,
     "media-src 'self'",
     "worker-src 'self' blob:",


### PR DESCRIPTION
## Summary

- Registers `plugin://` as a privileged Electron custom scheme (`standard`, `secure`, `supportFetchAPI`, `corsEnabled`, `bypassCSP: false`) before `app.whenReady()` — late registration silently downgrades the scheme so this has to be synchronous at startup.
- Handler resolves `plugin://{pluginId}/{path}` to disk via `PluginService.getPluginDir`, with `fs.realpath` + `O_NOFOLLOW` containment to block path traversal and symlink escapes out of the plugin directory.
- Registered on both the default session and per-project `persist:daintree` sessions; CORP + trusted-origin ACAO headers set on responses; `plugin:` added to `script-src`, `connect-src`, `img-src`, and `style-src` CSP directives in both prod and dev configs; `.mjs` and `.map` MIME entries included.

Resolves #9283. Prereq for #9229.

## Changes

- `electron/setup/protocols.ts` — scheme registration + handler implementation
- `electron/main.ts` — wires scheme registration before `app.whenReady()`
- `electron/services/PluginService.ts` — exposes `getPluginDir` for the handler
- `shared/config/csp.ts` — adds `plugin:` to relevant directives
- `electron/utils/appProtocol.ts` — `.mjs`/`.map` MIME entries
- Test coverage: `electron/setup/__tests__/protocols.test.ts`, `electron/services/__tests__/PluginService.test.ts`, `shared/config/__tests__/csp.test.ts`

## Testing

All 265 unit tests pass. Full `npm run check` clean (typecheck + lint + format). Traversal and symlink containment covered by adversarial test cases in `protocols.test.ts`.