### PR TITLE
feat(plugins): wire renderer consumer for plugin menu items

### DIFF
--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -58,6 +58,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "plugin:actions-changed": "external",
   "plugin:panel-kinds-changed": "external",
   "plugin:toolbar-buttons-changed": "external",
+  "plugin:menu-items-changed": "external",
   "plugin:decorations-changed": "external",
   "terminal:exit": "external",
   "terminal:spawn-result": "external",

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -76,10 +76,30 @@ function handleUpdateMenuClick(): void {
 // rebuilds — a stale listener would mutate items that no longer exist.
 let unsubscribeUpdateMenuState: (() => void) | null = null;
 
+// Last window + CLI-availability service the menu was built with, captured so a
+// data-only rebuild (e.g. plugin menu items changing) can re-run the template
+// without the caller threading those refs through. See rebuildApplicationMenu.
+let lastMenuWindow: BrowserWindow | null = null;
+let lastMenuCliAvailabilityService: CliAvailabilityService | undefined;
+
+/**
+ * Rebuild the application menu in place using the window + CLI-availability
+ * service from the most recent {@link createApplicationMenu} call. Used by the
+ * plugin menu-item broadcast so application-menu locations (`view`, `help`,
+ * `file`, `terminal`) reflect plugin load/unload without a project switch.
+ * No-op until the menu has been built once, or if the captured window is gone.
+ */
+export function rebuildApplicationMenu(): void {
+  if (!lastMenuWindow || lastMenuWindow.isDestroyed()) return;
+  createApplicationMenu(lastMenuWindow, lastMenuCliAvailabilityService);
+}
+
 export function createApplicationMenu(
   mainWindow: BrowserWindow,
   cliAvailabilityService?: CliAvailabilityService
 ): void {
+  lastMenuWindow = mainWindow;
+  lastMenuCliAvailabilityService = cliAvailabilityService;
   const getTargetBrowserWindow = (
     browserWindow: Electron.BaseWindow | undefined
   ): BrowserWindow | null => {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -126,7 +126,7 @@ import type {
 type SpawnResultPayload = SpawnResult;
 import type { PortalNewTabMenuAction } from "../shared/types/portal.js";
 import type { ResourceProfilePayload } from "../shared/types/resourceProfile.js";
-import type { PluginActionDescriptor } from "../shared/types/plugin.js";
+import type { PluginActionDescriptor, MenuItemContribution } from "../shared/types/plugin.js";
 import type { PanelKindConfig } from "../shared/config/panelKindRegistry.js";
 import type { ToolbarButtonConfig } from "../shared/config/toolbarButtonRegistry.js";
 
@@ -2411,6 +2411,9 @@ const api: ElectronAPI = {
     onToolbarButtonsChanged: (
       callback: (payload: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void
     ) => _eventBusOn("plugin:toolbar-buttons-changed", callback),
+    onMenuItemsChanged: (
+      callback: (payload: { items: { pluginId: string; item: MenuItemContribution }[] }) => void
+    ) => _eventBusOn("plugin:menu-items-changed", callback),
     onDecorationsChanged: (callback: (payload: { scope: string; paths?: string[] }) => void) =>
       _eventBusOn("plugin:decorations-changed", callback),
   },

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -45,6 +45,9 @@ export const MenuItemContributionSchema = z.object({
   actionId: z.string().min(1),
   location: z.enum(["terminal", "file", "view", "help"]),
   accelerator: z.string().optional(),
+  // Visibility expression evaluated by the when-clause runtime (#9273). Until
+  // that lands, the field is accepted but not evaluated — items always show.
+  when: z.string().optional(),
 });
 
 /**

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -49,7 +49,11 @@ import {
   unregisterPluginToolbarButtons,
   getAllPluginToolbarButtonConfigs,
 } from "../../shared/config/toolbarButtonRegistry.js";
-import { registerPluginMenuItem, unregisterPluginMenuItems } from "./pluginMenuRegistry.js";
+import {
+  registerPluginMenuItem,
+  unregisterPluginMenuItems,
+  getPluginMenuItems,
+} from "./pluginMenuRegistry.js";
 import {
   registerForgeProviderImpl,
   registerForgeProviders,
@@ -245,6 +249,18 @@ export class PluginService {
    * partial/growing snapshot (concurrent load + deferred init) and must not.
    */
   private toolbarButtonsBroadcastComplete = false;
+  /**
+   * Same coalescing rationale as the toolbar-button flag. No `complete`
+   * companion — menu items carry no persisted renderer-side state to sweep, so
+   * every broadcast is a full replacement and load/unload are symmetric.
+   */
+  private menuItemsBroadcastPending = false;
+  /**
+   * Main-side listeners (e.g. the application-menu rebuild) notified whenever
+   * the plugin menu-item set changes. Distinct from the renderer broadcast
+   * because the application menu is built in main and can't read renderer state.
+   */
+  private menuItemsChangedListeners: Array<() => void> = [];
   private disposed = false;
   private readonly disposeRegistrySubscriptions: () => void;
 
@@ -274,6 +290,7 @@ export class PluginService {
    */
   dispose(): void {
     this.disposed = true;
+    this.menuItemsChangedListeners = [];
     this.disposeRegistrySubscriptions();
   }
 
@@ -533,6 +550,9 @@ export class PluginService {
 
     for (const menuItem of manifest.contributes.menuItems) {
       registerPluginMenuItem(manifest.name, menuItem);
+    }
+    if (manifest.contributes.menuItems.length > 0) {
+      this.scheduleMenuItemsBroadcast();
     }
 
     if (manifest.contributes.experimental_views.length > 0) {
@@ -1078,7 +1098,6 @@ export class PluginService {
       this.cleanupMap.delete(pluginId);
     }
     this.flushPluginEventCleanups(pluginId);
-
     // Capture the unloaded plugin's declared decoration scopes before clearing
     // the registry so we can tell any renderer that was showing them to
     // re-pull (it will now resolve no impl and clear). Without this, stale
@@ -1106,6 +1125,7 @@ export class PluginService {
       this.unregisterPluginActions(pluginId)
     );
     runUnloadStep(pluginId, "unregisterPluginMenuItems", () => unregisterPluginMenuItems(pluginId));
+    runUnloadStep(pluginId, "scheduleMenuItemsBroadcast", () => this.scheduleMenuItemsBroadcast());
     runUnloadStep(pluginId, "unregisterPluginToolbarButtons", () =>
       unregisterPluginToolbarButtons(pluginId)
     );
@@ -1430,6 +1450,49 @@ export class PluginService {
       name: "plugin:toolbar-buttons-changed",
       payload: { buttons: getAllPluginToolbarButtonConfigs(), complete },
     });
+  }
+
+  /**
+   * Register a main-side listener invoked whenever the plugin menu-item set
+   * changes (load/unload). Used by the application-menu rebuild, which lives in
+   * main and can't subscribe to the renderer broadcast. Returns a disposer.
+   */
+  onMenuItemsChanged(listener: () => void): () => void {
+    this.menuItemsChangedListeners.push(listener);
+    return () => {
+      const idx = this.menuItemsChangedListeners.indexOf(listener);
+      if (idx !== -1) this.menuItemsChangedListeners.splice(idx, 1);
+    };
+  }
+
+  /**
+   * Coalesce the N `registerPluginMenuItem` calls a plugin makes on load (and
+   * the single bulk removal on unload) into one snapshot broadcast per tick,
+   * mirroring {@link scheduleToolbarButtonsBroadcast}.
+   */
+  private scheduleMenuItemsBroadcast(): void {
+    if (this.disposed) return;
+    if (this.menuItemsBroadcastPending) return;
+    this.menuItemsBroadcastPending = true;
+    queueMicrotask(() => {
+      this.menuItemsBroadcastPending = false;
+      if (this.disposed) return;
+      this.broadcastPluginMenuItems();
+    });
+  }
+
+  private broadcastPluginMenuItems(): void {
+    broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:menu-items-changed",
+      payload: { items: getPluginMenuItems() },
+    });
+    for (const listener of this.menuItemsChangedListeners) {
+      try {
+        listener();
+      } catch (err) {
+        console.error("[PluginService] menu-items-changed listener threw:", err);
+      }
+    }
   }
 }
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -42,6 +42,7 @@ vi.mock("../../../shared/config/toolbarButtonRegistry.js", () => ({
 vi.mock("../pluginMenuRegistry.js", () => ({
   registerPluginMenuItem: vi.fn(),
   unregisterPluginMenuItems: vi.fn(),
+  getPluginMenuItems: vi.fn(() => []),
 }));
 vi.mock("../forgeProviderRegistry.js", () => ({
   registerForgeProviders: vi.fn(),

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -302,6 +302,15 @@ export async function initGlobalServices(
       } catch (err) {
         console.error("[MAIN] PluginService initialization failed:", err);
       }
+      // Rebuild the application menu when plugin menu items change so `view` /
+      // `help` / `file` / `terminal` application-menu locations reflect plugin
+      // load/unload. Dynamic import breaks the menu.ts → windowServices.ts →
+      // globalServicesInit.ts static cycle; rebuildApplicationMenu reuses the
+      // window captured by the startup createApplicationMenu call.
+      const { rebuildApplicationMenu } = await import("../menu.js");
+      pluginService.onMenuItemsChanged(() => {
+        rebuildApplicationMenu();
+      });
     },
   });
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1459,6 +1459,12 @@ export interface ElectronAPI extends GeneratedElectronAPI {
         complete: boolean;
       }) => void
     ): () => void;
+    /** Subscribe to plugin menu item registry changes. Returns a cleanup. */
+    onMenuItemsChanged(
+      callback: (payload: {
+        items: { pluginId: string; item: import("../plugin.js").MenuItemContribution }[];
+      }) => void
+    ): () => void;
   };
   crashRecovery: {
     getPending(): Promise<import("./crashRecovery.js").PendingCrash | null>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1845,6 +1845,13 @@ export interface IpcEventMap {
     complete: boolean;
   };
 
+  // Plugin menu item registry events (main → renderer). No `complete` flag —
+  // menu items have no persisted renderer-side state to sweep (unlike toolbar
+  // buttons' pinned preferences), so every broadcast is a full replacement.
+  "plugin:menu-items-changed": {
+    items: { pluginId: string; item: import("../plugin.js").MenuItemContribution }[];
+  };
+
   // Plugin file-decoration invalidation (main → renderer). Carries only the
   // changed scope (optionally narrowed to `paths`) — never decoration data.
   // The renderer re-pulls fresh decorations via `plugin:file-decorations-get`.
@@ -1928,6 +1935,8 @@ export type IpcEventBusMap = Pick<
   | "plugin:panel-kinds-changed"
   // Plugin toolbar button registry (global broadcast)
   | "plugin:toolbar-buttons-changed"
+  // Plugin menu item registry (global broadcast)
+  | "plugin:menu-items-changed"
   // Plugin file-decoration invalidation (global broadcast)
   | "plugin:decorations-changed"
   // Terminal lifecycle (non-data) — exit, spawn-result, backend crash/ready

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -58,6 +58,11 @@ export interface MenuItemContribution {
   actionId: string;
   location: MenuItemLocation;
   accelerator?: string;
+  /**
+   * Visibility expression evaluated by the when-clause runtime (#9273). Until
+   * that lands, consumers pass it through unfiltered — items always show.
+   */
+  when?: string;
 }
 
 /**

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -8,6 +8,7 @@ import { useWorktrees } from "@/hooks/useWorktrees";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { isValidBrowserUrl } from "@/components/Browser/browserUtils";
 import { actionService } from "@/services/ActionService";
+import { usePluginMenuItems } from "@/hooks/usePluginMenuItems";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { isBrowserPanel, isDevPreviewPanel, isPtyPanel, isReviewPanel } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -94,6 +95,9 @@ export function TerminalContextMenu({
   const isArmed = useFleetArmingStore((s) => s.armedIds.has(terminalId));
   const fleetSize = useFleetArmingStore((s) => s.armedIds.size);
   const isHibernated = useIsHibernated(terminalId);
+  // Plugin-contributed items for the terminal context menu. Pulled on mount and
+  // kept in sync via push; empty until a plugin contributes a `"terminal"` item.
+  const pluginTerminalItems = usePluginMenuItems("terminal");
   // Pull the panel directly here (rather than indexing through the shallow
   // selector above) so the eligibility check sees the live record. The
   // dropdown only renders fleet items when the panel is fleet-arm-eligible
@@ -796,6 +800,23 @@ export function TerminalContextMenu({
             <OctagonX className={ICON_CLASS} aria-hidden="true" />
             Kill Terminal
           </ContextMenuItem>
+          {pluginTerminalItems.length > 0 && (
+            <>
+              <ContextMenuSeparator />
+              {pluginTerminalItems.map(({ pluginId, item }) => (
+                <ContextMenuItem
+                  key={`${pluginId}:${item.actionId}:${item.label}`}
+                  onSelect={() =>
+                    void actionService.dispatch(item.actionId, undefined, {
+                      source: sourceRef.current,
+                    })
+                  }
+                >
+                  {item.label}
+                </ContextMenuItem>
+              ))}
+            </>
+          )}
         </ContextMenuContent>
       </ContextMenu>
     </>

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -803,9 +803,9 @@ export function TerminalContextMenu({
           {pluginTerminalItems.length > 0 && (
             <>
               <ContextMenuSeparator />
-              {pluginTerminalItems.map(({ pluginId, item }) => (
+              {pluginTerminalItems.map(({ pluginId, item }, index) => (
                 <ContextMenuItem
-                  key={`${pluginId}:${item.actionId}:${item.label}`}
+                  key={`${pluginId}:${item.actionId}:${index}`}
                   onSelect={() =>
                     void actionService.dispatch(item.actionId, undefined, {
                       source: sourceRef.current,

--- a/src/hooks/__tests__/usePluginMenuItems.test.ts
+++ b/src/hooks/__tests__/usePluginMenuItems.test.ts
@@ -112,6 +112,41 @@ describe("usePluginMenuItems", () => {
     expect(result.current[0]?.item.when).toBe("view == 'terminal'");
   });
 
+  it("clears items immediately when the location changes", async () => {
+    menuItemsMock.mockImplementation(() => new Promise<MenuEntry[]>(() => {}));
+    onMenuItemsChangedMock.mockImplementation((cb: (p: { items: MenuEntry[] }) => void) => {
+      // Seed terminal items via push so there is something to clear.
+      cb({ items: [entry("acme", "terminal")] });
+      return () => {};
+    });
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+    const { result, rerender } = renderHook(
+      ({ loc }: { loc: MenuItemContribution["location"] }) => usePluginMenuItems(loc),
+      { initialProps: { loc: "terminal" as MenuItemContribution["location"] } }
+    );
+
+    await waitFor(() => expect(result.current).toHaveLength(1));
+
+    // Switching location tears down the old effect; the new pull never resolves.
+    onMenuItemsChangedMock.mockReturnValue(() => {});
+    rerender({ loc: "help" as MenuItemContribution["location"] });
+    expect(result.current).toHaveLength(0);
+  });
+
+  it("survives a malformed push payload without throwing", async () => {
+    let emit: ((p: { items: MenuEntry[] }) => void) | null = null;
+    onMenuItemsChangedMock.mockImplementation((cb: (p: { items: MenuEntry[] }) => void) => {
+      emit = cb;
+      return () => {};
+    });
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+    const { result } = renderHook(() => usePluginMenuItems("terminal"));
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    expect(() => emit!({ items: undefined as unknown as MenuEntry[] })).not.toThrow();
+    expect(result.current).toHaveLength(0);
+  });
+
   it("unsubscribes from the push channel on unmount", async () => {
     const cleanup = vi.fn();
     onMenuItemsChangedMock.mockReturnValue(cleanup);

--- a/src/hooks/__tests__/usePluginMenuItems.test.ts
+++ b/src/hooks/__tests__/usePluginMenuItems.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { MenuItemContribution } from "@shared/types/plugin";
+
+const { menuItemsMock, onMenuItemsChangedMock } = vi.hoisted(() => ({
+  menuItemsMock: vi.fn(),
+  onMenuItemsChangedMock: vi.fn(),
+}));
+
+interface MenuEntry {
+  pluginId: string;
+  item: MenuItemContribution;
+}
+
+function entry(
+  pluginId: string,
+  location: MenuItemContribution["location"],
+  overrides: Partial<MenuItemContribution> = {}
+): MenuEntry {
+  return {
+    pluginId,
+    item: { label: "Do thing", actionId: `${pluginId}.do`, location, ...overrides },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as unknown as { window: unknown }).window = Object.assign(globalThis.window ?? {}, {
+    electron: {
+      plugin: {
+        menuItems: menuItemsMock,
+        onMenuItemsChanged: onMenuItemsChangedMock,
+      },
+    },
+  });
+  vi.resetModules();
+  menuItemsMock.mockResolvedValue([]);
+  onMenuItemsChangedMock.mockReturnValue(() => {});
+});
+
+describe("usePluginMenuItems", () => {
+  it("exposes mount-time pull items filtered to the requested location", async () => {
+    menuItemsMock.mockResolvedValue([
+      entry("acme", "terminal"),
+      entry("acme", "help"),
+      entry("beta", "terminal"),
+    ]);
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+
+    const { result } = renderHook(() => usePluginMenuItems("terminal"));
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(2);
+    });
+    expect(result.current.map((e) => e.pluginId)).toEqual(["acme", "beta"]);
+  });
+
+  it("replaces state from an authoritative push", async () => {
+    let emit: ((p: { items: MenuEntry[] }) => void) | null = null;
+    onMenuItemsChangedMock.mockImplementation((cb: (p: { items: MenuEntry[] }) => void) => {
+      emit = cb;
+      return () => {};
+    });
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+    const { result } = renderHook(() => usePluginMenuItems("terminal"));
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    emit!({ items: [entry("acme", "terminal"), entry("acme", "view")] });
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1);
+    });
+    expect(result.current[0]?.item.actionId).toBe("acme.do");
+  });
+
+  it("drops a late-resolving pull once a push has arrived", async () => {
+    let resolvePull: ((entries: MenuEntry[]) => void) | null = null;
+    menuItemsMock.mockReturnValue(
+      new Promise<MenuEntry[]>((resolve) => {
+        resolvePull = resolve;
+      })
+    );
+    let emit: ((p: { items: MenuEntry[] }) => void) | null = null;
+    onMenuItemsChangedMock.mockImplementation((cb: (p: { items: MenuEntry[] }) => void) => {
+      emit = cb;
+      return () => {};
+    });
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+    const { result } = renderHook(() => usePluginMenuItems("terminal"));
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    // Push wins: authoritative snapshot lands first.
+    emit!({ items: [entry("beta", "terminal")] });
+    await waitFor(() => expect(result.current).toHaveLength(1));
+
+    // Stale pull resolves afterward and must be ignored.
+    resolvePull!([entry("acme", "terminal"), entry("acme", "terminal")]);
+    await Promise.resolve();
+    expect(result.current.map((e) => e.pluginId)).toEqual(["beta"]);
+  });
+
+  it("passes through items with a `when` clause unfiltered (pre-#9273)", async () => {
+    menuItemsMock.mockResolvedValue([entry("acme", "terminal", { when: "view == 'terminal'" })]);
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+
+    const { result } = renderHook(() => usePluginMenuItems("terminal"));
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1);
+    });
+    expect(result.current[0]?.item.when).toBe("view == 'terminal'");
+  });
+
+  it("unsubscribes from the push channel on unmount", async () => {
+    const cleanup = vi.fn();
+    onMenuItemsChangedMock.mockReturnValue(cleanup);
+    const { usePluginMenuItems } = await import("../usePluginMenuItems");
+
+    const { unmount } = renderHook(() => usePluginMenuItems("terminal"));
+    await waitFor(() => expect(onMenuItemsChangedMock).toHaveBeenCalled());
+    unmount();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/usePluginMenuItems.ts
+++ b/src/hooks/usePluginMenuItems.ts
@@ -1,0 +1,64 @@
+import { useState, useEffect } from "react";
+import type { MenuItemContribution, MenuItemLocation } from "@shared/types/plugin";
+import { logWarn } from "@/utils/logger";
+
+export interface PluginMenuItemEntry {
+  pluginId: string;
+  item: MenuItemContribution;
+}
+
+/**
+ * Pull plugin-contributed menu items for a given location on mount and keep
+ * them in sync with main's authoritative set via push. Pull-on-mount is a
+ * safety net for cached `WebContentsView`s that may have missed a broadcast;
+ * push is authoritative — once a push arrives, a later-resolving mount-time
+ * pull is dropped to avoid rolling back state (mirrors
+ * {@link usePluginToolbarButtons}).
+ *
+ * Unlike toolbar buttons there is no `complete`/sweep path: menu items carry no
+ * persisted renderer-side state, so every snapshot is a full replacement.
+ *
+ * `when` is passed through unfiltered for now — the when-clause evaluator
+ * (#9273) is not yet wired, and items without a `when` are always visible, so
+ * the safe interim behavior is to show every contributed item. Filtering moves
+ * here once #9273 lands.
+ */
+export function usePluginMenuItems(location: MenuItemLocation): PluginMenuItemEntry[] {
+  const [items, setItems] = useState<PluginMenuItemEntry[]>([]);
+
+  useEffect(() => {
+    let disposed = false;
+    let pushReceived = false;
+
+    const sync = (entries: PluginMenuItemEntry[]): void => {
+      if (disposed) return;
+      setItems(entries.filter((entry) => entry.item.location === location));
+    };
+
+    const electron = typeof window !== "undefined" ? window.electron : undefined;
+    if (!electron?.plugin) return;
+
+    void electron.plugin
+      .menuItems()
+      .then((entries) => {
+        if (disposed) return;
+        if (pushReceived) return;
+        sync(entries);
+      })
+      .catch((err: unknown) => {
+        logWarn("[PluginMenuItems] Failed to fetch initial plugin menu items", { error: err });
+      });
+
+    const cleanup = electron.plugin.onMenuItemsChanged((payload) => {
+      pushReceived = true;
+      sync(payload.items);
+    });
+
+    return () => {
+      disposed = true;
+      cleanup();
+    };
+  }, [location]);
+
+  return items;
+}

--- a/src/hooks/usePluginMenuItems.ts
+++ b/src/hooks/usePluginMenuItems.ts
@@ -32,6 +32,8 @@ export function usePluginMenuItems(location: MenuItemLocation): PluginMenuItemEn
 
     const sync = (entries: PluginMenuItemEntry[]): void => {
       if (disposed) return;
+      // Defensive: a malformed push payload shouldn't crash the menu.
+      if (!Array.isArray(entries)) return;
       setItems(entries.filter((entry) => entry.item.location === location));
     };
 
@@ -55,6 +57,9 @@ export function usePluginMenuItems(location: MenuItemLocation): PluginMenuItemEn
     });
 
     return () => {
+      // Clear before the next location's pull resolves so a re-keyed call site
+      // doesn't briefly show the previous location's items.
+      setItems([]);
       disposed = true;
       cleanup();
     };


### PR DESCRIPTION
## Summary

- Plugins could declare `contributes.menuItems` in their manifests and main-side registration worked, but the renderer had no consumer — no hook, no push event, no menu rebuild on plugin load/unload.
- Adds `usePluginMenuItems(location)`, mirroring `usePluginToolbarButtons`: pull-on-mount safety net + authoritative push (drops a late-resolving pull once a push arrives), filtered by location.
- `PluginService` now broadcasts `plugin:menu-items-changed` on register/unregister, coalesced via `queueMicrotask`. Application menu rebuilds on change via a new `globalServicesInit` listener + `rebuildApplicationMenu()` in `menu.ts` (dynamic import avoids circular dep). Terminal-location items surface at the bottom of `TerminalContextMenu` behind a separator.

Resolves #9288

## Changes

- `src/hooks/usePluginMenuItems.ts` — new renderer hook, location-filtered, push-authoritative
- `electron/services/PluginService.ts` — `scheduleMenuItemsBroadcast()` on load/unload, `onMenuItemsChanged()` for main-side subscribers
- `electron/window/globalServicesInit.ts` — registers `onMenuItemsChanged` listener → `rebuildApplicationMenu()`
- `electron/menu.ts` — new `rebuildApplicationMenu()` exported function
- `src/components/Terminal/TerminalContextMenu.tsx` — surfaces plugin items for the `terminal` location
- `electron/preload.cts`, `src/types/electron.d.ts`, `shared/types/ipc/api.ts`, `shared/types/ipc/maps.ts`, `electron/ipc/handlers/events.ts` — IPC plumbing for the push event
- `electron/schemas/plugin.ts`, `shared/types/plugin.ts` — optional `when` field on `MenuItemContribution` (forward-compat for the #9273 when-clause evaluator)

## Testing

Seven unit tests in `src/hooks/__tests__/usePluginMenuItems.test.ts`: location filter, push replacing a pending pull, late-pull dropped, `when` passthrough, location-change clearing, malformed-payload resilience, unmount cleanup. All pass. Full `npm run check` clean (typecheck, lint ratchet, format, IPC drift).