### PR TITLE
fix(notifications): tighten GridNotificationBar live-region a11y and motion parity

### DIFF
--- a/src/components/Terminal/GridNotificationBar.tsx
+++ b/src/components/Terminal/GridNotificationBar.tsx
@@ -2,7 +2,11 @@ import React, { useEffect, useRef, useState } from "react";
 import { AlertTriangle, CheckCircle2, Info, XCircle } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
-import { BANNER_ENTER_DURATION, BANNER_EXIT_DURATION } from "@/lib/animationUtils";
+import {
+  BANNER_ENTER_DURATION,
+  BANNER_EXIT_DURATION,
+  LIVE_REGION_SWAP_DELAY,
+} from "@/lib/animationUtils";
 import { useNotificationStore, type Notification } from "@/store/notificationStore";
 
 const STATUS_CONFIG = {
@@ -61,51 +65,105 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
   );
   const removeNotification = useNotificationStore((state) => state.removeNotification);
 
+  // Mirrors InlineStatusBanner.tsx — synchronous read at render time is the
+  // codebase precedent for non-SSR Electron consumers. Three signals collapse
+  // to one: the OS-level media query, plus two app-set body attributes that
+  // override it (settings → reduced-animations, perf governor → performance-mode).
+  const prefersReducedMotion =
+    typeof window !== "undefined" &&
+    (window.matchMedia("(prefers-reduced-motion: reduce)").matches ||
+      (typeof document !== "undefined" &&
+        (document.body.getAttribute("data-reduce-animations") === "true" ||
+          document.body.getAttribute("data-performance-mode") === "true")));
+
   // displayedNotification lags `notification` so the bar can keep rendering
-  // through the exit animation after the store entry is already gone.
+  // through the exit animation after the store entry is already gone, and so
+  // the live region can be cleared mid-swap without unmounting.
+  const initialNotification = notification ?? null;
   const [displayedNotification, setDisplayedNotification] = useState<Notification | null>(
-    notification ?? null
+    initialNotification
   );
-  const [isVisible, setIsVisible] = useState(false);
+  const [isVisible, setIsVisible] = useState(prefersReducedMotion && initialNotification !== null);
   const exitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const entryFrameRef = useRef<number | null>(null);
+  const swapTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (notification) {
-      // New or replacing notification: cancel any in-flight exit, swap content
-      // synchronously, and start fresh entry on the next frame so the browser
-      // sees the h-0/opacity-0 state before transitioning.
-      if (exitTimeoutRef.current !== null) {
-        clearTimeout(exitTimeoutRef.current);
-        exitTimeoutRef.current = null;
-      }
-      setDisplayedNotification(notification);
-
+    if (!notification) {
+      // Notification cleared: cancel any in-flight entry rAF or swap timer
+      // (either would otherwise re-open the bar mid-collapse), collapse, then
+      // unmount content after the exit window.
       if (entryFrameRef.current !== null) {
         cancelAnimationFrame(entryFrameRef.current);
-      }
-      entryFrameRef.current = requestAnimationFrame(() => {
         entryFrameRef.current = null;
-        setIsVisible(true);
-      });
+      }
+      if (swapTimeoutRef.current !== null) {
+        clearTimeout(swapTimeoutRef.current);
+        swapTimeoutRef.current = null;
+      }
+      setIsVisible(false);
+      if (exitTimeoutRef.current !== null) clearTimeout(exitTimeoutRef.current);
+      exitTimeoutRef.current = setTimeout(() => {
+        exitTimeoutRef.current = null;
+        setDisplayedNotification(null);
+      }, BANNER_EXIT_DURATION);
       return;
     }
 
-    // Notification cleared: cancel any in-flight entry rAF (would otherwise
-    // re-open the bar mid-collapse), then collapse and unmount content after
-    // the exit window. Guard against re-entry by clearing the timer in cleanup.
+    // Notification present — cancel any in-flight exit so we don't tear down.
+    if (exitTimeoutRef.current !== null) {
+      clearTimeout(exitTimeoutRef.current);
+      exitTimeoutRef.current = null;
+    }
+
+    // Replacement detection: there is (or was) live-region content that needs
+    // to be flushed before the new notification is announced. Covers two cases:
+    //   - displayed is non-null with a different id (active swap)
+    //   - a swap is already in flight (live region cleared, target pending)
+    //     and a third notification arrives — retarget the pending swap.
+    const isReplacement =
+      (displayedNotification !== null && displayedNotification.id !== notification.id) ||
+      swapTimeoutRef.current !== null;
+
+    if (isReplacement) {
+      // VoiceOver buffer flush: clear the live region first, wait ~150ms, then
+      // re-populate so AT picks up the change as a fresh announcement. The
+      // delay is a screen-reader concern, NOT motion — do not gate it on
+      // prefers-reduced-motion.
+      if (entryFrameRef.current !== null) {
+        cancelAnimationFrame(entryFrameRef.current);
+        entryFrameRef.current = null;
+      }
+      if (swapTimeoutRef.current !== null) {
+        clearTimeout(swapTimeoutRef.current);
+      }
+      setDisplayedNotification(null);
+      // Ensure the bar stays open during the swap gap (e.g. if a swap arrives
+      // mid-exit). Idempotent when already true.
+      setIsVisible(true);
+      swapTimeoutRef.current = setTimeout(() => {
+        swapTimeoutRef.current = null;
+        setDisplayedNotification(notification);
+      }, LIVE_REGION_SWAP_DELAY);
+      return;
+    }
+
+    // First entry from an empty live region: set content and animate in on the
+    // next frame so the browser sees the h-0/opacity-0 state before transitioning.
+    // Skip the rAF under reduced motion — the transition is zeroed out anyway.
+    setDisplayedNotification(notification);
     if (entryFrameRef.current !== null) {
       cancelAnimationFrame(entryFrameRef.current);
       entryFrameRef.current = null;
     }
-    setIsVisible(false);
-    if (exitTimeoutRef.current !== null) {
-      clearTimeout(exitTimeoutRef.current);
+    if (prefersReducedMotion) {
+      setIsVisible(true);
+    } else {
+      entryFrameRef.current = requestAnimationFrame(() => {
+        entryFrameRef.current = null;
+        setIsVisible(true);
+      });
     }
-    exitTimeoutRef.current = setTimeout(() => {
-      exitTimeoutRef.current = null;
-      setDisplayedNotification(null);
-    }, BANNER_EXIT_DURATION);
   }, [notification?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
@@ -118,16 +176,16 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
         cancelAnimationFrame(entryFrameRef.current);
         entryFrameRef.current = null;
       }
+      if (swapTimeoutRef.current !== null) {
+        clearTimeout(swapTimeoutRef.current);
+        swapTimeoutRef.current = null;
+      }
     };
   }, []);
 
-  if (!displayedNotification) {
-    return null;
-  }
-
-  const config = STATUS_CONFIG[displayedNotification.type];
-  const Icon = config.icon;
-  const actions = getActions(displayedNotification);
+  const config = displayedNotification ? STATUS_CONFIG[displayedNotification.type] : null;
+  const Icon = config?.icon;
+  const actions = displayedNotification ? getActions(displayedNotification) : [];
 
   // While not visible (entry pre-rAF or mid-exit), the bar is visually
   // collapsed but still in the DOM. Keep the wrapper out of the accessibility
@@ -145,37 +203,51 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
           : "h-0 opacity-0 ease-[var(--ease-exit)]"
       )}
       style={{
-        transitionDuration: `${isVisible ? BANNER_ENTER_DURATION : BANNER_EXIT_DURATION}ms`,
+        transitionDuration: prefersReducedMotion
+          ? "0ms"
+          : `${isVisible ? BANNER_ENTER_DURATION : BANNER_EXIT_DURATION}ms`,
       }}
-      role="status"
-      aria-live="polite"
     >
       <div
         className={cn(
           "flex items-center gap-3 rounded-[var(--radius-sm)] border px-3 py-2.5 shadow-[var(--theme-shadow-ambient)]",
-          config.containerClass,
+          config?.containerClass,
           className
         )}
       >
-        <Icon className={cn("h-4 w-4 shrink-0", config.iconClass)} aria-hidden="true" />
-
-        <div className="min-w-0 flex-1">
-          {displayedNotification.title && (
-            <p
-              className={cn(
-                "text-xs font-mono uppercase tracking-wide leading-tight",
-                config.titleClass
-              )}
-            >
-              {displayedNotification.title}
-            </p>
+        {/* Live region: text content only. APG anti-pattern to nest action
+         *  buttons here — they render as siblings below. Always mounted (even
+         *  when empty) so AT registers the region on page load rather than
+         *  ignoring a late-mounted live region. */}
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="flex min-w-0 flex-1 items-center gap-3"
+        >
+          {displayedNotification && Icon && config && (
+            <>
+              <Icon className={cn("h-4 w-4 shrink-0", config.iconClass)} aria-hidden="true" />
+              <div className="min-w-0 flex-1">
+                {displayedNotification.title && (
+                  <p
+                    className={cn(
+                      "text-xs font-mono uppercase tracking-wide leading-tight",
+                      config.titleClass
+                    )}
+                  >
+                    {displayedNotification.title}
+                  </p>
+                )}
+                <div className="text-xs leading-snug text-daintree-text/90">
+                  {displayedNotification.message}
+                </div>
+              </div>
+            </>
           )}
-          <div className="text-xs leading-snug text-daintree-text/90">
-            {displayedNotification.message}
-          </div>
         </div>
 
-        {actions.length > 0 && (
+        {displayedNotification && actions.length > 0 && (
           <div className="flex shrink-0 items-center gap-1.5">
             {actions.map((action, index) => (
               <button
@@ -200,7 +272,7 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
           </div>
         )}
 
-        {actions.length === 0 && (
+        {displayedNotification && actions.length === 0 && (
           <button
             type="button"
             onClick={() => removeNotification(displayedNotification.id)}

--- a/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
+++ b/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
@@ -261,8 +261,8 @@ describe("GridNotificationBar animation", () => {
     // But the button still exists in the bar as a sibling.
     const allButtons = container.querySelectorAll("button");
     expect(allButtons).toHaveLength(1);
-    expect(allButtons[0].textContent).toBe("Confirm");
-    expect(live!.contains(allButtons[0])).toBe(false);
+    expect(allButtons[0]?.textContent).toBe("Confirm");
+    expect(live!.contains(allButtons[0]!)).toBe(false);
   });
 
   it("renders the dismiss button as a sibling of the live region", () => {

--- a/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
+++ b/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
@@ -1,8 +1,12 @@
 // @vitest-environment jsdom
-import { render, act } from "@testing-library/react";
+import { render, act, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useNotificationStore } from "@/store/notificationStore";
-import { BANNER_ENTER_DURATION, BANNER_EXIT_DURATION } from "@/lib/animationUtils";
+import {
+  BANNER_ENTER_DURATION,
+  BANNER_EXIT_DURATION,
+  LIVE_REGION_SWAP_DELAY,
+} from "@/lib/animationUtils";
 import { GridNotificationBar } from "../GridNotificationBar";
 
 vi.stubGlobal("requestAnimationFrame", ((cb: FrameRequestCallback): number => {
@@ -12,6 +16,22 @@ vi.stubGlobal("requestAnimationFrame", ((cb: FrameRequestCallback): number => {
 vi.stubGlobal("cancelAnimationFrame", (id: number) =>
   clearTimeout(id as unknown as NodeJS.Timeout)
 );
+
+function stubMatchMedia(reducedMotion: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes("prefers-reduced-motion") ? reducedMotion : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  );
+}
 
 function addGridBar(overrides: Record<string, unknown> = {}): string {
   return useNotificationStore.getState().addNotification({
@@ -28,9 +48,14 @@ function getWrapper(container: HTMLElement): HTMLElement | null {
   return container.querySelector(".grid-notification-wrapper");
 }
 
+function getLiveRegion(container: HTMLElement): HTMLElement | null {
+  return container.querySelector('[role="status"]');
+}
+
 describe("GridNotificationBar animation", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    stubMatchMedia(false);
     useNotificationStore.getState().reset();
   });
 
@@ -39,9 +64,21 @@ describe("GridNotificationBar animation", () => {
     vi.useRealTimers();
   });
 
-  it("renders nothing when no grid-bar notification is present", () => {
+  it("keeps the live region mounted when no grid-bar notification is present", () => {
     const { container } = render(<GridNotificationBar />);
-    expect(container.firstChild).toBeNull();
+
+    const wrapper = getWrapper(container);
+    expect(wrapper).not.toBeNull();
+    // Outer wrapper exists but is collapsed.
+    expect(wrapper?.className).toContain("h-0");
+    expect(wrapper?.className).toContain("opacity-0");
+
+    // Live region is always mounted with aria-atomic so AT registers it on load.
+    const live = getLiveRegion(container);
+    expect(live).not.toBeNull();
+    expect(live?.getAttribute("aria-live")).toBe("polite");
+    expect(live?.getAttribute("aria-atomic")).toBe("true");
+    expect(live?.textContent).toBe("");
   });
 
   it("starts collapsed and animates open after one rAF tick", () => {
@@ -77,7 +114,7 @@ describe("GridNotificationBar animation", () => {
     expect(wrapperEl.className).toContain("ease-[var(--ease-snappy)]");
   });
 
-  it("collapses and unmounts content after the exit window", () => {
+  it("collapses and clears content after the exit window", () => {
     addGridBar({ message: "Goodbye" });
     const { container } = render(<GridNotificationBar />);
     act(() => {
@@ -85,12 +122,13 @@ describe("GridNotificationBar animation", () => {
     });
 
     expect(getWrapper(container)?.className).toContain("h-auto");
+    expect(getLiveRegion(container)?.textContent).toContain("Goodbye");
 
     act(() => {
       useNotificationStore.getState().reset();
     });
 
-    // Mid-exit: still mounted, collapsed, exit easing applied.
+    // Mid-exit: still mounted, collapsed, exit easing applied, content still visible.
     const exiting = getWrapper(container);
     expect(exiting).not.toBeNull();
     const exitingEl = exiting!;
@@ -99,16 +137,20 @@ describe("GridNotificationBar animation", () => {
     expect(exitingEl.className).toContain("ease-[var(--ease-exit)]");
     expect(exitingEl.style.transitionDuration).toBe(`${BANNER_EXIT_DURATION}ms`);
 
-    // After exit window: fully unmounted.
+    // After exit window: wrapper still mounted (always-mounted live region),
+    // but live region content is cleared.
     act(() => {
       vi.advanceTimersByTime(BANNER_EXIT_DURATION);
     });
-    expect(container.firstChild).toBeNull();
+    const settled = getWrapper(container);
+    expect(settled).not.toBeNull();
+    expect(settled?.className).toContain("h-0");
+    expect(getLiveRegion(container)?.textContent).toBe("");
   });
 
-  it("interrupts a pending exit when a replacement notification arrives", () => {
+  it("interrupts a pending exit and applies the swap delay when a replacement arrives", () => {
     addGridBar({ message: "First" });
-    const { container, getByText } = render(<GridNotificationBar />);
+    const { container, getByText, queryByText } = render(<GridNotificationBar />);
     act(() => {
       vi.advanceTimersByTime(16);
     });
@@ -124,21 +166,28 @@ describe("GridNotificationBar animation", () => {
     act(() => {
       addGridBar({ message: "Second" });
     });
+    // Effect runs (synchronous setState batch); swap timer scheduled.
     act(() => {
       vi.advanceTimersByTime(16);
     });
 
-    // Advance past the *original* exit timer's deadline. If it weren't
-    // cancelled, displayedNotification would be cleared and Second would
-    // disappear from the DOM.
+    // Mid-swap: live region cleared, "Second" not yet rendered.
+    expect(queryByText("Second")).toBeNull();
+    expect(queryByText("First")).toBeNull();
+    expect(getLiveRegion(container)?.textContent).toBe("");
+
+    // After the swap delay, "Second" appears.
+    act(() => {
+      vi.advanceTimersByTime(LIVE_REGION_SWAP_DELAY);
+    });
+    expect(getByText("Second")).toBeTruthy();
+
+    // Original exit timer's deadline passes; "Second" stays (exit was cancelled).
     act(() => {
       vi.advanceTimersByTime(BANNER_EXIT_DURATION);
     });
-
-    const wrapper = getWrapper(container);
-    expect(wrapper).not.toBeNull();
     expect(getByText("Second")).toBeTruthy();
-    expect(wrapper?.className).toContain("h-auto");
+    expect(getWrapper(container)?.className).toContain("h-auto");
   });
 
   it("cancels a pending entry rAF when the notification is removed pre-rAF", () => {
@@ -164,14 +213,15 @@ describe("GridNotificationBar animation", () => {
     expect(wrapper?.className).toContain("h-0");
     expect(wrapper?.className).not.toContain("h-auto");
 
-    // Exit window completes, content unmounts.
+    // Exit window completes, content cleared but wrapper persists.
     act(() => {
       vi.advanceTimersByTime(BANNER_EXIT_DURATION);
     });
-    expect(container.firstChild).toBeNull();
+    expect(getWrapper(container)).not.toBeNull();
+    expect(getLiveRegion(container)?.textContent).toBe("");
   });
 
-  it("renders aria-live status region on the wrapper for screen readers", () => {
+  it("scopes role=status, aria-live, and aria-atomic to the inner live region only", () => {
     addGridBar({ message: "Announce me" });
     const { container } = render(<GridNotificationBar />);
     act(() => {
@@ -179,10 +229,54 @@ describe("GridNotificationBar animation", () => {
     });
 
     const wrapper = getWrapper(container);
-    expect(wrapper?.getAttribute("role")).toBe("status");
-    expect(wrapper?.getAttribute("aria-live")).toBe("polite");
-    // Wrapper must NOT be inert — that would suppress live-region announcements.
+    // Outer animation wrapper must NOT carry live-region attributes — those
+    // belong to the inner text-only region.
+    expect(wrapper?.hasAttribute("role")).toBe(false);
+    expect(wrapper?.hasAttribute("aria-live")).toBe(false);
     expect(wrapper?.hasAttribute("inert")).toBe(false);
+
+    const live = getLiveRegion(container);
+    expect(live).not.toBeNull();
+    expect(live?.getAttribute("role")).toBe("status");
+    expect(live?.getAttribute("aria-live")).toBe("polite");
+    expect(live?.getAttribute("aria-atomic")).toBe("true");
+    expect(live?.textContent).toContain("Announce me");
+  });
+
+  it("renders action buttons as siblings of the live region, not inside it", () => {
+    const onClick = vi.fn();
+    addGridBar({
+      message: "Pick one",
+      action: { label: "Confirm", onClick },
+    });
+    const { container } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    const live = getLiveRegion(container);
+    expect(live).not.toBeNull();
+    // The live region announces flat text; buttons must not be its descendants.
+    expect(within(live!).queryAllByRole("button")).toHaveLength(0);
+    // But the button still exists in the bar as a sibling.
+    const allButtons = container.querySelectorAll("button");
+    expect(allButtons).toHaveLength(1);
+    expect(allButtons[0].textContent).toBe("Confirm");
+    expect(live!.contains(allButtons[0])).toBe(false);
+  });
+
+  it("renders the dismiss button as a sibling of the live region", () => {
+    addGridBar({ message: "Dismiss me" });
+    const { container } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    const live = getLiveRegion(container);
+    expect(live).not.toBeNull();
+    const dismissBtn = container.querySelector("button");
+    expect(dismissBtn?.textContent).toBe("Dismiss");
+    expect(live!.contains(dismissBtn!)).toBe(false);
   });
 
   it("blocks focus and screen readers on action buttons while collapsed", () => {
@@ -211,7 +305,9 @@ describe("GridNotificationBar animation", () => {
 
   it("animates in when a notification is added after mount", () => {
     const { container, getByText } = render(<GridNotificationBar />);
-    expect(container.firstChild).toBeNull();
+    // Always-mounted: wrapper exists, just collapsed.
+    expect(getWrapper(container)).not.toBeNull();
+    expect(getWrapper(container)?.className).toContain("h-0");
 
     act(() => {
       addGridBar({ message: "Late arrival" });
@@ -251,5 +347,165 @@ describe("GridNotificationBar animation", () => {
 
     errorSpy.mockRestore();
     warnSpy.mockRestore();
+  });
+
+  it("clears the swap timer on unmount mid-swap", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const firstId = addGridBar({ message: "First" });
+    const { unmount } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    // Trigger a swap (clears live region, schedules timer).
+    act(() => {
+      useNotificationStore.getState().removeNotification(firstId);
+      addGridBar({ message: "Second" });
+    });
+
+    expect(() => {
+      unmount();
+      vi.advanceTimersByTime(LIVE_REGION_SWAP_DELAY * 2);
+    }).not.toThrow();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});
+
+describe("GridNotificationBar swap delay", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stubMatchMedia(false);
+    useNotificationStore.getState().reset();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("clears the live region and waits LIVE_REGION_SWAP_DELAY before announcing the replacement", () => {
+    const firstId = addGridBar({ message: "First" });
+    const { container, queryByText, getByText } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+    expect(getByText("First")).toBeTruthy();
+
+    // Direct A→B swap (no intermediate null).
+    act(() => {
+      useNotificationStore.getState().removeNotification(firstId);
+      addGridBar({ message: "Second" });
+    });
+
+    // Live region is cleared immediately on swap.
+    expect(getLiveRegion(container)?.textContent).toBe("");
+    expect(queryByText("First")).toBeNull();
+    expect(queryByText("Second")).toBeNull();
+
+    // Just under the swap delay: still empty.
+    act(() => {
+      vi.advanceTimersByTime(LIVE_REGION_SWAP_DELAY - 1);
+    });
+    expect(queryByText("Second")).toBeNull();
+
+    // At the swap delay boundary: "Second" appears.
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(getByText("Second")).toBeTruthy();
+    expect(getLiveRegion(container)?.textContent).toContain("Second");
+    // Bar never collapsed visually — isVisible stayed true.
+    expect(getWrapper(container)?.className).toContain("h-auto");
+  });
+
+  it("collapses pending swaps so only the latest notification is announced (A→B→C)", () => {
+    const firstId = addGridBar({ message: "First" });
+    const { queryByText, getByText } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+
+    // Swap to Second, then to Third before Second's timer fires.
+    act(() => {
+      useNotificationStore.getState().removeNotification(firstId);
+      const secondId = addGridBar({ message: "Second" });
+      // Mid-swap clear is now in effect; before the timer fires, swap again.
+      useNotificationStore.getState().removeNotification(secondId);
+      addGridBar({ message: "Third" });
+    });
+
+    // Advance through the original swap delay window.
+    act(() => {
+      vi.advanceTimersByTime(LIVE_REGION_SWAP_DELAY);
+    });
+
+    // Second was retargeted to Third — Second never appears.
+    expect(queryByText("Second")).toBeNull();
+    expect(getByText("Third")).toBeTruthy();
+  });
+});
+
+describe("GridNotificationBar reduced motion", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stubMatchMedia(true);
+    useNotificationStore.getState().reset();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("renders the bar visible immediately without a rAF entry tick", () => {
+    addGridBar({ message: "Instant" });
+    const { container, getByText } = render(<GridNotificationBar />);
+
+    // No rAF needed: wrapper starts visible.
+    const wrapper = getWrapper(container);
+    expect(wrapper?.className).toContain("h-auto");
+    expect(wrapper?.className).toContain("opacity-100");
+    expect(getByText("Instant")).toBeTruthy();
+  });
+
+  it("zeroes out the wrapper transition duration", () => {
+    addGridBar({ message: "No motion" });
+    const { container } = render(<GridNotificationBar />);
+
+    const wrapper = getWrapper(container);
+    expect(wrapper?.style.transitionDuration).toBe("0ms");
+  });
+
+  it("still applies the 150ms swap delay even under reduced motion", () => {
+    const firstId = addGridBar({ message: "First" });
+    const { container, queryByText, getByText } = render(<GridNotificationBar />);
+
+    expect(getByText("First")).toBeTruthy();
+
+    act(() => {
+      useNotificationStore.getState().removeNotification(firstId);
+      addGridBar({ message: "Second" });
+    });
+
+    // Live region cleared immediately.
+    expect(getLiveRegion(container)?.textContent).toBe("");
+
+    // Swap delay still applies — not gated on prefers-reduced-motion.
+    act(() => {
+      vi.advanceTimersByTime(LIVE_REGION_SWAP_DELAY - 1);
+    });
+    expect(queryByText("Second")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(getByText("Second")).toBeTruthy();
   });
 });

--- a/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
+++ b/src/components/Terminal/__tests__/GridNotificationBar.test.tsx
@@ -425,6 +425,34 @@ describe("GridNotificationBar swap delay", () => {
     expect(getWrapper(container)?.className).toContain("h-auto");
   });
 
+  it("re-announces same-text content when the id changes (VoiceOver buffer flush)", () => {
+    const firstId = addGridBar({ message: "Saved" });
+    const { container, queryByText, getByText } = render(<GridNotificationBar />);
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+    expect(getByText("Saved")).toBeTruthy();
+
+    // Same message text, fresh id — must clear and re-announce so AT re-reads it.
+    act(() => {
+      useNotificationStore.getState().removeNotification(firstId);
+      addGridBar({ message: "Saved" });
+    });
+
+    expect(getLiveRegion(container)?.textContent).toBe("");
+    expect(queryByText("Saved")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(LIVE_REGION_SWAP_DELAY - 1);
+    });
+    expect(queryByText("Saved")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(getByText("Saved")).toBeTruthy();
+  });
+
   it("collapses pending swaps so only the latest notification is announced (A→B→C)", () => {
     const firstId = addGridBar({ message: "First" });
     const { queryByText, getByText } = render(<GridNotificationBar />);

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -140,6 +140,15 @@ export const PANEL_RESTORE_DURATION = DURATION_200;
 export const BANNER_ENTER_DURATION = DURATION_250;
 export const BANNER_EXIT_DURATION = DURATION_200;
 
+/** Screen-reader buffer flush delay for live-region content swaps. When a
+ *  `role="status"` / `aria-live` region's text changes synchronously, VoiceOver
+ *  on macOS Sequoia and iOS 18 has been observed to drop the announcement.
+ *  The APG mitigation is clear-then-add-on-next-tick: clear the region, wait
+ *  ~150ms, then render new content. Below the 400ms Doherty threshold so
+ *  sighted users perceive it as instant. Not a motion token — must not be
+ *  gated on `prefers-reduced-motion`. */
+export const LIVE_REGION_SWAP_DELAY = DURATION_150;
+
 export const DRAG_GHOST_OPACITY = 0.4;
 export const DRAG_GHOST_EASING = "easeOut";
 export const DRAG_OVERLAY_ENTRY_SCALE = 0.95;


### PR DESCRIPTION
## Summary

- Fixes four `GridNotificationBar` accessibility issues: action buttons split out of `role="status"` so screen readers only announce notification text; `aria-atomic="true"` set explicitly; a 150ms buffer-flush delay on notification swap so VoiceOver doesn't drop the announcement; and `prefers-reduced-motion` / `data-reduce-animations` / `data-performance-mode` honored, matching the `InlineStatusBanner` pattern.
- Always-mount the live region — removed the early-return that dropped `role="status"` from the DOM when empty. The outer wrapper collapses to `h-0` when there's nothing to show, but AT registers the region on page load and won't miss the first announcement.
- A→B→C retarget logic collapses rapid notification replacements into a single announcement of the latest.

Resolves #9190

## Changes

- `src/components/Terminal/GridNotificationBar.tsx` — structural split of live region and action buttons, always-mount, swap delay, reduced-motion guard, retarget collapse
- `src/lib/animationUtils.ts` — `LIVE_REGION_SWAP_DELAY` constant (150ms; not gated on reduced-motion — it's a screen-reader timing concern, not a motion concern)
- `src/components/Terminal/__tests__/GridNotificationBar.test.tsx` — 19 vitest cases covering structural split, swap delay, retarget, reduced motion, and existing animation behavior

## Testing

`npm run check` and build both clean. Test suite updated with 19 cases; all pass.
