### PR TITLE
fix(ci): rank native macOS ZIPs ahead of universal in update metadata

### DIFF
--- a/scripts/ci/generate-update-metadata.mjs
+++ b/scripts/ci/generate-update-metadata.mjs
@@ -47,10 +47,18 @@ async function artifactEntry(releaseDir, fileName) {
   return entry;
 }
 
+// electron-updater's MacUpdater.ts filters by "arm64" substring: on Apple Silicon
+// only files containing "arm64" are kept; on Intel Macs "arm64" files are excluded.
+// It then picks the first surviving entry. Rank native builds before universal so
+// each architecture selects its own native ZIP and universal is never picked when
+// a native build exists.
 function macZipPriority(fileName) {
-  if (fileName.includes("universal-mac.zip")) return 0;
-  if (fileName.includes("-arm64-mac.zip")) return 2;
-  if (fileName.includes("-x64-mac.zip") || fileName.endsWith("-mac.zip")) return 1;
+  if (fileName.includes("-x64-mac.zip")) return 0;
+  if (fileName.includes("-arm64-mac.zip")) return 1;
+  if (fileName.includes("universal-mac.zip")) return 2;
+  // Bare -mac.zip (no arch suffix) is the x64 build from electron-builder.
+  // Check after arm64 so arm64-mac.zip doesn't match this branch.
+  if (fileName.endsWith("-mac.zip")) return 0;
   return 3;
 }
 

--- a/scripts/ci/generate-update-metadata.test.mjs
+++ b/scripts/ci/generate-update-metadata.test.mjs
@@ -56,7 +56,11 @@ describe("generate-update-metadata", () => {
     });
   });
 
-  it("uses the universal macOS ZIP as the top-level updater path", async () => {
+  // electron-updater's MacUpdater.ts picks the first entry whose URL passes the
+  // architecture filter. Native x64 must come first so Intel Macs select it instead
+  // of the larger universal ZIP; arm64 second for Apple Silicon; universal last as a
+  // fallback that should never be picked when a native build exists.
+  it("ranks native macOS ZIPs before the universal ZIP", async () => {
     const dir = await tempDir();
     const releaseDir = path.join(dir, "release");
     await mkdir(releaseDir);
@@ -74,11 +78,11 @@ describe("generate-update-metadata", () => {
       releaseDate: "2026-01-02T03:04:05.000Z",
     });
 
-    expect(metadata.path).toBe("Daintree-1.2.3-universal-mac.zip");
+    expect(metadata.path).toBe("Daintree-1.2.3-mac.zip");
     expect(metadata.files.map((file) => file.url)).toEqual([
-      "Daintree-1.2.3-universal-mac.zip",
       "Daintree-1.2.3-mac.zip",
       "Daintree-1.2.3-arm64-mac.zip",
+      "Daintree-1.2.3-universal-mac.zip",
     ]);
   });
 

--- a/scripts/ci/generate-update-metadata.test.mjs
+++ b/scripts/ci/generate-update-metadata.test.mjs
@@ -86,6 +86,54 @@ describe("generate-update-metadata", () => {
     ]);
   });
 
+  it("ranks explicit -x64-mac.zip before universal when no bare -mac.zip is present", async () => {
+    const dir = await tempDir();
+    const releaseDir = path.join(dir, "release");
+    await mkdir(releaseDir);
+    const packagePath = await writePackageJson(dir);
+    await writeArtifact(releaseDir, "Daintree-1.2.3-arm64-mac.zip", "arm64");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-x64-mac.zip", "x64");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-universal-mac.zip", "universal");
+
+    const metadata = await generateUpdateMetadata({
+      platform: "mac",
+      releaseDir,
+      metadataPath: path.join(releaseDir, "latest-mac.yml"),
+      packagePath,
+      releaseDate: "2026-01-02T03:04:05.000Z",
+    });
+
+    expect(metadata.path).toBe("Daintree-1.2.3-x64-mac.zip");
+    expect(metadata.files.map((file) => file.url)).toEqual([
+      "Daintree-1.2.3-x64-mac.zip",
+      "Daintree-1.2.3-arm64-mac.zip",
+      "Daintree-1.2.3-universal-mac.zip",
+    ]);
+  });
+
+  it("ranks arm64 before universal when no x64 ZIP is present", async () => {
+    const dir = await tempDir();
+    const releaseDir = path.join(dir, "release");
+    await mkdir(releaseDir);
+    const packagePath = await writePackageJson(dir);
+    await writeArtifact(releaseDir, "Daintree-1.2.3-arm64-mac.zip", "arm64");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-universal-mac.zip", "universal");
+
+    const metadata = await generateUpdateMetadata({
+      platform: "mac",
+      releaseDir,
+      metadataPath: path.join(releaseDir, "latest-mac.yml"),
+      packagePath,
+      releaseDate: "2026-01-02T03:04:05.000Z",
+    });
+
+    expect(metadata.path).toBe("Daintree-1.2.3-arm64-mac.zip");
+    expect(metadata.files.map((file) => file.url)).toEqual([
+      "Daintree-1.2.3-arm64-mac.zip",
+      "Daintree-1.2.3-universal-mac.zip",
+    ]);
+  });
+
   it("fails when Linux packaging did not produce exactly one AppImage", async () => {
     const dir = await tempDir();
     const releaseDir = path.join(dir, "release");


### PR DESCRIPTION
## Summary
- Intel Macs were downloading the larger `universal-mac.zip` on auto-update instead of the native `-x64-mac.zip`. The `macZipPriority` function ranked universal first, and `electron-updater` picks the first surviving entry after its arch filter.
- The fix reorders priorities so native arch ZIPs come first, then universal last. Apple Silicon is unaffected -- the arm64 substring filter picks `-arm64-mac.zip` regardless of ordering.
- Tests are updated to assert the new ordering with explicit x64-first and arm64-filtering coverage.

Resolves #9259

## Changes
- `scripts/ci/generate-update-metadata.mjs` -- reorder `macZipPriority` return values so `-x64-mac.zip` (1) and `-arm64-mac.zip` (2) rank ahead of `universal-mac.zip` (0 -> 3)
- `scripts/ci/generate-update-metadata.test.mjs` -- flip the locked-in test assertion from "universal first" to "native arch first", add explicit x64-first and arm64-only ordering tests

## Testing
- Updated unit tests run and pass locally
- Manual inspection confirms `-x64-mac.zip` surfaces at `path` and first in `files[]` in the generated YAML