### PR TITLE
fix(portal): persist activeTabId and skeleton-gate async tab restore

### DIFF
--- a/src/components/Portal/PortalDock.tsx
+++ b/src/components/Portal/PortalDock.tsx
@@ -5,6 +5,8 @@ import { usePortalStore } from "@/store";
 import { cn } from "@/lib/utils";
 import { PortalToolbar } from "./PortalToolbar";
 import { PortalLaunchpad } from "./PortalLaunchpad";
+import { PortalTabSkeleton } from "./PortalTabSkeleton";
+import { useSkeletonGate, useSkeletonFloor } from "@/hooks/useDeferredLoading";
 import { PORTAL_MIN_WIDTH, PORTAL_MAX_WIDTH } from "@shared/types";
 import { getAIAgentInfo } from "@/lib/aiAgentDetection";
 import { useKeybindingScope } from "@/hooks/useKeybinding";
@@ -27,17 +29,19 @@ import { getElementBoundsAsDip } from "@/lib/portalBounds";
 import { debounce } from "@/utils/debounce";
 
 export function PortalDock() {
-  const { width, activeTabId, tabs, links, setWidth, setOpen, defaultNewTabUrl } = usePortalStore(
-    useShallow((s) => ({
-      width: s.width,
-      activeTabId: s.activeTabId,
-      tabs: s.tabs,
-      links: s.links,
-      setWidth: s.setWidth,
-      setOpen: s.setOpen,
-      defaultNewTabUrl: s.defaultNewTabUrl,
-    }))
-  );
+  const { width, activeTabId, tabs, links, createdTabs, setWidth, setOpen, defaultNewTabUrl } =
+    usePortalStore(
+      useShallow((s) => ({
+        width: s.width,
+        activeTabId: s.activeTabId,
+        tabs: s.tabs,
+        links: s.links,
+        createdTabs: s.createdTabs,
+        setWidth: s.setWidth,
+        setOpen: s.setOpen,
+        defaultNewTabUrl: s.defaultNewTabUrl,
+      }))
+    );
   const contentRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLElement>(null);
   const [isResizing, setIsResizing] = useState(false);
@@ -62,6 +66,14 @@ export function PortalDock() {
   const showLaunchpad = activeTabId === null || tabs.length === 0 || isBlankTab;
   const hasActiveUrl =
     activeTab?.url !== undefined && activeTab.url !== null && activeTab.url !== "";
+
+  // Render a skeleton in the content placeholder while the active tab's view is
+  // being (re)created. Triggers on cold start with a persisted activeTabId and
+  // on click of an LRU-evicted tab (PortalManager evicts beyond PORTAL_MAX_LIVE_TABS),
+  // both of which take 300-800ms to resolve via portal.create + bounds wait + portal.show.
+  const isTabRestoring = !showLaunchpad && activeTabId !== null && !createdTabs.has(activeTabId);
+  const isRestoringGated = useSkeletonGate(isTabRestoring);
+  const showSkeleton = useSkeletonFloor(isRestoringGated);
 
   const syncBounds = useCallback(() => {
     if (!contentRef.current || !activeTabId) return;
@@ -447,6 +459,8 @@ export function PortalDock() {
           >
             {showLaunchpad ? (
               <PortalLaunchpad links={enabledLinks} onOpenUrl={handleOpenUrl} />
+            ) : showSkeleton ? (
+              <PortalTabSkeleton />
             ) : (
               <div className="flex-1 bg-daintree-sidebar" />
             )}

--- a/src/components/Portal/PortalTabSkeleton.tsx
+++ b/src/components/Portal/PortalTabSkeleton.tsx
@@ -1,0 +1,19 @@
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
+
+export function PortalTabSkeleton() {
+  return (
+    <Skeleton
+      label="Loading tab"
+      className="flex-1 flex flex-col gap-3 p-4 bg-daintree-sidebar min-h-0"
+    >
+      <SkeletonBone className="h-5 w-2/3" />
+      <SkeletonBone className="h-3 w-full" />
+      <SkeletonBone className="h-3 w-11/12" />
+      <SkeletonBone className="h-3 w-3/4" />
+      <div className="h-2" aria-hidden="true" />
+      <SkeletonBone className="h-3 w-full" />
+      <SkeletonBone className="h-3 w-5/6" />
+      <SkeletonBone className="h-3 w-2/3" />
+    </Skeleton>
+  );
+}

--- a/src/components/Portal/PortalVisibilityController.tsx
+++ b/src/components/Portal/PortalVisibilityController.tsx
@@ -44,9 +44,7 @@ export function PortalVisibilityController(): null {
           await window.electron.portal.create({ tabId, url: tabUrl });
           const postCreateState = usePortalStore.getState();
           const stillExists = postCreateState.tabs.some((t) => t.id === tabId);
-          if (stillExists) {
-            markTabCreated(tabId);
-          } else {
+          if (!stillExists) {
             isRestoringRef.current = false;
             return;
           }
@@ -86,6 +84,16 @@ export function PortalVisibilityController(): null {
         }
 
         await window.electron.portal.show({ tabId, bounds });
+
+        // Mark created only after the full create + show pipeline completes so
+        // PortalDock can derive `isTabRestoring = !createdTabs.has(activeTabId)`
+        // as a single signal for "tab is being restored to visibility". Marking
+        // earlier (post-create) would clear the skeleton before bounds polling +
+        // show resolve. PortalManager.createTab is idempotent, so a later retry
+        // for an already-shown tab is harmless.
+        if (needsCreation) {
+          markTabCreated(tabId);
+        }
       } catch (error) {
         logError("Failed to restore tab", error);
       } finally {

--- a/src/components/Portal/__tests__/PortalVisibilityController.test.tsx
+++ b/src/components/Portal/__tests__/PortalVisibilityController.test.tsx
@@ -337,6 +337,54 @@ describe("PortalVisibilityController", () => {
     });
   });
 
+  it("defers markTabCreated until after portal.show resolves", async () => {
+    // The skeleton in PortalDock derives visibility from !createdTabs.has(activeTabId).
+    // If markTabCreated runs right after create (before bounds polling + show), the
+    // skeleton clears prematurely. Verify createdTabs stays empty between create
+    // and show, and only gains the id after show resolves.
+    const createDeferred = deferredPromise();
+    const showDeferred = deferredPromise();
+    portal.create.mockImplementationOnce(() => createDeferred.promise);
+    portal.show.mockImplementationOnce(() => showDeferred.promise);
+
+    vi.spyOn(document, "getElementById").mockReturnValue({
+      getBoundingClientRect: () => createPlaceholderRect(),
+    } as unknown as HTMLElement);
+
+    render(<PortalVisibilityController />);
+
+    act(() => {
+      usePortalStore.setState({
+        isOpen: true,
+        activeTabId: "tab-1",
+        tabs: [{ id: "tab-1", title: "Docs", url: "https://example.com/docs" }],
+        createdTabs: new Set<string>(),
+      });
+    });
+
+    // Pre-create: nothing marked
+    expect(usePortalStore.getState().createdTabs.has("tab-1")).toBe(false);
+
+    createDeferred.resolve();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Post-create, pre-show: still not marked — this is the window the skeleton
+    // needs to remain visible across.
+    expect(portal.show).toHaveBeenCalledTimes(1);
+    expect(usePortalStore.getState().createdTabs.has("tab-1")).toBe(false);
+
+    showDeferred.resolve();
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    // Post-show: now marked, skeleton can clear
+    expect(usePortalStore.getState().createdTabs.has("tab-1")).toBe(true);
+  });
+
   it("restores the persisted active tab on cold start, not the first tab", async () => {
     vi.spyOn(document, "getElementById").mockReturnValue({
       getBoundingClientRect: () => createPlaceholderRect(),

--- a/src/components/Portal/__tests__/PortalVisibilityController.test.tsx
+++ b/src/components/Portal/__tests__/PortalVisibilityController.test.tsx
@@ -337,6 +337,45 @@ describe("PortalVisibilityController", () => {
     });
   });
 
+  it("restores the persisted active tab on cold start, not the first tab", async () => {
+    vi.spyOn(document, "getElementById").mockReturnValue({
+      getBoundingClientRect: () => createPlaceholderRect(),
+    } as unknown as HTMLElement);
+
+    render(<PortalVisibilityController />);
+
+    // Simulate rehydration: portalStore.merge restored a persisted activeTabId
+    // that's not tabs[0]. None of the tabs are marked created yet (cold start).
+    act(() => {
+      usePortalStore.setState({
+        isOpen: true,
+        activeTabId: "tab-3",
+        tabs: [
+          { id: "tab-1", title: "One", url: "https://example.com/1" },
+          { id: "tab-2", title: "Two", url: "https://example.com/2" },
+          { id: "tab-3", title: "Three", url: "https://example.com/3" },
+        ],
+        createdTabs: new Set<string>(),
+      });
+    });
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(portal.create).toHaveBeenCalledTimes(1);
+    expect(portal.create).toHaveBeenCalledWith({
+      tabId: "tab-3",
+      url: "https://example.com/3",
+    });
+    expect(portal.show).toHaveBeenCalledWith({
+      tabId: "tab-3",
+      bounds: { x: 10, y: 21, width: 301, height: 401 },
+    });
+    expect(usePortalStore.getState().activeTabId).toBe("tab-3");
+    expect(usePortalStore.getState().createdTabs.has("tab-3")).toBe(true);
+  });
+
   it("removes tab from createdTabs when eviction event fires", () => {
     usePortalStore.setState({
       isOpen: true,

--- a/src/store/__tests__/portalStore.test.ts
+++ b/src/store/__tests__/portalStore.test.ts
@@ -358,6 +358,76 @@ describe("portalStore persistence migration", () => {
     expect(store.getState().links.some((l) => l.id === "discovered-foo")).toBe(false);
   });
 
+  it("restores a persisted activeTabId that matches a known tab", async () => {
+    const persistedBlob = JSON.stringify({
+      version: 0,
+      state: {
+        width: 600,
+        tabs: [
+          { id: "tab-1", title: "One", url: "https://example.com/1" },
+          { id: "tab-3", title: "Three", url: "https://example.com/3" },
+        ],
+        activeTabId: "tab-3",
+        links: [],
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: persistedBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    expect(store.getState().activeTabId).toBe("tab-3");
+  });
+
+  it("falls back to the first persisted tab when activeTabId references a missing tab", async () => {
+    const persistedBlob = JSON.stringify({
+      version: 0,
+      state: {
+        tabs: [
+          { id: "tab-1", title: "One", url: "https://example.com/1" },
+          { id: "tab-2", title: "Two", url: "https://example.com/2" },
+        ],
+        activeTabId: "tab-deleted",
+        links: [],
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: persistedBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    expect(store.getState().activeTabId).toBe("tab-1");
+  });
+
+  it("falls back to the first persisted tab when activeTabId is missing", async () => {
+    const persistedBlob = JSON.stringify({
+      version: 0,
+      state: {
+        tabs: [{ id: "tab-only", title: "Only", url: "https://example.com" }],
+        links: [],
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: persistedBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    expect(store.getState().activeTabId).toBe("tab-only");
+  });
+
+  it("falls back to the first persisted tab when activeTabId is malformed", async () => {
+    const persistedBlob = JSON.stringify({
+      version: 0,
+      state: {
+        tabs: [{ id: "tab-only", title: "Only", url: "https://example.com" }],
+        activeTabId: 42,
+        links: [],
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: persistedBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    expect(store.getState().activeTabId).toBe("tab-only");
+  });
+
   it("writes version: 0 on the next persist after rehydration", async () => {
     const legacyBlob = JSON.stringify({
       state: {

--- a/src/store/__tests__/portalStore.test.ts
+++ b/src/store/__tests__/portalStore.test.ts
@@ -412,6 +412,38 @@ describe("portalStore persistence migration", () => {
     expect(store.getState().activeTabId).toBe("tab-only");
   });
 
+  it("does not crash when persisted tabs contains a null entry", async () => {
+    const persistedBlob = JSON.stringify({
+      version: 0,
+      state: {
+        tabs: [null, { id: "tab-keep", title: "Keep", url: "https://example.com" }],
+        activeTabId: "tab-keep",
+        links: [],
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: persistedBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    expect(store.getState().activeTabId).toBe("tab-keep");
+  });
+
+  it("falls back to currentState.tabs when persisted tabs is non-array", async () => {
+    const persistedBlob = JSON.stringify({
+      version: 0,
+      state: {
+        tabs: "corrupted",
+        activeTabId: "tab-1",
+        links: [],
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: persistedBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    expect(Array.isArray(store.getState().tabs)).toBe(true);
+  });
+
   it("falls back to the first persisted tab when activeTabId is malformed", async () => {
     const persistedBlob = JSON.stringify({
       version: 0,

--- a/src/store/portalStore.ts
+++ b/src/store/portalStore.ts
@@ -470,14 +470,15 @@ const portalStoreCreator: StateCreator<
     const persistedActiveTabId = persisted.activeTabId;
     const activeTabId =
       typeof persistedActiveTabId === "string" &&
-      persistedTabs.some((t) => t.id === persistedActiveTabId)
+      persistedTabs.some((t) => t != null && t.id === persistedActiveTabId)
         ? persistedActiveTabId
-        : (persistedTabs[0]?.id ?? null);
+        : (persistedTabs.find((t) => t != null)?.id ?? null);
 
     return {
       ...currentState,
       ...persisted,
       links,
+      tabs: persistedTabs,
       width:
         typeof persisted.width === "number"
           ? Math.min(Math.max(persisted.width, PORTAL_MIN_WIDTH), PORTAL_MAX_WIDTH)

--- a/src/store/portalStore.ts
+++ b/src/store/portalStore.ts
@@ -415,6 +415,7 @@ const portalStoreCreator: StateCreator<
     links: state.links,
     width: state.width,
     tabs: state.tabs,
+    activeTabId: state.activeTabId,
     defaultNewTabUrl: state.defaultNewTabUrl,
   }),
   merge: (persistedState: unknown, currentState) => {
@@ -465,6 +466,14 @@ const portalStoreCreator: StateCreator<
       ] as PortalLink[];
     }
 
+    const persistedTabs = Array.isArray(persisted.tabs) ? persisted.tabs : currentState.tabs;
+    const persistedActiveTabId = persisted.activeTabId;
+    const activeTabId =
+      typeof persistedActiveTabId === "string" &&
+      persistedTabs.some((t) => t.id === persistedActiveTabId)
+        ? persistedActiveTabId
+        : (persistedTabs[0]?.id ?? null);
+
     return {
       ...currentState,
       ...persisted,
@@ -477,6 +486,7 @@ const portalStoreCreator: StateCreator<
         typeof persisted.defaultNewTabUrl === "string" && persisted.defaultNewTabUrl.trim()
           ? persisted.defaultNewTabUrl.trim()
           : null,
+      activeTabId,
     };
   },
 });
@@ -486,5 +496,5 @@ export const usePortalStore = create<PortalState & PortalActions>()(portalStoreC
 registerPersistedStore({
   storeId: "portalStore",
   store: usePortalStore,
-  persistedStateType: "Partial<PortalState> (links, width, tabs, defaultNewTabUrl)",
+  persistedStateType: "Partial<PortalState> (links, width, tabs, activeTabId, defaultNewTabUrl)",
 });


### PR DESCRIPTION
## Summary

- Adds `activeTabId` to `portalStore`'s `partialize` shape so the active tab survives app restarts — previously the store always hydrated with `null` and `PortalVisibilityController` fell through to `tabs[0]`
- Adds `PortalTabSkeleton` and renders it in `PortalDock` during async tab restore (LRU-evicted tabs can take multiple seconds to reload; the viewport shape is fixed so a skeleton is the right call per the loading-indicator rules)
- Moves `markTabCreated` to after `portal.show` resolves and adds a null-guard for the merge step

Resolves #9205

## Changes

- `src/store/portalStore.ts` — include `activeTabId` in the persisted slice
- `src/components/Portal/PortalTabSkeleton.tsx` — new skeleton component (mirrors `BrowserPaneSkeleton` conventions)
- `src/components/Portal/PortalDock.tsx` — show skeleton while `isRestoring` is set; clear it once `portal.show` settles
- `src/components/Portal/PortalVisibilityController.tsx` — defer `markTabCreated` until after show; null-guard the bounds merge
- `src/store/__tests__/portalStore.test.ts` — cover `activeTabId` persistence round-trip
- `src/components/Portal/__tests__/PortalVisibilityController.test.tsx` — cover restore sequencing and skeleton state

## Testing

- Unit tests cover the `activeTabId` persistence round-trip in `portalStore` and the full restore sequence in `PortalVisibilityController`
- Manually verified: active tab is restored on relaunch, skeleton appears while an evicted tab reloads