### PR TITLE
feat(mcp): show requesting-bearer identity in confirm dialog

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -17,6 +17,7 @@ import type { AppErrorCode } from "../shared/types/appError.js";
 import type {
   McpRuntimeSnapshot,
   McpGrantLifecyclePayload,
+  McpBearerIdentity,
 } from "../shared/types/ipc/mcpServer.js";
 import type { ActionContext } from "../shared/types/actions.js";
 import type { PushProgressEvent } from "../shared/types/ipc/gitPush.js";
@@ -2362,6 +2363,7 @@ const api: ElectronAPI = {
         args?: unknown;
         confirmed?: boolean;
         context?: ActionContext;
+        callerInfo?: McpBearerIdentity;
       }) => void
     ) => {
       const handler = (
@@ -2372,6 +2374,7 @@ const api: ElectronAPI = {
           args?: unknown;
           confirmed?: boolean;
           context?: ActionContext;
+          callerInfo?: McpBearerIdentity;
         }
       ) => callback(payload);
       ipcRenderer.on(CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST, handler);

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -186,8 +186,8 @@ export class McpServerService {
       turnOutcomeService: this.turnOutcomeService,
       abusePolicy,
       requestManifest: () => this.bridge.requestManifest(),
-      dispatchAction: (actionId, args, confirmed) =>
-        this.bridge.dispatchAction(actionId, args, confirmed),
+      dispatchAction: (actionId, args, confirmed, callerInfo) =>
+        this.bridge.dispatchAction(actionId, args, confirmed, callerInfo),
       requestManifestForWebContents: (id) => this.bridge.requestManifestForWebContents(id),
       dispatchActionForWebContents: (id, actionId, args, confirmed, contextOverride) =>
         this.bridge.dispatchActionForWebContents(id, actionId, args, confirmed, contextOverride),

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -913,7 +913,7 @@ describe("McpServerService", () => {
     await client.callTool({ name: "actions.list", arguments: {} });
 
     expect(dispatchMock).toHaveBeenCalledTimes(1);
-    const payload = dispatchMock.mock.calls[0]![0] as DispatchRequest;
+    const payload = (dispatchMock.mock.calls[0] as unknown as [DispatchRequest])[0];
     // External (api-key) dispatch carries display-only identity: the 4-char
     // token suffix and a non-empty user-agent. The raw key never crosses.
     expect(payload.callerInfo).toBeDefined();

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -180,6 +180,7 @@ type DispatchRequest = {
   actionId: string;
   args?: unknown;
   confirmed?: boolean;
+  callerInfo?: { token4LastChars: string; userAgent: string };
 };
 
 type TextToolResult = {
@@ -881,6 +882,44 @@ describe("McpServerService", () => {
         confirmed: false,
       })
     );
+  });
+
+  it("threads the external bearer's identity through to the renderer dispatch payload (#9157)", async () => {
+    // Regression guard: the production `dispatchAction` wrapper in
+    // McpServerService must forward the 4th `callerInfo` argument computed by
+    // HttpLifecycle — dropping it silently broke the "Requested by" row while
+    // every mocked unit test still passed.
+    const dispatchMock = vi.fn(
+      (): ActionDispatchResult => ({ ok: true, result: { listed: true } })
+    );
+
+    const { window } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "actions.list" as ActionId,
+          title: "List Actions",
+          description: "List available actions",
+          danger: "safe",
+        }),
+      ],
+      dispatchAction: dispatchMock,
+    });
+
+    await service.start(window);
+    const apiKey = service.getStatus().apiKey;
+    const { client, transport } = await connectClient(service.currentPort!);
+    transports.push(transport);
+
+    await client.callTool({ name: "actions.list", arguments: {} });
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    const payload = dispatchMock.mock.calls[0]![0] as DispatchRequest;
+    // External (api-key) dispatch carries display-only identity: the 4-char
+    // token suffix and a non-empty user-agent. The raw key never crosses.
+    expect(payload.callerInfo).toBeDefined();
+    expect(payload.callerInfo?.token4LastChars).toBe(apiKey.slice(-4));
+    expect(typeof payload.callerInfo?.userAgent).toBe("string");
+    expect(payload.callerInfo?.userAgent.length).toBeGreaterThan(0);
   });
 
   it("strips legacy `_meta.confirmed=true` from arguments instead of bypassing confirmation", async () => {

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -631,6 +631,84 @@ describe("HttpLifecycle", () => {
     });
   });
 
+  describe("getBearerInfoForSession (#9157)", () => {
+    const authExt = "Bearer ext-token-1234";
+
+    type BearerInfoHandle = BearerTestHandle & {
+      getBearerInfoForSession: (
+        sessionId: string
+      ) => { token4LastChars: string; userAgent: string } | null;
+    };
+
+    it("returns the display-only identity for an external bearer", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerInfoHandle;
+      handle.touchBearer(authExt, "Claude Code", "sess-ext", "external");
+
+      expect(handle.getBearerInfoForSession("sess-ext")).toEqual({
+        token4LastChars: "1234",
+        userAgent: "Claude Code",
+      });
+    });
+
+    it("returns null for help-session bearers — the assistant's own panel stays provenance-free", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerInfoHandle;
+      handle.touchBearer("Bearer help-token-9999", "Help/1", "sess-help", "action");
+
+      expect(handle.getBearerInfoForSession("sess-help")).toBeNull();
+    });
+
+    it("returns null for an unknown / detached session", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const handle = lc as unknown as BearerInfoHandle;
+      expect(handle.getBearerInfoForSession("ghost")).toBeNull();
+
+      handle.touchBearer(authExt, "Claude Code", "sess-ext", "external");
+      handle.detachBearerSession("sess-ext");
+      expect(handle.getBearerInfoForSession("sess-ext")).toBeNull();
+    });
+
+    it("threads callerInfo into the unpinned dispatch for external sessions", async () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+      const handle = lc as unknown as BearerTestHandle;
+      handle.touchBearer(authExt, "Claude Code", "sess-ext", "external");
+
+      const sessionDeps = (
+        lc as unknown as {
+          buildSessionServerDeps: (
+            sessionId: string
+          ) => import("../sessionServer.js").SessionServerDeps;
+        }
+      ).buildSessionServerDeps("sess-ext");
+
+      await sessionDeps.dispatchAction("terminal.kill", { id: "t-1" }, false);
+
+      expect(deps.dispatchAction).toHaveBeenCalledWith("terminal.kill", { id: "t-1" }, false, {
+        token4LastChars: "1234",
+        userAgent: "Claude Code",
+      });
+    });
+
+    it("passes callerInfo: undefined when the session has no tracked bearer", async () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+
+      const sessionDeps = (
+        lc as unknown as {
+          buildSessionServerDeps: (
+            sessionId: string
+          ) => import("../sessionServer.js").SessionServerDeps;
+        }
+      ).buildSessionServerDeps("sess-untracked");
+
+      await sessionDeps.dispatchAction("actions.list", {}, false);
+
+      expect(deps.dispatchAction).toHaveBeenCalledWith("actions.list", {}, false, undefined);
+    });
+  });
+
   describe("auth gate", () => {
     it("returns 401 with WWW-Authenticate: Bearer realm header", async () => {
       const deps = fakeDeps();

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -335,4 +335,32 @@ describe("rendererBridge — requesting-bearer identity passthrough (#9157)", ()
     expect(sentPayload).toBeDefined();
     expect(sentPayload?.callerInfo).toBeUndefined();
   });
+
+  it("the pinned dispatch path leaves callerInfo undefined (provenance-free)", async () => {
+    // Pinned (help-session) dispatch must stay provenance-free. Mirrors the
+    // `context: undefined` convention — the key is present but undefined, which
+    // structured clone strips at the IPC boundary so the renderer sees nothing.
+    const wc = makeWebContents(803);
+    mockWebContentsRegistry.set(803, wc);
+    const bridge = createRendererBridge(pendingManifests, pendingDispatches, () => null);
+    bridge.setupListeners([]);
+
+    let sentPayload: { requestId: string; callerInfo?: unknown } | undefined;
+    wc.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST) return;
+      sentPayload = payload as { requestId: string; callerInfo?: unknown };
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+          { sender: { id: 803 } },
+          { requestId: payload.requestId, result: { ok: true, result: "ok" } }
+        );
+      });
+    });
+
+    await bridge.dispatchActionForWebContents(803, "actions.list", {}, false);
+
+    expect(sentPayload).toBeDefined();
+    expect(sentPayload?.callerInfo).toBeUndefined();
+  });
 });

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -249,3 +249,90 @@ describe("rendererBridge — per-session pinned dispatch (#7002)", () => {
     await expect(promise).rejects.toThrow(/MCP renderer bridge destroyed/);
   });
 });
+
+describe("rendererBridge — requesting-bearer identity passthrough (#9157)", () => {
+  let pendingManifests: Map<string, PendingRequest<ActionManifestEntry[]>>;
+  let pendingDispatches: Map<string, PendingRequest<DispatchEnvelope>>;
+
+  beforeEach(() => {
+    mockIpcMain.removeAllListeners();
+    mockWebContentsRegistry.clear();
+    pendingManifests = new Map();
+    pendingDispatches = new Map();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Builds a bridge whose active-project resolver returns `wc`, exercising the
+   * unpinned `dispatchAction` path (external/api-key clients) — the only path
+   * that carries `callerInfo`.
+   */
+  function makeActiveBridge(wc: FakeWebContents) {
+    const registry = {
+      all: () => [
+        {
+          browserWindow: { isDestroyed: () => false },
+          services: {
+            projectViewManager: { getActiveView: () => ({ webContents: wc }) },
+          },
+        },
+      ],
+    };
+    const bridge = createRendererBridge(
+      pendingManifests,
+      pendingDispatches,
+      () => registry as never
+    );
+    bridge.setupListeners([]);
+    return bridge;
+  }
+
+  it("includes callerInfo in the unpinned dispatch IPC payload when provided", async () => {
+    const wc = makeWebContents(801);
+    const bridge = makeActiveBridge(wc);
+
+    let sentPayload: { requestId: string; callerInfo?: unknown } | undefined;
+    wc.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST) return;
+      sentPayload = payload as { requestId: string; callerInfo?: unknown };
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+          { sender: { id: 801 } },
+          { requestId: payload.requestId, result: { ok: true, result: "ok" } }
+        );
+      });
+    });
+
+    const callerInfo = { token4LastChars: "1234", userAgent: "Claude Code" };
+    await bridge.dispatchAction("terminal.kill", {}, false, callerInfo);
+
+    expect(sentPayload?.callerInfo).toEqual(callerInfo);
+  });
+
+  it("leaves callerInfo absent (undefined) when not provided", async () => {
+    const wc = makeWebContents(802);
+    const bridge = makeActiveBridge(wc);
+
+    let sentPayload: { requestId: string; callerInfo?: unknown } | undefined;
+    wc.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST) return;
+      sentPayload = payload as { requestId: string; callerInfo?: unknown };
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
+          { sender: { id: 802 } },
+          { requestId: payload.requestId, result: { ok: true, result: "ok" } }
+        );
+      });
+    });
+
+    await bridge.dispatchAction("actions.list", {}, false);
+
+    expect(sentPayload).toBeDefined();
+    expect(sentPayload?.callerInfo).toBeUndefined();
+  });
+});

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -21,6 +21,7 @@ import type {
 import type {
   ActiveBearerRecord,
   McpActiveClientInfo,
+  McpBearerIdentity,
   McpIssueGrantResult,
   McpRevokeSessionGrantsResult,
 } from "../../../shared/types/ipc/mcpServer.js";
@@ -57,7 +58,8 @@ export interface HttpLifecycleDeps {
   dispatchAction: (
     actionId: string,
     args: unknown,
-    confirmed?: boolean
+    confirmed?: boolean,
+    callerInfo?: McpBearerIdentity
   ) => Promise<import("./shared.js").DispatchEnvelope>;
   // Pinned variants used for help-session bearers — route to the renderer
   // WebContents that minted the bearer at provision time (#7002). Optional
@@ -327,6 +329,23 @@ export class HttpLifecycle {
     if (tokenHash === undefined) return;
     const entry = this.bearerRegister.get(tokenHash);
     if (entry) entry.lastActiveAt = Date.now();
+  }
+
+  /**
+   * Resolve the display-only bearer identity behind a session so the confirm
+   * dialog can show which external client is asking (#9157). Returns null for
+   * help-session bearers (`isHelpSession`) — the assistant's own pinned panel
+   * is its own context, so its dispatches stay provenance-free — and for any
+   * session not currently tracked (internal-tier / already detached). The
+   * lookup is O(1) over the two register Maps and runs at dispatch time, when
+   * the entry is guaranteed live (teardown only fires on transport close).
+   */
+  private getBearerInfoForSession(sessionId: string): McpBearerIdentity | null {
+    const tokenHash = this.sessionToTokenHash.get(sessionId);
+    if (tokenHash === undefined) return null;
+    const entry = this.bearerRegister.get(tokenHash);
+    if (!entry || entry.isHelpSession) return null;
+    return { token4LastChars: entry.token4LastChars, userAgent: entry.userAgent };
   }
 
   /**
@@ -1091,7 +1110,12 @@ export class HttpLifecycle {
         const boundContext = this.deps.sessionStore.sessionContextMap.get(sessionId);
         return pinnedDispatch(id, actionId, args, confirmed, boundContext);
       }
-      return this.deps.dispatchAction(actionId, args, confirmed);
+      // Unpinned external/api-key dispatch — surface the requesting bearer's
+      // identity so the confirm dialog can name the client (#9157). Returns
+      // null (→ undefined) for help-session bearers, so callerInfo never
+      // reaches the renderer for the assistant's own dispatches.
+      const callerInfo = this.getBearerInfoForSession(sessionId) ?? undefined;
+      return this.deps.dispatchAction(actionId, args, confirmed, callerInfo);
     };
 
     const getCachedManifest: import("./sessionServer.js").SessionServerDeps["getCachedManifest"] =

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import type { WindowRegistry } from "../../window/WindowRegistry.js";
 import { getProjectViewManager } from "../../window/windowRef.js";
 import type { ActionContext, ActionManifestEntry } from "../../../shared/types/actions.js";
+import type { McpBearerIdentity } from "../../../shared/types/ipc/mcpServer.js";
 import { CHANNELS } from "../../ipc/channels.js";
 import type { PendingRequest, DispatchEnvelope } from "./shared.js";
 import { MCP_MANIFEST_REQUEST_TIMEOUT_MS, MCP_DISPATCH_TIMEOUT_MS } from "./shared.js";
@@ -131,7 +132,8 @@ export function createRendererBridge(
     actionId: string,
     args: unknown,
     confirmed: boolean,
-    contextOverride?: ActionContext
+    contextOverride?: ActionContext,
+    callerInfo?: McpBearerIdentity
   ): Promise<DispatchEnvelope> {
     return new Promise((resolve, reject) => {
       let webContents: Electron.WebContents;
@@ -185,6 +187,10 @@ export function createRendererBridge(
           // unpinned external/api-key path leaves this undefined so the
           // renderer keeps its live focused-window context (#8317).
           context: contextOverride,
+          // Display-only requesting-bearer identity for the confirm dialog
+          // (#9157). Only the unpinned external path supplies it; absent for
+          // pinned help-session dispatch so the dialog stays provenance-free.
+          callerInfo,
         });
       } catch (err) {
         clearTimeout(timer);
@@ -207,9 +213,17 @@ export function createRendererBridge(
   function dispatchAction(
     actionId: string,
     args: unknown,
-    confirmed = false
+    confirmed = false,
+    callerInfo?: McpBearerIdentity
   ): Promise<DispatchEnvelope> {
-    return sendDispatchRequest(() => getActiveProjectWebContents(), actionId, args, confirmed);
+    return sendDispatchRequest(
+      () => getActiveProjectWebContents(),
+      actionId,
+      args,
+      confirmed,
+      undefined,
+      callerInfo
+    );
   }
 
   /**

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1417,6 +1417,13 @@ export interface ElectronAPI extends GeneratedElectronAPI {
          * external/api-key dispatch, which keeps live renderer context.
          */
         context?: ActionContext;
+        /**
+         * Display-only requesting-bearer identity for the confirm dialog
+         * (#9157). Present only for unpinned external/api-key dispatch;
+         * absent for pinned help-session dispatch so the dialog stays
+         * provenance-free.
+         */
+        callerInfo?: import("./mcpServer.js").McpBearerIdentity;
       }) => void
     ): () => void;
     /** Send action dispatch result to main process */

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -470,6 +470,19 @@ export interface ActiveBearerRecord {
 }
 
 /**
+ * Display-only provenance for the external bearer behind a `danger: "confirm"`
+ * dispatch, threaded into the MCP confirm dialog so the user can see which
+ * client is asking before approving (#9157). Carries only the non-sensitive
+ * fields — the 4-char token suffix and the client user-agent. Absent for
+ * pinned help-session dispatch (the assistant's own panel is the context), so
+ * the dialog stays provenance-free there.
+ */
+export interface McpBearerIdentity {
+  token4LastChars: string;
+  userAgent: string;
+}
+
+/**
  * Result of a renderer-driven `disconnectBearer` IPC. `disconnected` is true
  * when a matching bearer entry existed and its sessions were revoked — false
  * when the token hash was already absent (e.g. the client disconnected first).

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -22,6 +22,20 @@ const CONFIRMATION_TIMEOUT_MS = 28_000;
 const CONFIRM_COOLDOWN_MS = 1_200;
 
 /**
+ * Upper bound for the user-agent shown in the "Requested by" row. An external
+ * client controls its own `User-Agent` header (capped at Node's ~8 KB header
+ * limit, not at a sane length), so clamp the display value here so an oversized
+ * string can't push the Arguments block and confirm button below the fold.
+ */
+const MAX_USER_AGENT_DISPLAY = 120;
+
+function truncateUserAgent(userAgent: string): string {
+  return userAgent.length > MAX_USER_AGENT_DISPLAY
+    ? `${userAgent.slice(0, MAX_USER_AGENT_DISPLAY - 1)}…`
+    : userAgent;
+}
+
+/**
  * Singleton dialog driven by the MCP confirmation queue. Mounted once near
  * the top of `App.tsx`. Reads `current` from `useMcpConfirmStore` and
  * surfaces one `ConfirmDialog` at a time — concurrent agent calls queue
@@ -116,7 +130,7 @@ export function McpConfirmDialog() {
                 Requested by
               </div>
               <div className="text-xs text-daintree-text/80 break-words">
-                …{callerInfo.token4LastChars} · {callerInfo.userAgent}
+                …{callerInfo.token4LastChars} · {truncateUserAgent(callerInfo.userAgent)}
               </div>
             </div>
           )}

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -85,10 +85,15 @@ export function McpConfirmDialog() {
   }
 
   // Severity follows the action's registry classification, not the fact that
-  // an MCP client dispatched it. Provenance is already conveyed by the
-  // "Run '…'?" framing; only genuinely destructive dispatches earn red.
+  // an MCP client dispatched it; only genuinely destructive dispatches earn
+  // red. Provenance differs by dispatch origin: pinned help-session dispatch
+  // is the assistant's own panel, so `callerInfo` is absent and the dialog
+  // stays provenance-free. Unpinned external/api-key dispatch carries the
+  // requesting bearer's identity (#9157), surfaced in a "Requested by" row so
+  // the user can see which client is asking before approving.
   const isDestructive = current.danger === "confirm";
   const variant = isDestructive ? "destructive" : "default";
+  const callerInfo = current.callerInfo;
 
   return (
     <ErrorBoundary variant="component" componentName="McpConfirmDialog" resetKeys={[resetKey]}>
@@ -104,11 +109,23 @@ export function McpConfirmDialog() {
         confirmCooldownMs={isDestructive ? CONFIRM_COOLDOWN_MS : undefined}
         cooldownKey={current.requestId}
       >
-        <div className="space-y-2">
-          <div className="text-xs text-daintree-text/60 uppercase tracking-wide">Arguments</div>
-          <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">
-            {current.argsSummary || "(none)"}
-          </pre>
+        <div className="space-y-3">
+          {callerInfo && (
+            <div className="space-y-2">
+              <div className="text-xs text-daintree-text/60 uppercase tracking-wide">
+                Requested by
+              </div>
+              <div className="text-xs text-daintree-text/80 break-words">
+                …{callerInfo.token4LastChars} · {callerInfo.userAgent}
+              </div>
+            </div>
+          )}
+          <div className="space-y-2">
+            <div className="text-xs text-daintree-text/60 uppercase tracking-wide">Arguments</div>
+            <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">
+              {current.argsSummary || "(none)"}
+            </pre>
+          </div>
         </div>
       </ConfirmDialog>
     </ErrorBoundary>

--- a/src/components/__tests__/McpConfirmDialog.test.tsx
+++ b/src/components/__tests__/McpConfirmDialog.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { McpConfirmDialog } from "../McpConfirmDialog";
 import { __resetMcpConfirmStoreForTesting, requestMcpConfirmation } from "@/store/mcpConfirmStore";
 import type { ActionDanger } from "@shared/types/actions";
+import type { McpBearerIdentity } from "@shared/types/ipc/mcpServer";
 
 vi.mock("zustand/react/shallow", () => ({
   useShallow: (fn: unknown) => fn,
@@ -35,7 +36,12 @@ vi.stubGlobal(
 );
 
 function enqueue(
-  overrides: { requestId?: string; actionTitle?: string; danger?: ActionDanger } = {}
+  overrides: {
+    requestId?: string;
+    actionTitle?: string;
+    danger?: ActionDanger;
+    callerInfo?: McpBearerIdentity;
+  } = {}
 ) {
   return requestMcpConfirmation({
     requestId: overrides.requestId ?? "req-1",
@@ -44,6 +50,7 @@ function enqueue(
     actionDescription: "Permanently delete a worktree.",
     argsSummary: '{"worktreeId":"wt-1"}',
     danger: overrides.danger ?? "confirm",
+    callerInfo: overrides.callerInfo,
   });
 }
 
@@ -83,6 +90,24 @@ describe("McpConfirmDialog", () => {
 
     expect(screen.getByRole("button", { name: "Delete worktree" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /^run action$/i })).toBeNull();
+  });
+
+  it("shows the requesting-bearer identity for external dispatches (#9157)", () => {
+    void enqueue({
+      actionTitle: "Delete worktree",
+      callerInfo: { token4LastChars: "1234", userAgent: "Claude Code" },
+    });
+    render(<McpConfirmDialog />);
+
+    expect(screen.getByText("Requested by")).toBeTruthy();
+    expect(screen.getByText(/…1234 · Claude Code/)).toBeTruthy();
+  });
+
+  it("omits the requesting-bearer row when callerInfo is absent (pinned help-session)", () => {
+    void enqueue({ actionTitle: "Delete worktree" });
+    render(<McpConfirmDialog />);
+
+    expect(screen.queryByText("Requested by")).toBeNull();
   });
 
   it("renders destructive styling only for danger:confirm dispatches", () => {

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -60,6 +60,7 @@ describe("useMcpBridge", () => {
         args?: unknown;
         confirmed?: boolean;
         context?: Record<string, unknown>;
+        callerInfo?: { token4LastChars: string; userAgent: string };
       }) => void | Promise<void>)
     | undefined;
   let cleanupManifest: ReturnType<typeof vi.fn>;
@@ -96,6 +97,7 @@ describe("useMcpBridge", () => {
               args?: unknown;
               confirmed?: boolean;
               context?: Record<string, unknown>;
+              callerInfo?: { token4LastChars: string; userAgent: string };
             }) => void | Promise<void>
           ) => {
             dispatchHandler = callback;
@@ -251,6 +253,46 @@ describe("useMcpBridge", () => {
       result: { ok: true, result: { ok: true } },
       confirmationDecision: "approved",
     });
+  });
+
+  it("forwards the requesting-bearer identity into the confirm store (#9157)", async () => {
+    mocks.get.mockReturnValue(confirmManifestEntry());
+    mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+
+    renderHook(() => useMcpBridge());
+
+    const callerInfo = { token4LastChars: "1234", userAgent: "Claude Code" };
+    const dispatched = dispatchHandler?.({
+      requestId: "req-caller",
+      actionId: "worktree.delete",
+      args: { worktreeId: "wt-1" },
+      callerInfo,
+    });
+
+    await Promise.resolve();
+    expect(useMcpConfirmStore.getState().current?.callerInfo).toEqual(callerInfo);
+
+    useMcpConfirmStore.getState().resolveCurrent("approved");
+    await dispatched;
+  });
+
+  it("leaves callerInfo undefined in the store for pinned help-session dispatch (#9157)", async () => {
+    mocks.get.mockReturnValue(confirmManifestEntry());
+    mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+
+    renderHook(() => useMcpBridge());
+
+    const dispatched = dispatchHandler?.({
+      requestId: "req-no-caller",
+      actionId: "worktree.delete",
+      args: { worktreeId: "wt-1" },
+    });
+
+    await Promise.resolve();
+    expect(useMcpConfirmStore.getState().current?.callerInfo).toBeUndefined();
+
+    useMcpConfirmStore.getState().resolveCurrent("approved");
+    await dispatched;
   });
 
   it("preserves the bound context across the confirmation wait (#8317)", async () => {

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -87,7 +87,7 @@ export function useMcpBridge(): void {
     });
 
     const cleanupDispatch = window.electron.mcpBridge.onDispatchActionRequest(
-      async ({ requestId, actionId, args, confirmed, context }) => {
+      async ({ requestId, actionId, args, confirmed, context, callerInfo }) => {
         let confirmationDecision: McpConfirmationDecision | undefined;
         try {
           let effectiveConfirmed = confirmed;
@@ -105,6 +105,10 @@ export function useMcpBridge(): void {
                   actionDescription: definition.description,
                   argsSummary: summarizeMcpArgs(args),
                   danger: definition.danger,
+                  // Display-only requesting-bearer identity (#9157). Present
+                  // only for unpinned external dispatch; the dialog renders a
+                  // "Requested by" row when set, stays provenance-free when not.
+                  callerInfo,
                 });
               } finally {
                 inFlightConfirms.delete(requestId);

--- a/src/store/mcpConfirmStore.ts
+++ b/src/store/mcpConfirmStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { ActionDanger } from "@shared/types/actions";
-import type { McpConfirmationDecision } from "@shared/types/ipc/mcpServer";
+import type { McpBearerIdentity, McpConfirmationDecision } from "@shared/types/ipc/mcpServer";
 
 /**
  * One pending confirmation surfaced for a `danger: "confirm"` MCP dispatch.
@@ -19,6 +19,13 @@ export interface PendingMcpConfirm {
    * (red) styling; read-only/safe dispatches must not borrow that weight.
    */
   danger: ActionDanger;
+  /**
+   * Display-only identity of the external client behind this dispatch (#9157).
+   * Present only for unpinned external/api-key dispatch; absent for pinned
+   * help-session dispatch (the assistant's own panel is its own context), so
+   * the dialog shows a "Requested by" row only for genuine external clients.
+   */
+  callerInfo?: McpBearerIdentity;
   enqueuedAt: number;
 }
 


### PR DESCRIPTION
## Summary

- When an external API client dispatches a `danger:"confirm"` action, the MCP confirmation dialog now shows which client is requesting approval: last 4 chars of the token plus the user-agent string.
- Pinned help-session dispatches (the assistant's own panel) show nothing — `isHelpSession` gates the lookup at the source.
- Only `token4LastChars` and `userAgent` cross IPC; the raw token never leaves the main process.

Resolves #9157

## Changes

- `httpLifecycle.ts` — added `getBearerInfoForSession()` to extract bearer identity from the active session
- `McpBearerIdentity` shared type added to `shared/types/ipc/mcpServer.ts`
- `callerInfo` threaded through the full dispatch stack: `HttpLifecycleDeps`, `rendererBridge` (`sendDispatchRequest` + `dispatchAction`), `McpServerService` wrapper, preload `mcpBridge` binding, shared `api` type, `PendingMcpConfirm`, `useMcpBridge`, and `McpConfirmDialog`
- `McpConfirmDialog` renders a "Requested by" row when `callerInfo` is present; user-agent capped at 120 chars

## Testing

218 tests pass across 5 files:

- `getBearerInfoForSession` unit tests including the `isHelpSession` gate
- IPC passthrough for present, absent, and pinned cases
- `useMcpBridge` hook forwarding
- `McpConfirmDialog` display
- End-to-end `McpServerService` regression test — this one actually caught a production wrapper that was silently dropping `callerInfo`