### PR TITLE
feat(plugins): add hello-daintree sample plugin fixture

### DIFF
--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
+import { fileURLToPath } from "node:url";
 import type { PanelKindConfig } from "../../../shared/config/panelKindRegistry.js";
 
 const appMock = vi.hoisted(() => ({
@@ -4004,5 +4005,25 @@ describe("Plugin exception containment (#9276)", () => {
       expect(typeof record?.message).toBe("string");
       expect(record?.message.length).toBeGreaterThan(0);
     });
+describe("hello-daintree sample fixture", () => {
+  const fixturePath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../plugins/sample/hello-daintree/plugin.json"
+  );
+  const readManifest = async (): Promise<unknown> =>
+    JSON.parse(await fs.readFile(fixturePath, "utf8"));
+
+  it("validates against the manifest schema", async () => {
+    const result = PluginManifestSchema.safeParse(await readManifest());
+    expect(result.success).toBe(true);
+  });
+
+  it("declares the first-party name and the wired contribution points", async () => {
+    const manifest = PluginManifestSchema.parse(await readManifest());
+    expect(manifest.name).toBe("daintree.hello");
+    expect(manifest.contributes.toolbarButtons).toHaveLength(1);
+    expect(manifest.contributes.toolbarButtons[0].id).toBe("ping");
+    expect(manifest.contributes.menuItems).toHaveLength(1);
+    expect(manifest.contributes.fileDecorationProviders[0].scopes).toEqual(["hello:*"]);
   });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4005,6 +4005,9 @@ describe("Plugin exception containment (#9276)", () => {
       expect(typeof record?.message).toBe("string");
       expect(record?.message.length).toBeGreaterThan(0);
     });
+  });
+});
+
 describe("hello-daintree sample fixture", () => {
   const fixturePath = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4021,9 +4021,11 @@ describe("hello-daintree sample fixture", () => {
   it("declares the first-party name and the wired contribution points", async () => {
     const manifest = PluginManifestSchema.parse(await readManifest());
     expect(manifest.name).toBe("daintree.hello");
+    expect(manifest.engines?.daintree).toBe(">=0.11.0");
     expect(manifest.contributes.toolbarButtons).toHaveLength(1);
     expect(manifest.contributes.toolbarButtons[0].id).toBe("ping");
     expect(manifest.contributes.menuItems).toHaveLength(1);
+    expect(manifest.contributes.fileDecorationProviders).toHaveLength(1);
     expect(manifest.contributes.fileDecorationProviders[0].scopes).toEqual(["hello:*"]);
   });
 });

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -18,7 +18,11 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["./**/*.ts", "../plugins/builtin/github/main/**/*.ts"],
+  "include": [
+    "./**/*.ts",
+    "../plugins/builtin/github/main/**/*.ts",
+    "../plugins/sample/hello-daintree/main/**/*.ts"
+  ],
   "exclude": ["node_modules", "preload.cts"],
   "references": [{ "path": "../shared/tsconfig.json" }]
 }

--- a/plugins/sample/hello-daintree/main/index.ts
+++ b/plugins/sample/hello-daintree/main/index.ts
@@ -1,0 +1,44 @@
+import type { FileDecoration } from "../../../../shared/types/forge.js";
+import type { PluginHostApi, PluginIpcContext } from "../../../../shared/types/plugin.js";
+
+/**
+ * Hello Daintree — the minimal reference plugin. It wires up exactly the host
+ * APIs and contribution points that exist today, and grows by one contribution
+ * point per PR as the plugin host expands (issue #9275). Every line maps to a
+ * single capability so an author can read it in one sitting.
+ *
+ * Declared in plugin.json: one toolbar button and one menu item, both pointing
+ * at the `daintree.hello.ping` action, plus one file-decoration provider scoped
+ * to `hello:*`.
+ */
+export function activate(host: PluginHostApi): () => void {
+  // An IPC handler the renderer reaches over `plugin:daintree.hello:ping`.
+  host.registerHandler("ping", (ctx: PluginIpcContext) => ({
+    pluginId: host.pluginId,
+    worktreeId: ctx.worktreeId,
+  }));
+
+  // Badge every requested path with an "H" — the simplest honest decoration.
+  const disposeDecorations = host.registerFileDecorationProvider(
+    { id: "hello" },
+    {
+      provideDecorations: async (_scope, paths) => {
+        const decorations: Record<string, FileDecoration> = {};
+        for (const filePath of paths) {
+          decorations[filePath] = { badge: "H", tooltip: "Hello Daintree" };
+        }
+        return decorations;
+      },
+    }
+  );
+
+  // When the active worktree changes, ask the host to re-pull our decorations.
+  const disposeWorktree = host.onDidChangeActiveWorktree(() => {
+    host.invalidateFileDecorations("hello:active");
+  });
+
+  return () => {
+    disposeDecorations();
+    disposeWorktree();
+  };
+}

--- a/plugins/sample/hello-daintree/plugin.json
+++ b/plugins/sample/hello-daintree/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "daintree.hello",
+  "version": "0.1.0",
+  "displayName": "Hello Daintree",
+  "description": "Minimal reference plugin — the canonical example for plugin authors and the F10b host-contract test consumer. Grows by one contribution point per PR.",
+  "main": "main/index.js",
+  "engines": {
+    "daintree": ">=0.11.0"
+  },
+  "permissions": [],
+  "contributes": {
+    "toolbarButtons": [
+      {
+        "id": "ping",
+        "label": "Hello ping",
+        "iconId": "sparkles",
+        "actionId": "daintree.hello.ping",
+        "priority": 5
+      }
+    ],
+    "menuItems": [
+      {
+        "label": "Hello ping",
+        "actionId": "daintree.hello.ping",
+        "location": "help"
+      }
+    ],
+    "fileDecorationProviders": [
+      {
+        "id": "hello",
+        "scopes": ["hello:*"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the first increment of the `hello-daintree` sample plugin fixture at `plugins/sample/hello-daintree/` — only wires up host APIs and contribution points that exist today; the fixture grows one contribution point per PR as the dependent issues land.
- The manifest (`plugin.json`) declares name `daintree.hello`, version `0.1.0`, `engines.daintree >=0.11.0`, one `toolbarButton` and one `menuItem` both pointing to `daintree.hello.ping`, and one `fileDecorationProvider` with scopes `["hello:*"]`.
- The main entry (`main/index.ts`, ~46 lines) registers an IPC handler for `ping`, a file-decoration provider that badges paths with `H`, and an `onDidChangeActiveWorktree` subscription that calls `host.invalidateFileDecorations`.

Resolves #9275

## Changes

- `plugins/sample/hello-daintree/plugin.json` — manifest
- `plugins/sample/hello-daintree/main/index.ts` — activate/deactivate logic
- `electron/tsconfig.json` — includes the sample source for typecheck
- `electron/services/__tests__/PluginService.test.ts` — validates the on-disk fixture against `PluginManifestSchema`

The plugin lives in `plugins/sample/` (not `plugins/builtin/`) so it doesn't ship bundled. Future contribution points (`host.registerAction` #9277, `host.showToast` #9278, `host.settings` #9279, `host.dispatch` #9280, renderer view #9287) all depend on still-open issues and will be added incrementally.

## Testing

- vitest 190 pass
- `tsc -b` clean
- `npm run check` (9-step suite) clean