### PR TITLE
feat(plugins): implement main-side host.registerAction(descriptor, handler)

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -14,6 +14,7 @@ import type {
   PluginActivate,
   PluginActionContribution,
   PluginActionDescriptor,
+  PluginActionHandler,
   BuiltInPluginCapability,
 } from "../../shared/types/plugin.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
@@ -153,6 +154,16 @@ export class PluginService {
   private cleanupMap = new Map<string, () => void>();
   private pluginActions = new Map<string, PluginActionDescriptor>();
   private pluginActionOwners = new Map<string, Set<string>>();
+  /**
+   * Main-side action handlers bound via {@link PluginHostApi.registerAction},
+   * keyed by the fully-namespaced action id (`{pluginId}.{actionId}`) — the
+   * same key `pluginActions` uses. The renderer's synthetic action routes its
+   * `run()` back through `plugin:invoke` with this id as the channel, so
+   * {@link dispatchHandler} resolves the handler from here. The renderer IPC
+   * registration path (`plugin:actions-register`) never populates this map: it
+   * carries metadata only and has no handler closure to bind.
+   */
+  private actionHandlerMap = new Map<string, PluginActionHandler>();
   private pluginEventCleanups = new Map<string, Array<() => void>>();
   /**
    * Most recent activation error per plugin id. Populated by the catch in
@@ -801,6 +812,38 @@ export class PluginService {
           payload: { scope, ...(narrowed && narrowed.length > 0 ? { paths: narrowed } : {}) },
         });
       },
+      registerAction: (descriptor, handler) => {
+        if (revoked) {
+          throw new Error(
+            `Plugin "${pluginId}" host revoked: registerAction called after activate() returned or timed out`
+          );
+        }
+        if (!descriptor || typeof descriptor !== "object") {
+          throw new Error(`Plugin "${pluginId}" registerAction: descriptor must be an object`);
+        }
+        if (typeof descriptor.id !== "string" || descriptor.id.length === 0) {
+          throw new Error(
+            `Plugin "${pluginId}" registerAction: descriptor.id must be a non-empty string`
+          );
+        }
+        if (typeof handler !== "function") {
+          throw new Error(`Plugin "${pluginId}" registerAction: handler must be a function`);
+        }
+        // The plugin-supplied id omits the namespace; the host prepends it so
+        // the descriptor matches the `{pluginId}.{actionId}` routing key used
+        // everywhere else. Re-registering an id replaces silently (unlike the
+        // throw-on-duplicate IPC path), so build with "replace" semantics and
+        // overwrite both the descriptor and the handler in place.
+        const fullId = `${pluginId}.${descriptor.id}`;
+        const built = this.buildPluginActionDescriptor(
+          pluginId,
+          { ...descriptor, id: fullId },
+          "replace"
+        );
+        this.storePluginAction(built);
+        this.actionHandlerMap.set(fullId, handler);
+        this.broadcastPluginActions();
+      },
     };
     return {
       host,
@@ -940,6 +983,19 @@ export class PluginService {
     ctx: PluginIpcContext,
     args: unknown[]
   ): Promise<unknown> {
+    // Plugin actions registered via host.registerAction route here with the
+    // fully-namespaced action id as `channel`. Resolve those first, scoped to
+    // the calling plugin's namespace so a renderer can't dispatch another
+    // plugin's handler by passing a mismatched pluginId. Action handlers
+    // receive only the single args object the synthetic action forwards — the
+    // PluginIpcContext is not part of the action contract.
+    if (channel.startsWith(`${pluginId}.`)) {
+      const actionHandler = this.actionHandlerMap.get(channel);
+      if (actionHandler) {
+        return await actionHandler(args[0]);
+      }
+    }
+
     const key = `${pluginId}:${channel}`;
     const handler = this.handlerMap.get(key);
     if (!handler) {
@@ -1105,6 +1161,25 @@ export class PluginService {
    * Broadcasts the full action list to all renderers so windows stay in sync.
    */
   registerPluginAction(pluginId: string, contribution: PluginActionContribution): void {
+    const descriptor = this.buildPluginActionDescriptor(pluginId, contribution, "throw");
+    this.storePluginAction(descriptor);
+    this.broadcastPluginActions();
+  }
+
+  /**
+   * Validate a plugin action contribution and build its host-authoritative
+   * descriptor. Shared by the renderer IPC path ({@link registerPluginAction},
+   * `duplicateMode: "throw"`) and the main-side `host.registerAction`
+   * (`duplicateMode: "replace"`) so the id-format, namespace-ownership,
+   * `"restricted"`-danger rejection, and `effectiveDanger` promotion rules
+   * cannot drift between the two entry points. The caller is responsible for
+   * storing the result and broadcasting.
+   */
+  private buildPluginActionDescriptor(
+    pluginId: string,
+    contribution: PluginActionContribution,
+    duplicateMode: "throw" | "replace"
+  ): PluginActionDescriptor {
     if (!this.plugins.has(pluginId)) {
       throw new Error(`Unknown plugin: ${pluginId}`);
     }
@@ -1139,7 +1214,7 @@ export class PluginService {
         `Plugin action "${id}" has invalid danger "${danger}". Plugins may only register "safe" or "confirm" actions.`
       );
     }
-    if (this.pluginActions.has(id)) {
+    if (duplicateMode === "throw" && this.pluginActions.has(id)) {
       throw new Error(`Plugin action "${id}" is already registered`);
     }
 
@@ -1154,7 +1229,7 @@ export class PluginService {
     const effectiveDanger: "safe" | "confirm" =
       danger === "confirm" || hasHighRiskCapability ? "confirm" : "safe";
 
-    const descriptor: PluginActionDescriptor = {
+    return {
       pluginId,
       id,
       title,
@@ -1169,16 +1244,17 @@ export class PluginService {
           ? { ...contribution.inputSchema }
           : undefined,
     };
+  }
 
-    this.pluginActions.set(id, descriptor);
-    let owners = this.pluginActionOwners.get(pluginId);
+  /** Store a built descriptor in the action registry and track its owner. */
+  private storePluginAction(descriptor: PluginActionDescriptor): void {
+    this.pluginActions.set(descriptor.id, descriptor);
+    let owners = this.pluginActionOwners.get(descriptor.pluginId);
     if (!owners) {
       owners = new Set();
-      this.pluginActionOwners.set(pluginId, owners);
+      this.pluginActionOwners.set(descriptor.pluginId, owners);
     }
-    owners.add(id);
-
-    this.broadcastPluginActions();
+    owners.add(descriptor.id);
   }
 
   /** Remove a single plugin-registered action. Silent no-op if unknown. */
@@ -1187,6 +1263,7 @@ export class PluginService {
     if (!descriptor || descriptor.pluginId !== pluginId) return;
 
     this.pluginActions.delete(actionId);
+    this.actionHandlerMap.delete(actionId);
     const owners = this.pluginActionOwners.get(pluginId);
     if (owners) {
       owners.delete(actionId);
@@ -1203,6 +1280,7 @@ export class PluginService {
 
     for (const id of owners) {
       this.pluginActions.delete(id);
+      this.actionHandlerMap.delete(id);
     }
     this.pluginActionOwners.delete(pluginId);
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -826,6 +826,15 @@ export class PluginService {
             `Plugin "${pluginId}" registerAction: descriptor.id must be a non-empty string`
           );
         }
+        // The host owns namespacing — a plugin that pre-includes its own prefix
+        // would otherwise be registered under a double-prefixed id
+        // (`{pluginId}.{pluginId}.{name}`) that nothing references. Reject loudly
+        // rather than silently mis-register.
+        if (descriptor.id.startsWith(`${pluginId}.`)) {
+          throw new Error(
+            `Plugin "${pluginId}" registerAction: descriptor.id must not include the plugin prefix. Pass only the action name (e.g. "doThing").`
+          );
+        }
         if (typeof handler !== "function") {
           throw new Error(`Plugin "${pluginId}" registerAction: handler must be a function`);
         }
@@ -994,6 +1003,12 @@ export class PluginService {
       if (actionHandler) {
         return await actionHandler(args[0]);
       }
+      // The channel sits in this plugin's action namespace but no handler is
+      // bound (e.g. the action was unregistered and a stale dispatch arrived).
+      // Don't fall through to handlerMap — an IPC handler that happened to be
+      // registered under the same dotted name uses a different calling
+      // convention (ctx + spread args, not args[0]).
+      throw new Error(`No plugin action handler registered for ${channel}`);
     }
 
     const key = `${pluginId}:${channel}`;

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1791,6 +1791,57 @@ describe("createHost — registerAction", () => {
     );
   });
 
+  it("rejects a descriptor id that already includes the plugin prefix", async () => {
+    const { host } = await makeHost();
+    expect(() =>
+      host.registerAction({ ...validDescriptor(), id: "acme.act-host.doThing" }, () => undefined)
+    ).toThrow(/must not include the plugin prefix/);
+  });
+
+  it("rejects invalid kind, whitespace title, and whitespace category like the IPC path", async () => {
+    const { host } = await makeHost();
+    expect(() =>
+      host.registerAction({ ...validDescriptor(), kind: "navigation" }, () => undefined)
+    ).toThrow(/invalid kind/i);
+    expect(() =>
+      host.registerAction({ ...validDescriptor(), title: "   " }, () => undefined)
+    ).toThrow(/non-empty title/);
+    expect(() =>
+      host.registerAction({ ...validDescriptor(), category: "   " }, () => undefined)
+    ).toThrow(/non-empty category/);
+  });
+
+  it("passes undefined to the handler when dispatched with no args", async () => {
+    const { service, host } = await makeHost();
+    const handler = vi.fn().mockReturnValue("ok");
+    host.registerAction(validDescriptor(), handler);
+
+    await service.dispatchHandler(
+      "acme.act-host",
+      "acme.act-host.doThing",
+      makeCtx("acme.act-host"),
+      []
+    );
+    expect(handler).toHaveBeenCalledWith(undefined);
+  });
+
+  it("does not fall through to an IPC handler sharing the action's dotted name", async () => {
+    const { service, host } = await makeHost();
+    const ipcHandler = vi.fn().mockReturnValue("ipc");
+    // A regular IPC handler registered under the same dotted name as the action.
+    service.registerHandler("acme.act-host", "acme.act-host.doThing", ipcHandler);
+    host.registerAction(validDescriptor(), () => "action");
+
+    service.unregisterPluginAction("acme.act-host", "acme.act-host.doThing");
+
+    await expect(
+      service.dispatchHandler("acme.act-host", "acme.act-host.doThing", makeCtx("acme.act-host"), [
+        {},
+      ])
+    ).rejects.toThrow(/No plugin action handler registered/);
+    expect(ipcHandler).not.toHaveBeenCalled();
+  });
+
   it("raises effectiveDanger to confirm when the manifest grants a high-risk permission", async () => {
     const { service, host } = await makeHost("acme.act-risky", {
       permissions: ["fs:project-read", "shell:exec"],
@@ -1842,7 +1893,7 @@ describe("createHost — registerAction", () => {
       service.dispatchHandler("acme.act-host", "acme.act-host.doThing", makeCtx("acme.act-host"), [
         {},
       ])
-    ).rejects.toThrow(/No plugin handler registered/);
+    ).rejects.toThrow(/No plugin action handler registered/);
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1635,6 +1635,10 @@ type CreateHostShape = (pluginId: string) => {
     registerHandler: (channel: string, handler: (...args: unknown[]) => unknown) => void;
     broadcastToRenderer: (channel: string, payload: unknown) => void;
     registerForgeProvider: (descriptor: { id: string }, impl: unknown) => () => void;
+    registerAction: (
+      descriptor: Record<string, unknown>,
+      handler: (args: unknown) => unknown
+    ) => void;
   };
   revoke: () => void;
 };
@@ -1708,6 +1712,137 @@ describe("createHost (plugin activation API)", () => {
     expect(() => host.registerForgeProvider({ id: "github" }, {})).toThrow(
       /host revoked: registerForgeProvider/
     );
+    expect(() => host.registerAction({ id: "doThing" }, () => undefined)).toThrow(
+      /host revoked: registerAction/
+    );
+  });
+});
+
+describe("createHost — registerAction", () => {
+  const validDescriptor = () => ({
+    id: "doThing",
+    title: "Do Thing",
+    description: "Does a thing",
+    category: "plugin",
+    kind: "command" as const,
+    danger: "safe" as const,
+  });
+
+  async function makeHost(pluginId = "acme.act-host", manifest: Record<string, unknown> = {}) {
+    await writePlugin(pluginId.replace(/^acme\./, ""), {
+      name: pluginId,
+      version: "1.0.0",
+      ...manifest,
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(pluginId);
+    return { service, host };
+  }
+
+  it("namespaces the descriptor id and stores it in the action registry", async () => {
+    const { service, host } = await makeHost();
+    host.registerAction(validDescriptor(), () => "ok");
+
+    const actions = service.listPluginActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      pluginId: "acme.act-host",
+      id: "acme.act-host.doThing",
+      title: "Do Thing",
+      kind: "command",
+      danger: "safe",
+      effectiveDanger: "safe",
+    });
+  });
+
+  it("dispatches the handler with the single args object through dispatchHandler", async () => {
+    const { service, host } = await makeHost();
+    const handler = vi.fn().mockResolvedValue({ ok: true });
+    host.registerAction(validDescriptor(), handler);
+
+    const ctx = makeCtx("acme.act-host");
+    const result = await service.dispatchHandler("acme.act-host", "acme.act-host.doThing", ctx, [
+      { value: 42 },
+    ]);
+    expect(handler).toHaveBeenCalledWith({ value: 42 });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("reuses the shared validation: rejects restricted danger", async () => {
+    const { host } = await makeHost();
+    expect(() =>
+      host.registerAction({ ...validDescriptor(), danger: "restricted" }, () => undefined)
+    ).toThrow(/invalid danger/i);
+  });
+
+  it("rejects a non-function handler", async () => {
+    const { host } = await makeHost();
+    expect(() =>
+      host.registerAction(validDescriptor(), "not-a-function" as unknown as () => unknown)
+    ).toThrow(/handler must be a function/);
+  });
+
+  it("rejects a missing descriptor id", async () => {
+    const { host } = await makeHost();
+    expect(() => host.registerAction({ title: "x" }, () => undefined)).toThrow(
+      /descriptor.id must be a non-empty string/
+    );
+  });
+
+  it("raises effectiveDanger to confirm when the manifest grants a high-risk permission", async () => {
+    const { service, host } = await makeHost("acme.act-risky", {
+      permissions: ["fs:project-read", "shell:exec"],
+    });
+    host.registerAction(validDescriptor(), () => undefined);
+    expect(service.listPluginActions()[0].effectiveDanger).toBe("confirm");
+  });
+
+  it("replaces the descriptor and handler silently when the same id is re-registered", async () => {
+    const { service, host } = await makeHost();
+    const first = vi.fn().mockReturnValue("first");
+    const second = vi.fn().mockReturnValue("second");
+
+    host.registerAction(validDescriptor(), first);
+    host.registerAction({ ...validDescriptor(), title: "Updated" }, second);
+
+    const actions = service.listPluginActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0].title).toBe("Updated");
+
+    const result = await service.dispatchHandler(
+      "acme.act-host",
+      "acme.act-host.doThing",
+      makeCtx("acme.act-host"),
+      [{}]
+    );
+    expect(result).toBe("second");
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  it("does not let another plugin's namespace dispatch the handler", async () => {
+    const { service, host } = await makeHost();
+    host.registerAction(validDescriptor(), () => "ok");
+
+    await expect(
+      service.dispatchHandler("acme.other", "acme.act-host.doThing", makeCtx("acme.other"), [{}])
+    ).rejects.toThrow(/No plugin handler registered/);
+  });
+
+  it("clears the handler on plugin unload", async () => {
+    const { service, host } = await makeHost();
+    host.registerAction(validDescriptor(), () => "ok");
+    expect(service.listPluginActions()).toHaveLength(1);
+
+    service.unloadPlugin("acme.act-host");
+
+    expect(service.listPluginActions()).toHaveLength(0);
+    await expect(
+      service.dispatchHandler("acme.act-host", "acme.act-host.doThing", makeCtx("acme.act-host"), [
+        {},
+      ])
+    ).rejects.toThrow(/No plugin handler registered/);
   });
 });
 

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -2,7 +2,7 @@ import type { BuiltInKeyAction } from "./keymap.js";
 import type { BuiltInRuntimeActionId } from "../config/actionIds.js";
 import type { z } from "zod";
 
-export type ActionSource = "user" | "keybinding" | "menu" | "agent" | "context-menu";
+export type ActionSource = "user" | "keybinding" | "menu" | "agent" | "context-menu" | "plugin";
 
 export type ActionKind = "command" | "query";
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -268,6 +268,21 @@ export interface PluginHostApi {
    * unloaded.
    */
   invalidateFileDecorations(scope: string, paths?: string[]): void;
+  /**
+   * Bind a runtime action handler to a descriptor. The descriptor's `id` must
+   * NOT include the plugin prefix — the host namespaces it at runtime as
+   * `{pluginId}.{descriptor.id}`. The handler runs in main and is invoked when
+   * the synthetic renderer action dispatches back over `plugin:invoke`.
+   *
+   * Validation mirrors the renderer IPC registration path: id format, the
+   * `"restricted"`-danger rejection, and host-authoritative `effectiveDanger`
+   * promotion all apply. Returns `void` (not a disposer) — the handler is
+   * unregistered automatically on plugin unload. Calling this twice with the
+   * same `descriptor.id` replaces the prior descriptor and handler. Must be
+   * called during `activate()` — the host is revoked once activation resolves
+   * or times out.
+   */
+  registerAction(descriptor: PluginActionContribution, handler: PluginActionHandler): void;
 }
 
 export type PluginActivate = (
@@ -308,3 +323,12 @@ export interface PluginActionDescriptor extends PluginActionContribution {
    */
   effectiveDanger: "safe" | "confirm";
 }
+
+/**
+ * Runtime handler bound to a plugin action via {@link PluginHostApi.registerAction}.
+ * Handlers live only in main and never cross the IPC bridge. They receive the
+ * single `args` object the renderer's synthetic action passes through
+ * `plugin:invoke`, and may return any serializable value (or a Promise of one)
+ * that is relayed back to the dispatch caller.
+ */
+export type PluginActionHandler = (args: unknown) => unknown | Promise<unknown>;


### PR DESCRIPTION
## Summary

- Adds `host.registerAction(descriptor, handler)` to the main-side plugin host. Plugins call it during `activate()` to bind an action handler that runs in main; the handler fires when the renderer dispatches the synthetic `ActionDefinition` back over `plugin:invoke`.
- Introduces `PluginActionHandler` type and the `registerAction` signature to `PluginHostApi`; adds `"plugin"` to the `ActionSource` union per the issue's explicit direction.
- Covers the full validation surface: revoke-guard, descriptor/id/handler validation, double-prefix rejection, namespace-scoped dispatch resolution, and `actionHandlerMap` cleanup on unload.

Resolves #9277

## Changes

- `shared/types/plugin.ts` — `PluginActionHandler` type and `registerAction` on `PluginHostApi`
- `shared/types/actions.ts` — `"plugin"` added to `ActionSource` union
- `electron/services/PluginService.ts` — `actionHandlerMap` keyed by fully-namespaced action id; `buildPluginActionDescriptor` helper (shared validation between IPC and host paths); `storePluginAction` helper; `registerAction` closure in `createHost()` with revoke-guard, double-prefix rejection; `dispatchHandler` resolves action handlers first (namespace-scoped) and throws instead of falling through to IPC handlers; unregister paths clear `actionHandlerMap`
- `electron/services/__tests__/PluginService.test.ts` — `createHost — registerAction` suite covering namespacing, dispatch contract args[0], shared-validation reuse, restricted-danger/non-function/missing-id/double-prefix rejection, `effectiveDanger` promotion, silent replace semantics, cross-plugin dispatch rejection, IPC-fallthrough prevention, zero-args dispatch, and unload cleanup

**Note:** dependencies #9231 and #9269 are still open. `PluginActionHandler` is defined locally and `"plugin"` is added to `ActionSource` per the issue's direction; no cross-PR coordination required here.

## Testing

201 `PluginService` tests pass. `npm run check` clean (typecheck, IPC checks, `lint:ratchet`, `format:check`).