### PR TITLE
feat(plugin): audit plugin invokes and file-decoration failures

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1258,
-  "moduleCount": 1258,
+  "count": 1260,
+  "moduleCount": 1260,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -66,6 +66,7 @@
     "electron/services/mcp-server/httpLifecycle.ts",
     "electron/services/persistence/db.ts",
     "electron/services/persistence/readLastProjectId.ts",
+    "electron/services/pluginAuditService.ts",
     "electron/services/pty/TerminalRegistry.ts",
     "electron/services/pty/agentSessionHistory.ts",
     "electron/services/pty/terminalSessionPersistence.ts",
@@ -1045,6 +1046,16 @@
       "pattern": "sync-sqlite"
     },
     {
+      "file": "electron/services/pluginAuditService.ts",
+      "line": 169,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/pluginAuditService.ts",
+      "line": 176,
+      "pattern": "sync-store-get"
+    },
+    {
       "file": "electron/services/PluginService.ts",
       "line": 325,
       "pattern": "sync-store-get"
@@ -1381,57 +1392,57 @@
     },
     {
       "file": "electron/store.ts",
-      "line": 502,
+      "line": 512,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 504,
+      "line": 514,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 519,
+      "line": 529,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 534,
+      "line": 544,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 535,
+      "line": 545,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 537,
+      "line": 547,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 552,
+      "line": 562,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 554,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/store.ts",
-      "line": 571,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/store.ts",
-      "line": 580,
+      "line": 564,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
       "line": 581,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 590,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 591,
       "pattern": "sync-fs"
     },
     {

--- a/electron/__tests__/clipboard.test.ts
+++ b/electron/__tests__/clipboard.test.ts
@@ -8,6 +8,12 @@ vi.mock("electron", () => ({
   clipboard: { readImage: vi.fn(), writeImage: vi.fn(), writeText: vi.fn(), readText: vi.fn() },
   nativeImage: { createFromBuffer: vi.fn(), createFromPath: vi.fn() },
   ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  // `clipboard.ts` transitively constructs the `projectStore` singleton, whose
+  // constructor calls `app.getPath("userData")`. Without `app` on the mock the
+  // suite fails whenever it is the first file in its vitest worker to trigger
+  // that construction (otherwise the cached singleton skips the constructor) —
+  // a worker-ordering flake. Stub `getPath` so the import is order-independent.
+  app: { getPath: vi.fn(() => osMockState.base) },
 }));
 
 // Redirect os.tmpdir() to a throwaway directory so the cleanup operates on real

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -123,6 +123,7 @@ describe("registerPluginHandlers", () => {
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:actions-unregister");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:panel-kinds-get");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:forge-providers-get");
+    expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:file-decorations-get");
   });
 
   it("PLUGIN_LIST handler delegates to pluginService.listPlugins", async () => {
@@ -814,6 +815,36 @@ describe("PLUGIN_FILE_DECORATIONS_GET handler", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("audits a synchronously-throwing provider and still returns the healthy one", async () => {
+    mockGetFileDecorationImpls.mockReturnValue([
+      {
+        pluginId: "p.sync-throw",
+        contributionId: "d",
+        impl: {
+          provideDecorations: vi.fn(() => {
+            throw new Error("sync boom");
+          }),
+        },
+      },
+      {
+        pluginId: "p.good",
+        contributionId: "d",
+        impl: { provideDecorations: vi.fn().mockResolvedValue({ "a.ts": { badge: "5" } }) },
+      },
+    ]);
+    const handler = getHandler();
+    // The whole IPC call must not reject just because one provider threw.
+    expect(await handler({}, "worktree-diff:/r", ["a.ts"])).toEqual({ "a.ts": { badge: "5" } });
+    expect(mockAppendAuditRecord).toHaveBeenCalledTimes(1);
+    expect(mockAppendAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginId: "p.sync-throw",
+        result: "error",
+        errorCode: "PROVIDER_REJECTED",
+      })
+    );
   });
 
   it("does not audit when every provider settles successfully", async () => {

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -42,6 +42,13 @@ vi.mock("../../../services/fileDecorationRegistry.js", () => ({
   getFileDecorationImpls: (...args: unknown[]) => mockGetFileDecorationImpls(...args),
 }));
 
+const mockAppendAuditRecord = vi.fn();
+vi.mock("../../../services/pluginAuditService.js", () => ({
+  pluginAuditService: {
+    appendRecord: (...args: unknown[]) => mockAppendAuditRecord(...args),
+  },
+}));
+
 const mockIpcMainHandle = vi.fn();
 const mockIpcMainRemoveHandler = vi.fn();
 vi.mock("electron", () => ({
@@ -224,6 +231,77 @@ describe("registerPluginHandlers", () => {
       "plugin:invoke rejected: untrusted sender"
     );
     expect(mockDispatchHandler).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INVOKE audits a successful dispatch", async () => {
+    mockDispatchHandler.mockResolvedValue({ data: "hello" });
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    await invokeHandler(
+      { senderFrame: { url: "app://daintree/" }, sender: { id: 42 } },
+      "acme.my-plugin",
+      "get-data",
+      "arg1"
+    );
+    expect(mockAppendAuditRecord).toHaveBeenCalledTimes(1);
+    expect(mockAppendAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginId: "acme.my-plugin",
+        channel: "get-data",
+        result: "success",
+        webContentsId: 42,
+      })
+    );
+    expect(mockAppendAuditRecord.mock.calls[0][0]).not.toHaveProperty("errorCode");
+  });
+
+  it("PLUGIN_INVOKE audits a thrown dispatch with DISPATCH_THREW and rethrows", async () => {
+    mockDispatchHandler.mockRejectedValue(new Error("boom"));
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    await expect(
+      invokeHandler({ senderFrame: { url: "app://daintree/" }, sender: { id: 5 } }, "x", "y")
+    ).rejects.toThrow("boom");
+    expect(mockAppendAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginId: "x",
+        channel: "y",
+        result: "error",
+        errorCode: "DISPATCH_THREW",
+        webContentsId: 5,
+      })
+    );
+  });
+
+  it("PLUGIN_INVOKE audits an untrusted sender with UNTRUSTED_SENDER", async () => {
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    await expect(
+      invokeHandler(
+        { senderFrame: { url: "https://evil.com/x.html" }, sender: { id: 8 } },
+        "acme.my-plugin",
+        "get-data"
+      )
+    ).rejects.toThrow("untrusted sender");
+    expect(mockDispatchHandler).not.toHaveBeenCalled();
+    expect(mockAppendAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginId: "acme.my-plugin",
+        channel: "get-data",
+        result: "rejected",
+        errorCode: "UNTRUSTED_SENDER",
+        webContentsId: 8,
+      })
+    );
   });
 });
 
@@ -681,6 +759,74 @@ describe("PLUGIN_FILE_DECORATIONS_GET handler", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("audits a rejecting provider with PROVIDER_REJECTED and not the healthy one", async () => {
+    mockGetFileDecorationImpls.mockReturnValue([
+      {
+        pluginId: "p.bad",
+        contributionId: "d",
+        impl: { provideDecorations: vi.fn().mockRejectedValue(new Error("boom")) },
+      },
+      {
+        pluginId: "p.good",
+        contributionId: "d",
+        impl: { provideDecorations: vi.fn().mockResolvedValue({ "a.ts": { badge: "3" } }) },
+      },
+    ]);
+    const handler = getHandler();
+    await handler({}, "worktree-diff:/r", ["a.ts"]);
+    expect(mockAppendAuditRecord).toHaveBeenCalledTimes(1);
+    expect(mockAppendAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginId: "p.bad",
+        channel: "plugin:file-decorations-get",
+        contributionId: "d",
+        scope: "worktree-diff:/r",
+        result: "error",
+        errorCode: "PROVIDER_REJECTED",
+      })
+    );
+  });
+
+  it("audits a timed-out provider with TIMEOUT", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetFileDecorationImpls.mockReturnValue([
+        {
+          pluginId: "p.hang",
+          contributionId: "d",
+          impl: { provideDecorations: vi.fn().mockReturnValue(new Promise(() => {})) },
+        },
+      ]);
+      const handler = getHandler();
+      const promise = handler({}, "s:1", ["a.ts"]) as Promise<unknown>;
+      await vi.advanceTimersByTimeAsync(3000);
+      await promise;
+      expect(mockAppendAuditRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pluginId: "p.hang",
+          channel: "plugin:file-decorations-get",
+          result: "error",
+          errorCode: "TIMEOUT",
+        })
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not audit when every provider settles successfully", async () => {
+    mockGetFileDecorationImpls.mockReturnValue([
+      {
+        pluginId: "p.good",
+        contributionId: "d",
+        impl: { provideDecorations: vi.fn().mockResolvedValue({ "a.ts": { badge: "1" } }) },
+      },
+    ]);
+    const handler = getHandler();
+    await handler({}, "s:1", ["a.ts"]);
+    expect(mockAppendAuditRecord).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -168,7 +168,11 @@ async function handleFileDecorationsGet(
   const results = await Promise.allSettled(
     impls.map(({ impl }) =>
       Promise.race([
-        impl.provideDecorations(scope, cleanPaths),
+        // `Promise.resolve().then(...)` so a provider that *throws synchronously*
+        // (rather than returning a rejected promise) becomes a rejection the
+        // settle loop can audit — a raw throw here would escape `allSettled`
+        // and reject the whole IPC call with zero audit records.
+        Promise.resolve().then(() => impl.provideDecorations(scope, cleanPaths)),
         new Promise<typeof DECORATION_TIMEOUT>((resolve) =>
           setTimeout(() => resolve(DECORATION_TIMEOUT), DECORATION_PROVIDER_TIMEOUT_MS)
         ),

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -30,7 +30,7 @@ import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRe
 import { assertIpcSecurityReady } from "../ipcGuard.js";
 import { pluginAuditService } from "../../services/pluginAuditService.js";
 import { summarizeMcpArgs } from "../../../shared/utils/mcpArgsSummary.js";
-import { scrubSecrets } from "../../utils/secretScrubber.js";
+import { scrubSecrets } from "../../../shared/utils/secretScrubber.js";
 import { sanitizePath } from "../../utils/pathScrubber.js";
 
 const scrubSummary = (s: string): string => scrubSecrets(sanitizePath(s));

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -28,6 +28,15 @@ import type {
 } from "../../../shared/types/plugin.js";
 import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRegistry.js";
 import { assertIpcSecurityReady } from "../ipcGuard.js";
+import { pluginAuditService } from "../../services/pluginAuditService.js";
+import { summarizeMcpArgs } from "../../../shared/utils/mcpArgsSummary.js";
+import { scrubSecrets } from "../../utils/secretScrubber.js";
+import { sanitizePath } from "../../utils/pathScrubber.js";
+
+const scrubSummary = (s: string): string => scrubSecrets(sanitizePath(s));
+
+/** Synthetic channel id used for file-decoration provider audit records. */
+const FILE_DECORATIONS_AUDIT_CHANNEL = "plugin:file-decorations-get";
 
 async function handleList(): Promise<LoadedPluginInfo[]> {
   return pluginService.listPlugins();
@@ -153,6 +162,9 @@ async function handleFileDecorationsGet(
   if (impls.length === 0) return {};
 
   const merged: Record<string, FileDecoration> = {};
+  // Capture a per-provider start so a rejection's audited duration reflects
+  // the time until it actually rejected; a timeout always lands at ~the budget.
+  const starts = impls.map(() => Date.now());
   const results = await Promise.allSettled(
     impls.map(({ impl }) =>
       Promise.race([
@@ -164,6 +176,7 @@ async function handleFileDecorationsGet(
     )
   );
 
+  const scrubbedScope = sanitizePath(scope);
   for (let i = 0; i < results.length; i++) {
     const r = results[i];
     const { pluginId, contributionId } = impls[i];
@@ -172,12 +185,34 @@ async function handleFileDecorationsGet(
         `[Plugin] fileDecorationProvider "${pluginId}.${contributionId}" failed for scope "${scope}":`,
         r.reason
       );
+      // Audit failures only — successful settles run at render-tree-change
+      // frequency and would bloat the ring buffer (#9240).
+      pluginAuditService.appendRecord({
+        pluginId,
+        channel: FILE_DECORATIONS_AUDIT_CHANNEL,
+        contributionId,
+        scope: scrubbedScope,
+        argsSummary: scrubbedScope,
+        result: "error",
+        errorCode: "PROVIDER_REJECTED",
+        durationMs: Date.now() - starts[i]!,
+      });
       continue;
     }
     if (r.value === DECORATION_TIMEOUT) {
       console.warn(
         `[Plugin] fileDecorationProvider "${pluginId}.${contributionId}" timed out after ${DECORATION_PROVIDER_TIMEOUT_MS}ms for scope "${scope}"`
       );
+      pluginAuditService.appendRecord({
+        pluginId,
+        channel: FILE_DECORATIONS_AUDIT_CHANNEL,
+        contributionId,
+        scope: scrubbedScope,
+        argsSummary: scrubbedScope,
+        result: "error",
+        errorCode: "TIMEOUT",
+        durationMs: Date.now() - starts[i]!,
+      });
       continue;
     }
     if (!r.value || typeof r.value !== "object") continue;
@@ -244,17 +279,52 @@ export function registerPluginHandlers(): () => void {
   ipcMain.handle(
     CHANNELS.PLUGIN_INVOKE,
     async (event, pluginId: string, channel: string, ...args: unknown[]) => {
+      const start = Date.now();
+      const webContentsId = event.sender.id;
+      const argsSummary = summarizeMcpArgs(args, scrubSummary);
       const senderUrl = event.senderFrame?.url;
       if (!senderUrl || !isTrustedRendererUrl(senderUrl)) {
+        // Security-relevant rejection — audit even though it throws (#9240).
+        pluginAuditService.appendRecord({
+          pluginId,
+          channel,
+          argsSummary,
+          result: "rejected",
+          errorCode: "UNTRUSTED_SENDER",
+          durationMs: Date.now() - start,
+          webContentsId,
+        });
         throw new Error(`plugin:invoke rejected: untrusted sender (url=${senderUrl ?? "unknown"})`);
       }
       const ctx: PluginIpcContext = {
         projectId: null,
         worktreeId: null,
-        webContentsId: event.sender.id,
+        webContentsId,
         pluginId,
       };
-      return await pluginService.dispatchHandler(pluginId, channel, ctx, args);
+      try {
+        const result = await pluginService.dispatchHandler(pluginId, channel, ctx, args);
+        pluginAuditService.appendRecord({
+          pluginId,
+          channel,
+          argsSummary,
+          result: "success",
+          durationMs: Date.now() - start,
+          webContentsId,
+        });
+        return result;
+      } catch (err) {
+        pluginAuditService.appendRecord({
+          pluginId,
+          channel,
+          argsSummary,
+          result: "error",
+          errorCode: "DISPATCH_THREW",
+          durationMs: Date.now() - start,
+          webContentsId,
+        });
+        throw err;
+      }
     }
   );
   cleanups.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_INVOKE));

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -204,6 +204,12 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
           import("../services/McpServerService.js")
             .then(({ mcpServerService }) => mcpServerService.stop())
             .catch(() => {}),
+          // Flush the plugin audit ring buffer's debounced (unref'd) timer so
+          // records written within the last 2s aren't lost on quit. Lazy-import
+          // guarded like MCP — the module only loads if plugin IPC ran.
+          import("../services/pluginAuditService.js")
+            .then(({ pluginAuditService }) => pluginAuditService.flushNow())
+            .catch(() => {}),
           // Revoke and remove any in-flight help-session dirs. Same lazy-import
           // guard as MCP — the module only loads if a help session was provisioned.
           import("../services/HelpSessionService.js")

--- a/electron/services/__tests__/pluginAuditService.test.ts
+++ b/electron/services/__tests__/pluginAuditService.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The module instantiates a `store`-backed singleton at import; stub the store
+// so importing the class doesn't pull in electron-store. The tests below
+// construct their own service instances with explicit config fixtures.
+vi.mock("../../store.js", () => ({
+  store: { get: vi.fn(() => ({})), set: vi.fn() },
+}));
+
+import { PluginAuditService } from "../pluginAuditService.js";
+import {
+  PLUGIN_AUDIT_DEFAULT_MAX_RECORDS,
+  PLUGIN_AUDIT_MIN_RECORDS,
+  PLUGIN_AUDIT_SCHEMA_VERSION,
+} from "../../../shared/types/ipc/plugin.js";
+
+function makeFixture(initialConfig: Record<string, unknown> = {}) {
+  const config: Record<string, unknown> = {
+    auditEnabled: true,
+    auditMaxRecords: 500,
+    ...initialConfig,
+  };
+  const saveConfig = vi.fn((patch: Record<string, unknown>) => {
+    Object.assign(config, patch);
+  });
+  const service = new PluginAuditService(saveConfig, () => config);
+  return { service, saveConfig, config };
+}
+
+const baseInput = {
+  pluginId: "acme.my-plugin",
+  channel: "get-data",
+  argsSummary: '["arg1"]',
+  durationMs: 12,
+} as const;
+
+describe("PluginAuditService.appendRecord", () => {
+  it("stamps source, schemaVersion, severity, and rounds duration", () => {
+    const { service } = makeFixture();
+    service.appendRecord({ ...baseInput, result: "success", durationMs: 12.7 });
+    const [record] = service.getRecords();
+    expect(record).toMatchObject({
+      source: "plugin",
+      pluginId: "acme.my-plugin",
+      channel: "get-data",
+      result: "success",
+      severity: "info",
+      schemaVersion: PLUGIN_AUDIT_SCHEMA_VERSION,
+      durationMs: 13,
+    });
+    expect(record!.id).toMatch(/[0-9a-f-]{36}/);
+  });
+
+  it("derives critical severity for a thrown dispatch", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      ...baseInput,
+      result: "error",
+      errorCode: "DISPATCH_THREW",
+      webContentsId: 9,
+    });
+    const [record] = service.getRecords();
+    expect(record).toMatchObject({
+      result: "error",
+      errorCode: "DISPATCH_THREW",
+      severity: "critical",
+      webContentsId: 9,
+    });
+  });
+
+  it("records contributionId and scope for decoration failures", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      pluginId: "acme.deco",
+      channel: "plugin:file-decorations-get",
+      contributionId: "diff",
+      scope: "worktree-diff:/r",
+      argsSummary: "worktree-diff:/r",
+      result: "error",
+      errorCode: "TIMEOUT",
+      durationMs: 3000,
+    });
+    const [record] = service.getRecords();
+    expect(record).toMatchObject({
+      contributionId: "diff",
+      scope: "worktree-diff:/r",
+      errorCode: "TIMEOUT",
+      severity: "warning",
+    });
+  });
+
+  it("omits optional fields when not provided", () => {
+    const { service } = makeFixture();
+    service.appendRecord({ ...baseInput, result: "success" });
+    const [record] = service.getRecords();
+    expect(record).not.toHaveProperty("errorCode");
+    expect(record).not.toHaveProperty("webContentsId");
+    expect(record).not.toHaveProperty("contributionId");
+    expect(record).not.toHaveProperty("scope");
+  });
+
+  it("skips writing when auditEnabled is false", () => {
+    const { service } = makeFixture({ auditEnabled: false });
+    service.appendRecord({ ...baseInput, result: "success" });
+    expect(service.getRecords()).toHaveLength(0);
+  });
+
+  it("trims the ring buffer to the configured cap", () => {
+    const { service } = makeFixture({ auditMaxRecords: PLUGIN_AUDIT_MIN_RECORDS });
+    for (let i = 0; i < PLUGIN_AUDIT_MIN_RECORDS + 10; i++) {
+      service.appendRecord({ ...baseInput, channel: `c${i}`, result: "success" });
+    }
+    const records = service.getRecords();
+    expect(records).toHaveLength(PLUGIN_AUDIT_MIN_RECORDS);
+    // Newest-first: the most recent channel survives, the oldest is evicted.
+    expect(records[0]!.channel).toBe(`c${PLUGIN_AUDIT_MIN_RECORDS + 9}`);
+    expect(records.some((r) => r.channel === "c0")).toBe(false);
+  });
+});
+
+describe("PluginAuditService hydration", () => {
+  it("backfills source/schemaVersion/severity on legacy records", () => {
+    const { service } = makeFixture({
+      auditLog: [{ id: "x", timestamp: 1, pluginId: "p", channel: "c", result: "error" }],
+    });
+    const [record] = service.getRecords();
+    expect(record).toMatchObject({
+      source: "plugin",
+      schemaVersion: PLUGIN_AUDIT_SCHEMA_VERSION,
+      severity: "error",
+    });
+  });
+
+  it("drops non-object persisted entries", () => {
+    const { service } = makeFixture({
+      auditLog: [null, 5, "bad", { id: "ok", result: "success" }],
+    });
+    expect(service.getRecords()).toHaveLength(1);
+  });
+});
+
+describe("PluginAuditService flushing", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("flushes the ring buffer to saveConfig after the debounce window", () => {
+    const { service, saveConfig } = makeFixture();
+    service.appendRecord({ ...baseInput, result: "success" });
+    expect(saveConfig).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2000);
+    expect(saveConfig).toHaveBeenCalledWith({ auditLog: expect.any(Array) });
+  });
+
+  it("flushNow writes immediately and cancels the pending timer", () => {
+    const { service, saveConfig } = makeFixture();
+    service.appendRecord({ ...baseInput, result: "success" });
+    service.flushNow();
+    expect(saveConfig).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(2000);
+    expect(saveConfig).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PluginAuditService config", () => {
+  it("normalizes max records and reports enabled state", () => {
+    const { service } = makeFixture({ auditMaxRecords: 1 });
+    expect(service.getAuditConfig()).toEqual({
+      enabled: true,
+      maxRecords: PLUGIN_AUDIT_MIN_RECORDS,
+    });
+  });
+
+  it("falls back to the default cap for a non-numeric value", () => {
+    const { service } = makeFixture({ auditMaxRecords: "nope" });
+    expect(service.getAuditConfig().maxRecords).toBe(PLUGIN_AUDIT_DEFAULT_MAX_RECORDS);
+  });
+});

--- a/electron/services/__tests__/pluginAuditService.test.ts
+++ b/electron/services/__tests__/pluginAuditService.test.ts
@@ -137,6 +137,14 @@ describe("PluginAuditService hydration", () => {
     });
     expect(service.getRecords()).toHaveLength(1);
   });
+
+  it("falls back to a valid severity when a persisted result is unrecognized", () => {
+    const { service } = makeFixture({
+      auditLog: [{ id: "x", timestamp: 1, pluginId: "p", channel: "c", result: "bogus" }],
+    });
+    const [record] = service.getRecords();
+    expect(record!.severity).toBe("info");
+  });
 });
 
 describe("PluginAuditService flushing", () => {

--- a/electron/services/pluginAuditService.ts
+++ b/electron/services/pluginAuditService.ts
@@ -54,12 +54,16 @@ export class PluginAuditService {
         ...r,
         source: "plugin",
         schemaVersion: (r.schemaVersion as number) ?? PLUGIN_AUDIT_SCHEMA_VERSION,
+        // Fall back to "info" so a persisted record with an unrecognized
+        // `result` (which `computePluginAuditSeverity` can't map) never
+        // surfaces an `undefined` severity through the typed `getRecords()`.
         severity:
           (r.severity as string) ??
           computePluginAuditSeverity(
             r.result as PluginAuditResult,
             r.errorCode as string | undefined
-          ),
+          ) ??
+          "info",
       } as PluginAuditRecord;
     });
     this.records = backfilled.length > cap ? backfilled.slice(backfilled.length - cap) : backfilled;

--- a/electron/services/pluginAuditService.ts
+++ b/electron/services/pluginAuditService.ts
@@ -1,0 +1,173 @@
+// eager-import-allow: reads/writes the plugin audit log via store.get synchronously
+import { randomUUID } from "node:crypto";
+import type {
+  PluginAuditErrorCode,
+  PluginAuditRecord,
+  PluginAuditResult,
+} from "../../shared/types/ipc/plugin.js";
+import {
+  PLUGIN_AUDIT_DEFAULT_MAX_RECORDS,
+  PLUGIN_AUDIT_MAX_RECORDS,
+  PLUGIN_AUDIT_MIN_RECORDS,
+  PLUGIN_AUDIT_SCHEMA_VERSION,
+  computePluginAuditSeverity,
+} from "../../shared/types/ipc/plugin.js";
+import { store } from "../store.js";
+
+/**
+ * Debounce window for batching ring-buffer writes to disk. Defined locally
+ * rather than imported from the MCP server's `shared.ts` so the plugin audit
+ * surface stays self-contained and free of any MCP-subsystem dependency.
+ */
+const PLUGIN_AUDIT_FLUSH_DEBOUNCE_MS = 2000;
+
+/**
+ * Config-backed ring buffer for plugin IPC audit records. Mirrors the MCP
+ * `AuditService` lifecycle — lazy hydration on first use, synchronous
+ * in-memory append, debounced disk flush — but is scoped to plugin
+ * invocations and carries no anomaly-detection or grant-lifecycle logic.
+ *
+ * Append is synchronous on purpose: `handleFileDecorationsGet` calls it from
+ * inside its settle loop, so a blocking disk write per provider failure would
+ * stall the loop. The actual persistence is deferred to a debounced timer.
+ */
+export class PluginAuditService {
+  private records: PluginAuditRecord[] = [];
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private hydrated = false;
+
+  constructor(
+    private readonly saveConfig: (patch: Record<string, unknown>) => void,
+    private readonly readConfig: () => Record<string, unknown>
+  ) {}
+
+  hydrate(): void {
+    if (this.hydrated) return;
+    const config = this.readConfig();
+    const persisted = Array.isArray(config.auditLog) ? config.auditLog : [];
+    const cap = this.normalizeMaxRecords(config.auditMaxRecords);
+    const safe = persisted.filter(
+      (r: unknown): r is Record<string, unknown> => r !== null && typeof r === "object"
+    );
+    const backfilled = safe.map((r: Record<string, unknown>) => {
+      return {
+        ...r,
+        source: "plugin",
+        schemaVersion: (r.schemaVersion as number) ?? PLUGIN_AUDIT_SCHEMA_VERSION,
+        severity:
+          (r.severity as string) ??
+          computePluginAuditSeverity(
+            r.result as PluginAuditResult,
+            r.errorCode as string | undefined
+          ),
+      } as PluginAuditRecord;
+    });
+    this.records = backfilled.length > cap ? backfilled.slice(backfilled.length - cap) : backfilled;
+    this.hydrated = true;
+  }
+
+  normalizeMaxRecords(value: unknown): number {
+    const n = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : NaN;
+    if (!Number.isFinite(n)) return PLUGIN_AUDIT_DEFAULT_MAX_RECORDS;
+    if (n < PLUGIN_AUDIT_MIN_RECORDS) return PLUGIN_AUDIT_MIN_RECORDS;
+    if (n > PLUGIN_AUDIT_MAX_RECORDS) return PLUGIN_AUDIT_MAX_RECORDS;
+    return n;
+  }
+
+  appendRecord(input: {
+    pluginId: string;
+    channel: string;
+    argsSummary: string;
+    result: PluginAuditResult;
+    durationMs: number;
+    errorCode?: PluginAuditErrorCode;
+    webContentsId?: number;
+    contributionId?: string;
+    scope?: string;
+  }): void {
+    if (this.readConfig().auditEnabled === false) return;
+    this.hydrate();
+
+    const record: PluginAuditRecord = {
+      id: randomUUID(),
+      timestamp: Date.now(),
+      source: "plugin",
+      pluginId: input.pluginId,
+      channel: input.channel,
+      argsSummary: input.argsSummary,
+      result: input.result,
+      durationMs: Math.max(0, Math.round(input.durationMs)),
+      schemaVersion: PLUGIN_AUDIT_SCHEMA_VERSION,
+      severity: computePluginAuditSeverity(input.result, input.errorCode),
+    };
+    if (input.errorCode !== undefined) record.errorCode = input.errorCode;
+    if (input.webContentsId !== undefined) record.webContentsId = input.webContentsId;
+    if (input.contributionId !== undefined) record.contributionId = input.contributionId;
+    if (input.scope !== undefined) record.scope = input.scope;
+
+    this.records.push(record);
+    const cap = this.normalizeMaxRecords(this.readConfig().auditMaxRecords);
+    if (this.records.length > cap) {
+      this.records.splice(0, this.records.length - cap);
+    }
+    this.scheduleFlush();
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) return;
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.flush();
+    }, PLUGIN_AUDIT_FLUSH_DEBOUNCE_MS);
+    this.flushTimer.unref?.();
+  }
+
+  private flush(): void {
+    if (!this.hydrated) return;
+    try {
+      this.saveConfig({ auditLog: [...this.records] });
+    } catch (err) {
+      console.error("[Plugin] Failed to flush audit log:", err);
+    }
+  }
+
+  flushNow(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    this.flush();
+  }
+
+  /** Newest-first view of the audit records. Renderer-facing. */
+  getRecords(): PluginAuditRecord[] {
+    this.hydrate();
+    return [...this.records].reverse();
+  }
+
+  getAuditConfig(): { enabled: boolean; maxRecords: number } {
+    const config = this.readConfig();
+    return {
+      enabled: config.auditEnabled !== false,
+      maxRecords: this.normalizeMaxRecords(config.auditMaxRecords),
+    };
+  }
+
+  clear(): void {
+    this.hydrate();
+    this.records = [];
+    this.flushNow();
+  }
+}
+
+export const pluginAuditService = new PluginAuditService(
+  (patch) => {
+    const current = store.get("plugins");
+    store.set("plugins", {
+      ...current,
+      ...patch,
+      auditLog: "auditLog" in patch ? (patch.auditLog as PluginAuditRecord[]) : current.auditLog,
+    });
+  },
+  () => store.get("plugins") as unknown as Record<string, unknown>
+);

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -14,6 +14,8 @@ import type { IssueAssociation } from "../shared/types/ipc/worktree.js";
 import type { ErrorRecord } from "../shared/types/ipc/errors.js";
 import type { AssistantTurnRecord, McpAuditRecord } from "../shared/types/ipc/mcpServer.js";
 import { MCP_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/mcpServer.js";
+import type { PluginAuditRecord } from "../shared/types/ipc/plugin.js";
+import { PLUGIN_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/plugin.js";
 import type { BuiltInAgentId } from "../shared/config/agentIds.js";
 import type { AgentId } from "../shared/types/agent.js";
 import { DEFAULT_AGENT_SETTINGS, DEFAULT_APP_AGENT_CONFIG } from "../shared/types/index.js";
@@ -306,6 +308,12 @@ export interface StoreSchema {
    */
   plugins: {
     disabledBuiltins: string[];
+    /** Kill switch for the plugin IPC audit ring buffer. */
+    auditEnabled: boolean;
+    /** Ring-buffer cap, clamped to [PLUGIN_AUDIT_MIN_RECORDS, PLUGIN_AUDIT_MAX_RECORDS]. */
+    auditMaxRecords: number;
+    /** Persisted audit records for the plugin host (`plugin:invoke` + file decorations). */
+    auditLog?: PluginAuditRecord[];
   };
   /**
    * Global default forge provider id for newly opened projects. `null` (or
@@ -476,6 +484,8 @@ const storeOptions = {
     logLevelOverrides: {},
     plugins: {
       disabledBuiltins: [],
+      auditEnabled: true,
+      auditMaxRecords: PLUGIN_AUDIT_DEFAULT_MAX_RECORDS,
     },
   },
   cwd: process.env.DAINTREE_USER_DATA,

--- a/shared/types/ipc/index.ts
+++ b/shared/types/ipc/index.ts
@@ -28,3 +28,4 @@ export * from "./webviewConsole.js";
 export * from "./demo.js";
 export * from "./telemetryPreview.js";
 export * from "./help.js";
+export * from "./plugin.js";

--- a/shared/types/ipc/plugin.ts
+++ b/shared/types/ipc/plugin.ts
@@ -1,0 +1,90 @@
+/**
+ * Audit records for the plugin IPC surface. Two host paths that previously
+ * failed silently now write here: the raw `plugin:invoke` `ipcMain.handle`
+ * (every outcome — success, untrusted-sender rejection, and dispatch throw)
+ * and per-provider failures in `plugin:file-decorations-get` (timeout and
+ * rejection only — successful settles run at render-tree-change frequency
+ * and are deliberately not recorded). Extends the audit-even-when-silenced
+ * doctrine from #8442 to the plugin host.
+ *
+ * The shape mirrors `McpAuditRecord` structurally but is scoped to plugin
+ * invocations rather than MCP tool dispatches. The `source: "plugin"`
+ * discriminator narrows cleanly when the broader host-audit union from #9239
+ * lands — records narrow on the field's presence, never on a sentinel value.
+ */
+
+export type PluginAuditResult = "success" | "error" | "rejected";
+
+export type PluginAuditSeverity = "info" | "warning" | "error" | "critical";
+
+/**
+ * Error codes for the audited failure paths. `UNTRUSTED_SENDER` and
+ * `DISPATCH_THREW` come from `plugin:invoke`; `TIMEOUT` and
+ * `PROVIDER_REJECTED` from a file-decoration provider.
+ */
+export type PluginAuditErrorCode =
+  | "UNTRUSTED_SENDER"
+  | "DISPATCH_THREW"
+  | "TIMEOUT"
+  | "PROVIDER_REJECTED";
+
+export const PLUGIN_AUDIT_SCHEMA_VERSION = 1;
+
+export const PLUGIN_AUDIT_DEFAULT_MAX_RECORDS = 200;
+export const PLUGIN_AUDIT_MIN_RECORDS = 50;
+export const PLUGIN_AUDIT_MAX_RECORDS = 10000;
+
+const SEVERITY_BY_RESULT: Record<PluginAuditResult, PluginAuditSeverity> = {
+  success: "info",
+  rejected: "error",
+  error: "error",
+};
+
+const SEVERITY_BY_ERROR_CODE: Partial<Record<PluginAuditErrorCode, PluginAuditSeverity>> = {
+  UNTRUSTED_SENDER: "error",
+  // A handler that threw is a plugin-author bug surfacing through the host.
+  DISPATCH_THREW: "critical",
+  TIMEOUT: "warning",
+  PROVIDER_REJECTED: "warning",
+};
+
+export function computePluginAuditSeverity(
+  result: PluginAuditResult,
+  errorCode?: string
+): PluginAuditSeverity {
+  if (errorCode !== undefined && errorCode in SEVERITY_BY_ERROR_CODE) {
+    return SEVERITY_BY_ERROR_CODE[errorCode as PluginAuditErrorCode]!;
+  }
+  return SEVERITY_BY_RESULT[result];
+}
+
+export interface PluginAuditRecord {
+  id: string;
+  timestamp: number;
+  /**
+   * Discriminator for the forward-compatible host-audit union (#9239).
+   * Always `"plugin"` for records written by this surface.
+   */
+  source: "plugin";
+  /** Plugin that owns the invoked channel or the failing decoration provider. */
+  pluginId: string;
+  /**
+   * IPC channel for `plugin:invoke` records; the synthetic
+   * `"plugin:file-decorations-get"` channel for decoration-provider failures.
+   */
+  channel: string;
+  /** Forge/decoration contribution id — set only on file-decoration records. */
+  contributionId?: string;
+  /** Scrubbed decoration scope — set only on file-decoration records. */
+  scope?: string;
+  /** Redacted, single-level summary of the call args (via `summarizeMcpArgs`). */
+  argsSummary: string;
+  result: PluginAuditResult;
+  errorCode?: PluginAuditErrorCode;
+  durationMs: number;
+  /** Originating renderer's webContents id — set only on `plugin:invoke` records. */
+  webContentsId?: number;
+  severity: PluginAuditSeverity;
+  /** Schema version for forward-compat. New records always carry the current version. */
+  schemaVersion: number;
+}

--- a/src/store/__tests__/persistenceBoundaryHardening.test.ts
+++ b/src/store/__tests__/persistenceBoundaryHardening.test.ts
@@ -70,9 +70,17 @@ function clearPerfMarks(): void {
   delete (window as Window & typeof globalThis).__DAINTREE_PERF_MARKS__;
 }
 
-afterEach(() => {
+afterEach(async () => {
   restoreLocalStorage();
   clearPerfMarks();
+  // safeStorage fires its permanent-fallback notification via a dynamic
+  // `import("@/lib/notify")`, which settles on a later microtask. Tests that
+  // trigger a permanent fallback without awaiting that dispatch can leak the
+  // pending `.then` into the next test, where it lands on a freshly-installed
+  // notify spy and inflates the count (flaky "got N times" under slow CI).
+  // Drain pending microtasks on a macrotask boundary before resetting modules
+  // so each test starts clean.
+  await new Promise((resolve) => setTimeout(resolve, 0));
   vi.resetModules();
   vi.restoreAllMocks();
 });


### PR DESCRIPTION
## Summary

- Adds audit records for two previously-silent plugin IPC failure paths, extending the audit-even-when-silenced doctrine to the plugin host
- `plugin:invoke` now audits all outcomes: success, `UNTRUSTED_SENDER` rejection, and `DISPATCH_THREW` — `plugin:file-decorations-get` audits only per-provider failures (`TIMEOUT`, `PROVIDER_REJECTED`), since successful settles run at render-tree-change frequency and would flood the log
- New `PluginAuditService` mirrors the MCP `AuditService` (config-backed ring buffer, lazy hydration, debounced flush) and reuses the existing scrub pipeline so raw args and paths are never persisted

Resolves #9240

## Changes

- `shared/types/ipc/plugin.ts` — new `PluginAuditRecord` type with a `source: 'plugin'` discriminator; forward-compatible with the host-audit union planned in #9239
- `electron/services/pluginAuditService.ts` — new service; backed by audit fields added to the existing `plugins` store key; flushed on app shutdown via `electron/lifecycle/shutdown.ts`
- `electron/ipc/handlers/plugin.ts` — `plugin:invoke` wired for all three outcomes; `plugin:file-decorations-get` wired for per-provider failures; `provideDecorations` wrapped so synchronous throws become auditable rejections instead of escaping `Promise.allSettled`

## Testing

- `electron/services/__tests__/pluginAuditService.test.ts` — 13 new tests covering ring-buffer eviction, scrubbing, flush debounce, and hydration
- `electron/ipc/handlers/__tests__/plugin.handlers.test.ts` — additions covering all three `plugin:invoke` outcomes and both `plugin:file-decorations-get` failure paths
- 59 tests pass