### PR TITLE
feat(plugins): implement host.showToast

### DIFF
--- a/docs/plugins/getting-started.md
+++ b/docs/plugins/getting-started.md
@@ -60,7 +60,7 @@ The `commands[].name` maps to `src/say-hello.ts` by filesystem convention. Its d
 import { showToast } from "@daintreehq/plugin-sdk";
 
 export default async function sayHello() {
-  await showToast({ title: "Hello from my plugin" });
+  await showToast({ message: "Hello from my plugin" });
 }
 ```
 

--- a/docs/plugins/host-api.md
+++ b/docs/plugins/host-api.md
@@ -50,7 +50,7 @@ interface PluginHostApi {
   settings: SettingsApi;
 
   // UI helpers
-  showToast(options: ToastOptions): Promise<void>;
+  showToast(options: PluginToastOptions): Promise<void>;
 }
 ```
 
@@ -233,14 +233,15 @@ Secret-type settings are stored in the OS keychain via `keytar`. They're returne
 
 ```ts
 await host.showToast({
-  title: "Synced",
-  description: "Fetched 12 issues from Linear",
-  type: "success", // "info" | "success" | "warning" | "error"
-  durationMs: 4000,
+  message: "Fetched 12 issues from Linear",
+  type: "success", // "info" | "success" | "warning" | "error" — defaults to "info"
+  durationMs: 4000, // optional; defaults to the app's per-type duration
 });
 ```
 
-Toasts render in Daintree's standard toast container. There's no "sticky" or "action required" toast type — for persistent UI, register a panel view instead.
+The host prefixes `message` with your plugin id (`{pluginId}: {message}`) so users can tell which plugin raised the toast — you don't add the prefix yourself. `message` is a string only; `priority` and action buttons aren't exposed to plugins. An empty message or an unknown `type` rejects.
+
+Toasts route through Daintree's standard `notify()` path, so rate-limit, quiet-hours, and inbox-history semantics apply. Audit your toasts against the four-question checklist (timely, helpful, not already visible, ignorable) — the host delivers what you ask for, it doesn't second-guess. There's no "sticky" or "action required" toast type — for persistent UI, register a panel view instead.
 
 ## React hooks — `@daintreehq/plugin-sdk/react`
 

--- a/docs/plugins/host-api.md
+++ b/docs/plugins/host-api.md
@@ -239,9 +239,9 @@ await host.showToast({
 });
 ```
 
-The host prefixes `message` with your plugin id (`{pluginId}: {message}`) so users can tell which plugin raised the toast — you don't add the prefix yourself. `message` is a string only; `priority` and action buttons aren't exposed to plugins. An empty message or an unknown `type` rejects.
+The host prefixes `message` with your plugin id (`{pluginId}: {message}`) so users can tell which plugin raised the toast — you don't add the prefix yourself. `message` is a string only (max 2000 chars); `priority` and action buttons aren't exposed to plugins. `durationMs` must be a positive integer up to 60000 (60s). An empty message, an unknown `type`, or an out-of-range `durationMs` rejects.
 
-Toasts route through Daintree's standard `notify()` path, so rate-limit, quiet-hours, and inbox-history semantics apply. Audit your toasts against the four-question checklist (timely, helpful, not already visible, ignorable) — the host delivers what you ask for, it doesn't second-guess. There's no "sticky" or "action required" toast type — for persistent UI, register a panel view instead.
+Toasts route through Daintree's standard `notify()` path, so quiet-hours and inbox-history semantics apply. The rate-limit bucket is scoped per plugin and type, so a noisy plugin can't suppress another plugin's toasts (or system toasts). Audit your toasts against the four-question checklist (timely, helpful, not already visible, ignorable) — the host delivers what you ask for, it doesn't second-guess. There's no "sticky" or "action required" toast type — for persistent UI, register a panel view instead.
 
 ## React hooks — `@daintreehq/plugin-sdk/react`
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1988,6 +1988,8 @@ const api: ElectronAPI = {
         type: "success" | "error" | "info" | "warning";
         title?: string;
         message: string;
+        duration?: number;
+        rateLimitKey?: string;
         action?: { label: string; ipcChannel: string; data?: string };
       }) => void
     ) => _typedOn(CHANNELS.NOTIFICATION_SHOW_TOAST, callback),

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -115,6 +115,22 @@ export const FileDecorationContributionSchema = z
 
 export const PluginCapabilitySchema = z.enum(BUILT_IN_PLUGIN_CAPABILITIES);
 
+/**
+ * Validates the options passed to `host.showToast`. Both the main-process path
+ * (plugin `activate` code) and any future renderer path (SDK React hooks over
+ * IPC) converge on this schema. `priority` and `action` are intentionally
+ * absent — plugins cannot set them, so the banned `priority:"low"` +
+ * `type:"error"` combo is structurally impossible. Strict so unknown fields
+ * from plugin authors are rejected loudly rather than silently dropped.
+ */
+export const PluginToastOptionsSchema = z
+  .object({
+    message: z.string().trim().min(1).max(2000),
+    type: z.enum(["info", "success", "warning", "error"]).default("info"),
+    durationMs: z.number().int().positive().max(60_000).optional(),
+  })
+  .strict();
+
 export const PluginManifestSchema = z
   .strictObject({
     name: z.string().min(1).max(64).regex(SCOPED_PLUGIN_NAME_PATTERN, {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -23,7 +23,7 @@ interface ValidateFn {
 interface AjvInstance {
   compile(schema: Record<string, unknown>): ValidateFn;
 }
-import { PluginManifestSchema } from "../schemas/plugin.js";
+import { PluginManifestSchema, PluginToastOptionsSchema } from "../schemas/plugin.js";
 import type {
   PluginManifest,
   PluginIpcHandler,
@@ -819,6 +819,28 @@ export class PluginService {
         broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
           name: "plugin:decorations-changed",
           payload: { scope, ...(narrowed && narrowed.length > 0 ? { paths: narrowed } : {}) },
+        });
+      },
+      // NOT revoke-guarded for the same reason as invalidateFileDecorations:
+      // plugins fire toasts from post-activation callbacks and timers. Liveness
+      // is plugin membership, so it no-ops silently once the plugin unloads.
+      showToast: async (options) => {
+        if (!this.plugins.has(pluginId)) return;
+        const parsed = PluginToastOptionsSchema.safeParse(options);
+        if (!parsed.success) {
+          throw new Error(
+            `Plugin "${pluginId}" showToast: invalid options — ${parsed.error.issues
+              .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+              .join("; ")}`
+          );
+        }
+        // Provenance: prefix the message with the plugin id so users can see
+        // which plugin raised the toast. pluginId is bound to the host closure
+        // at activation and cannot be spoofed.
+        broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+          type: parsed.data.type,
+          message: `${pluginId}: ${parsed.data.message}`,
+          duration: parsed.data.durationMs,
         });
       },
     };

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -837,10 +837,15 @@ export class PluginService {
         // Provenance: prefix the message with the plugin id so users can see
         // which plugin raised the toast. pluginId is bound to the host closure
         // at activation and cannot be spoofed.
+        //
+        // rateLimitKey scopes the rate-limit bucket per plugin+type. Without it
+        // plugin toasts fall into the global type-keyed bucket and a burst of
+        // unrelated system toasts could silently suppress a plugin's toast.
         broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
           type: parsed.data.type,
           message: `${pluginId}: ${parsed.data.message}`,
           duration: parsed.data.durationMs,
+          rateLimitKey: `plugin:${pluginId}:${parsed.data.type}`,
         });
       },
     };

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2112,6 +2112,162 @@ describe("createHost (plugin activation API)", () => {
   });
 });
 
+type ShowToastOptions = {
+  message: string;
+  type?: "info" | "success" | "warning" | "error";
+  durationMs?: number;
+};
+type ToastHostShape = (pluginId: string) => {
+  host: { showToast: (options: ShowToastOptions) => Promise<void> };
+  revoke: () => void;
+};
+
+describe("createHost — showToast", () => {
+  it("broadcasts NOTIFICATION_SHOW_TOAST with the pluginId-namespaced message", async () => {
+    await writePlugin("toast-test", { name: "acme.toast-test", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ToastHostShape }).createHost(
+      "acme.toast-test"
+    );
+
+    broadcastToRendererMock.mockClear();
+    await host.showToast({ message: "Synced 12 issues", type: "success" });
+
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+      type: "success",
+      message: "acme.toast-test: Synced 12 issues",
+      duration: undefined,
+    });
+  });
+
+  it("defaults type to info when omitted", async () => {
+    await writePlugin("toast-default", { name: "acme.toast-default", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ToastHostShape }).createHost(
+      "acme.toast-default"
+    );
+
+    broadcastToRendererMock.mockClear();
+    await host.showToast({ message: "Done" });
+
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+      type: "info",
+      message: "acme.toast-default: Done",
+      duration: undefined,
+    });
+  });
+
+  it("forwards durationMs as duration", async () => {
+    await writePlugin("toast-duration", { name: "acme.toast-duration", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ToastHostShape }).createHost(
+      "acme.toast-duration"
+    );
+
+    broadcastToRendererMock.mockClear();
+    await host.showToast({ message: "Saved", type: "success", durationMs: 3000 });
+
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+      type: "success",
+      message: "acme.toast-duration: Saved",
+      duration: 3000,
+    });
+  });
+
+  it("rejects an empty/whitespace message and does not broadcast", async () => {
+    await writePlugin("toast-empty", { name: "acme.toast-empty", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ToastHostShape }).createHost(
+      "acme.toast-empty"
+    );
+
+    broadcastToRendererMock.mockClear();
+    await expect(host.showToast({ message: "   " })).rejects.toThrow(/showToast: invalid options/);
+    expect(broadcastToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown type and does not broadcast", async () => {
+    await writePlugin("toast-badtype", { name: "acme.toast-badtype", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ToastHostShape }).createHost(
+      "acme.toast-badtype"
+    );
+
+    broadcastToRendererMock.mockClear();
+    await expect(
+      host.showToast({ message: "Oops", type: "fatal" as ShowToastOptions["type"] })
+    ).rejects.toThrow(/showToast: invalid options/);
+    expect(broadcastToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown fields (strict schema)", async () => {
+    await writePlugin("toast-strict", { name: "acme.toast-strict", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ToastHostShape }).createHost(
+      "acme.toast-strict"
+    );
+
+    broadcastToRendererMock.mockClear();
+    await expect(
+      host.showToast({ message: "Hi", priority: "low" } as unknown as ShowToastOptions)
+    ).rejects.toThrow(/showToast: invalid options/);
+    expect(broadcastToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it("is NOT revoke-guarded — still delivers after revoke() while the plugin is loaded", async () => {
+    await writePlugin("toast-revoke", { name: "acme.toast-revoke", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host, revoke } = (service as unknown as { createHost: ToastHostShape }).createHost(
+      "acme.toast-revoke"
+    );
+
+    revoke();
+    broadcastToRendererMock.mockClear();
+    await host.showToast({ message: "Still alive" });
+
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+      type: "info",
+      message: "acme.toast-revoke: Still alive",
+      duration: undefined,
+    });
+  });
+
+  it("is a silent no-op once the plugin is unloaded (liveness guard)", async () => {
+    await writePlugin("toast-unload", { name: "acme.toast-unload", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ToastHostShape }).createHost(
+      "acme.toast-unload"
+    );
+
+    service.unloadPlugin("acme.toast-unload");
+    broadcastToRendererMock.mockClear();
+    await expect(host.showToast({ message: "Gone" })).resolves.toBeUndefined();
+
+    // unloadPlugin emits its own registry-change broadcasts; assert specifically
+    // that no toast was delivered rather than "no broadcast at all".
+    const toastBroadcasts = broadcastToRendererMock.mock.calls.filter(
+      (call: unknown[]) => call[0] === CHANNELS.NOTIFICATION_SHOW_TOAST
+    );
+    expect(toastBroadcasts).toHaveLength(0);
+  });
+});
+
 describe("createHost — registerForgeProvider", () => {
   function forgeManifest(
     name: string,

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2135,10 +2135,12 @@ describe("createHost — showToast", () => {
     broadcastToRendererMock.mockClear();
     await host.showToast({ message: "Synced 12 issues", type: "success" });
 
+    expect(broadcastToRendererMock).toHaveBeenCalledTimes(1);
     expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.NOTIFICATION_SHOW_TOAST, {
       type: "success",
       message: "acme.toast-test: Synced 12 issues",
       duration: undefined,
+      rateLimitKey: "plugin:acme.toast-test:success",
     });
   });
 
@@ -2158,6 +2160,7 @@ describe("createHost — showToast", () => {
       type: "info",
       message: "acme.toast-default: Done",
       duration: undefined,
+      rateLimitKey: "plugin:acme.toast-default:info",
     });
   });
 
@@ -2177,7 +2180,48 @@ describe("createHost — showToast", () => {
       type: "success",
       message: "acme.toast-duration: Saved",
       duration: 3000,
+      rateLimitKey: "plugin:acme.toast-duration:success",
     });
+  });
+
+  it("rejects an out-of-range or non-integer durationMs and does not broadcast", async () => {
+    await writePlugin("toast-dur-range", { name: "acme.toast-dur-range", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ToastHostShape }).createHost(
+      "acme.toast-dur-range"
+    );
+
+    broadcastToRendererMock.mockClear();
+    for (const durationMs of [0, -1, 1.5, 60_001]) {
+      await expect(host.showToast({ message: "x", durationMs })).rejects.toThrow(
+        /showToast: invalid options/
+      );
+    }
+    // Boundaries that should pass.
+    await host.showToast({ message: "min", durationMs: 1 });
+    await host.showToast({ message: "max", durationMs: 60_000 });
+    expect(broadcastToRendererMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a message over the max length and does not broadcast", async () => {
+    await writePlugin("toast-maxlen", { name: "acme.toast-maxlen", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ToastHostShape }).createHost(
+      "acme.toast-maxlen"
+    );
+
+    broadcastToRendererMock.mockClear();
+    await host.showToast({ message: "x".repeat(2000) });
+    expect(broadcastToRendererMock).toHaveBeenCalledTimes(1);
+
+    await expect(host.showToast({ message: "x".repeat(2001) })).rejects.toThrow(
+      /showToast: invalid options/
+    );
+    expect(broadcastToRendererMock).toHaveBeenCalledTimes(1);
   });
 
   it("rejects an empty/whitespace message and does not broadcast", async () => {
@@ -2243,6 +2287,7 @@ describe("createHost — showToast", () => {
       type: "info",
       message: "acme.toast-revoke: Still alive",
       duration: undefined,
+      rateLimitKey: "plugin:acme.toast-revoke:info",
     });
   });
 

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -199,6 +199,12 @@ export interface MainProcessToastPayload {
   title?: string;
   message: string;
   /**
+   * Auto-dismiss delay in milliseconds, threaded through to `notify({ duration })`.
+   * Omit to use the app's per-type default. Used by plugin-issued toasts that
+   * pass `durationMs`.
+   */
+  duration?: number;
+  /**
    * Rate-limit bucket override threaded through to `notify({ rateLimitKey })`.
    * Without this, payloads share a bucket keyed only on `type` (e.g. all
    * `"error"` toasts), so an unrelated burst of errors can absorb a billing-

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -8,6 +8,7 @@ import type {
   NormalizedPRState,
   ResourceRef,
 } from "./forge.js";
+import type { NotificationType } from "./notification.js";
 
 export interface PanelContribution {
   id: string;
@@ -197,6 +198,23 @@ export interface PluginWorktreeSnapshot {
   readonly createdAt?: number;
 }
 
+/**
+ * Options for {@link PluginHostApi.showToast}. Intentionally narrower than the
+ * app's internal `notify()` surface: plugins cannot set `priority` (a
+ * `priority:"low"` + `type:"error"` toast silently drops — see the lint rule at
+ * `eslint.config.js`), pass a `ReactNode` message, or attach an action button
+ * (plugins have no IPC channel to wire one to). `message` is namespaced with the
+ * plugin's id (`{pluginId}: {message}`) by the host for provenance.
+ */
+export interface PluginToastOptions {
+  /** Toast body. String only across the IPC boundary — no `ReactNode`. */
+  message: string;
+  /** Maps directly to the app's `NotificationType`. Defaults to `"info"`. */
+  type?: NotificationType;
+  /** Auto-dismiss delay in milliseconds. Defaults to the app's per-type default. */
+  durationMs?: number;
+}
+
 export interface PluginHostApi {
   readonly pluginId: string;
   registerHandler(channel: string, handler: PluginIpcHandler): void;
@@ -268,6 +286,19 @@ export interface PluginHostApi {
    * unloaded.
    */
   invalidateFileDecorations(scope: string, paths?: string[]): void;
+  /**
+   * Surface a toast notification. The host namespaces the message as
+   * `{pluginId}: {message}` for provenance — a plugin cannot spoof another
+   * plugin's id since `pluginId` is bound to the host at activation. Routes
+   * through the app's `notify()` path so rate-limit, quiet-hours, and
+   * inbox-history semantics apply identically to plugin toasts.
+   *
+   * Like {@link invalidateFileDecorations} this is NOT revoke-guarded: plugins
+   * call it from post-activation subscription callbacks and timers. It becomes
+   * a silent no-op once the plugin is unloaded. Invalid options (empty message,
+   * unknown `type`) reject so authoring mistakes surface loudly.
+   */
+  showToast(options: PluginToastOptions): Promise<void>;
 }
 
 export type PluginActivate = (

--- a/src/hooks/__tests__/useMainProcessToastListener.test.tsx
+++ b/src/hooks/__tests__/useMainProcessToastListener.test.tsx
@@ -15,6 +15,7 @@ type ToastCallback = (payload: {
   type: "success" | "error" | "info" | "warning";
   title?: string;
   message: string;
+  duration?: number;
   rateLimitKey?: string;
   action?: { label: string; ipcChannel: string };
 }) => void;
@@ -95,6 +96,20 @@ describe("useMainProcessToastListener", () => {
     expect(notifyMock).toHaveBeenCalledWith(
       expect.objectContaining({ rateLimitKey: "cloud-teardown-failure" })
     );
+  });
+
+  it("threads duration through to notify when provided", () => {
+    renderHook(() => useMainProcessToastListener());
+
+    act(() => {
+      capturedCallback!({
+        type: "info",
+        message: "acme.linear: Synced",
+        duration: 3000,
+      });
+    });
+
+    expect(notifyMock).toHaveBeenCalledWith(expect.objectContaining({ duration: 3000 }));
   });
 
   it("calls notify with an action that triggers checkForUpdates", () => {

--- a/src/hooks/useMainProcessToastListener.ts
+++ b/src/hooks/useMainProcessToastListener.ts
@@ -40,6 +40,7 @@ export function useMainProcessToastListener(): void {
         type: payload.type,
         title: payload.title,
         message: payload.message,
+        duration: payload.duration,
         rateLimitKey: payload.rateLimitKey,
         action,
       });


### PR DESCRIPTION
## Summary

- `host.showToast` was documented in the plugin host API but never wired up — this implements it end-to-end
- Adds `PluginToastOptions` type with strict Zod validation (`PluginToastOptionsSchema`); toasts are namespaced as `{pluginId}: {message}` so provenance can't be spoofed
- Rate-limit bucket is scoped per plugin + type; `durationMs` threads through `MainProcessToastPayload` to `notify()`

Resolves #9278

## Changes

- `shared/types/plugin.ts` — `PluginToastOptions` type and `PluginToastOptionsSchema`
- `shared/types/ipc/maps.ts` — `MainProcessToastPayload` extended with `duration`
- `electron/schemas/plugin.ts` — Zod schema for incoming toast options
- `electron/services/PluginService.ts` — `createHost()` implementation: liveness-guarded (mirrors `invalidateFileDecorations`), namespaced message, per-plugin+type rate-limit bucket
- `electron/preload.cts` — `PluginToastOptions` type exposed on preload
- `src/hooks/useMainProcessToastListener.ts` — threads `duration` through to `notify()`
- `electron/services/__tests__/PluginService.test.ts` — 8 new tests covering happy path, validation errors, revoked plugin, rate-limit, duration clamping, message namespacing
- `src/hooks/__tests__/useMainProcessToastListener.test.tsx` — boundary test for `duration` passthrough
- `docs/plugins/host-api.md` + `docs/plugins/getting-started.md` — reconciled with actual implementation

## Testing

Unit tests cover the full contract: valid calls, invalid option shapes, revoked plugins, rate-limit exhaustion, `durationMs` boundary clamping (positive int, max 60s), and message namespace format. Existing `useMainProcessToastListener` tests pass with the extended payload.